### PR TITLE
feat: add HttpMethodGuardFilter to block GET requests on mutator endpoints

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/app/HttpMethodGuardFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/app/HttpMethodGuardFilter.java
@@ -105,7 +105,9 @@ public class HttpMethodGuardFilter implements Filter {
             "setupaddmeasurementgroup",      // EctSetupAddMeasurementGroup2Action
             "setupaddmeasurementtype",       // EctSetupAddMeasurementType2Action
             "setupaddmeasuringinstruction",  // EctSetupAddMeasuringInstruction2Action
-            "rbtaddtogroup"           // RBTAddToGroup2Action (starts with "rbt", not "add")
+            "rbtaddtogroup",          // RBTAddToGroup2Action (starts with "rbt", not "add")
+            "reportreassign",         // ReportReassign2Action (reassigns lab reports to other providers)
+            "forward"                 // ReportReassign2Action (lab/MDS forwarding — same mutator class, 4 URLs)
     );
 
     /**
@@ -212,7 +214,11 @@ public class HttpMethodGuardFilter implements Filter {
             "providerrole.jsp",
             "providertemplate.jsp",
             "providersavedemographicaccessory.jsp",
-            "formsaveandexit.jsp"
+            "formsaveandexit.jsp",
+            // Waiting list mutators
+            "add2waitinglist.jsp",
+            // Provider availability (mutator when method=save)
+            "setprovideravailability.jsp"
     );
 
     private Set<String> allowList = Collections.emptySet();
@@ -354,6 +360,11 @@ public class HttpMethodGuardFilter implements Filter {
             if ("preventionmanager.jsp".equals(jspNameLower) || "preventionlistmanager.jsp".equals(jspNameLower)) {
                 String formAction = request.getParameter("formAction");
                 return formAction != null && ("update".equalsIgnoreCase(formAction) || "custom".equalsIgnoreCase(formAction));
+            }
+            // Special case: setProviderAvailability.jsp is only a mutator when method=save
+            if ("setprovideravailability.jsp".equals(jspNameLower)) {
+                String methodParam = request.getParameter("method");
+                return "save".equalsIgnoreCase(methodParam);
             }
             return true;
         }

--- a/src/main/java/io/github/carlos_emr/carlos/app/HttpMethodGuardFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/app/HttpMethodGuardFilter.java
@@ -217,6 +217,24 @@ public class HttpMethodGuardFilter implements Filter {
             "formsaveandexit.jsp",
             // Waiting list mutators
             "add2waitinglist.jsp",
+            "removefromwaitinglist.jsp",
+            // Pharmacy mutators
+            "managepharmacy.jsp",
+            // Tickler mutators (JSP-based)
+            "dbtickleradd.jsp",
+            // Demographic set mutators
+            "adddemotopatientset.jsp",
+            // Provider preference mutators
+            "providerpreferencequicklinksaction.jsp",
+            // Billing form management mutators
+            "dbmanagebillingform_add.jsp",
+            "billingsettings.jsp",
+            // Teleplan mutators
+            "genteplangroupreport.jsp",
+            // Document mutators
+            "uploadmultidocument.jsp",
+            // Antenatal mutators
+            "antenatalplanner.jsp",
             // Provider availability (mutator when method=save)
             "setprovideravailability.jsp"
     );

--- a/src/main/java/io/github/carlos_emr/carlos/app/HttpMethodGuardFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/app/HttpMethodGuardFilter.java
@@ -53,8 +53,8 @@ import java.util.stream.Collectors;
  *       mutator prefixes (Add, Delete, Save, Submit, Create, etc.). The {@code method} request
  *       parameter is also checked for mutator values (save, delete, update, etc.) to catch
  *       mixed-method actions that route via parameter.</li>
- *   <li><strong>.jsp pages</strong>: The JSP filename is checked against known mutator JSP
- *       patterns (names containing save, delete, add, submit, create, merge, control, etc.).</li>
+ *   <li><strong>.jsp pages</strong>: The JSP filename is checked against an explicit set of
+ *       known mutator JSPs identified by auditing form POST targets in the codebase.</li>
  * </ul>
  *
  * <h3>Configuration</h3>
@@ -74,12 +74,38 @@ public class HttpMethodGuardFilter implements Filter {
      * "Edit" and "Update" are intentionally excluded — they commonly load forms via GET,
      * and their actual save operations go through separate Save/Add actions or use
      * {@code ?method=save} (which IS caught by {@link #MUTATOR_METHOD_PARAMS}).
+     *
+     * <p>Includes abbreviated forms: "del" (for delGroup, DelService) and
+     * "rem" (for remFromGroup) which are used in some struts action names.</p>
      */
     private static final Set<String> MUTATOR_ACTION_PREFIXES = Set.of(
-            "add", "delete", "remove", "save", "submit", "create",
+            "add", "delete", "del",
+            "remove", "rem",
+            "save", "submit", "create",
             "assign", "complete", "process", "archive",
             "merge", "transfer", "approve", "reject", "toggle",
             "cancel", "close", "resubmit"
+    );
+
+    /**
+     * Specific action names (lowercased) that are known mutators but whose URL names
+     * do not match any prefix in {@link #MUTATOR_ACTION_PREFIXES}. These are struts
+     * action mappings where the URL name differs significantly from the class name.
+     *
+     * <p>Identified by auditing struts.xml for class names like Save*, Delete*, Add*
+     * mapped to non-matching URL action names.</p>
+     */
+    private static final Set<String> MUTATOR_ACTION_NAMES = Set.of(
+            "oncallclinic",           // SaveOnCallClinic2Action
+            "billingaddcode",         // BillingAddCode2Action (starts with "billing", not "add")
+            "reprocessbill",          // BillingReProcessBill2Action
+            "movemohfiles",           // ArchiveMOHFile2Action
+            "newmeasurementmap",      // EctAddMeasurementMap2Action
+            "remapmeasurementmap",    // EctRemoveMeasurementMap2Action
+            "setupaddmeasurementgroup",      // EctSetupAddMeasurementGroup2Action
+            "setupaddmeasurementtype",       // EctSetupAddMeasurementType2Action
+            "setupaddmeasuringinstruction",  // EctSetupAddMeasuringInstruction2Action
+            "rbtaddtogroup"           // RBTAddToGroup2Action (starts with "rbt", not "add")
     );
 
     /**
@@ -95,17 +121,14 @@ public class HttpMethodGuardFilter implements Filter {
     );
 
     /**
-     * Keywords in JSP filenames that indicate mutator JSPs (case-insensitive).
-     * These are JSPs that receive form POST submissions and perform state changes.
-     */
-    private static final Set<String> MUTATOR_JSP_KEYWORDS = Set.of(
-            "save", "delete", "submit", "create", "merge"
-    );
-
-    /**
      * Specific JSP filenames (without path, lowercased) known to be mutators.
-     * These are JSPs whose names don't match the keyword patterns above but are
-     * confirmed POST-only targets from the codebase analysis.
+     * These are confirmed POST-only form targets identified by auditing all
+     * {@code <form method="post" action="*.jsp">} patterns in the codebase.
+     *
+     * <p>Keyword-based detection (e.g., "contains 'save'") was intentionally avoided
+     * because past-tense confirmation pages like {@code batchsaved.jsp},
+     * {@code billingcreated.jsp}, and {@code efmformmanagerdeleted.jsp} are read-only
+     * pages that would be falsely blocked.</p>
      */
     private static final Set<String> MUTATOR_JSP_NAMES = Set.of(
             // Admin mutators
@@ -123,9 +146,11 @@ public class HttpMethodGuardFilter implements Filter {
             "lotnrdeleterecord.jsp",
             "manageflowsheetsupload.jsp",
             "dbmanageprovider.jsp",
+            "adminsavemygroup.jsp",
             // Appointment mutators
             "addappointment.jsp",
             "appointmentcontrol.jsp",
+            "appointmentdeletearecord.jsp",
             // Demographic mutators
             "demographicaddarecord.jsp",
             "demographicmergerecord.jsp",
@@ -140,33 +165,54 @@ public class HttpMethodGuardFilter implements Filter {
             "onaddedit3rdaddr.jsp",
             "settlebg.jsp",
             "gensimulation.jsp",
+            "billingdeletenoappt.jsp",
+            "billingdeletewithbillno.jsp",
+            "billingdeletewithoutno.jsp",
+            "deleteprivatecode.jsp",
+            "deleteservices.jsp",
+            "ongenreport.jsp",
+            "billingondisplay.jsp",
+            "billingoneditprivatecode.jsp",
             // Schedule mutators
             "scheduledatesave.jsp",
             "scheduledatefinal.jsp",
             "scheduleholidaysetting.jsp",
             "scheduletemplatecodesetting.jsp",
+            "schedulecreatedate.jsp",
             // Prevention mutators
             "preventionmanager.jsp",
             "preventionlistmanager.jsp",
             // Messenger mutators
             "postitems.jsp",
             "adjustattachments.jsp",
+            "createmessage.jsp",
             // Encounter mutators
             "measurementgroupdscomplete.jsp",
             // Tickler mutators
             "dbticklerdemomain.jsp",
             "dbticklermain.jsp",
+            // Lab mutators
+            "createlab.jsp",
+            "createlabtest.jsp",
+            // Decision support mutators
+            "checklistedit.jsp",
+            "riskedit.jsp",
+            // Report mutators
+            "reportformconfig.jsp",
+            "reportformdemoconfig.jsp",
+            "reportformorder.jsp",
+            "reportformrecord.jsp",
             // Other mutators
             "annotation.jsp",
             "groupnoteselectaction.jsp",
             "preference_action.jsp",
             "patientlettermanager.jsp",
-            "checklistedit.jsp",
-            "riskedit.jsp",
             "providercontrol.jsp",
             "providerprivilege.jsp",
             "providerrole.jsp",
-            "providertemplate.jsp"
+            "providertemplate.jsp",
+            "providersavedemographicaccessory.jsp",
+            "formsaveandexit.jsp"
     );
 
     private Set<String> allowList = Collections.emptySet();
@@ -206,8 +252,11 @@ public class HttpMethodGuardFilter implements Filter {
         HttpServletRequest httpRequest = (HttpServletRequest) request;
         HttpServletResponse httpResponse = (HttpServletResponse) response;
 
-        // Only inspect GET requests — all other methods pass through
-        if (!"GET".equalsIgnoreCase(httpRequest.getMethod())) {
+        // Only inspect GET and HEAD requests — all other methods pass through.
+        // HEAD is semantically identical to GET (RFC 7231 §4.3.2) and must be blocked
+        // on mutator endpoints for the same reason as GET.
+        String method = httpRequest.getMethod();
+        if (!"GET".equalsIgnoreCase(method) && !"HEAD".equalsIgnoreCase(method)) {
             chain.doFilter(request, response);
             return;
         }
@@ -255,6 +304,11 @@ public class HttpMethodGuardFilter implements Filter {
             return false;
         }
 
+        // Check action name against explicit mutator action names
+        if (MUTATOR_ACTION_NAMES.contains(actionNameLower)) {
+            return true;
+        }
+
         // Check action name against mutator prefixes
         for (String prefix : MUTATOR_ACTION_PREFIXES) {
             if (actionNameLower.startsWith(prefix)) {
@@ -293,7 +347,8 @@ public class HttpMethodGuardFilter implements Filter {
             return false;
         }
 
-        // Check against known mutator JSP names
+        // Check against known mutator JSP names (explicit set only — no keyword matching
+        // to avoid false positives on confirmation pages like batchsaved.jsp, billingcreated.jsp)
         if (MUTATOR_JSP_NAMES.contains(jspNameLower)) {
             // Special case: PreventionManager.jsp is only a mutator when formAction=update|custom
             if ("preventionmanager.jsp".equals(jspNameLower) || "preventionlistmanager.jsp".equals(jspNameLower)) {
@@ -301,13 +356,6 @@ public class HttpMethodGuardFilter implements Filter {
                 return formAction != null && ("update".equalsIgnoreCase(formAction) || "custom".equalsIgnoreCase(formAction));
             }
             return true;
-        }
-
-        // Check JSP name against mutator keywords
-        for (String keyword : MUTATOR_JSP_KEYWORDS) {
-            if (jspNameLower.contains(keyword)) {
-                return true;
-            }
         }
 
         return false;
@@ -355,7 +403,8 @@ public class HttpMethodGuardFilter implements Filter {
         String methodParam = request.getParameter("method");
         String detail = methodParam != null ? path + "?method=" + methodParam : path;
 
-        LOGGER.warn("Blocked GET request on mutator endpoint: {} (remote: {}, session: {})",
+        LOGGER.warn("Blocked {} request on mutator endpoint: {} (remote: {}, session: {})",
+                request.getMethod(),
                 detail,
                 request.getRemoteAddr(),
                 request.getRequestedSessionId() != null ? "present" : "none");

--- a/src/main/java/io/github/carlos_emr/carlos/app/HttpMethodGuardFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/app/HttpMethodGuardFilter.java
@@ -1,0 +1,372 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.app;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Blocks HTTP GET requests on mutator endpoints (actions and JSPs that perform state changes).
+ *
+ * <p>This filter enforces the principle that state-changing operations must use POST (or other
+ * non-GET methods). Combined with CSRFGuard 4.5 (which validates tokens on POST/PUT/DELETE/PATCH),
+ * this prevents attackers from triggering mutations via crafted GET URLs that bypass CSRF
+ * protection.</p>
+ *
+ * <h3>Detection Strategy</h3>
+ * <ul>
+ *   <li><strong>.do actions</strong>: Action name is extracted from the URL and checked against
+ *       mutator prefixes (Add, Delete, Save, Submit, Create, etc.). The {@code method} request
+ *       parameter is also checked for mutator values (save, delete, update, etc.) to catch
+ *       mixed-method actions that route via parameter.</li>
+ *   <li><strong>.jsp pages</strong>: The JSP filename is checked against known mutator JSP
+ *       patterns (names containing save, delete, add, submit, create, merge, control, etc.).</li>
+ * </ul>
+ *
+ * <h3>Configuration</h3>
+ * <p>Supports an {@code allowList} init-param (comma-separated) for action names or JSP paths
+ * that have mutator-sounding names but legitimately need GET access.</p>
+ *
+ * <p>Must be mapped <strong>after CSRFGuard but before Struts</strong> in the filter chain.</p>
+ *
+ * @since 2026-03-13
+ */
+public class HttpMethodGuardFilter implements Filter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(HttpMethodGuardFilter.class);
+
+    /**
+     * Action name prefixes that indicate mutator operations (case-insensitive).
+     * "Edit" and "Update" are intentionally excluded — they commonly load forms via GET,
+     * and their actual save operations go through separate Save/Add actions or use
+     * {@code ?method=save} (which IS caught by {@link #MUTATOR_METHOD_PARAMS}).
+     */
+    private static final Set<String> MUTATOR_ACTION_PREFIXES = Set.of(
+            "add", "delete", "remove", "save", "submit", "create",
+            "assign", "complete", "process", "archive",
+            "merge", "transfer", "approve", "reject", "toggle",
+            "cancel", "close", "resubmit"
+    );
+
+    /**
+     * Values of the {@code method} request parameter that indicate mutator operations.
+     * This catches mixed-method actions (e.g., SystemMessage2Action) where
+     * {@code ?method=save} routes to a save method within a read/write action.
+     */
+    private static final Set<String> MUTATOR_METHOD_PARAMS = Set.of(
+            "save", "delete", "update", "add", "create", "remove",
+            "submit", "merge", "archive", "assign", "transfer",
+            "approve", "reject", "toggle", "complete", "process",
+            "cancel", "close"
+    );
+
+    /**
+     * Keywords in JSP filenames that indicate mutator JSPs (case-insensitive).
+     * These are JSPs that receive form POST submissions and perform state changes.
+     */
+    private static final Set<String> MUTATOR_JSP_KEYWORDS = Set.of(
+            "save", "delete", "submit", "create", "merge"
+    );
+
+    /**
+     * Specific JSP filenames (without path, lowercased) known to be mutators.
+     * These are JSPs whose names don't match the keyword patterns above but are
+     * confirmed POST-only targets from the codebase analysis.
+     */
+    private static final Set<String> MUTATOR_JSP_NAMES = Set.of(
+            // Admin mutators
+            "securityaddsecurity.jsp",
+            "securitydelete.jsp",
+            "securityupdate.jsp",
+            "provideraddarecord.jsp",
+            "providerupdate.jsp",
+            "providerupdatepreference.jsp",
+            "provideraddrole.jsp",
+            "resourcebaseurl.jsp",
+            "unlock.jsp",
+            "fixrolesonnotes.jsp",
+            "lotnraddrecord.jsp",
+            "lotnrdeleterecord.jsp",
+            "manageflowsheetsupload.jsp",
+            "dbmanageprovider.jsp",
+            // Appointment mutators
+            "addappointment.jsp",
+            "appointmentcontrol.jsp",
+            // Demographic mutators
+            "demographicaddarecord.jsp",
+            "demographicmergerecord.jsp",
+            // Billing mutators
+            "billingonsave.jsp",
+            "billingcorrection.jsp",
+            "billingcorrectionsubmit.jsp",
+            "billingshortcutpg2.jsp",
+            "billingreportcontrol.jsp",
+            "billingonfavourite.jsp",
+            "addeditservicecode.jsp",
+            "onaddedit3rdaddr.jsp",
+            "settlebg.jsp",
+            "gensimulation.jsp",
+            // Schedule mutators
+            "scheduledatesave.jsp",
+            "scheduledatefinal.jsp",
+            "scheduleholidaysetting.jsp",
+            "scheduletemplatecodesetting.jsp",
+            // Prevention mutators
+            "preventionmanager.jsp",
+            "preventionlistmanager.jsp",
+            // Messenger mutators
+            "postitems.jsp",
+            "adjustattachments.jsp",
+            // Encounter mutators
+            "measurementgroupdscomplete.jsp",
+            // Tickler mutators
+            "dbticklerdemomain.jsp",
+            "dbticklermain.jsp",
+            // Other mutators
+            "annotation.jsp",
+            "groupnoteselectaction.jsp",
+            "preference_action.jsp",
+            "patientlettermanager.jsp",
+            "checklistedit.jsp",
+            "riskedit.jsp",
+            "providercontrol.jsp",
+            "providerprivilege.jsp",
+            "providerrole.jsp",
+            "providertemplate.jsp"
+    );
+
+    private Set<String> allowList = Collections.emptySet();
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        String allowListParam = filterConfig.getInitParameter("allowList");
+        if (allowListParam != null && !allowListParam.isBlank()) {
+            allowList = Arrays.stream(allowListParam.split(","))
+                    .map(String::trim)
+                    .filter(s -> !s.isEmpty())
+                    .map(s -> s.toLowerCase(Locale.ROOT))
+                    .collect(Collectors.toUnmodifiableSet());
+            LOGGER.info("HttpMethodGuardFilter initialized with allow-list: {}", allowList);
+        } else {
+            LOGGER.info("HttpMethodGuardFilter initialized (no allow-list configured)");
+        }
+    }
+
+    /**
+     * Checks GET requests against mutator detection rules and blocks with 405 if matched.
+     *
+     * @param request  the servlet request
+     * @param response the servlet response
+     * @param chain    the filter chain
+     * @throws IOException      if an I/O error occurs
+     * @throws ServletException if a servlet error occurs
+     */
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        if (!(request instanceof HttpServletRequest) || !(response instanceof HttpServletResponse)) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+        HttpServletResponse httpResponse = (HttpServletResponse) response;
+
+        // Only inspect GET requests — all other methods pass through
+        if (!"GET".equalsIgnoreCase(httpRequest.getMethod())) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        String uri = httpRequest.getRequestURI();
+        String contextPath = httpRequest.getContextPath();
+        // Strip context path for pattern matching
+        String path = uri.startsWith(contextPath) ? uri.substring(contextPath.length()) : uri;
+
+        if (path.endsWith(".do")) {
+            if (isMutatorAction(path, httpRequest)) {
+                blockRequest(httpRequest, httpResponse, path);
+                return;
+            }
+        } else if (path.endsWith(".jsp")) {
+            if (isMutatorJsp(path, httpRequest)) {
+                blockRequest(httpRequest, httpResponse, path);
+                return;
+            }
+        }
+
+        chain.doFilter(request, response);
+    }
+
+    /**
+     * Determines if a {@code .do} action URL targets a mutator action.
+     *
+     * <p>Checks the action name against mutator prefixes and the {@code method}
+     * request parameter against mutator method values.</p>
+     *
+     * @param path    the request path (without context path), e.g. {@code /tickler/addTickler.do}
+     * @param request the HTTP request (for parameter access)
+     * @return {@code true} if this is a mutator action on GET
+     */
+    private boolean isMutatorAction(String path, HttpServletRequest request) {
+        String actionName = extractActionName(path);
+        if (actionName == null || actionName.isEmpty()) {
+            return false;
+        }
+
+        String actionNameLower = actionName.toLowerCase(Locale.ROOT);
+
+        // Check allow-list first
+        if (allowList.contains(actionNameLower)) {
+            return false;
+        }
+
+        // Check action name against mutator prefixes
+        for (String prefix : MUTATOR_ACTION_PREFIXES) {
+            if (actionNameLower.startsWith(prefix)) {
+                return true;
+            }
+        }
+
+        // Check the 'method' request parameter for mixed-method actions
+        String methodParam = request.getParameter("method");
+        if (methodParam != null && !methodParam.isEmpty()) {
+            return MUTATOR_METHOD_PARAMS.contains(methodParam.toLowerCase(Locale.ROOT));
+        }
+
+        return false;
+    }
+
+    /**
+     * Determines if a {@code .jsp} URL targets a mutator JSP.
+     *
+     * <p>Checks the JSP filename against known mutator JSP names and keyword patterns.</p>
+     *
+     * @param path    the request path (without context path)
+     * @param request the HTTP request (for parameter access)
+     * @return {@code true} if this is a mutator JSP on GET
+     */
+    private boolean isMutatorJsp(String path, HttpServletRequest request) {
+        String jspName = extractFilename(path);
+        if (jspName == null || jspName.isEmpty()) {
+            return false;
+        }
+
+        String jspNameLower = jspName.toLowerCase(Locale.ROOT);
+
+        // Check allow-list first
+        if (allowList.contains(jspNameLower)) {
+            return false;
+        }
+
+        // Check against known mutator JSP names
+        if (MUTATOR_JSP_NAMES.contains(jspNameLower)) {
+            // Special case: PreventionManager.jsp is only a mutator when formAction=update|custom
+            if ("preventionmanager.jsp".equals(jspNameLower) || "preventionlistmanager.jsp".equals(jspNameLower)) {
+                String formAction = request.getParameter("formAction");
+                return formAction != null && ("update".equalsIgnoreCase(formAction) || "custom".equalsIgnoreCase(formAction));
+            }
+            return true;
+        }
+
+        // Check JSP name against mutator keywords
+        for (String keyword : MUTATOR_JSP_KEYWORDS) {
+            if (jspNameLower.contains(keyword)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Extracts the simple action name from a {@code .do} URL path.
+     *
+     * <p>For example, {@code /tickler/addTickler.do} returns {@code addTickler},
+     * and {@code /web/dashboard/display/AssignTickler.do} returns {@code AssignTickler}.</p>
+     *
+     * @param path the request path
+     * @return the action name, or {@code null} if not extractable
+     */
+    static String extractActionName(String path) {
+        if (path == null || !path.endsWith(".do")) {
+            return null;
+        }
+        // Remove .do suffix
+        String withoutSuffix = path.substring(0, path.length() - 3);
+        // Get the last path segment (the action name)
+        int lastSlash = withoutSuffix.lastIndexOf('/');
+        return lastSlash >= 0 ? withoutSuffix.substring(lastSlash + 1) : withoutSuffix;
+    }
+
+    /**
+     * Extracts the filename from a URL path.
+     *
+     * @param path the request path
+     * @return the filename, or {@code null} if not extractable
+     */
+    static String extractFilename(String path) {
+        if (path == null) {
+            return null;
+        }
+        int lastSlash = path.lastIndexOf('/');
+        return lastSlash >= 0 ? path.substring(lastSlash + 1) : path;
+    }
+
+    /**
+     * Sends a 405 Method Not Allowed response and logs the blocked request.
+     */
+    private void blockRequest(HttpServletRequest request, HttpServletResponse response, String path)
+            throws IOException {
+        String methodParam = request.getParameter("method");
+        String detail = methodParam != null ? path + "?method=" + methodParam : path;
+
+        LOGGER.warn("Blocked GET request on mutator endpoint: {} (remote: {}, session: {})",
+                detail,
+                request.getRemoteAddr(),
+                request.getRequestedSessionId() != null ? "present" : "none");
+
+        response.setHeader("Allow", "POST");
+        response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED,
+                "GET requests are not allowed on this endpoint. Use POST.");
+    }
+
+    @Override
+    public void destroy() {
+        // No cleanup required
+    }
+}

--- a/src/main/java/io/github/carlos_emr/carlos/app/HttpMethodGuardFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/app/HttpMethodGuardFilter.java
@@ -328,7 +328,7 @@ public class HttpMethodGuardFilter implements Filter {
     /**
      * Determines if a {@code .jsp} URL targets a mutator JSP.
      *
-     * <p>Checks the JSP filename against known mutator JSP names and keyword patterns.</p>
+     * <p>Checks the JSP filename against an explicit set of known mutator JSP names.</p>
      *
      * @param path    the request path (without context path)
      * @param request the HTTP request (for parameter access)

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -76,6 +76,23 @@
         <url-pattern>*.do</url-pattern>
     </filter-mapping>
 
+    <!-- HttpMethodGuardFilter: blocks GET requests on mutator actions and JSPs.
+         Must be ordered after CSRFGuard (which validates POST tokens) and before Struts
+         (which does not call chain.doFilter for handled requests). This ensures mutator
+         GET requests are rejected before Struts processes them. -->
+    <filter>
+        <filter-name>HttpMethodGuardFilter</filter-name>
+        <filter-class>io.github.carlos_emr.carlos.app.HttpMethodGuardFilter</filter-class>
+    </filter>
+    <filter-mapping>
+        <filter-name>HttpMethodGuardFilter</filter-name>
+        <url-pattern>*.do</url-pattern>
+    </filter-mapping>
+    <filter-mapping>
+        <filter-name>HttpMethodGuardFilter</filter-name>
+        <url-pattern>*.jsp</url-pattern>
+    </filter-mapping>
+
 	<filter>
 		<filter-name>struts2</filter-name>
 		<filter-class>org.apache.struts2.dispatcher.filter.StrutsPrepareAndExecuteFilter</filter-class>

--- a/src/test-modern/java/io/github/carlos_emr/carlos/app/HttpMethodGuardFilterUnitTest.java
+++ b/src/test-modern/java/io/github/carlos_emr/carlos/app/HttpMethodGuardFilterUnitTest.java
@@ -207,9 +207,6 @@ class HttpMethodGuardFilterUnitTest {
         @DisplayName("should block GET to Save* action")
         void shouldBlock_forGetToSaveAction() throws Exception {
             when(request.getMethod()).thenReturn("GET");
-            when(request.getRequestURI()).thenReturn("/carlos/admin/oncallClinic.do");
-            // SaveOnCallClinic2Action mapped as admin/oncallClinic - name doesn't match prefix
-            // But let's test a direct save-named action
             when(request.getRequestURI()).thenReturn("/carlos/SaveAssoc.do");
             when(request.getParameter("method")).thenReturn(null);
 
@@ -421,8 +418,8 @@ class HttpMethodGuardFilterUnitTest {
         }
 
         @Test
-        @DisplayName("should block GET to JSP matching keyword 'delete'")
-        void shouldBlock_forGetToJspWithDeleteKeyword() throws Exception {
+        @DisplayName("should block GET to lotnrdeleterecord.jsp (explicit mutator JSP)")
+        void shouldBlock_forGetToLotnrDeleteRecordJsp() throws Exception {
             when(request.getMethod()).thenReturn("GET");
             when(request.getRequestURI()).thenReturn("/carlos/admin/lotnrdeleterecord.jsp");
 
@@ -430,6 +427,166 @@ class HttpMethodGuardFilterUnitTest {
 
             verify(response).sendError(anyInt(), anyString());
             verify(chain, never()).doFilter(request, response);
+        }
+    }
+
+    @Nested
+    @DisplayName("GET requests to actions with mismatched URL/class names")
+    class MismatchedActionNames {
+
+        @Test
+        @DisplayName("should block GET to oncallClinic (SaveOnCallClinic2Action)")
+        void shouldBlock_forGetToOncallClinic() throws Exception {
+            when(request.getMethod()).thenReturn("GET");
+            when(request.getRequestURI()).thenReturn("/carlos/admin/oncallClinic.do");
+            when(request.getParameter("method")).thenReturn(null);
+
+            filter.doFilter(request, response, chain);
+
+            verify(response).sendError(anyInt(), anyString());
+            verify(chain, never()).doFilter(request, response);
+        }
+
+        @Test
+        @DisplayName("should block GET to billingAddCode (BillingAddCode2Action)")
+        void shouldBlock_forGetToBillingAddCode() throws Exception {
+            when(request.getMethod()).thenReturn("GET");
+            when(request.getRequestURI()).thenReturn("/carlos/billing/CA/BC/billingAddCode.do");
+            when(request.getParameter("method")).thenReturn(null);
+
+            filter.doFilter(request, response, chain);
+
+            verify(response).sendError(anyInt(), anyString());
+            verify(chain, never()).doFilter(request, response);
+        }
+
+        @Test
+        @DisplayName("should block GET to rbtAddToGroup (RBTAddToGroup2Action)")
+        void shouldBlock_forGetToRbtAddToGroup() throws Exception {
+            when(request.getMethod()).thenReturn("GET");
+            when(request.getRequestURI()).thenReturn("/carlos/oscarReport/reportByTemplate/actions/rbtAddToGroup.do");
+            when(request.getParameter("method")).thenReturn(null);
+
+            filter.doFilter(request, response, chain);
+
+            verify(response).sendError(anyInt(), anyString());
+            verify(chain, never()).doFilter(request, response);
+        }
+    }
+
+    @Nested
+    @DisplayName("GET requests with abbreviated prefixes (del/rem)")
+    class AbbreviatedPrefixes {
+
+        @Test
+        @DisplayName("should block GET to delGroup (DeleteGroup2Action)")
+        void shouldBlock_forGetToDelGroup() throws Exception {
+            when(request.getMethod()).thenReturn("GET");
+            when(request.getRequestURI()).thenReturn("/carlos/eforms/delGroup.do");
+            when(request.getParameter("method")).thenReturn(null);
+
+            filter.doFilter(request, response, chain);
+
+            verify(response).sendError(anyInt(), anyString());
+            verify(chain, never()).doFilter(request, response);
+        }
+
+        @Test
+        @DisplayName("should block GET to DelService (EctConDeleteServices2Action)")
+        void shouldBlock_forGetToDelService() throws Exception {
+            when(request.getMethod()).thenReturn("GET");
+            when(request.getRequestURI()).thenReturn("/carlos/oscarEncounter/DelService.do");
+            when(request.getParameter("method")).thenReturn(null);
+
+            filter.doFilter(request, response, chain);
+
+            verify(response).sendError(anyInt(), anyString());
+            verify(chain, never()).doFilter(request, response);
+        }
+
+        @Test
+        @DisplayName("should block GET to remFromGroup (RBTRemoveFromGroup2Action)")
+        void shouldBlock_forGetToRemFromGroup() throws Exception {
+            when(request.getMethod()).thenReturn("GET");
+            when(request.getRequestURI()).thenReturn("/carlos/oscarReport/reportByTemplate/actions/remFromGroup.do");
+            when(request.getParameter("method")).thenReturn(null);
+
+            filter.doFilter(request, response, chain);
+
+            verify(response).sendError(anyInt(), anyString());
+            verify(chain, never()).doFilter(request, response);
+        }
+    }
+
+    @Nested
+    @DisplayName("HEAD requests (blocked same as GET)")
+    class HeadRequests {
+
+        @Test
+        @DisplayName("should block HEAD to mutator action")
+        void shouldBlock_forHeadToMutatorAction() throws Exception {
+            when(request.getMethod()).thenReturn("HEAD");
+            when(request.getRequestURI()).thenReturn("/carlos/tickler/addTickler.do");
+            when(request.getParameter("method")).thenReturn(null);
+
+            filter.doFilter(request, response, chain);
+
+            verify(response).sendError(anyInt(), anyString());
+            verify(chain, never()).doFilter(request, response);
+        }
+
+        @Test
+        @DisplayName("should pass through HEAD to read-only action")
+        void shouldPassThrough_forHeadToReadOnlyAction() throws Exception {
+            when(request.getMethod()).thenReturn("HEAD");
+            when(request.getRequestURI()).thenReturn("/carlos/web/dashboard/display/DashboardDisplay.do");
+            when(request.getParameter("method")).thenReturn(null);
+
+            filter.doFilter(request, response, chain);
+
+            verify(chain).doFilter(request, response);
+            verify(response, never()).sendError(anyInt(), anyString());
+        }
+    }
+
+    @Nested
+    @DisplayName("JSP confirmation pages (past-tense names should NOT be blocked)")
+    class JspConfirmationPages {
+
+        @Test
+        @DisplayName("should pass through GET to batchsaved.jsp (confirmation page)")
+        void shouldPassThrough_forGetToBatchSavedJsp() throws Exception {
+            when(request.getMethod()).thenReturn("GET");
+            when(request.getRequestURI()).thenReturn("/carlos/admin/batchsaved.jsp");
+
+            filter.doFilter(request, response, chain);
+
+            verify(chain).doFilter(request, response);
+            verify(response, never()).sendError(anyInt(), anyString());
+        }
+
+        @Test
+        @DisplayName("should pass through GET to billingcreated.jsp (confirmation page)")
+        void shouldPassThrough_forGetToBillingCreatedJsp() throws Exception {
+            when(request.getMethod()).thenReturn("GET");
+            when(request.getRequestURI()).thenReturn("/carlos/billing/billingcreated.jsp");
+
+            filter.doFilter(request, response, chain);
+
+            verify(chain).doFilter(request, response);
+            verify(response, never()).sendError(anyInt(), anyString());
+        }
+
+        @Test
+        @DisplayName("should pass through GET to efmformmanagerdeleted.jsp (confirmation page)")
+        void shouldPassThrough_forGetToDeletedConfirmationJsp() throws Exception {
+            when(request.getMethod()).thenReturn("GET");
+            when(request.getRequestURI()).thenReturn("/carlos/eform/efmformmanagerdeleted.jsp");
+
+            filter.doFilter(request, response, chain);
+
+            verify(chain).doFilter(request, response);
+            verify(response, never()).sendError(anyInt(), anyString());
         }
     }
 

--- a/src/test-modern/java/io/github/carlos_emr/carlos/app/HttpMethodGuardFilterUnitTest.java
+++ b/src/test-modern/java/io/github/carlos_emr/carlos/app/HttpMethodGuardFilterUnitTest.java
@@ -428,6 +428,44 @@ class HttpMethodGuardFilterUnitTest {
             verify(response).sendError(anyInt(), anyString());
             verify(chain, never()).doFilter(request, response);
         }
+
+        @Test
+        @DisplayName("should block GET to Add2WaitingList.jsp (unconditional mutator)")
+        void shouldBlock_forGetToAdd2WaitingListJsp() throws Exception {
+            when(request.getMethod()).thenReturn("GET");
+            when(request.getRequestURI()).thenReturn("/carlos/oscarWaitingList/Add2WaitingList.jsp");
+
+            filter.doFilter(request, response, chain);
+
+            verify(response).sendError(anyInt(), anyString());
+            verify(chain, never()).doFilter(request, response);
+        }
+
+        @Test
+        @DisplayName("should block GET to setProviderAvailability.jsp with method=save")
+        void shouldBlock_forGetToSetProviderAvailabilityWithSave() throws Exception {
+            when(request.getMethod()).thenReturn("GET");
+            when(request.getRequestURI()).thenReturn("/carlos/admin/hamiltonPublicHealth/setProviderAvailability.jsp");
+            when(request.getParameter("method")).thenReturn("save");
+
+            filter.doFilter(request, response, chain);
+
+            verify(response).sendError(anyInt(), anyString());
+            verify(chain, never()).doFilter(request, response);
+        }
+
+        @Test
+        @DisplayName("should pass through GET to setProviderAvailability.jsp without method=save")
+        void shouldPassThrough_forGetToSetProviderAvailabilityWithoutSave() throws Exception {
+            when(request.getMethod()).thenReturn("GET");
+            when(request.getRequestURI()).thenReturn("/carlos/admin/hamiltonPublicHealth/setProviderAvailability.jsp");
+            when(request.getParameter("method")).thenReturn(null);
+
+            filter.doFilter(request, response, chain);
+
+            verify(chain).doFilter(request, response);
+            verify(response, never()).sendError(anyInt(), anyString());
+        }
     }
 
     @Nested
@@ -465,6 +503,32 @@ class HttpMethodGuardFilterUnitTest {
         void shouldBlock_forGetToRbtAddToGroup() throws Exception {
             when(request.getMethod()).thenReturn("GET");
             when(request.getRequestURI()).thenReturn("/carlos/oscarReport/reportByTemplate/actions/rbtAddToGroup.do");
+            when(request.getParameter("method")).thenReturn(null);
+
+            filter.doFilter(request, response, chain);
+
+            verify(response).sendError(anyInt(), anyString());
+            verify(chain, never()).doFilter(request, response);
+        }
+
+        @Test
+        @DisplayName("should block GET to ReportReassign (ReportReassign2Action)")
+        void shouldBlock_forGetToReportReassign() throws Exception {
+            when(request.getMethod()).thenReturn("GET");
+            when(request.getRequestURI()).thenReturn("/carlos/oscarMDS/ReportReassign.do");
+            when(request.getParameter("method")).thenReturn(null);
+
+            filter.doFilter(request, response, chain);
+
+            verify(response).sendError(anyInt(), anyString());
+            verify(chain, never()).doFilter(request, response);
+        }
+
+        @Test
+        @DisplayName("should block GET to Forward (ReportReassign2Action lab forwarding)")
+        void shouldBlock_forGetToForward() throws Exception {
+            when(request.getMethod()).thenReturn("GET");
+            when(request.getRequestURI()).thenReturn("/carlos/lab/CA/ALL/Forward.do");
             when(request.getParameter("method")).thenReturn(null);
 
             filter.doFilter(request, response, chain);

--- a/src/test-modern/java/io/github/carlos_emr/carlos/app/HttpMethodGuardFilterUnitTest.java
+++ b/src/test-modern/java/io/github/carlos_emr/carlos/app/HttpMethodGuardFilterUnitTest.java
@@ -1,0 +1,543 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.app;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link HttpMethodGuardFilter}.
+ *
+ * <p>Validates that GET requests to mutator endpoints are blocked with 405,
+ * while POST requests and GET requests to read-only endpoints pass through.</p>
+ *
+ * @since 2026-03-13
+ */
+@Tag("unit")
+@Tag("security")
+@DisplayName("HttpMethodGuardFilter")
+class HttpMethodGuardFilterUnitTest {
+
+    private HttpMethodGuardFilter filter;
+    private HttpServletRequest request;
+    private HttpServletResponse response;
+    private FilterChain chain;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        filter = new HttpMethodGuardFilter();
+        FilterConfig filterConfig = mock(FilterConfig.class);
+        when(filterConfig.getInitParameter("allowList")).thenReturn(null);
+        filter.init(filterConfig);
+
+        request = mock(HttpServletRequest.class);
+        response = mock(HttpServletResponse.class);
+        chain = mock(FilterChain.class);
+        when(request.getContextPath()).thenReturn("/carlos");
+        when(request.getRemoteAddr()).thenReturn("127.0.0.1");
+    }
+
+    @Nested
+    @DisplayName("POST requests")
+    class PostRequests {
+
+        @Test
+        @DisplayName("should pass through POST to mutator action")
+        void shouldPassThrough_forPostToMutatorAction() throws Exception {
+            when(request.getMethod()).thenReturn("POST");
+            when(request.getRequestURI()).thenReturn("/carlos/tickler/addTickler.do");
+
+            filter.doFilter(request, response, chain);
+
+            verify(chain).doFilter(request, response);
+            verify(response, never()).sendError(anyInt(), anyString());
+        }
+
+        @Test
+        @DisplayName("should pass through POST to mutator JSP")
+        void shouldPassThrough_forPostToMutatorJsp() throws Exception {
+            when(request.getMethod()).thenReturn("POST");
+            when(request.getRequestURI()).thenReturn("/carlos/admin/securitydelete.jsp");
+
+            filter.doFilter(request, response, chain);
+
+            verify(chain).doFilter(request, response);
+            verify(response, never()).sendError(anyInt(), anyString());
+        }
+    }
+
+    @Nested
+    @DisplayName("GET requests to read-only actions")
+    class ReadOnlyActions {
+
+        @Test
+        @DisplayName("should pass through GET to display action")
+        void shouldPassThrough_forGetToDisplayAction() throws Exception {
+            when(request.getMethod()).thenReturn("GET");
+            when(request.getRequestURI()).thenReturn("/carlos/web/dashboard/display/DashboardDisplay.do");
+            when(request.getParameter("method")).thenReturn(null);
+
+            filter.doFilter(request, response, chain);
+
+            verify(chain).doFilter(request, response);
+            verify(response, never()).sendError(anyInt(), anyString());
+        }
+
+        @Test
+        @DisplayName("should pass through GET to view method parameter")
+        void shouldPassThrough_forGetWithViewMethodParam() throws Exception {
+            when(request.getMethod()).thenReturn("GET");
+            when(request.getRequestURI()).thenReturn("/carlos/SystemMessage.do");
+            when(request.getParameter("method")).thenReturn("view");
+
+            filter.doFilter(request, response, chain);
+
+            verify(chain).doFilter(request, response);
+            verify(response, never()).sendError(anyInt(), anyString());
+        }
+
+        @Test
+        @DisplayName("should pass through GET to edit action (edit loads forms via GET)")
+        void shouldPassThrough_forGetToEditAction() throws Exception {
+            when(request.getMethod()).thenReturn("GET");
+            when(request.getRequestURI()).thenReturn("/carlos/tickler/EditTickler.do");
+            when(request.getParameter("method")).thenReturn(null);
+
+            filter.doFilter(request, response, chain);
+
+            verify(chain).doFilter(request, response);
+            verify(response, never()).sendError(anyInt(), anyString());
+        }
+
+        @Test
+        @DisplayName("should pass through GET to report JSP")
+        void shouldPassThrough_forGetToReportJsp() throws Exception {
+            when(request.getMethod()).thenReturn("GET");
+            when(request.getRequestURI()).thenReturn("/carlos/admin/logReport.jsp");
+            when(request.getParameter("method")).thenReturn(null);
+
+            filter.doFilter(request, response, chain);
+
+            verify(chain).doFilter(request, response);
+            verify(response, never()).sendError(anyInt(), anyString());
+        }
+
+        @Test
+        @DisplayName("should pass through GET to search JSP")
+        void shouldPassThrough_forGetToSearchJsp() throws Exception {
+            when(request.getMethod()).thenReturn("GET");
+            when(request.getRequestURI()).thenReturn("/carlos/demographic/demographicCohort.jsp");
+            when(request.getParameter("method")).thenReturn(null);
+
+            filter.doFilter(request, response, chain);
+
+            verify(chain).doFilter(request, response);
+            verify(response, never()).sendError(anyInt(), anyString());
+        }
+    }
+
+    @Nested
+    @DisplayName("GET requests to mutator .do actions")
+    class MutatorActions {
+
+        @Test
+        @DisplayName("should block GET to Add* action")
+        void shouldBlock_forGetToAddAction() throws Exception {
+            when(request.getMethod()).thenReturn("GET");
+            when(request.getRequestURI()).thenReturn("/carlos/tickler/addTickler.do");
+            when(request.getParameter("method")).thenReturn(null);
+
+            filter.doFilter(request, response, chain);
+
+            verify(response).sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED,
+                    "GET requests are not allowed on this endpoint. Use POST.");
+            verify(response).setHeader("Allow", "POST");
+            verify(chain, never()).doFilter(request, response);
+        }
+
+        @Test
+        @DisplayName("should block GET to Delete* action")
+        void shouldBlock_forGetToDeleteAction() throws Exception {
+            when(request.getMethod()).thenReturn("GET");
+            when(request.getRequestURI()).thenReturn("/carlos/oscarRx/deleteRx.do");
+            when(request.getParameter("method")).thenReturn(null);
+
+            filter.doFilter(request, response, chain);
+
+            verify(response).sendError(anyInt(), anyString());
+            verify(chain, never()).doFilter(request, response);
+        }
+
+        @Test
+        @DisplayName("should block GET to Save* action")
+        void shouldBlock_forGetToSaveAction() throws Exception {
+            when(request.getMethod()).thenReturn("GET");
+            when(request.getRequestURI()).thenReturn("/carlos/admin/oncallClinic.do");
+            // SaveOnCallClinic2Action mapped as admin/oncallClinic - name doesn't match prefix
+            // But let's test a direct save-named action
+            when(request.getRequestURI()).thenReturn("/carlos/SaveAssoc.do");
+            when(request.getParameter("method")).thenReturn(null);
+
+            filter.doFilter(request, response, chain);
+
+            verify(response).sendError(anyInt(), anyString());
+            verify(chain, never()).doFilter(request, response);
+        }
+
+        @Test
+        @DisplayName("should block GET to Submit* action")
+        void shouldBlock_forGetToSubmitAction() throws Exception {
+            when(request.getMethod()).thenReturn("GET");
+            when(request.getRequestURI()).thenReturn("/carlos/prevention/SubmitImmunization.do");
+            when(request.getParameter("method")).thenReturn(null);
+
+            filter.doFilter(request, response, chain);
+
+            verify(response).sendError(anyInt(), anyString());
+            verify(chain, never()).doFilter(request, response);
+        }
+
+        @Test
+        @DisplayName("should block GET to Create* action")
+        void shouldBlock_forGetToCreateAction() throws Exception {
+            when(request.getMethod()).thenReturn("GET");
+            when(request.getRequestURI()).thenReturn("/carlos/billing/CreateBillingReport.do");
+            when(request.getParameter("method")).thenReturn(null);
+
+            filter.doFilter(request, response, chain);
+
+            verify(response).sendError(anyInt(), anyString());
+            verify(chain, never()).doFilter(request, response);
+        }
+
+        @Test
+        @DisplayName("should block GET to Remove* action")
+        void shouldBlock_forGetToRemoveAction() throws Exception {
+            when(request.getMethod()).thenReturn("GET");
+            when(request.getRequestURI()).thenReturn("/carlos/RemoveFromGroup.do");
+            when(request.getParameter("method")).thenReturn(null);
+
+            filter.doFilter(request, response, chain);
+
+            verify(response).sendError(anyInt(), anyString());
+            verify(chain, never()).doFilter(request, response);
+        }
+
+        @Test
+        @DisplayName("should block GET to Assign* action")
+        void shouldBlock_forGetToAssignAction() throws Exception {
+            when(request.getMethod()).thenReturn("GET");
+            when(request.getRequestURI()).thenReturn("/carlos/web/dashboard/display/AssignTickler.do");
+            when(request.getParameter("method")).thenReturn(null);
+
+            filter.doFilter(request, response, chain);
+
+            verify(response).sendError(anyInt(), anyString());
+            verify(chain, never()).doFilter(request, response);
+        }
+    }
+
+    @Nested
+    @DisplayName("GET requests with mutator method parameter")
+    class MutatorMethodParams {
+
+        @Test
+        @DisplayName("should block GET with method=save on mixed action")
+        void shouldBlock_forGetWithSaveMethodParam() throws Exception {
+            when(request.getMethod()).thenReturn("GET");
+            when(request.getRequestURI()).thenReturn("/carlos/SystemMessage.do");
+            when(request.getParameter("method")).thenReturn("save");
+
+            filter.doFilter(request, response, chain);
+
+            verify(response).sendError(anyInt(), anyString());
+            verify(chain, never()).doFilter(request, response);
+        }
+
+        @Test
+        @DisplayName("should block GET with method=delete")
+        void shouldBlock_forGetWithDeleteMethodParam() throws Exception {
+            when(request.getMethod()).thenReturn("GET");
+            when(request.getRequestURI()).thenReturn("/carlos/SomeAction.do");
+            when(request.getParameter("method")).thenReturn("delete");
+
+            filter.doFilter(request, response, chain);
+
+            verify(response).sendError(anyInt(), anyString());
+            verify(chain, never()).doFilter(request, response);
+        }
+
+        @Test
+        @DisplayName("should block GET with method=update")
+        void shouldBlock_forGetWithUpdateMethodParam() throws Exception {
+            when(request.getMethod()).thenReturn("GET");
+            when(request.getRequestURI()).thenReturn("/carlos/SomeAction.do");
+            when(request.getParameter("method")).thenReturn("update");
+
+            filter.doFilter(request, response, chain);
+
+            verify(response).sendError(anyInt(), anyString());
+            verify(chain, never()).doFilter(request, response);
+        }
+
+        @Test
+        @DisplayName("should pass through GET with method=list (read operation)")
+        void shouldPassThrough_forGetWithListMethodParam() throws Exception {
+            when(request.getMethod()).thenReturn("GET");
+            when(request.getRequestURI()).thenReturn("/carlos/SystemMessage.do");
+            when(request.getParameter("method")).thenReturn("list");
+
+            filter.doFilter(request, response, chain);
+
+            verify(chain).doFilter(request, response);
+            verify(response, never()).sendError(anyInt(), anyString());
+        }
+
+        @Test
+        @DisplayName("should pass through GET with method=edit (loads form)")
+        void shouldPassThrough_forGetWithEditMethodParam() throws Exception {
+            when(request.getMethod()).thenReturn("GET");
+            when(request.getRequestURI()).thenReturn("/carlos/SystemMessage.do");
+            when(request.getParameter("method")).thenReturn("edit");
+
+            filter.doFilter(request, response, chain);
+
+            verify(chain).doFilter(request, response);
+            verify(response, never()).sendError(anyInt(), anyString());
+        }
+    }
+
+    @Nested
+    @DisplayName("GET requests to mutator JSPs")
+    class MutatorJsps {
+
+        @Test
+        @DisplayName("should block GET to securitydelete.jsp")
+        void shouldBlock_forGetToSecurityDeleteJsp() throws Exception {
+            when(request.getMethod()).thenReturn("GET");
+            when(request.getRequestURI()).thenReturn("/carlos/admin/securitydelete.jsp");
+
+            filter.doFilter(request, response, chain);
+
+            verify(response).sendError(anyInt(), anyString());
+            verify(chain, never()).doFilter(request, response);
+        }
+
+        @Test
+        @DisplayName("should block GET to providerupdate.jsp")
+        void shouldBlock_forGetToProviderUpdateJsp() throws Exception {
+            when(request.getMethod()).thenReturn("GET");
+            when(request.getRequestURI()).thenReturn("/carlos/admin/providerupdate.jsp");
+
+            filter.doFilter(request, response, chain);
+
+            verify(response).sendError(anyInt(), anyString());
+            verify(chain, never()).doFilter(request, response);
+        }
+
+        @Test
+        @DisplayName("should block GET to billingONSave.jsp")
+        void shouldBlock_forGetToBillingSaveJsp() throws Exception {
+            when(request.getMethod()).thenReturn("GET");
+            when(request.getRequestURI()).thenReturn("/carlos/billing/CA/ON/billingONSave.jsp");
+
+            filter.doFilter(request, response, chain);
+
+            verify(response).sendError(anyInt(), anyString());
+            verify(chain, never()).doFilter(request, response);
+        }
+
+        @Test
+        @DisplayName("should block GET to appointmentcontrol.jsp")
+        void shouldBlock_forGetToAppointmentControlJsp() throws Exception {
+            when(request.getMethod()).thenReturn("GET");
+            when(request.getRequestURI()).thenReturn("/carlos/appointment/appointmentcontrol.jsp");
+
+            filter.doFilter(request, response, chain);
+
+            verify(response).sendError(anyInt(), anyString());
+            verify(chain, never()).doFilter(request, response);
+        }
+
+        @Test
+        @DisplayName("should block GET to PreventionManager.jsp with formAction=update")
+        void shouldBlock_forGetToPreventionManagerWithUpdate() throws Exception {
+            when(request.getMethod()).thenReturn("GET");
+            when(request.getRequestURI()).thenReturn("/carlos/oscarPrevention/PreventionManager.jsp");
+            when(request.getParameter("formAction")).thenReturn("update");
+
+            filter.doFilter(request, response, chain);
+
+            verify(response).sendError(anyInt(), anyString());
+            verify(chain, never()).doFilter(request, response);
+        }
+
+        @Test
+        @DisplayName("should pass through GET to PreventionManager.jsp without formAction")
+        void shouldPassThrough_forGetToPreventionManagerWithoutFormAction() throws Exception {
+            when(request.getMethod()).thenReturn("GET");
+            when(request.getRequestURI()).thenReturn("/carlos/oscarPrevention/PreventionManager.jsp");
+            when(request.getParameter("formAction")).thenReturn(null);
+
+            filter.doFilter(request, response, chain);
+
+            verify(chain).doFilter(request, response);
+            verify(response, never()).sendError(anyInt(), anyString());
+        }
+
+        @Test
+        @DisplayName("should block GET to JSP matching keyword 'delete'")
+        void shouldBlock_forGetToJspWithDeleteKeyword() throws Exception {
+            when(request.getMethod()).thenReturn("GET");
+            when(request.getRequestURI()).thenReturn("/carlos/admin/lotnrdeleterecord.jsp");
+
+            filter.doFilter(request, response, chain);
+
+            verify(response).sendError(anyInt(), anyString());
+            verify(chain, never()).doFilter(request, response);
+        }
+    }
+
+    @Nested
+    @DisplayName("Allow-list overrides")
+    class AllowList {
+
+        @Test
+        @DisplayName("should pass through GET to allow-listed mutator action")
+        void shouldPassThrough_forAllowListedAction() throws Exception {
+            // Re-initialize with an allow-list
+            FilterConfig filterConfig = mock(FilterConfig.class);
+            when(filterConfig.getInitParameter("allowList")).thenReturn("addticklerview");
+            filter.init(filterConfig);
+
+            when(request.getMethod()).thenReturn("GET");
+            when(request.getRequestURI()).thenReturn("/carlos/tickler/AddTicklerView.do");
+            when(request.getParameter("method")).thenReturn(null);
+
+            filter.doFilter(request, response, chain);
+
+            verify(chain).doFilter(request, response);
+            verify(response, never()).sendError(anyInt(), anyString());
+        }
+
+        @Test
+        @DisplayName("should pass through GET to allow-listed mutator JSP")
+        void shouldPassThrough_forAllowListedJsp() throws Exception {
+            FilterConfig filterConfig = mock(FilterConfig.class);
+            when(filterConfig.getInitParameter("allowList")).thenReturn("annotation.jsp");
+            filter.init(filterConfig);
+
+            when(request.getMethod()).thenReturn("GET");
+            when(request.getRequestURI()).thenReturn("/carlos/annotation/annotation.jsp");
+
+            filter.doFilter(request, response, chain);
+
+            verify(chain).doFilter(request, response);
+            verify(response, never()).sendError(anyInt(), anyString());
+        }
+    }
+
+    @Nested
+    @DisplayName("Action name extraction")
+    class ActionNameExtraction {
+
+        @Test
+        @DisplayName("should extract simple action name from path")
+        void shouldExtractSimpleActionName_fromPath() {
+            assertThat(HttpMethodGuardFilter.extractActionName("/tickler/addTickler.do"))
+                    .isEqualTo("addTickler");
+        }
+
+        @Test
+        @DisplayName("should extract nested action name from deep path")
+        void shouldExtractNestedActionName_fromDeepPath() {
+            assertThat(HttpMethodGuardFilter.extractActionName("/web/dashboard/display/AssignTickler.do"))
+                    .isEqualTo("AssignTickler");
+        }
+
+        @Test
+        @DisplayName("should extract action name without leading slash")
+        void shouldExtractActionName_withoutLeadingSlash() {
+            assertThat(HttpMethodGuardFilter.extractActionName("logout.do"))
+                    .isEqualTo("logout");
+        }
+
+        @Test
+        @DisplayName("should return null for non-.do path")
+        void shouldReturnNull_forNonDoPath() {
+            assertThat(HttpMethodGuardFilter.extractActionName("/some/page.jsp"))
+                    .isNull();
+        }
+
+        @Test
+        @DisplayName("should return null for null path")
+        void shouldReturnNull_forNullPath() {
+            assertThat(HttpMethodGuardFilter.extractActionName(null))
+                    .isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("Other HTTP methods")
+    class OtherMethods {
+
+        @Test
+        @DisplayName("should pass through PUT requests")
+        void shouldPassThrough_forPutRequests() throws Exception {
+            when(request.getMethod()).thenReturn("PUT");
+            when(request.getRequestURI()).thenReturn("/carlos/tickler/addTickler.do");
+
+            filter.doFilter(request, response, chain);
+
+            verify(chain).doFilter(request, response);
+            verify(response, never()).sendError(anyInt(), anyString());
+        }
+
+        @Test
+        @DisplayName("should pass through DELETE requests")
+        void shouldPassThrough_forDeleteRequests() throws Exception {
+            when(request.getMethod()).thenReturn("DELETE");
+            when(request.getRequestURI()).thenReturn("/carlos/tickler/addTickler.do");
+
+            filter.doFilter(request, response, chain);
+
+            verify(chain).doFilter(request, response);
+            verify(response, never()).sendError(anyInt(), anyString());
+        }
+    }
+}


### PR DESCRIPTION
After upgrading to CSRFGuard 4.5, all mutator form submissions use POST.
This servlet filter enforces that server-side by rejecting GET requests to
mutator actions (.do) and JSPs with HTTP 405 Method Not Allowed.

Detection strategy:
- .do actions: checks action name against mutator prefixes (Add, Delete,
  Save, Submit, Create, Remove, Assign, etc.) and the 'method' request
  parameter for mutator values (save, delete, update, etc.)
- .jsp pages: checks filename against known mutator JSP names and keywords
- Edit/Update prefixes are allowed on GET (they load forms); their save
  operations use separate actions or ?method=save (which IS blocked)

Filter is placed after CSRFGuard but before Struts in the filter chain.
Includes configurable allow-list via web.xml init-param for exceptions.

https://claude.ai/code/session_01G1VB3ianqXw6aAAv15pRps

## Summary by Sourcery

Introduce an HTTP servlet filter to block unsafe GET/HEAD access to mutating Struts actions and JSP endpoints, enforcing POST-only semantics for state-changing operations.

New Features:
- Add HttpMethodGuardFilter to identify and block GET/HEAD requests to mutator .do actions and JSPs, with support for an allow-list of exceptions via init parameters.

Build:
- Register HttpMethodGuardFilter in web.xml, ordering it between CSRFGuard and Struts and mapping it to .do and .jsp URLs.

Tests:
- Add comprehensive unit tests for HttpMethodGuardFilter covering mutator/read-only detection, JSP and action name handling, method parameter behavior, allow-list overrides, and handling of various HTTP methods.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation to enforce POST requests for state-changing operations; GET/HEAD requests to these endpoints will receive HTTP 405 Method Not Allowed responses.

* **Tests**
  * Added comprehensive test coverage for HTTP method validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->