### PR TITLE
chore: dependency updates per dependabot

### DIFF
--- a/dependencies-lock.json
+++ b/dependencies-lock.json
@@ -731,117 +731,117 @@
   }, {
     "groupId" : "io.netty",
     "artifactId" : "netty-buffer",
-    "version" : "4.1.131.Final",
+    "version" : "4.1.132.Final",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:IZdrSKFh2lEA4ils+2Jooj6L4meH2m4Z0NUSBvKrUoD6D8B/aXBxDhXYFhldr77FPPwe+vLnIMeNl6QdotrXyA=="
+    "integrity" : "sha512:3zkmWuvVEQv9SPzscjm45mlFLOuOsQFw5emZt06o329JI6X60Bpds+Y5fatAvkHjDgTMnlI1P1HQvUz2fXgYfg=="
   }, {
     "groupId" : "io.netty",
     "artifactId" : "netty-codec-haproxy",
-    "version" : "4.1.131.Final",
+    "version" : "4.1.132.Final",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:gjHXu+SxrN1mcI3vufsJw4dG7EK224yL92zUVDHhoJhDDS7cM/s2qb1j9TeHjhSGDmvCUiBD8m9mQaM340wNwg=="
+    "integrity" : "sha512:NjyNnmE7xJWEyGESRrFYiWFSN+i+3i6Oki54+00nF/4j5UX+p7lia3kAp7UB7625KnFzSabTyDGbdCjIrqijiQ=="
   }, {
     "groupId" : "io.netty",
     "artifactId" : "netty-codec-http2",
-    "version" : "4.1.131.Final",
+    "version" : "4.1.132.Final",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:/CXe6CIaxZZDlR3WOpRccXWYqnlhGrjA23JVfWtb8TO942tGAoNxOGF/5Lkg7dGacrx3swcSRjYj+dWeQUhcwg=="
+    "integrity" : "sha512:gS8CjddCvBoxFEZMnpghMhkR2ERKMQRIibT2jA6PEeDI6B2oQ9SFNcq57d6B1APwmdtBLXTasSXPglEKnX/7vA=="
   }, {
     "groupId" : "io.netty",
     "artifactId" : "netty-codec-http",
-    "version" : "4.1.131.Final",
+    "version" : "4.1.132.Final",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:0J2VDUiGk4W0FwIH30XqJ0TeKPYtsu6RXvRSRPZW0zFXxKHa3m/cDqGv5hGnidl4Kjs8y++E6ATDyIZHmxW6CQ=="
+    "integrity" : "sha512:PM3snkvwzyVKxwqqvHvdxadWMwZh1KxyE8pQakEGeMLPH2ig9eD7GXL5iXURgYk6AKkA1S5pDJQWGD/sECk6JA=="
   }, {
     "groupId" : "io.netty",
     "artifactId" : "netty-codec-socks",
-    "version" : "4.1.131.Final",
+    "version" : "4.1.132.Final",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:5voVuGHN1m0508fJK3Z3vOTx1iHxdtlfBRwcbipue6E19RACh7/nGt4Pyc/J+eB5N/5qCPhtWtZddO57e0XdvQ=="
+    "integrity" : "sha512:fp4p2+vGYsoJi8+41fq2i4ok7Y0DmQ/KP89o1uNFpY5OBk17t9Aem4S3nHCM25PCTOmEUzfr2MVjPFU5T4HyyQ=="
   }, {
     "groupId" : "io.netty",
     "artifactId" : "netty-codec",
-    "version" : "4.1.131.Final",
+    "version" : "4.1.132.Final",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:rRK43aeWlVXvUuIvyTStqqXVLmTo1sH+VoqP69/yzGK6S6TBcB45Vs5ilSRIowadiY0AzwBk28QXig7fUHl65A=="
+    "integrity" : "sha512:Ecm56HXG+ue9qKFx0Tg72TOnF4LfGPkh/xM/EfII/jdJAf5XhC/CDFqlXZv9hanKtnSSuSjdTiHAzaEsDYNzfw=="
   }, {
     "groupId" : "io.netty",
     "artifactId" : "netty-handler-proxy",
-    "version" : "4.1.131.Final",
+    "version" : "4.1.132.Final",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:CO525YxDxMKdSmQv8GuaXC0z7uMHvUHq5Q6wk4IxSPwe0/PRWPvaTNMTnXu5K7Vf6CmQLv1QqfOUMA4KRs24PA=="
+    "integrity" : "sha512:d86f8yzpvHKymxCR8Hvbs75FZB9ArDaDzo1kZIQm+fvmobZ8aBoTyKeyxKA3QFqRcrSWXXeCNlej2SSudRloFA=="
   }, {
     "groupId" : "io.netty",
     "artifactId" : "netty-resolver",
-    "version" : "4.1.131.Final",
+    "version" : "4.1.132.Final",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:4to4Kvoku1p8BnLOtSw2aLjQAk31kpHoEPUF40Kyafv0RV6Awf+kU0jxPgAN3FKIQxUYhIf0vESt9AeO28lYyw=="
+    "integrity" : "sha512:LfruZSjZtR0U6/jPTU6PbCdEEkc05YpyMIFBu0fR2Jgh4zGnzeidrJFj/S7VFyUa0+PWY7qW/RKRkFbX8hSVDw=="
   }, {
     "groupId" : "io.netty",
     "artifactId" : "netty-transport-classes-epoll",
-    "version" : "4.1.131.Final",
+    "version" : "4.1.132.Final",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:e/AuXVQr2ySgy//LNZ1f0Ys/obB0sxeEemecCkWwv7KuO8RJioUbr+Ttky8kUZU7KzHfqCHJtjaXrP7z0r+tZQ=="
+    "integrity" : "sha512:Eu49re9oYf+WHpr54/vfTV3xES6pyXW+O9ey2Je0oUAxFY/aigUBDkV4/tKds+amER2X13rIp6fXudvhFqOOnA=="
   }, {
     "groupId" : "io.netty",
     "artifactId" : "netty-transport-classes-kqueue",
-    "version" : "4.1.131.Final",
+    "version" : "4.1.132.Final",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:OnHKbNVZCJ1zHeMGoUKBSSIWIIh3y6r7/5NjaJ/HhISNyTij0vS2xiGxY5hGUoqIy/XByHIwo1GcV/GFmlCjjQ=="
+    "integrity" : "sha512:P+lgs+uMBm193z8Ik9ARFLZpa4v76lrmJ0ZiSPg2sTB7S5n8e800nT6bbQ7BVFvTqZ8NQ3R052p7XAuUkmpjiA=="
   }, {
     "groupId" : "io.netty",
     "artifactId" : "netty-transport-native-epoll",
-    "version" : "4.1.131.Final",
+    "version" : "4.1.132.Final",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:z6E8PQq2u1fQHFjuVc2wjyCheL8HjnbDzWV5Q1XHL0tUQ3vENn8eAoYzysPkihQvfqp73TOM8i9bP80JsHqBzw==",
+    "integrity" : "sha512:YQWJkpuFslqpy86UPDTxa3mSCvb6dleIiDzfvb924GB3Cs53mPIVbiKCTylHRRehfh5YmmkGPAp7L1oLO1DTBQ==",
     "classifier" : "linux-x86_64"
   }, {
     "groupId" : "io.netty",
     "artifactId" : "netty-transport-native-kqueue",
-    "version" : "4.1.131.Final",
+    "version" : "4.1.132.Final",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:Y8kiDfWucr+ek03o60a59sFKX0IgCA+fTMLqD6MrWonxgRIL3lXPpkd0czt8EChlGSMOj7EJymoSHpmBTu9ykg==",
+    "integrity" : "sha512:3eJwfM895WB422M1IacwTTiCDY/wlPu8S7PVhwIe9DASKL7q1feXjVfyyzjMATQHOOmQ/09+8BGJ6NsJSJmMrA==",
     "classifier" : "osx-x86_64"
   }, {
     "groupId" : "io.netty",
     "artifactId" : "netty-transport-native-unix-common",
-    "version" : "4.1.131.Final",
+    "version" : "4.1.132.Final",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:yvM3cqYmA5oUu8VMjpn1qBm5PDbklWlvFWI0+9goK0I38Vliv+hqWBOnK0HQvaqQxfjpxYClBTlq2C/bxn/66g=="
+    "integrity" : "sha512:SFlwpbPZ4qr/Tdg/Y5TPHw+2bB8XhzDcX5mg2eX37tWNWu9ZXDTa/LlvnZVtPfbGK5lvt2qx2AYiTOo0/ELjcw=="
   }, {
     "groupId" : "io.netty",
     "artifactId" : "netty-transport",
-    "version" : "4.1.131.Final",
+    "version" : "4.1.132.Final",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:rFMrra2aax4aJqXuxRVWVy5g955woc23hG3up1tcCS9/D74jiFNTTttSs9jsjbY4fLyqtk9Tf+POX47SwRYtqQ=="
+    "integrity" : "sha512:CMvb5aINJf8f9wxpyBowRO03u/QFVqtLKfN4uXuIISTwWlcdXiTiB8YB7H8nQJIHK5mjVoTEfCBouUZga2fMTw=="
   }, {
     "groupId" : "io.opentelemetry.instrumentation",
     "artifactId" : "opentelemetry-instrumentation-annotations",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5518,7 +5518,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.3",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -7366,7 +7368,9 @@
       "license": "MIT"
     },
     "node_modules/express/node_modules/path-to-regexp": {
-      "version": "0.1.12",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
     "node_modules/express/node_modules/range-parser": {
@@ -11712,7 +11716,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -14062,9 +14068,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.3.tgz",
-      "integrity": "sha512-h+cZ/XXarqDgCjo+YSyQU/ulDEESGGf8AMK9pPNmhNSl/FzPl6L8pMp1leca5z6NuG6tvV/auC8/43tmovowww==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -48,6 +48,9 @@
     "webpack": "5.104.1",
     "lodash": "4.17.23",
     "svgo": "3.3.3",
-    "serialize-javascript": "7.0.3"
+    "serialize-javascript": "7.0.5",
+    "picomatch": "2.3.2",
+    "path-to-regexp@<0.1.13": "0.1.13",
+    "brace-expansion": "5.0.5"
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <!-- Apache CXF Version -->
         <cxf.version>4.1.5</cxf.version>
         <!-- Netty Version (for transitive dependency security fixes) -->
-        <netty.version>4.1.131.Final</netty.version>
+        <netty.version>4.1.132.Final</netty.version>
         <!-- Drools 10.x KIE API (upgraded from 7.74.1.Final for Jakarta EE compatibility) -->
         <drools.version>10.1.0</drools.version>
         <!-- Spring Framework Version -->


### PR DESCRIPTION
### **User description**
This pull request updates several dependencies to address security and compatibility concerns. The main focus is on upgrading the Netty library to the latest patch version and adding/updating some JavaScript dependencies.

Dependency upgrades:

* Upgraded all Netty-related dependencies from version `4.1.131.Final` to `4.1.132.Final` in both `pom.xml` and `dependencies-lock.json` to address security fixes and maintain compatibility. [[1]](diffhunk://#diff-9d6d26515ff9f0c84acf583c24af9ae33c3959c487518980183cf3515799afcbL734-R844) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L83-R83)

JavaScript dependency changes:

* Added or updated several dependencies in `package.json`:
  - Updated `serialize-javascript` to `7.0.5`
  - Added `picomatch` version `2.3.2`
  - Added `path-to-regexp@<0.1.13` version `0.1.13`
  - Added `brace-expansion` version `5.0.5`

## Summary by Sourcery

Update backend and frontend dependency versions to incorporate recent security and compatibility patches.

Build:
- Bump Netty BOM/version from 4.1.131.Final to 4.1.132.Final and refresh the dependency lock file accordingly.

Chores:
- Update JavaScript build-time dependencies, including serialize-javascript, and add new entries for picomatch, path-to-regexp@<0.1.13, and brace-expansion in package manifests.


___

### **Description**
- Upgraded `Netty` library to version `4.1.132.Final` to address security vulnerabilities.
- Updated various JavaScript dependencies to their latest versions for improved compatibility.
- Added `picomatch`, `path-to-regexp`, and `brace-expansion` to enhance build tooling.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pom.xml</strong><dd><code>Update Netty version for security fixes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pom.xml
- Upgraded `netty.version` from `4.1.131.Final` to `4.1.132.Final`.



</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/766/files#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>dependencies-lock.json</strong><dd><code>Upgrade Netty dependencies for security</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dependencies-lock.json
- Updated all Netty-related dependencies to `4.1.132.Final`.



</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/766/files#diff-9d6d26515ff9f0c84acf583c24af9ae33c3959c487518980183cf3515799afcb">+28/-28</a>&nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Refresh JavaScript dependencies for compatibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json
<li>Updated <code>serialize-javascript</code> to <code>7.0.5</code>.<br> <li> Added <code>picomatch</code> version <code>2.3.2</code>.<br> <li> Added <code>path-to-regexp@<0.1.13</code> version <code>0.1.13</code>.<br> <li> Added <code>brace-expansion</code> version <code>5.0.5</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/766/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>package-lock.json</strong><dd><code>Update JavaScript package dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package-lock.json
<li>Updated <code>brace-expansion</code> to <code>5.0.5</code>.<br> <li> Updated <code>path-to-regexp</code> to <code>0.1.13</code>.<br> <li> Updated <code>picomatch</code> to <code>2.3.2</code>.<br> <li> Updated <code>serialize-javascript</code> to <code>7.0.5</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/766/files#diff-053150b640a7ce75eff69d1a22cae7f0f94ad64ce9a855db544dda0929316519">+12/-6</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions

