### PR TITLE
605 bug immunization types not oscar 19 standard

### DIFF
--- a/database/mysql/updates/update-2026-03-10-standardize-prevention-types.sql
+++ b/database/mysql/updates/update-2026-03-10-standardize-prevention-types.sql
@@ -56,7 +56,6 @@ UPDATE preventions SET prevention_type = 'HAHB' WHERE prevention_type = 'HepA+B'
 
 -- Rabies
 UPDATE preventions SET prevention_type = 'Rab' WHERE prevention_type = 'Rabies';
-UPDATE preventions SET prevention_type = 'Rab' WHERE prevention_type = 'Rab';
 
 -- Typhoid
 UPDATE preventions SET prevention_type = 'Typh-I' WHERE prevention_type = 'Typhoid';
@@ -74,7 +73,6 @@ UPDATE preventions SET prevention_type = 'Pneu-C' WHERE prevention_type = 'Pneu'
 
 -- Meningococcal C Conjugate (MenC-C was non-standard CARLOS name)
 UPDATE preventions SET prevention_type = 'Men-C-C' WHERE prevention_type = 'MenC-C';
-UPDATE preventions SET prevention_type = 'Men-C-C' WHERE prevention_type = 'Men-C-C';
 
 -- HPV (generic HPV vaccine)
 UPDATE preventions SET prevention_type = 'HPV' WHERE prevention_type = 'HPV Vaccine';

--- a/database/mysql/updates/update-2026-03-10-standardize-prevention-types.sql
+++ b/database/mysql/updates/update-2026-03-10-standardize-prevention-types.sql
@@ -1,0 +1,225 @@
+-- ============================================================================
+-- Standardize prevention type names to Health Canada / OSCAR 19 standard
+-- ============================================================================
+-- This script migrates all legacy and non-standard prevention type names in the
+-- `preventions` table to the canonical Health Canada immunization abbreviations.
+--
+-- IDEMPOTENT: Safe to run multiple times. WHERE clauses prevent duplicate updates.
+--
+-- Table: preventions (column: prevention_type)
+-- Table: preventionsExt (columns: prevention_id, keyval, val)
+--
+-- Strategy:
+--   1. Direct type mappings: known O19 / legacy names → canonical HC type
+--   2. Catch-all: any remaining unrecognized types → OtherA
+--      with original type preserved in preventionsExt comment
+--
+-- Health Canada abbreviation reference:
+--   https://www.canada.ca/en/public-health/services/provincial-territorial-immunization-information.html
+-- ============================================================================
+
+-- ============================================================================
+-- SECTION 1: DIRECT TYPE MAPPINGS
+-- ============================================================================
+
+-- Influenza
+UPDATE preventions SET prevention_type = 'Inf' WHERE prevention_type = 'Flu';
+UPDATE preventions SET prevention_type = 'Inf' WHERE prevention_type = 'H1N1';
+UPDATE preventions SET prevention_type = 'Inf' WHERE prevention_type = 'Influenza';
+
+-- Varicella (Chickenpox)
+UPDATE preventions SET prevention_type = 'Var' WHERE prevention_type = 'VZ';
+UPDATE preventions SET prevention_type = 'Var' WHERE prevention_type = 'Varicella';
+
+-- MMR-Var (was MMRV)
+UPDATE preventions SET prevention_type = 'MMR-Var' WHERE prevention_type = 'MMRV';
+
+-- Rotavirus
+UPDATE preventions SET prevention_type = 'Rota' WHERE prevention_type = 'Rot';
+UPDATE preventions SET prevention_type = 'Rota' WHERE prevention_type = 'Rotavirus';
+
+-- Tdap / Td / Td-IPV (Tetanus-Diphtheria-Pertussis variants)
+UPDATE preventions SET prevention_type = 'Tdap' WHERE prevention_type = 'dTap';
+UPDATE preventions SET prevention_type = 'Tdap' WHERE prevention_type = 'dTaP';
+UPDATE preventions SET prevention_type = 'Td-IPV' WHERE prevention_type = 'TdP';
+UPDATE preventions SET prevention_type = 'Td-IPV' WHERE prevention_type = 'TdP-IPV';
+
+-- Hepatitis B
+UPDATE preventions SET prevention_type = 'HB' WHERE prevention_type = 'HepB';
+
+-- Hepatitis A
+UPDATE preventions SET prevention_type = 'HA' WHERE prevention_type = 'HepA';
+
+-- Hepatitis A+B
+UPDATE preventions SET prevention_type = 'HAHB' WHERE prevention_type = 'HepAB';
+UPDATE preventions SET prevention_type = 'HAHB' WHERE prevention_type = 'HepA+B';
+
+-- Rabies
+UPDATE preventions SET prevention_type = 'Rab' WHERE prevention_type = 'Rabies';
+UPDATE preventions SET prevention_type = 'Rab' WHERE prevention_type = 'Rab';
+
+-- Typhoid
+UPDATE preventions SET prevention_type = 'Typh-I' WHERE prevention_type = 'Typhoid';
+UPDATE preventions SET prevention_type = 'Typh-I' WHERE prevention_type = 'Typhoid-I';
+UPDATE preventions SET prevention_type = 'Typh-I' WHERE prevention_type = 'Typh';
+
+-- Pneumococcal Polysaccharide
+UPDATE preventions SET prevention_type = 'Pneu-P-23' WHERE prevention_type = 'Pneumovax';
+UPDATE preventions SET prevention_type = 'Pneu-P-23' WHERE prevention_type = 'Pneumococcus';
+
+-- Pneumococcal Conjugate (legacy valences)
+-- Note: Pneu-C-7 records are kept as Pneu-C (generic) for older 7-valent entries
+UPDATE preventions SET prevention_type = 'Pneu-C' WHERE prevention_type = 'Pneu-C-7';
+UPDATE preventions SET prevention_type = 'Pneu-C' WHERE prevention_type = 'Pneu';
+
+-- Meningococcal C Conjugate (MenC-C was non-standard CARLOS name)
+UPDATE preventions SET prevention_type = 'Men-C-C' WHERE prevention_type = 'MenC-C';
+UPDATE preventions SET prevention_type = 'Men-C-C' WHERE prevention_type = 'Men-C-C';
+
+-- HPV (generic HPV vaccine)
+UPDATE preventions SET prevention_type = 'HPV' WHERE prevention_type = 'HPV Vaccine';
+
+-- Zoster (Zostavax = LZV; Shingrix = RZV)
+UPDATE preventions SET prevention_type = 'LZV' WHERE prevention_type = 'HZV';
+UPDATE preventions SET prevention_type = 'LZV' WHERE prevention_type = 'Zos';
+UPDATE preventions SET prevention_type = 'LZV' WHERE prevention_type = 'Zostavax';
+
+-- DTaP-HB-IPV-Hib (was DTaP-HBV-IPV-Hib with erroneous V)
+UPDATE preventions SET prevention_type = 'DTaP-HB-IPV-Hib' WHERE prevention_type = 'DTaP-HBV-IPV-Hib';
+
+-- Cholera
+UPDATE preventions SET prevention_type = 'Chol-O' WHERE prevention_type = 'CHOLERA';
+UPDATE preventions SET prevention_type = 'Chol-O' WHERE prevention_type = 'Dukoral';
+
+-- LDCT (was CTC - low-dose chest CT for lung cancer screening)
+UPDATE preventions SET prevention_type = 'LDCT' WHERE prevention_type = 'CTC';
+
+-- Measles monovalent
+UPDATE preventions SET prevention_type = 'M' WHERE prevention_type = 'Measles';
+
+-- Tetanus monovalent
+UPDATE preventions SET prevention_type = 'T' WHERE prevention_type = 'Tetanus';
+
+-- IPV / OPV (historical)
+-- Note: OPV kept as-is since HC list includes it; consider OtherA if no clinical need
+UPDATE preventions SET prevention_type = 'IPV' WHERE prevention_type = 'Poliovirus';
+UPDATE preventions SET prevention_type = 'IPV' WHERE prevention_type = 'fIPV';
+
+-- rMenB (Meningococcal B recombinant)
+UPDATE preventions SET prevention_type = 'rMenB' WHERE prevention_type = 'Men-B';
+
+-- ============================================================================
+-- SECTION 2: CATCH-ALL - LEGACY AND UNRECOGNIZED TYPES → OtherA
+-- ============================================================================
+-- For any remaining prevention type not in the canonical list, preserve the
+-- original type in a preventionsExt comment and migrate to OtherA.
+--
+-- The canonical set of recognized prevention types (do NOT migrate these):
+--   Immunizations: Anth, BCG, Chol, Chol-Ecol-O, Chol-O, COVID-19, d, DT, DT-IPV,
+--     DTaP, DTaP-HB-IPV, DTaP-HB-IPV-Hib, DTaP-Hib, DTaP-IPV, DTaP-IPV-Hib,
+--     DTaP-IPV-HB, DTaP-IPV-Hib-HB, HA, HA-Typh-I, HAHB, HB, HBTmf, Hib,
+--     HPV, HPV-2, HPV-4, HPV-9, H1N1, Inf, IPV, JE, LZV, M, Men-C-ACYW-135,
+--     Men-C-C, Men-P-AC, Men-P-ACWY, Men-P-ACYW-135, MMR, MMR-Var, MR, OPV,
+--     Pneu-C, Pneu-C-10, Pneu-C-13, Pneu-C-15, Pneu-C-20, Pneu-P-23,
+--     Rab, rMenB, Rota, Rota-1, Rota-5, RSV, RSVAb, RZV, T, TBE, Td, Td-IPV,
+--     Tdap, Tdap-IPV, TdP-IPV-Hib, Typh-I, Typh-O, Var, YF,
+--     COVID-19, BCG, JE, TBE, Chol-Ecol-O, HA-Typh-I
+--   Screenings: AAA, BMD, chlamydia, COLONOSCOPY, FOBT, ghonorrhea PCR,
+--     HepB screen, HepC screen, HIV, HPV-CERVIX, LDCT, MAM, PAP, PHV, PSA,
+--     Smoking, Tuberculosis, VDRL
+--   Other: OtherA, OtherB
+-- ============================================================================
+
+-- Step 2a: For legacy records that have an existing comment in preventionsExt,
+--          prepend the original type to that comment.
+UPDATE preventionsExt pe
+JOIN preventions p ON pe.prevention_id = p.id
+SET pe.val = CONCAT('[Legacy prevention type: ', p.prevention_type, '] ', COALESCE(pe.val, ''))
+WHERE p.prevention_type NOT IN (
+    -- Immunizations
+    'Anth', 'BCG', 'Chol', 'Chol-Ecol-O', 'Chol-O', 'COVID-19',
+    'd', 'DT', 'DT-IPV', 'DTaP', 'DTaP-HB-IPV', 'DTaP-HB-IPV-Hib',
+    'DTaP-Hib', 'DTaP-IPV', 'DTaP-IPV-Hib', 'DTaP-IPV-HB', 'DTaP-IPV-Hib-HB',
+    'EZV', 'fIPV', 'HA', 'HA-Typh-I', 'HAHB', 'HB', 'HBTmf', 'Hib',
+    'HPV', 'HPV-2', 'HPV-4', 'HPV-9', 'H1N1', 'Inf', 'IPV', 'JE',
+    'LZV', 'M', 'Men-C-ACYW-135', 'Men-C-C', 'Men-P-AC', 'Men-P-ACWY',
+    'Men-P-ACYW-135', 'MMR', 'MMR-Var', 'MR', 'OPV',
+    'Pneu-C', 'Pneu-C-10', 'Pneu-C-13', 'Pneu-C-15', 'Pneu-C-20', 'Pneu-P-23',
+    'Rab', 'rMenB', 'Rota', 'Rota-1', 'Rota-5', 'RSV', 'RSVAb', 'RZV',
+    'T', 'TBE', 'Td', 'Td-IPV', 'Tdap', 'Tdap-IPV', 'TdP-IPV-Hib',
+    'Typh-I', 'Typh-O', 'Var', 'YF',
+    -- Screenings
+    'AAA', 'BMD', 'chlamydia', 'COLONOSCOPY', 'FOBT', 'ghonorrhea PCR',
+    'HepB screen', 'HepC screen', 'HIV', 'HPV-CERVIX', 'LDCT', 'MAM',
+    'PAP', 'PHV', 'PSA', 'Smoking', 'Tuberculosis', 'VDRL',
+    -- Other
+    'OtherA', 'OtherB'
+)
+AND pe.keyval = 'comments';
+
+-- Step 2b: For legacy records that do NOT yet have a comment, insert one with the type.
+INSERT INTO preventionsExt (prevention_id, keyval, val)
+SELECT p.id, 'comments', CONCAT('[Legacy prevention type: ', p.prevention_type, ']')
+FROM preventions p
+LEFT JOIN preventionsExt pe ON pe.prevention_id = p.id AND pe.keyval = 'comments'
+WHERE p.prevention_type NOT IN (
+    -- Immunizations
+    'Anth', 'BCG', 'Chol', 'Chol-Ecol-O', 'Chol-O', 'COVID-19',
+    'd', 'DT', 'DT-IPV', 'DTaP', 'DTaP-HB-IPV', 'DTaP-HB-IPV-Hib',
+    'DTaP-Hib', 'DTaP-IPV', 'DTaP-IPV-Hib', 'DTaP-IPV-HB', 'DTaP-IPV-Hib-HB',
+    'EZV', 'fIPV', 'HA', 'HA-Typh-I', 'HAHB', 'HB', 'HBTmf', 'Hib',
+    'HPV', 'HPV-2', 'HPV-4', 'HPV-9', 'H1N1', 'Inf', 'IPV', 'JE',
+    'LZV', 'M', 'Men-C-ACYW-135', 'Men-C-C', 'Men-P-AC', 'Men-P-ACWY',
+    'Men-P-ACYW-135', 'MMR', 'MMR-Var', 'MR', 'OPV',
+    'Pneu-C', 'Pneu-C-10', 'Pneu-C-13', 'Pneu-C-15', 'Pneu-C-20', 'Pneu-P-23',
+    'Rab', 'rMenB', 'Rota', 'Rota-1', 'Rota-5', 'RSV', 'RSVAb', 'RZV',
+    'T', 'TBE', 'Td', 'Td-IPV', 'Tdap', 'Tdap-IPV', 'TdP-IPV-Hib',
+    'Typh-I', 'Typh-O', 'Var', 'YF',
+    -- Screenings
+    'AAA', 'BMD', 'chlamydia', 'COLONOSCOPY', 'FOBT', 'ghonorrhea PCR',
+    'HepB screen', 'HepC screen', 'HIV', 'HPV-CERVIX', 'LDCT', 'MAM',
+    'PAP', 'PHV', 'PSA', 'Smoking', 'Tuberculosis', 'VDRL',
+    -- Other
+    'OtherA', 'OtherB'
+)
+AND pe.id IS NULL;
+
+-- Step 2c: Migrate all remaining unrecognized types to OtherA.
+UPDATE preventions SET prevention_type = 'OtherA'
+WHERE prevention_type NOT IN (
+    -- Immunizations
+    'Anth', 'BCG', 'Chol', 'Chol-Ecol-O', 'Chol-O', 'COVID-19',
+    'd', 'DT', 'DT-IPV', 'DTaP', 'DTaP-HB-IPV', 'DTaP-HB-IPV-Hib',
+    'DTaP-Hib', 'DTaP-IPV', 'DTaP-IPV-Hib', 'DTaP-IPV-HB', 'DTaP-IPV-Hib-HB',
+    'EZV', 'fIPV', 'HA', 'HA-Typh-I', 'HAHB', 'HB', 'HBTmf', 'Hib',
+    'HPV', 'HPV-2', 'HPV-4', 'HPV-9', 'H1N1', 'Inf', 'IPV', 'JE',
+    'LZV', 'M', 'Men-C-ACYW-135', 'Men-C-C', 'Men-P-AC', 'Men-P-ACWY',
+    'Men-P-ACYW-135', 'MMR', 'MMR-Var', 'MR', 'OPV',
+    'Pneu-C', 'Pneu-C-10', 'Pneu-C-13', 'Pneu-C-15', 'Pneu-C-20', 'Pneu-P-23',
+    'Rab', 'rMenB', 'Rota', 'Rota-1', 'Rota-5', 'RSV', 'RSVAb', 'RZV',
+    'T', 'TBE', 'Td', 'Td-IPV', 'Tdap', 'Tdap-IPV', 'TdP-IPV-Hib',
+    'Typh-I', 'Typh-O', 'Var', 'YF',
+    -- Screenings
+    'AAA', 'BMD', 'chlamydia', 'COLONOSCOPY', 'FOBT', 'ghonorrhea PCR',
+    'HepB screen', 'HepC screen', 'HIV', 'HPV-CERVIX', 'LDCT', 'MAM',
+    'PAP', 'PHV', 'PSA', 'Smoking', 'Tuberculosis', 'VDRL',
+    -- Other
+    'OtherA', 'OtherB'
+);
+
+-- ============================================================================
+-- VERIFICATION QUERIES (optional, for post-migration review):
+-- ============================================================================
+-- Check for any remaining non-standard types:
+-- SELECT DISTINCT prevention_type, COUNT(*) as cnt
+-- FROM preventions
+-- GROUP BY prevention_type
+-- ORDER BY cnt DESC;
+--
+-- Review preserved legacy type comments:
+-- SELECT p.id, p.prevention_type, pe.val
+-- FROM preventions p
+-- JOIN preventionsExt pe ON pe.prevention_id = p.id
+-- WHERE pe.keyval = 'comments' AND pe.val LIKE '[Legacy%'
+-- ORDER BY p.id DESC
+-- LIMIT 100;

--- a/src/main/resources/oscar/oscarPrevention/PreventionConfigSets.xml
+++ b/src/main/resources/oscar/oscarPrevention/PreventionConfigSets.xml
@@ -8,7 +8,7 @@
 
 <preventionConfig>
 	<set title="Childhood Immunization" effective="(June 2022)"
-       minAge="0" maxAge="19" prevList="DTaP-IPV,Hib,Pneu-C-15,RSVAb,MMR,MMR-Var,MenC-C,Var,HepB,Tdap,Tdap-IPV,Men-C-ACYW-135,HPV-9,Td,Inf,Rota" />
+       minAge="0" maxAge="19" prevList="DTaP-IPV,Hib,Pneu-C-15,RSVAb,MMR,MMR-Var,Men-C-C,Var,HB,Tdap,Tdap-IPV,Men-C-ACYW-135,HPV-9,Td,Inf,Rota" />
 
 	<set title="Women's Preventive Care" effective="" minAge="20"
 		maxAge="74" sex="F" prevList="PAP,HPV-CERVIX,MAM,Inf,Td,Tdap" />
@@ -28,5 +28,9 @@
 	<set title="Over 65 Preventive Care" effective="" minAge="65"
 		prevList="Inf,Td,Pneu-C-20,RSV" />
 
+	<set title="Lung Cancer Screening (LDCT)" effective="" minAge="55" maxAge="74"
+		prevList="LDCT,Smoking" />
+
 	<set title="Other" effective="" minAge="0" prevList="OtherA,OtherB" />
 </preventionConfig>
+

--- a/src/main/resources/oscar/oscarPrevention/PreventionConfigSets.xml
+++ b/src/main/resources/oscar/oscarPrevention/PreventionConfigSets.xml
@@ -8,7 +8,7 @@
 
 <preventionConfig>
 	<set title="Childhood Immunization" effective="(June 2022)"
-       minAge="0" maxAge="19" prevList="DTaP-IPV,Hib,Pneu-C-15,RSVAb,MMR,MMR-Var,MenC-C,Var,HepB,dTap,Tdap-IPV,Men-C-ACYW-135,HPV-9,Td,Inf,Rota" />
+       minAge="0" maxAge="19" prevList="DTaP-IPV,Hib,Pneu-C-15,RSVAb,MMR,MMR-Var,MenC-C,Var,HepB,Tdap,Tdap-IPV,Men-C-ACYW-135,HPV-9,Td,Inf,Rota" />
 
 	<set title="Women's Preventive Care" effective="" minAge="20"
 		maxAge="74" sex="F" prevList="PAP,HPV-CERVIX,MAM,Inf,Td,Tdap" />

--- a/src/main/resources/oscar/oscarPrevention/PreventionConfigSets.xml
+++ b/src/main/resources/oscar/oscarPrevention/PreventionConfigSets.xml
@@ -7,17 +7,26 @@
 	-->
 
 <preventionConfig>
-	<set title="Childhood Immunization" effective="(August 2011)"
-       minAge="0" maxAge="19" prevList="DTaP-IPV,Hib,Pneu-C,MMR,MMRV,MenC-C,VZ,HepB,dTap,Td,Flu,Rot" />
+	<set title="Childhood Immunization" effective="(June 2022)"
+       minAge="0" maxAge="19" prevList="DTaP-IPV,Hib,Pneu-C-15,RSVAb,MMR,MMR-Var,MenC-C,Var,HepB,dTap,Tdap-IPV,Men-C-ACYW-135,HPV-9,Td,Inf,Rota" />
 
 	<set title="Women's Preventive Care" effective="" minAge="20"
-		maxAge="65" sex="F" prevList="PAP,MAM,Flu,Td" />
+		maxAge="74" sex="F" prevList="PAP,HPV-CERVIX,MAM,Inf,Td,Tdap" />
 
-	<set title="Men's Preventive Care" effective="" minAge="20" maxAge="65"
-		sex="M" prevList="Td,Flu,PSA" />
+	<set title="Men's Preventive Care" effective="" minAge="20" maxAge="74"
+		sex="M" prevList="Td,Inf,Pneu-C-20,PSA" />
+
+  <set title="Men's Preventive Care - AAA" effective="" minAge="65" maxAge="80"
+		sex="M" prevList="AAA" />
+
+	<set title="Preventive Care" effective="" minAge="50" maxAge="74"
+		prevList="FOBT" />
+		
+	<set title="Shingles" effective="" minAge="65"
+		prevList="RZV" />
 
 	<set title="Over 65 Preventive Care" effective="" minAge="65"
-		prevList="Flu,Td" />
+		prevList="Inf,Td,Pneu-C-20,RSV" />
 
 	<set title="Other" effective="" minAge="0" prevList="OtherA,OtherB" />
 </preventionConfig>

--- a/src/main/resources/oscar/oscarPrevention/PreventionItems.xml
+++ b/src/main/resources/oscar/oscarPrevention/PreventionItems.xml
@@ -2,27 +2,164 @@
 
 <!--
     Document   : PreventionItems.xml
-    Created on : October 26, 2005, 3:06 PM
-    Author     : Jay Gallagher
     Source     : src/main/resources/oscar/oscarPrevention/PreventionItems.xml
-    Updated on : Dec 31, 2020
     Description:
-        Xml configuration used in the Prevention Module to set up the types of preventions available.
+        XML configuration for the Prevention Module. Defines all prevention types
+        available for recording and clinical decision support.
 
+    NAMING CONVENTION (Health Canada / NACI Standard):
+        The "name" attribute is the canonical INTERNAL type code used in database storage,
+        DRL rules, and config sets. It MUST match Health Canada abbreviations exactly.
+        The "desc" attribute and optional "displayName" attribute provide user-friendly labels.
+        Example: name="Inf" with displayName="Flu" and desc="Flu=Influenza vaccine"
 
-*Passive Immunizing Agents* *Agents	Abbreviations*
-Botulism Antitoxin	BAtx
-Diphtheria Antitoxin	DAtx
-Immune Globulin	Ig
-Hepatitis B Immunoglobulin	HBIg
-Rabies Immunoglobulin	RabIg
-Respiratory Syncytial Virus Immunoglobulin	RSVIg
-Tetanus Immunoglobulin	TIg
-Varicella Immunoglobulin	VarIg
+    HEALTH CANADA IMMUNIZATION ABBREVIATIONS (Reference):
+    -------------------------------------------------------
+    Active Immunizing Agents (Vaccines):
+      Anth      Anthrax
+      BCG       Bacillus Calmette-Guérin
+      Chik      Chikungunya
+      Chol      Cholera (general)
+      Chol-Ecol-O Cholera-E.coli oral (Dukoral)
+      Chol-O    Cholera oral
+      COVID-19  COVID-19 vaccine
+      d         Diphtheria (low-dose, rarely used alone)
+      DT        Diphtheria-Tetanus pediatric
+      DT-IPV    Diphtheria-Tetanus-Polio pediatric
+      DTaP      Diphtheria-Tetanus-acellular Pertussis pediatric
+      DTaP-HB-IPV      DTaP-HepB-IPV
+      DTaP-HB-IPV-Hib  DTaP-HepB-IPV-Hib (eg Infanrix Hexa)
+      DTaP-Hib         DTaP-Hib
+      DTaP-IPV         DTaP-IPV (eg Infanrix IPV, Pediarix)
+      DTaP-IPV-Hib     DTaP-IPV-Hib (eg Pediacel)
+      DTaP-IPV-HB      DTaP-IPV-HepB
+      DTaP-IPV-Hib-HB  DTaP-IPV-Hib-HepB (eg Infanrix Hexa)
+      EV-A71    Enterovirus A71
+      EZV       Ebola Zaire Vaccine
+      fIPV      Fractional Inactivated Poliovirus
+      HA        Hepatitis A (eg Havrix, Avaxim)
+      HA-Typh-I Hepatitis A + Typhoid injectable (eg Vivaxim)
+      HAHB      Hepatitis A + B (eg Twinrix)
+      HB        Hepatitis B (eg Engerix-B, Recombivax HB)
+      HBIg      Hepatitis B Immunoglobulin (passive)
+      Hib       Haemophilus influenzae type b
+      Hib+HB    Hib + Hepatitis B
+      HPV       Human Papillomavirus (generic)
+      HPV-2     HPV bivalent (Cervarix)
+      HPV-4     HPV quadrivalent (Gardasil)
+      HPV-9     HPV 9-valent (Gardasil 9)
+      HZ        Herpes Zoster (generic)
+      Ig        Immune Globulin (passive)
+      Inf       Influenza (eg Fluzone, Flucelvax, FluBlok)
+      IPV       Inactivated Poliovirus Vaccine
+      JE        Japanese Encephalitis
+      LYM       Lyme disease
+      LZV       Live Zoster Vaccine (Zostavax - being phased out)
+      M         Measles (monovalent)
+      Men       Meningococcal (generic)
+      Men-A     Meningococcal A
+      Men-AC    Meningococcal AC conjugate
+      Men-ACYW-135  Meningococcal ACYW-135 polysaccharide
+      Men-B     Meningococcal B (generic)
+      Men-C     Meningococcal C (generic)
+      Men-C-A   Meningococcal C-A conjugate
+      Men-C-AC  Meningococcal C-AC conjugate
+      Men-C-ACYW     Meningococcal C-ACYW conjugate
+      Men-C-ACYW-135 Meningococcal C-ACYW-135 conjugate (eg Menactra, Menveo)
+      Men-C-C   Meningococcal C conjugate (eg Menjugate, NeisVac-C)
+      Men-C-CY  Meningococcal C-CY conjugate
+      Men-C-CY-Hib   Meningococcal C-CY + Hib
+      Men-P     Meningococcal polysaccharide (generic)
+      Men-P-A   Meningococcal A polysaccharide
+      Men-P-AC  Meningococcal AC polysaccharide
+      Men-P-ACYW-135 Meningococcal ACYW-135 polysaccharide (eg Menomune)
+      MMR       Measles-Mumps-Rubella (eg Priorix, M-M-R II)
+      MMR-Var   Measles-Mumps-Rubella-Varicella (eg Priorix-Tetra)
+      MR        Measles-Rubella
+      Mu        Mumps (monovalent)
+      Nirsevimab RSV monoclonal antibody (Beyfortus) - see RSVAb
+      OPV       Oral Poliovirus Vaccine (historical)
+      PF        Pfizer-BioNTech COVID-19 (brand specific, use COVID-19)
+      PLAG      Plague
+      Pneu      Pneumococcal (generic, unspecified)
+      Pneu-C    Pneumococcal conjugate (generic/7-valent)
+      Pneu-C-7  Pneumococcal 7-valent conjugate (Prevnar 7 - discontinued)
+      Pneu-C-10 Pneumococcal 10-valent conjugate (Synflorix)
+      Pneu-C-13 Pneumococcal 13-valent conjugate (Prevnar 13)
+      Pneu-C-15 Pneumococcal 15-valent conjugate (Vaxneuvance)
+      Pneu-C-20 Pneumococcal 20-valent conjugate (Prevnar 20)
+      Pneu-C-21 Pneumococcal 21-valent conjugate (Apexxnar)
+      Pneu-P    Pneumococcal polysaccharide (generic)
+      Pneu-P-23 Pneumococcal 23-valent polysaccharide (Pneumovax 23)
+      Rab       Rabies (eg Imovax Rabies, RabAvert)
+      RabIg     Rabies Immunoglobulin (passive)
+      Rota      Rotavirus (generic)
+      Rota-1    Rotavirus monovalent (Rotarix)
+      Rota-5    Rotavirus pentavalent (RotaTeq)
+      RSV       RSV protein subunit vaccine (eg Arexvy, Abrysvo)
+      RSVAb     RSV monoclonal antibody (Beyfortus/Nirsevimab) - pediatric
+      RSVIg     RSV Immunoglobulin (passive, historical)
+      Rubella   Rubella (monovalent, rare)
+      RZV       Recombinant Zoster Vaccine (Shingrix)
+      Sma       Smallpox (historical)
+      T         Tetanus (monovalent)
+      T-IPV     Tetanus + IPV
+      TBE       Tick-borne Encephalitis
+      Td        Tetanus-Diphtheria adult formulation (eg Td Adsorbed)
+      Td-IPV    Tetanus-Diphtheria-Polio adult
+      Tdap      Tetanus-Diphtheria-acellular Pertussis adult/adolescent (eg Adacel, Boostrix)
+      Tdap-IPV  Tdap + IPV (eg Adacel-Polio)
+      TIg       Tetanus Immunoglobulin (passive)
+      Typh      Typhoid (generic)
+      Typh-I    Typhoid injectable (eg Typhim Vi)
+      Typh-O    Typhoid oral (eg Vivotif)
+      Var       Varicella (Chickenpox) (eg Varivax III)
+      VarIg     Varicella Immunoglobulin (passive)
+      VIG       Vaccinia Immune Globulin (passive)
+      wP        Whole-cell Pertussis (historical)
+      YF        Yellow Fever (eg YF-VAX)
+      Zos       Zostavax (brand name, use LZV)
+
+    Passive Immunizing Agents (for reference, not active vaccines):
+      BAtx      Botulism Antitoxin
+      BIG-IV    Botulism Immune Globulin Intravenous
+      CMVIg     Cytomegalovirus Immunoglobulin
+      DAtx      Diphtheria Antitoxin
+      HBIg      Hepatitis B Immunoglobulin
+      Ig        Immune Globulin
+      RabIg     Rabies Immunoglobulin
+      RSVIg     Respiratory Syncytial Virus Immunoglobulin
+      TIg       Tetanus Immunoglobulin
+      VarIg     Varicella Immunoglobulin
+
+    Non-Vaccine Screenings (CARLOS internal codes):
+      AAA           Abdominal Aortic Aneurysm ultrasound
+      BMD           Bone Mineral Density
+      chlamydia     Chlamydia PCR
+      COLONOSCOPY   Colonoscopy
+      FOBT          Fecal Occult Blood / Fecal Immunochemical Test (FIT)
+      ghonorrhea PCR  Gonorrhea NAAT/PCR
+      HepB screen   Hepatitis B serology
+      HepC screen   Hepatitis C serology
+      HIV           HIV serology
+      HPV-CERVIX    HPV primary cervical screening
+      LDCT          Low-Dose CT (lung cancer screening)
+      MAM           Mammogram
+      PAP           Pap smear (cervical cytology)
+      PHV           Periodic Health Visit
+      PSA           Prostate Specific Antigen
+      Smoking       Smoking history assessment
+      Tuberculosis  Tuberculosis Mantoux
+      VDRL          VDRL syphilis serology
+
+    Updated: March 2026 - Aligned with Health Canada immunization abbreviation standard
+    Source: https://www.canada.ca/en/public-health/services/provincial-territorial-immunization-information.html
 -->
 
 <preventions>
-	<!-- Immunizations -->
+	<!-- ============================================================ -->
+	<!-- IMMUNIZATIONS                                                 -->
+	<!-- ============================================================ -->
 
 	<item
 			resultDesc=""
@@ -30,7 +167,7 @@ Varicella Immunoglobulin	VarIg
 			name="DTaP"
 			headingName="Immunizations"
 			healthCanadaType="DTaP"
-			layout="injection" 
+			layout="injection"
             atc=""
 			showIfMinRecordNum="1"/>
 
@@ -40,7 +177,7 @@ Varicella Immunoglobulin	VarIg
 			name="DTaP-IPV-Hib-HB"
 			headingName="Immunizations"
 			healthCanadaType="DTaP-IPV-Hib-HB"
-			layout="injection" 
+			layout="injection"
             atc=""
 			showIfMinRecordNum="1"/>
 
@@ -50,7 +187,7 @@ Varicella Immunoglobulin	VarIg
 			name="DTaP-IPV-HB"
 			headingName="Immunizations"
 			healthCanadaType="DTaP-IPV-HB"
-			layout="injection" 
+			layout="injection"
             atc=""
 			showIfMinRecordNum="1"/>
 
@@ -60,7 +197,7 @@ Varicella Immunoglobulin	VarIg
 			name="DT-IPV"
 			headingName="Immunizations"
 			healthCanadaType="DT-IPV"
-			layout="injection" 
+			layout="injection"
             atc=""
 			showIfMinRecordNum="1"/>
 
@@ -81,7 +218,7 @@ Varicella Immunoglobulin	VarIg
 			headingName="Immunizations"
 			healthCanadaType="DTaP-IPV-Hib"
 			link="http://www.phac-aspc.gc.ca/"
-			layout="injection" 
+			layout="injection"
             atc="J07CA06" minAge="0" maxAge="6"
 			showIfMinRecordNum="1" />
 
@@ -108,11 +245,31 @@ Varicella Immunoglobulin	VarIg
 
 	<item
 			resultDesc=""
-			desc="Rota=Rotavirus Vaccine eg Rotarix"
+			desc="Rota=Rotavirus Vaccine (generic) eg Rotarix or RotaTeq"
 			name="Rota"
 			headingName="Immunizations"
 			healthCanadaType="Rota"
 			link="www.novaccine.com/pdffiles/Rotarix_new_package_insert.pdf"
+			layout="injection"
+            atc="J07BH01" minAge="0" maxAge="2"
+			showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="Rota-1=Rotavirus monovalent vaccine eg Rotarix (2 doses)"
+			name="Rota-1"
+			headingName="Immunizations"
+			healthCanadaType="Rota-1"
+			layout="injection"
+            atc="J07BH01" minAge="0" maxAge="2"
+			showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="Rota-5=Rotavirus pentavalent vaccine eg RotaTeq (3 doses)"
+			name="Rota-5"
+			headingName="Immunizations"
+			healthCanadaType="Rota-5"
 			layout="injection"
             atc="J07BH01" minAge="0" maxAge="2"
 			showIfMinRecordNum="1" />
@@ -124,29 +281,40 @@ Varicella Immunoglobulin	VarIg
 			headingName="Immunizations"
 			healthCanadaType="Hib"
 			link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html#Hib"
-			layout="injection" 
+			layout="injection"
             atc="J07AG51" minAge="0" maxAge="6"
 			showIfMinRecordNum="1" />
 
 	<item
 			resultDesc=""
-			desc="Pneumovax Pneumococcal-Polysaccharide - 23 valent eg Pneumovax"
-			name="Pneumovax"
-			headingName="Immunizations" 
-            link="" 
+			displayName="Pneumovax"
+			desc="Pneu-P-23=Pneumococcal Polysaccharide 23-valent eg Pneumovax 23"
+			name="Pneu-P-23"
+			headingName="Immunizations"
+            link=""
             layout="injection"
 			healthCanadaType="Pneu-P-23"
 			atc="J07AL01" showIfMinRecordNum="1" />
 
 	<item
 			resultDesc=""
-			desc="Pneu-C=Pneumococcal Multi Valent Conjugate eg Prevnar 13"
+			desc="Pneu-C=Pneumococcal Multi Valent Conjugate (generic/7-valent) eg Prevnar 7"
 			name="Pneu-C"
 			headingName="Immunizations"
 			healthCanadaType="Pneu-C-7"
 			link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html#PneuC"
 			layout="injection"
             atc="J07AL02" minAge="0" maxAge="2"
+			showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="Pneu-C-13=Pneumococcal 13-valent Conjugate eg Prevnar 13"
+			name="Pneu-C-13"
+			headingName="Immunizations"
+			healthCanadaType="Pneu-C-13"
+			layout="injection"
+            atc="J07AL02" minAge="0" maxAge="100"
 			showIfMinRecordNum="1" />
 
 	<item
@@ -171,11 +339,11 @@ Varicella Immunoglobulin	VarIg
 
 	<item
 			resultDesc=""
-			desc="Measles"
+			desc="Measles monovalent"
 			name="M"
 			headingName="Immunizations"
 			healthCanadaType="M"
-			layout="injection" 
+			layout="injection"
             atc=""
 			showIfMinRecordNum="1" />
 
@@ -195,7 +363,7 @@ Varicella Immunoglobulin	VarIg
 			headingName="Immunizations"
 			healthCanadaType="MMR"
 			link="http://www.phac-aspc.gc.ca/publicat/cig-gci/p04-meas-roug-eng.php"
-			layout="injection" 
+			layout="injection"
             atc="J07BD52" minAge="0" maxAge="9"
 			showIfMinRecordNum="1" />
 
@@ -212,50 +380,53 @@ Varicella Immunoglobulin	VarIg
 
 	<item
 			resultDesc=""
-			desc="Meningococcal - Polysaccharide"
+			desc="Men-P-AC=Meningococcal AC Polysaccharide"
 			name="Men-P-AC"
 			headingName="Immunizations"
 			healthCanadaType="Men-P-AC"
-			layout="injection" 
+			layout="injection"
             atc="J07AH"
 			showIfMinRecordNum="1" />
 
 	<item
 			resultDesc=""
-			desc="Meningococcal - Polysaccharide eg Menomune"
+			displayName="Menomune"
+			desc="Men-P-ACWY=Meningococcal ACWY Polysaccharide eg Menomune"
 			name="Men-P-ACWY"
 			headingName="Immunizations"
-			healthCanadaType="Men-P-ACWY"
-			layout="injection" 
+			healthCanadaType="Men-P-ACYW-135"
+			layout="injection"
             atc="J07AH"
 			showIfMinRecordNum="1" />
 
 	<item
 			resultDesc=""
-			desc="Meningococcal Conjugate ACYW-135 eg Menactra"
+			desc="Men-C-ACYW-135=Meningococcal ACYW-135 Conjugate eg Menactra, Menveo"
 			name="Men-C-ACYW-135"
 			headingName="Immunizations"
 			healthCanadaType="Men-C-ACYW-135"
-			layout="injection" 
+			layout="injection"
             atc="J07AH"
 			showIfMinRecordNum="1" />
 
 	<item
 			resultDesc=""
-			desc="MenC-C=Meningocococcal C Conjugate eg Menjugate"
-			name="MenC-C"
+			desc="Men-C-C=Meningococcal C Conjugate eg Menjugate, NeisVac-C"
+			name="Men-C-C"
 			headingName="Immunizations"
-			healthCanadaType="Men-C"
+			healthCanadaType="Men-C-C"
 			link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html#MenC"
-			layout="injection" 
+			layout="injection"
             atc="J07AH07" minAge="0" maxAge="19"
 			showIfMinRecordNum="1" />
 
 	<item
 			resultDesc=""
-			desc="rMenB=Meningocococcal B Recombinant Multicomponent eg Bexsero"
+			displayName="Bexsero"
+			desc="rMenB=Meningococcal B Recombinant Multicomponent eg Bexsero"
 			name="rMenB"
-			healthCanadaType="rMenB"
+			headingName="Immunizations"
+			healthCanadaType="Men-B"
 			link="http://www.hc-sc.gc.ca/dhp-mps/prodpharma/sbd-smd/drug-med/sbd_smd_2014_bexsero_147275-eng.php"
 			layout="injection"
 			atc="J07AH08"
@@ -265,7 +436,7 @@ Varicella Immunoglobulin	VarIg
 
 	<item
 			resultDesc=""
-			desc="Var=Varicella Zoster eg Varivax III"
+			desc="Var=Varicella (Chickenpox) eg Varivax III"
 			name="Var"
 			headingName="Immunizations"
 			healthCanadaType="Var"
@@ -278,9 +449,11 @@ Varicella Immunoglobulin	VarIg
 
 	<item
 			resultDesc=""
-			desc="HZV=Herpes Zoster Vaccine eg Zostavax"
-			name="HZV"
-			healthCanadaType="HZV"
+			displayName="Zostavax"
+			desc="LZV=Live Zoster Vaccine eg Zostavax (being replaced by Shingrix/RZV)"
+			name="LZV"
+			headingName="Immunizations"
+			healthCanadaType="LZV"
 			link="http://www.phac-aspc.gc.ca/naci-ccni/hzv-vcz-eng.php"
 			layout="injection"
 			atc="J07BK02"
@@ -289,9 +462,10 @@ Varicella Immunoglobulin	VarIg
 
 	<item
 			resultDesc=""
-			desc="RZV=herpes zoster recomb subunit vaccine eg Shingrix" 
-            name="RZV" 
-            healthCanadaType="HerpR"
+			desc="RZV=Recombinant Herpes Zoster (Subunit) Vaccine eg Shingrix (2 doses)"
+			name="RZV"
+			headingName="Immunizations"
+			healthCanadaType="RZV"
 			layout="injection"
 			atc="J07BK03"
 			minAge="50"
@@ -300,38 +474,40 @@ Varicella Immunoglobulin	VarIg
 
 	<item
 			resultDesc=""
-			desc="Hep B=Hepatitis B" 
-            name="HepB"
-			headingName="Immunizations" 
-            healthCanadaType="HB"
+			displayName="HepB"
+			desc="HepB=Hepatitis B eg Engerix-B, Recombivax HB"
+			name="HB"
+			headingName="Immunizations"
+			healthCanadaType="HB"
 			link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html#HepB"
-			layout="injection" 
+			layout="injection"
             atc="J07BC01" minAge="0" maxAge="1"
 			showIfMinRecordNum="1" />
 
 	<item
 			resultDesc=""
-			desc="Tetanus"
+			displayName="Tetanus"
+			desc="T=Tetanus monovalent"
 			name="T"
 			headingName="Immunizations"
 			healthCanadaType="T"
-			layout="injection" 
+			layout="injection"
             atc="J07AM"
 			showIfMinRecordNum="1" />
 
 	<item
 			resultDesc=""
-			desc="Tetanus, Diphtheria, Inactivated Polio - adult"
+			desc="Td-IPV=Tetanus, Diphtheria, Inactivated Polio - adult"
 			name="Td-IPV"
 			headingName="Immunizations"
 			healthCanadaType="Td-IPV"
-			layout="injection" 
+			layout="injection"
             atc=""
 			showIfMinRecordNum="1" />
 
 	<item
 			resultDesc=""
-			desc="Tdap=Diphtheria, Tetanus and Acellular Pertussis adult/adolescent formulation"
+			desc="Tdap=Diphtheria, Tetanus and Acellular Pertussis adult/adolescent formulation eg Adacel, Boostrix"
 			name="Tdap"
 			headingName="Immunizations"
             healthCanadaType="Tdap"
@@ -342,91 +518,104 @@ Varicella Immunoglobulin	VarIg
 
 	<item
 			resultDesc=""
-			desc="Td=Tetanus and Diphtheria adult type formulation"
+			desc="Td=Tetanus and Diphtheria adult type formulation eg Td Adsorbed"
 			name="Td"
-			headingName="Immunizations" 
+			headingName="Immunizations"
             healthCanadaType="Td"
 			link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html#dTap"
-			layout="injection" 
+			layout="injection"
             atc="J07CA01" minAge="0" showIfMinRecordNum="1" />
 
 	<item
 			resultDesc=""
-			desc="Inf=Influenza vaccine"
-            name="Inf"
+			displayName="Flu"
+			desc="Flu=Influenza vaccine eg Fluzone, Flucelvax, FluBlok"
+			name="Inf"
 			headingName="Immunizations"
-            healthCanadaType="Inf"
+			healthCanadaType="Inf"
 			link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html#Flu"
 			layout="injection"
             atc="J07BB01" minAge="0" />
 
 	<item
 			resultDesc=""
-			desc="Hepatitis A and Typhoid - Injection"
+			desc="HA-Typh-I=Hepatitis A and Typhoid Injectable eg Vivaxim"
 			name="HA-Typh-I"
 			headingName="Immunizations"
 			healthCanadaType="HA-Typh-I"
-			layout="injection" 
+			layout="injection"
             atc=""
 			showIfMinRecordNum="1" />
 
 	<item
 			resultDesc=""
-			desc="Hep A=Hepatitis A" 
-            name="HepA"
-			headingName="Immunizations" 
-            link="" 
-            layout="injection" 
+			displayName="HepA"
+			desc="HepA=Hepatitis A eg Havrix, Avaxim"
+			name="HA"
+			headingName="Immunizations"
+            link=""
+            layout="injection"
             healthCanadaType="HA"
 			atc="J07BC02" showIfMinRecordNum="1" />
 
 	<item
 			resultDesc=""
-			desc="Hep AB=Hepatitis AB" 
-            name="HepAB" link=""
-			headingName="Immunizations" 
-            layout="injection" 
+			displayName="HepAB"
+			desc="HepAB=Hepatitis A + B eg Twinrix"
+			name="HAHB"
+			headingName="Immunizations"
+            link=""
+			layout="injection"
             healthCanadaType="HAHB"
-			atc="J07BC20" 
+			atc="J07BC20"
             showIfMinRecordNum="1" />
 
 	<item
 			resultDesc=""
-			desc="Cholera - E.coli - Oral"
+			displayName="Dukoral"
+			desc="Chol-O=Cholera oral eg Dukoral"
+			name="Chol-O"
+			headingName="Immunizations"
+			healthCanadaType="Chol-O"
+			link=""
+            layout="injection"
+            atc="J07AE01" showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="Chol-Ecol-O=Cholera-E.coli oral (includes ETEC)"
 			name="Chol-Ecol-O"
 			headingName="Immunizations"
 			healthCanadaType="Chol-Ecol-O"
-			layout="injection" 
+			layout="injection"
             atc=""
 			showIfMinRecordNum="1" />
 
 	<item
 			resultDesc=""
-			desc="Dukoral" 
-            name="CHOLERA"
-			headingName="Immunizations" link="" 
-            layout="injection" 
-            healthCanadaType="Chol-O"
-			atc="J07AE01" showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc="Rabies=Rabies" name="Rabies" link=""
-			headingName="Immunizations" layout="injection" healthCanadaType="Rab"
+			displayName="Rabies"
+			desc="Rab=Rabies eg Imovax Rabies, RabAvert"
+			name="Rab"
+			headingName="Immunizations"
+			link=""
+			layout="injection"
+			healthCanadaType="Rab"
 			atc="J07BG01" showIfMinRecordNum="1" />
 
 	<item
 			resultDesc=""
-			desc="Typhoid=Typhoid" 
-            name="Typhoid" link=""
-			headingName="Immunizations" 
-            layout="injection" 
+			displayName="Typhoid"
+			desc="Typh-I=Typhoid injectable eg Typhim Vi"
+			name="Typh-I"
+			headingName="Immunizations"
+			link=""
+			layout="injection"
             healthCanadaType="Typh-I"
 			atc="J07AP01" showIfMinRecordNum="1" />
 
 	<item
 			resultDesc=""
-			desc="Typhoid - Oral"
+			desc="Typh-O=Typhoid oral eg Vivotif"
 			name="Typh-O"
 			headingName="Immunizations"
 			healthCanadaType="Typh-O"
@@ -435,15 +624,16 @@ Varicella Immunoglobulin	VarIg
 
 	<item
 			resultDesc=""
-			desc="Women ages of 9 and 26 years are recommended to receive Human Papillomavirus Vaccine eg Gardasil, Cervarix"
-			name="HPV Vaccine"
+			displayName="HPV Vaccine"
+			desc="HPV=Human Papillomavirus Vaccine (generic) eg Gardasil, Cervarix"
+			name="HPV"
 			headingName="Immunizations"
 			healthCanadaType="HPV"
 			link="http://www.cdc.gov/std/treatment/"
 			layout="injection"
 			atc="J07BM"
 			minAge="9"
-			maxAge="26" sex = "F"
+			maxAge="45"
 			showIfMinRecordNum="1" />
 
 	<item
@@ -461,7 +651,7 @@ Varicella Immunoglobulin	VarIg
 	<item
 			resultDesc=""
 			desc="IPV=Inactivated Poliovirus Vaccine"
-            name="IPV"
+			name="IPV"
 			headingName="Immunizations"
 			healthCanadaType="IPV"
             link=""
@@ -475,43 +665,44 @@ Varicella Immunoglobulin	VarIg
 			name="BCG"
 			headingName="Immunizations"
 			healthCanadaType="BCG"
-			layout="injection" 
+			layout="injection"
             atc="J07AN"
 			showIfMinRecordNum="1"/>
 
 	<item
 			resultDesc=""
-			desc="Yellow Fever eg YF-VAX"
+			desc="YF=Yellow Fever eg YF-VAX"
 			name="YF"
 			headingName="Immunizations"
 			healthCanadaType="YF"
-			layout="injection" 
+			layout="injection"
             atc="J07BL"
 			showIfMinRecordNum="1"/>
 
 	<item
 			resultDesc=""
-			desc="Tickborne Encephalitis"
+			desc="TBE=Tickborne Encephalitis"
 			name="TBE"
 			headingName="Immunizations"
 			healthCanadaType="TBE"
-			layout="injection" 
+			layout="injection"
             atc="J07BA"
 			showIfMinRecordNum="1"/>
 
 	<item
 			resultDesc=""
-			desc="Japanese Encephalitis"
+			desc="JE=Japanese Encephalitis"
 			name="JE"
 			headingName="Immunizations"
 			healthCanadaType="JE"
-			layout="injection" 
+			layout="injection"
             atc="J07BA"
 			showIfMinRecordNum="1" />
 
 	<item
 			resultDesc=""
-			desc="H1N1 Vaccination"
+			displayName="H1N1 / Pandemic Flu"
+			desc="H1N1=Pandemic H1N1 Influenza Vaccination (classified as Inf per Health Canada)"
 			name="H1N1"
 			headingName="Immunizations"
 			healthCanadaType="Inf"
@@ -521,77 +712,142 @@ Varicella Immunoglobulin	VarIg
 
 	<item
 			resultDesc=""
-			desc="COVID-19"
+			desc="COVID-19=COVID-19 vaccine eg Comirnaty, Spikevax, Nuvaxovid"
 			name="COVID-19"
             headingName="Immunizations"
 			healthCanadaType="COVID-19"
 			link="https://www.cdc.gov/vaccines/covid-19"
-			layout="injection" 
+			layout="injection"
             atc="J07BX03"
 			showIfMinRecordNum="1" />
 
-	<!--Screenings-->
+	<item
+			resultDesc=""
+			name="RSV"
+			desc="RSV=Recombinant PreF RSV Vaccine eg Arexvy, Abrysvo"
+			headingName="Immunizations"
+			healthCanadaType="RSV"
+			link="https://ca.gsk.com/media/6988/arexvy.pdf"
+			layout="injection"
+			minAge="60"
+			maxAge="100"
+            atc="J07BX05"
+			showIfMinRecordNum="1" />
 
 	<item
 			resultDesc=""
-			desc="TB=Tuberculosis Mantoux " 
-            name="Tuberculosis"
-			headingName="Screenings" link="" 
-            layout="injection"
+			displayName="Beyfortus"
+			name="RSVAb"
+			desc="RSVAb=Monoclonal Antibody RSV Prophylaxis eg Beyfortus (Nirsevimab) - pediatric"
+			headingName="Immunizations"
+			healthCanadaType="RSVAb"
+			link="https://www.ema.europa.eu/en/medicines/human/EPAR/beyfortus#product-info"
+			layout="injection"
+			minAge="0"
+			maxAge="2"
+            atc="J06BD08"
+			showIfMinRecordNum="1" />
+
+	<!-- ============================================================ -->
+	<!-- SCREENINGS                                                    -->
+	<!-- ============================================================ -->
+
+	<item
+			resultDesc=""
+			desc="Tuberculosis=Tuberculosis Mantoux test"
+			name="Tuberculosis"
+			headingName="Screenings"
+			link=""
+			layout="injection"
 			atc="J07AN01" showIfMinRecordNum="1" />
 
 	<item
 			resultDesc=""
-			desc="Women from ages 25 to 60 are recommended to receive a PAP" name="PAP"
-			headingName="Screenings" link="" layout="PAPMAM" minAge="25"
+			desc="PAP=Cervical cytology (Pap smear) - women ages 25 to 70"
+			name="PAP"
+			headingName="Screenings"
+			link=""
+			layout="PAPMAM" minAge="25"
+			maxAge="70" sex="F" showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="HPV-CERVIX=HPV primary cervical cancer screening every 5 years - women ages 25 to 69"
+			name="HPV-CERVIX"
+			headingName="Screenings"
+			link=""
+			layout="PAPMAM" minAge="25"
 			maxAge="69" sex="F" showIfMinRecordNum="1" />
 
 	<item
 			resultDesc=""
-			desc="Women from ages 25 to 69" name="HPV-CERVIX"
-			headingName="Screenings" link="" layout="PAPMAM" minAge="25"
-			maxAge="69" sex="F" showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc="Mammogram" name="MAM"
-			headingName="Screenings" link="" layout="PAPMAM" minAge="40"
+			desc="MAM=Mammogram breast cancer screening every 2 years - women ages 40 to 74"
+			name="MAM"
+			headingName="Screenings"
+			link=""
+			layout="PAPMAM" minAge="40"
 			maxAge="74" sex="F" showIfMinRecordNum="1" />
 
 	<item
 			resultDesc=""
-			desc="PSA" name="PSA"
-			headingName="Screenings" link="" layout="PAPMAM" minAge="50"
+			desc="PSA=Prostate Specific Antigen screening"
+			name="PSA"
+			headingName="Screenings"
+			link=""
+			layout="PAPMAM" minAge="50"
 			maxAge="70" sex="M" showIfMinRecordNum="1" />
 
 	<item
 			resultDesc=""
 			displayName="FIT/FOBT"
-			desc="Fecal Occult Blood Test or Fecal Immunochemical Test" name="FOBT"
-			headingName="Screenings" link="" layout="PAPMAM"
+			desc="FOBT=Fecal Occult Blood Test / Fecal Immunochemical Test (FIT) every 2 years ages 50-74"
+			name="FOBT"
+			headingName="Screenings"
+			link=""
+			layout="PAPMAM"
 			minAge="50" maxAge="74" showIfMinRecordNum="1" />
 
 	<item
 			resultDesc=""
-			desc="Abdominal Aortic Aneurysm ultrasound screening" name="AAA"
-			headingName="Screenings" link="" layout="PAPMAM" minAge="65"
+			desc="AAA=Abdominal Aortic Aneurysm ultrasound screening - once for men ages 65-80"
+			name="AAA"
+			headingName="Screenings"
+			link=""
+			layout="PAPMAM" minAge="65"
 			maxAge="80" sex="M" showIfMinRecordNum="1" />
 
 	<item
 			resultDesc=""
-			desc="Colonoscopy" name="COLONOSCOPY"
-			headingName="Screenings" link="" layout="PAPMAM"
+			desc="COLONOSCOPY=Colonoscopy for colorectal cancer screening every 10 years"
+			name="COLONOSCOPY"
+			headingName="Screenings"
+			link=""
+			layout="PAPMAM"
 			showIfMinRecordNum="1" />
 
 	<item
 			resultDesc=""
-			desc="Bone Mineral Density" name="BMD"
-			headingName="Screenings" link="" layout="PAPMAM" minAge="65"
+			displayName="LDCT Lung Cancer"
+			desc="LDCT=Low-Dose Computed Tomography for lung cancer screening - annual for high-risk smokers ages 55-74 (Canada CTFPHC: 20+ pack-years)"
+			name="LDCT"
+			headingName="Screenings"
+			link=""
+			layout="PAPMAM"
+			minAge="55" maxAge="74"
 			showIfMinRecordNum="1" />
 
 	<item
 			resultDesc=""
-			desc="HIV = all pregnant women, opt out routine screening of all adults"
+			desc="BMD=Bone Mineral Density screening"
+			name="BMD"
+			headingName="Screenings"
+			link=""
+			layout="PAPMAM" minAge="65"
+			showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="HIV=HIV serology - all pregnant women, opt-out routine screening of all adults"
 			name="HIV"
 			headingName="Screenings"
 			link="http://www.cdc.gov/std/treatment/"
@@ -602,7 +858,7 @@ Varicella Immunoglobulin	VarIg
 
 	<item
 			resultDesc=""
-			desc="HepB screen= Hepatitis B serology (hep B sAg + anti-HBc or anti-HBs) in those with multiple sex partners, MSM, and injection drug users"
+			desc="HepB screen=Hepatitis B serology (HBsAg + anti-HBc or anti-HBs) in those with multiple sex partners, MSM, and injection drug users"
 			name="HepB screen"
 			headingName="Screenings"
 			link="http://www.cdc.gov/std/treatment/"
@@ -613,18 +869,17 @@ Varicella Immunoglobulin	VarIg
 
 	<item
 			resultDesc=""
-			desc="HepC screen = Hep C Ab serology in contacts of multiple sex partners, traumatic anal intercourse with infected person, IVDU"
+			desc="HepC screen=Hepatitis C Ab serology in those with multiple sex partners, traumatic anal intercourse with infected person, IVDU; also recommended for 1945-1975 birth cohort"
 			name="HepC screen"
 			headingName="Screenings"
 			link="http://www.cdc.gov/std/treatment/"
 			layout="PAPMAM"
 			minAge="15"
-			maxAge="24"
 			showIfMinRecordNum="1" />
 
 	<item
 			resultDesc=""
-			desc="VDRL = VDRL screening for syphillis; pregnant women at the first prenatal visit (and 3rd trimester and delivery high-risk groups), all sex workers, in correctional facilities, diagnosed with another STD, MSM with high-risk behaviors"
+			desc="VDRL=VDRL syphilis serology; pregnant women at first prenatal visit, all sex workers, correctional facilities, MSM with high-risk behaviors"
 			name="VDRL"
 			headingName="Screenings"
 			link="http://www.cdc.gov/std/treatment/"
@@ -635,7 +890,7 @@ Varicella Immunoglobulin	VarIg
 
 	<item
 			resultDesc=""
-			desc="Chlamydia = chlamydia urine PCR; sexually active women age 25 years or younger (including pregnant women), women older than 25 years with: new sex partner in prior 60 days, more than one sex partner, inconsistent condom use, unmarried, or history of STD; men: asymptomatic screening may or may not benefit "
+			desc="chlamydia=Chlamydia urine PCR; sexually active women age 25 years or younger, women older than 25 with new sex partner or risk factors"
 			name="chlamydia"
 			headingName="Screenings"
 			link="http://www.cdc.gov/std/treatment/"
@@ -646,7 +901,7 @@ Varicella Immunoglobulin	VarIg
 
 	<item
 			resultDesc=""
-			desc= "ghonorrhea = ghonorrhea urine PCR in men with symptoms or asymptomatic women: Sexually active younger than 25 years, pregnancy, inconsistent condom use, multiple partners, partner with multiple contacts, sexual contact with partner with culture-proven STD, repeated episodes of STD, Sex work or drug use"
+			desc="ghonorrhea PCR=Gonorrhea NAAT/PCR in symptomatic men or asymptomatic women with risk factors"
 			name="ghonorrhea PCR"
 			headingName="Screenings"
 			link="http://www.cdc.gov/std/treatment/"
@@ -657,7 +912,7 @@ Varicella Immunoglobulin	VarIg
 
 	<item
 			resultDesc=""
-			desc= "Periodic Health Visit"
+			desc="PHV=Periodic Health Visit annual wellness check"
 			name="PHV"
 			headingName="Screenings"
 			layout="history"
@@ -665,19 +920,21 @@ Varicella Immunoglobulin	VarIg
 
 	<item
 			resultDesc=""
-			desc= "Smoking history"
+			desc="Smoking=Tobacco use history assessment"
 			name="Smoking"
 			layout="history"
 			headingName="Screenings"
 			minAge="13"
 			showIfMinRecordNum="1" />
 
-	<!-- Other -->
+	<!-- ============================================================ -->
+	<!-- OTHER                                                         -->
+	<!-- ============================================================ -->
 
 	<item
 			resultDesc=""
-			desc="Other Layout A" 
-            name="OtherA"
+			desc="OtherA=Other immunization or injection (catch-all for non-standard types)"
+			name="OtherA"
 			headingName="Other"
 			healthCanadaType=""
             link="" layout="injection"
@@ -685,62 +942,37 @@ Varicella Immunoglobulin	VarIg
 
 	<item
 			resultDesc=""
-			desc="Other Layout B" 
-            name="OtherB"
-			headingName="Other" 
+			desc="OtherB=Other screening or preventive procedure (catch-all for non-standard types)"
+			name="OtherB"
+			headingName="Other"
             link="" layout="PAPMAM"
 			showIfMinRecordNum="1" />
 
 	<item
 			resultDesc=""
-			desc="TdP-IPV-Hib=Diphtheria, Tetanus and Acellular Pertussis for children under 18 years of age; IPV=Inactivated Poliovirus; Haemophilus Influenzae type b for children under 5 years of age: combination given at 2, 4, 18 months and 4-6 years"
+			desc="TdP-IPV-Hib=Legacy combination vaccine (similar to DTaP-IPV-Hib); combination given at 2, 4, 18 months and 4-6 years"
 			name="TdP-IPV-Hib"
 			headingName="Other"
 			link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html"
 			layout="injection" atc="J07CA06" minAge="0" maxAge="6"
 			showIfMinRecordNum="1" />
 
-
 	<item
 			resultDesc=""
 			desc="DTaP-Hib=Diphtheria, Tetanus, Acellular Pertussis, Haemophilus Influenzae type b - pediatric"
 			name="DTaP-Hib"
-			headingName="Other"
-			healthCanadaType="DTaP-IPV-HB"
+			headingName="Immunizations"
+			healthCanadaType="DTaP-Hib"
 			layout="injection" atc=""
 			showIfMinRecordNum="1"/>
 
 	<item
 			resultDesc=""
-			desc="Hepatitis B - Thimerosal free"
+			desc="HBTmf=Hepatitis B Thimerosal-free formulation"
 			name="HBTmf"
 			headingName="Other"
-			healthCanadaType="HBTmf"
+			healthCanadaType="HB"
 			layout="injection" atc="J07BC"
 			showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			name="RSV"
-			desc="Recombinant PreF RSV Vaccine eg Arexvy"
-			healthCanadaType="RSV"
-			link="https://ca.gsk.com/media/6988/arexvy.pdf"
-			layout="injection"
-			minAge="60"
-			maxAge="100"
-            atc="J07BX05"
-   			showIfMinRecordNum="1" />
-			
-	<item
-			resultDesc=""
-			name="RSVAb"
-			desc="Monoclonal Antibody RSV Vaccine eg Beyfortus"
-			healthCanadaType="RSVAb"
-			link="https://www.ema.europa.eu/en/medicines/human/EPAR/beyfortus#product-info"
-			layout="injection"
-			minAge="0"
-			maxAge="2"
-            atc="J06BD08"
-   			showIfMinRecordNum="1" />
 
 </preventions>

--- a/src/main/resources/oscar/oscarPrevention/PreventionItems.xml
+++ b/src/main/resources/oscar/oscarPrevention/PreventionItems.xml
@@ -245,12 +245,12 @@
 
 	<item
 			resultDesc=""
-			desc="Rota=Rotavirus Vaccine (generic) eg Rotarix or RotaTeq"
+			desc="Rota=Rotavirus Vaccine (generic) eg Rotarix or RotaTeq (given orally)"
 			name="Rota"
 			headingName="Immunizations"
 			healthCanadaType="Rota"
 			link="www.novaccine.com/pdffiles/Rotarix_new_package_insert.pdf"
-			layout="injection"
+			layout="oral"
             atc="J07BH01" minAge="0" maxAge="2"
 			showIfMinRecordNum="1" />
 
@@ -513,7 +513,7 @@
             healthCanadaType="Tdap"
 			link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html#dTap"
 			layout="injection"
-            atc="J07AJ52" minAge="0" maxAge="6"
+            atc="J07AJ52" minAge="10"
 			showIfMinRecordNum="1" />
 
 	<item
@@ -573,12 +573,12 @@
 	<item
 			resultDesc=""
 			displayName="Dukoral"
-			desc="Chol-O=Cholera oral eg Dukoral"
+			desc="Chol-O=Cholera oral eg Dukoral (given orally)"
 			name="Chol-O"
 			headingName="Immunizations"
 			healthCanadaType="Chol-O"
 			link=""
-            layout="injection"
+            layout="oral"
             atc="J07AE01" showIfMinRecordNum="1" />
 
 	<item
@@ -615,11 +615,11 @@
 
 	<item
 			resultDesc=""
-			desc="Typh-O=Typhoid oral eg Vivotif"
+			desc="Typh-O=Typhoid oral eg Vivotif (given orally)"
 			name="Typh-O"
 			headingName="Immunizations"
 			healthCanadaType="Typh-O"
-			layout="injection" atc="J07AP"
+			layout="oral" atc="J07AP"
 			showIfMinRecordNum="1"/>
 
 	<item

--- a/src/main/resources/oscar/oscarPrevention/PreventionItems.xml
+++ b/src/main/resources/oscar/oscarPrevention/PreventionItems.xml
@@ -69,8 +69,8 @@ Varicella Immunoglobulin	VarIg
 			desc="Tdap-IPV=Diphtheria, Tetanus and Acellular Pertussis for children 4 - 6 years of age; IPV=Inactivated Poliovirus; eg Adacel-IPV"
 			name="Tdap-IPV"
 			headingName="Immunizations"
-			healthCanadaType=""
-			layout="injection" 
+			healthCanadaType="Tdap-IPV"
+			layout="injection"
             atc="J07AJ52" minAge="4" maxAge="6"
 			showIfMinRecordNum="1" />
 
@@ -87,12 +87,12 @@ Varicella Immunoglobulin	VarIg
 
 	<item
 			resultDesc=""
-			desc="Diphtheria, Tetanus, Pertussis, HepB, Polio, Haemophilus Influenzae type b (6wks-2yrs)"
-			name="DTaP-HBV-IPV-Hib"
+			desc="DTaP-HB-IPV-Hib=Diphtheria, Tetanus, Pertussis, Hepatitis B, Polio, Haemophilus Influenzae type b (6wks-2yrs)"
+			name="DTaP-HB-IPV-Hib"
 			headingName="Immunizations"
-			healthCanadaType=""
+			healthCanadaType="DTaP-HB-IPV-Hib"
 			link="http://www.phac-aspc.gc.ca/"
-			layout="injection" 
+			layout="injection"
             atc="J07CA02" minAge="0" maxAge="6"
 			showIfMinRecordNum="1" />
 
@@ -108,12 +108,12 @@ Varicella Immunoglobulin	VarIg
 
 	<item
 			resultDesc=""
-			desc="Rot-1=Rotavirus Vaccine eg Rotarix"
-			name="Rot"
+			desc="Rota=Rotavirus Vaccine eg Rotarix"
+			name="Rota"
 			headingName="Immunizations"
-			healthCanadaType=""
+			healthCanadaType="Rota"
 			link="www.novaccine.com/pdffiles/Rotarix_new_package_insert.pdf"
-			layout="injection" 
+			layout="injection"
             atc="J07BH01" minAge="0" maxAge="2"
 			showIfMinRecordNum="1" />
 
@@ -145,8 +145,28 @@ Varicella Immunoglobulin	VarIg
 			headingName="Immunizations"
 			healthCanadaType="Pneu-C-7"
 			link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html#PneuC"
-			layout="injection" 
+			layout="injection"
             atc="J07AL02" minAge="0" maxAge="2"
+			showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="Pneu-C-15=Pneumococcal 15-valent Conjugate eg Vaxneuvance"
+			name="Pneu-C-15"
+			headingName="Immunizations"
+			healthCanadaType="Pneu-C-15"
+			layout="injection"
+            atc="J07AL02" minAge="0" maxAge="5"
+			showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="Pneu-C-20=Pneumococcal 20-valent Conjugate eg Prevnar 20"
+			name="Pneu-C-20"
+			headingName="Immunizations"
+			healthCanadaType="Pneu-C-20"
+			layout="injection"
+            atc="J07AL02" minAge="18"
 			showIfMinRecordNum="1" />
 
 	<item
@@ -181,12 +201,12 @@ Varicella Immunoglobulin	VarIg
 
 	<item
 			resultDesc=""
-			desc="MMRV=Measles, Mumps, Rubella, Varicella eg Priorix-Tetra"
-			name="MMRV"
+			desc="MMR-Var=Measles, Mumps, Rubella, Varicella eg Priorix-Tetra"
+			name="MMR-Var"
 			headingName="Immunizations"
-			healthCanadaType="MMRV"
+			healthCanadaType="MMR-Var"
 			link="http://www.phac-aspc.gc.ca/publicat/ccdr-rmtc/10vol36/acs-9/index-eng.php"
-			layout="injection" 
+			layout="injection"
             atc="J07BD54" minAge="0" maxAge="9"
 			showIfMinRecordNum="1" />
 
@@ -245,8 +265,8 @@ Varicella Immunoglobulin	VarIg
 
 	<item
 			resultDesc=""
-			desc="VZ=Varicella Zoster eg Varivax III"
-			name="VZ"
+			desc="Var=Varicella Zoster eg Varivax III"
+			name="Var"
 			headingName="Immunizations"
 			healthCanadaType="Var"
 			link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html#Var"
@@ -311,12 +331,12 @@ Varicella Immunoglobulin	VarIg
 
 	<item
 			resultDesc=""
-			desc="dTap=Diphtheria, Tetanus and Acellular Pertussis adult/adolescent formulation"
-			name="dTap"
-			headingName="Immunizations" 
+			desc="Tdap=Diphtheria, Tetanus and Acellular Pertussis adult/adolescent formulation"
+			name="Tdap"
+			headingName="Immunizations"
             healthCanadaType="Tdap"
 			link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html#dTap"
-			layout="injection" 
+			layout="injection"
             atc="J07AJ52" minAge="0" maxAge="6"
 			showIfMinRecordNum="1" />
 
@@ -332,12 +352,12 @@ Varicella Immunoglobulin	VarIg
 
 	<item
 			resultDesc=""
-			desc="Flu=Influenza vaccine" 
-            name="Flu"
-			headingName="Immunizations" 
+			desc="Inf=Influenza vaccine"
+            name="Inf"
+			headingName="Immunizations"
             healthCanadaType="Inf"
 			link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html#Flu"
-			layout="injection" 
+			layout="injection"
             atc="J07BB01" minAge="0" />
 
 	<item
@@ -428,23 +448,24 @@ Varicella Immunoglobulin	VarIg
 
 	<item
 			resultDesc=""
-			desc="TdP" 
-            name="TdP"
-			headingName="Immunizations" 
-			healthCanadaType=""
-            link="" 
-            layout="injection" 
-            atc="J07AJ52"
+			desc="HPV-9=Human Papillomavirus 9-valent vaccine eg Gardasil 9"
+			name="HPV-9"
+			headingName="Immunizations"
+			healthCanadaType="HPV-9"
+			layout="injection"
+			atc="J07BM01"
+			minAge="9"
+			maxAge="45"
 			showIfMinRecordNum="1" />
 
 	<item
 			resultDesc=""
-			desc="IPV" 
+			desc="IPV=Inactivated Poliovirus Vaccine"
             name="IPV"
 			headingName="Immunizations"
-			healthCanadaType="" 
-            link="" 
-            layout="injection" 
+			healthCanadaType="IPV"
+            link=""
+            layout="injection"
             atc="J07BF03"
 			showIfMinRecordNum="1" />
 
@@ -493,7 +514,7 @@ Varicella Immunoglobulin	VarIg
 			desc="H1N1 Vaccination"
 			name="H1N1"
 			headingName="Immunizations"
-			healthCanadaType="" 
+			healthCanadaType="Inf"
             layout="h1n1"
 			minAge="0"
 			atc="J07BB02" />
@@ -549,6 +570,12 @@ Varicella Immunoglobulin	VarIg
 			desc="Fecal Occult Blood Test or Fecal Immunochemical Test" name="FOBT"
 			headingName="Screenings" link="" layout="PAPMAM"
 			minAge="50" maxAge="74" showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="Abdominal Aortic Aneurysm ultrasound screening" name="AAA"
+			headingName="Screenings" link="" layout="PAPMAM" minAge="65"
+			maxAge="80" sex="M" showIfMinRecordNum="1" />
 
 	<item
 			resultDesc=""

--- a/src/main/resources/oscar/oscarPrevention/PublicHealthPreventionItems.xml
+++ b/src/main/resources/oscar/oscarPrevention/PublicHealthPreventionItems.xml
@@ -4,6 +4,8 @@
     Document   : PreventionItems.xml
     Created on : October 26, 2005, 3:06 PM
     Author     : Jay Gallagher
+    Source     : src/main/resources/oscar/oscarPrevention/PreventionItems.xml
+    Updated on : March 10, 2026 by Peter Hutten-Czapski
     Description:
         Xml configuration used in the Prevention Module to set up the types of preventions available.
 
@@ -17,655 +19,710 @@ Rabies Immunoglobulin	RabIg
 Respiratory Syncytial Virus Immunoglobulin	RSVIg
 Tetanus Immunoglobulin	TIg
 Varicella Immunoglobulin	VarIg
-
-
+Respiratory Syncycial Virus RSVAb
 -->
+
 <preventions>
- 
-  	
-  		
-	<!--item 
-		resultDesc=""
-  		desc="DTaP=Diphtheria, Tetanus, Acellular Pertussis - pediatric"
-  		name="DTaP"
-  		healthCanadaType="DTaP"
-  		layout="injection" atc="" 
-  		showIfMinRecordNum="1"/>
-  		
-  		
+	<!-- Immunizations -->
+
+	<item
+			resultDesc=""
+			desc="DTaP=Diphtheria, Tetanus, Acellular Pertussis - pediatric eg Infanrix"
+			name="DTaP"
+			headingName="Immunizations"
+			healthCanadaType="DTaP"
+			layout="injection" 
+      atc=""
+			showIfMinRecordNum="1"/>
+
+	<item
+			resultDesc=""
+			desc="DTaP-IPV-Hib-HB=Diphtheria, Tetanus, Acellular Pertussis, Inactivated Polio, Haemophilus Influenzae type b, Hepatitis B - pediatric eg Infanrix Hexa"
+			name="DTaP-IPV-Hib-HB"
+			headingName="Immunizations"
+			healthCanadaType="DTaP-IPV-Hib-HB"
+			layout="injection" 
+      atc=""
+			showIfMinRecordNum="1"/>
+
+	<item
+			resultDesc=""
+			desc="DTaP-IPV-HB=Diphtheria, Tetanus, Acellular Pertussis, Inactivated Polio, Hepatitis B - pediatric eg PEDIARIX"
+			name="DTaP-IPV-HB"
+			headingName="Immunizations"
+			healthCanadaType="DTaP-IPV-HB"
+			layout="injection" 
+      atc=""
+			showIfMinRecordNum="1"/>
+			
+
+	<item
+			resultDesc=""
+			desc="DTaP-Hib=Diphtheria, Tetanus, Acellular Pertussis, Haemophilus Influenzae type b - pediatric"
+			name="DTaP-Hib"
+			headingName="Other"
+			healthCanadaType="DTaP-IPV-HB"
+			layout="injection" atc=""
+			showIfMinRecordNum="1"/>
+						
+	<item
+			resultDesc=""
+			desc="DT-IPV=Diphtheria, Tetanus, Polio - pediatric"
+			name="DT-IPV"
+			headingName="Immunizations"
+			healthCanadaType="DT-IPV"
+			layout="injection" 
+      atc=""
+			showIfMinRecordNum="1"/>
+
+	<item
+			resultDesc=""
+			desc="Tdap-IPV=Diphtheria, Tetanus and Acellular Pertussis for children 4 - 6 years of age; IPV=Inactivated Poliovirus; eg Adacel-Polio"
+			name="Tdap-IPV"
+			headingName="Immunizations"
+			healthCanadaType=""
+			layout="injection" 
+      atc="J07AJ52" minAge="4" maxAge="6"
+			showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="DTaP-IPV-Hib=Diphtheria, Tetanus, Acellular Pertussis, Inactivated Polio, Haemophilus Influenzae type b for children 6weeks to 4 years of age. Given at 2mth,4mth,6mth and 18mths, eg Pediacel"
+			name="DTaP-IPV-Hib"
+			headingName="Immunizations"
+			healthCanadaType="DTaP-IPV-Hib"
+			link="http://www.phac-aspc.gc.ca/"
+			layout="injection" 
+      atc="J07CA06" minAge="0" maxAge="6"
+			showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="Diphtheria, Tetanus, Pertussis, HepB, Polio, Haemophilus Influenzae type b (6wks-2yrs) eg INFANRIX hexa"
+			name="DTaP-HBV-IPV-Hib"
+			headingName="Immunizations"
+			healthCanadaType=""
+			link="http://www.phac-aspc.gc.ca/"
+			layout="injection" 
+      atc="J07CA02" minAge="0" maxAge="6"
+			showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="DTaP=Diphtheria, Tetanus, Acellular Pertussis and Polio for children under 18 years of age eg Quadracel"
+			name="DTaP-IPV"
+			headingName="Immunizations"
+			healthCanadaType="DTaP-IPV"
+			link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html#DTaPIPV"
+			layout="injection" atc="J07CA02" minAge="0" maxAge="6"
+			showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="Rot-1=Rotavirus Vaccine eg Rotarix"
+			name="Rota"
+			headingName="Immunizations"
+			healthCanadaType=""
+			link="www.novaccine.com/pdffiles/Rotarix_new_package_insert.pdf"
+			layout="injection" 
+      atc="J07BH01" minAge="0" maxAge="2"
+			showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="Hib=Haemophilus Influenzae type b for children under 5 years of age eg Act-HIB"
+			name="Hib"
+			headingName="Immunizations"
+			healthCanadaType="Hib"
+			link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html#Hib"
+			layout="injection" 
+      atc="J07AG51" minAge="0" maxAge="6"
+			showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="Pneumovax Pneumococcal-Polysaccharide - 23 valent eg Pneumovax"
+			name="Pneumovax"
+			headingName="Immunizations" 
+      link="" 
+      layout="injection"
+			healthCanadaType="Pneu-P-23"
+			atc="J07AL01" showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="Pneu-C=Pneumococcal Multi Valent Conjugate eg Prevnar 13"
+			name="Pneu-C"
+			headingName="Immunizations"
+			healthCanadaType="Pneu-C-13"
+			link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html#PneuC"
+			layout="injection" 
+      atc="J07AL02" minAge="0" maxAge="2"
+			showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="Measles"
+			name="M"
+			headingName="Immunizations"
+			healthCanadaType="M"
+			layout="injection" 
+      atc=""
+			showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="MR=Measles, Rubella"
+			name="MR"
+			headingName="Immunizations"
+			healthCanadaType="MR"
+			layout="injection" atc=""
+			showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="MMR=Measles, Mumps and Rubella eg Priorix"
+			name="MMR"
+			headingName="Immunizations"
+			healthCanadaType="MMR"
+			link="http://www.phac-aspc.gc.ca/publicat/cig-gci/p04-meas-roug-eng.php"
+			layout="injection" 
+      atc="J07BD52" minAge="0" maxAge="9"
+			showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="MMRV=Measles, Mumps, Rubella, Varicella eg Priorix-Tetra"
+			name="MMRV"
+			headingName="Immunizations"
+			healthCanadaType="MMRV"
+			link="http://www.phac-aspc.gc.ca/publicat/ccdr-rmtc/10vol36/acs-9/index-eng.php"
+			layout="injection" 
+      atc="J07BD54" minAge="0" maxAge="9"
+			showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="Meningococcal - Polysaccharide"
+			name="Men-P-AC"
+			headingName="Immunizations"
+			healthCanadaType="Men-P-AC"
+			layout="injection" 
+      atc="J07AH"
+			showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="Meningococcal - Polysaccharide eg Menomune"
+			name="Men-P-ACWY"
+			headingName="Immunizations"
+			healthCanadaType="Men-P-ACWY"
+			layout="injection" 
+      atc="J07AH"
+			showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="Meningococcal Conjugate ACYW-135 eg Menactra"
+			name="Men-C-ACYW-135"
+			headingName="Immunizations"
+			healthCanadaType="Men-C-ACYW-135"
+			layout="injection" 
+      atc="J07AH"
+			showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="MenC-C=Meningocococcal C Conjugate eg Menjugate"
+			name="MenC-C"
+			headingName="Immunizations"
+			healthCanadaType="Men-C"
+			link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html#MenC"
+			layout="injection" 
+      atc="J07AH07" minAge="0" maxAge="19"
+			showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="rMenB=Meningocococcal B Recombinant Multicomponent eg Bexsero"
+			name="rMenB"
+			healthCanadaType="rMenB"
+			link="http://www.hc-sc.gc.ca/dhp-mps/prodpharma/sbd-smd/drug-med/sbd_smd_2014_bexsero_147275-eng.php"
+			layout="injection"
+			atc="J07AH08"
+			minAge="1"
+			maxAge="17"
+			showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="VZ=Varicella Zoster eg Varivax III"
+			name="VZ"
+			headingName="Immunizations"
+			healthCanadaType="Var"
+			link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html#Var"
+			layout="injection"
+			atc="J07BK01"
+			minAge="0"
+			maxAge="2"
+			showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="HZV=Herpes Zoster Vaccine eg Zostavax"
+			name="HZV"
+			healthCanadaType="HZV"
+			link="http://www.phac-aspc.gc.ca/naci-ccni/hzv-vcz-eng.php"
+			layout="injection"
+			atc="J07BK02"
+			minAge="50"
+			showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="RZV=herpes zoster recomb subunit vaccine eg Shingrix" 
+      name="RZV" 
+      healthCanadaType="HerpR"
+			layout="injection"
+			atc="J07BK03"
+			minAge="50"
+			maxAge="100"
+			showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="Hep B=Hepatitis B eg Energix-B" 
+			displayName="Hep B"
+      name="HB"
+			headingName="Immunizations" 
+      healthCanadaType="HB"
+			link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html#HepB"
+			layout="injection" 
+      atc="J07BC01" minAge="0" maxAge="1"
+			showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="Tetanus"
+			name="T"
+			headingName="Immunizations"
+			healthCanadaType="T"
+			layout="injection" 
+      atc="J07AM"
+			showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="Tetanus, Diphtheria, Inactivated Polio - adult"
+			name="Td-IPV"
+			headingName="Immunizations"
+			healthCanadaType="Td-IPV"
+			layout="injection" 
+      atc=""
+			showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="dTap=Diphtheria, Tetanus and Acellular Pertussis adult/adolescent formulation"
+			name="Tdap"
+			headingName="Immunizations" 
+      healthCanadaType="Tdap"
+			link=""
+			layout="injection" 
+      atc="J07AJ52" minAge="0" maxAge="6"
+			showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="Td=Tetanus and Diphtheria adult type formulation"
+			name="Td"
+			headingName="Immunizations" 
+      healthCanadaType="Td"
+			link=""
+			layout="injection" 
+      atc="J07CA01" minAge="0" showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="Flu=Influenza vaccine"
+			displayName="Flu"
+      name="Inf"
+			headingName="Immunizations" 
+      healthCanadaType="Inf"
+			link=""
+			layout="injection" 
+      atc="J07BB01" minAge="0" />
+
+	<item
+			resultDesc=""
+			desc="Hepatitis A and Typhoid - Injection eg ViVAXIM"
+			name="HA-Typh-I"
+			headingName="Immunizations"
+			healthCanadaType="HA-Typh-I"
+			layout="injection" 
+      atc=""
+			showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="Hep A=Hepatitis A eg Havrix" 
+			displayName="Hep A"
+      name="HA"
+			headingName="Immunizations" 
+      link="" 
+      layout="injection" 
+      healthCanadaType="HA"
+			atc="J07BC02" showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="Hep AB=Hepatitis AB eg Twinrix" 
+      name="HAHB" link=""
+			headingName="Immunizations" 
+      layout="injection" 
+      healthCanadaType="HAHB"
+			atc="J07BC20" 
+      showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="Cholera - E.coli - Oral eg Dukoral"
+			name="Chol-Ecol-O"
+			headingName="Immunizations"
+			healthCanadaType="Chol-Ecol-O"
+			layout="injection" 
+      atc=""
+			showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="Dukoral" 
+      name="CHOLERA"
+			headingName="Immunizations" link="" 
+      layout="injection" 
+      healthCanadaType="Chol-O"
+			atc="J07AE01" showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			displayName="Rabies"
+			desc="Rab=Rabies eg Rabavert" 
+			name="Rab" 
+			link=""
+			headingName="Immunizations" 
+			layout="injection" 
+			healthCanadaType="Rab"
+			atc="J07BG01" showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			displayName="Typhoid"
+			desc="Typh=Typhoid eg Typhim VI" 
+      name="Typh" link=""
+			headingName="Immunizations" 
+      layout="injection" 
+      healthCanadaType="Typh-I"
+			atc="J07AP01" showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			displayName="Typhoid Oral eg Vivotif"
+			desc="Typhoid - Oral"
+			name="Typh-O"
+			headingName="Immunizations"
+			healthCanadaType="Typh-O"
+			layout="injection" atc="J07AP"
+			showIfMinRecordNum="1"/>
+
+	<item
+			resultDesc=""
+			desc="Women ages of 9 and 26 years are recommended to receive Human Papillomavirus Vaccine eg Gardasil 9, Cervarix"
+			name="HPV"
+			headingName="Immunizations"
+			healthCanadaType="HPV"
+			link="http://www.cdc.gov/std/treatment/"
+			layout="injection"
+			atc="J07BM"
+			minAge="9"
+			maxAge="26" sex = "F"
+			showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="TdP" 
+      name="TdP"
+			headingName="Immunizations" 
+			healthCanadaType=""
+      link="" 
+      layout="injection" 
+      atc="J07AJ52"
+			showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="IPV" 
+      name="IPV"
+			headingName="Immunizations"
+			healthCanadaType="" 
+      link="" 
+      layout="injection" 
+      atc="J07BF03"
+			showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="BCG=Bacillus Calmette-Guerin"
+			name="BCG"
+			headingName="Immunizations"
+			healthCanadaType="BCG"
+			layout="injection" 
+      atc="J07AN"
+			showIfMinRecordNum="1"/>
+
+	<item
+			resultDesc=""
+			desc="Yellow Fever eg YF-VAX"
+			name="YF"
+			headingName="Immunizations"
+			healthCanadaType="YF"
+			layout="injection" 
+      atc="J07BL"
+			showIfMinRecordNum="1"/>
+
+	<item
+			resultDesc=""
+			desc="Tickborne Encephalitis"
+			name="TBE"
+			headingName="Immunizations"
+			healthCanadaType="TBE"
+			layout="injection" 
+      atc="J07BA"
+			showIfMinRecordNum="1"/>
+
+	<item
+			resultDesc=""
+			desc="Japanese Encephalitis eg Ixiaro"
+			name="JE"
+			headingName="Immunizations"
+			healthCanadaType="JE"
+			layout="injection" 
+      atc="J07BA"
+			showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="H1N1 Vaccination"
+			name="H1N1"
+			headingName="Immunizations"
+			healthCanadaType="" 
+      layout="h1n1"
+			minAge="0"
+			atc="J07BB02" />
+
+	<item
+			resultDesc=""
+			desc="COVID-19"
+			name="COVID-19"
+      headingName="Immunizations"
+			healthCanadaType="COVID-19"
+			link="https://www.cdc.gov/vaccines/covid-19"
+			layout="injection" 
+      atc="J07BX03"
+			showIfMinRecordNum="1" />
+			
 	<item 
-		resultDesc=""
-  		desc="DTaP-IPV-Hib-HB=Diphtheria, Tetanus, Acellular Pertussis, Inactivated Polio, Haemophilus influenzae type b, Hepatitis B - pediatric"
-  		name="DTaP-IPV-Hib-HB"
-  		healthCanadaType="DTaP-IPV-Hib-HB"
-  		layout="injection" atc="" 
-  		showIfMinRecordNum="1"/>
-  		
-	<item 
-		resultDesc=""
-  		desc="DTaP-IPV-HB=Diphtheria, Tetanus, Acellular Pertussis, Inactivated Polio, Hepatitis B - pediatric"
-  		name="DTaP-IPV-HB"
-  		healthCanadaType="DTaP-IPV-HB"
-  		layout="injection" atc="" 
-  		showIfMinRecordNum="1"/>
-  		
-	<item 
-		resultDesc=""
-  		desc="DTaP-Hib=Diphtheria, Tetanus, Acellular Pertussis, Haemophilus influenzae type b - pediatric"
-  		name="DTaP-Hib"
-  		healthCanadaType="DTaP-IPV-HB"
-  		layout="injection" atc="" 
-  		showIfMinRecordNum="1"/>
-  		
-	<item 
-		resultDesc=""
-  		desc="DT-IPV=Diphtheria, Tetanus, Polio - pediatric"
-  		name="DT-IPV"
-  		healthCanadaType="DT-IPV"
-  		layout="injection" atc="" 
-  		showIfMinRecordNum="1"/>
-
-	<item
-		resultDesc=""
-		desc="Tdap-IPV=diphtheria, tetanus and acellular pertussis for children 4 - 6 years of age; IPV=inactivated poliovirus; Adacel"
-		name="Tdap-IPV"		
-		layout="injection" atc="J07AJ52" minAge="4" maxAge="6"
-		showIfMinRecordNum="1" />
-  		
-	<item
-		resultDesc=""
-		desc="TdP-IPV-Hib=diphtheria, tetanus and acellular pertussis for children under 18 years of age; IPV=inactivated poliovirus; haemophilus influenzae type B for children under 5 years of age: combination given at 2, 4, 18 months and 4-6 years"
-		name="TdP-IPV-Hib"
-		link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html"
-		layout="injection" atc="J07CA06" minAge="0" maxAge="6"
-		showIfMinRecordNum="1" />
-
-	<item
-		resultDesc=""
-		desc="DTaP-IPV-Hib=diphtheria, tetanus and acellular pertussis for children under 18 years of age; IPV=inactivated poliovirus; Hib=haemophilus influenzae type B for children under 5 years of age: combination given at 2, 4, 18 months and 4-6 years "
-		name="DTaP-IPV-Hib"
-		healthCanadaType="DTaP-IPV-Hib"
-		link="http://www.phac-aspc.gc.ca/"
-		layout="injection" atc="J07CA06" minAge="0" maxAge="6"
-		showIfMinRecordNum="1" />
-
-	<item
-		resultDesc=""
-		desc="DIPHTHERIA-PERTUSSIS-POLIOMYELITIS-TETANUS (6 wks - 2 yrs)"
-		name="DTaP-HBV-IPV-Hib"
-		link="http://www.phac-aspc.gc.ca/"
-		layout="injection" atc="J07CA02" minAge="0" maxAge="6"
-		showIfMinRecordNum="1" />
-
-	<item
-		resultDesc=""
-		desc="DTaP=diphtheria, tetanus and acellular pertussis for children under 18 years of age; IPV=inactivated poliovirus"
-		name="DTaP-IPV"
-		healthCanadaType="DTaP-IPV"
-		link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html#DTaPIPV"
-		layout="injection" atc="J07CA02" minAge="0" maxAge="6"
-		showIfMinRecordNum="1" />
-		
- 	<item 
-		resultDesc=""
- 		desc="Rot-1=Rotavirus Vaccine" 
- 		name="Rot"
-        link="www.novaccine.com/pdffiles/Rotarix_new_package_insert.pdf"
-		layout="injection" atc="J07BH01" minAge="0" maxAge="2"
-		showIfMinRecordNum="1" />
-
-	<item
-		resultDesc=""
-		desc="Hib=haemophilus influenzae type B for children under 5 years of age"
-		name="Hib"
-		healthCanadaType="Hib"
-		link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html#Hib"
-		layout="injection" atc="J07AG51" minAge="0" maxAge="6"
-		showIfMinRecordNum="1" />
-
-	<item 
-		resultDesc=""
-		desc="Pneumovax Pneumococcal-Polysaccharide - valent" 
-		name="Pneumovax" link="" layout="injection"
-		healthCanadaType="Pneu-P-23"
-		atc="J07AL02" showIfMinRecordNum="1" />
-
-	<item 
-		resultDesc=""
-		desc="Pneu-C=pneumococcal 7-valent conjugate" name="Pneu-C" healthCanadaType="Pneu-C-7"
-		link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html#PneuC"
-		layout="injection" atc="J07AL" minAge="0" maxAge="2"
-		showIfMinRecordNum="1" />
-		
-	<item
-		resultDesc=""
-		desc="MR=Measles, Rubella"
-		name="MR"
-		healthCanadaType="MR"
-		layout="injection" atc=""
-		showIfMinRecordNum="1" />
-
-	<item 
-		resultDesc=""
-		desc="MMR=measles, mumps and rubella" name="MMR" healthCanadaType="MMR"
-		link="http://www.phac-aspc.gc.ca/publicat/cig-gci/p04-meas-roug-eng.php"
-		layout="injection" atc="J07BD52" minAge="0" maxAge="6"
-		showIfMinRecordNum="1" />
-		
-	<item 
-		resultDesc=""
-		desc="MMRV=measles, mumps, rubella, varicella" name="MMRV" healthCanadaType="MMRV"
-		link="http://www.phac-aspc.gc.ca/publicat/ccdr-rmtc/10vol36/acs-9/index-eng.php"
-		layout="injection" atc="J07BD54" minAge="0" maxAge="6"
-		showIfMinRecordNum="1" />		
-
-	<item
-		resultDesc=""
-		desc="Meningococcal - Polysaccharide"
-		name="Men-P-AC"
-		healthCanadaType="Men-P-AC"
-		layout="injection" atc=""
-		showIfMinRecordNum="1" />
-		
-	<item
-		resultDesc=""
-		desc="Meningococcal - Polysaccharide"
-		name="Men-P-ACWY"
-		healthCanadaType="Men-P-ACWY"
-		layout="injection" atc=""
-		showIfMinRecordNum="1" />
-
-	<item 
-		resultDesc=""
-		desc="MenC-C=meningocococcal C conjugate" name="MenC-C" healthCanadaType="Men-C"
-		link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html#MenC"
-		layout="injection" atc="J07AH07" minAge="0" maxAge="19"
-		showIfMinRecordNum="1" />
-
-	<item 
-		resultDesc=""
-		desc="VZ=varicella zoster" name="VZ" healthCanadaType="Var"
-		link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html#Var"
-		layout="injection" atc="J07BK01" minAge="0" maxAge="2"
-		showIfMinRecordNum="1" />
-		
-	<item
-		resultDesc=""
-		desc="Tetanus"
-		name="T"
-		healthCanadaType="T"
-		layout="injection" atc=""
-		showIfMinRecordNum="1" />
-		
-	<item
-		resultDesc=""
-		desc="Tetanus, Diphtheria, Inactivated Polio - adult"
-		name="Td-IPV"
-		healthCanadaType="Td-IPV"
-		layout="injection" atc=""
-		showIfMinRecordNum="1" />
-
-	<item
-		resultDesc=""
-		desc="dTap=diphtheria, tatanus and acellular pertussis adult/adolescent formulation"
-		name="dTap" healthCanadaType="Tdap"
-		link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html#dTap"
-		layout="injection" atc="J07AJ52" minAge="0" maxAge="6"
-		showIfMinRecordNum="1" />
-
-	<item 
-		resultDesc=""
-		desc="Td=tetanus and diphtheria adult type formulation"
-		name="Td" healthCanadaType="Td"
-		link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html#dTap"
-		layout="injection" atc="J07CA01" minAge="0" showIfMinRecordNum="1" /-->
-
-
-	<item 
-		resultDesc=""
-		desc="Flu=influenza vaccine" name="Flu" healthCanadaType="Inf"
-		link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html#Flu"
-		layout="injection" atc="J07BB01" minAge="0" />
-
-	<!--item
-		resultDesc=""
-		desc="Hepatitis A and Typhoid - Injection"
-		name="HA-Typh-I"
-		healthCanadaType="HA-Typh-I"
-		layout="injection" atc=""
-		showIfMinRecordNum="1" />
-		
-	<item
-		resultDesc=""
-		desc="Hepatitis B - Thimerosal free"
-		name="HBTmf"
-		healthCanadaType="HBTmf"
-		layout="injection" atc=""
-		showIfMinRecordNum="1" />
-	<item 
-		resultDesc=""
-		desc="Hep AB=Hepatitis AB" name="HepAB" link="" layout="injection" healthCanadaType="HAHB"
-		atc="J07BC20" showIfMinRecordNum="1" />
-
-	<item
-		resultDesc=""
-		desc="Cholera - E.coli - Oral"
-		name="Chol-Ecol-O"
-		healthCanadaType="Chol-Ecol-O"
-		layout="injection" atc=""
-		showIfMinRecordNum="1" />
-
-	<item 
-		resultDesc=""
-		desc="Dukoral" name="CHOLERA" link="" layout="injection" healthCanadaType="Chol-O"
-		atc="J07AE01" showIfMinRecordNum="1" />
-        
-
-	<item 	
-		resultDesc=""
-		desc="Rabies=Rabies" name="Rabies" link="" layout="injection" healthCanadaType="Rab"
-		atc="J07BG01" showIfMinRecordNum="1" />
-
-	<item 
-		resultDesc=""
-		desc="Typhoid=Typhoid" name="Typhoid" link="" layout="injection" healthCanadaType="Typh-I"
-		atc="J07AP01" showIfMinRecordNum="1" />
-		
-		  		
-  	<item 
-		resultDesc=""
-  		desc="Typhoid - Oral"
-  		name="Typh-O"
-  		healthCanadaType="Typh-O"
-  		layout="injection" atc="" 
-  		showIfMinRecordNum="1"/>	
-
-	<item 
-		resultDesc=""
-		desc="TB=Tuberculosis" name="Tuberculosis" link="" layout="injection"
-		atc="J07AN01" showIfMinRecordNum="1" />
-
-	
-
-	<item 
-		resultDesc=""
-		desc="TdP" name="TdP" link="" layout="injection" atc="J07AJ52" 
-		showIfMinRecordNum="1" />
-
-	<item 
-		resultDesc=""
-		desc="IPV" name="IPV" link="" layout="injection" atc="J07BF03"
-		showIfMinRecordNum="1" />
-		
-	<item 
-		resultDesc=""
-  		desc="BCG=Bacillus Calmette-Guérin"
-  		name="BCG"
-  		healthCanadaType="BCG"
-  		layout="injection" atc="" 
-  		showIfMinRecordNum="1"/>
-  		
-  	<item 
-		resultDesc=""
-  		desc="Yellow Fever"
-  		name="YF"
-  		healthCanadaType="YF"
-  		layout="injection" atc="" 
-  		showIfMinRecordNum="1"/>		
-  		
-  	<item 
-		resultDesc=""
-  		desc="Tickborne Encephalitis"
-  		name="TBE"
-  		healthCanadaType="TBE"
-  		layout="injection" atc="" 
-  		showIfMinRecordNum="1"/>		
-  			
-	<item
-		resultDesc=""
-		desc="Japanese Encephalitis"
-		name="JE"
-		healthCanadaType="JE"
-		layout="injection" atc=""
-		showIfMinRecordNum="1" />
-
-	<item 
-		resultDesc=""
-		desc="Mammogram" name="MAM" link="" layout="PAPMAM" minAge="40"
-		maxAge="74" sex="F" showIfMinRecordNum="1" />
-
-	<item 
-		resultDesc=""
-		desc="PSA" name="PSA" link="" layout="PAPMAM" minAge="50"
-		maxAge="70" sex="M" showIfMinRecordNum="1" />
-
-	<item 
-		resultDesc=""
-		desc="Fecal Occult Blood Test" name="FOBT" link="" layout="PAPMAM"
-		minAge="49" maxAge="80" showIfMinRecordNum="1" />
-
-	<item 
-		resultDesc=""
-		desc="Colonoscopy" name="COLONOSCOPY" link="" layout="PAPMAM"
-		showIfMinRecordNum="1" /-->
-		
-		<!-- For eva.caisi.ca -->
-	<!--item
-		resultDesc=""
-		desc="HIV = all pregnant women, opt out routine screening of all adults"
-		name="HIV"
-	    link="http://www.cdc.gov/std/treatment/"
-	    layout="PAPMAM"
-	    minAge="13"
-	    maxAge="75"
-	    showIfMinRecordNum="1" />
-
- 
-	<item
-		resultDesc=""
-		desc="HepB screen= Hepatitis B serology (hep B sAg + anti-HBc or anti-HBs) in those with multiple sex partners, MSM, and injection drug users"
-		name="Hep B screen"
-		link="http://www.cdc.gov/std/treatment/"
-		layout="PAPMAM"
-		minAge="15"
-		maxAge="24"
-		showIfMinRecordNum="1" />
-		
-	<item		
-		resultDesc=""
-		desc="VDRL = VDRL screening for syphillis; pregnant women at the first prenatal visit (and 3rd trimester and delivery high-risk groups), all sex workers, in correctional facilities, diagnosed with another STD, MSM with high-risk behaviors"
-		name="VDRL"
-		link="http://www.cdc.gov/std/treatment/"
-		layout="PAPMAM"
-		minAge="15"
-		maxAge="25"
-		showIfMinRecordNum="1" />
-		
-	<item
-		resultDesc=""
-		desc="Chlamydia = chlamydia urine PCR; sexually active women age 25 years or younger (including pregnant women), women older than 25 years with: new sex partner in prior 60 days, more than one sex partner, inconsistent condom use, unmarried, or history of STD; men: asymptomatic screening may or may not benefit "
-		name="chlamydia"
-		link="http://www.cdc.gov/std/treatment/"
-		layout="PAPMAM"
-		minAge="12"
-		maxAge="25"
-		showIfMinRecordNum="1" />
-		
-	<item
-		resultDesc=""
-		desc= "ghonorrhea = ghonorrhea urine PCR in men with symptoms or asymptomatic women: Sexually active younger than 25 years, pregnancy, inconsistent condom use, multiple partners, partner with multiple contacts, sexual contact with partner with culture-proven STD, repeated episodes of STD, Sex work or drug use"
-		name="ghonorrhea PCR"
-		link="http://www.cdc.gov/std/treatment/"
-		layout="PAPMAM"
-		minAge="12"
-		maxAge="25"
-		showIfMinRecordNum="1" /-->
-	<!-- eva.caisi.ca -->
-
-    <!--item 
-		resultDesc=""
-		desc="H1N1 Vaccination" name="H1N1" layout="h1n1"
-            minAge="0" atc="J07BB02" />
-
-	<item 
-		resultDesc=""
-		desc="Other Layout A" name="OtherA" link="" layout="injection"
-		showIfMinRecordNum="1" />
-
-	<item 
-		resultDesc=""
-		desc="Other Layout B" name="OtherB" link="" layout="PAPMAM"
-		showIfMinRecordNum="1" />
-		
-	<item
-		resultDesc=""
-		desc= "Smoking history"
-		name="Smoking"		
-		layout="history"
-		minAge="13"		
-		showIfMinRecordNum="1" />
-	
-	<item
-		resultDesc=""
-		desc= "Bone Mineral Density"
-		name="BMD"		
-		layout="PAPMAM"
-		minAge="65"		
-		showIfMinRecordNum="1" />
-
-	<item
-		resultDesc=""
-		desc= "Periodic Health Visit"
-		name="PHV"		
-		layout="history"	
-		showIfMinRecordNum="1" /-->
-
-	<item
-		resultDesc=""
-		desc=""
-		name="Bacterial Vaginosis"
-		layout="PAPMAM"
-		showIfMinRecordNum="1" />
-
-	<item
-		resultDesc=""
-		desc=""
-		name="CT Culture Cervical"
-		layout="PAPMAM"
-		showIfMinRecordNum="1" />
-
-	<item
-		resultDesc=""
-		desc=""
-		name="CT Culture Throat"
-		layout="PAPMAM"
-		showIfMinRecordNum="1" />
-
-	<item
-		resultDesc=""
-		desc=""
-		name="CT Culture Rectal"
-		layout="PAPMAM"
-		showIfMinRecordNum="1" />
-
-	<item
-		resultDesc=""
-		desc=""
-		name="CT Culture Urethral"
-		layout="PAPMAM"
-		showIfMinRecordNum="1" />
-
-	<item
-		resultDesc=""
-		desc=""
-		name="CT NAAT Cervical"
-		layout="PAPMAM"
-		showIfMinRecordNum="1" />
-
-	<item
-		resultDesc=""
-		desc=""
-		name="CT NAAT Urethral"
-		layout="PAPMAM"
-		showIfMinRecordNum="1" />
-
-	<item
-		resultDesc=""
-		desc=""
-		name="CT NAAT Urine"
-		layout="PAPMAM"
-		showIfMinRecordNum="1" />
-
-	<item
-		resultDesc=""
-		desc=""
-		name="GC Culture Cervical"
-		layout="PAPMAM"
-		showIfMinRecordNum="1" />
-
-	<item
-		resultDesc=""
-		desc=""
-		name="GC Culture Throat"
-		layout="PAPMAM"
-		showIfMinRecordNum="1" />
-
-	<item
-		resultDesc=""
-		desc=""
-		name="GC Culture Rectal"
-		layout="PAPMAM"
-		showIfMinRecordNum="1" />
-
-	<item
-		resultDesc=""
-		desc=""
-		name="GC Culture Urethral"
-		layout="PAPMAM"
-		showIfMinRecordNum="1" />
-
-	<item
-		resultDesc=""
-		desc=""
-		name="GC NAAT Cervical"
-		layout="PAPMAM"
-		showIfMinRecordNum="1" />
-
-	<item
-		resultDesc=""
-		desc=""
-		name="GC NAAT Urethral"
-		layout="PAPMAM"
-		showIfMinRecordNum="1" />
-
-	<item
-		resultDesc=""
-		desc=""
-		name="GC NAAT Urine"
-		layout="PAPMAM"
-		showIfMinRecordNum="1" />
-
-	<item 
-		resultDesc=""
-		desc="Hep A=Hepatitis A" name="HepA" link="" layout="injection" healthCanadaType="HA"
-		atc="J07BC02" showIfMinRecordNum="1" />
-
-	<item 
-		resultDesc=""
-		desc="Hep B=Hepatitis B" name="HepB" healthCanadaType="HB"
-		link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html#HepB"
-		layout="injection" atc="J07BC01" minAge="0" maxAge="1"
-		showIfMinRecordNum="1" />
-
-	<item
-		resultDesc=""
-		desc=""
-		name="Hep A Screen"
-		layout="PAPMAM"
-		showIfMinRecordNum="1" />
-		
-	<item
-		resultDesc=""
-		desc="HepC screen = Hep C Ab serology in contacts of multiple sex partners, traumatic anal intercourse with infected person, IVDU"
-		name="Hep C screen"
-		link="http://www.cdc.gov/std/treatment/"
-		layout="PAPMAM"
-		minAge="15"
-		maxAge="24"
-		showIfMinRecordNum="1" />
-
-	<item
-		resultDesc=""
-		desc=""
-		name="HSV viral swab"
-		layout="PAPMAM"
-		showIfMinRecordNum="1" />
-
-	<item
-		resultDesc=""
-		desc=""
-		name="HIV Confirm Anon"
-		layout="PAPMAM"
-		showIfMinRecordNum="1" />
-
-	<item
-		resultDesc=""
-		desc=""
-		name="HIV Confirm Nominal"
-		layout="PAPMAM"
-		showIfMinRecordNum="1" />
-
-	<item
-		resultDesc=""
-		desc=""
-		name="HIV Serology Anon"
-		layout="PAPMAM"
-		showIfMinRecordNum="1" />
-
-	<item
-		resultDesc=""
-		desc=""
-		name="HIV Serology Nominal"
-		layout="PAPMAM"
-		showIfMinRecordNum="1" />
-
-	<item
-		resultDesc="Normal=Non-reactive, Abnormal=Reactive，Other=Invalid"
-		desc=""
-		name="HIV POC Nominal"
-		layout="PAPMAM"
-		showIfMinRecordNum="1" />
-
-	<item
-		resultDesc="Normal=Non-reactive, Abnormal=Reactive，Other=Invalid"
-		desc=""
-		name="HIV POC Anon"
-		layout="PAPMAM"
-		showIfMinRecordNum="1" />
-
-	<item 
-		resultDesc=""
-		desc="Women ages of 9 and 26 years are recommended to receive human papillomavirus vaccine" 
-		name="HPV Vaccine"
-		healthCanadaType="HPV"
-		link="http://www.cdc.gov/std/treatment/" 
-		layout="injection" 
-		minAge="9"
-		maxAge="26" sex = "F"
+			resultDesc=""
+			name="RSV" 
+			desc="Recombinant PreF RSV Vaccine eg Arexvy"
+			healthCanadaType="RSV"
+			link="https://ca.gsk.com/media/6988/arexvy.pdf" 
+			layout="injection" 
+			minAge="60"
+			maxAge="100"
+      atc="J07BX05"
    		showIfMinRecordNum="1" />
 
 	<item 
-		resultDesc=""
-		desc="PAP=" name="PAP" link="" layout="PAPMAM" minAge="20"
-		maxAge="65" sex="F" showIfMinRecordNum="1" />
-		
-	<item
-		resultDesc="Normal=Positive, Abnormal=Negative"
-		desc=""
-		name="Pregnancy Test"
-		layout="PAPMAM"
-		showIfMinRecordNum="1" />
-		
-	<item
-		resultDesc=""
-		desc=""
-		name="Syphilis Serology"
-		layout="PAPMAM"
-		showIfMinRecordNum="1" />
-		
-	<item
-		resultDesc=""
-		desc=""
-		name="Trichomaniasis"
-		layout="PAPMAM"
-		showIfMinRecordNum="1" />
+			resultDesc=""
+			name="RSVAb" 
+			desc="Monoclonal Antibody RSV Vaccine eg Beyfortus"
+			healthCanadaType="RSVAb"
+			link="https://www.ema.europa.eu/en/medicines/human/EPAR/beyfortus#product-info" 
+			layout="injection" 
+			minAge="0"
+			maxAge="2"
+      atc="J06BD08"
+   		showIfMinRecordNum="1" />
+
+	<!-- Other Immuunization -->
 
 	<item
-		resultDesc=""
-		desc=""
-		name="Yeast"
-		layout="PAPMAM"
-		showIfMinRecordNum="1" />
-		
+			resultDesc=""
+			desc="Other Layout A" 
+      name="OtherA"
+			headingName="Other"
+			healthCanadaType=""
+      link="" layout="injection"
+			showIfMinRecordNum="1" />
+
+	<!--Screenings-->
+
+	<item
+			resultDesc=""
+			desc="TB=Tuberculosis Mantoux " 
+            name="Tuberculosis"
+			headingName="Screenings" link="" 
+            layout="injection"
+			atc="J07AN01" showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="Women from ages 25 to 70 are recommended to receive a PAP" name="PAP"
+			headingName="Screenings" link="" layout="PAPMAM" minAge="25"
+			maxAge="70" sex="F" showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="Women from ages 25 to 74" name="HPV-CERVIX"
+			headingName="Screenings" link="" layout="PAPMAM" minAge="25"
+			maxAge="74" sex="F" showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="Mammogram" name="MAM"
+			headingName="Screenings" link="" layout="PAPMAM" minAge="50"
+			maxAge="70" sex="F" showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="PSA" name="PSA"
+			headingName="Screenings" link="" layout="PAPMAM" minAge="50"
+			maxAge="70" sex="M" showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			displayName="FIT/FOBT"
+			desc="Fecal Occult Blood Test or Fecal Immunochemical Test" name="FOBT"
+			headingName="Screenings" link="" layout="PAPMAM"
+			minAge="49" maxAge="80" showIfMinRecordNum="1" />
+			
+	<item
+			resultDesc=""
+			displayName="Abdominal U/S"
+			desc="One-time screening with ultrasound for abdominal aortic aneurysm" name="AAA"
+			headingName="Screenings" link="" layout="PAPMAM"
+			minAge="65" maxAge="80" sex="M" showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			displayName="Chest CT"
+			desc="Low Dose chest CT for 30 pack year smokers up to three times" name="CTC"
+			headingName="Screenings" link="" layout="PAPMAM"
+			minAge="55" maxAge="74" showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="Colonoscopy" name="COLONOSCOPY"
+			headingName="Screenings" link="" layout="PAPMAM"
+			showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="Bone Mineral Density" name="BMD"
+			headingName="Screenings" link="" layout="PAPMAM" minAge="65"
+			showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="HIV = all pregnant women, opt out routine screening of all adults"
+			name="HIV"
+			headingName="Screenings"
+			link="http://www.cdc.gov/std/treatment/"
+			layout="PAPMAM"
+			minAge="13"
+			maxAge="75"
+			showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="HepB screen= Hepatitis B serology (hep B sAg + anti-HBc or anti-HBs) in those with multiple sex partners, MSM, and injection drug users"
+			name="HepB screen"
+			headingName="Screenings"
+			link="http://www.cdc.gov/std/treatment/"
+			layout="PAPMAM"
+			minAge="15"
+			maxAge="24"
+			showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="HepC screen = Hep C Ab serology in contacts of multiple sex partners, traumatic anal intercourse with infected person, IVDU"
+			name="HepC screen"
+			headingName="Screenings"
+			link="http://www.cdc.gov/std/treatment/"
+			layout="PAPMAM"
+			minAge="15"
+			maxAge="24"
+			showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="VDRL = VDRL screening for syphillis; pregnant women at the first prenatal visit (and 3rd trimester and delivery high-risk groups), all sex workers, in correctional facilities, diagnosed with another STD, MSM with high-risk behaviors"
+			name="VDRL"
+			headingName="Screenings"
+			link="http://www.cdc.gov/std/treatment/"
+			layout="PAPMAM"
+			minAge="15"
+			maxAge="25"
+			showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc="Chlamydia = chlamydia urine PCR; sexually active women age 25 years or younger (including pregnant women), women older than 25 years with: new sex partner in prior 60 days, more than one sex partner, inconsistent condom use, unmarried, or history of STD; men: asymptomatic screening may or may not benefit "
+			name="chlamydia"
+			headingName="Screenings"
+			link="http://www.cdc.gov/std/treatment/"
+			layout="PAPMAM"
+			minAge="12"
+			maxAge="25"
+			showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc= "ghonorrhea = ghonorrhea urine PCR in men with symptoms or asymptomatic women: Sexually active younger than 25 years, pregnancy, inconsistent condom use, multiple partners, partner with multiple contacts, sexual contact with partner with culture-proven STD, repeated episodes of STD, Sex work or drug use"
+			name="ghonorrhea PCR"
+			headingName="Screenings"
+			link="http://www.cdc.gov/std/treatment/"
+			layout="PAPMAM"
+			minAge="12"
+			maxAge="25"
+			showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc= "Periodic Health Visit"
+			name="PHV"
+			headingName="Screenings"
+			layout="history"
+			showIfMinRecordNum="1" />
+
+	<item
+			resultDesc=""
+			desc= "Smoking history"
+			name="Smoking"
+			layout="history"
+			headingName="Screenings"
+			minAge="13"
+			showIfMinRecordNum="1" />
+
+	<!-- Other Screening -->
+
+	<item
+			resultDesc=""
+			desc="Other Layout B" 
+      name="OtherB"
+			headingName="Other" 
+      link="" layout="PAPMAM"
+			showIfMinRecordNum="1" />
+
 </preventions>
-

--- a/src/main/resources/oscar/oscarPrevention/PublicHealthPreventionItems.xml
+++ b/src/main/resources/oscar/oscarPrevention/PublicHealthPreventionItems.xml
@@ -107,10 +107,11 @@ Varicella Immunoglobulin	VarIg
 		layout="injection" atc="J07CA02" minAge="0" maxAge="6"
 		showIfMinRecordNum="1" />
 		
- 	<item 
+	<item
 		resultDesc=""
- 		desc="Rot-1=Rotavirus Vaccine" 
- 		name="Rot"
+		desc="Rota=Rotavirus Vaccine"
+		name="Rota"
+		healthCanadaType="Rota"
         link="www.novaccine.com/pdffiles/Rotarix_new_package_insert.pdf"
 		layout="injection" atc="J07BH01" minAge="0" maxAge="2"
 		showIfMinRecordNum="1" />
@@ -153,9 +154,9 @@ Varicella Immunoglobulin	VarIg
 		layout="injection" atc="J07BD52" minAge="0" maxAge="6"
 		showIfMinRecordNum="1" />
 		
-	<item 
+	<item
 		resultDesc=""
-		desc="MMRV=measles, mumps, rubella, varicella" name="MMRV" healthCanadaType="MMRV"
+		desc="MMR-Var=measles, mumps, rubella, varicella" name="MMR-Var" healthCanadaType="MMR-Var"
 		link="http://www.phac-aspc.gc.ca/publicat/ccdr-rmtc/10vol36/acs-9/index-eng.php"
 		layout="injection" atc="J07BD54" minAge="0" maxAge="6"
 		showIfMinRecordNum="1" />		
@@ -183,9 +184,9 @@ Varicella Immunoglobulin	VarIg
 		layout="injection" atc="J07AH07" minAge="0" maxAge="19"
 		showIfMinRecordNum="1" />
 
-	<item 
+	<item
 		resultDesc=""
-		desc="VZ=varicella zoster" name="VZ" healthCanadaType="Var"
+		desc="Var=varicella zoster" name="Var" healthCanadaType="Var"
 		link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html#Var"
 		layout="injection" atc="J07BK01" minAge="0" maxAge="2"
 		showIfMinRecordNum="1" />
@@ -208,8 +209,8 @@ Varicella Immunoglobulin	VarIg
 
 	<item
 		resultDesc=""
-		desc="dTap=diphtheria, tatanus and acellular pertussis adult/adolescent formulation"
-		name="dTap" healthCanadaType="Tdap"
+		desc="Tdap=Diphtheria, Tetanus and Acellular Pertussis adult/adolescent formulation"
+		name="Tdap" healthCanadaType="Tdap"
 		link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html#dTap"
 		layout="injection" atc="J07AJ52" minAge="0" maxAge="6"
 		showIfMinRecordNum="1" />
@@ -222,13 +223,227 @@ Varicella Immunoglobulin	VarIg
 		layout="injection" atc="J07CA01" minAge="0" showIfMinRecordNum="1" /-->
 
 
-	<item 
+	<!-- Immunizations - aligned with PreventionConfigSets and OSCAR 19 standard -->
+
+	<item
 		resultDesc=""
-		desc="Flu=influenza vaccine" 
-    displayName="Flu"
-    name="Inf" healthCanadaType="Inf"
+		desc="DTaP-IPV=Diphtheria, Tetanus, Acellular Pertussis, Inactivated Poliovirus"
+		name="DTaP-IPV"
+		headingName="Immunizations"
+		healthCanadaType="DTaP-IPV"
+		layout="injection" atc="J07CA02" minAge="0" maxAge="6"
+		showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc="Hib=Haemophilus Influenzae type b for children under 5 years of age"
+		name="Hib"
+		headingName="Immunizations"
+		healthCanadaType="Hib"
+		layout="injection" atc="J07AG51" minAge="0" maxAge="6"
+		showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc="Pneu-C-15=Pneumococcal 15-valent Conjugate eg Vaxneuvance"
+		name="Pneu-C-15"
+		headingName="Immunizations"
+		healthCanadaType="Pneu-C-15"
+		layout="injection" atc="J07AL02" minAge="0" maxAge="5"
+		showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc="Pneu-C-20=Pneumococcal 20-valent Conjugate eg Prevnar 20"
+		name="Pneu-C-20"
+		headingName="Immunizations"
+		healthCanadaType="Pneu-C-20"
+		layout="injection" atc="J07AL02" minAge="18"
+		showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc="RSVAb=Monoclonal Antibody RSV Vaccine eg Beyfortus"
+		name="RSVAb"
+		headingName="Immunizations"
+		healthCanadaType="RSVAb"
+		layout="injection" atc="J06BD08" minAge="0" maxAge="2"
+		showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc="RSV=Recombinant PreF RSV Vaccine eg Arexvy"
+		name="RSV"
+		headingName="Immunizations"
+		healthCanadaType="RSV"
+		layout="injection" atc="J07BX05" minAge="60" maxAge="100"
+		showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc="MMR=Measles, Mumps and Rubella eg Priorix"
+		name="MMR"
+		headingName="Immunizations"
+		healthCanadaType="MMR"
+		layout="injection" atc="J07BD52" minAge="0" maxAge="9"
+		showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc="MMR-Var=Measles, Mumps, Rubella, Varicella eg Priorix-Tetra"
+		name="MMR-Var"
+		headingName="Immunizations"
+		healthCanadaType="MMR-Var"
+		layout="injection" atc="J07BD54" minAge="0" maxAge="9"
+		showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc="MenC-C=Meningocococcal C Conjugate eg Menjugate"
+		name="MenC-C"
+		headingName="Immunizations"
+		healthCanadaType="Men-C"
+		layout="injection" atc="J07AH07" minAge="0" maxAge="19"
+		showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc="Var=Varicella Zoster eg Varivax III"
+		name="Var"
+		headingName="Immunizations"
+		healthCanadaType="Var"
+		layout="injection" atc="J07BK01" minAge="0" maxAge="2"
+		showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc="Tdap=Diphtheria, Tetanus and Acellular Pertussis adult/adolescent formulation"
+		name="Tdap"
+		headingName="Immunizations"
+		healthCanadaType="Tdap"
+		layout="injection" atc="J07AJ52" minAge="0" maxAge="6"
+		showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc="Tdap-IPV=Diphtheria, Tetanus, Acellular Pertussis, Inactivated Poliovirus eg Adacel-IPV"
+		name="Tdap-IPV"
+		headingName="Immunizations"
+		healthCanadaType="Tdap-IPV"
+		layout="injection" atc="J07AJ52" minAge="4" maxAge="6"
+		showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc="Men-C-ACYW-135=Meningococcal Conjugate ACYW-135 eg Menactra"
+		name="Men-C-ACYW-135"
+		headingName="Immunizations"
+		healthCanadaType="Men-C-ACYW-135"
+		layout="injection" atc="J07AH"
+		showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc="HPV-9=Human Papillomavirus 9-valent vaccine eg Gardasil 9"
+		name="HPV-9"
+		headingName="Immunizations"
+		healthCanadaType="HPV-9"
+		layout="injection" atc="J07BM01" minAge="9" maxAge="45"
+		showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc="Td=Tetanus and Diphtheria adult type formulation"
+		name="Td"
+		headingName="Immunizations"
+		healthCanadaType="Td"
+		layout="injection" atc="J07CA01" minAge="0"
+		showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc="Inf=Influenza vaccine"
+		displayName="Flu"
+		name="Inf" healthCanadaType="Inf"
+		headingName="Immunizations"
 		link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html#Flu"
 		layout="injection" atc="J07BB01" minAge="0" />
+
+	<item
+		resultDesc=""
+		desc="Rota=Rotavirus Vaccine eg Rotarix"
+		name="Rota"
+		headingName="Immunizations"
+		healthCanadaType="Rota"
+		layout="injection" atc="J07BH01" minAge="0" maxAge="2"
+		showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc="RZV=Recombinant Herpes Zoster eg Shingrix"
+		name="RZV"
+		headingName="Immunizations"
+		healthCanadaType="HerpR"
+		layout="injection" atc="J07BK03" minAge="50" maxAge="100"
+		showIfMinRecordNum="1" />
+
+	<!-- Screenings -->
+
+	<item
+		resultDesc=""
+		desc="Abdominal Aortic Aneurysm ultrasound screening" name="AAA"
+		headingName="Screenings" link="" layout="PAPMAM" minAge="65"
+		maxAge="80" sex="M" showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc="Fecal Occult Blood Test or Fecal Immunochemical Test" name="FOBT"
+		displayName="FIT/FOBT"
+		headingName="Screenings" link="" layout="PAPMAM"
+		minAge="50" maxAge="74" showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc="Mammogram" name="MAM"
+		headingName="Screenings" link="" layout="PAPMAM" minAge="40"
+		maxAge="74" sex="F" showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc="PSA" name="PSA"
+		headingName="Screenings" link="" layout="PAPMAM" minAge="50"
+		maxAge="70" sex="M" showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc="Women from ages 25 to 69" name="HPV-CERVIX"
+		headingName="Screenings" link="" layout="PAPMAM" minAge="25"
+		maxAge="69" sex="F" showIfMinRecordNum="1" />
+
+	<!-- Other -->
+
+	<item
+		resultDesc=""
+		desc="Other Layout A" name="OtherA"
+		headingName="Other"
+		healthCanadaType="" link="" layout="injection"
+		showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc="Other Layout B" name="OtherB"
+		headingName="Other"
+		link="" layout="PAPMAM"
+		showIfMinRecordNum="1" />
+
+	<!-- Legacy entry kept for backward compatibility - use Inf instead -->
+	<!--item
+		resultDesc=""
+		desc="Flu=influenza vaccine"
+    displayName="Flu"
+    name="Flu" healthCanadaType="Inf"
+		link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html#Flu"
+		layout="injection" atc="J07BB01" minAge="0" /-->
 
 	<!--item
 		resultDesc=""
@@ -290,9 +505,9 @@ Varicella Immunoglobulin	VarIg
 
 	
 
-	<item 
+	<item
 		resultDesc=""
-		desc="TdP" name="TdP" link="" layout="injection" atc="J07AJ52" 
+		desc="Td-IPV=Tetanus, Diphtheria, Inactivated Poliovirus" name="Td-IPV" healthCanadaType="Td-IPV" link="" layout="injection" atc="J07AJ52"
 		showIfMinRecordNum="1" />
 
 	<item 

--- a/src/main/resources/oscar/oscarPrevention/PublicHealthPreventionItems.xml
+++ b/src/main/resources/oscar/oscarPrevention/PublicHealthPreventionItems.xml
@@ -4,11 +4,10 @@
     Document   : PreventionItems.xml
     Created on : October 26, 2005, 3:06 PM
     Author     : Jay Gallagher
-    Source     : src/main/resources/oscar/oscarPrevention/PreventionItems.xml
-    Updated on : March 10, 2026 by Peter Hutten-Czapski
     Description:
         Xml configuration used in the Prevention Module to set up the types of preventions available.
-
+These are adapted from PreventionItems.xml to limit entries based on the particular public health unit
+and the particular programs they run.  This is an example
 
 *Passive Immunizing Agents* *Agents	Abbreviations*
 Botulism Antitoxin	BAtx
@@ -19,710 +18,655 @@ Rabies Immunoglobulin	RabIg
 Respiratory Syncytial Virus Immunoglobulin	RSVIg
 Tetanus Immunoglobulin	TIg
 Varicella Immunoglobulin	VarIg
-Respiratory Syncycial Virus RSVAb
+
+
 -->
-
 <preventions>
-	<!-- Immunizations -->
-
-	<item
-			resultDesc=""
-			desc="DTaP=Diphtheria, Tetanus, Acellular Pertussis - pediatric eg Infanrix"
-			name="DTaP"
-			headingName="Immunizations"
-			healthCanadaType="DTaP"
-			layout="injection" 
-      atc=""
-			showIfMinRecordNum="1"/>
-
-	<item
-			resultDesc=""
-			desc="DTaP-IPV-Hib-HB=Diphtheria, Tetanus, Acellular Pertussis, Inactivated Polio, Haemophilus Influenzae type b, Hepatitis B - pediatric eg Infanrix Hexa"
-			name="DTaP-IPV-Hib-HB"
-			headingName="Immunizations"
-			healthCanadaType="DTaP-IPV-Hib-HB"
-			layout="injection" 
-      atc=""
-			showIfMinRecordNum="1"/>
-
-	<item
-			resultDesc=""
-			desc="DTaP-IPV-HB=Diphtheria, Tetanus, Acellular Pertussis, Inactivated Polio, Hepatitis B - pediatric eg PEDIARIX"
-			name="DTaP-IPV-HB"
-			headingName="Immunizations"
-			healthCanadaType="DTaP-IPV-HB"
-			layout="injection" 
-      atc=""
-			showIfMinRecordNum="1"/>
-			
-
-	<item
-			resultDesc=""
-			desc="DTaP-Hib=Diphtheria, Tetanus, Acellular Pertussis, Haemophilus Influenzae type b - pediatric"
-			name="DTaP-Hib"
-			headingName="Other"
-			healthCanadaType="DTaP-IPV-HB"
-			layout="injection" atc=""
-			showIfMinRecordNum="1"/>
-						
-	<item
-			resultDesc=""
-			desc="DT-IPV=Diphtheria, Tetanus, Polio - pediatric"
-			name="DT-IPV"
-			headingName="Immunizations"
-			healthCanadaType="DT-IPV"
-			layout="injection" 
-      atc=""
-			showIfMinRecordNum="1"/>
-
-	<item
-			resultDesc=""
-			desc="Tdap-IPV=Diphtheria, Tetanus and Acellular Pertussis for children 4 - 6 years of age; IPV=Inactivated Poliovirus; eg Adacel-Polio"
-			name="Tdap-IPV"
-			headingName="Immunizations"
-			healthCanadaType=""
-			layout="injection" 
-      atc="J07AJ52" minAge="4" maxAge="6"
-			showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc="DTaP-IPV-Hib=Diphtheria, Tetanus, Acellular Pertussis, Inactivated Polio, Haemophilus Influenzae type b for children 6weeks to 4 years of age. Given at 2mth,4mth,6mth and 18mths, eg Pediacel"
-			name="DTaP-IPV-Hib"
-			headingName="Immunizations"
-			healthCanadaType="DTaP-IPV-Hib"
-			link="http://www.phac-aspc.gc.ca/"
-			layout="injection" 
-      atc="J07CA06" minAge="0" maxAge="6"
-			showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc="Diphtheria, Tetanus, Pertussis, HepB, Polio, Haemophilus Influenzae type b (6wks-2yrs) eg INFANRIX hexa"
-			name="DTaP-HBV-IPV-Hib"
-			headingName="Immunizations"
-			healthCanadaType=""
-			link="http://www.phac-aspc.gc.ca/"
-			layout="injection" 
-      atc="J07CA02" minAge="0" maxAge="6"
-			showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc="DTaP=Diphtheria, Tetanus, Acellular Pertussis and Polio for children under 18 years of age eg Quadracel"
-			name="DTaP-IPV"
-			headingName="Immunizations"
-			healthCanadaType="DTaP-IPV"
-			link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html#DTaPIPV"
-			layout="injection" atc="J07CA02" minAge="0" maxAge="6"
-			showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc="Rot-1=Rotavirus Vaccine eg Rotarix"
-			name="Rota"
-			headingName="Immunizations"
-			healthCanadaType=""
-			link="www.novaccine.com/pdffiles/Rotarix_new_package_insert.pdf"
-			layout="injection" 
-      atc="J07BH01" minAge="0" maxAge="2"
-			showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc="Hib=Haemophilus Influenzae type b for children under 5 years of age eg Act-HIB"
-			name="Hib"
-			headingName="Immunizations"
-			healthCanadaType="Hib"
-			link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html#Hib"
-			layout="injection" 
-      atc="J07AG51" minAge="0" maxAge="6"
-			showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc="Pneumovax Pneumococcal-Polysaccharide - 23 valent eg Pneumovax"
-			name="Pneumovax"
-			headingName="Immunizations" 
-      link="" 
-      layout="injection"
-			healthCanadaType="Pneu-P-23"
-			atc="J07AL01" showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc="Pneu-C=Pneumococcal Multi Valent Conjugate eg Prevnar 13"
-			name="Pneu-C"
-			headingName="Immunizations"
-			healthCanadaType="Pneu-C-13"
-			link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html#PneuC"
-			layout="injection" 
-      atc="J07AL02" minAge="0" maxAge="2"
-			showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc="Measles"
-			name="M"
-			headingName="Immunizations"
-			healthCanadaType="M"
-			layout="injection" 
-      atc=""
-			showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc="MR=Measles, Rubella"
-			name="MR"
-			headingName="Immunizations"
-			healthCanadaType="MR"
-			layout="injection" atc=""
-			showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc="MMR=Measles, Mumps and Rubella eg Priorix"
-			name="MMR"
-			headingName="Immunizations"
-			healthCanadaType="MMR"
-			link="http://www.phac-aspc.gc.ca/publicat/cig-gci/p04-meas-roug-eng.php"
-			layout="injection" 
-      atc="J07BD52" minAge="0" maxAge="9"
-			showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc="MMRV=Measles, Mumps, Rubella, Varicella eg Priorix-Tetra"
-			name="MMRV"
-			headingName="Immunizations"
-			healthCanadaType="MMRV"
-			link="http://www.phac-aspc.gc.ca/publicat/ccdr-rmtc/10vol36/acs-9/index-eng.php"
-			layout="injection" 
-      atc="J07BD54" minAge="0" maxAge="9"
-			showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc="Meningococcal - Polysaccharide"
-			name="Men-P-AC"
-			headingName="Immunizations"
-			healthCanadaType="Men-P-AC"
-			layout="injection" 
-      atc="J07AH"
-			showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc="Meningococcal - Polysaccharide eg Menomune"
-			name="Men-P-ACWY"
-			headingName="Immunizations"
-			healthCanadaType="Men-P-ACWY"
-			layout="injection" 
-      atc="J07AH"
-			showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc="Meningococcal Conjugate ACYW-135 eg Menactra"
-			name="Men-C-ACYW-135"
-			headingName="Immunizations"
-			healthCanadaType="Men-C-ACYW-135"
-			layout="injection" 
-      atc="J07AH"
-			showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc="MenC-C=Meningocococcal C Conjugate eg Menjugate"
-			name="MenC-C"
-			headingName="Immunizations"
-			healthCanadaType="Men-C"
-			link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html#MenC"
-			layout="injection" 
-      atc="J07AH07" minAge="0" maxAge="19"
-			showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc="rMenB=Meningocococcal B Recombinant Multicomponent eg Bexsero"
-			name="rMenB"
-			healthCanadaType="rMenB"
-			link="http://www.hc-sc.gc.ca/dhp-mps/prodpharma/sbd-smd/drug-med/sbd_smd_2014_bexsero_147275-eng.php"
-			layout="injection"
-			atc="J07AH08"
-			minAge="1"
-			maxAge="17"
-			showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc="VZ=Varicella Zoster eg Varivax III"
-			name="VZ"
-			headingName="Immunizations"
-			healthCanadaType="Var"
-			link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html#Var"
-			layout="injection"
-			atc="J07BK01"
-			minAge="0"
-			maxAge="2"
-			showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc="HZV=Herpes Zoster Vaccine eg Zostavax"
-			name="HZV"
-			healthCanadaType="HZV"
-			link="http://www.phac-aspc.gc.ca/naci-ccni/hzv-vcz-eng.php"
-			layout="injection"
-			atc="J07BK02"
-			minAge="50"
-			showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc="RZV=herpes zoster recomb subunit vaccine eg Shingrix" 
-      name="RZV" 
-      healthCanadaType="HerpR"
-			layout="injection"
-			atc="J07BK03"
-			minAge="50"
-			maxAge="100"
-			showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc="Hep B=Hepatitis B eg Energix-B" 
-			displayName="Hep B"
-      name="HB"
-			headingName="Immunizations" 
-      healthCanadaType="HB"
-			link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html#HepB"
-			layout="injection" 
-      atc="J07BC01" minAge="0" maxAge="1"
-			showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc="Tetanus"
-			name="T"
-			headingName="Immunizations"
-			healthCanadaType="T"
-			layout="injection" 
-      atc="J07AM"
-			showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc="Tetanus, Diphtheria, Inactivated Polio - adult"
-			name="Td-IPV"
-			headingName="Immunizations"
-			healthCanadaType="Td-IPV"
-			layout="injection" 
-      atc=""
-			showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc="dTap=Diphtheria, Tetanus and Acellular Pertussis adult/adolescent formulation"
-			name="Tdap"
-			headingName="Immunizations" 
-      healthCanadaType="Tdap"
-			link=""
-			layout="injection" 
-      atc="J07AJ52" minAge="0" maxAge="6"
-			showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc="Td=Tetanus and Diphtheria adult type formulation"
-			name="Td"
-			headingName="Immunizations" 
-      healthCanadaType="Td"
-			link=""
-			layout="injection" 
-      atc="J07CA01" minAge="0" showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc="Flu=Influenza vaccine"
-			displayName="Flu"
-      name="Inf"
-			headingName="Immunizations" 
-      healthCanadaType="Inf"
-			link=""
-			layout="injection" 
-      atc="J07BB01" minAge="0" />
-
-	<item
-			resultDesc=""
-			desc="Hepatitis A and Typhoid - Injection eg ViVAXIM"
-			name="HA-Typh-I"
-			headingName="Immunizations"
-			healthCanadaType="HA-Typh-I"
-			layout="injection" 
-      atc=""
-			showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc="Hep A=Hepatitis A eg Havrix" 
-			displayName="Hep A"
-      name="HA"
-			headingName="Immunizations" 
-      link="" 
-      layout="injection" 
-      healthCanadaType="HA"
-			atc="J07BC02" showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc="Hep AB=Hepatitis AB eg Twinrix" 
-      name="HAHB" link=""
-			headingName="Immunizations" 
-      layout="injection" 
-      healthCanadaType="HAHB"
-			atc="J07BC20" 
-      showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc="Cholera - E.coli - Oral eg Dukoral"
-			name="Chol-Ecol-O"
-			headingName="Immunizations"
-			healthCanadaType="Chol-Ecol-O"
-			layout="injection" 
-      atc=""
-			showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc="Dukoral" 
-      name="CHOLERA"
-			headingName="Immunizations" link="" 
-      layout="injection" 
-      healthCanadaType="Chol-O"
-			atc="J07AE01" showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			displayName="Rabies"
-			desc="Rab=Rabies eg Rabavert" 
-			name="Rab" 
-			link=""
-			headingName="Immunizations" 
-			layout="injection" 
-			healthCanadaType="Rab"
-			atc="J07BG01" showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			displayName="Typhoid"
-			desc="Typh=Typhoid eg Typhim VI" 
-      name="Typh" link=""
-			headingName="Immunizations" 
-      layout="injection" 
-      healthCanadaType="Typh-I"
-			atc="J07AP01" showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			displayName="Typhoid Oral eg Vivotif"
-			desc="Typhoid - Oral"
-			name="Typh-O"
-			headingName="Immunizations"
-			healthCanadaType="Typh-O"
-			layout="injection" atc="J07AP"
-			showIfMinRecordNum="1"/>
-
-	<item
-			resultDesc=""
-			desc="Women ages of 9 and 26 years are recommended to receive Human Papillomavirus Vaccine eg Gardasil 9, Cervarix"
-			name="HPV"
-			headingName="Immunizations"
-			healthCanadaType="HPV"
-			link="http://www.cdc.gov/std/treatment/"
-			layout="injection"
-			atc="J07BM"
-			minAge="9"
-			maxAge="26" sex = "F"
-			showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc="TdP" 
-      name="TdP"
-			headingName="Immunizations" 
-			healthCanadaType=""
-      link="" 
-      layout="injection" 
-      atc="J07AJ52"
-			showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc="IPV" 
-      name="IPV"
-			headingName="Immunizations"
-			healthCanadaType="" 
-      link="" 
-      layout="injection" 
-      atc="J07BF03"
-			showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc="BCG=Bacillus Calmette-Guerin"
-			name="BCG"
-			headingName="Immunizations"
-			healthCanadaType="BCG"
-			layout="injection" 
-      atc="J07AN"
-			showIfMinRecordNum="1"/>
-
-	<item
-			resultDesc=""
-			desc="Yellow Fever eg YF-VAX"
-			name="YF"
-			headingName="Immunizations"
-			healthCanadaType="YF"
-			layout="injection" 
-      atc="J07BL"
-			showIfMinRecordNum="1"/>
-
-	<item
-			resultDesc=""
-			desc="Tickborne Encephalitis"
-			name="TBE"
-			headingName="Immunizations"
-			healthCanadaType="TBE"
-			layout="injection" 
-      atc="J07BA"
-			showIfMinRecordNum="1"/>
-
-	<item
-			resultDesc=""
-			desc="Japanese Encephalitis eg Ixiaro"
-			name="JE"
-			headingName="Immunizations"
-			healthCanadaType="JE"
-			layout="injection" 
-      atc="J07BA"
-			showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc="H1N1 Vaccination"
-			name="H1N1"
-			headingName="Immunizations"
-			healthCanadaType="" 
-      layout="h1n1"
-			minAge="0"
-			atc="J07BB02" />
-
-	<item
-			resultDesc=""
-			desc="COVID-19"
-			name="COVID-19"
-      headingName="Immunizations"
-			healthCanadaType="COVID-19"
-			link="https://www.cdc.gov/vaccines/covid-19"
-			layout="injection" 
-      atc="J07BX03"
-			showIfMinRecordNum="1" />
-			
+ 
+  	
+  		
+	<!--item 
+		resultDesc=""
+  		desc="DTaP=Diphtheria, Tetanus, Acellular Pertussis - pediatric"
+  		name="DTaP"
+  		healthCanadaType="DTaP"
+  		layout="injection" atc="" 
+  		showIfMinRecordNum="1"/>
+  		
+  		
 	<item 
-			resultDesc=""
-			name="RSV" 
-			desc="Recombinant PreF RSV Vaccine eg Arexvy"
-			healthCanadaType="RSV"
-			link="https://ca.gsk.com/media/6988/arexvy.pdf" 
-			layout="injection" 
-			minAge="60"
-			maxAge="100"
-      atc="J07BX05"
+		resultDesc=""
+  		desc="DTaP-IPV-Hib-HB=Diphtheria, Tetanus, Acellular Pertussis, Inactivated Polio, Haemophilus influenzae type b, Hepatitis B - pediatric"
+  		name="DTaP-IPV-Hib-HB"
+  		healthCanadaType="DTaP-IPV-Hib-HB"
+  		layout="injection" atc="" 
+  		showIfMinRecordNum="1"/>
+  		
+	<item 
+		resultDesc=""
+  		desc="DTaP-IPV-HB=Diphtheria, Tetanus, Acellular Pertussis, Inactivated Polio, Hepatitis B - pediatric"
+  		name="DTaP-IPV-HB"
+  		healthCanadaType="DTaP-IPV-HB"
+  		layout="injection" atc="" 
+  		showIfMinRecordNum="1"/>
+  		
+	<item 
+		resultDesc=""
+  		desc="DTaP-Hib=Diphtheria, Tetanus, Acellular Pertussis, Haemophilus influenzae type b - pediatric"
+  		name="DTaP-Hib"
+  		healthCanadaType="DTaP-IPV-HB"
+  		layout="injection" atc="" 
+  		showIfMinRecordNum="1"/>
+  		
+	<item 
+		resultDesc=""
+  		desc="DT-IPV=Diphtheria, Tetanus, Polio - pediatric"
+  		name="DT-IPV"
+  		healthCanadaType="DT-IPV"
+  		layout="injection" atc="" 
+  		showIfMinRecordNum="1"/>
+
+	<item
+		resultDesc=""
+		desc="Tdap-IPV=diphtheria, tetanus and acellular pertussis for children 4 - 6 years of age; IPV=inactivated poliovirus; Adacel"
+		name="Tdap-IPV"		
+		layout="injection" atc="J07AJ52" minAge="4" maxAge="6"
+		showIfMinRecordNum="1" />
+  		
+	<item
+		resultDesc=""
+		desc="TdP-IPV-Hib=diphtheria, tetanus and acellular pertussis for children under 18 years of age; IPV=inactivated poliovirus; haemophilus influenzae type B for children under 5 years of age: combination given at 2, 4, 18 months and 4-6 years"
+		name="TdP-IPV-Hib"
+		link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html"
+		layout="injection" atc="J07CA06" minAge="0" maxAge="6"
+		showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc="DTaP-IPV-Hib=diphtheria, tetanus and acellular pertussis for children under 18 years of age; IPV=inactivated poliovirus; Hib=haemophilus influenzae type B for children under 5 years of age: combination given at 2, 4, 18 months and 4-6 years "
+		name="DTaP-IPV-Hib"
+		healthCanadaType="DTaP-IPV-Hib"
+		link="http://www.phac-aspc.gc.ca/"
+		layout="injection" atc="J07CA06" minAge="0" maxAge="6"
+		showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc="DIPHTHERIA-PERTUSSIS-POLIOMYELITIS-TETANUS (6 wks - 2 yrs)"
+		name="DTaP-HBV-IPV-Hib"
+		link="http://www.phac-aspc.gc.ca/"
+		layout="injection" atc="J07CA02" minAge="0" maxAge="6"
+		showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc="DTaP=diphtheria, tetanus and acellular pertussis for children under 18 years of age; IPV=inactivated poliovirus"
+		name="DTaP-IPV"
+		healthCanadaType="DTaP-IPV"
+		link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html#DTaPIPV"
+		layout="injection" atc="J07CA02" minAge="0" maxAge="6"
+		showIfMinRecordNum="1" />
+		
+ 	<item 
+		resultDesc=""
+ 		desc="Rot-1=Rotavirus Vaccine" 
+ 		name="Rot"
+        link="www.novaccine.com/pdffiles/Rotarix_new_package_insert.pdf"
+		layout="injection" atc="J07BH01" minAge="0" maxAge="2"
+		showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc="Hib=haemophilus influenzae type B for children under 5 years of age"
+		name="Hib"
+		healthCanadaType="Hib"
+		link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html#Hib"
+		layout="injection" atc="J07AG51" minAge="0" maxAge="6"
+		showIfMinRecordNum="1" />
+
+	<item 
+		resultDesc=""
+		desc="Pneumovax Pneumococcal-Polysaccharide - valent" 
+		name="Pneumovax" link="" layout="injection"
+		healthCanadaType="Pneu-P-23"
+		atc="J07AL02" showIfMinRecordNum="1" />
+
+	<item 
+		resultDesc=""
+		desc="Pneu-C=pneumococcal 7-valent conjugate" name="Pneu-C" healthCanadaType="Pneu-C-7"
+		link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html#PneuC"
+		layout="injection" atc="J07AL" minAge="0" maxAge="2"
+		showIfMinRecordNum="1" />
+		
+	<item
+		resultDesc=""
+		desc="MR=Measles, Rubella"
+		name="MR"
+		healthCanadaType="MR"
+		layout="injection" atc=""
+		showIfMinRecordNum="1" />
+
+	<item 
+		resultDesc=""
+		desc="MMR=measles, mumps and rubella" name="MMR" healthCanadaType="MMR"
+		link="http://www.phac-aspc.gc.ca/publicat/cig-gci/p04-meas-roug-eng.php"
+		layout="injection" atc="J07BD52" minAge="0" maxAge="6"
+		showIfMinRecordNum="1" />
+		
+	<item 
+		resultDesc=""
+		desc="MMRV=measles, mumps, rubella, varicella" name="MMRV" healthCanadaType="MMRV"
+		link="http://www.phac-aspc.gc.ca/publicat/ccdr-rmtc/10vol36/acs-9/index-eng.php"
+		layout="injection" atc="J07BD54" minAge="0" maxAge="6"
+		showIfMinRecordNum="1" />		
+
+	<item
+		resultDesc=""
+		desc="Meningococcal - Polysaccharide"
+		name="Men-P-AC"
+		healthCanadaType="Men-P-AC"
+		layout="injection" atc=""
+		showIfMinRecordNum="1" />
+		
+	<item
+		resultDesc=""
+		desc="Meningococcal - Polysaccharide"
+		name="Men-P-ACWY"
+		healthCanadaType="Men-P-ACWY"
+		layout="injection" atc=""
+		showIfMinRecordNum="1" />
+
+	<item 
+		resultDesc=""
+		desc="MenC-C=meningocococcal C conjugate" name="MenC-C" healthCanadaType="Men-C"
+		link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html#MenC"
+		layout="injection" atc="J07AH07" minAge="0" maxAge="19"
+		showIfMinRecordNum="1" />
+
+	<item 
+		resultDesc=""
+		desc="VZ=varicella zoster" name="VZ" healthCanadaType="Var"
+		link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html#Var"
+		layout="injection" atc="J07BK01" minAge="0" maxAge="2"
+		showIfMinRecordNum="1" />
+		
+	<item
+		resultDesc=""
+		desc="Tetanus"
+		name="T"
+		healthCanadaType="T"
+		layout="injection" atc=""
+		showIfMinRecordNum="1" />
+		
+	<item
+		resultDesc=""
+		desc="Tetanus, Diphtheria, Inactivated Polio - adult"
+		name="Td-IPV"
+		healthCanadaType="Td-IPV"
+		layout="injection" atc=""
+		showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc="dTap=diphtheria, tatanus and acellular pertussis adult/adolescent formulation"
+		name="dTap" healthCanadaType="Tdap"
+		link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html#dTap"
+		layout="injection" atc="J07AJ52" minAge="0" maxAge="6"
+		showIfMinRecordNum="1" />
+
+	<item 
+		resultDesc=""
+		desc="Td=tetanus and diphtheria adult type formulation"
+		name="Td" healthCanadaType="Td"
+		link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html#dTap"
+		layout="injection" atc="J07CA01" minAge="0" showIfMinRecordNum="1" /-->
+
+
+	<item 
+		resultDesc=""
+		desc="Flu=influenza vaccine" name="Flu" healthCanadaType="Inf"
+		link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html#Flu"
+		layout="injection" atc="J07BB01" minAge="0" />
+
+	<!--item
+		resultDesc=""
+		desc="Hepatitis A and Typhoid - Injection"
+		name="HA-Typh-I"
+		healthCanadaType="HA-Typh-I"
+		layout="injection" atc=""
+		showIfMinRecordNum="1" />
+		
+	<item
+		resultDesc=""
+		desc="Hepatitis B - Thimerosal free"
+		name="HBTmf"
+		healthCanadaType="HBTmf"
+		layout="injection" atc=""
+		showIfMinRecordNum="1" />
+	<item 
+		resultDesc=""
+		desc="Hep AB=Hepatitis AB" name="HepAB" link="" layout="injection" healthCanadaType="HAHB"
+		atc="J07BC20" showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc="Cholera - E.coli - Oral"
+		name="Chol-Ecol-O"
+		healthCanadaType="Chol-Ecol-O"
+		layout="injection" atc=""
+		showIfMinRecordNum="1" />
+
+	<item 
+		resultDesc=""
+		desc="Dukoral" name="CHOLERA" link="" layout="injection" healthCanadaType="Chol-O"
+		atc="J07AE01" showIfMinRecordNum="1" />
+        
+
+	<item 	
+		resultDesc=""
+		desc="Rabies=Rabies" name="Rabies" link="" layout="injection" healthCanadaType="Rab"
+		atc="J07BG01" showIfMinRecordNum="1" />
+
+	<item 
+		resultDesc=""
+		desc="Typhoid=Typhoid" name="Typhoid" link="" layout="injection" healthCanadaType="Typh-I"
+		atc="J07AP01" showIfMinRecordNum="1" />
+		
+		  		
+  	<item 
+		resultDesc=""
+  		desc="Typhoid - Oral"
+  		name="Typh-O"
+  		healthCanadaType="Typh-O"
+  		layout="injection" atc="" 
+  		showIfMinRecordNum="1"/>	
+
+	<item 
+		resultDesc=""
+		desc="TB=Tuberculosis" name="Tuberculosis" link="" layout="injection"
+		atc="J07AN01" showIfMinRecordNum="1" />
+
+	
+
+	<item 
+		resultDesc=""
+		desc="TdP" name="TdP" link="" layout="injection" atc="J07AJ52" 
+		showIfMinRecordNum="1" />
+
+	<item 
+		resultDesc=""
+		desc="IPV" name="IPV" link="" layout="injection" atc="J07BF03"
+		showIfMinRecordNum="1" />
+		
+	<item 
+		resultDesc=""
+  		desc="BCG=Bacillus Calmette-Guérin"
+  		name="BCG"
+  		healthCanadaType="BCG"
+  		layout="injection" atc="" 
+  		showIfMinRecordNum="1"/>
+  		
+  	<item 
+		resultDesc=""
+  		desc="Yellow Fever"
+  		name="YF"
+  		healthCanadaType="YF"
+  		layout="injection" atc="" 
+  		showIfMinRecordNum="1"/>		
+  		
+  	<item 
+		resultDesc=""
+  		desc="Tickborne Encephalitis"
+  		name="TBE"
+  		healthCanadaType="TBE"
+  		layout="injection" atc="" 
+  		showIfMinRecordNum="1"/>		
+  			
+	<item
+		resultDesc=""
+		desc="Japanese Encephalitis"
+		name="JE"
+		healthCanadaType="JE"
+		layout="injection" atc=""
+		showIfMinRecordNum="1" />
+
+	<item 
+		resultDesc=""
+		desc="Mammorgram" name="MAM" link="" layout="PAPMAM" minAge="50"
+		maxAge="70" sex="F" showIfMinRecordNum="1" />
+
+	<item 
+		resultDesc=""
+		desc="PSA" name="PSA" link="" layout="PAPMAM" minAge="50"
+		maxAge="70" sex="M" showIfMinRecordNum="1" />
+
+	<item 
+		resultDesc=""
+		desc="Fecal Occult Blood Test" name="FOBT" link="" layout="PAPMAM"
+		minAge="49" maxAge="80" showIfMinRecordNum="1" />
+
+	<item 
+		resultDesc=""
+		desc="Colonoscopy" name="COLONOSCOPY" link="" layout="PAPMAM"
+		showIfMinRecordNum="1" /-->
+		
+		<!-- For eva.caisi.ca -->
+	<!--item
+		resultDesc=""
+		desc="HIV = all pregnant women, opt out routine screening of all adults"
+		name="HIV"
+	    link="http://www.cdc.gov/std/treatment/"
+	    layout="PAPMAM"
+	    minAge="13"
+	    maxAge="75"
+	    showIfMinRecordNum="1" />
+
+ 
+	<item
+		resultDesc=""
+		desc="HepB screen= Hepatitis B serology (hep B sAg + anti-HBc or anti-HBs) in those with multiple sex partners, MSM, and injection drug users"
+		name="Hep B screen"
+		link="http://www.cdc.gov/std/treatment/"
+		layout="PAPMAM"
+		minAge="15"
+		maxAge="24"
+		showIfMinRecordNum="1" />
+		
+	<item		
+		resultDesc=""
+		desc="VDRL = VDRL screening for syphillis; pregnant women at the first prenatal visit (and 3rd trimester and delivery high-risk groups), all sex workers, in correctional facilities, diagnosed with another STD, MSM with high-risk behaviors"
+		name="VDRL"
+		link="http://www.cdc.gov/std/treatment/"
+		layout="PAPMAM"
+		minAge="15"
+		maxAge="25"
+		showIfMinRecordNum="1" />
+		
+	<item
+		resultDesc=""
+		desc="Chlamydia = chlamydia urine PCR; sexually active women age 25 years or younger (including pregnant women), women older than 25 years with: new sex partner in prior 60 days, more than one sex partner, inconsistent condom use, unmarried, or history of STD; men: asymptomatic screening may or may not benefit "
+		name="chlamydia"
+		link="http://www.cdc.gov/std/treatment/"
+		layout="PAPMAM"
+		minAge="12"
+		maxAge="25"
+		showIfMinRecordNum="1" />
+		
+	<item
+		resultDesc=""
+		desc= "ghonorrhea = ghonorrhea urine PCR in men with symptoms or asymptomatic women: Sexually active younger than 25 years, pregnancy, inconsistent condom use, multiple partners, partner with multiple contacts, sexual contact with partner with culture-proven STD, repeated episodes of STD, Sex work or drug use"
+		name="ghonorrhea PCR"
+		link="http://www.cdc.gov/std/treatment/"
+		layout="PAPMAM"
+		minAge="12"
+		maxAge="25"
+		showIfMinRecordNum="1" /-->
+	<!-- eva.caisi.ca -->
+
+    <!--item 
+		resultDesc=""
+		desc="H1N1 Vaccination" name="H1N1" layout="h1n1"
+            minAge="0" atc="J07BB02" />
+
+	<item 
+		resultDesc=""
+		desc="Other Layout A" name="OtherA" link="" layout="injection"
+		showIfMinRecordNum="1" />
+
+	<item 
+		resultDesc=""
+		desc="Other Layout B" name="OtherB" link="" layout="PAPMAM"
+		showIfMinRecordNum="1" />
+		
+	<item
+		resultDesc=""
+		desc= "Smoking history"
+		name="Smoking"		
+		layout="history"
+		minAge="13"		
+		showIfMinRecordNum="1" />
+	
+	<item
+		resultDesc=""
+		desc= "Bone Mineral Density"
+		name="BMD"		
+		layout="PAPMAM"
+		minAge="65"		
+		showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc= "Periodic Health Visit"
+		name="PHV"		
+		layout="history"	
+		showIfMinRecordNum="1" /-->
+
+	<item
+		resultDesc=""
+		desc=""
+		name="Bacterial Vaginosis"
+		layout="PAPMAM"
+		showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc=""
+		name="CT Culture Cervical"
+		layout="PAPMAM"
+		showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc=""
+		name="CT Culture Throat"
+		layout="PAPMAM"
+		showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc=""
+		name="CT Culture Rectal"
+		layout="PAPMAM"
+		showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc=""
+		name="CT Culture Urethral"
+		layout="PAPMAM"
+		showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc=""
+		name="CT NAAT Cervical"
+		layout="PAPMAM"
+		showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc=""
+		name="CT NAAT Urethral"
+		layout="PAPMAM"
+		showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc=""
+		name="CT NAAT Urine"
+		layout="PAPMAM"
+		showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc=""
+		name="GC Culture Cervical"
+		layout="PAPMAM"
+		showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc=""
+		name="GC Culture Throat"
+		layout="PAPMAM"
+		showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc=""
+		name="GC Culture Rectal"
+		layout="PAPMAM"
+		showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc=""
+		name="GC Culture Urethral"
+		layout="PAPMAM"
+		showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc=""
+		name="GC NAAT Cervical"
+		layout="PAPMAM"
+		showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc=""
+		name="GC NAAT Urethral"
+		layout="PAPMAM"
+		showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc=""
+		name="GC NAAT Urine"
+		layout="PAPMAM"
+		showIfMinRecordNum="1" />
+
+	<item 
+		resultDesc=""
+		desc="Hep A=Hepatitis A" name="HepA" link="" layout="injection" healthCanadaType="HA"
+		atc="J07BC02" showIfMinRecordNum="1" />
+
+	<item 
+		resultDesc=""
+		desc="Hep B=Hepatitis B" name="HepB" healthCanadaType="HB"
+		link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html#HepB"
+		layout="injection" atc="J07BC01" minAge="0" maxAge="1"
+		showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc=""
+		name="Hep A Screen"
+		layout="PAPMAM"
+		showIfMinRecordNum="1" />
+		
+	<item
+		resultDesc=""
+		desc="HepC screen = Hep C Ab serology in contacts of multiple sex partners, traumatic anal intercourse with infected person, IVDU"
+		name="Hep C screen"
+		link="http://www.cdc.gov/std/treatment/"
+		layout="PAPMAM"
+		minAge="15"
+		maxAge="24"
+		showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc=""
+		name="HSV viral swab"
+		layout="PAPMAM"
+		showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc=""
+		name="HIV Confirm Anon"
+		layout="PAPMAM"
+		showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc=""
+		name="HIV Confirm Nominal"
+		layout="PAPMAM"
+		showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc=""
+		name="HIV Serology Anon"
+		layout="PAPMAM"
+		showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc=""
+		name="HIV Serology Nominal"
+		layout="PAPMAM"
+		showIfMinRecordNum="1" />
+
+	<item
+		resultDesc="Normal=Non-reactive, Abnormal=Reactive，Other=Invalid"
+		desc=""
+		name="HIV POC Nominal"
+		layout="PAPMAM"
+		showIfMinRecordNum="1" />
+
+	<item
+		resultDesc="Normal=Non-reactive, Abnormal=Reactive，Other=Invalid"
+		desc=""
+		name="HIV POC Anon"
+		layout="PAPMAM"
+		showIfMinRecordNum="1" />
+
+	<item 
+		resultDesc=""
+		desc="Women ages of 9 and 26 years are recommended to receive human papillomavirus vaccine" 
+		name="HPV Vaccine"
+		healthCanadaType="HPV"
+		link="http://www.cdc.gov/std/treatment/" 
+		layout="injection" 
+		minAge="9"
+		maxAge="26" sex = "F"
    		showIfMinRecordNum="1" />
 
 	<item 
-			resultDesc=""
-			name="RSVAb" 
-			desc="Monoclonal Antibody RSV Vaccine eg Beyfortus"
-			healthCanadaType="RSVAb"
-			link="https://www.ema.europa.eu/en/medicines/human/EPAR/beyfortus#product-info" 
-			layout="injection" 
-			minAge="0"
-			maxAge="2"
-      atc="J06BD08"
-   		showIfMinRecordNum="1" />
-
-	<!-- Other Immuunization -->
+		resultDesc=""
+		desc="PAP=" name="PAP" link="" layout="PAPMAM" minAge="20"
+		maxAge="65" sex="F" showIfMinRecordNum="1" />
+		
+	<item
+		resultDesc="Normal=Positive, Abnormal=Negative"
+		desc=""
+		name="Pregnancy Test"
+		layout="PAPMAM"
+		showIfMinRecordNum="1" />
+		
+	<item
+		resultDesc=""
+		desc=""
+		name="Syphilis Serology"
+		layout="PAPMAM"
+		showIfMinRecordNum="1" />
+		
+	<item
+		resultDesc=""
+		desc=""
+		name="Trichomaniasis"
+		layout="PAPMAM"
+		showIfMinRecordNum="1" />
 
 	<item
-			resultDesc=""
-			desc="Other Layout A" 
-      name="OtherA"
-			headingName="Other"
-			healthCanadaType=""
-      link="" layout="injection"
-			showIfMinRecordNum="1" />
-
-	<!--Screenings-->
-
-	<item
-			resultDesc=""
-			desc="TB=Tuberculosis Mantoux " 
-            name="Tuberculosis"
-			headingName="Screenings" link="" 
-            layout="injection"
-			atc="J07AN01" showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc="Women from ages 25 to 70 are recommended to receive a PAP" name="PAP"
-			headingName="Screenings" link="" layout="PAPMAM" minAge="25"
-			maxAge="70" sex="F" showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc="Women from ages 25 to 74" name="HPV-CERVIX"
-			headingName="Screenings" link="" layout="PAPMAM" minAge="25"
-			maxAge="74" sex="F" showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc="Mammogram" name="MAM"
-			headingName="Screenings" link="" layout="PAPMAM" minAge="50"
-			maxAge="70" sex="F" showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc="PSA" name="PSA"
-			headingName="Screenings" link="" layout="PAPMAM" minAge="50"
-			maxAge="70" sex="M" showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			displayName="FIT/FOBT"
-			desc="Fecal Occult Blood Test or Fecal Immunochemical Test" name="FOBT"
-			headingName="Screenings" link="" layout="PAPMAM"
-			minAge="49" maxAge="80" showIfMinRecordNum="1" />
-			
-	<item
-			resultDesc=""
-			displayName="Abdominal U/S"
-			desc="One-time screening with ultrasound for abdominal aortic aneurysm" name="AAA"
-			headingName="Screenings" link="" layout="PAPMAM"
-			minAge="65" maxAge="80" sex="M" showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			displayName="Chest CT"
-			desc="Low Dose chest CT for 30 pack year smokers up to three times" name="CTC"
-			headingName="Screenings" link="" layout="PAPMAM"
-			minAge="55" maxAge="74" showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc="Colonoscopy" name="COLONOSCOPY"
-			headingName="Screenings" link="" layout="PAPMAM"
-			showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc="Bone Mineral Density" name="BMD"
-			headingName="Screenings" link="" layout="PAPMAM" minAge="65"
-			showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc="HIV = all pregnant women, opt out routine screening of all adults"
-			name="HIV"
-			headingName="Screenings"
-			link="http://www.cdc.gov/std/treatment/"
-			layout="PAPMAM"
-			minAge="13"
-			maxAge="75"
-			showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc="HepB screen= Hepatitis B serology (hep B sAg + anti-HBc or anti-HBs) in those with multiple sex partners, MSM, and injection drug users"
-			name="HepB screen"
-			headingName="Screenings"
-			link="http://www.cdc.gov/std/treatment/"
-			layout="PAPMAM"
-			minAge="15"
-			maxAge="24"
-			showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc="HepC screen = Hep C Ab serology in contacts of multiple sex partners, traumatic anal intercourse with infected person, IVDU"
-			name="HepC screen"
-			headingName="Screenings"
-			link="http://www.cdc.gov/std/treatment/"
-			layout="PAPMAM"
-			minAge="15"
-			maxAge="24"
-			showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc="VDRL = VDRL screening for syphillis; pregnant women at the first prenatal visit (and 3rd trimester and delivery high-risk groups), all sex workers, in correctional facilities, diagnosed with another STD, MSM with high-risk behaviors"
-			name="VDRL"
-			headingName="Screenings"
-			link="http://www.cdc.gov/std/treatment/"
-			layout="PAPMAM"
-			minAge="15"
-			maxAge="25"
-			showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc="Chlamydia = chlamydia urine PCR; sexually active women age 25 years or younger (including pregnant women), women older than 25 years with: new sex partner in prior 60 days, more than one sex partner, inconsistent condom use, unmarried, or history of STD; men: asymptomatic screening may or may not benefit "
-			name="chlamydia"
-			headingName="Screenings"
-			link="http://www.cdc.gov/std/treatment/"
-			layout="PAPMAM"
-			minAge="12"
-			maxAge="25"
-			showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc= "ghonorrhea = ghonorrhea urine PCR in men with symptoms or asymptomatic women: Sexually active younger than 25 years, pregnancy, inconsistent condom use, multiple partners, partner with multiple contacts, sexual contact with partner with culture-proven STD, repeated episodes of STD, Sex work or drug use"
-			name="ghonorrhea PCR"
-			headingName="Screenings"
-			link="http://www.cdc.gov/std/treatment/"
-			layout="PAPMAM"
-			minAge="12"
-			maxAge="25"
-			showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc= "Periodic Health Visit"
-			name="PHV"
-			headingName="Screenings"
-			layout="history"
-			showIfMinRecordNum="1" />
-
-	<item
-			resultDesc=""
-			desc= "Smoking history"
-			name="Smoking"
-			layout="history"
-			headingName="Screenings"
-			minAge="13"
-			showIfMinRecordNum="1" />
-
-	<!-- Other Screening -->
-
-	<item
-			resultDesc=""
-			desc="Other Layout B" 
-      name="OtherB"
-			headingName="Other" 
-      link="" layout="PAPMAM"
-			showIfMinRecordNum="1" />
-
+		resultDesc=""
+		desc=""
+		name="Yeast"
+		layout="PAPMAM"
+		showIfMinRecordNum="1" />
+		
 </preventions>
+

--- a/src/main/resources/oscar/oscarPrevention/PublicHealthPreventionItems.xml
+++ b/src/main/resources/oscar/oscarPrevention/PublicHealthPreventionItems.xml
@@ -299,10 +299,10 @@ Varicella Immunoglobulin	VarIg
 
 	<item
 		resultDesc=""
-		desc="MenC-C=Meningocococcal C Conjugate eg Menjugate"
-		name="MenC-C"
+		desc="Men-C-C=Meningococcal C Conjugate eg Menjugate, NeisVac-C"
+		name="Men-C-C"
 		headingName="Immunizations"
-		healthCanadaType="Men-C"
+		healthCanadaType="Men-C-C"
 		layout="injection" atc="J07AH07" minAge="0" maxAge="19"
 		showIfMinRecordNum="1" />
 
@@ -380,10 +380,10 @@ Varicella Immunoglobulin	VarIg
 
 	<item
 		resultDesc=""
-		desc="RZV=Recombinant Herpes Zoster eg Shingrix"
+		desc="RZV=Recombinant Herpes Zoster (Subunit) Vaccine eg Shingrix (2 doses)"
 		name="RZV"
 		headingName="Immunizations"
-		healthCanadaType="HerpR"
+		healthCanadaType="RZV"
 		layout="injection" atc="J07BK03" minAge="50" maxAge="100"
 		showIfMinRecordNum="1" />
 
@@ -416,9 +416,32 @@ Varicella Immunoglobulin	VarIg
 
 	<item
 		resultDesc=""
-		desc="Women from ages 25 to 69" name="HPV-CERVIX"
+		desc="HPV-CERVIX=HPV primary cervical cancer screening every 5 years - women ages 25 to 69"
+		name="HPV-CERVIX"
 		headingName="Screenings" link="" layout="PAPMAM" minAge="25"
 		maxAge="69" sex="F" showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc="PAP=Cervical cytology (Pap smear) - women ages 25 to 70"
+		name="PAP"
+		headingName="Screenings" link="" layout="PAPMAM" minAge="25"
+		maxAge="70" sex="F" showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		desc="COLONOSCOPY=Colonoscopy for colorectal cancer screening every 10 years"
+		name="COLONOSCOPY"
+		headingName="Screenings" link="" layout="PAPMAM"
+		showIfMinRecordNum="1" />
+
+	<item
+		resultDesc=""
+		displayName="LDCT Lung Cancer"
+		desc="LDCT=Low-Dose CT lung cancer screening - annual for high-risk smokers ages 55-74"
+		name="LDCT"
+		headingName="Screenings" link="" layout="PAPMAM" minAge="55" maxAge="74"
+		showIfMinRecordNum="1" />
 
 	<!-- Other -->
 

--- a/src/main/resources/oscar/oscarPrevention/PublicHealthPreventionItems.xml
+++ b/src/main/resources/oscar/oscarPrevention/PublicHealthPreventionItems.xml
@@ -224,7 +224,9 @@ Varicella Immunoglobulin	VarIg
 
 	<item 
 		resultDesc=""
-		desc="Flu=influenza vaccine" name="Flu" healthCanadaType="Inf"
+		desc="Flu=influenza vaccine" 
+    displayName="Flu"
+    name="Inf" healthCanadaType="Inf"
 		link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html#Flu"
 		layout="injection" atc="J07BB01" minAge="0" />
 

--- a/src/main/resources/oscar/oscarPrevention/PublicHealthPreventionItems.xml
+++ b/src/main/resources/oscar/oscarPrevention/PublicHealthPreventionItems.xml
@@ -109,11 +109,11 @@ Varicella Immunoglobulin	VarIg
 		
 	<item
 		resultDesc=""
-		desc="Rota=Rotavirus Vaccine"
+		desc="Rota=Rotavirus Vaccine (given orally)"
 		name="Rota"
 		healthCanadaType="Rota"
         link="www.novaccine.com/pdffiles/Rotarix_new_package_insert.pdf"
-		layout="injection" atc="J07BH01" minAge="0" maxAge="2"
+		layout="oral" atc="J07BH01" minAge="0" maxAge="2"
 		showIfMinRecordNum="1" />
 
 	<item
@@ -212,7 +212,7 @@ Varicella Immunoglobulin	VarIg
 		desc="Tdap=Diphtheria, Tetanus and Acellular Pertussis adult/adolescent formulation"
 		name="Tdap" healthCanadaType="Tdap"
 		link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html#dTap"
-		layout="injection" atc="J07AJ52" minAge="0" maxAge="6"
+		layout="injection" atc="J07AJ52" minAge="10"
 		showIfMinRecordNum="1" />
 
 	<item 
@@ -321,7 +321,7 @@ Varicella Immunoglobulin	VarIg
 		name="Tdap"
 		headingName="Immunizations"
 		healthCanadaType="Tdap"
-		layout="injection" atc="J07AJ52" minAge="0" maxAge="6"
+		layout="injection" atc="J07AJ52" minAge="10"
 		showIfMinRecordNum="1" />
 
 	<item
@@ -371,11 +371,11 @@ Varicella Immunoglobulin	VarIg
 
 	<item
 		resultDesc=""
-		desc="Rota=Rotavirus Vaccine eg Rotarix"
+		desc="Rota=Rotavirus Vaccine eg Rotarix (given orally)"
 		name="Rota"
 		headingName="Immunizations"
 		healthCanadaType="Rota"
-		layout="injection" atc="J07BH01" minAge="0" maxAge="2"
+		layout="oral" atc="J07BH01" minAge="0" maxAge="2"
 		showIfMinRecordNum="1" />
 
 	<item
@@ -496,9 +496,9 @@ Varicella Immunoglobulin	VarIg
 		layout="injection" atc=""
 		showIfMinRecordNum="1" />
 
-	<item 
+	<item
 		resultDesc=""
-		desc="Dukoral" name="CHOLERA" link="" layout="injection" healthCanadaType="Chol-O"
+		desc="Chol-O=Cholera oral eg Dukoral (given orally)" name="Chol-O" displayName="Dukoral" link="" layout="oral" healthCanadaType="Chol-O"
 		atc="J07AE01" showIfMinRecordNum="1" />
         
 
@@ -513,13 +513,13 @@ Varicella Immunoglobulin	VarIg
 		atc="J07AP01" showIfMinRecordNum="1" />
 		
 		  		
-  	<item 
+  	<item
 		resultDesc=""
-  		desc="Typhoid - Oral"
+  		desc="Typh-O=Typhoid oral eg Vivotif (given orally)"
   		name="Typh-O"
   		healthCanadaType="Typh-O"
-  		layout="injection" atc="" 
-  		showIfMinRecordNum="1"/>	
+  		layout="oral" atc="J07AP"
+  		showIfMinRecordNum="1"/>
 
 	<item 
 		resultDesc=""
@@ -786,14 +786,14 @@ Varicella Immunoglobulin	VarIg
 		layout="PAPMAM"
 		showIfMinRecordNum="1" />
 
-	<item 
+	<item
 		resultDesc=""
-		desc="Hep A=Hepatitis A" name="HepA" link="" layout="injection" healthCanadaType="HA"
+		desc="HA=Hepatitis A" name="HA" displayName="HepA" link="" layout="injection" healthCanadaType="HA"
 		atc="J07BC02" showIfMinRecordNum="1" />
 
-	<item 
+	<item
 		resultDesc=""
-		desc="Hep B=Hepatitis B" name="HepB" healthCanadaType="HB"
+		desc="HB=Hepatitis B" name="HB" displayName="HepB" healthCanadaType="HB"
 		link="http://www.phac-aspc.gc.ca/naci-ccni/is-si/recimmsche-icy_e.html#HepB"
 		layout="injection" atc="J07BC01" minAge="0" maxAge="1"
 		showIfMinRecordNum="1" />
@@ -808,7 +808,7 @@ Varicella Immunoglobulin	VarIg
 	<item
 		resultDesc=""
 		desc="HepC screen = Hep C Ab serology in contacts of multiple sex partners, traumatic anal intercourse with infected person, IVDU"
-		name="Hep C screen"
+		name="HepC screen"
 		link="http://www.cdc.gov/std/treatment/"
 		layout="PAPMAM"
 		minAge="15"
@@ -866,8 +866,8 @@ Varicella Immunoglobulin	VarIg
 
 	<item 
 		resultDesc=""
-		desc="Women ages of 9 and 26 years are recommended to receive human papillomavirus vaccine" 
-		name="HPV Vaccine"
+		desc="HPV=Human Papillomavirus Vaccine"
+		name="HPV" displayName="HPV Vaccine"
 		healthCanadaType="HPV"
 		link="http://www.cdc.gov/std/treatment/" 
 		layout="injection" 

--- a/src/main/resources/oscar/oscarPrevention/prevention.drl
+++ b/src/main/resources/oscar/oscarPrevention/prevention.drl
@@ -474,8 +474,14 @@ end
 // MMR / MMR-Var: Measles-Mumps-Rubella (2 rules) + Varicella combo (1 rule)
 // NACI Schedule: Dose 1 at 12mo, Dose 2 at 4-6yr (or as MMR-Var)
 // MMR 1: First dose, checks both MMR and MMR-Var counts (either satisfies)
-// MMR 2: Second dose at 48mo+, only checks MMR count (not MMR-Var)
-// MMR-Var 1: Second dose for those who got MMR-Var as first dose
+// MMR 2: Second MMR-component dose at 48mo+; uses total component count
+//        (MMR + MMR-Var) to avoid false positives when MMR-Var was given
+// MMR-Var 1: Comprehensive 2-dose coverage check at 48mo for BOTH MMR and
+//   Var components. MMR-Var counts toward both component totals:
+//     MMR component total = count(MMR) + count(MMR-Var)
+//     Var component total = count(Var) + count(MMR-Var)
+//   Typical schedule: MMR@12mo + Var@15mo + MMR-Var@48mo → fully covered
+//   Warning specifies exactly which component(s) are still needed.
 // Age range: 12 months to 10 years
 // --------------------------------------------------------------------------
 rule "MMR 1"
@@ -495,21 +501,39 @@ rule "MMR 2"
         prev : Prevention()
         eval( prev.getAgeInMonths() >= 48 )
         eval( prev.getAgeInYears() < 10 )
-        eval( prev.getNumberOfPreventionType("MMR") == 1 )
+        // Use total MMR component count (MMR + MMR-Var) to avoid false
+        // positives when a combined MMR-Var dose has already been given
+        eval( prev.getNumberOfPreventionType("MMR") + prev.getNumberOfPreventionType("MMR-Var") == 1 )
+        eval( prev.getNumberOfPreventionType("MMR-Var") == 0 )
     then
         prev.log("MMR 2");
         prev.addWarning("MMR", "Needs Second MMR or MMR-Var");
 end
 
+// MMR-Var 1: At 48mo, check full 2-dose coverage for both MMR and Var
+// components. Any combination that totals 2 doses per component is valid:
+//   - 2x MMR + 2x Var (all separate)
+//   - 1x MMR + 1x Var + 1x MMR-Var (typical schedule — no warning)
+//   - 2x MMR-Var
+//   - etc.
 rule "MMR-Var 1"
     when
         prev : Prevention()
         eval( prev.getAgeInMonths() >= 48 )
         eval( prev.getAgeInYears() < 10 )
-        eval( prev.getNumberOfPreventionType("MMR-Var") == 1 )
+        eval( (prev.getNumberOfPreventionType("MMR") + prev.getNumberOfPreventionType("MMR-Var") < 2)
+           || (prev.getNumberOfPreventionType("Var") + prev.getNumberOfPreventionType("MMR-Var") < 2) )
     then
         prev.log("MMR-Var 1");
-        prev.addWarning("MMR-Var", "Needs Second MMR or MMR-Var");
+        int mmrTotal = prev.getNumberOfPreventionType("MMR") + prev.getNumberOfPreventionType("MMR-Var");
+        int varTotal = prev.getNumberOfPreventionType("Var") + prev.getNumberOfPreventionType("MMR-Var");
+        if (mmrTotal < 2 && varTotal < 2) {
+            prev.addWarning("MMR-Var", "Needs MMR and Var immunization to complete series");
+        } else if (mmrTotal < 2) {
+            prev.addWarning("MMR-Var", "Needs MMR immunization to complete series");
+        } else {
+            prev.addWarning("MMR-Var", "Needs Var immunization to complete series");
+        }
 end
 
 // --------------------------------------------------------------------------

--- a/src/main/resources/oscar/oscarPrevention/prevention.drl
+++ b/src/main/resources/oscar/oscarPrevention/prevention.drl
@@ -68,7 +68,7 @@
 //   Childhood (2-18 months):  DTaP-IPV (5 doses), Hib (3-4 doses), Pneu-C (4 doses),
 //                              Rota (2 doses), MMR (2 doses), MMR-Var (1 dose), Var (1 dose)
 //   School-age (4-6 years):   DTaP-IPV booster, Tdap-IPV, Var catch-up
-//   Adolescent (12-18 years): MenC-C, HPV (3 doses)
+//   Adolescent (12-18 years): Men-C-C, HPV (3 doses)
 //   Adult:                    Tdap (10-year booster), Td (10-year repeat), Inf (annual 65+)
 //   Women's health:           HPV-CERVIX (5-year cycle, 25-69), PAP (3-year cycle, 25-69),
 //                              MAM (2-year cycle, 40-74)
@@ -81,7 +81,7 @@
 //   - "Rota 1"/"Rota 2" use System.out.println() instead of prev.log()
 //   - DTaP-IPV 4.1: Conditions duplicate DTaP-IPV 3.1 (checks count==2, not count==3)
 //   - DTaP-IPV 5/6: Warning says "Needs Third" but these are 5th/6th dose rules
-//   - MenC-C 1: Log message says "Pneu-C 4" (copy-paste artifact)
+//   - Men-C-C 1: Log message says "Pneu-C 4" (copy-paste artifact)
 //   - HPV-CERVIX 3: Typo in message "Neighter" should be "Neither"
 //   - "FOBT Inelligible": Misspelling of "Ineligible" in rule name and message
 //   - isInelligible(): Method name also misspelled (matches rule convention)
@@ -244,6 +244,11 @@ end
 // Strict upper age limits: dose 1 by 5mo, dose 2 by 6mo
 // QUIRK: Uses System.out.println() instead of prev.log() (original code)
 // Uses isNextDateSet() for dose 2 sequencing
+// MULTI-TYPE NOTE: Rules check "Rota" only. Records typed as "Rota-1" (Rotarix)
+//   or "Rota-5" (RotaTeq) will NOT satisfy these conditions. Consider migrating
+//   all Rota-1/Rota-5 records to "Rota" via SQL, or extend conditions like:
+//   eval( prev.getNumberOfPreventionType("Rota") + prev.getNumberOfPreventionType("Rota-1")
+//       + prev.getNumberOfPreventionType("Rota-5") == 0 )
 // --------------------------------------------------------------------------
 rule "Rota 1"
     when
@@ -357,6 +362,16 @@ end
 // Rules 1-4: Standard infant series (2-12mo) + booster (15-24mo)
 // Rules 5-6: Catch-up schedule for 12-24mo (fewer doses if starting late)
 // Minimum intervals: 2 months between primary doses, 6 months before booster
+// MULTI-TYPE NOTE: Rules check "Pneu-C" only. Records typed as "Pneu-C-7",
+//   "Pneu-C-10", "Pneu-C-13", "Pneu-C-15" should all satisfy these rules.
+//   Consider extending conditions to count all conjugate valences:
+//   eval( prev.getNumberOfPreventionType("Pneu-C")
+//       + prev.getNumberOfPreventionType("Pneu-C-7")
+//       + prev.getNumberOfPreventionType("Pneu-C-10")
+//       + prev.getNumberOfPreventionType("Pneu-C-13")
+//       + prev.getNumberOfPreventionType("Pneu-C-15")
+//       == 0 )
+//   Note: Pneu-C-20 is adult formulation and should NOT count for infant series.
 // --------------------------------------------------------------------------
 rule "Pneu-C 1"
     when
@@ -471,40 +486,41 @@ rule "MMR-Var 1"
 end
 
 // --------------------------------------------------------------------------
-// MenC-C: Meningococcal C Conjugate (3 rules)
+// Men-C-C: Meningococcal C Conjugate (3 rules)
 // NACI Schedule: Dose at 12mo, catch-up at 12yr for school programs
 // Rule 1: Primary dose at 12mo-24yr (broad catch-up window)
 // Rule 2: School-age catch-up at age 12-13yr
 // Rule 3: Adolescent catch-up at 15-19yr
 // QUIRK: Rule 1 log message says "Pneu-C 4" (copy-paste from Pneu-C section)
 // --------------------------------------------------------------------------
-rule "MenC-C 1"
+rule "Men-C-C 1"
     when
         prev : Prevention()
         eval( prev.getAgeInMonths() >= 12 )
         eval( prev.getAgeInYears() < 24 )
-        eval( prev.getNumberOfPreventionType("MenC-C") == 0 )
+        eval( prev.getNumberOfPreventionType("Men-C-C") == 0 )
     then
         prev.log("Pneu-C 4");
-        prev.addWarning("MenC-C", "Needs MenC-C");
+        prev.addWarning("Men-C-C", "Needs Men-C-C");
 end
 
-rule "MenC-C 2"
+rule "Men-C-C 2"
     when
         prev : Prevention()
         eval( prev.getAgeInYears() >= 12 )
         eval( prev.getAgeInYears() < 13 )
-        eval( prev.getNumberOfPreventionType("MenC-C") == 0 )
+        eval( prev.getNumberOfPreventionType("Men-C-C") == 0 )
     then
-        prev.log("MenC-C 2");
-        prev.addWarning("MenC-C", "Needs MenC-C");
+        prev.log("Men-C-C 2");
+        prev.addWarning("Men-C-C", "Needs Men-C-C");
 end
 
 // --------------------------------------------------------------------------
 // HPV: Human Papillomavirus vaccine (1 rule)
 // NACI Schedule: 2-3 dose series at age 12-18 (school-based programs)
-// Checks three vaccine product names: [HPV-9], [HPV-4], and generic "HPV Vaccine"
-// Sums all three product counts to determine if any HPV dose has been given
+// Checks Health Canada standard type codes: HPV-9, HPV-4, HPV (generic), HPV-2
+// Also checks legacy names from O19 migration for backward compatibility
+// Sums all product counts to determine if any HPV dose has been given
 // Age range: 12-18 years
 // --------------------------------------------------------------------------
 rule "HPV 1"
@@ -512,21 +528,26 @@ rule "HPV 1"
         prev : Prevention()
         eval( prev.getAgeInYears() >= 12 )
         eval( prev.getAgeInYears() < 19 )
-        eval( prev.getNumberOfPreventionType("[HPV-9] Human Papillomavirus") + prev.getNumberOfPreventionType("[HPV-4] Human Papillomavirus")  + prev.getNumberOfPreventionType("HPV Vaccine") == 0 )
+        eval( prev.getNumberOfPreventionType("HPV-9")
+            + prev.getNumberOfPreventionType("HPV-4")
+            + prev.getNumberOfPreventionType("HPV-2")
+            + prev.getNumberOfPreventionType("HPV")
+            + prev.getNumberOfPreventionType("HPV Vaccine")
+            == 0 )
     then
         prev.log("HPV 1");
         prev.addWarning("HPV", "Needs HPV");
 end
 
-rule "MenC-C 3"
+rule "Men-C-C 3"
     when
         prev : Prevention()
         eval( prev.getAgeInYears() >= 15 )
         eval( prev.getAgeInYears() <= 19 )
-        eval( prev.getNumberOfPreventionType("MenC-C") == 0 )
+        eval( prev.getNumberOfPreventionType("Men-C-C") == 0 )
     then
-        prev.log("MenC-C 3");
-        prev.addWarning("MenC-C", "Needs MenC-C");
+        prev.log("Men-C-C 3");
+        prev.addWarning("Men-C-C", "Needs Men-C-C");
 end
 
 // --------------------------------------------------------------------------
@@ -1066,4 +1087,43 @@ rule "Obesity 2"
     then
         prev.log("Obesity 2 debug");
         prev.addWarning("Obesity", "Obesity check has not occurred in over 12 months");
+end
+
+// --------------------------------------------------------------------------
+// LDCT: Low-Dose CT Lung Cancer Screening (2 rules)
+// Canadian guideline (CTFPHC 2016): Annual LDCT for adults aged 55-74 who are
+//   high-risk smokers (30+ pack-years or equivalent significant smoking history)
+// Rule 1: WARNING if no LDCT on record for patients aged 55-74 with smoking history
+// Rule 2: WARNING if LDCT is > 12 months old (annual screening required)
+// Precondition: Smoking assessment must be on record (getNumberOfPreventionType("Smoking") > 0)
+//   indicating a tobacco history assessment has been completed. Clinician determines
+//   if patient meets high-risk criteria (20-30+ pack-years per CT Canada criteria).
+// --------------------------------------------------------------------------
+rule "LDCT 1"
+    when
+        prev : Prevention()
+        eval( prev.getAgeInYears() >= 55 )
+        eval( prev.getAgeInYears() <= 74 )
+        eval( prev.getNumberOfPreventionType("Smoking") > 0 )
+        eval( prev.getHowManyMonthsSinceLast("LDCT") == -1 )
+        eval( !prev.isPreventionNever("LDCT") )
+        eval( !prev.isInelligible("LDCT") )
+    then
+        prev.log("LDCT 1");
+        prev.addWarning("LDCT", "LDCT lung cancer screening recommended for high-risk smoker aged 55-74 (no prior LDCT on record)");
+end
+
+rule "LDCT 2"
+    when
+        prev : Prevention()
+        eval( prev.getAgeInYears() >= 55 )
+        eval( prev.getAgeInYears() <= 74 )
+        eval( prev.getNumberOfPreventionType("Smoking") > 0 )
+        eval( prev.getHowManyMonthsSinceLast("LDCT") > 12 )
+        eval( !prev.isPreventionNever("LDCT") )
+        eval( !prev.isNextDateSet("LDCT") )
+        eval( !prev.isInelligible("LDCT") )
+    then
+        prev.log("LDCT 2");
+        prev.addWarning("LDCT", "Annual LDCT lung cancer screening is overdue for this patient (high-risk smoker aged 55-74)");
 end

--- a/src/main/resources/oscar/oscarPrevention/prevention.drl
+++ b/src/main/resources/oscar/oscarPrevention/prevention.drl
@@ -887,6 +887,24 @@ rule "MAM debug"
 end
 
 // --------------------------------------------------------------------------
+// AAA: Screening for AAA by u/s (1 rule)
+// Canadian guideline: one time screening for Men ages 65-80
+// Ontario guideline: one time screening for either gender ages 65-80
+// Rule 1: WARNING - AAA screen overdue no AAA screen on record
+// --------------------------------------------------------------------------
+rule "AAA 1"
+    when
+        prev : Prevention()
+        eval( prev.getAgeInYears() >= 65 )
+        eval( prev.getAgeInYears() <= 80 )
+        eval( prev.isMale() )
+        eval( prev.getHowManyMonthsSinceLast("AAA") == -1 )
+    then
+        prev.log("AAA 1 debug");
+        prev.addWarning("AAA", "AAA is overdue for this patient");
+end
+
+// --------------------------------------------------------------------------
 // FOBT / Colonoscopy: Colorectal cancer screening (4 rules)
 // Canadian guideline: FIT/FOBT every 2 years ages 50-74; colonoscopy every 10 years
 // Rule 1: WARNING - FIT overdue (>24mo since FOBT) AND no colonoscopy on record

--- a/src/main/resources/oscar/oscarPrevention/prevention.drl
+++ b/src/main/resources/oscar/oscarPrevention/prevention.drl
@@ -244,18 +244,19 @@ end
 // Strict upper age limits: dose 1 by 5mo, dose 2 by 6mo
 // QUIRK: Uses System.out.println() instead of prev.log() (original code)
 // Uses isNextDateSet() for dose 2 sequencing
-// MULTI-TYPE NOTE: Rules check "Rota" only. Records typed as "Rota-1" (Rotarix)
-//   or "Rota-5" (RotaTeq) will NOT satisfy these conditions. Consider migrating
-//   all Rota-1/Rota-5 records to "Rota" via SQL, or extend conditions like:
-//   eval( prev.getNumberOfPreventionType("Rota") + prev.getNumberOfPreventionType("Rota-1")
-//       + prev.getNumberOfPreventionType("Rota-5") == 0 )
+// MULTI-TYPE NOTE: Rule 1 counts Rota-1 (Rotarix) and Rota-5 (RotaTeq) as
+//   equivalent to generic Rota for the first-dose check. This allows records
+//   entered with product-specific codes to satisfy the rule.
 // --------------------------------------------------------------------------
 rule "Rota 1"
     when
         prev : Prevention()
         eval( prev.getAgeInMonths() >= 2 )
         eval( prev.getAgeInMonths() < 5 )
-        eval( prev.getNumberOfPreventionType("Rota") == 0 )
+        eval( prev.getNumberOfPreventionType("Rota")
+            + prev.getNumberOfPreventionType("Rota-1")
+            + prev.getNumberOfPreventionType("Rota-5")
+            == 0 )
         eval( !prev.isPreventionNever("Rota") )
     then
         System.out.println("Rota 1");
@@ -362,23 +363,21 @@ end
 // Rules 1-4: Standard infant series (2-12mo) + booster (15-24mo)
 // Rules 5-6: Catch-up schedule for 12-24mo (fewer doses if starting late)
 // Minimum intervals: 2 months between primary doses, 6 months before booster
-// MULTI-TYPE NOTE: Rules check "Pneu-C" only. Records typed as "Pneu-C-7",
-//   "Pneu-C-10", "Pneu-C-13", "Pneu-C-15" should all satisfy these rules.
-//   Consider extending conditions to count all conjugate valences:
-//   eval( prev.getNumberOfPreventionType("Pneu-C")
-//       + prev.getNumberOfPreventionType("Pneu-C-7")
-//       + prev.getNumberOfPreventionType("Pneu-C-10")
-//       + prev.getNumberOfPreventionType("Pneu-C-13")
-//       + prev.getNumberOfPreventionType("Pneu-C-15")
-//       == 0 )
-//   Note: Pneu-C-20 is adult formulation and should NOT count for infant series.
+// MULTI-TYPE NOTE: Rule 1 counts all pediatric conjugate valences (Pneu-C-7, -10, -13, -15)
+//   as equivalent to Pneu-C for the purpose of determining if a first dose has been given.
+//   Note: Pneu-C-20 is adult formulation and should NOT count for the infant series.
 // --------------------------------------------------------------------------
 rule "Pneu-C 1"
     when
         prev : Prevention()
         eval( prev.getAgeInMonths() >= 2 )
         eval( prev.getAgeInMonths() < 12 )
-        eval( prev.getNumberOfPreventionType("Pneu-C") == 0 )
+        eval( prev.getNumberOfPreventionType("Pneu-C")
+            + prev.getNumberOfPreventionType("Pneu-C-7")
+            + prev.getNumberOfPreventionType("Pneu-C-10")
+            + prev.getNumberOfPreventionType("Pneu-C-13")
+            + prev.getNumberOfPreventionType("Pneu-C-15")
+            == 0 )
     then
         prev.log("Pneu-C 1");
         prev.addWarning("Pneu-C", "Needs First Pneu-C");
@@ -1093,11 +1092,17 @@ end
 // LDCT: Low-Dose CT Lung Cancer Screening (2 rules)
 // Canadian guideline (CTFPHC 2016): Annual LDCT for adults aged 55-74 who are
 //   high-risk smokers (30+ pack-years or equivalent significant smoking history)
-// Rule 1: WARNING if no LDCT on record for patients aged 55-74 with smoking history
-// Rule 2: WARNING if LDCT is > 12 months old (annual screening required)
-// Precondition: Smoking assessment must be on record (getNumberOfPreventionType("Smoking") > 0)
-//   indicating a tobacco history assessment has been completed. Clinician determines
-//   if patient meets high-risk criteria (20-30+ pack-years per CT Canada criteria).
+// Rule 1: WARNING if no LDCT on record for patients aged 55-74 with positive smoking history
+// Rule 2: WARNING if LDCT count is 1 or 2 and it is > 12 months old (annual x3 years)
+//         LDCT 2 stops firing after 3rd annual screen (count >= 3).
+// Precondition (heavy smoker detection): Smoking assessment must be on record AND
+//   not marked as "never" (non-smoker). This uses the Prevention module's "Smoking" type.
+//   A Smoking record exists (getNumberOfPreventionType("Smoking") > 0) AND
+//   the record is NOT marked as never-smoked (!isPreventionNever("Smoking")).
+//   Note: Full heavy-smoker detection (pack-years, cigarettes/day) requires measurement
+//   values (NOSK > 23, POSK > 0, SKST = yes, SMK = yes, SmkS > 23) which are stored in
+//   the measurements table and are not accessible from the Prevention DRL fact object.
+//   Extending the Prevention class to support measurement queries would enable this.
 // --------------------------------------------------------------------------
 rule "LDCT 1"
     when
@@ -1105,6 +1110,7 @@ rule "LDCT 1"
         eval( prev.getAgeInYears() >= 55 )
         eval( prev.getAgeInYears() <= 74 )
         eval( prev.getNumberOfPreventionType("Smoking") > 0 )
+        eval( !prev.isPreventionNever("Smoking") )
         eval( prev.getHowManyMonthsSinceLast("LDCT") == -1 )
         eval( !prev.isPreventionNever("LDCT") )
         eval( !prev.isInelligible("LDCT") )
@@ -1119,11 +1125,14 @@ rule "LDCT 2"
         eval( prev.getAgeInYears() >= 55 )
         eval( prev.getAgeInYears() <= 74 )
         eval( prev.getNumberOfPreventionType("Smoking") > 0 )
+        eval( !prev.isPreventionNever("Smoking") )
+        eval( prev.getNumberOfPreventionType("LDCT") >= 1 )
+        eval( prev.getNumberOfPreventionType("LDCT") <= 2 )
         eval( prev.getHowManyMonthsSinceLast("LDCT") > 12 )
         eval( !prev.isPreventionNever("LDCT") )
         eval( !prev.isNextDateSet("LDCT") )
         eval( !prev.isInelligible("LDCT") )
     then
         prev.log("LDCT 2");
-        prev.addWarning("LDCT", "Annual LDCT lung cancer screening is overdue for this patient (high-risk smoker aged 55-74)");
+        prev.addWarning("LDCT", "LDCT lung cancer screening for older heavy smokers should be done annually for 3 years and is overdue");
 end

--- a/src/main/resources/oscar/oscarPrevention/prevention.drl
+++ b/src/main/resources/oscar/oscarPrevention/prevention.drl
@@ -66,10 +66,10 @@
 //
 // SCHEDULE REFERENCE (based on NACI Canadian Immunization Schedule):
 //   Childhood (2-18 months):  DTaP-IPV (5 doses), Hib (3-4 doses), Pneu-C (4 doses),
-//                              Rot (2 doses), MMR (2 doses), MMRV (1 dose), VZ (1 dose)
-//   School-age (4-6 years):   DTaP-IPV booster, Tdap-IPV, VZ catch-up
+//                              Rota (2 doses), MMR (2 doses), MMR-Var (1 dose), Var (1 dose)
+//   School-age (4-6 years):   DTaP-IPV booster, Tdap-IPV, Var catch-up
 //   Adolescent (12-18 years): MenC-C, HPV (3 doses)
-//   Adult:                    dTap (10-year booster), Td (10-year repeat), Flu (annual 65+)
+//   Adult:                    Tdap (10-year booster), Td (10-year repeat), Inf (annual 65+)
 //   Women's health:           HPV-CERVIX (5-year cycle, 25-69), PAP (3-year cycle, 25-69),
 //                              MAM (2-year cycle, 40-74)
 //   Colorectal screening:     FOBT/FIT (2-year cycle, 50-74), Colonoscopy (10-year)
@@ -77,8 +77,8 @@
 //                              Annual Physical (annual), Obesity screening (annual)
 //
 // KNOWN QUIRKS:
-//   - Flu 1: Hardcoded 2005-2006 flu season date range (historical, not updated)
-//   - "Rot 1"/"Rot 2" use System.out.println() instead of prev.log()
+//   - Inf 1: Hardcoded 2005-2006 flu season date range (historical, not updated)
+//   - "Rota 1"/"Rota 2" use System.out.println() instead of prev.log()
 //   - DTaP-IPV 4.1: Conditions duplicate DTaP-IPV 3.1 (checks count==2, not count==3)
 //   - DTaP-IPV 5/6: Warning says "Needs Third" but these are 5th/6th dose rules
 //   - MenC-C 1: Log message says "Pneu-C 4" (copy-paste artifact)
@@ -239,36 +239,36 @@ rule "Tdap-IPV 1"
 end
 
 // --------------------------------------------------------------------------
-// Rot: Rotavirus vaccine (2 rules)
+// Rota: Rotavirus vaccine (2 rules)
 // NACI Schedule: 2 doses at 2mo and 4mo (must complete by 8 months of age)
 // Strict upper age limits: dose 1 by 5mo, dose 2 by 6mo
 // QUIRK: Uses System.out.println() instead of prev.log() (original code)
 // Uses isNextDateSet() for dose 2 sequencing
 // --------------------------------------------------------------------------
-rule "Rot 1"
+rule "Rota 1"
     when
         prev : Prevention()
         eval( prev.getAgeInMonths() >= 2 )
         eval( prev.getAgeInMonths() < 5 )
-        eval( prev.getNumberOfPreventionType("Rot") == 0 )
-        eval( !prev.isPreventionNever("Rot") )
+        eval( prev.getNumberOfPreventionType("Rota") == 0 )
+        eval( !prev.isPreventionNever("Rota") )
     then
-        System.out.println("Rot 1");
-        prev.addWarning("Rot", "Needs First Rot-1 vaccine");
+        System.out.println("Rota 1");
+        prev.addWarning("Rota", "Needs First Rota vaccine");
 end
 
-rule "Rot 2"
+rule "Rota 2"
     when
         prev : Prevention()
         eval( prev.getAgeInMonths() >= 4 )
         eval( prev.getAgeInMonths() <= 6 )
-        eval( prev.getNumberOfPreventionType("Rot") == 1 )
-        eval( prev.getHowManyMonthsSinceLast("Rot") >= 1 )
-        eval( !prev.isPreventionNever("Rot") )
-        eval( prev.isNextDateSet("Rot") )
+        eval( prev.getNumberOfPreventionType("Rota") == 1 )
+        eval( prev.getHowManyMonthsSinceLast("Rota") >= 1 )
+        eval( !prev.isPreventionNever("Rota") )
+        eval( prev.isNextDateSet("Rota") )
     then
-        System.out.println("Rot 2");
-        prev.addWarning("Rot", "Needs Second Rot-1 vaccine");
+        System.out.println("Rota 2");
+        prev.addWarning("Rota", "Needs Second Rota vaccine");
 end
 
 // --------------------------------------------------------------------------
@@ -429,11 +429,11 @@ rule "Pneu-C 6"
 end
 
 // --------------------------------------------------------------------------
-// MMR / MMRV: Measles-Mumps-Rubella (2 rules) + Varicella combo (1 rule)
-// NACI Schedule: Dose 1 at 12mo, Dose 2 at 4-6yr (or as MMRV)
-// MMR 1: First dose, checks both MMR and MMRV counts (either satisfies)
-// MMR 2: Second dose at 48mo+, only checks MMR count (not MMRV)
-// MMRV 1: Second dose for those who got MMRV as first dose
+// MMR / MMR-Var: Measles-Mumps-Rubella (2 rules) + Varicella combo (1 rule)
+// NACI Schedule: Dose 1 at 12mo, Dose 2 at 4-6yr (or as MMR-Var)
+// MMR 1: First dose, checks both MMR and MMR-Var counts (either satisfies)
+// MMR 2: Second dose at 48mo+, only checks MMR count (not MMR-Var)
+// MMR-Var 1: Second dose for those who got MMR-Var as first dose
 // Age range: 12 months to 10 years
 // --------------------------------------------------------------------------
 rule "MMR 1"
@@ -442,10 +442,10 @@ rule "MMR 1"
         eval( prev.getAgeInMonths() >= 12 )
         eval( prev.getAgeInYears() < 10 )
         eval( prev.getNumberOfPreventionType("MMR") == 0 )
-        eval( prev.getNumberOfPreventionType("MMRV") == 0 )
+        eval( prev.getNumberOfPreventionType("MMR-Var") == 0 )
     then
         prev.log("MMR 1");
-        prev.addWarning("MMR", "Needs First MMR or MMRV");
+        prev.addWarning("MMR", "Needs First MMR or MMR-Var");
 end
 
 rule "MMR 2"
@@ -456,18 +456,18 @@ rule "MMR 2"
         eval( prev.getNumberOfPreventionType("MMR") == 1 )
     then
         prev.log("MMR 2");
-        prev.addWarning("MMR", "Needs Second MMR or MMRV");
+        prev.addWarning("MMR", "Needs Second MMR or MMR-Var");
 end
 
-rule "MMRV 1"
+rule "MMR-Var 1"
     when
         prev : Prevention()
         eval( prev.getAgeInMonths() >= 48 )
         eval( prev.getAgeInYears() < 10 )
-        eval( prev.getNumberOfPreventionType("MMRV") == 1 )
+        eval( prev.getNumberOfPreventionType("MMR-Var") == 1 )
     then
-        prev.log("MMRV 1");
-        prev.addWarning("MMRV", "Needs Second MMR or MMRV");
+        prev.log("MMR-Var 1");
+        prev.addWarning("MMR-Var", "Needs Second MMR or MMR-Var");
 end
 
 // --------------------------------------------------------------------------
@@ -530,7 +530,7 @@ rule "MenC-C 3"
 end
 
 // --------------------------------------------------------------------------
-// VZ: Varicella (Chickenpox) vaccine (4 rules)
+// Var: Varicella (Chickenpox) vaccine (4 rules)
 // NACI Schedule: Dose 1 at 15mo, catch-up at 4-6yr
 // Rules 1-2: First dose at 15-24mo, requiring 28+ days since last MMR
 //   Rule 1: Normal case (>=28 days since MMR - safe to give live vaccine)
@@ -538,78 +538,78 @@ end
 // Rules 3-4: Catch-up at 4-6 years with same MMR spacing logic
 // Live vaccine interval: Must wait 28 days after MMR (both are live vaccines)
 // --------------------------------------------------------------------------
-rule "VZ 1"
+rule "Var 1"
     when
         prev : Prevention()
         eval( prev.getAgeInMonths() >= 15 )
         eval( prev.getAgeInMonths() <= 24 )
-        eval( prev.getNumberOfPreventionType("VZ") == 0 )
+        eval( prev.getNumberOfPreventionType("Var") == 0 )
         eval( prev.getHowManyDaysSinceLast("MMR") >= 28 )
     then
-        prev.log("VZ 1");
-        prev.addWarning("VZ", "Needs VZ");
+        prev.log("Var 1");
+        prev.addWarning("Var", "Needs Var");
 end
 
-rule "VZ 2"
+rule "Var 2"
     when
         prev : Prevention()
         eval( prev.getAgeInMonths() >= 15 )
         eval( prev.getAgeInMonths() <= 24 )
-        eval( prev.getNumberOfPreventionType("VZ") == 0 )
+        eval( prev.getNumberOfPreventionType("Var") == 0 )
         eval( prev.getHowManyDaysSinceLast("MMR") == 0 )
     then
-        prev.log("VZ 2");
-        prev.addWarning("VZ", "Needs VZ");
+        prev.log("Var 2");
+        prev.addWarning("Var", "Needs Var");
 end
 
-rule "VZ 3"
+rule "Var 3"
     when
         prev : Prevention()
         eval( prev.getAgeInYears() >= 4 )
         eval( prev.getAgeInYears() <= 6 )
-        eval( prev.getNumberOfPreventionType("VZ") == 0 )
+        eval( prev.getNumberOfPreventionType("Var") == 0 )
         eval( prev.getHowManyDaysSinceLast("MMR") >= 28 )
     then
-        prev.log("VZ 3");
-        prev.addWarning("VZ", "Needs VZ");
+        prev.log("Var 3");
+        prev.addWarning("Var", "Needs Var");
 end
 
-rule "VZ 4"
+rule "Var 4"
     when
         prev : Prevention()
         eval( prev.getAgeInYears() >= 4 )
         eval( prev.getAgeInYears() <= 6 )
-        eval( prev.getNumberOfPreventionType("VZ") == 0 )
+        eval( prev.getNumberOfPreventionType("Var") == 0 )
         eval( prev.getHowManyDaysSinceLast("MMR") == 0 )
     then
-        prev.log("VZ 4");
-        prev.addWarning("VZ", "Needs VZ");
+        prev.log("Var 4");
+        prev.addWarning("Var", "Needs Var");
 end
 
 // --------------------------------------------------------------------------
-// dTap / Td: Adult Tetanus-Diphtheria boosters (3 rules)
-// NACI Schedule: dTap once in adulthood, then Td every 10 years
-// dTap 1: First adult acellular pertussis booster, >=120mo (10yr) since last DTaP-IPV
-// Td 1: First tetanus-diphtheria booster, >=120mo since last dTaP
+// Tdap / Td: Adult Tetanus-Diphtheria boosters (3 rules)
+// NACI Schedule: Tdap once in adulthood, then Td every 10 years
+// Tdap 1: First adult acellular pertussis booster, >=120mo (10yr) since last DTaP-IPV
+// Td 1: First tetanus-diphtheria booster, >=120mo since last Tdap
 // Td 2: Repeat Td booster every 10 years; checks ALL tetanus-containing vaccines:
-//   dTaP, Td, Td-IPV, TdP-IPV-Hib, Tdap-IPV (any resets the 10-year clock)
+//   Tdap, Td, Td-IPV, TdP-IPV-Hib, Tdap-IPV (any resets the 10-year clock)
 // NOTE: No age restrictions on adult boosters - applies to all ages
 // --------------------------------------------------------------------------
-rule "dTap 1"
+rule "Tdap 1"
     when
         prev : Prevention()
-        eval( prev.getNumberOfPreventionType("dTap") == 0 )
+        eval( prev.getNumberOfPreventionType("Tdap") == 0 )
         eval( prev.getHowManyMonthsSinceLast("DTaP-IPV") >= 120 )
     then
-        prev.log("dTap 1");
-        prev.addWarning("dTap", "Needs dTap");
+        prev.log("Tdap 1");
+        prev.addWarning("Tdap", "Needs Tdap");
 end
 
 rule "Td 1"
     when
         prev : Prevention()
         eval( prev.getNumberOfPreventionType("Td") == 0 )
-        eval( prev.getHowManyMonthsSinceLast("dTaP") >= 120 )
+        eval( prev.getHowManyMonthsSinceLast("Tdap") >= 120 )
     then
         prev.log("Td 1");
         prev.addWarning("Td", "Needs Td");
@@ -620,7 +620,7 @@ rule "Td 2"
         prev : Prevention()
         eval( prev.getNumberOfPreventionType("Td") >= 1 )
         eval( prev.getHowManyMonthsSinceLast("Td") >= 120 )
-        eval( prev.getHowManyMonthsSinceLast("dTaP") >= 120 )
+        eval( prev.getHowManyMonthsSinceLast("Tdap") >= 120 )
         eval( prev.getHowManyMonthsSinceLast("Td-IPV") >= 120 )
         eval( prev.getHowManyMonthsSinceLast("TdP-IPV-Hib") >= 120 )
         eval( prev.getHowManyMonthsSinceLast("Tdap-IPV") >= 120 )
@@ -630,54 +630,57 @@ rule "Td 2"
 end
 
 // --------------------------------------------------------------------------
-// Flu: Influenza vaccine (4 rules)
+// Inf: Influenza vaccine (4 rules)
 // NACI Schedule: Annual vaccination, especially for 65+ and high-risk groups
-// Rule "Flu 1": HARDCODED 2005-2006 flu season (historical, not dynamically updated)
+// Rule "Inf 1": HARDCODED 2005-2006 flu season (historical, not dynamically updated)
 //   Uses isTodayinDateRange/isLastPreventionWithinRange for season-specific check
-// Rules "Flu 2"/"Flu 3": Age 65+ annual check (12-month interval)
-//   Flu 2: Has previous flu shot but >12 months ago
-//   Flu 3: Never had a flu shot (months since last == -1, meaning no record)
-// "Flu Set Date": Generic next-date-passed catch-all for any age
-// QUIRK: Flu 1 date range is never updated; effectively dead code after 2006
+// Rules "Inf 2"/"Inf 3": Age 65+ annual check (12-month interval)
+//   Inf 2: Has previous flu shot but >12 months ago
+//   Inf 3: Never had a flu shot (months since last == -1, meaning no record)
+// "Inf Set Date": Generic next-date-passed catch-all for any age
+// QUIRK: Inf 1 date range is never updated; effectively dead code after 2006
+// Also checks legacy "Flu" type for backward compatibility with pre-migration records
 // --------------------------------------------------------------------------
-rule "Flu 1"
+rule "Inf 1"
     when
         prev : Prevention()
         eval( prev.isTodayinDateRange("2005-10-01","2006-01-29") )
-        eval( !prev.isLastPreventionWithinRange("Flu","2005-10-01","2006-01-29") )
+        eval( !prev.isLastPreventionWithinRange("Inf","2005-10-01","2006-01-29") )
     then
-        prev.log("Flu 1");
-        prev.addWarning("Flu", "Needs Flu Shot ");
+        prev.log("Inf 1");
+        prev.addWarning("Inf", "Needs Flu Shot ");
 end
 
-rule "Flu 2"
+rule "Inf 2"
     when
         prev : Prevention()
         eval( prev.getAgeInYears() >=65 )
+        eval( prev.getHowManyMonthsSinceLast("Inf") >= 12 )
         eval( prev.getHowManyMonthsSinceLast("Flu") >= 12 )
     then
-        prev.log("Flu 2");
-        prev.addWarning("Flu", "Needs Flu Shot ");
+        prev.log("Inf 2");
+        prev.addWarning("Inf", "Needs Flu Shot ");
 end
 
-rule "Flu 3"
+rule "Inf 3"
     when
         prev : Prevention()
         eval( prev.getAgeInYears() >=65 )
+        eval( prev.getHowManyMonthsSinceLast("Inf") == -1 )
         eval( prev.getHowManyMonthsSinceLast("Flu") == -1 )
     then
-        prev.log("Flu 3");
-        prev.addWarning("Flu", "Needs Flu Shot ");
+        prev.log("Inf 3");
+        prev.addWarning("Inf", "Needs Flu Shot ");
 end
 
-rule "Flu Set Date"
+rule "Inf Set Date"
     when
         prev : Prevention()
-        eval( prev.isNextDateSet("Flu") )
-        eval( prev.isPassedNextDate("Flu") )
+        eval( prev.isNextDateSet("Inf") )
+        eval( prev.isPassedNextDate("Inf") )
     then
-        prev.log("Flu 1");
-        prev.addWarning("Flu", "Needs Flu Shot ");
+        prev.log("Inf 1");
+        prev.addWarning("Inf", "Needs Flu Shot ");
 end
 
 // --------------------------------------------------------------------------

--- a/src/main/resources/oscar/oscarPrevention/prevention.drl
+++ b/src/main/resources/oscar/oscarPrevention/prevention.drl
@@ -268,7 +268,10 @@ rule "Rota 2"
         prev : Prevention()
         eval( prev.getAgeInMonths() >= 4 )
         eval( prev.getAgeInMonths() <= 6 )
-        eval( prev.getNumberOfPreventionType("Rota") == 1 )
+        eval( prev.getNumberOfPreventionType("Rota")
+            + prev.getNumberOfPreventionType("Rota-1")
+            + prev.getNumberOfPreventionType("Rota-5")
+            == 1 )
         eval( prev.getHowManyMonthsSinceLast("Rota") >= 1 )
         eval( !prev.isPreventionNever("Rota") )
         eval( prev.isNextDateSet("Rota") )
@@ -388,7 +391,12 @@ rule "Pneu-C 2"
         prev : Prevention()
         eval( prev.getAgeInMonths() >= 4 )
         eval( prev.getAgeInMonths() < 12 )
-        eval( prev.getNumberOfPreventionType("Pneu-C") == 1 )
+        eval( prev.getNumberOfPreventionType("Pneu-C")
+            + prev.getNumberOfPreventionType("Pneu-C-7")
+            + prev.getNumberOfPreventionType("Pneu-C-10")
+            + prev.getNumberOfPreventionType("Pneu-C-13")
+            + prev.getNumberOfPreventionType("Pneu-C-15")
+            == 1 )
         eval( prev.getHowManyMonthsSinceLast("Pneu-C") >= 2 )
     then
         prev.log("Pneu-C 2");
@@ -400,7 +408,12 @@ rule "Pneu-C 3"
         prev : Prevention()
         eval( prev.getAgeInMonths() >= 6 )
         eval( prev.getAgeInMonths() < 12 )
-        eval( prev.getNumberOfPreventionType("Pneu-C") == 2 )
+        eval( prev.getNumberOfPreventionType("Pneu-C")
+            + prev.getNumberOfPreventionType("Pneu-C-7")
+            + prev.getNumberOfPreventionType("Pneu-C-10")
+            + prev.getNumberOfPreventionType("Pneu-C-13")
+            + prev.getNumberOfPreventionType("Pneu-C-15")
+            == 2 )
         eval( prev.getHowManyMonthsSinceLast("Pneu-C") >= 2 )
     then
         prev.log("Pneu-C 3");
@@ -412,7 +425,12 @@ rule "Pneu-C 4"
         prev : Prevention()
         eval( prev.getAgeInMonths() >= 15 )
         eval( prev.getAgeInMonths() < 24 )
-        eval( prev.getNumberOfPreventionType("Pneu-C") == 3 )
+        eval( prev.getNumberOfPreventionType("Pneu-C")
+            + prev.getNumberOfPreventionType("Pneu-C-7")
+            + prev.getNumberOfPreventionType("Pneu-C-10")
+            + prev.getNumberOfPreventionType("Pneu-C-13")
+            + prev.getNumberOfPreventionType("Pneu-C-15")
+            == 3 )
         eval( prev.getHowManyMonthsSinceLast("Pneu-C") >= 6 )
     then
         prev.log("Pneu-C 4");
@@ -424,7 +442,12 @@ rule "Pneu-C 5"
         prev : Prevention()
         eval( prev.getAgeInMonths() >= 12 )
         eval( prev.getAgeInMonths() < 24 )
-        eval( prev.getNumberOfPreventionType("Pneu-C") == 0 )
+        eval( prev.getNumberOfPreventionType("Pneu-C")
+            + prev.getNumberOfPreventionType("Pneu-C-7")
+            + prev.getNumberOfPreventionType("Pneu-C-10")
+            + prev.getNumberOfPreventionType("Pneu-C-13")
+            + prev.getNumberOfPreventionType("Pneu-C-15")
+            == 0 )
     then
         prev.log("Pneu-C 5");
         prev.addWarning("Pneu-C", "Needs First Pneu-C");
@@ -435,7 +458,12 @@ rule "Pneu-C 6"
         prev : Prevention()
         eval( prev.getAgeInMonths() >= 14 )
         eval( prev.getAgeInMonths() < 24 )
-        eval( prev.getNumberOfPreventionType("Pneu-C") == 1 )
+        eval( prev.getNumberOfPreventionType("Pneu-C")
+            + prev.getNumberOfPreventionType("Pneu-C-7")
+            + prev.getNumberOfPreventionType("Pneu-C-10")
+            + prev.getNumberOfPreventionType("Pneu-C-13")
+            + prev.getNumberOfPreventionType("Pneu-C-15")
+            == 1 )
         eval( prev.getHowManyMonthsSinceLast("Pneu-C") >= 2 )
     then
         prev.log("Pneu-C 6");
@@ -1124,8 +1152,6 @@ rule "LDCT 2"
         prev : Prevention()
         eval( prev.getAgeInYears() >= 55 )
         eval( prev.getAgeInYears() <= 74 )
-        eval( prev.getNumberOfPreventionType("Smoking") > 0 )
-        eval( !prev.isPreventionNever("Smoking") )
         eval( prev.getNumberOfPreventionType("LDCT") >= 1 )
         eval( prev.getNumberOfPreventionType("LDCT") <= 2 )
         eval( prev.getHowManyMonthsSinceLast("LDCT") > 12 )


### PR DESCRIPTION
<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description

<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues
Fixes #605
<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?

<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Align prevention configuration, naming, and migration with standardized Health Canada / OSCAR 19 immunization and screening types.

New Features:
- Introduce standardized prevention type codes and metadata for newer vaccines (e.g., RSV, updated pneumococcal, HPV-9) and screenings (e.g., LDCT, AAA) in prevention XML configs.
- Add a database migration script to normalize legacy prevention_type values to the canonical Health Canada abbreviations while preserving original values in comments.

Bug Fixes:
- Correct non‑standard or inconsistent immunization and screening codes, names, and age ranges in prevention configuration files to match the OSCAR 19 / Health Canada standard.

Enhancements:
- Document Health Canada immunization abbreviation standards and internal naming conventions directly in PreventionItems.xml.
- Restructure prevention items into clearer sections (Immunizations, Screenings, Other) and refine descriptions, layouts (e.g., oral vs injection), display names, and healthCanadaType mappings.
- Align public health prevention item subsets and prevention config sets with the updated standardized prevention items and modern preventive care recommendations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Shingles prevention screening (age 65+)
  * Added Lung Cancer Screening (age 55-74)
  * Expanded women's and men's preventive care age eligibility up to age 74

* **Improvements**
  * Standardized vaccine naming and categorization aligned with health guidelines
  * Enhanced prevention item descriptions for improved clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->