### PR TITLE
chore: enable the new inboxhub by default and fix startup issue re hrm

### DIFF
--- a/.devcontainer/development/config/shared/volumes/oscar.properties
+++ b/.devcontainer/development/config/shared/volumes/oscar.properties
@@ -179,7 +179,7 @@ hibernate.show_sql=false
 ## CBI: to start the scheduler for data submission uncomment this
 ## ORN:
 ## Fax: enable the version 15 fax module
-ModuleNames=HRM,Fax
+ModuleNames=Fax
 ### Experimental UI for version 14, no longer working or in use.  Do not enable.
 ## requires REST www services.
 cobalt=no

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/PersonaService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/PersonaService.java
@@ -221,7 +221,7 @@ public class PersonaService extends AbstractServiceImpl {
 
         MenuTo1 menu = new MenuTo1()
                 .add(idCounter++, bundle.getString("navbar.menu.schedule"), null, "../provider/providercontrol.jsp")
-                .add(idCounter++, bundle.getString("navbar.menu.inbox"), null, "../documentManager/inboxManage.do?method=prepareForIndexPage", "inbox");
+                .add(idCounter++, bundle.getString("navbar.menu.inbox"), null, "../web/inboxhub/Inboxhub.do?method=displayInboxForm", "inbox");
 
         if (!consultationManager.isConsultResponseEnabled()) {
             menu.addWithState(idCounter++, bundle.getString("navbar.menu.consults"), null, "consultRequests");
@@ -381,8 +381,8 @@ public class PersonaService extends AbstractServiceImpl {
     /**
      * This will be a REST based way to get access to groups of preferences. It's not fully implemented yet
      *
-     * @param obj
-     * @return
+     * @param obj ObjectNode JSON object containing the preference type to retrieve
+     * @return PersonaResponse containing dashboard preferences and other user-specific settings
      */
     @POST
     @Path("/preferences")

--- a/src/main/webapp/layouts/nonPatientContextHeader.jspf
+++ b/src/main/webapp/layouts/nonPatientContextHeader.jspf
@@ -330,7 +330,7 @@ label.error {
 			</oscar:oscarPropertiesCheck>
 
 			 <oscar:oscarPropertiesCheck property="NOT_FOR_CAISI" value="no" defaultVal="true">			
-			 <security:oscarSec roleName="<%=roleName$%>" objectName="_appointment.doctorLink" rights="r">
+			 <security:oscarSec roleName="<%=roleName$%>" objectName="_lab" rights="r">
 			   <li>
 			       <a HREF="#" style="display:inline-block;padding-right:0px" onclick="popupInboxManager('<%=request.getContextPath()%>/web/inboxhub/Inboxhub.do?method=displayInboxForm', 800);return false;" TITLE='<fmt:setBundle basename="oscarResources"/><fmt:message key="provider.appointmentProviderAdminDay.viewLabReports"/>'>
 				   <span id="oscar_new_lab" ><fmt:setBundle basename="oscarResources"/><fmt:message key="global.lab"/></span>

--- a/src/main/webapp/layouts/nonPatientContextHeader.jspf
+++ b/src/main/webapp/layouts/nonPatientContextHeader.jspf
@@ -332,11 +332,11 @@ label.error {
 			 <oscar:oscarPropertiesCheck property="NOT_FOR_CAISI" value="no" defaultVal="true">			
 			 <security:oscarSec roleName="<%=roleName$%>" objectName="_appointment.doctorLink" rights="r">
 			   <li>
-			       <a HREF="#" style="display:inline-block;padding-right:0px" onclick="popupInboxManager('<%=request.getContextPath()%>/documentManager/inboxManage.do?method=prepareForIndexPage&providerNo=<%=curUser_no%>', 'Lab');return false;" TITLE='<fmt:setBundle basename="oscarResources"/><fmt:message key="provider.appointmentProviderAdminDay.viewLabReports"/>'>
+			       <a HREF="#" style="display:inline-block;padding-right:0px" onclick="popupInboxManager('<%=request.getContextPath()%>/web/inboxhub/Inboxhub.do?method=displayInboxForm', 800);return false;" TITLE='<fmt:setBundle basename="oscarResources"/><fmt:message key="provider.appointmentProviderAdminDay.viewLabReports"/>'>
 				   <span id="oscar_new_lab" ><fmt:setBundle basename="oscarResources"/><fmt:message key="global.lab"/></span>
 			       </a>
 			       <oscar:newUnclaimedLab>
-			       <a class="tabalert" HREF="#" style="display:inline-block;padding-left:0px" ONCLICK ="popupInboxManager('<%=request.getContextPath()%>/documentManager/inboxManage.do?method=prepareForIndexPage&providerNo=0&searchProviderNo=0&status=N&lname=&fname=&hnum=&pageNum=1&startIndex=0', 'Lab');return false;" TITLE='<fmt:setBundle basename="oscarResources"/><fmt:message key="provider.appointmentProviderAdminDay.viewLabReports"/>'>*</a>
+			       <a class="tabalert" HREF="#" style="display:inline-block;padding-left:0px" ONCLICK ="popupInboxManager('<%=request.getContextPath()%>/web/inboxhub/Inboxhub.do?method=displayInboxForm&unclaimed=1', 800);return false;" TITLE='<fmt:setBundle basename="oscarResources"/><fmt:message key="provider.appointmentProviderAdminDay.viewLabReports"/>'>*</a>
 			       </oscar:newUnclaimedLab>
 			   </li>
 			  </security:oscarSec>

--- a/src/main/webapp/provider/appointmentprovideradminday.jsp
+++ b/src/main/webapp/provider/appointmentprovideradminday.jsp
@@ -446,7 +446,7 @@
 <security:oscarSec roleName="<%=roleName$%>" objectName="_billing" rights="r">
     <c:set var="billingRights" value="true" scope="page"/>
 </security:oscarSec>
-<security:oscarSec roleName="<%=roleName$%>" objectName="_appointment.doctorLink" rights="r">
+<security:oscarSec roleName="<%=roleName$%>" objectName="_lab" rights="r">
     <c:set var="doctorLinkRights" value="true" scope="page"/>
 </security:oscarSec>
 <security:oscarSec roleName="<%=roleName$%>" objectName="_masterLink" rights="r">

--- a/src/main/webapp/provider/appointmentprovideradminday.jsp
+++ b/src/main/webapp/provider/appointmentprovideradminday.jsp
@@ -2509,6 +2509,12 @@
     const inboxLinkClickEvent = "popupInboxManager('" + contextPath + "/web/inboxhub/Inboxhub.do?method=displayInboxForm', 800);return false;";
     const unclaimedLabLinkClickEvent = "popupInboxManager('" + contextPath + "/web/inboxhub/Inboxhub.do?method=displayInboxForm&unclaimed=1', 800);return false;";
 
-    document.getElementById("inboxLink").setAttribute("onclick", inboxLinkClickEvent);
-    document.getElementById("unclaimedLabLink").setAttribute("onclick", unclaimedLabLinkClickEvent);
+    const inboxLink = document.getElementById("inboxLink");
+    if (inboxLink) {
+        inboxLink.setAttribute("onclick", inboxLinkClickEvent);
+    }
+    const unclaimedLabLink = document.getElementById("unclaimedLabLink");
+    if (unclaimedLabLink) {
+        unclaimedLabLink.setAttribute("onclick", unclaimedLabLinkClickEvent);
+    }
 </script>

--- a/src/main/webapp/provider/appointmentprovideradminday.jsp
+++ b/src/main/webapp/provider/appointmentprovideradminday.jsp
@@ -2416,7 +2416,7 @@
                         return false;
                     }
                     case <fmt:setBundle basename="oscarResources"/><fmt:message key="global.labShortcut"/> :
-                        popupOscarRx(600, 1024, '<%=request.getContextPath()%>/documentManager/inboxManage.do?method=prepareForIndexPage&providerNo=<%=loggedInInfo1.getLoggedInProviderNo()%>', '<fmt:setBundle basename="oscarResources"/><fmt:message key="global.lab"/>');
+                        popupOscarRx(600, 1024, '<%=request.getContextPath()%>/web/inboxhub/Inboxhub.do?method=displayInboxForm', '<fmt:setBundle basename="oscarResources"/><fmt:message key="global.lab"/>');
                         return false;  //run code for 'L'ab
                     case <fmt:setBundle basename="oscarResources"/><fmt:message key="global.msgShortcut"/> :
                         popupOscarRx(600, 1024, '<%=request.getContextPath()%>/messenger/DisplayMessages.do?providerNo=<%=loggedInInfo1.getLoggedInProviderNo()%>&userName=<%=URLEncoder.encode(userfirstname+" "+userlastname, StandardCharsets.UTF_8)%>');
@@ -2506,25 +2506,9 @@
 
 <script>
     const contextPath = document.getElementById("contextPath").value;
-    const originalInboxLinkClickEvent = "popupInboxManager('" + contextPath + "/documentManager/inboxManage.do?method=prepareForIndexPage&providerNo=<%=loggedInInfo1.getLoggedInProviderNo()%>');return false;";
-    const newInboxLinkClickEvent = "popupInboxManager('" + contextPath + "/web/inboxhub/Inboxhub.do?method=displayInboxForm', 800);return false;";
+    const inboxLinkClickEvent = "popupInboxManager('" + contextPath + "/web/inboxhub/Inboxhub.do?method=displayInboxForm', 800);return false;";
+    const unclaimedLabLinkClickEvent = "popupInboxManager('" + contextPath + "/web/inboxhub/Inboxhub.do?method=displayInboxForm&unclaimed=1', 800);return false;";
 
-    const originalUnclaimedLabLinkClickEvent = "popupInboxManager('" + contextPath + "/documentManager/inboxManage.do?method=prepareForIndexPage&providerNo=0&searchProviderNo=0&status=N&lname=&fname=&hnum=&pageNum=1&startIndex=0');return false;"
-    const newUnclaimedLabLinkClickEvent = "popupInboxManager('" + contextPath + "/web/inboxhub/Inboxhub.do?method=displayInboxForm&unclaimed=1', 800);return false;"
-
-    document.getElementById("inboxLink").addEventListener("mouseup", function(event) {
-        if(event.altKey) {
-            document.getElementById("inboxLink").setAttribute("onclick", newInboxLinkClickEvent);
-        } else {
-            document.getElementById("inboxLink").setAttribute("onclick", originalInboxLinkClickEvent);
-        }
-    });
-
-    document.getElementById("unclaimedLabLink").addEventListener("mouseup", function(event) {
-        if(event.altKey) {
-            document.getElementById("unclaimedLabLink").setAttribute("onclick", newUnclaimedLabLinkClickEvent);
-        } else {
-            document.getElementById("unclaimedLabLink").setAttribute("onclick", originalUnclaimedLabLinkClickEvent);
-        }
-    });
+    document.getElementById("inboxLink").setAttribute("onclick", inboxLinkClickEvent);
+    document.getElementById("unclaimedLabLink").setAttribute("onclick", unclaimedLabLinkClickEvent);
 </script>

--- a/src/main/webapp/provider/appointmentprovideradminmonth.jsp
+++ b/src/main/webapp/provider/appointmentprovideradminmonth.jsp
@@ -974,7 +974,7 @@
                         return false;
                     }
                     case <fmt:setBundle basename="oscarResources"/><fmt:message key="global.labShortcut"/> :
-                        popupOscarRx(600, 1024, '<%=request.getContextPath()%>/documentManager/inboxManage.do?method=prepareForIndexPage&providerNo=<%=curUser_no%>', '<fmt:setBundle basename="oscarResources"/><fmt:message key="global.lab"/>');
+                        popupOscarRx(600, 1024, '<%=request.getContextPath()%>/web/inboxhub/Inboxhub.do?method=displayInboxForm', '<fmt:setBundle basename="oscarResources"/><fmt:message key="global.lab"/>');
                         return false;  //run code for 'L'ab
                     case <fmt:setBundle basename="oscarResources"/><fmt:message key="global.msgShortcut"/> :
                         popupOscarRx(600, 1024, '<%=request.getContextPath()%>/messenger/DisplayMessages.do?providerNo=<%=curUser_no%>&userName=<%=URLEncoder.encode(userfirstname+" "+userlastname, StandardCharsets.UTF_8)%>');

--- a/src/main/webapp/provider/mainMenu.jsp
+++ b/src/main/webapp/provider/mainMenu.jsp
@@ -170,7 +170,7 @@
                                     </li>
                                 </security:oscarSec>
 
-                                <security:oscarSec roleName="<%=roleName$%>" objectName="_appointment.doctorLink"
+                                <security:oscarSec roleName="<%=roleName$%>" objectName="_lab"
                                                    rights="r">
                                     <li>
                                         <a HREF="#" id="inboxLink"

--- a/src/main/webapp/provider/mainMenu.jsp
+++ b/src/main/webapp/provider/mainMenu.jsp
@@ -371,27 +371,11 @@
         src="${pageContext.servletContext.contextPath}/library/jquery/jquery-ui-1.12.1.min.js"></script>
 <script>
     const contextPath = document.getElementById("contextPath").value;
-    const originalInboxLinkClickEvent = "popupInboxManager('" + contextPath + "/documentManager/inboxManage.do?method=prepareForIndexPage&providerNo=<%=curUser_no%>');return false;";
-    const newInboxLinkClickEvent = "popupInboxManager('" + contextPath + "/www/inboxhub/Inboxhub.do?method=displayInboxForm', 800);return false;";
+    const inboxLinkClickEvent = "popupInboxManager('" + contextPath + "/www/inboxhub/Inboxhub.do?method=displayInboxForm', 800);return false;";
+    const unclaimedLabLinkClickEvent = "popupInboxManager('" + contextPath + "/www/inboxhub/Inboxhub.do?method=displayInboxForm&unclaimed=1', 800);return false;";
 
-    const originalUnclaimedLabLinkClickEvent = "popupInboxManager('" + contextPath + "/documentManager/inboxManage.do?method=prepareForIndexPage&providerNo=0&searchProviderNo=0&status=N&lname=&fname=&hnum=&pageNum=1&startIndex=0');return false;";
-    const newUnclaimedLabLinkClickEvent = "popupInboxManager('" + contextPath + "/www/inboxhub/Inboxhub.do?method=displayInboxForm&unclaimed=1', 800);return false;";
-
-     document.getElementById("inboxLink").addEventListener("mouseup", function(event) {
-        if(event.altKey) {
-            document.getElementById("inboxLink").setAttribute("onclick", newInboxLinkClickEvent);
-        } else {
-            document.getElementById("inboxLink").setAttribute("onclick", originalInboxLinkClickEvent);
-        }
-    });
-
-    document.getElementById("unclaimedLabLink").addEventListener("mouseup", function(event) {
-        if(event.altKey) {
-            document.getElementById("unclaimedLabLink").setAttribute("onclick", newUnclaimedLabLinkClickEvent);
-        } else {
-            document.getElementById("unclaimedLabLink").setAttribute("onclick", originalUnclaimedLabLinkClickEvent);
-        }
-    });
+    document.getElementById("inboxLink").setAttribute("onclick", inboxLinkClickEvent);
+    document.getElementById("unclaimedLabLink").setAttribute("onclick", unclaimedLabLinkClickEvent);
 
     function openPreferences(providerNumber) {
         const $div = jQuery('<div />').appendTo('body');

--- a/src/main/webapp/provider/mainMenu.jsp
+++ b/src/main/webapp/provider/mainMenu.jsp
@@ -371,11 +371,17 @@
         src="${pageContext.servletContext.contextPath}/library/jquery/jquery-ui-1.12.1.min.js"></script>
 <script>
     const contextPath = document.getElementById("contextPath").value;
-    const inboxLinkClickEvent = "popupInboxManager('" + contextPath + "/www/inboxhub/Inboxhub.do?method=displayInboxForm', 800);return false;";
-    const unclaimedLabLinkClickEvent = "popupInboxManager('" + contextPath + "/www/inboxhub/Inboxhub.do?method=displayInboxForm&unclaimed=1', 800);return false;";
+    const inboxLinkClickEvent = "popupInboxManager('" + contextPath + "/web/inboxhub/Inboxhub.do?method=displayInboxForm', 800);return false;";
+    const unclaimedLabLinkClickEvent = "popupInboxManager('" + contextPath + "/web/inboxhub/Inboxhub.do?method=displayInboxForm&unclaimed=1', 800);return false;";
 
-    document.getElementById("inboxLink").setAttribute("onclick", inboxLinkClickEvent);
-    document.getElementById("unclaimedLabLink").setAttribute("onclick", unclaimedLabLinkClickEvent);
+    const inboxLink = document.getElementById("inboxLink");
+    if (inboxLink) {
+        inboxLink.setAttribute("onclick", inboxLinkClickEvent);
+    }
+    const unclaimedLabLink = document.getElementById("unclaimedLabLink");
+    if (unclaimedLabLink) {
+        unclaimedLabLink.setAttribute("onclick", unclaimedLabLinkClickEvent);
+    }
 
     function openPreferences(providerNumber) {
         const $div = jQuery('<div />').appendTo('body');

--- a/src/main/webapp/provider/providerheader-classic.jspf
+++ b/src/main/webapp/provider/providerheader-classic.jspf
@@ -85,10 +85,11 @@ window.onload=function(){
 }
 
 
-function popupInboxManager(varpage){
+function popupInboxManager(varpage, vheight){
+    vheight = typeof(vheight) != 'undefined' ? vheight : 700;
     var page = "" + varpage;
     var windowname="apptProviderInbox";
-    windowprops = "height=700,width=1215,location=no,"
+    windowprops = "height="+vheight+",width=1215,location=no,"
     + "scrollbars=yes,menubars=no,toolbars=no,resizable=yes,top=10,left=0";
     var popup = window.open(page, windowname, windowprops);
     if (popup != null) {
@@ -207,7 +208,7 @@ function popupPage2(varpage) {
 </li>
 </security:oscarSec>
 
-<security:oscarSec roleName="<%=roleName$%>" objectName="_appointment.doctorLink" rights="r">
+<security:oscarSec roleName="<%=roleName$%>" objectName="_lab" rights="r">
    <li>
        <a HREF="#" ONCLICK ="popupInboxManager('<%=request.getContextPath()%>/web/inboxhub/Inboxhub.do?method=displayInboxForm', 800);return false;" TITLE='<fmt:setBundle basename="oscarResources"/><fmt:message key="provider.appointmentProviderAdminDay.viewLabReports"/>'>
 	   <span id="oscar_new_lab"><fmt:setBundle basename="oscarResources"/><fmt:message key="global.lab"/></span>

--- a/src/main/webapp/provider/providerheader-classic.jspf
+++ b/src/main/webapp/provider/providerheader-classic.jspf
@@ -209,11 +209,11 @@ function popupPage2(varpage) {
 
 <security:oscarSec roleName="<%=roleName$%>" objectName="_appointment.doctorLink" rights="r">
    <li>
-       <a HREF="#" ONCLICK ="popupInboxManager('<%=request.getContextPath()%>/documentManager/inboxManage.do?method=prepareForIndexPage&providerNo=<%=curUser_no%>', 'Lab');return false;" TITLE='<fmt:setBundle basename="oscarResources"/><fmt:message key="provider.appointmentProviderAdminDay.viewLabReports"/>'>
+       <a HREF="#" ONCLICK ="popupInboxManager('<%=request.getContextPath()%>/web/inboxhub/Inboxhub.do?method=displayInboxForm', 800);return false;" TITLE='<fmt:setBundle basename="oscarResources"/><fmt:message key="provider.appointmentProviderAdminDay.viewLabReports"/>'>
 	   <span id="oscar_new_lab"><fmt:setBundle basename="oscarResources"/><fmt:message key="global.lab"/></span>
        </a>
        <oscar:newUnclaimedLab>
-       <a class="tabalert" HREF="#" ONCLICK ="popupInboxManager('<%=request.getContextPath()%>/documentManager/inboxManage.do?method=prepareForIndexPage&providerNo=0&searchProviderNo=0&status=N&lname=&fname=&hnum=&pageNum=1&startIndex=0', 'Lab');return false;" TITLE='<fmt:setBundle basename="oscarResources"/><fmt:message key="provider.appointmentProviderAdminDay.viewLabReports"/>'>*</a>
+       <a class="tabalert" HREF="#" ONCLICK ="popupInboxManager('<%=request.getContextPath()%>/web/inboxhub/Inboxhub.do?method=displayInboxForm&unclaimed=1', 800);return false;" TITLE='<fmt:setBundle basename="oscarResources"/><fmt:message key="provider.appointmentProviderAdminDay.viewLabReports"/>'>*</a>
        </oscar:newUnclaimedLab>
    </li>
   </security:oscarSec>


### PR DESCRIPTION
### **Description**
- Enabled the new `inboxhub` by default in the application.
- Updated various links across the application to point to the new `inboxhub` URL.
- Improved code clarity and documentation in several files.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>oscar.properties</strong><dd><code>Update ModuleNames to Enable Fax Module Only</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/development/config/shared/volumes/oscar.properties
- Updated `ModuleNames` to enable only the `Fax` module.



</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/353/files#diff-a81ab2ceed34c4d934bcebebc27f52e85ee3c617204a954e063a14b5355b67ae">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PersonaService.java</strong><dd><code>Update Navbar Menu and Improve Documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/io/github/carlos_emr/carlos/webserv/rest/PersonaService.java
<li>Updated the navbar menu link to point to the new <code>inboxhub</code> URL.<br> <li> Improved Javadoc comments for better clarity.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/353/files#diff-247e09741c889cafc656b6b5c0e46e5e4ff04d7933d2bfaa59546348631d6a27">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>nonPatientContextHeader.jspf</strong><dd><code>Update Inbox Manager Links in Non-Patient Context Header</code>&nbsp; </dd></summary>
<hr>

src/main/webapp/layouts/nonPatientContextHeader.jspf
<li>Changed the inbox manager link to use the new <code>inboxhub</code> URL.<br> <li> Updated unclaimed lab link to point to the new <code>inboxhub</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/353/files#diff-fad19c3d05f827a761cbcc33e37cfdda5e5232bd8d4e96e5dae452d49305a69f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>appointmentprovideradminday.jsp</strong><dd><code>Update Lab Shortcut Link to New Inboxhub</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/webapp/provider/appointmentprovideradminday.jsp
- Updated the lab shortcut link to use the new `inboxhub` URL.



</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/353/files#diff-f75048f3620da9a8aa96ad76eb74598e7d4a6e24ad79d327afb95e330a549a73">+5/-21</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>appointmentprovideradminmonth.jsp</strong><dd><code>Update Lab Shortcut Link in Admin Month View</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/webapp/provider/appointmentprovideradminmonth.jsp
- Updated the lab shortcut link to point to the new `inboxhub` URL.



</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/353/files#diff-ad4ee3d5c75081e03ad6378847fc9b9bdc81862f077a25d745e254f9047271aa">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>mainMenu.jsp</strong><dd><code>Simplify Link Handling and Update to Inboxhub</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/webapp/provider/mainMenu.jsp
<li>Simplified inbox and unclaimed lab link event handling.<br> <li> Updated links to the new <code>inboxhub</code> URL.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/353/files#diff-17e2149bae8c7ed27256d1ce3ba2cd5a5a35666023cd0dbc553ff971238f36d9">+5/-21</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>providerheader-classic.jspf</strong><dd><code>Update Inbox Manager Links in Classic Provider Header</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/webapp/provider/providerheader-classic.jspf
- Updated inbox manager links to point to the new `inboxhub` URL.



</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/353/files#diff-90269582255a5043472b0fb6491d28c925d9b3bb1a539cdc023f0285e7742e47">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated inbox and lab links to use the new Inboxhub display flow across provider pages.

* **Refactor**
  * Simplified event binding for inbox and unclaimed lab link handlers.

* **Chores**
  * Removed HRM from the default active modules list.

* **Documentation**
  * Improved Javadoc parameter and return descriptions for persona/preferences handling.

* **New Features**
  * Popup inbox now supports a configurable height with sensible defaults and uses the Inboxhub display form.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->