### PR TITLE
feat: add sending provider name to email chart notes

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/email/util/EmailNoteUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/email/util/EmailNoteUtil.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 
 import io.github.carlos_emr.carlos.casemgmt.model.ProviderExt;
@@ -302,7 +303,7 @@ public class EmailNoteUtil {
     }
 
     private void addSentByLine(StringBuilder noteBuilder) {
-        String dateTime = DateUtils.format(SENT_DATE_FORMAT, emailLog.getTimestamp(), null);
+        String dateTime = DateUtils.format(SENT_DATE_FORMAT, emailLog.getTimestamp(), Locale.ENGLISH);
         String displayName = resolveProviderDisplayName();
         noteBuilder.append("\n\n[Sent on ").append(dateTime);
         if (!displayName.isBlank()) {

--- a/src/main/java/io/github/carlos_emr/carlos/email/util/EmailNoteUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/email/util/EmailNoteUtil.java
@@ -6,11 +6,15 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 
+import io.github.carlos_emr.carlos.casemgmt.model.ProviderExt;
+import io.github.carlos_emr.carlos.commn.dao.ProviderExtDao;
 import io.github.carlos_emr.carlos.commn.model.EFormData;
 import io.github.carlos_emr.carlos.commn.model.EmailAttachment;
 import io.github.carlos_emr.carlos.commn.model.EmailLog;
 import io.github.carlos_emr.carlos.commn.model.EmailLog.ChartDisplayOption;
+import io.github.carlos_emr.carlos.commn.model.Provider;
 import io.github.carlos_emr.carlos.documentManager.EDoc;
 import io.github.carlos_emr.carlos.documentManager.EDocUtil;
 import io.github.carlos_emr.carlos.hospitalReportManager.HRMUtil;
@@ -58,10 +62,12 @@ public class EmailNoteUtil {
     private LoggedInInfo loggedInInfo;
     private String DATE_FORMAT = "yyyy.MM.dd";
     private String TIME_FORMAT = "hh:mm a";
+    private static final String SENT_DATE_FORMAT = "dd-MMM-yyyy H:mm";
 
     private CommonLabResultData commonLabResultData;
     private EformDataManager eFormDataManager = SpringUtils.getBean(EformDataManager.class);
     private FormsManager formsManager = SpringUtils.getBean(FormsManager.class);
+    private ProviderExtDao providerExtDao = SpringUtils.getBean(ProviderExtDao.class);
 
     /**
      * Private default constructor to prevent instantiation without required parameters.
@@ -119,6 +125,7 @@ public class EmailNoteUtil {
         addAttachments(emailLog, noteBuilder);
         addEncryptedBody(emailLog, noteBuilder);
         addTechnicalInformation(emailLog, noteBuilder);
+        addSentByLine(noteBuilder);
         addInternalComment(emailLog, noteBuilder);
         return noteBuilder.toString();
     }
@@ -292,6 +299,27 @@ public class EmailNoteUtil {
 
         noteBuilder.append("\n\n").append("***Internal Comment***").append("\n\n");
         noteBuilder.append(emailLog.getInternalComment());
+    }
+
+    private void addSentByLine(StringBuilder noteBuilder) {
+        String dateTime = DateUtils.format(SENT_DATE_FORMAT, emailLog.getTimestamp(), null);
+        String displayName = resolveProviderDisplayName();
+        noteBuilder.append("\n\n[Sent on ").append(dateTime);
+        if (!displayName.isBlank()) {
+            noteBuilder.append(" by ").append(displayName);
+        }
+        noteBuilder.append("]");
+    }
+
+    private String resolveProviderDisplayName() {
+        Provider provider = loggedInInfo.getLoggedInProvider();
+        if (provider == null) return "";
+        ProviderExt pe = providerExtDao.find(provider.getProviderNo());
+        return Optional.ofNullable(pe)
+            .map(ProviderExt::getSignature)
+            .filter(sig -> !sig.isBlank())
+            .map(String::trim)
+            .orElseGet(provider::getFullName);
     }
 
     private String getRecipientEmail() {


### PR DESCRIPTION
### **User description**
Port of openo-beta/open-o PR #2308 by D3V41 (Deval Italiya).

Appends a "[Sent on DD-MMM-YYYY H:mm by Provider Name]" line to email
chart notes after the technical information section. The provider display
name is resolved from ProviderExt signature (preferred) or falls back to
the provider's full name. When no provider is available, the "by" clause
is omitted to prevent malformed output.

Adapted for carlos namespace (io.github.carlos_emr.carlos.*) and
existing API signatures.

Generated with Claude Code


___

### **Description**
- Introduced a new feature to append a "[Sent on DD-MMM-YYYY H:mm by Provider Name]" line to email chart notes.
- The provider display name is resolved from `ProviderExt` signature or falls back to the provider's full name.
- If no provider is available, the "by" clause is omitted to prevent malformed output.
- Adapted for the `carlos` namespace and existing API signatures.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>EmailNoteUtil.java</strong><dd><code>Enhance Email Notes with Provider Name and Timestamp</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/io/github/carlos_emr/carlos/email/util/EmailNoteUtil.java
<li>Added a method to append the sent date and provider name to email <br>chart notes.<br> <li> Implemented logic to resolve provider display name from <code>ProviderExt</code> or <br>fallback to full name.<br> <li> Updated the <code>createNote</code> method to include the new sent by line.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/497/files#diff-7325fd06975510545af975f4fd4ec31d46b764448b21acb3aaabc75514403fb2">+28/-0</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Email notes now include a dedicated line displaying sender identification with timestamp in the format "Sent on [date] by [sender name/provider]".
  * System prioritizes showing the provider's configured signature when available; falls back to displaying the full provider name as an alternative.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->