### PR TITLE
PreventionDisplayConfig.java null checks

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/prevention/PreventionDisplayConfig.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prevention/PreventionDisplayConfig.java
@@ -167,7 +167,7 @@ public class PreventionDisplayConfig {
                 h.put("showIfMinRecordNum", "1");
                 h.put("snomedConceptCode", imm.getSnomedConceptId());
                 h.put("ispa", String.valueOf(imm.isIspa()));
-                if(!addedSnomeds.contains(imm.getSnomedConceptId()) && imm.getPicklistName() != null) {
+                if (!addedSnomeds.contains(imm.getSnomedConceptId()) && imm.getPicklistName() != null) {
                     prevList.add(h);
                     prevHash.put(h.get("name"), h);
                 }

--- a/src/main/java/io/github/carlos_emr/carlos/prevention/PreventionDisplayConfig.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prevention/PreventionDisplayConfig.java
@@ -149,9 +149,10 @@ public class PreventionDisplayConfig {
 
                 }
 
-                prevList.add(h);
-                prevHash.put(h.get("name"), h);
-
+				if (h.get("name") != null) {
+					prevList.add(h);
+					prevHash.put(h.get("name"), h);
+				}
             }
 
             for (CVCImmunization imm : cvcManager.getGenericImmunizationList()) {
@@ -166,7 +167,7 @@ public class PreventionDisplayConfig {
                 h.put("showIfMinRecordNum", "1");
                 h.put("snomedConceptCode", imm.getSnomedConceptId());
                 h.put("ispa", String.valueOf(imm.isIspa()));
-                if (!addedSnomeds.contains(imm.getSnomedConceptId())) {
+                if(!addedSnomeds.contains(imm.getSnomedConceptId()) && imm.getPicklistName() != null) {
                     prevList.add(h);
                     prevHash.put(h.get("name"), h);
                 }

--- a/src/main/java/io/github/carlos_emr/carlos/prevention/PreventionDisplayConfig.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prevention/PreventionDisplayConfig.java
@@ -149,10 +149,10 @@ public class PreventionDisplayConfig {
 
                 }
 
-				if (h.get("name") != null) {
-					prevList.add(h);
-					prevHash.put(h.get("name"), h);
-				}
+                if (h.get("name") != null) {
+                    prevList.add(h);
+                    prevHash.put(h.get("name"), h);
+                }
             }
 
             for (CVCImmunization imm : cvcManager.getGenericImmunizationList()) {


### PR DESCRIPTION
### **User description**
As I added in O19 to prevent null data from populating the hash

<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description
another attempt to Fix #572
<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues

<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?
I have tested this and it solved the display issues with CARLOS for preventions migrated from O19
<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->
Success as shown by O19 preventions from the same chart

## Screenshots
<img width="924" height="740" alt="carlosefixedPreventions" src="https://github.com/user-attachments/assets/ec6fa699-73df-4cb7-83c8-95ec750154db" />

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->
<img width="355" height="98" alt="eChartPreventions" src="https://github.com/user-attachments/assets/ce62b425-0916-40a2-b1ab-9efdad484f42" />

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Guard prevention display population against null names and incomplete immunization data to avoid inserting invalid entries into internal collections.

Bug Fixes:
- Avoid adding prevention entries with null names to the prevention list and hash map to prevent null-related errors and invalid map keys.
- Skip immunization-based prevention entries that lack a picklist name to avoid creating incomplete or invalid prevention records.


___

### **Description**
- Implemented null checks to prevent adding prevention entries with null names to the list and hash map.
- Enhanced data integrity by skipping immunization-based prevention entries that lack a valid picklist name.
- This change addresses issues related to null-related errors and invalid map keys.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PreventionDisplayConfig.java</strong><dd><code>Enhance null safety in PreventionDisplayConfig</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/io/github/carlos_emr/carlos/prevention/PreventionDisplayConfig.java
<li>Added null checks for prevention names before adding to the list and <br>hash map.<br> <li> Prevented invalid entries from being inserted into internal <br>collections.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/585/files#diff-69bb3c3995f798bbedf1685fd850c31cce3d02ecefb5932fb4457f4c9899b1b3">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions

## Summary by Sourcery

Ensure prevention display configuration ignores invalid or incomplete prevention records to avoid null-related issues in internal collections.

Bug Fixes:
- Avoid adding prevention entries with null names to the prevention list and hash map.
- Skip immunization-based prevention entries that lack a picklist name when building the prevention collections.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed an issue where prevention items with missing names could appear in prevention lists, and immunizations without required picklist information could be incorrectly included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->