### PR TITLE
fix: normalize MDS lab test codes with leading dashes

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/lab/ca/all/util/MDSLabHL7Generator.java
+++ b/src/main/java/io/github/carlos_emr/carlos/lab/ca/all/util/MDSLabHL7Generator.java
@@ -145,6 +145,13 @@ public class MDSLabHL7Generator {
 		int testIndex = 1;
 		for (LabTest test : lab.getTests()) {
 			String testCode = safeWithDefault(test.getCode(), String.valueOf(testIndex * 100));
+
+			// Extract code portion to match MDSHandler.matchOBXToHeader() parsing logic
+			// MDSHandler uses substring(lastIndexOf("-") + 1) on OBX-4, so ZMN field 8 must contain the extracted portion
+			String zmnCode = testCode.contains("-")
+				? testCode.substring(testCode.lastIndexOf("-") + 1)
+				: testCode;
+
 			String testName = safeWithDefault(test.getName(), "TEST");
 			String units = safe(test.getCodeUnit());
 			String value = safe(test.getCodeValue());
@@ -156,7 +163,7 @@ public class MDSLabHL7Generator {
 				.append("|").append(units)
 				.append("|").append(value)
 				.append("|").append(refRange)
-				.append("|").append(testCode)
+				.append("|").append(zmnCode)
 				.append("|").append(flag)
 				.append("|1000\n"); // Group 1000 matches ZRG above
 
@@ -326,12 +333,18 @@ public class MDSLabHL7Generator {
 	 * @param refRange the human-readable reference range to include for the test result
 	 */
 	private static void appendObx(StringBuilder sb, LabTest test, String testCode, String refRange) {
+		// OBX-3 identifier requires dash prefix per MDS format convention
+		String obxIdentifier = "-" + testCode;
+
+		// OBX-4 uses original code; MDSHandler.matchOBXToHeader() extracts substring(lastIndexOf("-") + 1) to match ZMN
+		String obxSubId = testCode;
+
 		sb.append("OBX|1|")
-			.append(safeWithDefault(test.getCodeType(), "ST")).append("|-")
-			.append(testCode).append("^")
+			.append(safeWithDefault(test.getCodeType(), "ST")).append("|")
+			.append(obxIdentifier).append("^")
 			.append(safeUpper(test.getName(), "TEST"))
 			.append("^L|")
-			.append(testCode).append("-1-").append(testCode)
+			.append(obxSubId)
 			.append("|")
 			.append(safe(test.getCodeValue()))
 			.append("|").append(safe(test.getCodeUnit()))


### PR DESCRIPTION
### **User description**
Test codes with leading dashes (e.g., '-HBAIC') were successfully saved
but failed to display in labDisplay.jsp. The root cause was mismatched
test code handling between HL7 segment types during MDS message
generation.

This fix normalizes test codes by:
- Extracting the code portion after the last dash for ZMN field 8,
  matching MDSHandler.matchOBXToHeader() parsing logic
- Simplifying OBX-4 to use the original test code directly, since the
  parser uses substring(lastIndexOf("-") + 1) to match against ZMN

Applied from upstream openo-beta/open-o PR #2271
(fixes openo-beta/open-o#2269, openo-beta/open-o#2270)
Original commits: a999458..fa1e517 by Deval Italiya (D3V41)

https://claude.ai/code/session_019EJEFNJZ37YHjMTXPEBESu


___

### **Description**
- Fixes the display issue of test codes with leading dashes in `labDisplay.jsp`.
- Normalizes test codes by extracting the relevant portion to match parsing logic.
- Updates OBX fields to conform to MDS format conventions.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MDSLabHL7Generator.java</strong><dd><code>Normalize MDS Lab Test Codes Handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/io/github/carlos_emr/carlos/lab/ca/all/util/MDSLabHL7Generator.java
<li>Extracted the code portion after the last dash for ZMN field 8.<br> <li> Updated OBX-3 identifier to include a dash prefix.<br> <li> Simplified OBX-4 to use the original test code directly.<br> <li> Ensured compatibility with MDSHandler.matchOBXToHeader() parsing <br>logic.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/336/files#diff-3ad55f741a83aac98923d5a142c6185e5640d22c39d30049f8e0497085fb8232">+17/-4</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions

