### PR TITLE
fix: update struts.xml DTD version from 6.5 to 7.1 to match Struts 7.1.1 dependency

### DIFF
--- a/src/main/webapp/WEB-INF/classes/struts.xml
+++ b/src/main/webapp/WEB-INF/classes/struts.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE struts PUBLIC "-//Apache Software Foundation//DTD Struts Configuration 6.5//EN" "https://struts.apache.org/dtds/struts-6.5.dtd">
+<!DOCTYPE struts PUBLIC "-//Apache Software Foundation//DTD Struts Configuration 7.1//EN" "https://struts.apache.org/dtds/struts-7.1.dtd">
 <struts>
     <constant name="struts.mapper.action.prefix.enabled" value="false"/>
 	<constant name="struts.action.extension" value="do" />


### PR DESCRIPTION
### **User description**
The DTD declaration was left at 6.5 after the Struts 6.8.0 → 7.1.1 upgrade,
causing a mismatch between the declared schema and the actual runtime version.

https://claude.ai/code/session_01S6Rm58iQx2Cy8Ljh1fqndK


___

### **Description**
- Updated the DTD declaration in `struts.xml` to version 7.1 to align with the Struts 7.1.1 dependency.
- This change resolves the mismatch between the declared schema and the actual runtime version.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>struts.xml</strong><dd><code>Update DTD version in struts.xml to match Struts 7.1.1</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/webapp/WEB-INF/classes/struts.xml
<li>Updated DTD version from 6.5 to 7.1<br> <li> Fixed mismatch between declared schema and runtime version<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/737/files#diff-646d390cb90e3eee94ce7f1764f772e6dd834da218ba284e463f0d09100c77f3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application's framework configuration to the latest supported version for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->