### PR TITLE
1001 bug ontario billing report is not in the reports tab

### DIFF
--- a/src/main/webapp/provider/appointmentprovideradminday.jsp
+++ b/src/main/webapp/provider/appointmentprovideradminday.jsp
@@ -2423,9 +2423,6 @@
                     case <fmt:setBundle basename="oscarResources"/><fmt:message key="global.adminShortcut"/> :
                         newWindow("<%= request.getContextPath() %>/administration/", "admin");
                         return false;  //run code for 'A'dmin
-                    case <fmt:setBundle basename="oscarResources"/><fmt:message key="global.billingShortcut"/> :
-                        popupOscarRx(600, 1024, '<%= request.getContextPath() %>/billing/CA/<%=prov%>/billingReportCenter.jsp?displaymode=billreport&providerview=<%=loggedInInfo1.getLoggedInProviderNo()%>');
-                        return false;  //code for 'B'illing
                     case <fmt:setBundle basename="oscarResources"/><fmt:message key="global.calendarShortcut"/> :
                         popupOscarRx(425, 430, '<%= request.getContextPath() %>/share/CalendarPopup.jsp?urlfrom=<%= request.getContextPath() %>/provider/providercontrol.jsp&year=<%=strYear%>&month=<%=strMonth%>&param=<%=URLEncoder.encode("&view=0&displaymode=day&dboperation=searchappointmentday","UTF-8")%>');
                         return false;  //run code for 'C'alendar

--- a/src/main/webapp/provider/appointmentprovideradminday.jsp
+++ b/src/main/webapp/provider/appointmentprovideradminday.jsp
@@ -1033,19 +1033,6 @@
                                 </security:oscarSec>
                             </caisi:isModuleLoad>
 
-                            <caisi:isModuleLoad moduleName="TORONTO_RFQ" reverse="true">
-                                <oscar:oscarPropertiesCheck property="NOT_FOR_CAISI" value="no" defaultVal="true">
-                                    <c:if test="${billingRights}">
-                                        <li>
-                                            <a HREF="#"
-                                               ONCLICK="popupPage2('<%= request.getContextPath() %>/billing/CA/<%=prov%>/billingReportCenter.jsp?displaymode=billreport&providerview=<%=loggedInInfo1.getLoggedInProviderNo()%>');return false;"
-                                               TITLE='<fmt:setBundle basename="oscarResources"/><fmt:message key="global.genBillReport"/>'
-                                               onMouseOver="window.status='<fmt:setBundle basename="oscarResources"/><fmt:message key="global.genBillReport"/>';return true"><fmt:setBundle basename="oscarResources"/><fmt:message key="global.billing"/></a>
-                                        </li>
-                                    </c:if>
-                                </oscar:oscarPropertiesCheck>
-                            </caisi:isModuleLoad>
-
                             <oscar:oscarPropertiesCheck property="referral_menu" value="yes">
                                 <security:oscarSec roleName="<%=roleName$%>" objectName="_admin,_admin.misc" rights="r">
                                     <li id="ref">

--- a/src/main/webapp/report/reportindex.jsp
+++ b/src/main/webapp/report/reportindex.jsp
@@ -63,15 +63,29 @@
         return;
     }
 %>
-
+<%@ page import="java.util.*" %>
+<%@ page import="java.sql.*" %>
+<%@ page import="java.text.*" %>
+<%@ page import="java.net.*" %>
 <%@ page import="java.nio.charset.StandardCharsets" %>
 <%@ page import="org.apache.commons.lang3.StringUtils" %>
 <%@ page import="org.owasp.encoder.Encode" %>
+<%@ page import="io.github.carlos_emr.*" %>
 <%@ page import="io.github.carlos_emr.carlos.commn.model.ProviderPreference" %>
 <%@ page import="io.github.carlos_emr.carlos.utility.SessionConstants" %>
+<%@ page import="io.github.carlos_emr.carlos.utility.LoggedInInfo" %>
+<%@ page import="io.github.carlos_emr.CarlosProperties" %>
+
+<%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="jakarta.tags.core" prefix="c" %>
+<%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
+<%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%
     String country = request.getLocale().getCountry();
+    CarlosProperties carlosVariables = CarlosProperties.getInstance();
+    String prov = (carlosVariables.getProperty("billregion", "")).trim().toUpperCase();
 
+    LoggedInInfo loggedInInfo1 = LoggedInInfo.getLoggedInInfoFromSession(request);
     ProviderPreference providerPreference = (ProviderPreference) session.getAttribute(SessionConstants.LOGGED_IN_PROVIDER_PREFERENCE);
     String curUser_no = (String) session.getAttribute("user");
     String mygroupno = "";
@@ -81,20 +95,14 @@
     mygroupno = StringUtils.trimToEmpty(mygroupno);
     String billingRegion = (io.github.carlos_emr.CarlosProperties.getInstance()).getProperty("billregion");
 %>
-<%@ page
-        import="java.util.*, io.github.carlos_emr.*, java.sql.*, java.text.*, java.net.*"
-        errorPage="/errorpage.jsp" %>
+
 <jsp:useBean id="reportMainBean" class="io.github.carlos_emr.AppointmentMainBean"
              scope="session"/>
 <% if (!reportMainBean.getBDoConfigure()) { %>
 <%@ include file="reportMainBeanConn.jspf" %>
 <% } %>
 
-<%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
-<%@ taglib uri="jakarta.tags.core" prefix="c" %>
 
-<%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
-<%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 
 <%
     boolean isSiteAccessPrivacy = false;
@@ -274,13 +282,26 @@
                 </td>
                 <td width="1"></td>
                 <td width="300"><a
-                        href="<%= request.getContextPath() %>/oscarPrevention/PreventionReporting.jsp" target="_blank"><fmt:setBundle basename="oscarResources"/><fmt:message key="report.reportindex.btnReport18n"/></a></td>
+                        href="<%= request.getContextPath() %>/oscarPrevention/PreventionReporting.jsp" target="_blank"><fmt:message key="report.reportindex.btnReport18n"/></a></td>
                 <td></td>
                 <td></td>
                 <td></td>
                 <td></td>
             </tr>
-
+            <security:oscarSec roleName="<%=roleName$%>" objectName="_admin" rights="r" reverse="<%=false%>">
+            <tr>
+                <td width="2"><%=j%>
+                    <%j++;%>
+                </td>
+                <td width="1"></td>
+                <td width="300">
+                  <a href="<%= request.getContextPath() %>/billing/CA/<%=prov%>/billingReportCenter.jsp?displaymode=billreport&providerview=<%=loggedInInfo1.getLoggedInProviderNo()%>" target="_blank"><fmt:message key="oscarReport.oscarReportAgeSex.title"/></a></td>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td></td>
+            </tr>
+            </security:oscarSec>
         </table>
     </form>
     </div>

--- a/src/main/webapp/report/reportindex.jsp
+++ b/src/main/webapp/report/reportindex.jsp
@@ -288,7 +288,7 @@
                 <td></td>
                 <td></td>
             </tr>
-            <security:oscarSec roleName="<%=roleName$%>" objectName="_admin" rights="r" reverse="<%=false%>">
+            <security:oscarSec roleName="<%=roleName2$%>" objectName="_admin" rights="r" reverse="<%=false%>">
             <tr>
                 <td width="2"><%=j%>
                     <%j++;%>

--- a/src/main/webapp/report/reportindex.jsp
+++ b/src/main/webapp/report/reportindex.jsp
@@ -63,18 +63,17 @@
         return;
     }
 %>
-<%@ page import="java.util.*" %>
-<%@ page import="java.sql.*" %>
-<%@ page import="java.text.*" %>
-<%@ page import="java.net.*" %>
+<%@ page import="java.net.URLEncoder" %>
 <%@ page import="java.nio.charset.StandardCharsets" %>
+<%@ page import="java.sql.ResultSet" %>
+<%@ page import="java.util.Calendar" %>
+<%@ page import="java.util.GregorianCalendar" %>
 <%@ page import="org.apache.commons.lang3.StringUtils" %>
 <%@ page import="org.owasp.encoder.Encode" %>
-<%@ page import="io.github.carlos_emr.*" %>
-<%@ page import="io.github.carlos_emr.carlos.commn.model.ProviderPreference" %>
-<%@ page import="io.github.carlos_emr.carlos.utility.SessionConstants" %>
-<%@ page import="io.github.carlos_emr.carlos.utility.LoggedInInfo" %>
 <%@ page import="io.github.carlos_emr.CarlosProperties" %>
+<%@ page import="io.github.carlos_emr.carlos.commn.model.ProviderPreference" %>
+<%@ page import="io.github.carlos_emr.carlos.utility.LoggedInInfo" %>
+<%@ page import="io.github.carlos_emr.carlos.utility.SessionConstants" %>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
@@ -93,7 +92,6 @@
         mygroupno = providerPreference.getMyGroupNo();
     }
     mygroupno = StringUtils.trimToEmpty(mygroupno);
-    String billingRegion = (io.github.carlos_emr.CarlosProperties.getInstance()).getProperty("billregion");
 %>
 
 <jsp:useBean id="reportMainBean" class="io.github.carlos_emr.AppointmentMainBean"
@@ -295,7 +293,7 @@
                 </td>
                 <td width="1"></td>
                 <td width="300">
-                  <a href="<%= request.getContextPath() %>/billing/CA/<%=prov%>/billingReportCenter.jsp?displaymode=billreport&providerview=<%=loggedInInfo1.getLoggedInProviderNo()%>" target="_blank"><fmt:message key="oscarReport.oscarReportAgeSex.title"/></a></td>
+                  <a href="<%= request.getContextPath() %>/billing/CA/<%=prov%>/billingReportCenter.jsp?displaymode=billreport&providerview=<%=loggedInInfo1.getLoggedInProviderNo()%>" target="_blank"><fmt:message key="global.genBillReport"/></a></td>
                 <td></td>
                 <td></td>
                 <td></td>

--- a/src/main/webapp/report/reportindex.jsp
+++ b/src/main/webapp/report/reportindex.jsp
@@ -293,7 +293,7 @@
                 </td>
                 <td width="1"></td>
                 <td width="300">
-                  <a href="<%= request.getContextPath() %>/billing/CA/<%=prov%>/billingReportCenter.jsp?displaymode=billreport&providerview=<%=loggedInInfo1.getLoggedInProviderNo()%>" target="_blank"><fmt:message key="global.genBillReport"/></a></td>
+                  <a href="<%= request.getContextPath() %>/billing/CA/<%=prov%>/billingReportCenter.jsp?displaymode=billreport&providerview=<%=URLEncoder.encode(loggedInInfo1.getLoggedInProviderNo(), StandardCharsets.UTF_8)%>" target="_blank"><fmt:message key="global.genBillReport"/></a></td>
                 <td></td>
                 <td></td>
                 <td></td>

--- a/src/main/webapp/report/reportindex.jsp
+++ b/src/main/webapp/report/reportindex.jsp
@@ -288,7 +288,7 @@
                 <td></td>
                 <td></td>
             </tr>
-            <security:oscarSec roleName="<%=roleName2$%>" objectName="_admin" rights="r" reverse="<%=false%>">
+            <security:oscarSec roleName="<%=roleName2$%>" objectName="_admin,_billing" rights="r" reverse="<%=false%>">
             <tr>
                 <td width="2"><%=j%>
                     <%j++;%>

--- a/src/main/webapp/report/reportindex.jsp
+++ b/src/main/webapp/report/reportindex.jsp
@@ -78,7 +78,6 @@
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
-<%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%
     String country = request.getLocale().getCountry();
     CarlosProperties carlosVariables = CarlosProperties.getInstance();
@@ -287,18 +286,20 @@
                 <td></td>
             </tr>
             <security:oscarSec roleName="<%=roleName2$%>" objectName="_admin,_billing" rights="r" reverse="<%=false%>">
+            <% if (StringUtils.isNotBlank(prov)) { %>
             <tr>
                 <td width="2"><%=j%>
                     <%j++;%>
                 </td>
                 <td width="1"></td>
                 <td width="300">
-                  <a href="<%= request.getContextPath() %>/billing/CA/<%=prov%>/billingReportCenter.jsp?displaymode=billreport&providerview=<%=URLEncoder.encode(loggedInInfo1.getLoggedInProviderNo(), StandardCharsets.UTF_8)%>" target="_blank"><fmt:message key="global.genBillReport"/></a></td>
+                  <a href="<%= request.getContextPath() %>/billing/CA/<%=prov%>/billingReportCenter.jsp?displaymode=billreport&amp;providerview=<%=URLEncoder.encode(loggedInInfo1.getLoggedInProviderNo(), StandardCharsets.UTF_8)%>" target="_blank"><fmt:message key="global.genBillReport"/></a></td>
                 <td></td>
                 <td></td>
                 <td></td>
                 <td></td>
             </tr>
+            <% } %>
             </security:oscarSec>
         </table>
     </form>


### PR DESCRIPTION
<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description
generally reports should fly with reports
there can be several ways to get there but there probably is no report special enough to warrant a tab by itself
<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues
Fixes #1001 
<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?

<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots
<img width="1301" height="272" alt="i18nCONFIGURATION DU RAPPPORT" src="https://github.com/user-attachments/assets/418040c8-ccc1-4e10-b10b-df10fcadae70" />

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an inaccessible billing menu entry from the provider appointment admin view.
  * Removed the related Alt-key shortcut that opened that billing page.

* **New Features**
  * Added a permission-guarded billing report link in the reports dashboard, visible only to authorized admin/billing users and passing the current provider context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->