### PR TITLE
fix: escape ampersand in DashboardManagerImpl JavaDoc

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/managers/DashboardManagerImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/DashboardManagerImpl.java
@@ -722,7 +722,7 @@ public class DashboardManagerImpl implements DashboardManager {
      * @param loggedInInfo LoggedInInfo the current logged-in user context containing
      *                     provider information to be included in the encrypted payload
      * @return String the complete dashboard URL with encrypted parameters (e.g.,
-     *         "https://dashboard.example.com?encodedParams=BASE64_STRING&version=1.1"),
+     *         "https://dashboard.example.com?encodedParams=BASE64_STRING&amp;version=1.1"),
      *         or null if the dashboard URL is not configured or encryption fails
      * @since 2026-01-28
      */


### PR DESCRIPTION
### **User description**
## Summary
- Escape `&` as `&amp;` in JavaDoc example URL to fix JavaDoc warning: `invalid input: '&version'`

## Test plan
- [ ] Verify `make install` produces no JavaDoc warnings for DashboardManagerImpl

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **Description**
- Escaped `&` as `&amp;` in the JavaDoc example URL to resolve a JavaDoc warning.
- Ensured that the URL format is compliant with HTML parsing in JavaDoc comments.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DashboardManagerImpl.java</strong><dd><code>Fix JavaDoc Warning by Escaping Ampersand</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/io/github/carlos_emr/carlos/managers/DashboardManagerImpl.java
<li>Escaped <code>&</code> as <code>&amp;</code> in JavaDoc example URL.<br> <li> Fixed JavaDoc warning related to invalid input.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/408/files#diff-acaa33c44208c3d625eb01a39eded3c798215bbfa02509a572e9920c40eab863">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected URL parameter formatting in API documentation examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->