### PR TITLE
Fix: CreateMessage.jsp i18n breakage

### DIFF
--- a/src/main/resources/oscarResources_en.properties
+++ b/src/main/resources/oscarResources_en.properties
@@ -4787,6 +4787,7 @@ messenger.CreateMessage.btnPasteToEchart=Paste to EChart
 messenger.CreateMessage.archiveFailed=Archive failed. The message will be sent without archiving.
 messenger.CreateMessage.archiveError=Archive request failed. The message will be sent without archiving.
 messenger.CreateMessage.archiveTimeout=Archive timed out. The message will be sent without archiving.
+messenger.CreateMessage.msgSelectDemographic=Please select a demographic.
 messenger.CreateMessage.btnOpenInOscarMsg=Open in Msg
 
 

--- a/src/main/resources/oscarResources_fr.properties
+++ b/src/main/resources/oscarResources_fr.properties
@@ -3498,6 +3498,7 @@ messenger.CreateMessage.btnPasteToEchart=Coller au Dossier Clinique
 messenger.CreateMessage.archiveFailed=L'archivage a \u00e9chou\u00e9. Le message sera envoy\u00e9 sans archivage.
 messenger.CreateMessage.archiveError=La demande d'archivage a \u00e9chou\u00e9. Le message sera envoy\u00e9 sans archivage.
 messenger.CreateMessage.archiveTimeout=D\u00e9lai d'archivage d\u00e9pass\u00e9. Le message sera envoy\u00e9 sans archivage.
+messenger.CreateMessage.msgSelectDemographic=Veuillez s\u00e9lectionner un patient.
 
 messenger.SentMessage.title=Message envoy\u00e9
 messenger.SentMessage.msgMessenger=Messagerie

--- a/src/main/webapp/messenger/CreateMessage.jsp
+++ b/src/main/webapp/messenger/CreateMessage.jsp
@@ -356,16 +356,16 @@ function validateFields() {
 				document.forms[0].submit();
 			} else {
 				showAlert(msgArchiveFailed, 'warning');
-				document.forms[0].submit();
+				setTimeout(function() { document.forms[0].submit(); }, 2500);
 			}
 		};
 		oRequest.onerror = function() {
 			showAlert(msgArchiveError, 'danger');
-			document.forms[0].submit();
+			setTimeout(function() { document.forms[0].submit(); }, 2500);
 		};
 		oRequest.ontimeout = function() {
 			showAlert(msgArchiveTimeout, 'warning');
-			document.forms[0].submit();
+			setTimeout(function() { document.forms[0].submit(); }, 2500);
 		};
 		oRequest.send('btnDelete=archive&messageNo=' + encodeURIComponent(messageNo));
 	}

--- a/src/main/webapp/messenger/CreateMessage.jsp
+++ b/src/main/webapp/messenger/CreateMessage.jsp
@@ -80,8 +80,6 @@
 --%>
 
 <%@ page import="io.github.carlos_emr.carlos.utility.LoggedInInfo" %>
-<%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
-
 
 <%@ page import="org.w3c.dom.*" %>
 <%@ page import="io.github.carlos_emr.carlos.messenger.util.Msgxml" %>
@@ -102,6 +100,8 @@
 <%@ page import="java.util.ResourceBundle" %>
 <%@ page import="org.owasp.encoder.Encode" %>
 
+<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
+<%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <fmt:setBundle basename="oscarResources"/>
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>

--- a/src/main/webapp/messenger/CreateMessage.jsp
+++ b/src/main/webapp/messenger/CreateMessage.jsp
@@ -222,6 +222,7 @@
     <%-- global.css: CARLOS color overrides for Bootstrap (messenger pages don't use global-head.jspf) --%>
     <link rel="stylesheet" href="<%=request.getContextPath() %>/share/css/global.css">
     <link href="<%=request.getContextPath() %>/css/fontawesome-all.min.css" rel="stylesheet"><!-- fontawesome 6.x -->
+    <script src="<%=request.getContextPath() %>/library/bootstrap/5.3.3/js/bootstrap.bundle.min.js"></script>
 
     <style>
         .toastui-editor-contents{
@@ -229,8 +230,45 @@
         }
     </style>
 
+<%-- Extract i18n alert messages into page-scope variables so they can be safely encoded for JavaScript --%>
+<fmt:message key="messenger.CreateMessage.msgEmptyMessage" var="msg_EmptyMessage"/>
+<fmt:message key="messenger.CreateMessage.msgNoProvider" var="msg_NoProvider"/>
+<fmt:message key="messenger.CreateMessage.archiveFailed" var="msg_ArchiveFailed"/>
+<fmt:message key="messenger.CreateMessage.archiveError" var="msg_ArchiveError"/>
+<fmt:message key="messenger.CreateMessage.archiveTimeout" var="msg_ArchiveTimeout"/>
+<fmt:message key="messenger.CreateMessage.msgSelectDemographic" var="msg_SelectDemographic"/>
+
 <script>
 
+// Encoded i18n strings for use in JavaScript — single quotes in French translations
+// (e.g. "n'a", "L'archivage") are safely escaped by forJavaScript()
+var msgEmptyMessage     = '${e:forJavaScript(msg_EmptyMessage)}';
+var msgNoProvider       = '${e:forJavaScript(msg_NoProvider)}';
+var msgArchiveFailed    = '${e:forJavaScript(msg_ArchiveFailed)}';
+var msgArchiveError     = '${e:forJavaScript(msg_ArchiveError)}';
+var msgArchiveTimeout   = '${e:forJavaScript(msg_ArchiveTimeout)}';
+var msgSelectDemographic = '${e:forJavaScript(msg_SelectDemographic)}';
+
+// Displays a dismissable Bootstrap alert in the fixed alert container at the top of the page.
+// type: Bootstrap contextual class ('warning', 'danger', 'info', 'success')
+function showAlert(message, type) {
+    type = type || 'warning';
+    var container = document.getElementById('msg-alert-container');
+    var alertDiv = document.createElement('div');
+    alertDiv.className = 'alert alert-' + type + ' alert-dismissible fade show';
+    alertDiv.role = 'alert';
+    var closeBtn = document.createElement('button');
+    closeBtn.type = 'button';
+    closeBtn.className = 'btn-close';
+    closeBtn.setAttribute('data-bs-dismiss', 'alert');
+    closeBtn.setAttribute('aria-label', 'Close');
+    var msgSpan = document.createElement('span');
+    msgSpan.textContent = message;
+    alertDiv.appendChild(msgSpan);
+    alertDiv.appendChild(closeBtn);
+    container.appendChild(alertDiv);
+    container.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+}
 
 // Toggles all provider checkboxes within a group when the group header checkbox is clicked
 function checkGroup(group) {
@@ -253,13 +291,13 @@ function validateFields() {
     }
     // Check if message body is empty
     if (document.forms[0].message.value.length === 0) {
-        alert('<fmt:message key="messenger.CreateMessage.msgEmptyMessage"/>');
+        showAlert(msgEmptyMessage, 'warning');
         return false;
     }
     // Validate check boxes
     var val = validateCheckBoxes(document.forms[0]);
     if (val === "0") {
-        alert('<fmt:message key="messenger.CreateMessage.msgNoProvider"/>');
+        showAlert(msgNoProvider, 'warning');
         return false;
     }
     return true;
@@ -277,10 +315,6 @@ function validateFields() {
 	    if (boxes[i].checked) return "1";
 	  return "0";
 	}
-
-	var msgArchiveFailed = '<fmt:message key="messenger.CreateMessage.archiveFailed"/>';
-	var msgArchiveError = '<fmt:message key="messenger.CreateMessage.archiveError"/>';
-	var msgArchiveTimeout = '<fmt:message key="messenger.CreateMessage.archiveTimeout"/>';
 
 	// Archives the current message via XHR before submitting the compose form.
 	// Includes CSRF token and 10-second timeout. On failure or timeout, still submits
@@ -321,16 +355,16 @@ function validateFields() {
 			if (oRequest.status >= 200 && oRequest.status < 300) {
 				document.forms[0].submit();
 			} else {
-				alert(msgArchiveFailed);
+				showAlert(msgArchiveFailed, 'warning');
 				document.forms[0].submit();
 			}
 		};
 		oRequest.onerror = function() {
-			alert(msgArchiveError);
+			showAlert(msgArchiveError, 'danger');
 			document.forms[0].submit();
 		};
 		oRequest.ontimeout = function() {
-			alert(msgArchiveTimeout);
+			showAlert(msgArchiveTimeout, 'warning');
 			document.forms[0].submit();
 		};
 		oRequest.send('btnDelete=archive&messageNo=' + encodeURIComponent(messageNo));
@@ -344,7 +378,7 @@ function validateFields() {
 	    var page = 'attachmentFrameset.jsp?demographic_no=' +demographic;
 
 	    if ( demographic == "" || !demographic || demographic == "null") {
-	        alert("Please select a demographic.");
+	        showAlert(msgSelectDemographic, 'warning');
 	    }
 	    else {
 	        var popUp=window.open(page, "msgAttachDemo", windowprops);
@@ -369,7 +403,7 @@ function validateFields() {
 		var submissionerror = '<%= Encode.forJavaScript(createMsgError) %>';
 		if(submissionerror)
 		{
-			alert(submissionerror);
+			showAlert(submissionerror, 'danger');
 		}
 
         document.getElementsByName("message")[0].setAttribute("style", "display:none;");
@@ -389,6 +423,8 @@ function validateFields() {
 </script>
 </head>
 <body>
+<%-- Dismissable Bootstrap alert container — alerts from showAlert() are appended here --%>
+<div id="msg-alert-container" style="position:sticky; top:0; z-index:1050; padding:0 0.5rem;"></div>
 <table style="width:100%;">
     <tr>
         <td style="vertical-align:top">


### PR DESCRIPTION
<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description

<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues

<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?

<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Integrate OWASP encoder tag library into the CreateMessage JSP to support safer output encoding and tidy up taglib declarations.

Enhancements:
- Add OWASP encoder Jakarta tag library to the CreateMessage JSP for standardized encoded output handling.
- Reorganize JSP taglib declarations in CreateMessage.jsp to keep formatting and resource tags grouped coherently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced blocking popup alerts with dismissible, sticky in-page alerts and improved notification behavior (non-blocking, auto-scroll into view).
  * Added localized, safely encoded alert messages for UI text.

* **Bug Fixes**
  * Enforced demographic selection validation before creating a message.
  * On archive failures/timeouts, show non-blocking alert and defer submission rather than blocking the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->