### PR TITLE
feat: exempt helper JSPs from Open in Tabs preference

### DIFF
--- a/src/main/webapp/provider/schedulePage.js.jsp
+++ b/src/main/webapp/provider/schedulePage.js.jsp
@@ -400,7 +400,7 @@ this.focus();
 
 function popupPage(vheight,vwidth,varpage) {
 var page = "" + varpage;
-if (openEncounterInTab) { return popupTab(page); }
+if (openEncounterInTab && !isForceWindowUrl(page)) { return popupTab(page); }
 windowprops = "height="+vheight+",width="+vwidth+",location=no,scrollbars=yes,menubars=no,toolbars=no,resizable=yes,screenX=50,screenY=50,top=0,left=0";
 var popup=window.open(page, "<fmt:setBundle basename="oscarResources"/><fmt:message key="provider.appointmentProviderAdminDay.apptProvider"/>", windowprops);
 if (popup != null) {
@@ -413,7 +413,7 @@ popup.focus();
 
 function popUpEncounter(vheight,vwidth,varpage) {
 var page = "" + varpage;
-if (openEncounterInTab) { return popupTab(page); }
+if (openEncounterInTab && !isForceWindowUrl(page)) { return popupTab(page); }
 windowprops = "height="+vheight+",width="+vwidth+",location=no,scrollbars=yes,menubars=no,toolbars=no,resizable=yes,screenX=50,screenY=50,top=0,left=0";
 var popup=window.open(page, "Encounter", windowprops);
 
@@ -442,7 +442,7 @@ changePassword.moveTo(0,0);
 }
 function popupInboxManager(varpage, height = 700, width = 1215) {
 var page = "" + varpage;
-if (openEncounterInTab) { return popupTab(page); }
+if (openEncounterInTab && !isForceWindowUrl(page)) { return popupTab(page); }
 var windowname="apptProviderInbox";
     windowprops = "height=" + height + ",width=" + width + ",location=no,"
 + "scrollbars=yes,menubars=no,toolbars=no,resizable=yes,top=10,left=0";
@@ -470,7 +470,7 @@ windowname = typeof(windowname)!= 'undefined' ? windowname : 'apptProviderSearch
 vheight = typeof(vheight) != 'undefined' ? vheight : '700px';
 vwidth = typeof(vwidth) != 'undefined' ? vwidth : '1024px';
 var page = "" + varpage;
-if (openEncounterInTab) { return popupTab(page); }
+if (openEncounterInTab && !isForceWindowUrl(page)) { return popupTab(page); }
 windowprops = "height="+vheight+",width="+vwidth+",location=no,scrollbars=yes,menubars=no,toolbars=no,resizable=yes,screenX=50,screenY=50,top=0,left=0";
 var popup = window.open(page, windowname, windowprops);
 if (popup != null) {
@@ -484,7 +484,7 @@ popup.focus();
 <!--messenger code block-->
 function popupOscarRx(vheight,vwidth,varpage) {
 var page = varpage;
-if (openEncounterInTab) { return popupTab(page); }
+if (openEncounterInTab && !isForceWindowUrl(page)) { return popupTab(page); }
 windowprops = "height="+vheight+",width="+vwidth+",location=no,scrollbars=yes,menubars=no,toolbars=no,resizable=yes,screenX=0,screenY=0,top=0,left=0";
 var popup=window.open(varpage, "<fmt:setBundle basename="oscarResources"/><fmt:message key="global.oscarRx"/>_appt", windowprops);
 if (popup != null) {

--- a/src/main/webapp/share/javascript/Oscar.js
+++ b/src/main/webapp/share/javascript/Oscar.js
@@ -42,15 +42,16 @@
  */
 function isForceWindowUrl(url) {
     if (!url) return false;
-    var forceWindowPaths = [
+    const forceWindowPaths = [
         'addappointment.jsp',
         'appointmentcontrol.jsp',
         'appointmentsearch.jsp',
         'scratch/index.jsp',
         'CalendarPopup.jsp'
     ];
+    const normalizedUrl = String(url).split('#')[0].split('?')[0];
     return forceWindowPaths.some(function(path) {
-        return url.indexOf(path) !== -1;
+        return normalizedUrl.lastIndexOf(path) === (normalizedUrl.length - path.length);
     });
 }
 
@@ -89,7 +90,7 @@ function popup(height, width, url, windowName) {
  * @returns {Window|null} The opened Window object, or null if the browser blocked the tab
  */
 function popupTab(url) {
-    var win = window.open(url, '_blank');
+    const win = window.open(url, '_blank');
     if (win) {
         // Manually sever the opener relationship to prevent reverse-tabnabbing.
         // All URLs opened via this helper are same-origin CARLOS pages, so the
@@ -117,8 +118,8 @@ function newWindow(url, windowName) {
         return popupTab(url);
     }
     //this way the w&d works with older browsers as well
-    var w = document.getElementsByTagName('body')[0].clientWidth;//window.innerWidth;
-    var h = document.getElementsByTagName('body')[0].clientHeight;//window.innerHeight;
+    let w = document.getElementsByTagName('body')[0].clientWidth;//window.innerWidth;
+    let h = document.getElementsByTagName('body')[0].clientHeight;//window.innerHeight;
     w = Math.max(w, window.innerWidth);
     h = Math.max(h, window.innerHeight);
 

--- a/src/main/webapp/share/javascript/Oscar.js
+++ b/src/main/webapp/share/javascript/Oscar.js
@@ -23,7 +23,41 @@
  */
 
 /**
+ * Returns true if the given URL must always open in a popup window, regardless of the
+ * "Open Encounters in Tab" provider preference.
+ *
+ * <p>Certain helper pages require access to {@code window.opener} (to read context or
+ * post updates back to the calling page) and cannot function correctly as standalone
+ * browser tabs. These pages are:
+ * <ul>
+ *   <li>{@code addappointment.jsp} — appointment booking; needs schedule page context</li>
+ *   <li>{@code appointmentcontrol.jsp} — appointment editing; needs schedule page context</li>
+ *   <li>{@code appointmentsearch.jsp} — appointment search; needs schedule page context</li>
+ *   <li>{@code scratch/index.jsp} — system clipboard; benefits from opener context for copy/paste</li>
+ *   <li>{@code CalendarPopup.jsp} — date picker; must update {@code window.opener} with selected date</li>
+ * </ul>
+ *
+ * @param {string} url - URL to test
+ * @returns {boolean} true if the URL must always open as a popup window
+ */
+function isForceWindowUrl(url) {
+    if (!url) return false;
+    var forceWindowPaths = [
+        'addappointment.jsp',
+        'appointmentcontrol.jsp',
+        'appointmentsearch.jsp',
+        'scratch/index.jsp',
+        'CalendarPopup.jsp'
+    ];
+    return forceWindowPaths.some(function(path) {
+        return url.indexOf(path) !== -1;
+    });
+}
+
+/**
  * Opens a URL in a named popup window or delegates to popupTab() if tab mode is active.
+ * URLs in the force-window list (see {@link isForceWindowUrl}) always open as popup
+ * windows regardless of the tab preference.
  * @param {number} height - Popup window height in pixels
  * @param {number} width - Popup window width in pixels
  * @param {string} url - URL to open
@@ -31,7 +65,7 @@
  * @returns {Window|null} The opened Window object, or null if tab mode is active
  */
 function popup(height, width, url, windowName) {
-    if (typeof openEncounterInTab !== 'undefined' && openEncounterInTab) {
+    if (typeof openEncounterInTab !== 'undefined' && openEncounterInTab && !isForceWindowUrl(url)) {
         return popupTab(url);
     }
     return popup2(height, width, 0, 0, url, windowName);
@@ -71,13 +105,15 @@ function popupTab(url) {
 /**
  * Opens a URL in a full-viewport popup window sized to the current window, or
  * delegates to popupTab() when the provider preference "Open Encounters in Tab" is enabled.
+ * URLs in the force-window list (see {@link isForceWindowUrl}) always open as popup
+ * windows regardless of the tab preference.
  *
  * @param {string} url - URL to open
  * @param {string} windowName - Named window target; reused across calls with the same name
  * @returns {Window|null} The opened Window object, or null if tab mode is active
  */
 function newWindow(url, windowName) {
-    if (typeof openEncounterInTab !== 'undefined' && openEncounterInTab) {
+    if (typeof openEncounterInTab !== 'undefined' && openEncounterInTab && !isForceWindowUrl(url)) {
         return popupTab(url);
     }
     //this way the w&d works with older browsers as well

--- a/src/main/webapp/share/javascript/Oscar.js
+++ b/src/main/webapp/share/javascript/Oscar.js
@@ -51,7 +51,8 @@ function isForceWindowUrl(url) {
     ];
     const normalizedUrl = String(url).split('#')[0].split('?')[0];
     return forceWindowPaths.some(function(path) {
-        return normalizedUrl.lastIndexOf(path) === (normalizedUrl.length - path.length);
+        const index = normalizedUrl.lastIndexOf(path);
+        return index !== -1 && index === (normalizedUrl.length - path.length);
     });
 }
 


### PR DESCRIPTION
### **User description**
Certain helper pages require window.opener access and must always open as popup windows, regardless of the provider's "Open Encounters in Tab" setting.

Changes:
- Add isForceWindowUrl() helper to Oscar.js with documented force-window list
- Update popup() and newWindow() in Oscar.js to skip tab delegation for force-window URLs
- Update all 5 local popup functions in schedulePage.js.jsp

Related to PR #464

Generated with [Claude Code](https://claude.ai/code)


___

### **Description**
- Introduced a new helper function `isForceWindowUrl()` to manage specific URLs that must open in popups.
- Updated existing popup handling functions to skip tab delegation for URLs identified as force-window.
- Ensured critical helper pages maintain access to `window.opener` by always opening in popup windows.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Oscar.js</strong><dd><code>Introduce force-window URL handling in Oscar.js</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/webapp/share/javascript/Oscar.js
<li>Added <code>isForceWindowUrl()</code> function to determine if a URL should always <br>open in a popup.<br> <li> Documented the rationale for force-window URLs.<br> <li> Updated <code>popup()</code> and <code>newWindow()</code> functions to respect force-window <br>URLs.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/548/files#diff-c848f586b76a76d764f3a0f2a2a6e1e9115e3667619af55ff550054f237a7a6b">+38/-2</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>schedulePage.js.jsp</strong><dd><code>Modify popup functions to handle force-window URLs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/webapp/provider/schedulePage.js.jsp
<li>Updated local popup functions to check for force-window URLs.<br> <li> Ensured certain pages always open in popups, bypassing tab delegation.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/548/files#diff-e432c2146410a5f56567a36c2ffebf3520c798142b6df49d18020be4d76f05fb">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Certain pages (patient encounters, appointment/calendar popups, inbox manager, and prescription flows) now consistently open in popup windows instead of browser tabs, preventing display and workflow issues.
  * Improved detection so pages that must open in a window are reliably routed through popup behavior across all relevant flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->