### PR TITLE
Fix: 3rd next appt isn't

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/commn/web/FindNextAvailableSlot2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/web/FindNextAvailableSlot2Action.java
@@ -37,6 +37,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.struts2.ActionSupport;
 import org.apache.struts2.ServletActionContext;
 
+import io.github.carlos_emr.CarlosProperties;
 import io.github.carlos_emr.carlos.commn.dao.OscarAppointmentDao;
 import io.github.carlos_emr.carlos.commn.dao.ScheduleTemplateCodeDao;
 import io.github.carlos_emr.carlos.commn.dao.ScheduleTemplateDao;
@@ -62,6 +63,12 @@ import io.github.carlos_emr.carlos.utility.SpringUtils;
  *       (optional; defaults to tomorrow)</li>
  * </ul>
  *
+ * <h3>Configuration (carlos.properties)</h3>
+ * <ul>
+ *   <li>{@code TARGET_SLOT_ORDINAL}  – which open slot to return (default: 3); must be &gt;= 1</li>
+ *   <li>{@code MAX_LOOKAHEAD_DAYS}   – days to search before giving up (default: 90); must be &gt;= 1</li>
+ * </ul>
+ *
  * <h3>Response JSON (on success)</h3>
  * <pre>
  * { "found": true, "year": 2026, "month": 3, "day": 25,
@@ -76,10 +83,51 @@ import io.github.carlos_emr.carlos.utility.SpringUtils;
 public class FindNextAvailableSlot2Action extends ActionSupport {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-    /** Maximum days to search ahead before giving up. */
-    private static final int MAX_LOOKAHEAD_DAYS = 90;
-    /** Number of available slots to skip before returning (returns the Nth available slot). */
-    private static final int TARGET_SLOT_ORDINAL = 3;
+
+    /** Default maximum days to search ahead; overridable via {@code MAX_LOOKAHEAD_DAYS} in carlos.properties. */
+    private static final int DEFAULT_MAX_LOOKAHEAD_DAYS = 90;
+    /** Default slot ordinal to return; overridable via {@code TARGET_SLOT_ORDINAL} in carlos.properties. */
+    private static final int DEFAULT_TARGET_SLOT_ORDINAL = 3;
+
+    /**
+     * Reads {@code MAX_LOOKAHEAD_DAYS} from carlos.properties with validation.
+     * Falls back to {@value #DEFAULT_MAX_LOOKAHEAD_DAYS} if the property is absent, non-numeric, or &lt;= 0.
+     *
+     * @return int the effective maximum lookahead days (always &gt;= 1)
+     */
+    static int resolveMaxLookaheadDays() {
+        String raw = CarlosProperties.getInstance().getProperty("MAX_LOOKAHEAD_DAYS");
+        if (raw != null) {
+            try {
+                int value = Integer.parseInt(raw.trim());
+                if (value >= 1) return value;
+                MiscUtils.getLogger().warn("FindNextAvailableSlot2Action: MAX_LOOKAHEAD_DAYS={} is not a positive integer; using default {}", value, DEFAULT_MAX_LOOKAHEAD_DAYS);
+            } catch (NumberFormatException e) {
+                MiscUtils.getLogger().warn("FindNextAvailableSlot2Action: MAX_LOOKAHEAD_DAYS='{}' is not a valid integer; using default {}", raw, DEFAULT_MAX_LOOKAHEAD_DAYS);
+            }
+        }
+        return DEFAULT_MAX_LOOKAHEAD_DAYS;
+    }
+
+    /**
+     * Reads {@code TARGET_SLOT_ORDINAL} from carlos.properties with validation.
+     * Falls back to {@value #DEFAULT_TARGET_SLOT_ORDINAL} if the property is absent, non-numeric, or &lt;= 0.
+     *
+     * @return int the effective target slot ordinal (always &gt;= 1)
+     */
+    static int resolveTargetSlotOrdinal() {
+        String raw = CarlosProperties.getInstance().getProperty("TARGET_SLOT_ORDINAL");
+        if (raw != null) {
+            try {
+                int value = Integer.parseInt(raw.trim());
+                if (value >= 1) return value;
+                MiscUtils.getLogger().warn("FindNextAvailableSlot2Action: TARGET_SLOT_ORDINAL={} is not a positive integer; using default {}", value, DEFAULT_TARGET_SLOT_ORDINAL);
+            } catch (NumberFormatException e) {
+                MiscUtils.getLogger().warn("FindNextAvailableSlot2Action: TARGET_SLOT_ORDINAL='{}' is not a valid integer; using default {}", raw, DEFAULT_TARGET_SLOT_ORDINAL);
+            }
+        }
+        return DEFAULT_TARGET_SLOT_ORDINAL;
+    }
 
     HttpServletRequest request = ServletActionContext.getRequest();
     HttpServletResponse response = ServletActionContext.getResponse();
@@ -127,10 +175,14 @@ public class FindNextAvailableSlot2Action extends ActionSupport {
         ScheduleTemplateDao scheduleTemplateDao = SpringUtils.getBean(ScheduleTemplateDao.class);
         OscarAppointmentDao appointmentDao = SpringUtils.getBean(OscarAppointmentDao.class);
 
-        // Search forward up to MAX_LOOKAHEAD_DAYS, returning the Nth available slot
+        // Read configurable limits from carlos.properties (validated, fall back to defaults if invalid)
+        int maxLookaheadDays  = resolveMaxLookaheadDays();
+        int targetSlotOrdinal = resolveTargetSlotOrdinal();
+
+        // Search forward up to maxLookaheadDays, returning the Nth available slot
         int slotsFound = 0;
         int consecutiveErrors = 0;
-        for (int day = 0; day < MAX_LOOKAHEAD_DAYS; day++) {
+        for (int day = 0; day < maxLookaheadDays; day++) {
             int searchYear  = searchCal.get(Calendar.YEAR);
             int searchMonth = searchCal.get(Calendar.MONTH) + 1;
             int searchDay   = searchCal.get(Calendar.DAY_OF_MONTH);
@@ -210,7 +262,7 @@ public class FindNextAvailableSlot2Action extends ActionSupport {
 
                         if (enoughRoom) {
                             slotsFound++;
-                            if (slotsFound < TARGET_SLOT_ORDINAL) {
+                            if (slotsFound < targetSlotOrdinal) {
                                 // Skip ahead past this slot and continue searching
                                 i += Math.max(1, slotsNeeded) - 1;
                                 continue;

--- a/src/main/java/io/github/carlos_emr/carlos/commn/web/FindNextAvailableSlot2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/web/FindNextAvailableSlot2Action.java
@@ -77,7 +77,7 @@ public class FindNextAvailableSlot2Action extends ActionSupport {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     /** Maximum days to search ahead before giving up. */
-    private static final int MAX_LOOKAHEAD_DAYS = 60;
+    private static final int MAX_LOOKAHEAD_DAYS = 90;
     /** Number of available slots to skip before returning (returns the Nth available slot). */
     private static final int TARGET_SLOT_ORDINAL = 3;
 

--- a/src/main/resources/carlos.properties
+++ b/src/main/resources/carlos.properties
@@ -1489,3 +1489,14 @@ mfa.registration.qrcode.provider.name=Open OSP
 mfa.registration.qrcode.logo.path=loginResource/openosp_logo.png
 # MFA Legacy PIN Control
 mfa.legacy.pin.enable=true
+
+# Appointment Availability Search
+# Controls the "Next Available Appointment" badge search behaviour.
+#
+# TARGET_SLOT_ORDINAL: which open slot to target (1 = first, 3 = third, etc.)
+#   Must be a positive integer >= 1. Non-positive or non-numeric values fall back to 3.
+TARGET_SLOT_ORDINAL=3
+#
+# MAX_LOOKAHEAD_DAYS: how many calendar days ahead to search before giving up.
+#   Must be a positive integer >= 1. Non-positive or non-numeric values fall back to 90.
+MAX_LOOKAHEAD_DAYS=90

--- a/src/main/webapp/appointment/addappointment.jsp
+++ b/src/main/webapp/appointment/addappointment.jsp
@@ -1155,7 +1155,26 @@ Ontario, Canada
                                 <div class="input-group input-group-sm">
                                 <%
                                     String name = "";
-                                    name = String.valueOf((bFirstDisp && !bFromWL) ? "" : request.getParameter("name") == null ? session.getAttribute("appointmentname") == null ? "" : session.getAttribute("appointmentname") : request.getParameter("name"));
+                                    if (!bFirstDisp || bFromWL) {
+                                        // Prefer server-side DB lookup over any name transmitted via URL to avoid PHI exposure.
+                                        // When demographic_no is present, resolve the patient name directly from the database.
+                                        String demoNoForName = StringUtils.trimToNull(request.getParameter("demographic_no"));
+                                        if (demoNoForName != null) {
+                                            try {
+                                                DemographicDao demographicDao = SpringUtils.getBean(DemographicDao.class);
+                                                Demographic demForName = demographicDao.getDemographic(demoNoForName);
+                                                if (demForName != null) {
+                                                    name = StringUtils.defaultString(demForName.getFullName());
+                                                }
+                                            } catch (Exception lookupEx) {
+                                                MiscUtils.getLogger().warn("addappointment.jsp: could not resolve patient name for demographic_no={}", demoNoForName, lookupEx);
+                                            }
+                                        }
+                                        // Fallback: use session attribute (set by other appointment workflows)
+                                        if (name.isEmpty()) {
+                                            name = String.valueOf(session.getAttribute("appointmentname") == null ? "" : session.getAttribute("appointmentname"));
+                                        }
+                                    }
                                 %>
                                     <input type="hidden" name="demographic_no" id="demographic_no"
                                            value='<%=(bFirstDisp && !bFromWL) ? "" : Encode.forHtmlAttribute(StringUtils.defaultString(request.getParameter("demographic_no")))%>'>

--- a/src/main/webapp/appointment/addappointment.jsp
+++ b/src/main/webapp/appointment/addappointment.jsp
@@ -28,6 +28,35 @@ Ontario, Canada
     CARLOS has no affiliation with OSCAR or McMaster University.
 
 --%>
+<%--
+    addappointment.jsp - Add/Create Appointment Form
+
+    Purpose:
+        Renders the appointment creation and editing form with patient selection,
+        scheduling details, and appointment metadata entry.
+
+    Features:
+        - Server-side patient name resolution via demographic_no (avoids PHI in URLs)
+        - Patient keyword search with demographic autocomplete
+        - Appointment type templates with auto-fill support
+        - Double-booking and group appointment detection
+        - Multi-site location support
+        - Patient status, alert, and do-not-book banners
+
+    Parameters:
+        - provider_no      : Target provider number
+        - year             : Appointment year
+        - month            : Appointment month (1-based)
+        - day              : Appointment day
+        - start_time       : Appointment start time (HHmm)
+        - end_time         : Appointment end time (HHmm)
+        - duration         : Appointment duration in minutes
+        - demographic_no   : Patient demographic number (optional — used for prefill and server-side name lookup)
+        - bFirstDisp       : "true" when opening blank form; "false" when prefilling from badge/worklist
+        - appointment_no   : Existing appointment number for edit mode
+
+    @since CARLOS 2026.03
+--%>
 <!DOCTYPE HTML>
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
@@ -1161,10 +1190,16 @@ Ontario, Canada
                                         String demoNoForName = StringUtils.trimToNull(request.getParameter("demographic_no"));
                                         if (demoNoForName != null) {
                                             try {
-                                                DemographicDao demographicDao = SpringUtils.getBean(DemographicDao.class);
+                                                // demographicDao is declared in the outer scriptlet scope (line ~157) — do not redeclare
                                                 Demographic demForName = demographicDao.getDemographic(demoNoForName);
                                                 if (demForName != null) {
-                                                    name = StringUtils.defaultString(demForName.getFullName());
+                                                    // Build name from individual fields to guard against null values
+                                                    // (getFullName() concatenates raw DB values and can produce "null, null")
+                                                    String ln = StringUtils.defaultString(demForName.getLastName()).trim();
+                                                    String fn = StringUtils.defaultString(demForName.getFirstName()).trim();
+                                                    if (!ln.isEmpty() || !fn.isEmpty()) {
+                                                        name = ln.isEmpty() ? fn : fn.isEmpty() ? ln : ln + ", " + fn;
+                                                    }
                                                 }
                                             } catch (Exception lookupEx) {
                                                 MiscUtils.getLogger().warn("addappointment.jsp: could not resolve patient name for demographic_no={}", demoNoForName, lookupEx);

--- a/src/main/webapp/provider/appointmentprovideradminday.jsp
+++ b/src/main/webapp/provider/appointmentprovideradminday.jsp
@@ -2824,9 +2824,10 @@
             badgeEl.style.opacity = '0.6';
             badgeEl.style.pointerEvents = 'none';
 
+            // No startDate: backend defaults to tomorrow, so today's (possibly past) open slots
+            // are not counted toward the 3-slot target.
             var url = ctx + '/demographic/FindNextAvailableSlot.do'
-                + '?providerNos=' + encodeURIComponent(mrpProviderNo)
-                + '&startDate='   + encodeURIComponent(scheduleCurrentDate);
+                + '?providerNos=' + encodeURIComponent(mrpProviderNo);
 
             fetch(url, { credentials: 'same-origin' })
                 .then(function(r) {
@@ -2860,6 +2861,7 @@
                     try {
                         sessionStorage.setItem('carlosPendingAppt', JSON.stringify({
                             demographicNo: item.demographicNo,
+                            formattedName: item.formattedName || '',
                             providerNo:    slot.providerNo,
                             startTime:     slot.startTime,
                             endTime:       endTime,
@@ -2870,7 +2872,7 @@
                         }));
                     } catch (storageErr) {
                         // sessionStorage unavailable — open popup directly (no schedule navigation)
-                        popupPage(360, 780, buildApptUrl(ctx, item.demographicNo, '',
+                        popupPage(360, 780, buildApptUrl(ctx, item.demographicNo, item.formattedName || '',
                             slot.providerNo, slot.startTime, endTime, slot.duration, appointmentDate));
                         hideDropdown();
                         return;
@@ -3003,7 +3005,7 @@
         var derivedApptDate = pending.year ? (pending.year + '-' + mm2 + '-' + dd2) : '';
         var popupUrl = buildApptUrl(ctx2,
             pending.demographicNo,
-            '',
+            pending.formattedName || '',
             pending.providerNo,
             pending.startTime,
             pending.endTime || '',

--- a/src/main/webapp/provider/appointmentprovideradminday.jsp
+++ b/src/main/webapp/provider/appointmentprovideradminday.jsp
@@ -2522,14 +2522,15 @@
     <script>
 
     /**
-     * Builds the addappointment.jsp URL pre-filled with slot and patient info.
+     * Builds the addappointment.jsp URL pre-filled with slot coordinates.
      * Uses bFirstDisp=false so patient alert and status banners load server-side.
+     * Patient name is resolved server-side in addappointment.jsp via demographic_no
+     * (no name PHI transmitted through the URL).
      * Requires appointment_date in YYYY-MM-DD format.
      */
-    function buildApptUrl(ctx, demographicNo, formattedName, providerNo, startTime, endTime, duration, appointmentDate) {
+    function buildApptUrl(ctx, demographicNo, providerNo, startTime, endTime, duration, appointmentDate) {
         return ctx + '/appointment/addappointment.jsp'
             + '?demographic_no='   + encodeURIComponent(demographicNo)
-            + '&name='             + encodeURIComponent(formattedName)
             + '&provider_no='      + encodeURIComponent(providerNo)
             + '&bFirstDisp=false'
             + '&appointment_date=' + encodeURIComponent(appointmentDate)
@@ -2857,11 +2858,11 @@
                     var appointmentDate = slot.year + '-' + mm + '-' + dd;
 
                     // Store pending appointment in sessionStorage so the page-load handler can open the popup.
-                    // Only non-PHI scheduling coordinates are stored; appointmentDate is derived on load from year/month/day.
+                    // Only scheduling coordinates are stored (no PHI); patient name is resolved server-side
+                    // by addappointment.jsp via demographic_no. appointmentDate is derived on load from year/month/day.
                     try {
                         sessionStorage.setItem('carlosPendingAppt', JSON.stringify({
                             demographicNo: item.demographicNo,
-                            formattedName: item.formattedName || '',
                             providerNo:    slot.providerNo,
                             startTime:     slot.startTime,
                             endTime:       endTime,
@@ -2872,7 +2873,7 @@
                         }));
                     } catch (storageErr) {
                         // sessionStorage unavailable — open popup directly (no schedule navigation)
-                        popupPage(360, 780, buildApptUrl(ctx, item.demographicNo, item.formattedName || '',
+                        popupPage(360, 780, buildApptUrl(ctx, item.demographicNo,
                             slot.providerNo, slot.startTime, endTime, slot.duration, appointmentDate));
                         hideDropdown();
                         return;
@@ -3005,7 +3006,6 @@
         var derivedApptDate = pending.year ? (pending.year + '-' + mm2 + '-' + dd2) : '';
         var popupUrl = buildApptUrl(ctx2,
             pending.demographicNo,
-            pending.formattedName || '',
             pending.providerNo,
             pending.startTime,
             pending.endTime || '',


### PR DESCRIPTION
### **User description**
<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description
Fixes #752
 Update FindNextAvailableSlot2Action.java move to 90 day look ahead
<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues

<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?

<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Adjust next-available-appointment lookup behavior and extend the search horizon.

Bug Fixes:
- Ensure next available appointment search relies on backend default start date so current-day slots are handled correctly.
- Preserve and pass the patient’s formatted name when creating pending appointments and opening the booking popup.

Enhancements:
- Increase the maximum appointment availability lookahead window from 60 to 90 days.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Appointment search settings are now configurable via properties (default lookahead expanded to 90 days); server-side logic uses these at runtime.
  * Patient names are no longer sent in popup URLs or client-side pending data; name resolution is performed server-side from demographics.

* **Bug Fixes**
  * Validation and safe fallbacks added for search settings; slot selection and date lookup now respect resolved configuration and backend defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

### **Description**
- Enhanced the appointment availability search window from 60 to 90 days.
- Fixed the next appointment badge logic to correctly start from tomorrow.
- Improved handling of patient names in appointment workflows.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FindNextAvailableSlot2Action.java</strong><dd><code>Update maximum lookahead for appointment availability</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/io/github/carlos_emr/carlos/commn/web/FindNextAvailableSlot2Action.java
<li>Increased maximum lookahead days for appointment availability from 60 <br>to 90.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/753/files#diff-f355ef91d6053d17852a14da65f016a3b242c1c6e2ad098d4090028e51792be8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>appointmentprovideradminday.jsp</strong><dd><code>Improve appointment badge search logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/webapp/provider/appointmentprovideradminday.jsp
<li>Removed <code>startDate</code> parameter to ensure backend defaults to tomorrow.<br> <li> Stored <code>formattedName</code> in sessionStorage for better patient name <br>handling.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/753/files#diff-f75048f3620da9a8aa96ad76eb74598e7d4a6e24ad79d327afb95e330a549a73">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions

