### PR TITLE
feat: sort active medications to top of eChart medication list

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/encounter/pageUtil/EctDisplayRx2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/pageUtil/EctDisplayRx2Action.java
@@ -39,11 +39,15 @@ import io.github.carlos_emr.carlos.util.StringUtils;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.Locale;
 
 public class EctDisplayRx2Action extends EctDisplayAction {
     private String cmd = "Rx";
+
+    public static final Comparator<Prescription> ACTIVE_FIRST =
+        Comparator.comparingInt(drug -> isActiveDrug(drug) ? 0 : 1);
 
     public boolean getInfo(EctSessionBean bean, HttpServletRequest request, NavBarDisplayDAO Dao) {
 
@@ -78,6 +82,11 @@ public class EctDisplayRx2Action extends EctDisplayAction {
 
             CppPreferencesUIBean prefsBean = new CppPreferencesUIBean(loggedInInfo.getLoggedInProviderNo());
             prefsBean.loadValues();
+
+            // Sort active medications to the top of the list, preserving
+            // relative order within each group (stable sort).
+            // Lower value = sorted higher in the list (0 = active first, 1 = non-active after).
+            uniqueDrugs.sort(ACTIVE_FIRST);
 
             long now = System.currentTimeMillis();
             long month = 1000L * 60L * 60L * 24L * 30L;
@@ -153,7 +162,7 @@ public class EctDisplayRx2Action extends EctDisplayAction {
             sb.append("expireInReference ");
         }
 
-        if ((drug.isCurrent() && !drug.isArchived()) || drug.isLongTerm()) {
+        if (isActiveDrug(drug)) {
             sb.append("currentDrug ");
         }
 
@@ -188,6 +197,26 @@ public class EctDisplayRx2Action extends EctDisplayAction {
 
     }
 
+
+    /**
+     * Determines whether a prescription is considered active for display purposes.
+     *
+     * <p>A drug is active if it is current and not archived, or if it is long-term.
+     * This definition is shared between the medication sort order ({@link #ACTIVE_FIRST})
+     * and the CSS class assignment in {@link #getClassColour}.</p>
+     *
+     * <p><b>Note:</b> This method does not filter archived long-term drugs — it will
+     * return {@code true} for a drug that is long-term even if archived. In
+     * {@link #getInfo}, archived drugs are pre-filtered before sort and display.
+     * If moving this to a utility class, additional checks (e.g. {@code !drug.isArchived()})
+     * would be needed for standalone use.</p>
+     *
+     * @param drug Prescription the prescription to evaluate
+     * @return boolean {@code true} if the drug is considered active
+     */
+    public static boolean isActiveDrug(Prescription drug) {
+        return (drug.isCurrent() && !drug.isArchived()) || drug.isLongTerm();
+    }
 
     public String getCmd() {
         return cmd;

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/pageUtil/EctDisplayRx2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/pageUtil/EctDisplayRx2Action.java
@@ -207,9 +207,10 @@ public class EctDisplayRx2Action extends EctDisplayAction {
      *
      * <p><b>Note:</b> This method does not filter archived long-term drugs — it will
      * return {@code true} for a drug that is long-term even if archived. In
-     * {@link #getInfo}, archived drugs are pre-filtered before sort and display.
-     * If moving this to a utility class, additional checks (e.g. {@code !drug.isArchived()})
-     * would be needed for standalone use.</p>
+     * {@link #getInfo}, archived drugs are filtered during iteration <em>after</em>
+     * the {@code uniqueDrugs.sort(ACTIVE_FIRST)} call and are therefore not displayed.
+     * If using this method in other contexts, additional checks (for example,
+     * {@code !drug.isArchived()}) may be required to exclude archived items.</p>
      *
      * @param drug Prescription the prescription to evaluate
      * @return boolean {@code true} if the drug is considered active

--- a/src/test-modern/java/io/github/carlos_emr/carlos/encounter/pageUtil/EctDisplayRx2ActionSortTest.java
+++ b/src/test-modern/java/io/github/carlos_emr/carlos/encounter/pageUtil/EctDisplayRx2ActionSortTest.java
@@ -1,0 +1,170 @@
+package io.github.carlos_emr.carlos.encounter.pageUtil;
+
+import io.github.carlos_emr.carlos.prescript.data.RxPrescriptionData.Prescription;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for the medication sort logic in {@link EctDisplayRx2Action}.
+ *
+ * <p>Verifies that active medications (current and not archived, or long-term)
+ * are sorted above non-active medications, and that relative order within
+ * each group is preserved by the stable sort.</p>
+ *
+ * @since 2026-02-25
+ */
+@DisplayName("EctDisplayRx2Action - Medication Sort")
+@Tag("unit")
+@Tag("fast")
+@Tag("encounter")
+public class EctDisplayRx2ActionSortTest {
+
+    private static final Comparator<Prescription> ACTIVE_FIRST =
+        EctDisplayRx2Action.ACTIVE_FIRST;
+
+    private static Date daysFromNow(int days) {
+        Calendar cal = Calendar.getInstance();
+        cal.add(Calendar.DATE, days);
+        return cal.getTime();
+    }
+
+    private static Prescription activeDrug(int id) {
+        Prescription p = new Prescription(id, "1", 1);
+        p.setEndDate(daysFromNow(90));
+        return p;
+    }
+
+    private static Prescription expiredDrug(int id) {
+        Prescription p = new Prescription(id, "1", 1);
+        p.setEndDate(daysFromNow(-30));
+        return p;
+    }
+
+    private static Prescription longTermDrug(int id) {
+        Prescription p = new Prescription(id, "1", 1);
+        p.setLongTerm(true);
+        return p;
+    }
+
+    private static Prescription archivedDrug(int id) {
+        Prescription p = new Prescription(id, "1", 1);
+        p.setEndDate(daysFromNow(90));
+        p.setArchived("true");
+        return p;
+    }
+
+    @Test
+    @DisplayName("Active medications should appear before expired ones")
+    void shouldSortActiveDrugsFirst_whenMixedWithExpired() {
+        Prescription expired1 = expiredDrug(3);
+        Prescription active1 = activeDrug(2);
+        Prescription expired2 = expiredDrug(1);
+
+        List<Prescription> drugs = new ArrayList<>(List.of(expired1, active1, expired2));
+        drugs.sort(ACTIVE_FIRST);
+
+        assertThat(drugs).containsExactly(active1, expired1, expired2);
+    }
+
+    @Test
+    @DisplayName("Long-term medications should appear at the top")
+    void shouldSortLongTermDrugsFirst_whenMixedWithExpired() {
+        Prescription expired = expiredDrug(3);
+        Prescription longTerm = longTermDrug(2);
+
+        List<Prescription> drugs = new ArrayList<>(List.of(expired, longTerm));
+        drugs.sort(ACTIVE_FIRST);
+
+        assertThat(drugs).containsExactly(longTerm, expired);
+    }
+
+    @Test
+    @DisplayName("Relative order within each group should be preserved")
+    void shouldPreserveRelativeOrder_whenMultipleDrugsInSameGroup() {
+        Prescription active1 = activeDrug(10);
+        Prescription active2 = activeDrug(5);
+        Prescription expired1 = expiredDrug(8);
+        Prescription expired2 = expiredDrug(3);
+
+        List<Prescription> drugs = new ArrayList<>(List.of(active1, expired1, active2, expired2));
+        drugs.sort(ACTIVE_FIRST);
+
+        assertThat(drugs).containsExactly(active1, active2, expired1, expired2);
+    }
+
+    @Test
+    @DisplayName("All active drugs should remain in original order")
+    void shouldNotReorder_whenAllDrugsAreActive() {
+        Prescription a1 = activeDrug(3);
+        Prescription a2 = activeDrug(2);
+        Prescription a3 = activeDrug(1);
+
+        List<Prescription> drugs = new ArrayList<>(List.of(a1, a2, a3));
+        drugs.sort(ACTIVE_FIRST);
+
+        assertThat(drugs).containsExactly(a1, a2, a3);
+    }
+
+    @Test
+    @DisplayName("All expired drugs should remain in original order")
+    void shouldNotReorder_whenAllDrugsAreExpired() {
+        Prescription e1 = expiredDrug(3);
+        Prescription e2 = expiredDrug(2);
+        Prescription e3 = expiredDrug(1);
+
+        List<Prescription> drugs = new ArrayList<>(List.of(e1, e2, e3));
+        drugs.sort(ACTIVE_FIRST);
+
+        assertThat(drugs).containsExactly(e1, e2, e3);
+    }
+
+    @Test
+    @DisplayName("Empty list should not throw")
+    void shouldHandleEmptyList_whenNoDrugsPresent() {
+        List<Prescription> drugs = new ArrayList<>();
+        drugs.sort(ACTIVE_FIRST);
+
+        assertThat(drugs).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Archived drugs should sort below active drugs")
+    void shouldSortArchivedBelow_whenMixedWithActive() {
+        Prescription archived = archivedDrug(3);
+        Prescription active = activeDrug(2);
+
+        List<Prescription> drugs = new ArrayList<>(List.of(archived, active));
+        drugs.sort(ACTIVE_FIRST);
+
+        assertThat(drugs).containsExactly(active, archived);
+    }
+
+    @Test
+    @DisplayName("Mixed active, long-term, and expired should group correctly")
+    void shouldGroupCorrectly_whenAllTypesPresent() {
+        Prescription expired = expiredDrug(5);
+        Prescription longTerm = longTermDrug(4);
+        Prescription active = activeDrug(3);
+        Prescription archived = archivedDrug(2);
+
+        List<Prescription> drugs = new ArrayList<>(List.of(expired, longTerm, active, archived));
+        drugs.sort(ACTIVE_FIRST);
+
+        // longTerm and active are both "active" — should come first, in original relative order
+        assertThat(drugs.indexOf(longTerm)).isLessThan(drugs.indexOf(expired));
+        assertThat(drugs.indexOf(active)).isLessThan(drugs.indexOf(expired));
+        assertThat(drugs.indexOf(longTerm)).isLessThan(drugs.indexOf(archived));
+        assertThat(drugs.indexOf(active)).isLessThan(drugs.indexOf(archived));
+        // Relative order within active group preserved: longTerm came before active in input
+        assertThat(drugs.indexOf(longTerm)).isLessThan(drugs.indexOf(active));
+    }
+}


### PR DESCRIPTION
### **User description**
Port of openo-beta/open-o#2307 by LiamStanziani.

Active medications (current and not archived, or long-term) now display
above expired/inactive ones in the eChart Medications tab. This improves
clinical usability by letting providers quickly find current prescriptions
without scrolling through expired entries.

Changes:
- Add ACTIVE_FIRST comparator with stable sort on uniqueDrugs list
- Extract isActiveDrug() helper shared by sort and getClassColour()
- Add 8 unit tests covering sort order, stability, and edge cases

https://claude.ai/code/session_011sjsotiSK6vrW5vHX2zf5U


___

### **Description**
- Introduced a new comparator `ACTIVE_FIRST` to sort active medications above expired ones in the eChart.
- Added a helper method `isActiveDrug()` to determine if a medication is active.
- Implemented unit tests to validate the sorting logic and ensure stability of order.
- Improved clinical usability by allowing providers to quickly identify current prescriptions.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>EctDisplayRx2Action.java</strong><dd><code>Enhance medication sorting logic in EctDisplayRx2Action</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/io/github/carlos_emr/carlos/encounter/pageUtil/EctDisplayRx2Action.java
<li>Added <code>ACTIVE_FIRST</code> comparator for sorting medications.<br> <li> Implemented <code>isActiveDrug()</code> helper method for determining active <br>status.<br> <li> Updated medication sorting logic to prioritize active medications.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/500/files#diff-8ef90d310c71d3b847a1769c665f546a142d2e7d8b6bfbe446993264b37f7c09">+30/-1</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>EctDisplayRx2ActionSortTest.java</strong><dd><code>Add unit tests for medication sorting logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test-modern/java/io/github/carlos_emr/carlos/encounter/pageUtil/EctDisplayRx2ActionSortTest.java
<li>Added unit tests for medication sorting functionality.<br> <li> Verified sorting behavior for active, expired, and long-term <br>medications.<br> <li> Ensured stability of sort order within medication groups.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/500/files#diff-a06238d0e51b145b74348f1c9536c207456fc84e6ad5b8c62226cf2284be87c6">+170/-0</a>&nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Prescriptions are now automatically sorted with active medications displayed first in the encounter view. This includes current non-archived treatments and long-term prescriptions, with expired and archived medications listed below, enhancing visibility of current patient treatments for faster clinical review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->