### PR TITLE
appointmentFormsLinks.jspf added tags for O19 compatibility

### DIFF
--- a/src/main/webapp/provider/appointmentFormsLinks.jspf
+++ b/src/main/webapp/provider/appointmentFormsLinks.jspf
@@ -9,6 +9,7 @@
 <%@page import="io.github.carlos_emr.carlos.daos.ProviderDAO"%>
 <%@page import="io.github.carlos_emr.carlos.utility.SpringUtils"%>
 <%@page import="org.owasp.encoder.Encode"%>
+<%@page import="java.net.URLEncoder"%>
 
 <%
 	LoggedInInfo loggedInInfo3=LoggedInInfo.getLoggedInInfoFromSession(request);
@@ -47,11 +48,11 @@
 			{
 				String trimmedLinkName = AppointmentProviderAdminDayUIBean.getLengthLimitedLinkName(loggedInInfo3, formNameTemp);
 				String url = request.getContextPath()
-						+ "/form/forwardshortcutname.do?formname=" + formNameTemp
-						+ "&demographic_no=" + (demographic_no != null ? demographic_no : "")
-						+ "&appointmentNo=" + (appointment_no != null ? appointment_no : "");
+						+ "/form/forwardshortcutname.do?formname=" + URLEncoder.encode(formNameTemp, "UTF-8")
+						+ "&demographic_no=" + (demographic_no != null ? URLEncoder.encode(demographic_no, "UTF-8") : "")
+						+ "&appointmentNo=" + (appointment_no != null ? URLEncoder.encode(appointment_no, "UTF-8") : "");
 				%>
-					|<a href=# onClick='popupPage2("<%=Encode.forHtmlAttribute(url)%>")' title='<%=Encode.forHtmlAttribute(formNameTemp)%>'><%=Encode.forHtmlContent(trimmedLinkName)%></a>
+					|<a href=# onClick='popupPage2("<%=Encode.forJavaScriptAttribute(url)%>")' title='<%=Encode.forHtmlAttribute(formNameTemp)%>'><%=Encode.forHtmlContent(trimmedLinkName)%></a>
 				<%
 			}
 
@@ -69,7 +70,7 @@
 						+ "&demographic_no=" + (demographic_no != null ? demographic_no : "")
 						+ "&appointment=" + (appointment_no != null ? appointment_no : "");
 				%>
-					|<a href=# onClick='popupPage2("<%=Encode.forHtmlAttribute(url)%>")' title='<%=Encode.forHtmlAttribute(eForm.getFormName())%>'><%=Encode.forHtmlContent(trimmedLinkName)%></a>
+					|<a href=# onClick='popupPage2("<%=Encode.forJavaScriptAttribute(url)%>")' title='<%=Encode.forHtmlAttribute(eForm.getFormName())%>'><%=Encode.forHtmlContent(trimmedLinkName)%></a>
 				<%
 			}
 		}
@@ -92,18 +93,18 @@
 			url = url.replace("${demographicId}", demographic_no != null ? demographic_no : "");
 			url = url.replace("${appointmentId}", appointment_no != null ? appointment_no : "");
 			url = url.replace("${providerId}", providerPreference.getProviderNo() != null ? providerPreference.getProviderNo() : "");
-			url = url.replace("${providerOhip}", provider != null && provider.getOhipNo() != null ? provider.getOhipNo().trim() : "");
-			url = url.replace("${demographicHin}", demographic != null && demographic.getHin() != null ? demographic.getHin().trim() : "");
-			url = url.replace("${demographicVer}", demographic != null && demographic.getVer() != null ? demographic.getVer().trim() : "");
+			url = url.replace("${providerOhip}", provider != null && provider.getOhipNo() != null ? URLEncoder.encode(provider.getOhipNo().trim(), "UTF-8") : "");
+			url = url.replace("${demographicHin}", demographic != null && demographic.getHin() != null ? URLEncoder.encode(demographic.getHin().trim(), "UTF-8") : "");
+			url = url.replace("${demographicVer}", demographic != null && demographic.getVer() != null ? URLEncoder.encode(demographic.getVer().trim(), "UTF-8") : "");
 
 			if (hinExposed) {
 				String warningTitle = "WARNING-The health number is exposed in " + quickLink.getName();
 				%>
-				|<a href=# onClick='popupPage2("<%=Encode.forHtmlAttribute(url)%>")' title='<%=Encode.forHtmlAttribute(warningTitle)%>' style='background-color:red;color:white;'><%=Encode.forHtmlContent(trimmedLinkName)%></a>
+				|<a href=# onClick='popupPage2("<%=Encode.forJavaScriptAttribute(url)%>")' title='<%=Encode.forHtmlAttribute(warningTitle)%>' style='background-color:red;color:white;'><%=Encode.forHtmlContent(trimmedLinkName)%></a>
 				<%
 			} else {
 				%>
-				|<a href=# onClick='popupPage2("<%=Encode.forHtmlAttribute(url)%>")' title='<%=Encode.forHtmlAttribute(quickLink.getName())%>'><%=Encode.forHtmlContent(trimmedLinkName)%></a>
+				|<a href=# onClick='popupPage2("<%=Encode.forJavaScriptAttribute(url)%>")' title='<%=Encode.forHtmlAttribute(quickLink.getName())%>'><%=Encode.forHtmlContent(trimmedLinkName)%></a>
 				<%
 			}
 		}

--- a/src/main/webapp/provider/appointmentFormsLinks.jspf
+++ b/src/main/webapp/provider/appointmentFormsLinks.jspf
@@ -71,6 +71,10 @@
 			{
 				Integer eFormIdTemp = eFormLink.getAppointmentScreenEForm();
 				EForm eForm=AppointmentProviderAdminDayUIBean.getEForms(eFormIdTemp);
+				if (eForm == null) {
+					org.apache.commons.logging.LogFactory.getLog("appointmentFormsLinks").debug("EForm not found for ID: " + eFormIdTemp);
+					continue;
+				}
 				String trimmedEscapedLinkName=StringEscapeUtils.escapeHtml4(AppointmentProviderAdminDayUIBean.getLengthLimitedLinkName(loggedInInfo3, eForm.getFormName()));
 				// Same JS-in-HTML-attribute encoding fix as forms above.
 				String eformUrl = request.getContextPath() + "/eform/efmformadd_data.jsp?fid=" + eFormIdTemp

--- a/src/main/webapp/provider/appointmentFormsLinks.jspf
+++ b/src/main/webapp/provider/appointmentFormsLinks.jspf
@@ -98,11 +98,11 @@
 			if (hinExposed) {
 				String warningTitle=StringEscapeUtils.escapeHtml4("WARNING-The health number is exposed in " + quickLink.getName());
 				%>
-				|<a href=# onClick='popupPage2("<%=escapedLinkUrl%>")' title='<%=warningTitle%>' style='background-color:red;color:white;'><%=trimmedEscapedLinkName%></a>
+				|<a href="javascript:void(0)" onClick='popupPage2("<%=escapedLinkUrl%>")' title='<%=warningTitle%>' style='background-color:red;color:white;'><%=trimmedEscapedLinkName%></a>
 				<%
 			} else {
 				%>
-				|<a href=# onClick='popupPage2("<%=escapedLinkUrl%>")' title='<%=escapedLinkName%>'><%=trimmedEscapedLinkName%></a>
+				|<a href="javascript:void(0)" onClick='popupPage2("<%=escapedLinkUrl%>")' title='<%=escapedLinkName%>'><%=trimmedEscapedLinkName%></a>
 				<%
 			}
 		}

--- a/src/main/webapp/provider/appointmentFormsLinks.jspf
+++ b/src/main/webapp/provider/appointmentFormsLinks.jspf
@@ -11,6 +11,7 @@
 <%@page import="io.github.carlos_emr.carlos.commn.model.Provider"%>
 <%@page import="io.github.carlos_emr.carlos.daos.ProviderDAO"%>
 <%@page import="io.github.carlos_emr.carlos.utility.SpringUtils"%>
+<%@page import="org.owasp.encoder.Encode"%>
 
 <%
 	LoggedInInfo loggedInInfo3=LoggedInInfo.getLoggedInInfoFromSession(request);
@@ -75,8 +76,7 @@
 			if (linkUrl == null) {
 				linkUrl = "";
 			}
-			// Unescape any HTML entities stored in the URL (e.g. &amp; → &) before substitution,
-			// then re-escape for HTML output after — prevents double-encoding.
+			// Unescape any HTML entities stored in the URL (e.g. &amp; → &) before substitution.
 			linkUrl = StringEscapeUtils.unescapeHtml4(linkUrl);
 
 			// Split "$" + "{...}" to prevent JSP EL parser from misidentifying these as EL expressions
@@ -92,17 +92,22 @@
 			escapedLinkUrl = escapedLinkUrl.replaceAll("\\$\\{providerOhip\\}", Matcher.quoteReplacement(provider != null ? StringUtils.trimToEmpty(provider.getOhipNo()) : ""));
 			escapedLinkUrl = escapedLinkUrl.replaceAll("\\$\\{demographicHin\\}", Matcher.quoteReplacement(demographic != null ? StringUtils.trimToEmpty(demographic.getHin()) : ""));
 			escapedLinkUrl = escapedLinkUrl.replaceAll("\\$\\{demographicVer\\}", Matcher.quoteReplacement(demographic != null ? StringUtils.trimToEmpty(demographic.getVer()) : ""));
-			escapedLinkUrl = StringEscapeUtils.escapeHtml4(escapedLinkUrl);
+			// Encode for JavaScript string inside HTML attribute context: hex-encodes JS special chars
+			// (e.g. " -> \x22, ' -> \x27) so they cannot break out of the JS string even after HTML
+			// attribute parsing. escapeHtml4() is NOT safe here because the browser decodes &quot; back
+			// to " before the JavaScript engine sees it, enabling JS string breakout (XSS).
+			String jsEncodedLinkUrl = Encode.forJavaScriptAttribute(escapedLinkUrl);
 
-			String escapedLinkName=StringEscapeUtils.escapeHtml4(quickLink.getName());
+			// Title attribute values use HTML attribute encoding (also encodes single quotes).
+			String escapedLinkName = Encode.forHtmlAttribute(quickLink.getName());
 			if (hinExposed) {
-				String warningTitle=StringEscapeUtils.escapeHtml4("WARNING-The health number is exposed in " + quickLink.getName());
+				String warningTitle = Encode.forHtmlAttribute("WARNING-The health number is exposed in " + quickLink.getName());
 				%>
-				|<a href="javascript:void(0)" onClick='popupPage2("<%=escapedLinkUrl%>")' title='<%=warningTitle%>' style='background-color:red;color:white;'><%=trimmedEscapedLinkName%></a>
+				|<a href="javascript:void(0)" onClick='popupPage2("<%=jsEncodedLinkUrl%>")' title='<%=warningTitle%>' style='background-color:red;color:white;'><%=trimmedEscapedLinkName%></a>
 				<%
 			} else {
 				%>
-				|<a href="javascript:void(0)" onClick='popupPage2("<%=escapedLinkUrl%>")' title='<%=escapedLinkName%>'><%=trimmedEscapedLinkName%></a>
+				|<a href="javascript:void(0)" onClick='popupPage2("<%=jsEncodedLinkUrl%>")' title='<%=escapedLinkName%>'><%=trimmedEscapedLinkName%></a>
 				<%
 			}
 		}

--- a/src/main/webapp/provider/appointmentFormsLinks.jspf
+++ b/src/main/webapp/provider/appointmentFormsLinks.jspf
@@ -1,5 +1,6 @@
 <%@page import="io.github.carlos_emr.carlos.web.AppointmentProviderAdminDayUIBean"%>
 <%@page import="java.util.Collection, java.util.Collections, java.util.List, java.util.ArrayList"%>
+<%@page import="java.util.regex.Matcher"%>
 <%@page import="org.apache.commons.text.StringEscapeUtils"%>
 <%@page import="org.apache.commons.lang3.StringUtils"%>
 <%@page import="io.github.carlos_emr.carlos.commn.model.ProviderPreference"%>
@@ -16,6 +17,8 @@
 	ProviderPreference providerPreference = (ProviderPreference)request.getAttribute("providerPreference");
 	String demographic_no = request.getParameter("demographic_no");
 	String appointment_no = request.getParameter("appointment_no");
+	// When true, caller already renders forms/eforms inline — skip them here to avoid duplication
+	boolean skipFormsAndEforms = "true".equals(request.getParameter("skipFormsAndEforms"));
 	if (providerPreference!=null)
 	{
 		// Load provider and demographic for quick link placeholder substitution
@@ -24,7 +27,11 @@
 
 		Demographic demographic = null;
 		if (demographic_no != null && !demographic_no.isEmpty()) {
-			demographic = demographicDao.getDemographic(demographic_no);
+			try {
+				demographic = demographicDao.getDemographic(demographic_no);
+			} catch (Exception e) {
+				// demographic_no invalid or not found — leave demographic null
+			}
 		}
 
 		Provider provider = null;
@@ -32,29 +39,31 @@
 			provider = providerDAO.getProvider(providerPreference.getProviderNo());
 		}
 
-		Collection<String> formNames=providerPreference.getAppointmentScreenForms();
-		List<String>formNamesList = new ArrayList<String>(formNames);
-		Collections.sort(formNamesList);
+		if (!skipFormsAndEforms) {
+			Collection<String> formNames=providerPreference.getAppointmentScreenForms();
+			List<String>formNamesList = new ArrayList<String>(formNames);
+			Collections.sort(formNamesList);
 
-		for (String formNameTemp : formNamesList)
-		{
-			String trimmedEscapedLinkName=StringEscapeUtils.escapeHtml4(AppointmentProviderAdminDayUIBean.getLengthLimitedLinkName(loggedInInfo3, formNameTemp));
-			String escapedLinkName=StringEscapeUtils.escapeHtml4(formNameTemp);
-			%>
-				|<a href=# onClick='popupPage2("<%= request.getContextPath() %>/form/forwardshortcutname.do?formname=<%=escapedLinkName%>&amp;demographic_no=<%=demographic_no%>&amp;appointmentNo=<%=appointment_no%>")' title='<%=escapedLinkName%>'><%=trimmedEscapedLinkName%></a>
-			<%
-		}
+			for (String formNameTemp : formNamesList)
+			{
+				String trimmedEscapedLinkName=StringEscapeUtils.escapeHtml4(AppointmentProviderAdminDayUIBean.getLengthLimitedLinkName(loggedInInfo3, formNameTemp));
+				String escapedLinkName=StringEscapeUtils.escapeHtml4(formNameTemp);
+				%>
+					|<a href=# onClick='popupPage2("<%= request.getContextPath() %>/form/forwardshortcutname.do?formname=<%=escapedLinkName%>&amp;demographic_no=<%=demographic_no%>&amp;appointmentNo=<%=appointment_no%>")' title='<%=escapedLinkName%>'><%=trimmedEscapedLinkName%></a>
+				<%
+			}
 
-		Collection<ProviderPreference.EformLink> eFormLinks = providerPreference.getAppointmentScreenEForms();
-		for (ProviderPreference.EformLink eFormLink : eFormLinks)
-		{
-			Integer eFormIdTemp = eFormLink.getAppointmentScreenEForm();
-			EForm eForm=AppointmentProviderAdminDayUIBean.getEForms(eFormIdTemp);
-			String trimmedEscapedLinkName=StringEscapeUtils.escapeHtml4(AppointmentProviderAdminDayUIBean.getLengthLimitedLinkName(loggedInInfo3, eForm.getFormName()));
-			String escapedLinkName=StringEscapeUtils.escapeHtml4(eForm.getFormName());
-			%>
-				|<a href=# onClick='popupPage2("<%=request.getContextPath()%>/eform/efmformadd_data.jsp?fid=<%=eFormIdTemp%>&amp;demographic_no=<%=demographic_no%>&amp;appointment=<%=appointment_no%>")' title='<%=escapedLinkName%>'><%=trimmedEscapedLinkName%></a>
-			<%
+			Collection<ProviderPreference.EformLink> eFormLinks = providerPreference.getAppointmentScreenEForms();
+			for (ProviderPreference.EformLink eFormLink : eFormLinks)
+			{
+				Integer eFormIdTemp = eFormLink.getAppointmentScreenEForm();
+				EForm eForm=AppointmentProviderAdminDayUIBean.getEForms(eFormIdTemp);
+				String trimmedEscapedLinkName=StringEscapeUtils.escapeHtml4(AppointmentProviderAdminDayUIBean.getLengthLimitedLinkName(loggedInInfo3, eForm.getFormName()));
+				String escapedLinkName=StringEscapeUtils.escapeHtml4(eForm.getFormName());
+				%>
+					|<a href=# onClick='popupPage2("<%=request.getContextPath()%>/eform/efmformadd_data.jsp?fid=<%=eFormIdTemp%>&amp;demographic_no=<%=demographic_no%>&amp;appointment=<%=appointment_no%>")' title='<%=escapedLinkName%>'><%=trimmedEscapedLinkName%></a>
+				<%
+			}
 		}
 
 		Collection<ProviderPreference.QuickLink> quickLinks=providerPreference.getAppointmentScreenQuickLinks();
@@ -62,19 +71,28 @@
 		{
 			String trimmedEscapedLinkName=StringEscapeUtils.escapeHtml4(AppointmentProviderAdminDayUIBean.getLengthLimitedLinkName(loggedInInfo3, quickLink.getName()));
 
-			// Check before substitution whether HIN or version code will appear in the URL
 			String linkUrl=quickLink.getUrl();
-			boolean hinExposed = linkUrl.contains("${demographicHin}") || linkUrl.contains("${demographicVer}");
+			if (linkUrl == null) {
+				linkUrl = "";
+			}
+			// Unescape any HTML entities stored in the URL (e.g. &amp; → &) before substitution,
+			// then re-escape for HTML output after — prevents double-encoding.
+			linkUrl = StringEscapeUtils.unescapeHtml4(linkUrl);
 
-			String escapedLinkUrl=linkUrl;
-			escapedLinkUrl=escapedLinkUrl.replaceAll("\\$\\{contextPath\\}", request.getContextPath());
-			escapedLinkUrl=escapedLinkUrl.replaceAll("\\$\\{demographicId\\}", String.valueOf(demographic_no));
-			escapedLinkUrl=escapedLinkUrl.replaceAll("\\$\\{appointmentId\\}", String.valueOf(appointment_no));
-			escapedLinkUrl=escapedLinkUrl.replaceAll("\\$\\{providerId\\}", String.valueOf(providerPreference.getProviderNo()));
-			escapedLinkUrl=escapedLinkUrl.replaceAll("\\$\\{providerOhip\\}", provider != null ? StringUtils.trimToEmpty(provider.getOhipNo()) : "");
-			escapedLinkUrl=escapedLinkUrl.replaceAll("\\$\\{demographicHin\\}", demographic != null ? StringUtils.trimToEmpty(demographic.getHin()) : "");
-			escapedLinkUrl=escapedLinkUrl.replaceAll("\\$\\{demographicVer\\}", demographic != null ? StringUtils.trimToEmpty(demographic.getVer()) : "");
-			escapedLinkUrl=StringEscapeUtils.escapeHtml4(escapedLinkUrl);
+			// Split "$" + "{...}" to prevent JSP EL parser from misidentifying these as EL expressions
+			// Check before substitution whether HIN or version code will appear in the URL
+			boolean hinExposed = linkUrl.contains("$" + "{demographicHin}") || linkUrl.contains("$" + "{demographicVer}");
+
+			String escapedLinkUrl = linkUrl;
+			// Use Matcher.quoteReplacement() so that $ or \ in substituted values are treated as literals
+			escapedLinkUrl = escapedLinkUrl.replaceAll("\\$\\{contextPath\\}", Matcher.quoteReplacement(request.getContextPath()));
+			escapedLinkUrl = escapedLinkUrl.replaceAll("\\$\\{demographicId\\}", Matcher.quoteReplacement(demographic_no != null ? demographic_no : ""));
+			escapedLinkUrl = escapedLinkUrl.replaceAll("\\$\\{appointmentId\\}", Matcher.quoteReplacement(appointment_no != null ? appointment_no : ""));
+			escapedLinkUrl = escapedLinkUrl.replaceAll("\\$\\{providerId\\}", Matcher.quoteReplacement(providerPreference.getProviderNo() != null ? providerPreference.getProviderNo() : ""));
+			escapedLinkUrl = escapedLinkUrl.replaceAll("\\$\\{providerOhip\\}", Matcher.quoteReplacement(provider != null ? StringUtils.trimToEmpty(provider.getOhipNo()) : ""));
+			escapedLinkUrl = escapedLinkUrl.replaceAll("\\$\\{demographicHin\\}", Matcher.quoteReplacement(demographic != null ? StringUtils.trimToEmpty(demographic.getHin()) : ""));
+			escapedLinkUrl = escapedLinkUrl.replaceAll("\\$\\{demographicVer\\}", Matcher.quoteReplacement(demographic != null ? StringUtils.trimToEmpty(demographic.getVer()) : ""));
+			escapedLinkUrl = StringEscapeUtils.escapeHtml4(escapedLinkUrl);
 
 			String escapedLinkName=StringEscapeUtils.escapeHtml4(quickLink.getName());
 			if (hinExposed) {

--- a/src/main/webapp/provider/appointmentFormsLinks.jspf
+++ b/src/main/webapp/provider/appointmentFormsLinks.jspf
@@ -45,6 +45,11 @@
 			String escapedLinkUrl=quickLink.getUrl();
 			escapedLinkUrl=escapedLinkUrl.replaceAll("\\$\\{contextPath\\}", request.getContextPath());
 			escapedLinkUrl=escapedLinkUrl.replaceAll("\\$\\{demographicId\\}", String.valueOf(demographic_no));
+			escapedLinkUrl=escapedLinkUrl.replaceAll("\$\{appointmentId\}", String.valueOf(appointment_no));
+			escapedLinkUrl=escapedLinkUrl.replaceAll("\$\{providerId\}", String.valueOf(providerPreference.getProviderNo()));
+			escapedLinkUrl=escapedLinkUrl.replaceAll("\$\{providerOhip\}", StringUtils.trimToEmpty(provider.getOhipNo()));
+			escapedLinkUrl=escapedLinkUrl.replaceAll("\$\{demographicHin\}", StringUtils.trimToEmpty(demographic.getHin()));
+			escapedLinkUrl=escapedLinkUrl.replaceAll("\$\{demographicVer\}", StringUtils.trimToEmpty(demographic.getVer()));
 			escapedLinkUrl=StringEscapeUtils.escapeHtml4(escapedLinkUrl);
 			
 			String escapedLinkName=StringEscapeUtils.escapeHtml4(quickLink.getName());

--- a/src/main/webapp/provider/appointmentFormsLinks.jspf
+++ b/src/main/webapp/provider/appointmentFormsLinks.jspf
@@ -32,6 +32,7 @@
 				demographic = demographicDao.getDemographic(demographic_no);
 			} catch (Exception e) {
 				// demographic_no invalid or not found — leave demographic null
+				org.apache.commons.logging.LogFactory.getLog("appointmentFormsLinks").debug("Could not load demographic: " + demographic_no, e);
 			}
 		}
 
@@ -48,9 +49,20 @@
 			for (String formNameTemp : formNamesList)
 			{
 				String trimmedEscapedLinkName=StringEscapeUtils.escapeHtml4(AppointmentProviderAdminDayUIBean.getLengthLimitedLinkName(loggedInInfo3, formNameTemp));
-				String escapedLinkName=StringEscapeUtils.escapeHtml4(formNameTemp);
+				// Build the full URL as a Java string, then encode for the JS-in-HTML-attribute context.
+				// escapeHtml4() is NOT safe here: the browser decodes &quot; → " before the JS engine
+				// sees it, enabling JS string breakout (XSS). Encode.forJavaScriptAttribute() hex-encodes
+				// JS special chars so they survive HTML attribute parsing intact.
+				String formUrl = request.getContextPath() + "/form/forwardshortcutname.do?formname="
+						+ java.net.URLEncoder.encode(formNameTemp, "UTF-8")
+						+ "&demographic_no=" + (demographic_no != null ? demographic_no : "")
+						+ "&appointmentNo=" + (appointment_no != null ? appointment_no : "");
+				String jsEncodedFormUrl = Encode.forJavaScriptAttribute(formUrl);
+				// Encode.forHtmlAttribute() also encodes single quotes (escapeHtml4 does not),
+				// preventing attribute breakout when the title is single-quote-delimited.
+				String encodedFormTitle = Encode.forHtmlAttribute(formNameTemp);
 				%>
-					|<a href=# onClick='popupPage2("<%= request.getContextPath() %>/form/forwardshortcutname.do?formname=<%=escapedLinkName%>&amp;demographic_no=<%=demographic_no%>&amp;appointmentNo=<%=appointment_no%>")' title='<%=escapedLinkName%>'><%=trimmedEscapedLinkName%></a>
+					|<a href="javascript:void(0)" onClick='popupPage2("<%=jsEncodedFormUrl%>")' title='<%=encodedFormTitle%>'><%=trimmedEscapedLinkName%></a>
 				<%
 			}
 
@@ -60,9 +72,14 @@
 				Integer eFormIdTemp = eFormLink.getAppointmentScreenEForm();
 				EForm eForm=AppointmentProviderAdminDayUIBean.getEForms(eFormIdTemp);
 				String trimmedEscapedLinkName=StringEscapeUtils.escapeHtml4(AppointmentProviderAdminDayUIBean.getLengthLimitedLinkName(loggedInInfo3, eForm.getFormName()));
-				String escapedLinkName=StringEscapeUtils.escapeHtml4(eForm.getFormName());
+				// Same JS-in-HTML-attribute encoding fix as forms above.
+				String eformUrl = request.getContextPath() + "/eform/efmformadd_data.jsp?fid=" + eFormIdTemp
+						+ "&demographic_no=" + (demographic_no != null ? demographic_no : "")
+						+ "&appointment=" + (appointment_no != null ? appointment_no : "");
+				String jsEncodedEformUrl = Encode.forJavaScriptAttribute(eformUrl);
+				String encodedEformTitle = Encode.forHtmlAttribute(eForm.getFormName());
 				%>
-					|<a href=# onClick='popupPage2("<%=request.getContextPath()%>/eform/efmformadd_data.jsp?fid=<%=eFormIdTemp%>&amp;demographic_no=<%=demographic_no%>&amp;appointment=<%=appointment_no%>")' title='<%=escapedLinkName%>'><%=trimmedEscapedLinkName%></a>
+					|<a href="javascript:void(0)" onClick='popupPage2("<%=jsEncodedEformUrl%>")' title='<%=encodedEformTitle%>'><%=trimmedEscapedLinkName%></a>
 				<%
 			}
 		}

--- a/src/main/webapp/provider/appointmentFormsLinks.jspf
+++ b/src/main/webapp/provider/appointmentFormsLinks.jspf
@@ -1,9 +1,15 @@
 <%@page import="io.github.carlos_emr.carlos.web.AppointmentProviderAdminDayUIBean"%>
 <%@page import="java.util.Collection, java.util.Collections, java.util.List, java.util.ArrayList"%>
 <%@page import="org.apache.commons.text.StringEscapeUtils"%>
+<%@page import="org.apache.commons.lang3.StringUtils"%>
 <%@page import="io.github.carlos_emr.carlos.commn.model.ProviderPreference"%>
 <%@page import="io.github.carlos_emr.carlos.utility.LoggedInInfo"%>
 <%@page import="io.github.carlos_emr.carlos.commn.model.EForm"%>
+<%@page import="io.github.carlos_emr.carlos.commn.model.Demographic"%>
+<%@page import="io.github.carlos_emr.carlos.commn.dao.DemographicDao"%>
+<%@page import="io.github.carlos_emr.carlos.commn.model.Provider"%>
+<%@page import="io.github.carlos_emr.carlos.daos.ProviderDAO"%>
+<%@page import="io.github.carlos_emr.carlos.utility.SpringUtils"%>
 
 <%
 	LoggedInInfo loggedInInfo3=LoggedInInfo.getLoggedInInfoFromSession(request);
@@ -12,10 +18,24 @@
 	String appointment_no = request.getParameter("appointment_no");
 	if (providerPreference!=null)
 	{
+		// Load provider and demographic for quick link placeholder substitution
+		DemographicDao demographicDao = SpringUtils.getBean(DemographicDao.class);
+		ProviderDAO providerDAO = SpringUtils.getBean(ProviderDAO.class);
+
+		Demographic demographic = null;
+		if (demographic_no != null && !demographic_no.isEmpty()) {
+			demographic = demographicDao.getDemographic(demographic_no);
+		}
+
+		Provider provider = null;
+		if (providerPreference.getProviderNo() != null) {
+			provider = providerDAO.getProvider(providerPreference.getProviderNo());
+		}
+
 		Collection<String> formNames=providerPreference.getAppointmentScreenForms();
 		List<String>formNamesList = new ArrayList<String>(formNames);
 		Collections.sort(formNamesList);
-		
+
 		for (String formNameTemp : formNamesList)
 		{
 			String trimmedEscapedLinkName=StringEscapeUtils.escapeHtml4(AppointmentProviderAdminDayUIBean.getLengthLimitedLinkName(loggedInInfo3, formNameTemp));
@@ -24,7 +44,7 @@
 				|<a href=# onClick='popupPage2("<%= request.getContextPath() %>/form/forwardshortcutname.do?formname=<%=escapedLinkName%>&amp;demographic_no=<%=demographic_no%>&amp;appointmentNo=<%=appointment_no%>")' title='<%=escapedLinkName%>'><%=trimmedEscapedLinkName%></a>
 			<%
 		}
-		
+
 		Collection<ProviderPreference.EformLink> eFormLinks = providerPreference.getAppointmentScreenEForms();
 		for (ProviderPreference.EformLink eFormLink : eFormLinks)
 		{
@@ -41,21 +61,32 @@
 		for (ProviderPreference.QuickLink quickLink : quickLinks)
 		{
 			String trimmedEscapedLinkName=StringEscapeUtils.escapeHtml4(AppointmentProviderAdminDayUIBean.getLengthLimitedLinkName(loggedInInfo3, quickLink.getName()));
-			
-			String escapedLinkUrl=quickLink.getUrl();
+
+			// Check before substitution whether HIN or version code will appear in the URL
+			String linkUrl=quickLink.getUrl();
+			boolean hinExposed = linkUrl.contains("${demographicHin}") || linkUrl.contains("${demographicVer}");
+
+			String escapedLinkUrl=linkUrl;
 			escapedLinkUrl=escapedLinkUrl.replaceAll("\\$\\{contextPath\\}", request.getContextPath());
 			escapedLinkUrl=escapedLinkUrl.replaceAll("\\$\\{demographicId\\}", String.valueOf(demographic_no));
-			escapedLinkUrl=escapedLinkUrl.replaceAll("\$\{appointmentId\}", String.valueOf(appointment_no));
-			escapedLinkUrl=escapedLinkUrl.replaceAll("\$\{providerId\}", String.valueOf(providerPreference.getProviderNo()));
-			escapedLinkUrl=escapedLinkUrl.replaceAll("\$\{providerOhip\}", StringUtils.trimToEmpty(provider.getOhipNo()));
-			escapedLinkUrl=escapedLinkUrl.replaceAll("\$\{demographicHin\}", StringUtils.trimToEmpty(demographic.getHin()));
-			escapedLinkUrl=escapedLinkUrl.replaceAll("\$\{demographicVer\}", StringUtils.trimToEmpty(demographic.getVer()));
+			escapedLinkUrl=escapedLinkUrl.replaceAll("\\$\\{appointmentId\\}", String.valueOf(appointment_no));
+			escapedLinkUrl=escapedLinkUrl.replaceAll("\\$\\{providerId\\}", String.valueOf(providerPreference.getProviderNo()));
+			escapedLinkUrl=escapedLinkUrl.replaceAll("\\$\\{providerOhip\\}", provider != null ? StringUtils.trimToEmpty(provider.getOhipNo()) : "");
+			escapedLinkUrl=escapedLinkUrl.replaceAll("\\$\\{demographicHin\\}", demographic != null ? StringUtils.trimToEmpty(demographic.getHin()) : "");
+			escapedLinkUrl=escapedLinkUrl.replaceAll("\\$\\{demographicVer\\}", demographic != null ? StringUtils.trimToEmpty(demographic.getVer()) : "");
 			escapedLinkUrl=StringEscapeUtils.escapeHtml4(escapedLinkUrl);
-			
+
 			String escapedLinkName=StringEscapeUtils.escapeHtml4(quickLink.getName());
-			%>
+			if (hinExposed) {
+				String warningTitle=StringEscapeUtils.escapeHtml4("WARNING-The health number is exposed in " + quickLink.getName());
+				%>
+				|<a href=# onClick='popupPage2("<%=escapedLinkUrl%>")' title='<%=warningTitle%>' style='background-color:red;color:white;'><%=trimmedEscapedLinkName%></a>
+				<%
+			} else {
+				%>
 				|<a href=# onClick='popupPage2("<%=escapedLinkUrl%>")' title='<%=escapedLinkName%>'><%=trimmedEscapedLinkName%></a>
-			<%
+				<%
+			}
 		}
 	}
 %>

--- a/src/main/webapp/provider/appointmentFormsLinks.jspf
+++ b/src/main/webapp/provider/appointmentFormsLinks.jspf
@@ -67,8 +67,8 @@
 				}
 				String trimmedLinkName = AppointmentProviderAdminDayUIBean.getLengthLimitedLinkName(loggedInInfo3, eForm.getFormName());
 				String url = request.getContextPath() + "/eform/efmformadd_data.jsp?fid=" + eFormIdTemp
-						+ "&demographic_no=" + (demographic_no != null ? demographic_no : "")
-						+ "&appointment=" + (appointment_no != null ? appointment_no : "");
+						+ "&demographic_no=" + (demographic_no != null ? URLEncoder.encode(demographic_no, "UTF-8") : "")
+						+ "&appointment=" + (appointment_no != null ? URLEncoder.encode(appointment_no, "UTF-8") : "");
 				%>
 					|<a href=# onClick='popupPage2("<%=Encode.forJavaScriptAttribute(url)%>")' title='<%=Encode.forHtmlAttribute(eForm.getFormName())%>'><%=Encode.forHtmlContent(trimmedLinkName)%></a>
 				<%
@@ -90,9 +90,9 @@
 
 			// Replace tokens using String.replace() (literal substitution, no regex needed)
 			url = url.replace("${contextPath}", request.getContextPath());
-			url = url.replace("${demographicId}", demographic_no != null ? demographic_no : "");
-			url = url.replace("${appointmentId}", appointment_no != null ? appointment_no : "");
-			url = url.replace("${providerId}", providerPreference.getProviderNo() != null ? providerPreference.getProviderNo() : "");
+			url = url.replace("${demographicId}", demographic_no != null ? Encode.forUriComponent(demographic_no) : "");
+			url = url.replace("${appointmentId}", appointment_no != null ? Encode.forUriComponent(appointment_no) : "");
+			url = url.replace("${providerId}", providerPreference.getProviderNo() != null ? Encode.forUriComponent(providerPreference.getProviderNo()) : "");
 			url = url.replace("${providerOhip}", provider != null && provider.getOhipNo() != null ? URLEncoder.encode(provider.getOhipNo().trim(), "UTF-8") : "");
 			url = url.replace("${demographicHin}", demographic != null && demographic.getHin() != null ? URLEncoder.encode(demographic.getHin().trim(), "UTF-8") : "");
 			url = url.replace("${demographicVer}", demographic != null && demographic.getVer() != null ? URLEncoder.encode(demographic.getVer().trim(), "UTF-8") : "");

--- a/src/main/webapp/provider/appointmentFormsLinks.jspf
+++ b/src/main/webapp/provider/appointmentFormsLinks.jspf
@@ -1,8 +1,5 @@
 <%@page import="io.github.carlos_emr.carlos.web.AppointmentProviderAdminDayUIBean"%>
 <%@page import="java.util.Collection, java.util.Collections, java.util.List, java.util.ArrayList"%>
-<%@page import="java.util.regex.Matcher"%>
-<%@page import="org.apache.commons.text.StringEscapeUtils"%>
-<%@page import="org.apache.commons.lang3.StringUtils"%>
 <%@page import="io.github.carlos_emr.carlos.commn.model.ProviderPreference"%>
 <%@page import="io.github.carlos_emr.carlos.utility.LoggedInInfo"%>
 <%@page import="io.github.carlos_emr.carlos.commn.model.EForm"%>
@@ -48,21 +45,13 @@
 
 			for (String formNameTemp : formNamesList)
 			{
-				String trimmedEscapedLinkName=StringEscapeUtils.escapeHtml4(AppointmentProviderAdminDayUIBean.getLengthLimitedLinkName(loggedInInfo3, formNameTemp));
-				// Build the full URL as a Java string, then encode for the JS-in-HTML-attribute context.
-				// escapeHtml4() is NOT safe here: the browser decodes &quot; → " before the JS engine
-				// sees it, enabling JS string breakout (XSS). Encode.forJavaScriptAttribute() hex-encodes
-				// JS special chars so they survive HTML attribute parsing intact.
-				String formUrl = request.getContextPath() + "/form/forwardshortcutname.do?formname="
-						+ java.net.URLEncoder.encode(formNameTemp, "UTF-8")
+				String trimmedLinkName = AppointmentProviderAdminDayUIBean.getLengthLimitedLinkName(loggedInInfo3, formNameTemp);
+				String url = request.getContextPath()
+						+ "/form/forwardshortcutname.do?formname=" + formNameTemp
 						+ "&demographic_no=" + (demographic_no != null ? demographic_no : "")
 						+ "&appointmentNo=" + (appointment_no != null ? appointment_no : "");
-				String jsEncodedFormUrl = Encode.forJavaScriptAttribute(formUrl);
-				// Encode.forHtmlAttribute() also encodes single quotes (escapeHtml4 does not),
-				// preventing attribute breakout when the title is single-quote-delimited.
-				String encodedFormTitle = Encode.forHtmlAttribute(formNameTemp);
 				%>
-					|<a href="javascript:void(0)" onClick='popupPage2("<%=jsEncodedFormUrl%>")' title='<%=encodedFormTitle%>'><%=trimmedEscapedLinkName%></a>
+					|<a href=# onClick='popupPage2("<%=Encode.forHtmlAttribute(url)%>")' title='<%=Encode.forHtmlAttribute(formNameTemp)%>'><%=Encode.forHtmlContent(trimmedLinkName)%></a>
 				<%
 			}
 
@@ -75,15 +64,12 @@
 					org.apache.commons.logging.LogFactory.getLog("appointmentFormsLinks").debug("EForm not found for ID: " + eFormIdTemp);
 					continue;
 				}
-				String trimmedEscapedLinkName=StringEscapeUtils.escapeHtml4(AppointmentProviderAdminDayUIBean.getLengthLimitedLinkName(loggedInInfo3, eForm.getFormName()));
-				// Same JS-in-HTML-attribute encoding fix as forms above.
-				String eformUrl = request.getContextPath() + "/eform/efmformadd_data.jsp?fid=" + eFormIdTemp
+				String trimmedLinkName = AppointmentProviderAdminDayUIBean.getLengthLimitedLinkName(loggedInInfo3, eForm.getFormName());
+				String url = request.getContextPath() + "/eform/efmformadd_data.jsp?fid=" + eFormIdTemp
 						+ "&demographic_no=" + (demographic_no != null ? demographic_no : "")
 						+ "&appointment=" + (appointment_no != null ? appointment_no : "");
-				String jsEncodedEformUrl = Encode.forJavaScriptAttribute(eformUrl);
-				String encodedEformTitle = Encode.forHtmlAttribute(eForm.getFormName());
 				%>
-					|<a href="javascript:void(0)" onClick='popupPage2("<%=jsEncodedEformUrl%>")' title='<%=encodedEformTitle%>'><%=trimmedEscapedLinkName%></a>
+					|<a href=# onClick='popupPage2("<%=Encode.forHtmlAttribute(url)%>")' title='<%=Encode.forHtmlAttribute(eForm.getFormName())%>'><%=Encode.forHtmlContent(trimmedLinkName)%></a>
 				<%
 			}
 		}
@@ -91,44 +77,33 @@
 		Collection<ProviderPreference.QuickLink> quickLinks=providerPreference.getAppointmentScreenQuickLinks();
 		for (ProviderPreference.QuickLink quickLink : quickLinks)
 		{
-			String trimmedEscapedLinkName=StringEscapeUtils.escapeHtml4(AppointmentProviderAdminDayUIBean.getLengthLimitedLinkName(loggedInInfo3, quickLink.getName()));
+			String trimmedLinkName = AppointmentProviderAdminDayUIBean.getLengthLimitedLinkName(loggedInInfo3, quickLink.getName());
 
-			String linkUrl=quickLink.getUrl();
-			if (linkUrl == null) {
-				linkUrl = "";
+			String url = quickLink.getUrl();
+			if (url == null) {
+				url = "";
 			}
-			// Unescape any HTML entities stored in the URL (e.g. &amp; → &) before substitution.
-			linkUrl = StringEscapeUtils.unescapeHtml4(linkUrl);
 
-			// Split "$" + "{...}" to prevent JSP EL parser from misidentifying these as EL expressions
 			// Check before substitution whether HIN or version code will appear in the URL
-			boolean hinExposed = linkUrl.contains("$" + "{demographicHin}") || linkUrl.contains("$" + "{demographicVer}");
+			boolean hinExposed = url.contains("${demographicHin}") || url.contains("${demographicVer}");
 
-			String escapedLinkUrl = linkUrl;
-			// Use Matcher.quoteReplacement() so that $ or \ in substituted values are treated as literals
-			escapedLinkUrl = escapedLinkUrl.replaceAll("\\$\\{contextPath\\}", Matcher.quoteReplacement(request.getContextPath()));
-			escapedLinkUrl = escapedLinkUrl.replaceAll("\\$\\{demographicId\\}", Matcher.quoteReplacement(demographic_no != null ? demographic_no : ""));
-			escapedLinkUrl = escapedLinkUrl.replaceAll("\\$\\{appointmentId\\}", Matcher.quoteReplacement(appointment_no != null ? appointment_no : ""));
-			escapedLinkUrl = escapedLinkUrl.replaceAll("\\$\\{providerId\\}", Matcher.quoteReplacement(providerPreference.getProviderNo() != null ? providerPreference.getProviderNo() : ""));
-			escapedLinkUrl = escapedLinkUrl.replaceAll("\\$\\{providerOhip\\}", Matcher.quoteReplacement(provider != null ? StringUtils.trimToEmpty(provider.getOhipNo()) : ""));
-			escapedLinkUrl = escapedLinkUrl.replaceAll("\\$\\{demographicHin\\}", Matcher.quoteReplacement(demographic != null ? StringUtils.trimToEmpty(demographic.getHin()) : ""));
-			escapedLinkUrl = escapedLinkUrl.replaceAll("\\$\\{demographicVer\\}", Matcher.quoteReplacement(demographic != null ? StringUtils.trimToEmpty(demographic.getVer()) : ""));
-			// Encode for JavaScript string inside HTML attribute context: hex-encodes JS special chars
-			// (e.g. " -> \x22, ' -> \x27) so they cannot break out of the JS string even after HTML
-			// attribute parsing. escapeHtml4() is NOT safe here because the browser decodes &quot; back
-			// to " before the JavaScript engine sees it, enabling JS string breakout (XSS).
-			String jsEncodedLinkUrl = Encode.forJavaScriptAttribute(escapedLinkUrl);
+			// Replace tokens using String.replace() (literal substitution, no regex needed)
+			url = url.replace("${contextPath}", request.getContextPath());
+			url = url.replace("${demographicId}", demographic_no != null ? demographic_no : "");
+			url = url.replace("${appointmentId}", appointment_no != null ? appointment_no : "");
+			url = url.replace("${providerId}", providerPreference.getProviderNo() != null ? providerPreference.getProviderNo() : "");
+			url = url.replace("${providerOhip}", provider != null && provider.getOhipNo() != null ? provider.getOhipNo().trim() : "");
+			url = url.replace("${demographicHin}", demographic != null && demographic.getHin() != null ? demographic.getHin().trim() : "");
+			url = url.replace("${demographicVer}", demographic != null && demographic.getVer() != null ? demographic.getVer().trim() : "");
 
-			// Title attribute values use HTML attribute encoding (also encodes single quotes).
-			String escapedLinkName = Encode.forHtmlAttribute(quickLink.getName());
 			if (hinExposed) {
-				String warningTitle = Encode.forHtmlAttribute("WARNING-The health number is exposed in " + quickLink.getName());
+				String warningTitle = "WARNING-The health number is exposed in " + quickLink.getName();
 				%>
-				|<a href="javascript:void(0)" onClick='popupPage2("<%=jsEncodedLinkUrl%>")' title='<%=warningTitle%>' style='background-color:red;color:white;'><%=trimmedEscapedLinkName%></a>
+				|<a href=# onClick='popupPage2("<%=Encode.forHtmlAttribute(url)%>")' title='<%=Encode.forHtmlAttribute(warningTitle)%>' style='background-color:red;color:white;'><%=Encode.forHtmlContent(trimmedLinkName)%></a>
 				<%
 			} else {
 				%>
-				|<a href="javascript:void(0)" onClick='popupPage2("<%=jsEncodedLinkUrl%>")' title='<%=escapedLinkName%>'><%=trimmedEscapedLinkName%></a>
+				|<a href=# onClick='popupPage2("<%=Encode.forHtmlAttribute(url)%>")' title='<%=Encode.forHtmlAttribute(quickLink.getName())%>'><%=Encode.forHtmlContent(trimmedLinkName)%></a>
 				<%
 			}
 		}

--- a/src/main/webapp/provider/appointmentprovideradminday.jsp
+++ b/src/main/webapp/provider/appointmentprovideradminday.jsp
@@ -2289,6 +2289,7 @@
                                                             <jsp:include page="appointmentFormsLinks.jspf">
                                                                 <jsp:param name="demographic_no" value="${appointment.demographicNo}"/>
                                                                 <jsp:param name="appointment_no" value="${appointment.id}"/>
+                                                                <jsp:param name="skipFormsAndEforms" value="true"/>
                                                             </jsp:include>
                                                         </c:if>
 

--- a/src/main/webapp/provider/appointmentprovideradminday.jsp
+++ b/src/main/webapp/provider/appointmentprovideradminday.jsp
@@ -262,6 +262,7 @@
     pageContext.setAttribute("quickLinksList", quickLinkCollection);
     pageContext.setAttribute("formNamesList", formNamesList);
     pageContext.setAttribute("eFormsList", eFormIdCollection);
+    request.setAttribute("providerPreference", providerPreference);
 
     StringBuilder eformIds = new StringBuilder();
     for (ProviderPreference.EformLink eform : eFormIdCollection) {
@@ -2284,13 +2285,12 @@
                                                             <c:out value="${fn:substring(eform.eFormName, 0, truncateLimit)}"/>
                                                             </a>
                                                         </c:forEach>
-                                                        <c:forEach items="${quickLinksList}" var="quickLink">
-                                                            |<a href="javascript:void(0)" onClick='popupPage2("<c:out
-                                                                value="${quickLink.url}"/>")' title='<c:out
-                                                                value="${quickLink.name}"/>'>
-                                                            <c:out value="${fn:substring(quickLink.name, 0, truncateLimit)}"/>
-                                                            </a>
-                                                        </c:forEach>
+                                                        <c:if test="${not empty quickLinksList}">
+                                                            <jsp:include page="appointmentFormsLinks.jspf">
+                                                                <jsp:param name="demographic_no" value="${appointment.demographicNo}"/>
+                                                                <jsp:param name="appointment_no" value="${appointment.id}"/>
+                                                            </jsp:include>
+                                                        </c:if>
 
                                                         <oscar:oscarPropertiesCheck
                                                                 property="appt_pregnancy" value="true"

--- a/src/main/webapp/provider/providerpreference.jsp
+++ b/src/main/webapp/provider/providerpreference.jsp
@@ -679,7 +679,7 @@
                             <td>URL</td>
                             <td>
                                 <input type="text" name="quickLinkUrl" class="pref-input" style="max-width:200px">
-                                <span class="hint">(tokens: ${contextPath} ${demographicId})</span>
+                                <span class="hint">(tokens: &#36;{contextPath} &#36;{demographicId} &#36;{appointmentId} &#36;{providerId} &#36;{providerOhip} &#36;{demographicHin} &#36;{demographicVer})</span>
                             </td>
                         </tr>
                         <tr>


### PR DESCRIPTION
### **User description**
<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description
Adds tags for compatibility for migration from other OSCARs
<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues
Fixes #417 
<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?

<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Integrate a shared appointment forms/links fragment and expand quick link token support for provider preferences.

Enhancements:
- Replace inline quick link rendering in the appointment provider admin day view with inclusion of the shared appointment forms/links JSP fragment.
- Expose provider preferences on the request for use by the shared appointment forms/links fragment.
- Document additional supported tokens for quick link URLs in the provider preferences UI, including appointment and provider-related placeholders.


___

### **Description**
- Enhanced `appointmentFormsLinks.jspf` for better interoperability with OSCAR systems.
- Implemented null checks and improved link rendering logic to prevent errors.
- Added warnings for links that expose sensitive health information.
- Updated related JSP files to utilize the new link rendering logic.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>appointmentFormsLinks.jspf</strong><dd><code>Enhance appointment forms links for OSCAR compatibility</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/main/webapp/provider/appointmentFormsLinks.jspf
<li>Added imports for <code>Demographic</code>, <code>Provider</code>, and their DAOs.<br> <li> Implemented logic to load demographic and provider data.<br> <li> Enhanced quick link rendering with null checks and HTML escaping.<br> <li> Added warning for links exposing health information.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/513/files#diff-bf4cc58ff1ad0416afeb0d2c6fc5e9d9ae119468fbbe504d04371a0bb091c6ce">+85/-31</a>&nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>appointmentprovideradminday.jsp</strong><dd><code>Update quick links rendering in appointment provider admin day</code></dd></summary>
<hr>

src/main/webapp/provider/appointmentprovideradminday.jsp
<li>Replaced quick links rendering with a conditional include of <br><code>appointmentFormsLinks.jspf</code>.<br> <li> Passed parameters for demographic and appointment numbers.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/513/files#diff-f75048f3620da9a8aa96ad76eb74598e7d4a6e24ad79d327afb95e330a549a73">+8/-7</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>providerpreference.jsp</strong><dd><code>Update URL tokens hint in provider preferences</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/webapp/provider/providerpreference.jsp
<li>Updated hint for URL tokens to include new demographic and provider <br>tokens.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/513/files#diff-f4ad6779435f1c1e0a4596cacb4efd0046c262df6329fc963a9de990e7ea66c8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * More dynamic quick-link placeholders (appointment ID, provider ID/OHIP, demographic HIN/version).
  * Option to hide inline display of forms and eForms.
  * Provider preferences now show the expanded quick-link tokens hint.

* **Bug Fixes**
  * Safer quick-link processing with context-aware encoding to reduce XSS risk.
  * Visual warning for links that may expose demographic identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->