### PR TITLE
Migrate Hibernate result transformers to H6 tuple/list APIs and add tests

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/commn/DemographicSearchResultTransformer.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/DemographicSearchResultTransformer.java
@@ -34,14 +34,16 @@ import java.util.Date;
 import java.util.List;
 
 import org.apache.tools.ant.util.DateUtils;
-import org.hibernate.transform.ResultTransformer;
+import org.hibernate.query.ResultListTransformer;
+import org.hibernate.query.TupleTransformer;
 import io.github.carlos_emr.carlos.commn.dao.DemographicDao;
 import io.github.carlos_emr.carlos.commn.model.Demographic;
 import io.github.carlos_emr.carlos.webserv.rest.to.model.DemographicSearchResult;
 
 import io.github.carlos_emr.carlos.demographic.data.DemographicMerged;
 
-public class DemographicSearchResultTransformer implements ResultTransformer {
+public class DemographicSearchResultTransformer
+        implements TupleTransformer<DemographicSearchResult>, ResultListTransformer<DemographicSearchResult> {
 
     private DemographicDao demographicDao;
     private SimpleDateFormat sdf = new SimpleDateFormat(DateUtils.ISO8601_DATE_PATTERN);
@@ -52,7 +54,7 @@ public class DemographicSearchResultTransformer implements ResultTransformer {
 
 
     @Override
-    public Object transformTuple(Object[] tuple, String[] aliases) {
+    public DemographicSearchResult transformTuple(Object[] tuple, String[] aliases) {
         Integer demographicNo = (Integer) tuple[0];
         String lastName = (String) tuple[1];
         String firstName = (String) tuple[2];
@@ -111,8 +113,7 @@ public class DemographicSearchResultTransformer implements ResultTransformer {
     }
 
     @Override
-    public List transformList(List collection) {
-
+    public List<DemographicSearchResult> transformList(List<DemographicSearchResult> collection) {
         return collection;
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDaoImpl.java
@@ -2677,21 +2677,20 @@ public class DemographicDaoImpl extends AbstractHibernateDao implements Applicat
                 "p.first_name as providerFirstName,d.hin,dm.merged_to");
 
         Session session = currentSession();
-            NativeQuery sqlQuery = session.createNativeQuery(demographicQuery);
+            NativeQuery<DemographicSearchResult> sqlQuery = session.createNativeQuery(demographicQuery);
 
             for (String key : params.keySet()) {
                 sqlQuery.setParameter(key, params.get(key));
             }
 
             sqlQuery.setFirstResult(startIndex);
-            // TODO H6-MIGRATE: setResultTransformer() is removed in Hibernate 6.
-            // Replace with setTupleTransformer() using DemographicSearchResultTransformer.transformTuple() (H6-only API).
             DemographicSearchResultTransformer transformer = new DemographicSearchResultTransformer();
             transformer.setDemographicDao(this);
-            sqlQuery.setResultTransformer(transformer);
+            sqlQuery.setTupleTransformer(transformer);
+            sqlQuery.setResultListTransformer(transformer);
             setLimit(sqlQuery, itemsToReturn);
 
-            return sqlQuery.list();
+            return sqlQuery.getResultList();
     }
 
     private String generateDemographicSearchQuery(LoggedInInfo loggedInInfo, DemographicSearchRequest searchRequest,

--- a/src/main/java/io/github/carlos_emr/carlos/dashboard/handler/AbstractQueryHandler.java
+++ b/src/main/java/io/github/carlos_emr/carlos/dashboard/handler/AbstractQueryHandler.java
@@ -28,7 +28,9 @@
  */
 package io.github.carlos_emr.carlos.dashboard.handler;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.logging.log4j.Logger;
 import org.hibernate.Session;
@@ -80,10 +82,15 @@ public abstract class AbstractQueryHandler extends AbstractHibernateDao {
         Transaction tx = null;
         try (Session session = getSessionFactory().openSession()) {
             tx = session.beginTransaction();
-            NativeQuery<?> sqlQuery = session.createNativeQuery(query);
-            // TODO H6-MIGRATE: setResultTransformer() is removed from Query in H6.
-            // Replace with setTupleTransformer() using a lambda-based tuple transformer (H6-only API).
-            sqlQuery.setResultTransformer(org.hibernate.transform.AliasToEntityMapResultTransformer.INSTANCE);
+            NativeQuery<Map<String, Object>> sqlQuery = session.createNativeQuery(query);
+            sqlQuery.setTupleTransformer((tuple, aliases) -> {
+                Map<String, Object> row = new LinkedHashMap<>();
+                for (int i = 0; i < tuple.length; i++) {
+                    String alias = aliases[i];
+                    row.put(alias != null ? alias : Integer.toString(i), tuple[i]);
+                }
+                return row;
+            });
             List<?> results = sqlQuery.getResultList();
 
             //TODO work on method to detect and exclude demographic files that are

--- a/src/test-modern/java/io/github/carlos_emr/carlos/commn/DemographicSearchResultTransformerUnitTest.java
+++ b/src/test-modern/java/io/github/carlos_emr/carlos/commn/DemographicSearchResultTransformerUnitTest.java
@@ -1,0 +1,148 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.commn;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.github.carlos_emr.carlos.commn.dao.DemographicDao;
+import io.github.carlos_emr.carlos.commn.dao.DemographicMergedDao;
+import io.github.carlos_emr.carlos.commn.dao.RecycleBinDao;
+import io.github.carlos_emr.carlos.commn.dao.SecObjPrivilegeDao;
+import io.github.carlos_emr.carlos.commn.model.Demographic;
+import io.github.carlos_emr.carlos.commn.model.Provider;
+import io.github.carlos_emr.carlos.demographic.data.DemographicMerged;
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
+import io.github.carlos_emr.carlos.webserv.rest.to.model.DemographicSearchResult;
+
+@Tag("unit")
+@Tag("fast")
+@DisplayName("DemographicSearchResultTransformer Unit Tests")
+class DemographicSearchResultTransformerUnitTest extends CarlosUnitTestBase {
+
+    private DemographicSearchResultTransformer transformer;
+    private DemographicDao demographicDao;
+    private DemographicMerged demographicMerged;
+
+    @BeforeEach
+    void setUp() {
+        registerMock(DemographicMergedDao.class, mock(DemographicMergedDao.class));
+        registerMock(SecObjPrivilegeDao.class, mock(SecObjPrivilegeDao.class));
+        registerMock(RecycleBinDao.class, mock(RecycleBinDao.class));
+
+        transformer = new DemographicSearchResultTransformer();
+        demographicDao = mock(DemographicDao.class);
+        demographicMerged = mock(DemographicMerged.class);
+
+        transformer.setDemographicDao(demographicDao);
+        injectDependency(transformer, "dm", demographicMerged);
+    }
+
+    @Test
+    @DisplayName("transformTuple should map native query columns directly when demographic is not merged")
+    void transformTuple_shouldMapTupleValues_whenDemographicIsNotMerged() {
+        Object[] tuple = {
+            42, "Smith", "Jane", "CH-001", "F", "1001", "ROSTERED", "AC",
+            "416-555-0100", "1990", "03", "05", "House", "Gregory", "1234567890", null
+        };
+
+        DemographicSearchResult result = transformer.transformTuple(tuple, new String[tuple.length]);
+
+        assertThat(result.getDemographicNo()).isEqualTo(42);
+        assertThat(result.getLastName()).isEqualTo("Smith");
+        assertThat(result.getFirstName()).isEqualTo("Jane");
+        assertThat(result.getChartNo()).isEqualTo("CH-001");
+        assertThat(result.getSex()).isEqualTo("F");
+        assertThat(result.getProviderNo()).isEqualTo("1001");
+        assertThat(result.getProviderName()).isEqualTo("House,Gregory");
+        assertThat(result.getRosterStatus()).isEqualTo("ROSTERED");
+        assertThat(result.getPatientStatus()).isEqualTo("AC");
+        assertThat(result.getPhone()).isEqualTo("416-555-0100");
+        assertThat(result.getHin()).isEqualTo("1234567890");
+        assertThat(result.getFormattedDOB()).isEqualTo("1990-03-05");
+    }
+
+    @Test
+    @DisplayName("transformTuple should use the head demographic details when source demographic is merged")
+    void transformTuple_shouldUseHeadDemographicValues_whenDemographicIsMerged() {
+        Provider provider = new Provider();
+        provider.setFirstName("Meredith");
+        provider.setLastName("Grey");
+
+        Demographic headDemographic = new Demographic();
+        headDemographic.setDemographicNo(99);
+        headDemographic.setLastName("Head");
+        headDemographic.setFirstName("Patient");
+        headDemographic.setChartNo("HEAD-99");
+        headDemographic.setSex("X");
+        headDemographic.setProviderNo("2002");
+        headDemographic.setRosterStatus("ACTIVE");
+        headDemographic.setPatientStatus("MO");
+        headDemographic.setPhone("647-555-0101");
+        headDemographic.setYearOfBirth("1985");
+        headDemographic.setMonthOfBirth("07");
+        headDemographic.setDateOfBirth("09");
+        headDemographic.setHin("9999999999");
+        headDemographic.setProvider(provider);
+
+        when(demographicMerged.getHead(42)).thenReturn(99);
+        when(demographicDao.getDemographicById(99)).thenReturn(headDemographic);
+
+        Object[] tuple = {
+            42, "Child", "Record", "CHILD-42", "F", "1001", "OLD", "AC",
+            "416-555-0100", "1990", "03", "05", "House", "Gregory", "1234567890", 99
+        };
+
+        DemographicSearchResult result = transformer.transformTuple(tuple, new String[tuple.length]);
+
+        assertThat(result.getDemographicNo()).isEqualTo(99);
+        assertThat(result.getLastName()).isEqualTo("Head");
+        assertThat(result.getFirstName()).isEqualTo("Patient");
+        assertThat(result.getChartNo()).isEqualTo("HEAD-99");
+        assertThat(result.getSex()).isEqualTo("X");
+        assertThat(result.getProviderNo()).isEqualTo("2002");
+        assertThat(result.getProviderName()).isEqualTo("Grey,Meredith");
+        assertThat(result.getRosterStatus()).isEqualTo("ACTIVE");
+        assertThat(result.getPatientStatus()).isEqualTo("MO");
+        assertThat(result.getPhone()).isEqualTo("647-555-0101");
+        assertThat(result.getHin()).isEqualTo("9999999999");
+        assertThat(result.getFormattedDOB()).isEqualTo("1985-07-09");
+    }
+
+    @Test
+    @DisplayName("transformList should return the same list instance unchanged")
+    void transformList_shouldReturnOriginalCollection() {
+        List<DemographicSearchResult> results = List.of(new DemographicSearchResult());
+
+        List<DemographicSearchResult> transformed = transformer.transformList(results);
+
+        assertThat(transformed).isSameAs(results);
+    }
+}

--- a/src/test-modern/java/io/github/carlos_emr/carlos/dashboard/handler/AbstractQueryHandlerIntegrationTest.java
+++ b/src/test-modern/java/io/github/carlos_emr/carlos/dashboard/handler/AbstractQueryHandlerIntegrationTest.java
@@ -135,7 +135,7 @@ public class AbstractQueryHandlerIntegrationTest extends CarlosTestBase {
          *
          * <p>The underlying method opens its own Hibernate {@code Session} and
          * {@code Transaction}, executes the given native SQL, applies the
-         * {@code ALIAS_TO_ENTITY_MAP} result transformer, and returns the results
+         * tuple transformer, and returns the results
          * as a list of {@code Map<String, Object>} entries.</p>
          *
          * @param query String the native SQL query to execute
@@ -645,7 +645,7 @@ public class AbstractQueryHandlerIntegrationTest extends CarlosTestBase {
      *       inserted via the EntityManager is NOT visible to executed queries.</li>
      *   <li>Tests therefore use self-contained queries (e.g., {@code SELECT 1})
      *       that do not depend on pre-existing database rows.</li>
-     *   <li>The result transformer {@code ALIAS_TO_ENTITY_MAP} converts each
+     *   <li>The Hibernate tuple transformer converts each
      *       result row into a {@code Map<String, Object>} keyed by column alias.</li>
      *   <li>Invalid SQL should trigger a {@code RuntimeException} wrapping the
      *       underlying Hibernate/database exception.</li>
@@ -663,7 +663,7 @@ public class AbstractQueryHandlerIntegrationTest extends CarlosTestBase {
          * and requires no pre-existing data. The test validates that:</p>
          * <ol>
          *   <li>The result list is non-null and contains exactly one row</li>
-         *   <li>Each row is a {@code Map} (from the ALIAS_TO_ENTITY_MAP transformer)</li>
+         *   <li>Each row is a {@code Map} (from the Hibernate tuple transformer)</li>
          *   <li>The map contains the expected {@code "result"} key matching the column alias</li>
          * </ol>
          */
@@ -683,7 +683,7 @@ public class AbstractQueryHandlerIntegrationTest extends CarlosTestBase {
             assertThat(results).isNotNull();
             assertThat(results).hasSize(1);
 
-            // The result transformer ALIAS_TO_ENTITY_MAP returns Map objects
+            // The tuple transformer returns Map objects keyed by column alias
             Object row = results.get(0);
             assertThat(row).isInstanceOf(Map.class);
 


### PR DESCRIPTION
### **User description**
### Motivation
- Update code to use Hibernate 6 result transformation APIs because `setResultTransformer` was removed and the newer tuple/list transformer APIs are required.
- Preserve alias-to-value mapping semantics for native queries while making transformer implementations type-safe and compatible with H6.
- Ensure behavior of the demographic tuple transformer remains correct for merged-demographics and add unit tests to prevent regressions.

### Description
- Replaced usages of the deprecated `ResultTransformer` with `TupleTransformer<T>` and `ResultListTransformer<T>` in `DemographicSearchResultTransformer`, changed method signatures to return `DemographicSearchResult`, and added proper generics and imports.
- Updated `DemographicDaoImpl.searchPatients` to use a generic `NativeQuery<DemographicSearchResult>`, applied `setTupleTransformer` and `setResultListTransformer`, and switched from `list()` to `getResultList()`.
- Reworked `AbstractQueryHandler.execute` to create a `NativeQuery<Map<String, Object>>` and set a tuple transformer lambda that builds a `LinkedHashMap` keyed by column alias to replace the old `AliasToEntityMapResultTransformer` behavior, and added necessary imports.
- Added `DemographicSearchResultTransformerUnitTest` to validate tuple mapping for normal and merged demographics and that `transformList` returns the original collection, and updated integration test comments to reflect tuple transformer behavior.

### Testing
- Ran the new unit test `DemographicSearchResultTransformerUnitTest`, which exercised `transformTuple` and `transformList`, and it passed.
- Ran integration-level tests touching `AbstractQueryHandler` (including `AbstractQueryHandlerIntegrationTest`) to verify native query execution and map-shaped row results, and they passed.
- Executed the test suite via standard Maven test goal (e.g. `mvn test`) to confirm no regressions in modified areas and observed success for the changed tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bad7fae04883289ea64160a9becb7c)


___

### **Description**
- Migrated from deprecated Hibernate 5 APIs to Hibernate 6 tuple and result list transformers.
- Ensured type safety and compatibility with new APIs in `DemographicSearchResultTransformer`.
- Added comprehensive unit tests to validate the new transformer implementations.
- Updated integration tests and comments to reflect the new transformer behavior.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DemographicSearchResultTransformer.java</strong><dd><code>Migrate to Hibernate 6 Tuple and Result List Transformers</code></dd></summary>
<hr>

src/main/java/io/github/carlos_emr/carlos/commn/DemographicSearchResultTransformer.java
<li>Replaced deprecated <code>ResultTransformer</code> with <code>TupleTransformer</code> and <br><code>ResultListTransformer</code>.<br> <li> Updated method signatures to return <code>DemographicSearchResult</code>.<br> <li> Added proper generics for type safety.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/678/files#diff-759c629f4fb7512907260fa7cb8a6224d2f02e3022902fb5fb24989711195d1e">+6/-5</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>DemographicDaoImpl.java</strong><dd><code>Update DemographicDaoImpl for Hibernate 6 Compatibility</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDaoImpl.java
<li>Changed <code>NativeQuery</code> to use generics for <code>DemographicSearchResult</code>.<br> <li> Replaced <code>setResultTransformer</code> with <code>setTupleTransformer</code> and <br><code>setResultListTransformer</code>.<br> <li> Updated method to use <code>getResultList()</code> instead of <code>list()</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/678/files#diff-707b9eff9909e3d94c68e545d5413c18a120657b816a6413cab6ca6a4d3a559f">+4/-5</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>AbstractQueryHandler.java</strong><dd><code>Refactor AbstractQueryHandler for Tuple Transformer Usage</code></dd></summary>
<hr>

src/main/java/io/github/carlos_emr/carlos/dashboard/handler/AbstractQueryHandler.java
<li>Updated to use a lambda-based tuple transformer for native queries.<br> <li> Removed deprecated <code>AliasToEntityMapResultTransformer</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/678/files#diff-823cd17a6eee67a392cb8d3624477fc309d8b76f8caf43aa2c1e2ef9d49de1ad">+11/-4</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DemographicSearchResultTransformerUnitTest.java</strong><dd><code>Add Unit Tests for DemographicSearchResultTransformer</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test-modern/java/io/github/carlos_emr/carlos/commn/DemographicSearchResultTransformerUnitTest.java
<li>Added unit tests for <code>DemographicSearchResultTransformer</code>.<br> <li> Validated tuple mapping for normal and merged demographics.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/678/files#diff-d549ea05d1c55c5086adc021b1ed7ea8aab806cfdf0d1daea8ade105326187d2">+148/-0</a>&nbsp; </td>
</tr>
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AbstractQueryHandlerIntegrationTest.java</strong><dd><code>Update Integration Test Comments for Tuple Transformer</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test-modern/java/io/github/carlos_emr/carlos/dashboard/handler/AbstractQueryHandlerIntegrationTest.java
- Updated comments to reflect changes in transformer usage.



</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/678/files#diff-82b3b98a52e1e9cbaf6ea42fd5545ba71a088fcdc6d588b9da0ea4840478442c">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for demographic search functionality covering merged and non-merged scenario handling.
  * Updated integration test documentation to reflect modernized query result processing.

* **Refactor**
  * Improved type safety across database query operations.
  * Modernized result transformation mechanisms for enhanced data handling reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->