### PR TITLE
fix: resolve CSRF duplicate header causing echart 403 errors

### DIFF
--- a/src/main/webapp/share/javascript/carlos-ajax.js
+++ b/src/main/webapp/share/javascript/carlos-ajax.js
@@ -84,12 +84,15 @@ var CarlosAjax = (function () {
             }
         }
 
-        // Security headers applied AFTER caller headers — cannot be overridden
-        headers['X-Requested-With'] = 'XMLHttpRequest';
-
-        if (MUTATING_METHODS.indexOf(method.toUpperCase()) !== -1) {
-            headers['CSRF-TOKEN'] = getCsrfToken();
-        }
+        // Do NOT set X-Requested-With or CSRF-TOKEN headers here.
+        // CSRFGuard 4.5's XHR onsend interceptor automatically injects both
+        // headers into every XMLHttpRequest.send() call. Setting them here
+        // causes duplicate setRequestHeader() calls, which per the XHR spec
+        // APPENDS values with a comma (e.g. "token, token") instead of
+        // replacing — CSRFGuard then rejects the request because the combined
+        // header value doesn't match the master token.
+        //
+        // CSRF tokens for the POST body are still injected in request() below.
 
         return headers;
     }
@@ -184,9 +187,9 @@ var CarlosAjax = (function () {
                             options.asynchronous === false;
 
         // Build body — inject CSRF token as a form parameter for POST requests.
-        // CSRFGuard 4.5 validates tokens from form parameters. We cannot rely on
-        // CSRFGuard's XHR.send() interception because prototype-compat.js overwrites
-        // the XHR prototype chain, bypassing CSRFGuard's token injection.
+        // CSRFGuard 4.5 validates tokens from both request parameters and headers.
+        // The header is injected automatically by CSRFGuard's XHR onsend interceptor.
+        // The body parameter provides a second source for token validation.
         var body = null;
         if (method !== 'GET' && method !== 'HEAD') {
             if (options.postBody != null) {
@@ -284,9 +287,9 @@ var CarlosAjax = (function () {
         var xhr = new XMLHttpRequest();
         xhr.open(method, url, true);
 
-        // Set request headers (X-Requested-With, Content-Type, etc.)
-        // Note: CSRF-TOKEN header is set here as a fallback, but CSRFGuard's
-        // XHR interceptor will also inject it automatically via send() patching.
+        // Set caller-provided headers (Content-Type, etc.)
+        // CSRFGuard's onsend interceptor adds X-Requested-With and CSRF-TOKEN
+        // automatically — do NOT set those here or they will be duplicated.
         for (var key in headers) {
             if (headers.hasOwnProperty(key)) {
                 xhr.setRequestHeader(key, headers[key]);


### PR DESCRIPTION
### **User description**
## Summary

- Fix CSRF token validation failure on all `CarlosAjax` POST requests (echart sidebar panels, encounter notes, nav bar sections)
- **Root cause**: `CarlosAjax.buildHeaders()` manually set `CSRF-TOKEN` and `X-Requested-With` headers via `xhr.setRequestHeader()`. CSRFGuard 4.5's XHR `onsend` interceptor also calls `setRequestHeader()` for both headers. Per the XHR spec, duplicate `setRequestHeader()` calls **append** values with a comma (e.g. `token, token`), and CSRFGuard rejects the combined value because it doesn't match the master token.
- **Fix**: Remove manual header injection from `buildHeaders()` — CSRFGuard's `onsend` interceptor handles both headers automatically. CSRF token injection into the POST body (form parameter) is retained as a secondary validation source.

## Test plan

- [ ] Hard-refresh browser (Ctrl+Shift+R) to clear cached JS
- [ ] Login and open echart — all sidebar panels (Dx, allergies, Rx, labs, ticklers, forms, etc.) should load without 403 errors
- [ ] Verify encounter notes load in the main content area
- [ ] Check server logs for absence of `CSRF violation` entries after login
- [ ] Test other pages using `CarlosAjax` (lab results, prescriptions, billing) for POST functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Resolve CSRF token validation failures on CarlosAjax POST requests by deferring CSRF-related headers to CSRFGuard’s XHR interceptor and relying on the existing POST body token injection.

Bug Fixes:
- Prevent 403 errors caused by duplicated CSRF-TOKEN and X-Requested-With headers on CarlosAjax XMLHttpRequests under CSRFGuard 4.5.

Enhancements:
- Clarify inline documentation around CSRFGuard’s header and form-parameter token validation behavior in CarlosAjax.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated AJAX security header handling to rely on automatic injection rather than manual implementation, reducing code complexity while maintaining security standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

### **Description**
- Fixed CSRF token validation failures on `CarlosAjax` POST requests by removing manual header settings.
- Enhanced inline documentation regarding CSRFGuard's header handling behavior.
- Prevented 403 errors caused by duplicate CSRF headers in XMLHttpRequests.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>carlos-ajax.js</strong><dd><code>Refactor CSRF header handling in CarlosAjax</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/webapp/share/javascript/carlos-ajax.js
<li>Removed manual setting of <code>X-Requested-With</code> and <code>CSRF-TOKEN</code> headers.<br> <li> Updated comments to clarify CSRFGuard's automatic header injection.<br> <li> Ensured CSRF token is still injected into the POST body for <br>validation.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/688/files#diff-421db5305916ea36cb54293aad81c0243792340dbeae3b95192ce67384dc98a4">+15/-12</a>&nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions

