### PR TITLE
fix: refresh Inboxhub after lab acknowledge or HRM sign-off

### DIFF
--- a/src/main/webapp/hospitalReportManager/hrmActions.js
+++ b/src/main/webapp/hospitalReportManager/hrmActions.js
@@ -37,7 +37,20 @@ function doSignOff(reportId, view, isSign) {
         data: data,
         success: function (data) {
             if (view) {
-                self.opener.removeReport(reportId);
+                // Remove the signed-off report from the opener's table if accessible.
+                // window.opener is null when Inboxhub is the opener due to Struts 7's
+                // CoopInterceptor setting Cross-Origin-Opener-Policy: same-origin.
+                if (self.opener && typeof self.opener.removeReport !== 'undefined') {
+                    self.opener.removeReport(reportId);
+                }
+                // Notify the Inboxhub to refresh its data after sign-off.
+                // BroadcastChannel provides reliable same-origin cross-window messaging
+                // that is unaffected by COOP headers.
+                try {
+                    new BroadcastChannel('inboxhub-refresh').postMessage('refresh');
+                } catch (e) {
+                    // BroadcastChannel unsupported — user must manually refresh the inbox
+                }
                 window.close();
             } else {
                 var signOffButton = document.getElementById('signoff' + reportId);

--- a/src/main/webapp/hospitalReportManager/hrmActions.js
+++ b/src/main/webapp/hospitalReportManager/hrmActions.js
@@ -40,14 +40,16 @@ function doSignOff(reportId, view, isSign) {
                 // Remove the signed-off report from the opener's table if accessible.
                 // window.opener is null when Inboxhub is the opener due to Struts 7's
                 // CoopInterceptor setting Cross-Origin-Opener-Policy: same-origin.
-                if (self.opener && typeof self.opener.removeReport !== 'undefined') {
+                if (self.opener && typeof self.opener.removeReport === 'function') {
                     self.opener.removeReport(reportId);
                 }
                 // Notify the Inboxhub to refresh its data after sign-off.
                 // BroadcastChannel provides reliable same-origin cross-window messaging
                 // that is unaffected by COOP headers.
                 try {
-                    new BroadcastChannel('inboxhub-refresh').postMessage('refresh');
+                    const bc = new BroadcastChannel('inboxhub-refresh');
+                    bc.postMessage('refresh');
+                    bc.close();
                 } catch (e) {
                     // BroadcastChannel unsupported — user must manually refresh the inbox
                 }

--- a/src/main/webapp/share/javascript/oscarMDSIndex.js
+++ b/src/main/webapp/share/javascript/oscarMDSIndex.js
@@ -1925,7 +1925,9 @@ function updateStatus(formid) {//acknowledge
                     // which nulls window.opener on popups opened from Inboxhub. BroadcastChannel provides
                     // reliable same-origin cross-window messaging that is unaffected by COOP.
                     try {
-                        new BroadcastChannel('inboxhub-refresh').postMessage('refresh');
+                        const bc = new BroadcastChannel('inboxhub-refresh');
+                        bc.postMessage('refresh');
+                        bc.close();
                     } catch (e) {
                         // BroadcastChannel unsupported — user must manually refresh the inbox
                     }

--- a/src/main/webapp/share/javascript/oscarMDSIndex.js
+++ b/src/main/webapp/share/javascript/oscarMDSIndex.js
@@ -1920,6 +1920,15 @@ function updateStatus(formid) {//acknowledge
 							if (id === doclabid) break;
 						}
                     }
+                    // Notify the Inboxhub to refresh its data after acknowledge.
+                    // Struts 7's CoopInterceptor sets Cross-Origin-Opener-Policy: same-origin on .do responses,
+                    // which nulls window.opener on popups opened from Inboxhub. BroadcastChannel provides
+                    // reliable same-origin cross-window messaging that is unaffected by COOP.
+                    try {
+                        new BroadcastChannel('inboxhub-refresh').postMessage('refresh');
+                    } catch (e) {
+                        // BroadcastChannel unsupported — user must manually refresh the inbox
+                    }
                     window.close();
                 } else {
                     //Hide document

--- a/src/main/webapp/web/inboxhub/InboxhubForm.jsp
+++ b/src/main/webapp/web/inboxhub/InboxhubForm.jsp
@@ -556,6 +556,23 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA
         }
     }
 
+    /**
+     * Listens for refresh requests from lab/HRM popup windows after acknowledge or sign-off.
+     *
+     * Popup windows cannot call fetchInboxhubData() directly via window.opener because
+     * Struts 7's CoopInterceptor sets Cross-Origin-Opener-Policy: same-origin on all .do
+     * responses, which nulls window.opener on popups opened from this page. BroadcastChannel
+     * provides reliable same-origin cross-window messaging that is unaffected by COOP.
+     *
+     * Senders: oscarMDSIndex.js updateStatus(), hrmActions.js doSignOff()
+     * Channel: 'inboxhub-refresh'
+     */
+    try {
+        new BroadcastChannel('inboxhub-refresh').onmessage = function() { fetchInboxhubData(); };
+    } catch (e) {
+        // BroadcastChannel unsupported — user must manually refresh the inbox
+    }
+
     function fetchInboxhubListData() {
         if (!hasMoreData || isFetchingData) { return; }
         isFetchingData = true; 

--- a/src/main/webapp/web/inboxhub/InboxhubForm.jsp
+++ b/src/main/webapp/web/inboxhub/InboxhubForm.jsp
@@ -568,7 +568,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA
      * Channel: 'inboxhub-refresh'
      */
     try {
-        new BroadcastChannel('inboxhub-refresh').onmessage = function() { fetchInboxhubData(); };
+        const inboxhubRefreshChannel = new BroadcastChannel('inboxhub-refresh');
+        inboxhubRefreshChannel.onmessage = function() { fetchInboxhubData(); };
     } catch (e) {
         // BroadcastChannel unsupported — user must manually refresh the inbox
     }


### PR DESCRIPTION
Struts 7's CoopInterceptor sets Cross-Origin-Opener-Policy: same-origin on all .do responses, which nulls window.opener on popup windows opened from Inboxhub. This prevented the existing removeReport() and any fetchInboxhubData() calls from reaching the opener.

Uses BroadcastChannel for same-origin cross-window messaging to notify the Inboxhub to refresh after acknowledge (oscarMDSIndex.js) or HRM sign-off (hrmActions.js). Also fixes a latent TypeError in hrmActions.js where self.opener.removeReport() was called without a null check.

<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description

<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues

<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?

<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->

## Checklist

- [ ] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [ ] I have not included any patient data (PHI) in this PR
- [ ] I have added tests for new functionality, or this change doesn't need new tests
- [ ] I have read the [contributing guide](CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inbox now auto-refreshes across browser windows when reports are signed off or acknowledged, providing near-real-time updates without manual refresh.
* **Bug Fixes / Reliability**
  * Refresh notifications are fail-safe in environments without newer browser messaging APIs and won't cause errors; popup behavior (including closure) remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->