### PR TITLE
fix: missing textbox to edit signature in preferences when no signature is set on the currently logged in provider

### DIFF
--- a/src/main/webapp/provider/editSignature.jsp
+++ b/src/main/webapp/provider/editSignature.jsp
@@ -113,7 +113,7 @@
                 <% } else {%>
                 <fmt:setBundle basename="oscarResources"/><fmt:message key="provider.editSignature.msgNew"/>
                 <br>
-                <input type="checkbox" name="signature" size="40" />
+                <input type="text" name="signature" size="40" />
                 <br>
                 <!-- add by caisi -->
                 <caisi:isModuleLoad moduleName="caisi">

--- a/src/main/webapp/provider/editSignature.jsp
+++ b/src/main/webapp/provider/editSignature.jsp
@@ -95,9 +95,9 @@
                 <%
                     if (sig.hasSignature(curUser_no)) {
                 %>
-                <fmt:setBundle basename="oscarResources"/><fmt:message key="provider.editSignature.msgEdit"/>
+                <label for="signature"><fmt:setBundle basename="oscarResources"/><fmt:message key="provider.editSignature.msgEdit"/></label>
                 <br>
-                <input type="text" name="signature" size="40" value="<%= Encode.forHtmlAttribute(sig.getSignature(curUser_no)) %>" />
+                <input type="text" name="signature" id="signature" size="40" value="<%= Encode.forHtmlAttribute(sig.getSignature(curUser_no)) %>" />
                 <br>
 
                 <!-- add by caisi -->
@@ -111,9 +111,9 @@
                 <input type="submit"
                        value="<fmt:setBundle basename="oscarResources"/><fmt:message key="provider.editSignature.btnUpdate"/>"/>
                 <% } else {%>
-                <fmt:setBundle basename="oscarResources"/><fmt:message key="provider.editSignature.msgNew"/>
+                <label for="signature"><fmt:setBundle basename="oscarResources"/><fmt:message key="provider.editSignature.msgNew"/></label>
                 <br>
-                <input type="text" name="signature" size="40" />
+                <input type="text" name="signature" id="signature" size="40" />
                 <br>
                 <!-- add by caisi -->
                 <caisi:isModuleLoad moduleName="caisi">


### PR DESCRIPTION
### **Description**
- Enhanced the signature editing interface by adding labels to input fields.
- Changed the input type for new signatures from checkbox to text for consistency.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>editSignature.jsp</strong><dd><code>Improve accessibility and input handling for signature editing</code></dd></summary>
<hr>

src/main/webapp/provider/editSignature.jsp
<li>Added labels for signature input fields for better accessibility.<br> <li> Changed input type from checkbox to text for new signature entry.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/334/files#diff-9a23525ae58e76a28d056b9228f233ccb565c4ec04b2ee8404ec6b3193fc6503">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions

