### PR TITLE
fix: tickler default provider validation error in multisite mode

### DIFF
--- a/src/main/webapp/tickler/ticklerAdd.jsp
+++ b/src/main/webapp/tickler/ticklerAdd.jsp
@@ -457,7 +457,9 @@
                     return false;
                 }
                 <% if (io.github.carlos_emr.carlos.commn.IsPropertiesOn.isMultisitesEnable()) { %>
-                else if (document.serviceform.site.value == "none" || document.serviceform.site.value == "0") {
+                else if (!document.serviceform.task_assigned_to ||
+                         document.serviceform.task_assigned_to.options.length === 0 ||
+                         document.serviceform.task_assigned_to.value === "") {
                     document.getElementById("error").insertAdjacentText("beforeend", '<%=Encode.forJavaScript(oscarBundle.getString("tickler.ticklerAdd.msgMustAssignProvider"))%>');
                     document.getElementById("error").style.display = 'block';
                     return false;


### PR DESCRIPTION
### **User description**
Fixes #543

The multisite validation in ticklerAdd.jsp used `site.value == "0"` as a sentinel for "no clinic selected". When a default provider preference exists, the preference option is assigned array index 0 as its value, causing the validation to incorrectly reject a valid provider selection with "Must assign task to a provider" error.

Fix: validate that task_assigned_to has options and a value instead of checking the site dropdown value.

Related to PR #517


Generated with [Claude Code](https://claude.ai/code)) | [View branch](https://github.com/carlos-emr/carlos/tree/claude/pr-517-20260304-1411


___

### **Description**
- Fixes validation error when a default provider is set in multisite mode.
- Ensures that the task_assigned_to field is properly validated.
- Prevents incorrect error messages related to provider assignment.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ticklerAdd.jsp</strong><dd><code>Improve validation for provider assignment in multisite mode</code></dd></summary>
<hr>

src/main/webapp/tickler/ticklerAdd.jsp
<li>Updated validation logic for provider assignment.<br> <li> Removed old check for site value as a sentinel.<br> <li> Added checks for task_assigned_to options and value.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/546/files#diff-3ecec79f3829d258bfc6402dcd3ccdd6e81a39e9e742700f84f2c1ce5eb3bab4">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced task assignment validation in multisite mode to ensure a provider or task is properly assigned before form submission, preventing incomplete tickler submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->