### PR TITLE
418 feature visibility toggle for password and pin

### DIFF
--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -75,6 +75,20 @@
                 }
             }
 
+            function togglepwd(){
+                const passwordInput = document.getElementById('password');
+                const toggleBtn = document.getElementById('toggleBtn');
+                const isPassword = passwordInput.type === 'password';
+                passwordInput.type = isPassword ? 'text' : 'password';
+
+            }
+
+            function togglepin(){
+                const pinInput = document.getElementById('pin');
+                const toggleBtn = document.getElementById('togglePin');
+                // Toggle the custom security class
+                pinInput.classList.toggle('secure-text');
+            }
             function setfocus() {
                 document.loginForm.username.focus();
                 document.loginForm.username.select();
@@ -85,6 +99,11 @@
                 windowprops = "height=" + vheight + ",width=" + vwidth + ",location=no,scrollbars=yes,menubars=no,toolbars=no,resizable=yes";
                 window.open(page, "gpl", windowprops);
             }
+
+            function addStartTime() {
+                document.getElementById("oneIdLogin").href += (Math.round(new Date().getTime() / 1000).toString());
+            }
+
 
             function enhancedOrClassic(choice) {
                 document.getElementById("loginType").value = choice;
@@ -131,7 +150,7 @@
             img {
                 max-width: 100%;
                 height: auto;
-                width: auto \9;
+                width: auto;
             }
 
             #clinic_logo {
@@ -441,6 +460,30 @@
             @media ( min-width: 1200px) {
             }
 
+            .oneIdLogin {
+                background-color: #000;
+                width: 60%;
+                height: 34px;
+                margin: 0 auto;
+            }
+
+            .oneIdLogo {
+                background-color: transparent;
+                background: url("${pageContext.request.contextPath}/images/oneId/oneIDLogo.png");
+                border: none;
+                display: inline-block;
+                float: left;
+                vertical-align: bottom;
+                width: 70px;
+                height: 16px;
+            }
+
+            .oneIDText {
+                display: inline-block;
+                float: left;
+                padding-left: 10px
+            }
+
             footer {
                 padding: 5px 10px;
                 margin-top: 50px;
@@ -474,6 +517,51 @@
             .support_details div {
                 font-size: smaller;
                 text-align: center;
+            }
+
+            /* Hide the default browser eye in Edge */
+            #password::-ms-reveal,
+            #password::-ms-clear {
+              display: none;
+            }
+            .secure-text { -webkit-text-security: disc; }
+
+            .input-wrapper { position: relative; display: inline-block; margin-bottom: 15px; width: 100%; }
+            .toggle-input { width: 100%; padding-right: 35px; box-sizing: border-box; }
+
+            .toggle-btn {
+              position: absolute; right: 10px; top: 17px; transform: translateY(-50%);
+              width: 26px; height: 26px; border: none;
+              cursor: pointer;
+            }
+
+            /* Svg for "Hidden" state (Class-based OR Type-based) */
+            .toggle-input.secure-text + .toggle-btn,
+            .toggle-input[type="password"] + .toggle-btn {
+              display: inline-block;
+              width: 24px; /* 24px+ for click area WCAG SC 2.5.8 AA */
+              height: 24px;
+              background-color: #959595; /* 3:1 contrast ratio as per WCAG, alternately use currentColor; to match text color */
+              -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>');
+              mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>');
+              mask-size: contain;
+              -webkit-mask-repeat: no-repeat;
+              mask-repeat: no-repeat;
+              mask-position: center;
+            }
+
+            /* Svg for "Visible" state */
+            .toggle-input:not(.secure-text):not([type="password"]) + .toggle-btn {
+            display: inline-block;
+              width: 24px; /* NO SMALLER for best practice */
+              height: 24px;
+              background-color: #959595; /* lightest grey that gives 3:1 contrast ratio */
+              -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2"><line x1="0" y1="24" x2="24" y2="0" /><line x1="0" y1="24" x2="24" y2="0" /></svg>');
+              mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/><line x1="0" y1="24" x2="24" y2="0" /></svg>');
+              mask-size: contain;
+              -webkit-mask-repeat: no-repeat;
+              mask-repeat: no-repeat;
+              mask-position: center;
             }
         </style>
 
@@ -518,8 +606,8 @@
                 <div class="panel-heading">
 
                         <%--			    	<div id="oscar_logo">--%>
-                        <%--				    	<!-- Oscar logo -->--%>
-                        <%--			        	<img title="OSCAR EMR Login" src="${pageContext.request.contextPath}/images/Logo.png"  alt="OSCAR EMR Login"--%>
+                        <%--				    	<!-- EMR logo -->--%>
+                        <%--			        	<img title="EMR Login" src="${pageContext.request.contextPath}/images/Logo.png"  alt="EMR Login"--%>
                         <%--			        		onerror="document.getElementById('default_logo').style.display='block'; this.style.display='none'; " />--%>
                         <%--		        	</div>--%>
 
@@ -540,58 +628,75 @@
                     <div class="leftinput">
                         <%--
                             Autocomplete attribute strategy (WHATWG HTML spec):
-                            - username: "off" — shared clinical workstations; prevent autofill of another provider's identity
-                            - password: "current-password" — enable browser password manager save/fill per
+                            - username: "off" \u2014 shared clinical workstations; prevent autofill of another provider's identity
+                            - password: "current-password" \u2014 enable browser password manager save/fill per
                               NIST SP 800-63B (https://pages.nist.gov/800-63-3/sp800-63b.html) and
                               OWASP Authentication Cheat Sheet (https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html)
                               which recommend allowing password managers for stronger credential hygiene
-                            - pin: "one-time-code" — signal browsers this is a session code, not a saveable credential
+                            - pin: "one-time-code" \u2014 signal browsers this is a session code, not a saveable credential
                         --%>
-                        <form action="login.do" method="POST">
+                        <form action="login.do" method="POST" name="loginForm">
+<input type="hidden" name="${empty _csrf.parameterName ? 'none' : _csrf.parameterName}" value="${_csrf.token}">
 
                             <div class="form-group ${ login_error }">
-                                <input type="text" name="username" placeholder="Enter your username"
+                                <input type="text" name="username" id="username" placeholder="<fmt:setBundle basename="oscarResources"/><fmt:message key="Logon.userName"/>"
                                        value="" size="15" maxlength="15" autocomplete="off"
-                                       class="form-control" required/>
+                                       class="form-control" required>
                             </div>
 
-                            <div class="form-group ${ login_error }">
-                                <input type="password" name="password" placeholder="Enter your password"
-                                       value="" size="15" maxlength="32" autocomplete="current-password"
-                                       class="form-control" required/>
+                            <div class="input-wrapper form-group ${ login_error }">
+                              <input type="password" name="password" id="password" placeholder="<fmt:message key="Logon.passWord"/>" autocomplete="current-password" class="form-control toggle-input" required>
+                              <button type="button" class="toggle-btn" aria-label="Toggle visibility" onclick="console.log('toggle clicked'); togglepwd();" >
+                            </button>
                             </div>
 
 							<% if (MfaManager.isOscarLegacyPinEnabled()) { %>
-                                <div class="form-group ${ login_error }">
-                                    <input type="text" name="pin" placeholder="Enter your PIN" value="" style="-webkit-text-security: disc;"
-                                           size="15" maxlength="15" autocomplete="one-time-code"
-                                           inputmode="numeric" class="form-control"/>
+                            <c:if test="${not LoginResourceBean.ssoEnabled}">
+                            <div class="pin-wrapper">
+                                <div class="input-wrapper form-group ${ login_error }">
+                                  <!-- The input starts with the secure-text class -->
+                                  <input type="text" id="pin" class="form-control secure-text toggle-input" name="pin" autocomplete="one-time-code"
+                                               inputmode="numeric"  placeholder="<fmt:message key="admin.securityrecord.formPIN"/>">
+                                    <button type="button" class="toggle-btn" aria-label="Toggle visibility" onclick="console.log('toggle clicked'); togglepin();"></button>
                                     <span class="extrasmall">
-										<fmt:setBundle basename="oscarResources"/><fmt:message key="loginApplication.formCmt"/>
-									</span>
+										    <fmt:message key="loginApplication.formCmt"/>
+                                    </span>
                                 </div>
+                            </div>
+                            </c:if>
 							<% } %>
-                            <input type="hidden" id="loginType" name="loginType" value=""/>
+                            <input type="hidden" id="oneIdKey" name="nameId" value="${ nameId }">
+                            <input type="hidden" id="loginType" name="loginType" value="">
                             <input type=hidden name='propname'
-                                   value='<fmt:setBundle basename="oscarResources"/><fmt:message key="loginApplication.propertyFile"/>'/>
+                                   value='<fmt:message key="loginApplication.propertyFile"/>'>
 
                             <div id="buttonContainer">
                                 <c:choose>
                                     <c:when test="${ isMobileDevice }">
                                         <input class="btn btn-oscar btn-primary btn-block" name="submit" id="fullSubmit"
-                                               type="submit" onclick="enhancedOrClassic('C');" value="Full"/>
+                                               type="submit" onclick="enhancedOrClassic('C');" value="Full">
                                         <input class="btn btn-oscar btn-primary btn-block" name="submit"
                                                id="mobileSubmit" type="submit" onclick="enhancedOrClassic('C');"
-                                               value="Mobile"/>
+                                               value="Mobile">
                                     </c:when>
                                     <c:otherwise>
                                         <input class="btn btn-oscar btn-primary btn-block" name="submit" type="submit"
-                                               onclick="enhancedOrClassic('C');" value="Login"/>
+                                               onclick="enhancedOrClassic('C');" value="<fmt:message key="index.btnSignIn"/>">
                                     </c:otherwise>
                                 </c:choose>
                             </div>
 
-                        <form>
+                        </form>
+
+                        <oscar:oscarPropertiesCheck property="oneid.enabled" value="true" defaultVal="false">
+                            <a href="${ LoginResourceBean.econsultURL }"
+                               id="oneIdLogin" onclick="addStartTime()" class="btn btn-primary btn-block oneIDLogin">
+                                <span class="oneIDLogo"></span>
+                                <span class="oneIdText">
+    									<fmt:setBundle basename="oscarResources"/><fmt:message key="loginApplication.oneid"/>
+    								</span>
+                            </a>
+                        </oscar:oscarPropertiesCheck>
 
                         <c:if test="${ LoginResourceBean.acceptableUseAgreementManager.auaAvailable }">
     			            <span class="extrasmall">
@@ -634,7 +739,7 @@
             </c:if>
             <div class="support_details">
                 <a target="_blank" href="${ LoginResourceBean.supportLink }" id="supportImageLink">
-                    <img width="150px" src="${ pageContext.request.contextPath }/loginResource/supportLogo.png"
+                    <img width="150" src="${ pageContext.request.contextPath }/loginResource/supportLogo.png"
                          alt="Support Image"
                          onerror="this.style.display='none'; document.getElementById('supportImageLink').style.display='none';">
                 </a>

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -77,23 +77,22 @@
 
             function togglepwd(){
                 const passwordInput = document.getElementById('password');
-                var isNowVisible = passwordInput.type === 'text';
                 const toggleBtn = document.getElementById('toggleBtn');
+                // Flip the input type first, then read the post-toggle state for ARIA
+                passwordInput.type = passwordInput.type === 'password' ? 'text' : 'password';
+                const isNowVisible = passwordInput.type === 'text';
                 toggleBtn.setAttribute('aria-pressed', isNowVisible ? 'true' : 'false');
                 toggleBtn.setAttribute('aria-label', isNowVisible ? 'Hide password' : 'Show password');
-                const isPassword = passwordInput.type === 'password';
-                passwordInput.type = isPassword ? 'text' : 'password';
-
             }
 
-            function togglepin(button){
+            function togglepin(){
                 const pinInput = document.getElementById('pin');
                 // Toggle the custom security class
                 pinInput.classList.toggle('secure-text');
                 const toggleBtn = document.getElementById('togglePin');
                 const isNowVisible = !(pinInput.classList.contains("secure-text"));
                 toggleBtn.setAttribute('aria-pressed', isNowVisible ? 'true' : 'false');
-                toggleBtn.setAttribute('aria-label', isNowVisible ? 'Hide password' : 'Show password');
+                toggleBtn.setAttribute('aria-label', isNowVisible ? 'Hide PIN' : 'Show PIN');
             }
 
             function setfocus() {
@@ -534,7 +533,7 @@
               width: 24px; /* NO SMALLER for best practice */
               height: 24px;
               background-color: #959595; /* lightest grey that gives 3:1 contrast ratio */
-              -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2"><line x1="0" y1="24" x2="24" y2="0" /><line x1="0" y1="24" x2="24" y2="0" /></svg>');
+              -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/><line x1="0" y1="24" x2="24" y2="0" /></svg>');
               mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/><line x1="0" y1="24" x2="24" y2="0" /></svg>');
               mask-size: contain;
               -webkit-mask-repeat: no-repeat;
@@ -614,7 +613,7 @@
                             - pin: "one-time-code" \u2014 signal browsers this is a session code, not a saveable credential
                         --%>
                         <form action="login.do" method="POST" name="loginForm">
-<input type="hidden" name="${empty _csrf.parameterName ? 'none' : _csrf.parameterName}" value="${_csrf.token}">
+<input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
 
                             <div class="form-group ${ login_error }">
                                 <input type="text" name="username" id="username" placeholder="<fmt:setBundle basename="oscarResources"/><fmt:message key="Logon.userName"/>"
@@ -625,10 +624,11 @@
                             <div class="input-wrapper form-group ${ login_error }">
                               <input type="password" name="password" id="password" placeholder="<fmt:message key="Logon.passWord"/>" autocomplete="current-password" class="form-control toggle-input" required>
                               <button type="button"
-                                      class="toggle-btn" 
+                                      id="toggleBtn"
+                                      class="toggle-btn"
                                       aria-label="Show Password"
-                                      aria-pressed="false
-                                      onclick="togglepwd();" >
+                                      aria-pressed="false"
+                                      onclick="togglepwd();">
                               </button>
                             </div>
 
@@ -638,8 +638,9 @@
                                   <!-- The input starts with the secure-text class -->
                                   <input type="text" id="pin" class="form-control secure-text toggle-input" name="pin" autocomplete="one-time-code"
                                                inputmode="numeric"  placeholder="<fmt:message key="admin.securityrecord.formPIN"/>">
-                                    <button type="button" 
-                                      class="toggle-btn" 
+                                    <button type="button"
+                                      id="togglePin"
+                                      class="toggle-btn"
                                       aria-label="Show PIN"
                                       aria-pressed="false"
                                       onclick="togglepin();">

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -496,6 +496,11 @@
                 text-align: center;
             }
 
+            #supportImageLink img {
+                max-width: 150px;
+                height: auto;
+            }
+
             /* Hide the default browser eye in Edge */
             #password::-ms-reveal,
             #password::-ms-clear {
@@ -714,7 +719,7 @@
             </c:if>
             <div class="support_details">
                 <a target="_blank" href="${ LoginResourceBean.supportLink }" id="supportImageLink">
-                    <img width="150" src="${ pageContext.request.contextPath }/loginResource/supportLogo.png"
+                    <img src="${ pageContext.request.contextPath }/loginResource/supportLogo.png"
                          alt="Support Image"
                          onerror="this.style.display='none'; document.getElementById('supportImageLink').style.display='none';">
                 </a>

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -77,18 +77,25 @@
 
             function togglepwd(){
                 const passwordInput = document.getElementById('password');
+                var isNowVisible = passwordInput.type === 'text';
                 const toggleBtn = document.getElementById('toggleBtn');
+                toggleBtn.setAttribute('aria-pressed', isNowVisible ? 'true' : 'false');
+                toggleBtn.setAttribute('aria-label', isNowVisible ? 'Hide password' : 'Show password');
                 const isPassword = passwordInput.type === 'password';
                 passwordInput.type = isPassword ? 'text' : 'password';
 
             }
 
-            function togglepin(){
+            function togglepin(button){
                 const pinInput = document.getElementById('pin');
-                const toggleBtn = document.getElementById('togglePin');
                 // Toggle the custom security class
                 pinInput.classList.toggle('secure-text');
+                const toggleBtn = document.getElementById('togglePin');
+                const isNowVisible = !(pinInput.classList.contains("secure-text"));
+                toggleBtn.setAttribute('aria-pressed', isNowVisible ? 'true' : 'false');
+                toggleBtn.setAttribute('aria-label', isNowVisible ? 'Hide password' : 'Show password');
             }
+
             function setfocus() {
                 document.loginForm.username.focus();
                 document.loginForm.username.select();
@@ -99,11 +106,6 @@
                 windowprops = "height=" + vheight + ",width=" + vwidth + ",location=no,scrollbars=yes,menubars=no,toolbars=no,resizable=yes";
                 window.open(page, "gpl", windowprops);
             }
-
-            function addStartTime() {
-                document.getElementById("oneIdLogin").href += (Math.round(new Date().getTime() / 1000).toString());
-            }
-
 
             function enhancedOrClassic(choice) {
                 document.getElementById("loginType").value = choice;
@@ -460,30 +462,6 @@
             @media ( min-width: 1200px) {
             }
 
-            .oneIdLogin {
-                background-color: #000;
-                width: 60%;
-                height: 34px;
-                margin: 0 auto;
-            }
-
-            .oneIdLogo {
-                background-color: transparent;
-                background: url("${pageContext.request.contextPath}/images/oneId/oneIDLogo.png");
-                border: none;
-                display: inline-block;
-                float: left;
-                vertical-align: bottom;
-                width: 70px;
-                height: 16px;
-            }
-
-            .oneIDText {
-                display: inline-block;
-                float: left;
-                padding-left: 10px
-            }
-
             footer {
                 padding: 5px 10px;
                 margin-top: 50px;
@@ -646,26 +624,32 @@
 
                             <div class="input-wrapper form-group ${ login_error }">
                               <input type="password" name="password" id="password" placeholder="<fmt:message key="Logon.passWord"/>" autocomplete="current-password" class="form-control toggle-input" required>
-                              <button type="button" class="toggle-btn" aria-label="Toggle visibility" onclick="console.log('toggle clicked'); togglepwd();" >
-                            </button>
+                              <button type="button"
+                                      class="toggle-btn" 
+                                      aria-label="Show Password"
+                                      aria-pressed="false
+                                      onclick="togglepwd();" >
+                              </button>
                             </div>
 
 							<% if (MfaManager.isOscarLegacyPinEnabled()) { %>
-                            <c:if test="${not LoginResourceBean.ssoEnabled}">
                             <div class="pin-wrapper">
                                 <div class="input-wrapper form-group ${ login_error }">
                                   <!-- The input starts with the secure-text class -->
                                   <input type="text" id="pin" class="form-control secure-text toggle-input" name="pin" autocomplete="one-time-code"
                                                inputmode="numeric"  placeholder="<fmt:message key="admin.securityrecord.formPIN"/>">
-                                    <button type="button" class="toggle-btn" aria-label="Toggle visibility" onclick="console.log('toggle clicked'); togglepin();"></button>
+                                    <button type="button" 
+                                      class="toggle-btn" 
+                                      aria-label="Show PIN"
+                                      aria-pressed="false"
+                                      onclick="togglepin();">
+                                    </button>
                                     <span class="extrasmall">
 										    <fmt:message key="loginApplication.formCmt"/>
                                     </span>
                                 </div>
                             </div>
-                            </c:if>
 							<% } %>
-                            <input type="hidden" id="oneIdKey" name="nameId" value="${ nameId }">
                             <input type="hidden" id="loginType" name="loginType" value="">
                             <input type=hidden name='propname'
                                    value='<fmt:message key="loginApplication.propertyFile"/>'>
@@ -687,16 +671,6 @@
                             </div>
 
                         </form>
-
-                        <oscar:oscarPropertiesCheck property="oneid.enabled" value="true" defaultVal="false">
-                            <a href="${ LoginResourceBean.econsultURL }"
-                               id="oneIdLogin" onclick="addStartTime()" class="btn btn-primary btn-block oneIDLogin">
-                                <span class="oneIDLogo"></span>
-                                <span class="oneIdText">
-    									<fmt:setBundle basename="oscarResources"/><fmt:message key="loginApplication.oneid"/>
-    								</span>
-                            </a>
-                        </oscar:oscarPropertiesCheck>
 
                         <c:if test="${ LoginResourceBean.acceptableUseAgreementManager.auaAvailable }">
     			            <span class="extrasmall">


### PR DESCRIPTION
### **User description**
# Description

Adds visibility toggles as per WCAG to provide increased end user convenience and reduce password lockouts
As this page is exposed prior to authentication neither internal nor external libraries were used to minimize attack surface
Mimics Bootstrap and Font Awesome without drawing on library, instead using SVG
Fixes HTML error
Adds back in i18n tags that were removed
Related Issues

Fixes #444

# How Was This Tested?

Both on Carlos yesterday and on OpenO (slightly modified).
This is just a UI tweak "unlikely" to cause regression
# Screenshots
<img width="450" height="357" alt="LoginVisibilityToggle" src="https://github.com/user-attachments/assets/38b6013a-8c1f-4feb-af5d-389d0245b3f4" />

LoginVisibilityToggle
# Checklist

    My commits are signed off for the [DCO](https://developercertificate.org/) (git commit -s)
    My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
    I have not included any patient data (PHI) in this PR
    I have added tests for new functionality, or this change doesn't need new tests
    I have read the [contributing guide](https://github.com/carlos-emr/carlos/pull/CONTRIBUTING.md)

## Summary by Sourcery

Add WCAG-compliant visibility toggles for password and PIN fields on the login page and restore localized text usage.

New Features:
- Introduce show/hide controls for the password field with accessible ARIA attributes and custom SVG-based icons.
- Add a visibility toggle for the legacy PIN input using a secure-text masking class.

Enhancements:
- Adjust login form markup and attributes, including CSRF handling, autocomplete hints, and i18n-based placeholders and button labels.
- Refine login page styling, including custom input wrappers, Edge-specific password eye hiding, and updated logo and support image attributes.
- Fix a minor HTML/CSS issue by removing an invalid width hack and correcting a stray form tag.


___

### **Description**
- Introduced WCAG-compliant visibility toggles for password and PIN fields.
- Added ARIA attributes and custom SVG icons for improved accessibility.
- Refined login form markup and styling for better user experience.
- Fixed HTML/CSS issues to ensure proper rendering.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.jsp</strong><dd><code>Enhanced Login Page with Password and PIN Visibility Toggles</code></dd></summary>
<hr>

src/main/webapp/index.jsp
<li>Added visibility toggles for password and PIN fields.<br> <li> Implemented ARIA attributes for accessibility.<br> <li> Enhanced styling for input fields and toggle buttons.<br> <li> Fixed minor HTML/CSS issues.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/445/files#diff-ccf6b624566bc4638f2cbae115ac03eeca70b61e3a6155ff6bd2793b8cecadd9">+105/-26</a></td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added visibility toggles for password and PIN so users can show/hide entries.
  * PIN field defaults to a protected visual style for added privacy.

* **Refactor**
  * Reworked login form structure and labels; added CSRF token and hidden login-type field.
  * Improved accessibility and styling: ARIA updates, input wrappers, Edge password UI suppressed, and new toggle icons/styles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->