### PR TITLE
fix: resolve 8KB response truncation breaking Struts-rendered JSP pages

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/app/CsrfGuardScriptInjectionFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/app/CsrfGuardScriptInjectionFilter.java
@@ -121,9 +121,12 @@ public class CsrfGuardScriptInjectionFilter implements Filter {
             return;
         }
 
-        // Skip Struts .do requests — Tomcat 11's RequestDispatcher.forward() commits
-        // the underlying response during the forward, making post-chain capture impossible.
-        // JSPs rendered by Struts already include <script src="csrfguard"> via their templates.
+        // Skip Struts .do requests — Tomcat 11's RequestDispatcher.forward() unwraps
+        // HttpServletResponseWrappers during the initial REQUEST dispatch. However, the
+        // filter-mapping includes FORWARD dispatcher, so this filter also runs when Struts
+        // forwards to the JSP. The forward request has a .jsp servletPath, so the wrapper
+        // is applied there — preventing the default 8KB response buffer from truncating
+        // the forwarded JSP output.
         String servletPath = httpRequest.getServletPath();
         if (servletPath != null && servletPath.endsWith(".do")) {
             chain.doFilter(request, response);

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -56,8 +56,10 @@
          requests it handles, so filters placed after it in the chain are never invoked for
          Struts action (.do) responses. Placing these filters here ensures:
            1. CSRFGuard validates tokens on all Struts action POST requests
-           2. CsrfGuardScriptInjectionFilter wraps the response BEFORE Struts renders,
-              so csrfguard.js is injected into Struts-rendered HTML pages
+           2. CsrfGuardScriptInjectionFilter skips .do REQUEST dispatch (Tomcat 11 unwraps
+              wrappers during forward), but runs on the FORWARD dispatch to the JSP where
+              it wraps the response and injects csrfguard.js. The FORWARD dispatcher also
+              prevents the default 8KB response buffer from truncating large JSP pages.
            3. LogoutBroadcastFilter wraps the response BEFORE Struts renders,
               so the logout broadcast script is injected into Struts-rendered HTML pages
               (e.g. Inboxhub.do, DisplayMessages.do)
@@ -70,6 +72,8 @@
     <filter-mapping>
         <filter-name>CsrfGuardScriptInjectionFilter</filter-name>
         <url-pattern>/*</url-pattern>
+        <dispatcher>REQUEST</dispatcher>
+        <dispatcher>FORWARD</dispatcher>
     </filter-mapping>
     <filter-mapping>
         <filter-name>LogoutBroadcastFilter</filter-name>


### PR DESCRIPTION
### **User description**
## Summary

- Struts `.do` actions that forward to JSPs were silently truncated at exactly 8192 bytes (the default Tomcat 11 response buffer), breaking the Messages module — column headers (From, Subject, Date, Patient) were missing
- Root cause: `CsrfGuardScriptInjectionFilter` skipped wrapping `.do` requests, so forwarded JSPs wrote directly to the real response buffer. When the 8KB buffer filled, Tomcat 11 committed and discarded remaining output
- Fix: Added `FORWARD` dispatcher to the `CsrfGuardScriptInjectionFilter` filter-mapping so it wraps the JSP response during Struts forwards, capturing all output in a `CharArrayWriter` and preventing truncation

## Details

The filter still skips `.do` REQUEST dispatch (Tomcat 11 unwraps `HttpServletResponseWrapper` during forward), but now also runs on the FORWARD dispatch to the JSP. Since the forward request has a `.jsp` servletPath, the `CaptureResponseWrapper` is applied — buffering all JSP output and enabling proper csrfguard script injection.

**Files changed:**
- `CsrfGuardScriptInjectionFilter.java` — updated comments documenting FORWARD dispatch behavior
- `web.xml` — added `<dispatcher>REQUEST</dispatcher>` and `<dispatcher>FORWARD</dispatcher>` to the filter mapping

**Before:** Response = 8192 bytes (truncated), missing table columns
**After:** Response = 11426 bytes (complete), all columns render

## Test plan

- [x] Login → click Msg in navbar → verify all 6 column headers render (Status, From, Subject, Date, Patient)
- [x] Verify response size > 8192 bytes in access log
- [x] Verify direct `.jsp` access still works
- [x] Verify non-messenger Struts actions still render correctly (schedule page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **Description**
- Fixed 8KB response truncation issue for Struts-rendered JSP pages.
- Added `FORWARD` dispatcher to `CsrfGuardScriptInjectionFilter` to ensure proper response wrapping.
- Updated comments in code to clarify the handling of `.do` requests and JSP forwards.
- Ensured that all output is captured, preventing loss of data in responses.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CsrfGuardScriptInjectionFilter.java</strong><dd><code>Improve handling of FORWARD dispatcher in </code><br><code>CsrfGuardScriptInjectionFilter</code></dd></summary>
<hr>

src/main/java/io/github/carlos_emr/carlos/app/CsrfGuardScriptInjectionFilter.java
<li>Updated comments to clarify behavior of FORWARD dispatcher.<br> <li> Explained how the filter now handles JSP responses to prevent <br>truncation.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/685/files#diff-c3a9524b2b53b1617686285cbb3efcea3c9372f4c69e296b4e9a9a03afc3d1cc">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>web.xml</strong><dd><code>Update web.xml to include FORWARD dispatcher</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/webapp/WEB-INF/web.xml
<li>Added FORWARD dispatcher to filter mapping for <br>CsrfGuardScriptInjectionFilter.<br> <li> Updated comments to reflect changes in response handling.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/685/files#diff-f1c1b2e33984786db489cb4229fb7610cabae6dc83df075488c9e1236a91268c">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated internal security filter configuration to optimize request and response processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->