### PR TITLE
chore: minor refactor and cleanup on caseload

### DIFF
--- a/src/main/webapp/css/receptionistapptstyle.css
+++ b/src/main/webapp/css/receptionistapptstyle.css
@@ -93,9 +93,7 @@ table#firstTable tr td.icon-container {
     padding-left: 10px;
 }
 
-table#caseloadTable tr.caseloadRow td:first-of-type {
-    background-color: whitesmoke !important;
-}
+
 
 table#firstTable td#oscarLogo a img {
     width: 22px;

--- a/src/main/webapp/provider/caseload.jspf
+++ b/src/main/webapp/provider/caseload.jspf
@@ -428,18 +428,23 @@ function draw(json) {
 			// Skip column index 1 (Display Mode with E/C/R letters) which needs precise targeting
 			if (i !== 1) {
 				td.onclick = function(e) {
-					// Only trigger if user clicked the cell background, not a link/button directly
-					if (e.target === this) {
-						var firstLink = this.querySelector('a');
-						if (firstLink) {
-							firstLink.click();
-							return;
-						}
-						var firstButton = this.querySelector('button, input[type="button"], input[type="submit"]');
-						if (firstButton) {
-							firstButton.click();
-							return;
-						}
+					// If the click originated on or inside an interactive control, let it handle itself
+					var target = e.target;
+					if (target && typeof target.closest === 'function' &&
+						target.closest('a, button, input, select, textarea, label')) {
+						return;
+					}
+
+					// Fallback: click the first link in the cell, otherwise the first button-like control
+					var firstLink = this.querySelector('a');
+					if (firstLink) {
+						firstLink.click();
+						return;
+					}
+					var firstButton = this.querySelector('button, input[type="button"], input[type="submit"]');
+					if (firstButton) {
+						firstButton.click();
+						return;
 					}
 				};
 			}

--- a/src/main/webapp/provider/caseload.jspf
+++ b/src/main/webapp/provider/caseload.jspf
@@ -129,7 +129,7 @@
     background-color: #c0c0c0;
 }
 /* Keep display mode links on a single line */
-.caseloadEntry td:nth-child(2) {
+#caseloadTable .caseloadEntry td:nth-child(2) {
     white-space: nowrap;
 }
 #leftSearch, #rightSearch { display: inline; }
@@ -230,14 +230,14 @@ String[] objIds = new String[] {"Demographic", "_caseload.DisplayMode", "_caselo
 
 <% for (int i=0; i < clH.length; i++) { %>
 	<% if (i == 0) { %>
-	<td class='selectedCategory' bgcolor='#c0c0c0' onclick='changeCategory("<%=i%>")'><b><%=clH[i]%> &Delta;</b></td>
+	<td class='selectedCategory' onclick='changeCategory("<%=i%>")'><b><%=clH[i]%> &Delta;</b></td>
 	<% } else if (i == 1) { %>
 	<security:oscarSec roleName="<%=caseloadroleName$%>" objectName="<%=objIds[i]%>" rights="r" reverse="<%=false%>" >
-		<td bgcolor='#c0c0c0' style='width:267px'><b><%=clH[i]%></b></td>
+		<td style='width:267px'><b><%=clH[i]%></b></td>
 	</security:oscarSec>
 	<% } else{ %>
 	<security:oscarSec roleName="<%=caseloadroleName$%>" objectName="<%=objIds[i]%>" rights="r" reverse="<%=false%>" >
-		<td bgcolor='#c0c0c0' onclick='changeCategory("<%=i%>")'><b><%=clH[i]%></b></td>
+		<td onclick='changeCategory("<%=i%>")'><b><%=clH[i]%></b></td>
 	</security:oscarSec>
 	<% } %>
 <% } %>
@@ -246,7 +246,7 @@ String[] objIds = new String[] {"Demographic", "_caseload.DisplayMode", "_caselo
 <tbody id="caseloadBody">
 </tbody>
 <tfoot>
-<tr id='loadingFooter' class='caseloadRow'><td colspan='<%=clH.length%>' style='text-align: center;' bgcolor='#fffff0' colspan='<%=clH.length%>'><img src="<%= request.getContextPath() %>/images/DMSLoader.gif" /><fmt:setBundle basename="oscarResources"/><fmt:message key="caseload.msgLoading"/></td></tr>
+<tr id='loadingFooter' class='caseloadRow'><td colspan='<%=clH.length%>' style='text-align: center;' bgcolor='#fffff0'><img src="<%= request.getContextPath() %>/images/DMSLoader.gif" /><fmt:setBundle basename="oscarResources"/><fmt:message key="caseload.msgLoading"/></td></tr>
 <tr id='noResults' class='caseloadRow'><td colspan='<%=clH.length%>' style='text-align: center;' bgcolor='#fffff0' ><fmt:setBundle basename="oscarResources"/><fmt:message key="caseload.msgTryAgain"/></td></tr>
 <tr id='totalResults1' class='caseloadRow'><td colspan='<%=clH.length%>' style='text-align: center;' bgcolor='#fffff0' ><span id="rows1"></span>/<span id="totalRows1"></span>&nbsp;<fmt:setBundle basename="oscarResources"/><fmt:message key="caseload.msgResults"/></td></tr>
 </tfoot>
@@ -364,7 +364,7 @@ function changeCategory(cat) {
 	}
 	if (cat == category) {
 		sortAsc = !sortAsc;
-		oldCat.attr(onclick,"changeCategory(\"" + category+ "\")");
+		oldCat.attr("onclick","changeCategory(\"" + category+ "\")");
 		oldCat.html("<b>" + clH[category] + " " + getSortDir() + "</b>");
 	}
 	else {
@@ -372,7 +372,7 @@ function changeCategory(cat) {
 		sortAsc = true;
 		oldCat.removeClass("selectedCategory");
 		newCat.addClass("selectedCategory");
-		oldCat.attr(onclick,"changeCategory(\"" + category+ "\")");
+		oldCat.attr("onclick","changeCategory(\"" + category+ "\")");
 		oldCat.html("<b>"+clH[category]+"</b>");
 		newCat.html("<b>" + clH[cat] + " " + getSortDir() + "</b>");
 		category = cat;
@@ -423,6 +423,27 @@ function draw(json) {
 		for (var i = 0; i < this.length; i++) {
 			var td = document.createElement('td');
 			td.innerHTML = this[i];
+
+			// Add click delegation to make cells more clickable (except Display Mode column)
+			// Skip column index 1 (Display Mode with E/C/R letters) which needs precise targeting
+			if (i !== 1) {
+				td.onclick = function(e) {
+					// Only trigger if user clicked the cell background, not a link/button directly
+					if (e.target === this) {
+						var firstLink = this.querySelector('a');
+						if (firstLink) {
+							firstLink.click();
+							return;
+						}
+						var firstButton = this.querySelector('button, input[type="button"], input[type="submit"]');
+						if (firstButton) {
+							firstButton.click();
+							return;
+						}
+					}
+				};
+			}
+
 			tr.appendChild(td);
 		}
 		fragment.appendChild(tr);

--- a/src/main/webapp/provider/caseload.jspf
+++ b/src/main/webapp/provider/caseload.jspf
@@ -86,10 +86,11 @@
 %>
 <tr><td colspan="3">
 <style>
-
-.caseloadRow td {
-    padding: 1px;
-    padding-left: 0.5em;
+/* Tight padding matching oscar19 density */
+#caseloadTable td,
+#caseloadTable th {
+    padding: 1px 0.5em;
+    vertical-align: middle;
 }
 #caseloadTable form {
     display: inline;
@@ -98,14 +99,27 @@
     background-color: #bfefff;
 }
 #caseloadTable a {
-    color:black;
+    color: black;
 }
 #caseloadTable {
-    background-color:white;
+    background-color: white;
+}
+/* Alternating row stripes (replicates Bootstrap table-striped, scoped to caseload) */
+#caseloadTable > tbody > tr:nth-child(odd) > td {
+    background-color: #f9f9f9;
+}
+/* Full-row hover (replicates Bootstrap table-hover, scoped to caseload) */
+#caseloadTable > tbody > tr:hover > td {
+    background-color: #f5f5f5;
+}
+/* Data rows: pointer cursor */
+#caseloadTable .caseloadEntry {
+    cursor: pointer;
 }
 #caseloadHeader b {
     cursor: pointer;
 }
+/* Sticky header — keeps column headings visible during scroll */
 #caseloadHeader {
     position: sticky;
     top: 25px;
@@ -114,22 +128,12 @@
 #caseloadHeader td {
     background-color: #c0c0c0;
 }
-#caseloadTable .caseloadEntry:hover td {
-    background-color: #f5f5f5;
+/* Keep display mode links on a single line */
+.caseloadEntry td:nth-child(2) {
+    white-space: nowrap;
 }
-#caseloadTable .row-even td {
-    background-color: #f9f9f9;
-}
-#leftSearch,
-#rightSearch {
-    display: block;
-    text-align: center;
-    margin-bottom: 5px;
-}
-#rightSearch form {
-    display: inline-block;
-    text-align: left;
-}
+#leftSearch, #rightSearch { display: inline; }
+#rightSearch { float: right; }
 </style>
 <%
 Locale locale = request.getLocale();
@@ -138,7 +142,8 @@ String[] clH = new String[] {   LocaleUtils.getMessage(locale, "caseload.msgDemo
 <script type="text/javascript">
 clH = ["<fmt:setBundle basename="oscarResources"/><fmt:message key="caseload.msgDemographic"/>", "", "<fmt:setBundle basename="oscarResources"/><fmt:message key="caseload.msgAge"/>", "<fmt:setBundle basename="oscarResources"/><fmt:message key="caseload.msgSex"/>", "<fmt:setBundle basename="oscarResources"/><fmt:message key="caseload.msgLastAppt"/>", "<fmt:setBundle basename="oscarResources"/><fmt:message key="caseload.msgNextAppt"/>", "<fmt:setBundle basename="oscarResources"/><fmt:message key="caseload.msgApptsLYTD"/>", "<fmt:setBundle basename="oscarResources"/><fmt:message key="caseload.msgLab"/>", "<fmt:setBundle basename="oscarResources"/><fmt:message key="caseload.msgDoc"/>", "<fmt:setBundle basename="oscarResources"/><fmt:message key="caseload.msgTickler"/>", "<fmt:setBundle basename="oscarResources"/><fmt:message key="caseload.msgMsg"/>", "<fmt:setBundle basename="oscarResources"/><fmt:message key="caseload.msgBMI"/>", "<fmt:setBundle basename="oscarResources"/><fmt:message key="caseload.msgBP"/>", "<fmt:setBundle basename="oscarResources"/><fmt:message key="caseload.msgWT"/>", "<fmt:setBundle basename="oscarResources"/><fmt:message key="caseload.msgSMK"/>", "<fmt:setBundle basename="oscarResources"/><fmt:message key="caseload.msgA1C"/>", "<fmt:setBundle basename="oscarResources"/><fmt:message key="caseload.msgACR"/>", "<fmt:setBundle basename="oscarResources"/><fmt:message key="caseload.msgSCR"/>", "<fmt:setBundle basename="oscarResources"/><fmt:message key="caseload.msgLDL"/>", "<fmt:setBundle basename="oscarResources"/><fmt:message key="caseload.msgHDL"/>", "<fmt:setBundle basename="oscarResources"/><fmt:message key="caseload.msgTCHD"/>", "<fmt:setBundle basename="oscarResources"/><fmt:message key="caseload.msgEYEE"/>", "<fmt:setBundle basename="oscarResources"/><fmt:message key="caseload.msgLastEncounterDate"/>", "<fmt:setBundle basename="oscarResources"/><fmt:message key="caseload.msgLastEncounterType"/>", "<fmt:setBundle basename="oscarResources"/><fmt:message key="caseload.msgCASHAdmissionDate"/>", "<fmt:setBundle basename="oscarResources"/><fmt:message key="caseload.msgACCESS1AdmissionDate"/>"];
 </script>
-<table border="1" cellpadding="0" cellspacing="0" width="100%" id="caseloadTable" class="table">
+<table border="1" cellpadding="0" cellspacing="0" width="100%" id="caseloadTable">
+<thead>
 <tr><td colspan='<%=clH.length%>'>
 	<table border='0' cellpadding='0'  cellspacing='0' width='100%'>
 		<tr class='caseloadRow'>
@@ -225,20 +230,26 @@ String[] objIds = new String[] {"Demographic", "_caseload.DisplayMode", "_caselo
 
 <% for (int i=0; i < clH.length; i++) { %>
 	<% if (i == 0) { %>
-	<td class='selectedCategory' onclick='changeCategory("<%=i%>")'><b><%=clH[i]%> &Delta;</b></td>
+	<td class='selectedCategory' bgcolor='#c0c0c0' onclick='changeCategory("<%=i%>")'><b><%=clH[i]%> &Delta;</b></td>
 	<% } else if (i == 1) { %>
 	<security:oscarSec roleName="<%=caseloadroleName$%>" objectName="<%=objIds[i]%>" rights="r" reverse="<%=false%>" >
-		<td style='width:267px'><b><%=clH[i]%></b></td>
+		<td bgcolor='#c0c0c0' style='width:267px'><b><%=clH[i]%></b></td>
 	</security:oscarSec>
 	<% } else{ %>
 	<security:oscarSec roleName="<%=caseloadroleName$%>" objectName="<%=objIds[i]%>" rights="r" reverse="<%=false%>" >
-		<td onclick='changeCategory("<%=i%>")'><b><%=clH[i]%></b></td>
+		<td bgcolor='#c0c0c0' onclick='changeCategory("<%=i%>")'><b><%=clH[i]%></b></td>
 	</security:oscarSec>
 	<% } %>
 <% } %>
+</tr>
+</thead>
+<tbody id="caseloadBody">
+</tbody>
+<tfoot>
 <tr id='loadingFooter' class='caseloadRow'><td colspan='<%=clH.length%>' style='text-align: center;' bgcolor='#fffff0' colspan='<%=clH.length%>'><img src="<%= request.getContextPath() %>/images/DMSLoader.gif" /><fmt:setBundle basename="oscarResources"/><fmt:message key="caseload.msgLoading"/></td></tr>
 <tr id='noResults' class='caseloadRow'><td colspan='<%=clH.length%>' style='text-align: center;' bgcolor='#fffff0' ><fmt:setBundle basename="oscarResources"/><fmt:message key="caseload.msgTryAgain"/></td></tr>
 <tr id='totalResults1' class='caseloadRow'><td colspan='<%=clH.length%>' style='text-align: center;' bgcolor='#fffff0' ><span id="rows1"></span>/<span id="totalRows1"></span>&nbsp;<fmt:setBundle basename="oscarResources"/><fmt:message key="caseload.msgResults"/></td></tr>
+</tfoot>
 </table>
 <script type="text/javascript">
 
@@ -353,13 +364,10 @@ function changeCategory(cat) {
 	}
 	if (cat == category) {
 		sortAsc = !sortAsc;
-//		headers.get(category).innerHTML = "<b onclick='changeCategory(\""+category+"\")'>"+clH[category] + " " + getSortDir() + "</b>";
 		oldCat.attr(onclick,"changeCategory(\"" + category+ "\")");
 		oldCat.html("<b>" + clH[category] + " " + getSortDir() + "</b>");
 	}
 	else {
-//		var oldCat = jQuery(headers.get(category));
-//		var newCat = jQuery(headers.get(cat));
 		var newCat = jQuery(getHeadersElement(headers,cat));
 		sortAsc = true;
 		oldCat.removeClass("selectedCategory");
@@ -407,7 +415,7 @@ function draw(json) {
 
 	jQuery.each(json.data, function() {
 		var tr = document.createElement('tr');
-		tr.className = 'caseloadRow caseloadEntry' + (rows % 2 === 0 ? ' row-even' : '');
+		tr.className = 'caseloadRow caseloadEntry';
 		rows++;
 
 		// Build cells via DOM (DocumentFragment avoids repeated reflows)
@@ -430,7 +438,7 @@ function draw(json) {
 		updateTotalRows();
 	}
 	else {
-		jQuery("#loadingFooter").before(fragment);
+		document.getElementById('caseloadBody').appendChild(fragment);
 		hideAllMessages();
 		// json.size is only defined on page 1
 		updateTotalRows(json.size);


### PR DESCRIPTION
### **User description**
<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description

Cleans up mild improvements from last commit to caseload. 

## How Was This Tested?

Automated and direct by myself.  
## Checklist

- [X ] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [ X] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [ X] I have not included any patient data (PHI) in this PR
- [ X] I have added tests for new functionality, or this change doesn't need new tests
- [ X] I have read the [contributing guide](CONTRIBUTING.md)


___

### **Description**
- Enhanced the `#caseloadTable` with improved styles for better readability and usability.
- Implemented sticky headers and alternating row colors for a more user-friendly interface.
- Cleaned up unnecessary styles and improved padding for a consistent look.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>receptionistapptstyle.css</strong><dd><code>CSS Cleanup for Caseload Table</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/webapp/css/receptionistapptstyle.css
<li>Removed unnecessary background color from <code>#caseloadTable</code> rows.<br> <li> Cleaned up padding styles for <code>#caseloadTable</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/295/files#diff-8765b857c90614d6c3ce091ab3f571e2e020a8578d3440b8bd4f7ca7e2b1a0e3">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>caseload.jspf</strong><dd><code>Refactor Caseload Table Structure and Styles</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/webapp/provider/caseload.jspf
<li>Improved padding and alignment for table cells in <code>#caseloadTable</code>.<br> <li> Added alternating row stripes and full-row hover effects.<br> <li> Introduced a sticky header for better usability.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/295/files#diff-ede4391cfb7d2f81ebdfa490bd5c82ed6f1c7041ffa82cb29f17f0d8684e2d0d">+38/-30</a>&nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Sticky caseload table headers, alternating row stripes, hover highlighting, unified white backgrounds, and tighter cell spacing; removed the special whitesmoke background from the first column.
  * Display-mode and search controls now stay inline for a cleaner header layout.

* **New Features**
  * Most row cells (except the Display Mode column) are clickable and show a pointer cursor.

* **UX**
  * Loading indicator moved to the table footer for smoother scrolling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->