### PR TITLE
fix: fax service startup failure and hardcoded directory path

### DIFF
--- a/src/main/java/io/github/carlos_emr/OscarProperties.java
+++ b/src/main/java/io/github/carlos_emr/OscarProperties.java
@@ -522,7 +522,7 @@ public class OscarProperties extends Properties {
     public String getFaxIncomingDirectory() {
         String faxIncoming = oscarProperties.getProperty("FAX_INCOMING_DIR");
 
-        if (faxIncoming == null) {
+        if (faxIncoming == null || faxIncoming.trim().isEmpty()) {
             // Prefer BASE_DOCUMENT_DIR — same pattern as DOCUMENT_DIR and EFORM_IMAGES_DIR.
             // This directory is already configured, writable by the app server, and outside the webroot.
             String baseDocDir = oscarProperties.getProperty("BASE_DOCUMENT_DIR");

--- a/src/main/java/io/github/carlos_emr/OscarProperties.java
+++ b/src/main/java/io/github/carlos_emr/OscarProperties.java
@@ -526,16 +526,16 @@ public class OscarProperties extends Properties {
             // Prefer BASE_DOCUMENT_DIR — same pattern as DOCUMENT_DIR and EFORM_IMAGES_DIR.
             // This directory is already configured, writable by the app server, and outside the webroot.
             String baseDocDir = oscarProperties.getProperty("BASE_DOCUMENT_DIR");
-            if (baseDocDir != null && !baseDocDir.isEmpty()) {
-                faxIncoming = Paths.get(baseDocDir, "fax-incoming").toString();
+            if (baseDocDir != null && !baseDocDir.trim().isEmpty()) {
+                faxIncoming = Paths.get(baseDocDir.trim(), "fax-incoming").toString();
             } else {
                 // Fall back to catalina.base only if BASE_DOCUMENT_DIR is not set.
                 // NOTE: On Debian/Ubuntu package installs, catalina.base = /var/lib/tomcat9,
                 // which is a system directory the Tomcat process may not have write access to.
                 // Set FAX_INCOMING_DIR or BASE_DOCUMENT_DIR in carlos.properties to avoid this.
                 String catalinaBase = System.getProperty("catalina.base");
-                if (catalinaBase != null && !catalinaBase.isEmpty()) {
-                    faxIncoming = Paths.get(catalinaBase, "fax-incoming").toString();
+                if (catalinaBase != null && !catalinaBase.trim().isEmpty()) {
+                    faxIncoming = Paths.get(catalinaBase.trim(), "fax-incoming").toString();
                 } else {
                     // Non-Tomcat environment (tests, standalone): use system temp
                     faxIncoming = Paths.get(System.getProperty("java.io.tmpdir"), "carlos-fax-incoming").toString();

--- a/src/main/java/io/github/carlos_emr/OscarProperties.java
+++ b/src/main/java/io/github/carlos_emr/OscarProperties.java
@@ -506,21 +506,40 @@ public class OscarProperties extends Properties {
     }
 
     /**
-     * Returns the directory for inbound fax files.
+     * Returns the directory for inbound fax files awaiting import.
+     *
+     * <p>Resolution order (first non-null/non-empty value wins):</p>
+     * <ol>
+     *   <li>{@code FAX_INCOMING_DIR} property from carlos.properties (explicit override)</li>
+     *   <li>{@code BASE_DOCUMENT_DIR/fax-incoming} — consistent with DOCUMENT_DIR and EFORM_IMAGES_DIR
+     *       patterns; uses a directory that is already configured, writable, and outside the webroot</li>
+     *   <li>{@code ${catalina.base}/fax-incoming} — Tomcat instance root fallback</li>
+     *   <li>{@code ${java.io.tmpdir}/carlos-fax-incoming} — test/non-Tomcat environments only</li>
+     * </ol>
+     *
+     * @return String path to the fax incoming directory, never null
      */
     public String getFaxIncomingDirectory() {
         String faxIncoming = oscarProperties.getProperty("FAX_INCOMING_DIR");
 
         if (faxIncoming == null) {
-            // Default to a path OUTSIDE the webroot for PHI protection.
-            // catalina.base is the Tomcat instance root (e.g., /usr/local/tomcat/)
-            // which is NOT under webapps/ and therefore not web-accessible.
-            String catalinaBase = System.getProperty("catalina.base");
-            if (catalinaBase != null && !catalinaBase.isEmpty()) {
-                faxIncoming = Paths.get(catalinaBase, "fax-incoming").toString();
+            // Prefer BASE_DOCUMENT_DIR — same pattern as DOCUMENT_DIR and EFORM_IMAGES_DIR.
+            // This directory is already configured, writable by the app server, and outside the webroot.
+            String baseDocDir = oscarProperties.getProperty("BASE_DOCUMENT_DIR");
+            if (baseDocDir != null && !baseDocDir.isEmpty()) {
+                faxIncoming = Paths.get(baseDocDir, "fax-incoming").toString();
             } else {
-                // Non-Tomcat environment (tests, standalone): use system temp
-                faxIncoming = Paths.get(System.getProperty("java.io.tmpdir"), "carlos-fax-incoming").toString();
+                // Fall back to catalina.base only if BASE_DOCUMENT_DIR is not set.
+                // NOTE: On Debian/Ubuntu package installs, catalina.base = /var/lib/tomcat9,
+                // which is a system directory the Tomcat process may not have write access to.
+                // Set FAX_INCOMING_DIR or BASE_DOCUMENT_DIR in carlos.properties to avoid this.
+                String catalinaBase = System.getProperty("catalina.base");
+                if (catalinaBase != null && !catalinaBase.isEmpty()) {
+                    faxIncoming = Paths.get(catalinaBase, "fax-incoming").toString();
+                } else {
+                    // Non-Tomcat environment (tests, standalone): use system temp
+                    faxIncoming = Paths.get(System.getProperty("java.io.tmpdir"), "carlos-fax-incoming").toString();
+                }
             }
         }
         return faxIncoming;

--- a/src/main/java/io/github/carlos_emr/carlos/fax/core/FaxImporter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/fax/core/FaxImporter.java
@@ -179,17 +179,19 @@ public class FaxImporter {
             return;
         }
 
-        Path resolvedDir = Paths.get(incomingDirPath.trim());
         try {
+            Path resolvedDir = Paths.get(incomingDirPath.trim());
             Files.createDirectories(resolvedDir);
             faxIncomingDir = resolvedDir;
             initialized = true;
             log.info("Fax incoming directory initialized: {}", faxIncomingDir);
-        } catch (IOException e) {
+        } catch (IOException | RuntimeException e) {
             // Log as error but do NOT throw — fax is optional and must not bring down the app.
+            // Catches IOException (permission/disk errors), InvalidPathException (bad path strings),
+            // and SecurityException (security manager rejection) to ensure startup is never blocked.
             log.error("FaxImporter: Cannot create fax incoming directory: {}. Fax import is disabled. "
                     + "Check permissions and disk space. Set FAX_INCOMING_DIR in carlos.properties "
-                    + "to a directory writable by the application server.", resolvedDir, e);
+                    + "to a directory writable by the application server.", incomingDirPath, e);
         }
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/fax/core/FaxImporter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/fax/core/FaxImporter.java
@@ -90,8 +90,11 @@ import org.springframework.stereotype.Service;
  * <pre>
  * # carlos.properties
  * FAX_INCOMING_DIR=/path/to/fax/incoming  # Optional; defaults resolved by OscarProperties:
- *                                         #   1. ${catalina.base}/fax-incoming (Tomcat)
- *                                         #   2. ${java.io.tmpdir}/carlos-fax-incoming (non-Tomcat)
+ *                                         #   1. FAX_INCOMING_DIR (this property, if set)
+ *                                         #   2. BASE_DOCUMENT_DIR/fax-incoming (preferred default)
+ *                                         #   3. ${catalina.base}/fax-incoming (Tomcat fallback;
+ *                                         #      may be unwritable on Debian/Ubuntu package installs)
+ *                                         #   4. ${java.io.tmpdir}/carlos-fax-incoming (non-Tomcat)
  * DOCUMENT_DIR=/path/to/documents         # Required, final document storage location
  * </pre>
  *
@@ -131,6 +134,13 @@ public class FaxImporter {
      * the rest of CARLOS EMR from starting or functioning.
      */
     private boolean initialized = false;
+
+    /**
+     * Guards against repeated "not initialized" log warnings on every poll cycle.
+     * The actionable warning is already emitted once during {@link #initialize()}, so
+     * subsequent poll cycles only need to log it once more to remain visible.
+     */
+    private volatile boolean pollInitializationWarningLogged = false;
 
     @Autowired
     public FaxImporter(FaxConfigDao faxConfigDao, FaxJobDao faxJobDao, QueueDocumentLinkDao queueDocumentLinkDao,
@@ -204,9 +214,12 @@ public class FaxImporter {
     public void poll() {
 
         if (!initialized) {
-            log.warn("FaxImporter is not initialized — fax directory configuration is missing or "
-                    + "unwritable. Skipping poll. Check startup log for details and set "
-                    + "BASE_DOCUMENT_DIR or FAX_INCOMING_DIR in carlos.properties.");
+            if (!pollInitializationWarningLogged) {
+                log.warn("FaxImporter is not initialized — fax directory configuration is missing or "
+                        + "unwritable. Skipping poll. Check startup log for details and set "
+                        + "BASE_DOCUMENT_DIR or FAX_INCOMING_DIR in carlos.properties.");
+                pollInitializationWarningLogged = true;
+            }
             return;
         }
 

--- a/src/main/java/io/github/carlos_emr/carlos/fax/core/FaxImporter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/fax/core/FaxImporter.java
@@ -125,6 +125,13 @@ public class FaxImporter {
     /** Incoming directory for quarantined fax files, initialized at startup */
     private Path faxIncomingDir;
 
+    /**
+     * Set to true only when {@link #initialize()} succeeds. Polling and all import
+     * operations are skipped when false so a misconfigured fax service never prevents
+     * the rest of CARLOS EMR from starting or functioning.
+     */
+    private boolean initialized = false;
+
     @Autowired
     public FaxImporter(FaxConfigDao faxConfigDao, FaxJobDao faxJobDao, QueueDocumentLinkDao queueDocumentLinkDao,
             ProviderLabRoutingDao providerLabRoutingDao, FaxProviderClientFactory faxProviderClientFactory) {
@@ -138,32 +145,51 @@ public class FaxImporter {
     /**
      * Validates directories and initializes the incoming fax directory at startup.
      *
-     * @throws IllegalStateException if DOCUMENT_DIR is not configured
+     * <p>This method is intentionally non-fatal: configuration problems are logged as
+     * warnings rather than thrown as exceptions. A misconfigured fax service must not
+     * prevent CARLOS EMR from starting — fax is an optional feature. If initialization
+     * fails, {@link #initialized} remains {@code false} and all poll/import operations
+     * are silently skipped until the configuration is corrected and Tomcat is restarted.</p>
+     *
+     * <p>To resolve startup warnings, set {@code BASE_DOCUMENT_DIR} or {@code FAX_INCOMING_DIR}
+     * in {@code carlos.properties}.</p>
      */
     @PostConstruct
     public void initialize() {
         if (DOCUMENT_DIR == null || DOCUMENT_DIR.trim().isEmpty()) {
-            throw new IllegalStateException(
-                    "DOCUMENT_DIR is not configured and cannot be derived from BASE_DOCUMENT_DIR. "
+            log.warn("FaxImporter: DOCUMENT_DIR is not configured. Fax import is disabled. "
                     + "Configure DOCUMENT_DIR or BASE_DOCUMENT_DIR in carlos.properties.");
+            return;
         }
 
         String incomingDirPath = OscarProperties.getInstance().getFaxIncomingDirectory();
         if (incomingDirPath == null || incomingDirPath.trim().isEmpty()) {
-            throw new IllegalStateException(
-                    "FAX_INCOMING_DIR cannot be resolved. "
-                    + "Configure FAX_INCOMING_DIR in carlos.properties.");
+            log.warn("FaxImporter: FAX_INCOMING_DIR cannot be resolved. Fax import is disabled. "
+                    + "Configure FAX_INCOMING_DIR or BASE_DOCUMENT_DIR in carlos.properties.");
+            return;
         }
 
-        faxIncomingDir = Paths.get(incomingDirPath.trim());
+        Path resolvedDir = Paths.get(incomingDirPath.trim());
         try {
-            Files.createDirectories(faxIncomingDir);
-            log.info("Fax incoming directory: {}", faxIncomingDir);
+            Files.createDirectories(resolvedDir);
+            faxIncomingDir = resolvedDir;
+            initialized = true;
+            log.info("Fax incoming directory initialized: {}", faxIncomingDir);
         } catch (IOException e) {
-            throw new IllegalStateException(
-                    "Cannot create fax incoming directory: " + faxIncomingDir
-                    + ". Check permissions and disk space.", e);
+            // Log as error but do NOT throw — fax is optional and must not bring down the app.
+            log.error("FaxImporter: Cannot create fax incoming directory: {}. Fax import is disabled. "
+                    + "Check permissions and disk space. Set FAX_INCOMING_DIR in carlos.properties "
+                    + "to a directory writable by the application server.", resolvedDir, e);
         }
+    }
+
+    /**
+     * Returns whether this service was successfully initialized at startup.
+     *
+     * @return true if the fax incoming directory is configured and writable
+     */
+    public boolean isInitialized() {
+        return initialized;
     }
 
     /**
@@ -176,6 +202,13 @@ public class FaxImporter {
      * @since 2014-08-29
      */
     public void poll() {
+
+        if (!initialized) {
+            log.warn("FaxImporter is not initialized — fax directory configuration is missing or "
+                    + "unwritable. Skipping poll. Check startup log for details and set "
+                    + "BASE_DOCUMENT_DIR or FAX_INCOMING_DIR in carlos.properties.");
+            return;
+        }
 
         log.info("CHECKING REMOTE FOR INCOMING FAXES");
 

--- a/src/main/resources/carlos.properties
+++ b/src/main/resources/carlos.properties
@@ -1095,7 +1095,16 @@ INCOMINGDOCUMENT_DIR=/usr/local/tomcat/webapps/OscarDocument/oscar_mcmaster/inco
 #
 # SECURITY: This directory MUST be outside the webroot (not under webapps/) to prevent
 # direct HTTP access to fax documents containing PHI.
-# Default if not set: ${catalina.base}/fax-incoming (Tomcat instance root, outside webroot)
+#
+# Default resolution order (first wins):
+#   1. FAX_INCOMING_DIR (this property, if set)
+#   2. BASE_DOCUMENT_DIR/fax-incoming  (recommended — uses already-configured, writable directory)
+#   3. ${catalina.base}/fax-incoming   (may be unwritable on Debian/Ubuntu package installs)
+#   4. ${java.io.tmpdir}/carlos-fax-incoming (test/non-Tomcat fallback only)
+#
+# Recommendation: leave this unset if BASE_DOCUMENT_DIR is already configured correctly.
+# Only set this explicitly if you need the fax incoming directory in a non-standard location.
+# Example: FAX_INCOMING_DIR=${BASE_DOCUMENT_DIR}/fax-incoming
 #FAX_INCOMING_DIR=/var/lib/carlos/fax/incoming
 
 # true : move the deleted page or deleted pdf into the deleted folder

--- a/src/main/resources/carlos.properties
+++ b/src/main/resources/carlos.properties
@@ -1104,7 +1104,7 @@ INCOMINGDOCUMENT_DIR=/usr/local/tomcat/webapps/OscarDocument/oscar_mcmaster/inco
 #
 # Recommendation: leave this unset if BASE_DOCUMENT_DIR is already configured correctly.
 # Only set this explicitly if you need the fax incoming directory in a non-standard location.
-# Example: FAX_INCOMING_DIR=${BASE_DOCUMENT_DIR}/fax-incoming
+# Example: FAX_INCOMING_DIR=/var/lib/carlos/documents/fax-incoming
 #FAX_INCOMING_DIR=/var/lib/carlos/fax/incoming
 
 # true : move the deleted page or deleted pdf into the deleted folder


### PR DESCRIPTION
### **User description**
- FaxImporter.initialize() is now non-fatal: catches exceptions and logs warnings instead of throwing IllegalStateException, so a misconfigured fax service no longer prevents carlos.war from starting. Sets initialized=false and poll() returns early with a warning.

- OscarProperties.getFaxIncomingDirectory() now prefers BASE_DOCUMENT_DIR as the default fallback (consistent with DOCUMENT_DIR and EFORM_IMAGES_DIR patterns), before falling back to catalina.base. On Debian/Ubuntu package installs catalina.base=/var/lib/tomcat9 is typically unwritable by Tomcat, while BASE_DOCUMENT_DIR is already configured and writable.

- carlos.properties documents the updated resolution order and explains that FAX_INCOMING_DIR need not be set when BASE_DOCUMENT_DIR is configured.

Fixes two issues reported against PR #431:
1. Entire app fails on startup if fax-incoming directory is unwritable
2. Default path /var/lib/tomcat9/fax-incoming is not writable on common installs

<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description

<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues
Fixes #529

## How Was This Tested?

<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->

## Checklist

- [ ] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [ ] I have not included any patient data (PHI) in this PR
- [ ] I have added tests for new functionality, or this change doesn't need new tests
- [ ] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Relax fax service startup behavior to avoid application failures when fax directories are misconfigured, and align the default fax incoming directory resolution with existing document directory patterns.

Bug Fixes:
- Prevent the application from failing to start when DOCUMENT_DIR or FAX_INCOMING_DIR is missing or the fax incoming directory cannot be created by making fax initialization non-fatal.

Enhancements:
- Add an initialization flag and guard fax polling so fax operations are skipped when the fax service is not correctly configured.
- Update fax incoming directory resolution to prioritize BASE_DOCUMENT_DIR, then Tomcat catalina.base, then a temp directory for non-Tomcat environments.

Documentation:
- Clarify fax incoming directory resolution order and configuration recommendations in carlos.properties comments.


___

### **Description**
- Improved fax service initialization to be non-fatal, allowing the application to start even if the fax configuration is incorrect.
- Updated the default resolution logic for the fax incoming directory to prioritize `BASE_DOCUMENT_DIR`, enhancing compatibility with typical Tomcat installations.
- Enhanced documentation in `carlos.properties` to clarify the directory resolution order and recommendations.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>OscarProperties.java</strong><dd><code>Enhance fax incoming directory resolution logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/io/github/carlos_emr/OscarProperties.java
<li>Updated the method <code>getFaxIncomingDirectory()</code> to prefer <br><code>BASE_DOCUMENT_DIR</code> as the default.<br> <li> Improved documentation for the directory resolution order.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/530/files#diff-bda3535a7a45b3ecfe7748e988a4c9ad087ebb8e9a8a4f5d1e2159c3bbd5463b">+28/-9</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FaxImporter.java</strong><dd><code>Modify FaxImporter initialization to be non-fatal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/io/github/carlos_emr/carlos/fax/core/FaxImporter.java
<li>Made <code>FaxImporter.initialize()</code> non-fatal, logging warnings instead of <br>throwing exceptions.<br> <li> Added a new method <code>isInitialized()</code> to check if the fax service was <br>successfully initialized.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/530/files#diff-c378972221eb4672522ea5a2463b5e6cbdfaebea20c1684be02dbcd112f02f4e">+45/-12</a>&nbsp; </td>
</tr>
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>carlos.properties</strong><dd><code>Update properties documentation for fax directory</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/resources/carlos.properties
<li>Updated comments to reflect the new resolution order for <br><code>FAX_INCOMING_DIR</code>.<br> <li> Clarified recommendations for setting <code>FAX_INCOMING_DIR</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/530/files#diff-be55339275cbd5f03108f13cfac28b2b6687da0a71c14d35468d6ed2dfc2ee76">+10/-1</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Save and update properties at runtime without restarting.
  * Expose fax importer initialization state to allow health checks.

* **Bug Fixes**
  * Application startup no longer fails due to fax configuration; fax import is gracefully disabled and polling skips until configured.
  * Fax incoming directory resolution now prioritizes configured base paths with clearer fallbacks.

* **Documentation**
  * Clarified property docs with prioritized fax directory resolution and usage example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->