### PR TITLE
Fix Lab acknowledgement refresh and removed null from display for InboxhubListMode.jsp

### DIFF
--- a/src/main/resources/oscarResources_en.properties
+++ b/src/main/resources/oscarResources_en.properties
@@ -6992,6 +6992,14 @@ oscarMDS.index.msgNoMoreReports=--- no more reports found matching the selected 
 oscarMDS.index.msgLabel = Label
 oscarMDS.index.btnLoadAll = Load All Inbox
 
+inboxhub.list.documents = Documents
+inboxhub.list.labs = Labs
+inboxhub.list.hrms = HRMs
+inboxhub.list.loadingSearchResults = Loading Search Results:
+inboxhub.list.stop = Stop
+inboxhub.list.ackNumber = Ack \#
+inboxhub.list.abnormal = Abnormal
+
 oscarMDS.search.title=Search Lab Reports
 oscarMDS.search.formPatientLastName=Patient Last Name
 oscarMDS.search.formPatientFirstName=Patient First Name

--- a/src/main/resources/oscarResources_es.properties
+++ b/src/main/resources/oscarResources_es.properties
@@ -5865,6 +5865,14 @@ oscarMDS.index.msgNoMoreReports=--- no se encontraron m&#225;s reportes con los 
 oscarMDS.index.msgLabel = Leyenda
 oscarMDS.index.btnLoadAll = Cargar bandeja de entrada
 
+inboxhub.list.documents = Documentos
+inboxhub.list.labs = An\u00e1lisis
+inboxhub.list.hrms = HRMs
+inboxhub.list.loadingSearchResults = Cargando resultados de b\u00fasqueda\:
+inboxhub.list.stop = Detener
+inboxhub.list.ackNumber = Acuse \#
+inboxhub.list.abnormal = Anormal
+
 oscarMDS.search.title=Buscar reportes lab
 oscarMDS.search.formPatientLastName=Apellido paciente
 oscarMDS.search.formPatientFirstName=Nombre paciente

--- a/src/main/resources/oscarResources_fr.properties
+++ b/src/main/resources/oscarResources_fr.properties
@@ -6292,6 +6292,14 @@ admin.provider.formOfficialLastName=Pr\u00e9nom Officiel
 global.pregnancy=Grossesse
 oscarMDS.index.msgNoMoreReports=Aucun rapport pour les dates configur\u00e9es
 
+inboxhub.list.documents = Documents
+inboxhub.list.labs = Analyses
+inboxhub.list.hrms = HRMs
+inboxhub.list.loadingSearchResults = Chargement des r\u00e9sultats\:
+inboxhub.list.stop = Arr\u00eater
+inboxhub.list.ackNumber = Acc. \#
+inboxhub.list.abnormal = Anormal
+
 provider.selectClinicSite=S\u00e9lectionnez le site de la clinique
 provider.clinicSite=Site de la clinique 
 admin.updatedemographicprovider.msgNoProvider=Provider

--- a/src/main/resources/oscarResources_pl.properties
+++ b/src/main/resources/oscarResources_pl.properties
@@ -5271,6 +5271,14 @@ oscarMDS.index.msgConfirmAcknowledge=Kliknij OK, aby potwierdzi\u0107
 oscarMDS.index.msgConfirmAcknowledgeUnmatched=Ten dodatek nie zosta\u0142 dopasowany do patient.Are na pewno chcesz to potwierdzi\u0107? OK, aby potwierdzi\u0107 i Anuluj, aby dopasowa\u0107 do pacjenta
 oscarMDS.index.btnLoadAll = Za&#322;aduj skrzynk&#281; odbiorcz&#261;
 
+inboxhub.list.documents = Dokumenty
+inboxhub.list.labs = Badania
+inboxhub.list.hrms = HRMs
+inboxhub.list.loadingSearchResults = \u0141adowanie wynik\u00f3w wyszukiwania\:
+inboxhub.list.stop = Zatrzymaj
+inboxhub.list.ackNumber = Potw. \#
+inboxhub.list.abnormal = Nieprawid\u0142owy
+
 oscarMDS.search.title=Szukaj Lab Raporty
 oscarMDS.search.formPatientLastName=pacjenta Nazwisko
 oscarMDS.search.formPatientFirstName=pacjenta Imi&#X119;

--- a/src/main/resources/oscarResources_pt_BR.properties
+++ b/src/main/resources/oscarResources_pt_BR.properties
@@ -6806,6 +6806,14 @@ oscarMDS.index.msgNoMoreReports=---  n\u00E3o foram encontrados mais relat\u00F3
 oscarMDS.index.msgLabel = Etiqueta
 oscarMDS.index.btnLoadAll = Carregar Caixa de Entrada
 
+inboxhub.list.documents = Documentos
+inboxhub.list.labs = Exames
+inboxhub.list.hrms = HRMs
+inboxhub.list.loadingSearchResults = Carregando resultados da pesquisa\:
+inboxhub.list.stop = Parar
+inboxhub.list.ackNumber = Rec. \#
+inboxhub.list.abnormal = Anormal
+
 oscarMDS.search.title=Relat\u00F3rios de laborat\u00F3rio de pesquisa
 oscarMDS.search.formPatientLastName=Sobrenome do paciente
 oscarMDS.search.formPatientFirstName=Nome do Paciente

--- a/src/main/webapp/web/inboxhub/InboxhubListMode.jsp
+++ b/src/main/webapp/web/inboxhub/InboxhubListMode.jsp
@@ -69,7 +69,7 @@
                     </td>
                     <td><c:out value="${labResult.sex}" /></td>
                     <td><c:out value="${labResult.resultStatus == 'A' ? 'Abnormal' : ''}" /></td>
-                    <td><c:out value="${labResult.label}" /></td>
+                    <td><c:out value="${labResult.label == 'null' ? '' : labResult.label}" /></td>
                     <td><c:out value="${labResult.dateTime}" /><c:out value="${labResult.document ? ' / ' : ''}" /><c:out value="${labResult.document ?  labResult.lastUpdateDate : ''}"/></td>
                     <td><c:out value="${labResult.requestingClient}" /></td>
                     <td><c:out value="${labResult.document ? (labResult.description == null ? '' : labResult.description) : labResult.disciplineDisplayString}" /></td>

--- a/src/main/webapp/web/inboxhub/InboxhubListMode.jsp
+++ b/src/main/webapp/web/inboxhub/InboxhubListMode.jsp
@@ -209,9 +209,9 @@
     });
 
     function removeReport(reportId) {
-        const el = jQuery("#labdoc_" + reportId);
-        if (el != null) {
-            el.remove();
+        const rowEl = jQuery("#labdoc_" + reportId);
+        if (rowEl.length > 0) {
+            jQuery('#inbox_table').DataTable().row(rowEl).remove().draw(false);
         }
     }
 </script>

--- a/src/main/webapp/web/inboxhub/InboxhubListMode.jsp
+++ b/src/main/webapp/web/inboxhub/InboxhubListMode.jsp
@@ -9,27 +9,28 @@
 <%@page import="org.apache.logging.log4j.Logger,io.github.carlos_emr.carlos.commn.dao.OscarLogDao,io.github.carlos_emr.carlos.utility.SpringUtils" %>
 <%@page import="io.github.carlos_emr.carlos.inboxhub.query.InboxhubQuery" %>
 <%@ page import="io.github.carlos_emr.carlos.mds.data.CategoryData" %>
+<% pageContext.setAttribute("currentUser", session.getAttribute("user")); %>
 
 <fmt:setBundle basename="oscarResources"/>
 
 <c:if test="${page eq 1}">
 <div class="bg-light text-light">
     <row>
-        <input id="topFBtn" type="button" class="btn btn-primary btn-sm ms-1" value="<fmt:message key="oscarMDS.index.btnForward"/>" onclick="submitForward('${sessionScope.user}')">
-        <input id="topFileBtn" type="button" class="btn btn-primary btn-sm" value="File" onclick="submitFile('${sessionScope.user}')"/>
+        <input id="topFBtn" type="button" class="btn btn-primary btn-sm ms-1" value="<fmt:message key="oscarMDS.index.btnForward"/>" onclick="submitForward('${e:forJavaScript(currentUser)}')">
+        <input id="topFileBtn" type="button" class="btn btn-primary btn-sm" value="<fmt:message key='oscarMDS.index.btnFile'/>" onclick="submitFile('${e:forJavaScript(currentUser)}')"/>
         <div class="d-flex align-items-center position-relative float-end">
-            <span class="d-inline me-2 py-1 text-dark fw-bold">Documents <span id="totalDocsCountStat" class="badge" style="background-color: #5a9bd3; color: white;">0</span></span>
-            <span class="d-inline me-2 py-1 text-dark fw-bold">Labs <span id="totalLabssCountStat" class="badge" style="background-color: #8cbfda; color: white;">0</span></span>
+            <span class="d-inline me-2 py-1 text-dark fw-bold"><fmt:message key="inboxhub.list.documents"/> <span id="totalDocsCountStat" class="badge" style="background-color: #5a9bd3; color: white;">0</span></span>
+            <span class="d-inline me-2 py-1 text-dark fw-bold"><fmt:message key="inboxhub.list.labs"/> <span id="totalLabssCountStat" class="badge" style="background-color: #8cbfda; color: white;">0</span></span>
             <c:if test="${!CarlosProperties.getInstance().isBritishColumbiaBillingRegion()}">
-                <span class="d-inline py-1 text-dark fw-bold">HRMs <span id="totalHRMsCountStat" class="badge" style="background-color: #b3d9eb; color: black;">0</span></span>
+                <span class="d-inline py-1 text-dark fw-bold"><fmt:message key="inboxhub.list.hrms"/> <span id="totalHRMsCountStat" class="badge" style="background-color: #b3d9eb; color: black;">0</span></span>
             </c:if>
-            <div id="loadingLabel" class="loading-label ms-2 me-2 text-dark">Loading Search Results:</div>
+            <div id="loadingLabel" class="loading-label ms-2 me-2 text-dark"><fmt:message key="inboxhub.list.loadingSearchResults"/></div>
             <div class="progress me-2 position-relative" id="loadInboxListProgress" style="width: 15vw; height: 25px; display: none; flex-grow: 1; background-color: #c7c7c7;">
                 <div id="loadInboxListProgressBar" class="progress-bar" role="progressbar" style="width: 0%;" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
                     <span id="inboxListProgressCount" class="count text-white" style="position: absolute; width: 100%; text-align: center; font-weight: 600;">0% Complete</span>
                 </div>
             </div>
-            <button id="stopLoadingInboxList" onclick="stopInboxhubListProgress(0)" class="btn btn-sm btn-danger" style="display: none;">Stop</button>
+            <button id="stopLoadingInboxList" onclick="stopInboxhubListProgress(0)" class="btn btn-sm btn-danger" style="display: none;"><fmt:message key="inboxhub.list.stop"/></button>
         </div>
     </row>
     <row>
@@ -48,7 +49,7 @@
                 <th><fmt:message key="oscarMDS.index.msgRequestingClient"/></th>
                 <th><fmt:message key="oscarMDS.index.msgDiscipline"/></th>
                 <th><fmt:message key="oscarMDS.index.msgReportStatus"/></th>
-                <th>Ack #</th>
+                <th><fmt:message key="inboxhub.list.ackNumber"/></th>
             </tr>
             </thead>
             <tbody id="inboxhubListModeTableBody">
@@ -61,14 +62,15 @@
                         <input type="checkbox" name="flaggedLabs" value="${labResult.segmentID}:${labResult.labType}" ${disabled}>
                     </td>
                     <td>
-                        <c:set var="labRead" value="${labResult.hasRead(sessionScope.user) ? '' : '*'}"/>
-                        <a href="javascript:void(0);" 
+                        <c:set var="labRead" value="*"/>
+                        <c:if test="${labResult.hasRead(currentUser)}"><c:set var="labRead" value=""/></c:if>
+                        <a href="javascript:void(0);"
                         onclick="reportWindow('${e:forJavaScript(labLinks[loopStatus.index])}', window.innerHeight, window.innerWidth); return false;">
                             <e:forHtmlContent value='${labRead}${labResult.patientName}' />
                         </a>
                     </td>
                     <td><c:out value="${labResult.sex}" /></td>
-                    <td><c:out value="${labResult.resultStatus == 'A' ? 'Abnormal' : ''}" /></td>
+                    <td><c:if test="${labResult.resultStatus == 'A'}"><fmt:message key="inboxhub.list.abnormal"/></c:if></td>
                     <td><c:out value="${labResult.label == 'null' ? '' : labResult.label}" /></td>
                     <td><c:out value="${labResult.dateTime}" /><c:out value="${labResult.document ? ' / ' : ''}" /><c:out value="${labResult.document ?  labResult.lastUpdateDate : ''}"/></td>
                     <td><c:out value="${labResult.requestingClient}" /></td>
@@ -144,7 +146,7 @@
     function stringToDate(str) {
         return new Date(str.includes("/") ? str.split(" / ")[0] : str);
     }
-    
+
     // Data table custom sorting to move empty or null slots on any selected sort to the bottom.
     jQuery.extend(jQuery.fn.dataTableExt.oSort, {
         "non-empty-string-asc": function (str1, str2) {


### PR DESCRIPTION
### **User description**
<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description
Fixes the following bugs
- null display for label
- failure to update list when lab is acknowledged
- i18n deficiencies

<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues
Fixes #656 
<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?

<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Bug Fixes:
- Hide lab result labels that are the literal string "null" instead of rendering them to users.


___

### **Description**
- Added internationalization (i18n) support for multiple languages in the Inboxhub.
- Replaced hardcoded strings in `InboxhubListMode.jsp` with i18n tags for better localization.
- Fixed a bug where acknowledged lab rows were not properly removed from the DataTables cache.
- Resolved issues with displaying 'null' labels by ensuring they are hidden.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>oscarResources_en.properties</strong><dd><code>Add i18n support for English language properties</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/resources/oscarResources_en.properties
<li>Added i18n keys for various labels in English.<br> <li> Improved localization support for the Inboxhub.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/703/files#diff-ec1ea2573170b49f2ce9345e4d8374ed08e9cd91bd3b610674b29a415e17d12b">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>oscarResources_es.properties</strong><dd><code>Add i18n support for Spanish language properties</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/resources/oscarResources_es.properties
<li>Added i18n keys for various labels in Spanish.<br> <li> Improved localization support for the Inboxhub.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/703/files#diff-070bfb71ce2c4f7be17e477125359b04c4ee96f3def7f1b7f9aaad077ceb650b">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>oscarResources_fr.properties</strong><dd><code>Add i18n support for French language properties</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/resources/oscarResources_fr.properties
<li>Added i18n keys for various labels in French.<br> <li> Improved localization support for the Inboxhub.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/703/files#diff-e96713ed5be7884dfcea354836bcb7f708450de88cb1cf78dd1f90ca4358ab28">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>oscarResources_pl.properties</strong><dd><code>Add i18n support for Polish language properties</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/resources/oscarResources_pl.properties
<li>Added i18n keys for various labels in Polish.<br> <li> Improved localization support for the Inboxhub.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/703/files#diff-fba61c17d724280f63ac4caf649954ddbc7441e9571ebc637c6e534c4f784161">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>oscarResources_pt_BR.properties</strong><dd><code>Add i18n support for Portuguese language properties</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/resources/oscarResources_pt_BR.properties
<li>Added i18n keys for various labels in Portuguese.<br> <li> Improved localization support for the Inboxhub.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/703/files#diff-7eb96fdf251040d084499033a7b8f4ee4c7aae5916aa5a9c2ba9b7a383fad57e">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>InboxhubListMode.jsp</strong><dd><code>Enhance InboxhubListMode.jsp with i18n and security fixes</code></dd></summary>
<hr>

src/main/webapp/web/inboxhub/InboxhubListMode.jsp
<li>Replaced hardcoded strings with i18n tags.<br> <li> Fixed XSS vulnerabilities by encoding user data.<br> <li> Updated logic to hide null labels.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/703/files#diff-17ca3e2993b3bccc07382ff25ef8d6f2bf2079b4e46dce72c0cf80351132db15">+19/-17</a>&nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions

## Summary by Sourcery

Fix lab inbox list behaviour and internationalize its UI labels.

Bug Fixes:
- Ensure lab acknowledgements remove the corresponding row from the inbox list DataTable instead of only manipulating the DOM element.
- Prevent the literal string "null" from being displayed as a lab label in the inbox list.
- Correct lab read-status handling by basing the unread marker on the current user from the session.

Enhancements:
- Replace hard-coded inbox list UI text with localized message keys across supported languages and add new i18n entries for related labels and statuses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended Inbox Hub localization support across five languages (English, Spanish, French, Polish, Portuguese Brazilian) with new UI labels for Documents, Labs, HRMs sections, loading messages, and control buttons.

* **Bug Fixes**
  * Improved handling of null values in list rendering and report removal functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->