### PR TITLE
fix: prevention reports no longer restricted to enrolled patients only

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/prevention/pageUtil/PreventionReport2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prevention/pageUtil/PreventionReport2Action.java
@@ -94,7 +94,11 @@ public class PreventionReport2Action extends ActionSupport {
         frm.addDemoIfNotPresent();
         frm.setAsofDate(asofDate);
         RptDemographicQueryBuilder demoQ = new RptDemographicQueryBuilder();
-        ArrayList<ArrayList<String>> list = demoQ.buildQuery(loggedInInfo, frm, asofDate);
+        // Use the overload without asofRosterDate so results are based on the demographic query and
+        // asofDate only. The overload that accepts an asofRosterDate may additionally apply a post-query
+        // rostering filter (skipping non-rostered patients) when an as-of roster date is provided and at
+        // least one provider filter is specified.
+        ArrayList<ArrayList<String>> list = demoQ.buildQuery(loggedInInfo, frm);
 
         log.debug("set size " + list.size());
 

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/RptDemographicQueryBuilder.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/RptDemographicQueryBuilder.java
@@ -71,6 +71,31 @@ public class RptDemographicQueryBuilder {
     public RptDemographicQueryBuilder() {
     }
 
+    /**
+     * Builds a demographic query without applying a rostering date filter.
+     * Delegates to {@link #buildQuery(LoggedInInfo, RptDemographicReport2Form, String)}
+     * with {@code asofRosterDate} set to {@code null}, so the post-query rostering
+     * check is skipped. Use this overload for general reporting (e.g., Ontario
+     * Prevention Reports) where non-rostered patients should be included.
+     *
+     * @param loggedInInfo LoggedInInfo the current user's session information
+     * @param frm RptDemographicReport2Form the demographic report form parameters
+     * @return ArrayList&lt;ArrayList&lt;String&gt;&gt; list of demographic result rows
+     */
+    public ArrayList<ArrayList<String>> buildQuery(LoggedInInfo loggedInInfo, RptDemographicReport2Form frm) {
+        return buildQuery(loggedInInfo, frm, null);
+    }
+
+    /**
+     * Builds a demographic query with optional post-query rostering filtering.
+     * When {@code asofRosterDate} is provided, results are filtered to only include patients
+     * who were rostered to the selected provider on that date.
+     *
+     * @param loggedInInfo LoggedInInfo the logged-in user session
+     * @param frm RptDemographicReport2Form the demographic query form with search criteria
+     * @param asofRosterDate String date (yyyy-MM-dd) to filter by rostering status, or null to skip
+     * @return ArrayList&lt;ArrayList&lt;String&gt;&gt; list of demographic result rows
+     */
     public java.util.ArrayList<ArrayList<String>> buildQuery(LoggedInInfo loggedInInfo, RptDemographicReport2Form frm, String asofRosterDate) {
         MiscUtils.getLogger().debug("in buildQuery");
 


### PR DESCRIPTION
### **User description**
Prevention reports were incorrectly passing asofDate as the asofRosterDate
parameter to RptDemographicQueryBuilder.buildQuery(), which caused a
post-query rostering filter to exclude non-rostered patients from results.

Added a new 2-param buildQuery() overload that delegates to the existing
3-param method with asofRosterDate=null, bypassing the roster filter.
PreventionReport2Action now calls this overload so all patients matching
demographic criteria are included in prevention reports.

The 3-param overload remains available for callers (e.g., CMS4 export)
that require roster-based filtering.

Ported from openo-beta/Open-O#2278.
Original author: LiamStanziani
https://github.com/openo-beta/Open-O/pull/2278

https://claude.ai/code/session_01BGzAph8FsPgK1PAFuktzHS

## Summary by Sourcery

Allow prevention demographic reports to include non-rostered patients by using a roster-agnostic demographic query overload.

Bug Fixes:
- Correct prevention report demographic queries so they no longer apply roster-based filtering tied to the as-of date, ensuring non-rostered patients are included when appropriate.

Enhancements:
- Introduce an overload of the demographic query builder that omits rostering date to support general reporting scenarios without roster filters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced demographic report query builder with improved roster date filtering capabilities. The system now supports multiple operational modes for handling historical roster dates during report construction. Both constrained and unconstrained filtering options are available, expanding the demographic query builder's flexibility for diverse reporting scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

### **Description**
- Introduced a new overload for `buildQuery()` in `RptDemographicQueryBuilder` that allows demographic queries without applying a rostering date filter.
- Updated `PreventionReport2Action` to utilize the new overload, ensuring that prevention reports now include non-rostered patients.
- Maintained the original 3-parameter method for cases requiring roster-based filtering.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PreventionReport2Action.java</strong><dd><code>Update PreventionReport2Action to Include Non-Rostered Patients</code></dd></summary>
<hr>

src/main/java/io/github/carlos_emr/carlos/prevention/pageUtil/PreventionReport2Action.java
<li>Updated call to <code>buildQuery()</code> to use the new overload without <br><code>asofRosterDate</code>.<br> <li> Ensured prevention reports include non-rostered patients.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/432/files#diff-db19923fb3c5c12934499cfc2cdd7901cd95c8de86e53bd4ee8e69c1df83fe2f">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>RptDemographicQueryBuilder.java</strong><dd><code>Add Overload to RptDemographicQueryBuilder for General Reporting</code></dd></summary>
<hr>

src/main/java/io/github/carlos_emr/carlos/report/data/RptDemographicQueryBuilder.java
<li>Added a new overload of <code>buildQuery()</code> that omits the <code>asofRosterDate</code>.<br> <li> Documented the behavior of the new method for clarity.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/432/files#diff-260d1c6126b3329f7f57b87de13234ee4c0027edaee5f847ab28aa85c75ad72f">+25/-0</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions

