### PR TITLE
Admin/User unable to add new user fix, legacy eRx columns not null

### DIFF
--- a/database/mysql/oscardata.sql
+++ b/database/mysql/oscardata.sql
@@ -1334,7 +1334,7 @@ INSERT INTO `measurementType` (`type`, `typeDisplayName`, `typeDescription`, `me
 INSERT INTO mygroup VALUES ('IT Support','88888','Support','IT',NULL,NULL);
 
 
-insert into ProviderPreference (providerNo, startHour, endHour, everyMin, myGroupNo, colourTemplate, defaultCaisiPmm, defaultNewOscarCme, printQrCodeOnPrescriptions, lastUpdated, appointmentScreenLinkNameDisplayLength,defaultDoNotDeleteBilling,eRxEnabled,eRxTrainingMode) values ('999998','8','18','15','.default','deepblue','disabled','disabled', 0, now(), 3,0,0,0);
+insert into ProviderPreference (providerNo, startHour, endHour, everyMin, myGroupNo, colourTemplate, defaultCaisiPmm, defaultNewOscarCme, printQrCodeOnPrescriptions, lastUpdated, appointmentScreenLinkNameDisplayLength,defaultDoNotDeleteBilling) values ('999998','8','18','15','.default','deepblue','disabled','disabled', 0, now(), 3,0);
 
 --
 -- Dumping data for table 'provider'

--- a/database/mysql/oscarinit.sql
+++ b/database/mysql/oscarinit.sql
@@ -6041,15 +6041,8 @@ CREATE TABLE IF NOT EXISTS ProviderPreference
 	appointmentScreenLinkNameDisplayLength int not null,
 	defaultDoNotDeleteBilling  tinyint(1) not null,
 	defaultDxCode varchar(4),
-	eRxEnabled tinyint(1) NOT NULL DEFAULT '0',
-    eRx_SSO_URL varchar(128),
-    eRxUsername varchar(32),
-    eRxPassword varchar(64),
-    eRxFacility varchar(32),
-    eRxTrainingMode tinyint(1) not null,
-    encryptedMyOscarPassword varbinary(255),
-    defaultBillingLocation varchar(4) DEFAULT 'no',
-    defaultSliCode varchar(4) default 'no'
+  defaultBillingLocation varchar(4) DEFAULT 'no',
+  defaultSliCode varchar(4) default 'no'
 );
 
 --

--- a/database/mysql/oscarinit.sql
+++ b/database/mysql/oscarinit.sql
@@ -6041,7 +6041,7 @@ CREATE TABLE IF NOT EXISTS ProviderPreference
 	appointmentScreenLinkNameDisplayLength int not null,
 	defaultDoNotDeleteBilling  tinyint(1) not null,
 	defaultDxCode varchar(4),
-	eRxEnabled tinyint(1) not null,
+	eRxEnabled tinyint(1) NOT NULL DEFAULT '0',
     eRx_SSO_URL varchar(128),
     eRxUsername varchar(32),
     eRxPassword varchar(64),

--- a/database/mysql/updates/update-2026-04-01-drop-erx-columns.sql
+++ b/database/mysql/updates/update-2026-04-01-drop-erx-columns.sql
@@ -1,0 +1,12 @@
+-- Deprecate eRx External Prescriber. This is safe to rerun.
+-- This must be run or you will be unable to add new users with the old schema
+-- as the insert would fail from adding a null to not null columns
+
+ALTER TABLE ProviderPreference
+  DROP COLUMN IF EXISTS eRxEnabled,
+  DROP COLUMN IF EXISTS eRx_SSO_URL,
+  DROP COLUMN IF EXISTS eRxUsername,
+  DROP COLUMN IF EXISTS eRxPassword,
+  DROP COLUMN IF EXISTS eRxFacility,
+  DROP COLUMN IF EXISTS eRxTrainingMode,
+  DROP COLUMN IF EXISTS encryptedMyOscarPassword;


### PR DESCRIPTION
<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description
allows new users to be entered
<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues
Fixes #818 
<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?

<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Bug Fixes:
- Prevent failures when creating new providers by defaulting the eRxEnabled flag to 0 in the ProviderPreference table schema.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed e-prescribing (eRx) provider preference fields from the system.
  * Retained provider billing preference defaults (default billing location and default SLI code) to preserve existing behavior for billing settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->