### PR TITLE
HOTFIX ViewMessage.jsp the bots keep insisting on encoding a number

### DIFF
--- a/src/main/webapp/messenger/ViewMessage.jsp
+++ b/src/main/webapp/messenger/ViewMessage.jsp
@@ -674,7 +674,7 @@ function fmtOscarMsg() {
 									    }
 									}
 
-                                    String demoKeyJs = Encode.forJavaScript((String) pageContext.getAttribute("demographicNumber"));
+                                    String demoKeyJs = Encode.forJavaScript((String) (pageContext.getAttribute("demographicNumber")+""));
                                     %>
                                     <a href="javascript:popupViewAttach(700,960,'../demographic/demographiccontrol.jsp?demographic_no=<%=demoKeyJs%>&displaymode=edit&dboperation=search_detail')"><fmt:message key="global.M" /></a>
                                     <a href="javascript:void(0)" onclick="popupViewAttach(700,960,'../oscarEncounter/IncomingEncounter.do?demographicNo=<%=demoKeyJs%>&curProviderNo=<%=Encode.forJavaScript((String)session.getAttribute("providerNo"))%><%=Encode.forJavaScript(params)%>');return false;"><fmt:message key="global.E" /></a>


### PR DESCRIPTION
### **User description**
... and Tomcat keeps throwing a 500 when the resultant code tries to encode an Integer. This simple hack keeps the bots quiet and the page working

<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description

<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues

<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?

<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->

## Checklist

- [ ] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [ ] I have not included any patient data (PHI) in this PR
- [ ] I have added tests for new functionality, or this change doesn't need new tests
- [ ] I have read the [contributing guide](CONTRIBUTING.md)


___

### **Description**
- Fixed a bug where encoding an `Integer` for JavaScript caused a 500 error in Tomcat.
- Updated the encoding logic in `ViewMessage.jsp` to ensure proper handling of `demographicNumber`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ViewMessage.jsp</strong><dd><code>Fix JavaScript Encoding Issue for Demographic Number</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/webapp/messenger/ViewMessage.jsp
<li>Modified the way <code>demographicNumber</code> is encoded for JavaScript.<br> <li> Appended an empty string to <code>demographicNumber</code> to prevent encoding <br>errors.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/462/files#diff-9f0dd86b4e6c24183feaf5ea711e6f07ea8701a094254f35e511726a2b7e5d23">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness when handling missing demographic data to prevent potential application errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->