### PR TITLE
 [Fix] visualEformEditor.jsp missing validation function for src 

### DIFF
--- a/src/main/webapp/eform/visualEformEditor.jsp
+++ b/src/main/webapp/eform/visualEformEditor.jsp
@@ -1894,8 +1894,7 @@ var EFORM_I18N = {
 
             // ------- the eforms generated are currently dependent on jQuery ------
             source += "\<script src='../library/jquery/jquery-3.7.1.min.js'\>\<\/script\>"; // present in CARLOS
-            source += "\<script src='../library/jquery/jquery-3.6.4.min.js'\>\<\/script\>"; // present in OSCAR 19 and OPEN OSP
-            source += "\<script src='$\{oscar_javascript_path\}jquery/jquery-2.2.4.min.js'\>\<\/script\>"; // only present in JUNO
+            source += "\<script\>window.jQuery || document.write(\"\\x3cscript src='../library/jquery/jquery-3.6.4.min.js'\\x3e\\x3c\\/script\\x3e\");\<\/script\>";  // present in OSCAR 19 and OPEN OSP
             source += "\<script\>window.jQuery || document.write(\"\\x3cscript src='../js/jquery-1.12.3.js'\\x3e\\x3c\\/script\\x3e\");\<\/script\>"; // present in WELL and others as
             source += "\<script\>window.jQuery || document.write(\"\\x3cscript src='https://code.jquery.com/jquery-3.6.4.min.js' integrity='sha256-oP6HI9z1XaZNBrJURtCoUT5SUnxFr8s3BzRl+cbzUq8=' crossorigin='anonymous'\\x3e\\x3c\\/script\\x3e\");\<\/script\>"; // if all else fails refer to a CND
 
@@ -2147,6 +2146,15 @@ var EFORM_I18N = {
                 }
             });
             $element.addClass("gen-droppable");
+        }
+
+        function isValidImageSrc(src) {
+          return new Promise((resolve) => {
+            const img = new Image();        
+            img.onload = () => resolve(true);
+            img.onerror = () => resolve(false);
+            img.src = src;
+          });
         }
 
         function makeSignatureCanvas($element) {
@@ -2401,7 +2409,7 @@ var EFORM_I18N = {
                         name: id
                     });
                 });
-                makeSignatureCanvas($newDraggable);
+                ($newDraggable);
             }
             setNoborderStyle($newDraggable.find(XBOX_INPUT_SELECTOR), xboxBordersVisibleState);
             setNoborderStyle($newDraggable.find(TEXT_INPUT_SELECTOR), textBordersVisibleState);
@@ -2838,7 +2846,7 @@ var EFORM_I18N = {
             $pages.find(TEXT_INPUT_SELECTOR).parent().append(createInputOverrideDiv());
             $pages.find(".signature_data").parent().append(createInputOverrideDiv());
             $pages.find(".signaturePad").each(function() {
-                makeSignatureCanvas($(this));
+                ($(this));
             });
 
             setNoborderStyle($pages.find(XBOX_INPUT_SELECTOR), xboxBordersVisibleState);
@@ -4674,6 +4682,18 @@ var EFORM_I18N = {
     </script>
 
     <script id="signature_script" class="toSource">
+
+        function isValidImageSrc(src) {
+          return new Promise((resolve) => {
+            const img = new Image();
+        
+            img.onload = () => resolve(true);
+            img.onerror = () => resolve(false);
+        
+            img.src = src;
+          });
+        }
+
         /** this function is run on page load to make signature pads work. */
         $(function() {
             $(".signaturePad").each(function() {

--- a/src/main/webapp/eform/visualEformEditor.jsp
+++ b/src/main/webapp/eform/visualEformEditor.jsp
@@ -1463,21 +1463,6 @@ var EFORM_I18N = {
         var OSCAR_EFORM_ENTITY_URL = "../ws/rs/eform/";
         var OSCAR_EFORM_SEARCH_URL = "../ws/rs/eforms/";
 
-        /**
-         * Validates image src URLs using an allowlist to prevent XSS via dangerous URI schemes
-         * (javascript:, data:text/html, etc.). Allows relative paths, http(s) URLs,
-         * data:image/ URIs (used by signature pads), and simple filenames.
-         */
-        function isValidImageSrc(url) {
-            if (!url || typeof url !== 'string') return false;
-            if (/^(\/(?!\/)|\.\/|\.\.\/)/.test(url)) return true;
-            if (/^https?:\/\//i.test(url)) return true;
-            if (/^data:image\//i.test(url)) return true;
-            if (/^[\w][\w.\- ]*$/.test(url)) return true; // simple filename
-            console.error('isValidImageSrc: rejected URL:', url.substring(0, 50));
-            return false;
-        }
-
         /** GLOBAL SCOPE VARIABLES */
         var groupTitle
         var linkTo
@@ -2148,15 +2133,6 @@ var EFORM_I18N = {
             $element.addClass("gen-droppable");
         }
 
-        function isValidImageSrc(src) {
-          return new Promise((resolve) => {
-            const img = new Image();        
-            img.onload = () => resolve(true);
-            img.onerror = () => resolve(false);
-            img.src = src;
-          });
-        }
-
         function makeSignatureCanvas($element) {
 
             var $canvasFrame = $element.children(".canvas_frame");
@@ -2409,7 +2385,7 @@ var EFORM_I18N = {
                         name: id
                     });
                 });
-                ($newDraggable);
+                makeSignatureCanvas($newDraggable);
             }
             setNoborderStyle($newDraggable.find(XBOX_INPUT_SELECTOR), xboxBordersVisibleState);
             setNoborderStyle($newDraggable.find(TEXT_INPUT_SELECTOR), textBordersVisibleState);
@@ -2846,7 +2822,7 @@ var EFORM_I18N = {
             $pages.find(TEXT_INPUT_SELECTOR).parent().append(createInputOverrideDiv());
             $pages.find(".signature_data").parent().append(createInputOverrideDiv());
             $pages.find(".signaturePad").each(function() {
-                ($(this));
+                makeSignatureCanvas($(this));
             });
 
             setNoborderStyle($pages.find(XBOX_INPUT_SELECTOR), xboxBordersVisibleState);
@@ -4683,15 +4659,19 @@ var EFORM_I18N = {
 
     <script id="signature_script" class="toSource">
 
-        function isValidImageSrc(src) {
-          return new Promise((resolve) => {
-            const img = new Image();
-        
-            img.onload = () => resolve(true);
-            img.onerror = () => resolve(false);
-        
-            img.src = src;
-          });
+        /**
+         * Validates image src URLs using an allowlist to prevent XSS via dangerous URI schemes
+         * (javascript:, data:text/html, etc.). Allows relative paths, http(s) URLs,
+         * data:image/ URIs (used by signature pads), and simple filenames.
+         */
+        function isValidImageSrc(url) {
+            if (!url || typeof url !== 'string') return false;
+            if (/^(\/(?!\/)|\.\/|\.\.\/)/.test(url)) return true;
+            if (/^https?:\/\//i.test(url)) return true;
+            if (/^data:image\//i.test(url)) return true;
+            if (/^[\w][\w.\- ]*$/.test(url)) return true; // simple filename
+            console.error('isValidImageSrc: rejected URL:', url.substring(0, 50));
+            return false;
         }
 
         /** this function is run on page load to make signature pads work. */


### PR DESCRIPTION
and cleaner calling of jQuery chain

<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description

<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues

<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?
making eforms and reopening them
<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->

## Checklist

- [ ] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [ ] I have not included any patient data (PHI) in this PR
- [ ] I have added tests for new functionality, or this change doesn't need new tests
- [ ] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Restore image source validation for generated eForms and make jQuery loading more robust and environment-independent.

Bug Fixes:
- Ensure the image src validation helper is included with the emitted signature script so reopened eForms can safely validate image URLs.

Enhancements:
- Simplify and harden jQuery script loading by using conditional fallbacks across bundled and CDN-hosted versions while removing an obsolete local jQuery reference.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds image src validation to generated eForms and streamlines the `jQuery` fallback so the visual editor and signature pads load reliably across environments.

- **Bug Fixes**
  - Moved `isValidImageSrc` into the emitted signature script, deduplicating the helper and fixing missing-function regressions when reopening eForms.

- **Refactors**
  - Consolidated `jQuery` loading: load `../library/jquery/jquery-3.7.1.min.js`, then inline fallback to `../library/jquery/jquery-3.6.4.min.js`, then `../js/jquery-1.12.3.js`, then a CDN.
  - Removed legacy `jquery-2.2.4.min.js` path and avoided duplicate helpers.

<sup>Written for commit 86bccf4f1fc088ff061b14d58d7fa83583a4b358. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

