### PR TITLE
Update make_CARLOS_deb.sh to skip destructive sql

### DIFF
--- a/release/make_CARLOS_deb.sh
+++ b/release/make_CARLOS_deb.sh
@@ -127,10 +127,19 @@ mkdir -p "${RELEASE_DIR}/${DEBNAME}/DEBIAN/"
 # so use ${RELEASE_DIR}/xxx for release/ files and ./xxx for repo-root files.
 cd "${REPO_ROOT}" || { echo "ERROR: Failed to cd to ${REPO_ROOT}" >&2; exit 1; }
 mvn -Dmaven.test.skip=true -Dcheckstyle.skip=true package
+MVN_EXIT=$?
 
-# Fail fast if the WAR was not produced — abort before doing any more package setup work.
+# Note: bash runs commands sequentially — mvn above is fully finished before this check runs.
+# There is no race condition; we explicitly capture the exit code for a clear failure message.
+if [ $MVN_EXIT -ne 0 ]; then
+    echo "ERROR: Maven build failed (exit code $MVN_EXIT), aborting deb creation." >&2
+    exit $MVN_EXIT
+fi
+
+# Sanity check: WAR should always exist after a successful Maven build.
+# If it is somehow missing despite exit 0, catch it here before wasting time on the rest of packaging.
 if [ ! -f "${REPO_ROOT}/target/${TARGET}" ]; then
-    echo "ERROR: Missing ${REPO_ROOT}/target/${TARGET} — Maven build failed, aborting deb creation." >&2
+    echo "ERROR: Missing ${REPO_ROOT}/target/${TARGET} — Maven reported success but WAR not found." >&2
     exit 1
 fi
 

--- a/release/make_CARLOS_deb.sh
+++ b/release/make_CARLOS_deb.sh
@@ -131,14 +131,14 @@ MVN_EXIT=$?
 
 # Note: bash runs commands sequentially — mvn above is fully finished before this check runs.
 # There is no race condition; we explicitly capture the exit code for a clear failure message.
-if [ $MVN_EXIT -ne 0 ]; then
+if [ "$MVN_EXIT" -ne 0 ]; then
     echo "ERROR: Maven build failed (exit code $MVN_EXIT), aborting deb creation." >&2
     exit $MVN_EXIT
 fi
 
 # Sanity check: WAR should always exist after a successful Maven build.
 # If it is somehow missing despite exit 0, catch it here before wasting time on the rest of packaging.
-if [ ! -f "${REPO_ROOT}/target/${TARGET}" ]; then
+if [ -z "${TARGET}" ] || [ ! -f "${REPO_ROOT}/target/${TARGET}" ]; then
     echo "ERROR: Missing ${REPO_ROOT}/target/${TARGET} — Maven reported success but WAR not found." >&2
     exit 1
 fi
@@ -432,11 +432,12 @@ chmod 755 ${RELEASE_DIR}/${DEBNAME}/var/lib/${PACKAGE}/schema/createdatabase_*.s
 # The postinst script applies these after the WAR is deployed to bring the schema current.
 echo "bundling incremental database update scripts from database/mysql/updates/"
 _update_sql_count=0
+mkdir -p "${RELEASE_DIR}/${DEBNAME}/var/lib/${PACKAGE}/"
 # Loop through the SQL files in the specified directory
 for _upd_sql in ./database/mysql/updates/update-2026-*.sql; do
     if [ -f "${_upd_sql}" ]; then
         # Skip the specific destructive SQL file for compatibility reasons.
-        if [[ "${_upd_sql}" == *"/update-2026-02-14-facility-integrator-removal.sql" ]]; then
+        if [[ "${_upd_sql}" == "./database/mysql/updates/update-2026-02-14-facility-integrator-removal.sql" ]]; then
             continue
         fi
         cp "${_upd_sql}" "${RELEASE_DIR}/${DEBNAME}/var/lib/${PACKAGE}/"

--- a/release/make_CARLOS_deb.sh
+++ b/release/make_CARLOS_deb.sh
@@ -409,14 +409,24 @@ cp ./database/mysql/createdatabase_on.sh      ${RELEASE_DIR}/${DEBNAME}/var/lib/
 cp ./database/mysql/createdatabase_bc.sh      ${RELEASE_DIR}/${DEBNAME}/var/lib/${PACKAGE}/schema/
 chmod 755 ${RELEASE_DIR}/${DEBNAME}/var/lib/${PACKAGE}/schema/createdatabase_*.sh
 
-# Bundle incremental update scripts (update-2026-*.sql) for CARLOS revision upgrades.
+# Bundle incremental update scripts after update-2026-02-14-facility-integrator-removal.sql
+# for CARLOS revision upgrades.  That update should not be run for compatability reasons.
 # The postinst script applies these after the WAR is deployed to bring the schema current.
 echo "bundling incremental database update scripts from database/mysql/updates/"
 _update_sql_count=0
+# Flag to start copying files after update-2026-02-14-facility-integrator-removal.sql
+start_copying=false
+# Loop through the SQL files in the specified directory
 for _upd_sql in ./database/mysql/updates/update-2026-*.sql; do
     if [ -f "${_upd_sql}" ]; then
-        cp "${_upd_sql}" "${RELEASE_DIR}/${DEBNAME}/var/lib/${PACKAGE}/"
-        _update_sql_count=$((_update_sql_count + 1))
+        if [[ "${_upd_sql}" == *"update-2026-02-14"* ]]; then
+            start_copying=true
+            continue  # Skip this file and move to the next one
+        fi
+        if $start_copying; then
+            cp "${_upd_sql}" "${RELEASE_DIR}/${DEBNAME}/var/lib/${PACKAGE}/"
+            _update_sql_count=$((_update_sql_count + 1))
+        fi
     fi
 done
 echo "Bundled ${_update_sql_count} incremental update SQL files into package"

--- a/release/make_CARLOS_deb.sh
+++ b/release/make_CARLOS_deb.sh
@@ -127,6 +127,13 @@ mkdir -p "${RELEASE_DIR}/${DEBNAME}/DEBIAN/"
 # so use ${RELEASE_DIR}/xxx for release/ files and ./xxx for repo-root files.
 cd "${REPO_ROOT}" || { echo "ERROR: Failed to cd to ${REPO_ROOT}" >&2; exit 1; }
 mvn -Dmaven.test.skip=true -Dcheckstyle.skip=true package
+
+# Fail fast if the WAR was not produced — abort before doing any more package setup work.
+if [ ! -f "${REPO_ROOT}/target/${TARGET}" ]; then
+    echo "ERROR: Missing ${REPO_ROOT}/target/${TARGET} — Maven build failed, aborting deb creation." >&2
+    exit 1
+fi
+
 mkdir -p "${RELEASE_DIR}/${DEBNAME}${C_BASE}webapps/"
 # WAR is copied generically below (after drugref download) using ${TARGET} and ${PROGRAM} variables.
 
@@ -409,24 +416,22 @@ cp ./database/mysql/createdatabase_on.sh      ${RELEASE_DIR}/${DEBNAME}/var/lib/
 cp ./database/mysql/createdatabase_bc.sh      ${RELEASE_DIR}/${DEBNAME}/var/lib/${PACKAGE}/schema/
 chmod 755 ${RELEASE_DIR}/${DEBNAME}/var/lib/${PACKAGE}/schema/createdatabase_*.sh
 
-# Bundle incremental update scripts after update-2026-02-14-facility-integrator-removal.sql
-# for CARLOS revision upgrades.  That update should not be run for compatability reasons.
+# Bundle incremental update scripts for CARLOS revision upgrades.
+# update-2026-02-14-facility-integrator-removal.sql is intentionally excluded because it
+# drops facility columns that are incompatible with OSCAR 19 installations and cannot be
+# safely applied during a package upgrade.  All other update scripts are included.
 # The postinst script applies these after the WAR is deployed to bring the schema current.
 echo "bundling incremental database update scripts from database/mysql/updates/"
 _update_sql_count=0
-# Flag to start copying files after update-2026-02-14-facility-integrator-removal.sql
-start_copying=false
 # Loop through the SQL files in the specified directory
 for _upd_sql in ./database/mysql/updates/update-2026-*.sql; do
     if [ -f "${_upd_sql}" ]; then
-        if [[ "${_upd_sql}" == *"update-2026-02-14"* ]]; then
-            start_copying=true
-            continue  # Skip this file and move to the next one
+        # Skip the specific destructive SQL file for compatibility reasons.
+        if [[ "${_upd_sql}" == *"/update-2026-02-14-facility-integrator-removal.sql" ]]; then
+            continue
         fi
-        if $start_copying; then
-            cp "${_upd_sql}" "${RELEASE_DIR}/${DEBNAME}/var/lib/${PACKAGE}/"
-            _update_sql_count=$((_update_sql_count + 1))
-        fi
+        cp "${_upd_sql}" "${RELEASE_DIR}/${DEBNAME}/var/lib/${PACKAGE}/"
+        _update_sql_count=$((_update_sql_count + 1))
     fi
 done
 echo "Bundled ${_update_sql_count} incremental update SQL files into package"


### PR DESCRIPTION
### **User description**
<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description
skips destructive dbupdate sql
<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues
Fixes #663 
<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?

<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Bug Fixes:
- Exclude the incompatible update-2026-02-14-facility-integrator-removal.sql from packaged incremental DB updates while continuing to include later update scripts.


___

### **Description**
- Improved error handling by capturing the exit code of the Maven build process.
- Added a check to ensure the WAR file exists after a successful build to prevent packaging errors.
- Excluded the `update-2026-02-14-facility-integrator-removal.sql` script to avoid destructive changes during upgrades.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>make_CARLOS_deb.sh</strong><dd><code>Enhance error handling and skip destructive SQL updates</code>&nbsp; &nbsp; </dd></summary>
<hr>

release/make_CARLOS_deb.sh
<li>Added error handling for Maven build failure.<br> <li> Implemented a sanity check for the existence of the WAR file.<br> <li> Excluded a specific destructive SQL update script from packaging.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/664/files#diff-d4c70271498303a4e6ea95768df9b2200aabc3c1ced7eaaced336cd77bfdfc0c">+25/-1</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved release packaging: better build failure detection and validation that artifacts exist before creating packages
  * Bundled incremental database update scripts into release packages and ensured target directory is created beforehand
  * Explicitly excluded a known destructive migration from packaging and tracked bundled script counts

* **Bug Fixes**
  * Prevented packaging from continuing when build or artifact checks fail
<!-- end of auto-generated comment: release notes by coderabbit.ai -->