### PR TITLE
Fix visualEformEditor.jsp malformation

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/eform/EFormLoader.java
+++ b/src/main/java/io/github/carlos_emr/carlos/eform/EFormLoader.java
@@ -177,7 +177,7 @@ public class EFormLoader {
             if (configpath == null) {
                 EFormLoader eLoader = new EFormLoader();
                 ClassLoader loader = eLoader.getClass().getClassLoader();
-                fs = loader.getResourceAsStream("/oscar/eform/apconfig.xml");
+                fs = loader.getResourceAsStream("oscar/eform/apconfig.xml");
             } else {
                 fs = new FileInputStream(configpath);
             }

--- a/src/main/resources/oscarResources_en.properties
+++ b/src/main/resources/oscarResources_en.properties
@@ -8462,4 +8462,5 @@ eform.visual.editor.text.trash=Trash
 eform.visual.editor.text.addWetSignature=Add Wet Signature:
 eform.visual.editor.text.controls=Controls
 eform.visual.editor.text.guideOptions=Guide Options
+eform.visual.editor.title=Visual eForm Editor
 

--- a/src/main/resources/oscarResources_es.properties
+++ b/src/main/resources/oscarResources_es.properties
@@ -6624,6 +6624,7 @@ eform.visual.editor.text.trash=Papelera
 eform.visual.editor.text.addWetSignature=Agregar Firma H\u00fameda:
 eform.visual.editor.text.controls=Controles
 eform.visual.editor.text.guideOptions=Opciones de Gu\u00eda
+eform.visual.editor.title=Editor Visual de eForm
 oscarprevention.addpreventiondata.comments=Comentarios
 oscarprevention.addpreventiondata.setnextdate=Establecer pr\u00f3xima fecha
 oscarprevention.addpreventiondata.nextdate=Pr\u00f3xima fecha:

--- a/src/main/resources/oscarResources_fr.properties
+++ b/src/main/resources/oscarResources_fr.properties
@@ -6456,3 +6456,4 @@ eform.visual.editor.text.trash=Corbeille
 eform.visual.editor.text.addWetSignature=Ajouter une signature manuelle:
 eform.visual.editor.text.controls=Contr\u00f4les
 eform.visual.editor.text.guideOptions=Options de guide
+eform.visual.editor.title=\u00c9diteur visuel d'eForm

--- a/src/main/resources/oscarResources_pl.properties
+++ b/src/main/resources/oscarResources_pl.properties
@@ -5946,6 +5946,7 @@ eform.visual.editor.text.trash=Kosz
 eform.visual.editor.text.addWetSignature=Dodaj podpis w\u0142asnor\u0119czny:
 eform.visual.editor.text.controls=Kontrolki
 eform.visual.editor.text.guideOptions=Opcje prowadnic
+eform.visual.editor.title=Wizualny edytor eFormularzy
 oscarprevention.addpreventiondata.comments=Komentarze
 oscarprevention.addpreventiondata.setnextdate=Ustaw nast\u0119pn\u0105 dat\u0119
 oscarprevention.addpreventiondata.nextdate=Nast\u0119pna data:

--- a/src/main/resources/oscarResources_pt_BR.properties
+++ b/src/main/resources/oscarResources_pt_BR.properties
@@ -8281,3 +8281,4 @@ eform.visual.editor.text.trash=Lixeira
 eform.visual.editor.text.addWetSignature=Adicionar Assinatura Manual:
 eform.visual.editor.text.controls=Controles
 eform.visual.editor.text.guideOptions=Op\u00e7\u00f5es de Guia
+eform.visual.editor.title=Editor Visual de eForm

--- a/src/main/resources/spring_ws.xml
+++ b/src/main/resources/spring_ws.xml
@@ -227,6 +227,8 @@
 			<bean class="io.github.carlos_emr.carlos.webserv.rest.LabService" autowire="byName" />
 			<bean class="io.github.carlos_emr.carlos.webserv.rest.MeasurementService" autowire="byName" />
 			<bean class="io.github.carlos_emr.carlos.webserv.rest.ConsentService" autowire="byName" />
+			<bean class="io.github.carlos_emr.carlos.webserv.rest.EFormService" autowire="byName"/>
+			<bean class="io.github.carlos_emr.carlos.webserv.rest.EFormsService" autowire="byName"/>
 		</jaxrs:serviceBeans>
 
 		<jaxrs:extensionMappings>

--- a/src/main/webapp/administration/leftNav.jspf
+++ b/src/main/webapp/administration/leftNav.jspf
@@ -284,7 +284,7 @@ String curProvider_no = (String)session.getAttribute("user");
 						<fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.msgManageEFrm"/>
 					</a></li>
 
-					<li><a href="javascript:void(0);" onclick="window.open('${ctx}/eform/visualEformEditor.jsp', '_blank'); return false;">Visual eForm Editor</a></li>
+					<li><a href="javascript:void(0);" onclick="window.open('${ctx}/eform/visualEformEditor.jsp', '_blank'); return false;"><fmt:setBundle basename="oscarResources"/><fmt:message key="eform.visual.editor.title"/></a></li>
 
 				<li><a href="${ctx}/eform/efmimagemanager.jsp"  class="contentLink defaultImageUpload">
 						<fmt:setBundle basename="oscarResources"/><fmt:message key="admin.admin.btnUploadImage"/>

--- a/src/main/webapp/administration/leftNav.jspf
+++ b/src/main/webapp/administration/leftNav.jspf
@@ -284,7 +284,9 @@ String curProvider_no = (String)session.getAttribute("user");
 						<fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.msgManageEFrm"/>
 					</a></li>
 
-					<li><a href="${ctx}/eform/efmimagemanager.jsp"  class="contentLink defaultImageUpload">
+					<li><a href="javascript:void(0);" onclick="window.open('${ctx}/eform/visualEformEditor.jsp', '_blank'); return false;">Visual eForm Editor</a></li>
+
+				<li><a href="${ctx}/eform/efmimagemanager.jsp"  class="contentLink defaultImageUpload">
 						<fmt:setBundle basename="oscarResources"/><fmt:message key="admin.admin.btnUploadImage"/>
 					</a></li>
 					<li><a href="${ctx}/eform/efmmanageformgroups.jsp" class="contentLink defaultFormsGroups">

--- a/src/main/webapp/administration/leftNav.jspf
+++ b/src/main/webapp/administration/leftNav.jspf
@@ -284,7 +284,9 @@ String curProvider_no = (String)session.getAttribute("user");
 						<fmt:setBundle basename="oscarResources"/><fmt:message key="eform.showmyform.msgManageEFrm"/>
 					</a></li>
 
-					<li><a href="javascript:void(0);" onclick="window.open('${ctx}/eform/visualEformEditor.jsp', '_blank'); return false;"><fmt:setBundle basename="oscarResources"/><fmt:message key="eform.visual.editor.title"/></a></li>
+					<security:oscarSec roleName="<%=roleName$%>" objectName="_admin.eform" rights="w" reverse="<%=false%>">
+				<li><a href="javascript:void(0);" onclick="window.open('${ctx}/eform/visualEformEditor.jsp', '_blank'); return false;"><fmt:setBundle basename="oscarResources"/><fmt:message key="eform.visual.editor.title"/></a></li>
+				</security:oscarSec>
 
 				<li><a href="${ctx}/eform/efmimagemanager.jsp"  class="contentLink defaultImageUpload">
 						<fmt:setBundle basename="oscarResources"/><fmt:message key="admin.admin.btnUploadImage"/>

--- a/src/main/webapp/eform/efmTopNav.jspf
+++ b/src/main/webapp/eform/efmTopNav.jspf
@@ -44,7 +44,7 @@
 		</a>
 		<ul class="dropdown-menu">
 
-		<li><a href='<%= request.getContextPath() %>/eform/visualEformEditor.jsp' target="_blank" rel="noreferrer noopener" class="dropdown-item contentLink">Visual eForm Editor</a></li>
+		<li><a href='<%= request.getContextPath() %>/eform/visualEformEditor.jsp' onclick="window.open(this.href, '_blank'); return false;" class="dropdown-item">Visual eForm Editor</a></li>
 		<li><a href="#" onclick="newWindow('<%= request.getContextPath() %>/eform/eformGenerator.jsp', 'createGenerator'); return false;" class="dropdown-item contentLink">eForm Generator</a></li>
 		<li><a href='<%= request.getContextPath() %>/eform/efmformmanageredit.jsp' class="dropdown-item contentLink">Create In Editor</a></li>
 

--- a/src/main/webapp/eform/efmTopNav.jspf
+++ b/src/main/webapp/eform/efmTopNav.jspf
@@ -44,7 +44,7 @@
 		</a>
 		<ul class="dropdown-menu">
 
-		<li><a href='<%= request.getContextPath() %>/eform/visualEformEditor.jsp' onclick="window.open(this.href, '_blank'); return false;" class="dropdown-item">Visual eForm Editor</a></li>
+		<li><a href='<%= request.getContextPath() %>/eform/visualEformEditor.jsp' onclick="window.open(this.href, '_blank'); return false;" class="dropdown-item"><fmt:setBundle basename="oscarResources"/><fmt:message key="eform.visual.editor.title"/></a></li>
 		<li><a href="#" onclick="newWindow('<%= request.getContextPath() %>/eform/eformGenerator.jsp', 'createGenerator'); return false;" class="dropdown-item contentLink">eForm Generator</a></li>
 		<li><a href='<%= request.getContextPath() %>/eform/efmformmanageredit.jsp' class="dropdown-item contentLink">Create In Editor</a></li>
 

--- a/src/main/webapp/eform/efmformadd_data.jsp
+++ b/src/main/webapp/eform/efmformadd_data.jsp
@@ -122,7 +122,7 @@
     }
 
     thisEForm.setContextPath(request.getContextPath());
-    thisEForm.setImagePath();
+    thisEForm.setImagePath(request.getContextPath());
     thisEForm.setDatabaseAPs();
     thisEForm.setOscarOPEN(request.getRequestURI());
     thisEForm.setAction();

--- a/src/main/webapp/eform/visualEformEditor.jsp
+++ b/src/main/webapp/eform/visualEformEditor.jsp
@@ -94,6 +94,9 @@ FOR STAND ALONE USE
 
     <!-- jQuery and UI -->
 	<script src="<%= request.getContextPath() %>/library/jquery/jquery-3.7.1.min.js"></script>
+	<script>
+        $.uiBackCompat = true;
+    </script>
 	<script src="<%= request.getContextPath() %>/library/jquery/jquery-ui-1.14.2.min.js"></script>
     <link href="<%= request.getContextPath() %>/library/jquery/jquery-ui.theme-1.14.2.min.css" rel="stylesheet" type="text/css">
     <link href="<%= request.getContextPath() %>/library/jquery/jquery-ui.structure-1.14.2.min.css" rel="stylesheet" type="text/css">

--- a/src/main/webapp/eform/visualEformEditor.jsp
+++ b/src/main/webapp/eform/visualEformEditor.jsp
@@ -1603,6 +1603,16 @@ var EFORM_I18N = {
             return string.replace(/[^a-z0-9\s]/gi, '');
         }
 
+        /** HTML-encodes a string for safe insertion into HTML content (e.g. title tags) */
+        function escapeHtmlText(value) {
+            return String(value)
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;');
+        }
+
         function destroy_gen_widgets($elementSelector) {
             $elementSelector.find(".gen-resizable").resizable("destroy").removeClass("gen-resizable").addClass("gen-resize-destroyed");
             $elementSelector.find(".gen-draggable").draggable("destroy").removeClass("gen-draggable").addClass("gen-draggable-destroyed");
@@ -1870,7 +1880,7 @@ var EFORM_I18N = {
 
             var source = "<!DOCTYPE html><html><head>";
             source += "\<META http-equiv='Content-Type' content='text/html; charset=UTF-8'\>";
-            source += "<title>" + eformName + "</title>";
+            source += "<title>" + escapeHtmlText(eformName) + "</title>";
 
             // ------- the eforms generated are currently dependent on jQuery ------
             source += "\<script src='../library/jquery/jquery-3.6.4.min.js'\>\<\/script\>"; // present in OSCAR 19 and OPEN OSP
@@ -4562,7 +4572,7 @@ var EFORM_I18N = {
                 var style3 = document.getElementById('eform_style_signature').innerHTML;
                 var newWin = window.open('', 'Print-Window');
                 newWin.document.open();
-                var htmlPrint = '<html><head><title>' + eformName + '</title><style>' + style1 + style2 + style3 +
+                var htmlPrint = '<html><head><title>' + escapeHtmlText(eformName) + '</title><style>' + style1 + style2 + style3 +
                     '</style></'+'head><body onload="window.print()">' + divToPrint.innerHTML + '</body></html>';
                 newWin.document.write(htmlPrint);
                 newWin.document.close();
@@ -5283,18 +5293,23 @@ var EFORM_I18N = {
  * the 'carlos_logout_signal' localStorage key. Either signal releases the dirty flag
  * so the beforeunload handler does not prompt the user, then closes this popup window. */
 (function() {
+    var logoutChannel = null;
     function handleLogoutSignal() {
         releaseDirtyFlag();
+        if (logoutChannel) { try { logoutChannel.close(); } catch(e) {} logoutChannel = null; }
         try { window.close(); } catch(e) {}
     }
     try {
-        var logoutChannel = new BroadcastChannel('carlos_logout');
+        logoutChannel = new BroadcastChannel('carlos_logout');
         logoutChannel.onmessage = function(e) {
             if (e.data === 'logout') { handleLogoutSignal(); }
         };
     } catch(e) {}
     window.addEventListener('storage', function(e) {
-        if (e.key === 'carlos_logout_signal') { handleLogoutSignal(); }
+        if (e.key === 'carlos_logout_signal' && e.newValue !== null) { handleLogoutSignal(); }
+    });
+    window.addEventListener('beforeunload', function() {
+        if (logoutChannel) { try { logoutChannel.close(); } catch(e) {} logoutChannel = null; }
     });
 }());
 </script>

--- a/src/main/webapp/eform/visualEformEditor.jsp
+++ b/src/main/webapp/eform/visualEformEditor.jsp
@@ -90,7 +90,8 @@ FOR STAND ALONE USE
 -->
 <head>
     <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
-    <title>Visual E-form Editor</title>
+    <fmt:setBundle basename="oscarResources"/>
+    <title><fmt:message key="eform.visual.editor.title"/></title>
 
     <!-- jQuery and UI -->
 	<script src="<%= request.getContextPath() %>/library/jquery/jquery-3.7.1.min.js"></script>
@@ -5276,6 +5277,27 @@ var EFORM_I18N = {
     </fieldset>
   </form>
 </div>
+<script>
+/* Suppress the leave-page confirmation dialog when a logout broadcast signal is received.
+ * logout.jsp broadcasts 'logout' on the 'carlos_logout' BroadcastChannel and sets
+ * the 'carlos_logout_signal' localStorage key. Either signal releases the dirty flag
+ * so the beforeunload handler does not prompt the user, then closes this popup window. */
+(function() {
+    function handleLogoutSignal() {
+        releaseDirtyFlag();
+        try { window.close(); } catch(e) {}
+    }
+    try {
+        var logoutChannel = new BroadcastChannel('carlos_logout');
+        logoutChannel.onmessage = function(e) {
+            if (e.data === 'logout') { handleLogoutSignal(); }
+        };
+    } catch(e) {}
+    window.addEventListener('storage', function(e) {
+        if (e.key === 'carlos_logout_signal') { handleLogoutSignal(); }
+    });
+}());
+</script>
 </body>
 
 </html>

--- a/src/main/webapp/eform/visualEformEditor.jsp
+++ b/src/main/webapp/eform/visualEformEditor.jsp
@@ -93,13 +93,15 @@ FOR STAND ALONE USE
     <title>Visual E-form Editor</title>
 
     <!-- jQuery and UI -->
-	<script src="<%= request.getContextPath() %>/library/jquery/jquery-3.6.4.min.js"></script>
-	<script src="<%= request.getContextPath() %>/library/jquery/jquery-ui-1.12.1.min.js"></script>
-    <link href="<%= request.getContextPath() %>/library/jquery/jquery-ui.theme-1.12.1.min.css" rel="stylesheet" type="text/css">
-    <link href="<%= request.getContextPath() %>/library/jquery/jquery-ui.structure-1.12.1.min.css" rel="stylesheet" type="text/css">
+	<script src="<%= request.getContextPath() %>/library/jquery/jquery-3.7.1.min.js"></script>
+	<script src="<%= request.getContextPath() %>/library/jquery/jquery-ui-1.14.2.min.js"></script>
+    <link href="<%= request.getContextPath() %>/library/jquery/jquery-ui.theme-1.14.2.min.css" rel="stylesheet" type="text/css">
+    <link href="<%= request.getContextPath() %>/library/jquery/jquery-ui.structure-1.14.2.min.css" rel="stylesheet" type="text/css">
 
-    <!-- javascript file for the signature pads * optional * -->
-    <script src="<%= request.getContextPath() %>/share/javascript/signature_pad.min.js"></script>
+    <!-- signature_pad.min.js (Szymon Nowak) was removed from the project.
+         Without it, wet-signature canvas widgets are unavailable in the editor
+         but existing eforms remain functional. Restore the file to re-enable. -->
+    <%-- <script src="<%= request.getContextPath() %>/share/javascript/signature_pad.min.js"></script> --%>
 
     <!-- main calendar program -->
     <script src="<%= request.getContextPath() %>/share/calendar/calendar.js"></script>

--- a/src/main/webapp/eform/visualEformEditor.jsp
+++ b/src/main/webapp/eform/visualEformEditor.jsp
@@ -1979,7 +1979,7 @@ var EFORM_I18N = {
             }
             source += findSelectedFunctions(htmlElements.innerHTML) + "\<\/script></"+"head><body onload='focusAll();" + loadFunctions + "'>";
             if (setSideBar == "on") {
-                source += "<iframe src='${oscar_image_path}SideBarTemplate.html' id='mySidenavGen2' class='sidenav DoNotPrint' style='margin-top:-60px;margin-left:-100px height 600px'></iframe>";
+                source += "<iframe src='${oscar_image_path}SideBarTemplate.html' id='mySidenavGen2' class='sidenav DoNotPrint' style='margin-top:-60px;margin-left:-100px;height:600px'></iframe>";
             }
 
             source += "<div id='eform_container' " + "style='max-width: " + eFormPageWidth + "px'>";

--- a/src/main/webapp/eform/visualEformEditor.jsp
+++ b/src/main/webapp/eform/visualEformEditor.jsp
@@ -1883,6 +1883,7 @@ var EFORM_I18N = {
             source += "<title>" + escapeHtmlText(eformName) + "</title>";
 
             // ------- the eforms generated are currently dependent on jQuery ------
+            source += "\<script src='../library/jquery/jquery-3.7.1.min.js'\>\<\/script\>"; // present in CARLOS
             source += "\<script src='../library/jquery/jquery-3.6.4.min.js'\>\<\/script\>"; // present in OSCAR 19 and OPEN OSP
             source += "\<script src='$\{oscar_javascript_path\}jquery/jquery-2.2.4.min.js'\>\<\/script\>"; // only present in JUNO
             source += "\<script\>window.jQuery || document.write(\"\\x3cscript src='../js/jquery-1.12.3.js'\\x3e\\x3c\\/script\\x3e\");\<\/script\>"; // present in WELL and others as

--- a/src/main/webapp/eform/visualEformEditor.jsp
+++ b/src/main/webapp/eform/visualEformEditor.jsp
@@ -1977,7 +1977,7 @@ var EFORM_I18N = {
                 source += stamp_script.innerHTML;
                 loadFunctions += " signForm()";
             }
-            source += findSelectedFunctions(htmlElements.innerHTML) + "\<\/script></head><body onload='focusAll();" + loadFunctions + "'>";
+            source += findSelectedFunctions(htmlElements.innerHTML) + "\<\/script></"+"head><body onload='focusAll();" + loadFunctions + "'>";
             if (setSideBar == "on") {
                 source += "<iframe src='${oscar_image_path}SideBarTemplate.html' id='mySidenavGen2' class='sidenav DoNotPrint' style='margin-top:-60px;margin-left:-100px height 600px'></iframe>";
             }
@@ -4557,7 +4557,7 @@ var EFORM_I18N = {
                 var newWin = window.open('', 'Print-Window');
                 newWin.document.open();
                 var htmlPrint = '<html><head><title>' + eformName + '</title><style>' + style1 + style2 + style3 +
-                    '</style></head><body onload="window.print()">' + divToPrint.innerHTML + '</body></html>';
+                    '</style></'+'head><body onload="window.print()">' + divToPrint.innerHTML + '</body></html>';
                 newWin.document.write(htmlPrint);
                 newWin.document.close();
                 var timeout = 1;


### PR DESCRIPTION
### **User description**
<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description
The editor is unusable currently, with the following identified issues
- at run time <script src="/carlos/csrfguard"></script> is inserted above the pattern <\head>  thus breaking the javascript
- There are jQuery and css conflicts when the VEE is displayed in the right panel
- Unregistered WS endpoints
- the closing alert that the work is not saved trips up the broadcast close
<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues
Fixes #695
<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?
javax develop
<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots
Before
<img width="1410" height="687" alt="brokeVisual" src="https://github.com/user-attachments/assets/c2a94e29-c490-4545-8648-af343df03a05" />

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->
After
<img width="1578" height="793" alt="fixedVisualE-formEditor" src="https://github.com/user-attachments/assets/b7d0228b-89b7-4871-8911-3061734a4c96" />

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Bug Fixes:
- Prevent runtime corruption of the HTML head section when injecting scripts in the visual eForm editor preview and print windows.


___

### **Description**
- Added localized titles for the Visual eForm Editor in multiple languages.
- Registered necessary services in the REST endpoint to prevent 404 errors.
- Updated navigation links to ensure the Visual eForm Editor opens in a new window.
- Improved jQuery references and fixed HTML structure in the editor.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>oscarResources_en.properties</strong><dd><code>Update English properties for Visual eForm Editor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/resources/oscarResources_en.properties
- Added a new title for the Visual eForm Editor in English.



</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/694/files#diff-ec1ea2573170b49f2ce9345e4d8374ed08e9cd91bd3b610674b29a415e17d12b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>oscarResources_es.properties</strong><dd><code>Update Spanish properties for Visual eForm Editor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/resources/oscarResources_es.properties
- Added a new title for the Visual eForm Editor in Spanish.



</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/694/files#diff-070bfb71ce2c4f7be17e477125359b04c4ee96f3def7f1b7f9aaad077ceb650b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>oscarResources_fr.properties</strong><dd><code>Update French properties for Visual eForm Editor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/resources/oscarResources_fr.properties
- Added a new title for the Visual eForm Editor in French.



</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/694/files#diff-e96713ed5be7884dfcea354836bcb7f708450de88cb1cf78dd1f90ca4358ab28">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>oscarResources_pl.properties</strong><dd><code>Update Polish properties for Visual eForm Editor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/resources/oscarResources_pl.properties
- Added a new title for the Visual eForm Editor in Polish.



</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/694/files#diff-fba61c17d724280f63ac4caf649954ddbc7441e9571ebc637c6e534c4f784161">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>oscarResources_pt_BR.properties</strong><dd><code>Update Portuguese properties for Visual eForm Editor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/resources/oscarResources_pt_BR.properties
- Added a new title for the Visual eForm Editor in Portuguese.



</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/694/files#diff-7eb96fdf251040d084499033a7b8f4ee4c7aae5916aa5a9c2ba9b7a383fad57e">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>leftNav.jspf</strong><dd><code>Update left navigation for Visual eForm Editor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/webapp/administration/leftNav.jspf
- Updated link to open the Visual eForm Editor in a new window.



</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/694/files#diff-94add39d41d782b327e9db418292645efc523f36b4fcbdf9281ce667e5eb9d8a">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>efmTopNav.jspf</strong><dd><code>Update top navigation for Visual eForm Editor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/webapp/eform/efmTopNav.jspf
- Updated link to open the Visual eForm Editor in a new window.



</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/694/files#diff-325b70c9e6017621a892714efee26c054bd9c00e2da3809f1a95e2d3706da5b9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></details></td></tr><tr><td><strong>Bug fix
</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>spring_ws.xml</strong><dd><code>Register EForm services in REST endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/resources/spring_ws.xml
<li>Registered <code>EFormService</code> and <code>EFormsService</code> in the REST endpoint.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/694/files#diff-2570f5568950958c77bb30deef5336880fdf0368dd59e44b88d7754654cbce3a">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>visualEformEditor.jsp</strong><dd><code>Fix visualEformEditor.jsp structure and functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/webapp/eform/visualEformEditor.jsp
<li>Fixed HTML structure and improved jQuery references.<br> <li> Added logout handling script to suppress leave-page confirmation.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/694/files#diff-206a18597d6078a3b09aea8b179c9291c1edb38afeb9d85da15728505d7b7c4b">+37/-10</a>&nbsp; </td>
</tr>
</table></details></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions

## Summary by Sourcery

Fix the visual eForm editor so it loads and renders reliably and integrates correctly with logout and web service infrastructure.

Bug Fixes:
- Prevent malformed HTML in preview and print windows that previously broke script loading and page rendering.
- Avoid jQuery/jQuery UI conflicts in the visual eForm editor by updating to compatible library versions and settings.
- Disable the unsaved-work confirmation dialog when a global logout signal is received so logout can complete cleanly.

Enhancements:
- Localize the visual eForm editor page title using message bundles.
- Register missing REST web service beans for eForm-related endpoints.
- Improve iframe layout styling for the editor sidebar.
- Document the temporary unavailability of wet-signature canvas widgets in the editor until the signature script is restored.

Documentation:
- Add localized visual eForm editor title strings to all supported language resource bundles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Visual eForm Editor added to navigation and localized in EN/ES/FR/PL/PT-BR with translated title.

* **Bug Fixes**
  * Title and generated HTML now use the localization key; form names are HTML-escaped to prevent malformed output.
  * Sidebar sizing corrected and logout flow improved to suppress unwanted leave-page confirmation.

* **Chores**
  * Upgraded jQuery and jQuery UI; adjusted client-side scripts and resource path handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->