### PR TITLE
Update PreventionData.java prevent passing of null preventions Fix for #572

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/prevention/PreventionData.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prevention/PreventionData.java
@@ -298,7 +298,7 @@ public class PreventionData {
                  * force case sensitive comparison of name; MySQL by default does case INsensitive
                  * DTaP and dTap are considered the same by MySQL
                  */
-                if (preventionType != null && !prevention.getPreventionType().equals(preventionType)) {
+                if (preventionType == null || (preventionType != null && !prevention.getPreventionType().equals(preventionType))) {
                     continue;
                 }
 

--- a/src/main/java/io/github/carlos_emr/carlos/prevention/PreventionData.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prevention/PreventionData.java
@@ -298,7 +298,7 @@ public class PreventionData {
                  * force case sensitive comparison of name; MySQL by default does case INsensitive
                  * DTaP and dTap are considered the same by MySQL
                  */
-if (preventionType != null && (prevention.getPreventionType() == null || !prevention.getPreventionType().equals(preventionType))) {
+                if (preventionType != null && !preventionType.equals(prevention.getPreventionType())) {
                     continue;
                 }
 

--- a/src/main/java/io/github/carlos_emr/carlos/prevention/PreventionData.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prevention/PreventionData.java
@@ -298,7 +298,7 @@ public class PreventionData {
                  * force case sensitive comparison of name; MySQL by default does case INsensitive
                  * DTaP and dTap are considered the same by MySQL
                  */
-                if (preventionType == null || !prevention.getPreventionType().equals(preventionType)) {
+if (preventionType != null && (prevention.getPreventionType() == null || !prevention.getPreventionType().equals(preventionType))) {
                     continue;
                 }
 

--- a/src/main/java/io/github/carlos_emr/carlos/prevention/PreventionData.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prevention/PreventionData.java
@@ -298,7 +298,7 @@ public class PreventionData {
                  * force case sensitive comparison of name; MySQL by default does case INsensitive
                  * DTaP and dTap are considered the same by MySQL
                  */
-                if (preventionType == null || (preventionType != null && !prevention.getPreventionType().equals(preventionType))) {
+                if (preventionType == null || !prevention.getPreventionType().equals(preventionType)) {
                     continue;
                 }
 


### PR DESCRIPTION
### **User description**
<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description
Fixes bug in eChart prevention display that displays null and the last valid prevention date

<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues
Fixes #572

<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?

<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Bug Fixes:
- Prevent null prevention types from causing null or stale prevention dates to appear in the eChart prevention display.


___

### **Description**
- Corrected the logic in `getPreventionData` to skip entries with null prevention types.
- This change prevents the display of null and stale prevention dates in the eChart.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PreventionData.java</strong><dd><code>Fix null prevention type handling in PreventionData</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/io/github/carlos_emr/carlos/prevention/PreventionData.java
<li>Updated condition to handle null prevention types.<br> <li> Prevents display of null and stale prevention dates in eChart.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/569/files#diff-c1475ee27b4f994f5f7d099de2b11b9a413f2b9fb60ecbdb1e43ca32b19dd497">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved null-safety handling in prevention type validation to prevent potential crashes when encountering null values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->