### PR TITLE
[Fix] 841 inboxhub doesn't refreash

### DIFF
--- a/src/main/webapp/lab/CA/ALL/labDisplay.jsp
+++ b/src/main/webapp/lab/CA/ALL/labDisplay.jsp
@@ -93,8 +93,8 @@
 <%@ page import="com.fasterxml.jackson.databind.ObjectMapper" %>
 <%@ page import="com.fasterxml.jackson.databind.node.ArrayNode" %>
 <%@ page import="com.fasterxml.jackson.databind.node.ObjectNode" %>
-<%@ page import="io.github.carlos_emr.MyDateFormat" %>
 <%@ page import="io.github.carlos_emr.CarlosProperties" %>
+<%@ page import="io.github.carlos_emr.MyDateFormat" %>
 <%@ page import="io.github.carlos_emr.carlos.casemgmt.model.CaseManagementNote" %>
 <%@ page import="io.github.carlos_emr.carlos.casemgmt.model.CaseManagementNoteLink" %>
 <%@ page import="io.github.carlos_emr.carlos.casemgmt.service.CaseManagementManager" %>
@@ -140,7 +140,6 @@
 <%@ page import="org.apache.commons.lang3.builder.ReflectionToStringBuilder" %>
 <%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="org.w3c.dom.Document" %>
-
 <jsp:useBean id="oscarVariables" class="java.util.Properties" scope="session"/>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>

--- a/src/main/webapp/web/inboxhub/InboxhubListMode.jsp
+++ b/src/main/webapp/web/inboxhub/InboxhubListMode.jsp
@@ -56,7 +56,7 @@
 </c:if>
             <c:if test="${page ge 1}">
             <c:forEach var="labResult" items="${labDocs}" varStatus="loopStatus">
-                <tr id="labdoc_${labResult.segmentID}" class="${!labResult.isMatchedToPatient() ? 'table-warning' : (labResult.resultStatus == 'A' ? 'table-danger' : '')}">
+                <tr id="labdoc_${labResult.segmentID}" data-lab-type="${labResult.labType}" class="${!labResult.isMatchedToPatient() ? 'table-warning' : (labResult.resultStatus == 'A' ? 'table-danger' : '')}">
                     <td>
                         <c:set var="disabled" value="${!labResult.matchedToPatient && labResult.labType != 'DOC' ? 'disabled' : ''}"/>
                         <input type="checkbox" name="flaggedLabs" value="${labResult.segmentID}:${labResult.labType}" ${disabled}>
@@ -218,7 +218,14 @@
     function removeReport(reportId) {
         const rowEl = jQuery("#labdoc_" + reportId);
         if (rowEl.length > 0) {
+            const labType = rowEl.data('labType');
             jQuery('#inbox_table').DataTable().row(rowEl).remove().draw(false);
+            const countStatId = labType === 'DOC' ? 'totalDocsCountStat' :
+                                labType === 'HRM' ? 'totalHRMsCountStat' : 'totalLabssCountStat';
+            const current = parseInt(jQuery('#' + countStatId).text()) || 0;
+            if (current > 0) {
+                jQuery('#' + countStatId).text(current - 1);
+            }
         }
     }
 </script>


### PR DESCRIPTION
<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description
Fix.  In list view when a report is acknowledged the parent provider inboxhub doesn't refreash the badge count nor does the datatables row get removed from view
<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues
Fixes #841 
<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?
Demo data on manual install
<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed reports now correctly update the visible per-type counters (HRM, labs, etc.), preventing negative values and ensuring badges reflect current totals.

* **Chores**
  * Minor internal cleanup with no user-facing impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->