### PR TITLE
chore: enable gemini client

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -36,7 +36,13 @@
         }
     },
 
-    "forwardPorts": [8080, 8000, 3306, 3000],
+    "forwardPorts": [8080, 8000, 3306, 3000, 13579],
+    "portsAttributes": {
+        "13579": {
+            "label": "Gemini OAuth Callback",
+            "onAutoForward": "notify"
+        }
+    },
     "containerUser": "root",
     "remoteUser": "root"
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - "18000:8000"
     volumes:
       - m2-volume:/root/.m2
+      - gemini-config:/root/.gemini
       - ..:/workspace:cached
       - ../.devcontainer/db/db_data/:/db-data/
     env_file:
@@ -17,6 +18,8 @@ services:
       LANG: en_US.UTF-8
       LANGUAGE: en_US:en
       TZ: America/Toronto
+      DISPLAY: ":0"
+      OAUTH_CALLBACK_PORT: "13579"
     networks:
       - carlos-network
     depends_on:
@@ -84,6 +87,9 @@ volumes:
     driver: local
 
   m2-volume:
+    driver: local
+
+  gemini-config:
     driver: local
 
 networks:


### PR DESCRIPTION
<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description

<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues

<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?

<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->

## Checklist

- [ ] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [ ] I have not included any patient data (PHI) in this PR
- [ ] I have added tests for new functionality, or this change doesn't need new tests
- [ ] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Enable persistent Gemini client configuration and OAuth support in the development container.

Enhancements:
- Mount a dedicated volume for persistent Gemini configuration in the dev container.
- Expose DISPLAY and OAuth callback port environment variables to support local Gemini authentication flows.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Gemini client in the devcontainer by forwarding OAuth callback port 13579 and mounting a persistent /root/.gemini config volume. Adds DISPLAY and OAUTH_CALLBACK_PORT env vars to support local auth flows.

- **Migration**
  - Rebuild/reopen the dev container to apply port, volume, and env changes.
  - Ensure your OAuth redirect URI uses localhost:13579 if required.

<sup>Written for commit ca1945fbf68b665ecaea9d9b93cc350dae2850ce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

