### PR TITLE
chore: fix security issue in HAPI

### DIFF
--- a/dependencies-lock.json
+++ b/dependencies-lock.json
@@ -34,19 +34,19 @@
   }, {
     "groupId" : "ca.uhn.hapi.fhir",
     "artifactId" : "org.hl7.fhir.dstu3",
-    "version" : "6.9.0",
+    "version" : "6.9.4",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:418c8a5fSkA9MYCVMtbSMj5Q5MPkKsktmB9QumetkRswUMrsbkURzHB07fXO8QjdvX0lQWIC89iumDk3OJL4Pg=="
+    "integrity" : "sha512:KL2GeiGIAvHg7NbVQ+dcNbMjv0iKIJ40c6pmCdFGRQqlii5yeT/L9xVXUo08O2i3CnmWC+uZstgci64/GZpvBg=="
   }, {
     "groupId" : "ca.uhn.hapi.fhir",
     "artifactId" : "org.hl7.fhir.utilities",
-    "version" : "6.9.0",
+    "version" : "6.9.4",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:GQyoUjS1NifPBtHh64ks9KU3snmWoefyabQFxylMtmX4yu0N4/JAo8MkqrFHVkjrZIz+DQm0yzULlWySze4ohw=="
+    "integrity" : "sha512:ZxLeEItb6jugXgLZ7gvWdIdUAqTyn2LZuAd96nqsBIKSqUTxIazIL+ly7rMrWDxccHRN3NUkMSPGVaWkVj7Iuw=="
   }, {
     "groupId" : "ca.uhn.hapi",
     "artifactId" : "hapi-base",
@@ -3343,7 +3343,7 @@
     "groupId" : "org.springframework",
     "artifactId" : "spring-test",
     "version" : "7.0.6",
-    "scope" : "compile",
+    "scope" : "test",
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:HxUYfIpEzgmY/1DgzW6upuQ/PSGmpMvnitAviABpNLntP2KDvzOo/Y2UOLEmXa1hRxXfa9OOZqYhcuaHfw3ZcQ=="

--- a/pom.xml
+++ b/pom.xml
@@ -246,16 +246,17 @@
             </dependency>
             <!-- Override transitive org.hl7.fhir.core (6.5.27) from hapi-fhir-structures-dstu3.
                  Fixes: CVE-2024-45294, CVE-2024-51132, CVE-2024-52007 (all patched in 6.4.0),
-                 CVE-2026-33180 HTTP auth credential leak in redirects (patched in 6.9.0). -->
+                 CVE-2026-33180 HTTP auth credential leak in redirects (patched in 6.9.0),
+                 CVE-2026-34359 credential leak via URL prefix matching on redirect (patched in 6.9.4). -->
             <dependency>
                 <groupId>ca.uhn.hapi.fhir</groupId>
                 <artifactId>org.hl7.fhir.utilities</artifactId>
-                <version>6.9.0</version>
+                <version>6.9.4</version>
             </dependency>
             <dependency>
                 <groupId>ca.uhn.hapi.fhir</groupId>
                 <artifactId>org.hl7.fhir.dstu3</artifactId>
-                <version>6.9.0</version>
+                <version>6.9.4</version>
             </dependency>
             <!-- Override transitive Artemis 2.50.0 from cxf-services-wsn-core.
                  Security fix for missing authentication on critical functions (patched in 2.52.0);


### PR DESCRIPTION
### **User description**
This pull request updates dependencies to address recent security vulnerabilities and corrects the scope of a test dependency. The most important changes are summarized below:

**Dependency version upgrades for security:**

* Upgraded `org.hl7.fhir.utilities` and `org.hl7.fhir.dstu3` dependencies from version `6.9.0` to `6.9.4` in both `pom.xml` and `dependencies-lock.json` to address additional credential leak vulnerabilities, specifically CVE-2026-34359, in addition to previously patched issues. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L249-R259) [[2]](diffhunk://#diff-9d6d26515ff9f0c84acf583c24af9ae33c3959c487518980183cf3515799afcbL37-R49)

**Dependency scope correction:**

* Changed the scope of the `spring-test` dependency from `compile` to `test` in `dependencies-lock.json`, ensuring it is only included in the test classpath.

**Documentation update:**

* Updated comments in `pom.xml` to reflect the newly addressed security vulnerability (CVE-2026-34359) and its fix in version `6.9.4`.

## Summary by Sourcery

Update HAPI FHIR dependencies to a secure version and adjust related build metadata.

Build:
- Bump ca.uhn.hapi.fhir org.hl7.fhir.utilities and org.hl7.fhir.dstu3 dependencies from 6.9.0 to 6.9.4 to pick up the latest security fixes.
- Correct the scope of the spring-test dependency so it is only included on the test classpath.
- Refresh pom.xml comments to document the newly addressed CVE and its fixed version.


___

### **Description**
- Upgraded HAPI FHIR dependencies to version `6.9.4` to address security vulnerabilities.
- Corrected the scope of the `spring-test` dependency to ensure it is only included in the test classpath.
- Updated documentation in `pom.xml` to reflect the new security vulnerability and its fix.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dependencies-lock.json</strong><dd><code>Update HAPI FHIR dependencies for security fixes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dependencies-lock.json
<li>Upgraded <code>org.hl7.fhir.utilities</code> and <code>org.hl7.fhir.dstu3</code> dependencies <br>from version <code>6.9.0</code> to <code>6.9.4</code>.<br> <li> Changed the scope of the <code>spring-test</code> dependency from <code>compile</code> to <code>test</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/773/files#diff-9d6d26515ff9f0c84acf583c24af9ae33c3959c487518980183cf3515799afcb">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pom.xml</strong><dd><code>Update dependency versions and documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pom.xml
<li>Updated <code>org.hl7.fhir.utilities</code> and <code>org.hl7.fhir.dstu3</code> versions to <br><code>6.9.4</code>.<br> <li> Revised comments to reflect the newly addressed security vulnerability <br>(CVE-2026-34359).<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/773/files#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions

