### PR TITLE
fix: include src/main/webapp in SonarCloud analysis sources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,8 +26,15 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- SonarCloud -->
         <sonar.organization>carlos-emr</sonar.organization>
-        <!-- Include webapp (JSP/JS/HTML) in SonarCloud analysis alongside Java sources -->
-        <sonar.sources>src/main/java,src/main/webapp</sonar.sources>
+        <!-- Include webapp (JSP/JS/HTML) and resources in SonarCloud analysis alongside Java sources -->
+        <sonar.sources>src/main/java,src/main/resources,src/main/webapp</sonar.sources>
+        <!-- Exclude vendored/minified third-party assets to avoid inflating LOC count and generating noise -->
+        <sonar.exclusions>
+            src/main/webapp/library/**,
+            src/main/webapp/share/**,
+            src/main/webapp/**/*.min.js,
+            src/main/webapp/**/*.min.css
+        </sonar.exclusions>
         <sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
         <!--
             Suppress SonarCloud S2083 (path traversal) false positives in files that use

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- SonarCloud -->
         <sonar.organization>carlos-emr</sonar.organization>
+        <!-- Include webapp (JSP/JS/HTML) in SonarCloud analysis alongside Java sources -->
+        <sonar.sources>src/main/java,src/main/webapp</sonar.sources>
         <sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
         <!--
             Suppress SonarCloud S2083 (path traversal) false positives in files that use


### PR DESCRIPTION
SonarCloud's Maven scanner defaults sonar.sources to src/main/java only,
which means JSP, JavaScript, and HTML files under src/main/webapp were
never being analyzed for security vulnerabilities (XSS, injection, etc.).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Broadened SonarCloud analysis to include frontend assets along with backend sources.
  * Added exclusions to omit third‑party/vendor static libraries and minified assets from scans to reduce noise and focus results on project code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->