### PR TITLE
fix(prevention): use 2-arg buildQuery overload to avoid roster-date filtering

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/prevention/pageUtil/PreventionReport2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prevention/pageUtil/PreventionReport2Action.java
@@ -94,7 +94,8 @@ public class PreventionReport2Action extends ActionSupport {
         frm.addDemoIfNotPresent();
         frm.setAsofDate(asofDate);
         RptDemographicQueryBuilder demoQ = new RptDemographicQueryBuilder();
-        ArrayList<ArrayList<String>> list = demoQ.buildQuery(loggedInInfo, frm, asofDate);
+        // Use overload without asofRosterDate to avoid roster-date filtering for prevention reports.
+        ArrayList<ArrayList<String>> list = demoQ.buildQuery(loggedInInfo, frm);
 
         log.debug("set size " + list.size());
 

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/RptDemographicQueryBuilder.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/RptDemographicQueryBuilder.java
@@ -71,6 +71,27 @@ public class RptDemographicQueryBuilder {
     public RptDemographicQueryBuilder() {
     }
 
+    /**
+     * Builds a demographic query without applying a rostering date filter.
+     * Delegates to {@link #buildQuery(LoggedInInfo, RptDemographicReport2Form, String)}
+     * with {@code asofRosterDate} set to {@code null}.
+     *
+     * @param loggedInInfo LoggedInInfo the current user's session information
+     * @param frm RptDemographicReport2Form the demographic report form parameters
+     * @return ArrayList&lt;ArrayList&lt;String&gt;&gt; list of demographic result rows
+     */
+    public ArrayList<ArrayList<String>> buildQuery(LoggedInInfo loggedInInfo, RptDemographicReport2Form frm) {
+        return buildQuery(loggedInInfo, frm, null);
+    }
+
+    /**
+     * Builds a demographic query with optional post-query rostering filtering.
+     *
+     * @param loggedInInfo LoggedInInfo the logged-in user session
+     * @param frm RptDemographicReport2Form the demographic query form with search criteria
+     * @param asofRosterDate String date (yyyy-MM-dd) to filter by rostering status, or null to skip
+     * @return ArrayList&lt;ArrayList&lt;String&gt;&gt; list of demographic result rows
+     */
     public java.util.ArrayList<ArrayList<String>> buildQuery(LoggedInInfo loggedInInfo, RptDemographicReport2Form frm, String asofRosterDate) {
         MiscUtils.getLogger().debug("in buildQuery");
 

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/RptDemographicQueryBuilder.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/RptDemographicQueryBuilder.java
@@ -68,9 +68,6 @@ public class RptDemographicQueryBuilder {
         }
     }
 
-    public RptDemographicQueryBuilder() {
-    }
-
     /**
      * Builds a demographic query without applying a rostering date filter.
      * Delegates to {@link #buildQuery(LoggedInInfo, RptDemographicReport2Form, String)}


### PR DESCRIPTION
### **User description**
### Motivation
- Restore the upstream fix shape so prevention reports are not unintentionally filtered by a roster date.
- Ensure the prevention-report call site uses a 2-argument API rather than passing `asofDate` as an `asofRosterDate` parameter.

### Description
- Changed `PreventionReport2Action` to call `RptDemographicQueryBuilder.buildQuery(loggedInInfo, frm)` so prevention reports bypass roster-date filtering.
- Added a two-argument overload `buildQuery(LoggedInInfo, RptDemographicReport2Form)` in `RptDemographicQueryBuilder` that delegates to the existing three-argument method with `null` for `asofRosterDate`.
- Preserved the existing three-argument `buildQuery(LoggedInInfo, RptDemographicReport2Form, String)` implementation and added Javadoc for the new overload.
- Affected files: `src/main/java/io/github/carlos_emr/carlos/prevention/pageUtil/PreventionReport2Action.java` and `src/main/java/io/github/carlos_emr/carlos/report/data/RptDemographicQueryBuilder.java`.

### Testing
- Ran `mvn -DskipTests compile -q` to validate compilation, which failed due to dependency resolution error for `com.github.openosp:ultrabuk-htmltopdf-java:1.0.11` from `https://jitpack.io` returning HTTP 403 in this environment.
- No unit tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cfe347860832882cb3084f4f30fb4)

## Summary by Sourcery

Adjust prevention reporting to bypass roster-date filtering when building demographic queries.

Bug Fixes:
- Prevent prevention reports from being unintentionally filtered by roster date by changing their demographic query invocation.

Enhancements:
- Add a two-argument demographic query builder overload that omits roster-date filtering and delegates to the existing three-argument method.
- Document the demographic query builder overloads with Javadoc clarifying roster-date filtering behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Prevention reports no longer filter data by roster date, allowing all roster records to be included in report results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

### **Description**
- Prevent prevention reports from being unintentionally filtered by roster date.
- Introduced a two-argument overload for `buildQuery` in `RptDemographicQueryBuilder` to bypass roster-date filtering.
- Updated `PreventionReport2Action` to utilize the new overload for demographic queries.
- Added Javadoc documentation for clarity on the new overload's behavior.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PreventionReport2Action.java</strong><dd><code>Update PreventionReport2Action to Bypass Roster-Date Filtering</code></dd></summary>
<hr>

src/main/java/io/github/carlos_emr/carlos/prevention/pageUtil/PreventionReport2Action.java
<li>Updated the call to <code>buildQuery</code> to use the two-argument overload.<br> <li> Removed the <code>asofDate</code> parameter to prevent roster-date filtering.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/346/files#diff-db19923fb3c5c12934499cfc2cdd7901cd95c8de86e53bd4ee8e69c1df83fe2f">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RptDemographicQueryBuilder.java</strong><dd><code>Add Overload to RptDemographicQueryBuilder for Demographic Queries</code></dd></summary>
<hr>

src/main/java/io/github/carlos_emr/carlos/report/data/RptDemographicQueryBuilder.java
<li>Added a two-argument overload for <code>buildQuery</code> to skip roster-date <br>filtering.<br> <li> Documented the new overload with Javadoc comments.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/346/files#diff-260d1c6126b3329f7f57b87de13234ee4c0027edaee5f847ab28aa85c75ad72f">+21/-0</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions

