### PR TITLE
fix(security): Add OWASP encoding to admin, provider, remaining JSPs, Java, JS — 21 files, ~86 XSS alerts

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/BillingEditCode2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/BillingEditCode2Action.java
@@ -82,6 +82,7 @@ public final class BillingEditCode2Action extends ActionSupport {
         ObjectNode jsonObject = objectMapper.valueToTree(itemCode);
         jsonObject.put("id", id);
         MiscUtils.getLogger().debug(jsonObject.toString());
+        response.setContentType("application/json;charset=UTF-8");
         response.getOutputStream().write(jsonObject.toString().getBytes());
         return null;
     }

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/BillingEditCode2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/BillingEditCode2Action.java
@@ -31,6 +31,7 @@
 package io.github.carlos_emr.carlos.billings.ca.bc.pageUtil;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -83,7 +84,7 @@ public final class BillingEditCode2Action extends ActionSupport {
         jsonObject.put("id", id);
         MiscUtils.getLogger().debug(jsonObject.toString());
         response.setContentType("application/json;charset=UTF-8");
-        response.getOutputStream().write(jsonObject.toString().getBytes());
+        response.getOutputStream().write(jsonObject.toString().getBytes(StandardCharsets.UTF_8));
         return null;
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/commn/web/BillingONReview2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/web/BillingONReview2Action.java
@@ -85,6 +85,7 @@ public class BillingONReview2Action extends ActionSupport {
         Demographic demographic = demographicDao.getDemographic(demographicNo);
 
         String json = objectMapper.writeValueAsString(demographic);
+        response.setContentType("application/json;charset=UTF-8");
         response.getOutputStream().write(json.getBytes());
         return null;
     }
@@ -92,6 +93,7 @@ public class BillingONReview2Action extends ActionSupport {
     public String getClinic() throws IOException {
         Clinic clinic = clinicDao.getClinic();
         String json = objectMapper.writeValueAsString(clinic);
+        response.setContentType("application/json;charset=UTF-8");
         response.getOutputStream().write(json.getBytes());
         return null;
     }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/web/BillingONReview2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/web/BillingONReview2Action.java
@@ -30,6 +30,7 @@
 package io.github.carlos_emr.carlos.commn.web;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -86,7 +87,7 @@ public class BillingONReview2Action extends ActionSupport {
 
         String json = objectMapper.writeValueAsString(demographic);
         response.setContentType("application/json;charset=UTF-8");
-        response.getOutputStream().write(json.getBytes());
+        response.getOutputStream().write(json.getBytes(StandardCharsets.UTF_8));
         return null;
     }
 
@@ -94,7 +95,7 @@ public class BillingONReview2Action extends ActionSupport {
         Clinic clinic = clinicDao.getClinic();
         String json = objectMapper.writeValueAsString(clinic);
         response.setContentType("application/json;charset=UTF-8");
-        response.getOutputStream().write(json.getBytes());
+        response.getOutputStream().write(json.getBytes(StandardCharsets.UTF_8));
         return null;
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/ManageDocument2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/ManageDocument2Action.java
@@ -990,17 +990,17 @@ public class ManageDocument2Action extends ActionSupport {
         if (viewDocumentDescriptionFlag) {
             EDoc curDoc = EDocUtil.getDoc(doc_no);
             ResourceBundle props = ResourceBundle.getBundle("oscarResources", locale);
-            out.println("<br>" + props.getString("dms.documentBrowser.DocumentUpdated") + ": " + Encode.forHtml(curDoc.getDateTimeStamp()));
-            out.println("<br>" + props.getString("dms.documentBrowser.ContentUpdated") + ": " + Encode.forHtml(String.valueOf(curDoc.getContentDateTime())));
-            out.println("<br>" + props.getString("dms.documentBrowser.ObservationDate") + ": " + Encode.forHtml(curDoc.getObservationDate()));
-            out.println("<br>" + props.getString("dms.documentBrowser.Type") + ": " + Encode.forHtml(curDoc.getType()));
-            out.println("<br>" + props.getString("dms.documentBrowser.Class") + ": " + Encode.forHtml(curDoc.getDocClass()));
-            out.println("<br>" + props.getString("dms.documentBrowser.Subclass") + ": " + Encode.forHtml(curDoc.getDocSubClass()));
-            out.println("<br>" + props.getString("dms.documentBrowser.Description") + ": " + Encode.forHtml(curDoc.getDescription()));
-            out.println("<br>" + props.getString("dms.documentBrowser.Creator") + ": " + Encode.forHtml(curDoc.getCreatorName()));
-            out.println("<br>" + props.getString("dms.documentBrowser.Responsible") + ": " + Encode.forHtml(curDoc.getResponsibleName()));
-            out.println("<br>" + props.getString("dms.documentBrowser.Reviewer") + ": " + Encode.forHtml(curDoc.getReviewerName()));
-            out.println("<br>" + props.getString("dms.documentBrowser.Source") + ": " + Encode.forHtml(curDoc.getSource()));
+            out.println("<br>" + props.getString("dms.documentBrowser.DocumentUpdated") + ": " + Encode.forHtml(Objects.toString(curDoc.getDateTimeStamp(), "")));
+            out.println("<br>" + props.getString("dms.documentBrowser.ContentUpdated") + ": " + Encode.forHtml(Objects.toString(curDoc.getContentDateTime(), "")));
+            out.println("<br>" + props.getString("dms.documentBrowser.ObservationDate") + ": " + Encode.forHtml(Objects.toString(curDoc.getObservationDate(), "")));
+            out.println("<br>" + props.getString("dms.documentBrowser.Type") + ": " + Encode.forHtml(Objects.toString(curDoc.getType(), "")));
+            out.println("<br>" + props.getString("dms.documentBrowser.Class") + ": " + Encode.forHtml(Objects.toString(curDoc.getDocClass(), "")));
+            out.println("<br>" + props.getString("dms.documentBrowser.Subclass") + ": " + Encode.forHtml(Objects.toString(curDoc.getDocSubClass(), "")));
+            out.println("<br>" + props.getString("dms.documentBrowser.Description") + ": " + Encode.forHtml(Objects.toString(curDoc.getDescription(), "")));
+            out.println("<br>" + props.getString("dms.documentBrowser.Creator") + ": " + Encode.forHtml(Objects.toString(curDoc.getCreatorName(), "")));
+            out.println("<br>" + props.getString("dms.documentBrowser.Responsible") + ": " + Encode.forHtml(Objects.toString(curDoc.getResponsibleName(), "")));
+            out.println("<br>" + props.getString("dms.documentBrowser.Reviewer") + ": " + Encode.forHtml(Objects.toString(curDoc.getReviewerName(), "")));
+            out.println("<br>" + props.getString("dms.documentBrowser.Source") + ": " + Encode.forHtml(Objects.toString(curDoc.getSource(), "")));
         }
 
         out.println("</body></html>");

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/ManageDocument2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/ManageDocument2Action.java
@@ -990,17 +990,17 @@ public class ManageDocument2Action extends ActionSupport {
         if (viewDocumentDescriptionFlag) {
             EDoc curDoc = EDocUtil.getDoc(doc_no);
             ResourceBundle props = ResourceBundle.getBundle("oscarResources", locale);
-            out.println("<br>" + props.getString("dms.documentBrowser.DocumentUpdated") + ": " + curDoc.getDateTimeStamp());
-            out.println("<br>" + props.getString("dms.documentBrowser.ContentUpdated") + ": " + curDoc.getContentDateTime());
-            out.println("<br>" + props.getString("dms.documentBrowser.ObservationDate") + ": " + curDoc.getObservationDate());
-            out.println("<br>" + props.getString("dms.documentBrowser.Type") + ": " + curDoc.getType());
-            out.println("<br>" + props.getString("dms.documentBrowser.Class") + ": " + curDoc.getDocClass());
-            out.println("<br>" + props.getString("dms.documentBrowser.Subclass") + ": " + curDoc.getDocSubClass());
-            out.println("<br>" + props.getString("dms.documentBrowser.Description") + ": " + curDoc.getDescription());
-            out.println("<br>" + props.getString("dms.documentBrowser.Creator") + ": " + curDoc.getCreatorName());
-            out.println("<br>" + props.getString("dms.documentBrowser.Responsible") + ": " + curDoc.getResponsibleName());
-            out.println("<br>" + props.getString("dms.documentBrowser.Reviewer") + ": " + curDoc.getReviewerName());
-            out.println("<br>" + props.getString("dms.documentBrowser.Source") + ": " + curDoc.getSource());
+            out.println("<br>" + props.getString("dms.documentBrowser.DocumentUpdated") + ": " + Encode.forHtml(curDoc.getDateTimeStamp()));
+            out.println("<br>" + props.getString("dms.documentBrowser.ContentUpdated") + ": " + Encode.forHtml(String.valueOf(curDoc.getContentDateTime())));
+            out.println("<br>" + props.getString("dms.documentBrowser.ObservationDate") + ": " + Encode.forHtml(curDoc.getObservationDate()));
+            out.println("<br>" + props.getString("dms.documentBrowser.Type") + ": " + Encode.forHtml(curDoc.getType()));
+            out.println("<br>" + props.getString("dms.documentBrowser.Class") + ": " + Encode.forHtml(curDoc.getDocClass()));
+            out.println("<br>" + props.getString("dms.documentBrowser.Subclass") + ": " + Encode.forHtml(curDoc.getDocSubClass()));
+            out.println("<br>" + props.getString("dms.documentBrowser.Description") + ": " + Encode.forHtml(curDoc.getDescription()));
+            out.println("<br>" + props.getString("dms.documentBrowser.Creator") + ": " + Encode.forHtml(curDoc.getCreatorName()));
+            out.println("<br>" + props.getString("dms.documentBrowser.Responsible") + ": " + Encode.forHtml(curDoc.getResponsibleName()));
+            out.println("<br>" + props.getString("dms.documentBrowser.Reviewer") + ": " + Encode.forHtml(curDoc.getReviewerName()));
+            out.println("<br>" + props.getString("dms.documentBrowser.Source") + ": " + Encode.forHtml(curDoc.getSource()));
         }
 
         out.println("</body></html>");

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/oscarReportFluBilling.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/oscarReportFluBilling.jsp
@@ -93,7 +93,7 @@
 <div class="pb-2 mt-4 mb-3 border-bottom">
     <h4>
         <fmt:setBundle basename="oscarResources"/><fmt:message key="oscarReport.oscarReportFluBilling.title"/>
-        <%=years%>
+        <%=Encode.forHtml(years)%>
     </h4>
 </div>
 
@@ -115,7 +115,7 @@
     <%
         for (Provider p : providers) {
     %>
-    <option value="<%=p.getProviderNo()%>" <%=selled(p.getProviderNo(), pros)%>><%=p.getFormattedName()%>
+    <option value="<%=Encode.forHtmlAttribute(p.getProviderNo())%>" <%=selled(p.getProviderNo(), pros)%>><%=Encode.forHtml(p.getFormattedName())%>
     </option>
     <%
         }

--- a/src/main/webapp/admin/providerPrivilege.jsp
+++ b/src/main/webapp/admin/providerPrivilege.jsp
@@ -549,7 +549,7 @@
                     %> <input type="text" name="object$<%=objName%>" value=""> <% } else {
 
                     objName = (String) vecObjectId.get(i);
-                %> <input type="checkbox" name="object$<%=objName%>"> <%= Encode.forHtml(vecObjectId.get(i).toString()) %>
+                %> <input type="checkbox" name="object$<%=Encode.forHtmlAttribute(objName)%>"> <%= Encode.forHtml(vecObjectId.get(i).toString()) %>
                     <% if (objName.startsWith("_queue.")) {
                         String d = null;
                         SecObjectName son = secObjectNameDao.find(objName);
@@ -579,10 +579,10 @@
                                 bSet = false;
                             }
                     %> <input type="checkbox"
-                              name="privilege$<%=objName%>$<%=vecRightsName.get(j)%>"/> <%=Encode.forHtml(vecRightsDesc.get(j).toString())%>
+                              name="privilege$<%=Encode.forHtmlAttribute(objName)%>$<%=Encode.forHtmlAttribute(vecRightsName.get(j).toString())%>"/> <%=Encode.forHtml(vecRightsDesc.get(j).toString())%>
                     <% }%>
                 </td>
-                <td><select name="priority$<%=objName%>" style="width:50px;">
+                <td><select name="priority$<%=Encode.forHtmlAttribute(objName)%>" style="width:50px;">
                     <option value="">-</option>
                     <% for (int j = 10; j >= 0; j--) { %>
                     <option value="<%=j%>" <%= ("" + j).equals("0") ? "selected" : "" %>>
@@ -618,7 +618,7 @@
                                 bSet = false;
                             }
                     %> <input type="checkbox"
-                              name="privilege$Name1$<%=vecRightsName.get(j)%>"> <%=Encode.forHtml(vecRightsDesc.get(j).toString())%>
+                              name="privilege$Name1$<%=Encode.forHtmlAttribute(vecRightsName.get(j).toString())%>"> <%=Encode.forHtml(vecRightsDesc.get(j).toString())%>
                     <% }%>
                 </td>
                 <td>Priority <select name="priority$Name1" style="width:50px;">

--- a/src/main/webapp/admin/providerPrivilege.jsp
+++ b/src/main/webapp/admin/providerPrivilege.jsp
@@ -179,9 +179,9 @@
                 secExceptionMsg = divEx.getMostSpecificCause().getLocalizedMessage();
             }
             if (secExceptionMsg.length() > 0)
-                msg += secExceptionMsg;
+                msg += Encode.forHtml(secExceptionMsg);
             else {
-                msg += "Role/Obj/Rights " + encodedRoleUserGroup + "/" + encodedObjectName + "/" + privilege + " is added. ";
+                msg += "Role/Obj/Rights " + encodedRoleUserGroup + "/" + encodedObjectName + "/" + Encode.forHtml(privilege) + " is added. ";
                 LogAction.addLog(curUser_no, LogConst.ADD, LogConst.CON_PRIVILEGE, roleUserGroup + "|" + encodedObjectName + "|" + privilege, ip);
             }
         }
@@ -262,7 +262,7 @@
             priority = String.valueOf(sop.getPriority());
             provider_no = sop.getProviderNo();
             secObjPrivilegeDao.remove(sop.getId());
-            msg = "Role/Obj/Rights " + encodedRoleUserGroup + "/" + encodedObjectName + "/" + privilege + " is deleted. ";
+            msg = "Role/Obj/Rights " + encodedRoleUserGroup + "/" + encodedObjectName + "/" + Encode.forHtml(privilege) + " is deleted. ";
 
             RecycleBin recycleBin = new RecycleBin();
             recycleBin.setProviderNo(curUser_no);
@@ -276,7 +276,7 @@
             recycleBinDao.persist(recycleBin);
             LogAction.addLog(curUser_no, LogConst.DELETE, LogConst.CON_PRIVILEGE, roleUserGroup + "|" + objectName, ip);
         } else {
-            msg = "Role/Obj/Rights " + encodedRoleUserGroup + "/" + encodedObjectName + "/" + privilege + " is <span style='color:red'>NOT</span> deleted!!! ";
+            msg = "Role/Obj/Rights " + encodedRoleUserGroup + "/" + encodedObjectName + "/" + Encode.forHtml(privilege) + " is <span style='color:red'>NOT</span> deleted!!! ";
         }
     }
 
@@ -470,9 +470,9 @@
                                 out.print("</br>");
                                 bSet = false;
                             }
-                    %> <input type="checkbox" name="privilege<%=vecRightsName.get(j)%>"
+                    %> <input type="checkbox" name="privilege<%=Encode.forHtmlAttribute(vecRightsName.get(j).toString())%>"
                     <%=priv.indexOf(((String)vecRightsName.get(j)))>=0?"checked":""%> >
-                    <%=((String) vecRightsDesc.get(j)).replaceAll("Only", "O")%>
+                    <%=Encode.forHtml(((String) vecRightsDesc.get(j)).replaceAll("Only", "O"))%>
                     <% }%> <!--input type="text" name="privilege" value="<%--= priv--%>" /-->
                 </td>
                 <td><select name="priority" class="input-min" style="width:50px">
@@ -486,8 +486,8 @@
                 <td style="text-align:center">
                     <% if (!roleUser.equals("admin") && !obj.equals("_admin")) { %> <input
                         type="hidden" name="keyword" value="<%=Encode.forHtmlAttribute(keyword)%>"> <input
-                        type="hidden" name="objectName" value="<%=obj %>"> <input
-                        type="hidden" name="roleUserGroup" value="<%=roleUser %>"> <input
+                        type="hidden" name="objectName" value="<%=Encode.forHtmlAttribute(obj) %>"> <input
+                        type="hidden" name="roleUserGroup" value="<%=Encode.forHtmlAttribute(roleUser) %>"> <input
                         type="submit" name="buttonUpdate" value="Update" class="btn btn-secondary"> <input
                         type="submit" name="submit" value="Delete" class="btn btn-secondary"> <% } %>
                 </td>
@@ -513,7 +513,7 @@
         </select> or <select name="roleUserGroup1">
         <option value="">-</option>
         <% for (int j = 0; j < vecProviderNo.size(); j++) {%>
-        <option value="<%=vecProviderNo.get(j)%>"><%= Encode.forHtmlContent((String) vecProviderName.get(j)) %>
+        <option value="<%=Encode.forHtmlAttribute(vecProviderNo.get(j).toString())%>"><%= Encode.forHtmlContent((String) vecProviderName.get(j)) %>
         </option>
         <% }%>
         <option value="_principal">_principal</option>
@@ -546,10 +546,10 @@
                         String objName = "";
                         if (i == vecObjectId.size()) {
                             objName = "Name1";
-                    %> <input type="text" name="object$<%=objName%>" value=""> <% } else {
+                    %> <input type="text" name="object$<%=Encode.forHtmlAttribute(objName)%>" value=""> <% } else {
 
                     objName = (String) vecObjectId.get(i);
-                %> <input type="checkbox" name="object$<%=objName%>"> <%= vecObjectId.get(i) %>
+                %> <input type="checkbox" name="object$<%=Encode.forHtmlAttribute(objName)%>"> <%= Encode.forHtml(vecObjectId.get(i).toString()) %>
                     <% if (objName.startsWith("_queue.")) {
                         String d = null;
                         SecObjectName son = secObjectNameDao.find(objName);
@@ -564,7 +564,7 @@
                         }
                     %>
 
-                    <%=d%>
+                    <%=Encode.forHtml(d)%>
                     <%
                             }
                         }
@@ -579,10 +579,10 @@
                                 bSet = false;
                             }
                     %> <input type="checkbox"
-                              name="privilege$<%=objName%>$<%=vecRightsName.get(j)%>"/> <%=vecRightsDesc.get(j)%>
+                              name="privilege$<%=Encode.forHtmlAttribute(objName)%>$<%=Encode.forHtmlAttribute(vecRightsName.get(j).toString())%>"/> <%=Encode.forHtml(vecRightsDesc.get(j).toString())%>
                     <% }%>
                 </td>
-                <td><select name="priority$<%=objName%>" style="width:50px;">
+                <td><select name="priority$<%=Encode.forHtmlAttribute(objName)%>" style="width:50px;">
                     <option value="">-</option>
                     <% for (int j = 10; j >= 0; j--) { %>
                     <option value="<%=j%>" <%= ("" + j).equals("0") ? "selected" : "" %>>
@@ -618,7 +618,7 @@
                                 bSet = false;
                             }
                     %> <input type="checkbox"
-                              name="privilege$Name1$<%=vecRightsName.get(j)%>"> <%=vecRightsDesc.get(j)%>
+                              name="privilege$Name1$<%=Encode.forHtmlAttribute(vecRightsName.get(j).toString())%>"> <%=Encode.forHtml(vecRightsDesc.get(j).toString())%>
                     <% }%>
                 </td>
                 <td>Priority <select name="priority$Name1" style="width:50px;">

--- a/src/main/webapp/admin/providerPrivilege.jsp
+++ b/src/main/webapp/admin/providerPrivilege.jsp
@@ -486,8 +486,8 @@
                 <td style="text-align:center">
                     <% if (!roleUser.equals("admin") && !obj.equals("_admin")) { %> <input
                         type="hidden" name="keyword" value="<%=Encode.forHtmlAttribute(keyword)%>"> <input
-                        type="hidden" name="objectName" value="<%=Encode.forHtmlAttribute(obj) %>"> <input
-                        type="hidden" name="roleUserGroup" value="<%=Encode.forHtmlAttribute(roleUser) %>"> <input
+                        type="hidden" name="objectName" value="<%=obj %>"> <input
+                        type="hidden" name="roleUserGroup" value="<%=roleUser %>"> <input
                         type="submit" name="buttonUpdate" value="Update" class="btn btn-secondary"> <input
                         type="submit" name="submit" value="Delete" class="btn btn-secondary"> <% } %>
                 </td>
@@ -546,10 +546,10 @@
                         String objName = "";
                         if (i == vecObjectId.size()) {
                             objName = "Name1";
-                    %> <input type="text" name="object$<%=Encode.forHtmlAttribute(objName)%>" value=""> <% } else {
+                    %> <input type="text" name="object$<%=objName%>" value=""> <% } else {
 
                     objName = (String) vecObjectId.get(i);
-                %> <input type="checkbox" name="object$<%=Encode.forHtmlAttribute(objName)%>"> <%= Encode.forHtml(vecObjectId.get(i).toString()) %>
+                %> <input type="checkbox" name="object$<%=objName%>"> <%= Encode.forHtml(vecObjectId.get(i).toString()) %>
                     <% if (objName.startsWith("_queue.")) {
                         String d = null;
                         SecObjectName son = secObjectNameDao.find(objName);
@@ -579,10 +579,10 @@
                                 bSet = false;
                             }
                     %> <input type="checkbox"
-                              name="privilege$<%=Encode.forHtmlAttribute(objName)%>$<%=Encode.forHtmlAttribute(vecRightsName.get(j).toString())%>"/> <%=Encode.forHtml(vecRightsDesc.get(j).toString())%>
+                              name="privilege$<%=objName%>$<%=vecRightsName.get(j)%>"/> <%=Encode.forHtml(vecRightsDesc.get(j).toString())%>
                     <% }%>
                 </td>
-                <td><select name="priority$<%=Encode.forHtmlAttribute(objName)%>" style="width:50px;">
+                <td><select name="priority$<%=objName%>" style="width:50px;">
                     <option value="">-</option>
                     <% for (int j = 10; j >= 0; j--) { %>
                     <option value="<%=j%>" <%= ("" + j).equals("0") ? "selected" : "" %>>
@@ -618,7 +618,7 @@
                                 bSet = false;
                             }
                     %> <input type="checkbox"
-                              name="privilege$Name1$<%=Encode.forHtmlAttribute(vecRightsName.get(j).toString())%>"> <%=Encode.forHtml(vecRightsDesc.get(j).toString())%>
+                              name="privilege$Name1$<%=vecRightsName.get(j)%>"> <%=Encode.forHtml(vecRightsDesc.get(j).toString())%>
                     <% }%>
                 </td>
                 <td>Priority <select name="priority$Name1" style="width:50px;">

--- a/src/main/webapp/annotation/importExtra.jsp
+++ b/src/main/webapp/annotation/importExtra.jsp
@@ -52,6 +52,7 @@
 <%@page import="io.github.carlos_emr.carlos.casemgmt.model.CaseManagementNoteLink" %>
 <%@page import="io.github.carlos_emr.carlos.casemgmt.model.CaseManagementNote" %>
 <%@page import="java.util.List" %>
+<%@ page import="org.owasp.encoder.Encode" %>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 
@@ -85,7 +86,7 @@
 
 <html>
     <head>
-        <title><%=display %> Import</title>
+        <title><%=Encode.forHtml(display) %> Import</title>
         <% if (isMobileOptimized) { %>
         <meta name="viewport"
               content="initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, width=device-width"/>
@@ -113,7 +114,7 @@
     <div class="header"></div>
     <div class="card">
         Extra data from Import:<br>
-        <textarea rows="10" name="dump" readonly="readonly"><%=dump%></textarea>
+        <textarea rows="10" name="dump" readonly="readonly"><%=Encode.forHtml(dump)%></textarea>
         <input type="button" value="Close" onclick="window.close();"/>
     </div>
     </body>

--- a/src/main/webapp/annotation/showHistory.jsp
+++ b/src/main/webapp/annotation/showHistory.jsp
@@ -51,7 +51,8 @@
                 io.github.carlos_emr.carlos.casemgmt.model.CaseManagementNoteLink,
                 io.github.carlos_emr.carlos.casemgmt.service.CaseManagementManager,
                 org.owasp.encoder.Encode,
-                java.util.List" %>
+                java.util.List,
+                java.util.Objects" %>
 <%
     HttpSession se = request.getSession();
     WebApplicationContext ctx = WebApplicationContextUtils.getRequiredWebApplicationContext(se.getServletContext());
@@ -77,7 +78,7 @@
 <div style="width: 99%; background-color: #EFEFEF; font-size: 12px; border-left: thin groove #000000; border-bottom: thin groove #000000; border-right: thin groove #000000;">
     <%=Encode.forHtml("Lab Reports".equals(display) ? cmm.getNoteContentForDisplay(showNote) : showNote)%>
     <div style="color: #0000FF;">
-        Documentation Date: <%=Encode.forHtml(cmn.getCreate_date() != null ? String.valueOf(cmn.getCreate_date()) : "")%><br>
+        Documentation Date: <%=Encode.forHtml(Objects.toString(cmn.getCreate_date(), ""))%><br>
         Saved by <%=Encode.forHtml(cmn.getProviderName())%>
     </div>
 </div>

--- a/src/main/webapp/annotation/showHistory.jsp
+++ b/src/main/webapp/annotation/showHistory.jsp
@@ -77,8 +77,8 @@
 <div style="width: 99%; background-color: #EFEFEF; font-size: 12px; border-left: thin groove #000000; border-bottom: thin groove #000000; border-right: thin groove #000000;">
     <%=Encode.forHtml("Lab Reports".equals(display) ? cmm.getNoteContentForDisplay(showNote) : showNote)%>
     <div style="color: #0000FF;">
-        Documentation Date: <%=cmn.getCreate_date()%><br>
-        Saved by <%=cmn.getProviderName()%>
+        Documentation Date: <%=Encode.forHtml(String.valueOf(cmn.getCreate_date()))%><br>
+        Saved by <%=Encode.forHtml(cmn.getProviderName())%>
     </div>
 </div>
 <br>

--- a/src/main/webapp/annotation/showHistory.jsp
+++ b/src/main/webapp/annotation/showHistory.jsp
@@ -77,7 +77,7 @@
 <div style="width: 99%; background-color: #EFEFEF; font-size: 12px; border-left: thin groove #000000; border-bottom: thin groove #000000; border-right: thin groove #000000;">
     <%=Encode.forHtml("Lab Reports".equals(display) ? cmm.getNoteContentForDisplay(showNote) : showNote)%>
     <div style="color: #0000FF;">
-        Documentation Date: <%=Encode.forHtml(String.valueOf(cmn.getCreate_date()))%><br>
+        Documentation Date: <%=Encode.forHtml(cmn.getCreate_date() != null ? String.valueOf(cmn.getCreate_date()) : "")%><br>
         Saved by <%=Encode.forHtml(cmn.getProviderName())%>
     </div>
 </div>

--- a/src/main/webapp/appointment/appointmentaddrecordcard.jsp
+++ b/src/main/webapp/appointment/appointmentaddrecordcard.jsp
@@ -57,6 +57,7 @@
 <%@page import="io.github.carlos_emr.carlos.commn.dao.OscarAppointmentDao" %>
 <%@page import="io.github.carlos_emr.carlos.commn.model.Appointment" %>
 <%@page import="io.github.carlos_emr.carlos.commn.model.Provider" %>
+<%@ page import="org.owasp.encoder.Encode" %>
 <%
     AppointmentArchiveDao appointmentArchiveDao = (AppointmentArchiveDao) SpringUtils.getBean(AppointmentArchiveDao.class);
     OscarAppointmentDao appointmentDao = (OscarAppointmentDao) SpringUtils.getBean(OscarAppointmentDao.class);
@@ -179,7 +180,7 @@
                         <table style="font-size: 8pt;" align="left" valign="top">
 
                             <tr style="font-family: arial, sans-serif; font-size: 6pt;">
-                                <th colspan="3"><%=patientname%>
+                                <th colspan="3"><%=Encode.forHtml(patientname)%>
                                 </th>
                             </tr>
                             <tr style="font-family: arial, sans-serif; font-size: 8pt;">
@@ -200,9 +201,9 @@
 
                             %>
                             <tr bgcolor="#eeeeff">
-                                <td style="padding-right: 10px"><%=appt_date%>
+                                <td style="padding-right: 10px"><%=Encode.forHtml(appt_date)%>
                                 </td>
-                                <td style="padding-right: 10px"><%=appt_time%>
+                                <td style="padding-right: 10px"><%=Encode.forHtml(appt_time)%>
                                 </td>
                                 <td style="padding-right: 10px">&nbsp;</td>
                             </tr>
@@ -224,11 +225,11 @@
                                     pname = "" + p.getLastName() + ", " + pname.substring(0, 1);
                             %>
                             <tr bgcolor="#eeeeff">
-                                <td style="padding-right: 10px"><%=ConversionUtils.toDateString(ap.getAppointmentDate())%>
+                                <td style="padding-right: 10px"><%=Encode.forHtml(ConversionUtils.toDateString(ap.getAppointmentDate()))%>
                                 </td>
-                                <td style="padding-right: 10px"><%=appt_time%>
+                                <td style="padding-right: 10px"><%=Encode.forHtml(appt_time)%>
                                 </td>
-                                <td style="padding-right: 10px"><%=pname%>
+                                <td style="padding-right: 10px"><%=Encode.forHtml(pname)%>
                                 </td>
                             </tr>
                             <%

--- a/src/main/webapp/appointment/appointmenteditrepeatbooking.jsp
+++ b/src/main/webapp/appointment/appointmenteditrepeatbooking.jsp
@@ -439,7 +439,7 @@
                 temp = e.nextElement().toString();
                 if (temp.equals("dboperation") || temp.equals("displaymode") || temp.equals("search_mode") || temp.equals("chart_no"))
                     continue;
-                out.println("<input type='hidden' name='" + Encode.forHtmlAttribute(temp) + "' value=\"" + Encode.forHtmlAttribute(request.getParameter(temp)) + "\">");
+                out.println("<input type='hidden' name='" + temp + "' value=\"" + Encode.forHtmlAttribute(request.getParameter(temp) != null ? request.getParameter(temp) : "") + "\">");
             }
         %>
     </form>

--- a/src/main/webapp/appointment/appointmenteditrepeatbooking.jsp
+++ b/src/main/webapp/appointment/appointmenteditrepeatbooking.jsp
@@ -63,6 +63,7 @@
 <%@ page import="io.github.carlos_emr.carlos.util.UtilDateUtilities" %>
 <%@ page import="io.github.carlos_emr.carlos.util.ConversionUtils" %>
 <%@ page import="io.github.carlos_emr.MyDateFormat" %>
+<%@ page import="org.owasp.encoder.Encode" %>
 <%
     AppointmentArchiveDao appointmentArchiveDao = (AppointmentArchiveDao) SpringUtils.getBean(AppointmentArchiveDao.class);
     OscarAppointmentDao appointmentDao = (OscarAppointmentDao) SpringUtils.getBean(OscarAppointmentDao.class);
@@ -438,7 +439,7 @@
                 temp = e.nextElement().toString();
                 if (temp.equals("dboperation") || temp.equals("displaymode") || temp.equals("search_mode") || temp.equals("chart_no"))
                     continue;
-                out.println("<input type='hidden' name='" + temp + "' value=\"" + UtilMisc.htmlEscape(request.getParameter(temp)) + "\">");
+                out.println("<input type='hidden' name='" + Encode.forHtmlAttribute(temp) + "' value=\"" + Encode.forHtmlAttribute(request.getParameter(temp)) + "\">");
             }
         %>
     </form>

--- a/src/main/webapp/appointment/appointmenteditrepeatbooking.jsp
+++ b/src/main/webapp/appointment/appointmenteditrepeatbooking.jsp
@@ -439,7 +439,7 @@
                 temp = e.nextElement().toString();
                 if (temp.equals("dboperation") || temp.equals("displaymode") || temp.equals("search_mode") || temp.equals("chart_no"))
                     continue;
-                out.println("<input type='hidden' name='" + temp + "' value=\"" + Encode.forHtmlAttribute(request.getParameter(temp) != null ? request.getParameter(temp) : "") + "\">");
+                out.println("<input type='hidden' name='" + Encode.forHtmlAttribute(temp) + "' value=\"" + Encode.forHtmlAttribute(request.getParameter(temp) != null ? request.getParameter(temp) : "") + "\">");
             }
         %>
     </form>

--- a/src/main/webapp/common/OntarioMDRedirect.jsp
+++ b/src/main/webapp/common/OntarioMDRedirect.jsp
@@ -88,9 +88,9 @@ Invalid Requestor Value. - Please contact your support vendor for configuration
 <body>
 <form id="loginFormID" name="loginForm" action="https://www.ontariomd.ca/AutoAuthentication/redirect.jsp" method="post">
     <p>JSESSIONID:</p>
-    <input type="text" size="70" id="jsessionID" name="jsessionID" value="<%=Encode.forHtmlAttribute(String.valueOf(loginCreds.get("jsessionID")))%>"/>
+    <input type="text" size="70" id="jsessionID" name="jsessionID" value="<%=Encode.forHtmlAttribute(loginCreds.get("jsessionID") != null ? String.valueOf(loginCreds.get("jsessionID")) : "")%>"/>
     <p>PT login Token:</p>
-    <input type="text" size="70" id="ptLoginToken" name="ptLoginToken" value="<%=Encode.forHtmlAttribute(String.valueOf(loginCreds.get("ptLoginToken")))%>"/>
+    <input type="text" size="70" id="ptLoginToken" name="ptLoginToken" value="<%=Encode.forHtmlAttribute(loginCreds.get("ptLoginToken") != null ? String.valueOf(loginCreds.get("ptLoginToken")) : "")%>"/>
     <p>Keyword:</p>
     <input type="text" size="100" id="keyword" name="keyword" value="<%=Encode.forHtmlAttribute(keyword)%>"/>
     <p>Params:</p>

--- a/src/main/webapp/common/OntarioMDRedirect.jsp
+++ b/src/main/webapp/common/OntarioMDRedirect.jsp
@@ -88,17 +88,17 @@ Invalid Requestor Value. - Please contact your support vendor for configuration
 <body>
 <form id="loginFormID" name="loginForm" action="https://www.ontariomd.ca/AutoAuthentication/redirect.jsp" method="post">
     <p>JSESSIONID:</p>
-    <input type="text" size="70" id="jsessionID" name="jsessionID" value="<%=loginCreds.get("jsessionID")%>"/>
+    <input type="text" size="70" id="jsessionID" name="jsessionID" value="<%=Encode.forHtmlAttribute(String.valueOf(loginCreds.get("jsessionID")))%>"/>
     <p>PT login Token:</p>
-    <input type="text" size="70" id="ptLoginToken" name="ptLoginToken" value="<%=loginCreds.get("ptLoginToken")%>"/>
+    <input type="text" size="70" id="ptLoginToken" name="ptLoginToken" value="<%=Encode.forHtmlAttribute(String.valueOf(loginCreds.get("ptLoginToken")))%>"/>
     <p>Keyword:</p>
     <input type="text" size="100" id="keyword" name="keyword" value="<%=Encode.forHtmlAttribute(keyword)%>"/>
     <p>Params:</p>
     <input type="text" size="200" id="params" name="params" value="<%=Encode.forHtmlAttribute(params)%>"/>
     <p>Requestor:</p>
-    <input type="text" size="50" id="requestor" name="requestor" value="<%=requestor%>"/>
+    <input type="text" size="50" id="requestor" name="requestor" value="<%=Encode.forHtmlAttribute(requestor)%>"/>
     <p>Username:</p>
-    <input type="text" size="50" id="username" name="username" value="<%=uname%>"/>
+    <input type="text" size="50" id="username" name="username" value="<%=Encode.forHtmlAttribute(uname)%>"/>
     <p></p>
     <input type="submit" value="Submit"/>
 </form>

--- a/src/main/webapp/common/OntarioMDRedirect.jsp
+++ b/src/main/webapp/common/OntarioMDRedirect.jsp
@@ -30,6 +30,7 @@
 --%>
 
 <%@page import="org.owasp.encoder.Encode" %>
+<%@page import="java.util.Objects" %>
 <%@page import="org.springframework.web.context.support.WebApplicationContextUtils,io.github.carlos_emr.carlos.utility.OntarioMD,java.util.Hashtable" %>
 <%@page import="org.springframework.web.context.WebApplicationContext,io.github.carlos_emr.carlos.commn.dao.*,io.github.carlos_emr.carlos.commn.model.*" %>
 <%@ page import="io.github.carlos_emr.carlos.commn.dao.UserPropertyDAO" %>
@@ -88,9 +89,9 @@ Invalid Requestor Value. - Please contact your support vendor for configuration
 <body>
 <form id="loginFormID" name="loginForm" action="https://www.ontariomd.ca/AutoAuthentication/redirect.jsp" method="post">
     <p>JSESSIONID:</p>
-    <input type="text" size="70" id="jsessionID" name="jsessionID" value="<%=Encode.forHtmlAttribute(loginCreds.get("jsessionID") != null ? String.valueOf(loginCreds.get("jsessionID")) : "")%>"/>
+    <input type="text" size="70" id="jsessionID" name="jsessionID" value="<%=Encode.forHtmlAttribute(Objects.toString(loginCreds.get("jsessionID"), ""))%>"/>
     <p>PT login Token:</p>
-    <input type="text" size="70" id="ptLoginToken" name="ptLoginToken" value="<%=Encode.forHtmlAttribute(loginCreds.get("ptLoginToken") != null ? String.valueOf(loginCreds.get("ptLoginToken")) : "")%>"/>
+    <input type="text" size="70" id="ptLoginToken" name="ptLoginToken" value="<%=Encode.forHtmlAttribute(Objects.toString(loginCreds.get("ptLoginToken"), ""))%>"/>
     <p>Keyword:</p>
     <input type="text" size="100" id="keyword" name="keyword" value="<%=Encode.forHtmlAttribute(keyword)%>"/>
     <p>Params:</p>

--- a/src/main/webapp/common/OntarioMDRedirect.jsp
+++ b/src/main/webapp/common/OntarioMDRedirect.jsp
@@ -93,11 +93,11 @@ Invalid Requestor Value. - Please contact your support vendor for configuration
     <p>PT login Token:</p>
     <input type="text" size="70" id="ptLoginToken" name="ptLoginToken" value="<%=Encode.forHtmlAttribute(Objects.toString(loginCreds.get("ptLoginToken"), ""))%>"/>
     <p>Keyword:</p>
-    <input type="text" size="100" id="keyword" name="keyword" value="<%=Encode.forHtmlAttribute(keyword)%>"/>
+    <input type="text" size="100" id="keyword" name="keyword" value="<%=Encode.forHtmlAttribute(Objects.toString(keyword, ""))%>"/>
     <p>Params:</p>
-    <input type="text" size="200" id="params" name="params" value="<%=Encode.forHtmlAttribute(params)%>"/>
+    <input type="text" size="200" id="params" name="params" value="<%=Encode.forHtmlAttribute(Objects.toString(params, ""))%>"/>
     <p>Requestor:</p>
-    <input type="text" size="50" id="requestor" name="requestor" value="<%=Encode.forHtmlAttribute(requestor)%>"/>
+    <input type="text" size="50" id="requestor" name="requestor" value="<%=Encode.forHtmlAttribute(Objects.toString(requestor, ""))%>"/>
     <p>Username:</p>
     <input type="text" size="50" id="username" name="username" value="<%=Encode.forHtmlAttribute(uname)%>"/>
     <p></p>

--- a/src/main/webapp/forcepasswordreset.jsp
+++ b/src/main/webapp/forcepasswordreset.jsp
@@ -42,6 +42,7 @@
 %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <%@ page import="org.springframework.web.util.JavaScriptUtils" %>
+<%@ page import="org.owasp.encoder.Encode" %>
 <%@ page
         import="java.lang.*,io.github.carlos_emr.*"
         errorPage="/errorpage.jsp" %>
@@ -239,7 +240,7 @@
         </table>
         <center>
 
-            <p><b><font color='red'><%=errormsg%>
+            <p><b><font color='red'><%=Encode.forHtml(errormsg)%>
             </font></b>
 
             <table border="0" width="100%" cellpadding="4" cellspacing="0">

--- a/src/main/webapp/hospitalReportManager/displayHRMReport.jsp
+++ b/src/main/webapp/hospitalReportManager/displayHRMReport.jsp
@@ -544,7 +544,7 @@
                     <td>
                         <%=Encode.forHtml(hrmReport.getLegalName()) %><br/>
                         <%=Encode.forHtml(hrmReport.getAddressLine1()) %><br/>
-                        <%=Encode.forHtml(hrmReport.getAddressLine2() != null ? hrmReport.getAddressLine2() : "") %><br/>
+                        <%=Encode.forHtml(Objects.toString(hrmReport.getAddressLine2(), "")) %><br/>
                         <%=Encode.forHtml(hrmReport.getAddressCity()) %>
                     </td>
                 </tr>
@@ -650,8 +650,14 @@
                         <div id="provstatus<%=hrmReportId %>"></div>
                         <% if (providerLinkList != null && providerLinkList.size() > 0) {
                             for (HRMDocumentToProvider p : providerLinkList) {
-                                if (!p.getProviderNo().equalsIgnoreCase("-1")) { %>
-                        <%=Encode.forHtml(providerDao.getProviderName(p.getProviderNo()))%> <%=p.getSignedOff() != null && p.getSignedOff() == 1 ? "<abbr title='" + Encode.forHtmlAttribute(p.getSignedOffTimestamp() != null ? String.valueOf(p.getSignedOffTimestamp()) : "") + "'>(Signed-Off " + Encode.forHtml(p.getSignedOffTimestamp() != null ? String.valueOf(p.getSignedOffTimestamp()) : "") + ")</abbr>" : "" %>
+                                if (!p.getProviderNo().equalsIgnoreCase("-1")) {
+                                    String signedOffDisplay = "";
+                                    if (p.getSignedOff() != null && p.getSignedOff() == 1) {
+                                        String ts = Objects.toString(p.getSignedOffTimestamp(), "");
+                                        signedOffDisplay = "<abbr title='" + Encode.forHtmlAttribute(ts) + "'>(Signed-Off " + Encode.forHtml(ts) + ")</abbr>";
+                                    }
+                        %>
+                        <%=Encode.forHtml(providerDao.getProviderName(p.getProviderNo()))%> <%=signedOffDisplay%>
                         <a href="#"
                            onclick="removeProvFromHrm('<%=p.getId() %>', '<%=hrmReportId %>')">(remove)</a><br/>
                         <% }

--- a/src/main/webapp/hospitalReportManager/displayHRMReport.jsp
+++ b/src/main/webapp/hospitalReportManager/displayHRMReport.jsp
@@ -445,9 +445,9 @@
     <div id="reportViewer">
         <div id="hrmReportContent">
             <div id="hrmHeader"><b>Demographic Info:</b><br/>
-                <%=hrmReport.getLegalName() %> <br/>
-                <%=hrmReport.getHCN() %> &nbsp; <%=hrmReport.getHCNVersion() %> &nbsp; <%=hrmReport.getGender() %><br/>
-                <b>DOB:</b><%=hrmReport.getDateOfBirthAsString() %>
+                <%=Encode.forHtml(hrmReport.getLegalName()) %> <br/>
+                <%=Encode.forHtml(hrmReport.getHCN()) %> &nbsp; <%=Encode.forHtml(hrmReport.getHCNVersion()) %> &nbsp; <%=Encode.forHtml(hrmReport.getGender()) %><br/>
+                <b>DOB:</b><%=Encode.forHtml(hrmReport.getDateOfBirthAsString()) %>
             </div>
 
 
@@ -526,7 +526,7 @@
                 if (confidentialityStatement != null && confidentialityStatement.trim().length() > 0) {
             %>
             <hr/>
-            <em><strong>Provider Confidentiality Statement</strong><br/><%=confidentialityStatement %>
+            <em><strong>Provider Confidentiality Statement</strong><br/><%=Encode.forHtml(confidentialityStatement) %>
             </em>
             <% } %>
         </div>
@@ -542,10 +542,10 @@
                 <tr>
                     <th>Demographic Info:</th>
                     <td>
-                        <%=hrmReport.getLegalName() %><br/>
-                        <%=hrmReport.getAddressLine1() %><br/>
-                        <%=hrmReport.getAddressLine2() != null ? hrmReport.getAddressLine2() : "" %><br/>
-                        <%=hrmReport.getAddressCity() %>
+                        <%=Encode.forHtml(hrmReport.getLegalName()) %><br/>
+                        <%=Encode.forHtml(hrmReport.getAddressLine1()) %><br/>
+                        <%=Encode.forHtml(hrmReport.getAddressLine2() != null ? hrmReport.getAddressLine2() : "") %><br/>
+                        <%=Encode.forHtml(hrmReport.getAddressCity()) %>
                     </td>
                 </tr>
 
@@ -651,7 +651,7 @@
                         <% if (providerLinkList != null && providerLinkList.size() > 0) {
                             for (HRMDocumentToProvider p : providerLinkList) {
                                 if (!p.getProviderNo().equalsIgnoreCase("-1")) { %>
-                        <%=Encode.forHtml(providerDao.getProviderName(p.getProviderNo()))%> <%=p.getSignedOff() != null && p.getSignedOff() == 1 ? "<abbr title='" + p.getSignedOffTimestamp() + "'>(Signed-Off " + p.getSignedOffTimestamp() + ")</abbr>" : "" %>
+                        <%=Encode.forHtml(providerDao.getProviderName(p.getProviderNo()))%> <%=p.getSignedOff() != null && p.getSignedOff() == 1 ? "<abbr title='" + Encode.forHtmlAttribute(String.valueOf(p.getSignedOffTimestamp())) + "'>(Signed-Off " + Encode.forHtml(String.valueOf(p.getSignedOffTimestamp())) + ")</abbr>" : "" %>
                         <a href="#"
                            onclick="removeProvFromHrm('<%=p.getId() %>', '<%=hrmReportId %>')">(remove)</a><br/>
                         <% }
@@ -662,7 +662,7 @@
                         <% if (document.getUnmatchedProviders() != null && document.getUnmatchedProviders().trim().length() >= 1) {
                             String[] unmatchedProviders = document.getUnmatchedProviders().substring(1).split("\\|");
                             for (String unmatchedProvider : unmatchedProviders) { %>
-                        <i><abbr title="From the HRM document"><%=unmatchedProvider %>
+                        <i><abbr title="From the HRM document"><%=Encode.forHtml(unmatchedProvider) %>
                         </abbr></i><br/>
                         <% }
                         } %>

--- a/src/main/webapp/hospitalReportManager/displayHRMReport.jsp
+++ b/src/main/webapp/hospitalReportManager/displayHRMReport.jsp
@@ -16,6 +16,7 @@
 <%@page import="io.github.carlos_emr.carlos.utility.LoggedInInfo" %>
 <%@page import="org.apache.commons.lang3.StringUtils,io.github.carlos_emr.carlos.log.*" %>
 <%@page import="java.text.SimpleDateFormat" %>
+<%@page import="java.util.Objects" %>
 <%@ page import="io.github.carlos_emr.CarlosProperties" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 
@@ -445,9 +446,9 @@
     <div id="reportViewer">
         <div id="hrmReportContent">
             <div id="hrmHeader"><b>Demographic Info:</b><br/>
-                <%=Encode.forHtml(hrmReport.getLegalName()) %> <br/>
-                <%=Encode.forHtml(hrmReport.getHCN()) %> &nbsp; <%=Encode.forHtml(hrmReport.getHCNVersion()) %> &nbsp; <%=Encode.forHtml(hrmReport.getGender()) %><br/>
-                <b>DOB:</b><%=Encode.forHtml(hrmReport.getDateOfBirthAsString()) %>
+                <%=Encode.forHtml(Objects.toString(hrmReport.getLegalName(), "")) %> <br/>
+                <%=Encode.forHtml(Objects.toString(hrmReport.getHCN(), "")) %> &nbsp; <%=Encode.forHtml(Objects.toString(hrmReport.getHCNVersion(), "")) %> &nbsp; <%=Encode.forHtml(Objects.toString(hrmReport.getGender(), "")) %><br/>
+                <b>DOB:</b><%=Encode.forHtml(Objects.toString(hrmReport.getDateOfBirthAsString(), "")) %>
             </div>
 
 
@@ -542,10 +543,10 @@
                 <tr>
                     <th>Demographic Info:</th>
                     <td>
-                        <%=Encode.forHtml(hrmReport.getLegalName()) %><br/>
-                        <%=Encode.forHtml(hrmReport.getAddressLine1()) %><br/>
+                        <%=Encode.forHtml(Objects.toString(hrmReport.getLegalName(), "")) %><br/>
+                        <%=Encode.forHtml(Objects.toString(hrmReport.getAddressLine1(), "")) %><br/>
                         <%=Encode.forHtml(Objects.toString(hrmReport.getAddressLine2(), "")) %><br/>
-                        <%=Encode.forHtml(hrmReport.getAddressCity()) %>
+                        <%=Encode.forHtml(Objects.toString(hrmReport.getAddressCity(), "")) %>
                     </td>
                 </tr>
 

--- a/src/main/webapp/hospitalReportManager/displayHRMReport.jsp
+++ b/src/main/webapp/hospitalReportManager/displayHRMReport.jsp
@@ -651,7 +651,7 @@
                         <% if (providerLinkList != null && providerLinkList.size() > 0) {
                             for (HRMDocumentToProvider p : providerLinkList) {
                                 if (!p.getProviderNo().equalsIgnoreCase("-1")) { %>
-                        <%=Encode.forHtml(providerDao.getProviderName(p.getProviderNo()))%> <%=p.getSignedOff() != null && p.getSignedOff() == 1 ? "<abbr title='" + Encode.forHtmlAttribute(String.valueOf(p.getSignedOffTimestamp())) + "'>(Signed-Off " + Encode.forHtml(String.valueOf(p.getSignedOffTimestamp())) + ")</abbr>" : "" %>
+                        <%=Encode.forHtml(providerDao.getProviderName(p.getProviderNo()))%> <%=p.getSignedOff() != null && p.getSignedOff() == 1 ? "<abbr title='" + Encode.forHtmlAttribute(p.getSignedOffTimestamp() != null ? String.valueOf(p.getSignedOffTimestamp()) : "") + "'>(Signed-Off " + Encode.forHtml(p.getSignedOffTimestamp() != null ? String.valueOf(p.getSignedOffTimestamp()) : "") + ")</abbr>" : "" %>
                         <a href="#"
                            onclick="removeProvFromHrm('<%=p.getId() %>', '<%=hrmReportId %>')">(remove)</a><br/>
                         <% }

--- a/src/main/webapp/provider/appointmentprovideradminmonth.jsp
+++ b/src/main/webapp/provider/appointmentprovideradminmonth.jsp
@@ -547,7 +547,7 @@
                     function changeSite(sel) {
                         sel.style.backgroundColor = sel.options[sel.selectedIndex].style.backgroundColor;
                         var siteName = sel.options[sel.selectedIndex].value;
-                        var newGroupNo = "<%=(mygroupno == null ? "all" : mygroupno)%>";
+                        var newGroupNo = "<%=Encode.forJavaScript(mygroupno == null ? "all" : mygroupno)%>";
                         var providerview = "<%= Encode.forJavaScript(providerview) %>";
                         if (providerview.indexOf("_grp_") != -1) {
 
@@ -559,15 +559,15 @@
                 </script>
 
                 <select id="site" name="site" onchange="changeSite(this)"
-                        style="background-color: <%=( selectedSite == null || siteBgColor.get(selectedSite) == null ? "#FFFFFF" : siteBgColor.get(selectedSite))%>">
+                        style="background-color: <%=Encode.forCssString( selectedSite == null || siteBgColor.get(selectedSite) == null ? "#FFFFFF" : siteBgColor.get(selectedSite))%>">
                     <option value="none" style="background-color:white">---all clinic---</option>
                     <%
                         for (int i = 0; i < curUserSites.size(); i++) {
                     %>
-                    <option value="<%= curUserSites.get(i).getName() %>"
-                            style="background-color:<%= curUserSites.get(i).getBgColor() %>"
+                    <option value="<%= Encode.forHtmlAttribute(curUserSites.get(i).getName()) %>"
+                            style="background-color:<%= Encode.forCssString(curUserSites.get(i).getBgColor()) %>"
                             <%=(curUserSites.get(i).getName().equals(selectedSite)) ? " selected " : "" %> >
-                        <%= curUserSites.get(i).getName() %>
+                        <%= Encode.forHtml(curUserSites.get(i).getName()) %>
                     </option>
                     <% } %>
                 </select>
@@ -998,10 +998,10 @@
                         popupOscarRx('700', '1024', '<%= request.getContextPath() %>/documentManager/documentReport.jsp?function=providers&functionid=<%=curUser_no%>&curUser=<%=curUser_no%>', 'edocView');
                         return false;  //run code for e'D'oc
                     case <fmt:setBundle basename="oscarResources"/><fmt:message key="global.resourcesShortcut"/> :
-                        popupOscarRx(550, 687, '<%=resourcebaseurl%>');
+                        popupOscarRx(550, 687, '<%=Encode.forJavaScript(resourcebaseurl)%>');
                         return false; // code for R'e'sources
                     case <fmt:setBundle basename="oscarResources"/><fmt:message key="global.helpShortcut"/> :
-                        popupOscarRx(600, 750, '<%=resourcebaseurl%>');
+                        popupOscarRx(600, 750, '<%=Encode.forJavaScript(resourcebaseurl)%>');
                         return false;  //run code for 'H'elp
                     case <fmt:setBundle basename="oscarResources"/><fmt:message key="global.ticklerShortcut"/> : {
                         popupOscarRx(700, 1024, '<%= request.getContextPath() %>/tickler/ticklerMain.jsp', '<fmt:setBundle basename="oscarResources"/><fmt:message key="global.tickler"/>') //run code for t'I'ckler
@@ -1023,7 +1023,7 @@
                         popupOscarRx(650, 1024, '<%= request.getContextPath() %>/report/reportindex.jsp', 'reportPage');
                         return false;  //run code for 'R'eports
                     case <fmt:setBundle basename="oscarResources"/><fmt:message key="global.prefShortcut"/> : {
-                        popupOscarRx(715, 680, 'providerpreference.jsp?provider_no=<%=curUser_no%>&start_hour=<%=startHour%>&end_hour=<%=endHour%>&every_min=<%=everyMin%>&mygroup_no=<%=mygroupno%>'); //run code for 'P'references
+                        popupOscarRx(715, 680, 'providerpreference.jsp?provider_no=<%=Encode.forUriComponent(curUser_no)%>&start_hour=<%=startHour%>&end_hour=<%=endHour%>&every_min=<%=everyMin%>&mygroup_no=<%=Encode.forUriComponent(mygroupno)%>'); //run code for 'P'references
                         return false;
                     }
                     case <fmt:setBundle basename="oscarResources"/><fmt:message key="global.searchShortcut"/> :

--- a/src/main/webapp/provider/providerDefaultDxCode.jsp
+++ b/src/main/webapp/provider/providerDefaultDxCode.jsp
@@ -98,7 +98,7 @@
         <tr>
             <td>Dx &nbsp;&nbsp;
                 <input type="text" name="dxCode" size="5" maxlength="5" ondblClick="dxScriptAttach('dxCode')"
-                       value="<%=defaultDxCode%>"/>
+                       value="<%=Encode.forHtmlAttribute(defaultDxCode)%>"/>
                 <a href=# onclick="dxScriptAttach('dxCode');">Search</a>
             </td>
         </tr>

--- a/src/main/webapp/provider/providerencountersingle.jsp
+++ b/src/main/webapp/provider/providerencountersingle.jsp
@@ -38,7 +38,7 @@
 <%@page import="io.github.carlos_emr.carlos.commn.dao.EncounterDao" %>
 <%@page import="io.github.carlos_emr.carlos.commn.model.Encounter" %>
 <%@page import="io.github.carlos_emr.carlos.util.ConversionUtils" %>
-<%@page import="org.owasp.encoder.Encode" %>
+<%@page import="io.github.carlos_emr.carlos.util.StringUtils" %>
 <%
     EncounterTemplateDao encounterTemplateDao = SpringUtils.getBean(EncounterTemplateDao.class);
     EncounterDao encounterDao = SpringUtils.getBean(EncounterDao.class);
@@ -73,13 +73,13 @@
         content = enc.getContent();
         encounterattachment = enc.getEncounterAttachment();
 %>
-<font size="-1"><%=ConversionUtils.toDateString(enc.getEncounterDate())%> <%=ConversionUtils.toTimeString(enc.getEncounterTime())%>
-    &nbsp;<font color="green"><%=enc.getSubject().equals("") ? "Unknown" : enc.getSubject()%>
+<font size="-1"><%=Encode.forHtml(ConversionUtils.toDateString(enc.getEncounterDate()))%> <%=Encode.forHtml(ConversionUtils.toTimeString(enc.getEncounterTime()))%>
+    &nbsp;<font color="green"><%=Encode.forHtml(enc.getSubject().equals("") ? "Unknown" : enc.getSubject())%>
     </font></font>
 <br>
 <xml id="xml_list">
     <encounter>
-        <%=content%>
+        <%=Encode.forHtml(content)%>
     </encounter>
 </xml>
 <%
@@ -92,8 +92,8 @@
             while (st.hasMoreTokens()) {
                 temp = st.nextToken(">").substring(1);
         %> <a href=#
-              onClick="popupPage(600,800, '<%=st.nextToken("<").substring(1)%>')">
-            <%=temp%>
+              onClick="popupPage(600,800, '<%=Encode.forJavaScript(st.nextToken("<").substring(1))%>')">
+            <%=Encode.forHtml(temp)%>
         </a> <%
                 st.nextToken(">");
             }

--- a/src/main/webapp/provider/providerencountersingle.jsp
+++ b/src/main/webapp/provider/providerencountersingle.jsp
@@ -74,12 +74,12 @@
         encounterattachment = enc.getEncounterAttachment();
 %>
 <font size="-1"><%=Encode.forHtml(ConversionUtils.toDateString(enc.getEncounterDate()))%> <%=Encode.forHtml(ConversionUtils.toTimeString(enc.getEncounterTime()))%>
-    &nbsp;<font color="green"><%=Encode.forHtml(enc.getSubject().equals("") ? "Unknown" : enc.getSubject())%>
+    &nbsp;<font color="green"><%=Encode.forHtml(StringUtils.noNull(enc.getSubject()).isEmpty() ? "Unknown" : enc.getSubject())%>
     </font></font>
 <br>
 <xml id="xml_list">
     <encounter>
-        <%=Encode.forHtml(content)%>
+        <%=content%>
     </encounter>
 </xml>
 <%

--- a/src/main/webapp/report/GenerateLetters.jsp
+++ b/src/main/webapp/report/GenerateLetters.jsp
@@ -226,7 +226,7 @@
                         for (int i = 0; i < list.size(); i++) {
                             Hashtable h = (Hashtable) list.get(i);
                     %>
-                    <option value="<%=h.get("ID")%>"><%=h.get("report_name")%>
+                    <option value="<%=Encode.forHtmlAttribute(String.valueOf(h.get("ID")))%>"><%=Encode.forHtml(String.valueOf(h.get("report_name")))%>
                     </option>
                     <%}%>
                 </select> <%
@@ -263,7 +263,7 @@
                     <tr>
                         <td><%=i + 1%>
                         </td>
-                        <td><input type="checkbox" name="demos" value="<%=demos[i]%>"
+                        <td><input type="checkbox" name="demos" value="<%=Encode.forHtmlAttribute(demos[i])%>"
                                    checked/></td>
 					<td><%=Encode.forHtmlContent(h.get("lastName"))%>, <%=Encode.forHtmlContent(h.get("firstName"))%></td>
 					<td><%=Encode.forHtmlContent(h.get("sex"))%></td>

--- a/src/main/webapp/report/reportecharthistory.jsp
+++ b/src/main/webapp/report/reportecharthistory.jsp
@@ -156,16 +156,17 @@
 <CENTER>
     <%
         int nLastPage = 0, nNextPage = 0;
-        nNextPage = Integer.parseInt(strLimit2) + Integer.parseInt(strLimit1);
-        nLastPage = Integer.parseInt(strLimit1) - Integer.parseInt(strLimit2);
+        int intLimit2 = Integer.parseInt(strLimit2);
+        nNextPage = intLimit2 + Integer.parseInt(strLimit1);
+        nLastPage = Integer.parseInt(strLimit1) - intLimit2;
         if (nLastPage >= 0) {
     %> <a
-        href="reportecharthistory.jsp?demographic_no=<%= Encode.forUriComponent(demographic_no) %>&limit1=<%=nLastPage%>&limit2=<%=strLimit2%>">Last
+        href="reportecharthistory.jsp?demographic_no=<%= Encode.forUriComponent(demographic_no) %>&limit1=<%=nLastPage%>&limit2=<%=intLimit2%>">Last
     Page</a> | <%
     }
-    if (nItems == Integer.parseInt(strLimit2)) {
+    if (nItems == intLimit2) {
 %> <a
-        href="reportecharthistory.jsp?demographic_no=<%= Encode.forUriComponent(demographic_no) %>&limit1=<%=nNextPage%>&limit2=<%=strLimit2%>&splitectsize=<%= Encode.forUriComponent(splitectsize) %>">
+        href="reportecharthistory.jsp?demographic_no=<%= Encode.forUriComponent(demographic_no) %>&limit1=<%=nNextPage%>&limit2=<%=intLimit2%>&splitectsize=<%= Encode.forUriComponent(splitectsize) %>">
     Next Page</a> <%
     }
 %>

--- a/src/main/webapp/report/reportedblist.jsp
+++ b/src/main/webapp/report/reportedblist.jsp
@@ -173,7 +173,7 @@
             <td align="center"><%=nItems%>
             </td>
             <td align="center"
-                nowrap><%=ConversionUtils.toDateString(rt.getId().getEdb()).replace('-', '/')%>
+                nowrap><%=Encode.forHtml(ConversionUtils.toDateString(rt.getId().getEdb()).replace('-', '/'))%>
             </td>
             <td><%=Encode.forHtml(rt.getDemoName())%>
             </td>
@@ -199,16 +199,17 @@
     <CENTER><br>
             <%
     int nLastPage=0,nNextPage=0;
-    nNextPage=Integer.parseInt(strLimit2)+Integer.parseInt(strLimit1);
-    nLastPage=Integer.parseInt(strLimit1)-Integer.parseInt(strLimit2);
+    int intLimit2=Integer.parseInt(strLimit2);
+    nNextPage=intLimit2+Integer.parseInt(strLimit1);
+    nLastPage=Integer.parseInt(strLimit1)-intLimit2;
     if(nLastPage>=0) {
 %> <a
-                href="reportedblist.jsp?startDate=<%=Encode.forUriComponent(request.getParameter("startDate") != null ? request.getParameter("startDate") : "")%>&endDate=<%=Encode.forUriComponent(request.getParameter("endDate") != null ? request.getParameter("endDate") : "")%>&limit1=<%=nLastPage%>&limit2=<%=strLimit2%>">Last
+                href="reportedblist.jsp?startDate=<%=Encode.forUriComponent(request.getParameter("startDate") != null ? request.getParameter("startDate") : "")%>&endDate=<%=Encode.forUriComponent(request.getParameter("endDate") != null ? request.getParameter("endDate") : "")%>&limit1=<%=nLastPage%>&limit2=<%=intLimit2%>">Last
             Page</a> | <%
   }
-  if(nItems==Integer.parseInt(strLimit2)) {
+  if(nItems==intLimit2) {
 %> <a
-                href="reportedblist.jsp?startDate=<%=Encode.forUriComponent(request.getParameter("startDate") != null ? request.getParameter("startDate") : "")%>&endDate=<%=Encode.forUriComponent(request.getParameter("endDate") != null ? request.getParameter("endDate") : "")%>&limit1=<%=nNextPage%>&limit2=<%=strLimit2%>">
+                href="reportedblist.jsp?startDate=<%=Encode.forUriComponent(request.getParameter("startDate") != null ? request.getParameter("startDate") : "")%>&endDate=<%=Encode.forUriComponent(request.getParameter("endDate") != null ? request.getParameter("endDate") : "")%>&limit1=<%=nNextPage%>&limit2=<%=intLimit2%>">
             Next Page</a> <%}%>
 
 </body>

--- a/src/main/webapp/report/reportedblist.jsp
+++ b/src/main/webapp/report/reportedblist.jsp
@@ -202,14 +202,16 @@
     int intLimit2=Integer.parseInt(strLimit2);
     nNextPage=intLimit2+Integer.parseInt(strLimit1);
     nLastPage=Integer.parseInt(strLimit1)-intLimit2;
+    String encodedStartDate = Encode.forUriComponent(startDate != null ? startDate : "");
+    String encodedEndDate = Encode.forUriComponent(endDate != null ? endDate : "");
     if(nLastPage>=0) {
 %> <a
-                href="reportedblist.jsp?startDate=<%=Encode.forUriComponent(request.getParameter("startDate") != null ? request.getParameter("startDate") : "")%>&endDate=<%=Encode.forUriComponent(request.getParameter("endDate") != null ? request.getParameter("endDate") : "")%>&limit1=<%=nLastPage%>&limit2=<%=intLimit2%>">Last
+                href="reportedblist.jsp?startDate=<%=encodedStartDate%>&endDate=<%=encodedEndDate%>&limit1=<%=nLastPage%>&limit2=<%=intLimit2%>">Last
             Page</a> | <%
   }
   if(nItems==intLimit2) {
 %> <a
-                href="reportedblist.jsp?startDate=<%=Encode.forUriComponent(request.getParameter("startDate") != null ? request.getParameter("startDate") : "")%>&endDate=<%=Encode.forUriComponent(request.getParameter("endDate") != null ? request.getParameter("endDate") : "")%>&limit1=<%=nNextPage%>&limit2=<%=intLimit2%>">
+                href="reportedblist.jsp?startDate=<%=encodedStartDate%>&endDate=<%=encodedEndDate%>&limit1=<%=nNextPage%>&limit2=<%=intLimit2%>">
             Next Page</a> <%}%>
 
 </body>

--- a/src/main/webapp/share/javascript/oscarMDSIndex.js
+++ b/src/main/webapp/share/javascript/oscarMDSIndex.js
@@ -2342,7 +2342,7 @@ function addDocComment(docId, providerNo) {
     let comment = "";
     const text = jQuery("#comment_" + docId + "_" + providerNo);
     if (text.length > 0) {
-        comment = jQuery("#comment_" + docId + "_" + providerNo).html();
+        comment = jQuery("#comment_" + docId + "_" + providerNo).text();
         if (comment == null || comment == "no comment") {
             comment = "";
         }
@@ -2391,7 +2391,7 @@ function getDocComment(docId, providerNo, inQueueB) {
     let comment = "";
     const text = jQuery("#comment_" + docId + "_" + providerNo);
     if (text.length > 0) {
-        comment = jQuery("#comment_" + docId + "_" + providerNo).html();
+        comment = jQuery("#comment_" + docId + "_" + providerNo).text();
         if (comment == null || comment == "no comment") {
             comment = "";
         }

--- a/src/main/webapp/signature_pad/tabletSignature.jsp
+++ b/src/main/webapp/signature_pad/tabletSignature.jsp
@@ -51,7 +51,7 @@ is hosted in an IFrame and that the IFrame's parent window implements signatureH
     if (requestIdKey == null) {
         requestIdKey = DigitalSignatureUtils.generateSignatureRequestId(loggedInInfo.getLoggedInProviderNo());
     }
-    String imageUrl = request.getContextPath() + "/imageRenderingServlet?source=" + ImageRenderingServlet.Source.signature_preview.name() + "&" + DigitalSignatureUtils.SIGNATURE_REQUEST_ID_KEY + "=" + requestIdKey;
+    String imageUrl = request.getContextPath() + "/imageRenderingServlet?source=" + ImageRenderingServlet.Source.signature_preview.name() + "&" + DigitalSignatureUtils.SIGNATURE_REQUEST_ID_KEY + "=" + Encode.forUriComponent(requestIdKey);
     String storedImageUrl = request.getContextPath() + "/imageRenderingServlet?source=" + ImageRenderingServlet.Source.signature_stored.name() + "&digitalSignatureId=";
     boolean saveToDB = "true".equals(request.getParameter("saveToDB"));
 %>
@@ -64,7 +64,7 @@ is hosted in an IFrame and that the IFrame's parent window implements signatureH
 
     var storedImageUrl = "<%= Encode.forJavaScript(storedImageUrl) %>";
 
-    var contextPath = "<%=request.getContextPath() %>";
+    var contextPath = "<%= Encode.forJavaScript(request.getContextPath()) %>";
 
 </script>
 

--- a/src/main/webapp/web/dashboard/display/drilldownDisplayController.js
+++ b/src/main/webapp/web/dashboard/display/drilldownDisplayController.js
@@ -187,11 +187,10 @@ $(document).ready(function () {
         $('#drilldownTable thead th').each(function () {
             var id = this.id;
             if (id > 1) {
-                select.append('<option value="'
-                    + id
-                    + '">'
-                    + $(this).html()
-                    + '</option>');
+                var option = document.createElement('option');
+                option.value = id;
+                option.textContent = $(this).text();
+                select.append(option);
             }
         });
 
@@ -252,7 +251,10 @@ $(document).ready(function () {
                 });
 
             drilldownTable.column(columnId).data().unique().sort().each(function (d, j) {
-                select.append('<option value="' + d + '">' + d + '</option>')
+                var option = document.createElement('option');
+                option.value = d;
+                option.textContent = d;
+                select.append(option);
             });
         }
 


### PR DESCRIPTION
## Summary

- Add OWASP output encoding to 21 files across admin, provider, remaining JSPs, Java actions, and JavaScript files
- Resolves ~86 XSS alerts — the final batch for issue #1112
- Null-safe patterns throughout using `StringUtils.noNull()` and property defaults

## Changes

### Admin (1 file changed, 4 already encoded)
| File | Fixes | Key patterns |
|------|------:|--------------|
| providerPrivilege.jsp | 15+ | secExceptionMsg, privilege, role/object names, rights |

Already encoded: demographicmergerecord, providersearchresults, keygen/createKey, keygen/keyManager

### Provider (3 files changed, 2 not found in codebase)
| File | Fixes | Key patterns |
|------|------:|--------------|
| appointmentprovideradminmonth.jsp | 7 | mygroupno in JS/URL, resourcebaseurl, site names/bgColors |
| providerencountersingle.jsp | 5 | encounter date/time/subject/content, attachment names |
| providerDefaultDxCode.jsp | 1 | defaultDxCode input value |

Not found: formar2_99_08.jsp, formar1_99_12.jsp (stale scanner paths)

### Remaining JSPs (12 files)
| File | Fixes | Key patterns |
|------|------:|--------------|
| displayHRMReport.jsp | 10+ | HRM patient data, confidentiality, signed-off info |
| appointmentaddrecordcard.jsp | 5 | patientname, dates, provider name |
| reportecharthistory.jsp | 3 | strLimit2 parsed to int, date conversion |
| reportedblist.jsp | 3 | Same limit/date fix pattern |
| OntarioMDRedirect.jsp | 4 | jsessionID, ptLoginToken, requestor, uname |
| GenerateLetters.jsp | 3 | report IDs/names, demographic checkboxes |
| showHistory.jsp | 2 | create_date, providerName |
| importExtra.jsp | 2 | display param in title, dump in textarea |
| tabletSignature.jsp | 2 | contextPath in JS, requestIdKey in URL |
| oscarReportFluBilling.jsp | 2 | numMonth heading, provider options |
| forcepasswordreset.jsp | 1 | errormsg reflected XSS |
| appointmenteditrepeatbooking.jsp | 1 | UtilMisc.htmlEscape replaced with Encode |

Already encoded: episode/success.jsp, select_facility.jsp

### Java files (3 files)
| File | Fix |
|------|-----|
| ManageDocument2Action.java | Encode 11 EDoc fields in HTML response |
| BillingONReview2Action.java | Set JSON content-type on response |
| BillingEditCode2Action.java | Set JSON content-type on response |

### JavaScript files (2 files changed, 3 already safe)
| File | Fix |
|------|-----|
| drilldownDisplayController.js | Safe DOM element creation instead of string concatenation |
| oscarMDSIndex.js | `.html()` to `.text()` for reading comment content |

Already safe: annualreviewplanner.js (uses textContent), editControl2.js (designMode fundamental), dashboardDisplayController.js (trusted server HTML)

## Test plan

- [x] `make install` — BUILD SUCCESS
- [ ] Visual spot-check: provider privileges, appointment month view, HRM reports, force password reset
- [ ] After merge: verify alerts close on GitHub Security tab

Fixes #1112

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Apply OWASP output encoding across multiple JSPs, Java actions, and JavaScript to address XSS findings and improve output safety.

Bug Fixes:
- Escape user- and data-derived content in admin, provider, reporting, and common JSPs using appropriate OWASP encoders for HTML, attributes, JavaScript, CSS, and URIs to prevent XSS.
- Ensure document metadata and encounter content are HTML-encoded before being written to responses to avoid script injection.
- Update client-side DOM manipulation to use safe text APIs instead of HTML insertion for dynamically generated options.
- Treat pagination and other numeric request parameters more safely by parsing once and reusing typed values instead of re-parsing strings.
- Use text retrieval instead of HTML for comment fields in JavaScript to avoid propagating markup as data.
- Set JSON content-type headers on billing-related AJAX responses to correctly identify JSON payloads and reduce parsing ambiguity.

Enhancements:
- Standardize encoding of IDs, tokens, and request parameters in redirect and form JSPs to harden authentication and integration flows.
- Improve server-side generation of hidden inputs and form controls by encoding both names and values, aligning with secure coding practices.
- Refine display of clinical and demographic information by consistently encoding all dynamic fields rendered in reports and history views.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OWASP Encoder-based output encoding across admin, provider, and remaining JSP/JS/Java files to close ~86 XSS vectors. Also sets JSON content types with UTF-8; this completes the final batch for #1112.

- **Bug Fixes**
  - JSPs: escape dynamic text, attributes, CSS, JS, and URLs using `org.owasp.encoder.Encode` across key pages (privileges, HRM reports, OntarioMD redirect, appointments, forms); encode dynamic name attributes in `providerPrivilege.jsp`; standardize null-safety with `Objects.toString()` in several pages; DRY and harden pagination links in report pages.
  - Java: HTML-encode EDoc fields in `ManageDocument2Action`; set `application/json;charset=UTF-8` and write UTF‑8 bytes in `BillingONReview2Action` and `BillingEditCode2Action`.
  - JS: build options with safe DOM APIs; read comment content with `.text()` instead of `.html()`.

<sup>Written for commit 9b4e91f863c2fd557b7953b819e8ae84189958e5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

