### PR TITLE
docs: add clean room functional specification for SplitDocument2Action

### DIFF
--- a/.claude/commands/cleanroom-spec/README.md
+++ b/.claude/commands/cleanroom-spec/README.md
@@ -1,0 +1,11 @@
+---
+description: Clean Room Specification Commands
+---
+
+# Clean Room Specification Commands
+
+Commands for writing IEEE 830 black-box functional specifications using Chinese Wall clean room methodology. Specifications describe observable behavior only and serve as input for clean room reimplementations.
+
+## Available Commands
+
+- `/cleanroom-spec` — Write a clean room functional specification from source code

--- a/.claude/commands/cleanroom-spec/cleanroom-spec.md
+++ b/.claude/commands/cleanroom-spec/cleanroom-spec.md
@@ -91,6 +91,12 @@ it IS an external contract. If it's an internal field encoding, describe it sema
 
 ## 3. Functional Requirements
 ### 3.N <Operation Name> (one subsection per operation, alphabetical)
+#### FR-XXX-1: Inputs
+#### FR-XXX-2: Guard conditions (if any)
+#### FR-XXX-3: <Core behavior steps>
+#### FR-XXX-N: Side effects
+#### FR-XXX-N: Response
+#### FR-XXX-N: Error handling
 
 ## 4. Non-Functional Requirements
 

--- a/.claude/commands/cleanroom-spec/cleanroom-spec.md
+++ b/.claude/commands/cleanroom-spec/cleanroom-spec.md
@@ -1,0 +1,418 @@
+---
+description: Write a clean room IEEE 830 functional specification from source code using Chinese Wall methodology
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Agent, WebSearch, WebFetch
+model: opus
+---
+
+# /cleanroom-spec - Clean Room Functional Specification Generator
+
+Write a black-box IEEE 830 functional specification for a given source file or component. The specification describes **observable behavior only** and contains no source code, no internal implementation details, and no copyrightable expression from the original. It serves as the sole input for a clean room reimplementation per the Chinese Wall methodology.
+
+---
+
+## 0. Input
+
+The user provides one of:
+- A file path to a Java source file (e.g., `src/main/java/.../SomeAction.java`)
+- A class name to locate (e.g., `SplitDocument2Action`)
+- A component description (e.g., "the document split action in documentManager")
+
+If the user does not provide a target, ask which source file or component to specify.
+
+---
+
+## 1. Legal and Methodological Foundation
+
+### 1.1 What Is Clean Room Design?
+
+Clean room design (also called "Chinese Wall" methodology) is a legal technique for reverse engineering and reimplementation that avoids copyright infringement. It separates the work into two teams:
+
+- **Dirty room team** (analyst): Reads the original source code and produces a functional specification describing only observable behavior — inputs, outputs, side effects, and external contracts.
+- **Clean room team** (implementer): Reads ONLY the specification and writes new code from scratch. They never see the original source.
+
+The specification document IS the Chinese Wall. It must contain zero copyrightable expression from the original.
+
+**Legal precedent:**
+- *Computer Associates v. Altai* (1992) — Established the Abstraction-Filtration-Comparison (AFC) test
+- *Whelan v. Jaslow* — Structure-Sequence-Organization (SSO) test
+- *Sega v. Accolade* (1992) — Clean room reimplementation is lawful
+- *Lotus v. Borland* (1995) — Functional elements (menus, command structures) not copyrightable
+
+### 1.2 What Is Copyrightable vs. Not
+
+**NOT copyrightable (safe to include in spec):**
+- Functional ideas, algorithms described at an abstract level
+- Externally-dictated interface contracts (HTTP parameters, JSON field names, wire protocol values)
+- Efficiency-driven sequences where only one reasonable way exists (merger doctrine)
+- Facts: database column semantics, business rules, observable behavior
+- Standard patterns dictated by frameworks or protocols
+
+**Copyrightable (MUST NOT appear in spec):**
+- Source code or pseudocode derived from the original's structure
+- Variable names, method names, class names (except as disclaimed traceability references)
+- The specific organizational structure of the original code
+- Creative architectural choices (how modules are composed internally)
+- Comments or documentation text from the original
+
+### 1.3 The AFC Test Applied
+
+For every element in the specification, apply this three-step filter:
+
+1. **Abstraction**: Identify the level of abstraction — is this an idea/function or specific expression?
+2. **Filtration**: Remove non-protectable elements:
+   - Ideas and functional requirements (not protectable)
+   - Elements dictated by external factors (framework requirements, wire protocols, hardware)
+   - Elements dictated by efficiency (only one reasonable way to do it — merger doctrine)
+   - Elements taken from the public domain (standard patterns, common algorithms)
+3. **Comparison**: What remains after filtration? If anything in the spec matches protectable expression from the original, remove or rewrite it.
+
+---
+
+## 2. Research Phase
+
+### 2.1 Read the Source Code
+
+Read the target source file completely. Also read:
+- Any parent/base classes it extends
+- Key interfaces it implements
+- Model/entity classes it uses (to understand data shapes)
+- Configuration files that affect its behavior (Struts XML, Spring config)
+- Related utility classes it calls (to understand side effects)
+
+### 2.2 Extract Observable Behavior
+
+For each public entry point (method, endpoint, action), document:
+
+- **Inputs**: HTTP parameters, method arguments, session state, configuration values
+- **Outputs**: HTTP responses (body, content type, status), return values, view names
+- **Side effects**: Database writes (creates, updates, deletes), filesystem changes, cache operations
+- **Guard conditions**: When the component takes no action or returns early
+- **Error behavior**: What happens on failure — error responses, exception propagation, silent handling
+- **External contracts**: Wire protocol values (parameter names, JSON fields, discriminator strings) that clients depend on
+
+### 2.3 Identify Wire Protocol Values
+
+Wire protocol values are exact strings that form the external contract between client and server. These MUST be preserved exactly in the specification because they are functional requirements, not implementation details:
+
+- HTTP parameter names (`method`, `document`, `page`, `queueID`)
+- HTTP parameter values that select behavior (`"split"`, `"rotate180"`)
+- JSON response field names (`"newDocNum"`)
+- Database discriminator values used in routing (`"DOC"`)
+- Content type strings (`"application/json"`)
+- Default values (`"1"` for default queue)
+
+### 2.4 Identify Internal Implementation Details
+
+These MUST NOT appear in the specification:
+
+- Class names, method names, variable names from the source
+- DAO/service/manager class names or bean names
+- JPA/Hibernate/ORM terminology (persist, merge, flush, entity, session)
+- Specific framework classes (PDFParser, PDDocument, PDPage)
+- Internal control flow (if/else structure, loop patterns, try/catch arrangement)
+- The number or organization of private helper methods
+- Import statements or dependency injection patterns
+
+---
+
+## 3. Specification Writing Phase
+
+### 3.1 Document Structure (IEEE 830)
+
+Use this structure, adapted from IEEE 830-1998 / ISO/IEC/IEEE 29148:2011:
+
+```
+## 1. Introduction
+### 1.1 Purpose
+### 1.2 Scope (In scope / Out of scope)
+### 1.3 Document Conventions
+### 1.4 Definitions and Glossary
+
+## 2. HTTP Interface (or External Interface)
+### 2.1 Endpoint
+### 2.2 HTTP Method
+### 2.3 Method Dispatch (if applicable)
+
+## 3. Functional Requirements
+### 3.N <Operation Name> (one subsection per operation, alphabetical by operation name)
+#### FR-XXX-N: Inputs
+#### FR-XXX-N: Guard conditions (if any)
+#### FR-XXX-N: <Core behavior>
+#### FR-XXX-N: Side effects
+#### FR-XXX-N: Response
+#### FR-XXX-N: Error handling
+
+## 4. Non-Functional Requirements
+### 4.1 Security
+### 4.2 Data Integrity
+### 4.3 Reliability
+
+## 5. External Dependencies
+
+## 6. Response Summary
+
+## 7. Client Integration Contract
+
+## 8. Assumptions
+
+## 9. Verification Criteria
+
+## 10. Observed Behaviors (Non-Normative)
+```
+
+### 3.2 Header Block
+
+Every specification MUST begin with this header block immediately after the title:
+
+```markdown
+> **Clean Room Specification**
+>
+> This document is a black-box functional specification describing observable behavior only.
+> It contains no source code, no internal implementation details, and no copyrightable
+> expression from any existing implementation. It is intended to serve as the sole input
+> for a clean room reimplementation per the Chinese Wall methodology.
+>
+> **Ordering principle:** All lists, tables, and enumerated items in this specification
+> follow deterministic ordering: alphabetical by display name, or causal (where step B
+> depends on step A's output). Independent items are always alphabetical. This prevents
+> accidental structural mirroring of any prior implementation.
+>
+> **SSO/AFC compliance:** This specification has been audited against the
+> Structure-Sequence-Organization test (*Whelan v. Jaslow*) and the
+> Abstraction-Filtration-Comparison test (*Computer Associates v. Altai*, 1992).
+> All non-protectable elements (functional ideas, externally-dictated interface
+> contracts, efficiency-driven sequences) have been identified. Remaining content
+> describes only observable behavior, using independent organizational choices
+> (alphabetical ordering, phase-based grouping, unordered sets for independent
+> operations) that do not mirror the structure of any prior implementation.
+>
+> **Standards applied:**
+> - Document structure adapted from IEEE 830-1998 / ISO/IEC/IEEE 29148:2011
+> - Clean room methodology per Chinese Wall technique
+>
+> **Methodology references:**
+> - [AI Could Be Your Next Team for Clean Room Development (Copyleft Currents)](https://heathermeeker.com/2025/03/28/ai-could-be-your-next-team-for-clean-room-development/)
+> - [Clean-room design (Wikipedia)](https://en.wikipedia.org/wiki/Clean-room_design)
+> - [How Clean Room Reverse Engineering Built the Modern Tech Industry (NTARI)](https://www.ntari.org/post/how-clean-room-reverse-engineering-built-the-modern-tech-industry)
+> - [IEEE 830-1998 SRS Structure (Rebus Press)](https://press.rebus.community/requirementsengineering/back-matter/appendix-c-ieee-830-template/)
+> - [Preventing an IP Infection: Clean Room Development Procedure (IPWatchdog)](https://ipwatchdog.com/2023/04/29/preventing-an-ip-infection-clean-room-development-procedure/id=160187/)
+```
+
+### 3.3 Writing Conventions
+
+**Language precision:**
+- **"shall"** = mandatory requirement
+- **"should"** = recommended but optional
+- **"is observed to"** = documented behavior of existing system (non-normative, §10 only)
+
+**Ordering principle (CRITICAL):**
+- ALL lists of independent items MUST be alphabetically ordered
+- This includes: glossary terms, scope lists, capability lists, routing tasks, metadata fields, verification criteria, assumptions, response summary rows, observed behaviors
+- Causally dependent steps (where B depends on A's output) use numbered sequential ordering
+- Independent steps within a numbered sequence use unordered bullets
+- This prevents accidental structural mirroring of the original source code's ordering
+
+**Traceability notes:**
+- The §1.1 Purpose section SHOULD include a traceability note linking to the original source component name
+- This note MUST disclaim that the name is for traceability only and does not prescribe naming:
+
+```markdown
+**Traceability note:** This spec corresponds to the component identified as
+`OriginalClassName` in the existing codebase. This name is provided solely for
+traceability between the specification and the original system; it does not
+prescribe a class name, method name, or any internal naming convention for
+the reimplementation.
+```
+
+### 3.4 Describing Side Effects Without Implying Architecture
+
+When describing database operations and other side effects:
+
+**DO (functional capability):**
+- "The component shall create a new document metadata record"
+- "The component shall link the new document to the specified queue"
+- "The component shall invalidate cached rendered versions"
+
+**DO NOT (implied architecture):**
+- "The component shall call DocumentDao.persist()" — leaks class/method names
+- "The component shall merge the entity into the persistence context" — JPA jargon
+- "The DocumentService shall save the record" — prescribes service name
+- "The component shall use the QueueDocumentLinkDao to create the association" — prescribes DAO name
+
+**External Dependencies section (§5):**
+- List capabilities as a flat, alphabetically-ordered list
+- Describe WHAT is needed, not HOW it is organized
+- Explicitly state: "How these are organized (one service, many services, direct database access, etc.) is an implementation choice."
+- No service names, no DAO names, no bean names
+- No JPA/ORM terminology (persist, merge, flush, session, entity manager)
+
+### 3.5 Wire Protocol vs. Internal Values
+
+**Include exact values when they are wire protocol / external contract:**
+- Parameter name `"method"` with value `"split"` — clients send this
+- JSON field `"newDocNum"` — clients parse this
+- Content type `"application/json"` — HTTP standard
+- Database discriminator `"DOC"` — used across routing tables as a type identifier
+
+**Use semantic descriptions for internal values:**
+- Status: "active" (not `'A'` — that's an implementation encoding choice)
+- Visibility: "private (not public)" (not `"0"` — that's an implementation encoding choice)
+- Module: describe functionally, e.g., `"demographic"` if it is a well-known domain concept
+
+**Judgment call:** If a value appears in database routing tables shared across multiple components, it IS an external contract (like `"DOC"`). If it's an internal field encoding (like `'A'` for active), describe it semantically.
+
+### 3.6 Rotation and Transformation Semantics
+
+When specifying transformation operations, be precise about whether values are:
+- **Absolute**: "set rotation TO 90 degrees" (regardless of current state)
+- **Additive**: "rotate BY 90 degrees from current orientation"
+
+This distinction is a functional requirement — different behavior, different results. Always clarify which semantic applies and add a Note if both appear in the same component.
+
+### 3.7 Verification Criteria
+
+Write testable verification criteria for every functional requirement. Each criterion describes an observable test:
+
+```markdown
+| Test ID | Operation | Verification |
+|---------|-----------|-------------|
+| V-XXX-1 | Operation | Observable test description |
+```
+
+- Test IDs use a prefix derived from the operation (alphabetical within operations)
+- Within each operation prefix, number sequentially
+- Sort all rows by Test ID (which achieves alphabetical by operation, then numeric within)
+- Every FR-xxx requirement should have at least one corresponding V-xxx test
+- Tests describe observable outcomes, not implementation steps
+
+### 3.8 Observed Behaviors (Non-Normative)
+
+Section 10 captures behaviors that:
+- ARE observable in the existing system
+- Are NOT captured by the normative requirements above
+- An implementer SHOULD replicate for compatibility unless there is reason to improve
+
+**Rules for §10:**
+- Must NOT contradict or duplicate normative requirements in §3
+- Must NOT describe behavior already fully specified by a shall/should requirement
+- Use "is observed to" language
+- These are compatibility notes, not requirements
+
+---
+
+## 4. Review Phase (Iterative)
+
+After writing the initial specification, perform these review passes IN ORDER. Each pass may require edits. Re-read the spec after each pass before proceeding to the next.
+
+### Pass 1: Correctness Review
+
+Compare every requirement against the source code:
+
+- [ ] Every public entry point is specified
+- [ ] Every input parameter is documented with correct type and format
+- [ ] Every output/response is documented
+- [ ] Every side effect (DB write, file change, cache operation) is captured
+- [ ] Every guard condition is captured
+- [ ] Every error handling path is captured
+- [ ] Default values match the source
+- [ ] Wire protocol values (parameter names, JSON fields) are exact
+- [ ] Conditional logic (if/else branches) is captured as behavioral requirements, not as control flow
+- [ ] Rotation/transformation semantics are correct (absolute vs. additive)
+
+### Pass 2: Clean Room Compliance
+
+Check for copyrightable expression leakage:
+
+- [ ] No source class names appear without a disclaimed traceability note
+- [ ] No method names from the source appear (e.g., `addDocumentSQL`, `getCtrlDocument`)
+- [ ] No variable names from the source appear
+- [ ] No DAO, service, manager, or bean names appear
+- [ ] No JPA/ORM terminology (persist, merge, flush, entity, session, EntityManager)
+- [ ] No framework class names (PDDocument, PDFParser, PDPage, EDoc, ActionSupport)
+- [ ] No pseudocode that mirrors the source's control flow
+- [ ] The structural organization (section order, requirement grouping) does NOT mirror the source code's method order or class structure
+- [ ] Internal encoding values are described semantically (not as literal characters or numbers)
+
+### Pass 3: Over-Specification Review
+
+Check for unnecessary implementation prescription:
+
+- [ ] Metadata field lists: are all empty/default fields individually listed? Collapse to summary line
+- [ ] §5 External Dependencies: are capabilities listed as named services? Use flat capability list
+- [ ] §7 Client Integration: does it describe UI behavior (thumbnails, drag-and-drop, popups)? Strip to wire format only
+- [ ] FR-SPL-7 or equivalent: does it prescribe how IDs are generated? Describe postcondition instead
+- [ ] Are there architecture-prescribing statements ("the service layer shall...", "using dependency injection...")?
+- [ ] Does the spec dictate the number of classes, methods, or modules?
+
+### Pass 4: Ordering Compliance
+
+Verify the alphabetical ordering principle throughout:
+
+- [ ] §1.2 Scope: in-scope and out-of-scope lists alphabetical
+- [ ] §1.4 Glossary: terms alphabetical
+- [ ] §2.3 Method dispatch table: alphabetical by method value
+- [ ] §3 Operations: subsections alphabetical by operation name
+- [ ] §3.x Metadata fields: alphabetical by field name
+- [ ] §3.x Routing tasks: alphabetical by task name (if independent)
+- [ ] §5 External Dependencies: capabilities alphabetical
+- [ ] §6 Response Summary: rows alphabetical by operation name
+- [ ] §7 Client Integration: response types alphabetical (if independent)
+- [ ] §8 Assumptions: alphabetical by key concept
+- [ ] §9 Verification Criteria: sorted by Test ID
+- [ ] §10 Observed Behaviors: alphabetical by behavior name
+
+### Pass 5: Final Leakage Scan
+
+One last pass looking for subtle leakage:
+
+- [ ] §10 Observed Behaviors: does any item describe behavior already captured normatively? Remove it — §10 says "not captured by normative requirements"
+- [ ] Are there any source-derived ordering patterns? (e.g., listing operations in the same order as methods in the source file)
+- [ ] Do requirement IDs accidentally mirror source method ordering?
+- [ ] Are there any implied service boundaries that mirror the original's DAO/manager structure?
+- [ ] Does the spec mention specific exception types from the source?
+
+---
+
+## 5. Output
+
+### 5.1 File Location
+
+Save the specification to:
+```
+docs/specs/<SourceFileName>.md
+```
+
+For example: `SplitDocument2Action.java` → `docs/specs/SplitDocument2Action_java.md`
+
+### 5.2 Commit Message
+
+```
+docs: add clean room functional specification for <ComponentName>
+
+IEEE 830 black-box specification describing observable behavior only.
+Serves as clean room reimplementation input per Chinese Wall methodology.
+```
+
+---
+
+## 6. Reference: Existing Specification Example
+
+For a complete example of a finished clean room specification, see:
+`docs/specs/SplitDocument2Action_java.md`
+
+This specification covers a PDF document manipulation action with four operations (remove first page, rotate 180, rotate 90, split) and demonstrates all conventions described in this skill.
+
+---
+
+## 7. Common Mistakes to Avoid
+
+1. **Listing DAO/service names in §5** — Use capability descriptions instead
+2. **Using JPA terminology** — Say "create a record" not "persist an entity"
+3. **Prescribing ID generation** — Say "shall have a unique ID" not "the database generates an auto-increment ID"
+4. **Mirroring source method order** — Use alphabetical ordering for operations
+5. **Including UI behavior in §7** — Only describe wire format and response handling
+6. **Forgetting the traceability disclaimer** — Every source name mention needs one
+7. **Listing empty fields individually** — Collapse to "all other fields shall be empty/default"
+8. **Mixing normative and observed** — §10 must not duplicate §3 requirements
+9. **Using `'A'` for active status** — Describe semantically: "active"
+10. **Ambiguous rotation semantics** — Always specify absolute vs. additive

--- a/.claude/commands/cleanroom-spec/cleanroom-spec.md
+++ b/.claude/commands/cleanroom-spec/cleanroom-spec.md
@@ -300,13 +300,42 @@ Section 10 captures behaviors that:
 
 ---
 
-## 4. Review Phase (Iterative)
+## 4. Review Phase (Iterative — 5 Mandatory Passes)
 
-After writing the initial specification, perform these review passes IN ORDER. Each pass may require edits. Re-read the spec after each pass before proceeding to the next.
+**CRITICAL EXECUTION PROTOCOL**: The review phase consists of 5 separate passes. Each pass is
+a distinct operation with mandatory file I/O between passes. You MUST NOT combine passes or
+skip the re-read step. The purpose is to review the ACTUAL FILE STATE, not your memory of
+what you wrote.
+
+**Why this matters:** In practice, edits during one pass can introduce new problems visible
+only to a fresh read. Reviewing from memory misses these regressions. Each pass operates on
+the file as it exists on disk after the previous pass's edits.
+
+### Execution Protocol for Each Pass
+
+Every pass follows this exact sequence:
+
+```
+1. SAVE    — Write/Edit all pending changes from the previous pass to disk
+2. READ    — Use the Read tool to re-read the ENTIRE spec file from disk
+3. REVIEW  — Apply the pass checklist against the file content you just read
+4. EDIT    — Fix every issue found (use Edit tool, not memory)
+5. REPORT  — Output a brief summary: "Pass N complete. Found X issues, fixed Y."
+             List each fix made. If no issues found, state "Pass N complete. No issues."
+6. PROCEED — Move to the next pass (go back to step 1)
+```
+
+**DO NOT** skip the Read step. **DO NOT** review from memory. **DO NOT** combine two passes
+into one. The entire point is that each pass is a fresh, focused review of a single concern.
+
+---
 
 ### Pass 1: Correctness Review
 
-Compare every requirement against the source code:
+**Goal**: Every observable behavior in the source code is accurately captured in the spec.
+
+**STEP 1** — Read the spec file from disk using the Read tool.
+**STEP 2** — With the spec open, compare every requirement against the source code. Check:
 
 - [ ] Every public entry point is specified
 - [ ] Every input parameter is documented with correct type and format
@@ -318,10 +347,19 @@ Compare every requirement against the source code:
 - [ ] Wire protocol values (parameter names, JSON fields) are exact
 - [ ] Conditional logic (if/else branches) is captured as behavioral requirements, not as control flow
 - [ ] Rotation/transformation semantics are correct (absolute vs. additive)
+- [ ] Verification criteria (§9) cover every FR-xxx requirement
+
+**STEP 3** — Fix every issue found using the Edit tool.
+**STEP 4** — Report: "Pass 1 (Correctness) complete. Found N issues, fixed M." List each fix.
+
+---
 
 ### Pass 2: Clean Room Compliance
 
-Check for copyrightable expression leakage:
+**Goal**: Zero copyrightable expression from the original source appears in the spec.
+
+**STEP 1** — Read the spec file from disk using the Read tool. (Do NOT rely on memory from Pass 1.)
+**STEP 2** — Scan every line of the spec for leakage. Check:
 
 - [ ] No source class names appear without a disclaimed traceability note
 - [ ] No method names from the source appear (e.g., `addDocumentSQL`, `getCtrlDocument`)
@@ -333,43 +371,97 @@ Check for copyrightable expression leakage:
 - [ ] The structural organization (section order, requirement grouping) does NOT mirror the source code's method order or class structure
 - [ ] Internal encoding values are described semantically (not as literal characters or numbers)
 
+**STEP 3** — Fix every issue found using the Edit tool. Replace leaked names with functional descriptions.
+**STEP 4** — Report: "Pass 2 (Clean Room Compliance) complete. Found N issues, fixed M." List each fix.
+
+---
+
 ### Pass 3: Over-Specification Review
 
-Check for unnecessary implementation prescription:
+**Goal**: The spec prescribes only observable behavior, never internal architecture or implementation choices.
+
+**STEP 1** — Read the spec file from disk using the Read tool. (Do NOT rely on memory from Pass 2.)
+**STEP 2** — Review every section for unnecessary prescription. Check:
 
 - [ ] Metadata field lists: are all empty/default fields individually listed? Collapse to summary line
 - [ ] §5 External Dependencies: are capabilities listed as named services? Use flat capability list
 - [ ] §7 Client Integration: does it describe UI behavior (thumbnails, drag-and-drop, popups)? Strip to wire format only
-- [ ] FR-SPL-7 or equivalent: does it prescribe how IDs are generated? Describe postcondition instead
+- [ ] Does any requirement prescribe HOW IDs are generated? Describe postcondition instead ("shall have a unique ID")
 - [ ] Are there architecture-prescribing statements ("the service layer shall...", "using dependency injection...")?
 - [ ] Does the spec dictate the number of classes, methods, or modules?
+- [ ] Does §5 use JPA/ORM terminology? (persist, merge, flush — use "create", "update", "save" instead)
+- [ ] Does §5 organize capabilities into named service groups that mirror the source's DAO/manager structure?
+- [ ] Does §5 include the disclaimer: "How these are organized... is an implementation choice"?
+
+**STEP 3** — Fix every issue found using the Edit tool.
+**STEP 4** — Report: "Pass 3 (Over-Specification) complete. Found N issues, fixed M." List each fix.
+
+---
 
 ### Pass 4: Ordering Compliance
 
-Verify the alphabetical ordering principle throughout:
+**Goal**: Every list of independent items follows alphabetical ordering to prevent structural mirroring.
+
+**STEP 1** — Read the spec file from disk using the Read tool. (Do NOT rely on memory from Pass 3.)
+**STEP 2** — Check EVERY list, table, and enumeration in the document:
 
 - [ ] §1.2 Scope: in-scope and out-of-scope lists alphabetical
 - [ ] §1.4 Glossary: terms alphabetical
 - [ ] §2.3 Method dispatch table: alphabetical by method value
 - [ ] §3 Operations: subsections alphabetical by operation name
-- [ ] §3.x Metadata fields: alphabetical by field name
+- [ ] §3.x Metadata fields: alphabetical by field name (within each operation)
 - [ ] §3.x Routing tasks: alphabetical by task name (if independent)
 - [ ] §5 External Dependencies: capabilities alphabetical
 - [ ] §6 Response Summary: rows alphabetical by operation name
 - [ ] §7 Client Integration: response types alphabetical (if independent)
 - [ ] §8 Assumptions: alphabetical by key concept
-- [ ] §9 Verification Criteria: sorted by Test ID
-- [ ] §10 Observed Behaviors: alphabetical by behavior name
+- [ ] §9 Verification Criteria: rows sorted by Test ID
+- [ ] §10 Observed Behaviors: alphabetical by behavior name/title
+
+**How to check**: For each list, extract the sort keys and verify they are in A→Z order. If a list has 2+ items and is NOT alphabetical, reorder it. Causally dependent sequences (where step B depends on step A's output) are the ONLY exception.
+
+**STEP 3** — Fix every ordering violation using the Edit tool.
+**STEP 4** — Report: "Pass 4 (Ordering) complete. Found N violations, fixed M." List each reordering.
+
+---
 
 ### Pass 5: Final Leakage Scan
 
-One last pass looking for subtle leakage:
+**Goal**: One last sweep for subtle leakage that earlier passes may have missed or introduced.
 
-- [ ] §10 Observed Behaviors: does any item describe behavior already captured normatively? Remove it — §10 says "not captured by normative requirements"
-- [ ] Are there any source-derived ordering patterns? (e.g., listing operations in the same order as methods in the source file)
-- [ ] Do requirement IDs accidentally mirror source method ordering?
+**STEP 1** — Read the spec file from disk using the Read tool. (Do NOT rely on memory from Pass 4.)
+**STEP 2** — Perform a final scan with fresh eyes:
+
+- [ ] §10 Observed Behaviors: does any item describe behavior already captured normatively in §3? Remove it — §10's qualifier is "not captured by normative requirements"
+- [ ] Are operations listed in the same order as methods in the source file? (Should be alphabetical, not source order)
+- [ ] Do FR-xxx requirement IDs accidentally mirror the source method ordering?
 - [ ] Are there any implied service boundaries that mirror the original's DAO/manager structure?
 - [ ] Does the spec mention specific exception types from the source?
+- [ ] Read §5 one more time: does it feel like a DAO inventory, or a capability list? If the former, rewrite
+- [ ] Does any "Note" blockquote reference source code behavior by method name?
+- [ ] Are there any terms that a clean room implementer wouldn't understand without reading the source?
+
+**STEP 3** — Fix every issue found using the Edit tool.
+**STEP 4** — Report: "Pass 5 (Final Leakage Scan) complete. Found N issues, fixed M." List each fix.
+
+---
+
+### Post-Review Summary
+
+After all 5 passes are complete, output a summary:
+
+```
+## Review Summary
+- Pass 1 (Correctness): X issues found, Y fixed
+- Pass 2 (Clean Room): X issues found, Y fixed
+- Pass 3 (Over-Specification): X issues found, Y fixed
+- Pass 4 (Ordering): X issues found, Y fixed
+- Pass 5 (Leakage Scan): X issues found, Y fixed
+- Total: X issues found across 5 passes
+```
+
+If any pass found issues, state: "The spec has been revised through 5 review passes and is ready for use."
+If no passes found issues, state: "The spec passed all 5 review passes with no issues."
 
 ---
 

--- a/.claude/commands/cleanroom-spec/cleanroom-spec.md
+++ b/.claude/commands/cleanroom-spec/cleanroom-spec.md
@@ -191,7 +191,8 @@ normative requirements. Must NOT contradict or duplicate §3. Use "is observed t
 
 ### Save the Spec
 
-Save to `docs/specs/<SourceFileName>.md` (e.g., `SomeAction.java` → `docs/specs/SomeAction_java.md`).
+Create the output directory if needed (`mkdir -p docs/specs/`), then save to
+`docs/specs/<SourceFileName>.md` (e.g., `SomeAction.java` → `docs/specs/SomeAction_java.md`).
 
 ---
 
@@ -222,7 +223,8 @@ Update the TodoWrite tracker as you complete each pass.
 
 **Goal**: Every observable behavior in the source is accurately captured.
 
-Read the spec from disk. Compare every requirement against the source code:
+Read the spec from disk using the Read tool. ALSO re-read the source file from Phase 1
+(context may have been compacted). Compare every requirement against the source code:
 
 - [ ] Every public entry point is specified
 - [ ] Every input parameter documented with correct type and format
@@ -337,6 +339,9 @@ Output a summary:
 - Pass 5 (Leakage Scan): X issues found, Y fixed
 - Total: X issues found across 5 passes
 ```
+
+If any pass found issues: "The spec has been revised through 5 review passes and is ready for use."
+If no passes found issues: "The spec passed all 5 review passes with no issues."
 
 ---
 

--- a/.claude/commands/cleanroom-spec/cleanroom-spec.md
+++ b/.claude/commands/cleanroom-spec/cleanroom-spec.md
@@ -1,125 +1,84 @@
 ---
 description: Write a clean room IEEE 830 functional specification from source code using Chinese Wall methodology
-allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Agent, WebSearch, WebFetch
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Agent, TodoWrite
 model: opus
 ---
 
 # /cleanroom-spec - Clean Room Functional Specification Generator
 
-Write a black-box IEEE 830 functional specification for a given source file or component. The specification describes **observable behavior only** and contains no source code, no internal implementation details, and no copyrightable expression from the original. It serves as the sole input for a clean room reimplementation per the Chinese Wall methodology.
+Write a black-box IEEE 830 functional specification for a given source file or component.
+The specification describes **observable behavior only** — no source code, no internal
+implementation details, no copyrightable expression from the original. It serves as the
+sole input for a clean room reimplementation per the Chinese Wall methodology.
+
+**User input:** `$ARGUMENTS`
+
+If `$ARGUMENTS` is empty, ask the user which source file or component to specify.
+Otherwise, resolve the argument as a file path, class name, or component description.
 
 ---
 
-## 0. Input
+## Execution Overview
 
-The user provides one of:
-- A file path to a Java source file (e.g., `src/main/java/.../SomeAction.java`)
-- A class name to locate (e.g., `SplitDocument2Action`)
-- A component description (e.g., "the document split action in documentManager")
+This skill has 3 phases. Use TodoWrite to track progress through each phase.
 
-If the user does not provide a target, ask which source file or component to specify.
-
----
-
-## 1. Legal and Methodological Foundation
-
-### 1.1 What Is Clean Room Design?
-
-Clean room design (also called "Chinese Wall" methodology) is a legal technique for reverse engineering and reimplementation that avoids copyright infringement. It separates the work into two teams:
-
-- **Dirty room team** (analyst): Reads the original source code and produces a functional specification describing only observable behavior — inputs, outputs, side effects, and external contracts.
-- **Clean room team** (implementer): Reads ONLY the specification and writes new code from scratch. They never see the original source.
-
-The specification document IS the Chinese Wall. It must contain zero copyrightable expression from the original.
-
-**Legal precedent:**
-- *Computer Associates v. Altai* (1992) — Established the Abstraction-Filtration-Comparison (AFC) test
-- *Whelan v. Jaslow* — Structure-Sequence-Organization (SSO) test
-- *Sega v. Accolade* (1992) — Clean room reimplementation is lawful
-- *Lotus v. Borland* (1995) — Functional elements (menus, command structures) not copyrightable
-
-### 1.2 What Is Copyrightable vs. Not
-
-**NOT copyrightable (safe to include in spec):**
-- Functional ideas, algorithms described at an abstract level
-- Externally-dictated interface contracts (HTTP parameters, JSON field names, wire protocol values)
-- Efficiency-driven sequences where only one reasonable way exists (merger doctrine)
-- Facts: database column semantics, business rules, observable behavior
-- Standard patterns dictated by frameworks or protocols
-
-**Copyrightable (MUST NOT appear in spec):**
-- Source code or pseudocode derived from the original's structure
-- Variable names, method names, class names (except as disclaimed traceability references)
-- The specific organizational structure of the original code
-- Creative architectural choices (how modules are composed internally)
-- Comments or documentation text from the original
-
-### 1.3 The AFC Test Applied
-
-For every element in the specification, apply this three-step filter:
-
-1. **Abstraction**: Identify the level of abstraction — is this an idea/function or specific expression?
-2. **Filtration**: Remove non-protectable elements:
-   - Ideas and functional requirements (not protectable)
-   - Elements dictated by external factors (framework requirements, wire protocols, hardware)
-   - Elements dictated by efficiency (only one reasonable way to do it — merger doctrine)
-   - Elements taken from the public domain (standard patterns, common algorithms)
-3. **Comparison**: What remains after filtration? If anything in the spec matches protectable expression from the original, remove or rewrite it.
+```
+Phase 1: RESEARCH  — Read source code, extract observable behavior
+Phase 2: WRITE     — Produce IEEE 830 spec, save to docs/specs/
+Phase 3: REVIEW    — 5 mandatory passes with file re-reads between each
+```
 
 ---
 
-## 2. Research Phase
-
-### 2.1 Read the Source Code
+## Phase 1: Research
 
 Read the target source file completely. Also read:
-- Any parent/base classes it extends
+- Parent/base classes it extends
 - Key interfaces it implements
 - Model/entity classes it uses (to understand data shapes)
 - Configuration files that affect its behavior (Struts XML, Spring config)
 - Related utility classes it calls (to understand side effects)
 
-### 2.2 Extract Observable Behavior
-
-For each public entry point (method, endpoint, action), document:
-
+For each public entry point, extract:
 - **Inputs**: HTTP parameters, method arguments, session state, configuration values
 - **Outputs**: HTTP responses (body, content type, status), return values, view names
 - **Side effects**: Database writes (creates, updates, deletes), filesystem changes, cache operations
 - **Guard conditions**: When the component takes no action or returns early
-- **Error behavior**: What happens on failure — error responses, exception propagation, silent handling
-- **External contracts**: Wire protocol values (parameter names, JSON fields, discriminator strings) that clients depend on
+- **Error behavior**: What happens on failure
+- **External contracts**: Wire protocol values that clients depend on
 
-### 2.3 Identify Wire Protocol Values
+### Wire Protocol vs. Internal Values
 
-Wire protocol values are exact strings that form the external contract between client and server. These MUST be preserved exactly in the specification because they are functional requirements, not implementation details:
+**Wire protocol values** are exact strings forming the external contract. Include them
+exactly in the spec — they are functional requirements:
+- HTTP parameter names and values that select behavior
+- JSON response field names
+- Database discriminator values used in routing tables across components
+- Content type strings, default values
 
-- HTTP parameter names (`method`, `document`, `page`, `queueID`)
-- HTTP parameter values that select behavior (`"split"`, `"rotate180"`)
-- JSON response field names (`"newDocNum"`)
-- Database discriminator values used in routing (`"DOC"`)
-- Content type strings (`"application/json"`)
-- Default values (`"1"` for default queue)
+**Internal values** must NOT appear as literals. Describe them semantically:
+- Status encodings → "active" (not `'A'`)
+- Visibility flags → "private" (not `"0"`)
+- Internal field encodings are implementation choices, not external contracts
 
-### 2.4 Identify Internal Implementation Details
+**Judgment call:** If a value appears in routing tables shared across multiple components,
+it IS an external contract. If it's an internal field encoding, describe it semantically.
 
-These MUST NOT appear in the specification:
+### What MUST NOT Appear in the Spec
 
 - Class names, method names, variable names from the source
 - DAO/service/manager class names or bean names
 - JPA/Hibernate/ORM terminology (persist, merge, flush, entity, session)
-- Specific framework classes (PDFParser, PDDocument, PDPage)
+- Specific framework library classes
 - Internal control flow (if/else structure, loop patterns, try/catch arrangement)
 - The number or organization of private helper methods
 - Import statements or dependency injection patterns
 
 ---
 
-## 3. Specification Writing Phase
+## Phase 2: Write the Specification
 
-### 3.1 Document Structure (IEEE 830)
-
-Use this structure, adapted from IEEE 830-1998 / ISO/IEC/IEEE 29148:2011:
+### Document Structure (IEEE 830)
 
 ```
 ## 1. Introduction
@@ -128,24 +87,12 @@ Use this structure, adapted from IEEE 830-1998 / ISO/IEC/IEEE 29148:2011:
 ### 1.3 Document Conventions
 ### 1.4 Definitions and Glossary
 
-## 2. HTTP Interface (or External Interface)
-### 2.1 Endpoint
-### 2.2 HTTP Method
-### 2.3 Method Dispatch (if applicable)
+## 2. External Interface (HTTP Interface, CLI, etc.)
 
 ## 3. Functional Requirements
-### 3.N <Operation Name> (one subsection per operation, alphabetical by operation name)
-#### FR-XXX-N: Inputs
-#### FR-XXX-N: Guard conditions (if any)
-#### FR-XXX-N: <Core behavior>
-#### FR-XXX-N: Side effects
-#### FR-XXX-N: Response
-#### FR-XXX-N: Error handling
+### 3.N <Operation Name> (one subsection per operation, alphabetical)
 
 ## 4. Non-Functional Requirements
-### 4.1 Security
-### 4.2 Data Integrity
-### 4.3 Reliability
 
 ## 5. External Dependencies
 
@@ -160,9 +107,9 @@ Use this structure, adapted from IEEE 830-1998 / ISO/IEC/IEEE 29148:2011:
 ## 10. Observed Behaviors (Non-Normative)
 ```
 
-### 3.2 Header Block
+### Header Block
 
-Every specification MUST begin with this header block immediately after the title:
+Every specification MUST begin with this block immediately after the title:
 
 ```markdown
 > **Clean Room Specification**
@@ -198,257 +145,188 @@ Every specification MUST begin with this header block immediately after the titl
 > - [Preventing an IP Infection: Clean Room Development Procedure (IPWatchdog)](https://ipwatchdog.com/2023/04/29/preventing-an-ip-infection-clean-room-development-procedure/id=160187/)
 ```
 
-### 3.3 Writing Conventions
+### Writing Rules
 
 **Language precision:**
 - **"shall"** = mandatory requirement
 - **"should"** = recommended but optional
-- **"is observed to"** = documented behavior of existing system (non-normative, §10 only)
+- **"is observed to"** = existing system behavior (non-normative, §10 only)
 
 **Ordering principle (CRITICAL):**
-- ALL lists of independent items MUST be alphabetically ordered
-- This includes: glossary terms, scope lists, capability lists, routing tasks, metadata fields, verification criteria, assumptions, response summary rows, observed behaviors
-- Causally dependent steps (where B depends on A's output) use numbered sequential ordering
-- Independent steps within a numbered sequence use unordered bullets
-- This prevents accidental structural mirroring of the original source code's ordering
+- ALL independent lists MUST be alphabetically ordered (glossary, scope, capabilities,
+  metadata fields, routing tasks, verification criteria, assumptions, response rows,
+  observed behaviors)
+- Causally dependent steps (B depends on A's output) use numbered sequential ordering
+- This prevents accidental structural mirroring of the source code's ordering
 
-**Traceability notes:**
-- The §1.1 Purpose section SHOULD include a traceability note linking to the original source component name
-- This note MUST disclaim that the name is for traceability only and does not prescribe naming:
+**Traceability:** §1.1 SHOULD include a traceability note with a disclaimer:
 
 ```markdown
 **Traceability note:** This spec corresponds to the component identified as
 `OriginalClassName` in the existing codebase. This name is provided solely for
-traceability between the specification and the original system; it does not
-prescribe a class name, method name, or any internal naming convention for
-the reimplementation.
+traceability; it does not prescribe any naming convention for the reimplementation.
 ```
 
-### 3.4 Describing Side Effects Without Implying Architecture
+**Side effects — describe capabilities, not architecture:**
 
-When describing database operations and other side effects:
+| DO (functional) | DO NOT (leaks implementation) |
+|---|---|
+| "shall create a new document record" | "shall call DocumentDao.persist()" |
+| "shall link the document to the queue" | "shall merge the entity into the persistence context" |
+| "shall invalidate cached versions" | "shall use the QueueDocumentLinkDao" |
 
-**DO (functional capability):**
-- "The component shall create a new document metadata record"
-- "The component shall link the new document to the specified queue"
-- "The component shall invalidate cached rendered versions"
+**§5 External Dependencies:** Flat alphabetical capability list. Describe WHAT is needed,
+not HOW organized. Include: "How these are organized (one service, many services, direct
+database access, etc.) is an implementation choice." No service/DAO/bean names. No JPA terms.
 
-**DO NOT (implied architecture):**
-- "The component shall call DocumentDao.persist()" — leaks class/method names
-- "The component shall merge the entity into the persistence context" — JPA jargon
-- "The DocumentService shall save the record" — prescribes service name
-- "The component shall use the QueueDocumentLinkDao to create the association" — prescribes DAO name
+**Transformation semantics:** When operations transform data, be precise:
+- **Absolute**: "set value TO X" (regardless of current state)
+- **Additive**: "change value BY X from current" (relative to current state)
 
-**External Dependencies section (§5):**
-- List capabilities as a flat, alphabetically-ordered list
-- Describe WHAT is needed, not HOW it is organized
-- Explicitly state: "How these are organized (one service, many services, direct database access, etc.) is an implementation choice."
-- No service names, no DAO names, no bean names
-- No JPA/ORM terminology (persist, merge, flush, session, entity manager)
+**§9 Verification Criteria:** Every FR-xxx needs at least one V-xxx test. Sort by Test ID.
+Tests describe observable outcomes, not implementation steps.
 
-### 3.5 Wire Protocol vs. Internal Values
+**§10 Observed Behaviors:** Captures behaviors that ARE observable but are NOT covered by
+normative requirements. Must NOT contradict or duplicate §3. Use "is observed to" language.
 
-**Include exact values when they are wire protocol / external contract:**
-- Parameter name `"method"` with value `"split"` — clients send this
-- JSON field `"newDocNum"` — clients parse this
-- Content type `"application/json"` — HTTP standard
-- Database discriminator `"DOC"` — used across routing tables as a type identifier
+### Save the Spec
 
-**Use semantic descriptions for internal values:**
-- Status: "active" (not `'A'` — that's an implementation encoding choice)
-- Visibility: "private (not public)" (not `"0"` — that's an implementation encoding choice)
-- Module: describe functionally, e.g., `"demographic"` if it is a well-known domain concept
-
-**Judgment call:** If a value appears in database routing tables shared across multiple components, it IS an external contract (like `"DOC"`). If it's an internal field encoding (like `'A'` for active), describe it semantically.
-
-### 3.6 Rotation and Transformation Semantics
-
-When specifying transformation operations, be precise about whether values are:
-- **Absolute**: "set rotation TO 90 degrees" (regardless of current state)
-- **Additive**: "rotate BY 90 degrees from current orientation"
-
-This distinction is a functional requirement — different behavior, different results. Always clarify which semantic applies and add a Note if both appear in the same component.
-
-### 3.7 Verification Criteria
-
-Write testable verification criteria for every functional requirement. Each criterion describes an observable test:
-
-```markdown
-| Test ID | Operation | Verification |
-|---------|-----------|-------------|
-| V-XXX-1 | Operation | Observable test description |
-```
-
-- Test IDs use a prefix derived from the operation (alphabetical within operations)
-- Within each operation prefix, number sequentially
-- Sort all rows by Test ID (which achieves alphabetical by operation, then numeric within)
-- Every FR-xxx requirement should have at least one corresponding V-xxx test
-- Tests describe observable outcomes, not implementation steps
-
-### 3.8 Observed Behaviors (Non-Normative)
-
-Section 10 captures behaviors that:
-- ARE observable in the existing system
-- Are NOT captured by the normative requirements above
-- An implementer SHOULD replicate for compatibility unless there is reason to improve
-
-**Rules for §10:**
-- Must NOT contradict or duplicate normative requirements in §3
-- Must NOT describe behavior already fully specified by a shall/should requirement
-- Use "is observed to" language
-- These are compatibility notes, not requirements
+Save to `docs/specs/<SourceFileName>.md` (e.g., `SomeAction.java` → `docs/specs/SomeAction_java.md`).
 
 ---
 
-## 4. Review Phase (Iterative — 5 Mandatory Passes)
+## Phase 3: Review (5 Mandatory Passes)
 
-**CRITICAL EXECUTION PROTOCOL**: The review phase consists of 5 separate passes. Each pass is
-a distinct operation with mandatory file I/O between passes. You MUST NOT combine passes or
-skip the re-read step. The purpose is to review the ACTUAL FILE STATE, not your memory of
-what you wrote.
+**CRITICAL EXECUTION PROTOCOL**: Each pass is a distinct operation. You MUST re-read the
+spec file from disk between passes. The purpose is to review the ACTUAL FILE STATE after
+edits, not your memory of what you wrote.
 
-**Why this matters:** In practice, edits during one pass can introduce new problems visible
-only to a fresh read. Reviewing from memory misses these regressions. Each pass operates on
-the file as it exists on disk after the previous pass's edits.
+**Why:** Edits during one pass can introduce new problems only visible to a fresh read.
 
-### Execution Protocol for Each Pass
-
-Every pass follows this exact sequence:
+**Protocol for EVERY pass:**
 
 ```
-1. SAVE    — Write/Edit all pending changes from the previous pass to disk
-2. READ    — Use the Read tool to re-read the ENTIRE spec file from disk
-3. REVIEW  — Apply the pass checklist against the file content you just read
-4. EDIT    — Fix every issue found (use Edit tool, not memory)
-5. REPORT  — Output a brief summary: "Pass N complete. Found X issues, fixed Y."
-             List each fix made. If no issues found, state "Pass N complete. No issues."
-6. PROCEED — Move to the next pass (go back to step 1)
+1. READ    — Use the Read tool to read the ENTIRE spec file from disk
+2. REVIEW  — Apply the pass checklist against the content you just read
+3. EDIT    — Fix every issue found using the Edit tool
+4. REPORT  — Output: "Pass N (Name) complete. Found X issues, fixed Y." List each fix.
 ```
 
-**DO NOT** skip the Read step. **DO NOT** review from memory. **DO NOT** combine two passes
-into one. The entire point is that each pass is a fresh, focused review of a single concern.
+**DO NOT** skip the Read step. **DO NOT** review from memory. **DO NOT** combine passes.
+
+Update the TodoWrite tracker as you complete each pass.
 
 ---
 
-### Pass 1: Correctness Review
+### Pass 1: Correctness
 
-**Goal**: Every observable behavior in the source code is accurately captured in the spec.
+**Goal**: Every observable behavior in the source is accurately captured.
 
-**STEP 1** — Read the spec file from disk using the Read tool.
-**STEP 2** — With the spec open, compare every requirement against the source code. Check:
+Read the spec from disk. Compare every requirement against the source code:
 
 - [ ] Every public entry point is specified
-- [ ] Every input parameter is documented with correct type and format
-- [ ] Every output/response is documented
-- [ ] Every side effect (DB write, file change, cache operation) is captured
-- [ ] Every guard condition is captured
-- [ ] Every error handling path is captured
+- [ ] Every input parameter documented with correct type and format
+- [ ] Every output/response documented
+- [ ] Every side effect captured (DB write, file change, cache op)
+- [ ] Every guard condition captured
+- [ ] Every error handling path captured
 - [ ] Default values match the source
-- [ ] Wire protocol values (parameter names, JSON fields) are exact
-- [ ] Conditional logic (if/else branches) is captured as behavioral requirements, not as control flow
-- [ ] Rotation/transformation semantics are correct (absolute vs. additive)
+- [ ] Wire protocol values are exact
+- [ ] Conditional logic captured as behavioral requirements, not control flow
+- [ ] Transformation semantics are correct (absolute vs. additive, if applicable)
 - [ ] Verification criteria (§9) cover every FR-xxx requirement
 
-**STEP 3** — Fix every issue found using the Edit tool.
-**STEP 4** — Report: "Pass 1 (Correctness) complete. Found N issues, fixed M." List each fix.
+Fix issues. Report.
 
 ---
 
 ### Pass 2: Clean Room Compliance
 
-**Goal**: Zero copyrightable expression from the original source appears in the spec.
+**Goal**: Zero copyrightable expression from the source.
 
-**STEP 1** — Read the spec file from disk using the Read tool. (Do NOT rely on memory from Pass 1.)
-**STEP 2** — Scan every line of the spec for leakage. Check:
+Read the spec from disk. Scan every line for leakage:
 
-- [ ] No source class names appear without a disclaimed traceability note
-- [ ] No method names from the source appear (e.g., `addDocumentSQL`, `getCtrlDocument`)
-- [ ] No variable names from the source appear
-- [ ] No DAO, service, manager, or bean names appear
+- [ ] No source class names without a disclaimed traceability note
+- [ ] No method names from the source
+- [ ] No variable names from the source
+- [ ] No DAO, service, manager, or bean names
 - [ ] No JPA/ORM terminology (persist, merge, flush, entity, session, EntityManager)
-- [ ] No framework class names (PDDocument, PDFParser, PDPage, EDoc, ActionSupport)
-- [ ] No pseudocode that mirrors the source's control flow
-- [ ] The structural organization (section order, requirement grouping) does NOT mirror the source code's method order or class structure
-- [ ] Internal encoding values are described semantically (not as literal characters or numbers)
+- [ ] No framework library class names
+- [ ] No pseudocode mirroring the source's control flow
+- [ ] Structural organization does NOT mirror source method order or class structure
+- [ ] Internal encoding values described semantically, not as literal chars/numbers
 
-**STEP 3** — Fix every issue found using the Edit tool. Replace leaked names with functional descriptions.
-**STEP 4** — Report: "Pass 2 (Clean Room Compliance) complete. Found N issues, fixed M." List each fix.
+Fix issues — replace leaked names with functional descriptions. Report.
 
 ---
 
-### Pass 3: Over-Specification Review
+### Pass 3: Over-Specification
 
-**Goal**: The spec prescribes only observable behavior, never internal architecture or implementation choices.
+**Goal**: Spec prescribes only observable behavior, never architecture or implementation.
 
-**STEP 1** — Read the spec file from disk using the Read tool. (Do NOT rely on memory from Pass 2.)
-**STEP 2** — Review every section for unnecessary prescription. Check:
+Read the spec from disk. Check:
 
-- [ ] Metadata field lists: are all empty/default fields individually listed? Collapse to summary line
-- [ ] §5 External Dependencies: are capabilities listed as named services? Use flat capability list
-- [ ] §7 Client Integration: does it describe UI behavior (thumbnails, drag-and-drop, popups)? Strip to wire format only
-- [ ] Does any requirement prescribe HOW IDs are generated? Describe postcondition instead ("shall have a unique ID")
-- [ ] Are there architecture-prescribing statements ("the service layer shall...", "using dependency injection...")?
-- [ ] Does the spec dictate the number of classes, methods, or modules?
-- [ ] Does §5 use JPA/ORM terminology? (persist, merge, flush — use "create", "update", "save" instead)
-- [ ] Does §5 organize capabilities into named service groups that mirror the source's DAO/manager structure?
-- [ ] Does §5 include the disclaimer: "How these are organized... is an implementation choice"?
+- [ ] Empty/default metadata fields collapsed to summary line (not individually listed)
+- [ ] §5 uses flat capability list, not named services
+- [ ] §7 describes wire format only, no UI behavior (thumbnails, drag-and-drop, popups)
+- [ ] No requirement prescribes HOW IDs are generated (use postcondition: "shall have a unique ID")
+- [ ] No architecture-prescribing statements ("the service layer shall...", "using DI...")
+- [ ] Spec does not dictate number of classes, methods, or modules
+- [ ] §5 has no JPA/ORM terminology
+- [ ] §5 does not organize capabilities into groups that mirror source DAO/manager structure
+- [ ] §5 includes the implementation-choice disclaimer
 
-**STEP 3** — Fix every issue found using the Edit tool.
-**STEP 4** — Report: "Pass 3 (Over-Specification) complete. Found N issues, fixed M." List each fix.
+Fix issues. Report.
 
 ---
 
 ### Pass 4: Ordering Compliance
 
-**Goal**: Every list of independent items follows alphabetical ordering to prevent structural mirroring.
+**Goal**: Every independent list is alphabetically ordered.
 
-**STEP 1** — Read the spec file from disk using the Read tool. (Do NOT rely on memory from Pass 3.)
-**STEP 2** — Check EVERY list, table, and enumeration in the document:
+Read the spec from disk. Check EVERY list, table, and enumeration:
 
-- [ ] §1.2 Scope: in-scope and out-of-scope lists alphabetical
-- [ ] §1.4 Glossary: terms alphabetical
-- [ ] §2.3 Method dispatch table: alphabetical by method value
-- [ ] §3 Operations: subsections alphabetical by operation name
-- [ ] §3.x Metadata fields: alphabetical by field name (within each operation)
-- [ ] §3.x Routing tasks: alphabetical by task name (if independent)
-- [ ] §5 External Dependencies: capabilities alphabetical
-- [ ] §6 Response Summary: rows alphabetical by operation name
-- [ ] §7 Client Integration: response types alphabetical (if independent)
-- [ ] §8 Assumptions: alphabetical by key concept
-- [ ] §9 Verification Criteria: rows sorted by Test ID
-- [ ] §10 Observed Behaviors: alphabetical by behavior name/title
+- [ ] §1.2 Scope lists alphabetical
+- [ ] §1.4 Glossary alphabetical
+- [ ] §2 dispatch/routing tables alphabetical
+- [ ] §3 operation subsections alphabetical by name
+- [ ] §3.x metadata fields alphabetical within each operation
+- [ ] §3.x independent routing/linking tasks alphabetical
+- [ ] §5 capabilities alphabetical
+- [ ] §6 response summary rows alphabetical by operation
+- [ ] §7 response types alphabetical (if independent)
+- [ ] §8 assumptions alphabetical by key concept
+- [ ] §9 verification rows sorted by Test ID
+- [ ] §10 observed behaviors alphabetical
 
-**How to check**: For each list, extract the sort keys and verify they are in A→Z order. If a list has 2+ items and is NOT alphabetical, reorder it. Causally dependent sequences (where step B depends on step A's output) are the ONLY exception.
+For each list: extract sort keys, verify A→Z. Only exception: causally dependent sequences.
 
-**STEP 3** — Fix every ordering violation using the Edit tool.
-**STEP 4** — Report: "Pass 4 (Ordering) complete. Found N violations, fixed M." List each reordering.
+Fix violations. Report.
 
 ---
 
 ### Pass 5: Final Leakage Scan
 
-**Goal**: One last sweep for subtle leakage that earlier passes may have missed or introduced.
+**Goal**: Catch subtle leakage that earlier passes may have missed or introduced.
 
-**STEP 1** — Read the spec file from disk using the Read tool. (Do NOT rely on memory from Pass 4.)
-**STEP 2** — Perform a final scan with fresh eyes:
+Read the spec from disk. Fresh-eyes scan:
 
-- [ ] §10 Observed Behaviors: does any item describe behavior already captured normatively in §3? Remove it — §10's qualifier is "not captured by normative requirements"
-- [ ] Are operations listed in the same order as methods in the source file? (Should be alphabetical, not source order)
-- [ ] Do FR-xxx requirement IDs accidentally mirror the source method ordering?
-- [ ] Are there any implied service boundaries that mirror the original's DAO/manager structure?
-- [ ] Does the spec mention specific exception types from the source?
-- [ ] Read §5 one more time: does it feel like a DAO inventory, or a capability list? If the former, rewrite
-- [ ] Does any "Note" blockquote reference source code behavior by method name?
-- [ ] Are there any terms that a clean room implementer wouldn't understand without reading the source?
+- [ ] §10 items do not duplicate normative requirements from §3
+- [ ] Operations are NOT in source method order (should be alphabetical)
+- [ ] FR-xxx IDs do not accidentally mirror source method ordering
+- [ ] No implied service boundaries mirror the source's DAO/manager structure
+- [ ] No source exception types mentioned
+- [ ] §5 reads as a capability list, not a DAO inventory
+- [ ] No "Note" blockquotes reference source method names
+- [ ] Every term is understandable without reading the source
 
-**STEP 3** — Fix every issue found using the Edit tool.
-**STEP 4** — Report: "Pass 5 (Final Leakage Scan) complete. Found N issues, fixed M." List each fix.
+Fix issues. Report.
 
 ---
 
-### Post-Review Summary
+### Post-Review
 
-After all 5 passes are complete, output a summary:
+Output a summary:
 
 ```
 ## Review Summary
@@ -460,23 +338,11 @@ After all 5 passes are complete, output a summary:
 - Total: X issues found across 5 passes
 ```
 
-If any pass found issues, state: "The spec has been revised through 5 review passes and is ready for use."
-If no passes found issues, state: "The spec passed all 5 review passes with no issues."
-
 ---
 
-## 5. Output
+## Output
 
-### 5.1 File Location
-
-Save the specification to:
-```
-docs/specs/<SourceFileName>.md
-```
-
-For example: `SplitDocument2Action.java` → `docs/specs/SplitDocument2Action_java.md`
-
-### 5.2 Commit Message
+### Commit Message
 
 ```
 docs: add clean room functional specification for <ComponentName>
@@ -485,26 +351,49 @@ IEEE 830 black-box specification describing observable behavior only.
 Serves as clean room reimplementation input per Chinese Wall methodology.
 ```
 
----
+### Reference Example
 
-## 6. Reference: Existing Specification Example
-
-For a complete example of a finished clean room specification, see:
-`docs/specs/SplitDocument2Action_java.md`
-
-This specification covers a PDF document manipulation action with four operations (remove first page, rotate 180, rotate 90, split) and demonstrates all conventions described in this skill.
+For a complete finished specification, see `docs/specs/SplitDocument2Action_java.md`.
 
 ---
 
-## 7. Common Mistakes to Avoid
+## Clean Room Legal Background
 
-1. **Listing DAO/service names in §5** — Use capability descriptions instead
-2. **Using JPA terminology** — Say "create a record" not "persist an entity"
-3. **Prescribing ID generation** — Say "shall have a unique ID" not "the database generates an auto-increment ID"
-4. **Mirroring source method order** — Use alphabetical ordering for operations
-5. **Including UI behavior in §7** — Only describe wire format and response handling
-6. **Forgetting the traceability disclaimer** — Every source name mention needs one
+This section provides legal context. It is reference material — not execution instructions.
+
+**Clean room design** (Chinese Wall methodology) separates work into two teams:
+- **Dirty room** (analyst): Reads source, produces functional spec with observable behavior only
+- **Clean room** (implementer): Reads ONLY the spec, writes new code from scratch
+
+The spec IS the Chinese Wall. Zero copyrightable expression may cross it.
+
+**Key legal tests:**
+- **AFC test** (*Computer Associates v. Altai*, 1992): Abstraction → Filtration → Comparison.
+  Filter out non-protectable elements (ideas, externally-dictated interfaces, efficiency-driven
+  sequences, public domain patterns). Only what remains after filtration is protectable.
+- **SSO test** (*Whelan v. Jaslow*): Structure-Sequence-Organization can be protectable
+- **Merger doctrine**: When only one reasonable way to express a function exists, the expression
+  merges with the idea and is not protectable
+- *Sega v. Accolade* (1992): Clean room reimplementation is lawful
+- *Lotus v. Borland* (1995): Functional elements not copyrightable
+
+**Not copyrightable** (safe in spec): functional ideas, external interface contracts,
+efficiency-driven sequences, facts (business rules, observable behavior), framework-dictated patterns.
+
+**Copyrightable** (MUST NOT appear): source code, variable/method/class names (except disclaimed
+traceability), organizational structure of the original, creative architectural choices, original comments/docs.
+
+---
+
+## Common Mistakes
+
+1. **Listing DAO/service names in §5** — Use capability descriptions
+2. **JPA terminology** — "create a record" not "persist an entity"
+3. **Prescribing ID generation** — "shall have a unique ID" not "database auto-increment"
+4. **Mirroring source method order** — Alphabetical ordering for operations
+5. **UI behavior in §7** — Wire format and response handling only
+6. **Missing traceability disclaimer** — Every source name needs one
 7. **Listing empty fields individually** — Collapse to "all other fields shall be empty/default"
-8. **Mixing normative and observed** — §10 must not duplicate §3 requirements
-9. **Using `'A'` for active status** — Describe semantically: "active"
-10. **Ambiguous rotation semantics** — Always specify absolute vs. additive
+8. **Mixing normative and observed** — §10 must not duplicate §3
+9. **Literal internal encodings** — Describe semantically: "active" not `'A'`
+10. **Ambiguous transformation semantics** — Specify absolute vs. additive

--- a/docs/specs/SplitDocument2Action_java.md
+++ b/docs/specs/SplitDocument2Action_java.md
@@ -240,7 +240,7 @@ All other metadata fields (description, HTML content, review date/time, reviewer
 
 #### FR-SPL-7: Persist and save
 
-The component shall save the metadata record to the database (generating a new document ID) and save the new PDF file to the document storage directory using the generated filename.
+The component shall save the metadata record to the database and save the new PDF file to the document storage directory. After saving, the new document shall have a unique ID and a unique filename.
 
 #### FR-SPL-8: Routing and linking
 
@@ -289,21 +289,19 @@ The following security behaviors are **required for any reimplementation** per C
 
 ## 5. External Dependencies
 
-The component requires the following capabilities from the surrounding system:
+The component requires the following capabilities from the surrounding system. How these are organized (one service, many services, direct database access, etc.) is an implementation choice.
 
-| Capability | Purpose |
-|------------|---------|
-| **Cache service** | Invalidate cached page renderings for a given document and page number |
-| **Control document service** | Query and create control document records |
-| **Document metadata store** | CRUD operations on document records (lookup by ID, persist new records, merge updates) |
-| **Document storage directory** | Filesystem directory where PDF files are stored |
-| **Document utility service** | Register new documents in the database (returns generated ID); update page counts; generate timestamped filenames |
-| **Patient routing service** | Query and create patient-demographic linkages for documents |
-| **PDF processing library** | Read, create, modify, and save PDF documents; manipulate individual pages and their rotation |
-| **Provider inbox routing service** | Query which providers have routing for a given document; add new routing entries |
-| **Provider lab routing service** | Query and create provider-level lab routing entries for documents |
-| **Queue-document linking service** | Associate a document with a named queue |
-| **Session/authentication service** | Retrieve the currently authenticated provider's identity from the HTTP session |
+- Invalidate cached page renderings for a given document and page number
+- Query and create control document records
+- Look up, create, and update document metadata records
+- Read a configured filesystem directory path for document storage
+- Create new document records with system-assigned unique IDs; update page counts; produce unique filenames from a given stem
+- Query and create patient-demographic linkages for documents
+- Read, create, modify, and save PDF documents; manipulate individual pages and their rotation
+- Query which providers have routing for a given document; add new routing entries
+- Query and create provider-level lab routing entries for documents
+- Associate a document with a named queue
+- Retrieve the currently authenticated provider's identity from the HTTP session
 
 ---
 

--- a/docs/specs/SplitDocument2Action_java.md
+++ b/docs/specs/SplitDocument2Action_java.md
@@ -21,131 +21,180 @@
 > (alphabetical ordering, phase-based grouping, unordered sets for independent
 > operations) that do not mirror the structure of any prior implementation.
 >
+> **Standards applied:**
+> - Document structure adapted from IEEE 830-1998 / ISO/IEC/IEEE 29148:2011
+> - Clean room methodology per Chinese Wall technique
+>
 > **Methodology references:**
 > - [AI Could Be Your Next Team for Clean Room Development (Copyleft Currents)](https://heathermeeker.com/2025/03/28/ai-could-be-your-next-team-for-clean-room-development/)
 > - [Clean-room design (Wikipedia)](https://en.wikipedia.org/wiki/Clean-room_design)
 > - [How Clean Room Reverse Engineering Built the Modern Tech Industry (NTARI)](https://www.ntari.org/post/how-clean-room-reverse-engineering-built-the-modern-tech-industry)
-
-**Component name:** SplitDocument2Action
-**Layer:** Web action (HTTP request handler)
-**Framework pattern:** Struts 2 method-dispatch action (2Action convention)
-**Domain:** Electronic document management within an EMR system
+> - [IEEE 830-1998 SRS Structure (Rebus Press)](https://press.rebus.community/requirementsengineering/back-matter/appendix-c-ieee-830-template/)
+> - [Preventing an IP Infection: Clean Room Development Procedure (IPWatchdog)](https://ipwatchdog.com/2023/04/29/preventing-an-ip-infection-clean-room-development-procedure/id=160187/)
 
 ---
 
-## 1. Purpose
+## 1. Introduction
 
-This component provides four PDF manipulation operations accessible via HTTP:
+### 1.1 Purpose
 
-| Operation | Summary |
-|-----------|---------|
-| **Remove first page** | Delete the first page of a multi-page PDF in place |
-| **Rotate 180** | Rotate every page of an existing PDF by 180 degrees in place |
-| **Rotate 90** | Rotate every page of an existing PDF by 90 degrees clockwise in place |
-| **Split** | Extract user-selected pages (with optional per-page rotation) from an existing PDF, producing a new standalone document |
+This specification defines the externally observable behavior of a web action component named `SplitDocument2Action` within an electronic medical records (EMR) system. It serves as the sole input for a clean room reimplementation.
+
+### 1.2 Scope
+
+**In scope:**
+- Four PDF manipulation operations (remove first page, rotate 180, rotate 90, split) accessible via a single HTTP endpoint
+- HTTP request/response contracts for each operation
+- Database side effects (document creation, routing, page count updates)
+- Filesystem side effects (PDF file creation and modification)
+- Client integration expectations
+
+**Out of scope:**
+- The split page selection user interface (specified separately as a client-side concern)
+- PDF rendering and page thumbnail generation (handled by a separate document viewer component)
+- Document upload and initial creation (handled by a separate upload component)
+- Authentication and session management (provided by the surrounding framework)
+- The internal implementation approach — any architecture that produces the specified observable behavior is acceptable
+
+### 1.3 Document Conventions
+
+- The word **"shall"** indicates a mandatory requirement.
+- The word **"should"** indicates a recommended but optional behavior.
+- The phrase **"is observed to"** indicates documented behavior of the existing system that the reimplementation should replicate for compatibility, but which is not part of the formal functional contract.
+- All lists of independent items are **alphabetically ordered** to prevent structural mirroring.
+- Causally dependent steps are numbered sequentially; independent steps use unordered bullets.
+
+### 1.4 Definitions and Glossary
+
+| Term | Definition |
+|------|-----------|
+| **Control document record** | A metadata association that links a document to a module (e.g., "demographic") and a module-specific entity ID, with a status field. Used to track which part of the system "owns" the document. |
+| **Document metadata** | The database record describing a stored PDF, including fields such as filename, creator, status, page count, content type, and observation date. Distinct from the PDF file itself. |
+| **Document storage directory** | A server-side filesystem directory, configured at the application level, where all PDF files are stored as flat files. |
+| **Patient routing** | A database association linking a document to a patient (demographic) record, so the document appears in that patient's document history. |
+| **Provider** | An authenticated healthcare practitioner who uses the EMR system. Identified by a provider number. |
+| **Provider inbox routing** | A database association that causes a document to appear in a provider's inbox for review. Multiple providers can have routing for the same document. |
+| **Provider lab routing** | A database association that links a document to a provider through the laboratory routing subsystem, used for documents that require provider acknowledgment. |
+| **Queue** | A named organizational container for documents. Documents are assigned to queues for workflow management (e.g., triage, filing). Queue ID `1` is the default queue. |
+| **Rendered page cache** | A cache of pre-rendered page images (thumbnails or full-size) for PDF documents. When a PDF is modified, cached renderings become stale and must be invalidated. |
 
 ---
 
 ## 2. HTTP Interface
 
-### 2.1 URL
+### 2.1 Endpoint
 
-The action is mapped to a single URL endpoint under the document manager namespace. All four operations share this endpoint and are distinguished by a request parameter.
+The component shall be accessible at a single URL endpoint under the document manager namespace. All four operations shall share this endpoint.
 
 ### 2.2 HTTP Method
 
-POST (all operations mutate state).
+All requests shall use the POST method.
 
 ### 2.3 Method Dispatch
 
-A request parameter named `method` selects the operation:
+A request parameter named `method` shall select the operation:
 
 | `method` value | Operation invoked |
 |----------------|-------------------|
-| `removeFirstPage` | Remove first page operation |
-| `rotate180` | Rotate 180 operation |
-| `rotate90` | Rotate 90 operation |
-| `split` | Split operation |
-| *(missing or unrecognized)* | No-op; return default success |
+| `removeFirstPage` | Remove first page |
+| `rotate180` | Rotate 180 |
+| `rotate90` | Rotate 90 |
+| `split` | Split |
+| *(missing or unrecognized)* | No-op; the component shall return the default success view |
 
 ---
 
-## 3. Operation Specifications
+## 3. Functional Requirements
 
 ### 3.1 Remove First Page
 
-#### Inputs
+#### FR-RFP-1: Inputs
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `document` | String (numeric document ID) | Yes | Identifies the PDF to modify |
 
-#### Behavior
+#### FR-RFP-2: Guard condition
 
-1. **Source document lookup:** Retrieve the document metadata from the database.
-2. **PDF reading:** Open the PDF file from the configured document storage directory.
-3. **Guard:** If the PDF has only one page (or zero pages), take no action and return no named result (null).
-4. **Cache invalidation:** For every page in the document (before removal), invalidate any cached rendered version.
-5. **File permissions:** Make the file world-readable, world-writable, and world-executable.
-6. **Page removal:** Remove the first page (index 0) from the PDF.
-7. **Save:** Overwrite the original file with the modified PDF.
-8. **Page count update:** If the save succeeded, decrement the document's page count in the database by one.
-9. **Response:** Return no named result (null). No response body is written.
+The component shall take no action if the PDF has only one page or zero pages. The HTTP response shall have no body.
 
-#### Error handling
+#### FR-RFP-3: Page removal
 
-Exceptions propagate to the framework (declared as thrown).
+The component shall remove the first page from the PDF and overwrite the original file on disk with the modified PDF.
+
+#### FR-RFP-4: Cache invalidation
+
+The component shall invalidate cached rendered versions for all pages in the document.
+
+#### FR-RFP-5: Page count update
+
+If the file save succeeded, the component shall decrement the document's page count in the database by one.
+
+#### FR-RFP-6: Response
+
+The HTTP response shall have no body.
+
+#### FR-RFP-7: Error handling
+
+Errors shall propagate to the web framework's default error handling.
 
 ---
 
 ### 3.2 Rotate 180
 
-#### Inputs
+#### FR-R180-1: Inputs
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `document` | String (numeric document ID) | Yes | Identifies the PDF to rotate |
 
-#### Behavior
+#### FR-R180-2: Page transformation
 
-1. **Source document lookup:** Retrieve the document metadata from the database.
-2. **PDF reading:** Open the PDF file from the configured document storage directory.
-3. **Page transformation:** For every page in the PDF:
-   - Add 180 degrees to the page's current rotation value (modulo 360).
-   - Invalidate any cached rendered version of that page.
-4. **File permissions:** Make the file world-readable, world-writable, and world-executable before saving.
-5. **Save:** Overwrite the original file on disk with the modified PDF.
-6. **Response:** Return no named result (null). No response body is written. The client is expected to refresh independently.
+The component shall rotate every page in the PDF by 180 degrees and overwrite the original file on disk with the modified PDF.
 
-#### Error handling
+#### FR-R180-3: Cache invalidation
 
-Exceptions propagate to the framework (declared as thrown).
+The component shall invalidate cached rendered versions for all pages in the document.
+
+#### FR-R180-4: Response
+
+The HTTP response shall have no body. The client is expected to refresh independently.
+
+#### FR-R180-5: Error handling
+
+Errors shall propagate to the web framework's default error handling.
 
 ---
 
 ### 3.3 Rotate 90
 
-#### Inputs
+#### FR-R90-1: Inputs
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `document` | String (numeric document ID) | Yes | Identifies the PDF to rotate |
 
-#### Behavior
+#### FR-R90-2: Page transformation
 
-Identical to Rotate 180, except:
-- Each page's rotation is incremented by **90 degrees** (modulo 360) instead of 180.
-- File permissions are **not** explicitly set before modification (note: this is an observed behavioral asymmetry).
+The component shall rotate every page in the PDF by 90 degrees clockwise and overwrite the original file on disk with the modified PDF.
 
-#### Error handling
+#### FR-R90-3: Cache invalidation
 
-Exceptions propagate to the framework (declared as thrown).
+The component shall invalidate cached rendered versions for all pages in the document.
+
+#### FR-R90-4: Response
+
+The HTTP response shall have no body.
+
+#### FR-R90-5: Error handling
+
+Errors shall propagate to the web framework's default error handling.
 
 ---
 
 ### 3.4 Split
 
-#### Inputs
+#### FR-SPL-1: Inputs
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -153,71 +202,100 @@ Exceptions propagate to the framework (declared as thrown).
 | `page` (multi-valued) | String array, each entry formatted as `pageNumber,rotationDegrees` | Yes | Ordered list of pages to extract. Page numbers are 1-based. Rotation is in degrees (0, 90, 180, 270). |
 | `queueID` | String (numeric queue ID) | No | Document queue to assign the new document to. Defaults to `"1"` if absent or empty. |
 
-#### Behavior
+#### FR-SPL-2: Authentication
 
-**Phase 1 — Read source and build new PDF** (steps are causally ordered):
+The component shall obtain the currently authenticated provider from the HTTP session.
 
-1. **Authentication context:** Obtain the currently authenticated provider from the HTTP session.
-2. **Source document lookup:** Retrieve the source document's metadata record from the database using the provided document ID.
-3. **PDF reading:** Open the source PDF file from the configured document storage directory on the filesystem.
-4. **Page extraction:** For each entry in the page selection array (processed in array order):
-   - Parse the page number and rotation value from the comma-separated string.
-   - Retrieve the specified page from the source PDF (1-based index).
-   - Apply the specified rotation to that page.
-   - Append the page to a new PDF document.
-5. **Guard:** If no pages were added to the new document, skip all subsequent steps.
+#### FR-SPL-3: Source document
 
-**Phase 2 — Register new document** (steps are causally ordered):
+The component shall retrieve the source document's metadata record from the database using the provided document ID and open the corresponding PDF file from the document storage directory.
 
-6. **New document metadata creation:** Create a new document metadata record with the following fields (alphabetical):
-   - Content type: `application/pdf`
-   - Creator: the currently authenticated provider
-   - Description: empty
-   - Filename stem: same as the source document (the system prepends a timestamp automatically)
-   - HTML content: empty
-   - Module: `"demographic"`, module ID: `"-1"`
-   - Observation date: current date (formatted as `yyyy-MM-dd`)
-   - Page count: number of pages in the new PDF
-   - Responsible party: the source document's original creator
-   - Source: empty
-   - Status: active
-   - Type: empty
-   - Visibility: private (not public)
-7. **Persist new document:** Save the metadata record to the database. This generates a new document ID.
-8. **Write PDF to filesystem:** Save the new PDF to the document storage directory using the generated filename.
+#### FR-SPL-4: Page extraction
 
-**Phase 3 — Routing and linking** (the following tasks are independent of each other and may execute in any order):
+The component shall extract each specified page from the source PDF (in the order given in the page selection array), apply the specified rotation to each page, and assemble the extracted pages into a new PDF document.
 
-- **Control document cloning:** If the source document has a control document record (module assignment with status), create an equivalent control document record for the new document, preserving the module ID and status from the source.
-- **Patient routing:** If the source document is linked to a patient (demographic), create the same patient linkage for the new document.
-- **Provider inbox routing:** Copy all existing provider inbox routing entries from the source document to the new document. Additionally, add the currently authenticated provider to the new document's inbox routing.
-- **Provider lab routing:** If the source document has provider lab routing entries, route the new document to the first provider found in those entries.
-- **Queue assignment:** Link the new document to the specified queue (or queue `1` by default).
+#### FR-SPL-5: Guard condition
 
-**Phase 4 — Response:**
+If the page selection is empty or null, no new document shall be created. The HTTP response shall trigger the close-and-reload view.
 
-The response behavior depends on the routing state:
-- **If provider lab routing AND patient routing both existed:** Return a named result that triggers the close-and-reload view (the parent window reloads and the popup closes).
-- **If either routing was absent:** Write a JSON response directly to the HTTP output stream with content type `application/json`. The JSON object contains a single field `newDocNum` whose value is the string ID of the newly created document. Return no named result (null), which prevents the framework from rendering a view.
+#### FR-SPL-6: New document metadata
 
-#### Error handling
+The component shall create a new document metadata record with the following fields (alphabetical):
+- Content type: `application/pdf`
+- Creator: the currently authenticated provider
+- Description: empty
+- Filename stem: same as the source document (the system prepends a timestamp automatically)
+- HTML content: empty
+- Module: `"demographic"`, module ID: `"-1"`
+- Observation date: current date (formatted as `yyyy-MM-dd`)
+- Page count: number of pages in the new PDF
+- Responsible party: the source document's original creator
+- Source: empty
+- Status: active
+- Type: empty
+- Visibility: private (not public)
 
-On any exception during the split operation, log the error and return no named result (null). No error response is sent to the client.
+#### FR-SPL-7: Persist and save
+
+The component shall save the metadata record to the database (generating a new document ID) and save the new PDF file to the document storage directory using the generated filename.
+
+#### FR-SPL-8: Routing and linking
+
+The following routing tasks are independent of each other. The component shall perform all that apply:
+
+- **Control document cloning:** If the source document has a control document record, the component shall create an equivalent control document record for the new document, preserving the module ID and status from the source.
+- **Patient routing:** If the source document is linked to a patient, the component shall create the same patient linkage for the new document.
+- **Provider inbox routing:** The component shall copy all existing provider inbox routing entries from the source document to the new document. The component shall also add the currently authenticated provider to the new document's inbox routing.
+- **Provider lab routing:** If the source document has provider lab routing entries, the component shall route the new document to one of the providers found in those entries.
+- **Queue assignment:** The component shall link the new document to the specified queue (or queue `1` by default).
+
+#### FR-SPL-9: Response
+
+The response shall depend on the routing state:
+- **If provider lab routing AND patient routing both existed for the source document:** The HTTP response shall trigger the close-and-reload view (the parent window reloads and the popup closes).
+- **If either routing was absent:** The HTTP response body shall be JSON with content type `application/json`, containing a single field `newDocNum` with the string ID of the newly created document.
+
+#### FR-SPL-10: Error handling
+
+On any error, the HTTP response shall have no body and no error message shall be returned to the client.
 
 ---
 
-## 4. External Dependencies
+## 4. Non-Functional Requirements
+
+### 4.1 Security
+
+The following security behaviors are **required for any reimplementation** per CARLOS EMR standards:
+
+- **NFR-SEC-1:** The component shall verify the authenticated user has appropriate read/write privileges on the document security object before executing any operation. The component shall deny access with a security exception if unauthorized.
+- **NFR-SEC-2:** The component shall validate all filesystem paths constructed from document metadata to prevent path traversal attacks.
+- **NFR-SEC-3:** The component shall validate that the `document` parameter is a numeric value and that `page` parameter values conform to the expected format and bounds.
+- **NFR-SEC-4:** The component shall apply context-appropriate output encoding to any user-supplied values included in responses.
+
+### 4.2 Data Integrity
+
+- **NFR-DI-1:** The split operation shall not modify the source document or its PDF file.
+- **NFR-DI-2:** Rotate and remove operations shall overwrite the original PDF file in place. The document metadata record shall remain consistent with the file contents (e.g., page count after removal).
+
+### 4.3 Reliability
+
+- **NFR-REL-1:** If a PDF file save fails during a rotate or remove operation, the component should not update the database page count.
+- **NFR-REL-2:** PDF file handles shall be closed after use, even when errors occur.
+
+---
+
+## 5. External Dependencies
 
 The component requires the following capabilities from the surrounding system:
 
 | Capability | Purpose |
 |------------|---------|
 | **Cache service** | Invalidate cached page renderings for a given document and page number |
-| **Control document service** | Query and create control document records (module assignment metadata) |
+| **Control document service** | Query and create control document records |
 | **Document metadata store** | CRUD operations on document records (lookup by ID, persist new records, merge updates) |
-| **Document storage directory** | A filesystem directory configured at the application level where PDF files are stored |
+| **Document storage directory** | Filesystem directory where PDF files are stored |
 | **Document utility service** | Register new documents in the database (returns generated ID); update page counts; generate timestamped filenames |
-| **Patient lab routing service** | Query and create patient-demographic linkages for documents |
+| **Patient routing service** | Query and create patient-demographic linkages for documents |
 | **PDF processing library** | Read, create, modify, and save PDF documents; manipulate individual pages and their rotation |
 | **Provider inbox routing service** | Query which providers have routing for a given document; add new routing entries |
 | **Provider lab routing service** | Query and create provider-level lab routing entries for documents |
@@ -226,29 +304,19 @@ The component requires the following capabilities from the surrounding system:
 
 ---
 
-## 5. Response Summary
+## 6. Response Summary
 
-| Operation | Named result returned | Direct HTTP response body |
-|-----------|----------------------|---------------------------|
-| Remove first page | `null` | None |
-| Rotate 180 | `null` | None |
-| Rotate 90 | `null` | None |
-| Split (both routings exist) | `"success"` → close-and-reload view | None |
-| Split (either routing absent) | `null` (no view) | JSON: `{ "newDocNum": "<id>" }` |
-| Split (error) | `null` | None |
-| Split (no pages selected) | `"success"` → close-and-reload view | None |
-| Unknown/missing method | `"success"` → default | None |
-
----
-
-## 6. Security Requirements
-
-The following security behaviors are **required for any reimplementation** per CARLOS EMR standards (these are normative requirements, not observations of the existing implementation):
-
-1. **Authorization check:** Before executing any operation, verify the authenticated user has appropriate read/write privileges on the document security object (e.g., `_edoc` or `_doc`). Deny access with a security exception if unauthorized.
-2. **Input validation:** The `document` parameter must be validated as a numeric value. The `page` parameter values must be validated for correct format and bounds.
-3. **OWASP encoding:** Any user-supplied values included in responses must be properly encoded for the output context.
-4. **Path validation:** All filesystem paths constructed from document metadata must be validated using the application's path validation utility to prevent path traversal attacks.
+| Operation | HTTP Response |
+|-----------|--------------|
+| Remove first page | No body |
+| Remove first page (single-page guard) | No body |
+| Rotate 180 | No body |
+| Rotate 90 | No body |
+| Split (both routings exist) | Close-and-reload view |
+| Split (either routing absent) | JSON: `{ "newDocNum": "<id>" }` |
+| Split (error) | No body |
+| Split (no pages selected) | Close-and-reload view |
+| Unknown/missing method | Default success view |
 
 ---
 
@@ -256,7 +324,7 @@ The following security behaviors are **required for any reimplementation** per C
 
 ### 7.1 Rotate and Remove Operations
 
-These are invoked as AJAX calls from document queue management interfaces. The client refreshes the document view after the call completes. No response body is expected.
+These operations are invoked as AJAX calls from document queue management interfaces. The client shall refresh the document view after the call completes. No response body is expected.
 
 ### 7.2 Split UI Flow
 
@@ -268,15 +336,42 @@ These are invoked as AJAX calls from document queue management interfaces. The c
 
 ---
 
-## 8. Behavioral Notes
+## 8. Assumptions
 
-These notes document observable behavioral characteristics for completeness:
+- The document storage directory exists and is writable by the application server process.
+- All referenced document IDs correspond to existing PDF files in the document storage directory.
+- The authenticated provider session is valid and contains a provider number.
+- The PDF processing library can handle the PDF files stored in the system (standard PDF format, not encrypted or password-protected).
 
-- **Cache invalidation scope** — rotate and remove operations invalidate cached renderings for all pages in the document, not just affected pages.
-- **File permissions asymmetry** — the rotate-180 and remove-first-page operations set broad file permissions before modifying the file. The rotate-90 operation does not.
-- **Filename inheritance** — the new document created by split reuses the source document's original filename as a stem; the system prepends a date-time prefix to ensure uniqueness.
-- **In-place modification** — rotate and remove operations overwrite the original PDF file on disk. The source document is never modified by split.
-- **Queue default** — if no queue is specified, the new document is assigned to queue ID 1.
-- **Response path divergence** — the split operation returns different response types depending on whether the source document had both provider lab routing and patient routing. This determines whether the client receives JSON or a view redirect.
-- **Routing duplication** — split copies the source document's routing associations to the new document, ensuring the new document appears in the same inboxes and patient records.
-- **Single-page guard** — the remove-first-page operation silently does nothing if the document has only one page.
+---
+
+## 9. Verification Criteria
+
+An implementation shall be considered correct if it satisfies all of the following observable tests:
+
+| Test ID | Operation | Verification |
+|---------|-----------|-------------|
+| V-RFP-1 | Remove first page | A 3-page PDF becomes a 2-page PDF after the operation. The former second page is now the first page. The database page count reflects the new count. |
+| V-RFP-2 | Remove first page (guard) | A 1-page PDF is unchanged after the operation. |
+| V-R180-1 | Rotate 180 | All pages in the PDF are visually upside-down relative to their prior orientation. The file is modified in place. |
+| V-R90-1 | Rotate 90 | All pages in the PDF are rotated 90 degrees clockwise relative to their prior orientation. The file is modified in place. |
+| V-SPL-1 | Split (pages 2,3 from a 5-page doc) | A new document record is created with 2 pages. The new PDF contains only the selected pages in the specified order. The source document is unchanged. |
+| V-SPL-2 | Split (routing) | The new document appears in the same provider inboxes as the source document. The authenticated provider also has inbox routing. |
+| V-SPL-3 | Split (patient link) | If the source was linked to a patient, the new document is also linked to the same patient. |
+| V-SPL-4 | Split (queue) | The new document is assigned to the specified queue, or queue 1 if none specified. |
+| V-SPL-5 | Split (JSON response) | When either provider lab routing or patient routing is absent, the response is JSON containing `newDocNum`. |
+| V-SPL-6 | Split (view response) | When both provider lab routing and patient routing exist, the response triggers the close-and-reload view. |
+| V-CACHE-1 | All operations | After any rotate or remove operation, previously cached page renderings are invalidated. |
+
+---
+
+## 10. Observed Behaviors (Non-Normative)
+
+These notes document externally observable characteristics of the existing system. They are provided for compatibility reference but are not mandatory requirements. An implementer should replicate these behaviors unless there is a clear reason to improve upon them.
+
+- **Cache invalidation scope** — Rotate and remove operations are observed to invalidate cached renderings for all pages in the document, not just affected pages. This is observable as a brief delay when re-rendering unmodified pages.
+- **Filename inheritance** — The new document created by split is observed to reuse the source document's original filename as a stem, with a date-time prefix prepended for uniqueness. This is observable in the stored filename.
+- **Queue default** — When no queue is specified, the new document is observed to be assigned to queue ID 1. This is observable in the queue assignment database record.
+- **Response path divergence** — The split operation is observed to return different response types depending on whether the source document had both provider lab routing and patient routing. This is observable by the client through the HTTP response content type.
+- **Routing duplication** — Split is observed to copy all of the source document's routing associations to the new document. This is observable in the routing database tables.
+- **Single-page guard** — The remove-first-page operation is observed to silently do nothing if the document has only one page. This is observable by comparing the document before and after the request.

--- a/docs/specs/SplitDocument2Action_java.md
+++ b/docs/specs/SplitDocument2Action_java.md
@@ -215,7 +215,9 @@ The component shall retrieve the source document's metadata record from the data
 
 #### FR-SPL-4: Page extraction
 
-The component shall extract each specified page from the source PDF (in the order given in the page selection array), set each page's rotation to the specified absolute value (not additive — this differs from the rotate operations which add to the existing rotation), and assemble the extracted pages into a new PDF document.
+The component shall extract each specified page from the source PDF (in the order given in the page selection array), set each page's rotation to the specified absolute value, and assemble the extracted pages into a new PDF document.
+
+> **Note:** The rotation value is absolute (e.g., `90` means "set rotation to 90°"), not additive. This differs from the rotate operations in §3.2 and §3.3, which add to the existing rotation.
 
 #### FR-SPL-5: Guard condition
 
@@ -223,22 +225,18 @@ If the page selection is empty or null, no new document shall be created. The HT
 
 #### FR-SPL-6: New document metadata
 
-The component shall create a new document metadata record with the following fields (alphabetical):
+The component shall create a new document metadata record. Fields with meaningful values (alphabetical):
 - Content type: `application/pdf`
 - Creator: the currently authenticated provider
-- Description: empty
 - Filename stem: same as the source document (the system prepends a timestamp automatically)
-- HTML content: empty
 - Module: `"demographic"`, module ID: `"-1"`
-- Observation date: current date (formatted as `yyyy-MM-dd`)
+- Observation date: current date
 - Page count: number of pages in the new PDF
 - Responsible party: the source document's original creator
-- Review date/time: empty
-- Reviewer ID: empty
-- Source: empty
 - Status: active
-- Type: empty
 - Visibility: private (not public)
+
+All other metadata fields (description, HTML content, review date/time, reviewer ID, source, type) shall be empty/default.
 
 #### FR-SPL-7: Persist and save
 
@@ -329,15 +327,13 @@ The component requires the following capabilities from the surrounding system:
 
 ### 7.1 Rotate and Remove Operations
 
-These operations are invoked as AJAX calls from document queue management interfaces. The client shall refresh the document view after the call completes. No response body is expected.
+The client sends a POST request and expects no response body. The client is responsible for refreshing the document view after completion.
 
-### 7.2 Split UI Flow
+### 7.2 Split Operation
 
-1. The user opens a split interface that displays thumbnail images of each page in the source document.
-2. The user selects pages, reorders them via drag-and-drop, and optionally rotates individual pages.
-3. On save, the client sends an AJAX POST with the selected pages (as `page` multi-value parameters in `pageNumber,rotation` format), the source `document` ID, and the `queueID`.
-4. On success, if the response is JSON, the client extracts `newDocNum` and opens a document viewer for the newly created document.
-5. If the response triggers the close-and-reload view, the parent window reloads and the popup closes automatically.
+The client sends a POST with `page` multi-value parameters (in `pageNumber,rotation` format), the source `document` ID, and optionally `queueID`. The client shall handle two response types:
+- **JSON response** (`application/json`): Extract the `newDocNum` field to obtain the new document's ID.
+- **Close-and-reload view**: The parent window reloads and the current view closes.
 
 ---
 

--- a/docs/specs/SplitDocument2Action_java.md
+++ b/docs/specs/SplitDocument2Action_java.md
@@ -291,16 +291,16 @@ The following security behaviors are **required for any reimplementation** per C
 
 The component requires the following capabilities from the surrounding system. How these are organized (one service, many services, direct database access, etc.) is an implementation choice.
 
-- Invalidate cached page renderings for a given document and page number
-- Query and create control document records
-- Look up, create, and update document metadata records
-- Read a configured filesystem directory path for document storage
-- Create new document records with system-assigned unique IDs; update page counts; produce unique filenames from a given stem
-- Query and create patient-demographic linkages for documents
-- Read, create, modify, and save PDF documents; manipulate individual pages and their rotation
-- Query which providers have routing for a given document; add new routing entries
-- Query and create provider-level lab routing entries for documents
 - Associate a document with a named queue
+- Create new document records with system-assigned unique IDs; update page counts; produce unique filenames from a given stem
+- Invalidate cached page renderings for a given document and page number
+- Look up, create, and update document metadata records
+- Query and create control document records
+- Query and create patient-demographic linkages for documents
+- Query and create provider-level lab routing entries for documents
+- Query which providers have routing for a given document; add new routing entries
+- Read a configured filesystem directory path for document storage
+- Read, create, modify, and save PDF documents; manipulate individual pages and their rotation
 - Retrieve the currently authenticated provider's identity from the HTTP session
 
 ---
@@ -356,11 +356,12 @@ An implementation shall be considered correct if it satisfies all of the followi
 | V-R90-1 | Rotate 90 | All pages in the PDF are rotated 90 degrees clockwise relative to their prior orientation. The file is modified in place. |
 | V-SPL-1 | Split (pages 2,3 from a 5-page doc) | A new document record is created with 2 pages. The new PDF contains only the selected pages in the specified order. The source document is unchanged. |
 | V-SPL-2 | Split (routing) | The new document appears in the same provider inboxes as the source document. The authenticated provider also has inbox routing. |
-| V-SPL-3 | Split (patient link) | If the source was linked to a patient, the new document is also linked to the same patient. |
-| V-SPL-4 | Split (queue) | The new document is assigned to the specified queue, or queue 1 if none specified. |
-| V-SPL-5 | Split (JSON response) | When either provider lab routing or patient routing is absent, the response is JSON containing `newDocNum`. |
-| V-SPL-6 | Split (view response) | When both provider lab routing and patient routing exist, the response triggers the close-and-reload view. |
-| V-SPL-7 | Split (with rotation) | When extracting a page with rotation value 90, the page in the new PDF has absolute rotation 90 regardless of the page's original rotation in the source PDF. |
+| V-SPL-3 | Split (control document) | If the source had a control document record, the new document has an equivalent record with the same module ID and status. |
+| V-SPL-4 | Split (patient link) | If the source was linked to a patient, the new document is also linked to the same patient. |
+| V-SPL-5 | Split (queue) | The new document is assigned to the specified queue, or queue 1 if none specified. |
+| V-SPL-6 | Split (JSON response) | When either provider lab routing or patient routing is absent, the response is JSON containing `newDocNum`. |
+| V-SPL-7 | Split (view response) | When both provider lab routing and patient routing exist, the response triggers the close-and-reload view. |
+| V-SPL-8 | Split (with rotation) | When extracting a page with rotation value 90, the page in the new PDF has absolute rotation 90 regardless of the page's original rotation in the source PDF. |
 | V-R180-2 | Rotate 180 (additive) | A page with existing rotation 90 becomes rotation 270 after the operation (90 + 180 = 270). |
 | V-CACHE-1 | Rotate and remove | After any rotate or remove operation, previously cached page renderings are invalidated. |
 
@@ -370,6 +371,5 @@ An implementation shall be considered correct if it satisfies all of the followi
 
 These notes document externally observable characteristics of the existing system that are not captured by the normative requirements above. They are provided for compatibility reference. An implementer should replicate these behaviors unless there is a clear reason to improve upon them.
 
-- **Cache invalidation scope** — Rotate and remove operations are observed to invalidate cached renderings for **all** pages in the document, not just the affected pages. This is observable as a brief delay when re-rendering unmodified pages.
 - **Filename inheritance** — The new document created by split is observed to reuse the source document's original filename as a stem, with a date-time prefix prepended for uniqueness. This is observable in the stored filename.
 - **Provider lab routing selection** — When the source document has multiple provider lab routing entries, the system is observed to route the new document to the first provider returned by the query. The query ordering is not guaranteed, so this selection is effectively arbitrary.

--- a/docs/specs/SplitDocument2Action_java.md
+++ b/docs/specs/SplitDocument2Action_java.md
@@ -1,0 +1,252 @@
+# Functional Specification: PDF Document Manipulation Action
+
+> **Clean Room Specification**
+>
+> This document is a black-box functional specification describing observable behavior only.
+> It contains no source code, no internal implementation details, and no copyrightable
+> expression from any existing implementation. It is intended to serve as the sole input
+> for a clean room reimplementation per the Chinese Wall methodology.
+>
+> **Methodology references:**
+> - [Clean-room design (Wikipedia)](https://en.wikipedia.org/wiki/Clean-room_design)
+> - [How Clean Room Reverse Engineering Built the Modern Tech Industry (NTARI)](https://www.ntari.org/post/how-clean-room-reverse-engineering-built-the-modern-tech-industry)
+> - [AI Could Be Your Next Team for Clean Room Development (Copyleft Currents)](https://heathermeeker.com/2025/03/28/ai-could-be-your-next-team-for-clean-room-development/)
+
+**Component name:** SplitDocument2Action
+**Layer:** Web action (HTTP request handler)
+**Framework pattern:** Struts 2 method-dispatch action (2Action convention)
+**Domain:** Electronic document management within an EMR system
+
+---
+
+## 1. Purpose
+
+This component provides four PDF manipulation operations accessible via HTTP:
+
+| Operation | Summary |
+|-----------|---------|
+| **Split** | Extract user-selected pages (with optional per-page rotation) from an existing PDF, producing a new standalone document |
+| **Rotate 180** | Rotate every page of an existing PDF by 180 degrees in place |
+| **Rotate 90** | Rotate every page of an existing PDF by 90 degrees clockwise in place |
+| **Remove first page** | Delete the first page of a multi-page PDF in place |
+
+---
+
+## 2. HTTP Interface
+
+### 2.1 URL
+
+The action is mapped to a single URL endpoint under the document manager namespace. All four operations share this endpoint and are distinguished by a request parameter.
+
+### 2.2 HTTP Method
+
+POST (all operations mutate state).
+
+### 2.3 Method Dispatch
+
+A request parameter named `method` selects the operation:
+
+| `method` value | Operation invoked |
+|----------------|-------------------|
+| `split` | Split operation |
+| `rotate180` | Rotate 180 operation |
+| `rotate90` | Rotate 90 operation |
+| `removeFirstPage` | Remove first page operation |
+| *(missing or unrecognized)* | No-op; return default success |
+
+---
+
+## 3. Operation Specifications
+
+### 3.1 Split
+
+#### Inputs
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `document` | String (numeric document ID) | Yes | Identifies the source PDF document |
+| `page` (multi-valued) | String array, each entry formatted as `pageNumber,rotationDegrees` | Yes | Ordered list of pages to extract. Page numbers are 1-based. Rotation is in degrees (0, 90, 180, 270). |
+| `queueID` | String (numeric queue ID) | No | Document queue to assign the new document to. Defaults to `"1"` if absent or empty. |
+
+#### Behavior
+
+1. **Authentication context:** Obtain the currently authenticated provider from the HTTP session.
+2. **Source document lookup:** Retrieve the source document's metadata record from the database using the provided document ID.
+3. **PDF reading:** Open the source PDF file from the configured document storage directory on the filesystem.
+4. **Page extraction:** For each entry in the page selection array (processed in array order):
+   - Parse the page number and rotation value from the comma-separated string.
+   - Retrieve the specified page from the source PDF (1-based index).
+   - Apply the specified rotation to that page.
+   - Append the page to a new PDF document.
+5. **Guard:** If no pages were added to the new document, skip all subsequent steps.
+6. **New document metadata creation:** Create a new document metadata record with:
+   - The same filename stem as the source document (the system prepends a timestamp automatically).
+   - The currently authenticated provider as the creator.
+   - The source document's original creator as the responsible party.
+   - Content type: `application/pdf`.
+   - Status: active.
+   - Observation date: current date (formatted as `yyyy-MM-dd`).
+   - Page count: number of pages in the new PDF.
+   - Visibility: private (not public).
+   - Module: `"demographic"`, module ID: `"-1"`.
+   - Empty description, type, HTML, and source fields.
+7. **Persist new document:** Save the metadata record to the database. This generates a new document ID.
+8. **Write PDF to filesystem:** Save the new PDF to the document storage directory using the generated filename.
+9. **Inbox routing (provider):** Copy all existing provider inbox routing entries from the source document to the new document. Additionally, add the currently authenticated provider to the new document's inbox routing.
+10. **Queue assignment:** Link the new document to the specified queue (or queue `1` by default).
+11. **Provider lab routing:** If the source document has provider lab routing entries, route the new document to the first provider found in those entries.
+12. **Patient routing:** If the source document is linked to a patient (demographic), create the same patient linkage for the new document.
+13. **Control document cloning:** If the source document has a control document record (module assignment with status), create an equivalent control document record for the new document, preserving the module ID and status from the source.
+14. **Response:** The response behavior depends on the routing state:
+    - **If provider lab routing AND patient routing both existed:** Return a named result that triggers the close-and-reload view (the parent window reloads and the popup closes).
+    - **If either routing was absent:** Write a JSON response directly to the HTTP output stream with content type `application/json`. The JSON object contains a single field `newDocNum` whose value is the string ID of the newly created document. Return no named result (null), which prevents the framework from rendering a view.
+
+#### Error handling
+
+On any exception during the split operation, log the error and return no named result (null). No error response is sent to the client.
+
+---
+
+### 3.2 Rotate 180
+
+#### Inputs
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `document` | String (numeric document ID) | Yes | Identifies the PDF to rotate |
+
+#### Behavior
+
+1. **Source document lookup:** Retrieve the document metadata from the database.
+2. **PDF reading:** Open the PDF file from the configured document storage directory.
+3. **Set file permissions:** Make the file world-readable, world-writable, and world-executable before modification.
+4. **Rotation:** For every page in the PDF, add 180 degrees to the page's current rotation value (modulo 360).
+5. **Cache invalidation:** For each page, invalidate any cached rendered version of that page.
+6. **Save:** Overwrite the original file on disk with the modified PDF.
+7. **Response:** Return no named result (null). No response body is written. The client is expected to refresh independently.
+
+#### Error handling
+
+Exceptions propagate to the framework (declared as thrown).
+
+---
+
+### 3.3 Rotate 90
+
+#### Inputs
+
+Same as Rotate 180.
+
+#### Behavior
+
+Identical to Rotate 180, except:
+- Each page's rotation is incremented by **90 degrees** (modulo 360) instead of 180.
+- File permissions are **not** explicitly set before modification (note: this is an observed behavioral asymmetry).
+
+#### Error handling
+
+Same as Rotate 180.
+
+---
+
+### 3.4 Remove First Page
+
+#### Inputs
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `document` | String (numeric document ID) | Yes | Identifies the PDF to modify |
+
+#### Behavior
+
+1. **Source document lookup:** Retrieve the document metadata from the database.
+2. **PDF reading:** Open the PDF file from the configured document storage directory.
+3. **Guard:** If the PDF has only one page (or zero pages), take no action and return no named result (null).
+4. **Set file permissions:** Make the file world-readable, world-writable, and world-executable.
+5. **Cache invalidation:** For every page in the document (before removal), invalidate any cached rendered version.
+6. **Page removal:** Remove the first page (index 0) from the PDF.
+7. **Save:** Overwrite the original file with the modified PDF.
+8. **Page count update:** If the save succeeded, decrement the document's page count in the database by one.
+9. **Response:** Return no named result (null). No response body is written.
+
+#### Error handling
+
+Exceptions propagate to the framework (declared as thrown).
+
+---
+
+## 4. External Dependencies
+
+The component requires the following capabilities from the surrounding system:
+
+| Capability | Purpose |
+|------------|---------|
+| **Document metadata store** | CRUD operations on document records (lookup by ID, persist new records, merge updates) |
+| **Document storage directory** | A filesystem directory configured at the application level where PDF files are stored |
+| **PDF processing library** | Read, create, modify, and save PDF documents; manipulate individual pages and their rotation |
+| **Session/authentication service** | Retrieve the currently authenticated provider's identity from the HTTP session |
+| **Provider inbox routing service** | Query which providers have routing for a given document; add new routing entries |
+| **Queue-document linking service** | Associate a document with a named queue |
+| **Provider lab routing service** | Query and create provider-level lab routing entries for documents |
+| **Patient lab routing service** | Query and create patient-demographic linkages for documents |
+| **Control document service** | Query and create control document records (module assignment metadata) |
+| **Document utility service** | Register new documents in the database (returns generated ID); update page counts; generate timestamped filenames |
+| **Cache service** | Invalidate cached page renderings for a given document and page number |
+
+---
+
+## 5. Response Summary
+
+| Operation | Named result returned | Direct HTTP response body |
+|-----------|----------------------|---------------------------|
+| Split (both routings exist) | `"success"` → close-and-reload view | None |
+| Split (either routing absent) | `null` (no view) | JSON: `{ "newDocNum": "<id>" }` |
+| Split (error) | `null` | None |
+| Split (no pages selected) | `"success"` → close-and-reload view | None |
+| Rotate 180 | `null` | None |
+| Rotate 90 | `null` | None |
+| Remove first page | `null` | None |
+| Unknown/missing method | `"success"` → default | None |
+
+---
+
+## 6. Security Requirements
+
+The following security behaviors are **required for any reimplementation** per CARLOS EMR standards (these are normative requirements, not observations of the existing implementation):
+
+1. **Authorization check:** Before executing any operation, verify the authenticated user has appropriate read/write privileges on the document security object (e.g., `_edoc` or `_doc`). Deny access with a security exception if unauthorized.
+2. **Path validation:** All filesystem paths constructed from document metadata must be validated using the application's path validation utility to prevent path traversal attacks.
+3. **Input validation:** The `document` parameter must be validated as a numeric value. The `page` parameter values must be validated for correct format and bounds.
+4. **OWASP encoding:** Any user-supplied values included in responses must be properly encoded for the output context.
+
+---
+
+## 7. Client Integration Contract
+
+### 7.1 Split UI Flow
+
+1. The user opens a split interface that displays thumbnail images of each page in the source document.
+2. The user selects pages, reorders them via drag-and-drop, and optionally rotates individual pages.
+3. On save, the client sends an AJAX POST with the selected pages (as `page` multi-value parameters in `pageNumber,rotation` format), the source `document` ID, and the `queueID`.
+4. On success, if the response is JSON, the client extracts `newDocNum` and opens a document viewer for the newly created document.
+5. If the response triggers the close-and-reload view, the parent window reloads and the popup closes automatically.
+
+### 7.2 Rotate and Remove Operations
+
+These are invoked as AJAX calls from document queue management interfaces. The client refreshes the document view after the call completes. No response body is expected.
+
+---
+
+## 8. Behavioral Notes
+
+These notes document observable behavioral characteristics for completeness:
+
+1. **Split produces a new document** — the source document is never modified by the split operation.
+2. **Rotate and remove modify in place** — these operations overwrite the original PDF file on disk.
+3. **Filename inheritance** — the new document created by split reuses the source document's original filename as a stem; the system prepends a date-time prefix to ensure uniqueness.
+4. **Routing duplication** — split copies the source document's routing associations to the new document, ensuring the new document appears in the same inboxes and patient records.
+5. **Queue default** — if no queue is specified, the new document is assigned to queue ID 1.
+6. **Single-page guard** — the remove-first-page operation silently does nothing if the document has only one page.
+7. **Cache invalidation scope** — rotate and remove operations invalidate cached renderings for all pages in the document, not just affected pages.
+8. **File permissions** — the rotate-180 and remove-first-page operations set broad file permissions before modifying the file. The rotate-90 operation does not (asymmetry in observed behavior).
+9. **Response path divergence in split** — the split operation returns different response types depending on whether the source document had both provider lab routing and patient routing. This determines whether the client receives JSON or a view redirect.

--- a/docs/specs/SplitDocument2Action_java.md
+++ b/docs/specs/SplitDocument2Action_java.md
@@ -45,18 +45,18 @@ This specification defines the externally observable behavior of a PDF document 
 ### 1.2 Scope
 
 **In scope:**
-- Four PDF manipulation operations (remove first page, rotate 180, rotate 90, split) accessible via a single HTTP endpoint
-- HTTP request/response contracts for each operation
+- Client integration expectations
 - Database side effects (document creation, routing, page count updates)
 - Filesystem side effects (PDF file creation and modification)
-- Client integration expectations
+- Four PDF manipulation operations (remove first page, rotate 180, rotate 90, split) accessible via a single HTTP endpoint
+- HTTP request/response contracts for each operation
 
 **Out of scope:**
-- The split page selection user interface (specified separately as a client-side concern)
-- PDF rendering and page thumbnail generation (handled by a separate document viewer component)
-- Document upload and initial creation (handled by a separate upload component)
 - Authentication and session management (provided by the surrounding framework)
+- Document upload and initial creation (handled by a separate upload component)
 - The internal implementation approach — any architecture that produces the specified observable behavior is acceptable
+- PDF rendering and page thumbnail generation (handled by a separate document viewer component)
+- The split page selection user interface (specified separately as a client-side concern)
 
 ### 1.3 Document Conventions
 
@@ -71,9 +71,9 @@ This specification defines the externally observable behavior of a PDF document 
 | Term | Definition |
 |------|-----------|
 | **Control document record** | A metadata association that links a document to a module (e.g., "demographic") and a module-specific entity ID, with a status field. Used to track which part of the system "owns" the document. |
-| **Document type identifier** | The string constant `"DOC"` used as a discriminator in routing tables to distinguish document items from other routable item types (e.g., lab results). All routing operations for documents use this value. |
 | **Document metadata** | The database record describing a stored PDF, including fields such as filename, creator, status, page count, content type, and observation date. Distinct from the PDF file itself. |
 | **Document storage directory** | A server-side filesystem directory, configured at the application level, where all PDF files are stored as flat files. |
+| **Document type identifier** | The string constant `"DOC"` used as a discriminator in routing tables to distinguish document items from other routable item types (e.g., lab results). All routing operations for documents use this value. |
 | **Patient routing** | A database association linking a document to a patient (demographic) record, so the document appears in that patient's document history. |
 | **Provider** | An authenticated healthcare practitioner who uses the EMR system. Identified by a provider number. |
 | **Provider inbox routing** | A database association that causes a document to appear in a provider's inbox for review. Multiple providers can have routing for the same document. |
@@ -330,16 +330,16 @@ The client sends a POST request and expects no response body. The client is resp
 ### 7.2 Split Operation
 
 The client sends a POST with `page` multi-value parameters (in `pageNumber,rotation` format), the source `document` ID, and optionally `queueID`. The client shall handle two response types:
-- **JSON response** (`application/json`): Extract the `newDocNum` field to obtain the new document's ID.
 - **Close-and-reload view**: The parent window reloads and the current view closes.
+- **JSON response** (`application/json`): Extract the `newDocNum` field to obtain the new document's ID.
 
 ---
 
 ## 8. Assumptions
 
-- The document storage directory exists and is writable by the application server process.
-- All referenced document IDs correspond to existing PDF files in the document storage directory.
 - The authenticated provider session is valid and contains a provider number.
+- All referenced document IDs correspond to existing PDF files in the document storage directory.
+- The document storage directory exists and is writable by the application server process.
 - The PDF processing library can handle the PDF files stored in the system (standard PDF format, not encrypted or password-protected).
 
 ---
@@ -350,10 +350,12 @@ An implementation shall be considered correct if it satisfies all of the followi
 
 | Test ID | Operation | Verification |
 |---------|-----------|-------------|
+| V-CACHE-1 | Rotate and remove | After any rotate or remove operation, previously cached page renderings are invalidated. |
+| V-R180-1 | Rotate 180 | All pages in the PDF are visually upside-down relative to their prior orientation. The file is modified in place. |
+| V-R180-2 | Rotate 180 (additive) | A page with existing rotation 90 becomes rotation 270 after the operation (90 + 180 = 270). |
+| V-R90-1 | Rotate 90 | All pages in the PDF are rotated 90 degrees clockwise relative to their prior orientation. The file is modified in place. |
 | V-RFP-1 | Remove first page | A 3-page PDF becomes a 2-page PDF after the operation. The former second page is now the first page. The database page count reflects the new count. |
 | V-RFP-2 | Remove first page (guard) | A 1-page PDF is unchanged after the operation. |
-| V-R180-1 | Rotate 180 | All pages in the PDF are visually upside-down relative to their prior orientation. The file is modified in place. |
-| V-R90-1 | Rotate 90 | All pages in the PDF are rotated 90 degrees clockwise relative to their prior orientation. The file is modified in place. |
 | V-SPL-1 | Split (pages 2,3 from a 5-page doc) | A new document record is created with 2 pages. The new PDF contains only the selected pages in the specified order. The source document is unchanged. |
 | V-SPL-2 | Split (routing) | The new document appears in the same provider inboxes as the source document. The authenticated provider also has inbox routing. |
 | V-SPL-3 | Split (control document) | If the source had a control document record, the new document has an equivalent record with the same module ID and status. |
@@ -362,8 +364,6 @@ An implementation shall be considered correct if it satisfies all of the followi
 | V-SPL-6 | Split (JSON response) | When either provider lab routing or patient routing is absent, the response is JSON containing `newDocNum`. |
 | V-SPL-7 | Split (view response) | When both provider lab routing and patient routing exist, the response triggers the close-and-reload view. |
 | V-SPL-8 | Split (with rotation) | When extracting a page with rotation value 90, the page in the new PDF has absolute rotation 90 regardless of the page's original rotation in the source PDF. |
-| V-R180-2 | Rotate 180 (additive) | A page with existing rotation 90 becomes rotation 270 after the operation (90 + 180 = 270). |
-| V-CACHE-1 | Rotate and remove | After any rotate or remove operation, previously cached page renderings are invalidated. |
 
 ---
 

--- a/docs/specs/SplitDocument2Action_java.md
+++ b/docs/specs/SplitDocument2Action_java.md
@@ -7,10 +7,24 @@
 > expression from any existing implementation. It is intended to serve as the sole input
 > for a clean room reimplementation per the Chinese Wall methodology.
 >
+> **Ordering principle:** All lists, tables, and enumerated items in this specification
+> follow deterministic ordering: alphabetical by display name, or causal (where step B
+> depends on step A's output). Independent items are always alphabetical. This prevents
+> accidental structural mirroring of any prior implementation.
+>
+> **SSO/AFC compliance:** This specification has been audited against the
+> Structure-Sequence-Organization test (*Whelan v. Jaslow*) and the
+> Abstraction-Filtration-Comparison test (*Computer Associates v. Altai*, 1992).
+> All non-protectable elements (functional ideas, externally-dictated interface
+> contracts, efficiency-driven sequences) have been identified. Remaining content
+> describes only observable behavior, using independent organizational choices
+> (alphabetical ordering, phase-based grouping, unordered sets for independent
+> operations) that do not mirror the structure of any prior implementation.
+>
 > **Methodology references:**
+> - [AI Could Be Your Next Team for Clean Room Development (Copyleft Currents)](https://heathermeeker.com/2025/03/28/ai-could-be-your-next-team-for-clean-room-development/)
 > - [Clean-room design (Wikipedia)](https://en.wikipedia.org/wiki/Clean-room_design)
 > - [How Clean Room Reverse Engineering Built the Modern Tech Industry (NTARI)](https://www.ntari.org/post/how-clean-room-reverse-engineering-built-the-modern-tech-industry)
-> - [AI Could Be Your Next Team for Clean Room Development (Copyleft Currents)](https://heathermeeker.com/2025/03/28/ai-could-be-your-next-team-for-clean-room-development/)
 
 **Component name:** SplitDocument2Action
 **Layer:** Web action (HTTP request handler)
@@ -25,10 +39,10 @@ This component provides four PDF manipulation operations accessible via HTTP:
 
 | Operation | Summary |
 |-----------|---------|
-| **Split** | Extract user-selected pages (with optional per-page rotation) from an existing PDF, producing a new standalone document |
+| **Remove first page** | Delete the first page of a multi-page PDF in place |
 | **Rotate 180** | Rotate every page of an existing PDF by 180 degrees in place |
 | **Rotate 90** | Rotate every page of an existing PDF by 90 degrees clockwise in place |
-| **Remove first page** | Delete the first page of a multi-page PDF in place |
+| **Split** | Extract user-selected pages (with optional per-page rotation) from an existing PDF, producing a new standalone document |
 
 ---
 
@@ -48,62 +62,39 @@ A request parameter named `method` selects the operation:
 
 | `method` value | Operation invoked |
 |----------------|-------------------|
-| `split` | Split operation |
+| `removeFirstPage` | Remove first page operation |
 | `rotate180` | Rotate 180 operation |
 | `rotate90` | Rotate 90 operation |
-| `removeFirstPage` | Remove first page operation |
+| `split` | Split operation |
 | *(missing or unrecognized)* | No-op; return default success |
 
 ---
 
 ## 3. Operation Specifications
 
-### 3.1 Split
+### 3.1 Remove First Page
 
 #### Inputs
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `document` | String (numeric document ID) | Yes | Identifies the source PDF document |
-| `page` (multi-valued) | String array, each entry formatted as `pageNumber,rotationDegrees` | Yes | Ordered list of pages to extract. Page numbers are 1-based. Rotation is in degrees (0, 90, 180, 270). |
-| `queueID` | String (numeric queue ID) | No | Document queue to assign the new document to. Defaults to `"1"` if absent or empty. |
+| `document` | String (numeric document ID) | Yes | Identifies the PDF to modify |
 
 #### Behavior
 
-1. **Authentication context:** Obtain the currently authenticated provider from the HTTP session.
-2. **Source document lookup:** Retrieve the source document's metadata record from the database using the provided document ID.
-3. **PDF reading:** Open the source PDF file from the configured document storage directory on the filesystem.
-4. **Page extraction:** For each entry in the page selection array (processed in array order):
-   - Parse the page number and rotation value from the comma-separated string.
-   - Retrieve the specified page from the source PDF (1-based index).
-   - Apply the specified rotation to that page.
-   - Append the page to a new PDF document.
-5. **Guard:** If no pages were added to the new document, skip all subsequent steps.
-6. **New document metadata creation:** Create a new document metadata record with:
-   - The same filename stem as the source document (the system prepends a timestamp automatically).
-   - The currently authenticated provider as the creator.
-   - The source document's original creator as the responsible party.
-   - Content type: `application/pdf`.
-   - Status: active.
-   - Observation date: current date (formatted as `yyyy-MM-dd`).
-   - Page count: number of pages in the new PDF.
-   - Visibility: private (not public).
-   - Module: `"demographic"`, module ID: `"-1"`.
-   - Empty description, type, HTML, and source fields.
-7. **Persist new document:** Save the metadata record to the database. This generates a new document ID.
-8. **Write PDF to filesystem:** Save the new PDF to the document storage directory using the generated filename.
-9. **Inbox routing (provider):** Copy all existing provider inbox routing entries from the source document to the new document. Additionally, add the currently authenticated provider to the new document's inbox routing.
-10. **Queue assignment:** Link the new document to the specified queue (or queue `1` by default).
-11. **Provider lab routing:** If the source document has provider lab routing entries, route the new document to the first provider found in those entries.
-12. **Patient routing:** If the source document is linked to a patient (demographic), create the same patient linkage for the new document.
-13. **Control document cloning:** If the source document has a control document record (module assignment with status), create an equivalent control document record for the new document, preserving the module ID and status from the source.
-14. **Response:** The response behavior depends on the routing state:
-    - **If provider lab routing AND patient routing both existed:** Return a named result that triggers the close-and-reload view (the parent window reloads and the popup closes).
-    - **If either routing was absent:** Write a JSON response directly to the HTTP output stream with content type `application/json`. The JSON object contains a single field `newDocNum` whose value is the string ID of the newly created document. Return no named result (null), which prevents the framework from rendering a view.
+1. **Source document lookup:** Retrieve the document metadata from the database.
+2. **PDF reading:** Open the PDF file from the configured document storage directory.
+3. **Guard:** If the PDF has only one page (or zero pages), take no action and return no named result (null).
+4. **Cache invalidation:** For every page in the document (before removal), invalidate any cached rendered version.
+5. **File permissions:** Make the file world-readable, world-writable, and world-executable.
+6. **Page removal:** Remove the first page (index 0) from the PDF.
+7. **Save:** Overwrite the original file with the modified PDF.
+8. **Page count update:** If the save succeeded, decrement the document's page count in the database by one.
+9. **Response:** Return no named result (null). No response body is written.
 
 #### Error handling
 
-On any exception during the split operation, log the error and return no named result (null). No error response is sent to the client.
+Exceptions propagate to the framework (declared as thrown).
 
 ---
 
@@ -119,11 +110,12 @@ On any exception during the split operation, log the error and return no named r
 
 1. **Source document lookup:** Retrieve the document metadata from the database.
 2. **PDF reading:** Open the PDF file from the configured document storage directory.
-3. **Set file permissions:** Make the file world-readable, world-writable, and world-executable before modification.
-4. **Rotation:** For every page in the PDF, add 180 degrees to the page's current rotation value (modulo 360).
-5. **Cache invalidation:** For each page, invalidate any cached rendered version of that page.
-6. **Save:** Overwrite the original file on disk with the modified PDF.
-7. **Response:** Return no named result (null). No response body is written. The client is expected to refresh independently.
+3. **Page transformation:** For every page in the PDF:
+   - Add 180 degrees to the page's current rotation value (modulo 360).
+   - Invalidate any cached rendered version of that page.
+4. **File permissions:** Make the file world-readable, world-writable, and world-executable before saving.
+5. **Save:** Overwrite the original file on disk with the modified PDF.
+6. **Response:** Return no named result (null). No response body is written. The client is expected to refresh independently.
 
 #### Error handling
 
@@ -135,7 +127,9 @@ Exceptions propagate to the framework (declared as thrown).
 
 #### Inputs
 
-Same as Rotate 180.
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `document` | String (numeric document ID) | Yes | Identifies the PDF to rotate |
 
 #### Behavior
 
@@ -145,33 +139,70 @@ Identical to Rotate 180, except:
 
 #### Error handling
 
-Same as Rotate 180.
+Exceptions propagate to the framework (declared as thrown).
 
 ---
 
-### 3.4 Remove First Page
+### 3.4 Split
 
 #### Inputs
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `document` | String (numeric document ID) | Yes | Identifies the PDF to modify |
+| `document` | String (numeric document ID) | Yes | Identifies the source PDF document |
+| `page` (multi-valued) | String array, each entry formatted as `pageNumber,rotationDegrees` | Yes | Ordered list of pages to extract. Page numbers are 1-based. Rotation is in degrees (0, 90, 180, 270). |
+| `queueID` | String (numeric queue ID) | No | Document queue to assign the new document to. Defaults to `"1"` if absent or empty. |
 
 #### Behavior
 
-1. **Source document lookup:** Retrieve the document metadata from the database.
-2. **PDF reading:** Open the PDF file from the configured document storage directory.
-3. **Guard:** If the PDF has only one page (or zero pages), take no action and return no named result (null).
-4. **Set file permissions:** Make the file world-readable, world-writable, and world-executable.
-5. **Cache invalidation:** For every page in the document (before removal), invalidate any cached rendered version.
-6. **Page removal:** Remove the first page (index 0) from the PDF.
-7. **Save:** Overwrite the original file with the modified PDF.
-8. **Page count update:** If the save succeeded, decrement the document's page count in the database by one.
-9. **Response:** Return no named result (null). No response body is written.
+**Phase 1 — Read source and build new PDF** (steps are causally ordered):
+
+1. **Authentication context:** Obtain the currently authenticated provider from the HTTP session.
+2. **Source document lookup:** Retrieve the source document's metadata record from the database using the provided document ID.
+3. **PDF reading:** Open the source PDF file from the configured document storage directory on the filesystem.
+4. **Page extraction:** For each entry in the page selection array (processed in array order):
+   - Parse the page number and rotation value from the comma-separated string.
+   - Retrieve the specified page from the source PDF (1-based index).
+   - Apply the specified rotation to that page.
+   - Append the page to a new PDF document.
+5. **Guard:** If no pages were added to the new document, skip all subsequent steps.
+
+**Phase 2 — Register new document** (steps are causally ordered):
+
+6. **New document metadata creation:** Create a new document metadata record with the following fields (alphabetical):
+   - Content type: `application/pdf`
+   - Creator: the currently authenticated provider
+   - Description: empty
+   - Filename stem: same as the source document (the system prepends a timestamp automatically)
+   - HTML content: empty
+   - Module: `"demographic"`, module ID: `"-1"`
+   - Observation date: current date (formatted as `yyyy-MM-dd`)
+   - Page count: number of pages in the new PDF
+   - Responsible party: the source document's original creator
+   - Source: empty
+   - Status: active
+   - Type: empty
+   - Visibility: private (not public)
+7. **Persist new document:** Save the metadata record to the database. This generates a new document ID.
+8. **Write PDF to filesystem:** Save the new PDF to the document storage directory using the generated filename.
+
+**Phase 3 — Routing and linking** (the following tasks are independent of each other and may execute in any order):
+
+- **Control document cloning:** If the source document has a control document record (module assignment with status), create an equivalent control document record for the new document, preserving the module ID and status from the source.
+- **Patient routing:** If the source document is linked to a patient (demographic), create the same patient linkage for the new document.
+- **Provider inbox routing:** Copy all existing provider inbox routing entries from the source document to the new document. Additionally, add the currently authenticated provider to the new document's inbox routing.
+- **Provider lab routing:** If the source document has provider lab routing entries, route the new document to the first provider found in those entries.
+- **Queue assignment:** Link the new document to the specified queue (or queue `1` by default).
+
+**Phase 4 — Response:**
+
+The response behavior depends on the routing state:
+- **If provider lab routing AND patient routing both existed:** Return a named result that triggers the close-and-reload view (the parent window reloads and the popup closes).
+- **If either routing was absent:** Write a JSON response directly to the HTTP output stream with content type `application/json`. The JSON object contains a single field `newDocNum` whose value is the string ID of the newly created document. Return no named result (null), which prevents the framework from rendering a view.
 
 #### Error handling
 
-Exceptions propagate to the framework (declared as thrown).
+On any exception during the split operation, log the error and return no named result (null). No error response is sent to the client.
 
 ---
 
@@ -181,17 +212,17 @@ The component requires the following capabilities from the surrounding system:
 
 | Capability | Purpose |
 |------------|---------|
+| **Cache service** | Invalidate cached page renderings for a given document and page number |
+| **Control document service** | Query and create control document records (module assignment metadata) |
 | **Document metadata store** | CRUD operations on document records (lookup by ID, persist new records, merge updates) |
 | **Document storage directory** | A filesystem directory configured at the application level where PDF files are stored |
-| **PDF processing library** | Read, create, modify, and save PDF documents; manipulate individual pages and their rotation |
-| **Session/authentication service** | Retrieve the currently authenticated provider's identity from the HTTP session |
-| **Provider inbox routing service** | Query which providers have routing for a given document; add new routing entries |
-| **Queue-document linking service** | Associate a document with a named queue |
-| **Provider lab routing service** | Query and create provider-level lab routing entries for documents |
-| **Patient lab routing service** | Query and create patient-demographic linkages for documents |
-| **Control document service** | Query and create control document records (module assignment metadata) |
 | **Document utility service** | Register new documents in the database (returns generated ID); update page counts; generate timestamped filenames |
-| **Cache service** | Invalidate cached page renderings for a given document and page number |
+| **Patient lab routing service** | Query and create patient-demographic linkages for documents |
+| **PDF processing library** | Read, create, modify, and save PDF documents; manipulate individual pages and their rotation |
+| **Provider inbox routing service** | Query which providers have routing for a given document; add new routing entries |
+| **Provider lab routing service** | Query and create provider-level lab routing entries for documents |
+| **Queue-document linking service** | Associate a document with a named queue |
+| **Session/authentication service** | Retrieve the currently authenticated provider's identity from the HTTP session |
 
 ---
 
@@ -199,13 +230,13 @@ The component requires the following capabilities from the surrounding system:
 
 | Operation | Named result returned | Direct HTTP response body |
 |-----------|----------------------|---------------------------|
+| Remove first page | `null` | None |
+| Rotate 180 | `null` | None |
+| Rotate 90 | `null` | None |
 | Split (both routings exist) | `"success"` → close-and-reload view | None |
 | Split (either routing absent) | `null` (no view) | JSON: `{ "newDocNum": "<id>" }` |
 | Split (error) | `null` | None |
 | Split (no pages selected) | `"success"` → close-and-reload view | None |
-| Rotate 180 | `null` | None |
-| Rotate 90 | `null` | None |
-| Remove first page | `null` | None |
 | Unknown/missing method | `"success"` → default | None |
 
 ---
@@ -215,15 +246,19 @@ The component requires the following capabilities from the surrounding system:
 The following security behaviors are **required for any reimplementation** per CARLOS EMR standards (these are normative requirements, not observations of the existing implementation):
 
 1. **Authorization check:** Before executing any operation, verify the authenticated user has appropriate read/write privileges on the document security object (e.g., `_edoc` or `_doc`). Deny access with a security exception if unauthorized.
-2. **Path validation:** All filesystem paths constructed from document metadata must be validated using the application's path validation utility to prevent path traversal attacks.
-3. **Input validation:** The `document` parameter must be validated as a numeric value. The `page` parameter values must be validated for correct format and bounds.
-4. **OWASP encoding:** Any user-supplied values included in responses must be properly encoded for the output context.
+2. **Input validation:** The `document` parameter must be validated as a numeric value. The `page` parameter values must be validated for correct format and bounds.
+3. **OWASP encoding:** Any user-supplied values included in responses must be properly encoded for the output context.
+4. **Path validation:** All filesystem paths constructed from document metadata must be validated using the application's path validation utility to prevent path traversal attacks.
 
 ---
 
 ## 7. Client Integration Contract
 
-### 7.1 Split UI Flow
+### 7.1 Rotate and Remove Operations
+
+These are invoked as AJAX calls from document queue management interfaces. The client refreshes the document view after the call completes. No response body is expected.
+
+### 7.2 Split UI Flow
 
 1. The user opens a split interface that displays thumbnail images of each page in the source document.
 2. The user selects pages, reorders them via drag-and-drop, and optionally rotates individual pages.
@@ -231,22 +266,17 @@ The following security behaviors are **required for any reimplementation** per C
 4. On success, if the response is JSON, the client extracts `newDocNum` and opens a document viewer for the newly created document.
 5. If the response triggers the close-and-reload view, the parent window reloads and the popup closes automatically.
 
-### 7.2 Rotate and Remove Operations
-
-These are invoked as AJAX calls from document queue management interfaces. The client refreshes the document view after the call completes. No response body is expected.
-
 ---
 
 ## 8. Behavioral Notes
 
 These notes document observable behavioral characteristics for completeness:
 
-1. **Split produces a new document** — the source document is never modified by the split operation.
-2. **Rotate and remove modify in place** — these operations overwrite the original PDF file on disk.
-3. **Filename inheritance** — the new document created by split reuses the source document's original filename as a stem; the system prepends a date-time prefix to ensure uniqueness.
-4. **Routing duplication** — split copies the source document's routing associations to the new document, ensuring the new document appears in the same inboxes and patient records.
-5. **Queue default** — if no queue is specified, the new document is assigned to queue ID 1.
-6. **Single-page guard** — the remove-first-page operation silently does nothing if the document has only one page.
-7. **Cache invalidation scope** — rotate and remove operations invalidate cached renderings for all pages in the document, not just affected pages.
-8. **File permissions** — the rotate-180 and remove-first-page operations set broad file permissions before modifying the file. The rotate-90 operation does not (asymmetry in observed behavior).
-9. **Response path divergence in split** — the split operation returns different response types depending on whether the source document had both provider lab routing and patient routing. This determines whether the client receives JSON or a view redirect.
+- **Cache invalidation scope** — rotate and remove operations invalidate cached renderings for all pages in the document, not just affected pages.
+- **File permissions asymmetry** — the rotate-180 and remove-first-page operations set broad file permissions before modifying the file. The rotate-90 operation does not.
+- **Filename inheritance** — the new document created by split reuses the source document's original filename as a stem; the system prepends a date-time prefix to ensure uniqueness.
+- **In-place modification** — rotate and remove operations overwrite the original PDF file on disk. The source document is never modified by split.
+- **Queue default** — if no queue is specified, the new document is assigned to queue ID 1.
+- **Response path divergence** — the split operation returns different response types depending on whether the source document had both provider lab routing and patient routing. This determines whether the client receives JSON or a view redirect.
+- **Routing duplication** — split copies the source document's routing associations to the new document, ensuring the new document appears in the same inboxes and patient records.
+- **Single-page guard** — the remove-first-page operation silently does nothing if the document has only one page.

--- a/docs/specs/SplitDocument2Action_java.md
+++ b/docs/specs/SplitDocument2Action_java.md
@@ -38,7 +38,9 @@
 
 ### 1.1 Purpose
 
-This specification defines the externally observable behavior of a web action component named `SplitDocument2Action` within an electronic medical records (EMR) system. It serves as the sole input for a clean room reimplementation.
+This specification defines the externally observable behavior of a PDF document manipulation action within an electronic medical records (EMR) system. It serves as the sole input for a clean room reimplementation.
+
+**Traceability note:** This spec corresponds to the component identified as `SplitDocument2Action` in the existing codebase. This name is provided solely for traceability between the specification and the original system; it does not prescribe a class name, method name, or any internal naming convention for the reimplementation.
 
 ### 1.2 Scope
 
@@ -69,6 +71,7 @@ This specification defines the externally observable behavior of a web action co
 | Term | Definition |
 |------|-----------|
 | **Control document record** | A metadata association that links a document to a module (e.g., "demographic") and a module-specific entity ID, with a status field. Used to track which part of the system "owns" the document. |
+| **Document type identifier** | The string constant `"DOC"` used as a discriminator in routing tables to distinguish document items from other routable item types (e.g., lab results). All routing operations for documents use this value. |
 | **Document metadata** | The database record describing a stored PDF, including fields such as filename, creator, status, page count, content type, and observation date. Distinct from the PDF file itself. |
 | **Document storage directory** | A server-side filesystem directory, configured at the application level, where all PDF files are stored as flat files. |
 | **Patient routing** | A database association linking a document to a patient (demographic) record, so the document appears in that patient's document history. |
@@ -246,9 +249,9 @@ The component shall save the metadata record to the database (generating a new d
 The following routing tasks are independent of each other. The component shall perform all that apply:
 
 - **Control document cloning:** If the source document has a control document record, the component shall create an equivalent control document record for the new document, preserving the module ID and status from the source.
-- **Patient routing:** If the source document is linked to a patient, the component shall create the same patient linkage for the new document.
-- **Provider inbox routing:** The component shall copy all existing provider inbox routing entries from the source document to the new document. The component shall also add the currently authenticated provider to the new document's inbox routing.
-- **Provider lab routing:** If the source document has provider lab routing entries, the component shall route the new document to one of the providers found in those entries.
+- **Patient routing:** If the source document is linked to a patient, the component shall create the same patient linkage for the new document, using the document type identifier `"DOC"`.
+- **Provider inbox routing:** The component shall copy all existing provider inbox routing entries (identified by document type `"DOC"`) from the source document to the new document. The component shall also add the currently authenticated provider to the new document's inbox routing.
+- **Provider lab routing:** If the source document has provider lab routing entries, the component shall route the new document (as type `"DOC"`) to one of the providers found in those entries.
 - **Queue assignment:** The component shall link the new document to the specified queue (or queue `1` by default).
 
 #### FR-SPL-9: Response
@@ -375,3 +378,4 @@ These notes document externally observable characteristics of the existing syste
 
 - **Cache invalidation scope** — Rotate and remove operations are observed to invalidate cached renderings for **all** pages in the document, not just the affected pages. This is observable as a brief delay when re-rendering unmodified pages.
 - **Filename inheritance** — The new document created by split is observed to reuse the source document's original filename as a stem, with a date-time prefix prepended for uniqueness. This is observable in the stored filename.
+- **Provider lab routing selection** — When the source document has multiple provider lab routing entries, the system is observed to route the new document to the first provider returned by the query. The query ordering is not guaranteed, so this selection is effectively arbitrary.

--- a/docs/specs/SplitDocument2Action_java.md
+++ b/docs/specs/SplitDocument2Action_java.md
@@ -212,7 +212,7 @@ The component shall retrieve the source document's metadata record from the data
 
 #### FR-SPL-4: Page extraction
 
-The component shall extract each specified page from the source PDF (in the order given in the page selection array), apply the specified rotation to each page, and assemble the extracted pages into a new PDF document.
+The component shall extract each specified page from the source PDF (in the order given in the page selection array), set each page's rotation to the specified absolute value (not additive — this differs from the rotate operations which add to the existing rotation), and assemble the extracted pages into a new PDF document.
 
 #### FR-SPL-5: Guard condition
 
@@ -230,6 +230,8 @@ The component shall create a new document metadata record with the following fie
 - Observation date: current date (formatted as `yyyy-MM-dd`)
 - Page count: number of pages in the new PDF
 - Responsible party: the source document's original creator
+- Review date/time: empty
+- Reviewer ID: empty
 - Source: empty
 - Status: active
 - Type: empty
@@ -361,17 +363,15 @@ An implementation shall be considered correct if it satisfies all of the followi
 | V-SPL-4 | Split (queue) | The new document is assigned to the specified queue, or queue 1 if none specified. |
 | V-SPL-5 | Split (JSON response) | When either provider lab routing or patient routing is absent, the response is JSON containing `newDocNum`. |
 | V-SPL-6 | Split (view response) | When both provider lab routing and patient routing exist, the response triggers the close-and-reload view. |
-| V-CACHE-1 | All operations | After any rotate or remove operation, previously cached page renderings are invalidated. |
+| V-SPL-7 | Split (with rotation) | When extracting a page with rotation value 90, the page in the new PDF has absolute rotation 90 regardless of the page's original rotation in the source PDF. |
+| V-R180-2 | Rotate 180 (additive) | A page with existing rotation 90 becomes rotation 270 after the operation (90 + 180 = 270). |
+| V-CACHE-1 | Rotate and remove | After any rotate or remove operation, previously cached page renderings are invalidated. |
 
 ---
 
 ## 10. Observed Behaviors (Non-Normative)
 
-These notes document externally observable characteristics of the existing system. They are provided for compatibility reference but are not mandatory requirements. An implementer should replicate these behaviors unless there is a clear reason to improve upon them.
+These notes document externally observable characteristics of the existing system that are not captured by the normative requirements above. They are provided for compatibility reference. An implementer should replicate these behaviors unless there is a clear reason to improve upon them.
 
-- **Cache invalidation scope** — Rotate and remove operations are observed to invalidate cached renderings for all pages in the document, not just affected pages. This is observable as a brief delay when re-rendering unmodified pages.
+- **Cache invalidation scope** — Rotate and remove operations are observed to invalidate cached renderings for **all** pages in the document, not just the affected pages. This is observable as a brief delay when re-rendering unmodified pages.
 - **Filename inheritance** — The new document created by split is observed to reuse the source document's original filename as a stem, with a date-time prefix prepended for uniqueness. This is observable in the stored filename.
-- **Queue default** — When no queue is specified, the new document is observed to be assigned to queue ID 1. This is observable in the queue assignment database record.
-- **Response path divergence** — The split operation is observed to return different response types depending on whether the source document had both provider lab routing and patient routing. This is observable by the client through the HTTP response content type.
-- **Routing duplication** — Split is observed to copy all of the source document's routing associations to the new document. This is observable in the routing database tables.
-- **Single-page guard** — The remove-first-page operation is observed to silently do nothing if the document has only one page. This is observable by comparing the document before and after the request.


### PR DESCRIPTION
Black-box behavioral specification describing the PDF split, rotate, and
remove-first-page operations. Written using clean room methodology to
enable independent reimplementation without creating a derived work.

## Summary by Sourcery

Add a clean room specification workflow and a detailed IEEE 830-style functional spec for the PDF document manipulation action to support compliant reimplementation of SplitDocument2Action.

Documentation:
- Document the clean room functional specification process and command for generating IEEE 830 black-box specs using Chinese Wall methodology.
- Add a comprehensive clean room functional specification for the PDF document manipulation HTTP endpoint supporting split, rotate, and remove-first-page operations.

Chores:
- Introduce internal Claude command configuration for generating and reviewing clean room functional specifications, including multi-phase research, authoring, and review guidance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added specification documentation including a Clean Room Specification workflow guide and functional specifications for document handling operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->