### PR TITLE
fix: resolve intermittent e-chart note lock failures

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementEntry2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementEntry2Action.java
@@ -636,12 +636,16 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
         }
 
         if (casemgmtNoteLock == null) {
-            logger.warn("updateNoteLock: lock not found for demographic {} noteId {} - lock may have been released", demoNo, noteId);
+            logger.warn("updateNoteLock: lock not found - lock may have been released");
             return null;
         }
 
         casemgmtNoteLock.setIpAddress(request.getRemoteAddr());
-        casemgmtNoteLock.setSessionId(request.getRequestedSessionId());
+        String currentSessionId = request.getRequestedSessionId();
+        if (currentSessionId == null) {
+            currentSessionId = session.getId();
+        }
+        casemgmtNoteLock.setSessionId(currentSessionId);
         logger.debug("UPDATING LOCK DEMO " + demoNo + " SESSION " + casemgmtNoteLock.getSessionId() + " LOCK IP " + casemgmtNoteLock.getIpAddress());
         casemgmtNoteLockDao.merge(casemgmtNoteLock);
 
@@ -678,6 +682,11 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
         String issueCode = request.getParameter("issue_id");
         String issueAlphaCode = request.getParameter("issue_code");
         String archived = request.getParameter("archived");
+
+        if (!hasNoteLock(demographicNo)) {
+            logger.debug("issueNoteSaveJson rejected: no valid lock for demographic {}", demographicNo);
+            return null;
+        }
 
         Date noteDate = new Date();
 
@@ -845,7 +854,7 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
         String demo = getDemographicNo(request);
 
         if (!hasNoteLock(demo)) {
-            logger.debug("issueNoteSave rejected: no valid lock for demographic " + demo);
+            logger.debug("issueNoteSave rejected: no valid lock for demographic {}", demo);
             return "windowCloseError";
         }
 
@@ -1656,7 +1665,7 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
         String demo = getDemographicNo(request);
 
         if (!hasNoteLock(demo)) {
-            logger.debug("ajaxsave rejected: no valid lock for demographic " + demo);
+            logger.debug("ajaxsave rejected: no valid lock for demographic {}", demo);
             response.setStatus(HttpServletResponse.SC_CONFLICT);
             return null;
         }
@@ -1855,10 +1864,10 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
             if (casemgmtNoteLock == null) {
                 return false;
             }
-            return casemgmtNoteLock.getSessionId().equals(casemgmtNoteLockSession.getSessionId())
-                && request.getRequestedSessionId().equals(casemgmtNoteLockSession.getSessionId());
+            return Objects.equals(casemgmtNoteLock.getSessionId(), casemgmtNoteLockSession.getSessionId())
+                && Objects.equals(request.getRequestedSessionId(), casemgmtNoteLockSession.getSessionId());
         } catch (Exception e) {
-            logger.error("Lock check failed for demographic " + demo, e);
+            logger.warn("Lock check failed unexpectedly", e);
             return false;
         }
     }
@@ -2723,7 +2732,7 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
         String noteId = request.getParameter("note_id");
 
         if (!hasNoteLock(demographicNo)) {
-            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+            response.setStatus(HttpServletResponse.SC_CONFLICT);
             return null;
         }
 

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementEntry2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementEntry2Action.java
@@ -1244,7 +1244,7 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
         CaseManagementEntryFormBean sessionFrm = (CaseManagementEntryFormBean) session.getAttribute(sessionFrmName);
 
         if (!hasNoteLock(demo)) {
-            logger.debug("DO NOT HAVE LOCK FOR " + demo + " PROVIDER " + providerNo + " SESSION " + request.getRequestedSessionId() + " IP " + request.getRemoteAddr());
+            logger.debug("noteSave rejected: no valid lock for demographic {}", demo);
             return -1L;
         }
 
@@ -1864,8 +1864,12 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
             if (casemgmtNoteLock == null) {
                 return false;
             }
+            String currentSessionId = request.getRequestedSessionId();
+            if (currentSessionId == null) {
+                currentSessionId = session.getId();
+            }
             return Objects.equals(casemgmtNoteLock.getSessionId(), casemgmtNoteLockSession.getSessionId())
-                && Objects.equals(request.getRequestedSessionId(), casemgmtNoteLockSession.getSessionId());
+                && Objects.equals(currentSessionId, casemgmtNoteLockSession.getSessionId());
         } catch (Exception e) {
             logger.warn("Lock check failed unexpectedly", e);
             return false;

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementEntry2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementEntry2Action.java
@@ -635,6 +635,11 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
             casemgmtNoteLock = (CasemgmtNoteLock) session.getAttribute("casemgmtNoteLock" + demoNo);
         }
 
+        if (casemgmtNoteLock == null) {
+            logger.warn("updateNoteLock: lock not found for demographic {} noteId {} - lock may have been released", demoNo, noteId);
+            return null;
+        }
+
         casemgmtNoteLock.setIpAddress(request.getRemoteAddr());
         casemgmtNoteLock.setSessionId(request.getRequestedSessionId());
         logger.debug("UPDATING LOCK DEMO " + demoNo + " SESSION " + casemgmtNoteLock.getSessionId() + " LOCK IP " + casemgmtNoteLock.getIpAddress());
@@ -838,6 +843,11 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
         String userName = loggedInInfo.getLoggedInProvider().getFullName();
 
         String demo = getDemographicNo(request);
+
+        if (!hasNoteLock(demo)) {
+            logger.debug("issueNoteSave rejected: no valid lock for demographic " + demo);
+            return "windowCloseError";
+        }
 
         String noteId = request.getParameter("noteId");
         logger.debug("SAVING NOTE " + noteId + " STRING: " + strNote);
@@ -1224,23 +1234,8 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
 
         CaseManagementEntryFormBean sessionFrm = (CaseManagementEntryFormBean) session.getAttribute(sessionFrmName);
 
-        //compare locks and see if they are the same
-        CasemgmtNoteLock casemgmtNoteLockSession = (CasemgmtNoteLock) session.getAttribute("casemgmtNoteLock" + demo);
-
-        try {
-            if (casemgmtNoteLockSession == null) {
-                throw new Exception("SESSION CASEMANAGEMENT NOTE LOCK OBJECT IS NULL");
-            }
-
-            CasemgmtNoteLock casemgmtNoteLock = casemgmtNoteLockDao.find(casemgmtNoteLockSession.getId());
-            //if other window has acquired lock we reject save
-            if (!casemgmtNoteLock.getSessionId().equals(casemgmtNoteLockSession.getSessionId()) || !request.getRequestedSessionId().equals(casemgmtNoteLockSession.getSessionId())) {
-                logger.debug("DO NOT HAVE LOCK FOR " + demo + " PROVIDER " + providerNo + " CONTINUE SAVING LOCAL SESSION " + request.getRequestedSessionId() + " LOCAL IP " + request.getRemoteAddr() + " LOCK SESSION " + casemgmtNoteLockSession.getSessionId() + " LOCK IP " + casemgmtNoteLockSession.getIpAddress());
-                return -1L;
-            }
-        } catch (Exception e) {
-            //Exception thrown if other window has saved and exited so lock is gone
-            logger.error("Lock not found for " + demo + " providers " + providerNo + " IP " + request.getRemoteAddr(), e);
+        if (!hasNoteLock(demo)) {
+            logger.debug("DO NOT HAVE LOCK FOR " + demo + " PROVIDER " + providerNo + " SESSION " + request.getRequestedSessionId() + " IP " + request.getRemoteAddr());
             return -1L;
         }
 
@@ -1454,10 +1449,13 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
         this.setCaseNote(note);
 
         //update lock to new note id
-        casemgmtNoteLockSession.setNoteId(note.getId());
-        logger.debug("UPDATING NOTE ID in LOCK");
-        casemgmtNoteLockDao.merge(casemgmtNoteLockSession);
-        session.setAttribute("casemgmtNoteLock" + demo, casemgmtNoteLockSession);
+        CasemgmtNoteLock casemgmtNoteLockSession = (CasemgmtNoteLock) session.getAttribute("casemgmtNoteLock" + demo);
+        if (casemgmtNoteLockSession != null) {
+            casemgmtNoteLockSession.setNoteId(note.getId());
+            logger.debug("UPDATING NOTE ID in LOCK");
+            casemgmtNoteLockDao.merge(casemgmtNoteLockSession);
+            session.setAttribute("casemgmtNoteLock" + demo, casemgmtNoteLockSession);
+        }
         session.removeAttribute(attrib_name);
 
         try {
@@ -1624,6 +1622,10 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
         request.setAttribute("demoAge", getDemoAge(demono));
         request.setAttribute("demoDOB", getDemoDOB(demono));
 
+        if (!hasNoteLock(demono)) {
+            return "windowCloseError";
+        }
+
         request.setAttribute("from", request.getParameter("from"));
         long noteId = noteSave();
 
@@ -1652,6 +1654,13 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
         logger.debug("Saving Note" + request.getParameter("nId"));
         logger.debug("Text -- " + noteTxt);
         String demo = getDemographicNo(request);
+
+        if (!hasNoteLock(demo)) {
+            logger.debug("ajaxsave rejected: no valid lock for demographic " + demo);
+            response.setStatus(HttpServletResponse.SC_CONFLICT);
+            return null;
+        }
+
         Provider provider = loggedInInfo.getLoggedInProvider();
 
         CaseManagementNote note;
@@ -1820,6 +1829,38 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
         LogAction.addLog((String) session.getAttribute("user"), logAction, LogConst.CON_CME_NOTE, String.valueOf(note.getId()), request.getRemoteAddr(), demo, note.getAuditString());
 
         return "issueList_ajax";
+    }
+
+    /**
+     * Checks whether the current HTTP session holds a valid note lock for the given demographic.
+     * Performs two validations:
+     * <ol>
+     *   <li>The database lock's session ID matches the session-stored lock's session ID
+     *       (detects if another window/session has taken over the lock)</li>
+     *   <li>The current request's session ID matches the session-stored lock's session ID
+     *       (detects session ID staleness after rotation or migration)</li>
+     * </ol>
+     *
+     * @param demo String the demographic number to check lock ownership for
+     * @return boolean true if this session owns the lock, false otherwise
+     */
+    private boolean hasNoteLock(String demo) {
+        HttpSession session = request.getSession();
+        CasemgmtNoteLock casemgmtNoteLockSession = (CasemgmtNoteLock) session.getAttribute("casemgmtNoteLock" + demo);
+        try {
+            if (casemgmtNoteLockSession == null) {
+                return false;
+            }
+            CasemgmtNoteLock casemgmtNoteLock = casemgmtNoteLockDao.find(casemgmtNoteLockSession.getId());
+            if (casemgmtNoteLock == null) {
+                return false;
+            }
+            return casemgmtNoteLock.getSessionId().equals(casemgmtNoteLockSession.getSessionId())
+                && request.getRequestedSessionId().equals(casemgmtNoteLockSession.getSessionId());
+        } catch (Exception e) {
+            logger.error("Lock check failed for demographic " + demo, e);
+            return false;
+        }
     }
 
     private void releaseNoteLock(String providerNo, Integer demographicNo, Long noteId) {
@@ -2681,20 +2722,9 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
         String note = request.getParameter("note");
         String noteId = request.getParameter("note_id");
 
-        //compare locks and see if they are the same
-        CasemgmtNoteLock casemgmtNoteLockSession = (CasemgmtNoteLock) request.getSession().getAttribute("casemgmtNoteLock" + demographicNo);
-        try {
-            //if other window has acquired lock don't save
-            CasemgmtNoteLock casemgmtNoteLock = casemgmtNoteLockDao.find(casemgmtNoteLockSession.getId());
-            if (!casemgmtNoteLock.getSessionId().equals(casemgmtNoteLockSession.getSessionId())) {
-                response.setStatus(HttpServletResponse.SC_FORBIDDEN);
-                return null;
-            }
-        } catch (Exception e) {
-            //Exception thrown if other window has saved and exited so lock is gone
+        if (!hasNoteLock(demographicNo)) {
             response.setStatus(HttpServletResponse.SC_FORBIDDEN);
             return null;
-
         }
 
         if (note == null || note.length() == 0) {

--- a/src/main/resources/oscarResources_en.properties
+++ b/src/main/resources/oscarResources_en.properties
@@ -1090,6 +1090,7 @@ encounter.closeWithoutSave.msg = Are you sure you wish to close the encounter? A
 encounter.templateError.msg = Inserting template failed
 encounter.unsavedNoteWarning.msg = Your current note has not been saved.  Click OK to save it or Cancel to continue editing the current note.
 encounter.sessionExpiredError.msg = Session Expired
+encounter.noteLockLostError.msg = Your note lock has been lost. Please copy your note text, close this window, and reopen the chart.
 encounter.unlockNoteError.msg = An error occurred while unlocking note
 encounter.filterError.msg = An error occurred while performing your filter request
 encounter.pastObservationDateError.msg = Observation date must be in the past

--- a/src/main/webapp/casemgmt/newEncounterLayout.jsp
+++ b/src/main/webapp/casemgmt/newEncounterLayout.jsp
@@ -432,6 +432,7 @@
 
             assignEncTypeError = "<fmt:setBundle basename="oscarResources"/><fmt:message key="encounter.assignEncTypeError.msg"/>";
             savingNoteError = "<fmt:setBundle basename="oscarResources"/><fmt:message key="encounter.savingNoteError.msg"/>";
+            noteLockLostError = "<fmt:setBundle basename="oscarResources"/><fmt:message key="encounter.noteLockLostError.msg"/>";
             changeIssueMsg = "<fmt:setBundle basename="oscarResources"/><fmt:message key="encounter.change.title"/>";
             closeWithoutSaveMsg = "<fmt:setBundle basename="oscarResources"/><fmt:message key="encounter.closeWithoutSave.msg"/>";
             pickIssueMsg = "<fmt:setBundle basename="oscarResources"/><fmt:message key="encounter.pickIssue.msg"/>";

--- a/src/main/webapp/js/newCaseManagementView.js.jsp
+++ b/src/main/webapp/js/newCaseManagementView.js.jsp
@@ -167,11 +167,11 @@
         }
     }
 
-    // Use visibilitychange for reliable lock release (fires more reliably than beforeunload)
-    document.addEventListener('visibilitychange', function() {
-        if (document.visibilityState === 'hidden') {
-            onClosing();
-        }
+    // Use pagehide for lock release on actual page unload (navigation, tab close, window close).
+    // Do NOT use visibilitychange here — it fires on tab switch and minimize, which would
+    // prematurely release the note lock while the user is still editing.
+    window.addEventListener('pagehide', function() {
+        onClosing();
     });
 
     var numMenus = 3;
@@ -2292,6 +2292,11 @@ function updateCPPNote() {
     var encTimeMandatory;
     function ajaxSaveNote(div, noteId, noteTxt) {
 
+        if (lostNoteLock) {
+            alert("Your note lock has been lost. Please copy your note text, close this window, and reopen the chart.");
+            return false;
+        }
+
         if ($("observationDate") != null && $("observationDate").value.length > 0 && !validDate()) {
             alert(pastObservationDateError);
             return false;
@@ -2379,10 +2384,14 @@ function updateCPPNote() {
                 evalScripts: true,
                 postBody: params,
                 onFailure: function (request) {
-                    if (request.status == 403)
+                    if (request.status == 409) {
+                        lostNoteLock = true;
+                        alert("Your note lock has been lost. Please copy your note text, close this window, and reopen the chart.");
+                    } else if (request.status == 403) {
                         alert(sessionExpiredError);
-                    else
+                    } else {
                         alert(savingNoteError + " " + request.status + " " + request.responseText);
+                    }
                 }
             }
         );

--- a/src/main/webapp/js/newCaseManagementView.js.jsp
+++ b/src/main/webapp/js/newCaseManagementView.js.jsp
@@ -2286,6 +2286,7 @@ function updateCPPNote() {
     var assignObservationDateError;
     var assignIssueError;
     var savingNoteError;
+    var noteLockLostError;
     var encTimeError;
     var encMinError;
     var encTimeMandatoryMsg;
@@ -2293,7 +2294,7 @@ function updateCPPNote() {
     function ajaxSaveNote(div, noteId, noteTxt) {
 
         if (lostNoteLock) {
-            alert("Your note lock has been lost. Please copy your note text, close this window, and reopen the chart.");
+            alert(noteLockLostError);
             return false;
         }
 
@@ -2386,7 +2387,7 @@ function updateCPPNote() {
                 onFailure: function (request) {
                     if (request.status == 409) {
                         lostNoteLock = true;
-                        alert("Your note lock has been lost. Please copy your note text, close this window, and reopen the chart.");
+                        alert(noteLockLostError);
                     } else if (request.status == 403) {
                         alert(sessionExpiredError);
                     } else {
@@ -3021,7 +3022,7 @@ function autoSave() {
                     $("autosaveTime").update(fmtDate);
                 },
                 onFailure: function (req) {
-                    if (req.status == 403) {
+                    if (req.status == 409) {
                         lostNoteLock = true;
                         var msg = "<i>Autosave cancelled due to note being edited in another window</i>";
                         $("autosaveTime").update(msg);


### PR DESCRIPTION
### **User description**
## Summary

- **Fix premature lock release**: Replaced `visibilitychange` event listener with `pagehide` — locks were being released on tab switch, minimize, or popup open, not just page close
- **Add lock verification to all save paths**: `ajaxsave()`, `issueNoteSave()`, and `save()` now verify lock ownership before writing. Previously only `saveAndExit()` checked.
- **Distinguish lock-lost from session-expired**: `ajaxsave()` returns 409 Conflict (not 403) so the JS handler shows the correct error message and sets `lostNoteLock` flag
- **Prevent NPE in `updateNoteLock()`**: Added null guard when lock is missing from DB/session, preventing silent state corruption
- **Refactor `autosave()` to use `hasNoteLock()`**: Consistent lock checking across all save paths, eliminates NPE-into-catch pattern

### Root Cause

The `visibilitychange` event fires on *any* tab visibility change (switching tabs, minimizing, opening popups), not just page close. This silently released the note lock via `sendBeacon`, and when the user returned to save, the lock was gone. Compounding this, `ajaxsave()` and `issueNoteSave()` had no lock verification at all — they would write to the database without checking lock ownership.

### Files Changed

- `CaseManagementEntry2Action.java` — extracted `hasNoteLock()` helper, added lock checks to `save()`, `ajaxsave()`, `issueNoteSave()`, refactored `autosave()`, null guard in `updateNoteLock()`
- `newCaseManagementView.js.jsp` — `pagehide` instead of `visibilitychange`, `lostNoteLock` guard in `ajaxSaveNote()`, 409 handling in failure callback

## Test plan

- [x] Build compiles (`make install`)
- [x] Playwright: login → open e-chart → create note → save → verify DB
- [x] Playwright: reopen same note → update text → save → verify DB updated in-place
- [x] Playwright: close browser → verify lock released (count = 0)
- [x] No lock-related errors in browser console or server logs
- [ ] Manual: open e-chart, switch tabs, switch back — note should still be editable (no premature lock release)
- [ ] Manual: open same patient chart in two windows — second window should see "locked by another user"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure e-chart note save operations consistently respect and validate note locks, and avoid premature lock release on browser events.

Bug Fixes:
- Prevent null pointer errors in note lock updates when the lock is missing from session or database.
- Block note saves (including issue note save, regular save, ajax save, and autosave) when the current session does not hold a valid note lock.
- Return HTTP 409 Conflict for ajax note saves when the lock is lost so the client can distinguish lock loss from session expiration.
- Stop releasing note locks on simple tab visibility changes by switching from visibilitychange to pagehide for unload handling in the note view JavaScript.

Enhancements:
- Centralize note lock validation logic in a reusable hasNoteLock() helper for consistent lock ownership checks across server-side save paths.
- Add client-side handling for lost note locks to prevent further saves and guide users to preserve their note content when a 409 Conflict is returned.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents saves when a note lock is no longer held, avoiding conflicting edits.
  * Autosave and manual save now detect lock loss, stop saving, and present a conflict/error instead of overwriting.
  * Improved page-exit detection to more reliably release locks.

* **User Messaging**
  * Added a clear localized error instructing users to copy their note, close the window, and reopen the chart if the lock is lost.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

### **Description**
- Enhanced note lock management to prevent premature releases and ensure ownership verification.
- Implemented a new method `hasNoteLock()` for consistent lock checks across save operations.
- Changed event handling from `visibilitychange` to `pagehide` to avoid unintended lock releases.
- Improved error handling to notify users when their note lock is lost.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CaseManagementEntry2Action.java</strong><dd><code>Improve note lock handling and verification</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementEntry2Action.java
<li>Added null guard in <code>updateNoteLock()</code> to prevent NPE.<br> <li> Introduced <code>hasNoteLock()</code> method for consistent lock verification.<br> <li> Updated <code>ajaxsave()</code>, <code>issueNoteSave()</code>, and <code>save()</code> to check lock <br>ownership.<br> <li> Refactored <code>autosave()</code> to utilize <code>hasNoteLock()</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/793/files#diff-115e35c18fa28b4166b1579a87c498a77bf143b7478ebb2737f3b89e066e4276">+63/-33</a>&nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>newCaseManagementView.js.jsp</strong><dd><code>Update lock release mechanism in frontend</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/webapp/js/newCaseManagementView.js.jsp
<li>Changed event listener from <code>visibilitychange</code> to <code>pagehide</code> for lock <br>release.<br> <li> Updated error handling in <code>ajaxSaveNote()</code> for lock loss.<br>


</details>


  </td>
  <td><a href="https://github.com/carlos-emr/carlos/pull/793/files#diff-eeb7b7d852589f92cf844257af29d244a68f4df07a3cd834dd9855f3ac474f2e">+16/-7</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions

