### PR TITLE
fix: override org.hl7.fhir.core transitive deps to 6.4.0 to fix XXE vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,8 @@
         <slf4j.version>2.0.17</slf4j.version>
         <!-- Hapi Fhir Version -->
         <hapifhir.version>6.10.5</hapifhir.version>
+        <!-- org.hl7.fhir.core Version (override transitive from HAPI FHIR to fix XXE CVEs) -->
+        <fhir.core.version>6.4.0</fhir.core.version>
         <!-- Apache CXF Version -->
         <cxf.version>3.6.9</cxf.version>
         <!-- Netty Version (for transitive dependency security fixes) -->
@@ -165,6 +167,28 @@
                 <groupId>jakarta.persistence</groupId>
                 <artifactId>jakarta.persistence-api</artifactId>
                 <version>2.2.3</version>
+            </dependency>
+            <!-- Override transitive org.hl7.fhir.core dependencies from HAPI FHIR 6.10.5
+                 (which ships fhir.core 6.1.2.2) to fix multiple XXE vulnerabilities:
+                 - CVE-2024-51132: XXE via crafted XML requests
+                 - CVE-2024-52007: XXE in XSLT parsing (incomplete fix for CVE-2024-45294)
+                 - CVE-2024-45294: XXE in XSLT transforms
+                 Fixed in org.hl7.fhir.core 6.4.0. Only model classes are used (DSTU3),
+                 so this minor version override is backward-compatible. -->
+            <dependency>
+                <groupId>ca.uhn.hapi.fhir</groupId>
+                <artifactId>org.hl7.fhir.utilities</artifactId>
+                <version>${fhir.core.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ca.uhn.hapi.fhir</groupId>
+                <artifactId>org.hl7.fhir.dstu3</artifactId>
+                <version>${fhir.core.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ca.uhn.hapi.fhir</groupId>
+                <artifactId>org.hl7.fhir.dstu2</artifactId>
+                <version>${fhir.core.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
### **User description**
Override transitive org.hl7.fhir.core dependencies (utilities, dstu3, dstu2) from
HAPI FHIR 6.10.5's default 6.1.2.2 to 6.4.0 via dependencyManagement.

Fixes the following Dependabot alerts:
- CVE-2024-51132: HAPI FHIR XXE vulnerability (#19, #18)
- CVE-2024-52007: XXE in XSLT parsing in org.hl7.fhir.core (#21, #20)
- CVE-2024-45294: XXE in XSLT transforms in org.hl7.fhir.core (#17, #16)

CVE-2022-34169 (xalan integer truncation, #15) was already mitigated by the
existing xalan exclusion on hapi-base 1.0.1.

This is a minor version override (6.1.2.2 → 6.4.0) within the same major line,
avoiding the breaking changes of upgrading HAPI FHIR from 6.x to 7.x. The
codebase uses only stable DSTU3 model classes from org.hl7.fhir.core, which
maintain backward compatibility across this version range.

https://claude.ai/code/session_01NN6QzJswY33rfKSESHBptW


___

### **Description**
- Override transitive dependencies of `org.hl7.fhir.core` to version `6.4.0` to fix multiple XXE vulnerabilities.
- This update addresses Dependabot alerts for CVEs related to XXE attacks.
- Maintains backward compatibility by using stable DSTU3 model classes.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pom.xml</strong><dd><code>Update HAPI FHIR Dependencies to Address Security Vulnerabilities</code></dd></summary>
<hr>

pom.xml
<li>Added dependency management for <code>org.hl7.fhir.core</code> version <code>6.4.0</code>.<br> <li> Included dependencies for <code>org.hl7.fhir.utilities</code>, <code>org.hl7.fhir.dstu3</code>, <br>and <code>org.hl7.fhir.dstu2</code>.<br> <li> Provided comments explaining the rationale for the version override to <br>address XXE vulnerabilities.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/409/files#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8">+24/-0</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated HL7 FHIR dependency versions to address security vulnerabilities in healthcare data processing components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->