### PR TITLE
chore: remove 31 Struts action results pointing to non-existent JSP files

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/web/ClientManager2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/web/ClientManager2Action.java
@@ -27,7 +27,6 @@
 
 package io.github.carlos_emr.carlos.PMmodule.web;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
@@ -351,18 +350,6 @@ public class ClientManager2Action extends ActionSupport {
         setEditAttributes(request, id);
 
         LogAction.log("read", "pmm client record", id, request);
-
-        String roles = (String) request.getSession().getAttribute("userrole");
-
-        // for Vaccine Provider
-        if (roles.indexOf("Vaccine Provider") != -1) {
-            try {
-                response.sendRedirect(request.getContextPath() + "/VaccineProviderReport.do?id=" + id);
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-            return null;
-        }
 
         Demographic demographic = clientManager.getClientByDemographicNo(id);
         request.getSession().setAttribute("clientGender", demographic.getSex());

--- a/src/main/java/io/github/carlos_emr/carlos/eform/EFormAttachDocs2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/eform/EFormAttachDocs2Action.java
@@ -68,7 +68,7 @@ public class EFormAttachDocs2Action
         String provNo = providerNo;
 
         if (StringUtils.isEmpty(requestId)) {
-            writeOkResponse();
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Missing requestId");
             return null;
         }
         if (!CarlosProperties.getInstance().isPropertyActive("consultation_indivica_attachment_enabled")) {

--- a/src/main/java/io/github/carlos_emr/carlos/eform/EFormAttachDocs2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/eform/EFormAttachDocs2Action.java
@@ -68,7 +68,8 @@ public class EFormAttachDocs2Action
         String provNo = providerNo;
 
         if (StringUtils.isEmpty(requestId)) {
-            return SUCCESS;
+            writeOkResponse();
+            return null;
         }
         if (!CarlosProperties.getInstance().isPropertyActive("consultation_indivica_attachment_enabled")) {
             String[] arrDocs = attachedDocs;
@@ -84,7 +85,6 @@ public class EFormAttachDocs2Action
 
             EFormAttachEForms eForms = new EFormAttachEForms(provNo, demoNo, requestId, arrDocs);
             eForms.attach(loggedInInfo);
-            return SUCCESS;
         } else {
             String[] labs = request.getParameterValues("labNo");
             String[] docs = request.getParameterValues("docNo");
@@ -113,8 +113,15 @@ public class EFormAttachDocs2Action
             hrmReports.attach();
             EFormAttachEForms eForms = new EFormAttachEForms(provNo, demoNo, requestId, eFormIds);
             eForms.attach(loggedInInfo);
-            return SUCCESS;
         }
+        writeOkResponse();
+        return null;
+    }
+
+    private void writeOkResponse() throws IOException {
+        response.setContentType("text/plain");
+        response.getWriter().write("ok");
+        response.getWriter().flush();
     }
 
     private String requestId;

--- a/src/main/webapp/WEB-INF/classes/struts-admin.xml
+++ b/src/main/webapp/WEB-INF/classes/struts-admin.xml
@@ -50,18 +50,6 @@
             <result name="list">/caisicore/issueAdminList.jsp</result>
             <result name="edit">/caisicore/issueAdminForm.jsp</result>
         </action>
-        <action name="Lookup/LookupList" class="io.github.carlos_emr.carlos.www.lookup.LookupList2Action" method="execute">
-            <result name="list">/PMmodule/lookup/LookupList.jsp</result>
-        </action>
-        <action name="Lookup/LookupTableList" class="io.github.carlos_emr.carlos.www.lookup.LookupTableList2Action" method="execute">
-            <result name="list">/PMmodule/lookup/LookupTableList.jsp</result>
-        </action>
-        <action name="Lookup/LookupCodeList" class="io.github.carlos_emr.carlos.www.lookup.LookupCodeList2Action" method="execute">
-            <result name="list">/PMmodule/lookup/LookupCodeList.jsp</result>
-        </action>
-        <action name="Lookup/LookupCodeEdit" class="io.github.carlos_emr.carlos.www.lookup.LookupCodeEdit2Action" method="execute">
-            <result name="edit">/PMmodule/lookup/LookupCodeEdit.jsp</result>
-        </action>
         <action name="admin/GenerateTraceAction" class="io.github.carlos_emr.carlos.admin.traceability.GenerateTrace2Action"/>
         <action name="admin/GenerateTraceabilityReportAction" class="io.github.carlos_emr.carlos.admin.traceability.GenerateTraceabilityReport2Action">
             <interceptor-ref name="defaultStack"/>

--- a/src/main/webapp/WEB-INF/classes/struts-clinical.xml
+++ b/src/main/webapp/WEB-INF/classes/struts-clinical.xml
@@ -88,7 +88,6 @@
             <result name="clientNeverInTheProgramError">/casemgmt/clientNeverInTheProgramError.jsp</result>
             <result name="unlockForm">/casemgmt/unlockNoteForm.jsp</result>
             <result name="unlockSuccess">/casemgmt/unlockNoteSuccess.jsp</result>
-            <result name="unlockError">/casemgmt/unlockNoteError.jsp</result>
             <result name="unlock_ajax">/casemgmt/unlockAjax.jsp</result>
             <result name="expired">/casemgmt/expired.jsp</result>
             <result name="listNotes">/casemgmt/viewNotes.jsp</result>
@@ -108,7 +107,6 @@
             <result name="windowCloseError">/casemgmt/closeWithError.jsp</result>
             <result name="historyview">/casemgmt/historyview.jsp</result>
             <result name="showHistory">/casemgmt/showHistory.jsp</result>
-            <result name="issueAutoCompletion">/casemgmt/IssueList.jsp</result>
             <result name="issueList_ajax">/casemgmt/noteIssueList.jsp</result>
             <result name="expired">/casemgmt/expired.jsp</result>
         </action>

--- a/src/main/webapp/WEB-INF/classes/struts-document.xml
+++ b/src/main/webapp/WEB-INF/classes/struts-document.xml
@@ -91,7 +91,6 @@
             <result name="failed">/documentManager/addedithtmldocument.jsp</result>
         </action>
         <action name="documentManager/ManageDocument" class="io.github.carlos_emr.carlos.documentManager.actions.ManageDocument2Action">
-            <result name="success">/documentManager/undocument.jsp</result>
             <result name="displaySingleDoc">/documentManager/MultiPageDocDisplay.jsp</result>
             <result name="nextIncomingDoc">/documentManager/incomingDocs.jsp</result>
             <result name="error">/failure.jsp</result>

--- a/src/main/webapp/WEB-INF/classes/struts-eform.xml
+++ b/src/main/webapp/WEB-INF/classes/struts-eform.xml
@@ -29,7 +29,6 @@
     <package name="eform" namespace="/" extends="struts-default">
 
         <action name="eform/attachDoc" class="io.github.carlos_emr.carlos.eform.EFormAttachDocs2Action">
-            <result name="success">/encounter/oscarConsultationRequest/attachSuccessfull.jsp</result>
         </action>
         <action name="eform/logEformError" class="io.github.carlos_emr.carlos.eform.EformLogError2Action"/>
         <action name="eform/uploadHtml" class="io.github.carlos_emr.carlos.eform.upload.HtmlUpload2Action">
@@ -73,7 +72,6 @@
             <result name="independent">/eform/efmmanageindependentdeleted.jsp</result>
         </action>
         <action name="eform/eFormAttachmentForm" class="io.github.carlos_emr.carlos.eform.upload.UploadEFormAttachment2Action">
-            <result name="success">/eform/eformupload.jsp</result>
         </action>
         <action name="eform/deleteImage" class="io.github.carlos_emr.carlos.eform.actions.DelImage2Action">
             <result name="success">/eform/efmimagemanager.jsp</result>

--- a/src/main/webapp/WEB-INF/classes/struts-encounter.xml
+++ b/src/main/webapp/WEB-INF/classes/struts-encounter.xml
@@ -419,8 +419,6 @@
             <result name="success">/encounter/oscarConsultationRequest/ConfirmConsultationRequest.jsp</result>
             <result name="error">/encounter/ViewRequest.do?error=true</result>
             <result name="failESend">/encounter/ViewRequest.do</result>
-            <result name="print">/encounter/oscarConsultationRequest/ConsultationFormPrint.jsp</result>
-            <result name="printalt">/encounter/oscarConsultationRequest/ConsultationFormPrint2.jsp</result>
             <result name="printpdf">/encounter/oscarConsultationRequest/printPdf.do</result>
             <result name="printIndivica">/encounter/oscarConsultationRequest/printPdf2.do</result>
             <result name="fax">/fax/CoverPage.jsp</result>
@@ -487,14 +485,6 @@
         <action name="encounter/InsertTemplate" class="io.github.carlos_emr.carlos.encounter.pageUtil.EctInsertTemplate2Action">
             <result name="success">/encounter/InsertTemplate.jsp</result>
             <result name="success2">/encounter/InsertTemplate2.jsp</result>
-        </action>
-        <action name="CreateImmunizationSetConfig" class="io.github.carlos_emr.carlos.encounter.immunization.config.pageUtil.EctImmCreateImmunizationSetConfig2Action">
-            <result name="success">/immunizationConfig/AdministrateImmunizationSets.jsp</result>
-            <result name="goBack">/immunizationConfig/CreateImmunizationSetConfig.jsp</result>
-        </action>
-
-        <action name="ImmunizationSetDisplay" class="io.github.carlos_emr.carlos.encounter.immunization.config.pageUtil.EctImmImmunizationSetDisplay2Action">
-            <result name="success">/immunizationConfig/ImmunizationSetDisplay.jsp</result>
         </action>
         <action name="encounter/immunization/deleteSchedule" class="io.github.carlos_emr.carlos.encounter.immunization.pageUtil.EctImmDeleteImmSchedule2Action">
             <result name="success">/encounter/immunization/Schedule.jsp</result>

--- a/src/main/webapp/WEB-INF/classes/struts-form.xml
+++ b/src/main/webapp/WEB-INF/classes/struts-form.xml
@@ -75,7 +75,6 @@
         </action>
         <action name="form/formname" class="io.github.carlos_emr.carlos.form.Frm2Action">
             <result name="exit">/encounter/close.jsp</result>
-            <result name="print">/form/forwardprint.jsp</result>
             <result name="printAll">/form/createpdf</result>
             <result name="printAllJasperReport">/form/formPdfJasperReport.do</result>
             <result name="printLabReq">/form/formlabreqprint.jsp</result>
@@ -91,9 +90,6 @@
         </action>
         <action name="form/AddRHWorkFlow" class="io.github.carlos_emr.carlos.form.pageUtil.FrmFormAddRHWorkFlow2Action">
             <result name="success">/form/RHPrevention.do</result>
-        </action>
-        <action name="VaccineProviderReport" class="io.github.carlos_emr.carlos.vaccine.VaccineProviderReport2Action" method="execute">
-            <result name="report">/PMmodule/vaccine/vaccine_provider_report.jsp</result>
         </action>
         <action name="form/BCAR2020" class="io.github.carlos_emr.carlos.form.FrmBCAR20202Action">
             <result name="pg1">/form/formBCAR2020pg1.jsp</result>

--- a/src/main/webapp/WEB-INF/classes/struts-form.xml
+++ b/src/main/webapp/WEB-INF/classes/struts-form.xml
@@ -78,6 +78,7 @@
             <result name="printAll">/form/createpdf</result>
             <result name="printAllJasperReport">/form/formPdfJasperReport.do</result>
             <result name="printLabReq">/form/formlabreqprint.jsp</result>
+            <result name="print">/errorpage.jsp</result>
             <result name="save">/form/forwardname.jsp</result>
             <result name="graph">/form/createpdf</result>
             <result name="failure">/errorpage.jsp</result>

--- a/src/main/webapp/WEB-INF/classes/struts-messenger.xml
+++ b/src/main/webapp/WEB-INF/classes/struts-messenger.xml
@@ -52,7 +52,6 @@
         <action name="messenger/ViewMessage" class="io.github.carlos_emr.carlos.messenger.pageUtil.MsgViewMessage2Action">
             <result name="noRights">/messenger/DisplayMessages.jsp</result>
             <result name="success">/messenger/ViewMessage.jsp</result>
-            <result name="viewFromEncounter">/messenger/ViewMessageFromEncounter.jsp</result>
         </action>
         <!-- DEPRECATED: This action is used by the legacy encounter page (encounter/Index.jsp) -->
         <action name="messenger/ViewMessageByPosition" class="io.github.carlos_emr.carlos.messenger.pageUtil.MsgViewMessageByPosition2Action">

--- a/src/main/webapp/WEB-INF/classes/struts-pmmodule.xml
+++ b/src/main/webapp/WEB-INF/classes/struts-pmmodule.xml
@@ -80,7 +80,6 @@
             <result name="edit">page.pmm.client</result>
             <result name="refer_vacancy">page.pmm.client.vacancy</result>
             <result name="edit-redirect">page.pmm.client</result>
-            <result name="vaccine-report">/VaccineProviderReport.do</result>
             <result name="search">/PMmodule/ClientSearch2.do</result>
             <result name="service_restriction_error">page.pmm.client.service_restriction_error</result>
         </action>

--- a/src/main/webapp/WEB-INF/classes/struts-pmmodule.xml
+++ b/src/main/webapp/WEB-INF/classes/struts-pmmodule.xml
@@ -57,7 +57,6 @@
         <action name="PMmodule/ProgramManager" class="io.github.carlos_emr.carlos.PMmodule.web.admin.ProgramManager2Action" method="execute">
             <result name="list">page.pmm.admin.list</result>
             <result name="edit">page.pmm.admin.edit</result>
-            <result name="timeout">/PMmodule/Timeout.jsp</result>
             <result name="programSignatures">/PMmodule/Admin/ProgramSignatures.jsp</result>
         </action>
 
@@ -81,14 +80,9 @@
             <result name="edit">page.pmm.client</result>
             <result name="refer_vacancy">page.pmm.client.vacancy</result>
             <result name="edit-redirect">page.pmm.client</result>
-            <result name="search_programs">/PMmodule/ClientManager/ProgramSearch.jsp</result>
             <result name="vaccine-report">/VaccineProviderReport.do</result>
             <result name="search">/PMmodule/ClientSearch2.do</result>
-            <result name="links">/PMmodule/ClientManager/links.jsp</result>
-            <result name="view_referral">/PMmodule/ClientManager/view_referral.jsp</result>
-            <result name="view_admission">/PMmodule/ClientManager/view_admission.jsp</result>
             <result name="service_restriction_error">page.pmm.client.service_restriction_error</result>
-            <result name="generalFormsReport">/PMmodule/GeneralFormsReport.jsp</result>
         </action>
         <action name="PMmodule/ProviderInfo" class="io.github.carlos_emr.carlos.PMmodule.web.ProviderInfo2Action" method="execute">
             <result name="view">page.pmm.provider.view</result>
@@ -98,10 +92,6 @@
             <result name="edit">page.pmm.staff.edit</result>
         </action>
 
-        <action name="PMmodule/Reports/ProgramActivityReport" class="io.github.carlos_emr.carlos.PMmodule.web.reports.ActivityReport2Action" method="execute">
-            <result name="form">/PMmodule/reports/ActivityReportForm.jsp</result>
-            <result name="report">/PMmodule/reports/ActivityReport.jsp</result>
-        </action>
 
 
     </package>

--- a/src/main/webapp/WEB-INF/classes/struts-provider.xml
+++ b/src/main/webapp/WEB-INF/classes/struts-provider.xml
@@ -36,7 +36,6 @@
             <result name="error">/failure.jsp</result>
         </action>
         <action name="admin/ManageFax" class="io.github.carlos_emr.carlos.fax.admin.ConfigureFax2Action">
-            <result name="completed">/admin/manageFax.jsp</result>
         </action>
         <action name="admin/ManageFaxes" class="io.github.carlos_emr.carlos.fax.admin.ManageFaxes2Action">
             <result name="faxstatus">/admin/faxStatusResults.jspf</result>

--- a/src/main/webapp/WEB-INF/classes/struts-report.xml
+++ b/src/main/webapp/WEB-INF/classes/struts-report.xml
@@ -29,9 +29,6 @@
     <package name="report" namespace="/" extends="struts-default">
 
         <action name="report/printLabDaySheetAction" class="io.github.carlos_emr.carlos.report.pageUtil.printLabDaySheet2Action"/>
-        <action name="oscarReport/ShowConsult" class="io.github.carlos_emr.carlos.report.pageUtil.RptShowConsult2Action">
-            <result name="success">/encounter/oscarConsultationRequest/ConsultationFormPrint.jsp</result>
-        </action>
         <action name="oscarReport/FluBilling" class="io.github.carlos_emr.carlos.report.pageUtil.RptFluBilling2Action">
             <result name="success">/oscarReport/oscarReportFluBilling.jsp</result>
         </action>
@@ -50,7 +47,6 @@
         </action>
         <action name="report/DemographicReport" class="io.github.carlos_emr.carlos.report.pageUtil.RptDemographicReport2Action">
             <result name="success">/oscarReport/ReportDemographicReport.jsp</result>
-            <result name="failure">/oscar_sfhc/JAYREPORTS/DemographicReport.jsp</result>
         </action>
         <action name="report/CreateDemographicSet" class="io.github.carlos_emr.carlos.report.pageUtil.RptCreateDemographicSet2Action">
             <result name="success">/oscarReport/ReportDemographicReport.jsp</result>

--- a/src/main/webapp/WEB-INF/classes/struts-scheduling.xml
+++ b/src/main/webapp/WEB-INF/classes/struts-scheduling.xml
@@ -115,11 +115,6 @@
             <result name="form">/episode/episodeForm.jsp</result>
             <result name="success">/episode/success.jsp</result>
         </action>
-        <action name="Pregnancy" class="io.github.carlos_emr.carlos.commn.web.Pregnancy2Action">
-            <result name="list">/pregnancy/list.jsp</result>
-            <result name="success">/pregnancy/success.jsp</result>
-            <result name="complete">/pregnancy/complete.jsp</result>
-        </action>
         <action name="PageMonitoringService" class="io.github.carlos_emr.carlos.commn.web.PageMonitoring2Action"/>
         <action name="BillingInvoice" class="io.github.carlos_emr.carlos.commn.web.BillingInvoice2Action">
             <result name="success">/billing/CA/ON/billingONCorrection.jsp</result>

--- a/src/main/webapp/admin/admin.jsp
+++ b/src/main/webapp/admin/admin.jsp
@@ -569,7 +569,7 @@
                     </security:oscarSec>
                     <security:oscarSec roleName="<%=roleName$%>"
                                        objectName="_admin.lookupFieldEditor" rights="r">
-                        <li><a href="${pageContext.request.contextPath}/Lookup/LookupTableList.do"> <fmt:setBundle basename="oscarResources"/><fmt:message key="admin.admin.LookupFieldEditor"/></a></li>
+                        <li><a href="${pageContext.request.contextPath}/lookupListManagerAction"> <fmt:setBundle basename="oscarResources"/><fmt:message key="admin.admin.LookupFieldEditor"/></a></li>
                     </security:oscarSec>
                     <security:oscarSec roleName="<%=roleName$%>"
                                        objectName="_admin.issueEditor" rights="r">

--- a/src/main/webapp/administration/leftNav.jspf
+++ b/src/main/webapp/administration/leftNav.jspf
@@ -542,7 +542,7 @@ String curProvider_no = (String)session.getAttribute("user");
 					<security:oscarSec roleName="<%=roleName$%>"
 						objectName="_admin.lookupFieldEditor" rights="r">
 						<li><a href="javascript:void(0);"
-						class="xlink" rel="${ctx}/Lookup/LookupTableList.do"> <fmt:message key="admin.admin.LookupFieldEditor"/></a></li>
+						class="xlink" rel="${ctx}/lookupListManagerAction"> <fmt:message key="admin.admin.LookupFieldEditor"/></a></li>
 					</security:oscarSec>
 					<security:oscarSec roleName="<%=roleName$%>"
 						objectName="_admin.issueEditor" rights="r">


### PR DESCRIPTION
Remove dead result mappings across 11 Struts config files where the
referenced JSP files no longer exist. This includes removing entire
actions where all results were dead (Lookup/*, Pregnancy,
VaccineProviderReport, ProgramActivityReport, immunization config
duplicates, ShowConsult) and removing individual dead results from
actions that retain valid results (CaseManagementView,
CaseManagementEntry, ManageDocument, RequestConsultation,
ClientManager, ProgramManager, ViewMessage, ManageFax, formname,
DemographicReport, attachDoc, eFormAttachmentForm).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified client edit and vaccine-provider flows to a single edit experience.
  * Form attachment now returns direct HTTP responses ("ok" or 400) instead of page redirects.

* **Chores**
  * Removed numerous now-unused page routes and action mappings across admin, clinical, forms, eform, encounter, reporting, scheduling, and PM modules.
  * Updated admin/navigation links for lookup field editing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->