### PR TITLE
chore: fix 12 Dependabot security alerts (non-breaking)

### DIFF
--- a/dependencies-lock-modern.json
+++ b/dependencies-lock-modern.json
@@ -50,19 +50,19 @@
   }, {
     "groupId" : "ca.uhn.hapi.fhir",
     "artifactId" : "org.hl7.fhir.dstu3",
-    "version" : "6.1.2.2",
+    "version" : "6.4.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:FWmTxJBRTMOK8eV+EvfqIBpdyR8O9SEu1Ht6pdC0d8+Xd29mJc6f+u1uRl/iLHm0tik9qGqqpTeokGidbfwtbg=="
+    "integrity" : "sha512:jsXA+nxwtcREDusL853GitoYNywUJULdej+gWT0Wc7zo01zAPhblaiRS3UeBcFJ/5vWV0tD3LQhG7OTPnTIx+A=="
   }, {
     "groupId" : "ca.uhn.hapi.fhir",
     "artifactId" : "org.hl7.fhir.utilities",
-    "version" : "6.1.2.2",
+    "version" : "6.4.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:NfYQE5mn7hz70Yee6W/FhI8InLxl68U0hYqjcMURlTkZQ+LqpFnOGU7nvtj617lkGFOVm+d4ginIannacM61qQ=="
+    "integrity" : "sha512:0HVxuI390ovXEuMjSTpKyjTIgcUyDpxXb9/4kioGcIBQJTq80sz7Q1/HzOEEW8KOQpmhUEZc8ac3PS1NRQXiSw=="
   }, {
     "groupId" : "ca.uhn.hapi",
     "artifactId" : "hapi-base",
@@ -2379,11 +2379,11 @@
   }, {
     "groupId" : "org.assertj",
     "artifactId" : "assertj-core",
-    "version" : "3.27.6",
+    "version" : "3.27.7",
     "scope" : "test",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:T1v3S64AN4EUG9RwZr5nVuHHS6SPj0EuLNl4p1hbAT/x9Gcs4lnUDc0eaRpHECoeq0/14vwxINwicqlv8RH91A=="
+    "integrity" : "sha512:rd4W35/Qth2bjPTCh0C5OljUETAAQyWMWUYS1Z52MhpCQG94R/VkO6rYvd8I+4tqxtZVTDZznosfps41RW+dGQ=="
   }, {
     "groupId" : "org.bouncycastle",
     "artifactId" : "bcpkix-jdk18on",
@@ -3497,14 +3497,6 @@
     "optional" : false,
     "integrity" : "sha512:vowFRRgmOo6zoaEpT13mi6GAWMYADi0yvogsXp2919yO4v8fKdfLuSy3WZ+noey+VC/aNXTA0Efe1dTHAhBCCg=="
   }, {
-    "groupId" : "org.springframework",
-    "artifactId" : "spring-webmvc",
-    "version" : "5.3.39",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:rA94Jqmh3Upf+6QZyBkU8WOm1jj3PBvyNt3oIIo0N4x8wtgke4xD3b0txAorBh3G9if2S6hs/qLUJef7nzvSUg=="
-  }, {
     "groupId" : "org.swinglabs",
     "artifactId" : "pdf-renderer",
     "version" : "1.0.5",
@@ -3578,20 +3570,12 @@
     "integrity" : "sha512:N3k2Pv5LfPI7/Gg4jzxrUQXe25GSCA8URTT8rMincBT58+s64ZJzRKJnNkwk3u3r8l4wb4DfwpOFGXNoXMWMUg=="
   }, {
     "groupId" : "xalan",
-    "artifactId" : "serializer",
-    "version" : "2.7.2",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:iE2GWGWFikYwajaA32nz8O+g3xMTcGtU5pANNq8h4Xy2go9aa6xVHFn3+AvdHLZMP9veROITUZxK+Hlp6ecHdA=="
-  }, {
-    "groupId" : "xalan",
     "artifactId" : "xalan",
-    "version" : "2.7.2",
+    "version" : "2.7.3",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:APhZxb1l9tyR45bOkf4vbTCyNU1rQZzZ6paYTFQD5c0TQruTYrCuHyeSYS8N9zHE96yS8WqCW7fiIInCehKcbA=="
+    "integrity" : "sha512:tIFRUYHvKPjQOSPCctrk1C8sKlzSl2jxE1RIl6nQZ/eIFjzHBNDK41uva+00qmBEQuK56caXKc9XH8gtSJIy0Q=="
   }, {
     "groupId" : "xerces",
     "artifactId" : "xercesImpl",

--- a/dependencies-lock.json
+++ b/dependencies-lock.json
@@ -50,19 +50,19 @@
   }, {
     "groupId" : "ca.uhn.hapi.fhir",
     "artifactId" : "org.hl7.fhir.dstu3",
-    "version" : "6.1.2.2",
+    "version" : "6.4.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:FWmTxJBRTMOK8eV+EvfqIBpdyR8O9SEu1Ht6pdC0d8+Xd29mJc6f+u1uRl/iLHm0tik9qGqqpTeokGidbfwtbg=="
+    "integrity" : "sha512:jsXA+nxwtcREDusL853GitoYNywUJULdej+gWT0Wc7zo01zAPhblaiRS3UeBcFJ/5vWV0tD3LQhG7OTPnTIx+A=="
   }, {
     "groupId" : "ca.uhn.hapi.fhir",
     "artifactId" : "org.hl7.fhir.utilities",
-    "version" : "6.1.2.2",
+    "version" : "6.4.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:NfYQE5mn7hz70Yee6W/FhI8InLxl68U0hYqjcMURlTkZQ+LqpFnOGU7nvtj617lkGFOVm+d4ginIannacM61qQ=="
+    "integrity" : "sha512:0HVxuI390ovXEuMjSTpKyjTIgcUyDpxXb9/4kioGcIBQJTq80sz7Q1/HzOEEW8KOQpmhUEZc8ac3PS1NRQXiSw=="
   }, {
     "groupId" : "ca.uhn.hapi",
     "artifactId" : "hapi-base",
@@ -2371,11 +2371,11 @@
   }, {
     "groupId" : "org.assertj",
     "artifactId" : "assertj-core",
-    "version" : "3.27.6",
+    "version" : "3.27.7",
     "scope" : "test",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:T1v3S64AN4EUG9RwZr5nVuHHS6SPj0EuLNl4p1hbAT/x9Gcs4lnUDc0eaRpHECoeq0/14vwxINwicqlv8RH91A=="
+    "integrity" : "sha512:rd4W35/Qth2bjPTCh0C5OljUETAAQyWMWUYS1Z52MhpCQG94R/VkO6rYvd8I+4tqxtZVTDZznosfps41RW+dGQ=="
   }, {
     "groupId" : "org.bouncycastle",
     "artifactId" : "bcpkix-jdk18on",
@@ -3433,14 +3433,6 @@
     "optional" : false,
     "integrity" : "sha512:vowFRRgmOo6zoaEpT13mi6GAWMYADi0yvogsXp2919yO4v8fKdfLuSy3WZ+noey+VC/aNXTA0Efe1dTHAhBCCg=="
   }, {
-    "groupId" : "org.springframework",
-    "artifactId" : "spring-webmvc",
-    "version" : "5.3.39",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:rA94Jqmh3Upf+6QZyBkU8WOm1jj3PBvyNt3oIIo0N4x8wtgke4xD3b0txAorBh3G9if2S6hs/qLUJef7nzvSUg=="
-  }, {
     "groupId" : "org.swinglabs",
     "artifactId" : "pdf-renderer",
     "version" : "1.0.5",
@@ -3514,20 +3506,12 @@
     "integrity" : "sha512:N3k2Pv5LfPI7/Gg4jzxrUQXe25GSCA8URTT8rMincBT58+s64ZJzRKJnNkwk3u3r8l4wb4DfwpOFGXNoXMWMUg=="
   }, {
     "groupId" : "xalan",
-    "artifactId" : "serializer",
-    "version" : "2.7.2",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:iE2GWGWFikYwajaA32nz8O+g3xMTcGtU5pANNq8h4Xy2go9aa6xVHFn3+AvdHLZMP9veROITUZxK+Hlp6ecHdA=="
-  }, {
-    "groupId" : "xalan",
     "artifactId" : "xalan",
-    "version" : "2.7.2",
+    "version" : "2.7.3",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:APhZxb1l9tyR45bOkf4vbTCyNU1rQZzZ6paYTFQD5c0TQruTYrCuHyeSYS8N9zHE96yS8WqCW7fiIInCehKcbA=="
+    "integrity" : "sha512:tIFRUYHvKPjQOSPCctrk1C8sKlzSl2jxE1RIl6nQZ/eIFjzHBNDK41uva+00qmBEQuK56caXKc9XH8gtSJIy0Q=="
   }, {
     "groupId" : "xerces",
     "artifactId" : "xercesImpl",

--- a/pom.xml
+++ b/pom.xml
@@ -177,6 +177,26 @@
                 <artifactId>xstream</artifactId>
                 <version>1.4.21</version>
             </dependency>
+            <!-- Override transitive Xalan from javax.servlet.jsp.jstl to fix CVE-2022-34169
+                 (integer truncation in XSLTC compiler allows arbitrary bytecode execution) -->
+            <dependency>
+                <groupId>xalan</groupId>
+                <artifactId>xalan</artifactId>
+                <version>2.7.3</version>
+            </dependency>
+            <!-- Override transitive org.hl7.fhir.core from hapi-fhir-structures-dstu3 to fix:
+                 - CVE-2024-45294 (XXE in XSLT transforms)
+                 - CVE-2024-51132 (XXE via crafted XML entities) -->
+            <dependency>
+                <groupId>ca.uhn.hapi.fhir</groupId>
+                <artifactId>org.hl7.fhir.utilities</artifactId>
+                <version>6.4.0</version>
+            </dependency>
+            <dependency>
+                <groupId>ca.uhn.hapi.fhir</groupId>
+                <artifactId>org.hl7.fhir.dstu3</artifactId>
+                <version>6.4.0</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -450,9 +470,12 @@
             <artifactId>spring-orm</artifactId>
             <version>5.3.39</version>
         </dependency>
+        <!-- spring-webmvc removed: no DispatcherServlet, no @Controller annotations, no Spring MVC.
+             Replaced with spring-web which provides WebApplicationContext used by CXF and Struts.
+             Eliminates CVE alerts on spring-webmvc (path traversal, DoS). -->
         <dependency>
             <groupId>org.springframework</groupId>
-            <artifactId>spring-webmvc</artifactId>
+            <artifactId>spring-web</artifactId>
             <version>5.3.39</version>
         </dependency>
         <!-- throws an compilation error when removed/commented -->
@@ -1235,7 +1258,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.27.6</version>
+            <version>3.27.7</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/resources/spring_ws.xml
+++ b/src/main/resources/spring_ws.xml
@@ -290,14 +290,5 @@
         <property name="mapper" ref="jacksonObjectMapper"/>
     </bean>
 
-    <!-- =========================================================
-         View resolver for OAuth authorize JSPs (Spring MVC)
-         Adjust prefix/suffix to match your project.
-         ========================================================= -->
-    <bean class="org.springframework.web.servlet.view.InternalResourceViewResolver">
-        <property name="prefix" value="/WEB-INF/jsp/"/>
-        <property name="suffix" value=".jsp"/>
-        <property name="order"  value="2"/>
-    </bean>
 
 </beans>

--- a/src/main/webapp/billing/CA/BC/billingBCEditPrivateCode.jsp
+++ b/src/main/webapp/billing/CA/BC/billingBCEditPrivateCode.jsp
@@ -154,7 +154,6 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 
 <%@ taglib uri="http://displaytag.sf.net" prefix="display" %>
-<%@ taglib prefix="form" uri="http://www.springframework.org/tags/form" %>
 
 <html>
     <head>

--- a/src/main/webapp/email/emailCompose.jsp
+++ b/src/main/webapp/email/emailCompose.jsp
@@ -5,7 +5,6 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
-<%@ taglib prefix="html" uri="http://www.springframework.org/tags/form" %>
 
 <html>
 <head>

--- a/src/main/webapp/oscarMDS/Search.jsp
+++ b/src/main/webapp/oscarMDS/Search.jsp
@@ -31,8 +31,6 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 
 
-<%@ taglib prefix="form" uri="http://www.springframework.org/tags/form" %>
-
 <!DOCTYPE html>
 <html>
 <head>

--- a/src/main/webapp/oscarWaitingList/DisplayWaitingList.jsp
+++ b/src/main/webapp/oscarWaitingList/DisplayWaitingList.jsp
@@ -42,7 +42,6 @@
 <%@ page import="io.github.carlos_emr.carlos.waitinglist.bean.WLWaitingListNameBean" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
-<%@ taglib prefix="form" uri="http://www.springframework.org/tags/form" %>
 <%
     String wlid = (String) request.getAttribute("WLId");
     if (wlid == null) {


### PR DESCRIPTION
### **User description**
## Summary

Resolves 12 Dependabot security alerts through non-breaking dependency updates and dead code removal. All changes verified with 869 unit tests passing.

- **Remove spring-webmvc** entirely — replaced with spring-web. No DispatcherServlet, no @Controller, no Spring MVC usage found. The only references were 4 unused taglib declarations in JSPs and a dead `InternalResourceViewResolver` pointing to a nonexistent `/WEB-INF/jsp/` directory. Fixes alerts #3, #5, #6, #7
- **Bump AssertJ** 3.27.6 → 3.27.7 (test-scope only, fixes CVE-2026-24400 XXE in `isXmlEqualTo`). Fixes alert #13
- **Force Xalan** 2.7.2 → 2.7.3 via `<dependencyManagement>` (transitive from javax.servlet.jsp.jstl, no direct usage). Fixes alert #15 (CVE-2022-34169)
- **Force org.hl7.fhir.core** 6.1.2.2 → 6.4.0 via `<dependencyManagement>` (transitive from hapi-fhir-structures-dstu3). Fixes alerts #16, #17, #18, #19, #20, #21 (CVE-2024-45294, CVE-2024-51132)

### Alerts NOT addressed (with rationale)

| Alert | Reason |
|-------|--------|
| #2 CSRFGuard | Requires 3.x→4.x major upgrade (breaking API changes, 32 files affected). Needs dedicated epic |
| #11 JasperReports | No community edition fix available. Mitigated by Java 21 + predefined templates only |
| #1,26-32 npm | Documentation build only (Docusaurus), not in production WAR |
| #8,14,23,24 Spring core/web/context | Requires Spring 5→6 + Jakarta EE migration |

## Test plan

- [x] `mvn compile` — clean compilation, zero errors
- [x] `make install --run-unit-tests` — 869 tests pass, 0 failures
- [x] `mvn dependency:tree -Dincludes=org.springframework:spring-webmvc` — confirms spring-webmvc fully removed
- [x] `mvn dependency:tree -Dincludes=xalan:xalan` — confirms 2.7.3
- [x] `mvn dependency:tree -Dincludes=ca.uhn.hapi.fhir:org.hl7.fhir.utilities` — confirms 6.4.0
- [ ] Integration tests
- [ ] Manual smoke test of CSRF-protected forms, report generation, FHIR endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **Description**
- Resolved 12 Dependabot security alerts through non-breaking dependency updates and dead code removal.
- Removed `spring-webmvc` entirely, replacing it with `spring-web`, eliminating several CVE alerts.
- Updated `AssertJ` from 3.27.6 to 3.27.7 to fix CVE-2026-24400.
- Forced updates for `Xalan` and `org.hl7.fhir.core` to address multiple CVEs.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dependencies-lock-modern.json</strong><dd><code>Update dependencies and remove unused spring-webmvc</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dependencies-lock-modern.json
<li>Updated <code>org.hl7.fhir.dstu3</code> and <code>org.hl7.fhir.utilities</code> versions to <br>6.4.0.<br> <li> Bumped <code>assertj-core</code> version to 3.27.7.<br> <li> Updated <code>xalan</code> version to 2.7.3.<br> <li> Removed <code>spring-webmvc</code> dependency entirely.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/458/files#diff-1472f999235657abcd3a220fef24a1a1a4bfdcd834722e6ee710499c3e8d4e24">+8/-24</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>dependencies-lock.json</strong><dd><code>Update dependencies and remove unused spring-webmvc</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dependencies-lock.json
<li>Updated <code>org.hl7.fhir.dstu3</code> and <code>org.hl7.fhir.utilities</code> versions to <br>6.4.0.<br> <li> Bumped <code>assertj-core</code> version to 3.27.7.<br> <li> Updated <code>xalan</code> version to 2.7.3.<br> <li> Removed <code>spring-webmvc</code> dependency entirely.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/458/files#diff-9d6d26515ff9f0c84acf583c24af9ae33c3959c487518980183cf3515799afcb">+8/-24</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pom.xml</strong><dd><code>Modify POM for security fixes and dependency updates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pom.xml
<li>Added new dependencies for <code>xalan</code> and <code>org.hl7.fhir</code> to fix security <br>vulnerabilities.<br> <li> Removed <code>spring-webmvc</code> and replaced it with <code>spring-web</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/458/files#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8">+25/-2</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>spring_ws.xml</strong><dd><code>Remove unused Spring MVC configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/resources/spring_ws.xml
- Removed `InternalResourceViewResolver` bean related to Spring MVC.



</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/458/files#diff-2570f5568950958c77bb30deef5336880fdf0368dd59e44b88d7754654cbce3a">+0/-9</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr><tr><td><strong>Formatting
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>billingBCEditPrivateCode.jsp</strong><dd><code>Clean up JSP by removing unused taglib</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/webapp/billing/CA/BC/billingBCEditPrivateCode.jsp
- Removed unused Spring form taglib declaration.



</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/458/files#diff-af062880ea7ab574988fe9da8c9a25a39f1f75945f5284d83b23538a2c7dd02f">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>emailCompose.jsp</strong><dd><code>Clean up JSP by removing unused taglib</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/webapp/email/emailCompose.jsp
- Removed unused Spring form taglib declaration.



</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/458/files#diff-a3a580e1cf05f498ef694b203935665966ea993e1d2400da06c00a94cb2bbf76">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>Search.jsp</strong><dd><code>Clean up JSP by removing unused taglib</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/webapp/oscarMDS/Search.jsp
- Removed unused Spring form taglib declaration.



</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/458/files#diff-87dccd9d0c9d31369265c0c0c9dadb79ff0cbf528663f9e0b21c886f0b1b35fc">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>DisplayWaitingList.jsp</strong><dd><code>Clean up JSP by removing unused taglib</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/webapp/oscarWaitingList/DisplayWaitingList.jsp
- Removed unused Spring form taglib declaration.



</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/458/files#diff-3becd5399e2f3e729e8006132097ac5fb003020a6787b9415b11866a76df4f7d">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated FHIR libraries to version 6.4.0
  * Updated Xalan to version 2.7.3
  * Updated AssertJ testing library to version 3.27.7
  * Replaced Spring MVC dependency with Spring Web
  * Removed JSP view resolver configuration
  * Removed unused taglib declarations from multiple JSP pages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->