### PR TITLE
chore: updates relating to contextpath carlos

### DIFF
--- a/.devcontainer/development/Dockerfile
+++ b/.devcontainer/development/Dockerfile
@@ -4,7 +4,7 @@ FROM tomcat:9.0.97-jdk21-temurin
 ENV CATALINA_HOME /usr/local/tomcat
 ENV PATH $CATALINA_HOME/bin:$PATH
 # ENV CATALINA_OPTS="--add-opens java.base/java.net=ALL-UNNAMED -agentlib:jdwp=transport=dt_socket,address=8000,server=y,suspend=n"
-ENV CATALINA_OPTS="--add-opens java.base/java.net=ALL-UNNAMED -Djava.awt.headless=true"
+ENV CATALINA_OPTS="--add-opens java.base/java.net=ALL-UNNAMED -Djava.awt.headless=true -Doscar_override_properties=/root/oscar.properties"
 ENV JPDA_OPTS="-agentlib:jdwp=transport=dt_socket,address=8000,server=y,suspend=n"
 ENV JPDA_ADDRESS=8000
 ENV JPDA_TRANSPORT=dt_socket
@@ -13,9 +13,9 @@ ENV JPDA_TRANSPORT=dt_socket
 COPY --from=tomcat:9.0.97 /usr/local/tomcat $CATALINA_HOME
 
 # Labels
-LABEL author="OpenOSP" \
-      version="0.0.2" \
-      description="OpenOSP Docker Image for Development Environment"
+LABEL author="CARLOS EMR Project" \
+      version="1.0.0" \
+      description="CARLOS EMR Docker Image for Development Environment"
 
 ARG TOMCAT_PATH=/usr/local/tomcat
 ARG DOCS_PATH='/home/oscar/development/volumes'

--- a/.devcontainer/development/scripts/make
+++ b/.devcontainer/development/scripts/make
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-# Script to manage building and deploying the openosp emr www application to Tomcat
+# Script to manage building and deploying the CARLOS EMR application to Tomcat
 # This script supports the following operations:
 # - clean: Cleans the project and removes the deployed www app from Tomcat.
 # - install: Builds the project and deploys it to Tomcat. Optionally, you can run tests by passing --run-tests.
@@ -67,7 +67,7 @@ build_and_deploy() {
     echo ""
     echo ">>> Cleaning up between test phases..."
     # Remove the deployed WAR to avoid any state pollution
-    rm -rf /usr/local/tomcat/webapps/oscar
+    rm -rf /usr/local/tomcat/webapps/carlos
     # Clean target directory to ensure fresh state
     mvn clean -q
 
@@ -120,10 +120,10 @@ build_and_deploy() {
   pom_file="pom.xml"
   version=$(grep -oPm 1 '<version>\K[^<]+' "$pom_file")
   snapshot_src_dir="carlos-$version"
-  snapshot_dest_dir="oscar"
+  snapshot_dest_dir="carlos"
 
   # Create a symlink from the exploded WAR directory to the Tomcat webapps directory.
-  # This ensures the app is deployed with the context path `/oscar` for backward compatibility.
+  # This ensures the app is deployed with the context path `/carlos`.
   if [ -d "target/$snapshot_src_dir" ] && [ ! -L "target/$snapshot_src_dir" ]; then
     mv "target/$snapshot_src_dir" "/usr/local/tomcat/webapps/$snapshot_dest_dir"
     ln -s "/usr/local/tomcat/webapps/$snapshot_dest_dir" "target/$snapshot_src_dir"
@@ -298,7 +298,7 @@ for arg in "$@"; do
       # Clean the project using Maven and remove the deployed app from Tomcat.
       # Skip modern tests to use default lock file
       mvn clean -DskipModernTests=true
-      rm -rf /usr/local/tomcat/webapps/oscar
+      rm -rf /usr/local/tomcat/webapps/carlos
       ;;
     install)
       # Shift the arguments so that we can check for optional arguments.


### PR DESCRIPTION
### **User description**
## Summary by Sourcery

Update the development Tomcat container configuration and metadata for the CARLOS EMR project.

Build:
- Configure CATALINA_OPTS to load an external oscar.properties override file in the dev Tomcat image.
- Update dev container image labels to reflect the CARLOS EMR project and new version.


___

### **Description**
- Enhanced the Docker configuration for the `CARLOS EMR` project by updating the Tomcat container settings.
- Updated the deployment script to reflect the new context path and project name.
- Improved clarity in comments and labels to align with the `CARLOS EMR` branding.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Update Dockerfile for CARLOS EMR project</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/development/Dockerfile
<li>Updated <code>CATALINA_OPTS</code> to load an external <code>oscar.properties</code> override <br>file.<br> <li> Changed image labels to reflect the <code>CARLOS EMR</code> project and updated <br>version.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/7/files#diff-1156fff9feb7b60add461ba1fffbd806d74d07dd7254ada003052a839c80dcd6">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>make</strong><dd><code>Modify deployment script for CARLOS EMR</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/development/scripts/make
<li>Renamed script comments to refer to <code>CARLOS EMR</code> instead of <code>openosp</code>.<br> <li> Updated deployment paths from <code>oscar</code> to <code>carlos</code> in the script.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/7/files#diff-e38f04c61436582e52ee4fff32ba68d1d9987e5c99a5d89f26824992f697a07c">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions

