### PR TITLE
chore: register pathvalidationutils with codeql

### DIFF
--- a/.github/codeql/extensions/carlos-java-models/models/path-validation-sanitizers.yml
+++ b/.github/codeql/extensions/carlos-java-models/models/path-validation-sanitizers.yml
@@ -1,0 +1,37 @@
+# PathValidationUtils - Path Traversal Sanitizer Models
+#
+# Registers PathValidationUtils methods as neutral summaries so CodeQL
+# does not propagate taint through them. These methods validate/sanitize
+# file paths and throw SecurityException on invalid input, making their
+# return values safe from path traversal (CWE-022).
+#
+# See: src/main/java/io/github/carlos_emr/carlos/utility/PathValidationUtils.java
+
+extensions:
+
+  # Mark all public PathValidationUtils methods as neutral summaries.
+  # This tells CodeQL that taint does NOT flow from arguments to return values,
+  # preventing false positives on java/path-injection (CWE-022) and related queries.
+  - addsTo:
+      pack: codeql/java-all
+      extensible: neutralModel
+    data:
+      # validatePath(String, File) -> File
+      # Sanitizes user-provided filename and validates path within allowed directory
+      - ["io.github.carlos_emr.carlos.utility", "PathValidationUtils", "validatePath", "(String,File)", "summary"]
+
+      # validateExistingPath(File, File) -> File
+      # Validates existing file path is within allowed directory
+      - ["io.github.carlos_emr.carlos.utility", "PathValidationUtils", "validateExistingPath", "(File,File)", "summary"]
+
+      # validateUpload(File) -> File
+      # Validates uploaded source file is from allowed temp location
+      - ["io.github.carlos_emr.carlos.utility", "PathValidationUtils", "validateUpload", "(File)", "summary"]
+
+      # validateUpload(File, String, File) -> File
+      # End-to-end upload validation: source + filename sanitization + destination
+      - ["io.github.carlos_emr.carlos.utility", "PathValidationUtils", "validateUpload", "(File,String,File)", "summary"]
+
+      # isInAllowedTempDirectory(File) -> boolean
+      # Guard condition: checks if file is in allowed temp directory
+      - ["io.github.carlos_emr.carlos.utility", "PathValidationUtils", "isInAllowedTempDirectory", "(File)", "summary"]

--- a/.github/codeql/extensions/carlos-java-models/models/path-validation-sanitizers.yml
+++ b/.github/codeql/extensions/carlos-java-models/models/path-validation-sanitizers.yml
@@ -18,20 +18,20 @@ extensions:
     data:
       # validatePath(String, File) -> File
       # Sanitizes user-provided filename and validates path within allowed directory
-      - ["io.github.carlos_emr.carlos.utility", "PathValidationUtils", "validatePath", "(String,File)", "summary"]
+      - ["io.github.carlos_emr.carlos.utility", "PathValidationUtils", "validatePath", "(String,File)", "summary", "manual"]
 
       # validateExistingPath(File, File) -> File
       # Validates existing file path is within allowed directory
-      - ["io.github.carlos_emr.carlos.utility", "PathValidationUtils", "validateExistingPath", "(File,File)", "summary"]
+      - ["io.github.carlos_emr.carlos.utility", "PathValidationUtils", "validateExistingPath", "(File,File)", "summary", "manual"]
 
       # validateUpload(File) -> File
       # Validates uploaded source file is from allowed temp location
-      - ["io.github.carlos_emr.carlos.utility", "PathValidationUtils", "validateUpload", "(File)", "summary"]
+      - ["io.github.carlos_emr.carlos.utility", "PathValidationUtils", "validateUpload", "(File)", "summary", "manual"]
 
       # validateUpload(File, String, File) -> File
       # End-to-end upload validation: source + filename sanitization + destination
-      - ["io.github.carlos_emr.carlos.utility", "PathValidationUtils", "validateUpload", "(File,String,File)", "summary"]
+      - ["io.github.carlos_emr.carlos.utility", "PathValidationUtils", "validateUpload", "(File,String,File)", "summary", "manual"]
 
       # isInAllowedTempDirectory(File) -> boolean
       # Guard condition: checks if file is in allowed temp directory
-      - ["io.github.carlos_emr.carlos.utility", "PathValidationUtils", "isInAllowedTempDirectory", "(File)", "summary"]
+      - ["io.github.carlos_emr.carlos.utility", "PathValidationUtils", "isInAllowedTempDirectory", "(File)", "summary", "manual"]

--- a/.github/codeql/extensions/carlos-java-models/qlpack.yml
+++ b/.github/codeql/extensions/carlos-java-models/qlpack.yml
@@ -1,0 +1,5 @@
+name: carlos-emr/carlos-java-models
+version: 1.0.0
+library: true
+extensionTargets:
+  codeql/java-all: "*"

--- a/src/main/java/io/github/carlos_emr/carlos/billing/CA/ON/web/MoveMOHFiles2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billing/CA/ON/web/MoveMOHFiles2Action.java
@@ -190,7 +190,7 @@ public class MoveMOHFiles2Action extends ActionSupport {
             for (EDTFolder folder : EDTFolder.values()) {
                 File edtFolderFile = new File(folder.getPath());
                 try {
-                    PathValidationUtils.validateExistingPath(file, edtFolderFile);
+                    file = PathValidationUtils.validateExistingPath(file, edtFolderFile);
                     result = true;
                     break;
                 } catch (SecurityException e) {

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/Teleplan/TeleplanCodesManager.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/Teleplan/TeleplanCodesManager.java
@@ -71,7 +71,7 @@ REM076 **                                                             **
         // Use PathValidationUtils to validate file is in allowed directory or temp
         File allowedDir = new File(CarlosProperties.getInstance().getProperty("DOCUMENT_DIR"));
         try {
-            PathValidationUtils.validateExistingPath(f, allowedDir);
+            f = PathValidationUtils.validateExistingPath(f, allowedDir);
         } catch (SecurityException e) {
             // File might be in temp directory from Teleplan API
             if (!PathValidationUtils.isInAllowedTempDirectory(f)) {

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/ManageTeleplan2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/ManageTeleplan2Action.java
@@ -168,7 +168,7 @@ public class ManageTeleplan2Action extends ActionSupport {
         // Use PathValidationUtils to validate file is in allowed directory or temp
         File allowedDir = new File(CarlosProperties.getInstance().getProperty("DOCUMENT_DIR"));
         try {
-            PathValidationUtils.validateExistingPath(file, allowedDir);
+            file = PathValidationUtils.validateExistingPath(file, allowedDir);
         } catch (SecurityException e) {
             // File might be in temp directory from Teleplan API
             if (!PathValidationUtils.isInAllowedTempDirectory(file)) {
@@ -241,7 +241,7 @@ public class ManageTeleplan2Action extends ActionSupport {
         // Use PathValidationUtils to validate file is in allowed directory or temp
         File allowedDir = new File(CarlosProperties.getInstance().getProperty("DOCUMENT_DIR"));
         try {
-            PathValidationUtils.validateExistingPath(file, allowedDir);
+            file = PathValidationUtils.validateExistingPath(file, allowedDir);
         } catch (SecurityException e) {
             // File might be in temp directory from Teleplan API
             if (!PathValidationUtils.isInAllowedTempDirectory(file)) {
@@ -543,7 +543,7 @@ public class ManageTeleplan2Action extends ActionSupport {
             // Use PathValidationUtils to validate file is in allowed directory or temp
             File allowedDir = new File(CarlosProperties.getInstance().getProperty("DOCUMENT_DIR"));
             try {
-                PathValidationUtils.validateExistingPath(file, allowedDir);
+                file = PathValidationUtils.validateExistingPath(file, allowedDir);
             } catch (SecurityException e) {
                 // File might be in temp directory from Teleplan API
                 if (!PathValidationUtils.isInAllowedTempDirectory(file)) {

--- a/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/ImportDemographicDataAction42Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/ImportDemographicDataAction42Action.java
@@ -492,7 +492,7 @@ public class ImportDemographicDataAction42Action extends ActionSupport {
         // Uses validateExistingPath for containment check without stripping path components
         try {
             // First, perform any existing validation logic
-            PathValidationUtils.validateExistingPath(newFile, targetDir);
+            newFile = PathValidationUtils.validateExistingPath(newFile, targetDir);
 
             // Explicit canonical / normalized path containment check to prevent Zip Slip
             // and to make the security property obvious to static analysis tools.
@@ -2784,7 +2784,7 @@ public class ImportDemographicDataAction42Action extends ActionSupport {
                                 // This prevents path traversal attacks from malicious XML file paths
                                 try {
                                     File allowedRoot = new File(currentDirectory);
-                                    PathValidationUtils.validateExistingPath(sourceFile, allowedRoot);
+                                    sourceFile = PathValidationUtils.validateExistingPath(sourceFile, allowedRoot);
                                 } catch (SecurityException e) {
                                     logger.error("SECURITY: Rejecting file copy - resolved path outside allowed directory. FilePath: {}, SourceFile: {}",
                                         Encode.forJava(new File(filePath).getName()),
@@ -3374,7 +3374,7 @@ public class ImportDemographicDataAction42Action extends ActionSupport {
         // CRITICAL SECURITY: Validate the resolved path is within the allowed directory
         // This prevents path traversal attacks from malicious XML (e.g., "../../../etc/passwd")
         try {
-            PathValidationUtils.validateExistingPath(file, allowedRoot);
+            file = PathValidationUtils.validateExistingPath(file, allowedRoot);
             return file;
         } catch (SecurityException e) {
             logger.error("SECURITY: Rejecting malicious file path from XML. originalPath='{}', resolvedPath='{}'",

--- a/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/ImportLogDownload2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/ImportLogDownload2Action.java
@@ -99,7 +99,7 @@ public class ImportLogDownload2Action extends ActionSupport {
 
             // Validate using PathValidationUtils to prevent directory traversal
             try {
-                PathValidationUtils.validateExistingPath(importLogFile, tempDir);
+                importLogFile = PathValidationUtils.validateExistingPath(importLogFile, tempDir);
             } catch (SecurityException e) {
                 logger.error("Path is not in the correct directory: " + importLogParam);
                 return "error";

--- a/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/Util.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/Util.java
@@ -196,7 +196,7 @@ public class Util {
 
         // Validate that the resolved path is within the allowed directory
         try {
-            PathValidationUtils.validateExistingPath(f, baseDir);
+            f = PathValidationUtils.validateExistingPath(f, baseDir);
         } catch (SecurityException e) {
             logger.error("Error! Attempted path traversal attack detected for file: " + filename);
             return false;
@@ -276,7 +276,7 @@ public class Util {
 
             // Validate the file path using PathValidationUtils
             try {
-                PathValidationUtils.validateExistingPath(requestedFile, documentDir);
+                requestedFile = PathValidationUtils.validateExistingPath(requestedFile, documentDir);
             } catch (SecurityException e) {
                 logger.error("Path traversal attempt detected for file: " + fileName);
                 return;

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/EDocUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/EDocUtil.java
@@ -1243,7 +1243,7 @@ public final class EDocUtil {
             // Use PathValidationUtils for validation
             // First try document directory
             try {
-                PathValidationUtils.validateExistingPath(inputFile, documentDir);
+                inputFile = PathValidationUtils.validateExistingPath(inputFile, documentDir);
                 return canonicalPath;
             } catch (SecurityException e) {
                 // Not in document directory, check temp directories

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/IncomingDocUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/IncomingDocUtil.java
@@ -311,7 +311,7 @@ public final class IncomingDocUtil {
                 File deletedPathDir = new File(filePath, pdfDir + "_deleted");
 
                 // Validate path is within bounds using PathValidationUtils
-                PathValidationUtils.validateExistingPath(deletedPathDir, baseDir);
+                deletedPathDir = PathValidationUtils.validateExistingPath(deletedPathDir, baseDir);
 
                 File canonicalDeletedDir = deletedPathDir.getCanonicalFile();
 
@@ -403,7 +403,7 @@ public final class IncomingDocUtil {
         // Validate path is within bounds using PathValidationUtils
         try {
             File baseDirFile = new File(baseDir);
-            PathValidationUtils.validateExistingPath(filePathDir, baseDirFile);
+            filePathDir = PathValidationUtils.validateExistingPath(filePathDir, baseDirFile);
 
             File canonicalDir = filePathDir.getCanonicalFile();
 

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/ManageDocument2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/ManageDocument2Action.java
@@ -1245,7 +1245,7 @@ public class ManageDocument2Action extends ActionSupport {
         // Validate file path using PathValidationUtils
         File baseDir = new File(incomingDocDir);
         File file = new File(filePath);
-        PathValidationUtils.validateExistingPath(file, baseDir);
+        file = PathValidationUtils.validateExistingPath(file, baseDir);
 
         Locale locale = request.getLocale();
         ResourceBundle props = ResourceBundle.getBundle("oscarResources", locale);
@@ -1356,7 +1356,7 @@ public class ManageDocument2Action extends ActionSupport {
         // Validate file path using PathValidationUtils
         File baseDir = new File(incomingDocDir);
         File file = new File(filePath);
-        PathValidationUtils.validateExistingPath(file, baseDir);
+        file = PathValidationUtils.validateExistingPath(file, baseDir);
 
         String contentType = "application/pdf";
         response.setContentType(contentType);
@@ -1506,7 +1506,7 @@ public class ManageDocument2Action extends ActionSupport {
         File documentDir = new File(incomingDocPath);
         File documentCacheDir = getDocumentCacheDir(incomingDocPath);
         File file = new File(documentDir, sanitizedPdfName);
-        PathValidationUtils.validateExistingPath(file, baseDir);
+        file = PathValidationUtils.validateExistingPath(file, baseDir);
 
         // Re-validate file path at point of use for static analysis visibility
         File validatedFile = PathValidationUtils.validateExistingPath(file, baseDir);
@@ -1606,7 +1606,7 @@ public class ManageDocument2Action extends ActionSupport {
 
         for (File allowedDir : allowedDirs) {
             try {
-                PathValidationUtils.validateExistingPath(file, allowedDir);
+                file = PathValidationUtils.validateExistingPath(file, allowedDir);
                 return; // Valid if we get here without exception
             } catch (SecurityException e) {
                 // File not in this directory, try next

--- a/src/main/java/io/github/carlos_emr/carlos/eform/actions/DelImage2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/eform/actions/DelImage2Action.java
@@ -82,7 +82,7 @@ public class DelImage2Action extends ActionSupport {
         
         try {
             // Validate using PathValidationUtils to ensure the path is within the expected directory
-            PathValidationUtils.validateExistingPath(image, imageDir);
+            image = PathValidationUtils.validateExistingPath(image, imageDir);
 
             // Delete the file
             Path imagePath = image.toPath();

--- a/src/main/java/io/github/carlos_emr/carlos/fax/core/FaxSender.java
+++ b/src/main/java/io/github/carlos_emr/carlos/fax/core/FaxSender.java
@@ -258,7 +258,7 @@ public class FaxSender {
             File absoluteFile = path.toFile();
             try {
                 // Prefer files that are under DOCUMENT_DIR and already exist
-                PathValidationUtils.validateExistingPath(absoluteFile, new File(documentDir));
+                absoluteFile = PathValidationUtils.validateExistingPath(absoluteFile, new File(documentDir));
                 return absoluteFile.toPath();
             } catch (SecurityException e) {
                 // Allow absolute paths in an explicitly allowed temp directory

--- a/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FrmXmlUpload2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FrmXmlUpload2Action.java
@@ -81,7 +81,7 @@ public class FrmXmlUpload2Action extends ActionSupport {
 
         // Validate file path using PathValidationUtils
         try {
-            PathValidationUtils.validateExistingPath(normalizedFile, safeDir);
+            normalizedFile = PathValidationUtils.validateExistingPath(normalizedFile, safeDir);
         } catch (SecurityException e) {
             throw new IllegalArgumentException("Invalid file path: " + normalizedFile.getPath());
         }

--- a/src/main/java/io/github/carlos_emr/carlos/integration/hl7/handlers/upload/PhsStarHandler.java
+++ b/src/main/java/io/github/carlos_emr/carlos/integration/hl7/handlers/upload/PhsStarHandler.java
@@ -71,7 +71,7 @@ public class PhsStarHandler implements MessageHandler {
             if (documentDir != null && !documentDir.isEmpty()) {
                 File docDir = new File(documentDir).getCanonicalFile();
                 try {
-                    PathValidationUtils.validateExistingPath(file, docDir);
+                    file = PathValidationUtils.validateExistingPath(file, docDir);
                 } catch (SecurityException e) {
                     logger.error("Attempted to access file outside document directory: " + fileName);
                     MessageUploader.clean(fileId);

--- a/src/main/java/io/github/carlos_emr/carlos/lab/ca/all/upload/handlers/DefaultHandler.java
+++ b/src/main/java/io/github/carlos_emr/carlos/lab/ca/all/upload/handlers/DefaultHandler.java
@@ -136,7 +136,7 @@ public class DefaultHandler implements MessageHandler {
             String documentDir = props.getProperty("DOCUMENT_DIR");
             if (documentDir != null && !documentDir.isEmpty()) {
                 File docDir = new File(documentDir).getCanonicalFile();
-                PathValidationUtils.validateExistingPath(file, docDir);
+                file = PathValidationUtils.validateExistingPath(file, docDir);
             }
 
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
@@ -169,7 +169,7 @@ public class DefaultHandler implements MessageHandler {
         String documentDir = props.getProperty("DOCUMENT_DIR");
         if (documentDir != null && !documentDir.isEmpty()) {
             File docDir = new File(documentDir).getCanonicalFile();
-            PathValidationUtils.validateExistingPath(file, docDir);
+            file = PathValidationUtils.validateExistingPath(file, docDir);
         }
 
         StringBuilder sb = new StringBuilder(1024);

--- a/src/main/java/io/github/carlos_emr/carlos/lab/ca/all/upload/handlers/ExcellerisOntarioHandler.java
+++ b/src/main/java/io/github/carlos_emr/carlos/lab/ca/all/upload/handlers/ExcellerisOntarioHandler.java
@@ -87,7 +87,7 @@ public class ExcellerisOntarioHandler implements MessageHandler {
             // Create file object and validate using PathValidationUtils
             File file = new File(fileName);
             try {
-                PathValidationUtils.validateExistingPath(file, docDir);
+                file = PathValidationUtils.validateExistingPath(file, docDir);
             } catch (SecurityException e) {
                 logger.error("Attempted path traversal detected - file outside document directory: " + fileName);
                 throw new SecurityException("Access denied: file outside permitted directory");

--- a/src/main/java/io/github/carlos_emr/carlos/lab/ca/all/upload/handlers/FHIRCommunicationRequestHandler.java
+++ b/src/main/java/io/github/carlos_emr/carlos/lab/ca/all/upload/handlers/FHIRCommunicationRequestHandler.java
@@ -124,7 +124,7 @@ public class FHIRCommunicationRequestHandler implements MessageHandler {
             File baseDir = new File(baseDocDir);
             File targetFile = new File(fileName);
             try {
-                PathValidationUtils.validateExistingPath(targetFile, baseDir);
+                targetFile = PathValidationUtils.validateExistingPath(targetFile, baseDir);
             } catch (SecurityException e) {
                 logger.error("Path traversal attempt detected: " + fileName);
                 return null;

--- a/src/main/java/io/github/carlos_emr/carlos/lab/ca/all/upload/handlers/IHAHandler.java
+++ b/src/main/java/io/github/carlos_emr/carlos/lab/ca/all/upload/handlers/IHAHandler.java
@@ -202,7 +202,7 @@ public class IHAHandler extends DefaultGenericHandler implements MessageHandler 
             String documentDir = props.getProperty("DOCUMENT_DIR");
             if (documentDir != null && !documentDir.isEmpty()) {
                 File docDir = new File(documentDir).getCanonicalFile();
-                PathValidationUtils.validateExistingPath(file, docDir);
+                file = PathValidationUtils.validateExistingPath(file, docDir);
             }
 
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();

--- a/src/main/java/io/github/carlos_emr/carlos/lab/ca/all/upload/handlers/IHAPOIHandler.java
+++ b/src/main/java/io/github/carlos_emr/carlos/lab/ca/all/upload/handlers/IHAPOIHandler.java
@@ -271,7 +271,7 @@ public class IHAPOIHandler implements MessageHandler {
         // Check if the file is within the allowed base directory or temp directory
         boolean isValidPath = false;
         try {
-            PathValidationUtils.validateExistingPath(file, baseDirFile);
+            file = PathValidationUtils.validateExistingPath(file, baseDirFile);
             isValidPath = true;
         } catch (SecurityException e) {
             // Try allowed temp directories as fallback

--- a/src/main/java/io/github/carlos_emr/carlos/lab/ca/all/upload/handlers/OscarToOscarHl7V2Handler.java
+++ b/src/main/java/io/github/carlos_emr/carlos/lab/ca/all/upload/handlers/OscarToOscarHl7V2Handler.java
@@ -105,7 +105,7 @@ public class OscarToOscarHl7V2Handler implements MessageHandler {
             File baseDir = new File(baseDocDir);
             File canonicalFile = new File(fileName).getCanonicalFile();
             try {
-                PathValidationUtils.validateExistingPath(canonicalFile, baseDir);
+                canonicalFile = PathValidationUtils.validateExistingPath(canonicalFile, baseDir);
             } catch (SecurityException e) {
                 logger.error("File path is outside allowed directory. Base: " + baseDocDir + ", File: " + canonicalFile.getPath());
                 return null;

--- a/src/main/java/io/github/carlos_emr/carlos/lab/ca/all/upload/handlers/PATHL7Handler.java
+++ b/src/main/java/io/github/carlos_emr/carlos/lab/ca/all/upload/handlers/PATHL7Handler.java
@@ -82,7 +82,7 @@ public class PATHL7Handler implements MessageHandler {
             java.io.File targetFile = new java.io.File(fileName);
 
             // Validate the existing file is within the allowed directory
-            PathValidationUtils.validateExistingPath(targetFile, baseDirFile);
+            targetFile = PathValidationUtils.validateExistingPath(targetFile, baseDirFile);
 
             if (!targetFile.exists() || !targetFile.isFile()) {
                 logger.error("File does not exist or is not a regular file: " + fileName);

--- a/src/main/java/io/github/carlos_emr/carlos/lab/ca/all/upload/handlers/PDFHandler.java
+++ b/src/main/java/io/github/carlos_emr/carlos/lab/ca/all/upload/handlers/PDFHandler.java
@@ -110,7 +110,7 @@ public class PDFHandler implements MessageHandler {
             // Validate the file path using PathValidationUtils
             File baseDir = new File(baseDocDir);
             File targetFile = new File(filePath);
-            PathValidationUtils.validateExistingPath(targetFile, baseDir);
+            targetFile = PathValidationUtils.validateExistingPath(targetFile, baseDir);
 
             // Verify the file exists and is a regular file
             if (!targetFile.exists() || !targetFile.isFile()) {

--- a/src/main/java/io/github/carlos_emr/carlos/lab/ca/on/CML/Upload/LabUpload2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/lab/ca/on/CML/Upload/LabUpload2Action.java
@@ -113,7 +113,7 @@ public class LabUpload2Action extends ActionSupport {
                     if (documentDir != null) {
                         try {
                             File docDirFile = new File(documentDir);
-                            PathValidationUtils.validateExistingPath(localFile, docDirFile);
+                            localFile = PathValidationUtils.validateExistingPath(localFile, docDirFile);
                         } catch (SecurityException e) {
                             _logger.error("Invalid file path: " + localFileName);
                             outcome = "accessDenied";

--- a/src/main/java/io/github/carlos_emr/carlos/managers/FaxManagerImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/FaxManagerImpl.java
@@ -797,7 +797,7 @@ public class FaxManagerImpl implements FaxManager {
         File documentDir = new File(CarlosProperties.getInstance().getProperty("DOCUMENT_DIR", "/var/lib/OscarDocument/"));
 
         try {
-            PathValidationUtils.validateExistingPath(file, documentDir);
+            file = PathValidationUtils.validateExistingPath(file, documentDir);
         } catch (SecurityException e) {
             // File not in document dir, check if it's in allowed temp directories
             if (!PathValidationUtils.isInAllowedTempDirectory(file)) {
@@ -830,7 +830,7 @@ public class FaxManagerImpl implements FaxManager {
         File documentDir = new File(CarlosProperties.getInstance().getProperty("DOCUMENT_DIR", "/var/lib/OscarDocument/"));
 
         try {
-            PathValidationUtils.validateExistingPath(file, documentDir);
+            file = PathValidationUtils.validateExistingPath(file, documentDir);
         } catch (SecurityException e) {
             // File not in document dir, check if it's in allowed temp directories
             if (!PathValidationUtils.isInAllowedTempDirectory(file)) {

--- a/src/main/java/io/github/carlos_emr/carlos/provider/web/ProviderSignatureStamp2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/provider/web/ProviderSignatureStamp2Action.java
@@ -258,7 +258,7 @@ public class ProviderSignatureStamp2Action extends ActionSupport {
             try {
                 File imageFolder = getImageFolder();
                 File sigFile = new File(imageFolder, expectedName);
-                PathValidationUtils.validateExistingPath(sigFile, imageFolder);
+                sigFile = PathValidationUtils.validateExistingPath(sigFile, imageFolder);
                 if (sigFile.exists() && !sigFile.delete()) {
                     MiscUtils.getLogger().warn("Could not delete signature file for provider {}: {}", providerNo, sigFile.getAbsolutePath());
                 }
@@ -303,7 +303,7 @@ public class ProviderSignatureStamp2Action extends ActionSupport {
             try {
                 File imageFolder = getImageFolder();
                 File sigFile = new File(imageFolder, expectedName);
-                PathValidationUtils.validateExistingPath(sigFile, imageFolder);
+                sigFile = PathValidationUtils.validateExistingPath(sigFile, imageFolder);
                 if (sigFile.exists()) {
                     exists = true;
                     imageUrl = request.getContextPath() + "/provider/providerSignatureImage.do";


### PR DESCRIPTION
### **User description**
This pull request introduces a new CodeQL extension that models the `PathValidationUtils` Java utility as a sanitizer for path traversal vulnerabilities. The main goal is to help CodeQL correctly recognize these methods as safe, reducing false positives for path traversal (CWE-022) in code analysis.

Key changes:

**CodeQL Extension for Path Sanitization:**
* Added `.github/codeql/extensions/carlos-java-models/models/path-validation-sanitizers.yml` to mark all public methods in `PathValidationUtils` as neutral summaries, so CodeQL will not propagate taint through them. This ensures that validated file paths are not incorrectly flagged as vulnerable.

**CodeQL Pack Configuration:**
* Introduced a new `qlpack.yml` (`.github/codeql/extensions/carlos-java-models/qlpack.yml`) to define the extension pack, set its version, and declare it as a library targeting `codeql/java-all`.

## Summary by Sourcery

Register CodeQL models for Java path validation utilities to prevent taint from propagating through validated file paths.

Enhancements:
- Add a CodeQL extension that treats PathValidationUtils validation methods as neutral summaries for path traversal analysis.
- Introduce a dedicated CodeQL library pack configuration for the custom Java models.


___

### **Description**
- Introduced a CodeQL extension to model `PathValidationUtils` methods as neutral summaries.
- This change helps reduce false positives for path traversal vulnerabilities (CWE-022) in code analysis.
- Added a new CodeQL library pack configuration to define the extension and its target.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>path-validation-sanitizers.yml</strong><dd><code>CodeQL Extension for PathValidationUtils Sanitization</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/codeql/extensions/carlos-java-models/models/path-validation-sanitizers.yml
<li>Added models for <code>PathValidationUtils</code> methods as neutral summaries.<br> <li> Prevented taint propagation for path traversal vulnerabilities.<br> <li> Documented the purpose and usage of the models.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/713/files#diff-c1c803ef65bf56ee42301a9c5b3d5dc9178404d6dbe4a19c7c2e62e95aeceb3f">+37/-0</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>qlpack.yml</strong><dd><code>CodeQL Pack Configuration for Java Models</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/codeql/extensions/carlos-java-models/qlpack.yml
<li>Defined a new CodeQL library pack configuration.<br> <li> Set version and target for the extension.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/713/files#diff-579006726784ef48dbbe9c19b42dd176734a6816b812fac7bf9e1a0fd6cb3d33">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a CodeQL extension pack and models to enhance automated path-validation analysis.
* **Bug Fixes**
  * Numerous file-handling flows now use the validator's returned/normalized file references so subsequent file operations act on validated, canonicalized paths, reducing path-related errors and improving consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->