### PR TITLE
Fix CalendarPopup.jsp to show today

### DIFF
--- a/src/main/webapp/share/CalendarPopup.jsp
+++ b/src/main/webapp/share/CalendarPopup.jsp
@@ -70,11 +70,19 @@
     <meta name="viewport"
           content="initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, width=device-width"/>
     <% } %>
-    <LINK REL="StyleSheet" HREF="<%= request.getContextPath() %>/web.css" TYPE="text/css">
+    <link rel="stylesheet" href="<%= request.getContextPath() %>/web.css" TYPE="text/css">
     <style type="text/css">
         td, th {
             font-size: 14px;
         }
+        .circle {
+            background: lightblue;
+            width: 25px;
+            height: 25px;
+            border-radius: 50%;
+            display: inline-block;
+        }
+
     </style>
     <script language="JavaScript">
         <!--
@@ -96,7 +104,7 @@
         //-->
     </script>
 </head>
-<body bgcolor="ivory" onLoad="setfocus()" leftmargin="0" rightmargin="0">
+<body onLoad="setfocus()">
 <%
     ResourceBundle oscarRec = ResourceBundle.getBundle("oscarResources");
     String jan = oscarRec.getString("share.CalendarPopUp.msgJan");
@@ -121,7 +129,7 @@
     int[][] dateGrid = aDate.getMonthDateGrid();
 %>
 
-<table BORDER="0" CELLPADDING="0" CELLSPACING="0" WIDTH="100%">
+<table style="width:100%">
     <tr>
         <td align="left">
             <h2>&nbsp;<%=arrayMonth[month-1]%>&nbsp;<%=year%>&nbsp;</h2>
@@ -143,8 +151,8 @@
     </tr>
 </table>
 
-<table width="100%" border="0" cellspacing="0" cellpadding="2">
-    <tr align="center" bgcolor="#FFFFFF">
+<table style="width:100%">
+    <tr align="center" >
         <th>
             <%
                 for (int i = 0; i < 12; i++) {
@@ -157,7 +165,7 @@
     </tr>
 </table>
 
-<table width="100%" border="0" cellspacing="1" cellpadding="2"
+<table style="width:100%"
        class="table">
     <tr align="center">
         <th width="14%"><font color="red"><fmt:setBundle basename="oscarResources"/><fmt:message key="share.CalendarPopUp.msgSun"/></font>
@@ -173,7 +181,7 @@
         <th width="14%">
             <fmt:setBundle basename="oscarResources"/><fmt:message key="share.CalendarPopUp.msgFri"/>
             </td>
-        <th width="14%"><font color="green"><fmt:setBundle basename="oscarResources"/><fmt:message key="share.CalendarPopUp.msgSat"/></font>
+        <th width="14%"><span style="color:green"><fmt:setBundle basename="oscarResources"/><fmt:message key="share.CalendarPopUp.msgSat"/></font>
             </td>
     </tr>
 
@@ -189,7 +197,7 @@
                         bTodayDate = true;
                     }
     %>
-    <td align="center" bgcolor='<%=bTodayDate?"gold":"white"%>'><a
+    <td align="center"><a class='<%=bTodayDate?"circle":""%>'
             href="#"
             onClick="typeInDate(<%=year%>,<%=month%>,<%= dateGrid[i][j] %>)">
         <%= dateGrid[i][j] %>

--- a/src/main/webapp/share/CalendarPopup.jsp
+++ b/src/main/webapp/share/CalendarPopup.jsp
@@ -81,6 +81,9 @@
             height: 25px;
             border-radius: 50%;
             display: inline-block;
+            line-height: 25px;
+            text-align: center;
+            text-decoration: none;
         }
 
     </style>
@@ -181,7 +184,7 @@
         <th width="14%">
             <fmt:setBundle basename="oscarResources"/><fmt:message key="share.CalendarPopUp.msgFri"/>
             </td>
-        <th width="14%"><span style="color:green"><fmt:setBundle basename="oscarResources"/><fmt:message key="share.CalendarPopUp.msgSat"/></font>
+        <th width="14%"><span style="color:green"><fmt:setBundle basename="oscarResources"/><fmt:message key="share.CalendarPopUp.msgSat"/></span>
             </td>
     </tr>
 
@@ -211,7 +214,7 @@
 
 </table>
 
-<table width="100%" border="0" cellspacing="0" cellpadding="0">
+<table style="width:100%; border-collapse: collapse; padding: 0;">
     <tr>
         <td align="right"><input type="button" class="btn btn-link"
                                  name="Cancel" value="Cancel" onClick="window.close()"></td>

--- a/src/main/webapp/share/CalendarPopup.jsp
+++ b/src/main/webapp/share/CalendarPopup.jsp
@@ -45,7 +45,7 @@
 <%
     String urlfrom = request.getParameter("urlfrom") == null ? "" : request.getParameter("urlfrom");
     String param = request.getParameter("param") == null ? "" : request.getParameter("param");
-//to prepare calendar display  
+//to prepare calendar display
     int year = Integer.parseInt(request.getParameter("year"));
     int month = Integer.parseInt(request.getParameter("month"));
     int delta = request.getParameter("delta") == null ? 0 : Integer.parseInt(request.getParameter("delta")); //add or minus month
@@ -60,18 +60,20 @@
     int todayDate = cal.get(Calendar.DATE);
     boolean bTodayDate = false;
 %>
-<html>
+<!DOCTYPE html>
+<html lang="en">
 <head>
-    <link href="<%=request.getContextPath() %>/library/bootstrap/5.3.3/css/bootstrap.min.css" rel="stylesheet" type="text/css">
+    <meta charset="UTF-8">
+    <link href="<%=request.getContextPath() %>/library/bootstrap/5.3.3/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="<%=request.getContextPath() %>/css/fontawesome-all.min.css">
-    <script type="text/javascript" src="<%= request.getContextPath() %>/js/global.js"></script>
+    <script src="<%= request.getContextPath() %>/js/global.js"></script>
     <title>CALENDAR</title>
     <% if (session.getAttribute("mobileOptimized") != null) { %>
     <meta name="viewport"
-          content="initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, width=device-width"/>
+          content="initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, width=device-width">
     <% } %>
-    <link rel="stylesheet" href="<%= request.getContextPath() %>/web.css" TYPE="text/css">
-    <style type="text/css">
+    <link rel="stylesheet" href="<%= request.getContextPath() %>/web.css">
+    <style>
         td, th {
             font-size: 14px;
         }
@@ -81,12 +83,12 @@
             height: 25px;
             border-radius: 50%;
             display: inline-block;
+            line-height: 25px;
+            text-align: center;
+            text-decoration: none;
         }
-
     </style>
-    <script language="JavaScript">
-        <!--
-
+    <script>
         function typeInDate(year1, month1, day1) {
 
             <%
@@ -100,11 +102,9 @@
             <%  }  %>
             self.close();
         }
-
-        //-->
     </script>
 </head>
-<body onLoad="setfocus()">
+<body onload="setfocus()">
 <%
     ResourceBundle oscarRec = ResourceBundle.getBundle("oscarResources");
     String jan = oscarRec.getString("share.CalendarPopUp.msgJan");
@@ -131,10 +131,10 @@
 
 <table style="width:100%">
     <tr>
-        <td align="left">
+        <td style="text-align:left">
             <h2>&nbsp;<%=arrayMonth[month-1]%>&nbsp;<%=year%>&nbsp;</h2>
         </td>
-        <td align="right"><h2>
+        <td style="text-align:right"><h2>
             <a href="CalendarPopup.jsp?urlfrom=<%=Encode.forHtmlAttribute(urlfrom)%>&year=<%=year%>&month=<%=month%>&param=<%=URLEncoder.encode(param, StandardCharsets.UTF_8)%>&delta=-12">
                 <i class="fa-solid fa-angles-left" title="<fmt:setBundle basename="oscarResources"/><fmt:message key="share.CalendarPopUp.msgLastYear"/>"></i>
             </a>
@@ -152,37 +152,28 @@
 </table>
 
 <table style="width:100%">
-    <tr align="center" >
+    <tr style="text-align:center">
         <th>
             <%
                 for (int i = 0; i < 12; i++) {
             %> <a
-                href="CalendarPopup.jsp?urlfrom=<%=Encode.forHtmlAttribute(urlfrom)%>&year=<%=year%>&month=<%=i+1%>&param=<%=URLEncoder.encode(param, StandardCharsets.UTF_8)%>"><font
-                SIZE="2" <%=(i+1)==month?"color='red'":""%>><%=arrayMonth[i]%>
+                href="CalendarPopup.jsp?urlfrom=<%=Encode.forHtmlAttribute(urlfrom)%>&year=<%=year%>&month=<%=i+1%>&param=<%=URLEncoder.encode(param, StandardCharsets.UTF_8)%>"
+                <%=(i+1)==month?"style=\"color:red\"":""%>><span style="font-size:smaller"><%=arrayMonth[i]%></span>
         </a>
             <% } %>
         </th>
     </tr>
 </table>
 
-<table style="width:100%"
-       class="table">
-    <tr align="center">
-        <th width="14%"><font color="red"><fmt:setBundle basename="oscarResources"/><fmt:message key="share.CalendarPopUp.msgSun"/></font>
-            </td>
-        <th width="14%"><fmt:setBundle basename="oscarResources"/><fmt:message key="share.CalendarPopUp.msgMon"/></font>
-            </td>
-        <th width="14%"><fmt:setBundle basename="oscarResources"/><fmt:message key="share.CalendarPopUp.msgTue"/></font>
-            </td>
-        <th width="14%"><fmt:setBundle basename="oscarResources"/><fmt:message key="share.CalendarPopUp.msgWed"/></font>
-            </td>
-        <th width="14%"><fmt:setBundle basename="oscarResources"/><fmt:message key="share.CalendarPopUp.msgThu"/></font>
-            </td>
-        <th width="14%">
-            <fmt:setBundle basename="oscarResources"/><fmt:message key="share.CalendarPopUp.msgFri"/>
-            </td>
-        <th width="14%"><span style="color:green"><fmt:setBundle basename="oscarResources"/><fmt:message key="share.CalendarPopUp.msgSat"/></font>
-            </td>
+<table style="width:100%" class="table">
+    <tr style="text-align:center">
+        <th style="width:14%"><span style="color:red"><fmt:setBundle basename="oscarResources"/><fmt:message key="share.CalendarPopUp.msgSun"/></span></th>
+        <th style="width:14%"><fmt:setBundle basename="oscarResources"/><fmt:message key="share.CalendarPopUp.msgMon"/></th>
+        <th style="width:14%"><fmt:setBundle basename="oscarResources"/><fmt:message key="share.CalendarPopUp.msgTue"/></th>
+        <th style="width:14%"><fmt:setBundle basename="oscarResources"/><fmt:message key="share.CalendarPopUp.msgWed"/></th>
+        <th style="width:14%"><fmt:setBundle basename="oscarResources"/><fmt:message key="share.CalendarPopUp.msgThu"/></th>
+        <th style="width:14%"><fmt:setBundle basename="oscarResources"/><fmt:message key="share.CalendarPopUp.msgFri"/></th>
+        <th style="width:14%"><span style="color:green"><fmt:setBundle basename="oscarResources"/><fmt:message key="share.CalendarPopUp.msgSat"/></span></th>
     </tr>
 
     <%
@@ -197,9 +188,9 @@
                         bTodayDate = true;
                     }
     %>
-    <td align="center"><a class='<%=bTodayDate?"circle":""%>'
+    <td style="text-align:center"><a class='<%=bTodayDate?"circle":""%>'
             href="#"
-            onClick="typeInDate(<%=year%>,<%=month%>,<%= dateGrid[i][j] %>)">
+            onclick="typeInDate(<%=year%>,<%=month%>,<%= dateGrid[i][j] %>)">
         <%= dateGrid[i][j] %>
     </a></td>
     <%
@@ -211,10 +202,10 @@
 
 </table>
 
-<table width="100%" border="0" cellspacing="0" cellpadding="0">
+<table style="width:100%">
     <tr>
-        <td align="right"><input type="button" class="btn btn-link"
-                                 name="Cancel" value="Cancel" onClick="window.close()"></td>
+        <td style="text-align:right"><input type="button" class="btn btn-link"
+                                 name="Cancel" value="Cancel" onclick="window.close()"></td>
     </tr>
 </table>
 


### PR DESCRIPTION
### **User description**
<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description
Calendar lost its reference for today
Previously the td turned gold for today
now it doesn't do anything
<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues

<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?

<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots
fixed
<img width="430" height="425" alt="fixedCALENDAR" src="https://github.com/user-attachments/assets/e0b48b6e-f14a-4e75-90ce-f49e52286419" />

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Update calendar popup styling so that the current day is visually highlighted and legacy HTML attributes are modernized.

Enhancements:
- Highlight the current day in the calendar popup using a circular light-blue indicator instead of cell background color.
- Align calendar markup with modern HTML by updating link/table elements and removing deprecated or inline visual attributes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Modernized calendar popup markup and styling to current HTML/CSS practices for improved consistency and maintainability.
  * Replaced deprecated presentational attributes with CSS-based styling and simplified script/link tags.

* **Bug Fixes**
  * Improved current-date highlight to render more reliably and visibly within the calendar.
  * Normalized event attributes for more consistent interaction behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

### **Description**
- Enhanced the calendar popup to visually highlight the current day using a circular light-blue indicator.
- Updated the HTML structure to comply with HTML5 standards by removing deprecated attributes and improving markup consistency.
- Fixed issues related to the rendering of the current date and ensured better interaction behavior.
- Improved styling and accessibility for better user experience.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CalendarPopup.jsp</strong><dd><code>Modernize Calendar Popup and Fix Current Day Highlight</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/webapp/share/CalendarPopup.jsp
<li>Modernized HTML structure and styling for the calendar popup.<br> <li> Highlighted the current day with a circular light-blue indicator.<br> <li> Removed deprecated HTML attributes and improved accessibility.<br> <li> Fixed various HTML mismatches and ensured compliance with HTML5 <br>standards.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/697/files#diff-b40530f3fee7fef8e1247234b180c7cca1de35e45a14d098db4a262dbe722426">+42/-43</a>&nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions

