### PR TITLE
Fix/e chart truncation

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/app/CsrfGuardScriptInjectionFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/app/CsrfGuardScriptInjectionFilter.java
@@ -122,11 +122,10 @@ public class CsrfGuardScriptInjectionFilter implements Filter {
         }
 
         // Skip Struts .do requests — Tomcat 11's RequestDispatcher.forward() unwraps
-        // HttpServletResponseWrappers during the initial REQUEST dispatch. However, the
-        // filter-mapping includes FORWARD dispatcher, so this filter also runs when Struts
-        // forwards to the JSP. The forward request has a .jsp servletPath, so the wrapper
-        // is applied there — preventing the default 8KB response buffer from truncating
-        // the forwarded JSP output.
+        // HttpServletResponseWrappers, so our CaptureResponseWrapper cannot intercept
+        // the JSP output during forward. Struts-rendered JSPs that exceed the default
+        // 8KB response buffer use <%@ page buffer="none" %> to disable JSP-level
+        // buffering, allowing content to stream directly without truncation.
         String servletPath = httpRequest.getServletPath();
         if (servletPath != null && servletPath.endsWith(".do")) {
             chain.doFilter(request, response);
@@ -248,6 +247,11 @@ public class CsrfGuardScriptInjectionFilter implements Filter {
 
     /**
      * Writes the final content to the real response, updating Content-Length.
+     *
+     * <p>Uses {@code getWriter()} for text content because Tomcat 11's
+     * {@code RequestDispatcher.forward()} may have already opened the writer
+     * on the underlying response. Calling {@code getOutputStream()} after
+     * {@code getWriter()} throws {@code IllegalStateException}.</p>
      */
     private void writeToResponse(HttpServletResponse response, String content) throws IOException {
         // Clear only the response body buffer, preserving status code, headers, and cookies
@@ -264,8 +268,14 @@ public class CsrfGuardScriptInjectionFilter implements Filter {
         }
         byte[] bytes = content.getBytes(encoding);
         response.setContentLength(bytes.length);
-        response.getOutputStream().write(bytes);
-        response.getOutputStream().flush();
+        try {
+            response.getWriter().write(content);
+            response.getWriter().flush();
+        } catch (IllegalStateException e) {
+            // getWriter() failed because getOutputStream() was already called — use stream instead
+            response.getOutputStream().write(bytes);
+            response.getOutputStream().flush();
+        }
     }
 
     @Override

--- a/src/main/java/io/github/carlos_emr/carlos/app/CsrfGuardScriptInjectionFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/app/CsrfGuardScriptInjectionFilter.java
@@ -121,11 +121,11 @@ public class CsrfGuardScriptInjectionFilter implements Filter {
             return;
         }
 
-        // Skip Struts .do requests — Tomcat 11's RequestDispatcher.forward() unwraps
-        // HttpServletResponseWrappers, so our CaptureResponseWrapper cannot intercept
-        // the JSP output during forward. Struts-rendered JSPs that exceed the default
-        // 8KB response buffer use <%@ page buffer="none" %> to disable JSP-level
-        // buffering, allowing content to stream directly without truncation.
+        // Skip Struts .do requests — Tomcat 11's RequestDispatcher.forward() closes
+        // the output stream after the first buffer flush, truncating responses > 8KB.
+        // The filter-mapping includes FORWARD dispatcher so this filter also runs when
+        // Struts forwards to the JSP, wrapping it to prevent truncation. AJAX sidebar
+        // calls use EctDisplayAction.include() which bypasses Struts results entirely.
         String servletPath = httpRequest.getServletPath();
         if (servletPath != null && servletPath.endsWith(".do")) {
             chain.doFilter(request, response);

--- a/src/main/java/io/github/carlos_emr/carlos/app/CsrfGuardScriptInjectionFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/app/CsrfGuardScriptInjectionFilter.java
@@ -266,13 +266,18 @@ public class CsrfGuardScriptInjectionFilter implements Filter {
         if (encoding == null || encoding.isEmpty()) {
             encoding = "UTF-8";
         }
-        byte[] bytes = content.getBytes(encoding);
-        response.setContentLength(bytes.length);
         try {
+            // Use getWriter() for text responses. Content-Length is not set here — the byte
+            // count from content.getBytes(encoding) may differ from what the writer sends if
+            // the response encoding changes, causing client-side truncation from a mismatched
+            // header. The container computes the correct length via chunked transfer encoding.
             response.getWriter().write(content);
             response.getWriter().flush();
         } catch (IllegalStateException e) {
-            // getWriter() failed because getOutputStream() was already called — use stream instead
+            // getWriter() failed because getOutputStream() was already called — use byte stream.
+            // Content-Length is safe here since we write the exact same bytes array.
+            byte[] bytes = content.getBytes(encoding);
+            response.setContentLength(bytes.length);
             response.getOutputStream().write(bytes);
             response.getOutputStream().flush();
         }

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/pageUtil/EctDisplayAction.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/pageUtil/EctDisplayAction.java
@@ -215,10 +215,11 @@ public class EctDisplayAction extends ActionSupport {
             MiscUtils.getLogger().error("Forward :" + forward + " navName :" + navName + " cmd " + cmd + " params " + params);
         }
 
-        // Use include() instead of returning "success" which triggers Struts' forward().
-        // RequestDispatcher.forward() closes the output stream in Tomcat 11, truncating
-        // responses at the 8KB buffer boundary. include() leaves the stream open.
-        if ("success".equals(forward)) {
+        // Use include() for XHR requests only. Struts' forward() closes the output stream
+        // in Tomcat 11, truncating AJAX responses at the 8KB buffer boundary — include()
+        // leaves the stream open. For non-XHR requests, return "success" so Struts performs
+        // a FORWARD dispatch, allowing CsrfGuardScriptInjectionFilter to run on the FORWARD.
+        if ("success".equals(forward) && "XMLHttpRequest".equalsIgnoreCase(request.getHeader("X-Requested-With"))) {
             String jspPath = Actions.get("success");
             request.getRequestDispatcher(jspPath).include(request, response);
             return NONE;

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/pageUtil/EctDisplayAction.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/pageUtil/EctDisplayAction.java
@@ -214,6 +214,16 @@ public class EctDisplayAction extends ActionSupport {
         if (forward != null && !forward.equals("success")) {
             MiscUtils.getLogger().error("Forward :" + forward + " navName :" + navName + " cmd " + cmd + " params " + params);
         }
+
+        // Use include() instead of returning "success" which triggers Struts' forward().
+        // RequestDispatcher.forward() closes the output stream in Tomcat 11, truncating
+        // responses at the 8KB buffer boundary. include() leaves the stream open.
+        if ("success".equals(forward)) {
+            String jspPath = Actions.get("success");
+            request.getRequestDispatcher(jspPath).include(request, response);
+            return NONE;
+        }
+
         return forward;
     }
 

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -56,10 +56,8 @@
          requests it handles, so filters placed after it in the chain are never invoked for
          Struts action (.do) responses. Placing these filters here ensures:
            1. CSRFGuard validates tokens on all Struts action POST requests
-           2. CsrfGuardScriptInjectionFilter skips .do REQUEST dispatch (Tomcat 11 unwraps
-              wrappers during forward), but runs on the FORWARD dispatch to the JSP where
-              it wraps the response and injects csrfguard.js. The FORWARD dispatcher also
-              prevents the default 8KB response buffer from truncating large JSP pages.
+           2. CsrfGuardScriptInjectionFilter wraps the response BEFORE Struts renders,
+              so csrfguard.js is injected into Struts-rendered HTML pages
            3. LogoutBroadcastFilter wraps the response BEFORE Struts renders,
               so the logout broadcast script is injected into Struts-rendered HTML pages
               (e.g. Inboxhub.do, DisplayMessages.do)
@@ -72,8 +70,6 @@
     <filter-mapping>
         <filter-name>CsrfGuardScriptInjectionFilter</filter-name>
         <url-pattern>/*</url-pattern>
-        <dispatcher>REQUEST</dispatcher>
-        <dispatcher>FORWARD</dispatcher>
     </filter-mapping>
     <filter-mapping>
         <filter-name>LogoutBroadcastFilter</filter-name>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -70,6 +70,8 @@
     <filter-mapping>
         <filter-name>CsrfGuardScriptInjectionFilter</filter-name>
         <url-pattern>/*</url-pattern>
+        <dispatcher>REQUEST</dispatcher>
+        <dispatcher>FORWARD</dispatcher>
     </filter-mapping>
     <filter-mapping>
         <filter-name>LogoutBroadcastFilter</filter-name>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -56,8 +56,10 @@
          requests it handles, so filters placed after it in the chain are never invoked for
          Struts action (.do) responses. Placing these filters here ensures:
            1. CSRFGuard validates tokens on all Struts action POST requests
-           2. CsrfGuardScriptInjectionFilter wraps the response BEFORE Struts renders,
-              so csrfguard.js is injected into Struts-rendered HTML pages
+           2. CsrfGuardScriptInjectionFilter skips .do REQUEST dispatch (Tomcat 11 unwraps
+              wrappers during forward), but runs on the FORWARD dispatch to the JSP where
+              it wraps the response and injects csrfguard.js. The FORWARD dispatcher also
+              prevents the default 8KB response buffer from truncating large JSP pages.
            3. LogoutBroadcastFilter wraps the response BEFORE Struts renders,
               so the logout broadcast script is injected into Struts-rendered HTML pages
               (e.g. Inboxhub.do, DisplayMessages.do)

--- a/src/main/webapp/casemgmt/newEncounterLayout.js.jsp
+++ b/src/main/webapp/casemgmt/newEncounterLayout.js.jsp
@@ -31,12 +31,6 @@
     <%@ taglib uri="jakarta.tags.core" prefix="c"%>
     <c:set var="ctx" value="${pageContext.request.contextPath}"	scope="request" />
 
-    Messenger.options = {
-        delay: 10,
-        extraClasses: 'messenger-fixed messenger-on-top messenger-on-left',
-        theme: 'future'
-    };
-
 // global message
     var msg;
 

--- a/src/main/webapp/casemgmt/newEncounterLayout.jsp
+++ b/src/main/webapp/casemgmt/newEncounterLayout.jsp
@@ -89,7 +89,6 @@
         <link rel="stylesheet" href="<c:out value="${ctx}"/>/css/encounterStyles.css" type="text/css">
         <link rel="stylesheet" type="text/css" href="<c:out value="${ctx}"/>/css/print.css" media="print">
 
-        <script src="<c:out value="${ctx}/csrfguard"/>"></script>
         <script type="text/javascript" src="<c:out value="${ctx}/library/jquery/jquery-3.7.1.min.js"/>"></script>
         <script type="text/javascript" src="<c:out value="${ctx}/library/jquery/jquery-ui-1.14.2.min.js" />"></script>
         <script type="text/javascript">jQuery.noConflict();</script>
@@ -97,6 +96,9 @@
         <!-- jQuery.noConflict() frees $ for the Prototype shim; use jQuery() or jQuery.ajax() for jQuery calls -->
         <script src="<c:out value="${ctx}"/>/share/javascript/prototype-compat.js" type="text/javascript"></script>
         <script src="<c:out value="${ctx}"/>/share/javascript/carlos-ajax.js" type="text/javascript"></script>
+        <!-- CSRFGuard must load AFTER prototype-compat.js so its XHR.send() interception
+             takes final precedence for automatic CSRF token injection -->
+        <script src="<c:out value="${ctx}/csrfguard"/>"></script>
 
         <script type="text/javascript" src="<c:out value="${ctx}"/>/casemgmt/newEncounterLayout.js.jsp"></script>
 

--- a/src/main/webapp/eform/visualEformEditor.jsp
+++ b/src/main/webapp/eform/visualEformEditor.jsp
@@ -46,7 +46,7 @@
 --%>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
-<%@ taglib uri="https://www.owasp.org/index.php/OWASP_Java_Encoder_Project" prefix="e" %>
+<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%
     String roleName$ = (String)session.getAttribute("userrole") + "," + (String) session.getAttribute("user");

--- a/src/main/webapp/errorpage.jsp
+++ b/src/main/webapp/errorpage.jsp
@@ -46,7 +46,7 @@
 <!-- only true can access exception object -->
 <%@ taglib uri='jakarta.tags.core' prefix="c" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
-<%@ taglib uri="https://www.owasp.org/index.php/OWASP_Java_Encoder_Project" prefix="e" %>
+<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 <fmt:message key="messenger.config.MessengerAdmin.goBack" var="btnBackTitle"/>
 <fmt:message key="provider.appointmentProviderAdminDay.schedView" var="btnExitTitle"/>

--- a/src/main/webapp/share/javascript/carlos-ajax.js
+++ b/src/main/webapp/share/javascript/carlos-ajax.js
@@ -183,13 +183,23 @@ var CarlosAjax = (function () {
         var isSynchronous = options.synchronous === true ||
                             options.asynchronous === false;
 
-        // Build body
+        // Build body — inject CSRF token as a form parameter for POST requests.
+        // CSRFGuard 4.5 validates tokens from form parameters. We cannot rely on
+        // CSRFGuard's XHR.send() interception because prototype-compat.js overwrites
+        // the XHR prototype chain, bypassing CSRFGuard's token injection.
         var body = null;
         if (method !== 'GET' && method !== 'HEAD') {
             if (options.postBody != null) {
                 body = options.postBody;
             } else if (options.parameters != null) {
                 body = encodeParams(options.parameters);
+            }
+            // Append CSRF token to body if not already present
+            var csrfToken = getCsrfToken();
+            if (csrfToken && body != null && typeof body === 'string' && body.indexOf('CSRF-TOKEN=') === -1) {
+                body += (body ? '&' : '') + 'CSRF-TOKEN=' + encodeURIComponent(csrfToken);
+            } else if (csrfToken && body == null) {
+                body = 'CSRF-TOKEN=' + encodeURIComponent(csrfToken);
             }
         } else if (options.parameters) {
             // Append parameters to URL for GET requests
@@ -261,63 +271,69 @@ var CarlosAjax = (function () {
     }
 
     /**
-     * Asynchronous request using fetch().
+     * Asynchronous request using XMLHttpRequest.
+     *
+     * <p>Uses XHR instead of fetch() so that CSRFGuard 4.5's JavaScript interceptor
+     * can automatically inject CSRF tokens into outgoing requests. CSRFGuard patches
+     * XMLHttpRequest.prototype.send() but cannot intercept the fetch() API.</p>
      */
     function requestAsync(url, method, headers, body, options) {
-        var fetchOptions = {
-            method: method,
-            headers: headers,
-            credentials: 'same-origin'
-        };
-        if (body != null) {
-            fetchOptions.body = body;
+        var xhr = new XMLHttpRequest();
+        xhr.open(method, url, true);
+
+        // Set request headers (X-Requested-With, Content-Type, etc.)
+        // Note: CSRF-TOKEN header is set here as a fallback, but CSRFGuard's
+        // XHR interceptor will also inject it automatically via send() patching.
+        for (var key in headers) {
+            if (headers.hasOwnProperty(key)) {
+                xhr.setRequestHeader(key, headers[key]);
+            }
         }
 
-        return fetch(url, fetchOptions)
-            .then(function (response) {
-                return response.text().then(function (text) {
-                    var transport = makeTransport(response.status, text, response.url, response.statusText);
+        xhr.onload = function () {
+            var transport = makeTransport(xhr.status, xhr.responseText, xhr.responseURL, xhr.statusText);
 
-                    // Detect CSRF rejection (redirect to error page)
-                    if (isCsrfRedirect(response)) {
-                        transport.status = 403;
-                        transport.responseText = 'CSRF validation failed — request was rejected by the server.';
-                        if (options.onFailure) options.onFailure(transport);
-                        if (options.onComplete) options.onComplete(transport);
-                        return;
-                    }
-
-                    // Wrap callbacks in try-catch so that exceptions thrown inside
-                    // onSuccess do NOT propagate to the .catch() and trigger
-                    // onFailure. Prototype's Ajax.Request isolated callback errors
-                    // the same way — an error in onSuccess never fired onFailure.
-                    if (isSuccess(response.status)) {
-                        if (options.onSuccess) {
-                            try { options.onSuccess(transport); } catch (e) {
-                                console.error('CarlosAjax onSuccess error:', e);
-                            }
-                        }
-                    } else {
-                        if (options.onFailure) {
-                            try { options.onFailure(transport); } catch (e) {
-                                console.error('CarlosAjax onFailure error:', e);
-                            }
-                        }
-                    }
-
-                    if (options.onComplete) {
-                        try { options.onComplete(transport); } catch (e) {
-                            console.error('CarlosAjax onComplete error:', e);
-                        }
-                    }
-                });
-            })
-            .catch(function (err) {
-                // Network errors (DNS, connection refused, etc.)
-                var transport = makeTransport(0, 'Network error: ' + err.message);
+            // Detect CSRF rejection (redirect to error page)
+            if (isCsrfRedirect(transport)) {
+                transport.status = 403;
+                transport.responseText = 'CSRF validation failed — request was rejected by the server.';
                 if (options.onFailure) options.onFailure(transport);
                 if (options.onComplete) options.onComplete(transport);
-            });
+                return;
+            }
+
+            // Wrap callbacks in try-catch so that exceptions thrown inside
+            // onSuccess do NOT propagate to onerror and trigger onFailure.
+            // Prototype's Ajax.Request isolated callback errors the same way.
+            if (isSuccess(xhr.status)) {
+                if (options.onSuccess) {
+                    try { options.onSuccess(transport); } catch (e) {
+                        console.error('CarlosAjax onSuccess error:', e);
+                    }
+                }
+            } else {
+                if (options.onFailure) {
+                    try { options.onFailure(transport); } catch (e) {
+                        console.error('CarlosAjax onFailure error:', e);
+                    }
+                }
+            }
+
+            if (options.onComplete) {
+                try { options.onComplete(transport); } catch (e) {
+                    console.error('CarlosAjax onComplete error:', e);
+                }
+            }
+        };
+
+        xhr.onerror = function () {
+            // Network errors (DNS, connection refused, etc.)
+            var transport = makeTransport(0, 'Network error');
+            if (options.onFailure) options.onFailure(transport);
+            if (options.onComplete) options.onComplete(transport);
+        };
+
+        xhr.send(body);
     }
 
     /**

--- a/src/main/webapp/share/javascript/carlos-ajax.js
+++ b/src/main/webapp/share/javascript/carlos-ajax.js
@@ -194,12 +194,15 @@ var CarlosAjax = (function () {
             } else if (options.parameters != null) {
                 body = encodeParams(options.parameters);
             }
-            // Append CSRF token to body if not already present
+            // Append CSRF token to body for form-encoded requests only.
+            // Non-form bodies (e.g. JSON) receive the token via the CSRF-TOKEN header in buildHeaders().
             var csrfToken = getCsrfToken();
-            if (csrfToken && body != null && typeof body === 'string' && body.indexOf('CSRF-TOKEN=') === -1) {
-                body += (body ? '&' : '') + 'CSRF-TOKEN=' + encodeURIComponent(csrfToken);
-            } else if (csrfToken && body == null) {
-                body = 'CSRF-TOKEN=' + encodeURIComponent(csrfToken);
+            if (csrfToken && contentType.indexOf('application/x-www-form-urlencoded') !== -1) {
+                if (body != null && typeof body === 'string' && !/(^|[&])CSRF-TOKEN=/.test(body)) {
+                    body += (body ? '&' : '') + 'CSRF-TOKEN=' + encodeURIComponent(csrfToken);
+                } else if (body == null) {
+                    body = 'CSRF-TOKEN=' + encodeURIComponent(csrfToken);
+                }
             }
         } else if (options.parameters) {
             // Append parameters to URL for GET requests
@@ -297,8 +300,16 @@ var CarlosAjax = (function () {
             if (isCsrfRedirect(transport)) {
                 transport.status = 403;
                 transport.responseText = 'CSRF validation failed — request was rejected by the server.';
-                if (options.onFailure) options.onFailure(transport);
-                if (options.onComplete) options.onComplete(transport);
+                if (options.onFailure) {
+                    try { options.onFailure(transport); } catch (e) {
+                        console.error('CarlosAjax onFailure error:', e);
+                    }
+                }
+                if (options.onComplete) {
+                    try { options.onComplete(transport); } catch (e) {
+                        console.error('CarlosAjax onComplete error:', e);
+                    }
+                }
                 return;
             }
 
@@ -329,8 +340,16 @@ var CarlosAjax = (function () {
         xhr.onerror = function () {
             // Network errors (DNS, connection refused, etc.)
             var transport = makeTransport(0, 'Network error');
-            if (options.onFailure) options.onFailure(transport);
-            if (options.onComplete) options.onComplete(transport);
+            if (options.onFailure) {
+                try { options.onFailure(transport); } catch (e) {
+                    console.error('CarlosAjax onFailure error:', e);
+                }
+            }
+            if (options.onComplete) {
+                try { options.onComplete(transport); } catch (e) {
+                    console.error('CarlosAjax onComplete error:', e);
+                }
+            }
         };
 
         xhr.send(body);


### PR DESCRIPTION
### **User description**
This pull request addresses compatibility issues with Tomcat 11, especially regarding response truncation and CSRF protection, and improves the robustness of AJAX requests and CSRF token injection. The main changes include workarounds for Tomcat 11's handling of response streams, updates to AJAX request logic to ensure CSRF tokens are always sent, and several minor improvements and fixes.

**Tomcat 11 Compatibility and Response Handling:**

* Updated `CsrfGuardScriptInjectionFilter` to clarify and work around Tomcat 11's behavior where `RequestDispatcher.forward()` closes the output stream after the first buffer flush, which could truncate large responses. The filter now ensures that response wrapping and CSRF script injection occur correctly for Struts-rendered pages, and its documentation has been updated for clarity. (`CsrfGuardScriptInjectionFilter.java`, `web.xml`) [[1]](diffhunk://#diff-c3a9524b2b53b1617686285cbb3efcea3c9372f4c69e296b4e9a9a03afc3d1ccL124-R128) [[2]](diffhunk://#diff-f1c1b2e33984786db489cb4229fb7610cabae6dc83df075488c9e1236a91268cL59-R60)
* Modified the filter's `writeToResponse` method to always use `getWriter()` for text content, falling back to `getOutputStream()` only if necessary, to avoid `IllegalStateException` when Tomcat 11 has already opened the writer. (`CsrfGuardScriptInjectionFilter.java`) [[1]](diffhunk://#diff-c3a9524b2b53b1617686285cbb3efcea3c9372f4c69e296b4e9a9a03afc3d1ccR250-R254) [[2]](diffhunk://#diff-c3a9524b2b53b1617686285cbb3efcea3c9372f4c69e296b4e9a9a03afc3d1ccR271-R279)
* Changed `EctDisplayAction` to use `RequestDispatcher.include()` instead of returning "success" (which would trigger a forward), preventing output stream closure and response truncation for AJAX sidebar calls. (`EctDisplayAction.java`)

**CSRF Token Injection and AJAX Improvements:**

* Enhanced `CarlosAjax` to always inject the CSRF token as a form parameter for POST requests, ensuring compatibility with CSRFGuard 4.5 even when prototype-compat.js overwrites the XHR prototype chain. (`carlos-ajax.js`)
* Replaced the use of `fetch()` with `XMLHttpRequest` for asynchronous requests so that CSRFGuard's JavaScript interceptor can patch and inject CSRF tokens automatically, and improved error handling and callback isolation in the AJAX logic. (`carlos-ajax.js`) [[1]](diffhunk://#diff-421db5305916ea36cb54293aad81c0243792340dbeae3b95192ce67384dc98a4L264-R297) [[2]](diffhunk://#diff-421db5305916ea36cb54293aad81c0243792340dbeae3b95192ce67384dc98a4L291-R308) [[3]](diffhunk://#diff-421db5305916ea36cb54293aad81c0243792340dbeae3b95192ce67384dc98a4L313-R336)

**JavaScript and JSP Fixes:**

* Moved the inclusion of the CSRFGuard script in `newEncounterLayout.jsp` to load after `prototype-compat.js`, ensuring proper interception of XHR requests for CSRF protection. (`newEncounterLayout.jsp`)
* Updated taglib URIs for the OWASP Java Encoder Project to use the new `owasp.encoder.jakarta` namespace for Jakarta EE 10 compatibility. (`visualEformEditor.jsp`, `errorpage.jsp`) [[1]](diffhunk://#diff-206a18597d6078a3b09aea8b179c9291c1edb38afeb9d85da15728505d7b7c4bL49-R49) [[2]](diffhunk://#diff-43833d52a809c697cd63cafcf3361a0de7fc87c0b48219f8cfaa8c0d8d1e898bL49-R49)
* Removed unused or redundant Messenger.js configuration from `newEncounterLayout.js.jsp`. (`newEncounterLayout.js.jsp`)

These changes collectively ensure robust CSRF protection, prevent response truncation on Tomcat 11, and maintain compatibility with updated libraries and servlet containers.

## Summary by Sourcery

Ensure robust CSRF protection and prevent response truncation when running under Tomcat 11 by adjusting CSRF script injection, AJAX utilities, and JSP configuration.

Bug Fixes:
- Prevent truncation of large Struts-rendered responses on Tomcat 11 by adjusting CSRF script injection and ECT display handling.
- Ensure CSRF tokens are reliably sent with AJAX POST requests even when prototype shims interfere with CSRFGuard's XHR interception.

Enhancements:
- Replace fetch()-based AJAX calls with XMLHttpRequest to integrate with CSRFGuard's interceptor and improve callback error isolation.
- Simplify encounter layout JavaScript by removing unused Messenger configuration.
- Update OWASP Java Encoder JSP taglib URIs for Jakarta EE compatibility.


___

### **Description**
- Improved compatibility with Tomcat 11 by updating response handling in `CsrfGuardScriptInjectionFilter`.
- Prevented response truncation for AJAX calls by using `include()` in `EctDisplayAction`.
- Updated OWASP encoder taglib URIs to be Jakarta-compatible across multiple JSP files.
- Enhanced AJAX request handling in `carlos-ajax.js` to ensure CSRF tokens are properly injected.
- Cleaned up JavaScript initialization in `newEncounterLayout.js.jsp`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CsrfGuardScriptInjectionFilter.java</strong><dd><code>Improve CSRF Handling and Response Writing in Filter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/io/github/carlos_emr/carlos/app/CsrfGuardScriptInjectionFilter.java
<li>Updated <code>writeToResponse</code> to use <code>getWriter()</code> for text content to prevent <br><code>IllegalStateException</code>.<br> <li> Clarified comments regarding Tomcat 11's behavior with <br><code>RequestDispatcher.forward()</code>.<br> <li> Enhanced handling of AJAX sidebar calls to prevent response <br>truncation.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/687/files#diff-c3a9524b2b53b1617686285cbb3efcea3c9372f4c69e296b4e9a9a03afc3d1cc">+18/-8</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>EctDisplayAction.java</strong><dd><code>Prevent Response Truncation in EctDisplayAction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/io/github/carlos_emr/carlos/encounter/pageUtil/EctDisplayAction.java
<li>Changed to use <code>RequestDispatcher.include()</code> instead of returning <br>"success" to prevent output stream closure.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/687/files#diff-70f00044d6c50a6d0f269397b1561c73472298a1970d7366aa14ee1de99b4fed">+10/-0</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>web.xml</strong><dd><code>Update Filter Behavior Documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/webapp/WEB-INF/web.xml
<li>Updated comments to reflect changes in CSRFGuard filter behavior with <br>Struts.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/687/files#diff-f1c1b2e33984786db489cb4229fb7610cabae6dc83df075488c9e1236a91268c">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>newEncounterLayout.js.jsp</strong><dd><code>Clean Up JavaScript Initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/webapp/casemgmt/newEncounterLayout.js.jsp
- Removed orphaned `Messenger.options` initialization.



</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/687/files#diff-8b2dc954e130592a5163185667447a428b38936ec503762737d95122aec8f12a">+0/-6</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>newEncounterLayout.jsp</strong><dd><code>Adjust Script Loading Order for CSRFGuard</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/webapp/casemgmt/newEncounterLayout.jsp
<li>Moved CSRFGuard script tag to ensure proper loading order for AJAX <br>requests.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/687/files#diff-2c2dd592db64269f34f5e292d31c1ff762588cf8be021b043d9506f09b992d4c">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>visualEformEditor.jsp</strong><dd><code>Update OWASP Encoder Taglib URI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/webapp/eform/visualEformEditor.jsp
- Updated OWASP encoder taglib URI to Jakarta-compatible version.



</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/687/files#diff-206a18597d6078a3b09aea8b179c9291c1edb38afeb9d85da15728505d7b7c4b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>errorpage.jsp</strong><dd><code>Update OWASP Encoder Taglib URI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/webapp/errorpage.jsp
- Updated OWASP encoder taglib URI to Jakarta-compatible version.



</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/687/files#diff-43833d52a809c697cd63cafcf3361a0de7fc87c0b48219f8cfaa8c0d8d1e898b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>carlos-ajax.js</strong><dd><code>Enhance AJAX Requests for CSRF Compatibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/webapp/share/javascript/carlos-ajax.js
<li>Migrated from <code>fetch()</code> to <code>XMLHttpRequest</code> for AJAX requests to ensure <br>CSRF token injection.<br> <li> Injected CSRF token as a form parameter for POST requests.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/687/files#diff-421db5305916ea36cb54293aad81c0243792340dbeae3b95192ce67384dc98a4">+67/-51</a>&nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSRF protection filter reliability and compatibility with Tomcat 11 application server
  * Fixed JavaScript initialization order to ensure security scripts execute with proper precedence
  * Enhanced error handling for AJAX state management

* **New Features**
  * Automatic CSRF token injection for AJAX requests to improve security

* **Chores**
  * Updated to Jakarta-compatible OWASP encoder library for encoding functions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->