### PR TITLE
chore: resolve 7 Dependabot security alerts (Mar 2024)

### DIFF
--- a/dependencies-lock.json
+++ b/dependencies-lock.json
@@ -10,43 +10,43 @@
   }, {
     "groupId" : "ca.uhn.hapi.fhir",
     "artifactId" : "hapi-fhir-base",
-    "version" : "6.10.5",
+    "version" : "8.4.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:+yroXyyOv20n0FZL7MzFG/yixcn/dBko09lAivI+uJaEMNJUtTGusVZI0krwXJm8ZgyqE6eGWrvPQfnhh8EmJA=="
+    "integrity" : "sha512:yuMn1jI/ZX3khsDDBKzBbMzDVeKk/fDxVHFSXFBc79j3MMzrHOgt2jLZadKI+Ji9rfTP9rftZviM0ay/fX8iYQ=="
   }, {
     "groupId" : "ca.uhn.hapi.fhir",
     "artifactId" : "hapi-fhir-caching-api",
-    "version" : "6.10.5",
+    "version" : "8.4.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:P7sy4EBGDXhLcZPUsS3xCkperUfAmQV/AJpOV9VLTudj9qt42wVGzUSTSX1GqrCBtyTz+7iF4wmpCi6dXnTuhQ=="
+    "integrity" : "sha512:rhV/IsQSsbw99JKwoq9jTZBisUL77TYelQEWwcCTESz4qTT0R0wqI6hlaAJJuWH0I1Eal7lGQ4X7CWSTWbFdNA=="
   }, {
     "groupId" : "ca.uhn.hapi.fhir",
     "artifactId" : "hapi-fhir-structures-dstu3",
-    "version" : "6.10.5",
+    "version" : "8.4.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:TwbsA/lm8DAkBibmgATRxK3WBM/iGZsuO0SV7QI65QGXEDMWM8v4IvkjPfAybFU8NswYIYLI3DT57SGEWBBPKw=="
+    "integrity" : "sha512:KxJ/drvaUY7HoUpaOb3Qh6fSFKa/H1zwLKZQXr96odG2an7AfXXmWoZ+G6GCjYXECMdxnFkvkl/GYeVPe5xpyw=="
   }, {
     "groupId" : "ca.uhn.hapi.fhir",
     "artifactId" : "org.hl7.fhir.dstu3",
-    "version" : "6.7.10",
+    "version" : "6.9.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:bBM1YXeHS0zCspujbitSlNaIjTWeEZWoLAv1vAH+XXb4dQpMzhIN5tPNw/jivU6j//8B/7PCLnhL3qeEfdHVeA=="
+    "integrity" : "sha512:418c8a5fSkA9MYCVMtbSMj5Q5MPkKsktmB9QumetkRswUMrsbkURzHB07fXO8QjdvX0lQWIC89iumDk3OJL4Pg=="
   }, {
     "groupId" : "ca.uhn.hapi.fhir",
     "artifactId" : "org.hl7.fhir.utilities",
-    "version" : "6.7.10",
+    "version" : "6.9.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:7ODgnMYuvS931x9Rx9+xe7YKHtBoUdAATDr74TTPrr/bEiESIRM/uceF9n7MGQufh5wVmZ9gPSx+Oddm64S7aw=="
+    "integrity" : "sha512:GQyoUjS1NifPBtHh64ks9KU3snmWoefyabQFxylMtmX4yu0N4/JAo8MkqrFHVkjrZIz+DQm0yzULlWySze4ohw=="
   }, {
     "groupId" : "ca.uhn.hapi",
     "artifactId" : "hapi-base",
@@ -186,11 +186,11 @@
   }, {
     "groupId" : "com.fasterxml.jackson.datatype",
     "artifactId" : "jackson-datatype-jsr310",
-    "version" : "2.15.3",
+    "version" : "2.17.1",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:HFvebJGiqJ88HyMfThfENQY9kBK6u/y6UJo7JTY7H9mfDc1CNPHgBVnkPT3I5scYNCgscvLr8VSErpAHVMXXVw=="
+    "integrity" : "sha512:9QMLwoIxc0/gY0cSsqMHDjZLFFJHKdDYidF57egGutMbpdGzqrmRGDBvuvUQ4coHuW9ub37UKL9LDjbWZX36pw=="
   }, {
     "groupId" : "com.fasterxml.jackson.jakarta.rs",
     "artifactId" : "jackson-jakarta-rs-base",
@@ -1237,11 +1237,11 @@
   }, {
     "groupId" : "org.apache.artemis",
     "artifactId" : "artemis-jdbc-store",
-    "version" : "2.50.0",
+    "version" : "2.52.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:fUd8iABHgfY/Mxk5RnqqvuWOrnYnJG3h06lurnnu1DAMSzpJqR5kXPqpzE1Xog8Ah7XfvsFuOaIetJ4m5uah0w=="
+    "integrity" : "sha512:0wuWpIU3Zd3fC9BBHADUSjDUW+evsgPDfTSbZYGvmZjaD9/wu5453i0jfqVllXVG0ndnitt5pEEGIkFtmDt8YA=="
   }, {
     "groupId" : "org.apache.artemis",
     "artifactId" : "artemis-journal",
@@ -1253,11 +1253,11 @@
   }, {
     "groupId" : "org.apache.artemis",
     "artifactId" : "artemis-lockmanager-api",
-    "version" : "2.50.0",
+    "version" : "2.52.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:LE09pwf+i+QA/vC/HhQi4M3lg9EPJuMBvVUCVBrLNvvd4sTXIYHIw8lUy+lHlx12oGdItYkNV5vIAeKDDpj5jQ=="
+    "integrity" : "sha512:N2u43bE/UuMsKkmh4q0YF0GjuiDjR7fmVzghBCn6xYMz+mDrplOYLf8yYEWu1BRtDX3TJDvUxFr6Jevvc4pljg=="
   }, {
     "groupId" : "org.apache.artemis",
     "artifactId" : "artemis-selector",
@@ -1269,11 +1269,11 @@
   }, {
     "groupId" : "org.apache.artemis",
     "artifactId" : "artemis-server",
-    "version" : "2.50.0",
+    "version" : "2.52.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:Jfa85RDtFuwjzSVxs/k82uELqyFNmljGuXqckjoo0Rr3tDqqXrgF5rAlyeIIQBtH04EICMInnCZzPGwlKlg7Dg=="
+    "integrity" : "sha512:ARcVPHDvlS0OmlhdfuMEGU6mt1XB1nOl0CYU0iNj7oNhCUTlO9QEH8DbMiHIbn+ZJo3V9NubmRzjNVStdSyGLg=="
   }, {
     "groupId" : "org.apache.commons",
     "artifactId" : "commons-beanutils2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4606,13 +4606,6 @@
         "node": ">=14.16"
       }
     },
-    "node_modules/@trysound/sax": {
-      "version": "0.2.0",
-      "license": "ISC",
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "license": "MIT",
@@ -11172,13 +11165,15 @@
       "license": "ISC"
     },
     "node_modules/minimatch": {
-      "version": "10.2.1",
+      "version": "10.2.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.3.tgz",
+      "integrity": "sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -13223,13 +13218,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.0",
       "license": "MIT",
@@ -13943,7 +13931,9 @@
       "license": "MIT"
     },
     "node_modules/sax": {
-      "version": "1.4.4",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -14072,10 +14062,12 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.3.tgz",
+      "integrity": "sha512-h+cZ/XXarqDgCjo+YSyQU/ulDEESGGf8AMK9pPNmhNSl/FzPl6L8pMp1leca5z6NuG6tvV/auC8/43tmovowww==",
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-handler": {
@@ -14634,16 +14626,18 @@
       "license": "MIT"
     },
     "node_modules/svgo": {
-      "version": "3.3.2",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.3.tgz",
+      "integrity": "sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng==",
       "license": "MIT",
       "dependencies": {
-        "@trysound/sax": "0.2.0",
         "commander": "^7.2.0",
         "css-select": "^5.1.0",
         "css-tree": "^2.3.1",
         "css-what": "^6.1.0",
         "csso": "^5.0.5",
-        "picocolors": "^1.0.0"
+        "picocolors": "^1.0.0",
+        "sax": "^1.5.0"
       },
       "bin": {
         "svgo": "bin/svgo"

--- a/package.json
+++ b/package.json
@@ -43,9 +43,11 @@
   "overrides": {
     "ajv@>=7.0.0-alpha.0 <8.18.0": "8.18.0",
     "ajv@<6.14.0": "6.14.0",
-    "minimatch": "10.2.1",
+    "minimatch": "10.2.3",
     "qs": "6.15.0",
     "webpack": "5.104.1",
-    "lodash": "4.17.23"
+    "lodash": "4.17.23",
+    "svgo": "3.3.3",
+    "serialize-javascript": "7.0.3"
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <!-- Slf4j Version -->
         <slf4j.version>2.0.17</slf4j.version>
         <!-- Hapi Fhir Version -->
-        <hapifhir.version>6.10.5</hapifhir.version>
+        <hapifhir.version>8.4.0</hapifhir.version>
         <!-- Apache CXF Version -->
         <cxf.version>4.1.5</cxf.version>
         <!-- Netty Version (for transitive dependency security fixes) -->
@@ -223,18 +223,25 @@
                 <artifactId>serializer</artifactId>
                 <version>2.7.3</version>
             </dependency>
-            <!-- Override transitive org.hl7.fhir.core (6.1.2.2) from hapi-fhir-structures-dstu3.
-                 Fixes: CVE-2024-45294, CVE-2024-51132, CVE-2024-52007 (all patched in 6.4.0).
-                 Aligned to 6.7.10 to reduce drift from HAPI FHIR development baseline (6.7.9). -->
+            <!-- Override transitive org.hl7.fhir.core (6.5.27) from hapi-fhir-structures-dstu3.
+                 Fixes: CVE-2024-45294, CVE-2024-51132, CVE-2024-52007 (all patched in 6.4.0),
+                 CVE-2026-33180 HTTP auth credential leak in redirects (patched in 6.9.0). -->
             <dependency>
                 <groupId>ca.uhn.hapi.fhir</groupId>
                 <artifactId>org.hl7.fhir.utilities</artifactId>
-                <version>6.7.10</version>
+                <version>6.9.0</version>
             </dependency>
             <dependency>
                 <groupId>ca.uhn.hapi.fhir</groupId>
                 <artifactId>org.hl7.fhir.dstu3</artifactId>
-                <version>6.7.10</version>
+                <version>6.9.0</version>
+            </dependency>
+            <!-- Override transitive Artemis 2.50.0 from cxf-services-wsn-core.
+                 Fixes: CVE-2025-XXXXX missing authentication for critical functions (patched in 2.52.0). -->
+            <dependency>
+                <groupId>org.apache.artemis</groupId>
+                <artifactId>artemis-server</artifactId>
+                <version>2.52.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -237,7 +237,8 @@
                 <version>6.9.0</version>
             </dependency>
             <!-- Override transitive Artemis 2.50.0 from cxf-services-wsn-core.
-                 Fixes: CVE-2025-XXXXX missing authentication for critical functions (patched in 2.52.0). -->
+                 Security fix for missing authentication on critical functions (patched in 2.52.0);
+                 see the Dependabot alert for org.apache.artemis:artemis-server 2.50.0. -->
             <dependency>
                 <groupId>org.apache.artemis</groupId>
                 <artifactId>artemis-server</artifactId>

--- a/src/test/java/io/github/carlos_emr/carlos/integration/fhir/builder/FhirMessageBuilderIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/integration/fhir/builder/FhirMessageBuilderIntegrationTest.java
@@ -274,13 +274,13 @@ class FhirMessageBuilderIntegrationTest {
         @Test
         @DisplayName("should contain Bundle resource type in JSON")
         void shouldContainBundleResourceType_inJson() {
-            assertThat(json).contains("\"resourceType\" : \"Bundle\"");
+            assertThat(json).contains("\"resourceType\": \"Bundle\"");
         }
 
         @Test
         @DisplayName("should contain MessageHeader as first entry")
         void shouldContainMessageHeader_asFirstEntry() {
-            assertThat(json).contains("\"resourceType\" : \"MessageHeader\"");
+            assertThat(json).contains("\"resourceType\": \"MessageHeader\"");
         }
 
         @Test
@@ -293,13 +293,13 @@ class FhirMessageBuilderIntegrationTest {
         @Test
         @DisplayName("should contain immunization resources in JSON")
         void shouldContainImmunizationResources_inJson() {
-            assertThat(json).contains("\"resourceType\" : \"Immunization\"");
+            assertThat(json).contains("\"resourceType\": \"Immunization\"");
         }
 
         @Test
         @DisplayName("should contain practitioner resources in JSON")
         void shouldContainPractitionerResources_inJson() {
-            assertThat(json).contains("\"resourceType\" : \"Practitioner\"");
+            assertThat(json).contains("\"resourceType\": \"Practitioner\"");
         }
 
         @Test

--- a/src/test/java/io/github/carlos_emr/carlos/integration/fhir/builder/FhirMessageBuilderIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/integration/fhir/builder/FhirMessageBuilderIntegrationTest.java
@@ -280,7 +280,11 @@ class FhirMessageBuilderIntegrationTest {
         @Test
         @DisplayName("should contain MessageHeader as first entry")
         void shouldContainMessageHeader_asFirstEntry() {
-            assertThat(json).contains("\"resourceType\": \"MessageHeader\"");
+            Bundle bundle = fhirBundleBuilder.getBundle();
+            assertThat(bundle).isNotNull();
+            assertThat(bundle.getEntry()).isNotEmpty();
+            assertThat(bundle.getEntryFirstRep().getResource()).isNotNull();
+            assertThat(bundle.getEntryFirstRep().getResource().fhirType()).isEqualTo("MessageHeader");
         }
 
         @Test


### PR DESCRIPTION
### **User description**
## Summary

Resolves all 7 open Dependabot security alerts by upgrading vulnerable dependencies:

- **HAPI FHIR 6.10.5 → 8.4.0** + **FHIR Core 6.7.10 → 6.9.0** — fixes CVE-2026-33180 (CRITICAL, CVSS 9.8) HTTP auth credential leak in redirects. The fhir.core 6.9.0 release is explicitly paired with hapi-fhir 8.4.0, and CARLOS's minimal FHIR API surface (3 classes across 4 files) is fully preserved. Also fixes javax→jakarta servlet alignment.
- **Apache Artemis 2.50.0 → 2.52.0** — fixes missing authentication for critical functions (CRITICAL). Transitive via CXF WSN; overridden in dependencyManagement.
- **minimatch 10.2.1 → 10.2.3** — fixes 2 ReDoS vulnerabilities (HIGH). Docusaurus transitive.
- **svgo 3.3.2 → 3.3.3** — fixes DoS via entity expansion (HIGH). Docusaurus transitive.
- **serialize-javascript 6.0.2 → 7.0.3** — fixes RCE via RegExp.flags (HIGH). Docusaurus transitive.

### Alerts resolved
| # | Severity | Package | CVE |
|---|----------|---------|-----|
| 44 | Critical | artemis-server | Missing auth for critical functions |
| 41 | Critical | org.hl7.fhir.utilities | CVE-2026-33180 |
| 40 | Critical | org.hl7.fhir.dstu3 | CVE-2026-33180 |
| 37 | High | svgo | Billion Laughs DoS |
| 36 | High | serialize-javascript | RCE |
| 34 | High | minimatch | ReDoS |
| 33 | High | minimatch | ReDoS |

### Files changed
- `pom.xml` — version bumps for HAPI FHIR, FHIR Core, Artemis
- `package.json` / `package-lock.json` — npm override updates
- `dependencies-lock.json` — regenerated
- `FhirMessageBuilderIntegrationTest.java` — 4 assertion updates for JSON serialization format change (HAPI FHIR 8.x uses `"key": "value"` instead of `"key" : "value"` in pretty-printed output)

## Test plan

- [x] `make install --run-tests` — 4,527 tests pass, 0 failures
- [x] `mvn dependency:tree` — confirms correct versions, no javax.servlet remnants
- [x] `npm audit` — 0 vulnerabilities
- [ ] Verify Dependabot alerts auto-dismiss after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **Description**
- This PR resolves 7 Dependabot security alerts by upgrading vulnerable dependencies.
- Significant upgrades include `hapi-fhir` to `8.4.0` and `artemis-server` to `2.52.0`.
- Updates to test assertions were made to accommodate changes in JSON serialization format.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dependencies-lock.json</strong><dd><code>Update dependencies to resolve security vulnerabilities</code>&nbsp; &nbsp; </dd></summary>
<hr>

dependencies-lock.json
<li>Updated versions of several dependencies to resolve security <br>vulnerabilities.<br> <li> Bumped <code>hapi-fhir</code> from <code>6.10.5</code> to <code>8.4.0</code> and <code>org.hl7.fhir</code> from <code>6.7.10</code> to <br><code>6.9.0</code>.<br> <li> Updated <code>artemis-server</code> from <code>2.50.0</code> to <code>2.52.0</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/722/files#diff-9d6d26515ff9f0c84acf583c24af9ae33c3959c487518980183cf3515799afcb">+18/-18</a>&nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>package-lock.json</strong><dd><code>Update npm packages for security fixes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package-lock.json
<li>Updated <code>minimatch</code> from <code>10.2.1</code> to <code>10.2.3</code>.<br> <li> Updated <code>serialize-javascript</code> from <code>6.0.2</code> to <code>7.0.3</code>.<br> <li> Updated <code>svgo</code> from <code>3.3.2</code> to <code>3.3.3</code>.<br> <li> Updated <code>sax</code> from <code>1.4.4</code> to <code>1.6.0</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/722/files#diff-053150b640a7ce75eff69d1a22cae7f0f94ad64ce9a855db544dda0929316519">+17/-23</a>&nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>pom.xml</strong><dd><code>Update Maven dependencies for security patches</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pom.xml
<li>Updated <code>hapifhir.version</code> from <code>6.10.5</code> to <code>8.4.0</code>.<br> <li> Updated <code>org.hl7.fhir.utilities</code> and <code>org.hl7.fhir.dstu3</code> versions to <br><code>6.9.0</code>.<br> <li> Updated <code>artemis-server</code> version to <code>2.52.0</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/722/files#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8">+13/-6</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FhirMessageBuilderIntegrationTest.java</strong><dd><code>Update tests for JSON format changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test/java/io/github/carlos_emr/carlos/integration/fhir/builder/FhirMessageBuilderIntegrationTest.java
<li>Updated assertions in tests to match new JSON serialization format.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/722/files#diff-3802432cc9a7f93b17c5bd5924f4c334cf3049a4ae44082d4989f14437b93d6a">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded core FHIR libraries to a newer major release for improved compatibility and security.
  * Updated JSON date/time handling library to a newer version.
  * Bumped messaging server libraries to a newer release addressing stability/security fixes.
  * Refreshed dependency lock entries and package overrides to resolve transitive conflicts and pin select tooling packages.

* **Tests**
  * Tightened JSON formatting assertions in integration tests for more robust validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->