### PR TITLE
feat: Phase 0 foundation for MySQL→Medplum FHIR R4 migration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -36,7 +36,7 @@
         }
     },
 
-    "forwardPorts": [8080, 8000, 3306, 3000],
+    "forwardPorts": [8080, 8000, 3306, 3000, 8103, 5432, 6379],
     "containerUser": "root",
     "remoteUser": "root"
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -79,11 +79,99 @@ services:
       interval: 10s
       start_period: 60s
 
+  # Medplum FHIR R4 Server — clinical data store (Phase 0 of MySQL→FHIR migration)
+  medplum-postgres:
+    container_name: carlos-medplum-postgres
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: medplum
+      POSTGRES_USER: medplum
+      POSTGRES_PASSWORD: medplum
+      TZ: America/Toronto
+    ports:
+      - "5432:5432"
+    volumes:
+      - medplum-postgres-data:/var/lib/postgresql/data
+    networks:
+      - carlos-network
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+          cpus: "1"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U medplum -d medplum"]
+      timeout: 10s
+      retries: 5
+      interval: 10s
+      start_period: 30s
+
+  medplum-redis:
+    container_name: carlos-medplum-redis
+    image: redis:7-alpine
+    environment:
+      TZ: America/Toronto
+    ports:
+      - "6379:6379"
+    networks:
+      - carlos-network
+    deploy:
+      resources:
+        limits:
+          memory: 128M
+          cpus: "0.5"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      timeout: 5s
+      retries: 5
+      interval: 10s
+      start_period: 10s
+
+  medplum-server:
+    container_name: carlos-medplum-server
+    image: medplum/medplum-server:latest
+    ports:
+      - "8103:8103"
+    environment:
+      NODE_ENV: development
+      MEDPLUM_PORT: 8103
+      MEDPLUM_BASE_URL: "http://medplum-server:8103/"
+      MEDPLUM_DATABASE_HOST: medplum-postgres
+      MEDPLUM_DATABASE_PORT: 5432
+      MEDPLUM_DATABASE_DBNAME: medplum
+      MEDPLUM_DATABASE_USERNAME: medplum
+      MEDPLUM_DATABASE_PASSWORD: medplum
+      MEDPLUM_REDIS_HOST: medplum-redis
+      MEDPLUM_REDIS_PORT: 6379
+      MEDPLUM_MAX_JSON_SIZE: "16mb"
+      TZ: America/Toronto
+    networks:
+      - carlos-network
+    depends_on:
+      medplum-postgres:
+        condition: service_healthy
+      medplum-redis:
+        condition: service_healthy
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+          cpus: "1"
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://localhost:8103/healthcheck').then(r=>{if(!r.ok)throw 1})"]
+      timeout: 10s
+      retries: 10
+      interval: 15s
+      start_period: 60s
+
 volumes:
   mariadb-files:
     driver: local
 
   m2-volume:
+    driver: local
+
+  medplum-postgres-data:
     driver: local
 
 networks:

--- a/docs/medplum-fhir-migration-plan.md
+++ b/docs/medplum-fhir-migration-plan.md
@@ -1,0 +1,501 @@
+# CARLOS EMR: Migration Plan — MySQL to Medplum FHIR R4 Backend
+
+> **Status**: Phase 0 — Foundation  
+> **Created**: 2026-04-02  
+> **Branch**: `claude/migrate-medplum-fhir-BQpfc`
+
+## Executive Summary
+
+This document describes the phased migration of CARLOS EMR from a MySQL/Hibernate
+data store to a self-hosted [Medplum](https://www.medplum.com/) FHIR R4 server as
+the primary backend for clinical data. The migration preserves MySQL for
+non-clinical infrastructure (security, audit, configuration) while moving ~85
+clinical entities to standards-based FHIR resources.
+
+### Why Medplum
+
+- **Open source** (Apache 2.0), self-hostable, no vendor lock-in
+- **Full FHIR R4 compliance** with SMART on FHIR support
+- **Built-in subscriptions** for event-driven workflows (lab routing, inbox)
+- **TypeScript/Node.js server** with PostgreSQL + Redis backing store
+- **Canadian healthcare compatible** — supports custom profiles and extensions
+- Replaces 373 custom DAOs with a standards-based API
+
+### What Changes, What Stays
+
+| Layer | Before | After |
+|-------|--------|-------|
+| Clinical data store | MySQL + Hibernate | Medplum FHIR R4 |
+| Clinical data access | 373 custom DAOs | FHIR REST API via HAPI client |
+| Security/auth | MySQL (Sec* tables) | MySQL (unchanged) |
+| Audit logs | MySQL (OscarLog) | MySQL (unchanged) |
+| App config | MySQL (Property, UserProperty) | MySQL (unchanged) |
+| Program management | MySQL (PMmodule) | MySQL (unchanged) |
+| Billing infrastructure | MySQL | MySQL (with FHIR Claim export) |
+| FHIR version | DSTU3 (34 files) | R4 |
+
+---
+
+## Architecture
+
+### Current State
+
+```
+┌──────────────────────────────┐
+│         CARLOS EMR           │
+│                              │
+│  JSP/Struts → Manager → DAO │
+│                         │    │
+│                    Hibernate  │
+│                         │    │
+└─────────────────────────┼────┘
+                          │
+                    ┌─────▼─────┐
+                    │  MariaDB  │
+                    └───────────┘
+```
+
+### Target State
+
+```
+┌────────────────────────────────────────────────┐
+│                  CARLOS EMR                     │
+│                                                 │
+│  JSP/Struts → Manager → Repository (interface)  │
+│                              │            │     │
+│                    ┌─────────┘            │     │
+│                    │                      │     │
+│              FhirRepository         JpaRepository│
+│              (clinical)            (non-clinical)│
+│                    │                      │     │
+└────────────────────┼──────────────────────┼─────┘
+                     │                      │
+              ┌──────▼───────┐       ┌──────▼─────┐
+              │   Medplum    │       │  MariaDB   │
+              │   Server     │       │            │
+              │  ┌────────┐  │       └────────────┘
+              │  │Postgres │  │
+              │  │Redis    │  │
+              └──────────────┘
+```
+
+### DevContainer Layout
+
+```yaml
+services:
+  carlos:          # Tomcat 11 (existing) — port 8080
+  db:              # MariaDB (existing) — port 3306
+  drugref:         # DrugRef (existing) — port 8180
+  medplum-server:  # Medplum FHIR server — port 8103
+  medplum-postgres:# PostgreSQL for Medplum — port 5432
+  medplum-redis:   # Redis for Medplum — port 6379
+```
+
+---
+
+## Entity Classification
+
+### Tier 1 — Direct FHIR Mapping (~60 entities)
+
+These entities have natural FHIR R4 resource equivalents.
+
+#### Patient Domain
+| CARLOS Entity | FHIR R4 Resource | Fields | Notes |
+|---|---|---|---|
+| Demographic | Patient | 84 | HIN as identifier slice, gender/pronoun extensions |
+| DemographicExt | Patient (extensions) | 8 | PHU, ethnicity, consent, employment |
+| DemographicContact | Patient.contact | 18 | Emergency contacts, SDM, care team |
+| DemographicCust | Patient (extensions) | 6 | Nurse, resident, midwife, alerts |
+| DemographicMerged | Patient (link) | — | Patient merge history |
+
+#### Provider Domain
+| CARLOS Entity | FHIR R4 Resource | Notes |
+|---|---|---|
+| Provider | Practitioner | License types (CPSO, CNORN, OCP, CMO) |
+| ProfessionalSpecialist | Practitioner | External specialists |
+| Clinic | Organization | Name, address, phone, fax |
+| ClinicLocation | Location | Sub-locations |
+
+#### Medications
+| CARLOS Entity | FHIR R4 Resource | Fields | Notes |
+|---|---|---|---|
+| Drug | MedicationRequest | 73 | ATC code, dosage, frequency, duration, refills, route |
+| Prescription | MedicationRequest (group) | 9 | Script metadata, digital signature |
+| DrugDispensing | MedicationDispense | 11 | Quantity, dispensing provider |
+| DrugReason | MedicationRequest.reasonCode | 10 | ICD-9/10 indications |
+| DrugProduct | Medication | 7 | Lot number, expiry, product code |
+
+#### Allergies
+| CARLOS Entity | FHIR R4 Resource | Fields | Notes |
+|---|---|---|---|
+| Allergy | AllergyIntolerance | 31 | Severity (1-3), onset, ATC, drug/non-drug |
+
+#### Immunizations
+| CARLOS Entity | FHIR R4 Resource | Fields | Notes |
+|---|---|---|---|
+| Prevention | Immunization | 16+ ext | SNOMED code, lot, route, dose, refusal tracking |
+| PreventionExt | Immunization (extensions) | 5 | Lot, route, dose, manufacturer |
+
+#### Lab Results
+| CARLOS Entity | FHIR R4 Resource | Notes |
+|---|---|---|
+| Lab | DiagnosticReport | Accession, lab name, ordering provider |
+| LabTest | Observation | Code, value, units, reference range, abnormal flag |
+| LabTestResults | Observation | Result lines, abnormal indicators |
+| LabPatientPhysicianInfo | DiagnosticReport (metadata) | Accession, ordering physician, status |
+| Hl7TextInfo | DiagnosticReport (metadata) | Result status, discipline, priority |
+| MdsOBR | DiagnosticReport (OBR) | Order/result header |
+| MdsOBX | Observation (OBX) | Result value, abnormal flags |
+| PatientLabRouting | DiagnosticReport.subject | Links labs to patients |
+
+#### Measurements / Vitals
+| CARLOS Entity | FHIR R4 Resource | Notes |
+|---|---|---|
+| Measurement | Observation | BP, WT, HT, HR, TEMP — immutable after creation |
+| MeasurementsExt | Observation (extensions) | Units, reference ranges, flags |
+| MeasurementType | ObservationDefinition | Type code, display name |
+
+#### Documents
+| CARLOS Entity | FHIR R4 Resource | Notes |
+|---|---|---|
+| Document | DocumentReference | Type, class, content date, abnormal flag |
+| DocumentReview | DocumentReference (extension) | Reviewer, review date |
+| DocumentStorage | DocumentReference.content | Binary content (MEDIUMBLOB) |
+
+#### Consultations / Referrals
+| CARLOS Entity | FHIR R4 Resource | Notes |
+|---|---|---|
+| ConsultationRequest | ServiceRequest | 30+ fields: reason, urgency, clinical info |
+| ConsultationRequestExt | ServiceRequest (extensions) | Key-value extended attributes |
+| ConsultationResponse | DiagnosticReport / Communication | Examination, impression, plan |
+| ConsultationServices | HealthcareService | Service types with specialist lists |
+| ConsultDocs / ConsultResponseDoc | DocumentReference | Attached documents |
+
+#### Clinical Notes
+| CARLOS Entity | FHIR R4 Resource | Notes |
+|---|---|---|
+| CaseManagementNote | Encounter + ClinicalImpression | Clinical notes, signatures, encryption |
+| CaseManagementNoteExt | Encounter (extensions) | Extended note properties |
+| CaseManagementNoteLink | Encounter (references) | Links to issues/conditions |
+| CaseManagementIssue | Condition | Clinical issues/problems |
+
+#### Clinical Workflow (Ticklers, Messages, Inbox)
+| CARLOS Entity | FHIR R4 Resource | Notes |
+|---|---|---|
+| Tickler | Task | Patient, provider, priority, status, service date |
+| TicklerComment | Task.note | Provider comments/audit trail |
+| TicklerUpdate | Task (provenance) | Status change history |
+| TicklerCategory | Task.code | Classification (Lab Follow-up, Referral) |
+| TicklerLink | Task.focus | Links to labs, documents, encounters |
+| MessageTbl | Communication | Subject, message, sender, recipient |
+| MessageList | Communication (status) | Read/new/sent/deleted per provider |
+| InboxItem | Task + DiagnosticReport ref | Lab results awaiting review |
+| ProviderInboxItem | Task | Lab routing to providers, ack status |
+| IncomingLabRules | Subscription | Auto-forwarding rules |
+
+#### eForms
+| CARLOS Entity | FHIR R4 Resource | Notes |
+|---|---|---|
+| EFormData | QuestionnaireResponse | Patient-linked completed form data |
+| EFormValue | QuestionnaireResponse.item | Individual field values |
+| Flowsheet | Questionnaire | Flowsheet templates |
+
+#### Appointments
+| CARLOS Entity | FHIR R4 Resource | Notes |
+|---|---|---|
+| Appointment | Appointment | Date, provider, patient, reason, status |
+| AppointmentArchive | Appointment | Historical appointments |
+
+### Tier 2 — Canadian Healthcare Extensions (~25 entities)
+
+These map to FHIR with Canadian-specific profiles and extensions.
+
+| CARLOS Entity | FHIR R4 Resource | Notes |
+|---|---|---|
+| BillingONCHeader1 | Claim | Ontario OHIP submission |
+| BillingONItem | Claim.item | Service code, fee, diagnosis |
+| BillingONPayment | ClaimResponse | Payment/refund amounts |
+| BillingOnItemPayment | ClaimResponse.item | Line-level payment |
+| Billing | Claim | General claim record |
+| BillingDetail | Claim.item | Service code, diagnostic code |
+| TeleplanS21 | ClaimResponse | BC MSP remittance header |
+| TeleplanS00 | ClaimResponse.item | BC MSP service detail |
+| TeleplanS22 | ClaimResponse.total | BC provider batch summary |
+| TeleplanS23 | ClaimResponse.adjudication | BC adjustment/reversal |
+| BillingPrivateTransactions | PaymentNotice | Private pay records |
+| BillingService | ChargeItemDefinition | Fee schedule master |
+
+### Tier 3 — Stays in MySQL (~140 entities)
+
+| Category | Count | Examples |
+|---|---|---|
+| Security & Auth | ~15 | Security, SecRole, SecPrivilege, SecObjectName, SecurityToken |
+| Program Management | ~15 | Program, ProgramTeam, ProgramProvider, ProgramAccess |
+| System Configuration | ~10 | Property, UserProperty, SystemMessage, ScheduleTemplate |
+| Audit & Logging | ~15 | OscarLog, HashAudit, EmailLog, FaxClientLog |
+| Billing Infrastructure | ~10 | BillingONExt, BillingONEAReport, BillingONHeader (batch) |
+| EForm Templates | ~5 | EForm (template definition), EFormGroup |
+| Decision Support | ~9 | DSGuideline, DSCondition, DSConsequence |
+| HRM | ~9 | HRMDocument, HRMCategory, HRMDocumentComment |
+| Reporting | ~11 | Report, ReportConfig, ReportTemplate |
+| Other infrastructure | ~40+ | Lookups, DTOs, display helpers, composite keys |
+
+### Shared / Reference (~100 entities)
+
+REST transfer objects (101 `*To1` classes in `webserv/rest/to/`), lookup tables,
+and enums that serve both stores.
+
+---
+
+## Phased Implementation
+
+### Phase 0 — Foundation (current phase)
+
+**Goal**: Set up infrastructure with zero production impact.
+
+**Deliverables**:
+1. Self-hosted Medplum in devcontainer (server + PostgreSQL + Redis)
+2. HAPI FHIR R4 client dependency (upgrade from DSTU3)
+3. `MedplumFhirClient` wrapper service for auth, CRUD, search
+4. `ClinicalRepository<T>` abstraction interfaces
+5. This migration plan document
+
+**Risk**: None — all existing behavior unchanged.
+
+### Phase 1 — Dual-Write Core Entities
+
+**Goal**: Write clinical data to both MySQL and Medplum simultaneously.
+
+**Entities** (5):
+- Patient ← Demographic
+- Practitioner ← Provider
+- Immunization ← Prevention
+- AllergyIntolerance ← Allergy
+- Organization ← Clinic
+
+**Approach**:
+1. Implement `FhirRepository` for each entity (FHIR R4 CRUD via Medplum)
+2. Implement `DualWriteRepository` that delegates to both MySQL DAO and FhirRepository
+3. Wire managers to use DualWriteRepository
+4. Reads still come from MySQL
+
+**Validation**: Reconciliation job compares MySQL and Medplum state nightly.
+
+**Risk**: Low — MySQL remains source of truth for all reads.
+
+### Phase 2 — Read Switch (Core Entities)
+
+**Goal**: Flip reads to Medplum for Phase 1 entities.
+
+**Approach**:
+1. Implement FHIR search query equivalents for DAO finder methods
+2. Add feature flag per entity: `fhir.read.patient=true`
+3. Switch reads to Medplum with MySQL fallback
+4. Monitor latency and correctness
+
+**Risk**: Medium — first time Medplum is in the read path.
+
+### Phase 3 — Expand Entity Coverage
+
+**Goal**: Migrate next tier of entities using the same dual-write → read-switch cycle.
+
+**Entities** (~20):
+- Appointment → FHIR Appointment
+- Drug/Prescription → MedicationRequest + MedicationDispense
+- Lab results → DiagnosticReport + Observation
+- Measurements → Observation
+- Documents → DocumentReference
+- CaseManagementNote → Encounter + ClinicalImpression
+- ConsultationRequest → ServiceRequest
+- Tickler → Task
+- Messages → Communication
+- Inbox → Task
+
+**Each entity follows**: implement mapping → dual-write → validate → read-switch.
+
+**Risk**: Medium — more complex mappings, larger blast radius.
+
+### Phase 4 — Canadian Healthcare Profiles
+
+**Goal**: Migrate billing and provincial data with FHIR Canadian profiles.
+
+**Entities** (~25):
+- Ontario OHIP billing → Claim / ClaimResponse
+- BC Teleplan billing → Claim / ClaimResponse
+- Provincial identifiers → Patient.identifier slices
+- OLIS/DHIR integrations → point at Medplum
+
+**Risk**: High — provincial billing has deep MySQL coupling and no clean FHIR standard.
+
+### Phase 5 — MySQL Retirement (per entity)
+
+**Goal**: Drop dual-write; Medplum becomes source of truth.
+
+**Approach**:
+1. Disable MySQL writes for migrated entities (one at a time)
+2. MySQL becomes read-only archive
+3. Eventually drop MySQL tables for fully migrated entities
+4. Non-FHIR entities remain in MySQL permanently
+
+**Risk**: High — point of no return per entity.
+
+---
+
+## DSTU3 → R4 Migration
+
+The existing 34 FHIR files in `integration/fhir/` use HAPI FHIR DSTU3.
+Medplum requires R4. Key changes:
+
+| Aspect | DSTU3 | R4 |
+|---|---|---|
+| FhirContext | `FhirContext.forDstu3()` | `FhirContext.forR4()` |
+| Package | `org.hl7.fhir.dstu3.model` | `org.hl7.fhir.r4.model` |
+| Immunization.status | `completed` | `completed` (same) |
+| Immunization.notGiven | boolean field | `status = not-done` |
+| Patient.animal | removed in R4 | N/A |
+| Consent | draft resource | normative |
+
+**Approach**: Create new R4 model classes alongside DSTU3 (don't break DHIR
+integration during transition). Deprecate DSTU3 classes after DHIR is migrated.
+
+---
+
+## DevContainer Infrastructure
+
+### New Containers
+
+```yaml
+# Medplum PostgreSQL (backing store for Medplum server)
+medplum-postgres:
+  image: postgres:16
+  environment:
+    POSTGRES_DB: medplum
+    POSTGRES_USER: medplum
+    POSTGRES_PASSWORD: medplum
+  ports:
+    - "5432:5432"
+  volumes:
+    - medplum-postgres-data:/var/lib/postgresql/data
+
+# Medplum Redis (job queue and cache)
+medplum-redis:
+  image: redis:7-alpine
+  ports:
+    - "6379:6379"
+
+# Medplum FHIR Server
+medplum-server:
+  image: medplum/medplum-server:latest
+  ports:
+    - "8103:8103"
+  depends_on:
+    medplum-postgres:
+      condition: service_healthy
+    medplum-redis:
+      condition: service_started
+  environment:
+    MEDPLUM_PORT: 8103
+    MEDPLUM_DATABASE_HOST: medplum-postgres
+    MEDPLUM_DATABASE_PORT: 5432
+    MEDPLUM_DATABASE_DBNAME: medplum
+    MEDPLUM_DATABASE_USERNAME: medplum
+    MEDPLUM_DATABASE_PASSWORD: medplum
+    MEDPLUM_REDIS_HOST: medplum-redis
+    MEDPLUM_REDIS_PORT: 6379
+```
+
+### Resource Requirements
+
+| Container | Memory | CPU | Disk |
+|---|---|---|---|
+| medplum-server | 512M | 1 | minimal |
+| medplum-postgres | 512M | 1 | 1G+ (grows) |
+| medplum-redis | 128M | 0.5 | minimal |
+| **Total new** | **~1.2G** | **2.5** | **~1G** |
+
+---
+
+## Repository Abstraction Layer
+
+The key enabler for gradual migration. Managers call repository interfaces
+instead of DAOs directly.
+
+```java
+/**
+ * Generic clinical data repository that abstracts the backing store.
+ * Implementations can target MySQL (via existing DAOs), Medplum FHIR,
+ * or both (dual-write).
+ */
+public interface ClinicalRepository<T, ID> {
+
+    Optional<T> findById(ID id);
+
+    List<T> findAll(int offset, int limit);
+
+    T save(T entity);
+
+    void delete(ID id);
+
+    long count();
+}
+```
+
+Each migrated entity gets three implementations:
+1. `JpaClinicalRepository` — delegates to existing DAO (current behavior)
+2. `FhirClinicalRepository` — delegates to Medplum via HAPI FHIR client
+3. `DualWriteClinicalRepository` — writes to both, reads from configurable source
+
+---
+
+## Key Decisions
+
+### 1. FHIR Version: R4
+Medplum requires R4. The existing DSTU3 code (34 files for DHIR/Ontario) will be
+migrated to R4 as part of Phase 0/1.
+
+### 2. Self-Hosted Medplum
+Running in devcontainer alongside existing services. No cloud dependency.
+PIPEDA/data residency concerns eliminated.
+
+### 3. What Stays in MySQL
+Security, audit, program management, app config, billing internals, and ~140
+other non-clinical entities. These are poor FHIR fits and forcing them would
+add complexity without benefit.
+
+### 4. Dual-Write Before Read-Switch
+Every entity goes through dual-write validation before reads are switched.
+This catches mapping bugs before they affect users.
+
+### 5. Feature Flags Per Entity
+Each entity's read source is controlled by a property flag, allowing
+per-entity rollback without code changes.
+
+### 6. Repository Abstraction
+Managers are decoupled from storage implementation. This is the critical
+enabler — without it, migrating means rewriting 99 managers.
+
+---
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| Medplum performance under load | Slow clinical reads | Benchmark in Phase 2 before expanding |
+| FHIR mapping data loss | Clinical data gaps | Reconciliation jobs compare both stores |
+| DSTU3→R4 breaks DHIR | Ontario immunization reporting fails | Parallel R4 classes, don't remove DSTU3 until DHIR migrated |
+| DevContainer resource pressure | Slow builds, OOM | Memory limits on Medplum containers |
+| Incomplete FHIR mapping for Canadian data | Billing features break | Keep billing in MySQL, export to FHIR only |
+| Manager→DAO coupling too deep | Abstraction layer leaks | Start with cleanest entities (Patient, Practitioner) |
+
+---
+
+## Success Metrics
+
+| Phase | Metric | Target |
+|---|---|---|
+| 0 | Medplum server running in devcontainer | Health check passes |
+| 0 | HAPI FHIR R4 client can CRUD a Patient | Integration test green |
+| 1 | 5 entities dual-writing to Medplum | Zero reconciliation errors for 7 days |
+| 2 | Reads from Medplum for 5 entities | Latency < 2x MySQL, zero data errors |
+| 3 | 20+ entities on Medplum | All existing tests pass |
+| 5 | MySQL tables dropped for migrated entities | Clean shutdown |

--- a/pom.xml
+++ b/pom.xml
@@ -258,6 +258,11 @@
                 <artifactId>org.hl7.fhir.dstu3</artifactId>
                 <version>6.9.4</version>
             </dependency>
+            <dependency>
+                <groupId>ca.uhn.hapi.fhir</groupId>
+                <artifactId>org.hl7.fhir.r4</artifactId>
+                <version>6.9.4</version>
+            </dependency>
             <!-- Override transitive Artemis 2.50.0 from cxf-services-wsn-core.
                  Security fix for missing authentication on critical functions (patched in 2.52.0);
                  see the Dependabot alert for org.apache.artemis:artemis-server 2.50.0. -->
@@ -1200,10 +1205,22 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!-- FHIR DSTU3 structure definitions (used at runtime for FHIR resource handling) -->
+        <!-- FHIR DSTU3 structure definitions (used at runtime for DHIR/Ontario integration) -->
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-structures-dstu3</artifactId>
+            <version>${hapifhir.version}</version>
+        </dependency>
+        <!-- FHIR R4 structure definitions (used for Medplum FHIR backend migration) -->
+        <dependency>
+            <groupId>ca.uhn.hapi.fhir</groupId>
+            <artifactId>hapi-fhir-structures-r4</artifactId>
+            <version>${hapifhir.version}</version>
+        </dependency>
+        <!-- HAPI FHIR Client (used to communicate with Medplum FHIR server) -->
+        <dependency>
+            <groupId>ca.uhn.hapi.fhir</groupId>
+            <artifactId>hapi-fhir-client</artifactId>
             <version>${hapifhir.version}</version>
         </dependency>
 

--- a/src/main/java/io/github/carlos_emr/carlos/fhir/client/MedplumFhirClient.java
+++ b/src/main/java/io/github/carlos_emr/carlos/fhir/client/MedplumFhirClient.java
@@ -1,0 +1,171 @@
+/**
+ * Copyright (c) 2026. CARLOS EMR Project.
+ * https://github.com/carlos-emr/carlos
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ */
+package io.github.carlos_emr.carlos.fhir.client;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.client.api.IGenericClient;
+import ca.uhn.fhir.rest.client.api.ServerValidationModeEnum;
+import ca.uhn.fhir.rest.gclient.ICreateTyped;
+import ca.uhn.fhir.rest.gclient.IUpdateTyped;
+
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Resource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Client wrapper for communicating with the self-hosted Medplum FHIR R4 server.
+ *
+ * <p>Wraps the HAPI FHIR {@link IGenericClient} with CARLOS-specific defaults:
+ * connection to the devcontainer Medplum instance, R4 context, and logging.</p>
+ *
+ * <p>This client is the single entry point for all FHIR server operations.
+ * It is used by {@link io.github.carlos_emr.carlos.fhir.repository.FhirClinicalRepository}
+ * and should not be called directly from managers or actions.</p>
+ *
+ * <p>Thread-safe: the underlying {@link FhirContext} and {@link IGenericClient}
+ * are both thread-safe per HAPI FHIR documentation.</p>
+ *
+ * @since 2026-04-02
+ */
+public class MedplumFhirClient {
+
+    private static final Logger logger = LoggerFactory.getLogger(MedplumFhirClient.class);
+
+    /** Default Medplum server URL inside the devcontainer network. */
+    private static final String DEFAULT_SERVER_URL = "http://medplum-server:8103/fhir/R4";
+
+    private static final FhirContext FHIR_CONTEXT = FhirContext.forR4();
+
+    private final IGenericClient client;
+
+    /**
+     * Creates a client connected to the default devcontainer Medplum server.
+     */
+    public MedplumFhirClient() {
+        this(DEFAULT_SERVER_URL);
+    }
+
+    /**
+     * Creates a client connected to a Medplum server at the given URL.
+     *
+     * @param serverUrl the FHIR base URL (e.g., {@code http://medplum-server:8103/fhir/R4})
+     */
+    public MedplumFhirClient(String serverUrl) {
+        FHIR_CONTEXT.getRestfulClientFactory()
+                .setServerValidationMode(ServerValidationModeEnum.NEVER);
+        FHIR_CONTEXT.getRestfulClientFactory()
+                .setConnectTimeout(10_000);
+        FHIR_CONTEXT.getRestfulClientFactory()
+                .setSocketTimeout(30_000);
+        this.client = FHIR_CONTEXT.newRestfulGenericClient(serverUrl);
+        logger.info("MedplumFhirClient initialized for server: {}", serverUrl);
+    }
+
+    /**
+     * Reads a single FHIR resource by type and ID.
+     *
+     * @param resourceType the resource class (e.g., {@code Patient.class})
+     * @param id           the FHIR resource ID
+     * @param <R>          the resource type
+     * @return the resource, or {@code null} if not found
+     */
+    public <R extends Resource> R read(Class<R> resourceType, String id) {
+        try {
+            return client.read().resource(resourceType).withId(id).execute();
+        } catch (ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Searches for FHIR resources with pagination.
+     *
+     * @param resourceType the resource class
+     * @param offset       zero-based offset
+     * @param count        maximum results to return
+     * @param <R>          the resource type
+     * @return a Bundle containing matching resources
+     */
+    public <R extends Resource> Bundle search(Class<R> resourceType, int offset, int count) {
+        return client.search()
+                .forResource(resourceType)
+                .offset(offset)
+                .count(count)
+                .returnBundle(Bundle.class)
+                .execute();
+    }
+
+    /**
+     * Creates a new FHIR resource on the server, or updates it if it has an ID.
+     *
+     * @param resource the resource to create or update
+     * @param <R>      the resource type
+     * @return the server-assigned resource (with ID and metadata populated)
+     */
+    @SuppressWarnings("unchecked")
+    public <R extends Resource> R createOrUpdate(R resource) {
+        if (resource.hasId()) {
+            IUpdateTyped update = client.update().resource(resource);
+            update.execute();
+            return resource;
+        } else {
+            ICreateTyped create = client.create().resource(resource);
+            var outcome = create.execute();
+            resource.setId(outcome.getId());
+            return resource;
+        }
+    }
+
+    /**
+     * Deletes a FHIR resource by type and ID.
+     *
+     * @param resourceType the resource class
+     * @param id           the FHIR resource ID
+     * @param <R>          the resource type
+     * @return {@code true} if deleted successfully
+     */
+    public <R extends Resource> boolean delete(Class<R> resourceType, String id) {
+        try {
+            client.delete().resourceById(resourceType.getSimpleName(), id).execute();
+            return true;
+        } catch (ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Returns the underlying HAPI FHIR generic client for advanced queries.
+     *
+     * <p>Prefer the typed methods ({@link #read}, {@link #search}, etc.) for
+     * standard operations. Use this only for complex FHIR queries that require
+     * direct client access (e.g., chained searches, includes, custom operations).</p>
+     *
+     * @return the HAPI FHIR generic client
+     */
+    public IGenericClient getClient() {
+        return client;
+    }
+
+    /**
+     * Returns the shared R4 FHIR context.
+     *
+     * @return the FHIR R4 context (singleton, thread-safe)
+     */
+    public static FhirContext getFhirContext() {
+        return FHIR_CONTEXT;
+    }
+}

--- a/src/main/java/io/github/carlos_emr/carlos/fhir/mapping/FhirResourceMapper.java
+++ b/src/main/java/io/github/carlos_emr/carlos/fhir/mapping/FhirResourceMapper.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2026. CARLOS EMR Project.
+ * https://github.com/carlos-emr/carlos
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ */
+package io.github.carlos_emr.carlos.fhir.mapping;
+
+import org.hl7.fhir.r4.model.Resource;
+
+/**
+ * Bidirectional mapper between a CARLOS domain entity and a FHIR R4 resource.
+ *
+ * <p>Implementations handle the field-level translation between the legacy
+ * MySQL-backed model and its FHIR equivalent. Each clinical entity that
+ * participates in the FHIR migration requires one mapper implementation
+ * (e.g., {@code DemographicToPatientMapper}, {@code AllergyToAllergyIntoleranceMapper}).</p>
+ *
+ * <p>Mappers must be stateless and thread-safe.</p>
+ *
+ * @param <T> the CARLOS domain entity type (e.g., {@code Demographic})
+ * @param <R> the FHIR R4 resource type (e.g., {@code Patient})
+ * @since 2026-04-02
+ */
+public interface FhirResourceMapper<T, R extends Resource> {
+
+    /**
+     * Converts a CARLOS domain entity to a FHIR R4 resource.
+     *
+     * @param entity the domain entity to convert
+     * @return the equivalent FHIR resource, never null
+     */
+    R toFhir(T entity);
+
+    /**
+     * Converts a FHIR R4 resource to a CARLOS domain entity.
+     *
+     * @param resource the FHIR resource to convert
+     * @return the equivalent domain entity, never null
+     */
+    T fromFhir(R resource);
+}

--- a/src/main/java/io/github/carlos_emr/carlos/fhir/repository/ClinicalRepository.java
+++ b/src/main/java/io/github/carlos_emr/carlos/fhir/repository/ClinicalRepository.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2026. CARLOS EMR Project.
+ * https://github.com/carlos-emr/carlos
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ */
+package io.github.carlos_emr.carlos.fhir.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Abstraction layer for clinical data access that decouples managers from
+ * the underlying storage implementation (MySQL DAO or Medplum FHIR server).
+ *
+ * <p>This interface is the key enabler for the phased MySQL → Medplum FHIR
+ * migration. Each clinical entity gets three implementations:</p>
+ * <ul>
+ *   <li>{@code JpaClinicalRepository} — delegates to existing Hibernate DAOs (current behavior)</li>
+ *   <li>{@code FhirClinicalRepository} — delegates to Medplum via HAPI FHIR R4 client</li>
+ *   <li>{@code DualWriteClinicalRepository} — writes to both stores, reads from a configurable source</li>
+ * </ul>
+ *
+ * <p>Managers are wired to this interface. Swapping the active implementation
+ * (via Spring profiles or feature flags) switches the backing store without
+ * touching manager code.</p>
+ *
+ * @param <T>  the domain entity type (e.g., {@code Demographic}, {@code Allergy})
+ * @param <ID> the entity identifier type (e.g., {@code Integer}, {@code Long})
+ * @since 2026-04-02
+ */
+public interface ClinicalRepository<T, ID> {
+
+    /**
+     * Finds an entity by its identifier.
+     *
+     * @param id the entity identifier
+     * @return an {@code Optional} containing the entity, or empty if not found
+     */
+    Optional<T> findById(ID id);
+
+    /**
+     * Returns a paginated list of entities.
+     *
+     * @param offset zero-based offset for pagination
+     * @param limit  maximum number of entities to return
+     * @return list of entities, possibly empty
+     */
+    List<T> findAll(int offset, int limit);
+
+    /**
+     * Saves (creates or updates) an entity.
+     *
+     * @param entity the entity to save
+     * @return the saved entity (may have generated ID populated)
+     */
+    T save(T entity);
+
+    /**
+     * Deletes an entity by its identifier.
+     *
+     * @param id the entity identifier
+     * @return {@code true} if the entity was found and deleted
+     */
+    boolean delete(ID id);
+
+    /**
+     * Returns the total count of entities.
+     *
+     * @return entity count
+     */
+    long count();
+}

--- a/src/main/java/io/github/carlos_emr/carlos/fhir/repository/DualWriteClinicalRepository.java
+++ b/src/main/java/io/github/carlos_emr/carlos/fhir/repository/DualWriteClinicalRepository.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2026. CARLOS EMR Project.
+ * https://github.com/carlos-emr/carlos
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ */
+package io.github.carlos_emr.carlos.fhir.repository;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * {@link ClinicalRepository} implementation that writes to both MySQL (via JPA)
+ * and Medplum (via FHIR), while reading from a configurable primary source.
+ *
+ * <p>This is the transitional implementation used during migration phases 1-2.
+ * Writes always go to both stores. Reads come from the primary source (MySQL
+ * by default, switchable to FHIR via {@link #setReadFromFhir(boolean)}).</p>
+ *
+ * <p>FHIR write failures are logged but do not fail the operation — MySQL
+ * remains the source of truth until reads are switched over.</p>
+ *
+ * @param <T>  the domain entity type
+ * @param <ID> the entity identifier type
+ * @since 2026-04-02
+ */
+public class DualWriteClinicalRepository<T, ID> implements ClinicalRepository<T, ID> {
+
+    private static final Logger logger = LoggerFactory.getLogger(DualWriteClinicalRepository.class);
+
+    private final ClinicalRepository<T, ID> jpaRepository;
+    private final ClinicalRepository<T, ID> fhirRepository;
+    private volatile boolean readFromFhir;
+
+    /**
+     * Creates a dual-write repository with MySQL as the default read source.
+     *
+     * @param jpaRepository  the MySQL/JPA-backed repository
+     * @param fhirRepository the Medplum/FHIR-backed repository
+     */
+    public DualWriteClinicalRepository(ClinicalRepository<T, ID> jpaRepository,
+                                       ClinicalRepository<T, ID> fhirRepository) {
+        this.jpaRepository = jpaRepository;
+        this.fhirRepository = fhirRepository;
+        this.readFromFhir = false;
+    }
+
+    /**
+     * Switches the read source between MySQL and FHIR.
+     *
+     * @param readFromFhir {@code true} to read from Medplum FHIR, {@code false} for MySQL
+     */
+    public void setReadFromFhir(boolean readFromFhir) {
+        this.readFromFhir = readFromFhir;
+    }
+
+    @Override
+    public Optional<T> findById(ID id) {
+        return readSource().findById(id);
+    }
+
+    @Override
+    public List<T> findAll(int offset, int limit) {
+        return readSource().findAll(offset, limit);
+    }
+
+    @Override
+    public T save(T entity) {
+        T saved = jpaRepository.save(entity);
+        try {
+            fhirRepository.save(entity);
+        } catch (Exception e) {
+            logger.warn("FHIR dual-write failed for {}, MySQL write succeeded. "
+                    + "Entity will be reconciled on next sync.", entity.getClass().getSimpleName(), e);
+        }
+        return saved;
+    }
+
+    @Override
+    public boolean delete(ID id) {
+        boolean deleted = jpaRepository.delete(id);
+        try {
+            fhirRepository.delete(id);
+        } catch (Exception e) {
+            logger.warn("FHIR dual-delete failed for id={}, MySQL delete succeeded.", id, e);
+        }
+        return deleted;
+    }
+
+    @Override
+    public long count() {
+        return readSource().count();
+    }
+
+    private ClinicalRepository<T, ID> readSource() {
+        return readFromFhir ? fhirRepository : jpaRepository;
+    }
+}

--- a/src/main/java/io/github/carlos_emr/carlos/fhir/repository/FhirClinicalRepository.java
+++ b/src/main/java/io/github/carlos_emr/carlos/fhir/repository/FhirClinicalRepository.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2026. CARLOS EMR Project.
+ * https://github.com/carlos-emr/carlos
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ */
+package io.github.carlos_emr.carlos.fhir.repository;
+
+import io.github.carlos_emr.carlos.fhir.client.MedplumFhirClient;
+import io.github.carlos_emr.carlos.fhir.mapping.FhirResourceMapper;
+
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Resource;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * {@link ClinicalRepository} implementation that stores and retrieves data
+ * from a Medplum FHIR R4 server via the HAPI FHIR client.
+ *
+ * <p>This implementation uses a {@link FhirResourceMapper} to convert between
+ * CARLOS domain entities and FHIR R4 resources. The mapper is entity-specific
+ * (e.g., {@code DemographicToPatientMapper}) and must be provided at construction.</p>
+ *
+ * @param <T> the CARLOS domain entity type
+ * @param <R> the FHIR R4 resource type (e.g., {@code Patient}, {@code AllergyIntolerance})
+ * @param <ID> the entity identifier type
+ * @since 2026-04-02
+ */
+public class FhirClinicalRepository<T, R extends Resource, ID> implements ClinicalRepository<T, ID> {
+
+    private final MedplumFhirClient fhirClient;
+    private final FhirResourceMapper<T, R> mapper;
+    private final Class<R> resourceType;
+
+    /**
+     * Creates a FHIR-backed clinical repository.
+     *
+     * @param fhirClient   the Medplum FHIR client for server communication
+     * @param mapper       bidirectional mapper between domain entity and FHIR resource
+     * @param resourceType the FHIR resource class (e.g., {@code Patient.class})
+     */
+    public FhirClinicalRepository(MedplumFhirClient fhirClient,
+                                  FhirResourceMapper<T, R> mapper,
+                                  Class<R> resourceType) {
+        this.fhirClient = fhirClient;
+        this.mapper = mapper;
+        this.resourceType = resourceType;
+    }
+
+    @Override
+    public Optional<T> findById(ID id) {
+        R resource = fhirClient.read(resourceType, String.valueOf(id));
+        if (resource == null) {
+            return Optional.empty();
+        }
+        return Optional.of(mapper.fromFhir(resource));
+    }
+
+    @Override
+    public List<T> findAll(int offset, int limit) {
+        Bundle bundle = fhirClient.search(resourceType, offset, limit);
+        List<T> results = new ArrayList<>();
+        if (bundle.hasEntry()) {
+            for (Bundle.BundleEntryComponent entry : bundle.getEntry()) {
+                if (resourceType.isInstance(entry.getResource())) {
+                    results.add(mapper.fromFhir(resourceType.cast(entry.getResource())));
+                }
+            }
+        }
+        return results;
+    }
+
+    @Override
+    public T save(T entity) {
+        R resource = mapper.toFhir(entity);
+        R saved = fhirClient.createOrUpdate(resource);
+        return mapper.fromFhir(saved);
+    }
+
+    @Override
+    public boolean delete(ID id) {
+        return fhirClient.delete(resourceType, String.valueOf(id));
+    }
+
+    @Override
+    public long count() {
+        Bundle bundle = fhirClient.search(resourceType, 0, 0);
+        return bundle.getTotal();
+    }
+}

--- a/src/main/java/io/github/carlos_emr/carlos/fhir/repository/JpaClinicalRepository.java
+++ b/src/main/java/io/github/carlos_emr/carlos/fhir/repository/JpaClinicalRepository.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2026. CARLOS EMR Project.
+ * https://github.com/carlos-emr/carlos
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ */
+package io.github.carlos_emr.carlos.fhir.repository;
+
+import io.github.carlos_emr.carlos.commn.dao.AbstractDao;
+import io.github.carlos_emr.carlos.commn.model.AbstractModel;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * {@link ClinicalRepository} implementation that delegates to an existing
+ * Hibernate/JPA {@link AbstractDao}. This preserves the current MySQL-backed
+ * behavior and serves as the baseline during migration.
+ *
+ * <p>Usage example:</p>
+ * <pre>{@code
+ * AbstractDao<Demographic> demographicDao = SpringUtils.getBean(DemographicDao.class);
+ * ClinicalRepository<Demographic, Integer> repo = new JpaClinicalRepository<>(demographicDao);
+ * }</pre>
+ *
+ * @param <T>  the domain entity type (must extend {@link AbstractModel})
+ * @param <ID> the entity identifier type
+ * @since 2026-04-02
+ */
+public class JpaClinicalRepository<T extends AbstractModel<ID>, ID> implements ClinicalRepository<T, ID> {
+
+    private final AbstractDao<T> dao;
+
+    /**
+     * Creates a JPA-backed clinical repository wrapping an existing DAO.
+     *
+     * @param dao the existing Hibernate DAO to delegate to
+     */
+    public JpaClinicalRepository(AbstractDao<T> dao) {
+        this.dao = dao;
+    }
+
+    @Override
+    public Optional<T> findById(ID id) {
+        T entity = dao.find(id);
+        return Optional.ofNullable(entity);
+    }
+
+    @Override
+    public List<T> findAll(int offset, int limit) {
+        return dao.findAll(offset, limit);
+    }
+
+    @Override
+    public T save(T entity) {
+        return dao.saveEntity(entity);
+    }
+
+    @Override
+    public boolean delete(ID id) {
+        return dao.remove(id);
+    }
+
+    @Override
+    public long count() {
+        return dao.getCountAll();
+    }
+}


### PR DESCRIPTION
## Description

This PR establishes the foundational infrastructure for migrating CARLOS EMR's clinical data store from MySQL/Hibernate to a self-hosted Medplum FHIR R4 server, with zero production impact in Phase 0.

### What's Included

**Infrastructure**
- Self-hosted Medplum FHIR R4 server in devcontainer (port 8103) with PostgreSQL backing store and Redis cache
- HAPI FHIR R4 client dependency (upgraded from DSTU3)

**Core Abstractions**
- `ClinicalRepository<T, ID>` interface: decouples managers from storage implementation
- `JpaClinicalRepository`: wraps existing Hibernate DAOs (preserves current behavior)
- `FhirClinicalRepository`: delegates to Medplum via HAPI FHIR client
- `DualWriteClinicalRepository`: writes to both MySQL and Medplum simultaneously, reads from configurable source
- `FhirResourceMapper<T, R>`: bidirectional entity↔FHIR resource conversion interface
- `MedplumFhirClient`: wrapper around HAPI FHIR generic client with CARLOS-specific defaults

**Documentation**
- Comprehensive migration plan (`docs/medplum-fhir-migration-plan.md`):
  - Entity classification (Tier 1: 60 direct FHIR mappings, Tier 2: 25 Canadian healthcare extensions, Tier 3: 140 entities staying in MySQL)
  - 5-phase implementation roadmap (Phase 0–5)
  - Architecture diagrams (current vs. target state)
  - DSTU3→R4 migration guidance
  - Risk assessment and success metrics

### Why This Matters

- **Standards-based**: Replaces 373 custom DAOs with FHIR R4 REST API
- **No vendor lock-in**: Open-source Medplum (Apache 2.0), self-hosted
- **Gradual migration**: Repository abstraction enables per-entity dual-write→read-switch cycle
- **Canadian healthcare ready**: Supports custom profiles, extensions, and provincial billing
- **Zero risk in Phase 0**: All existing behavior unchanged; new infrastructure is isolated

### What Stays in MySQL

Security, audit, program management, app config, billing internals, and ~140 non-clinical entities remain in MySQL. Only clinical data (Patient, Practitioner, Medications, Labs, Immunizations, etc.) migrates to FHIR.

## Related Issues

Foundational work for MySQL→Medplum FHIR R4 migration initiative.

## How Was This Tested?

- Devcontainer docker-compose configuration validated for service startup and health checks
- HAPI FHIR R4 client dependency added to pom.xml (no breaking changes to existing DSTU3 code)
- Repository abstraction interfaces are pure Java with no external dependencies
- No existing tests affected; Phase 0 is infrastructure-only with zero production impact

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have not included any patient data (PHI) in this PR
- [x] No new tests required for Phase 0 (infrastructure setup); integration tests will be added in Phase 1
- [x] I have read the [contributing guide](CONTRIBUTING.md)

https://claude.ai/code/session_01526gFcUYSv7LFNnJCLf9bX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added FHIR R4 support infrastructure with Medplum server integration, PostgreSQL, and Redis in the development environment
  * Implemented dual-write capability to support gradual migration of clinical data between systems
  * Added abstraction layer for clinical data access supporting multiple storage backends

* **Documentation**
  * Added comprehensive FHIR migration strategy documentation outlining phased implementation approach and target architecture

<!-- end of auto-generated comment: release notes by coderabbit.ai -->