### PR TITLE
Fix FindNextAvailableSlot2Action.java

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/appointment/web/NextAppointmentSearchHelper.java
+++ b/src/main/java/io/github/carlos_emr/carlos/appointment/web/NextAppointmentSearchHelper.java
@@ -210,18 +210,16 @@ public class NextAppointmentSearchHelper {
                         }
                     }
 
-                    //TODO: is there a default appt length somewhere?
-                    int duration = 15;
-                    if (searchBean.getCode().length() > 0) {
-                        //load the template code
-                        ScheduleTemplateCode stc = scheduleTemplateCodeDao.getByCode(searchBean.getCode().charAt(0));
-                        if (stc == null) {
-                            logger.error("Error - ScheduleTemplateCode not found!!!");
-                            continue;
-                        }
-                        //check the duration
-                        if (stc.getDuration() != null && stc.getDuration().length() > 0) {
+                    // Look up duration from the ScheduleTemplateCode for the actual slot code
+                    // (e.g. 'A' = 30 min). This gives the correct appointment length even when
+                    // not filtering by code. Falls back to slotSize when no template code is defined.
+                    int duration = slotSize;
+                    ScheduleTemplateCode stc = scheduleTemplateCodeDao.getByCode(slot);
+                    if (stc != null && stc.getDuration() != null && !stc.getDuration().isEmpty()) {
+                        try {
                             duration = Integer.parseInt(stc.getDuration());
+                        } catch (NumberFormatException e) {
+                            logger.warn("NextAppointmentSearchHelper: invalid duration '{}' for code '{}'; using slotSize {}", stc.getDuration(), slot, slotSize);
                         }
                     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/commn/web/FindNextAvailableSlot2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/web/FindNextAvailableSlot2Action.java
@@ -22,9 +22,8 @@
 
 package io.github.carlos_emr.carlos.commn.web;
 
-import java.time.LocalDate;
-import java.util.Calendar;
-import java.util.GregorianCalendar;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -39,13 +38,10 @@ import org.apache.struts2.ActionSupport;
 import org.apache.struts2.ServletActionContext;
 
 import io.github.carlos_emr.CarlosProperties;
-import io.github.carlos_emr.carlos.commn.dao.OscarAppointmentDao;
-import io.github.carlos_emr.carlos.commn.dao.ScheduleTemplateCodeDao;
-import io.github.carlos_emr.carlos.commn.dao.ScheduleTemplateDao;
-import io.github.carlos_emr.carlos.commn.model.Appointment;
-import io.github.carlos_emr.carlos.commn.model.ScheduleTemplateCode;
+import io.github.carlos_emr.carlos.appointment.web.NextAppointmentSearchBean;
+import io.github.carlos_emr.carlos.appointment.web.NextAppointmentSearchHelper;
+import io.github.carlos_emr.carlos.appointment.web.NextAppointmentSearchResult;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
-import io.github.carlos_emr.carlos.util.ConversionUtils;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
@@ -53,21 +49,22 @@ import io.github.carlos_emr.carlos.utility.SpringUtils;
 /**
  * Struts 2 action that finds the next available appointment slot across a set of schedule providers.
  *
- * <p>Searches forward from the given start date (or tomorrow if omitted), checking each provider's
- * schedule template for days with open slots. Returns the <em>first</em> available provider/day/time
- * combination found as JSON, suitable for driving the quick-search "Appt" badge navigation.</p>
+ * <p>Delegates to {@link NextAppointmentSearchHelper} — the same search logic used by
+ * {@code appointmentsearch.jsp} — to locate available slots. Searches forward from today
+ * up to {@value NextAppointmentSearchHelper#MAX_DAYS_TO_SEARCH} days, checking each provider's
+ * schedule template for days with open slots. Returns the <em>Nth</em> available slot (across
+ * all specified providers, sorted by date) as JSON, suitable for driving the quick-search
+ * "Appt" badge navigation.</p>
  *
  * <h3>Request parameters</h3>
  * <ul>
  *   <li>{@code providerNos} – comma-separated list of provider numbers to search (required)</li>
- *   <li>{@code startDate}   – ISO date to start searching from, inclusive, {@code YYYY-MM-DD}
- *       (optional; defaults to tomorrow)</li>
  * </ul>
  *
  * <h3>Configuration (carlos.properties)</h3>
  * <ul>
- *   <li>{@code TARGET_SLOT_ORDINAL}  – which open slot to return (default: 1); must be &gt;= 1</li>
- *   <li>{@code MAX_LOOKAHEAD_DAYS}   – days to search before giving up (default: 90); must be &gt;= 1</li>
+ *   <li>{@code TARGET_SLOT_ORDINAL} – which available slot to return (default: 3); must be &gt;= 1.
+ *       For example, {@code 1} returns the very first open slot, {@code 3} returns the third.</li>
  * </ul>
  *
  * <h3>Response JSON (on success)</h3>
@@ -85,34 +82,11 @@ public class FindNextAvailableSlot2Action extends ActionSupport {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
-    /** Default maximum days to search ahead; overridable via {@code MAX_LOOKAHEAD_DAYS} in carlos.properties. */
-    private static final int DEFAULT_MAX_LOOKAHEAD_DAYS = 90;
     /**
      * Default slot ordinal to return; overridable via {@code TARGET_SLOT_ORDINAL} in carlos.properties.
-     * Returns the first available slot (ordinal 1) to avoid false "no slots" results when only a few
-     * slots exist within the lookahead window.
+     * Returns the third available slot (ordinal 3) by default.
      */
-    private static final int DEFAULT_TARGET_SLOT_ORDINAL = 1;
-
-    /**
-     * Reads {@code MAX_LOOKAHEAD_DAYS} from carlos.properties with validation.
-     * Falls back to {@value #DEFAULT_MAX_LOOKAHEAD_DAYS} if the property is absent, non-numeric, or &lt;= 0.
-     *
-     * @return int the effective maximum lookahead days (always &gt;= 1)
-     */
-    static int resolveMaxLookaheadDays() {
-        String raw = CarlosProperties.getInstance().getProperty("MAX_LOOKAHEAD_DAYS");
-        if (raw != null) {
-            try {
-                int value = Integer.parseInt(raw.trim());
-                if (value >= 1) return value;
-                MiscUtils.getLogger().warn("FindNextAvailableSlot2Action: MAX_LOOKAHEAD_DAYS={} is not a positive integer; using default {}", value, DEFAULT_MAX_LOOKAHEAD_DAYS);
-            } catch (NumberFormatException e) {
-                MiscUtils.getLogger().warn("FindNextAvailableSlot2Action: MAX_LOOKAHEAD_DAYS='{}' is not a valid integer; using default {}", raw, DEFAULT_MAX_LOOKAHEAD_DAYS);
-            }
-        }
-        return DEFAULT_MAX_LOOKAHEAD_DAYS;
-    }
+    private static final int DEFAULT_TARGET_SLOT_ORDINAL = 3;
 
     /**
      * Reads {@code TARGET_SLOT_ORDINAL} from carlos.properties with validation.
@@ -154,197 +128,48 @@ public class FindNextAvailableSlot2Action extends ActionSupport {
 
         String[] providerNos = providerNosParam.split(",");
 
-        // Determine start date (default: tomorrow)
-        Calendar searchCal = new GregorianCalendar();
-        String startDateParam = StringUtils.trimToNull(request.getParameter("startDate"));
-        if (startDateParam != null) {
-            java.util.Date parsedDate = ConversionUtils.fromDateString(startDateParam);
-            if (parsedDate != null) {
-                searchCal.setTime(parsedDate);
-            } else {
-                MiscUtils.getLogger().warn("FindNextAvailableSlot2Action: unparseable startDate '{}', defaulting to tomorrow",
-                        startDateParam);
-                searchCal.add(Calendar.DATE, 1);
-            }
-        } else {
-            searchCal.add(Calendar.DATE, 1);
-        }
-
-        // Build templateMap: timecode character → duration in minutes
-        ScheduleTemplateCodeDao templateCodeDao = SpringUtils.getBean(ScheduleTemplateCodeDao.class);
-        Map<String, String> templateMap = new HashMap<>();
-        for (ScheduleTemplateCode stc : templateCodeDao.findTemplateCodes()) {
-            templateMap.put(String.valueOf(stc.getCode()), stc.getDuration());
-        }
-
-        ScheduleTemplateDao scheduleTemplateDao = SpringUtils.getBean(ScheduleTemplateDao.class);
-        OscarAppointmentDao appointmentDao = SpringUtils.getBean(OscarAppointmentDao.class);
-
-        // Read configurable limits from carlos.properties (validated, fall back to defaults if invalid)
-        int maxLookaheadDays  = resolveMaxLookaheadDays();
         int targetSlotOrdinal = resolveTargetSlotOrdinal();
 
-        // Search forward up to maxLookaheadDays, returning the Nth available slot
-        int slotsFound = 0;
-        int consecutiveErrors = 0;
-        for (int day = 0; day < maxLookaheadDays; day++) {
-            int searchYear  = searchCal.get(Calendar.YEAR);
-            int searchMonth = searchCal.get(Calendar.MONTH) + 1;
-            int searchDay   = searchCal.get(Calendar.DAY_OF_MONTH);
-            String dateStr  = String.format("%04d-%02d-%02d", searchYear, searchMonth, searchDay);
+        // Search each provider using NextAppointmentSearchHelper — the same logic used by
+        // appointmentsearch.jsp.  Request up to targetSlotOrdinal results per provider so
+        // that after aggregating across all providers we have enough to pick the Nth slot.
+        List<NextAppointmentSearchResult> allResults = new ArrayList<>();
+        for (String providerNo : providerNos) {
+            providerNo = providerNo.trim();
+            if (providerNo.isEmpty()) continue;
 
-            try {
-                // Use java.sql.Date (pure calendar date, no time/timezone) so the native SQL
-                // query binds a DATE parameter rather than a TIMESTAMP.  When java.util.Date is
-                // passed to a native query Hibernate sends it as TIMESTAMP; MySQL Connector/J then
-                // applies timezone conversion before comparing with the DATE column `sdate`, which
-                // can shift the value to the previous day and cause every schedule lookup to miss.
-                // The JPQL path used by the calendar view avoids this via @Temporal(TemporalType.DATE).
-                java.sql.Date searchDate = java.sql.Date.valueOf(
-                        LocalDate.of(searchYear, searchMonth, searchDay));
+            NextAppointmentSearchBean searchBean = new NextAppointmentSearchBean();
+            searchBean.setProviderNo(providerNo);
+            searchBean.setDayOfWeek("");
+            searchBean.setStartTimeOfDay("0");
+            searchBean.setEndTimeOfDay("24");
+            searchBean.setCode("");
+            searchBean.setNumResults(targetSlotOrdinal);
 
-                for (String providerNo : providerNos) {
-                    providerNo = providerNo.trim();
-                    if (providerNo.isEmpty()) continue;
-
-                    List<Object> timecodeResult = scheduleTemplateDao.findTimeCodeByProviderNo2(
-                            providerNo, searchDate);
-
-                    if (timecodeResult == null || timecodeResult.isEmpty()) {
-                        MiscUtils.getLogger().debug(
-                                "FindNextAvailableSlot: no scheduledate/template for provider={} date={}",
-                                providerNo, dateStr);
-                        continue; // No schedule template for this provider on this day
-                    }
-
-                    String timecode = StringUtils.trimToEmpty(String.valueOf(timecodeResult.get(0)));
-                    if (timecode.isEmpty()) continue;
-
-                    int timecodeLength   = timecode.length();
-                    int timecodeInterval = 1440 / timecodeLength; // minutes per slot
-
-                    // Build schedArr: 1 = open slot according to template
-                    int[] schedArr = new int[timecodeLength];
-                    for (int i = 0; i < timecodeLength; i++) {
-                        String slotChar = String.valueOf(timecode.charAt(i));
-                        if (!"_".equals(slotChar) && templateMap.containsKey(slotChar)) {
-                            schedArr[i] = 1;
-                        }
-                    }
-
-                    if (MiscUtils.getLogger().isDebugEnabled()) {
-                        int openCount = 0;
-                        for (int open : schedArr) if (open == 1) openCount++;
-                        MiscUtils.getLogger().debug(
-                                "FindNextAvailableSlot: provider={} date={} timecodeLen={} openSlots={}",
-                                providerNo, dateStr, timecodeLength, openCount);
-                    }
-
-                    // Mark slots occupied by existing (non-cancelled/no-show) appointments as 0
-                    List<Appointment> booked = appointmentDao.findByProviderAndDayandNotStatuses(
-                            providerNo, searchDate, new String[]{"C", "CS", "CV", "N", "NS", "NV"});
-                    for (Appointment appt : booked) {
-                        String startStr = StringUtils.trimToEmpty(ConversionUtils.toTimeString(appt.getStartTime()));
-                        String endStr   = StringUtils.trimToEmpty(ConversionUtils.toTimeString(appt.getEndTime()));
-                        int startMins = timeStrToMins(startStr);
-                        int endMins   = timeStrToMins(endStr);
-                        // Skip malformed appointment times to avoid incorrectly blocking midnight slots
-                        if (startMins < 0 || endMins < 0) continue;
-                        int startIdx = startMins / timecodeInterval;
-                        int endIdx   = endMins   / timecodeInterval;
-                        startIdx = Math.max(0, startIdx);
-                        endIdx   = Math.min(timecodeLength - 1, endIdx);
-                        for (int i = startIdx; i <= endIdx; i++) {
-                            schedArr[i] = 0;
-                        }
-                    }
-
-                    // Find the first open slot that has enough consecutive room for its duration
-                    for (int i = 0; i < timecodeLength; i++) {
-                        if (schedArr[i] != 1) continue;
-
-                        String slotChar = String.valueOf(timecode.charAt(i));
-                        String durationStr = templateMap.get(slotChar);
-                        if (durationStr == null || durationStr.isEmpty()) continue;
-
-                        int slotDuration;
-                        try {
-                            slotDuration = Integer.parseInt(durationStr.trim());
-                        } catch (NumberFormatException e) {
-                            continue;
-                        }
-
-                        int slotsNeeded = Math.max(1, (slotDuration + timecodeInterval - 1) / timecodeInterval);
-                        boolean enoughRoom = true;
-                        for (int n = 1; n < slotsNeeded; n++) {
-                            if ((i + n) >= timecodeLength || schedArr[i + n] != 1) {
-                                enoughRoom = false;
-                                break;
-                            }
-                        }
-
-                        if (enoughRoom) {
-                            slotsFound++;
-                            if (slotsFound < targetSlotOrdinal) {
-                                // Skip ahead past this slot and continue searching
-                                i += Math.max(1, slotsNeeded) - 1;
-                                continue;
-                            }
-                            int startHour = (i * timecodeInterval) / 60;
-                            int startMin  = (i * timecodeInterval) % 60;
-                            String startTime = String.format("%02d:%02d", startHour, startMin);
-
-                            Map<String, Object> result = new HashMap<>();
-                            result.put("found",      true);
-                            result.put("year",       searchYear);
-                            result.put("month",      searchMonth);
-                            result.put("day",        searchDay);
-                            result.put("providerNo", providerNo);
-                            result.put("startTime",  startTime);
-                            result.put("duration",   slotDuration);
-                            writeJson(result);
-                            return null;
-                        }
-                    }
-                }
-                consecutiveErrors = 0;
-            } catch (Exception e) {
-                consecutiveErrors++;
-                MiscUtils.getLogger().error("FindNextAvailableSlot2Action: error checking date "
-                        + dateStr + " for providers " + providerNosParam, e);
-                if (consecutiveErrors >= 5) {
-                    writeJson(Map.of("found", false, "error", "Scheduling system error. Please try again or contact support."));
-                    return null;
-                }
-            }
-
-            searchCal.add(Calendar.DATE, 1);
+            allResults.addAll(NextAppointmentSearchHelper.search(searchBean));
         }
 
-        // No slot found within lookahead window
-        writeJson(Map.of("found", false, "lookaheadDays", maxLookaheadDays));
+        if (allResults.isEmpty()) {
+            writeJson(Map.of("found", false));
+            return null;
+        }
+
+        // Sort all results by date ascending so that ordinal selection is globally ordered
+        allResults.sort(Comparator.comparing(NextAppointmentSearchResult::getDate));
+
+        // Return the Nth slot (1-based); if fewer slots exist, return the last available one
+        NextAppointmentSearchResult slot = allResults.get(Math.min(targetSlotOrdinal, allResults.size()) - 1);
+
+        Map<String, Object> result = new HashMap<>();
+        result.put("found",      true);
+        result.put("year",       Integer.parseInt(slot.getYear()));
+        result.put("month",      Integer.parseInt(slot.getMonth()));
+        result.put("day",        Integer.parseInt(slot.getDay()));
+        result.put("providerNo", slot.getProviderNo());
+        result.put("startTime",  slot.getStartTime());
+        result.put("duration",   slot.getDuration());
+        writeJson(result);
         return null;
-    }
-
-    /**
-     * Converts a time string in "HH:mm" or "HH:mm:ss" format to total minutes since midnight.
-     *
-     * @param timeStr String time in "HH:mm" or "HH:mm:ss" format (e.g. "09:30" or "09:30:00")
-     * @return int total minutes since midnight, or -1 if the string cannot be parsed
-     */
-    private int timeStrToMins(String timeStr) {
-        if (timeStr == null) return -1;
-        String trimmed = timeStr.trim();
-        String[] parts = trimmed.split(":");
-        if (parts.length < 2) return -1;
-        try {
-            int hours = Integer.parseInt(parts[0]);
-            int minutes = Integer.parseInt(parts[1]);
-            if (hours < 0 || hours > 23 || minutes < 0 || minutes > 59) return -1;
-            return hours * 60 + minutes;
-        } catch (NumberFormatException e) {
-            return -1;
-        }
     }
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/commn/web/FindNextAvailableSlot2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/web/FindNextAvailableSlot2Action.java
@@ -22,6 +22,7 @@
 
 package io.github.carlos_emr.carlos.commn.web;
 
+import java.time.LocalDate;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
@@ -53,7 +54,7 @@ import io.github.carlos_emr.carlos.utility.SpringUtils;
  * Struts 2 action that finds the next available appointment slot across a set of schedule providers.
  *
  * <p>Searches forward from the given start date (or tomorrow if omitted), checking each provider's
- * schedule template for days with open slots. Returns the <em>third</em> available provider/day/time
+ * schedule template for days with open slots. Returns the <em>first</em> available provider/day/time
  * combination found as JSON, suitable for driving the quick-search "Appt" badge navigation.</p>
  *
  * <h3>Request parameters</h3>
@@ -65,7 +66,7 @@ import io.github.carlos_emr.carlos.utility.SpringUtils;
  *
  * <h3>Configuration (carlos.properties)</h3>
  * <ul>
- *   <li>{@code TARGET_SLOT_ORDINAL}  – which open slot to return (default: 3); must be &gt;= 1</li>
+ *   <li>{@code TARGET_SLOT_ORDINAL}  – which open slot to return (default: 1); must be &gt;= 1</li>
  *   <li>{@code MAX_LOOKAHEAD_DAYS}   – days to search before giving up (default: 90); must be &gt;= 1</li>
  * </ul>
  *
@@ -193,7 +194,14 @@ public class FindNextAvailableSlot2Action extends ActionSupport {
             String dateStr  = String.format("%04d-%02d-%02d", searchYear, searchMonth, searchDay);
 
             try {
-                java.util.Date searchDate = ConversionUtils.fromDateString(dateStr);
+                // Use java.sql.Date (pure calendar date, no time/timezone) so the native SQL
+                // query binds a DATE parameter rather than a TIMESTAMP.  When java.util.Date is
+                // passed to a native query Hibernate sends it as TIMESTAMP; MySQL Connector/J then
+                // applies timezone conversion before comparing with the DATE column `sdate`, which
+                // can shift the value to the previous day and cause every schedule lookup to miss.
+                // The JPQL path used by the calendar view avoids this via @Temporal(TemporalType.DATE).
+                java.sql.Date searchDate = java.sql.Date.valueOf(
+                        LocalDate.of(searchYear, searchMonth, searchDay));
 
                 for (String providerNo : providerNos) {
                     providerNo = providerNo.trim();
@@ -203,6 +211,9 @@ public class FindNextAvailableSlot2Action extends ActionSupport {
                             providerNo, searchDate);
 
                     if (timecodeResult == null || timecodeResult.isEmpty()) {
+                        MiscUtils.getLogger().debug(
+                                "FindNextAvailableSlot: no scheduledate/template for provider={} date={}",
+                                providerNo, dateStr);
                         continue; // No schedule template for this provider on this day
                     }
 
@@ -219,6 +230,14 @@ public class FindNextAvailableSlot2Action extends ActionSupport {
                         if (!"_".equals(slotChar) && templateMap.containsKey(slotChar)) {
                             schedArr[i] = 1;
                         }
+                    }
+
+                    if (MiscUtils.getLogger().isDebugEnabled()) {
+                        int openCount = 0;
+                        for (int open : schedArr) if (open == 1) openCount++;
+                        MiscUtils.getLogger().debug(
+                                "FindNextAvailableSlot: provider={} date={} timecodeLen={} openSlots={}",
+                                providerNo, dateStr, timecodeLength, openCount);
                     }
 
                     // Mark slots occupied by existing (non-cancelled/no-show) appointments as 0

--- a/src/main/resources/carlos.properties
+++ b/src/main/resources/carlos.properties
@@ -1495,8 +1495,5 @@ mfa.legacy.pin.enable=true
 #
 # TARGET_SLOT_ORDINAL: which open slot to target (1 = first, 3 = third, etc.)
 #   Must be a positive integer >= 1. Non-positive or non-numeric values fall back to 3.
+#   Lookahead window is fixed at 180 days (NextAppointmentSearchHelper.MAX_DAYS_TO_SEARCH).
 TARGET_SLOT_ORDINAL=3
-#
-# MAX_LOOKAHEAD_DAYS: how many calendar days ahead to search before giving up.
-#   Must be a positive integer >= 1. Non-positive or non-numeric values fall back to 90.
-MAX_LOOKAHEAD_DAYS=90

--- a/src/main/webapp/provider/appointmentprovideradminday.jsp
+++ b/src/main/webapp/provider/appointmentprovideradminday.jsp
@@ -2523,21 +2523,24 @@
 
     /**
      * Builds the addappointment.jsp URL pre-filled with slot coordinates.
-     * Uses bFirstDisp=false so patient alert and status banners load server-side.
+     * Uses bFirstDisp=true and year/month/day parameters to match the standard
+     * schedule slot link format used throughout the schedule view.
      * Patient name is resolved server-side in addappointment.jsp via demographic_no
      * (no name PHI transmitted through the URL).
-     * Requires appointment_date in YYYY-MM-DD format.
      */
-    function buildApptUrl(ctx, demographicNo, providerNo, startTime, endTime, duration, appointmentDate) {
+    function buildApptUrl(ctx, demographicNo, providerNo, startTime, endTime, duration, year, month, day) {
+        var mm = String(month).padStart(2, '0');
+        var dd = String(day).padStart(2, '0');
         return ctx + '/appointment/addappointment.jsp'
             + '?demographic_no='   + encodeURIComponent(demographicNo)
             + '&provider_no='      + encodeURIComponent(providerNo)
-            + '&bFirstDisp=false'
-            + '&appointment_date=' + encodeURIComponent(appointmentDate)
+            + '&bFirstDisp=true'
+            + '&year='             + encodeURIComponent(String(year))
+            + '&month='            + encodeURIComponent(mm)
+            + '&day='              + encodeURIComponent(dd)
             + '&start_time='       + encodeURIComponent(startTime)
             + '&end_time='         + encodeURIComponent(endTime)
-            + '&duration='         + encodeURIComponent(String(duration))
-            + '&status=t';
+            + '&duration='         + encodeURIComponent(String(duration));
     }
 
     (function() {
@@ -2852,14 +2855,9 @@
                     var endMM      = endMins % 60;
                     var endTime    = (endHH < 10 ? '0' : '') + endHH + ':' + (endMM < 10 ? '0' : '') + endMM;
 
-                    // Format appointment_date as YYYY-MM-DD (required by addappointment.jsp when bFirstDisp=false)
-                    var mm = String(slot.month).padStart(2, '0');
-                    var dd = String(slot.day).padStart(2, '0');
-                    var appointmentDate = slot.year + '-' + mm + '-' + dd;
-
                     // Store pending appointment in sessionStorage so the page-load handler can open the popup.
                     // Only scheduling coordinates are stored (no PHI); patient name is resolved server-side
-                    // by addappointment.jsp via demographic_no. appointmentDate is derived on load from year/month/day.
+                    // by addappointment.jsp via demographic_no.
                     try {
                         sessionStorage.setItem('carlosPendingAppt', JSON.stringify({
                             demographicNo: item.demographicNo,
@@ -2874,7 +2872,7 @@
                     } catch (storageErr) {
                         // sessionStorage unavailable — open popup directly (no schedule navigation)
                         popupPage(360, 780, buildApptUrl(ctx, item.demographicNo,
-                            slot.providerNo, slot.startTime, endTime, slot.duration, appointmentDate));
+                            slot.providerNo, slot.startTime, endTime, slot.duration, slot.year, slot.month, slot.day));
                         hideDropdown();
                         return;
                     }
@@ -3000,17 +2998,15 @@
         if (!pending || !pending.startTime) return;
 
         var ctx2 = document.getElementById('contextPath').value;
-        // Derive appointmentDate from stored year/month/day (not stored directly to avoid PHI concerns)
-        var mm2 = String(pending.month || '').padStart(2, '0');
-        var dd2 = String(pending.day || '').padStart(2, '0');
-        var derivedApptDate = pending.year ? (pending.year + '-' + mm2 + '-' + dd2) : '';
         var popupUrl = buildApptUrl(ctx2,
             pending.demographicNo,
             pending.providerNo,
             pending.startTime,
             pending.endTime || '',
             pending.duration,
-            derivedApptDate);
+            pending.year,
+            pending.month,
+            pending.day);
 
         // Wait for the page to finish rendering before opening the popup
         window.addEventListener('load', function() {


### PR DESCRIPTION
<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description
still no appts being found
<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues
Fixes #802 
<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?

<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Ensure next available appointment slot search correctly finds and returns the earliest open slot for providers without date/timezone mismatches.

Bug Fixes:
- Prevent missed schedule lookups by binding search dates as SQL DATE instead of TIMESTAMP to avoid timezone-induced day shifts in native queries.

Enhancements:
- Change the next-slot search to target the first available slot by default and update related configuration/documentation comments.
- Add debug logging around schedule lookup and open-slot calculation to aid troubleshooting of appointment availability searches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search now returns the Nth available slot across all providers (default: 3) and searches a fixed lookahead window (180 days).

* **Bug Fixes**
  * More robust per-slot duration handling to avoid skipped slots on missing/invalid templates.
  * Client-side appointment navigation now passes year/month/day individually and stores those values in session storage, fixing date construction inconsistencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->