### PR TITLE
chore: migrate <c:out> to OWASP encoder in 42 JSP files (Phase 2)

### DIFF
--- a/.claude/hooks/validate-owasp-encoding.py
+++ b/.claude/hooks/validate-owasp-encoding.py
@@ -52,6 +52,7 @@ def check_jsp_unsafe_patterns(content: str) -> list[str]:
     # Safe wrappers that indicate proper encoding
     safe_wrappers = [
         r'Encode\.for\w+\s*\(',  # Encode.forHtml(), Encode.forJavaScript(), etc.
+        r'e:for\w+\s*\(',        # OWASP Encoder EL functions: ${e:forHtml()}, ${e:forHtmlAttribute()}, etc.
         r'fn:escapeXml\s*\(',    # JSTL escapeXml function
     ]
 

--- a/src/main/webapp/WEB-INF/jsp/admin/facility/EditFacility.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/facility/EditFacility.jsp
@@ -30,6 +30,7 @@
 --%>
 
 <%@ include file="/taglibs.jsp" %>
+<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 
 
@@ -79,7 +80,7 @@
         <table width="100%" border="1" cellspacing="2" cellpadding="3">
             <tr class="b">
                 <td>Facility Id:</td>
-                <td><c:out value="${requestScope.id}"/></td>
+                <td>${e:forHtml(requestScope.id)}</td>
             </tr>
             <tr class="b">
                 <td>Name: *</td>

--- a/src/main/webapp/WEB-INF/jsp/admin/facility/ListFacilities.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/facility/ListFacilities.jsp
@@ -30,6 +30,7 @@
 --%>
 
 <%@ include file="/taglibs.jsp" %>
+<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
@@ -77,7 +78,7 @@
             <display:column property="description" sortable="true" title="Description"/>
 
             <display:column sortable="false" title="">
-                <a href="<%=request.getContextPath() %>/FacilityManager.do?method=edit&id=<c:out value="${facility.id}" />">
+                <a href="<%=request.getContextPath() %>/FacilityManager.do?method=edit&id=${e:forHtmlAttribute(facility.id)}">
                     Edit </a>
             </display:column>
             <!--

--- a/src/main/webapp/WEB-INF/jsp/admin/facility/ListFacilities.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/facility/ListFacilities.jsp
@@ -78,7 +78,7 @@
             <display:column property="description" sortable="true" title="Description"/>
 
             <display:column sortable="false" title="">
-                <a href="<%=request.getContextPath() %>/FacilityManager.do?method=edit&id=${e:forHtmlAttribute(facility.id)}">
+                <a href="<%=request.getContextPath() %>/FacilityManager.do?method=edit&id=${e:forUriComponent(facility.id)}">
                     Edit </a>
             </display:column>
             <!--

--- a/src/main/webapp/WEB-INF/jsp/demographic/rourkeExport.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/rourkeExport.jsp
@@ -51,6 +51,7 @@
 <%@page import="java.util.List" %>
 <%@page import="io.github.carlos_emr.carlos.commn.model.DataExport" %>
 <%@include file="/casemgmt/taglibs.jsp" %>
+<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
 <c:set var="ctx" value="${pageContext.request.contextPath}" scope="request"/>
 <%
     DemographicSets ds = new DemographicSets();
@@ -180,7 +181,7 @@
                 <td><%=DateFormatUtils.format(dataExport.getDaterun().getTime(), DateFormatUtils.ISO_DATETIME_FORMAT.getPattern()) %>
                 </td>
                 <td>
-                    <a href='<c:out value="${ctx}/demographic/eRourkeExport.do"></c:out>?method=getFile&zipFile=<%=file%>'><%=file %>
+                    <a href='${e:forHtmlAttribute(ctx)}/demographic/eRourkeExport.do?method=getFile&zipFile=<%=file%>'><%=file %>
                     </a></td>
                 <td><%=dataExport.getUser()%>
                 <td><%=dataExport.getType()%>

--- a/src/main/webapp/WEB-INF/jsp/demographic/rourkeExport.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/rourkeExport.jsp
@@ -181,7 +181,7 @@
                 <td><%=DateFormatUtils.format(dataExport.getDaterun().getTime(), DateFormatUtils.ISO_DATETIME_FORMAT.getPattern()) %>
                 </td>
                 <td>
-                    <a href='${e:forHtmlAttribute(ctx)}/demographic/eRourkeExport.do?method=getFile&zipFile=<%=file%>'><%=file %>
+                    <a href='${e:forHtmlAttribute(ctx)}/demographic/eRourkeExport.do?method=getFile&zipFile=<%=org.owasp.encoder.Encode.forUriComponent(file)%>'><%=org.owasp.encoder.Encode.forHtml(file)%>
                     </a></td>
                 <td><%=dataExport.getUser()%>
                 <td><%=dataExport.getType()%>

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/AddMeasurementStyleSheet.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/AddMeasurementStyleSheet.jsp
@@ -35,6 +35,7 @@
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
+<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
 <link rel="stylesheet" type="text/css" href="<%= request.getContextPath() %>/css/encounterStyles.css">
 
 <html>
@@ -84,7 +85,7 @@
                                             <c:if test="${not empty messages}">
                                                 <tr>
                                                 <c:forEach var="msg" items="${messages}">
-                                                    <td><c:out value="${msg}"/></td>
+                                                    <td>${e:forHtml(msg)}</td>
                                                     </c:forEach>
                                                 </tr>
                                             </c:if>

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/AddMeasurementType.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/AddMeasurementType.jsp
@@ -36,6 +36,7 @@
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
+<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
 <link rel="stylesheet" type="text/css" href="<%= request.getContextPath() %>/css/encounterStyles.css">
 <html>
     <head>
@@ -90,7 +91,7 @@
                                         <td colspan="2">
                                             <c:if test="${not empty messages}">
                                                 <c:forEach var="msg" items="${messages}">
-                                                    <c:out value="${msg}"/>
+                                                    ${e:forHtml(msg)}
                                                     <br>
                                                 </c:forEach>
                                             </c:if>

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/AddMeasuringInstruction.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/AddMeasuringInstruction.jsp
@@ -35,6 +35,7 @@
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
+<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
 <link rel="stylesheet" type="text/css" href="<%= request.getContextPath() %>/css/encounterStyles.css">
 <html>
     <head>
@@ -89,7 +90,7 @@
                                         <td colspan="2">
                                             <c:if test="${not empty messages}">
                                                 <c:forEach var="msg" items="${messages}">
-                                                    <c:out value="${msg}"/>
+                                                    ${e:forHtml(msg)}
                                                     <br>
                                                 </c:forEach>
                                             </c:if>

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/AddMeasuringInstruction.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/AddMeasuringInstruction.jsp
@@ -36,6 +36,7 @@
 
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
 <%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
+<%@ page import="org.owasp.encoder.Encode" %>
 <link rel="stylesheet" type="text/css" href="<%= request.getContextPath() %>/css/encounterStyles.css">
 <html>
     <head>
@@ -60,7 +61,7 @@
     <div class="action-errors">
         <ul>
             <% for (String error : actionErrors) { %>
-                <li><%= error %></li>
+                <li><%= Encode.forHtml(error) %></li>
             <% } %>
         </ul>
     </div>

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/demographicSetEdit.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/demographicSetEdit.jsp
@@ -56,6 +56,7 @@
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
 
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
+<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
 <jsp:useBean id="providerBean" class="java.util.Properties"
              scope="session"/>
 
@@ -148,7 +149,7 @@
             <div class="alert alert-success fade show">
                 <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
                 <h4 class="alert-heading">Success!</h4>
-                <p>Patient set "<c:out value="${requestScope.setname}"/>" has been successfully deleted.</p>
+                <p>Patient set "${e:forHtml(requestScope.setname)}" has been successfully deleted.</p>
             </div>
             <% } %>
             <div class="row">

--- a/src/main/webapp/WEB-INF/jsp/provider/UserPreferences.jsp
+++ b/src/main/webapp/WEB-INF/jsp/provider/UserPreferences.jsp
@@ -31,6 +31,7 @@
 
 <%@page import="io.github.carlos_emr.carlos.utility.LoggedInInfo" %>
 <%@ include file="/taglibs.jsp" %>
+<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
 <%@ page import="java.util.Map" %>
 <%@ page import="io.github.carlos_emr.carlos.provider.web.UserPreference2Action" %>
 <%@ page import="io.github.carlos_emr.carlos.commn.model.UserProperty" %>
@@ -45,8 +46,8 @@
 <head>
     <script type="text/javascript" src="<%= request.getContextPath() %>/js/global.js"></script>
     <title><fmt:setBundle basename="oscarResources"/><fmt:message key="provider.pref.title"/></title>
-    <script src="<c:out value="${ctx}/js/checkPassword.js.jsp"/>"></script>
-    <script src="<c:out value="${ctx}/library/jquery/jquery-3.7.1.min.js"/>"></script>
+    <script src="${e:forHtmlAttribute(ctx)}/js/checkPassword.js.jsp"></script>
+    <script src="${e:forHtmlAttribute(ctx)}/library/jquery/jquery-3.7.1.min.js"></script>
     <script>
         jQuery(document).ready(function () {
             //jQuery("#general").hide();

--- a/src/main/webapp/admin/sitesAdmin.jsp
+++ b/src/main/webapp/admin/sitesAdmin.jsp
@@ -26,6 +26,7 @@
 "http://www.w3.org/TR/html4/loose.dtd">
 <%-- This JSP is the multi-site admin page --%>
 <%@ include file="/taglibs.jsp" %>
+<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
@@ -85,8 +86,7 @@
                     <display-el:column title="Active"><c:choose><c:when
                             test="${site.status==0}">No</c:when><c:otherwise>Yes</c:otherwise></c:choose></display-el:column>
                     <display-el:column title="Site Name">
-                        <a href="<%= request.getContextPath() %>/admin/ManageSites.do?method=update&siteId=<c:out value='${site.siteId}'/>"><c:out
-                                value="${site.name}"/></a></display-el:column>
+                        <a href="<%= request.getContextPath() %>/admin/ManageSites.do?method=update&siteId=${e:forHtmlAttribute(site.siteId)}">${e:forHtml(site.name)}</a></display-el:column>
                     <display-el:column property="shortName" title="Short Name"/>
                     <display-el:column property="bgColor" title="Color" style="background-color:${site.bgColor}"/>
                     <display-el:column property="phone" title="Telephone"/>

--- a/src/main/webapp/appointment/addappointment.jsp
+++ b/src/main/webapp/appointment/addappointment.jsp
@@ -1240,7 +1240,7 @@ Ontario, Canada
                                             <c:forEach items="${ reasonCodes.items }" var="reason">
                                                 <c:if test="${ reason.active }">
                                                     <option value="${ reason.id }" id="${ reason.value }">
-                                                        <c:out value="${ reason.label }"/>
+                                                        ${e:forHtml(reason.label)}
                                                     </option>
                                                 </c:if>
                                             </c:forEach>

--- a/src/main/webapp/billing/CA/BC/DxReference.jsp
+++ b/src/main/webapp/billing/CA/BC/DxReference.jsp
@@ -30,6 +30,7 @@
 --%>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
+<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;
@@ -59,7 +60,7 @@
         <select class="form-select" size="10" style="width:100%;height:100%;">
             <c:forEach items="${ dxList }" var="dx">
                 <option onClick="quickPickDiagnostic('${ dx.dx }');return false;" title="${ dx.desc }">
-                    <c:out value="${ dx.dx }"/> - <c:out value="${ dx.numMonthSinceDate }m"/>
+                    ${e:forHtml(dx.dx)} - ${e:forHtml(dx.numMonthSinceDate)}m
                 </option>
             </c:forEach>
         </select>

--- a/src/main/webapp/billing/CA/BC/DxReference.jsp
+++ b/src/main/webapp/billing/CA/BC/DxReference.jsp
@@ -59,7 +59,7 @@
     <c:if test="${ not empty dxList }">
         <select class="form-select" size="10" style="width:100%;height:100%;">
             <c:forEach items="${ dxList }" var="dx">
-                <option onClick="quickPickDiagnostic('${ dx.dx }');return false;" title="${ dx.desc }">
+                <option onClick="quickPickDiagnostic('${e:forJavaScript(dx.dx)}');return false;" title="${e:forHtmlAttribute(dx.desc)}">
                     ${e:forHtml(dx.dx)} - ${e:forHtml(dx.numMonthSinceDate)}m
                 </option>
             </c:forEach>

--- a/src/main/webapp/billing/CA/BC/TeleplanSimulation.jsp
+++ b/src/main/webapp/billing/CA/BC/TeleplanSimulation.jsp
@@ -56,6 +56,7 @@
 <%@ page import="io.github.carlos_emr.carlos.billings.ca.bc.data.BillActivityDAO" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
+<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
 <%
     GregorianCalendar now = new GregorianCalendar();
     int curYear = now.get(Calendar.YEAR);
@@ -149,7 +150,7 @@
 
     <h4>Simulate Teleplan Report - <%=Encode.forHtml(thisyear)%>
     </h4>
-    <c:if test="${!empty error}"><c:out value="${error}"/></c:if>
+    <c:if test="${!empty error}">${e:forHtml(error)}</c:if>
 
     <form action="${pageContext.request.contextPath}/billing/CA/BC/SimulateTeleplanFile.do"
                onsubmit="return checkSubmit();" class="d-flex flex-wrap align-items-center gap-2">

--- a/src/main/webapp/billing/CA/BC/billingBC.jsp
+++ b/src/main/webapp/billing/CA/BC/billingBC.jsp
@@ -52,6 +52,7 @@
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
+<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
 <%@page import="java.util.*, io.github.carlos_emr.carlos.billing.ca.bc.data.*,io.github.carlos_emr.carlos.billing.ca.bc.pageUtil.*,io.github.carlos_emr.*,io.github.carlos_emr.carlos.entities.*" %>
 <%@page import="io.github.carlos_emr.carlos.utility.SpringUtils" %>
 <%@page import="io.github.carlos_emr.carlos.commn.dao.BillingreferralDao" %>
@@ -2061,7 +2062,7 @@
                                                         </oscar:oscarPropertiesCheck>
                                                         <c:forEach var="codeSystem" items="${dxCodeSystemList.codingSystems}">
                                                             <option value="${codeSystem}">
-                                                                <c:out value="${codeSystem}"/>
+                                                                ${e:forHtml(codeSystem)}
                                                             </option>
                                                         </c:forEach>
                                                     </select>

--- a/src/main/webapp/billing/CA/BC/privateBilling/viewStatement.jsp
+++ b/src/main/webapp/billing/CA/BC/privateBilling/viewStatement.jsp
@@ -156,7 +156,7 @@
                           - by default, show the bill recipient's name
                           - if it's empty, just display 'Patient'
                         --%>
-                    <td><c:out value="${invoice.recipientName}" default="Patient"/></td>
+                    <td>${e:forHtml(empty invoice.recipientName ? 'Patient' : invoice.recipientName)}</td>
 
                         <%-- Balance:
                           - by default, show balance in Canadian dollars

--- a/src/main/webapp/billing/CA/ON/billingShortcutPg1.jsp
+++ b/src/main/webapp/billing/CA/ON/billingShortcutPg1.jsp
@@ -58,6 +58,7 @@
 
 
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
+<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
 <%@ page errorPage="/errorpage.jsp" %>
 <%@ page import="java.util.*,java.net.*, java.sql.*, io.github.carlos_emr.*" %>
 <%@ page import="org.owasp.encoder.Encode" %>
@@ -421,7 +422,7 @@
     <script type="text/javascript" src="<%= request.getContextPath() %>/share/calendar/calendar.js"></script>
     <!-- language for the calendar -->
     <script type="text/javascript"
-            src="<c:out value="${ctx}"/>/share/calendar/lang/<fmt:setBundle basename="oscarResources"/><fmt:message key="global.javascript.calendar"/>"></script>
+            src="${e:forHtmlAttribute(ctx)}/share/calendar/lang/<fmt:setBundle basename="oscarResources"/><fmt:message key="global.javascript.calendar"/>"></script>
     <!-- the following script defines the Calendar.setup helper function, which makes
            adding a calendar a matter of 1 or 2 lines of code. -->
     <script type="text/javascript"

--- a/src/main/webapp/casemgmt/ChartNotesAjax.jsp
+++ b/src/main/webapp/casemgmt/ChartNotesAjax.jsp
@@ -998,7 +998,7 @@ EmailComposeManager emailComposeManager = SpringUtils.getBean(EmailComposeManage
     var submitIssues = false;
     //AutoCompleter for Issues
     <%--    <c:url value="/CaseManagementEntry.do?method=issueList&demographicNo=${param.demographicNo}&providerNo=${param.providerNo}" var="issueURL" />--%>
-    <%--    let issueAutoCompleter = new Ajax.Autocompleter("issueAutocomplete", "issueAutocompleteList", "<c:out value="${issueURL}"/>", {minChars: 3, indicator: 'busy', afterUpdateElement: saveIssueId, onShow: autoCompleteShowMenu, onHide: autoCompleteHideMenu});--%>
+
 
     <%int MaxLen = 20;
 			int TruncLen = 17;

--- a/src/main/webapp/casemgmt/reminders.jsp
+++ b/src/main/webapp/casemgmt/reminders.jsp
@@ -30,6 +30,7 @@
 
 
 <%@ include file="/casemgmt/taglibs.jsp" %>
+<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;
@@ -71,6 +72,6 @@
 <input type="submit" name="submit" value="save" onclick="this.form.method.value='patientCPPSave'"/>
 <c:if test="${not empty messages}">
     <c:forEach var="message" items="${messages}">
-        <div style="color: blue"><I><c:out value="${message}"/></I></div>
+        <div style="color: blue"><I>${e:forHtml(message)}</I></div>
     </c:forEach>
 </c:if>

--- a/src/main/webapp/casemgmt/unlockNoteForm.jsp
+++ b/src/main/webapp/casemgmt/unlockNoteForm.jsp
@@ -30,6 +30,7 @@
 
 
 <%@ include file="/casemgmt/taglibs.jsp" %>
+<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;
@@ -50,7 +51,7 @@
     <title>Case Management</title>
     <c:set var="ctx" value="${pageContext.request.contextPath}"
            scope="request"/>
-    <link rel="stylesheet" href="<c:out value="${ctx}"/>/css/casemgmt.css"
+    <link rel="stylesheet" href="${e:forHtmlAttribute(ctx)}/css/casemgmt.css"
           type="text/css">
 </head>
 

--- a/src/main/webapp/casemgmt/unlockNoteSuccess.jsp
+++ b/src/main/webapp/casemgmt/unlockNoteSuccess.jsp
@@ -30,13 +30,14 @@
 
 
 <%@ include file="/casemgmt/taglibs.jsp" %>
+<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
 <html>
 <head>
     <script type="text/javascript" src="<%= request.getContextPath() %>/js/global.js"></script>
     <title>Case Management</title>
     <c:set var="ctx" value="${pageContext.request.contextPath}"
            scope="request"/>
-    <link rel="stylesheet" href="<c:out value="${ctx}"/>/css/casemgmt.css"
+    <link rel="stylesheet" href="${e:forHtmlAttribute(ctx)}/css/casemgmt.css"
           type="text/css">
 
     <script>

--- a/src/main/webapp/common/messages.jsp
+++ b/src/main/webapp/common/messages.jsp
@@ -36,7 +36,7 @@
            bgcolor="#C0C0C0">
         <c:if test="${not empty savedMessage}">
             <tr>
-                <td class="error">${savedMessage}</td>
+                <td class="error">${e:forHtml(savedMessage)}</td>
             </tr>
         </c:if>
     </table>

--- a/src/main/webapp/common/messages.jsp
+++ b/src/main/webapp/common/messages.jsp
@@ -28,6 +28,7 @@
 
 --%>
 <%@ include file="/taglibs.jsp" %>
+<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
 <br/>
 <%-- Error Messages --%>
 <c:if test="${not empty pageContext.request.getAttribute('org.apache.struts.action.ERROR')}">
@@ -46,7 +47,7 @@
            bgcolor="#C0C0C0">
         <c:if test="${not empty savedMessage}">
             <tr>
-                <td class="message"><c:out value="${savedMessage}"/></td>
+                <td class="message">${e:forHtml(savedMessage)}</td>
             </tr>
         </c:if>
     </table>

--- a/src/main/webapp/demographic/autocomplete.jsp
+++ b/src/main/webapp/demographic/autocomplete.jsp
@@ -30,10 +30,10 @@
 --%>
 
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
+<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
 <ul>
     <c:forEach var="l" items="${list}">
-        <li id="<c:out value="${l.demographicNo}"/>"><c:out value="${l.formattedName}"/> (<c:out
-                value="${l.formattedDob}"/>)
+        <li id="${e:forHtmlAttribute(l.demographicNo)}">${e:forHtml(l.formattedName)} (${e:forHtml(l.formattedDob)})
         </li>
     </c:forEach>
 </ul>

--- a/src/main/webapp/demographic/manageFirstNationsModule.jsp
+++ b/src/main/webapp/demographic/manageFirstNationsModule.jsp
@@ -31,6 +31,7 @@
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;
@@ -150,7 +151,7 @@
         <select id="fNationCom" name="fNationCom">
             <c:forEach items="${firstNationCommunities.items}" var="firstNationCommunity">
                 <option value="${firstNationCommunity.value}" ${firstNationCommunity.value eq demoExt["fNationCom"] ? 'selected' : '' }>
-                    <c:out value="${firstNationCommunity.label}"/>
+                    ${e:forHtml(firstNationCommunity.label)}
                 </option>
             </c:forEach>
         </select>

--- a/src/main/webapp/demographic/manageFirstNationsModule.jsp
+++ b/src/main/webapp/demographic/manageFirstNationsModule.jsp
@@ -150,7 +150,7 @@
     <td align="left">
         <select id="fNationCom" name="fNationCom">
             <c:forEach items="${firstNationCommunities.items}" var="firstNationCommunity">
-                <option value="${firstNationCommunity.value}" ${firstNationCommunity.value eq demoExt["fNationCom"] ? 'selected' : '' }>
+                <option value="${e:forHtmlAttribute(firstNationCommunity.value)}" ${firstNationCommunity.value eq demoExt["fNationCom"] ? 'selected' : '' }>
                     ${e:forHtml(firstNationCommunity.label)}
                 </option>
             </c:forEach>

--- a/src/main/webapp/encounter/Index2.jsp
+++ b/src/main/webapp/encounter/Index2.jsp
@@ -191,7 +191,7 @@
         <div class="action-errors">
             <ul>
                 <c:forEach var="error" items="${actionErrors}">
-                    <li><c:out value="${error}"/></li>
+                    <li>${e:forHtml(error)}</li>
                 </c:forEach>
             </ul>
         </div>

--- a/src/main/webapp/encounter/decisionSupport/guidelineList.jsp
+++ b/src/main/webapp/encounter/decisionSupport/guidelineList.jsp
@@ -57,6 +57,7 @@
 
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
+<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
 
 <%@ page import="io.github.carlos_emr.carlos.decisionSupport.model.DSGuideline" %>
 
@@ -74,7 +75,7 @@
 <body>
 <div style="font-size: 16px; font-weight: bold;"><fmt:setBundle basename="oscarResources"/><fmt:message key="encounter.guidelinelist.youcurrently"/></div>
 <c:if test="${not empty demographic_no}">
-    <div style="font-size: 10px;"><fmt:setBundle basename="oscarResources"/><fmt:message key="encounter.guidelinelist.demographicno"/> <c:out value="${demographic_no}"/></div>
+    <div style="font-size: 10px;"><fmt:setBundle basename="oscarResources"/><fmt:message key="encounter.guidelinelist.demographicno"/> ${e:forHtml(demographic_no)}</div>
 </c:if>
 <br>
 <table class="dsTable">

--- a/src/main/webapp/encounter/oscarMeasurements/DisplayMeasurementStyleSheet.jsp
+++ b/src/main/webapp/encounter/oscarMeasurements/DisplayMeasurementStyleSheet.jsp
@@ -36,6 +36,7 @@
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
+<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
 <link rel="stylesheet" type="text/css" href="<%= request.getContextPath() %>/css/encounterStyles.css">
 <html>
     <head>
@@ -95,7 +96,7 @@
                                     </tr>
                                     <c:forEach var="styleSheet" items="${styleSheets.styleSheetNameVector}" varStatus="ctr">
                                     <tr class="data">
-                                        <td width="300"><c:out value="${styleSheet.styleSheetName}"/></td>
+                                        <td width="300">${e:forHtml(styleSheet.styleSheetName)}</td>
                                         <td width="10">
                                             <input type="checkbox" name="deleteCheckbox" value="${styleSheet.cssId}"/>
                                         </td>

--- a/src/main/webapp/encounter/oscarMeasurements/Measurements.jsp
+++ b/src/main/webapp/encounter/oscarMeasurements/Measurements.jsp
@@ -36,6 +36,7 @@
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
 <%@ taglib uri="jakarta.tags.functions" prefix="fn" %>
+<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
 
 <%@ page
         import="io.github.carlos_emr.carlos.encounter.oscarMeasurements.bean.EctMeasuringInstructionBeanHandler, io.github.carlos_emr.carlos.encounter.oscarMeasurements.bean.EctMeasuringInstructionBean" %>
@@ -55,7 +56,7 @@
     <head>
         <script type="text/javascript" src="<%= request.getContextPath() %>/js/global.js"></script>
         <title><c:if test="${not empty groupName}">
-            <c:out value="${groupName}"/>
+            ${e:forHtml(groupName)}
         </c:if> <fmt:setBundle basename="oscarResources"/><fmt:message key="encounter.Index.measurements"/></title>
 
         <base href="<%= request.getScheme() + "://" + request.getServerName() + ":" + request.getServerPort() + request.getContextPath() + "/" %>">

--- a/src/main/webapp/encounter/oscarMeasurements/Measurements.jsp
+++ b/src/main/webapp/encounter/oscarMeasurements/Measurements.jsp
@@ -200,7 +200,7 @@
             <tr class="MainTableTopRow">
                 <td class="MainTableTopRowLeftColumn"><h4>
                     <c:if test="${not empty groupName}">
-                    <h4>${groupName}</h4>
+                    <h4>${e:forHtml(groupName)}</h4>
                     </c:if>
                 </td>
                 <td class="MainTableTopRowRightColumn" style="padding:0px">

--- a/src/main/webapp/encounter/oscarMeasurements/adminFlowsheet/EditFlowsheet.jsp
+++ b/src/main/webapp/encounter/oscarMeasurements/adminFlowsheet/EditFlowsheet.jsp
@@ -54,6 +54,7 @@
 <%@ taglib uri="/WEB-INF/rewrite-tag.tld" prefix="rewrite" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
 <%!
     /**
      * Represents a customization inherited from a higher scope level.
@@ -399,7 +400,7 @@
 
             <%}%>
 
-Flowsheet: <span style="font-weight:normal"><c:out value="${requestScope.displayName ? requestScope.displayName : param.displayName}" />(<%=Encode.forHtml(flowsheet)%>)</span>
+Flowsheet: <span style="font-weight:normal">${e:forHtml(requestScope.displayName ? requestScope.displayName : param.displayName)}(<%=Encode.forHtml(flowsheet)%>)</span>
         </h4>
         <span class="mode-toggle">
 		  	<% if (scope == null) {

--- a/src/main/webapp/encounter/oscarMeasurements/adminFlowsheet/EditFlowsheet.jsp
+++ b/src/main/webapp/encounter/oscarMeasurements/adminFlowsheet/EditFlowsheet.jsp
@@ -400,7 +400,7 @@
 
             <%}%>
 
-Flowsheet: <span style="font-weight:normal">${e:forHtml(requestScope.displayName ? requestScope.displayName : param.displayName)}(<%=Encode.forHtml(flowsheet)%>)</span>
+Flowsheet: <span style="font-weight:normal">${e:forHtml(not empty requestScope.displayName ? requestScope.displayName : param.displayName)}(<%=Encode.forHtml(flowsheet)%>)</span>
         </h4>
         <span class="mode-toggle">
 		  	<% if (scope == null) {

--- a/src/main/webapp/form/eCARES/sections/patient_info.jsp
+++ b/src/main/webapp/form/eCARES/sections/patient_info.jsp
@@ -30,13 +30,14 @@
 --%>
 
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
+<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
 
 <ul class="m-0 p-0 patient-info">
     <li class="flex justify-center items-center" style="min-width: 600px;">
         <div>
             <span>Chart #:</span>
             <span class="font-bold" data-field-name="demographicNo">
-                <c:out value="${ param.demographicNo }"/>
+                ${e:forHtml(param.demographicNo)}
             </span>
         </div>
         <div class="ml-2">

--- a/src/main/webapp/lab/CA/ALL/testUploader.jsp
+++ b/src/main/webapp/lab/CA/ALL/testUploader.jsp
@@ -47,6 +47,7 @@
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
+<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
 <c:set var="ctx" value="${pageContext.request.contextPath}"/>
 
 <%
@@ -311,7 +312,7 @@
 
         <c:forEach var="file" items="${filesStatusMap}">
             <script>
-                addFileNameWithStatus("<c:out value="${file.key}" />", "<c:out value="${file.value}" />");
+                addFileNameWithStatus("${e:forJavaScript(file.key)}", "${e:forJavaScript(file.value)}");
             </script>
         </c:forEach>
     </form>

--- a/src/main/webapp/mfa/mfa_otp_handler.jsp
+++ b/src/main/webapp/mfa/mfa_otp_handler.jsp
@@ -30,6 +30,7 @@
 <%@ page contentType="text/html;charset=UTF-8" pageEncoding="UTF-8" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
 
 <fmt:setBundle basename="oscarResources"/>
 
@@ -46,7 +47,7 @@
                        placeholder="Enter code" aria-label=".form-control-sm"
                        required maxlength="6">
                 <div id="otpInputFeedback" class="invalid-feedback">
-                    <c:out value="${requestScope.mfaValidateCodeErr}"/>
+                    ${e:forHtml(requestScope.mfaValidateCodeErr)}
                 </div>
             </div>
 

--- a/src/main/webapp/oscarMDS/SelectProvider.jsp
+++ b/src/main/webapp/oscarMDS/SelectProvider.jsp
@@ -29,6 +29,7 @@
 
 --%>
 <%@include file="/casemgmt/taglibs.jsp" %>
+<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
 <%@ page
         import="io.github.carlos_emr.carlos.providers.data.ProviderData, java.util.ArrayList,java.util.Map, java.util.List, io.github.carlos_emr.carlos.utility.SpringUtils" %>
 <%@ page
@@ -119,7 +120,7 @@
 </style>
 </head>
 <body>
-<input type="hidden" id="forwardList" value="<c:out value="${ param.forwardList }" />"/>
+<input type="hidden" id="forwardList" value="${e:forHtmlAttribute(param.forwardList)}"/>
 <form name="providerSelectForm" class="mx-1">
     <p style="font-weight:bold;">
         <fmt:setBundle basename="oscarResources"/><fmt:message key="oscarMDS.forward.msgInstruction1"/>

--- a/src/main/webapp/oscarRx/ListDrugs.jsp
+++ b/src/main/webapp/oscarRx/ListDrugs.jsp
@@ -37,6 +37,7 @@
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
 <%@ page import="io.github.carlos_emr.CarlosProperties,io.github.carlos_emr.carlos.log.*" %>
 <%@page import="io.github.carlos_emr.carlos.casemgmt.service.CaseManagementManager,
                 io.github.carlos_emr.carlos.casemgmt.model.CaseManagementNoteLink,
@@ -454,7 +455,7 @@
                         var csrfEl = document.querySelector('input[name="CSRF-TOKEN"]');
                         var csrfToken = csrfEl ? csrfEl.value : '';
                         var val = document.getElementById('hidecpp_<%=prescriptIdInt%>').checked;
-                        fetch('<c:out value="${ctx}"/>/oscarRx/hideCpp.do', {
+                        fetch('${e:forJavaScript(ctx)}/oscarRx/hideCpp.do', {
                             method: 'POST',
                             headers: {'Content-Type': 'application/x-www-form-urlencoded', 'X-Requested-With': 'XMLHttpRequest', 'CSRF-TOKEN': csrfToken},
                             credentials: 'same-origin',

--- a/src/main/webapp/oscarRx/displayMedHistory.jsp
+++ b/src/main/webapp/oscarRx/displayMedHistory.jsp
@@ -46,6 +46,7 @@
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
+<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
 <%@page import="io.github.carlos_emr.carlos.prescript.data.RxDrugData,java.util.*" %>
 <%@page import="java.text.SimpleDateFormat" %>
 <%@page import="java.util.Calendar" %>
@@ -75,7 +76,7 @@
 %>
 
 <a onmouseover="this.style.cursor='pointer';" onMouseDown="parent.mb.hide();"><img
-        src="<c:out value="${ctx}/images/close.png"/>" border="0" TITLE="Close"
+        src="${e:forHtmlAttribute(ctx)}/images/close.png" border="0" TITLE="Close"
         style="position: absolute; top: 0.5em; right: 0.5em; "></a>
 <br/><br/>
 <table class="mhTable">

--- a/src/main/webapp/oscarRx/prescribe.jsp
+++ b/src/main/webapp/oscarRx/prescribe.jsp
@@ -74,6 +74,7 @@
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security"%>
+<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
 
 <c:set var="ctx" value="${pageContext.request.contextPath}" />
 <%
@@ -271,7 +272,7 @@ List<RxPrescriptionData.Prescription> listRxDrugs=(List)request.getAttribute("li
 <fmt:message key="WriteScript.msgClose" var="i18nClose"/>
 
 <fieldset style="margin-top:2px;" id="<%=fieldSetId%>">
-    <a tabindex="-1" href="javascript:void(0);"  style="float:right;margin-left:5px;margin-top:0px;padding-top:0px;" onclick="removePrescribingDrug(<%=fieldSetId%>, <%=DrugReferenceId%>);"><img src='<c:out value="${ctx}/images/close.png"/>' border="0"></a>
+    <a tabindex="-1" href="javascript:void(0);"  style="float:right;margin-left:5px;margin-top:0px;padding-top:0px;" onclick="removePrescribingDrug(<%=fieldSetId%>, <%=DrugReferenceId%>);"><img src='${e:forHtmlAttribute(ctx)}/images/close.png' border="0"></a>
     <a tabindex="-1" href="javascript:void(0);"  style="float:right;;margin-left:5px;margin-top:0px;padding-top:0px;" title="${i18nAddToFavorites}" onclick="addFav('<%=rand%>','<%=Encode.forJavaScript(drugName)%>')">F</a>
     <a tabindex="-1" href="javascript:void(0);" style="float:right;margin-top:0px;padding-top:0px;" onclick="var el=document.getElementById('rx_more_<%=rand%>');el.style.display=el.style.display==='none'?'':'none';">  <span id="moreLessWord_<%=rand%>" onclick="updateMoreLess(id)" >${i18nMore}</span> </a>
 

--- a/src/main/webapp/oscarRx/prescribe.jsp
+++ b/src/main/webapp/oscarRx/prescribe.jsp
@@ -272,7 +272,7 @@ List<RxPrescriptionData.Prescription> listRxDrugs=(List)request.getAttribute("li
 <fmt:message key="WriteScript.msgClose" var="i18nClose"/>
 
 <fieldset style="margin-top:2px;" id="<%=fieldSetId%>">
-    <a tabindex="-1" href="javascript:void(0);"  style="float:right;margin-left:5px;margin-top:0px;padding-top:0px;" onclick="removePrescribingDrug(<%=fieldSetId%>, <%=DrugReferenceId%>);"><img src='${e:forHtmlAttribute(ctx)}/images/close.png' border="0"></a>
+    <a tabindex="-1" href="javascript:void(0);"  style="float:right;margin-left:5px;margin-top:0px;padding-top:0px;" onclick="removePrescribingDrug(document.getElementById('<%=Encode.forJavaScript(fieldSetId)%>'), <%=DrugReferenceId%>);"><img src='${e:forHtmlAttribute(ctx)}/images/close.png' border="0"></a>
     <a tabindex="-1" href="javascript:void(0);"  style="float:right;;margin-left:5px;margin-top:0px;padding-top:0px;" title="${i18nAddToFavorites}" onclick="addFav('<%=rand%>','<%=Encode.forJavaScript(drugName)%>')">F</a>
     <a tabindex="-1" href="javascript:void(0);" style="float:right;margin-top:0px;padding-top:0px;" onclick="var el=document.getElementById('rx_more_<%=rand%>');el.style.display=el.style.display==='none'?'':'none';">  <span id="moreLessWord_<%=rand%>" onclick="updateMoreLess(id)" >${i18nMore}</span> </a>
 

--- a/src/main/webapp/provider/providerpreference.jsp
+++ b/src/main/webapp/provider/providerpreference.jsp
@@ -48,6 +48,7 @@
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 <%@ page errorPage="/errorpage.jsp" %>
 
@@ -1556,7 +1557,7 @@ function isValidAutoSaveResponse(status, body) {
         var self = this;
         var csrfEl = document.querySelector('input[name="CSRF-TOKEN"]');
         var csrfToken = csrfEl ? csrfEl.value : '';
-        fetch('<c:out value="${ctx}"/>/provider/rxInteractionWarningLevel.do', {
+        fetch('${e:forJavaScript(ctx)}/provider/rxInteractionWarningLevel.do', {
             method: 'POST',
             credentials: 'same-origin',
             headers: {

--- a/src/main/webapp/provider/setDashboardPrefs.jsp
+++ b/src/main/webapp/provider/setDashboardPrefs.jsp
@@ -31,6 +31,7 @@
 
 <%@page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <%@ include file="/casemgmt/taglibs.jsp" %>
+<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
 <%@page import="java.util.*" %>
 <%@ page import="java.util.ResourceBundle"%>
 
@@ -68,7 +69,7 @@
             <td class="MainTableRightColumn">
                 <%if (request.getAttribute("status") == null) {%>
                 <form action="${pageContext.request.contextPath}/setProviderStaleDate.do" method="post">
-                    <input type="hidden" name="method" value="<c:out value="${method}"/>">
+                    <input type="hidden" name="method" value="${e:forHtmlAttribute(method)}">
                     <input type="checkbox" name="dashboardShareProperty.checked" <c:if test="${dashboardShareProperty.checked}">checked</c:if> />
                         <fmt:setBundle basename="oscarResources"/><fmt:message key="provider.pref.dashboardShare"/>
                     <br/><br/>

--- a/src/main/webapp/provider/setDisplayDocumentAs.jsp
+++ b/src/main/webapp/provider/setDisplayDocumentAs.jsp
@@ -31,6 +31,7 @@
 
 <%@page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <%@ include file="/casemgmt/taglibs.jsp" %>
+<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
 <%@page import="java.util.*" %>
 <%@ page import="java.util.ResourceBundle"%>
 <%
@@ -69,7 +70,7 @@
             <td class="MainTableRightColumn">
                 <%if (request.getAttribute("status") == null) {%> <%=bundle.getString(providermsgEdit)%>
                 <form action="${pageContext.request.contextPath}/setProviderStaleDate.do" method="post">
-                    <input type="hidden" name="method" value="<c:out value="${method}"/>">
+                    <input type="hidden" name="method" value="${e:forHtmlAttribute(method)}">
                     <select name="displayDocumentAsProperty.value" id="displayDocumentAsProperty.value">
                         <c:forEach var="dropOpt" items="${dropOpts}">
                             <option value="${dropOpt.value}" 

--- a/src/main/webapp/provider/setEDocBrowserInDocumentReport.jsp
+++ b/src/main/webapp/provider/setEDocBrowserInDocumentReport.jsp
@@ -31,6 +31,7 @@
 
 <%@page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <%@ include file="/casemgmt/taglibs.jsp" %>
+<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
 <%@page import="java.util.*" %>
 <%@ page import="java.util.ResourceBundle"%>
 <%
@@ -70,7 +71,7 @@
             <td class="MainTableRightColumn">
                 <%if (request.getAttribute("status") == null) {%> <%=bundle.getString(providermsgEdit)%>
                 <form action="${pageContext.request.contextPath}/setProviderStaleDate.do" method="post">
-                    <input type="hidden" name="method" value="<c:out value="${method}"/>">
+                    <input type="hidden" name="method" value="${e:forHtmlAttribute(method)}">
                     <input type="checkbox" name="eDocBrowserInDocumentReportProperty.checked" <c:if test="${eDocBrowserInDocumentReportProperty.checked}">checked</c:if> /><fmt:setBundle basename="oscarResources"/><fmt:message key="provider.setEDocBrowserInDocumentReport.msgEnableLink"/>
                     <br/>
                     <input type="submit" name="btnApply" value="Apply" />

--- a/src/main/webapp/provider/setEDocBrowserInMasterFile.jsp
+++ b/src/main/webapp/provider/setEDocBrowserInMasterFile.jsp
@@ -31,6 +31,7 @@
 
 <%@page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <%@ include file="/casemgmt/taglibs.jsp" %>
+<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
 <%@page import="java.util.*" %>
 <%@ page import="java.util.ResourceBundle"%>
 <%
@@ -69,7 +70,7 @@
             <td class="MainTableRightColumn">
                 <%if (request.getAttribute("status") == null) {%> <%=bundle.getString(providermsgEdit)%>
                 <form action="${pageContext.request.contextPath}/setProviderStaleDate.do" method="post">
-                    <input type="hidden" name="method" value="<c:out value="${method}"/>">
+                    <input type="hidden" name="method" value="${e:forHtmlAttribute(method)}">
                     <input type="checkbox" name="eDocBrowserInMasterFileProperty.checked" <c:if test="${eDocBrowserInMasterFileProperty.checked}">checked</c:if>  /><fmt:setBundle basename="oscarResources"/><fmt:message key="provider.btnSetEDocBrowserInMasterFile"/>
                     <br/>
                     <input type="submit" name="btnApply" value="Apply" />

--- a/src/main/webapp/provider/setNoteStaleDate.jsp
+++ b/src/main/webapp/provider/setNoteStaleDate.jsp
@@ -30,6 +30,7 @@
 --%>
 
 <%@ include file="/casemgmt/taglibs.jsp" %>
+<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
 
 <%
     if (session.getAttribute("user") == null)
@@ -54,7 +55,7 @@
               href="<%= request.getContextPath() %>/encounter/encounterStyles.css">
         <!-- calendar stylesheet -->
         <link rel="stylesheet" type="text/css" media="all"
-              href="<c:out value="${ctx}"/>/share/calendar/calendar.css"
+              href="${e:forHtmlAttribute(ctx)}/share/calendar/calendar.css"
               title="win2k-cold-1">
 
         <script type="text/javascript">

--- a/src/main/webapp/provider/setPreventionPrefs.jsp
+++ b/src/main/webapp/provider/setPreventionPrefs.jsp
@@ -31,6 +31,7 @@
 
 <%@page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <%@ include file="/casemgmt/taglibs.jsp" %>
+<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
 <%@page import="java.util.*" %>
 <%@ page import="java.util.ResourceBundle"%>
 
@@ -67,7 +68,7 @@
             <td class="MainTableRightColumn">
                 <%if (request.getAttribute("status") == null) {%>
                 <form action="${pageContext.request.contextPath}/setProviderStaleDate.do" method="post">
-                    <input type="hidden" name="method" value="<c:out value="${method}"/>">
+                    <input type="hidden" name="method" value="${e:forHtmlAttribute(method)}">
                     <input type="checkbox" name="preventionSSOWarningProperty.checked" <c:if test="${preventionSSOWarningProperty.checked}">checked</c:if>/>
                         Hide Warning when not logged into OneID Single Sign On.
                     <br/>

--- a/src/main/webapp/tickler/ticklerMain.jsp
+++ b/src/main/webapp/tickler/ticklerMain.jsp
@@ -49,6 +49,7 @@
 
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
+<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
 
 <%
     String roleName$ = session.getAttribute("userrole") + "," + session.getAttribute("user");
@@ -855,7 +856,7 @@
         </form>
 
         <form name="ticklerform" method="post" action="dbTicklerMain.jsp">
-            <input type="hidden" name="parentAjaxId" value="<c:out value='${param.parentAjaxId}' />"/>
+            <input type="hidden" name="parentAjaxId" value="${e:forHtmlAttribute(param.parentAjaxId)}"/>
             <table id="ticklerResults" class="table table-striped table-sm" style="width:100%">
                 <thead>
                 <tr>


### PR DESCRIPTION
## Summary

Phase 2 of 6 in the `<c:out>` → OWASP Encoder migration. Migrates 42 single-instance JSP files (1-2 `<c:out>` each) — the fastest batch with lowest risk.

- Replace `<c:out value="..."/>` with context-appropriate OWASP encoder EL functions (`${e:forHtml()}`, `${e:forHtmlAttribute()}`, `${e:forJavaScript()}`)
- Add `<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>` declaration to each file
- Handle `<c:out default="...">` via EL ternary operator (`viewStatement.jsp`)
- Remove commented-out dead code in `ChartNotesAjax.jsp`
- Update OWASP encoding validator hook to recognize `${e:forXxx()}` EL functions as safe (prevents false positives)

### Files by area (42 JSP + 1 hook)

| Group | Files | Key patterns |
|-------|-------|-------------|
| Provider preferences | 7 files (`set*.jsp`, `providerpreference.jsp`) | HTML attr, JS fetch() |
| Admin | 3 files (`sitesAdmin`, `EditFacility`, `ListFacilities`) | Mixed attr + body |
| Case management | 4 files (`reminders`, `unlockNote*`, `ChartNotesAjax`) | HTML body, href attr |
| Encounter | 6 files (`Index2`, `guidelineList`, `Measurements`, etc.) | HTML body |
| Billing | 5 files (BC + ON billing JSPs) | HTML body, src attr, default= |
| Rx | 3 files (`ListDrugs`, `displayMedHistory`, `prescribe`) | JS fetch(), src attr |
| Lab/MDS | 2 files (`testUploader`, `SelectProvider`) | JS context, value attr |
| Demographic | 2 files (`autocomplete`, `manageFirstNations`) | Mixed contexts |
| MFA/common | 2 files (`mfa_otp_handler`, `messages`) | HTML body |
| WEB-INF misc | 7 files (`AddMeasurement*`, `demographicSetEdit`, etc.) | HTML body, src attr |
| Tickler/appointment | 2 files | value attr, HTML body |

### Encoding context decisions

- **HTML body** → `${e:forHtml()}` (majority of instances)
- **HTML attributes** (value=, href=, src=) → `${e:forHtmlAttribute()}`
- **JavaScript strings** (fetch URLs, function args) → `${e:forJavaScript()}`
- **`default=` attribute** → EL ternary: `${e:forHtml(empty x ? 'Default' : x)}`

## Test plan

- [ ] JSPC compilation passes (`make install`) — catches malformed EL and taglib errors
- [ ] Verify no remaining `<c:out` in modified files
- [ ] Spot-check provider preferences page renders correctly
- [ ] Spot-check billing pages (BC/ON) render correctly
- [ ] Spot-check tickler and appointment pages render correctly

Generated with Claude Code

https://claude.ai/code/session_01ELTt3CqZSeuw8aKQkBL2ro

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Phase 2 migrates 42 JSPs from `<c:out>` to OWASP Encoder EL for context-aware escaping, reducing XSS risk and standardizing output encoding. Adds validator hook support for `${e:forXxx()}` and addresses missed sinks from review.

- **Refactors**
  - Replaced `<c:out>` with `${e:forHtml()}`, `${e:forHtmlAttribute()}`, `${e:forJavaScript()}`, and `${e:forUriComponent()}` by context.
  - Added `<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>` to updated JSPs; used `Encode.forHtml()` in scriptlets where needed.
  - Converted `<c:out default="...">` to EL ternary (e.g., `viewStatement.jsp`).
  - Updated `.claude/hooks/validate-owasp-encoding.py` to accept `${e:forXxx()}`.

- **Bug Fixes**
  - Escaped user messages and errors (`messages.jsp`, `Measurements.jsp`, `AddMeasuringInstruction.jsp`).
  - Corrected URL/JS encodings: facility/file IDs via `forUriComponent`; JS args via `forJavaScript` (`ListFacilities.jsp`, `rourkeExport.jsp`, `DxReference.jsp`).
  - Fixed EL ternary with `not empty` in `EditFlowsheet.jsp` and passed DOM element to `removePrescribingDrug` in `prescribe.jsp`.

<sup>Written for commit 9b6f8470a06280bc70b4b93362fe825d859a8d3a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

