### PR TITLE
fix(security): Add OWASP encoding to ON billing JSPs — 7 files, ~32 XSS alerts

### DIFF
--- a/src/main/webapp/billing/CA/ON/billingONEditPrivateCode.jsp
+++ b/src/main/webapp/billing/CA/ON/billingONEditPrivateCode.jsp
@@ -33,6 +33,7 @@
 <%@ page import="org.apache.commons.text.StringEscapeUtils" %>
 <%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="io.github.carlos_emr.carlos.utility.MiscUtils" %>
+<%@ page import="io.github.carlos_emr.carlos.util.StringUtils" %>
 <%@ page import="io.github.carlos_emr.carlos.billings.ca.on.data.JdbcBillingCodeImpl" %>
 <%
     //
@@ -54,12 +55,12 @@
             if (serviceCode.equals(request.getParameter("action").substring("edit".length()))) {
                 if (dbObj.updateCodeByName(serviceCode, request.getParameter("description"), valuePara, "0.00",
                         request.getParameter("billingservice_date"), request.getParameter("gstFlag"))) {
-                    msg = serviceCode + " is updated.<br>"
+                    msg = Encode.forHtml(serviceCode) + " is updated.<br>"
                             + "Type in a service code and search first to see if it is available.";
                     action = "search";
                     prop.setProperty("service_code", serviceCode);
                 } else {
-                    msg = serviceCode
+                    msg = Encode.forHtml(serviceCode)
                             + " is <font color='red'>NOT</font> updated. Action failed! Try edit it again.";
                     action = "edit" + serviceCode;
                     prop.setProperty("service_code", serviceCode);
@@ -72,7 +73,7 @@
                     prop.setProperty("gstFlag", request.getParameter("gstFlag"));
                 }
             } else {
-                msg = "You can <font color='red'>NOT</font> save the service code - " + serviceCode
+                msg = "You can <font color='red'>NOT</font> save the service code - " + Encode.forHtml(serviceCode)
                         + ". Please search the service code first.";
                 action = "search";
                 prop.setProperty("service_code", serviceCode);
@@ -85,12 +86,12 @@
             if (serviceCode.equals(request.getParameter("action").substring("add".length()))) {
                 if (dbObj.addCodeByStr(serviceCode, request.getParameter("description"), valuePara, "0.00",
                         request.getParameter("billingservice_date"), request.getParameter("gstFlag")) > 0) {
-                    msg = serviceCode + " is added.<br>"
+                    msg = Encode.forHtml(serviceCode) + " is added.<br>"
                             + "Type in a service code and search first to see if it is available.";
                     action = "search";
                     prop.setProperty("service_code", serviceCode);
                 } else {
-                    msg = serviceCode
+                    msg = Encode.forHtml(serviceCode)
                             + " is not added. Action failed! Try edit it again.";
                     action = "add" + serviceCode;
                     prop.setProperty("service_code", serviceCode);
@@ -104,7 +105,7 @@
                     alert = "error";
                 }
             } else {
-                msg = "You can not save the service code - " + serviceCode
+                msg = "You can not save the service code - " + Encode.forHtml(serviceCode)
                         + ". Please search the service code first.";
                 action = "search";
                 prop.setProperty("service_code", serviceCode);
@@ -151,7 +152,7 @@
                 serviceCode = "";
             serviceCode = "_" + serviceCode;
             if (dbObj.deletePrivateCode(serviceCode)) {
-                msg = serviceCode + " is deleted.<br>"
+                msg = Encode.forHtml(serviceCode) + " is deleted.<br>"
                         + "Type in a service code and search first to see if it is available.";
                 action = "search";
                 prop.setProperty("service_code", "_");
@@ -180,7 +181,7 @@
                 document.forms[1].service_code.focus();
                 document.forms[1].service_code.select();
                 <% if ( prop.getProperty("gstFlag") != null ) {%>
-                if ("<%=prop.getProperty("gstFlag")%>" == "1") {
+                if ("<%=Encode.forJavaScript(prop.getProperty("gstFlag", ""))%>" == "1") {
                     document.getElementById("gstCheck").checked = true;
                     document.getElementById("gstFlag").value = 1;
                 } else {
@@ -308,7 +309,7 @@
                                 MiscUtils.getLogger().warn("NULL value set for a private billing code description (code is '" + strCode + "')");
                             }
                     %>
-                    <option value="<%=strCode%>"><%=(strCode + "| " + strDesc)%>
+                    <option value="<%=Encode.forHtmlAttribute(strCode)%>"><%=Encode.forHtml(strCode + "| " + strDesc)%>
                     </option>
                     <%
                         }
@@ -362,7 +363,7 @@
 
                 <br>
                 <input class="btn btn-secondary" type="submit" name="submit" value="Delete" onclick="javascript:return onDelete();">
-                <input type="hidden" name="action" value='<%=action%>'>
+                <input type="hidden" name="action" value='<%=Encode.forHtmlAttribute(action)%>'>
                 <input class="btn btn-secondary" type="submit" name="submit"
                        value="<fmt:setBundle basename="oscarResources"/><fmt:message key="admin.resourcebaseurl.btnSave"/>"
                        onclick="javascript:return onSave();">

--- a/src/main/webapp/billing/CA/ON/billingONEditPrivateCode.jsp
+++ b/src/main/webapp/billing/CA/ON/billingONEditPrivateCode.jsp
@@ -30,10 +30,8 @@
 %>
 <%@ page errorPage="/errorpage.jsp" import="java.util.*,java.sql.*" %>
 <%@ page import="io.github.carlos_emr.carlos.billing.ca.on.data.*" %>
-<%@ page import="org.apache.commons.text.StringEscapeUtils" %>
 <%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="io.github.carlos_emr.carlos.utility.MiscUtils" %>
-<%@ page import="io.github.carlos_emr.carlos.util.StringUtils" %>
 <%@ page import="io.github.carlos_emr.carlos.billings.ca.on.data.JdbcBillingCodeImpl" %>
 <%
     //
@@ -324,7 +322,7 @@
         <div class="card card-body bg-body-tertiary">
             <form method="post" name="baseurl" action="billingONEditPrivateCode.jsp">
 
-                <div class="alert alert-<%=alert%>">
+                <div class="alert alert-<%=Encode.forHtmlAttribute(alert)%>">
                     <%=msg%>
                 </div>
 

--- a/src/main/webapp/billing/CA/ON/billingONHistorySpec.jsp
+++ b/src/main/webapp/billing/CA/ON/billingONHistorySpec.jsp
@@ -128,7 +128,7 @@ for(int i=0; i<aL.size(); i=i+2) {
 	}
 %>
     <tr>
-        <td style="text-align:center"><%=obj.getId()%>
+        <td style="text-align:center"><%=Encode.forHtml(String.valueOf(obj.getId()))%>
         </td>
         <td style="text-align:center"><%=Encode.forHtml(obj.getBilling_date())%> <%--=obj.getBilling_time()--%></td>
         <td style="text-align:center"><%=Encode.forHtml(BillingDataHlp.propBillingType.getProperty(obj.getStatus(), ""))%>

--- a/src/main/webapp/billing/CA/ON/billingONPayment.jsp
+++ b/src/main/webapp/billing/CA/ON/billingONPayment.jsp
@@ -404,15 +404,15 @@
                 </td>
                 <td style="text-align:center"><%=Encode.forHtml(serviceCode)%>
                 </td>
-                <td style="text-align:center"><%=rad.getServiceCount()%>
+                <td style="text-align:center"><%=Encode.forHtml(rad.getServiceCount())%>
                 </td>
                 <td style="text-align:right"><%=Encode.forHtml(bItemFee)%>
                 </td>
                 <td style="text-align:right"><%=Encode.forHtml(claimAmtStr)%>
                 </td>
-                <td style="text-align:right"><%=paidAmt.toPlainString()%>
+                <td style="text-align:right"><%=Encode.forHtml(paidAmt.toPlainString())%>
                 </td>
-                <td style="text-align:right"><%=adjAmt.toPlainString()%>
+                <td style="text-align:right"><%=Encode.forHtml(adjAmt.toPlainString())%>
                 </td>
                 <td style="text-align:center"><%=Encode.forHtml(rad.getBillType())%>
                 </td>
@@ -427,17 +427,17 @@
             <tr>
                 <td colspan="2" style="font-weight:bold;"><fmt:setBundle basename="oscarResources"/><fmt:message key="oscar.billing.on.paymentReceived.itemCount"/>:
                 </td>
-                <td colspan="4"><%=numItems%>
+                <td colspan="4"><%=Encode.forHtml(String.valueOf(numItems))%>
                 </td>
                 <td style="font-weight:bold"><fmt:setBundle basename="oscarResources"/><fmt:message key="oscar.billing.on.paymentReceived.cumulativeTotal"/>:
                 </td>
-                <td style="text-align:right"><%=feeTotal%>
+                <td style="text-align:right"><%=Encode.forHtml(feeTotal.toPlainString())%>
                 </td>
-                <td style="text-align:right"><%=claimTotal%>
+                <td style="text-align:right"><%=Encode.forHtml(claimTotal.toPlainString())%>
                 </td>
-                <td style="text-align:right"><%=paidTotal%>
+                <td style="text-align:right"><%=Encode.forHtml(paidTotal.toPlainString())%>
                 </td>
-                <td style="text-align:right"><%=adjTotal%>
+                <td style="text-align:right"><%=Encode.forHtml(adjTotal.toPlainString())%>
                 </td>
                 <td colspan="5"></td>
             </tr>
@@ -503,11 +503,11 @@
             <tr>
                 <td colspan="2" style="font-weight:bold;"><fmt:setBundle basename="oscarResources"/><fmt:message key="oscar.billing.on.paymentReceived.itemCount"/>:
                 </td>
-                <td colspan="3"><%=numPremiumItems%>
+                <td colspan="3"><%=Encode.forHtml(String.valueOf(numPremiumItems))%>
                 </td>
                 <td style="font-weight:bold"><fmt:setBundle basename="oscarResources"/><fmt:message key="oscar.billing.on.paymentReceived.cumulativeTotal"/>:
                 </td>
-                <td style="text-align:right;font-weight:bold"><%=totalPremiums.toPlainString()%>
+                <td style="text-align:right;font-weight:bold"><%=Encode.forHtml(totalPremiums.toPlainString())%>
                 </td>
                 <td colspan="4"></td>
             </tr>
@@ -623,18 +623,18 @@
                 </td>
                 <td style="text-align:right"><%=Encode.forHtml(amtBilled)%>
                 </td>
-                <td style="text-align:right"><%=amtPaid.toPlainString()%>
+                <td style="text-align:right"><%=Encode.forHtml(amtPaid.toPlainString())%>
                 </td>
-                <td style="text-align:right"><%=amtRefund.toPlainString()%>
+                <td style="text-align:right"><%=Encode.forHtml(amtRefund.toPlainString())%>
                 </td>
                 <td colspan="2"></td>
 
 
                 <% } %>
             </tr>
-            <tr class="<%=rowColor%>">
+            <tr class="<%=Encode.forHtmlAttribute(rowColor)%>">
                 <td colspan="6"></td>
-                <td style="font-weight:bold;text-align:right"><%=totalBilled.toPlainString()%>
+                <td style="font-weight:bold;text-align:right"><%=Encode.forHtml(totalBilled.toPlainString())%>
                 </td>
 
 
@@ -660,9 +660,9 @@
                     }
 
                 %>
-                <td colspan="<%=colSpan%>" style="text-align:right"><%=payAmt.toPlainString()%>
+                <td colspan="<%=Encode.forHtmlAttribute(colSpan)%>" style="text-align:right"><%=Encode.forHtml(payAmt.toPlainString())%>
                 </td>
-                <td style="text-align:right"><%=refundAmt.toPlainString()%>
+                <td style="text-align:right"><%=Encode.forHtml(refundAmt.toPlainString())%>
                 </td>
                 <td style="text-align:center"><%=Encode.forHtml(payDate)%>
                 </td>
@@ -705,15 +705,15 @@
             <tr>
                 <td colspan="2" style="font-weight:bold;"><fmt:setBundle basename="oscarResources"/><fmt:message key="oscar.billing.on.paymentReceived.itemCount"/>:
                 </td>
-                <td colspan="3"><%=num3rdItems%>
+                <td colspan="3"><%=Encode.forHtml(String.valueOf(num3rdItems))%>
                 </td>
                 <td style="font-weight:bold"><fmt:setBundle basename="oscarResources"/><fmt:message key="oscar.billing.on.paymentReceived.cumulativeTotal"/>:
                 </td>
-                <td style="text-align:right"><%=total3rdBilled%>
+                <td style="text-align:right"><%=Encode.forHtml(total3rdBilled.toPlainString())%>
                 </td>
-                <td style="text-align:right"><%=total3rdPaid%>
+                <td style="text-align:right"><%=Encode.forHtml(total3rdPaid.toPlainString())%>
                 </td>
-                <td style="text-align:right"><%=total3rdRefunded%>
+                <td style="text-align:right"><%=Encode.forHtml(total3rdRefunded.toPlainString())%>
                 </td>
                 <td colspan="2"></td>
             </tr>
@@ -723,7 +723,7 @@
         <%
             BigDecimal finalAmt = paidTotal.add(total3rdPaid).subtract(total3rdRefunded).add(totalPremiums);
         %>
-        <h3><fmt:setBundle basename="oscarResources"/><fmt:message key="oscar.billing.on.paymentReceived.totalPaid"/>: <%=finalAmt%>
+        <h3><fmt:setBundle basename="oscarResources"/><fmt:message key="oscar.billing.on.paymentReceived.totalPaid"/>: <%=Encode.forHtml(finalAmt.toPlainString())%>
         </h3>
 
         </form>

--- a/src/main/webapp/billing/CA/ON/genRASummary.jsp
+++ b/src/main/webapp/billing/CA/ON/genRASummary.jsp
@@ -353,7 +353,7 @@
             </td>
             <td height="16"><%=Encode.forHtml(servicecode)%>
             </td>
-            <!-- <td width="8%" height="16"><%=serviceno%></td>-->
+            <!-- <td width="8%" height="16"><%=Encode.forHtml(serviceno)%></td>-->
             <td height="16" align=right><%=Encode.forHtml(amountsubmit)%>
             </td>
             <td height="16" align=right><%=Encode.forHtml(amountpay)%>
@@ -389,7 +389,7 @@
             </td>
             <td height="16"><%=Encode.forHtml(servicecode)%>
             </td>
-            <!-- <td width="8%" height="16"><%=serviceno%></td>-->
+            <!-- <td width="8%" height="16"><%=Encode.forHtml(serviceno)%></td>-->
             <td height="16" align=right><%=Encode.forHtml(amountsubmit)%>
             </td>
             <td height="16" align=right><%=Encode.forHtml(amountpay)%>
@@ -422,7 +422,7 @@
             </td>
             <td height="16"><%=Encode.forHtml(servicecode)%>
             </td>
-            <!-- <td width="8%" height="16"><%=serviceno%></td>-->
+            <!-- <td width="8%" height="16"><%=Encode.forHtml(serviceno)%></td>-->
             <td height="16" align=right><%=Encode.forHtml(amountsubmit)%>
             </td>
             <td height="16" align=right><%=Encode.forHtml(amountpay)%>
@@ -567,7 +567,7 @@
                 </td>
                 <td height="16"><%=Encode.forHtml(servicecode)%>
                 </td>
-                <!--<td width="8%" height="16"><%=serviceno%></td>-->
+                <!--<td width="8%" height="16"><%=Encode.forHtml(serviceno)%></td>-->
                 <td height="16" align=right><%=Encode.forHtml(amountsubmit)%>
                 </td>
                 <td height="16" align=right><%=Encode.forHtml(amountpay)%>
@@ -601,7 +601,7 @@
                 </td>
                 <td height="16"><%=Encode.forHtml(servicecode)%>
                 </td>
-                <!-- <td width="8%" height="16"><%=serviceno%></td>-->
+                <!-- <td width="8%" height="16"><%=Encode.forHtml(serviceno)%></td>-->
                 <td height="16" align=right><%=Encode.forHtml(amountsubmit)%>
                 </td>
                 <td height="16" align=right><%=Encode.forHtml(amountpay)%>
@@ -634,7 +634,7 @@
                 </td>
                 <td height="16"><%=Encode.forHtml(servicecode)%>
                 </td>
-                <!-- <td width="8%" height="16"><%=serviceno%></td>-->
+                <!-- <td width="8%" height="16"><%=Encode.forHtml(serviceno)%></td>-->
                 <td height="16" align=right><%=Encode.forHtml(amountsubmit)%>
                 </td>
                 <td height="16" align=right><%=Encode.forHtml(amountpay)%>

--- a/src/main/webapp/billing/CA/ON/genRASummary.jsp
+++ b/src/main/webapp/billing/CA/ON/genRASummary.jsp
@@ -667,13 +667,13 @@
                 <td height="16"></td>
                 <td height="16"></td>
                 <td height="16">Total</td>
-                <td height="16" align=right><%=BigCTotal%>
+                <td height="16" align=right><%=Encode.forHtml(BigCTotal.toPlainString())%>
                 </td>
-                <td height="16" align=right><%=BigPTotal%><!-- <%=BigOTotal%>--></td>
-                <td height="16" align=right><%=BigTotal%><!--<%=BigLTotal%>--></td>
-                <td height="16" align=right><%=BigHTotal%>
+                <td height="16" align=right><%=Encode.forHtml(BigPTotal.toPlainString())%><!-- <%=Encode.forHtml(BigOTotal.toPlainString())%>--></td>
+                <td height="16" align=right><%=Encode.forHtml(BigTotal.toPlainString())%><!--<%=Encode.forHtml(BigLTotal.toPlainString())%>--></td>
+                <td height="16" align=right><%=Encode.forHtml(BigHTotal.toPlainString())%>
                 </td>
-                <td height="16" align=right><%=BigOBTotal%>
+                <td height="16" align=right><%=Encode.forHtml(BigOBTotal.toPlainString())%>
                 </td>
                 <td height="16"></td>
             </tr>

--- a/src/main/webapp/billing/CA/ON/genRASummaryDetail.jsp
+++ b/src/main/webapp/billing/CA/ON/genRASummaryDetail.jsp
@@ -347,7 +347,7 @@
             </td>
             <td height="16"><%=Encode.forHtml(servicecode)%>
             </td>
-            <!-- <td width="8%" height="16"><%=serviceno%></td>-->
+            <!-- <td width="8%" height="16"><%=Encode.forHtml(serviceno)%></td>-->
             <td height="16" align=right><%=Encode.forHtml(amountsubmit)%>
             </td>
             <td height="16" align=right><%=Encode.forHtml(amountpay)%>
@@ -382,7 +382,7 @@
             </td>
             <td height="16"><%=Encode.forHtml(servicecode)%>
             </td>
-            <!-- <td width="8%" height="16"><%=serviceno%></td>-->
+            <!-- <td width="8%" height="16"><%=Encode.forHtml(serviceno)%></td>-->
             <td height="16" align=right><%=Encode.forHtml(amountsubmit)%>
             </td>
             <td height="16" align=right><%=Encode.forHtml(amountpay)%>
@@ -415,7 +415,7 @@
             </td>
             <td height="16"><%=Encode.forHtml(servicecode)%>
             </td>
-            <!-- <td width="8%" height="16"><%=serviceno%></td>-->
+            <!-- <td width="8%" height="16"><%=Encode.forHtml(serviceno)%></td>-->
             <td height="16" align=right><%=Encode.forHtml(amountsubmit)%>
             </td>
             <td height="16" align=right><%=Encode.forHtml(amountpay)%>
@@ -560,7 +560,7 @@
                 </td>
                 <td height="16"><%=Encode.forHtml(servicecode)%>
                 </td>
-                <!--<td width="8%" height="16"><%=serviceno%></td>-->
+                <!--<td width="8%" height="16"><%=Encode.forHtml(serviceno)%></td>-->
                 <td height="16" align=right><%=Encode.forHtml(amountsubmit)%>
                 </td>
                 <td height="16" align=right><%=Encode.forHtml(amountpay)%>
@@ -594,7 +594,7 @@
                 </td>
                 <td height="16"><%=Encode.forHtml(servicecode)%>
                 </td>
-                <!-- <td width="8%" height="16"><%=serviceno%></td>-->
+                <!-- <td width="8%" height="16"><%=Encode.forHtml(serviceno)%></td>-->
                 <td height="16" align=right><%=Encode.forHtml(amountsubmit)%>
                 </td>
                 <td height="16" align=right><%=Encode.forHtml(amountpay)%>
@@ -627,7 +627,7 @@
                 </td>
                 <td height="16"><%=Encode.forHtml(servicecode)%>
                 </td>
-                <!-- <td width="8%" height="16"><%=serviceno%></td>-->
+                <!-- <td width="8%" height="16"><%=Encode.forHtml(serviceno)%></td>-->
                 <td height="16" align=right><%=Encode.forHtml(amountsubmit)%>
                 </td>
                 <td height="16" align=right><%=Encode.forHtml(amountpay)%>

--- a/src/main/webapp/billing/CA/ON/genRASummaryDetail.jsp
+++ b/src/main/webapp/billing/CA/ON/genRASummaryDetail.jsp
@@ -660,13 +660,13 @@
                 <td height="16"></td>
                 <td height="16"></td>
                 <td height="16">Total</td>
-                <td height="16" align=right><%=BigCTotal%>
+                <td height="16" align=right><%=Encode.forHtml(BigCTotal.toPlainString())%>
                 </td>
-                <td height="16" align=right><%=BigPTotal%><!-- <%=BigOTotal%>--></td>
-                <td height="16" align=right><%=BigTotal%><!--<%=BigLTotal%>--></td>
-                <td height="16" align=right><%=BigHTotal%>
+                <td height="16" align=right><%=Encode.forHtml(BigPTotal.toPlainString())%><!-- <%=Encode.forHtml(BigOTotal.toPlainString())%>--></td>
+                <td height="16" align=right><%=Encode.forHtml(BigTotal.toPlainString())%><!--<%=Encode.forHtml(BigLTotal.toPlainString())%>--></td>
+                <td height="16" align=right><%=Encode.forHtml(BigHTotal.toPlainString())%>
                 </td>
-                <td height="16" align=right><%=BigOBTotal%>
+                <td height="16" align=right><%=Encode.forHtml(BigOBTotal.toPlainString())%>
                 </td>
                 <td height="16"></td>
             </tr>

--- a/src/main/webapp/billing/CA/ON/onAddEdit3rdAddr.jsp
+++ b/src/main/webapp/billing/CA/ON/onAddEdit3rdAddr.jsp
@@ -61,12 +61,12 @@
 
                 boolean ni = dbObj.update3rdAddr(request.getParameter("id"), val);
                 if (ni) {
-                    msg = company_name + " is updated.<br>"
+                    msg = Encode.forHtml(company_name) + " is updated.<br>"
                             + "Type in a name and search first to see if it is available.";
                     action = "search";
                     prop.setProperty("company_name", company_name);
                 } else {
-                    msg = company_name + " is <font color='red'>NOT</font> updated. Action failed! Try edit it again.";
+                    msg = Encode.forHtml(company_name) + " is <font color='red'>NOT</font> updated. Action failed! Try edit it again.";
                     action = "edit" + company_name;
                     prop.setProperty("company_name", company_name);
                     prop.setProperty("id", request.getParameter("id"));
@@ -80,7 +80,7 @@
                     prop.setProperty("fax", request.getParameter("fax"));
                 }
             } else {
-                msg = "You can <font color='red'>NOT</font> save the name - " + company_name
+                msg = "You can <font color='red'>NOT</font> save the name - " + Encode.forHtml(company_name)
                         + ". Please search the name first.";
                 action = "search";
                 prop.setProperty("company_name", company_name);
@@ -100,12 +100,12 @@
                 val.setProperty("fax", request.getParameter("fax"));
                 int ni = dbObj.addOne3rdAddrRecord(val);
                 if (ni > 0) {
-                    msg = company_name + " is added.<br>"
+                    msg = Encode.forHtml(company_name) + " is added.<br>"
                             + "Type in a name and search first to see if it is available.";
                     action = "search";
                     prop.setProperty("company_name", company_name);
                 } else {
-                    msg = company_name + " is <font color='red'>NOT</font> added. Action failed! Try edit it again.";
+                    msg = Encode.forHtml(company_name) + " is <font color='red'>NOT</font> added. Action failed! Try edit it again.";
                     action = "add" + company_name;
                     prop.setProperty("company_name", company_name);
                     prop.setProperty("attention", request.getParameter("attention"));
@@ -118,7 +118,7 @@
                     prop.setProperty("fax", request.getParameter("fax"));
                 }
             } else {
-                msg = "You can <font color='red'>NOT</font> save the name - " + company_name
+                msg = "You can <font color='red'>NOT</font> save the name - " + Encode.forHtml(company_name)
                         + ". Please search the name first.";
                 action = "search";
                 prop.setProperty("company_name", company_name);

--- a/src/main/webapp/billing/CA/ON/onAddEdit3rdAddr.jsp
+++ b/src/main/webapp/billing/CA/ON/onAddEdit3rdAddr.jsp
@@ -32,7 +32,6 @@
 <%@ page errorPage="/errorpage.jsp"
          import="java.util.*,java.sql.*,io.github.carlos_emr.*,java.text.*,java.net.*" %>
 <%@ page import="io.github.carlos_emr.carlos.billing.ca.on.data.*" %>
-<%@ page import="org.apache.commons.text.StringEscapeUtils" %>
 <%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="io.github.carlos_emr.carlos.billings.ca.on.data.JdbcBilling3rdPartImpl" %>
 <% //

--- a/src/main/webapp/billing/CA/ON/onSearch3rdBillAddr.jsp
+++ b/src/main/webapp/billing/CA/ON/onSearch3rdBillAddr.jsp
@@ -210,7 +210,7 @@
                 </td>
                 <td><%=Encode.forHtml(prop.getProperty("telephone", ""))%>
                 </td>
-                <!--td><%=prop.getProperty("fax", "")%></td-->
+                <!--td><%=Encode.forHtml(prop.getProperty("fax", ""))%></td-->
             </tr>
             <%
                 }


### PR DESCRIPTION
## Summary

- Add OWASP output encoding to 7 Ontario billing JSP files, resolving ~32 XSS alerts
- 9 additional files were already fully encoded — no changes needed
- CLINICAID/billingClinicaidReport.jsp was removed in PR #969 — alert is stale

## Changes

| File | Fixes | Key patterns |
|------|------:|--------------|
| billingONEditPrivateCode.jsp | 7 | `request.getParameter("serviceCode")` reflected XSS, gstFlag in JS |
| billingONPayment.jsp | 21 | Service counts, BigDecimal amounts, CSS class attributes |
| genRASummary.jsp | 7 | BigDecimal totals in HTML body |
| genRASummaryDetail.jsp | 7 | BigDecimal totals in HTML body |
| onAddEdit3rdAddr.jsp | 6 | `request.getParameter("company_name")` reflected XSS |
| onSearch3rdBillAddr.jsp | 1 | Fax number in HTML comment |
| billingONHistorySpec.jsp | 1 | obj.getId() defense-in-depth |

### Already encoded (no changes needed)
billingCodeSearch, billingCodeUpdate, billingReportControl, printBillingClipboard, endYearStatement, billingReport_unbilled.jspf, onGenRAError

### Missing files (stale scanner alerts)
- `addFluBilling.jsp` and `addINRbilling.jsp` — files no longer exist at these paths
- CLINICAID/billingClinicaidReport.jsp — removed in PR #969

## Test plan

- [x] `make install` — BUILD SUCCESS
- [ ] Visual spot-check: ON billing edit, payment, RA summary pages
- [ ] After merge: verify alerts close on GitHub Security tab

Partial fix for #1112

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add OWASP output encoding to Ontario billing JSP pages to address reflected and stored XSS risks in payment, history, RA summary, and third-party address flows.

Bug Fixes:
- Escape Ontario billing payment counts, monetary totals, and row attributes using OWASP encoders to prevent XSS in rendered tables and summaries.
- Sanitize service code and company name values when reflected in on-page messages and form options on Ontario private code and third-party address pages.
- Encode IDs and fax values in Ontario billing history and search pages as a defense-in-depth measure against XSS in HTML, attributes, comments, and JavaScript contexts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OWASP output encoding to 7 Ontario billing JSPs to block reflected XSS in HTML, attributes, and JS, and removes unused imports. Fixes ~32 XSS alerts. Partial fix for #1112.

- **Bug Fixes**
  - Applied `org.owasp.encoder.Encode` (`forHtml`, `forHtmlAttribute`, `forJavaScript`) across edit private code, payment, RA summary/detail, 3rd‑party address add/edit & search, and history spec.
  - Encoded service codes, company names, item counts, monetary totals, CSS class/colspan attributes (incl. `alert`), hidden inputs, and JS values; added defense-in-depth for IDs and `serviceno` in commented outputs.
  - Removed unused `StringEscapeUtils`; 9 related files were already encoded; noted stale alerts for removed/moved files.

<sup>Written for commit f56f2ced54352f16ab0dcf094d88b56997997824. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

