### PR TITLE
fix: PACKAGING further fixes #2

### DIFF
--- a/release/config
+++ b/release/config
@@ -275,7 +275,7 @@ else
                                                 # Remove stale legacy path if present (old installs used /var/lib/OscarDocument/ which no longer exists)
                                                 sed -i '/ReadWritePaths=\/var\/lib\/OscarDocument\//d' /etc/systemd/system/tomcat9.service.d/override.conf 2>>$LOG_FILE || true
                                                 echo "ReadWritePaths=${BASE_DOCUMENT_DIR}/" >> /etc/systemd/system/tomcat9.service.d/override.conf
-                                                echo "ReadWritePaths=/tmp/" >> /etc/systemd/system/tomcat9.service.d/override.conf
+                                                grep -qF "ReadWritePaths=/tmp/" /etc/systemd/system/tomcat9.service.d/override.conf || echo "ReadWritePaths=/tmp/" >> /etc/systemd/system/tomcat9.service.d/override.conf
                                                 echo "Edited override to allow Tomcat read write on ${BASE_DOCUMENT_DIR} and /tmp"
                                                 echo "Added Tomcat read and write on ${BASE_DOCUMENT_DIR}/ and /tmp/ to existing override /etc/systemd/system/tomcat9.service.d/override.conf"  >>$LOG_FILE
                                                 systemctl daemon-reload
@@ -291,7 +291,7 @@ else
                                                 # Remove stale legacy path if present
                                                 sed -i '/ReadWritePaths=\/var\/lib\/OscarDocument\//d' /lib/systemd/system/tomcat9.service 2>>$LOG_FILE || true
                                                 sed -i "/ReadWritePaths=\/var\/log\/tomcat9\//a ReadWritePaths=${BASE_DOCUMENT_DIR}/" /lib/systemd/system/tomcat9.service
-                                                sed -i '/ReadWritePaths=\/var\/log\/tomcat9\//a ReadWritePaths=\/tmp\//' /lib/systemd/system/tomcat9.service
+                                                grep -qF "ReadWritePaths=/tmp/" /lib/systemd/system/tomcat9.service || sed -i '/ReadWritePaths=\/var\/log\/tomcat9\//a ReadWritePaths=\/tmp\//' /lib/systemd/system/tomcat9.service
                                                 echo "Edited tomcat9.service to allow Tomcat read write on ${BASE_DOCUMENT_DIR}/ and /tmp/"
                                                 echo "Edited /lib/systemd/system/tomcat9.service to allow Tomcat read write on ${BASE_DOCUMENT_DIR}/ and /tmp/" >>$LOG_FILE
                                                 systemctl daemon-reload
@@ -307,7 +307,7 @@ else
                                                 # Remove stale legacy path if present
                                                 sed -i '/ReadWritePaths=\/var\/lib\/OscarDocument\//d' /etc/systemd/system/multi-user.target.wants/tomcat9.service 2>>$LOG_FILE || true
                                                 sed -i "/ReadWritePaths=\/var\/log\/tomcat9\//a ReadWritePaths=${BASE_DOCUMENT_DIR}/" /etc/systemd/system/multi-user.target.wants/tomcat9.service
-                                                sed -i '/ReadWritePaths=\/var\/log\/tomcat9\//a ReadWritePaths=\/tmp\//' /etc/systemd/system/multi-user.target.wants/tomcat9.service
+                                                grep -qF "ReadWritePaths=/tmp/" /etc/systemd/system/multi-user.target.wants/tomcat9.service || sed -i '/ReadWritePaths=\/var\/log\/tomcat9\//a ReadWritePaths=\/tmp\//' /etc/systemd/system/multi-user.target.wants/tomcat9.service
                                                 echo "Edited tomcatX.service to allow Tomcat read write on ${BASE_DOCUMENT_DIR}/ and /tmp"
                                                 echo "Edited /etc/systemd/system/multi-user.target.wants/tomcatX.service to allow Tomcat read write on ${BASE_DOCUMENT_DIR}/ and /tmp" >>$LOG_FILE
                                                 systemctl daemon-reload

--- a/release/config
+++ b/release/config
@@ -253,56 +253,66 @@ else
                 if [ -f /usr/share/tomcat9/bin/version.sh ] ; then
                         
                         # add carlos directory structure to the paths that tomcat9 can read and write to
-                        # DO NOT ADD read write to non existing paths or Tomcat will fail to start
+                        # DO NOT ADD read write to non existing paths or Tomcat will fail to start.
+                        # BASE_DOCUMENT_DIR is /var/lib/carlos-emr/OscarDocument — ensure it exists
+                        # before adding it to the service file or systemd will refuse to start Tomcat.
+                        mkdir -p "${BASE_DOCUMENT_DIR}" 2>>$LOG_FILE
+                        chown -R ${TOMCAT_USER}:${TOMCAT_USER} "${BASE_DOCUMENT_DIR}" 2>>$LOG_FILE || true
                         if [ -d "/etc/systemd/system/tomcat9.service.d" ] ; then
                                 if [ ! -f /etc/systemd/system/tomcat9.service.d/override.conf ] ; then
                                         touch /etc/systemd/system/tomcat9.service.d/override.conf
                                         echo "[Service]" >> /etc/systemd/system/tomcat9.service.d/override.conf
-                                        echo "ReadWritePaths=/var/lib/OscarDocument/" >> /etc/systemd/system/tomcat9.service.d/override.conf
+                                        echo "ReadWritePaths=${BASE_DOCUMENT_DIR}/" >> /etc/systemd/system/tomcat9.service.d/override.conf
                                         echo "ReadWritePaths=/tmp/" >> /etc/systemd/system/tomcat9.service.d/override.conf
-                                        echo "Created /etc/systemd/system/tomcat9.service.d/override.conf so that tomcat9 read and write on /usr/share/carlos-emr " >>$LOG_FILE
-                                        echo "Allowing tomcat9 read and write on /var/lib/OscarDocument/ and /tmp/ by override"
+                                        echo "Created /etc/systemd/system/tomcat9.service.d/override.conf so that tomcat9 read and write on ${BASE_DOCUMENT_DIR}" >>$LOG_FILE
+                                        echo "Allowing tomcat9 read and write on ${BASE_DOCUMENT_DIR}/ and /tmp/ by override"
                                         systemctl daemon-reload
                                 else
                                #test to see if the ReadWritePaths entry is already present
-                                        if grep -Fq "ReadWritePaths=/var/lib/OscarDocument/" /etc/systemd/system/tomcat9.service.d/override.conf ; then
+                                        if grep -Fq "ReadWritePaths=${BASE_DOCUMENT_DIR}/" /etc/systemd/system/tomcat9.service.d/override.conf ; then
                                                 echo "Tomcat already has an override set, not modified"
                                         else
-                                                sed -i '/ReadWritePaths=\/var\/log\/tomcat9\//a ReadWritePaths=/var/lib/OscarDocument/' /etc/systemd/system/tomcat9.service.d/override.conf
-                                                sed -i '/ReadWritePaths=\/var\/log\/tomcat9\//a ReadWritePaths=/tmp/' /etc/systemd/system/tomcat9.service.d/override.conf
-                                                echo "Edited override to allow Tomcat read write on /var/lib/OscarDocument and /tmp"
-                                                echo "Added Tomcat read and write on /var/lib/OscarDocument/ and /tmp/ to existing override /etc/systemd/system/tomcat9.service.d/override.conf"  >>$LOG_FILE
+                                                # Remove stale legacy path if present (old installs used /var/lib/OscarDocument/ which no longer exists)
+                                                sed -i '/ReadWritePaths=\/var\/lib\/OscarDocument\//d' /etc/systemd/system/tomcat9.service.d/override.conf 2>>$LOG_FILE || true
+                                                echo "ReadWritePaths=${BASE_DOCUMENT_DIR}/" >> /etc/systemd/system/tomcat9.service.d/override.conf
+                                                echo "ReadWritePaths=/tmp/" >> /etc/systemd/system/tomcat9.service.d/override.conf
+                                                echo "Edited override to allow Tomcat read write on ${BASE_DOCUMENT_DIR} and /tmp"
+                                                echo "Added Tomcat read and write on ${BASE_DOCUMENT_DIR}/ and /tmp/ to existing override /etc/systemd/system/tomcat9.service.d/override.conf"  >>$LOG_FILE
                                                 systemctl daemon-reload
-                                        fi                
+                                        fi
                                 fi
                         fi
                         if [ ! -d "/etc/systemd/system/tomcat9.service.d" ] ; then
                                 if [ -f /lib/systemd/system/tomcat9.service ] ; then
                                 #test to see if entry present already
-                                        if grep -Fq "/var/lib/OscarDocument/" /lib/systemd/system/tomcat9.service ; then
-                                                echo "Tomcat already has read write on /var/lib/OscarDocument/"
+                                        if grep -Fq "${BASE_DOCUMENT_DIR}/" /lib/systemd/system/tomcat9.service ; then
+                                                echo "Tomcat already has read write on ${BASE_DOCUMENT_DIR}/"
                                         else
-                                                sed -i '/ReadWritePaths=\/var\/log\/tomcat9\//a ReadWritePaths=/var/lib/OscarDocument/' /lib/systemd/system/tomcat9.service
-                                                sed -i '/ReadWritePaths=\/var\/log\/tomcat9\//a ReadWritePaths=/tmp/' /lib/systemd/system/tomcat9.service
-                                                echo "Edited tomcat9.service to allow Tomcat read write on /var/lib/OscarDocument/ and /tmp/"
-                                                echo "Edited /lib/systemd/system/tomcat9.service to allow Tomcat read write on /var/lib/OscarDocument/ and /tmp/" >>$LOG_FILE 
+                                                # Remove stale legacy path if present
+                                                sed -i '/ReadWritePaths=\/var\/lib\/OscarDocument\//d' /lib/systemd/system/tomcat9.service 2>>$LOG_FILE || true
+                                                sed -i '/ReadWritePaths=\/var\/log\/tomcat9\//a ReadWritePaths=\/var\/lib\/carlos-emr\/OscarDocument\/' /lib/systemd/system/tomcat9.service
+                                                sed -i '/ReadWritePaths=\/var\/log\/tomcat9\//a ReadWritePaths=\/tmp\//' /lib/systemd/system/tomcat9.service
+                                                echo "Edited tomcat9.service to allow Tomcat read write on ${BASE_DOCUMENT_DIR}/ and /tmp/"
+                                                echo "Edited /lib/systemd/system/tomcat9.service to allow Tomcat read write on ${BASE_DOCUMENT_DIR}/ and /tmp/" >>$LOG_FILE
                                                 systemctl daemon-reload
                                         fi
                                 fi
                         fi
                         if [ -f /etc/systemd/system/multi-user.target.wants/tomcat9.service ] ; then
                                 #test to see if entry present already
-                                        if grep -Fq "/var/lib/OscarDocument/" /etc/systemd/system/multi-user.target.wants/tomcat9.service ; then
+                                        if grep -Fq "${BASE_DOCUMENT_DIR}/" /etc/systemd/system/multi-user.target.wants/tomcat9.service ; then
                                                 # in Ubuntu this file is actually a link to tomcatX.service
-                                                echo "Tomcat already has read write on /var/lib/OscarDocument/ with an entry in tomcatX.service" >>$LOG_FILE 
+                                                echo "Tomcat already has read write on ${BASE_DOCUMENT_DIR}/ with an entry in tomcatX.service" >>$LOG_FILE
                                         else
-                                                sed -i '/ReadWritePaths=\/var\/log\/tomcat9\//a ReadWritePaths=/var/lib/OscarDocument/' /etc/systemd/system/multi-user.target.wants/tomcat9.service 
-                                                sed -i '/ReadWritePaths=\/var\/log\/tomcat9\//a ReadWritePaths=/tmp/' /etc/systemd/system/multi-user.target.wants/tomcat9.service        
-                                                echo "Edited tomcatX.service to allow Tomcat read write on /var/lib/OscarDocument/ and /tmp"
-                                                echo "Edited /etc/systemd/system/multi-user.target.wants/tomcatX.service to allow Tomcat read write on /var/lib/OscarDocument/ and /tmp" >>$LOG_FILE 
-                                                systemctl daemon-reload 
-                                        fi        
-                        fi      
+                                                # Remove stale legacy path if present
+                                                sed -i '/ReadWritePaths=\/var\/lib\/OscarDocument\//d' /etc/systemd/system/multi-user.target.wants/tomcat9.service 2>>$LOG_FILE || true
+                                                sed -i '/ReadWritePaths=\/var\/log\/tomcat9\//a ReadWritePaths=\/var\/lib\/carlos-emr\/OscarDocument\//' /etc/systemd/system/multi-user.target.wants/tomcat9.service
+                                                sed -i '/ReadWritePaths=\/var\/log\/tomcat9\//a ReadWritePaths=\/tmp\//' /etc/systemd/system/multi-user.target.wants/tomcat9.service
+                                                echo "Edited tomcatX.service to allow Tomcat read write on ${BASE_DOCUMENT_DIR}/ and /tmp"
+                                                echo "Edited /etc/systemd/system/multi-user.target.wants/tomcatX.service to allow Tomcat read write on ${BASE_DOCUMENT_DIR}/ and /tmp" >>$LOG_FILE
+                                                systemctl daemon-reload
+                                        fi
+                        fi
                         
                         
                 fi

--- a/release/config
+++ b/release/config
@@ -257,7 +257,7 @@ else
                         # BASE_DOCUMENT_DIR is /var/lib/carlos-emr/OscarDocument — ensure it exists
                         # before adding it to the service file or systemd will refuse to start Tomcat.
                         mkdir -p "${BASE_DOCUMENT_DIR}" 2>>$LOG_FILE
-                        chown -R ${TOMCAT_USER}:${TOMCAT_USER} "${BASE_DOCUMENT_DIR}" 2>>$LOG_FILE || true
+                        chown -R "${TOMCAT_USER}:${TOMCAT_USER}" "${BASE_DOCUMENT_DIR}" 2>>$LOG_FILE || true
                         if [ -d "/etc/systemd/system/tomcat9.service.d" ] ; then
                                 if [ ! -f /etc/systemd/system/tomcat9.service.d/override.conf ] ; then
                                         touch /etc/systemd/system/tomcat9.service.d/override.conf
@@ -548,6 +548,7 @@ if [ "${UPGRADE}" = "true" ] ; then
   	db_set carlos-emr/phoneprefix ${phoneprefix}
   	echo "priorschema=${db_name}" >> $LOG_FILE
   	db_set carlos-emr/priorschema $db_name
+  	priorschema=$db_name
   	db_fset carlos-emr/priorschema seen true
     # Initialize ${PROGRAM}.tmp from the bundled source carlos.properties so that the
     # subsequent property-append block (below) has a valid base file to work from.

--- a/release/config
+++ b/release/config
@@ -290,7 +290,7 @@ else
                                         else
                                                 # Remove stale legacy path if present
                                                 sed -i '/ReadWritePaths=\/var\/lib\/OscarDocument\//d' /lib/systemd/system/tomcat9.service 2>>$LOG_FILE || true
-                                                sed -i '/ReadWritePaths=\/var\/log\/tomcat9\//a ReadWritePaths=\/var\/lib\/carlos-emr\/OscarDocument\/' /lib/systemd/system/tomcat9.service
+                                                sed -i "/ReadWritePaths=\/var\/log\/tomcat9\//a ReadWritePaths=${BASE_DOCUMENT_DIR}/" /lib/systemd/system/tomcat9.service
                                                 sed -i '/ReadWritePaths=\/var\/log\/tomcat9\//a ReadWritePaths=\/tmp\//' /lib/systemd/system/tomcat9.service
                                                 echo "Edited tomcat9.service to allow Tomcat read write on ${BASE_DOCUMENT_DIR}/ and /tmp/"
                                                 echo "Edited /lib/systemd/system/tomcat9.service to allow Tomcat read write on ${BASE_DOCUMENT_DIR}/ and /tmp/" >>$LOG_FILE
@@ -306,7 +306,7 @@ else
                                         else
                                                 # Remove stale legacy path if present
                                                 sed -i '/ReadWritePaths=\/var\/lib\/OscarDocument\//d' /etc/systemd/system/multi-user.target.wants/tomcat9.service 2>>$LOG_FILE || true
-                                                sed -i '/ReadWritePaths=\/var\/log\/tomcat9\//a ReadWritePaths=\/var\/lib\/carlos-emr\/OscarDocument\//' /etc/systemd/system/multi-user.target.wants/tomcat9.service
+                                                sed -i "/ReadWritePaths=\/var\/log\/tomcat9\//a ReadWritePaths=${BASE_DOCUMENT_DIR}/" /etc/systemd/system/multi-user.target.wants/tomcat9.service
                                                 sed -i '/ReadWritePaths=\/var\/log\/tomcat9\//a ReadWritePaths=\/tmp\//' /etc/systemd/system/multi-user.target.wants/tomcat9.service
                                                 echo "Edited tomcatX.service to allow Tomcat read write on ${BASE_DOCUMENT_DIR}/ and /tmp"
                                                 echo "Edited /etc/systemd/system/multi-user.target.wants/tomcatX.service to allow Tomcat read write on ${BASE_DOCUMENT_DIR}/ and /tmp" >>$LOG_FILE
@@ -548,6 +548,7 @@ if [ "${UPGRADE}" = "true" ] ; then
   	db_set carlos-emr/phoneprefix ${phoneprefix}
   	echo "priorschema=${db_name}" >> $LOG_FILE
   	db_set carlos-emr/priorschema $db_name
+  	db_fset carlos-emr/priorschema seen true
     # Initialize ${PROGRAM}.tmp from the bundled source carlos.properties so that the
     # subsequent property-append block (below) has a valid base file to work from.
     # The Tomcat path and commented-out properties are adjusted the same way as a new install.

--- a/release/postinst
+++ b/release/postinst
@@ -1,10 +1,10 @@
 #!/bin/bash
 # postinst
 # a script file for CARLOS EMR that installs and tweaks the necessary files
-#===================================================================
-# Copyright Peter Hutten-Czapski 2012-2021 released under the GPL v2
-# v 19.16
-#===================================================================
+#====================================================================
+# Copyright Peter Hutten-Czapski 2012-2026 released under the GPL v2+
+# v 0.1
+#====================================================================
 
 #set -e
 
@@ -12,13 +12,16 @@
 . /usr/share/debconf/confmodule
 
 # PROGRAM matches the war and properties
+# These defaults will be overridden by make_CARLOS_deb.sh
 PROGRAM=carlos
 PACKAGE=carlos-emr
+VERSION=0.1
+PREVIOUS=19
+REVISION=1~1
 db_name=oscar_15
-VERSION=19
-PREVIOUS=15
-REVISION=4~944
-buildDateTime="May 14, 2019 8:55:27 PM"
+buildDateTime="March 14, 2026"
+
+
 if [ -f /usr/share/tomcat10/bin/version.sh ] ; then
         TOMCAT=tomcat10
         TOMCAT_USER=tomcat
@@ -59,9 +62,6 @@ DOCUMENT_DIR=${SRC}OscarDocument/${PROGRAM}/document/
 HL7_COMPLETED_DIR=${SRC}OscarDocument/${PROGRAM}/document/
 JAVA=/usr/lib/jvm/java-8-openjdk-amd64/
 newdate=2019-04-18
-
-#for debug
-#SRC=~/Documents/oscar12-1.6/usr/share/OscarEMR/
 
 LOG_FILE=${SRC}Oscar${VERSION}install.log
 
@@ -1045,5 +1045,4 @@ echo "#########" `date` "#########"  >>$LOG_FILE
 		exit 1
 	;;
 esac
-
 

--- a/release/postrm
+++ b/release/postrm
@@ -1,21 +1,24 @@
 #!/bin/sh
 # postrm
 # a script file for CARLOS EMR that uninstalls and tweaks the necessary files
-#=================================================================
-# Copyright Peter Hutten-Czapski 2012-20 released under the GPL v2
-# v 19.11
-#=================================================================
+#==================================================================
+# Copyright Peter Hutten-Czapski 2012-26 released under the GPL v2+
+# v 0.1
+#==================================================================
 
 # Source debconf library.
 . /usr/share/debconf/confmodule
 
 # PROGRAM matches the war and properties name
+# These defaults will be overridden by make_CARLOS_deb.sh
 PROGRAM=carlos
 PACKAGE=carlos-emr
+VERSION=0.1
+PREVIOUS=19
+REVISION=1~1
 db_name=oscar_15
-VERSION=19
-PREVIOUS=15
-REVISION=4~944
+buildDateTime="March 14, 2026"
+
 if [ -f /usr/share/tomcat10/bin/version.sh ] ; then
         TOMCAT=tomcat10
         TOMCAT_USER=tomcat
@@ -37,7 +40,7 @@ if [ -f /usr/share/tomcat10/bin/version.sh ] ; then
  fi
 C_HOME=/usr/share/${TOMCAT}/
 C_BASE=/var/lib/${TOMCAT}/
-SRC=/usr/share/${PACKAGE}/
+SRC=/var/lib/${PACKAGE}/
 db_password=""
 DOCS=${SRC}/OscarDocument/
 
@@ -194,11 +197,11 @@ case "$1" in
 
 
     #remove the eform library and HRM files added in postinst so as to clear for a new install
-    if [ -e "${SRC}/OscarDocument/oscar/eform/images" ]; then
-	    echo "Deleting ${SRC}/OscarDocument/oscar/eform/images"
-	    rm -f -r ${SRC}/OscarDocument/oscar/eform/images/*.*
-	    echo "Deleting ${SRC}/OscarDocument/oscar/hrm/OMD"
-	    rm -f -r ${SRC}/OscarDocument/oscar/hrm/OMD/*.*
+    if [ -e "${SRC}OscarDocument/${PROGRAM}/eform/images" ]; then
+	    echo "Deleting ${SRC}OscarDocument/${PROGRAM}/eform/images"
+	    rm -f -r ${SRC}OscarDocument/${PROGRAM}/eform/images/*.*
+	    echo "Deleting ${SRC}OscarDocument/${PROGRAM}/hrm/OMD"
+	    rm -f -r ${SRC}OscarDocument/${PROGRAM}/hrm/OMD/*.*
     fi 
 
     # delete all OscarDocuments and files in /usr/share/carlos-emr
@@ -228,4 +231,3 @@ esac
 
 
 exit 0
-

--- a/release/postrm
+++ b/release/postrm
@@ -178,6 +178,17 @@ case "$1" in
         rm -f /etc/systemd/system/${TOMCAT}.service.d/override.conf 2>>$LOG_FILE
         systemctl daemon-reload
     fi
+    # Remove ReadWritePaths entries added by the config script to fallback service files
+    # (only applies when /etc/systemd/system/tomcat9.service.d/ did not exist at install time)
+    if [ -f /lib/systemd/system/tomcat9.service ] ; then
+        sed -i '/ReadWritePaths=\/var\/lib\/carlos-emr\/OscarDocument\//d' /lib/systemd/system/tomcat9.service 2>>$LOG_FILE || true
+        sed -i '/ReadWritePaths=\/tmp\//d' /lib/systemd/system/tomcat9.service 2>>$LOG_FILE || true
+    fi
+    if [ -f /etc/systemd/system/multi-user.target.wants/tomcat9.service ] ; then
+        sed -i '/ReadWritePaths=\/var\/lib\/carlos-emr\/OscarDocument\//d' /etc/systemd/system/multi-user.target.wants/tomcat9.service 2>>$LOG_FILE || true
+        sed -i '/ReadWritePaths=\/tmp\//d' /etc/systemd/system/multi-user.target.wants/tomcat9.service 2>>$LOG_FILE || true
+    fi
+    systemctl daemon-reload 2>>$LOG_FILE || true
 
     # remove property files and the oscar schema
     echo "Dropping ${db_name}"

--- a/release/templates
+++ b/release/templates
@@ -57,6 +57,13 @@ Default: false
 Description: Do you want to use the new contacts interface?
   The new contacts interface allows for an expanded number of relations and other contacts related to the patient.
 
+Template: carlos-emr/priorschema
+Type: string
+Default: none
+Description: Prior database schema name (internal)
+ Used internally to track which schema was in place before upgrade.
+ This is set automatically during OSCAR 19 to CARLOS migration.
+
 Template: carlos-emr/readme
 Type: boolean
 Default: true


### PR DESCRIPTION
### **User description**
Two bugs causing new installs to fail with exit status 10 and Tomcat namespace mount errors:

1. `release/config` hardcoded `ReadWritePaths=/var/lib/OscarDocument/` in the tomcat9 systemd override, but CARLOS stores documents at `/var/lib/carlos-emr/OscarDocument/` (BASE_DOCUMENT_DIR). Systemd refuses to start Tomcat when a listed ReadWritePaths directory does not exist.

2. `release/postinst` calls `db_get carlos-emr/priorschema` but the template was not registered in `release/templates`. Debconf returns exit code 10 for unregistered keys; the confmodule exit trap propagates this as the postinst exit code.

Related to #664.

## Summary by Sourcery

Align packaging scripts and systemd configuration with CARLOS runtime paths to fix installation and startup failures.

Bug Fixes:
- Prevent Tomcat from failing to start on new installs by updating systemd ReadWritePaths and directory handling to use the CARLOS document base directory.
- Avoid Debconf exit status 10 during installation by registering and wiring the missing priorschema template.

Enhancements:
- Add cleanup of Tomcat ReadWritePaths configuration during package removal.
- Update packaging script metadata, including copyright years and version information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated version/revision metadata, build timestamp and install script defaults.
  * Improved document-directory creation, permission handling and service startup/cleanup for Tomcat 9+; removed legacy document path references.
  * Restructured Tomcat selection and install/remove flows for clearer control and daemon reload sequencing.

* **New Features**
  * Added automatic tracking of the prior database schema to assist upgrades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

### **Description**
- Fixes installation issues for CARLOS/Tomcat by aligning systemd configuration with runtime paths.
- Registers the missing `priorschema` Debconf template to prevent installation errors.
- Cleans up legacy paths in Tomcat service files to ensure proper startup.
- Updates copyright information and version metadata across scripts.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config</strong><dd><code>Fix Tomcat ReadWritePaths and Directory Handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release/config
<li>Updated <code>ReadWritePaths</code> to use <code>${BASE_DOCUMENT_DIR}</code> for Tomcat.<br> <li> Added directory creation and permission handling for <br><code>${BASE_DOCUMENT_DIR}</code>.<br> <li> Removed legacy paths to prevent startup failures.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/673/files#diff-4b36345a7700ff49413fc08b0ffcf204552ae5c524cef7ad84e467dfcd881e42">+36/-25</a>&nbsp; </td>
</tr>
</table></td></tr><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>postinst</strong><dd><code>Update Post Installation Script and Metadata</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release/postinst
<li>Registered missing <code>priorschema</code> Debconf template.<br> <li> Updated copyright year and version metadata.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/673/files#diff-7c37c9f79913a59b019dafa1c00f659b425e516d5e9b948cc863ed4c3f65f76e">+11/-12</a>&nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>postrm</strong><dd><code>Enhance Uninstallation Script with Cleanup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release/postrm
<li>Added cleanup for <code>ReadWritePaths</code> on uninstall.<br> <li> Updated copyright year and version metadata.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/673/files#diff-545ec3c41c2499cafb99b46898b872dbee7160ee384650bd82684266fa96bfb1">+27/-14</a>&nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>templates</strong><dd><code>Add Debconf Template for Prior Schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release/templates
- Added `priorschema` template for tracking database schema.



</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/673/files#diff-bab3ad27853ad40245eb231ffc7cd80c5c1e79cf3ae31b7072c7dc2aedb6577a">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions

