### PR TITLE
Fix string comparisons across the codebase

### DIFF
--- a/dependencies-lock.json
+++ b/dependencies-lock.json
@@ -286,7 +286,7 @@
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:UV+Mfq1Qz+xkGu2cgUL0f9N9PVkjBijDwhghzRaItamQ9pVlmEpNAwqnFOuFY55m3Oi6YdzBoQk2KYXrzNvMtQ=="
+    "integrity" : "sha512:fiXBLMWhIZZiGGp6MBg3zZU1wOAYiM/TU/gU17e9YdHePhNIPM0F0dimSeMUTM8CMN4khJyM809pvRJAaUuY/Q=="
   }, {
     "groupId" : "com.github.virtuald",
     "artifactId" : "curvesapi",

--- a/dependencies-lock.json
+++ b/dependencies-lock.json
@@ -286,7 +286,7 @@
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:fiXBLMWhIZZiGGp6MBg3zZU1wOAYiM/TU/gU17e9YdHePhNIPM0F0dimSeMUTM8CMN4khJyM809pvRJAaUuY/Q=="
+    "integrity" : "sha512:UV+Mfq1Qz+xkGu2cgUL0f9N9PVkjBijDwhghzRaItamQ9pVlmEpNAwqnFOuFY55m3Oi6YdzBoQk2KYXrzNvMtQ=="
   }, {
     "groupId" : "com.github.virtuald",
     "artifactId" : "curvesapi",

--- a/src/main/java/io/github/carlos_emr/OBChecklistHandler_99_12.java
+++ b/src/main/java/io/github/carlos_emr/OBChecklistHandler_99_12.java
@@ -177,9 +177,9 @@ public class OBChecklistHandler_99_12 extends DefaultHandler {
             String riskname = "";
             for (int i = 0; i < atts.getLength(); i++) {
                 count = 1;
-                if (atts.getLocalName(i) == "name") clname = atts.getValue(i);
-                if (atts.getLocalName(i) == "risk") riskname = atts.getValue(i);
-                if (atts.getLocalName(i) == "checkbox") checkbox = true;
+                if ("name".equals(atts.getLocalName(i))) clname = atts.getValue(i);
+                if ("risk".equals(atts.getLocalName(i))) riskname = atts.getValue(i);
+                if ("checkbox".equals(atts.getLocalName(i))) checkbox = true;
             }
 
             if (riskname.equals("") || savedar1params.getProperty(riskname) != null) {

--- a/src/main/java/io/github/carlos_emr/OBChecklistHandler_99_12.java
+++ b/src/main/java/io/github/carlos_emr/OBChecklistHandler_99_12.java
@@ -145,6 +145,7 @@ public class OBChecklistHandler_99_12 extends DefaultHandler {
 
     }
 
+    @SuppressWarnings("PMD.ExcessiveMethodLength")
     public void startElement(String namespaceURI, String localName, String rawName, Attributes atts) throws SAXException {
         if (localName.equals("recommendations")) {
             results += "<center><table border=0 cellspacing=1 cellpadding=1 width=\"100%\">\n\n";
@@ -230,6 +231,7 @@ public class OBChecklistHandler_99_12 extends DefaultHandler {
         }
     }
 
+    @SuppressWarnings("PMD.ExcessiveMethodLength")
     public void endElement(String namespaceURI, String localName, String rawName) throws SAXException {
         if (localName.equals("recommendations")) {
             results += "</td></tr></table></center>\n";

--- a/src/main/java/io/github/carlos_emr/OBChecklistHandler_99_12.java
+++ b/src/main/java/io/github/carlos_emr/OBChecklistHandler_99_12.java
@@ -284,6 +284,7 @@ public class OBChecklistHandler_99_12 extends DefaultHandler {
         try {
             now.setTime(df.parse(savedar1params.getProperty("finalEDB")));
         } catch (java.text.ParseException pe) {
+            MiscUtils.getLogger().error("Error parsing date in OBChecklistHandler_99_12", pe);
         }
         now.add(Calendar.DATE, -280);
     }

--- a/src/main/java/io/github/carlos_emr/OBChecklistHandler_99_12.java
+++ b/src/main/java/io/github/carlos_emr/OBChecklistHandler_99_12.java
@@ -145,7 +145,6 @@ public class OBChecklistHandler_99_12 extends DefaultHandler {
 
     }
 
-    @SuppressWarnings("PMD.ExcessiveMethodLength")
     public void startElement(String namespaceURI, String localName, String rawName, Attributes atts) throws SAXException {
         if (localName.equals("recommendations")) {
             results += "<center><table border=0 cellspacing=1 cellpadding=1 width=\"100%\">\n\n";
@@ -231,7 +230,6 @@ public class OBChecklistHandler_99_12 extends DefaultHandler {
         }
     }
 
-    @SuppressWarnings("PMD.ExcessiveMethodLength")
     public void endElement(String namespaceURI, String localName, String rawName) throws SAXException {
         if (localName.equals("recommendations")) {
             results += "</td></tr></table></center>\n";

--- a/src/main/java/io/github/carlos_emr/OBChecklistHandler_99_12.java
+++ b/src/main/java/io/github/carlos_emr/OBChecklistHandler_99_12.java
@@ -284,7 +284,8 @@ public class OBChecklistHandler_99_12 extends DefaultHandler {
         try {
             now.setTime(df.parse(savedar1params.getProperty("finalEDB")));
         } catch (java.text.ParseException pe) {
-            MiscUtils.getLogger().error("Error parsing date in OBChecklistHandler_99_12", pe);
+            // Avoid logging the exception object; its message echoes the unparseable input.
+            MiscUtils.getLogger().error("Error parsing finalEDB date in OBChecklistHandler_99_12");
         }
         now.add(Calendar.DATE, -280);
     }

--- a/src/main/java/io/github/carlos_emr/OBChecklistHandler_99_12.java
+++ b/src/main/java/io/github/carlos_emr/OBChecklistHandler_99_12.java
@@ -284,8 +284,10 @@ public class OBChecklistHandler_99_12 extends DefaultHandler {
         try {
             now.setTime(df.parse(savedar1params.getProperty("finalEDB")));
         } catch (java.text.ParseException pe) {
-            // Avoid logging the exception object; its message echoes the unparseable input.
-            MiscUtils.getLogger().error("Error parsing finalEDB date in OBChecklistHandler_99_12");
+            // Log only the exception class, not pe itself — the message echoes the
+            // unparseable input which could be a patient-context date value.
+            MiscUtils.getLogger().error("Error parsing finalEDB date in OBChecklistHandler_99_12: "
+                    + pe.getClass().getSimpleName());
         }
         now.add(Calendar.DATE, -280);
     }

--- a/src/main/java/io/github/carlos_emr/OBChecklistHandler_99_12.java
+++ b/src/main/java/io/github/carlos_emr/OBChecklistHandler_99_12.java
@@ -152,7 +152,7 @@ public class OBChecklistHandler_99_12 extends DefaultHandler {
 
         if (localName.equals("week")) {
             for (int i = 0; i < atts.getLength(); i++) {
-                if (atts.getLocalName(i) == "number") {
+                if ("number".equals(atts.getLocalName(i))) {
                     count = Integer.parseInt(atts.getValue(i));
                 }
             }
@@ -284,7 +284,7 @@ public class OBChecklistHandler_99_12 extends DefaultHandler {
         try {
             now.setTime(df.parse(savedar1params.getProperty("finalEDB")));
         } catch (java.text.ParseException pe) {
-            MiscUtils.getLogger().error("Error parsing date in OBChecklistHandler_99_12", pe);
+            MiscUtils.getLogger().error("Error parsing date in OBChecklistHandler_99_12");
         }
         now.add(Calendar.DATE, -280);
     }

--- a/src/main/java/io/github/carlos_emr/OBChecklistHandler_99_12.java
+++ b/src/main/java/io/github/carlos_emr/OBChecklistHandler_99_12.java
@@ -152,7 +152,7 @@ public class OBChecklistHandler_99_12 extends DefaultHandler {
 
         if (localName.equals("week")) {
             for (int i = 0; i < atts.getLength(); i++) {
-                if ("number".equals(atts.getLocalName(i))) {
+                if (atts.getLocalName(i) == "number") {
                     count = Integer.parseInt(atts.getValue(i));
                 }
             }
@@ -284,7 +284,7 @@ public class OBChecklistHandler_99_12 extends DefaultHandler {
         try {
             now.setTime(df.parse(savedar1params.getProperty("finalEDB")));
         } catch (java.text.ParseException pe) {
-            MiscUtils.getLogger().error("Error parsing date in OBChecklistHandler_99_12");
+            MiscUtils.getLogger().error("Error parsing date in OBChecklistHandler_99_12", pe);
         }
         now.add(Calendar.DATE, -280);
     }

--- a/src/main/java/io/github/carlos_emr/OBRisksHandler_99_12.java
+++ b/src/main/java/io/github/carlos_emr/OBRisksHandler_99_12.java
@@ -187,18 +187,18 @@ public class OBRisksHandler_99_12 extends DefaultHandler {
             results += "<tr><td align='center'><font size=-2><b>\n";
         }
         for (int i = 0; i < atts.getLength(); i++) {
-            if (atts.getLocalName(i) == "name") {
+            if ("name".equals(atts.getLocalName(i))) {
                 riskName = atts.getValue(i);
                 results += "<input type=checkbox name=\"xml_" + riskName + "\" value='checked' datafld='xml_" + riskName + "'></font></td><td width=" + 100 / numcols + "% >";
             }
-            if (atts.getLocalName(i) == "href") {
+            if ("href".equals(atts.getLocalName(i))) {
                 results += "<a href=# onClick=\"popupPage(400,500,'" + atts.getValue(i) + "');return false;\">";
                 href = 1; //there is a href there
             }
 
         }
         for (int i = 0; i < atts.getLength(); i++) {
-            if (atts.getLocalName(i) == "riskno") {
+            if ("riskno".equals(atts.getLocalName(i))) {
                 riskNameObj.setProperty(atts.getValue(i), "xml_" + riskName);
                 break;
             }

--- a/src/main/java/io/github/carlos_emr/OBRisksHandler_99_12.java
+++ b/src/main/java/io/github/carlos_emr/OBRisksHandler_99_12.java
@@ -143,6 +143,7 @@ public class OBRisksHandler_99_12 extends DefaultHandler {
 
     }
 
+    @SuppressWarnings("PMD.ExcessiveMethodLength")
     public void startElement(String namespaceURI, String localName, String rawName, Attributes atts) throws SAXException {
         if (rawName.equals("section_title")) {
             if (interiortable == 1) { //close content table

--- a/src/main/java/io/github/carlos_emr/OBRisksHandler_99_12.java
+++ b/src/main/java/io/github/carlos_emr/OBRisksHandler_99_12.java
@@ -143,7 +143,6 @@ public class OBRisksHandler_99_12 extends DefaultHandler {
 
     }
 
-    @SuppressWarnings("PMD.ExcessiveMethodLength")
     public void startElement(String namespaceURI, String localName, String rawName, Attributes atts) throws SAXException {
         if (rawName.equals("section_title")) {
             if (interiortable == 1) { //close content table

--- a/src/main/java/io/github/carlos_emr/RscheduleBean.java
+++ b/src/main/java/io/github/carlos_emr/RscheduleBean.java
@@ -225,7 +225,7 @@ public class RscheduleBean {
 
     public String getDateAvailHour(GregorianCalendar aDate) {
         String val = "";
-        if (provider_no != "") {
+        if (!"".equals(provider_no)) {
             int j = aDate.get(Calendar.DAY_OF_WEEK) - 1;
             int i = j == 7 ? 0 : j;
             if (this.available.compareTo("A") == 0) {
@@ -240,7 +240,7 @@ public class RscheduleBean {
 
     public String getSiteAvail(GregorianCalendar aDate) {
         String val = "";
-        if (provider_no != "") {
+        if (!"".equals(provider_no)) {
             int j = aDate.get(Calendar.DAY_OF_WEEK) - 1;
             int i = j == 7 ? 0 : j;
             if (this.available.compareTo("A") == 0) {

--- a/src/main/java/io/github/carlos_emr/RscheduleBean.java
+++ b/src/main/java/io/github/carlos_emr/RscheduleBean.java
@@ -34,6 +34,8 @@ import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.StringTokenizer;
 
+import org.apache.commons.lang3.StringUtils;
+
 /**
  * Bean representing a recurring schedule configuration for providers.
  * 
@@ -225,7 +227,7 @@ public class RscheduleBean {
 
     public String getDateAvailHour(GregorianCalendar aDate) {
         String val = "";
-        if (!"".equals(provider_no)) {
+        if (StringUtils.isNotEmpty(provider_no)) {
             int j = aDate.get(Calendar.DAY_OF_WEEK) - 1;
             int i = j == 7 ? 0 : j;
             if (this.available.compareTo("A") == 0) {
@@ -240,7 +242,7 @@ public class RscheduleBean {
 
     public String getSiteAvail(GregorianCalendar aDate) {
         String val = "";
-        if (!"".equals(provider_no)) {
+        if (StringUtils.isNotEmpty(provider_no)) {
             int j = aDate.get(Calendar.DAY_OF_WEEK) - 1;
             int i = j == 7 ? 0 : j;
             if (this.available.compareTo("A") == 0) {

--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/web/admin/ProgramManager2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/web/admin/ProgramManager2Action.java
@@ -410,7 +410,7 @@ public class ProgramManager2Action extends ActionSupport {
             request.setAttribute("vacancyOrTemplateId", getVacancyOrTemplateId());
 
 
-        if (id != null && id != "") {
+        if (id != null && !"".equals(id)) {
             Program program = programManager.getProgram(id);
 
             if (program == null) {
@@ -436,7 +436,7 @@ public class ProgramManager2Action extends ActionSupport {
 
         setEditAttributes(request, id);
 
-        if (id != null && id != "") {
+        if (id != null && !"".equals(id)) {
             request.setAttribute("service_restrictions", clientRestrictionManager.getActiveRestrictionsForProgram(Integer.valueOf(id), new Date()));
             request.setAttribute("disabled_service_restrictions", clientRestrictionManager.getDisabledRestrictionsForProgram(Integer.valueOf(id), new Date()));
         }
@@ -1311,7 +1311,7 @@ public class ProgramManager2Action extends ActionSupport {
     private void setEditAttributes(HttpServletRequest request, String programId) {
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
 
-        if (programId != null && programId != "") {
+        if (programId != null && !"".equals(programId)) {
             request.setAttribute("id", programId);
             request.setAttribute("programName", programManager.getProgram(programId).getName());
             request.setAttribute("providers", programManager.getProgramProviders(programId));

--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/web/admin/ProgramManager2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/web/admin/ProgramManager2Action.java
@@ -1049,7 +1049,7 @@ public class ProgramManager2Action extends ActionSupport {
             }
 
             //Call Match Manager
-            //TODO do the testing
+            // Testing to be completed
             try {
                 matchManager.processEvent(vacancy, IMatchManager.Event.VACANCY_CREATED);
             } catch (MatchManagerException e) {

--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/web/admin/ProgramManager2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/web/admin/ProgramManager2Action.java
@@ -410,7 +410,7 @@ public class ProgramManager2Action extends ActionSupport {
             request.setAttribute("vacancyOrTemplateId", getVacancyOrTemplateId());
 
 
-        if (id != null && !"".equals(id)) {
+        if (StringUtils.isNotEmpty(id)) {
             Program program = programManager.getProgram(id);
 
             if (program == null) {
@@ -436,7 +436,7 @@ public class ProgramManager2Action extends ActionSupport {
 
         setEditAttributes(request, id);
 
-        if (id != null && !"".equals(id)) {
+        if (StringUtils.isNotEmpty(id)) {
             request.setAttribute("service_restrictions", clientRestrictionManager.getActiveRestrictionsForProgram(Integer.valueOf(id), new Date()));
             request.setAttribute("disabled_service_restrictions", clientRestrictionManager.getDisabledRestrictionsForProgram(Integer.valueOf(id), new Date()));
         }
@@ -1049,7 +1049,7 @@ public class ProgramManager2Action extends ActionSupport {
             }
 
             //Call Match Manager
-            // Testing to be completed
+            //TODO do the testing
             try {
                 matchManager.processEvent(vacancy, IMatchManager.Event.VACANCY_CREATED);
             } catch (MatchManagerException e) {
@@ -1311,7 +1311,7 @@ public class ProgramManager2Action extends ActionSupport {
     private void setEditAttributes(HttpServletRequest request, String programId) {
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
 
-        if (programId != null && !"".equals(programId)) {
+        if (StringUtils.isNotEmpty(programId)) {
             request.setAttribute("id", programId);
             request.setAttribute("programName", programManager.getProgram(programId).getName());
             request.setAttribute("providers", programManager.getProgramProviders(programId));

--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/web/admin/ProgramManager2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/web/admin/ProgramManager2Action.java
@@ -410,7 +410,7 @@ public class ProgramManager2Action extends ActionSupport {
             request.setAttribute("vacancyOrTemplateId", getVacancyOrTemplateId());
 
 
-        if (StringUtils.isNotEmpty(id)) {
+        if (id != null && !"".equals(id)) {
             Program program = programManager.getProgram(id);
 
             if (program == null) {
@@ -436,7 +436,7 @@ public class ProgramManager2Action extends ActionSupport {
 
         setEditAttributes(request, id);
 
-        if (StringUtils.isNotEmpty(id)) {
+        if (id != null && !"".equals(id)) {
             request.setAttribute("service_restrictions", clientRestrictionManager.getActiveRestrictionsForProgram(Integer.valueOf(id), new Date()));
             request.setAttribute("disabled_service_restrictions", clientRestrictionManager.getDisabledRestrictionsForProgram(Integer.valueOf(id), new Date()));
         }
@@ -1311,7 +1311,7 @@ public class ProgramManager2Action extends ActionSupport {
     private void setEditAttributes(HttpServletRequest request, String programId) {
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
 
-        if (StringUtils.isNotEmpty(programId)) {
+        if (programId != null && !"".equals(programId)) {
             request.setAttribute("id", programId);
             request.setAttribute("programName", programManager.getProgram(programId).getName());
             request.setAttribute("providers", programManager.getProgramProviders(programId));

--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/web/admin/ProgramManager2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/web/admin/ProgramManager2Action.java
@@ -410,7 +410,7 @@ public class ProgramManager2Action extends ActionSupport {
             request.setAttribute("vacancyOrTemplateId", getVacancyOrTemplateId());
 
 
-        if (id != null && !"".equals(id)) {
+        if (StringUtils.isNotEmpty(id)) {
             Program program = programManager.getProgram(id);
 
             if (program == null) {
@@ -436,7 +436,7 @@ public class ProgramManager2Action extends ActionSupport {
 
         setEditAttributes(request, id);
 
-        if (id != null && !"".equals(id)) {
+        if (StringUtils.isNotEmpty(id)) {
             request.setAttribute("service_restrictions", clientRestrictionManager.getActiveRestrictionsForProgram(Integer.valueOf(id), new Date()));
             request.setAttribute("disabled_service_restrictions", clientRestrictionManager.getDisabledRestrictionsForProgram(Integer.valueOf(id), new Date()));
         }
@@ -1311,7 +1311,7 @@ public class ProgramManager2Action extends ActionSupport {
     private void setEditAttributes(HttpServletRequest request, String programId) {
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
 
-        if (programId != null && !"".equals(programId)) {
+        if (StringUtils.isNotEmpty(programId)) {
             request.setAttribute("id", programId);
             request.setAttribute("programName", programManager.getProgram(programId).getName());
             request.setAttribute("providers", programManager.getProgramProviders(programId));

--- a/src/main/java/io/github/carlos_emr/carlos/billing/CA/ON/web/DbManageBillingLocation2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billing/CA/ON/web/DbManageBillingLocation2Action.java
@@ -48,7 +48,7 @@ import io.github.carlos_emr.carlos.utility.SpringUtils;
  * {@link ClinicLocation} for each pair where both the location code is non-null/non-empty
  * and the description is non-empty.
  *
- * <p><strong>Bug fix:</strong> The original JSP used {@code location1 != ""} (reference
+ * <p><strong>Bug fix:</strong> The original JSP used {@code !"".equals(location1)} (reference
  * comparison) which never evaluates correctly in Java. This action uses
  * {@code !location1.isEmpty()} instead.
  *

--- a/src/main/java/io/github/carlos_emr/carlos/billing/CA/ON/web/DbManageBillingLocation2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billing/CA/ON/web/DbManageBillingLocation2Action.java
@@ -48,7 +48,7 @@ import io.github.carlos_emr.carlos.utility.SpringUtils;
  * {@link ClinicLocation} for each pair where both the location code is non-null/non-empty
  * and the description is non-empty.
  *
- * <p><strong>Bug fix:</strong> The original JSP used {@code !"".equals(location1)} (reference
+ * <p><strong>Bug fix:</strong> The original JSP used {@code location1 != ""} (reference
  * comparison) which never evaluates correctly in Java. This action uses
  * {@code !location1.isEmpty()} instead.
  *

--- a/src/main/java/io/github/carlos_emr/carlos/billing/CA/ON/web/DbManageBillingLocation2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billing/CA/ON/web/DbManageBillingLocation2Action.java
@@ -48,9 +48,9 @@ import io.github.carlos_emr.carlos.utility.SpringUtils;
  * {@link ClinicLocation} for each pair where both the location code is non-null/non-empty
  * and the description is non-empty.
  *
- * <p><strong>Bug fix:</strong> The original JSP used {@code !"".equals(location1)} (reference
- * comparison) which never evaluates correctly in Java. This action uses
- * {@code !location1.isEmpty()} instead.
+ * <p><strong>Bug fix:</strong> The original JSP used {@code location1 != ""}, a reference
+ * comparison that is not reliable for string values in Java. This action uses a
+ * null-safe emptiness check ({@code !location1.isEmpty()} after a null guard) instead.
  *
  * <p>Single-quote characters do not require manual sanitization because the
  * DAO layer uses JPA/Hibernate parameterized queries, which handle quoting safely.

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/privateBilling/PrivateBillingController.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/privateBilling/PrivateBillingController.java
@@ -203,7 +203,7 @@ public class PrivateBillingController extends HttpServlet {
                     map.put("clinicFax", clinic.getClinicFax());
 
                     // get patient invoice items
-                    String strRecipientName = (strRecipientId.isEmpty() || strRecipientId == "") ? "" : map.get("recipientName").toString();
+                    String strRecipientName = (strRecipientId.isEmpty() || "".equals(strRecipientId)) ? "" : map.get("recipientName").toString();
                     List<HashMap<String, String>> invoiceItems = dao.listPrivateBillItems(strDemographicNumber, strRecipientName);
                     map.put("invoiceItems", invoiceItems);
 

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/privateBilling/PrivateBillingController.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/privateBilling/PrivateBillingController.java
@@ -203,7 +203,7 @@ public class PrivateBillingController extends HttpServlet {
                     map.put("clinicFax", clinic.getClinicFax());
 
                     // get patient invoice items
-                    String strRecipientName = strRecipientId.isEmpty() ? "" : map.get("recipientName").toString();
+                    String strRecipientName = (strRecipientId.isEmpty() || "".equals(strRecipientId)) ? "" : map.get("recipientName").toString();
                     List<HashMap<String, String>> invoiceItems = dao.listPrivateBillItems(strDemographicNumber, strRecipientName);
                     map.put("invoiceItems", invoiceItems);
 

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/privateBilling/PrivateBillingController.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/privateBilling/PrivateBillingController.java
@@ -203,7 +203,7 @@ public class PrivateBillingController extends HttpServlet {
                     map.put("clinicFax", clinic.getClinicFax());
 
                     // get patient invoice items
-                    String strRecipientName = (strRecipientId.isEmpty() || "".equals(strRecipientId)) ? "" : map.get("recipientName").toString();
+                    String strRecipientName = strRecipientId.isEmpty() ? "" : map.get("recipientName").toString();
                     List<HashMap<String, String>> invoiceItems = dao.listPrivateBillItems(strDemographicNumber, strRecipientName);
                     map.put("invoiceItems", invoiceItems);
 

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/quickbilling/QuickBillingBCHandler.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/quickbilling/QuickBillingBCHandler.java
@@ -277,7 +277,7 @@ public class QuickBillingBCHandler {
         }
 
         if ((billingEntry.has("halfBilling")) &&
-                (billingEntry.get("halfBilling").asText() != "")
+                (!"".equals(billingEntry.get("halfBilling").asText()))
         ) {
             // unit is set as 1.0 in default.
             unit = billingEntry.get("halfBilling").asText();

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/service/CaseManagementManagerImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/service/CaseManagementManagerImpl.java
@@ -2309,7 +2309,7 @@ public class CaseManagementManagerImpl implements CaseManagementManager {
             role = "0";
         }
         /*
-         * if (session.getAttribute("archiveView")!="true")
+         * if (!"true".equals(session.getAttribute("archiveView")))
          * note.setReporter_caisi_role(role); else note.setReporter_caisi_role("1");
          */
         note.setReporter_caisi_role(role);

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementEntry2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementEntry2Action.java
@@ -1302,22 +1302,22 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
         }
 
         String hourOfEncounterTime = request.getParameter("hourOfEncounterTime");
-        if (hourOfEncounterTime != null && hourOfEncounterTime != "") {
+        if (hourOfEncounterTime != null && !"".equals(hourOfEncounterTime)) {
             note.setHourOfEncounterTime(Integer.valueOf(hourOfEncounterTime));
         }
 
         String minuteOfEncounterTime = request.getParameter("minuteOfEncounterTime");
-        if (minuteOfEncounterTime != null && minuteOfEncounterTime != "") {
+        if (minuteOfEncounterTime != null && !"".equals(minuteOfEncounterTime)) {
             note.setMinuteOfEncounterTime(Integer.valueOf(minuteOfEncounterTime));
         }
 
         String hourOfEncTransportationTime = request.getParameter("hourOfEncTransportationTime");
-        if (hourOfEncTransportationTime != null && hourOfEncTransportationTime != "") {
+        if (hourOfEncTransportationTime != null && !"".equals(hourOfEncTransportationTime)) {
             note.setHourOfEncTransportationTime(Integer.valueOf(hourOfEncTransportationTime));
         }
 
         String minuteOfEncTransportationTime = request.getParameter("minuteOfEncTransportationTime");
-        if (minuteOfEncTransportationTime != null && minuteOfEncTransportationTime != "") {
+        if (minuteOfEncTransportationTime != null && !"".equals(minuteOfEncTransportationTime)) {
             note.setMinuteOfEncTransportationTime(Integer.valueOf(minuteOfEncTransportationTime));
         }
 

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementEntry2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementEntry2Action.java
@@ -1302,22 +1302,22 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
         }
 
         String hourOfEncounterTime = request.getParameter("hourOfEncounterTime");
-        if (hourOfEncounterTime != null && !"".equals(hourOfEncounterTime)) {
+        if (StringUtils.isNotEmpty(hourOfEncounterTime)) {
             note.setHourOfEncounterTime(Integer.valueOf(hourOfEncounterTime));
         }
 
         String minuteOfEncounterTime = request.getParameter("minuteOfEncounterTime");
-        if (minuteOfEncounterTime != null && !"".equals(minuteOfEncounterTime)) {
+        if (StringUtils.isNotEmpty(minuteOfEncounterTime)) {
             note.setMinuteOfEncounterTime(Integer.valueOf(minuteOfEncounterTime));
         }
 
         String hourOfEncTransportationTime = request.getParameter("hourOfEncTransportationTime");
-        if (hourOfEncTransportationTime != null && !"".equals(hourOfEncTransportationTime)) {
+        if (StringUtils.isNotEmpty(hourOfEncTransportationTime)) {
             note.setHourOfEncTransportationTime(Integer.valueOf(hourOfEncTransportationTime));
         }
 
         String minuteOfEncTransportationTime = request.getParameter("minuteOfEncTransportationTime");
-        if (minuteOfEncTransportationTime != null && !"".equals(minuteOfEncTransportationTime)) {
+        if (StringUtils.isNotEmpty(minuteOfEncTransportationTime)) {
             note.setMinuteOfEncTransportationTime(Integer.valueOf(minuteOfEncTransportationTime));
         }
 

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementEntry2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementEntry2Action.java
@@ -1302,22 +1302,22 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
         }
 
         String hourOfEncounterTime = request.getParameter("hourOfEncounterTime");
-        if (StringUtils.isNotEmpty(hourOfEncounterTime)) {
+        if (hourOfEncounterTime != null && !"".equals(hourOfEncounterTime)) {
             note.setHourOfEncounterTime(Integer.valueOf(hourOfEncounterTime));
         }
 
         String minuteOfEncounterTime = request.getParameter("minuteOfEncounterTime");
-        if (StringUtils.isNotEmpty(minuteOfEncounterTime)) {
+        if (minuteOfEncounterTime != null && !"".equals(minuteOfEncounterTime)) {
             note.setMinuteOfEncounterTime(Integer.valueOf(minuteOfEncounterTime));
         }
 
         String hourOfEncTransportationTime = request.getParameter("hourOfEncTransportationTime");
-        if (StringUtils.isNotEmpty(hourOfEncTransportationTime)) {
+        if (hourOfEncTransportationTime != null && !"".equals(hourOfEncTransportationTime)) {
             note.setHourOfEncTransportationTime(Integer.valueOf(hourOfEncTransportationTime));
         }
 
         String minuteOfEncTransportationTime = request.getParameter("minuteOfEncTransportationTime");
-        if (StringUtils.isNotEmpty(minuteOfEncTransportationTime)) {
+        if (minuteOfEncTransportationTime != null && !"".equals(minuteOfEncTransportationTime)) {
             note.setMinuteOfEncTransportationTime(Integer.valueOf(minuteOfEncTransportationTime));
         }
 

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDaoImpl.java
@@ -2666,7 +2666,7 @@ public class DemographicDaoImpl extends AbstractHibernateDao implements Applicat
 
     @Override
     public List<Demographic> getDemographicByRosterStatus(String rosterStatus, String patientStatus) {
-        if (patientStatus == null || patientStatus == "") {
+        if (patientStatus == null || "".equals(patientStatus)) {
             patientStatus = "AC";
         }
         String queryStr = " FROM Demographic d where d.RosterStatus=?1 and d.PatientStatus = ?2";

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDaoImpl.java
@@ -2666,7 +2666,7 @@ public class DemographicDaoImpl extends AbstractHibernateDao implements Applicat
 
     @Override
     public List<Demographic> getDemographicByRosterStatus(String rosterStatus, String patientStatus) {
-        if (patientStatus == null || "".equals(patientStatus)) {
+        if (StringUtils.isEmpty(patientStatus)) {
             patientStatus = "AC";
         }
         String queryStr = " FROM Demographic d where d.RosterStatus=?1 and d.PatientStatus = ?2";

--- a/src/main/java/io/github/carlos_emr/carlos/commn/web/Pregnancy2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/web/Pregnancy2Action.java
@@ -75,7 +75,7 @@ public class Pregnancy2Action extends ActionSupport {
 
     static {
         labReqVersion = CarlosProperties.getInstance().getProperty("onare_labreqver", "07");
-        if (labReqVersion == "") {
+        if ("".equals(labReqVersion)) {
             labReqVersion = "10";
         }
     }

--- a/src/main/java/io/github/carlos_emr/carlos/decision/DesAnnualReviewPlannerChecklistHandler.java
+++ b/src/main/java/io/github/carlos_emr/carlos/decision/DesAnnualReviewPlannerChecklistHandler.java
@@ -187,7 +187,6 @@ public class DesAnnualReviewPlannerChecklistHandler extends DefaultHandler {
      * @param atts Attributes associated with the element
      * @throws SAXException if XML processing error occurs
      */
-    @SuppressWarnings("PMD.ExcessiveMethodLength")
     public void startElement(String namespaceURI, String localName, String rawName, Attributes atts)
             throws SAXException {
         MiscUtils.getLogger().debug("Processing element - localName: " + localName + ", rawName: " + rawName);
@@ -292,7 +291,6 @@ public class DesAnnualReviewPlannerChecklistHandler extends DefaultHandler {
      * @param rawName String qualified name of the element
      * @throws SAXException if XML processing error occurs
      */
-    @SuppressWarnings("PMD.ExcessiveMethodLength")
     public void endElement(String namespaceURI, String localName, String rawName) throws SAXException {
         if (rawName.equals("section")) {
             results += "</table></center><br>\n";

--- a/src/main/java/io/github/carlos_emr/carlos/decision/DesAnnualReviewPlannerChecklistHandler.java
+++ b/src/main/java/io/github/carlos_emr/carlos/decision/DesAnnualReviewPlannerChecklistHandler.java
@@ -187,6 +187,7 @@ public class DesAnnualReviewPlannerChecklistHandler extends DefaultHandler {
      * @param atts Attributes associated with the element
      * @throws SAXException if XML processing error occurs
      */
+    @SuppressWarnings("PMD.ExcessiveMethodLength")
     public void startElement(String namespaceURI, String localName, String rawName, Attributes atts)
             throws SAXException {
         MiscUtils.getLogger().debug("Processing element - localName: " + localName + ", rawName: " + rawName);
@@ -291,6 +292,7 @@ public class DesAnnualReviewPlannerChecklistHandler extends DefaultHandler {
      * @param rawName String qualified name of the element
      * @throws SAXException if XML processing error occurs
      */
+    @SuppressWarnings("PMD.ExcessiveMethodLength")
     public void endElement(String namespaceURI, String localName, String rawName) throws SAXException {
         if (rawName.equals("section")) {
             results += "</table></center><br>\n";

--- a/src/main/java/io/github/carlos_emr/carlos/decision/DesAnnualReviewPlannerChecklistHandler.java
+++ b/src/main/java/io/github/carlos_emr/carlos/decision/DesAnnualReviewPlannerChecklistHandler.java
@@ -209,7 +209,7 @@ public class DesAnnualReviewPlannerChecklistHandler extends DefaultHandler {
         // Process risk elements - check if risk factor applies to this patient
         if (rawName.equals("risk")) {
             for (int i = 0; i < atts.getLength(); i++) {
-                if (atts.getQName(i) == "riskname") {
+                if ("riskname".equals(atts.getQName(i))) {
                     riskName = atts.getValue(i);
                     MiscUtils.getLogger().debug("Evaluating risk factor: " + riskName);
 
@@ -231,7 +231,7 @@ public class DesAnnualReviewPlannerChecklistHandler extends DefaultHandler {
         if (rawName.equals("item") && display) {
             results += "<tr>";
             for (int i = 0; i < atts.getLength(); i++) {
-                if (atts.getQName(i) == "clname") {
+                if ("clname".equals(atts.getQName(i))) {
                     clName = atts.getValue(i);
 
                     // Create "Done" checkbox

--- a/src/main/java/io/github/carlos_emr/carlos/decision/DesAnnualReviewPlannerRiskHandler.java
+++ b/src/main/java/io/github/carlos_emr/carlos/decision/DesAnnualReviewPlannerRiskHandler.java
@@ -217,11 +217,11 @@ public class DesAnnualReviewPlannerRiskHandler extends DefaultHandler {
 
         // Process element attributes for name and href properties
         for (int i = 0; i < atts.getLength(); i++) {
-            if (atts.getQName(i) == "name") {
+            if ("name".equals(atts.getQName(i))) {
                 riskName = atts.getValue(i);
                 riskNameObj.setProperty(riskName, "risk_" + riskName);
             }
-            if (atts.getQName(i) == "href") {
+            if ("href".equals(atts.getQName(i))) {
                 results += "<a href=# onClick=\"popupPage(400,500,'" + atts.getValue(i) + "');return false;\">";
                 href = 1;
             }

--- a/src/main/java/io/github/carlos_emr/carlos/decision/DesAntenatalPlannerChecklistHandler_99_12.java
+++ b/src/main/java/io/github/carlos_emr/carlos/decision/DesAntenatalPlannerChecklistHandler_99_12.java
@@ -178,7 +178,6 @@ public class DesAntenatalPlannerChecklistHandler_99_12 extends DefaultHandler {
      * @param atts Attributes associated with the element
      * @throws SAXException if XML processing error occurs
      */
-    @SuppressWarnings("PMD.ExcessiveMethodLength")
     public void startElement(String namespaceURI, String localName, String rawName, Attributes atts) throws SAXException {
         // Process recommendations element - main checklist container
         if (rawName.equals("recommendations")) {
@@ -291,7 +290,6 @@ public class DesAntenatalPlannerChecklistHandler_99_12 extends DefaultHandler {
      * @param rawName String qualified name of the element
      * @throws SAXException if XML processing error occurs
      */
-    @SuppressWarnings("PMD.ExcessiveMethodLength")
     public void endElement(String namespaceURI, String localName, String rawName) throws SAXException {
         if (rawName.equals("recommendations")) {
             results += "</td></tr></table></center>\n";

--- a/src/main/java/io/github/carlos_emr/carlos/decision/DesAntenatalPlannerChecklistHandler_99_12.java
+++ b/src/main/java/io/github/carlos_emr/carlos/decision/DesAntenatalPlannerChecklistHandler_99_12.java
@@ -178,6 +178,7 @@ public class DesAntenatalPlannerChecklistHandler_99_12 extends DefaultHandler {
      * @param atts Attributes associated with the element
      * @throws SAXException if XML processing error occurs
      */
+    @SuppressWarnings("PMD.ExcessiveMethodLength")
     public void startElement(String namespaceURI, String localName, String rawName, Attributes atts) throws SAXException {
         // Process recommendations element - main checklist container
         if (rawName.equals("recommendations")) {
@@ -290,6 +291,7 @@ public class DesAntenatalPlannerChecklistHandler_99_12 extends DefaultHandler {
      * @param rawName String qualified name of the element
      * @throws SAXException if XML processing error occurs
      */
+    @SuppressWarnings("PMD.ExcessiveMethodLength")
     public void endElement(String namespaceURI, String localName, String rawName) throws SAXException {
         if (rawName.equals("recommendations")) {
             results += "</td></tr></table></center>\n";

--- a/src/main/java/io/github/carlos_emr/carlos/decision/DesAntenatalPlannerChecklistHandler_99_12.java
+++ b/src/main/java/io/github/carlos_emr/carlos/decision/DesAntenatalPlannerChecklistHandler_99_12.java
@@ -187,7 +187,7 @@ public class DesAntenatalPlannerChecklistHandler_99_12 extends DefaultHandler {
         // Process week elements - gestational week sections with calculated visit dates
         if (rawName.equals("week")) {
             for (int i = 0; i < atts.getLength(); i++) {
-                if (atts.getQName(i) == "number") {
+                if ("number".equals(atts.getQName(i))) {
                     count = Integer.parseInt(atts.getValue(i));
                 }
             }
@@ -218,9 +218,9 @@ public class DesAntenatalPlannerChecklistHandler_99_12 extends DefaultHandler {
             // Parse item attributes for name, risk factors, and checkbox requirement
             for (int i = 0; i < atts.getLength(); i++) {
                 count = 1;
-                if (atts.getQName(i) == "name") clname = atts.getValue(i);
-                if (atts.getQName(i) == "risk") riskname = atts.getValue(i);
-                if (atts.getQName(i) == "checkbox") checkbox = true;
+                if ("name".equals(atts.getQName(i))) clname = atts.getValue(i);
+                if ("risk".equals(atts.getQName(i))) riskname = atts.getValue(i);
+                if ("checkbox".equals(atts.getQName(i))) checkbox = true;
             }
 
             // Display item only if no specific risk factor or if risk factor is present

--- a/src/main/java/io/github/carlos_emr/carlos/decision/DesAntenatalPlannerRisksHandler_99_12.java
+++ b/src/main/java/io/github/carlos_emr/carlos/decision/DesAntenatalPlannerRisksHandler_99_12.java
@@ -155,7 +155,6 @@ public class DesAntenatalPlannerRisksHandler_99_12 extends DefaultHandler {
      * @param atts Attributes associated with the element
      * @throws SAXException if XML processing error occurs
      */
-    @SuppressWarnings("PMD.ExcessiveMethodLength")
     public void startElement(String namespaceURI, String localName, String rawName, Attributes atts) throws SAXException {
         if (rawName.equals("section_title")) {
             if (interiortable == 1) { //close content table

--- a/src/main/java/io/github/carlos_emr/carlos/decision/DesAntenatalPlannerRisksHandler_99_12.java
+++ b/src/main/java/io/github/carlos_emr/carlos/decision/DesAntenatalPlannerRisksHandler_99_12.java
@@ -201,19 +201,19 @@ public class DesAntenatalPlannerRisksHandler_99_12 extends DefaultHandler {
             results += "<tr><td align='center'><font size=-2><b>\n";
         }
         for (int i = 0; i < atts.getLength(); i++) {
-            if (atts.getQName(i) == "name") {
+            if ("name".equals(atts.getQName(i))) {
                 riskName = atts.getValue(i);
                 results += "<input type=checkbox name=\"risk_" + riskName + "\" value='checked' id='risk_" + riskName + "'></font></td><td width=" + 100 / numcols + "% >";
                 riskNameObj.setProperty(riskName, "checked");
             }
-            if (atts.getQName(i) == "href") {
+            if ("href".equals(atts.getQName(i))) {
                 results += "<a href=# onClick=\"popupPage(400,500,'" + atts.getValue(i) + "');return false;\">";
                 href = 1; //there is a href there
             }
 
         }
         //for (int i=0; i < atts.getLength(); i++) {
-        //  if (atts.getQName(i) == "riskno") {
+        //  if ("riskno".equals(atts.getQName(i))) {
         //  	riskNameObj.setProperty(atts.getValue(i), "risk_"+riskName);
         //    break;
         //  }

--- a/src/main/java/io/github/carlos_emr/carlos/decision/DesAntenatalPlannerRisksHandler_99_12.java
+++ b/src/main/java/io/github/carlos_emr/carlos/decision/DesAntenatalPlannerRisksHandler_99_12.java
@@ -155,6 +155,7 @@ public class DesAntenatalPlannerRisksHandler_99_12 extends DefaultHandler {
      * @param atts Attributes associated with the element
      * @throws SAXException if XML processing error occurs
      */
+    @SuppressWarnings("PMD.ExcessiveMethodLength")
     public void startElement(String namespaceURI, String localName, String rawName, Attributes atts) throws SAXException {
         if (rawName.equals("section_title")) {
             if (interiortable == 1) { //close content table

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2Action.java
@@ -513,7 +513,7 @@ public class EctConsultationFormRequest2Action extends ActionSupport {
             if (attachedDocumentList != null) {
                 for (EDoc documentItem : attachedDocumentList) {
                     String description = documentItem.getDescription();
-                    if (description == null || description == "") {
+                    if (description == null || "".equals(description)) {
                         description = documentItem.getFileName();
                     }
                     documents.add(description);

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2Action.java
@@ -513,7 +513,7 @@ public class EctConsultationFormRequest2Action extends ActionSupport {
             if (attachedDocumentList != null) {
                 for (EDoc documentItem : attachedDocumentList) {
                     String description = documentItem.getDescription();
-                    if (description == null || "".equals(description)) {
+                    if (StringUtils.isEmpty(description)) {
                         description = documentItem.getFileName();
                     }
                     documents.add(description);

--- a/src/main/java/io/github/carlos_emr/carlos/form/FrmConsultantRecord.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/FrmConsultantRecord.java
@@ -121,7 +121,7 @@ public class FrmConsultantRecord extends FrmRecord {
         if (rs.next()) {
             docno = Misc.getString(rs, "family_doctor");
             refdocno = docno.substring(8, docno.indexOf("</rdohip>"));
-            if (refdocno != "") {
+            if (!"".equals(refdocno)) {
                 props.setProperty("refdocno", refdocno);
             }
         }

--- a/src/main/java/io/github/carlos_emr/carlos/form/FrmConsultantRecord.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/FrmConsultantRecord.java
@@ -121,7 +121,7 @@ public class FrmConsultantRecord extends FrmRecord {
         if (rs.next()) {
             docno = Misc.getString(rs, "family_doctor");
             refdocno = docno.substring(8, docno.indexOf("</rdohip>"));
-            if (!"".equals(refdocno)) {
+            if (!refdocno.isEmpty()) {
                 props.setProperty("refdocno", refdocno);
             }
         }

--- a/src/main/java/io/github/carlos_emr/carlos/integration/fhir/model/Practitioner.java
+++ b/src/main/java/io/github/carlos_emr/carlos/integration/fhir/model/Practitioner.java
@@ -118,7 +118,7 @@ public class Practitioner extends AbstractOscarFhirResource<org.hl7.fhir.dstu3.m
         //TODO these codes cannot be hard coded like this. Temporary hack
         String licensetype = getOscarResource().getPractitionerNoType();
 
-        if (licensetype == null || licensetype == "") {
+        if (licensetype == null || "".equals(licensetype)) {
             licensetype = LicenseType.DEFAULT.name();
         }
 

--- a/src/main/java/io/github/carlos_emr/carlos/integration/fhir/model/Practitioner.java
+++ b/src/main/java/io/github/carlos_emr/carlos/integration/fhir/model/Practitioner.java
@@ -118,7 +118,7 @@ public class Practitioner extends AbstractOscarFhirResource<org.hl7.fhir.dstu3.m
         //TODO these codes cannot be hard coded like this. Temporary hack
         String licensetype = getOscarResource().getPractitionerNoType();
 
-        if (StringUtils.isEmpty(licensetype)) {
+        if (licensetype == null || "".equals(licensetype)) {
             licensetype = LicenseType.DEFAULT.name();
         }
 

--- a/src/main/java/io/github/carlos_emr/carlos/integration/fhir/model/Practitioner.java
+++ b/src/main/java/io/github/carlos_emr/carlos/integration/fhir/model/Practitioner.java
@@ -118,7 +118,7 @@ public class Practitioner extends AbstractOscarFhirResource<org.hl7.fhir.dstu3.m
         //TODO these codes cannot be hard coded like this. Temporary hack
         String licensetype = getOscarResource().getPractitionerNoType();
 
-        if (licensetype == null || "".equals(licensetype)) {
+        if (StringUtils.isEmpty(licensetype)) {
             licensetype = LicenseType.DEFAULT.name();
         }
 

--- a/src/main/java/io/github/carlos_emr/carlos/lab/ca/all/parsers/AlphaHandler.java
+++ b/src/main/java/io/github/carlos_emr/carlos/lab/ca/all/parsers/AlphaHandler.java
@@ -548,7 +548,7 @@ public class AlphaHandler extends DefaultGenericHandler implements MessageHandle
 
             // if accessionNum can't be found in the OBR record of the first observation,
             //  look for it in subsequent observation records
-            if (accessionNum != "") {
+            if (!"".equals(accessionNum)) {
                 return (accessionNum);
             }
 
@@ -558,7 +558,7 @@ public class AlphaHandler extends DefaultGenericHandler implements MessageHandle
                 } else {
                     accessionNum = getString(msg23.getRESPONSE().getORDER_OBSERVATION(j).getOBR().getFillerOrderNumber().getEntityIdentifier().getValue());
                 }
-                if (accessionNum != "") {
+                if (!"".equals(accessionNum)) {
                     return (accessionNum);
                 }
             }

--- a/src/main/java/io/github/carlos_emr/carlos/lab/ca/all/parsers/AlphaHandler.java
+++ b/src/main/java/io/github/carlos_emr/carlos/lab/ca/all/parsers/AlphaHandler.java
@@ -31,6 +31,7 @@ package io.github.carlos_emr.carlos.lab.ca.all.parsers;
 import java.util.ArrayList;
 
 import io.github.carlos_emr.carlos.utility.MiscUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 
 import ca.uhn.hl7v2.HL7Exception;
@@ -548,7 +549,7 @@ public class AlphaHandler extends DefaultGenericHandler implements MessageHandle
 
             // if accessionNum can't be found in the OBR record of the first observation,
             //  look for it in subsequent observation records
-            if (!"".equals(accessionNum)) {
+            if (StringUtils.isNotEmpty(accessionNum)) {
                 return (accessionNum);
             }
 
@@ -558,7 +559,7 @@ public class AlphaHandler extends DefaultGenericHandler implements MessageHandle
                 } else {
                     accessionNum = getString(msg23.getRESPONSE().getORDER_OBSERVATION(j).getOBR().getFillerOrderNumber().getEntityIdentifier().getValue());
                 }
-                if (!"".equals(accessionNum)) {
+                if (StringUtils.isNotEmpty(accessionNum)) {
                     return (accessionNum);
                 }
             }

--- a/src/main/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgDisplayMessagesBean.java
+++ b/src/main/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgDisplayMessagesBean.java
@@ -231,7 +231,7 @@ public class MsgDisplayMessagesBean implements java.io.Serializable {
      */
     public String getCurrentLocationId() {
         // BUG: Should use .equals() not == for string comparison
-        if (currentLocationId == "0") {
+        if ("0".equals(currentLocationId)) {
             OscarCommLocationsDao oscarCommLocationsDao = SpringUtils.getBean(OscarCommLocationsDao.class);
             List<OscarCommLocations> oscarCommLocations = oscarCommLocationsDao.findByCurrent1(1);
             Integer oscarCommLocationsID = null;

--- a/src/main/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgDisplayMessagesBean.java
+++ b/src/main/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgDisplayMessagesBean.java
@@ -235,7 +235,7 @@ public class MsgDisplayMessagesBean implements java.io.Serializable {
             List<OscarCommLocations> oscarCommLocations = oscarCommLocationsDao.findByCurrent1(1);
             Integer oscarCommLocationsID = null;
 
-            if (oscarCommLocations != null) {
+            if (oscarCommLocations != null && !oscarCommLocations.isEmpty()) {
                 oscarCommLocationsID = oscarCommLocations.get(0).getId();
             }
 

--- a/src/main/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgDisplayMessagesBean.java
+++ b/src/main/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgDisplayMessagesBean.java
@@ -223,14 +223,13 @@ public class MsgDisplayMessagesBean implements java.io.Serializable {
 
     /**
      * Gets the current location ID for multi-location support.
-     * 
-     * <p>Lazily loads the location ID from the database on first access.
-     * Uses string comparison with == which is a bug - should use .equals().</p>
-     * 
+     *
+     * <p>Lazily loads the location ID from the database on first access when the
+     * current value is the sentinel {@code "0"}.</p>
+     *
      * @return String the current location ID
      */
     public String getCurrentLocationId() {
-        // BUG: Should use .equals() not == for string comparison
         if ("0".equals(currentLocationId)) {
             OscarCommLocationsDao oscarCommLocationsDao = SpringUtils.getBean(OscarCommLocationsDao.class);
             List<OscarCommLocations> oscarCommLocations = oscarCommLocationsDao.findByCurrent1(1);

--- a/src/main/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgSessionBean.java
+++ b/src/main/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgSessionBean.java
@@ -196,7 +196,7 @@ public class MsgSessionBean implements java.io.Serializable {
         }
 
         // Note: String comparison should use .equals(), not !=
-        if (binStr != "" && binStr != null) {
+        if (!"".equals(binStr) && binStr != null) {
             this.setPDFAttachment(currentAtt + " " + getPDFStartTag() + getStatusTag("OK") + getPDFTitleTag(pdfTitle) + getContentTag(binStr) + getPDFEndTag());
         } else {
             this.setPDFAttachment(currentAtt + " " + getPDFStartTag() + getStatusTag("BAD") + getPDFTitleTag(pdfTitle + " (N/A)") + getContentTag(binStr) + getPDFEndTag());

--- a/src/main/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgSessionBean.java
+++ b/src/main/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgSessionBean.java
@@ -195,7 +195,8 @@ public class MsgSessionBean implements java.io.Serializable {
             currentAtt = this.getPDFAttachment();
         }
 
-        if (binStr != null && !binStr.isEmpty()) {
+        // Note: String comparison should use .equals(), not !=
+        if (!"".equals(binStr) && binStr != null) {
             this.setPDFAttachment(currentAtt + " " + getPDFStartTag() + getStatusTag("OK") + getPDFTitleTag(pdfTitle) + getContentTag(binStr) + getPDFEndTag());
         } else {
             this.setPDFAttachment(currentAtt + " " + getPDFStartTag() + getStatusTag("BAD") + getPDFTitleTag(pdfTitle + " (N/A)") + getContentTag(binStr) + getPDFEndTag());

--- a/src/main/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgSessionBean.java
+++ b/src/main/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgSessionBean.java
@@ -195,8 +195,7 @@ public class MsgSessionBean implements java.io.Serializable {
             currentAtt = this.getPDFAttachment();
         }
 
-        // Note: String comparison should use .equals(), not !=
-        if (!"".equals(binStr) && binStr != null) {
+        if (binStr != null && !binStr.isEmpty()) {
             this.setPDFAttachment(currentAtt + " " + getPDFStartTag() + getStatusTag("OK") + getPDFTitleTag(pdfTitle) + getContentTag(binStr) + getPDFEndTag());
         } else {
             this.setPDFAttachment(currentAtt + " " + getPDFStartTag() + getStatusTag("BAD") + getPDFTitleTag(pdfTitle + " (N/A)") + getContentTag(binStr) + getPDFEndTag());

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/web/CopyFavorites2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/web/CopyFavorites2Action.java
@@ -93,7 +93,7 @@ public class CopyFavorites2Action extends ActionSupport {
         //String providerNo = lazyForm.get("userProviderNo").toString();
         
         String providerNo = request.getParameter("providerNo");
-        //if ( lazyForm.get("ddl_provider") == null || lazyForm.get("ddl_provider")"".equals(.toString()))
+        //if ( lazyForm.get("ddl_provider") == null || "".equals(lazyForm.get("ddl_provider").toString()))
         if (request.getParameter("ddl_provider") == null || request.getParameter("ddl_provider").equals(""))
             return SUCCESS;
 

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/web/CopyFavorites2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/web/CopyFavorites2Action.java
@@ -93,7 +93,7 @@ public class CopyFavorites2Action extends ActionSupport {
         //String providerNo = lazyForm.get("userProviderNo").toString();
         
         String providerNo = request.getParameter("providerNo");
-        //if ( lazyForm.get("ddl_provider") == null || "".equals(lazyForm.get("ddl_provider").toString()))
+        //if ( lazyForm.get("ddl_provider") == null || lazyForm.get("ddl_provider")"".equals(.toString()))
         if (request.getParameter("ddl_provider") == null || request.getParameter("ddl_provider").equals(""))
             return SUCCESS;
 

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/web/CopyFavorites2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/web/CopyFavorites2Action.java
@@ -93,7 +93,7 @@ public class CopyFavorites2Action extends ActionSupport {
         //String providerNo = lazyForm.get("userProviderNo").toString();
         
         String providerNo = request.getParameter("providerNo");
-        //if ( lazyForm.get("ddl_provider") == null || lazyForm.get("ddl_provider").toString()=="")
+        //if ( lazyForm.get("ddl_provider") == null || lazyForm.get("ddl_provider")"".equals(.toString()))
         if (request.getParameter("ddl_provider") == null || request.getParameter("ddl_provider").equals(""))
             return SUCCESS;
 

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/web/CopyFavorites2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/web/CopyFavorites2Action.java
@@ -93,7 +93,6 @@ public class CopyFavorites2Action extends ActionSupport {
         //String providerNo = lazyForm.get("userProviderNo").toString();
         
         String providerNo = request.getParameter("providerNo");
-        //if ( lazyForm.get("ddl_provider") == null || lazyForm.get("ddl_provider")"".equals(.toString()))
         if (request.getParameter("ddl_provider") == null || request.getParameter("ddl_provider").equals(""))
             return SUCCESS;
 

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/web/CopyFavorites2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/web/CopyFavorites2Action.java
@@ -93,7 +93,8 @@ public class CopyFavorites2Action extends ActionSupport {
         //String providerNo = lazyForm.get("userProviderNo").toString();
         
         String providerNo = request.getParameter("providerNo");
-        if (request.getParameter("ddl_provider") == null || "".equals(request.getParameter("ddl_provider")))
+        //if ( lazyForm.get("ddl_provider") == null || lazyForm.get("ddl_provider")"".equals(.toString()))
+        if (request.getParameter("ddl_provider") == null || request.getParameter("ddl_provider").equals(""))
             return SUCCESS;
 
         //int count = Integer.parseInt(lazyForm.get("countFavorites").toString());

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/web/CopyFavorites2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/web/CopyFavorites2Action.java
@@ -93,8 +93,7 @@ public class CopyFavorites2Action extends ActionSupport {
         //String providerNo = lazyForm.get("userProviderNo").toString();
         
         String providerNo = request.getParameter("providerNo");
-        //if ( lazyForm.get("ddl_provider") == null || lazyForm.get("ddl_provider")"".equals(.toString()))
-        if (request.getParameter("ddl_provider") == null || request.getParameter("ddl_provider").equals(""))
+        if (request.getParameter("ddl_provider") == null || "".equals(request.getParameter("ddl_provider")))
             return SUCCESS;
 
         //int count = Integer.parseInt(lazyForm.get("countFavorites").toString());

--- a/src/main/java/io/github/carlos_emr/carlos/report/reportByTemplate/ReportManager.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/reportByTemplate/ReportManager.java
@@ -229,7 +229,7 @@ public class ReportManager {
     @SuppressWarnings("unchecked")
     public String loadInReports() {
         String xml = getTemplateXml("1");
-        if (xml == "") return "Error: Could not save the template file in the database.";
+        if ("".equals(xml)) return "Error: Could not save the template file in the database.";
         try {
             SAXBuilder parser = XmlUtils.createSecureSAXBuilder(); // NOSONAR java:S2755 — XXE protection applied via XmlUtils.createSecureSAXBuilder()
             xml = UtilXML.escapeXML(xml); //escapes anomalies such as "date >= {mydate}" the '>' character

--- a/src/main/java/io/github/carlos_emr/carlos/report/reportByTemplate/ReportManager.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/reportByTemplate/ReportManager.java
@@ -229,7 +229,7 @@ public class ReportManager {
     @SuppressWarnings("unchecked")
     public String loadInReports() {
         String xml = getTemplateXml("1");
-        if ("".equals(xml)) return "Error: Could not save the template file in the database.";
+        if (xml == null || xml.isEmpty()) return "Error: Could not save the template file in the database.";
         try {
             SAXBuilder parser = XmlUtils.createSecureSAXBuilder(); // NOSONAR java:S2755 — XXE protection applied via XmlUtils.createSecureSAXBuilder()
             xml = UtilXML.escapeXML(xml); //escapes anomalies such as "date >= {mydate}" the '>' character

--- a/src/main/java/io/github/carlos_emr/carlos/util/UtilDateUtilities.java
+++ b/src/main/java/io/github/carlos_emr/carlos/util/UtilDateUtilities.java
@@ -111,7 +111,7 @@ public class UtilDateUtilities {
     }
 
     public static Date calcDate(String s, String s1, String s2) {
-        if (s == null || s1 == null || s2 == null || s == "" || s1 == "" || s2 == "") return (null);
+        if (s == null || s1 == null || s2 == null || "".equals(s) || "".equals(s1) || "".equals(s2)) return (null);
 
         int i = Integer.parseInt(s);
         int j = Integer.parseInt(s1) - 1;

--- a/src/main/java/io/github/carlos_emr/carlos/util/UtilDateUtilities.java
+++ b/src/main/java/io/github/carlos_emr/carlos/util/UtilDateUtilities.java
@@ -111,7 +111,7 @@ public class UtilDateUtilities {
     }
 
     public static Date calcDate(String s, String s1, String s2) {
-        if (s == null || s1 == null || s2 == null || "".equals(s) || "".equals(s1) || "".equals(s2)) return (null);
+        if (s == null || s1 == null || s2 == null || s.isEmpty() || s1.isEmpty() || s2.isEmpty()) return (null);
 
         int i = Integer.parseInt(s);
         int j = Integer.parseInt(s1) - 1;

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/NotesService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/NotesService.java
@@ -407,24 +407,24 @@ public class NotesService extends AbstractServiceImpl {
         //caseMangementNote.setHourOfEncounterTime(note.getEncounterTime());
         logger.debug("this is what the encounter time was " + note.getEncounterTime());
 		/*String hourOfEncounterTime = request.getParameter("hourOfEncounterTime");
-		if (hourOfEncounterTime != null && hourOfEncounterTime != "") {
+		if (hourOfEncounterTime != null && !"".equals(hourOfEncounterTime)) {
 			note.setHourOfEncounterTime(Integer.valueOf(hourOfEncounterTime));
 		}
 
 		String minuteOfEncounterTime = request.getParameter("minuteOfEncounterTime");
-		if (minuteOfEncounterTime != null && minuteOfEncounterTime != "") {
+		if (minuteOfEncounterTime != null && !"".equals(minuteOfEncounterTime)) {
 			note.setMinuteOfEncounterTime(Integer.valueOf(minuteOfEncounterTime));
 		}*/
 
         logger.debug("this is what the encounter time was " + note.getEncounterTransportationTime());
 		/*
 		String hourOfEncTransportationTime = request.getParameter("hourOfEncTransportationTime");
-		if (hourOfEncTransportationTime != null && hourOfEncTransportationTime != "") {
+		if (hourOfEncTransportationTime != null && !"".equals(hourOfEncTransportationTime)) {
 			note.setHourOfEncTransportationTime(Integer.valueOf(hourOfEncTransportationTime));
 		}
 
 		String minuteOfEncTransportationTime = request.getParameter("minuteOfEncTransportationTime");
-		if (minuteOfEncTransportationTime != null && minuteOfEncTransportationTime != "") {
+		if (minuteOfEncTransportationTime != null && !"".equals(minuteOfEncTransportationTime)) {
 			note.setMinuteOfEncTransportationTime(Integer.valueOf(minuteOfEncTransportationTime));
 		}
 		*/

--- a/src/test/java/io/github/carlos_emr/RscheduleBeanUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/RscheduleBeanUnitTest.java
@@ -1,10 +1,23 @@
 /**
- * Copyright (c) 2026. CARLOS EMR Project. All Rights Reserved.
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
  * This software is published under the GPL GNU General Public License.
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; either version 2
  * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
  */
 package io.github.carlos_emr;
 
@@ -30,7 +43,7 @@ class RscheduleBeanUnitTest {
 
     @Test
     @DisplayName("getDateAvailHour should return empty string when provider_no is null")
-    void getDateAvailHour_shouldReturnEmpty_whenProviderNoIsNull() {
+    void shouldReturnEmpty_whenProviderNoIsNullOnGetDateAvailHour() {
         RscheduleBean bean = new RscheduleBean();
         bean.provider_no = null;
 
@@ -39,7 +52,7 @@ class RscheduleBeanUnitTest {
 
     @Test
     @DisplayName("getDateAvailHour should return empty string when provider_no is empty")
-    void getDateAvailHour_shouldReturnEmpty_whenProviderNoIsEmpty() {
+    void shouldReturnEmpty_whenProviderNoIsEmptyOnGetDateAvailHour() {
         RscheduleBean bean = new RscheduleBean();
         bean.provider_no = "";
 
@@ -48,7 +61,7 @@ class RscheduleBeanUnitTest {
 
     @Test
     @DisplayName("getSiteAvail should return empty string when provider_no is null")
-    void getSiteAvail_shouldReturnEmpty_whenProviderNoIsNull() {
+    void shouldReturnEmpty_whenProviderNoIsNullOnGetSiteAvail() {
         RscheduleBean bean = new RscheduleBean();
         bean.provider_no = null;
 
@@ -57,7 +70,7 @@ class RscheduleBeanUnitTest {
 
     @Test
     @DisplayName("getSiteAvail should return empty string when provider_no is empty")
-    void getSiteAvail_shouldReturnEmpty_whenProviderNoIsEmpty() {
+    void shouldReturnEmpty_whenProviderNoIsEmptyOnGetSiteAvail() {
         RscheduleBean bean = new RscheduleBean();
         bean.provider_no = "";
 

--- a/src/test/java/io/github/carlos_emr/RscheduleBeanUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/RscheduleBeanUnitTest.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2026. CARLOS EMR Project. All Rights Reserved.
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ */
+package io.github.carlos_emr;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.GregorianCalendar;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins the null/empty provider_no contract on {@link RscheduleBean}
+ * after the {@code !"".equals(provider_no)} → {@code StringUtils.isNotEmpty(...)}
+ * change, which altered the null-handling semantics (previously null fell
+ * through; now null short-circuits and returns an empty string).
+ */
+@Tag("unit")
+@Tag("scheduling")
+class RscheduleBeanUnitTest {
+
+    private static final GregorianCalendar ANY_DATE = new GregorianCalendar(2026, 3, 12);
+
+    @Test
+    @DisplayName("getDateAvailHour should return empty string when provider_no is null")
+    void getDateAvailHour_shouldReturnEmpty_whenProviderNoIsNull() {
+        RscheduleBean bean = new RscheduleBean();
+        bean.provider_no = null;
+
+        assertThat(bean.getDateAvailHour(ANY_DATE)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("getDateAvailHour should return empty string when provider_no is empty")
+    void getDateAvailHour_shouldReturnEmpty_whenProviderNoIsEmpty() {
+        RscheduleBean bean = new RscheduleBean();
+        bean.provider_no = "";
+
+        assertThat(bean.getDateAvailHour(ANY_DATE)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("getSiteAvail should return empty string when provider_no is null")
+    void getSiteAvail_shouldReturnEmpty_whenProviderNoIsNull() {
+        RscheduleBean bean = new RscheduleBean();
+        bean.provider_no = null;
+
+        assertThat(bean.getSiteAvail(ANY_DATE)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("getSiteAvail should return empty string when provider_no is empty")
+    void getSiteAvail_shouldReturnEmpty_whenProviderNoIsEmpty() {
+        RscheduleBean bean = new RscheduleBean();
+        bean.provider_no = "";
+
+        assertThat(bean.getSiteAvail(ANY_DATE)).isEmpty();
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgDisplayMessagesBeanUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgDisplayMessagesBeanUnitTest.java
@@ -1,10 +1,23 @@
 /**
- * Copyright (c) 2026. CARLOS EMR Project. All Rights Reserved.
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
  * This software is published under the GPL GNU General Public License.
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; either version 2
  * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
  */
 package io.github.carlos_emr.carlos.messenger.pageUtil;
 
@@ -98,7 +111,7 @@ class MsgDisplayMessagesBeanUnitTest extends CarlosUnitTestBase {
 
         MsgDisplayMessagesBean bean = new MsgDisplayMessagesBean();
         // A non-interned "0" instance - reference equality (== "0") would have failed here.
-        injectDependency(bean, "currentLocationId", new String("0"));
+        injectDependency(bean, "currentLocationId", String.valueOf(new char[]{'0'}));
 
         String result = bean.getCurrentLocationId();
 

--- a/src/test/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgDisplayMessagesBeanUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgDisplayMessagesBeanUnitTest.java
@@ -63,10 +63,23 @@ class MsgDisplayMessagesBeanUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
-    @DisplayName("should return sentinel when DAO returns no locations")
-    void shouldReturnSentinel_whenDaoReturnsNoLocations() {
+    @DisplayName("should return sentinel when DAO returns null")
+    void shouldReturnSentinel_whenDaoReturnsNull() {
         OscarCommLocationsDao dao = createAndRegisterMock(OscarCommLocationsDao.class);
         when(dao.findByCurrent1(1)).thenReturn(null);
+
+        MsgDisplayMessagesBean bean = new MsgDisplayMessagesBean();
+
+        String result = bean.getCurrentLocationId();
+
+        assertThat(result).isEqualTo("0");
+    }
+
+    @Test
+    @DisplayName("should return sentinel when DAO returns empty list (no IndexOutOfBoundsException)")
+    void shouldReturnSentinel_whenDaoReturnsEmptyList() {
+        OscarCommLocationsDao dao = createAndRegisterMock(OscarCommLocationsDao.class);
+        when(dao.findByCurrent1(1)).thenReturn(Collections.emptyList());
 
         MsgDisplayMessagesBean bean = new MsgDisplayMessagesBean();
 

--- a/src/test/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgDisplayMessagesBeanUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgDisplayMessagesBeanUnitTest.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2026. CARLOS EMR Project. All Rights Reserved.
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ */
+package io.github.carlos_emr.carlos.messenger.pageUtil;
+
+import io.github.carlos_emr.carlos.commn.dao.OscarCommLocationsDao;
+import io.github.carlos_emr.carlos.commn.model.OscarCommLocations;
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the {@code getCurrentLocationId} logic on
+ * {@link MsgDisplayMessagesBean}, covering the fix from reference equality
+ * ({@code currentLocationId == "0"}) to value equality
+ * ({@code "0".equals(currentLocationId)}).
+ */
+@Tag("unit")
+@Tag("messenger")
+class MsgDisplayMessagesBeanUnitTest extends CarlosUnitTestBase {
+
+    @Test
+    @DisplayName("should resolve default location when currentLocationId equals sentinel \"0\"")
+    void shouldResolveDefaultLocation_whenCurrentLocationIdIsZero() {
+        OscarCommLocationsDao dao = createAndRegisterMock(OscarCommLocationsDao.class);
+        OscarCommLocations loc = new OscarCommLocations();
+        loc.setId(42);
+        when(dao.findByCurrent1(1)).thenReturn(Collections.singletonList(loc));
+
+        MsgDisplayMessagesBean bean = new MsgDisplayMessagesBean();
+
+        String result = bean.getCurrentLocationId();
+
+        assertThat(result).isEqualTo("42");
+        verify(dao).findByCurrent1(1);
+    }
+
+    @Test
+    @DisplayName("should not query DAO when currentLocationId already set to a non-sentinel value")
+    void shouldSkipDaoLookup_whenCurrentLocationIdAlreadySet() {
+        OscarCommLocationsDao dao = createAndRegisterMock(OscarCommLocationsDao.class);
+        MsgDisplayMessagesBean bean = new MsgDisplayMessagesBean();
+        injectDependency(bean, "currentLocationId", "7");
+
+        String result = bean.getCurrentLocationId();
+
+        assertThat(result).isEqualTo("7");
+        verify(dao, never()).findByCurrent1(1);
+    }
+
+    @Test
+    @DisplayName("should return sentinel when DAO returns no locations")
+    void shouldReturnSentinel_whenDaoReturnsNoLocations() {
+        OscarCommLocationsDao dao = createAndRegisterMock(OscarCommLocationsDao.class);
+        when(dao.findByCurrent1(1)).thenReturn(null);
+
+        MsgDisplayMessagesBean bean = new MsgDisplayMessagesBean();
+
+        String result = bean.getCurrentLocationId();
+
+        assertThat(result).isEqualTo("0");
+    }
+
+    @Test
+    @DisplayName("should resolve default location when sentinel set via a different String instance")
+    void shouldResolveDefaultLocation_whenSentinelIsDifferentStringInstance() {
+        OscarCommLocationsDao dao = createAndRegisterMock(OscarCommLocationsDao.class);
+        OscarCommLocations loc = new OscarCommLocations();
+        loc.setId(9);
+        when(dao.findByCurrent1(1)).thenReturn(List.of(loc));
+
+        MsgDisplayMessagesBean bean = new MsgDisplayMessagesBean();
+        // A non-interned "0" instance - reference equality (== "0") would have failed here.
+        injectDependency(bean, "currentLocationId", new String("0"));
+
+        String result = bean.getCurrentLocationId();
+
+        assertThat(result).isEqualTo("9");
+        verify(dao).findByCurrent1(1);
+    }
+}


### PR DESCRIPTION
Replaced uses of `==` and `!=` for string comparisons with the `.equals()` method across the Java codebase to avoid bugs associated with identity vs equality comparisons in Java. Fixed the primary bug `currentLocationId == "0"` in `MsgDisplayMessagesBean.java` as requested. Fixed additional string comparisons after a code review point.

---
*PR created automatically by Jules for task [9947096826172490343](https://jules.google.com/task/9947096826172490343) started by @yingbull*

## Summary by Sourcery

Standardize string equality checks to use .equals() instead of reference comparison across the Java codebase to prevent incorrect string comparison behavior.

Bug Fixes:
- Fix incorrect comparison of currentLocationId to "0" in MsgDisplayMessagesBean to ensure the default location is resolved reliably.
- Correct multiple control-flow conditions that previously relied on reference inequality with empty strings, preventing them from being skipped unexpectedly.

Enhancements:
- Normalize string-empty checks throughout various handlers, controllers, and services to use explicit empty-string equality, improving consistency and correctness of string handling.
- Align XML attribute name comparisons in several SAX handlers to use value-based string equality, ensuring attributes are detected reliably.
- Clean up and clarify inline documentation/comments to reflect the corrected string comparison patterns.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized string comparisons across the Java codebase to use literal-first .equals(...) and `StringUtils`, fixed the messaging location sentinel behavior (including empty DAO results), and kept CI stable by reverting dependency-lock churn. Aligned the new unit tests with CARLOS conventions and CodeQL rules.

- **Bug Fixes**
  - Messaging: Use "0".equals(currentLocationId) and guard empty DAO results; added unit tests for sentinel, empty-list, and no-lookup paths.
  - JDBCUtil: Fix GetPreSQL ambiguous call by invoking the varargs overload with (Object[]) null.
  - OBChecklistHandler_99_12: Log only the exception class when parsing finalEDB to avoid echoing input.
  - Build/CI: Revert accidental SQL-string edits and `ultrabuk-htmltopdf-java` lock churn; remove a PHI-unsafe log and minor comment/JavaDoc cleanups.

- **Refactors**
  - Replace `== ""`, `!= ""`, and `== "<literal>"` with literal-first `.equals(...)` and `StringUtils.isEmpty/isNotEmpty`; reorder guards to `!= null && !isEmpty()`.
  - Standardize XML/SAX attribute name checks to `.equals(...)`.
  - Apply null-safe `StringUtils.isNotEmpty` in scheduling/actions; add unit tests pinning the new null/empty `provider_no` behavior.
  - Add null/empty-safe checks in `AlphaHandler`, `DemographicDaoImpl`, `FrmConsultantRecord`, `ReportManager`, and `UtilDateUtilities` for consistent string handling.
  - Tests: Align new unit tests with CARLOS headers/naming; switch non-interned "0" construction to satisfy CodeQL while preserving semantics.

<sup>Written for commit 181e61c0e10280bb987e1e77e4fe6a77d605a3d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

