### PR TITLE
fix: disable resizing on all eForm textarea elements

### DIFF
--- a/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
+++ b/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
@@ -7,6 +7,7 @@ document.addEventListener("DOMContentLoaded", function(){
     removeElements();
     hideElements();
     addNavElement();
+    disableTextareaResize();
     moveSubjectReverse();
 
     // Add eForm attachments
@@ -835,6 +836,21 @@ function HideSpin() {
 	jQuery(window).on('load', function() {
 		appendImageInputs();
 	})
+
+	/**
+	 * Disables resizing on all textarea elements to prevent content from being
+	 * truncated during PDF generation.
+	 */
+	function disableTextareaResize() {
+		if (document.getElementById("eform-disable-textarea-resize")) {
+			return;
+		}
+
+		const style = document.createElement("style");
+		style.id = "eform-disable-textarea-resize";
+		style.textContent = "textarea { resize: none !important; }";
+		document.head.appendChild(style);
+	}
 
 	function handleEmailPrivilege() {
 		// Get the value of the element with ID 'hasEmailPrivilege'


### PR DESCRIPTION
### **User description**
Bootstrap's default CSS applies resize: vertical to all textareas,
allowing users to expand them beyond intended dimensions. When eForms
convert to PDF via "Add to Documents", content outside original
boundaries gets truncated, causing data loss.

Inject a global CSS rule (textarea { resize: none !important; }) via
the eForm floating toolbar on page load. Uses an idempotent pattern
with an element ID guard check to prevent duplicate style injection.

Ported from openo-beta/open-o PR #2309.
Original author: LiamStanziani




___

### **Description**
- Introduced a new function `disableTextareaResize` to prevent users from resizing textareas.
- This change addresses content truncation issues when eForms are converted to PDF.
- The global CSS rule `textarea { resize: none !important; }` is injected on page load.
- The implementation ensures that the style is only added once using an ID guard check.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>eform_floating_toolbar.js</strong><dd><code>Disable Textarea Resizing for eForms</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
<li>Added a function to disable resizing of all textarea elements.<br> <li> Injected a global CSS rule to prevent content truncation during PDF <br>generation.<br> <li> Implemented an idempotent pattern to avoid duplicate style injection.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/498/files#diff-894fc39649d9be8c6207db59938b58289f5c93e88d3a8d6fa45818fea51ec346">+16/-0</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved textarea content truncation issues during PDF document generation, ensuring all content is properly preserved and exported
  * Enhanced application stability by adding preventative validation checks to email privilege handling, reducing the risk of unexpected errors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->