### PR TITLE
fix(security): fix 4 genuine XSS issues from 40-file triage (#1326)

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementView2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementView2Action.java
@@ -1130,6 +1130,8 @@ public class CaseManagementView2Action extends ActionSupport {
             hashMap.put("Issues", issues);
 
             ObjectNode json = objectMapper.valueToTree(hashMap);
+            response.setContentType("application/json");
+            response.setCharacterEncoding("UTF-8");
             response.getOutputStream().write(json.toString().getBytes());
             return null;
         }

--- a/src/main/webapp/admin/keygen/createKey.jsp
+++ b/src/main/webapp/admin/keygen/createKey.jsp
@@ -90,7 +90,7 @@
                     String keyPairOut = "-------- Service Name --------\n" + name + "\n------------------------------\n" +
                             "----- Client Private Key -----\n" + clientKey + "\n------------------------------\n" +
                             "------ Oscar Public Key ------\n" + oscarKey + "\n------------------------------";
-                    response.setContentType("text");
+                    response.setContentType("text/plain");
                     response.setContentLength(keyPairOut.length());
                     response.setHeader("Content-Disposition", "attachment; filename=keyPair.key");
                     ServletOutputStream output = null;

--- a/src/main/webapp/billing/CA/BC/onSearch3rdBillAddr.jsp
+++ b/src/main/webapp/billing/CA/BC/onSearch3rdBillAddr.jsp
@@ -282,12 +282,12 @@
         <script language="JavaScript">
             <!--
             function last() {
-                document.nextform.action = "<%= request.getContextPath() %>/billing/CA/BC/onSearch3rdBillAddr.jsp?param=<%=URLEncoder.encode(param,"UTF-8")%>&param2=<%=URLEncoder.encode(param2,"UTF-8")%>&keyword=<%=Encode.forJavaScript(StringUtils.noNull(request.getParameter("keyword")))%>&search_mode=<%=Encode.forJavaScript(StringUtils.noNull(request.getParameter("search_mode")))%>&orderby=<%=Encode.forJavaScript(StringUtils.noNull(request.getParameter("orderby")))%>&limit1=<%=nLastPage%>&limit2=<%=strLimit2%>";
+                document.nextform.action = "<%= request.getContextPath() %>/billing/CA/BC/onSearch3rdBillAddr.jsp?param=<%=URLEncoder.encode(param,"UTF-8")%>&param2=<%=URLEncoder.encode(param2,"UTF-8")%>&keyword=<%=Encode.forJavaScript(URLEncoder.encode(StringUtils.noNull(request.getParameter("keyword")), "UTF-8"))%>&search_mode=<%=Encode.forJavaScript(URLEncoder.encode(StringUtils.noNull(request.getParameter("search_mode")), "UTF-8"))%>&orderby=<%=Encode.forJavaScript(URLEncoder.encode(StringUtils.noNull(request.getParameter("orderby")), "UTF-8"))%>&limit1=<%=nLastPage%>&limit2=<%=strLimit2%>";
                 document.nextform.submit();
             }
 
             function next() {
-                document.nextform.action = "<%= request.getContextPath() %>/billing/CA/BC/onSearch3rdBillAddr.jsp?param=<%=URLEncoder.encode(param,"UTF-8")%>&param2=<%=URLEncoder.encode(param2,"UTF-8")%>&keyword=<%=Encode.forJavaScript(StringUtils.noNull(request.getParameter("keyword")))%>&search_mode=<%=Encode.forJavaScript(StringUtils.noNull(request.getParameter("search_mode")))%>&orderby=<%=Encode.forJavaScript(StringUtils.noNull(request.getParameter("orderby")))%>&limit1=<%=nNextPage%>&limit2=<%=strLimit2%>";
+                document.nextform.action = "<%= request.getContextPath() %>/billing/CA/BC/onSearch3rdBillAddr.jsp?param=<%=URLEncoder.encode(param,"UTF-8")%>&param2=<%=URLEncoder.encode(param2,"UTF-8")%>&keyword=<%=Encode.forJavaScript(URLEncoder.encode(StringUtils.noNull(request.getParameter("keyword")), "UTF-8"))%>&search_mode=<%=Encode.forJavaScript(URLEncoder.encode(StringUtils.noNull(request.getParameter("search_mode")), "UTF-8"))%>&orderby=<%=Encode.forJavaScript(URLEncoder.encode(StringUtils.noNull(request.getParameter("orderby")), "UTF-8"))%>&limit1=<%=nNextPage%>&limit2=<%=strLimit2%>";
                 document.nextform.submit();
             }
 

--- a/src/main/webapp/billing/CA/ON/onSearch3rdBillAddr.jsp
+++ b/src/main/webapp/billing/CA/ON/onSearch3rdBillAddr.jsp
@@ -233,12 +233,12 @@
         <script language="JavaScript">
             <!--
             function last() {
-                document.nextform.action = "<%= request.getContextPath() %>/billing/CA/ON/onSearch3rdBillAddr.jsp?param=<%=URLEncoder.encode(param,"UTF-8")%>&param2=<%=URLEncoder.encode(param2,"UTF-8")%>&keyword=<%=Encode.forJavaScript(StringUtils.noNull(request.getParameter("keyword")))%>&search_mode=<%=Encode.forJavaScript(StringUtils.noNull(request.getParameter("search_mode")))%>&orderby=<%=Encode.forJavaScript(StringUtils.noNull(request.getParameter("orderby")))%>&limit1=<%=nLastPage%>&limit2=<%=strLimit2%>";
+                document.nextform.action = "<%= request.getContextPath() %>/billing/CA/ON/onSearch3rdBillAddr.jsp?param=<%=URLEncoder.encode(param,"UTF-8")%>&param2=<%=URLEncoder.encode(param2,"UTF-8")%>&keyword=<%=Encode.forJavaScript(URLEncoder.encode(StringUtils.noNull(request.getParameter("keyword")), "UTF-8"))%>&search_mode=<%=Encode.forJavaScript(URLEncoder.encode(StringUtils.noNull(request.getParameter("search_mode")), "UTF-8"))%>&orderby=<%=Encode.forJavaScript(URLEncoder.encode(StringUtils.noNull(request.getParameter("orderby")), "UTF-8"))%>&limit1=<%=nLastPage%>&limit2=<%=strLimit2%>";
                 document.nextform.submit();
             }
 
             function next() {
-                document.nextform.action = "<%= request.getContextPath() %>/billing/CA/ON/onSearch3rdBillAddr.jsp?param=<%=URLEncoder.encode(param,"UTF-8")%>&param2=<%=URLEncoder.encode(param2,"UTF-8")%>&keyword=<%=Encode.forJavaScript(StringUtils.noNull(request.getParameter("keyword")))%>&search_mode=<%=Encode.forJavaScript(StringUtils.noNull(request.getParameter("search_mode")))%>&orderby=<%=Encode.forJavaScript(StringUtils.noNull(request.getParameter("orderby")))%>&limit1=<%=nNextPage%>&limit2=<%=strLimit2%>";
+                document.nextform.action = "<%= request.getContextPath() %>/billing/CA/ON/onSearch3rdBillAddr.jsp?param=<%=URLEncoder.encode(param,"UTF-8")%>&param2=<%=URLEncoder.encode(param2,"UTF-8")%>&keyword=<%=Encode.forJavaScript(URLEncoder.encode(StringUtils.noNull(request.getParameter("keyword")), "UTF-8"))%>&search_mode=<%=Encode.forJavaScript(URLEncoder.encode(StringUtils.noNull(request.getParameter("search_mode")), "UTF-8"))%>&orderby=<%=Encode.forJavaScript(URLEncoder.encode(StringUtils.noNull(request.getParameter("orderby")), "UTF-8"))%>&limit1=<%=nNextPage%>&limit2=<%=strLimit2%>";
                 document.nextform.submit();
             }
 


### PR DESCRIPTION
## Summary

Triaged all 40 files listed in #1326 and found the actual scope is much smaller than expected:

- **34 files already have OWASP encoding** on develop — their ~104 `javasecurity:S5131` alerts are SonarQube false positives (SonarQube does not recognize OWASP Encoder as a valid sanitizer)
- **6 files were deleted** from the codebase — stale alerts for `billingClinicaidReport.jsp` (PR #969), `addINRbilling.jsp` + `addFluBilling.jsp` (PR #994), `viewOruR01.jsp` (PR #965), `formar1_99_12.jsp` + `formar2_99_08.jsp` (PR #727)
- **4 genuine code fixes** in this PR (3 from the original list + ON version with same vulnerability)

## Changes

### 1. BC & ON `onSearch3rdBillAddr.jsp` — URL encoding gap (CWE-79)
URL query params `keyword`, `search_mode`, `orderby` were wrapped with `Encode.forJavaScript()` but lacked URL encoding. The `param`/`param2` values on the same lines already correctly used `URLEncoder.encode()`. Added `URLEncoder.encode(..., "UTF-8")` inside the existing `Encode.forJavaScript()` wrapper to match.

### 2. `CaseManagementView2Action.java` — missing JSON Content-Type
JSON response written to output stream without `Content-Type: application/json`, allowing browsers to potentially interpret the response as HTML. Added `response.setContentType("application/json")` and `response.setCharacterEncoding("UTF-8")`.

### 3. `createKey.jsp` — invalid MIME type
Content-Type was set to `"text"` (not a valid MIME type). Changed to `"text/plain"`.

## Remaining alerts (not addressable by code changes)

| Category | Count | Action Needed |
|----------|-------|---------------|
| SonarQube `S5131` false positives | ~104 | Configure SonarQube to recognize OWASP Encoder, or dismiss |
| Stale alerts on deleted files | ~34 | Dismiss via GitHub API as "won't fix" |
| `dbTicklerAdd.jsp` S5131 on `Integer.parseInt()` | 4 | False positive — not HTML output |

## Test plan

- [x] `make install` — build succeeds
- [ ] Verify BC/ON 3rd-party billing address search pagination still works
- [ ] Verify case management notes JSON endpoint returns proper Content-Type
- [ ] Verify key pair download from admin keygen works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix four real XSS issues from the #1326 triage and correct MIME types. Of the 40 flagged files, 34 already use OWASP Encoder and 6 were deleted; only these four fixes were needed.

- **Bug Fixes**
  - `billing/CA/BC/onSearch3rdBillAddr.jsp` and `billing/CA/ON/onSearch3rdBillAddr.jsp`: URL-encode `keyword`, `search_mode`, and `orderby` inside existing `Encode.forJavaScript(...)` to prevent URL parameter injection.
  - `CaseManagementView2Action.java`: set `Content-Type: application/json` and UTF‑8 before writing JSON.
  - `admin/keygen/createKey.jsp`: change invalid `"text"` MIME type to `"text/plain"`.

<sup>Written for commit fce6e955307590e84ead687b67e9eb6b37ce0709. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

