### PR TITLE
chore: remove 14 unused dependencies

### DIFF
--- a/dependencies-lock-modern.json
+++ b/dependencies-lock-modern.json
@@ -33,14 +33,6 @@
     "integrity" : "sha512:P7sy4EBGDXhLcZPUsS3xCkperUfAmQV/AJpOV9VLTudj9qt42wVGzUSTSX1GqrCBtyTz+7iF4wmpCi6dXnTuhQ=="
   }, {
     "groupId" : "ca.uhn.hapi.fhir",
-    "artifactId" : "hapi-fhir-structures-dstu2",
-    "version" : "6.10.5",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:dvDZ+0AGbT8G/IyHLgIK4WdosfJB2XBHNTAkPfijL260i1Y+uhr0WJKikH+Zx8HlCdwZ0NZ6M7VM6kcBE27aeA=="
-  }, {
-    "groupId" : "ca.uhn.hapi.fhir",
     "artifactId" : "hapi-fhir-structures-dstu3",
     "version" : "6.10.5",
     "scope" : "compile",
@@ -169,14 +161,6 @@
     "integrity" : "sha512:kGAn8E5VII/duD6uY/Elj64QAQfijpy9Z2qNS99znBh9P5v6nLNyEc5KC3LzZQHeMAzYgG4fSwO8O9mDA7laOw=="
   }, {
     "groupId" : "cglib",
-    "artifactId" : "cglib-nodep",
-    "version" : "3.3.0",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:+qHSEh6HrmnheeOq4heszQg04Npxa5GgKf1SbhkmEucWdfJ0C+30jiPvHtxF9nKivhs+eLv7GtWclt09L+7tug=="
-  }, {
-    "groupId" : "cglib",
     "artifactId" : "cglib",
     "version" : "2.2.2",
     "scope" : "compile",
@@ -226,11 +210,11 @@
   }, {
     "groupId" : "com.fasterxml.jackson.datatype",
     "artifactId" : "jackson-datatype-jsr310",
-    "version" : "2.19.2",
+    "version" : "2.15.3",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:0QzuKuiPt3Dik5PtntjT1qLLsgDPZejLAV1iqAdntWDeChOjJe8GfF2Mhn/Ad+/H2buXc0DKw2JuL5ZKOpwOJg=="
+    "integrity" : "sha512:HFvebJGiqJ88HyMfThfENQY9kBK6u/y6UJo7JTY7H9mfDc1CNPHgBVnkPT3I5scYNCgscvLr8VSErpAHVMXXVw=="
   }, {
     "groupId" : "com.fasterxml.jackson.jaxrs",
     "artifactId" : "jackson-jaxrs-base",
@@ -401,14 +385,6 @@
     "integrity" : "sha512:UV+Mfq1Qz+xkGu2cgUL0f9N9PVkjBijDwhghzRaItamQ9pVlmEpNAwqnFOuFY55m3Oi6YdzBoQk2KYXrzNvMtQ=="
   }, {
     "groupId" : "com.github.scribejava",
-    "artifactId" : "scribejava-apis",
-    "version" : "8.3.3",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:lLEza8HPLUwJiAihUOXImG2NImnjSwW5V5xa7Oo4MvqzaQc8zIw1JXEitKlwtZ66a7SY6SYV6B+gHUUmi8VVKw=="
-  }, {
-    "groupId" : "com.github.scribejava",
     "artifactId" : "scribejava-core",
     "version" : "8.3.3",
     "scope" : "compile",
@@ -543,30 +519,6 @@
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:k8jO0QMHnJwgWpF6c1nn5ga8E6GsaZo2jDPwZWK6nTVoWa7i/OE3DT5vMwkx0vROptpnFABOnJ1Mm7R5JRD8Ag=="
-  }, {
-    "groupId" : "com.microsoft.playwright",
-    "artifactId" : "driver-bundle",
-    "version" : "1.40.0",
-    "scope" : "test",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:agROXmL2hH8Rzp3HMeoaESr0OE1qCX3yZCzj1yIY67YOew65EbdoH8eFSZfRSKv++dSW9Nn2Z8qXPpoxYI5QuQ=="
-  }, {
-    "groupId" : "com.microsoft.playwright",
-    "artifactId" : "driver",
-    "version" : "1.40.0",
-    "scope" : "test",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:Bx2BbMFbviEofoqyuU7P4Okf9wg1IB26dQPgSaxfBgpgt8eJ63KS9MKf6me4lI8XityepIFf4lyl7ZTk8/Z57w=="
-  }, {
-    "groupId" : "com.microsoft.playwright",
-    "artifactId" : "playwright",
-    "version" : "1.40.0",
-    "scope" : "test",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:Pz7iBFzXb6MNVlG1zUjxlNI5MlS1w03dvnMtDt8+Vub1w6llHSZye1NqGu5v+jRJng4EPJbMu6/gGsVuylbNxw=="
   }, {
     "groupId" : "com.mysql",
     "artifactId" : "mysql-connector-j",
@@ -856,14 +808,6 @@
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:Uccvmsp3JvPDhwleZr6Fpt+Xx0sAolQ0uJGIwbjqtuK1Wsz3ub1BJDDSK9CTJN7AduMAs9H6OfzK1HHw8qPaFg=="
-  }, {
-    "groupId" : "commons-configuration",
-    "artifactId" : "commons-configuration",
-    "version" : "1.10",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:zH/dfXvRhRtI0QiDdm+snXKwQHcUs8ZTNpEw4yJL3Rmky5QfuBPd4ejH0puwelsaRNYRJA6tFxflGhWjHJYw+A=="
   }, {
     "groupId" : "commons-digester",
     "artifactId" : "commons-digester",
@@ -1257,14 +1201,6 @@
     "optional" : false,
     "integrity" : "sha512:4au63KYDxrIDNSxBLUrkUATz+DPhsjZmQRYSICBGbc2Gj2q5ZTrb4ZB5R5V8zR7faGqV0qYX6UhPr1+nqf9kSw=="
   }, {
-    "groupId" : "net.sourceforge.serp",
-    "artifactId" : "serp",
-    "version" : "1.15.1",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:XLrAyogt9NN4GXOZ69bE4crUKMER6+xw6m0qbGSYXI1DlKpWr6fOW9Qxp2wppKuSI4Wk7BnXbAO5nvMS5IJSZQ=="
-  }, {
     "groupId" : "ognl",
     "artifactId" : "ognl",
     "version" : "3.3.5",
@@ -1336,14 +1272,6 @@
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:7kPFE6ydy9fdI7XLtOpfZaLhDN+7QD0IC4fneLO0UGIxVSIpfEHspRSpqUYiitdlDwpXLVt47/uCYN2AhBMZiA=="
-  }, {
-    "groupId" : "org.apache.commons",
-    "artifactId" : "commons-compress",
-    "version" : "1.28.0",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:8fFA9PQKs88yZZGdudu5WmMaKap4TjBfKR3k5oh2u3EdkhfWLXk3zd3dOTmC3s33GmCLSzq39OY3XPKK8ok9fw=="
   }, {
     "groupId" : "org.apache.commons",
     "artifactId" : "commons-csv",
@@ -1945,30 +1873,6 @@
     "optional" : false,
     "integrity" : "sha512:pToK7Wki1tHzfnjL3hbyqY29Q/cZgpOpYMdh4sbwrEVncKniHKZN1GCmYS0Lrp002Q7yGkqa6Ale1Gd6C1IJ6w=="
   }, {
-    "groupId" : "org.apache.geronimo.specs",
-    "artifactId" : "geronimo-jms_1.1_spec",
-    "version" : "1.1.1",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:lMuGYHdVlrKY25PhH9uyjSpYKxYfem1mfUGUb1nosRSqgOFcKMQYbwW0P0MrGsVV2EWthwMJYJICOCw/YGHjGQ=="
-  }, {
-    "groupId" : "org.apache.geronimo.specs",
-    "artifactId" : "geronimo-jpa_2.2_spec",
-    "version" : "1.1",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:mytw5JAr9n8979XakR3YguXhs+DEoXswS+Uh5Lsw+EnNVu7ZaR86/8H0hAkaKBOavhLzveQKiHa4s4OEPp/g2w=="
-  }, {
-    "groupId" : "org.apache.geronimo.specs",
-    "artifactId" : "geronimo-jta_1.1_spec",
-    "version" : "1.1.1",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:7hD5Qu2nGZpSKqCDitacm1gRdYC9YBhbTAG/xDkT/UhRVLGz1Dewo2HRvtihiXTIT1vfHLJ+2bwY/jP7pNjx+A=="
-  }, {
     "groupId" : "org.apache.httpcomponents.client5",
     "artifactId" : "httpclient5",
     "version" : "5.4.4",
@@ -2064,14 +1968,6 @@
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:bu6I1zsvMcd4r4O7bEQ94lIHNjbd0RIZwZQ3cS2WlZdc1qq/612Lw15nNtChnbR3YQ+cjdrlgh6RTenIW+wvMQ=="
-  }, {
-    "groupId" : "org.apache.openjpa",
-    "artifactId" : "openjpa",
-    "version" : "3.2.2",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:fxElSgQRT4+AeHo9UAqy7TgJjDrLDs1O0BtvTnfVpiqnUHnDLB7IYeDZ5oPNuoDP9/5iSNMr72C+tj7Phah8TQ=="
   }, {
     "groupId" : "org.apache.pdfbox",
     "artifactId" : "fontbox",
@@ -2192,14 +2088,6 @@
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:lz8NdizrBojcKX4DZqqdY/lksn2CKY3ZXV9pi9upoCkg7V+MXBdNE+yciYpx+oaKyn0gFSNEPZ3m+He4o1rFog=="
-  }, {
-    "groupId" : "org.apache.xbean",
-    "artifactId" : "xbean-asm9-shaded",
-    "version" : "4.20",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:k+b5dZYwerV9DC4Eankdza6HA11mSI+0fS3ZjIiERutDGxL0W9nMiHLfhDhG2uK4iHgGaWnpw+N5IqPw34hLwQ=="
   }, {
     "groupId" : "org.apache.xmlbeans",
     "artifactId" : "xmlbeans",
@@ -2416,22 +2304,6 @@
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:YzoMOWvAGIPWxp28U9qYB4TYg31xsJuFnRVxylo7YI5s8km6wEV1pvM0mPyS2Nbu1yAOSax2irDVsNKyvy2Lhg=="
-  }, {
-    "groupId" : "org.codehaus.janino",
-    "artifactId" : "commons-compiler",
-    "version" : "3.1.12",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:zY7Os8nNKE9LOAMhurtfoLB+tEN2hn9QHH4lO/yWvYx/K2D8BJ3yHummwJIlraGCjJ+JIoRtkEMvZPT7EEur3g=="
-  }, {
-    "groupId" : "org.codehaus.janino",
-    "artifactId" : "janino",
-    "version" : "3.1.12",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:9hmz5sUSJ1s8GLyeMEwvWUfXZV0RhKdzAM/+6SmA1C8fQ8y2aSyl4zQDEnuOQdpZT2md3wfw6bAkNXmkNfEgJA=="
   }, {
     "groupId" : "org.codehaus.jettison",
     "artifactId" : "jettison",
@@ -3147,11 +3019,11 @@
   }, {
     "groupId" : "org.opentest4j",
     "artifactId" : "opentest4j",
-    "version" : "1.2.0",
+    "version" : "1.3.0",
     "scope" : "test",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:F/d3l6Jg6yvRZmqQ4l78eaVBOvqd8cHLbEzRlJ1hw4skHjuyCVY5a19U0URyAwPXKirAC8W/JFomCjwwmeAcdA=="
+    "integrity" : "sha512:ePxpinhxu1AwXjZXiTwQUAWV8EM0jYdfV7w5ykpqUe2jlnt8jIp+w+j4XyFxvKSqmII+kS5BbofoHGultwo3ww=="
   }, {
     "groupId" : "org.ow2.asm",
     "artifactId" : "asm",
@@ -3360,14 +3232,6 @@
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:oLJBpSJVMilWLLrVNjahJpw4uAYn+8gLeT8HfqsfmlIjKBLxHCTaC/mSvUJy1fZZZTfihnXkt5HlmTpBY2H+VQ=="
-  }, {
-    "groupId" : "org.springframework.integration",
-    "artifactId" : "spring-integration-sftp",
-    "version" : "5.5.20",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:iaT6kwrl9YzfGRLBSstbB1Hx6dZDlnpEgjYNB870k2ERc5z7DDFClTdvqyOa+1vFo6GCSVVW0uHAWOKiFK2AxQ=="
   }, {
     "groupId" : "org.springframework.retry",
     "artifactId" : "spring-retry",

--- a/dependencies-lock-modern.json
+++ b/dependencies-lock-modern.json
@@ -65,14 +65,6 @@
     "integrity" : "sha512:52LSZKam5t5rMnXtXw8fN3i/ngUQp6vz1Wve+KNgYxHDh4nYcW9uX0lf8UeHvoZoWfGpeBGNXYeV+DP3Bj122A=="
   }, {
     "groupId" : "ca.uhn.hapi",
-    "artifactId" : "hapi-structures-v21",
-    "version" : "1.0.1",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:NCMpcJGrsvrshD64gZOzLnr029MEphePqjdIAO6PnNWjijsjnihjYw6CvstY/Vi7sAmQKTAjzH0KHIoI3SOtJA=="
-  }, {
-    "groupId" : "ca.uhn.hapi",
     "artifactId" : "hapi-structures-v22",
     "version" : "1.0.1",
     "scope" : "compile",
@@ -95,14 +87,6 @@
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:ZB+6VTphE8XInCdGchvAuZaW+9r7et3pt9VUM4aIvd0HMrKUXbzS5Rbk6+8623Z/3TP3TncXz06bzF9gSQmrqg=="
-  }, {
-    "groupId" : "ca.uhn.hapi",
-    "artifactId" : "hapi-structures-v24",
-    "version" : "1.0.1",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:MM19XuIm4Ud+yZPqJ7E/kJG1bUhOk6krph+k4wU3ha8POHO0IkaJGRKc1w+cLHxZxMTHXSSContBKpkZm/UdTg=="
   }, {
     "groupId" : "ca.uhn.hapi",
     "artifactId" : "hapi-structures-v25",
@@ -841,14 +825,6 @@
     "optional" : false,
     "integrity" : "sha512:7QDb+r2a4A76Jt1ACYNgHQdv42QIt9ZSAIS0R+XR+lJ85lvWr9y1hQbDqAgyPSjojybLmcb125/2T2Ul7N+lVw=="
   }, {
-    "groupId" : "commons-net",
-    "artifactId" : "commons-net",
-    "version" : "3.12.0",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:ZbJN+RpJt9BJCnNhhS6Z23zOH80p8+sKPN3RNegaKEO/NTYYU4H0QeNLUbq2/NV99/eFmshIB2TotbvVulaXFA=="
-  }, {
     "groupId" : "commons-validator",
     "artifactId" : "commons-validator",
     "version" : "1.10.1",
@@ -912,14 +888,6 @@
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:3ulAVVAU1Ng/XJrXMIUomsIeAzf9x+svAjqmt4v+7iS2uhdUREU1+4JrIoe+AKY8fBI2Ay74MBl6l3lJs2hZpA=="
-  }, {
-    "groupId" : "io.projectreactor",
-    "artifactId" : "reactor-core",
-    "version" : "3.4.34",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:B4R9OcejzxZEJi2clUS3dcxshmISIIMPA1+CY0d8kvkm4AU4+s3pt4HpK5NlAfWx78lPuc78wISyR9A4SOx1aQ=="
   }, {
     "groupId" : "io.undertow",
     "artifactId" : "undertow-servlet",
@@ -3209,38 +3177,6 @@
     "optional" : false,
     "integrity" : "sha512:mj5522ZmpglqMCG7Lh2RjzD1idjeUda2APjr2SUVpRCuLY+HkZzC36g2XWTxAZTKyN+g+5UBYO7w6doG9squuQ=="
   }, {
-    "groupId" : "org.springframework.integration",
-    "artifactId" : "spring-integration-core",
-    "version" : "5.5.20",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:R09ycTCEtaA4cfUQR8eaP2Wt72oMph9jXj0y432N7RUcGuh9hCwDyiUgZ0By6sn1GT0INCOqjWE4Oba7kz1Gug=="
-  }, {
-    "groupId" : "org.springframework.integration",
-    "artifactId" : "spring-integration-file",
-    "version" : "5.5.20",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:Eo34+cSyi5V0nNFqUDw5i2Vn8PXLnocgnQbhymLDplKiOTXIFZ0a1UlNS86GROKfGhzbsDbGaZR/ZMMB5xoGHA=="
-  }, {
-    "groupId" : "org.springframework.integration",
-    "artifactId" : "spring-integration-ftp",
-    "version" : "5.5.20",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:oLJBpSJVMilWLLrVNjahJpw4uAYn+8gLeT8HfqsfmlIjKBLxHCTaC/mSvUJy1fZZZTfihnXkt5HlmTpBY2H+VQ=="
-  }, {
-    "groupId" : "org.springframework.retry",
-    "artifactId" : "spring-retry",
-    "version" : "1.3.4",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:3BwvcFqB8d2IEyX3Q65nkBsrHcdgRTawbllr47DYPXvNqYI5c1Xu1QQIJMunuxXTYkWjiSUWOl+LLqSoJ4/nGg=="
-  }, {
     "groupId" : "org.springframework.security",
     "artifactId" : "spring-security-crypto",
     "version" : "6.3.9",
@@ -3320,14 +3256,6 @@
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:n7wLbtOLlizchNGi6mI5NDDUR9PomXk7aNB2dNpnv6U7IvHqJEk9c38jbHbtCtaEhRM5fvIiWoxiMuUWrhUuoQ=="
-  }, {
-    "groupId" : "org.springframework",
-    "artifactId" : "spring-messaging",
-    "version" : "5.3.39",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:Dto49i3yV7hKoGYBZZoHz/XJmPjlhZlvVyMFULF3Ca8zg+sUubxDsEoxHgiOqYPgKtrnwtSDfaH2/iCDzo18sQ=="
   }, {
     "groupId" : "org.springframework",
     "artifactId" : "spring-orm",

--- a/dependencies-lock.json
+++ b/dependencies-lock.json
@@ -65,14 +65,6 @@
     "integrity" : "sha512:52LSZKam5t5rMnXtXw8fN3i/ngUQp6vz1Wve+KNgYxHDh4nYcW9uX0lf8UeHvoZoWfGpeBGNXYeV+DP3Bj122A=="
   }, {
     "groupId" : "ca.uhn.hapi",
-    "artifactId" : "hapi-structures-v21",
-    "version" : "1.0.1",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:NCMpcJGrsvrshD64gZOzLnr029MEphePqjdIAO6PnNWjijsjnihjYw6CvstY/Vi7sAmQKTAjzH0KHIoI3SOtJA=="
-  }, {
-    "groupId" : "ca.uhn.hapi",
     "artifactId" : "hapi-structures-v22",
     "version" : "1.0.1",
     "scope" : "compile",
@@ -95,14 +87,6 @@
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:ZB+6VTphE8XInCdGchvAuZaW+9r7et3pt9VUM4aIvd0HMrKUXbzS5Rbk6+8623Z/3TP3TncXz06bzF9gSQmrqg=="
-  }, {
-    "groupId" : "ca.uhn.hapi",
-    "artifactId" : "hapi-structures-v24",
-    "version" : "1.0.1",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:MM19XuIm4Ud+yZPqJ7E/kJG1bUhOk6krph+k4wU3ha8POHO0IkaJGRKc1w+cLHxZxMTHXSSContBKpkZm/UdTg=="
   }, {
     "groupId" : "ca.uhn.hapi",
     "artifactId" : "hapi-structures-v25",
@@ -841,14 +825,6 @@
     "optional" : false,
     "integrity" : "sha512:7QDb+r2a4A76Jt1ACYNgHQdv42QIt9ZSAIS0R+XR+lJ85lvWr9y1hQbDqAgyPSjojybLmcb125/2T2Ul7N+lVw=="
   }, {
-    "groupId" : "commons-net",
-    "artifactId" : "commons-net",
-    "version" : "3.12.0",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:ZbJN+RpJt9BJCnNhhS6Z23zOH80p8+sKPN3RNegaKEO/NTYYU4H0QeNLUbq2/NV99/eFmshIB2TotbvVulaXFA=="
-  }, {
     "groupId" : "commons-validator",
     "artifactId" : "commons-validator",
     "version" : "1.10.1",
@@ -912,14 +888,6 @@
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:3ulAVVAU1Ng/XJrXMIUomsIeAzf9x+svAjqmt4v+7iS2uhdUREU1+4JrIoe+AKY8fBI2Ay74MBl6l3lJs2hZpA=="
-  }, {
-    "groupId" : "io.projectreactor",
-    "artifactId" : "reactor-core",
-    "version" : "3.4.34",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:B4R9OcejzxZEJi2clUS3dcxshmISIIMPA1+CY0d8kvkm4AU4+s3pt4HpK5NlAfWx78lPuc78wISyR9A4SOx1aQ=="
   }, {
     "groupId" : "io.undertow",
     "artifactId" : "undertow-servlet",
@@ -3137,38 +3105,6 @@
     "optional" : false,
     "integrity" : "sha512:mj5522ZmpglqMCG7Lh2RjzD1idjeUda2APjr2SUVpRCuLY+HkZzC36g2XWTxAZTKyN+g+5UBYO7w6doG9squuQ=="
   }, {
-    "groupId" : "org.springframework.integration",
-    "artifactId" : "spring-integration-core",
-    "version" : "5.5.20",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:R09ycTCEtaA4cfUQR8eaP2Wt72oMph9jXj0y432N7RUcGuh9hCwDyiUgZ0By6sn1GT0INCOqjWE4Oba7kz1Gug=="
-  }, {
-    "groupId" : "org.springframework.integration",
-    "artifactId" : "spring-integration-file",
-    "version" : "5.5.20",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:Eo34+cSyi5V0nNFqUDw5i2Vn8PXLnocgnQbhymLDplKiOTXIFZ0a1UlNS86GROKfGhzbsDbGaZR/ZMMB5xoGHA=="
-  }, {
-    "groupId" : "org.springframework.integration",
-    "artifactId" : "spring-integration-ftp",
-    "version" : "5.5.20",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:oLJBpSJVMilWLLrVNjahJpw4uAYn+8gLeT8HfqsfmlIjKBLxHCTaC/mSvUJy1fZZZTfihnXkt5HlmTpBY2H+VQ=="
-  }, {
-    "groupId" : "org.springframework.retry",
-    "artifactId" : "spring-retry",
-    "version" : "1.3.4",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:3BwvcFqB8d2IEyX3Q65nkBsrHcdgRTawbllr47DYPXvNqYI5c1Xu1QQIJMunuxXTYkWjiSUWOl+LLqSoJ4/nGg=="
-  }, {
     "groupId" : "org.springframework.security",
     "artifactId" : "spring-security-crypto",
     "version" : "6.3.9",
@@ -3248,14 +3184,6 @@
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:n7wLbtOLlizchNGi6mI5NDDUR9PomXk7aNB2dNpnv6U7IvHqJEk9c38jbHbtCtaEhRM5fvIiWoxiMuUWrhUuoQ=="
-  }, {
-    "groupId" : "org.springframework",
-    "artifactId" : "spring-messaging",
-    "version" : "5.3.39",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:Dto49i3yV7hKoGYBZZoHz/XJmPjlhZlvVyMFULF3Ca8zg+sUubxDsEoxHgiOqYPgKtrnwtSDfaH2/iCDzo18sQ=="
   }, {
     "groupId" : "org.springframework",
     "artifactId" : "spring-orm",

--- a/dependencies-lock.json
+++ b/dependencies-lock.json
@@ -33,14 +33,6 @@
     "integrity" : "sha512:P7sy4EBGDXhLcZPUsS3xCkperUfAmQV/AJpOV9VLTudj9qt42wVGzUSTSX1GqrCBtyTz+7iF4wmpCi6dXnTuhQ=="
   }, {
     "groupId" : "ca.uhn.hapi.fhir",
-    "artifactId" : "hapi-fhir-structures-dstu2",
-    "version" : "6.10.5",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:dvDZ+0AGbT8G/IyHLgIK4WdosfJB2XBHNTAkPfijL260i1Y+uhr0WJKikH+Zx8HlCdwZ0NZ6M7VM6kcBE27aeA=="
-  }, {
-    "groupId" : "ca.uhn.hapi.fhir",
     "artifactId" : "hapi-fhir-structures-dstu3",
     "version" : "6.10.5",
     "scope" : "compile",
@@ -169,14 +161,6 @@
     "integrity" : "sha512:kGAn8E5VII/duD6uY/Elj64QAQfijpy9Z2qNS99znBh9P5v6nLNyEc5KC3LzZQHeMAzYgG4fSwO8O9mDA7laOw=="
   }, {
     "groupId" : "cglib",
-    "artifactId" : "cglib-nodep",
-    "version" : "3.3.0",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:+qHSEh6HrmnheeOq4heszQg04Npxa5GgKf1SbhkmEucWdfJ0C+30jiPvHtxF9nKivhs+eLv7GtWclt09L+7tug=="
-  }, {
-    "groupId" : "cglib",
     "artifactId" : "cglib",
     "version" : "2.2.2",
     "scope" : "compile",
@@ -226,11 +210,11 @@
   }, {
     "groupId" : "com.fasterxml.jackson.datatype",
     "artifactId" : "jackson-datatype-jsr310",
-    "version" : "2.19.2",
+    "version" : "2.15.3",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:0QzuKuiPt3Dik5PtntjT1qLLsgDPZejLAV1iqAdntWDeChOjJe8GfF2Mhn/Ad+/H2buXc0DKw2JuL5ZKOpwOJg=="
+    "integrity" : "sha512:HFvebJGiqJ88HyMfThfENQY9kBK6u/y6UJo7JTY7H9mfDc1CNPHgBVnkPT3I5scYNCgscvLr8VSErpAHVMXXVw=="
   }, {
     "groupId" : "com.fasterxml.jackson.jaxrs",
     "artifactId" : "jackson-jaxrs-base",
@@ -401,14 +385,6 @@
     "integrity" : "sha512:UV+Mfq1Qz+xkGu2cgUL0f9N9PVkjBijDwhghzRaItamQ9pVlmEpNAwqnFOuFY55m3Oi6YdzBoQk2KYXrzNvMtQ=="
   }, {
     "groupId" : "com.github.scribejava",
-    "artifactId" : "scribejava-apis",
-    "version" : "8.3.3",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:lLEza8HPLUwJiAihUOXImG2NImnjSwW5V5xa7Oo4MvqzaQc8zIw1JXEitKlwtZ66a7SY6SYV6B+gHUUmi8VVKw=="
-  }, {
-    "groupId" : "com.github.scribejava",
     "artifactId" : "scribejava-core",
     "version" : "8.3.3",
     "scope" : "compile",
@@ -543,30 +519,6 @@
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:k8jO0QMHnJwgWpF6c1nn5ga8E6GsaZo2jDPwZWK6nTVoWa7i/OE3DT5vMwkx0vROptpnFABOnJ1Mm7R5JRD8Ag=="
-  }, {
-    "groupId" : "com.microsoft.playwright",
-    "artifactId" : "driver-bundle",
-    "version" : "1.40.0",
-    "scope" : "test",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:agROXmL2hH8Rzp3HMeoaESr0OE1qCX3yZCzj1yIY67YOew65EbdoH8eFSZfRSKv++dSW9Nn2Z8qXPpoxYI5QuQ=="
-  }, {
-    "groupId" : "com.microsoft.playwright",
-    "artifactId" : "driver",
-    "version" : "1.40.0",
-    "scope" : "test",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:Bx2BbMFbviEofoqyuU7P4Okf9wg1IB26dQPgSaxfBgpgt8eJ63KS9MKf6me4lI8XityepIFf4lyl7ZTk8/Z57w=="
-  }, {
-    "groupId" : "com.microsoft.playwright",
-    "artifactId" : "playwright",
-    "version" : "1.40.0",
-    "scope" : "test",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:Pz7iBFzXb6MNVlG1zUjxlNI5MlS1w03dvnMtDt8+Vub1w6llHSZye1NqGu5v+jRJng4EPJbMu6/gGsVuylbNxw=="
   }, {
     "groupId" : "com.mysql",
     "artifactId" : "mysql-connector-j",
@@ -856,14 +808,6 @@
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:Uccvmsp3JvPDhwleZr6Fpt+Xx0sAolQ0uJGIwbjqtuK1Wsz3ub1BJDDSK9CTJN7AduMAs9H6OfzK1HHw8qPaFg=="
-  }, {
-    "groupId" : "commons-configuration",
-    "artifactId" : "commons-configuration",
-    "version" : "1.10",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:zH/dfXvRhRtI0QiDdm+snXKwQHcUs8ZTNpEw4yJL3Rmky5QfuBPd4ejH0puwelsaRNYRJA6tFxflGhWjHJYw+A=="
   }, {
     "groupId" : "commons-digester",
     "artifactId" : "commons-digester",
@@ -1257,14 +1201,6 @@
     "optional" : false,
     "integrity" : "sha512:4au63KYDxrIDNSxBLUrkUATz+DPhsjZmQRYSICBGbc2Gj2q5ZTrb4ZB5R5V8zR7faGqV0qYX6UhPr1+nqf9kSw=="
   }, {
-    "groupId" : "net.sourceforge.serp",
-    "artifactId" : "serp",
-    "version" : "1.15.1",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:XLrAyogt9NN4GXOZ69bE4crUKMER6+xw6m0qbGSYXI1DlKpWr6fOW9Qxp2wppKuSI4Wk7BnXbAO5nvMS5IJSZQ=="
-  }, {
     "groupId" : "ognl",
     "artifactId" : "ognl",
     "version" : "3.3.5",
@@ -1336,14 +1272,6 @@
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:7kPFE6ydy9fdI7XLtOpfZaLhDN+7QD0IC4fneLO0UGIxVSIpfEHspRSpqUYiitdlDwpXLVt47/uCYN2AhBMZiA=="
-  }, {
-    "groupId" : "org.apache.commons",
-    "artifactId" : "commons-compress",
-    "version" : "1.28.0",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:8fFA9PQKs88yZZGdudu5WmMaKap4TjBfKR3k5oh2u3EdkhfWLXk3zd3dOTmC3s33GmCLSzq39OY3XPKK8ok9fw=="
   }, {
     "groupId" : "org.apache.commons",
     "artifactId" : "commons-csv",
@@ -1945,30 +1873,6 @@
     "optional" : false,
     "integrity" : "sha512:pToK7Wki1tHzfnjL3hbyqY29Q/cZgpOpYMdh4sbwrEVncKniHKZN1GCmYS0Lrp002Q7yGkqa6Ale1Gd6C1IJ6w=="
   }, {
-    "groupId" : "org.apache.geronimo.specs",
-    "artifactId" : "geronimo-jms_1.1_spec",
-    "version" : "1.1.1",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:lMuGYHdVlrKY25PhH9uyjSpYKxYfem1mfUGUb1nosRSqgOFcKMQYbwW0P0MrGsVV2EWthwMJYJICOCw/YGHjGQ=="
-  }, {
-    "groupId" : "org.apache.geronimo.specs",
-    "artifactId" : "geronimo-jpa_2.2_spec",
-    "version" : "1.1",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:mytw5JAr9n8979XakR3YguXhs+DEoXswS+Uh5Lsw+EnNVu7ZaR86/8H0hAkaKBOavhLzveQKiHa4s4OEPp/g2w=="
-  }, {
-    "groupId" : "org.apache.geronimo.specs",
-    "artifactId" : "geronimo-jta_1.1_spec",
-    "version" : "1.1.1",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:7hD5Qu2nGZpSKqCDitacm1gRdYC9YBhbTAG/xDkT/UhRVLGz1Dewo2HRvtihiXTIT1vfHLJ+2bwY/jP7pNjx+A=="
-  }, {
     "groupId" : "org.apache.httpcomponents.client5",
     "artifactId" : "httpclient5",
     "version" : "5.4.4",
@@ -2064,14 +1968,6 @@
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:bu6I1zsvMcd4r4O7bEQ94lIHNjbd0RIZwZQ3cS2WlZdc1qq/612Lw15nNtChnbR3YQ+cjdrlgh6RTenIW+wvMQ=="
-  }, {
-    "groupId" : "org.apache.openjpa",
-    "artifactId" : "openjpa",
-    "version" : "3.2.2",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:fxElSgQRT4+AeHo9UAqy7TgJjDrLDs1O0BtvTnfVpiqnUHnDLB7IYeDZ5oPNuoDP9/5iSNMr72C+tj7Phah8TQ=="
   }, {
     "groupId" : "org.apache.pdfbox",
     "artifactId" : "fontbox",
@@ -2192,14 +2088,6 @@
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:lz8NdizrBojcKX4DZqqdY/lksn2CKY3ZXV9pi9upoCkg7V+MXBdNE+yciYpx+oaKyn0gFSNEPZ3m+He4o1rFog=="
-  }, {
-    "groupId" : "org.apache.xbean",
-    "artifactId" : "xbean-asm9-shaded",
-    "version" : "4.20",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:k+b5dZYwerV9DC4Eankdza6HA11mSI+0fS3ZjIiERutDGxL0W9nMiHLfhDhG2uK4iHgGaWnpw+N5IqPw34hLwQ=="
   }, {
     "groupId" : "org.apache.xmlbeans",
     "artifactId" : "xmlbeans",
@@ -2408,22 +2296,6 @@
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:YzoMOWvAGIPWxp28U9qYB4TYg31xsJuFnRVxylo7YI5s8km6wEV1pvM0mPyS2Nbu1yAOSax2irDVsNKyvy2Lhg=="
-  }, {
-    "groupId" : "org.codehaus.janino",
-    "artifactId" : "commons-compiler",
-    "version" : "3.1.12",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:zY7Os8nNKE9LOAMhurtfoLB+tEN2hn9QHH4lO/yWvYx/K2D8BJ3yHummwJIlraGCjJ+JIoRtkEMvZPT7EEur3g=="
-  }, {
-    "groupId" : "org.codehaus.janino",
-    "artifactId" : "janino",
-    "version" : "3.1.12",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:9hmz5sUSJ1s8GLyeMEwvWUfXZV0RhKdzAM/+6SmA1C8fQ8y2aSyl4zQDEnuOQdpZT2md3wfw6bAkNXmkNfEgJA=="
   }, {
     "groupId" : "org.codehaus.jettison",
     "artifactId" : "jettison",
@@ -3081,14 +2953,6 @@
     "optional" : false,
     "integrity" : "sha512:DW9IfOyQ7JMfzwFeQnWNkKy8BW2rILzLiJc3Ml/HRD7l7zvlHQKBQO9CQxNWLTfu0Kvnlfr7u1oWrjPpQ/EElg=="
   }, {
-    "groupId" : "org.opentest4j",
-    "artifactId" : "opentest4j",
-    "version" : "1.2.0",
-    "scope" : "test",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:F/d3l6Jg6yvRZmqQ4l78eaVBOvqd8cHLbEzRlJ1hw4skHjuyCVY5a19U0URyAwPXKirAC8W/JFomCjwwmeAcdA=="
-  }, {
     "groupId" : "org.ow2.asm",
     "artifactId" : "asm",
     "version" : "9.9",
@@ -3296,14 +3160,6 @@
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:oLJBpSJVMilWLLrVNjahJpw4uAYn+8gLeT8HfqsfmlIjKBLxHCTaC/mSvUJy1fZZZTfihnXkt5HlmTpBY2H+VQ=="
-  }, {
-    "groupId" : "org.springframework.integration",
-    "artifactId" : "spring-integration-sftp",
-    "version" : "5.5.20",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:iaT6kwrl9YzfGRLBSstbB1Hx6dZDlnpEgjYNB870k2ERc5z7DDFClTdvqyOa+1vFo6GCSVVW0uHAWOKiFK2AxQ=="
   }, {
     "groupId" : "org.springframework.retry",
     "artifactId" : "spring-retry",

--- a/pom.xml
+++ b/pom.xml
@@ -327,11 +327,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
-            <artifactId>commons-compress</artifactId>
-            <version>1.28.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.18.0</version>
         </dependency>
@@ -491,18 +486,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.integration</groupId>
-            <artifactId>spring-integration-sftp</artifactId>
-            <version>5.5.20</version>
-            <exclusions>
-                <exclusion>
-                    <!-- Exclude old jcraft JSch in favor of maintained mwiede fork -->
-                    <groupId>com.jcraft</groupId>
-                    <artifactId>jsch</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
         <!-- throws 10 compilation errors when removed/commented -->
         <dependency>
             <groupId>org.springframework</groupId>
@@ -524,12 +507,6 @@
                     <artifactId>cglib</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <!-- cglib-nodep to replace old cglib 2.2.2 and eliminate ASM conflicts -->
-        <dependency>
-            <groupId>cglib</groupId>
-            <artifactId>cglib-nodep</artifactId>
-            <version>3.3.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.springframework.security/spring-security-crypto -->
         <dependency>
@@ -705,12 +682,6 @@
             <version>2.19.2</version>
         </dependency>
 
-        <!-- Jackson Java 8 Date/Time support -->
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.19.2</version>
-        </dependency>
 
         <!-- Jackson JAXB annotations support - provides JaxbAnnotationIntrospector used in Spring configs -->
         <dependency>
@@ -864,14 +835,6 @@
             <version>1.17.2</version>
         </dependency>
 
-        <!-- janino - Updated to 3.x now that Drools has been upgraded to 7.x -->
-        <!-- Drools 7.x uses its own internal compiler (ecj), but janino may still be -->
-        <!-- used by other runtime components (e.g., JasperReports, Spring expression evaluation) -->
-        <dependency>
-            <groupId>org.codehaus.janino</groupId>
-            <artifactId>janino</artifactId>
-            <version>3.1.12</version>
-        </dependency>
 
 
         <dependency>
@@ -1112,12 +1075,7 @@
             <version>${cxf.version}</version>
         </dependency> -->
 
-        <!-- ScribeJava OAuth 1.0a dependencies. Added after apache cxf was bumped to version 3.5.10 and lost support. -->
-        <dependency>
-            <groupId>com.github.scribejava</groupId>
-            <artifactId>scribejava-apis</artifactId>
-            <version>8.3.3</version>
-        </dependency>
+        <!-- ScribeJava OAuth 1.0a core. Added after apache cxf was bumped to version 3.5.10 and lost support. -->
         <dependency>
             <groupId>com.github.scribejava</groupId>
             <artifactId>scribejava-core</artifactId>
@@ -1173,14 +1131,14 @@
                     <groupId>commons-lang</groupId>
                     <artifactId>commons-lang</artifactId>
                 </exclusion>
+                <!-- CVE-2025-46392: Only used by ESAPI AccessControlRule classes, not by ClickjackFilter -->
+                <exclusion>
+                    <groupId>commons-configuration</groupId>
+                    <artifactId>commons-configuration</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
-        <dependency>
-            <groupId>org.jasypt</groupId>
-            <artifactId>jasypt</artifactId>
-            <version>1.9.3</version>
-        </dependency>
         <!-- Apache Commons Exec - used by ExternalEDocConverter -->
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -1286,13 +1244,6 @@
             </exclusions>
         </dependency>
 
-        <!-- Playwright for UI/smoke testing -->
-        <dependency>
-            <groupId>com.microsoft.playwright</groupId>
-            <artifactId>playwright</artifactId>
-            <version>1.40.0</version>
-            <scope>test</scope>
-        </dependency>
         <!-- https://mvnrepository.com/artifact/com.google.guava/guava -->
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -1308,14 +1259,6 @@
         </dependency>
 
 
-        <!-- This is a dependency for the Caisi Integrator Objects. Only required until
-        OpenJPA is no longer needed in Integrator. -->
-        <!-- Detected as "Unused dependency" but don't remove it, it's using actually -->
-        <dependency>
-            <groupId>org.apache.openjpa</groupId>
-            <artifactId>openjpa</artifactId>
-            <version>3.2.2</version>
-        </dependency>
 
         <!-- HAPI FHIR -->
         <!-- can be found in the local_repo folder -->
@@ -1333,11 +1276,6 @@
                     <artifactId>jcl-over-slf4j</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>ca.uhn.hapi.fhir</groupId>
-            <artifactId>hapi-fhir-structures-dstu2</artifactId>
-            <version>${hapifhir.version}</version>
         </dependency>
         <!-- Detected as "Unused dependency" but don't remove it, it's using actually -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -336,14 +336,7 @@
             <version>1.12.0</version>
         </dependency>
         <!-- commons-beanutils removed: migrated to Spring BeanUtils (Phase 1 of issue #2202) -->
-        <!-- Added higher version to avoid security issue, suggested by GitHub Dependabot -->
-        <!-- https://mvnrepository.com/artifact/commons-net/commons-net -->
-        <dependency>
-            <groupId>commons-net</groupId>
-            <artifactId>commons-net</artifactId>
-            <version>3.12.0</version>
-        </dependency>
-        
+
         <!-- Added higher version to avoid security issue, suggested by GitHub Dependabot -->
         <!-- https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient -->
         <dependency>
@@ -417,22 +410,12 @@
         </dependency>
         <dependency>
             <groupId>ca.uhn.hapi</groupId>
-            <artifactId>hapi-structures-v21</artifactId>
-            <version>1.0.1</version>
-        </dependency>
-        <dependency>
-            <groupId>ca.uhn.hapi</groupId>
             <artifactId>hapi-structures-v22</artifactId>
             <version>1.0.1</version>
         </dependency>
         <dependency>
             <groupId>ca.uhn.hapi</groupId>
             <artifactId>hapi-structures-v23</artifactId>
-            <version>1.0.1</version>
-        </dependency>
-        <dependency>
-            <groupId>ca.uhn.hapi</groupId>
-            <artifactId>hapi-structures-v24</artifactId>
             <version>1.0.1</version>
         </dependency>
         <dependency>
@@ -472,19 +455,6 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
             <version>5.3.39</version>
-        </dependency>
-        <!-- throws an compilation error when removed/commented -->
-        <dependency>
-            <groupId>org.springframework.integration</groupId>
-            <artifactId>spring-integration-ftp</artifactId>
-            <version>5.5.20</version>
-            <exclusions>
-                <!-- Excluded this low version to avoid triggering security issue -->
-                <exclusion>
-                    <groupId>commons-net</groupId>
-                    <artifactId>commons-net</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <!-- throws 10 compilation errors when removed/commented -->
         <dependency>

--- a/src/main/resources/applicationContextORN.xml
+++ b/src/main/resources/applicationContextORN.xml
@@ -1,19 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tx="http://www.springframework.org/schema/tx"
-	xmlns:int-ftp="http://www.springframework.org/schema/integration/ftp"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd http://www.springframework.org/schema/integration/ftp
-	http://www.springframework.org/schema/integration/ftp/spring-integration-ftp.xsd"
-       default-autowire="no"> -->
-
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:tx="http://www.springframework.org/schema/tx"
-       xmlns:int-ftp="http://www.springframework.org/schema/integration/ftp"
        xsi:schemaLocation="
            http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-           http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd
-           http://www.springframework.org/schema/integration/ftp http://www.springframework.org/schema/integration/ftp/spring-integration-ftp.xsd"
+           http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd"
        default-autowire="no">
 
 


### PR DESCRIPTION
### **User description**
## Summary

- Remove 14 verified-unused Maven dependencies, reducing attack surface and build size
- Clean stale `xmlns:int-ftp` namespace from `applicationContextORN.xml`
- Update both dependency lock files

## Dependencies Removed

### Round 1 — Zero imports, no transitive consumers

| # | Dependency | Version | Evidence |
|---|-----------|---------|----------|
| 1 | `commons-compress` | 1.28.0 | Zero imports anywhere, top-level only |
| 2 | `spring-integration-sftp` | 5.5.20 | Zero usage; SFTP uses JSch directly |
| 3 | `cglib-nodep` | 3.3.0 | Zero `net.sf.cglib` imports; Spring 5 bundles its own CGLIB |
| 4 | `jackson-datatype-jsr310` | 2.19.2 | Zero `JavaTimeModule` usage |
| 5 | `janino` | 3.1.12 | Zero usage; log4j2 not logback; Drools 7 uses ECJ |
| 6 | `scribejava-apis` | 8.3.3 | Only `scribejava-core` imported (3 files); `-apis` provides unused 3rd-party providers |
| 7 | `jasypt` | 1.9.3 | Zero `org.jasypt` imports; migrated to Spring Security Crypto |
| 8 | `openjpa` | 3.2.2 | Zero imports; CAISI Integrator removed; stale pom comment |
| 9 | `hapi-fhir-structures-dstu2` | 6.10.5 | Zero DSTU2 references; only DSTU3 is used |
| 10 | `playwright` (test) | 1.40.0 | Zero `com.microsoft.playwright` imports |

### Round 2 — Orphaned after round 1 + independently unused

| # | Dependency | Version | Evidence |
|---|-----------|---------|----------|
| 11 | `commons-net` | 3.12.0 | Zero `org.apache.commons.net` references anywhere |
| 12 | `spring-integration-ftp` | 5.5.20 | Zero code usage; XML namespace declared but zero elements used |
| 13 | `hapi-structures-v21` | 1.0.1 | Only in `/* */` comments; v2.1 handler was already disabled |
| 14 | `hapi-structures-v24` | 1.0.1 | Only in `/* */` comments; v2.4 handler was already disabled |

## Companion cleanup

- `applicationContextORN.xml`: Removed stale `xmlns:int-ftp` namespace declaration and `spring-integration-ftp.xsd` schema location (zero `<int-ftp:*>` elements existed)

## Verification

- `mvn dependency:tree` confirms no orphaned transitives
- `mvn dependency:analyze` shows no new unused entries
- Full build + deploy passes (`make install`)
- Lock files regenerated (`make lock`)

## Test plan

- [x] `make install` — full compilation and WAR deployment
- [x] `make lock` — both lock files updated and validated
- [x] `mvn dependency:tree` — clean tree, no orphans
- [x] `mvn dependency:analyze` — no new unused declared deps
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **Description**
- Removed 14 verified unused Maven dependencies, reducing attack surface and build size.
- Cleaned stale `xmlns:int-ftp` namespace from `applicationContextORN.xml`.
- Updated both dependency lock files.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dependencies-lock-modern.json</strong><dd><code>Clean up and update Maven dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dependencies-lock-modern.json
<li>Removed 14 unused Maven dependencies.<br> <li> Updated dependency versions for <code>jackson-datatype-jsr310</code> and <br><code>opentest4j</code>.<br> <li> Cleaned up orphaned dependencies.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/461/files#diff-1472f999235657abcd3a220fef24a1a1a4bfdcd834722e6ee710499c3e8d4e24">+4/-212</a>&nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>dependencies-lock.json</strong><dd><code>Clean up and update Maven dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dependencies-lock.json
<li>Removed 14 unused Maven dependencies.<br> <li> Updated dependency versions for <code>jackson-datatype-jsr310</code> and <br><code>opentest4j</code>.<br> <li> Cleaned up orphaned dependencies.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/461/files#diff-9d6d26515ff9f0c84acf583c24af9ae33c3959c487518980183cf3515799afcb">+2/-218</a>&nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>pom.xml</strong><dd><code>Update and clean up project dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pom.xml
<li>Removed unused dependencies from the project.<br> <li> Updated dependency versions for better security and compatibility.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/461/files#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8">+7/-99</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>applicationContextORN.xml</strong><dd><code>Clean up XML namespace in application context</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/resources/applicationContextORN.xml
- Cleaned stale `xmlns:int-ftp` namespace.



</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/461/files#diff-cdcf23a9b31dc4e9c44c74ae34a7b8b679fb86ac205e64bea292bed314f44e48">+1/-10</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced automated CKD (Chronic Kidney Disease) screening that runs on a scheduled basis.

* **Improvements**
  * Removed legacy FHIR structure support and deprecated FTP/SFTP integration functionality.
  * Strengthened security by eliminating outdated and vulnerable dependencies.

* **Chores**
  * Cleaned up dependency management and streamlined project configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->