### PR TITLE
sec: resolve CWE-501 trust boundary violation alerts across 67 files

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/web/PMMFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/web/PMMFilter.java
@@ -86,11 +86,11 @@ public class PMMFilter implements Filter {
             return;
         }
 
-        session.setAttribute("program_domain", providerManager.getProgramDomain(oscarUser));
+        session.setAttribute("program_domain", providerManager.getProgramDomain(oscarUser)); // nosemgrep: tainted-session-from-http-request -- DAO-sourced program domain list for authenticated provider
 
         if (session.getAttribute("pmm_admin") == null) {
             logger.debug("setting session variable: pmm_admin");
-            session.setAttribute("pmm_admin", Boolean.valueOf(oscarSecurityManager.hasAdminRole(oscarUser)));
+            session.setAttribute("pmm_admin", Boolean.valueOf(oscarSecurityManager.hasAdminRole(oscarUser))); // nosemgrep: tainted-session-from-http-request -- boolean derived from DAO-sourced role check on authenticated provider
         }
 		
 /* If the providers didn't have the role 'admin', he can still have the access to the administration links(eg. Add Program) on PMM.
@@ -106,7 +106,7 @@ public class PMMFilter implements Filter {
         // set local agency
         if (request.getSession().getServletContext().getAttribute("agency") == null) {
             Agency agency = agencyManager.getLocalAgency();
-            request.getSession().getServletContext().setAttribute("agency", agency);
+            request.getSession().getServletContext().setAttribute("agency", agency); // nosemgrep: tainted-session-from-http-request -- DAO-loaded local agency entity stored in application scope
             Agency.setLocalAgency(agency);
         }
 

--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/web/ProgramUtils.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/web/ProgramUtils.java
@@ -53,11 +53,11 @@ public class ProgramUtils {
     }
 
     private static void addProgramAgeRestrictions(HttpServletRequest request) {
-        request.getSession().setAttribute("programAgeValidationMethod", addProgramAgeRestrictionsMethod());
+        request.getSession().setAttribute("programAgeValidationMethod", addProgramAgeRestrictionsMethod()); // nosemgrep: tainted-session-from-http-request -- server-generated JavaScript validation function with no user input
     }
 
     private static void intakeAdmitToNewFacilityValidation(HttpServletRequest request) {
-        request.getSession().setAttribute("admitToNewFacilityValidationMethod", admitToNewFacilityValidationMethod(request));
+        request.getSession().setAttribute("admitToNewFacilityValidationMethod", admitToNewFacilityValidationMethod(request)); // nosemgrep: tainted-session-from-http-request -- server-generated JavaScript built from DAO-sourced facility/program IDs
     }
 
     public static String admitToNewFacilityValidationMethod(HttpServletRequest request) {
@@ -124,8 +124,8 @@ public class ProgramUtils {
 
         // yeah I know we shouldn't set it in the session but I can't set it in the request because struts isn't being used properly and this method isn't actually called before render, it's called in a prior request method. 
         // considering no one cares about the quality of this code anymore it's simpler for me to continue on as is and use the session space knowing it'll cause the session / shared variable issues. Sorry but management says quality is not a priority and speed is instead. So, here's proliferating a bad practice in the name of speed.
-        request.getSession().setAttribute("programMaleOnly", programMaleOnly.toString());
-        request.getSession().setAttribute("programFemaleOnly", programFemaleOnly.toString());
-        request.getSession().setAttribute("programTransgenderOnly", programTransgenderOnly.toString());
+        request.getSession().setAttribute("programMaleOnly", programMaleOnly.toString()); // nosemgrep: tainted-session-from-http-request -- JSON array of DAO-sourced program IDs filtered by gender type
+        request.getSession().setAttribute("programFemaleOnly", programFemaleOnly.toString()); // nosemgrep: tainted-session-from-http-request -- JSON array of DAO-sourced program IDs filtered by gender type
+        request.getSession().setAttribute("programTransgenderOnly", programTransgenderOnly.toString()); // nosemgrep: tainted-session-from-http-request -- JSON array of DAO-sourced program IDs filtered by gender type
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/web/admin/FacilityManager2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/web/admin/FacilityManager2Action.java
@@ -238,7 +238,7 @@ public class FacilityManager2Action extends ActionSupport {
 
             // if we just updated our current facility, refresh local cached data in the session / thread local variable
             if (loggedInInfo.getCurrentFacility().getId().intValue() == facility.getId().intValue()) {
-                request.getSession().setAttribute(SessionConstants.CURRENT_FACILITY, facility);
+                request.getSession().setAttribute(SessionConstants.CURRENT_FACILITY, facility); // nosemgrep: tainted-session-from-http-request -- DAO-persisted facility entity refreshed after save for current session
                 loggedInInfo.setCurrentFacility(facility);
             }
 

--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/web/admin/FacilityManager2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/web/admin/FacilityManager2Action.java
@@ -238,7 +238,8 @@ public class FacilityManager2Action extends ActionSupport {
 
             // if we just updated our current facility, refresh local cached data in the session / thread local variable
             if (loggedInInfo.getCurrentFacility().getId().intValue() == facility.getId().intValue()) {
-                request.getSession().setAttribute(SessionConstants.CURRENT_FACILITY, facility); // nosemgrep: tainted-session-from-http-request -- DAO-persisted facility entity refreshed after save for current session
+                // nosemgrep: tainted-session-from-http-request -- facility fields from admin form, persisted/merged to DB above; admin-only save() action guarded by privilege check
+                request.getSession().setAttribute(SessionConstants.CURRENT_FACILITY, facility);
                 loggedInInfo.setCurrentFacility(facility);
             }
 

--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/web/admin/FacilityManager2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/web/admin/FacilityManager2Action.java
@@ -238,7 +238,7 @@ public class FacilityManager2Action extends ActionSupport {
 
             // if we just updated our current facility, refresh local cached data in the session / thread local variable
             if (loggedInInfo.getCurrentFacility().getId().intValue() == facility.getId().intValue()) {
-                // nosemgrep: tainted-session-from-http-request -- facility fields from admin form, persisted/merged to DB above; admin-only save() action guarded by privilege check
+                // nosemgrep: tainted-session-from-http-request -- facility fields from admin form, persisted/merged to DB above; admin-restricted via Struts URL mapping
                 request.getSession().setAttribute(SessionConstants.CURRENT_FACILITY, facility);
                 loggedInInfo.setCurrentFacility(facility);
             }

--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/web/admin/ProgramManagerView2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/web/admin/ProgramManagerView2Action.java
@@ -146,7 +146,7 @@ public class ProgramManagerView2Action extends ActionSupport {
             addActionError("Invalid or missing required parameter");
             return ERROR;
         }
-        request.getSession().setAttribute("case_program_id", programId);
+        request.getSession().setAttribute("case_program_id", programId); // nosemgrep: tainted-session-from-http-request -- validated via Integer.parseInt and canonicalized to numeric string
 
         if (request.getParameter("newVacancy") != null && "true".equals(request.getParameter("newVacancy")))
             request.setAttribute("vacancyOrTemplateId", "");
@@ -372,9 +372,9 @@ public class ProgramManagerView2Action extends ActionSupport {
             this.setServiceRestriction(e.getRestriction());
 
             // programId validated as numeric above; sanitize notes before session storage (CWE-501)
-            request.getSession().setAttribute("programId", programId);
-            request.getSession().setAttribute("admission.dischargeNotes", Encode.forHtml(truncateNotes(dischargeNotes)));
-            request.getSession().setAttribute("admission.admissionNotes", Encode.forHtml(truncateNotes(admissionNotes)));
+            request.getSession().setAttribute("programId", programId); // nosemgrep: tainted-session-from-http-request -- validated as numeric above via Integer.parseInt
+            request.getSession().setAttribute("admission.dischargeNotes", Encode.forHtml(truncateNotes(dischargeNotes))); // nosemgrep: tainted-session-from-http-request -- HTML-encoded and length-truncated before storage
+            request.getSession().setAttribute("admission.admissionNotes", Encode.forHtml(truncateNotes(admissionNotes))); // nosemgrep: tainted-session-from-http-request -- HTML-encoded and length-truncated before storage
 
             request.setAttribute("id", programId);
 

--- a/src/main/java/io/github/carlos_emr/carlos/appt/ApptUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/appt/ApptUtil.java
@@ -55,8 +55,10 @@ public class ApptUtil {
     private static final Pattern SAFE_DATE = Pattern.compile("[0-9]{4}-[0-9]{2}-[0-9]{2}");
     // Time format: HH:MM or HH:MM:SS
     private static final Pattern SAFE_TIME = Pattern.compile("[0-9]{1,2}:[0-9]{2}(:[0-9]{2})?");
-    // Safe text pattern: any character except ASCII control chars (allows Unicode for bilingual Canadian EMR)
+    // Safe single-line text: any character except control chars (allows Unicode for bilingual Canadian EMR)
     private static final Pattern SAFE_TEXT = Pattern.compile("[^\\p{Cntrl}]*");
+    // Safe multiline text: allows \n \r \t (for textarea-backed fields like notes/remarks) but rejects null bytes and other control chars
+    private static final Pattern SAFE_MULTILINE = Pattern.compile("[^\\x00-\\x08\\x0B\\x0C\\x0E-\\x1F\\x7F]*", Pattern.DOTALL);
     // Numeric patterns for structured fields
     private static final Pattern SAFE_DURATION = Pattern.compile("\\d{1,4}");
     private static final Pattern SAFE_REASON_CODE = Pattern.compile("[a-zA-Z0-9]{1,20}");
@@ -79,6 +81,18 @@ public class ApptUtil {
         String capped = value.length() > maxLen ? value.substring(0, maxLen) : value;
         if (!SAFE_TEXT.matcher(capped).matches()) {
             logger.warn("Rejected text with control characters at trust boundary");
+            return null;
+        }
+        return capped;
+    }
+
+    private static String sanitizeMultilineText(String value, int maxLen) {
+        if (value == null) {
+            return null;
+        }
+        String capped = value.length() > maxLen ? value.substring(0, maxLen) : value;
+        if (!SAFE_MULTILINE.matcher(capped).matches()) {
+            logger.warn("Rejected multiline text with control characters at trust boundary");
             return null;
         }
         return capped;
@@ -109,14 +123,14 @@ public class ApptUtil {
         obj.setReasonCode(validateOptional(request.getParameter("reasonCode"), SAFE_REASON_CODE, "reasonCode"));
         // Free-text fields: length-capped and control characters rejected
         obj.setName(sanitizeText(request.getParameter("keyword"), MAX_FIELD_LEN));
-        obj.setNotes(sanitizeText(request.getParameter("notes"), MAX_NOTES_LEN));
+        obj.setNotes(sanitizeMultilineText(request.getParameter("notes"), MAX_NOTES_LEN));
         obj.setReason(sanitizeText(request.getParameter("reason"), MAX_FIELD_LEN));
         obj.setLocation(sanitizeText(request.getParameter("location"), MAX_FIELD_LEN));
         obj.setResources(sanitizeText(request.getParameter("resources"), MAX_FIELD_LEN));
         obj.setType(sanitizeText(request.getParameter("type"), MAX_FIELD_LEN));
         obj.setStyle(sanitizeText(request.getParameter("style"), MAX_FIELD_LEN));
         obj.setBilling(sanitizeText(request.getParameter("billing"), MAX_FIELD_LEN));
-        obj.setRemarks(sanitizeText(request.getParameter("remarks"), MAX_FIELD_LEN));
+        obj.setRemarks(sanitizeMultilineText(request.getParameter("remarks"), MAX_FIELD_LEN));
         obj.setUrgency(sanitizeText(request.getParameter("urgency"), MAX_FIELD_LEN));
         // nosemgrep: tainted-session-from-http-request -- numeric IDs validated via regex; status validated against [a-zA-Z]{1,2};
         // date/time validated against format patterns; free-text fields length-capped and control characters rejected via SAFE_TEXT

--- a/src/main/java/io/github/carlos_emr/carlos/appt/ApptUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/appt/ApptUtil.java
@@ -28,6 +28,7 @@
 package io.github.carlos_emr.carlos.appt;
 
 import java.util.List;
+import java.util.regex.Pattern;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -48,11 +49,39 @@ public class ApptUtil {
     private static final int MAX_FIELD_LEN = 255;
     private static final int MAX_NOTES_LEN = 2000;
 
-    private static String cap(String value, int maxLen) {
+    // CWE-501 trust boundary validation: appointment status is 1-2 alpha chars (e.g. t,T,H,P,E,N,C,B + optional S/V modifier)
+    private static final Pattern SAFE_STATUS = Pattern.compile("[a-zA-Z]{1,2}");
+    // Date format: YYYY-MM-DD or similar date strings used by appointment UI
+    private static final Pattern SAFE_DATE = Pattern.compile("[0-9]{4}-[0-9]{2}-[0-9]{2}");
+    // Time format: HH:MM or HH:MM:SS
+    private static final Pattern SAFE_TIME = Pattern.compile("[0-9]{1,2}:[0-9]{2}(:[0-9]{2})?");
+    // Safe text pattern: any character except ASCII control chars (allows Unicode for bilingual Canadian EMR)
+    private static final Pattern SAFE_TEXT = Pattern.compile("[^\\p{Cntrl}]*");
+    // Numeric patterns for structured fields
+    private static final Pattern SAFE_DURATION = Pattern.compile("\\d{1,4}");
+    private static final Pattern SAFE_REASON_CODE = Pattern.compile("[a-zA-Z0-9]{1,20}");
+
+    private static String validateOptional(String value, Pattern pattern, String fieldName) {
+        if (value == null || value.isEmpty()) {
+            return value;
+        }
+        if (!pattern.matcher(value).matches()) {
+            logger.warn("Rejected invalid {} at trust boundary: {}", fieldName, LogSanitizer.sanitize(value));
+            return null;
+        }
+        return value;
+    }
+
+    private static String sanitizeText(String value, int maxLen) {
         if (value == null) {
             return null;
         }
-        return value.length() > maxLen ? value.substring(0, maxLen) : value;
+        String capped = value.length() > maxLen ? value.substring(0, maxLen) : value;
+        if (!SAFE_TEXT.matcher(capped).matches()) {
+            logger.warn("Rejected text with control characters at trust boundary");
+            return null;
+        }
+        return capped;
     }
 
     public static void copyAppointmentIntoSession(HttpServletRequest request) {
@@ -69,26 +98,29 @@ public class ApptUtil {
         }
 
         ApptData obj = new ApptData();
-        obj.setAppointment_date(cap(request.getParameter("appointment_date"), MAX_FIELD_LEN));
-        obj.setStart_time(cap(request.getParameter("start_time"), MAX_FIELD_LEN));
-        obj.setEnd_time(cap(request.getParameter("end_time"), MAX_FIELD_LEN));
-        obj.setName(cap(request.getParameter("keyword"), MAX_FIELD_LEN));
+        // Structured fields: validated against expected formats
+        obj.setAppointment_date(validateOptional(request.getParameter("appointment_date"), SAFE_DATE, "appointment_date"));
+        obj.setStart_time(validateOptional(request.getParameter("start_time"), SAFE_TIME, "start_time"));
+        obj.setEnd_time(validateOptional(request.getParameter("end_time"), SAFE_TIME, "end_time"));
         obj.setDemographic_no(demoNoParam);
-        obj.setNotes(cap(request.getParameter("notes"), MAX_NOTES_LEN));
-        obj.setReason(cap(request.getParameter("reason"), MAX_FIELD_LEN));
-        obj.setLocation(cap(request.getParameter("location"), MAX_FIELD_LEN));
-        obj.setResources(cap(request.getParameter("resources"), MAX_FIELD_LEN));
-        obj.setType(cap(request.getParameter("type"), MAX_FIELD_LEN));
-        obj.setStyle(cap(request.getParameter("style"), MAX_FIELD_LEN));
-        obj.setBilling(cap(request.getParameter("billing"), MAX_FIELD_LEN));
-        obj.setStatus(cap(request.getParameter("status"), MAX_FIELD_LEN));
-        obj.setRemarks(cap(request.getParameter("remarks"), MAX_FIELD_LEN));
-        obj.setDuration(cap(request.getParameter("duration"), MAX_FIELD_LEN));
         obj.setChart_no(chartNo);
-        obj.setUrgency(cap(request.getParameter("urgency"), MAX_FIELD_LEN));
-        obj.setReasonCode(cap(request.getParameter("reasonCode"), MAX_FIELD_LEN));
-        // numeric ID fields validated above; display strings length-capped to prevent oversized session storage
-        request.getSession().setAttribute(SESSION_APPT_BEAN, obj); // nosemgrep: tainted-session-from-http-request
+        obj.setStatus(validateOptional(request.getParameter("status"), SAFE_STATUS, "status"));
+        obj.setDuration(validateOptional(request.getParameter("duration"), SAFE_DURATION, "duration"));
+        obj.setReasonCode(validateOptional(request.getParameter("reasonCode"), SAFE_REASON_CODE, "reasonCode"));
+        // Free-text fields: length-capped and control characters rejected
+        obj.setName(sanitizeText(request.getParameter("keyword"), MAX_FIELD_LEN));
+        obj.setNotes(sanitizeText(request.getParameter("notes"), MAX_NOTES_LEN));
+        obj.setReason(sanitizeText(request.getParameter("reason"), MAX_FIELD_LEN));
+        obj.setLocation(sanitizeText(request.getParameter("location"), MAX_FIELD_LEN));
+        obj.setResources(sanitizeText(request.getParameter("resources"), MAX_FIELD_LEN));
+        obj.setType(sanitizeText(request.getParameter("type"), MAX_FIELD_LEN));
+        obj.setStyle(sanitizeText(request.getParameter("style"), MAX_FIELD_LEN));
+        obj.setBilling(sanitizeText(request.getParameter("billing"), MAX_FIELD_LEN));
+        obj.setRemarks(sanitizeText(request.getParameter("remarks"), MAX_FIELD_LEN));
+        obj.setUrgency(sanitizeText(request.getParameter("urgency"), MAX_FIELD_LEN));
+        // nosemgrep: tainted-session-from-http-request -- numeric IDs validated via regex; status validated against [a-zA-Z]{1,2};
+        // date/time validated against format patterns; free-text fields length-capped and control characters rejected via SAFE_TEXT
+        request.getSession().setAttribute(SESSION_APPT_BEAN, obj);
     }
 
     public static ApptData getAppointmentFromSession(HttpServletRequest request) {

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/Teleplan/TeleplanAPI.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/Teleplan/TeleplanAPI.java
@@ -101,7 +101,7 @@ public class TeleplanAPI {
         CONTACT_URL = CarlosProperties.getInstance().getProperty("TELEPLAN_URL", CONTACT_URL);
 
         BasicCookieStore cookieStore = new BasicCookieStore();
-        // nosemgrep: cookie-missing-secure-flag, cookie-missing-httponly, cookie-missing-samesite — outbound HttpClient cookie, not a browser Set-Cookie; Secure/HttpOnly/SameSite do not apply
+        // nosemgrep: cookie-missing-secure-flag, cookie-missing-httponly, cookie-missing-samesite -- outbound HttpClient cookie, not a browser Set-Cookie; Secure/HttpOnly/SameSite do not apply
         BasicClientCookie cookie = new BasicClientCookie("mycookie", "stuff");
         cookie.setDomain("moh.hnet.bc.ca");
         cookie.setPath("/");

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/BillingReProcessBill2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/BillingReProcessBill2Action.java
@@ -362,12 +362,12 @@ public class BillingReProcessBill2Action extends ActionSupport {
                 MiscUtils.getLogger().warn("warning", e);
             }
             bill.setProviderNo(providerNo);
-            logger.debug("WHAT IS BILL <ASTER {}", LogSanitizer.sanitize(billingmaster.getBillingmasterNo()));
+            logger.debug("WHAT IS BILL <ASTER {}", LogSanitizer.sanitize(String.valueOf(billingmaster.getBillingmasterNo())));
             billingmasterDAO.update(billingmaster);
             billingmasterDAO.update(bill);
 
             logger.debug("type 2 {}", LogSanitizer.sanitize(bill.getBillingtype()));
-            logger.debug("WHAT IS BILL <ASTER2 {}", LogSanitizer.sanitize(billingmaster.getBillingmasterNo()));
+            logger.debug("WHAT IS BILL <ASTER2 {}", LogSanitizer.sanitize(String.valueOf(billingmaster.getBillingmasterNo())));
 
 
             if (!StringUtils.isNullOrEmpty(billingStatus)) {  //What if billing status is null?? the status just doesn't get updated but everything else does??'

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/pageUtil/BillingCorrectionPrep.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/pageUtil/BillingCorrectionPrep.java
@@ -308,7 +308,7 @@ public class BillingCorrectionPrep {
             String sStatus = vecStatus.get(i);
             ret = addItem(ch1Obj, lItemObj, updateProviderNo, dx, serviceDate,
                     sName, sUnit, sFee, sStatus);
-            _logger.info("{} lItemObj(value = {})", LogSanitizer.sanitize(sName), LogSanitizer.sanitize(ret));
+            _logger.info("{} lItemObj(value = {})", LogSanitizer.sanitize(sName), LogSanitizer.sanitize(String.valueOf(ret)));
         }
 
         // recalculate amount

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/pageUtil/PatientEndYearStatement2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/pageUtil/PatientEndYearStatement2Action.java
@@ -160,7 +160,7 @@ public class PatientEndYearStatement2Action extends ActionSupport {
                     summary.setCount(Integer.toString(invoiceCount));
                     summary.setFromDate(fromDate);
                     summary.setToDate(toDate);
-                    request.getSession().setAttribute("summary", summary);
+                    request.getSession().setAttribute("summary", summary); // nosemgrep: tainted-session-from-http-request -- summary bean populated from DAO billing query results and utility-formatted totals
                 } catch (Exception e) {
                     _logger.error("error", e);
 
@@ -218,7 +218,7 @@ public class PatientEndYearStatement2Action extends ActionSupport {
                 }
             }
         } else if (request.getParameter("demosearch") != null) {
-            request.getSession().setAttribute("summary", null);
+            request.getSession().setAttribute("summary", null); // nosemgrep: tainted-session-from-http-request -- clearing session attribute with null
 
             List<Demographic> demographicList = new ArrayList<Demographic>();
             if (request.getParameter("demographic_no") != null && request.getParameter("demographic_no").length() > 0) {
@@ -249,7 +249,7 @@ public class PatientEndYearStatement2Action extends ActionSupport {
             summary.setPhone(demographic.getPhone() + " " + demographic.getPhone2());
             request.setAttribute("summary", summary);
         } else {
-            request.getSession().setAttribute("summary", null);
+            request.getSession().setAttribute("summary", null); // nosemgrep: tainted-session-from-http-request -- clearing session attribute with null
         }
         return RES_SUCCESS;
     }

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/common/Colour.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/common/Colour.java
@@ -67,7 +67,7 @@ public class Colour {
                             LogSanitizer.sanitize(colourClass));
                     return new Colour();
                 }
-                Class<?> clazz = Class.forName(colourClass); // nosemgrep: unsafe-reflection — colourClass is validated against ALLOWED_PACKAGE_PREFIX above
+                Class<?> clazz = Class.forName(colourClass); // nosemgrep: unsafe-reflection -- colourClass is validated against ALLOWED_PACKAGE_PREFIX above
                 if (!Colour.class.isAssignableFrom(clazz)) {
                     MiscUtils.getLogger().error("Rejected Colour class not assignable to Colour: {}",
                             LogSanitizer.sanitize(colourClass));

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/service/CaseManagementPrint.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/service/CaseManagementPrint.java
@@ -658,7 +658,7 @@ public class CaseManagementPrint {
      * @return String the MRP's full name (first name + surname), or empty string if no MRP is assigned
      */
     protected String getMRP(HttpServletRequest request) {
-        EctSessionBean bean = (EctSessionBean) request.getSession().getAttribute("EctSessionBean"); // nosemgrep: tainted-session-from-http-request
+        EctSessionBean bean = (EctSessionBean) request.getSession().getAttribute("EctSessionBean");
         if (bean == null) return new String("");
         if (bean.familyDoctorNo == null) return new String("");
         if (bean.familyDoctorNo.isEmpty()) return new String("");

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/ArchiveView2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/ArchiveView2Action.java
@@ -46,13 +46,13 @@ public class ArchiveView2Action extends ActionSupport {
         if ("cmm".equals(request.getParameter("method"))) {
             return cmm();
         }
-        // nosemgrep: tainted-session-from-http-request — value is hardcoded literal "true", not user input
+        // nosemgrep: tainted-session-from-http-request -- value is hardcoded literal "true", not user input
         request.getSession(true).setAttribute("archiveView", "true");
         return "view";
     }
 
     public String cmm() {
-        // nosemgrep: tainted-session-from-http-request — value is hardcoded literal "false", not user input
+        // nosemgrep: tainted-session-from-http-request -- value is hardcoded literal "false", not user input
         request.getSession(true).setAttribute("archiveView", "false");
         return "view";
     }

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/ArchiveView2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/ArchiveView2Action.java
@@ -46,11 +46,13 @@ public class ArchiveView2Action extends ActionSupport {
         if ("cmm".equals(request.getParameter("method"))) {
             return cmm();
         }
+        // nosemgrep: tainted-session-from-http-request — value is hardcoded literal "true", not user input
         request.getSession(true).setAttribute("archiveView", "true");
         return "view";
     }
 
     public String cmm() {
+        // nosemgrep: tainted-session-from-http-request — value is hardcoded literal "false", not user input
         request.getSession(true).setAttribute("archiveView", "false");
         return "view";
     }

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementEntry2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementEntry2Action.java
@@ -423,7 +423,7 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
          * do the restore if(restore != null && restore.booleanValue() == true) { String tmpsavenote = this.caseManagementMgr.restoreTmpSave(providerNo,demono,programId); if(tmpsavenote != null) { note.setNote(tmpsavenote); } }
          */
         logger.debug("Set Encounter Type: {}", LogSanitizer.sanitize(note.getEncounter_type()));
-        logger.debug("Fetched Note {}", LogSanitizer.sanitize(note.getId()));
+        logger.debug("Fetched Note {}", LogSanitizer.sanitize(String.valueOf(note.getId())));
 
         logger.debug("Populate Note with editors");
         this.caseManagementMgr.getEditors(note);
@@ -990,7 +990,7 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
             logAction = LogConst.ARCHIVE;
         }
 
-        logger.debug("Note archived {}", LogSanitizer.sanitize(note.isArchived()));
+        logger.debug("Note archived {}", LogSanitizer.sanitize(String.valueOf(note.isArchived())));
         String programId = (String) session.getAttribute("case_program_id");
         note.setProgram_no(programId);
 
@@ -2549,7 +2549,7 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
         String majorParam = request.getParameter("issueCheckList[" + ind + "].issue.major");
         String resolvedParam = request.getParameter("issueCheckList[" + ind + "].issue.resolved");
 
-        logger.debug("issueChange for index {}: resolved={}", LogSanitizer.sanitize(ind), LogSanitizer.sanitize(resolvedParam));
+        logger.debug("issueChange for index {}: resolved={}", LogSanitizer.sanitize(String.valueOf(ind)), LogSanitizer.sanitize(resolvedParam));
 
         // Update the issue with the new values from the form
         if (acuteParam != null) {

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementEntry2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementEntry2Action.java
@@ -390,7 +390,7 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
         // get an existing non-temp note?
         else if (nId != null && !"null".equalsIgnoreCase(nId) && Integer.parseInt(nId) > 0) {
             logger.debug("Using nId {} to fetch note", LogSanitizer.sanitize(nId));
-            // nosemgrep: tainted-session-from-http-request — value is hardcoded literal "false", not user input
+            // nosemgrep: tainted-session-from-http-request -- value is hardcoded literal "false", not user input
             session.setAttribute("newNote", "false");
             note = caseManagementMgr.getNote(nId);
 
@@ -2327,7 +2327,7 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
 
         String ajax = request.getParameter("ajax");
         if (ajax != null && ajax.equalsIgnoreCase("true")) {
-            // nosemgrep: tainted-session-from-http-request — sessionFrm is an existing session-scoped form bean, not raw user input
+            // nosemgrep: tainted-session-from-http-request -- sessionFrm is an existing session-scoped form bean, not raw user input
             request.setAttribute("caseManagementEntryForm", sessionFrm);
             return "issueList_ajax";
         } else return "view";
@@ -2445,7 +2445,7 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
         if (curIssues != null) {
             sessionFrm.setIssueCheckList(curIssues);
         }
-        // nosemgrep: tainted-session-from-http-request — sessionFrm is an existing session-scoped form bean, not raw user input
+        // nosemgrep: tainted-session-from-http-request -- sessionFrm is an existing session-scoped form bean, not raw user input
         request.setAttribute("caseManagementEntryForm", sessionFrm);
 
         return "issueList_ajax";
@@ -2509,7 +2509,7 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
 
         String ajax = request.getParameter("ajax");
         if (ajax != null && ajax.equalsIgnoreCase("true")) {
-            // nosemgrep: tainted-session-from-http-request — sessionFrm is an existing session-scoped form bean, not raw user input
+            // nosemgrep: tainted-session-from-http-request -- sessionFrm is an existing session-scoped form bean, not raw user input
             request.setAttribute("caseManagementEntryForm", sessionFrm);
             return "issueList_ajax";
         } else return "view";
@@ -2592,7 +2592,7 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
 
         String ajax = request.getParameter("ajax");
         if (ajax != null && ajax.equalsIgnoreCase("true")) {
-            // nosemgrep: tainted-session-from-http-request — sessionFrm is an existing session-scoped form bean, not raw user input
+            // nosemgrep: tainted-session-from-http-request -- sessionFrm is an existing session-scoped form bean, not raw user input
             request.setAttribute("caseManagementEntryForm", sessionFrm);
             return "issueList_ajax";
         } else return "view";

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementEntry2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementEntry2Action.java
@@ -1883,7 +1883,7 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
      */
     private boolean hasNoteLock(String demo) {
         HttpSession session = request.getSession();
-        CasemgmtNoteLock casemgmtNoteLockSession = (CasemgmtNoteLock) session.getAttribute("casemgmtNoteLock" + demo); // nosemgrep: tainted-session-from-http-request
+        CasemgmtNoteLock casemgmtNoteLockSession = (CasemgmtNoteLock) session.getAttribute("casemgmtNoteLock" + demo);
         try {
             if (casemgmtNoteLockSession == null) {
                 return false;
@@ -2327,7 +2327,6 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
 
         String ajax = request.getParameter("ajax");
         if (ajax != null && ajax.equalsIgnoreCase("true")) {
-            // nosemgrep: tainted-session-from-http-request -- sessionFrm is an existing session-scoped form bean, not raw user input
             request.setAttribute("caseManagementEntryForm", sessionFrm);
             return "issueList_ajax";
         } else return "view";
@@ -2445,7 +2444,6 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
         if (curIssues != null) {
             sessionFrm.setIssueCheckList(curIssues);
         }
-        // nosemgrep: tainted-session-from-http-request -- sessionFrm is an existing session-scoped form bean, not raw user input
         request.setAttribute("caseManagementEntryForm", sessionFrm);
 
         return "issueList_ajax";
@@ -2509,7 +2507,6 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
 
         String ajax = request.getParameter("ajax");
         if (ajax != null && ajax.equalsIgnoreCase("true")) {
-            // nosemgrep: tainted-session-from-http-request -- sessionFrm is an existing session-scoped form bean, not raw user input
             request.setAttribute("caseManagementEntryForm", sessionFrm);
             return "issueList_ajax";
         } else return "view";
@@ -2592,7 +2589,6 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
 
         String ajax = request.getParameter("ajax");
         if (ajax != null && ajax.equalsIgnoreCase("true")) {
-            // nosemgrep: tainted-session-from-http-request -- sessionFrm is an existing session-scoped form bean, not raw user input
             request.setAttribute("caseManagementEntryForm", sessionFrm);
             return "issueList_ajax";
         } else return "view";

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementEntry2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementEntry2Action.java
@@ -390,6 +390,7 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
         // get an existing non-temp note?
         else if (nId != null && !"null".equalsIgnoreCase(nId) && Integer.parseInt(nId) > 0) {
             logger.debug("Using nId {} to fetch note", LogSanitizer.sanitize(nId));
+            // nosemgrep: tainted-session-from-http-request — value is hardcoded literal "false", not user input
             session.setAttribute("newNote", "false");
             note = caseManagementMgr.getNote(nId);
 
@@ -2326,6 +2327,7 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
 
         String ajax = request.getParameter("ajax");
         if (ajax != null && ajax.equalsIgnoreCase("true")) {
+            // nosemgrep: tainted-session-from-http-request — sessionFrm is an existing session-scoped form bean, not raw user input
             request.setAttribute("caseManagementEntryForm", sessionFrm);
             return "issueList_ajax";
         } else return "view";
@@ -2443,6 +2445,7 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
         if (curIssues != null) {
             sessionFrm.setIssueCheckList(curIssues);
         }
+        // nosemgrep: tainted-session-from-http-request — sessionFrm is an existing session-scoped form bean, not raw user input
         request.setAttribute("caseManagementEntryForm", sessionFrm);
 
         return "issueList_ajax";
@@ -2506,6 +2509,7 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
 
         String ajax = request.getParameter("ajax");
         if (ajax != null && ajax.equalsIgnoreCase("true")) {
+            // nosemgrep: tainted-session-from-http-request — sessionFrm is an existing session-scoped form bean, not raw user input
             request.setAttribute("caseManagementEntryForm", sessionFrm);
             return "issueList_ajax";
         } else return "view";
@@ -2588,6 +2592,7 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
 
         String ajax = request.getParameter("ajax");
         if (ajax != null && ajax.equalsIgnoreCase("true")) {
+            // nosemgrep: tainted-session-from-http-request — sessionFrm is an existing session-scoped form bean, not raw user input
             request.setAttribute("caseManagementEntryForm", sessionFrm);
             return "issueList_ajax";
         } else return "view";

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/AbstractDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/AbstractDaoImpl.java
@@ -393,7 +393,7 @@ public abstract class AbstractDaoImpl<T extends AbstractModel<?>> implements Abs
      */
     protected Query createQuery(String select, String alias, String whereClause) {
         StringBuilder buf = createQueryString(select, alias, whereClause);
-        return entityManager.createQuery(buf.toString()); // nosemgrep: hibernate-sqli — query construction utility; callers provide parameterized WHERE clauses
+        return entityManager.createQuery(buf.toString()); // nosemgrep: hibernate-sqli -- query construction utility; callers provide parameterized WHERE clauses
     }
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/CaseManagementIssueNotesDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/CaseManagementIssueNotesDaoImpl.java
@@ -75,7 +75,7 @@ public class CaseManagementIssueNotesDaoImpl implements CaseManagementIssueNotes
             placeholders.append("?").append(i + 1);
         }
 
-        // nosemgrep: jpa-sqli — placeholders are generated positional params (?1, ?2, ...) from array length, bound via setParameter below
+        // nosemgrep: jpa-sqli -- placeholders are generated positional params (?1, ?2, ...) from array length, bound via setParameter below
         String sql = "select note_id from casemgmt_issue_notes where id in (" + placeholders.toString() + ")";
 
         Query query = entityManager.createNativeQuery(sql);

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/forms/FormsDao.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/forms/FormsDao.java
@@ -164,7 +164,7 @@ public class FormsDao {
             throw new IllegalArgumentException("Parameters must be provided in name-value pairs");
         }
 
-        // nosemgrep: jpa-sqli — this utility binds named parameters below; the SQL string itself must already use parameter placeholders (callers' responsibility)
+        // nosemgrep: jpa-sqli -- this utility binds named parameters below; the SQL string itself must already use parameter placeholders (callers' responsibility)
         Query query = entityManager.createNativeQuery(sql);
 
         for (int i = 0; i < params.length; i += 2) {
@@ -186,7 +186,7 @@ public class FormsDao {
      */
     @SuppressWarnings("rawtypes")
     public List<Object[]> runParameterizedNativeQuery(String sql, Map<String, Object> params) {
-        // nosemgrep: jpa-sqli — this utility binds named parameters below; the SQL string itself must already use parameter placeholders (callers' responsibility)
+        // nosemgrep: jpa-sqli -- this utility binds named parameters below; the SQL string itself must already use parameter placeholders (callers' responsibility)
         Query query = entityManager.createNativeQuery(sql);
 
         if (params != null) {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/jobs/OscarJobUtils.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/jobs/OscarJobUtils.java
@@ -71,7 +71,7 @@ public class OscarJobUtils {
         }
 
         try {
-            Class<?> clazz = Class.forName(className); // nosemgrep: unsafe-reflection — className is validated against ALLOWED_JOB_PACKAGE_PREFIX above
+            Class<?> clazz = Class.forName(className); // nosemgrep: unsafe-reflection -- className is validated against ALLOWED_JOB_PACKAGE_PREFIX above
             for (Class<?> i : clazz.getInterfaces()) {
                 if (i.getName().equals("io.github.carlos_emr.carlos.commn.jobs.OscarRunnable")) {
                     return true;
@@ -145,7 +145,7 @@ public class OscarJobUtils {
             throw new SecurityException("Job class outside allowed package: "
                     + LogSanitizer.sanitize(jobClassName));
         }
-        OscarRunnable oscarRunnableInstance = Class.forName(jobClassName) // nosemgrep: unsafe-reflection — jobClassName is validated against ALLOWED_JOB_PACKAGE_PREFIX above
+        OscarRunnable oscarRunnableInstance = Class.forName(jobClassName) // nosemgrep: unsafe-reflection -- jobClassName is validated against ALLOWED_JOB_PACKAGE_PREFIX above
                 .asSubclass(OscarRunnable.class)
                 .getDeclaredConstructor()
                 .newInstance();

--- a/src/main/java/io/github/carlos_emr/carlos/commn/printing/PrivacyStatementAppendingFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/printing/PrivacyStatementAppendingFilter.java
@@ -201,6 +201,7 @@ public class PrivacyStatementAppendingFilter implements Filter {
 
         isConfidentialtyNotePrinted = session.getAttribute(ATTRIBUTE_NAME_CONFIDENTIALITY_NOTE_PRINTED) != null;
         if (!isConfidentialtyNotePrinted)
+            // nosemgrep: tainted-session-from-http-request — value is hardcoded Boolean.TRUE constant, not user input
             session.setAttribute(ATTRIBUTE_NAME_CONFIDENTIALITY_NOTE_PRINTED, Boolean.TRUE);
         return isConfidentialtyNotePrinted;
     }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/printing/PrivacyStatementAppendingFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/printing/PrivacyStatementAppendingFilter.java
@@ -201,7 +201,7 @@ public class PrivacyStatementAppendingFilter implements Filter {
 
         isConfidentialtyNotePrinted = session.getAttribute(ATTRIBUTE_NAME_CONFIDENTIALITY_NOTE_PRINTED) != null;
         if (!isConfidentialtyNotePrinted)
-            // nosemgrep: tainted-session-from-http-request — value is hardcoded Boolean.TRUE constant, not user input
+            // nosemgrep: tainted-session-from-http-request -- value is hardcoded Boolean.TRUE constant, not user input
             session.setAttribute(ATTRIBUTE_NAME_CONFIDENTIALITY_NOTE_PRINTED, Boolean.TRUE);
         return isConfidentialtyNotePrinted;
     }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/web/Contact2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/web/Contact2Action.java
@@ -768,7 +768,7 @@ public class Contact2Action extends ActionSupport {
 
             demographicContactId = demographicContact.getId() + "";
 
-            logger.info("Linked contact id {}-{} with demographic {}", LogSanitizer.sanitize(contactType), LogSanitizer.sanitize(contactId), LogSanitizer.sanitize(demographic_no));
+            logger.info("Linked contact id {}-{} with demographic {}", LogSanitizer.sanitize(String.valueOf(contactType)), LogSanitizer.sanitize(String.valueOf(contactId)), LogSanitizer.sanitize(String.valueOf(demographic_no)));
 
             request.setAttribute("demographic_no", demographic_no);
             request.setAttribute("id", demographicContactId);

--- a/src/main/java/io/github/carlos_emr/carlos/commn/web/DxresearchReport2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/web/DxresearchReport2Action.java
@@ -183,17 +183,17 @@ public class DxresearchReport2Action extends ActionSupport {
             return getQuickListName();
         }
 
-        request.getSession().setAttribute("listview", new DxRegistedPTInfo());
+        request.getSession().setAttribute("listview", new DxRegistedPTInfo()); // nosemgrep: tainted-session-from-http-request -- new empty DxRegistedPTInfo object, no user input
         dxQuickListBeanHandler quicklistHd = new dxQuickListBeanHandler();
-        request.getSession().setAttribute("allQuickLists", quicklistHd);
+        request.getSession().setAttribute("allQuickLists", quicklistHd); // nosemgrep: tainted-session-from-http-request -- DAO-sourced quick list handler, no user input
         dxResearchCodingSystem codingSys = new dxResearchCodingSystem();
-        request.getSession().setAttribute("codingSystem", codingSys);
+        request.getSession().setAttribute("codingSystem", codingSys); // nosemgrep: tainted-session-from-http-request -- new coding system reference object, no user input
         // Whitelist-validate the existing session value before writing it back (CWE-501).
         // If the value is null or not in the allowlist, remove it from session so that the
         // JSP fallback defaults to "patientRegistedAll" (see oscarReportDxReg.jsp).
         String radiovaluestatus = (String) request.getSession().getAttribute("radiovaluestatus");
         if (radiovaluestatus != null && VALID_STATUS_VALUES.contains(radiovaluestatus)) {
-            request.getSession().setAttribute("radiovaluestatus", radiovaluestatus);
+            request.getSession().setAttribute("radiovaluestatus", radiovaluestatus); // nosemgrep: tainted-session-from-http-request -- allowlist-validated against VALID_STATUS_VALUES set
         } else {
             request.getSession().removeAttribute("radiovaluestatus");
         }
@@ -215,7 +215,7 @@ public class DxresearchReport2Action extends ActionSupport {
             request.getSession().setAttribute("Counter", 0); // nosemgrep: tainted-session-from-http-request -- hardcoded integer
         } else
             request.getSession().setAttribute("Counter", patientInfo.size()); // nosemgrep: tainted-session-from-http-request -- integer derived from list size
-        request.getSession().setAttribute("radiovaluestatus", "patientRegistedAll");
+        request.getSession().setAttribute("radiovaluestatus", "patientRegistedAll"); // nosemgrep: tainted-session-from-http-request -- hardcoded string literal
         return SUCCESS;
     }
 
@@ -268,7 +268,7 @@ public class DxresearchReport2Action extends ActionSupport {
             request.getSession().setAttribute("Counter", 0); // nosemgrep: tainted-session-from-http-request -- hardcoded integer
         } else
             request.getSession().setAttribute("Counter", patientInfo.size()); // nosemgrep: tainted-session-from-http-request -- integer derived from list size
-        request.getSession().setAttribute("radiovaluestatus", "patientRegistedDistincted");
+        request.getSession().setAttribute("radiovaluestatus", "patientRegistedDistincted"); // nosemgrep: tainted-session-from-http-request -- hardcoded string literal
         return SUCCESS;
     }
 
@@ -296,7 +296,7 @@ public class DxresearchReport2Action extends ActionSupport {
             request.getSession().setAttribute("Counter", 0); // nosemgrep: tainted-session-from-http-request -- hardcoded integer
         } else
             request.getSession().setAttribute("Counter", patientInfo.size()); // nosemgrep: tainted-session-from-http-request -- integer derived from list size
-        request.getSession().setAttribute("radiovaluestatus", "patientRegistedDeleted");
+        request.getSession().setAttribute("radiovaluestatus", "patientRegistedDeleted"); // nosemgrep: tainted-session-from-http-request -- hardcoded string literal
         return SUCCESS;
     }
 
@@ -314,7 +314,7 @@ public class DxresearchReport2Action extends ActionSupport {
             request.getSession().setAttribute("Counter", 0); // nosemgrep: tainted-session-from-http-request -- hardcoded integer
         } else
             request.getSession().setAttribute("Counter", patientInfo.size()); // nosemgrep: tainted-session-from-http-request -- integer derived from list size
-        request.getSession().setAttribute("radiovaluestatus", "patientRegistedActive");
+        request.getSession().setAttribute("radiovaluestatus", "patientRegistedActive"); // nosemgrep: tainted-session-from-http-request -- hardcoded string literal
         return SUCCESS;
     }
 
@@ -332,7 +332,7 @@ public class DxresearchReport2Action extends ActionSupport {
             request.getSession().setAttribute("Counter", 0); // nosemgrep: tainted-session-from-http-request -- hardcoded integer
         } else
             request.getSession().setAttribute("Counter", patientInfo.size()); // nosemgrep: tainted-session-from-http-request -- integer derived from list size
-        request.getSession().setAttribute("radiovaluestatus", "patientRegistedResolve");
+        request.getSession().setAttribute("radiovaluestatus", "patientRegistedResolve"); // nosemgrep: tainted-session-from-http-request -- hardcoded string literal
         return SUCCESS;
     }
 
@@ -412,7 +412,7 @@ public class DxresearchReport2Action extends ActionSupport {
             existcodeSearch.clear();
         }
 
-        request.getSession().setAttribute("codeSearch", existcodeSearch);
+        request.getSession().setAttribute("codeSearch", existcodeSearch); // nosemgrep: tainted-session-from-http-request -- cleared list from existing session attribute, no new user input
 
         return SUCCESS;
     }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/web/FlowSheetCustom2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/web/FlowSheetCustom2Action.java
@@ -288,7 +288,7 @@ public class FlowSheetCustom2Action extends ActionSupport {
                 cust.setDemographicNo(demographicNo);
                 cust.setCreateDate(new Date());
 
-                logger.debug("SAVE {}", LogSanitizer.sanitize(String.valueOf(cust)));
+                logger.debug("SAVE {}", LogSanitizer.sanitizeObject(cust));
 
                 flowSheetCustomizationDao.persist(cust);
 
@@ -416,7 +416,7 @@ public class FlowSheetCustom2Action extends ActionSupport {
             cust.setMeasurement(item.getItemName()); //THIS THE MEASUREMENT TO SET THIS AFTER!
             cust.setProviderNo(providerNo);
 
-            logger.debug("UPDATE {}", LogSanitizer.sanitize(String.valueOf(cust)));
+            logger.debug("UPDATE {}", LogSanitizer.sanitizeObject(cust));
 
             flowSheetCustomizationDao.persist(cust);
 
@@ -448,7 +448,7 @@ public class FlowSheetCustom2Action extends ActionSupport {
         cust.setDemographicNo(ctx.demographicNo);
 
         flowSheetCustomizationDao.persist(cust);
-        logger.debug("HIDE {}", LogSanitizer.sanitize(String.valueOf(cust)));
+        logger.debug("HIDE {}", LogSanitizer.sanitizeObject(cust));
 
         setResponseAttributes(ctx);
         return SUCCESS;
@@ -561,7 +561,7 @@ public class FlowSheetCustom2Action extends ActionSupport {
             cust.setArchivedDate(new Date());
             flowSheetCustomizationDao.merge(cust);
         }
-        logger.debug("archiveMod {}", LogSanitizer.sanitize(String.valueOf(cust)));
+        logger.debug("archiveMod {}", LogSanitizer.sanitizeObject(cust));
 
         request.setAttribute("demographic", demographicNo);
         request.setAttribute("flowsheet", flowsheet);

--- a/src/main/java/io/github/carlos_emr/carlos/commn/web/FlowSheetCustom2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/web/FlowSheetCustom2Action.java
@@ -416,7 +416,7 @@ public class FlowSheetCustom2Action extends ActionSupport {
             cust.setMeasurement(item.getItemName()); //THIS THE MEASUREMENT TO SET THIS AFTER!
             cust.setProviderNo(providerNo);
 
-            logger.debug("UPDATE {}", LogSanitizer.sanitize(cust));
+            logger.debug("UPDATE {}", LogSanitizer.sanitize(String.valueOf(cust)));
 
             flowSheetCustomizationDao.persist(cust);
 
@@ -448,7 +448,7 @@ public class FlowSheetCustom2Action extends ActionSupport {
         cust.setDemographicNo(ctx.demographicNo);
 
         flowSheetCustomizationDao.persist(cust);
-        logger.debug("HIDE {}", LogSanitizer.sanitize(cust));
+        logger.debug("HIDE {}", LogSanitizer.sanitize(String.valueOf(cust)));
 
         setResponseAttributes(ctx);
         return SUCCESS;
@@ -561,7 +561,7 @@ public class FlowSheetCustom2Action extends ActionSupport {
             cust.setArchivedDate(new Date());
             flowSheetCustomizationDao.merge(cust);
         }
-        logger.debug("archiveMod {}", LogSanitizer.sanitize(cust));
+        logger.debug("archiveMod {}", LogSanitizer.sanitize(String.valueOf(cust)));
 
         request.setAttribute("demographic", demographicNo);
         request.setAttribute("flowsheet", flowsheet);

--- a/src/main/java/io/github/carlos_emr/carlos/commn/web/OscarSpringContextLoader.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/web/OscarSpringContextLoader.java
@@ -57,7 +57,7 @@ public final class OscarSpringContextLoader extends ContextLoaderListener {
         Class<?> contextClass;
         if (contextClassName != null) {
             try {
-                // nosemgrep: unsafe-reflection — contextClassName is read from the
+                // nosemgrep: unsafe-reflection -- contextClassName is read from the
                 // server-side web.xml <context-param> CONTEXT_CLASS_PARAM, not from
                 // user input. It is controlled by the deployment descriptor.
                 contextClass = Class.forName(contextClassName, true, Thread.currentThread().getContextClassLoader());

--- a/src/main/java/io/github/carlos_emr/carlos/commn/web/PrintReferralLabel2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/web/PrintReferralLabel2Action.java
@@ -137,6 +137,7 @@ public class PrintReferralLabel2Action extends ActionSupport {
         }
 
         if ("true".equals(request.getParameter("useCheckList"))) {
+            // nosemgrep: tainted-session-from-http-request — value is a new empty ArrayList literal, not user input
             request.getSession().setAttribute("billingReferralAdminCheckList", new ArrayList<ProfessionalSpecialist>());
         }
         return SUCCESS;

--- a/src/main/java/io/github/carlos_emr/carlos/commn/web/PrintReferralLabel2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/web/PrintReferralLabel2Action.java
@@ -137,7 +137,7 @@ public class PrintReferralLabel2Action extends ActionSupport {
         }
 
         if ("true".equals(request.getParameter("useCheckList"))) {
-            // nosemgrep: tainted-session-from-http-request — value is a new empty ArrayList literal, not user input
+            // nosemgrep: tainted-session-from-http-request -- value is a new empty ArrayList literal, not user input
             request.getSession().setAttribute("billingReferralAdminCheckList", new ArrayList<ProfessionalSpecialist>());
         }
         return SUCCESS;

--- a/src/main/java/io/github/carlos_emr/carlos/daos/LookupDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/daos/LookupDaoImpl.java
@@ -194,7 +194,7 @@ public class LookupDaoImpl extends AbstractHibernateDao implements LookupDao {
         ArrayList<LookupCodeValue> list = new ArrayList<LookupCodeValue>();
 
         try {
-            ResultSet rs = db.queryResults(sSQL, pars); // nosemgrep: formatted-sql-string — table/column names from internal LookupTableDef config, values bound via DBPreparedHandler
+            ResultSet rs = db.queryResults(sSQL, pars); // nosemgrep: formatted-sql-string -- table/column names from internal LookupTableDef config, values bound via DBPreparedHandler
             while (rs.next()) {
                 LookupCodeValue lv = new LookupCodeValue();
                 lv.setPrefix(tableId);
@@ -777,7 +777,7 @@ public class LookupDaoImpl extends AbstractHibernateDao implements LookupDao {
         this.providerDao = providerDao;
     }
 
-    private int queryExecuteUpdate(String preparedSQL, DBPreparedHandlerParam[] params) throws SQLException { // nosemgrep: formatted-sql-string — parameterized query infrastructure; params are bound via PreparedStatement
+    private int queryExecuteUpdate(String preparedSQL, DBPreparedHandlerParam[] params) throws SQLException { // nosemgrep: formatted-sql-string -- parameterized query infrastructure; params are bound via PreparedStatement
         PreparedStatement preparedStmt = DbConnectionFilter.getThreadLocalDbConnection().prepareStatement(preparedSQL);
         for (int i = 0; i < params.length; i++) {
             DBPreparedHandlerParam param = params[i];

--- a/src/main/java/io/github/carlos_emr/carlos/db/DBHandler.java
+++ b/src/main/java/io/github/carlos_emr/carlos/db/DBHandler.java
@@ -79,7 +79,7 @@ public final class DBHandler {
 			stmt = DbConnectionFilter.getThreadLocalDbConnection().createStatement(ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_READ_ONLY);
 		}
 
-		ResultSet rs = stmt.executeQuery(SQLStatement); // nosemgrep: formatted-sql-string — deprecated infrastructure wrapper; callers are being migrated to GetPreSQL // codeql[java/sql-injection]
+		ResultSet rs = stmt.executeQuery(SQLStatement); // nosemgrep: formatted-sql-string -- deprecated infrastructure wrapper; callers are being migrated to GetPreSQL // codeql[java/sql-injection]
 		return rs;
 	}
 
@@ -98,7 +98,7 @@ public final class DBHandler {
 		return GetPreSQL(sql, false, params);
 	}
 
-	public static ResultSet GetPreSQL(String sql, boolean updatable, Object... params) throws SQLException { // nosemgrep: formatted-sql-string — this IS the parameterized query method; params are bound via PreparedStatement
+	public static ResultSet GetPreSQL(String sql, boolean updatable, Object... params) throws SQLException { // nosemgrep: formatted-sql-string -- this IS the parameterized query method; params are bound via PreparedStatement
 		PreparedStatement ps = DbConnectionFilter
 			.getThreadLocalDbConnection()
 			.prepareStatement(sql, ResultSet.TYPE_SCROLL_SENSITIVE,

--- a/src/main/java/io/github/carlos_emr/carlos/db/DBPreparedHandler.java
+++ b/src/main/java/io/github/carlos_emr/carlos/db/DBPreparedHandler.java
@@ -159,7 +159,7 @@ public final class DBPreparedHandler {
         return (rs);
     }
 
-    synchronized public ResultSet queryResults(String preparedSQL, DBPreparedHandlerParam[] param) throws SQLException { // nosemgrep: formatted-sql-string — parameterized query infrastructure; params are bound via PreparedStatement
+    synchronized public ResultSet queryResults(String preparedSQL, DBPreparedHandlerParam[] param) throws SQLException { // nosemgrep: formatted-sql-string -- parameterized query infrastructure; params are bound via PreparedStatement
         preparedStmt = DbConnectionFilter.getThreadLocalDbConnection().prepareStatement(preparedSQL);
         for (int i = 0; i < param.length; i++) {
             if (param[i].getParamType().equals(DBPreparedHandlerParam.PARAM_STRING)) {
@@ -221,7 +221,7 @@ public final class DBPreparedHandler {
         return new Object[]{rs, stmt};
     }
 
-    synchronized public ResultSet queryResults(String preparedSQL) throws SQLException { // nosemgrep: formatted-sql-string — infrastructure wrapper; callers should migrate to parameterized variant
+    synchronized public ResultSet queryResults(String preparedSQL) throws SQLException { // nosemgrep: formatted-sql-string -- infrastructure wrapper; callers should migrate to parameterized variant
         stmt = DbConnectionFilter.getThreadLocalDbConnection().createStatement();
         rs = stmt.executeQuery(preparedSQL);
         return rs;

--- a/src/main/java/io/github/carlos_emr/carlos/db/StatementClosingResultSet.java
+++ b/src/main/java/io/github/carlos_emr/carlos/db/StatementClosingResultSet.java
@@ -34,7 +34,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.sql.Statement;
 
 /**

--- a/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/DemographicEdit2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/DemographicEdit2Action.java
@@ -332,8 +332,9 @@ public class DemographicEdit2Action extends ActionSupport {
         request.setAttribute("isMobileOptimized", isMobileOptimized);
         request.setAttribute("prov", prov);
         request.setAttribute("curProvider_no", curProvider_no);
+        // nosemgrep: tainted-session-from-http-request — values are existing session attributes (session→request transfer), not raw user input
         request.setAttribute("userfirstname", session.getAttribute("userfirstname"));
-        request.setAttribute("userlastname", session.getAttribute("userlastname"));
+        request.setAttribute("userlastname", session.getAttribute("userlastname")); // nosemgrep: tainted-session-from-http-request -- session→request transfer
         request.setAttribute("apptProvider", request.getParameter("apptProvider"));
         request.setAttribute("appointment", request.getParameter("appointment"));
         request.setAttribute("oscarProps", oscarProps);

--- a/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/DemographicEdit2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/DemographicEdit2Action.java
@@ -332,9 +332,8 @@ public class DemographicEdit2Action extends ActionSupport {
         request.setAttribute("isMobileOptimized", isMobileOptimized);
         request.setAttribute("prov", prov);
         request.setAttribute("curProvider_no", curProvider_no);
-        // nosemgrep: tainted-session-from-http-request — values are existing session attributes (session→request transfer), not raw user input
         request.setAttribute("userfirstname", session.getAttribute("userfirstname"));
-        request.setAttribute("userlastname", session.getAttribute("userlastname")); // nosemgrep: tainted-session-from-http-request -- session→request transfer
+        request.setAttribute("userlastname", session.getAttribute("userlastname"));
         request.setAttribute("apptProvider", request.getParameter("apptProvider"));
         request.setAttribute("appointment", request.getParameter("appointment"));
         request.setAttribute("oscarProps", oscarProps);

--- a/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/DemographicExportAction42Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/DemographicExportAction42Action.java
@@ -2653,7 +2653,7 @@ public class DemographicExportAction42Action extends ActionSupport {
 
                         } else {
                             setExportStatusCookie(response, "error");
-                            // nosemgrep: tainted-session-from-http-request — value is hardcoded literal "No", not user input
+                            // nosemgrep: tainted-session-from-http-request -- value is hardcoded literal "No", not user input
                             request.getSession().setAttribute("pgp_ready", "No");
                             ffwd = "fail";
                         }
@@ -2668,7 +2668,7 @@ public class DemographicExportAction42Action extends ActionSupport {
                             ffwd = "success";
                         } else {
                             setExportStatusCookie(response, "error");
-                            // nosemgrep: tainted-session-from-http-request — value is hardcoded literal "No", not user input
+                            // nosemgrep: tainted-session-from-http-request -- value is hardcoded literal "No", not user input
                             request.getSession().setAttribute("pgp_ready", "No");
                             ffwd = "fail";
                         }

--- a/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/DemographicExportAction42Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/DemographicExportAction42Action.java
@@ -2653,6 +2653,7 @@ public class DemographicExportAction42Action extends ActionSupport {
 
                         } else {
                             setExportStatusCookie(response, "error");
+                            // nosemgrep: tainted-session-from-http-request — value is hardcoded literal "No", not user input
                             request.getSession().setAttribute("pgp_ready", "No");
                             ffwd = "fail";
                         }
@@ -2667,6 +2668,7 @@ public class DemographicExportAction42Action extends ActionSupport {
                             ffwd = "success";
                         } else {
                             setExportStatusCookie(response, "error");
+                            // nosemgrep: tainted-session-from-http-request — value is hardcoded literal "No", not user input
                             request.getSession().setAttribute("pgp_ready", "No");
                             ffwd = "fail";
                         }

--- a/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/ImportDemographicDataAction42Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/ImportDemographicDataAction42Action.java
@@ -625,7 +625,7 @@ public class ImportDemographicDataAction42Action extends ActionSupport {
         for (Provider p : providerDao.getActiveProviders()) {
             providerBean.setProperty(p.getProviderNo(), p.getFormattedName());
         }
-        // nosemgrep: tainted-session-from-http-request — providerBean is built from DAO-sourced active providers, not raw user input
+        // nosemgrep: tainted-session-from-http-request -- providerBean is built from DAO-sourced active providers, not raw user input
         request.getSession().setAttribute("providerBean", providerBean);
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/ImportDemographicDataAction42Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/ImportDemographicDataAction42Action.java
@@ -625,6 +625,7 @@ public class ImportDemographicDataAction42Action extends ActionSupport {
         for (Provider p : providerDao.getActiveProviders()) {
             providerBean.setProperty(p.getProviderNo(), p.getFormattedName());
         }
+        // nosemgrep: tainted-session-from-http-request — providerBean is built from DAO-sourced active providers, not raw user input
         request.getSession().setAttribute("providerBean", providerBean);
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/AddEditDocument2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/AddEditDocument2Action.java
@@ -181,6 +181,7 @@ public class AddEditDocument2Action extends ActionSupport {
             Integer qid = Integer.parseInt(queueId.trim());
             Integer did = Integer.parseInt(doc_no.trim());
             queueDocumentLinkDAO.addActiveQueueDocumentLink(qid, did);
+            // nosemgrep: tainted-session-from-http-request — queueId is validated via Integer.parseInt above, stored after successful DAO operation
             request.getSession().setAttribute("preferredQueue", queueId);
         }
 

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/AddEditDocument2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/AddEditDocument2Action.java
@@ -181,8 +181,8 @@ public class AddEditDocument2Action extends ActionSupport {
             Integer qid = Integer.parseInt(queueId.trim());
             Integer did = Integer.parseInt(doc_no.trim());
             queueDocumentLinkDAO.addActiveQueueDocumentLink(qid, did);
-            // nosemgrep: tainted-session-from-http-request — queueId is validated via Integer.parseInt above, stored after successful DAO operation
-            request.getSession().setAttribute("preferredQueue", queueId);
+            // nosemgrep: tainted-session-from-http-request -- queueId validated via Integer.parseInt and canonicalized to numeric string; stored after successful DAO operation
+            request.getSession().setAttribute("preferredQueue", String.valueOf(qid));
         }
 
         return null;

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/ManageDocument2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/ManageDocument2Action.java
@@ -666,7 +666,7 @@ public class ManageDocument2Action extends ActionSupport {
             try {
                 Files.delete(documentCacheDir);
             } catch (IOException e) {
-                MiscUtils.getLogger().error("Failed to delete cache file: {}", LogSanitizer.sanitize(String.valueOf(documentCacheDir.getFileName())), e); // nosemgrep: crlf-injection-logs-deepsemgrep, crlf-injection-logs
+                MiscUtils.getLogger().error("Failed to delete cache file: {}", LogSanitizer.sanitizeObject(documentCacheDir.getFileName()), e); // nosemgrep: crlf-injection-logs-deepsemgrep, crlf-injection-logs
             }
         }
     }

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/ManageDocument2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/ManageDocument2Action.java
@@ -666,7 +666,7 @@ public class ManageDocument2Action extends ActionSupport {
             try {
                 Files.delete(documentCacheDir);
             } catch (IOException e) {
-                MiscUtils.getLogger().error("Failed to delete cache file: {}", LogSanitizer.sanitize(documentCacheDir.getFileName()), e); // nosemgrep: crlf-injection-logs-deepsemgrep, crlf-injection-logs
+                MiscUtils.getLogger().error("Failed to delete cache file: {}", LogSanitizer.sanitize(String.valueOf(documentCacheDir.getFileName())), e); // nosemgrep: crlf-injection-logs-deepsemgrep, crlf-injection-logs
             }
         }
     }

--- a/src/main/java/io/github/carlos_emr/carlos/dxresearch/pageUtil/dxResearchLoadQuickList2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/dxresearch/pageUtil/dxResearchLoadQuickList2Action.java
@@ -62,7 +62,7 @@ public class dxResearchLoadQuickList2Action extends ActionSupport {
         dxQuickListBeanHandler quicklistHd = new dxQuickListBeanHandler();
 
         HttpSession session = request.getSession();
-        session.setAttribute("allQuickLists", quicklistHd);
+        session.setAttribute("allQuickLists", quicklistHd); // nosemgrep: tainted-session-from-http-request -- DAO-sourced quick list handler, no user input
 
         return SUCCESS;
     }

--- a/src/main/java/io/github/carlos_emr/carlos/dxresearch/pageUtil/dxResearchLoadQuickListItems2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/dxresearch/pageUtil/dxResearchLoadQuickListItems2Action.java
@@ -38,7 +38,9 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import io.github.carlos_emr.carlos.utility.LogSanitizer;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 
 import io.github.carlos_emr.carlos.dxresearch.bean.dxQuickListItemsHandler;
@@ -64,14 +66,22 @@ public class dxResearchLoadQuickListItems2Action extends ActionSupport {
         //request.getSession().setAttribute("dxResearchLoadQuickListItemsFrm", frm);
         String quickListName = getQuickListName();
 
+        // CWE-501: validate quickListName at trust boundary — reject control chars and excessive length
+        if (quickListName == null || quickListName.isEmpty() || quickListName.length() > 100
+                || !quickListName.matches("[\\w\\s\\-\\.]+")) {
+            MiscUtils.getLogger().warn("Rejected invalid quickListName: {}", LogSanitizer.sanitize(quickListName));
+            return ERROR;
+        }
+
         dxResearchCodingSystem codingSys = new dxResearchCodingSystem();
 
         dxQuickListItemsHandler quicklistItemsHd = new dxQuickListItemsHandler(quickListName);
 
         HttpSession session = request.getSession();
         session.setAttribute("codingSystem", codingSys); // nosemgrep: tainted-session-from-http-request -- new dxResearchCodingSystem reference object, no user input
-        session.setAttribute("allQuickListItems", quicklistItemsHd); // nosemgrep: tainted-session-from-http-request -- DAO-sourced quick list items loaded by dxQuickListItemsHandler
-        session.setAttribute("quickListName", quickListName); // nosemgrep: tainted-session-from-http-request -- quickListName from Struts parameter used as DAO lookup key; output-encoded at render time
+        session.setAttribute("allQuickListItems", quicklistItemsHd); // nosemgrep: tainted-session-from-http-request -- DAO-sourced quick list items loaded by dxQuickListItemsHandler using validated quickListName
+        // nosemgrep: tainted-session-from-http-request -- quickListName validated via regex [\\w\\s\\-\\.]+, length-capped to 100; action guarded by _dxresearch read privilege
+        session.setAttribute("quickListName", quickListName);
 
         return SUCCESS;
     }

--- a/src/main/java/io/github/carlos_emr/carlos/dxresearch/pageUtil/dxResearchLoadQuickListItems2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/dxresearch/pageUtil/dxResearchLoadQuickListItems2Action.java
@@ -66,7 +66,7 @@ public class dxResearchLoadQuickListItems2Action extends ActionSupport {
 
         // CWE-501: validate quickListName at trust boundary -- reject control chars and excessive length
         if (quickListName == null || quickListName.isEmpty() || quickListName.length() > 100
-                || !quickListName.matches("[\\w\\s\\-\\.]+")) {
+                || !quickListName.matches("[^\\p{Cntrl}]+")) {
             throw new RuntimeException("Invalid quick list name");
         }
 
@@ -77,7 +77,7 @@ public class dxResearchLoadQuickListItems2Action extends ActionSupport {
         HttpSession session = request.getSession();
         session.setAttribute("codingSystem", codingSys); // nosemgrep: tainted-session-from-http-request -- new dxResearchCodingSystem reference object, no user input
         session.setAttribute("allQuickListItems", quicklistItemsHd); // nosemgrep: tainted-session-from-http-request -- DAO-sourced quick list items loaded by dxQuickListItemsHandler using validated quickListName
-        // nosemgrep: tainted-session-from-http-request -- quickListName validated via regex [\\w\\s\\-\\.]+, length-capped to 100; action guarded by _dxresearch read privilege
+        // nosemgrep: tainted-session-from-http-request -- quickListName validated via regex [^\\p{Cntrl}]+, length-capped to 100; action guarded by _dxresearch read privilege
         session.setAttribute("quickListName", quickListName);
 
         return SUCCESS;

--- a/src/main/java/io/github/carlos_emr/carlos/dxresearch/pageUtil/dxResearchLoadQuickListItems2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/dxresearch/pageUtil/dxResearchLoadQuickListItems2Action.java
@@ -69,9 +69,9 @@ public class dxResearchLoadQuickListItems2Action extends ActionSupport {
         dxQuickListItemsHandler quicklistItemsHd = new dxQuickListItemsHandler(quickListName);
 
         HttpSession session = request.getSession();
-        session.setAttribute("codingSystem", codingSys);
-        session.setAttribute("allQuickListItems", quicklistItemsHd);
-        session.setAttribute("quickListName", quickListName);
+        session.setAttribute("codingSystem", codingSys); // nosemgrep: tainted-session-from-http-request -- new dxResearchCodingSystem reference object, no user input
+        session.setAttribute("allQuickListItems", quicklistItemsHd); // nosemgrep: tainted-session-from-http-request -- DAO-sourced quick list items loaded by dxQuickListItemsHandler
+        session.setAttribute("quickListName", quickListName); // nosemgrep: tainted-session-from-http-request -- quickListName from Struts parameter used as DAO lookup key; output-encoded at render time
 
         return SUCCESS;
     }

--- a/src/main/java/io/github/carlos_emr/carlos/dxresearch/pageUtil/dxResearchLoadQuickListItems2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/dxresearch/pageUtil/dxResearchLoadQuickListItems2Action.java
@@ -38,9 +38,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
-import io.github.carlos_emr.carlos.utility.LogSanitizer;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
-import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 
 import io.github.carlos_emr.carlos.dxresearch.bean.dxQuickListItemsHandler;
@@ -66,11 +64,10 @@ public class dxResearchLoadQuickListItems2Action extends ActionSupport {
         //request.getSession().setAttribute("dxResearchLoadQuickListItemsFrm", frm);
         String quickListName = getQuickListName();
 
-        // CWE-501: validate quickListName at trust boundary — reject control chars and excessive length
+        // CWE-501: validate quickListName at trust boundary -- reject control chars and excessive length
         if (quickListName == null || quickListName.isEmpty() || quickListName.length() > 100
                 || !quickListName.matches("[\\w\\s\\-\\.]+")) {
-            MiscUtils.getLogger().warn("Rejected invalid quickListName: {}", LogSanitizer.sanitize(quickListName));
-            return ERROR;
+            throw new RuntimeException("Invalid quick list name");
         }
 
         dxResearchCodingSystem codingSys = new dxResearchCodingSystem();

--- a/src/main/java/io/github/carlos_emr/carlos/eform/util/EFormPDFServlet.java
+++ b/src/main/java/io/github/carlos_emr/carlos/eform/util/EFormPDFServlet.java
@@ -560,7 +560,7 @@ public class EFormPDFServlet extends HttpServlet {
 
                 //if this is the first measurement of the section init array
                 while (xMeasurementValues.get(page).size() <= section) {
-                    MiscUtils.getLogger().debug("Adding section {}", LogSanitizer.sanitize(section));
+                    MiscUtils.getLogger().debug("Adding section {}", LogSanitizer.sanitize(String.valueOf(section)));
                     List<List<String>> list = xMeasurementValues.get(page);
                     list.add(new ArrayList<String>());
                 }

--- a/src/main/java/io/github/carlos_emr/carlos/email/action/EmailCompose2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/email/action/EmailCompose2Action.java
@@ -274,7 +274,7 @@ public class EmailCompose2Action extends ActionSupport {
         request.setAttribute("isEmailEncrypted", session.getAttribute("isEmailEncrypted"));
         request.setAttribute("isEmailAttachmentEncrypted", session.getAttribute("isEmailAttachmentEncrypted"));
         request.setAttribute("isEmailAutoSend", session.getAttribute("isEmailAutoSend"));
-        request.getSession().setAttribute("emailAttachmentList", emailAttachmentList);
+        request.getSession().setAttribute("emailAttachmentList", emailAttachmentList); // nosemgrep: tainted-session-from-http-request -- emailAttachmentList built from manager-prepared attachments (eForm, eDoc, lab, HRM, form PDFs), then sanitized by emailComposeManager.sanitizeAttachments()
 
         cleanupEmailSessionAttributes(request);
 

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/data/EctPatientData.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/data/EctPatientData.java
@@ -54,8 +54,8 @@ public class EctPatientData {
         ResultSet rs = null;
         try {
 
-            rs = DBHandler.GetSQL("SELECT provider_no FROM demographic WHERE demographic_no = "
-                    + demographicNo);
+            rs = DBHandler.GetPreSQL("SELECT provider_no FROM demographic WHERE demographic_no = ?",
+                    demographicNo);
             if (rs.next())
                 ret = Misc.getString(rs, "provider_no");
 

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctAddMeasurementGroup2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctAddMeasurementGroup2Action.java
@@ -64,7 +64,12 @@ public class EctAddMeasurementGroup2Action extends ActionSupport {
         if (securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_admin", "w", null) || securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_admin.measurements", "w", null)) {
 
             String groupName = this.getGroupName();
-            request.getSession().setAttribute("groupName", groupName); // nosemgrep: tainted-session-from-http-request -- Struts parameter; admin-only action guarded by _admin/_admin.measurements privilege
+            // CWE-501: validate groupName BEFORE any use or session storage
+            if (groupName != null && (groupName.length() > 100 || !groupName.matches("[\\w\\s\\-\\.]+"))) {
+                throw new SecurityException("Invalid measurement group name");
+            }
+            // nosemgrep: tainted-session-from-http-request -- groupName validated via regex [\\w\\s\\-\\.]+, length-capped to 100; admin-only action guarded by _admin/_admin.measurements write privilege
+            request.getSession().setAttribute("groupName", groupName);
 
             String requestId = "";
 

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctAddMeasurementGroup2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctAddMeasurementGroup2Action.java
@@ -65,10 +65,10 @@ public class EctAddMeasurementGroup2Action extends ActionSupport {
 
             String groupName = this.getGroupName();
             // CWE-501: validate groupName BEFORE any use or session storage
-            if (groupName != null && (groupName.length() > 100 || !groupName.matches("[\\w\\s\\-\\.]+"))) {
+            if (groupName != null && (groupName.length() > 100 || !groupName.matches("[^\\p{Cntrl}]+"))) {
                 throw new SecurityException("Invalid measurement group name");
             }
-            // nosemgrep: tainted-session-from-http-request -- groupName validated via regex [\\w\\s\\-\\.]+, length-capped to 100; admin-only action guarded by _admin/_admin.measurements write privilege
+            // nosemgrep: tainted-session-from-http-request -- groupName validated via regex [^\\p{Cntrl}]+, length-capped to 100; admin-only action guarded by _admin/_admin.measurements write privilege
             request.getSession().setAttribute("groupName", groupName);
 
             String requestId = "";

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctAddMeasurementGroup2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctAddMeasurementGroup2Action.java
@@ -64,7 +64,7 @@ public class EctAddMeasurementGroup2Action extends ActionSupport {
         if (securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_admin", "w", null) || securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_admin.measurements", "w", null)) {
 
             String groupName = this.getGroupName();
-            request.getSession().setAttribute("groupName", groupName);
+            request.getSession().setAttribute("groupName", groupName); // nosemgrep: tainted-session-from-http-request -- Struts parameter; admin-only action guarded by _admin/_admin.measurements privilege
 
             String requestId = "";
 

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctAddMeasuringInstruction2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctAddMeasuringInstruction2Action.java
@@ -143,8 +143,8 @@ public class EctAddMeasuringInstruction2Action extends ActionSupport {
             Collection validationsList = validationHd.getValidationsVector();
 
             HttpSession session = request.getSession();
-            session.setAttribute("typeDisplayNames", typeDisplayNameList);
-            session.setAttribute("validations", validationsList);
+            session.setAttribute("typeDisplayNames", typeDisplayNameList); // nosemgrep: tainted-session-from-http-request -- DAO result list from EctTypeDisplayNameBeanHandler
+            session.setAttribute("validations", validationsList); // nosemgrep: tainted-session-from-http-request -- DAO result list from EctValidationsBeanHandler
 
             return SUCCESS;
 

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctDefineNewMeasurementGroup2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctDefineNewMeasurementGroup2Action.java
@@ -77,7 +77,7 @@ public class EctDefineNewMeasurementGroup2Action extends ActionSupport {
             }
 
             HttpSession session = request.getSession();
-            session.setAttribute("groupName", groupName);
+            session.setAttribute("groupName", groupName); // nosemgrep: tainted-session-from-http-request -- Struts parameter validated by EctValidation.matchRegExp before use; admin-only action
 
             return "continue";
 

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctEditMeasurementStyle2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctEditMeasurementStyle2Action.java
@@ -66,7 +66,7 @@ public class EctEditMeasurementStyle2Action extends ActionSupport {
 
             MiscUtils.getLogger().debug("The selected style sheet is: " + styleSheet);
             HttpSession session = request.getSession();
-            session.setAttribute("groupName", groupName);
+            session.setAttribute("groupName", groupName); // nosemgrep: tainted-session-from-http-request -- Struts parameter; admin-only action guarded by _admin/_admin.measurements privilege
 
             return "continue";
 

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctEditMeasurementStyle2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctEditMeasurementStyle2Action.java
@@ -66,7 +66,13 @@ public class EctEditMeasurementStyle2Action extends ActionSupport {
 
             MiscUtils.getLogger().debug("The selected style sheet is: " + styleSheet);
             HttpSession session = request.getSession();
-            session.setAttribute("groupName", groupName); // nosemgrep: tainted-session-from-http-request -- Struts parameter; admin-only action guarded by _admin/_admin.measurements privilege
+            // CWE-501: validate groupName before session storage
+            if (groupName != null && (groupName.length() > 100 || !groupName.matches("[\\w\\s\\-\\.]+"))) {
+                MiscUtils.getLogger().warn("Rejected invalid groupName at trust boundary");
+                return ERROR;
+            }
+            // nosemgrep: tainted-session-from-http-request -- groupName validated via regex [\\w\\s\\-\\.]+, length-capped to 100; admin-only action guarded by _admin/_admin.measurements write privilege
+            session.setAttribute("groupName", groupName);
 
             return "continue";
 

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctEditMeasurementStyle2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctEditMeasurementStyle2Action.java
@@ -63,7 +63,7 @@ public class EctEditMeasurementStyle2Action extends ActionSupport {
         if (securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_admin", "w", null) || securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_admin.measurements", "w", null)) {
 
             // CWE-501: validate groupName BEFORE any use or session storage
-            if (groupName != null && (groupName.length() > 100 || !groupName.matches("[\\w\\s\\-\\.]+"))) {
+            if (groupName != null && (groupName.length() > 100 || !groupName.matches("[^\\p{Cntrl}]+"))) {
                 throw new SecurityException("Invalid measurement group name");
             }
 
@@ -71,7 +71,7 @@ public class EctEditMeasurementStyle2Action extends ActionSupport {
 
             MiscUtils.getLogger().debug("The selected style sheet is: {}", styleSheet);
             HttpSession session = request.getSession();
-            // nosemgrep: tainted-session-from-http-request -- groupName validated via regex [\\w\\s\\-\\.]+, length-capped to 100; admin-only action guarded by _admin/_admin.measurements write privilege
+            // nosemgrep: tainted-session-from-http-request -- groupName validated via regex [^\\p{Cntrl}]+, length-capped to 100; admin-only action guarded by _admin/_admin.measurements write privilege
             session.setAttribute("groupName", groupName);
 
             return "continue";

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctEditMeasurementStyle2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctEditMeasurementStyle2Action.java
@@ -62,15 +62,15 @@ public class EctEditMeasurementStyle2Action extends ActionSupport {
 
         if (securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_admin", "w", null) || securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_admin.measurements", "w", null)) {
 
+            // CWE-501: validate groupName BEFORE any use or session storage
+            if (groupName != null && (groupName.length() > 100 || !groupName.matches("[\\w\\s\\-\\.]+"))) {
+                throw new SecurityException("Invalid measurement group name");
+            }
+
             changeCSS(groupName, styleSheet);
 
-            MiscUtils.getLogger().debug("The selected style sheet is: " + styleSheet);
+            MiscUtils.getLogger().debug("The selected style sheet is: {}", styleSheet);
             HttpSession session = request.getSession();
-            // CWE-501: validate groupName before session storage
-            if (groupName != null && (groupName.length() > 100 || !groupName.matches("[\\w\\s\\-\\.]+"))) {
-                MiscUtils.getLogger().warn("Rejected invalid groupName at trust boundary");
-                return ERROR;
-            }
             // nosemgrep: tainted-session-from-http-request -- groupName validated via regex [\\w\\s\\-\\.]+, length-capped to 100; admin-only action guarded by _admin/_admin.measurements write privilege
             session.setAttribute("groupName", groupName);
 

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSelectMeasurementGroup2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSelectMeasurementGroup2Action.java
@@ -70,14 +70,28 @@ public class EctSelectMeasurementGroup2Action extends ActionSupport {
 
         // CWE-501: validate groupName at trust boundary — reject control chars and excessive length
         if (groupName == null || groupName.isEmpty() || groupName.length() > 100
-                || !groupName.matches("[\\w\\s\\-\\.]+")) {
+                || !groupName.matches("[^\\p{Cntrl}]+")) {
             throw new SecurityException("Invalid measurement group name");
         }
 
         MiscUtils.getLogger().debug("The forward message is: " + forward);
 
         HttpSession session = request.getSession();
-        // nosemgrep: tainted-session-from-http-request -- groupName validated via regex [\\w\\s\\-\\.]+, length-capped to 100
+
+        // Delete requires admin privilege check BEFORE any session mutation
+        if (forward.compareTo("delete") == 0) {
+            if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_admin", "w", null)
+                    && !securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_admin.measurements", "w", null)) {
+                throw new SecurityException("missing required sec object (_admin.measurements)");
+            }
+            // nosemgrep: tainted-session-from-http-request -- groupName validated via regex [^\\p{Cntrl}]+, length-capped to 100; admin privilege verified above
+            session.setAttribute("groupName", groupName);
+            deleteGroup(groupName);
+            return "delete";
+        }
+
+        // For non-delete paths, store validated groupName for navigation
+        // nosemgrep: tainted-session-from-http-request -- groupName validated via regex [^\\p{Cntrl}]+, length-capped to 100
         session.setAttribute("groupName", groupName);
 
         if (forward.compareTo("style") == 0) {
@@ -90,14 +104,6 @@ public class EctSelectMeasurementGroup2Action extends ActionSupport {
             request.setAttribute("allStyleSheets", allStyleSheets);
             request.setAttribute("groupName", groupName);
             return "style";
-        } else if (forward.compareTo("delete") == 0) {
-            // Delete is a write operation — require admin privilege (matches EctAddMeasurementGroup2Action pattern)
-            if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_admin", "w", null)
-                    && !securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_admin.measurements", "w", null)) {
-                throw new SecurityException("missing required sec object (_admin.measurements)");
-            }
-            deleteGroup(groupName);
-            return "delete";
         }
         if (forward.compareTo("dsHTML") == 0) {
 

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSelectMeasurementGroup2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSelectMeasurementGroup2Action.java
@@ -44,9 +44,12 @@ import io.github.carlos_emr.carlos.commn.dao.MeasurementGroupDao;
 import io.github.carlos_emr.carlos.commn.dao.MeasurementGroupStyleDao;
 import io.github.carlos_emr.carlos.commn.model.MeasurementGroup;
 import io.github.carlos_emr.carlos.commn.model.MeasurementGroupStyle;
+import io.github.carlos_emr.carlos.utility.LogSanitizer;
+import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 import io.github.carlos_emr.carlos.managers.MeasurementManager;
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 
 import io.github.carlos_emr.carlos.encounter.oscarMeasurements.bean.EctStyleSheetBeanHandler;
 
@@ -58,19 +61,26 @@ public class EctSelectMeasurementGroup2Action extends ActionSupport {
     HttpServletRequest request = ServletActionContext.getRequest();
     HttpServletResponse response = ServletActionContext.getResponse();
 
-
+    private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
     private MeasurementGroupStyleDao styleDao = SpringUtils.getBean(MeasurementGroupStyleDao.class);
     private MeasurementGroupDao groupDao = SpringUtils.getBean(MeasurementGroupDao.class);
     private MeasurementManager measurementManager = SpringUtils.getBean(MeasurementManager.class);
 
     public String execute() throws ServletException, IOException {
         String groupName = this.getSelectedGroupName();
-        //String forward = frm.getForward();
+
+        // CWE-501: validate groupName at trust boundary — reject control chars and excessive length
+        if (groupName == null || groupName.isEmpty() || groupName.length() > 100
+                || !groupName.matches("[\\w\\s\\-\\.]+")) {
+            MiscUtils.getLogger().warn("Rejected invalid measurement group name: {}", LogSanitizer.sanitize(groupName));
+            return ERROR;
+        }
 
         MiscUtils.getLogger().debug("The forward message is: " + forward);
 
         HttpSession session = request.getSession();
-        session.setAttribute("groupName", groupName); // nosemgrep: tainted-session-from-http-request -- Struts parameter (selectedGroupName); used as display key for measurement group navigation
+        // nosemgrep: tainted-session-from-http-request -- groupName validated via regex [\\w\\s\\-\\.]+, length-capped to 100
+        session.setAttribute("groupName", groupName);
 
         if (forward.compareTo("style") == 0) {
             //get the current style
@@ -83,6 +93,11 @@ public class EctSelectMeasurementGroup2Action extends ActionSupport {
             request.setAttribute("groupName", groupName);
             return "style";
         } else if (forward.compareTo("delete") == 0) {
+            // Delete is a write operation — require admin privilege (matches EctAddMeasurementGroup2Action pattern)
+            if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_admin", "w", null)
+                    && !securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_admin.measurements", "w", null)) {
+                throw new SecurityException("missing required sec object (_admin.measurements)");
+            }
             deleteGroup(groupName);
             return "delete";
         }

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSelectMeasurementGroup2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSelectMeasurementGroup2Action.java
@@ -70,7 +70,7 @@ public class EctSelectMeasurementGroup2Action extends ActionSupport {
         MiscUtils.getLogger().debug("The forward message is: " + forward);
 
         HttpSession session = request.getSession();
-        session.setAttribute("groupName", groupName);
+        session.setAttribute("groupName", groupName); // nosemgrep: tainted-session-from-http-request -- Struts parameter (selectedGroupName); used as display key for measurement group navigation
 
         if (forward.compareTo("style") == 0) {
             //get the current style

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSelectMeasurementGroup2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSelectMeasurementGroup2Action.java
@@ -44,7 +44,6 @@ import io.github.carlos_emr.carlos.commn.dao.MeasurementGroupDao;
 import io.github.carlos_emr.carlos.commn.dao.MeasurementGroupStyleDao;
 import io.github.carlos_emr.carlos.commn.model.MeasurementGroup;
 import io.github.carlos_emr.carlos.commn.model.MeasurementGroupStyle;
-import io.github.carlos_emr.carlos.utility.LogSanitizer;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
@@ -72,8 +71,7 @@ public class EctSelectMeasurementGroup2Action extends ActionSupport {
         // CWE-501: validate groupName at trust boundary — reject control chars and excessive length
         if (groupName == null || groupName.isEmpty() || groupName.length() > 100
                 || !groupName.matches("[\\w\\s\\-\\.]+")) {
-            MiscUtils.getLogger().warn("Rejected invalid measurement group name: {}", LogSanitizer.sanitize(groupName));
-            return ERROR;
+            throw new SecurityException("Invalid measurement group name");
         }
 
         MiscUtils.getLogger().debug("The forward message is: " + forward);

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSetupAddMeasurementGroup2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSetupAddMeasurementGroup2Action.java
@@ -67,9 +67,9 @@ public class EctSetupAddMeasurementGroup2Action extends ActionSupport {
             Collection allTypeDisplayName = hd.getTypeDisplayNameVector();
 
             HttpSession session = request.getSession();
-            session.setAttribute("existingTypeDisplayNames", existingTypeDisplayName);
-            session.setAttribute("allTypeDisplayNames", allTypeDisplayName);
-            session.setAttribute("groupName", groupName);
+            session.setAttribute("existingTypeDisplayNames", existingTypeDisplayName); // nosemgrep: tainted-session-from-http-request -- DAO result list from EctTypeDisplayNameBeanHandler (existing types for group)
+            session.setAttribute("allTypeDisplayNames", allTypeDisplayName); // nosemgrep: tainted-session-from-http-request -- DAO result list from EctTypeDisplayNameBeanHandler (all types)
+            session.setAttribute("groupName", groupName); // nosemgrep: tainted-session-from-http-request -- Struts parameter; admin-only action guarded by _admin/_admin.measurements privilege
             
             return "continue";
 

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSetupAddMeasurementGroup2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSetupAddMeasurementGroup2Action.java
@@ -60,7 +60,7 @@ public class EctSetupAddMeasurementGroup2Action extends ActionSupport {
     public String execute() throws ServletException, IOException {
         if (securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_admin", "w", null) || securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_admin.measurements", "w", null)) {
             // CWE-501: validate groupName BEFORE any DAO use or session storage
-            if (groupName != null && (groupName.length() > 100 || !groupName.matches("[\\w\\s\\-\\.]+"))) {
+            if (groupName != null && (groupName.length() > 100 || !groupName.matches("[^\\p{Cntrl}]+"))) {
                 throw new SecurityException("Invalid measurement group name");
             }
 
@@ -74,7 +74,7 @@ public class EctSetupAddMeasurementGroup2Action extends ActionSupport {
             HttpSession session = request.getSession();
             session.setAttribute("existingTypeDisplayNames", existingTypeDisplayName); // nosemgrep: tainted-session-from-http-request -- DAO result list from EctTypeDisplayNameBeanHandler (existing types for group)
             session.setAttribute("allTypeDisplayNames", allTypeDisplayName); // nosemgrep: tainted-session-from-http-request -- DAO result list from EctTypeDisplayNameBeanHandler (all types)
-            // nosemgrep: tainted-session-from-http-request -- groupName validated via regex [\\w\\s\\-\\.]+, length-capped to 100; admin-only action guarded by _admin/_admin.measurements write privilege
+            // nosemgrep: tainted-session-from-http-request -- groupName validated via regex [^\\p{Cntrl}]+, length-capped to 100; admin-only action guarded by _admin/_admin.measurements write privilege
             session.setAttribute("groupName", groupName);
             
             return "continue";

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSetupAddMeasurementGroup2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSetupAddMeasurementGroup2Action.java
@@ -69,7 +69,13 @@ public class EctSetupAddMeasurementGroup2Action extends ActionSupport {
             HttpSession session = request.getSession();
             session.setAttribute("existingTypeDisplayNames", existingTypeDisplayName); // nosemgrep: tainted-session-from-http-request -- DAO result list from EctTypeDisplayNameBeanHandler (existing types for group)
             session.setAttribute("allTypeDisplayNames", allTypeDisplayName); // nosemgrep: tainted-session-from-http-request -- DAO result list from EctTypeDisplayNameBeanHandler (all types)
-            session.setAttribute("groupName", groupName); // nosemgrep: tainted-session-from-http-request -- Struts parameter; admin-only action guarded by _admin/_admin.measurements privilege
+            // CWE-501: validate groupName before session storage
+            if (groupName != null && (groupName.length() > 100 || !groupName.matches("[\\w\\s\\-\\.]+"))) {
+                MiscUtils.getLogger().warn("Rejected invalid groupName at trust boundary");
+                return ERROR;
+            }
+            // nosemgrep: tainted-session-from-http-request -- groupName validated via regex [\\w\\s\\-\\.]+, length-capped to 100; admin-only action guarded by _admin/_admin.measurements write privilege
+            session.setAttribute("groupName", groupName);
             
             return "continue";
 

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSetupAddMeasurementGroup2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSetupAddMeasurementGroup2Action.java
@@ -59,7 +59,12 @@ public class EctSetupAddMeasurementGroup2Action extends ActionSupport {
 
     public String execute() throws ServletException, IOException {
         if (securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_admin", "w", null) || securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_admin.measurements", "w", null)) {
-            MiscUtils.getLogger().debug("The selected groupName is: " + groupName);
+            // CWE-501: validate groupName BEFORE any DAO use or session storage
+            if (groupName != null && (groupName.length() > 100 || !groupName.matches("[\\w\\s\\-\\.]+"))) {
+                throw new SecurityException("Invalid measurement group name");
+            }
+
+            MiscUtils.getLogger().debug("The selected groupName is: {}", groupName);
 
             EctTypeDisplayNameBeanHandler hd = new EctTypeDisplayNameBeanHandler(groupName, false);
             Collection existingTypeDisplayName = hd.getTypeDisplayNameVector();
@@ -69,11 +74,6 @@ public class EctSetupAddMeasurementGroup2Action extends ActionSupport {
             HttpSession session = request.getSession();
             session.setAttribute("existingTypeDisplayNames", existingTypeDisplayName); // nosemgrep: tainted-session-from-http-request -- DAO result list from EctTypeDisplayNameBeanHandler (existing types for group)
             session.setAttribute("allTypeDisplayNames", allTypeDisplayName); // nosemgrep: tainted-session-from-http-request -- DAO result list from EctTypeDisplayNameBeanHandler (all types)
-            // CWE-501: validate groupName before session storage
-            if (groupName != null && (groupName.length() > 100 || !groupName.matches("[\\w\\s\\-\\.]+"))) {
-                MiscUtils.getLogger().warn("Rejected invalid groupName at trust boundary");
-                return ERROR;
-            }
             // nosemgrep: tainted-session-from-http-request -- groupName validated via regex [\\w\\s\\-\\.]+, length-capped to 100; admin-only action guarded by _admin/_admin.measurements write privilege
             session.setAttribute("groupName", groupName);
             

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSetupAddMeasurementType2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSetupAddMeasurementType2Action.java
@@ -53,7 +53,7 @@ public final class EctSetupAddMeasurementType2Action extends ActionSupport {
         EctValidationsBeanHandler hd = new EctValidationsBeanHandler();
         Collection validations = hd.getValidationsVector();
         HttpSession session = request.getSession();
-        session.setAttribute("validations", validations);
+        session.setAttribute("validations", validations); // nosemgrep: tainted-session-from-http-request -- DAO result list from EctValidationsBeanHandler
 
         return "continue";
     }

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSetupAddMeasuringInstruction2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSetupAddMeasuringInstruction2Action.java
@@ -58,8 +58,8 @@ public final class EctSetupAddMeasuringInstruction2Action extends ActionSupport 
         Collection validations = validationHd.getValidationsVector();
 
         HttpSession session = request.getSession();
-        session.setAttribute("typeDisplayNames", typeDisplayName);
-        session.setAttribute("validations", validations);
+        session.setAttribute("typeDisplayNames", typeDisplayName); // nosemgrep: tainted-session-from-http-request -- DAO result list from EctTypeDisplayNameBeanHandler
+        session.setAttribute("validations", validations); // nosemgrep: tainted-session-from-http-request -- DAO result list from EctValidationsBeanHandler
         return "continue";
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSetupDisplayHistory2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSetupDisplayHistory2Action.java
@@ -60,7 +60,7 @@ public final class EctSetupDisplayHistory2Action extends ActionSupport {
         }
 
         EctSessionBean bean = (EctSessionBean) request.getSession().getAttribute("EctSessionBean");
-        request.getSession().setAttribute("EctSessionBean", bean);
+        request.getSession().setAttribute("EctSessionBean", bean); // nosemgrep: tainted-session-from-http-request -- re-storing existing session bean retrieved from session; no new tainted data added
         String type = request.getParameter("type");
         MiscUtils.getLogger().debug("Type: " + type);
         if (bean != null) {

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSetupDisplayMeasurementStyleSheet2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSetupDisplayMeasurementStyleSheet2Action.java
@@ -57,7 +57,7 @@ public final class EctSetupDisplayMeasurementStyleSheet2Action extends ActionSup
 
             EctStyleSheetBeanHandler hd = new EctStyleSheetBeanHandler();
             HttpSession session = request.getSession();
-            session.setAttribute("styleSheets", hd);
+            session.setAttribute("styleSheets", hd); // nosemgrep: tainted-session-from-http-request -- DAO result bean from EctStyleSheetBeanHandler
 
             return "continue";
 

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSetupDisplayMeasurementTypes2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSetupDisplayMeasurementTypes2Action.java
@@ -57,7 +57,7 @@ public final class EctSetupDisplayMeasurementTypes2Action extends ActionSupport 
 
             EctMeasurementTypesBeanHandler hd = new EctMeasurementTypesBeanHandler();
             HttpSession session = request.getSession();
-            session.setAttribute("measurementTypes", hd);
+            session.setAttribute("measurementTypes", hd); // nosemgrep: tainted-session-from-http-request -- DAO result bean from EctMeasurementTypesBeanHandler
 
             return "continue";
 

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSetupEditMeasurementGroup2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSetupEditMeasurementGroup2Action.java
@@ -42,6 +42,7 @@ import jakarta.servlet.http.HttpSession;
 
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 
 import io.github.carlos_emr.carlos.encounter.oscarMeasurements.bean.EctTypeDisplayNameBeanHandler;
@@ -67,7 +68,13 @@ public class EctSetupEditMeasurementGroup2Action extends ActionSupport {
             HttpSession session = request.getSession();
             session.setAttribute("existingTypeDisplayNames", existingTypeDisplayName); // nosemgrep: tainted-session-from-http-request -- DAO result list from EctTypeDisplayNameBeanHandler (existing types for group)
             session.setAttribute("allTypeDisplayNames", allTypeDisplayName); // nosemgrep: tainted-session-from-http-request -- DAO result list from EctTypeDisplayNameBeanHandler (all types)
-            session.setAttribute("groupName", groupName); // nosemgrep: tainted-session-from-http-request -- Struts parameter; admin-only action guarded by _admin/_admin.measurements privilege
+            // CWE-501: validate groupName before session storage
+            if (groupName != null && (groupName.length() > 100 || !groupName.matches("[\\w\\s\\-\\.]+"))) {
+                MiscUtils.getLogger().warn("Rejected invalid groupName at trust boundary");
+                return ERROR;
+            }
+            // nosemgrep: tainted-session-from-http-request -- groupName validated via regex [\\w\\s\\-\\.]+, length-capped to 100; admin-only action guarded by _admin/_admin.measurements write privilege
+            session.setAttribute("groupName", groupName);
             return "continue";
 
         } else {

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSetupEditMeasurementGroup2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSetupEditMeasurementGroup2Action.java
@@ -42,7 +42,6 @@ import jakarta.servlet.http.HttpSession;
 
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
-import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 
 import io.github.carlos_emr.carlos.encounter.oscarMeasurements.bean.EctTypeDisplayNameBeanHandler;
@@ -60,6 +59,11 @@ public class EctSetupEditMeasurementGroup2Action extends ActionSupport {
 
     public String execute() throws ServletException, IOException {
         if (securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_admin", "w", null) || securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_admin.measurements", "w", null)) {
+            // CWE-501: validate groupName BEFORE any DAO use or session storage
+            if (groupName != null && (groupName.length() > 100 || !groupName.matches("[\\w\\s\\-\\.]+"))) {
+                throw new SecurityException("Invalid measurement group name");
+            }
+
             EctTypeDisplayNameBeanHandler hd = new EctTypeDisplayNameBeanHandler(groupName, false);
             Collection existingTypeDisplayName = hd.getTypeDisplayNameVector();
             hd = new EctTypeDisplayNameBeanHandler(groupName, true);
@@ -68,11 +72,6 @@ public class EctSetupEditMeasurementGroup2Action extends ActionSupport {
             HttpSession session = request.getSession();
             session.setAttribute("existingTypeDisplayNames", existingTypeDisplayName); // nosemgrep: tainted-session-from-http-request -- DAO result list from EctTypeDisplayNameBeanHandler (existing types for group)
             session.setAttribute("allTypeDisplayNames", allTypeDisplayName); // nosemgrep: tainted-session-from-http-request -- DAO result list from EctTypeDisplayNameBeanHandler (all types)
-            // CWE-501: validate groupName before session storage
-            if (groupName != null && (groupName.length() > 100 || !groupName.matches("[\\w\\s\\-\\.]+"))) {
-                MiscUtils.getLogger().warn("Rejected invalid groupName at trust boundary");
-                return ERROR;
-            }
             // nosemgrep: tainted-session-from-http-request -- groupName validated via regex [\\w\\s\\-\\.]+, length-capped to 100; admin-only action guarded by _admin/_admin.measurements write privilege
             session.setAttribute("groupName", groupName);
             return "continue";

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSetupEditMeasurementGroup2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSetupEditMeasurementGroup2Action.java
@@ -60,7 +60,7 @@ public class EctSetupEditMeasurementGroup2Action extends ActionSupport {
     public String execute() throws ServletException, IOException {
         if (securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_admin", "w", null) || securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_admin.measurements", "w", null)) {
             // CWE-501: validate groupName BEFORE any DAO use or session storage
-            if (groupName != null && (groupName.length() > 100 || !groupName.matches("[\\w\\s\\-\\.]+"))) {
+            if (groupName != null && (groupName.length() > 100 || !groupName.matches("[^\\p{Cntrl}]+"))) {
                 throw new SecurityException("Invalid measurement group name");
             }
 
@@ -72,7 +72,7 @@ public class EctSetupEditMeasurementGroup2Action extends ActionSupport {
             HttpSession session = request.getSession();
             session.setAttribute("existingTypeDisplayNames", existingTypeDisplayName); // nosemgrep: tainted-session-from-http-request -- DAO result list from EctTypeDisplayNameBeanHandler (existing types for group)
             session.setAttribute("allTypeDisplayNames", allTypeDisplayName); // nosemgrep: tainted-session-from-http-request -- DAO result list from EctTypeDisplayNameBeanHandler (all types)
-            // nosemgrep: tainted-session-from-http-request -- groupName validated via regex [\\w\\s\\-\\.]+, length-capped to 100; admin-only action guarded by _admin/_admin.measurements write privilege
+            // nosemgrep: tainted-session-from-http-request -- groupName validated via regex [^\\p{Cntrl}]+, length-capped to 100; admin-only action guarded by _admin/_admin.measurements write privilege
             session.setAttribute("groupName", groupName);
             return "continue";
 

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSetupEditMeasurementGroup2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSetupEditMeasurementGroup2Action.java
@@ -65,9 +65,9 @@ public class EctSetupEditMeasurementGroup2Action extends ActionSupport {
             Collection allTypeDisplayName = hd.getTypeDisplayNameVector();
 
             HttpSession session = request.getSession();
-            session.setAttribute("existingTypeDisplayNames", existingTypeDisplayName);
-            session.setAttribute("allTypeDisplayNames", allTypeDisplayName);
-            session.setAttribute("groupName", groupName);
+            session.setAttribute("existingTypeDisplayNames", existingTypeDisplayName); // nosemgrep: tainted-session-from-http-request -- DAO result list from EctTypeDisplayNameBeanHandler (existing types for group)
+            session.setAttribute("allTypeDisplayNames", allTypeDisplayName); // nosemgrep: tainted-session-from-http-request -- DAO result list from EctTypeDisplayNameBeanHandler (all types)
+            session.setAttribute("groupName", groupName); // nosemgrep: tainted-session-from-http-request -- Struts parameter; admin-only action guarded by _admin/_admin.measurements privilege
             return "continue";
 
         } else {

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSetupGroupList2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSetupGroupList2Action.java
@@ -60,7 +60,7 @@ public final class EctSetupGroupList2Action extends ActionSupport {
             EctGroupNameBeanHandler hd = new EctGroupNameBeanHandler();
             Collection groups = hd.getGroupNameVector();
             HttpSession session = request.getSession();
-            session.setAttribute("groups", groups);
+            session.setAttribute("groups", groups); // nosemgrep: tainted-session-from-http-request -- DAO result list from EctGroupNameBeanHandler
 
             return "continue";
 

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSetupHistoryIndex2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSetupHistoryIndex2Action.java
@@ -61,12 +61,12 @@ public final class EctSetupHistoryIndex2Action extends ActionSupport {
         }
 
         EctSessionBean bean = (EctSessionBean) request.getSession().getAttribute("EctSessionBean");
-        request.getSession().setAttribute("EctSessionBean", bean);
+        request.getSession().setAttribute("EctSessionBean", bean); // nosemgrep: tainted-session-from-http-request -- re-storing existing session bean retrieved from session on previous line
 
         if (bean != null) {
             Integer demo = Integer.valueOf(bean.getDemographicNo());
 
-            request.getSession().setAttribute("EctSessionBean", bean);
+            request.getSession().setAttribute("EctSessionBean", bean); // nosemgrep: tainted-session-from-http-request -- re-storing existing session bean; no new tainted data added
 
             measurementsData = new EctMeasurementsDataBeanHandler(demo);
 

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSetupHistoryIndex2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSetupHistoryIndex2Action.java
@@ -61,12 +61,9 @@ public final class EctSetupHistoryIndex2Action extends ActionSupport {
         }
 
         EctSessionBean bean = (EctSessionBean) request.getSession().getAttribute("EctSessionBean");
-        request.getSession().setAttribute("EctSessionBean", bean); // nosemgrep: tainted-session-from-http-request -- re-storing existing session bean retrieved from session on previous line
 
         if (bean != null) {
             Integer demo = Integer.valueOf(bean.getDemographicNo());
-
-            request.getSession().setAttribute("EctSessionBean", bean); // nosemgrep: tainted-session-from-http-request -- re-storing existing session bean; no new tainted data added
 
             measurementsData = new EctMeasurementsDataBeanHandler(demo);
 

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSetupStyleSheetList2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSetupStyleSheetList2Action.java
@@ -61,7 +61,7 @@ public final class EctSetupStyleSheetList2Action extends ActionSupport {
             Collection allStyleSheets = sshd.getStyleSheetNameVector();
 
             HttpSession session = request.getSession();
-            session.setAttribute("allStyleSheets", allStyleSheets);
+            session.setAttribute("allStyleSheets", allStyleSheets); // nosemgrep: tainted-session-from-http-request -- DAO result list from EctStyleSheetBeanHandler
 
             return "continue";
 

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/MeasurementGraphAction22Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/MeasurementGraphAction22Action.java
@@ -129,7 +129,7 @@ public class MeasurementGraphAction22Action extends ActionSupport {
 
         String method = request.getParameter("method");
 
-        log.debug("Creating graph for demo {} type1: {} type2: {}", LogSanitizer.sanitize(String.valueOf(demographicNo)), LogSanitizer.sanitize(String.valueOf(typeIdName)), LogSanitizer.sanitize(String.valueOf(typeIdName2)));
+        log.debug("Creating graph for demo {} type1: {} type2: {}", LogSanitizer.sanitizeObject(demographicNo), LogSanitizer.sanitize(typeIdName), LogSanitizer.sanitize(typeIdName2));
         JFreeChart chart = null;
         if (method == null) {
             log.debug("Calling DefaultChart");

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/MeasurementGraphAction22Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/MeasurementGraphAction22Action.java
@@ -129,7 +129,7 @@ public class MeasurementGraphAction22Action extends ActionSupport {
 
         String method = request.getParameter("method");
 
-        log.debug("Creating graph for demo {} type1: {} type2: {}", LogSanitizer.sanitize(demographicNo), LogSanitizer.sanitize(typeIdName), LogSanitizer.sanitize(typeIdName2));
+        log.debug("Creating graph for demo {} type1: {} type2: {}", LogSanitizer.sanitize(String.valueOf(demographicNo)), LogSanitizer.sanitize(String.valueOf(typeIdName)), LogSanitizer.sanitize(String.valueOf(typeIdName2)));
         JFreeChart chart = null;
         if (method == null) {
             log.debug("Calling DefaultChart");
@@ -960,7 +960,7 @@ public class MeasurementGraphAction22Action extends ActionSupport {
                     systolic.addOrUpdate(new Day(mdb.getDateObservedAsDate()), Double.parseDouble(str[0]));
                     diastolic.addOrUpdate(new Day(mdb.getDateObservedAsDate()), Double.parseDouble(str[1]));
                 } else {
-                    log.debug("Error passing measurement value to chart. DataField is empty for ID: {}", LogSanitizer.sanitize(mdb.getId()));
+                    log.debug("Error passing measurement value to chart. DataField is empty for ID: {}", LogSanitizer.sanitize(String.valueOf(mdb.getId())));
                 }
             }
             dataset.addSeries(diastolic);
@@ -983,7 +983,7 @@ public class MeasurementGraphAction22Action extends ActionSupport {
                                 Double.parseDouble(result));
                     }
                 } else {
-                    log.debug("Error passing measurement value to chart. DataField is empty for ID: {}", LogSanitizer.sanitize(mdb.getId()));
+                    log.debug("Error passing measurement value to chart. DataField is empty for ID: {}", LogSanitizer.sanitize(String.valueOf(mdb.getId())));
                 }
             }
             dataset.addSeries(newSeries);
@@ -1012,7 +1012,7 @@ public class MeasurementGraphAction22Action extends ActionSupport {
                                 Double.parseDouble(result));
                     }
                 } else {
-                    log.debug("Error passing measurement value to chart. DataField is empty for ID: {}", LogSanitizer.sanitize(mdb.getId()));
+                    log.debug("Error passing measurement value to chart. DataField is empty for ID: {}", LogSanitizer.sanitize(String.valueOf(mdb.getId())));
                 }
             }
             dataset2.addSeries(newSeries);

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/pageUtil/EctDisplayAction.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/pageUtil/EctDisplayAction.java
@@ -166,8 +166,8 @@ public class EctDisplayAction extends ActionSupport {
             bean.appointmentNo = apptNoParam;
             bean.curProviderNo = request.getParameter("curProviderNo");
             if (bean.curProviderNo != null && !bean.curProviderNo.isEmpty() && !bean.curProviderNo.matches("[a-zA-Z0-9]{1,6}")) {
-                logger.warn("Invalid curProviderNo: {}", LogSanitizer.sanitize(bean.curProviderNo));
-                return "error";
+                logger.warn("Invalid curProviderNo rejected, falling back to logged-in provider: {}", LogSanitizer.sanitize(bean.curProviderNo));
+                bean.curProviderNo = null;
             }
             // Fall back to authenticated provider — the logged-in user IS the provider unless viewing another provider's schedule
             if (bean.curProviderNo == null || bean.curProviderNo.trim().isEmpty()) {
@@ -175,26 +175,55 @@ public class EctDisplayAction extends ActionSupport {
             }
             // CWE-501 trust boundary: validate structured fields, sanitize free-text
             String reasonParam = request.getParameter("reason");
-            bean.reason = (reasonParam != null && SAFE_TEXT.matcher(reasonParam).matches() && reasonParam.length() <= 255) ? reasonParam : null;
+            if (reasonParam != null && (!SAFE_TEXT.matcher(reasonParam).matches() || reasonParam.length() > 255)) {
+                logger.warn("Rejected invalid reason at trust boundary");
+                reasonParam = null;
+            }
+            bean.reason = reasonParam;
             String encTypeParam = request.getParameter("encType");
-            bean.encType = (encTypeParam != null && encTypeParam.matches("[a-zA-Z0-9_ ]{1,50}")) ? encTypeParam : null;
+            if (encTypeParam != null && !encTypeParam.matches("[a-zA-Z0-9_ ]{1,50}")) {
+                logger.warn("Rejected invalid encType at trust boundary: {}", LogSanitizer.sanitize(encTypeParam));
+                encTypeParam = null;
+            }
+            bean.encType = encTypeParam;
             bean.userName = request.getParameter("userName");
             if (bean.userName == null) {
                 bean.userName = ((String) request.getSession().getAttribute("userfirstname")) + " " + ((String) request.getSession().getAttribute("userlastname"));
             } else if (!SAFE_TEXT.matcher(bean.userName).matches() || bean.userName.length() > 100) {
-                bean.userName = null;
+                logger.warn("Rejected invalid userName at trust boundary, falling back to session-derived name");
+                bean.userName = ((String) request.getSession().getAttribute("userfirstname")) + " " + ((String) request.getSession().getAttribute("userlastname"));
             }
 
             String apptDateParam = request.getParameter("appointmentDate");
-            bean.appointmentDate = (apptDateParam != null && SAFE_DATE.matcher(apptDateParam).matches()) ? apptDateParam : null;
+            if (apptDateParam != null && !SAFE_DATE.matcher(apptDateParam).matches()) {
+                logger.warn("Rejected invalid appointmentDate at trust boundary: {}", LogSanitizer.sanitize(apptDateParam));
+                apptDateParam = null;
+            }
+            bean.appointmentDate = apptDateParam;
             String startTimeParam = request.getParameter("startTime");
-            bean.startTime = (startTimeParam != null && SAFE_TIME.matcher(startTimeParam).matches()) ? startTimeParam : null;
+            if (startTimeParam != null && !SAFE_TIME.matcher(startTimeParam).matches()) {
+                logger.warn("Rejected invalid startTime at trust boundary: {}", LogSanitizer.sanitize(startTimeParam));
+                startTimeParam = null;
+            }
+            bean.startTime = startTimeParam;
             String statusParam = request.getParameter("status");
-            bean.status = (statusParam != null && SAFE_STATUS.matcher(statusParam).matches()) ? statusParam : null;
+            if (statusParam != null && !SAFE_STATUS.matcher(statusParam).matches()) {
+                logger.warn("Rejected invalid status at trust boundary: {}", LogSanitizer.sanitize(statusParam));
+                statusParam = null;
+            }
+            bean.status = statusParam;
             String dateParam = request.getParameter("date");
-            bean.date = (dateParam != null && SAFE_DATE.matcher(dateParam).matches()) ? dateParam : null;
+            if (dateParam != null && !SAFE_DATE.matcher(dateParam).matches()) {
+                logger.warn("Rejected invalid date at trust boundary: {}", LogSanitizer.sanitize(dateParam));
+                dateParam = null;
+            }
+            bean.date = dateParam;
             bean.check = "myCheck";
             bean.oscarMsgID = request.getParameter("msgId");
+            if (bean.oscarMsgID != null && !bean.oscarMsgID.matches("\\d+")) {
+                logger.warn("Invalid msgId: {}", LogSanitizer.sanitize(bean.oscarMsgID));
+                bean.oscarMsgID = null;
+            }
             bean.setUpEncounterPage(LoggedInInfo.getLoggedInInfoFromSession(request));
             // nosemgrep: tainted-session-from-http-request -- demographicNo/appointmentNo validated numeric;
             // status validated [a-zA-Z]{1,2}; dates validated YYYY-MM-DD; time validated HH:MM; encType validated alphanumeric;

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/pageUtil/EctDisplayAction.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/pageUtil/EctDisplayAction.java
@@ -47,6 +47,8 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Set;
+import java.util.regex.Pattern;
 import io.github.carlos_emr.carlos.utility.LogSanitizer;
 
 
@@ -67,6 +69,14 @@ public class EctDisplayAction extends ActionSupport {
     protected static final int CROP_LEN_TITLE = 45;
     protected static final int MAX_LEN_KEY = 12;
     protected static final int CROP_LEN_KEY = 9;
+
+    // CWE-501 trust boundary validation patterns
+    private static final Pattern SAFE_STATUS = Pattern.compile("[a-zA-Z]{1,2}");
+    private static final Pattern SAFE_DATE = Pattern.compile("[0-9]{4}-[0-9]{2}-[0-9]{2}");
+    private static final Pattern SAFE_TIME = Pattern.compile("[0-9]{1,2}:[0-9]{2}(:[0-9]{2})?");
+    // Any character except ASCII control chars (allows Unicode for bilingual Canadian EMR)
+    private static final Pattern SAFE_TEXT = Pattern.compile("[^\\p{Cntrl}]*");
+    private static final Set<String> VALID_SOURCES = Set.of("encounter", "messenger");
 
     private boolean enabled;
 
@@ -155,25 +165,45 @@ public class EctDisplayAction extends ActionSupport {
             }
             bean.appointmentNo = apptNoParam;
             bean.curProviderNo = request.getParameter("curProviderNo");
-            bean.reason = request.getParameter("reason");
-            bean.encType = request.getParameter("encType");
+            if (bean.curProviderNo != null && !bean.curProviderNo.isEmpty() && !bean.curProviderNo.matches("[a-zA-Z0-9]{1,6}")) {
+                logger.warn("Invalid curProviderNo: {}", LogSanitizer.sanitize(bean.curProviderNo));
+                return "error";
+            }
+            // Fall back to authenticated provider — the logged-in user IS the provider unless viewing another provider's schedule
+            if (bean.curProviderNo == null || bean.curProviderNo.trim().isEmpty()) {
+                bean.curProviderNo = LoggedInInfo.getLoggedInInfoFromSession(request).getLoggedInProvider().getProviderNo();
+            }
+            // CWE-501 trust boundary: validate structured fields, sanitize free-text
+            String reasonParam = request.getParameter("reason");
+            bean.reason = (reasonParam != null && SAFE_TEXT.matcher(reasonParam).matches() && reasonParam.length() <= 255) ? reasonParam : null;
+            String encTypeParam = request.getParameter("encType");
+            bean.encType = (encTypeParam != null && encTypeParam.matches("[a-zA-Z0-9_ ]{1,50}")) ? encTypeParam : null;
             bean.userName = request.getParameter("userName");
             if (bean.userName == null) {
                 bean.userName = ((String) request.getSession().getAttribute("userfirstname")) + " " + ((String) request.getSession().getAttribute("userlastname"));
+            } else if (!SAFE_TEXT.matcher(bean.userName).matches() || bean.userName.length() > 100) {
+                bean.userName = null;
             }
 
-            bean.appointmentDate = request.getParameter("appointmentDate");
-            bean.startTime = request.getParameter("startTime");
-            bean.status = request.getParameter("status");
-            bean.date = request.getParameter("date");
+            String apptDateParam = request.getParameter("appointmentDate");
+            bean.appointmentDate = (apptDateParam != null && SAFE_DATE.matcher(apptDateParam).matches()) ? apptDateParam : null;
+            String startTimeParam = request.getParameter("startTime");
+            bean.startTime = (startTimeParam != null && SAFE_TIME.matcher(startTimeParam).matches()) ? startTimeParam : null;
+            String statusParam = request.getParameter("status");
+            bean.status = (statusParam != null && SAFE_STATUS.matcher(statusParam).matches()) ? statusParam : null;
+            String dateParam = request.getParameter("date");
+            bean.date = (dateParam != null && SAFE_DATE.matcher(dateParam).matches()) ? dateParam : null;
             bean.check = "myCheck";
             bean.oscarMsgID = request.getParameter("msgId");
             bean.setUpEncounterPage(LoggedInInfo.getLoggedInInfoFromSession(request));
-            // demographicNo and appointmentNo validated as numeric; other bean fields (reason, encType, userName, etc.) are unsanitized request params — consuming JSPs MUST use OWASP encoding when rendering
-            request.getSession().setAttribute("EctSessionBean", bean); // nosemgrep: tainted-session-from-http-request
-            request.getSession().setAttribute("eChartID", bean.eChartId); // nosemgrep: tainted-session-from-http-request
-            if (request.getParameter("source") != null) {
-                bean.source = request.getParameter("source");
+            // nosemgrep: tainted-session-from-http-request -- demographicNo/appointmentNo validated numeric;
+            // status validated [a-zA-Z]{1,2}; dates validated YYYY-MM-DD; time validated HH:MM; encType validated alphanumeric;
+            // reason/userName sanitized for control chars and length-capped; eChartId is server-generated
+            request.getSession().setAttribute("EctSessionBean", bean);
+            request.getSession().setAttribute("eChartID", bean.eChartId); // nosemgrep: tainted-session-from-http-request -- server-generated ID from EctSessionBean.setUpEncounterPage()
+            String sourceParam = request.getParameter("source");
+            if (sourceParam != null) {
+                bean.source = VALID_SOURCES.contains(sourceParam) ? sourceParam : null;
             }
 
             request.setAttribute("EctSessionBean", bean);

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/pageUtil/EctDisplayAction.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/pageUtil/EctDisplayAction.java
@@ -134,8 +134,7 @@ public class EctDisplayAction extends ActionSupport {
         if (rebuildBean) {
             demoNoParam = request.getParameter("demographicNo");
             if (demoNoParam != null && !demoNoParam.isEmpty() && !demoNoParam.matches("\\d+")) {
-                logger.warn("Invalid non-numeric demographicNo: {}", LogSanitizer.sanitize(demoNoParam));
-                return "error";
+                throw new SecurityException("Invalid non-numeric demographicNo");
             }
         } else {
             demoNoParam = bean.demographicNo;
@@ -160,8 +159,7 @@ public class EctDisplayAction extends ActionSupport {
             bean.demographicNo = demoNoParam;
             String apptNoParam = request.getParameter("appointmentNo");
             if (apptNoParam != null && !apptNoParam.isEmpty() && !apptNoParam.matches("\\d+")) {
-                logger.warn("Invalid non-numeric appointmentNo: {}", LogSanitizer.sanitize(apptNoParam));
-                return "error";
+                throw new SecurityException("Invalid non-numeric appointmentNo");
             }
             bean.appointmentNo = apptNoParam;
             bean.curProviderNo = request.getParameter("curProviderNo");

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/pageUtil/EctIncomingEncounter2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/pageUtil/EctIncomingEncounter2Action.java
@@ -250,8 +250,9 @@ public class EctIncomingEncounter2Action extends ActionSupport {
                 bean.userName = ((String) request.getSession().getAttribute("userfirstname")) + " "
                         + ((String) request.getSession().getAttribute("userlastname"));
             } else if (!SAFE_TEXT.matcher(bean.userName).matches() || bean.userName.length() > 100) {
-                log.warn("Rejected invalid userName at trust boundary");
-                bean.userName = null;
+                log.warn("Rejected invalid userName at trust boundary, falling back to session-derived name");
+                bean.userName = ((String) request.getSession().getAttribute("userfirstname")) + " "
+                        + ((String) request.getSession().getAttribute("userlastname"));
             }
 
             String apptDateParam = request.getParameter("appointmentDate");

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/pageUtil/EctIncomingEncounter2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/pageUtil/EctIncomingEncounter2Action.java
@@ -82,6 +82,7 @@ import org.owasp.encoder.Encode;
 
 import java.util.Properties;
 import java.util.Vector;
+import java.util.regex.Pattern;
 
 import org.apache.struts2.ActionSupport;
 import org.apache.struts2.ServletActionContext;
@@ -89,6 +90,14 @@ import org.apache.struts2.ServletActionContext;
 public class EctIncomingEncounter2Action extends ActionSupport {
 
     private static Logger log = MiscUtils.getLogger();
+
+    // CWE-501 trust boundary validation patterns
+    private static final Pattern SAFE_STATUS = Pattern.compile("[a-zA-Z]{1,2}");
+    private static final Pattern SAFE_DATE = Pattern.compile("[0-9]{4}-[0-9]{2}-[0-9]{2}");
+    private static final Pattern SAFE_TIME = Pattern.compile("[0-9]{1,2}:[0-9]{2}(:[0-9]{2})?");
+    // Any character except ASCII control chars (allows Unicode for bilingual Canadian EMR)
+    private static final Pattern SAFE_TEXT = Pattern.compile("[^\\p{Cntrl}]*");
+    private static final Set<String> VALID_SOURCES = Set.of("encounter", "messenger");
     private CaseManagementNoteDAO caseManagementNoteDao = SpringUtils.getBean(CaseManagementNoteDAO.class);
     private CaseManagementManager caseManagementMgr = SpringUtils.getBean(CaseManagementManager.class);
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
@@ -229,32 +238,47 @@ public class EctIncomingEncounter2Action extends ActionSupport {
                 }
             }
 
-            bean.reason = request.getParameter("reason");
-            bean.reasonCode = request.getParameter("reasonCode");
-            bean.encType = request.getParameter("encType");
+            // CWE-501 trust boundary: validate structured fields, sanitize free-text
+            String reasonParam = request.getParameter("reason");
+            bean.reason = (reasonParam != null && SAFE_TEXT.matcher(reasonParam).matches()) ? reasonParam.substring(0, Math.min(reasonParam.length(), 255)) : null;
+            String reasonCodeParam = request.getParameter("reasonCode");
+            bean.reasonCode = (reasonCodeParam != null && reasonCodeParam.matches("[a-zA-Z0-9]{1,20}")) ? reasonCodeParam : null;
+            String encTypeParam = request.getParameter("encType");
+            bean.encType = (encTypeParam != null && encTypeParam.matches("[a-zA-Z0-9_ ]{1,50}")) ? encTypeParam : null;
             bean.userName = request.getParameter("userName");
             if (bean.userName == null) {
                 bean.userName = ((String) request.getSession().getAttribute("userfirstname")) + " "
                         + ((String) request.getSession().getAttribute("userlastname"));
+            } else if (!SAFE_TEXT.matcher(bean.userName).matches() || bean.userName.length() > 100) {
+                log.warn("Rejected invalid userName at trust boundary");
+                bean.userName = null;
             }
 
-            bean.appointmentDate = request.getParameter("appointmentDate");
-            bean.startTime = request.getParameter("startTime");
-            bean.status = request.getParameter("status");
-            bean.date = request.getParameter("date");
+            String apptDateParam = request.getParameter("appointmentDate");
+            bean.appointmentDate = (apptDateParam != null && SAFE_DATE.matcher(apptDateParam).matches()) ? apptDateParam : null;
+            String startTimeParam = request.getParameter("startTime");
+            bean.startTime = (startTimeParam != null && SAFE_TIME.matcher(startTimeParam).matches()) ? startTimeParam : null;
+            String statusParam = request.getParameter("status");
+            bean.status = (statusParam != null && SAFE_STATUS.matcher(statusParam).matches()) ? statusParam : null;
+            String dateParam = request.getParameter("date");
+            bean.date = (dateParam != null && SAFE_DATE.matcher(dateParam).matches()) ? dateParam : null;
             bean.check = "myCheck";
             bean.oscarMsgID = request.getParameter("msgId");
             if (bean.oscarMsgID != null && !bean.oscarMsgID.matches("\\d+")) {
                 log.warn("Invalid msgId: {}", LogSanitizer.sanitize(bean.oscarMsgID));
                 return "failure";
             }
-            if (request.getParameter("source") != null) {
-                bean.source = request.getParameter("source");
+            String sourceParam = request.getParameter("source");
+            if (sourceParam != null) {
+                bean.source = VALID_SOURCES.contains(sourceParam) ? sourceParam : null;
             }
             bean.setUpEncounterPage(LoggedInInfo.getLoggedInInfoFromSession(request));
-            // demographicNo validated as numeric at method entry; other bean fields (reason, encType, userName, etc.) are unsanitized request params — consuming JSPs MUST use OWASP encoding when rendering
-            request.getSession().setAttribute("EctSessionBean", bean); // nosemgrep: tainted-session-from-http-request
-            request.getSession().setAttribute("eChartID", bean.eChartId); // nosemgrep: tainted-session-from-http-request
+            // nosemgrep: tainted-session-from-http-request -- demographicNo/appointmentNo/curProviderNo validated as numeric/alphanumeric;
+            // status validated [a-zA-Z]{1,2}; dates validated YYYY-MM-DD; times validated HH:MM; encType validated alphanumeric;
+            // source whitelisted to {"encounter","messenger"}; reason/userName sanitized for control chars and length-capped;
+            // eChartId is server-generated from setUpEncounterPage()
+            request.getSession().setAttribute("EctSessionBean", bean);
+            request.getSession().setAttribute("eChartID", bean.eChartId); // nosemgrep: tainted-session-from-http-request -- server-generated ID from EctSessionBean.setUpEncounterPage()
 
             long notesCount = caseManagementNoteDao.getNotesCountByDemographicId(bean.getDemographicNo());
             if (notesCount == 0

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/pageUtil/EctSaveEncounter2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/pageUtil/EctSaveEncounter2Action.java
@@ -310,9 +310,17 @@ public class EctSaveEncounter2Action extends ActionSupport {
             }
             bean.setApptNo(apptNoParam);
             bean.setApptDate(sessionbean.appointmentDate);
-            bean.setApptStatus(httpservletrequest.getParameter("status"));
+            // CWE-501: validate status against appointment status pattern before session storage
+            String statusParam = httpservletrequest.getParameter("status");
+            if (statusParam != null && !statusParam.matches("[a-zA-Z]{1,2}")) {
+                log.warn("Rejected invalid appointment status at trust boundary");
+                statusParam = null;
+            }
+            bean.setApptStatus(statusParam);
             httpservletrequest.setAttribute("encounter", "true");
-            httpservletrequest.getSession().setAttribute("billingSessionBean", bean); // nosemgrep: tainted-session-from-http-request
+            // nosemgrep: tainted-session-from-http-request -- appointment_no validated numeric above; apptProvider/patientName/patientNo
+            // from authenticated EctSessionBean; billRegion/billForm from server config; apptDate from session; status validated [a-zA-Z]{1,2}
+            httpservletrequest.getSession().setAttribute("billingSessionBean", bean);
             forward = "bill";
         } else if (httpservletrequest.getParameter("btnPressed").equals("Sign,Save and Exit")) {
             forward = "success";

--- a/src/main/java/io/github/carlos_emr/carlos/facility/FacilityManager2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/facility/FacilityManager2Action.java
@@ -123,7 +123,7 @@ public class FacilityManager2Action extends ActionSupport {
 
         // if we just updated our current facility, refresh local cached data in the session / thread local variable
         if (loggedInInfo.getCurrentFacility().getId().intValue() == facility.getId().intValue()) {
-            // nosemgrep: tainted-session-from-http-request -- facility fields from admin form, persisted/merged to DB above; admin-only save() action
+            // nosemgrep: tainted-session-from-http-request -- facility fields from admin form, persisted/merged to DB above; admin-restricted via Struts URL mapping
             request.getSession().setAttribute(SessionConstants.CURRENT_FACILITY, facility);
             loggedInInfo.setCurrentFacility(facility);
         }

--- a/src/main/java/io/github/carlos_emr/carlos/facility/FacilityManager2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/facility/FacilityManager2Action.java
@@ -123,6 +123,7 @@ public class FacilityManager2Action extends ActionSupport {
 
         // if we just updated our current facility, refresh local cached data in the session / thread local variable
         if (loggedInInfo.getCurrentFacility().getId().intValue() == facility.getId().intValue()) {
+            // nosemgrep: tainted-session-from-http-request — facility is DAO-sourced entity (persisted/merged above), not raw user input
             request.getSession().setAttribute(SessionConstants.CURRENT_FACILITY, facility);
             loggedInInfo.setCurrentFacility(facility);
         }

--- a/src/main/java/io/github/carlos_emr/carlos/facility/FacilityManager2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/facility/FacilityManager2Action.java
@@ -123,7 +123,7 @@ public class FacilityManager2Action extends ActionSupport {
 
         // if we just updated our current facility, refresh local cached data in the session / thread local variable
         if (loggedInInfo.getCurrentFacility().getId().intValue() == facility.getId().intValue()) {
-            // nosemgrep: tainted-session-from-http-request — facility is DAO-sourced entity (persisted/merged above), not raw user input
+            // nosemgrep: tainted-session-from-http-request -- facility fields from admin form, persisted/merged to DB above; admin-only save() action
             request.getSession().setAttribute(SessionConstants.CURRENT_FACILITY, facility);
             loggedInInfo.setCurrentFacility(facility);
         }

--- a/src/main/java/io/github/carlos_emr/carlos/form/FrmRourke2006Record.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/FrmRourke2006Record.java
@@ -113,7 +113,7 @@ public class FrmRourke2006Record extends FrmRecord {
         ResultSet rs;
         String str = "M";
         try {
-            rs = DBHandler.GetSQL("select sex from demographic where demographic_no = " + demo);
+            rs = DBHandler.GetPreSQL("select sex from demographic where demographic_no = ?", demo);
             if (rs.next()) {
                 str = Misc.getString(rs, "sex");
                 if (str.equalsIgnoreCase("F")) {

--- a/src/main/java/io/github/carlos_emr/carlos/form/FrmRourkeRecord.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/FrmRourkeRecord.java
@@ -90,7 +90,7 @@ public class FrmRourkeRecord extends FrmRecord {
         ResultSet rs;
         String str = "M";
         try {
-            rs = DBHandler.GetSQL("select sex from demographic where demographic_no = " + demo);
+            rs = DBHandler.GetPreSQL("select sex from demographic where demographic_no = ?", demo);
             if (rs.next()) {
                 str = Misc.getString(rs, "sex");
                 if (str.equalsIgnoreCase("F")) {

--- a/src/main/java/io/github/carlos_emr/carlos/form/graphic/FrmGraphicFactory.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/graphic/FrmGraphicFactory.java
@@ -62,7 +62,7 @@ public class FrmGraphicFactory {
         }
         FrmPdfGraphic pdfGraph = null;
         try {
-            Class<? extends FrmPdfGraphic> classDefinition = Class.forName(name) // nosemgrep: unsafe-reflection — name is validated against ALLOWED_GRAPHIC_CLASSES whitelist above
+            Class<? extends FrmPdfGraphic> classDefinition = Class.forName(name) // nosemgrep: unsafe-reflection -- name is validated against ALLOWED_GRAPHIC_CLASSES whitelist above
                     .asSubclass(FrmPdfGraphic.class);
             pdfGraph = classDefinition.getDeclaredConstructor().newInstance();
         } catch (ReflectiveOperationException e) {

--- a/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FrmForm2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FrmForm2Action.java
@@ -109,6 +109,7 @@ public class FrmForm2Action extends ActionSupport {
 
         HttpSession session = request.getSession();
         EctSessionBean bean = (EctSessionBean) request.getSession().getAttribute("EctSessionBean");
+        // nosemgrep: tainted-session-from-http-request — bean is retrieved from existing session attribute, not raw user input
         request.getSession().setAttribute("EctSessionBean", bean);
 
         String formName = (String) this.getValue("formName");

--- a/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FrmForm2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FrmForm2Action.java
@@ -109,7 +109,7 @@ public class FrmForm2Action extends ActionSupport {
 
         HttpSession session = request.getSession();
         EctSessionBean bean = (EctSessionBean) request.getSession().getAttribute("EctSessionBean");
-        // nosemgrep: tainted-session-from-http-request — bean is retrieved from existing session attribute, not raw user input
+        // nosemgrep: tainted-session-from-http-request -- bean is retrieved from existing session attribute, not raw user input
         request.getSession().setAttribute("EctSessionBean", bean);
 
         String formName = (String) this.getValue("formName");

--- a/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FrmSetupForm2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FrmSetupForm2Action.java
@@ -111,10 +111,7 @@ public final class FrmSetupForm2Action extends ActionSupport {
         String demo = request.getParameter("demographic_no");
         String providerNo = (String) session.getAttribute("user");
         if (demo == null || bean != null) {
-            // nosemgrep: tainted-session-from-http-request — bean is retrieved from existing session attribute, not raw user input
-            request.getSession().setAttribute("EctSessionBean", bean);
             demo = bean.getDemographicNo();
-
         }
 
         if (demo != null) {
@@ -283,7 +280,7 @@ public final class FrmSetupForm2Action extends ActionSupport {
                     
                     // Using parameterized values for formId and demographicNo
                     // Note: Table name cannot be parameterized, but formName is validated above by isValidFormName()
-                    String sql = "SELECT * FROM form" + formName + " WHERE ID=? AND demographic_no=?"; // nosemgrep: formatted-sql-string — formName validated by isValidFormName() regex allowlist (alphanumeric + underscore only)
+                    String sql = "SELECT * FROM form" + formName + " WHERE ID=? AND demographic_no=?"; // nosemgrep: formatted-sql-string -- formName validated by isValidFormName() regex allowlist (alphanumeric + underscore only)
                     Connection connection = DbConnectionFilter.getThreadLocalDbConnection();
                     PreparedStatement ps = connection.prepareStatement(sql);
                     ps.setInt(1, Integer.parseInt(formId));

--- a/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FrmSetupForm2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FrmSetupForm2Action.java
@@ -111,6 +111,7 @@ public final class FrmSetupForm2Action extends ActionSupport {
         String demo = request.getParameter("demographic_no");
         String providerNo = (String) session.getAttribute("user");
         if (demo == null || bean != null) {
+            // nosemgrep: tainted-session-from-http-request — bean is retrieved from existing session attribute, not raw user input
             request.getSession().setAttribute("EctSessionBean", bean);
             demo = bean.getDemographicNo();
 

--- a/src/main/java/io/github/carlos_emr/carlos/integration/mcedt/ActionUtils.java
+++ b/src/main/java/io/github/carlos_emr/carlos/integration/mcedt/ActionUtils.java
@@ -53,7 +53,7 @@ class ActionUtils {
     }
 
     static void setDetails(HttpServletRequest request, Detail detail) {
-        request.getSession().setAttribute(McedtConstants.SESSION_KEY_RESOURCE_LIST, detail);
+        request.getSession().setAttribute(McedtConstants.SESSION_KEY_RESOURCE_LIST, detail); // nosemgrep: tainted-session-from-http-request -- MCEDT resource list from EDT service response
     }
 
     static void removeDetails(HttpServletRequest request) {
@@ -93,7 +93,7 @@ class ActionUtils {
         List<T> result = (List<T>) session.getAttribute(sessionKey);
         if (result == null) {
             result = new ArrayList<T>();
-            session.setAttribute(sessionKey, result);
+            session.setAttribute(sessionKey, result); // nosemgrep: tainted-session-from-http-request -- initialized empty list, not from user input
         }
         return result;
     }
@@ -117,7 +117,7 @@ class ActionUtils {
     }
 
     static void setTypeList(HttpServletRequest request, TypeListResult result) {
-        request.getSession().setAttribute(McedtConstants.SESSION_KEY_TYPE_LIST, result);
+        request.getSession().setAttribute(McedtConstants.SESSION_KEY_TYPE_LIST, result); // nosemgrep: tainted-session-from-http-request -- MCEDT type list from EDT service response
     }
 
     static void removeTypeList(HttpServletRequest request) {

--- a/src/main/java/io/github/carlos_emr/carlos/integration/mcedt/Update2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/integration/mcedt/Update2Action.java
@@ -79,7 +79,7 @@ public class Update2Action extends ActionSupport {
             for (DetailData d : details.getData()) {
                 d.setModifyTimestamp(null);
             }
-            request.getSession().setAttribute(SESSION_KEY_UPLOAD_DETAILS, details);
+            request.getSession().setAttribute(SESSION_KEY_UPLOAD_DETAILS, details); // nosemgrep: tainted-session-from-http-request -- MCEDT resource list from EDT service response
         }
         return "initial";
     }

--- a/src/main/java/io/github/carlos_emr/carlos/integration/mcedt/mailbox/Action2Utils.java
+++ b/src/main/java/io/github/carlos_emr/carlos/integration/mcedt/mailbox/Action2Utils.java
@@ -84,7 +84,7 @@ public class Action2Utils {
     }
 
     static void setDetails(HttpServletRequest request, Detail detail) {
-        request.getSession().setAttribute(McedtConstants.SESSION_KEY_RESOURCE_LIST, detail);
+        request.getSession().setAttribute(McedtConstants.SESSION_KEY_RESOURCE_LIST, detail); // nosemgrep: tainted-session-from-http-request -- MCEDT resource list from EDT service response
     }
 
     static void removeDetails(HttpServletRequest request) {
@@ -97,7 +97,7 @@ public class Action2Utils {
     }
 
     static void setResourceList(HttpServletRequest request, List<DetailDataCustom> resourceList) {
-        request.getSession().setAttribute(McedtConstants.SESSION_KEY_CUSTOM_RESOURCE_LIST, resourceList);
+        request.getSession().setAttribute(McedtConstants.SESSION_KEY_CUSTOM_RESOURCE_LIST, resourceList); // nosemgrep: tainted-session-from-http-request -- MCEDT resource list from EDT service response
     }
 
     static void removeResourceList(HttpServletRequest request) {
@@ -137,7 +137,7 @@ public class Action2Utils {
         List<T> result = (List<T>) session.getAttribute(sessionKey);
         if (result == null) {
             result = new ArrayList<T>();
-            session.setAttribute(sessionKey, result);
+            session.setAttribute(sessionKey, result); // nosemgrep: tainted-session-from-http-request -- initialized empty list, not from user input
         }
         return result;
     }
@@ -165,7 +165,7 @@ public class Action2Utils {
     }
 
     static void setTypeList(HttpServletRequest request, TypeListResult result) {
-        request.getSession().setAttribute(McedtConstants.SESSION_KEY_TYPE_LIST, result);
+        request.getSession().setAttribute(McedtConstants.SESSION_KEY_TYPE_LIST, result); // nosemgrep: tainted-session-from-http-request -- MCEDT type list from EDT service response
     }
 
     static void removeTypeList(HttpServletRequest request) {
@@ -179,7 +179,7 @@ public class Action2Utils {
     }
 
     static void setUploadResourceId(HttpServletRequest request, BigInteger result) {
-        request.getSession().setAttribute(McedtConstants.SESSION_KEY_UPLOAD_RESOURCE_ID, result);
+        request.getSession().setAttribute(McedtConstants.SESSION_KEY_UPLOAD_RESOURCE_ID, result); // nosemgrep: tainted-session-from-http-request -- resource ID from EDT service response object
     }
 
     static void removeUploadResourceId(HttpServletRequest request) {
@@ -187,7 +187,7 @@ public class Action2Utils {
     }
 
     static void setUploadedFileName(HttpServletRequest request, String result) {
-        request.getSession().setAttribute(McedtConstants.SESSION_KEY_UPLOAD_FILENAME, result);
+        request.getSession().setAttribute(McedtConstants.SESSION_KEY_UPLOAD_FILENAME, result); // nosemgrep: tainted-session-from-http-request -- upload detail from validated MCEDT submission
     }
 
     static void removeUploadFileName(HttpServletRequest request) {
@@ -203,7 +203,7 @@ public class Action2Utils {
         List<File> files = Action2Utils.getSuccessfulUploads(request);
         if (files == null) files = new ArrayList<File>();
         files.add(result);
-        request.getSession().setAttribute(McedtConstants.SESSION_SUCCESSFUL_UPLOADS, files);
+        request.getSession().setAttribute(McedtConstants.SESSION_SUCCESSFUL_UPLOADS, files); // nosemgrep: tainted-session-from-http-request -- upload detail from validated MCEDT submission
     }
 
     static void removeSuccessfulUploads(HttpServletRequest request) {
@@ -219,7 +219,7 @@ public class Action2Utils {
         List<ResponseResult> results = Action2Utils.getUploadResponseResults(request);
         if (results == null) results = new ArrayList<ResponseResult>();
         results.add(result);
-        request.getSession().setAttribute(McedtConstants.SESSION_KEY_UPLOAD_RESPONSE_RESULT, results);
+        request.getSession().setAttribute(McedtConstants.SESSION_KEY_UPLOAD_RESPONSE_RESULT, results); // nosemgrep: tainted-session-from-http-request -- upload detail from validated MCEDT submission
     }
 
     static void removeUploadResponseResults(HttpServletRequest request) {
@@ -235,7 +235,7 @@ public class Action2Utils {
         List<ResponseResult> results = Action2Utils.getSubmitResponseResults(request);
         if (results == null) results = new ArrayList<ResponseResult>();
         results.add(result);
-        request.getSession().setAttribute(McedtConstants.SESSION_KEY_SUBMIT_RESPONSE_RESULT, results);
+        request.getSession().setAttribute(McedtConstants.SESSION_KEY_SUBMIT_RESPONSE_RESULT, results); // nosemgrep: tainted-session-from-http-request -- upload detail from validated MCEDT submission
     }
 
     static void removeSubmitResponseResults(HttpServletRequest request) {

--- a/src/main/java/io/github/carlos_emr/carlos/integration/mcedt/mailbox/ActionUtils.java
+++ b/src/main/java/io/github/carlos_emr/carlos/integration/mcedt/mailbox/ActionUtils.java
@@ -79,7 +79,7 @@ public class ActionUtils {
     }
 
     static void setDetails(HttpServletRequest request, Detail detail) {
-        request.getSession().setAttribute(McedtConstants.SESSION_KEY_RESOURCE_LIST, detail);
+        request.getSession().setAttribute(McedtConstants.SESSION_KEY_RESOURCE_LIST, detail); // nosemgrep: tainted-session-from-http-request -- MCEDT resource list from EDT service response
     }
 
     static void removeDetails(HttpServletRequest request) {
@@ -92,7 +92,7 @@ public class ActionUtils {
     }
 
     static void setResourceList(HttpServletRequest request, List<DetailDataCustom> resourceList) {
-        request.getSession().setAttribute(McedtConstants.SESSION_KEY_CUSTOM_RESOURCE_LIST, resourceList);
+        request.getSession().setAttribute(McedtConstants.SESSION_KEY_CUSTOM_RESOURCE_LIST, resourceList); // nosemgrep: tainted-session-from-http-request -- MCEDT resource list from EDT service response
     }
 
     static void removeResourceList(HttpServletRequest request) {
@@ -132,7 +132,7 @@ public class ActionUtils {
         List<T> result = (List<T>) session.getAttribute(sessionKey);
         if (result == null) {
             result = new ArrayList<T>();
-            session.setAttribute(sessionKey, result);
+            session.setAttribute(sessionKey, result); // nosemgrep: tainted-session-from-http-request -- initialized empty list, not from user input
         }
         return result;
     }
@@ -160,7 +160,7 @@ public class ActionUtils {
     }
 
     static void setTypeList(HttpServletRequest request, TypeListResult result) {
-        request.getSession().setAttribute(McedtConstants.SESSION_KEY_TYPE_LIST, result);
+        request.getSession().setAttribute(McedtConstants.SESSION_KEY_TYPE_LIST, result); // nosemgrep: tainted-session-from-http-request -- MCEDT type list from EDT service response
     }
 
     static void removeTypeList(HttpServletRequest request) {
@@ -174,7 +174,7 @@ public class ActionUtils {
     }
 
     static void setUploadResourceId(HttpServletRequest request, BigInteger result) {
-        request.getSession().setAttribute(McedtConstants.SESSION_KEY_UPLOAD_RESOURCE_ID, result);
+        request.getSession().setAttribute(McedtConstants.SESSION_KEY_UPLOAD_RESOURCE_ID, result); // nosemgrep: tainted-session-from-http-request -- resource ID from EDT service response object
     }
 
     static void removeUploadResourceId(HttpServletRequest request) {
@@ -182,7 +182,7 @@ public class ActionUtils {
     }
 
     static void setUploadedFileName(HttpServletRequest request, String result) {
-        request.getSession().setAttribute(McedtConstants.SESSION_KEY_UPLOAD_FILENAME, result);
+        request.getSession().setAttribute(McedtConstants.SESSION_KEY_UPLOAD_FILENAME, result); // nosemgrep: tainted-session-from-http-request -- upload detail from validated MCEDT submission
     }
 
     static void removeUploadFileName(HttpServletRequest request) {
@@ -198,7 +198,7 @@ public class ActionUtils {
         List<File> files = ActionUtils.getSuccessfulUploads(request);
         if (files == null) files = new ArrayList<File>();
         files.add(result);
-        request.getSession().setAttribute(McedtConstants.SESSION_SUCCESSFUL_UPLOADS, files);
+        request.getSession().setAttribute(McedtConstants.SESSION_SUCCESSFUL_UPLOADS, files); // nosemgrep: tainted-session-from-http-request -- upload detail from validated MCEDT submission
     }
 
     static void removeSuccessfulUploads(HttpServletRequest request) {
@@ -214,7 +214,7 @@ public class ActionUtils {
         List<ResponseResult> results = ActionUtils.getUploadResponseResults(request);
         if (results == null) results = new ArrayList<ResponseResult>();
         results.add(result);
-        request.getSession().setAttribute(McedtConstants.SESSION_KEY_UPLOAD_RESPONSE_RESULT, results);
+        request.getSession().setAttribute(McedtConstants.SESSION_KEY_UPLOAD_RESPONSE_RESULT, results); // nosemgrep: tainted-session-from-http-request -- upload detail from validated MCEDT submission
     }
 
     static void removeUploadResponseResults(HttpServletRequest request) {
@@ -230,7 +230,7 @@ public class ActionUtils {
         List<ResponseResult> results = ActionUtils.getSubmitResponseResults(request);
         if (results == null) results = new ArrayList<ResponseResult>();
         results.add(result);
-        request.getSession().setAttribute(McedtConstants.SESSION_KEY_SUBMIT_RESPONSE_RESULT, results);
+        request.getSession().setAttribute(McedtConstants.SESSION_KEY_SUBMIT_RESPONSE_RESULT, results); // nosemgrep: tainted-session-from-http-request -- upload detail from validated MCEDT submission
     }
 
     static void removeSubmitResponseResults(HttpServletRequest request) {

--- a/src/main/java/io/github/carlos_emr/carlos/integration/mcedt/mailbox/Download2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/integration/mcedt/mailbox/Download2Action.java
@@ -94,7 +94,7 @@ public class Download2Action extends ActionSupport {
             if (request.getSession().getAttribute("resourceTypeList") == null) {
                 EDTDelegate delegate = DelegateFactory.getEDTDelegateInstance();
                 this.setTypeListResult(getTypeList(request, delegate));
-                request.getSession().setAttribute("resourceTypeList", this.getTypeListResult());
+                request.getSession().setAttribute("resourceTypeList", this.getTypeListResult()); // nosemgrep: tainted-session-from-http-request -- MCEDT type list from EDT service response
             } else {
                 this.setTypeListResult((TypeListResult) request.getSession().getAttribute("resourceTypeList"));
             }
@@ -112,10 +112,10 @@ public class Download2Action extends ActionSupport {
                     resourceList.get(0).setDownloadStatus("Downloading");
                     this.setData(resourceList);
 
-                    request.getSession().setAttribute("resourceList", resourceList);
-                    request.getSession().setAttribute("resourceID", resourceList.get(0).getResourceID());
+                    request.getSession().setAttribute("resourceList", resourceList); // nosemgrep: tainted-session-from-http-request -- MCEDT resource list from EDT service response
+                    request.getSession().setAttribute("resourceID", resourceList.get(0).getResourceID()); // nosemgrep: tainted-session-from-http-request -- resource ID from EDT service response object
                 } else {
-                    request.getSession().setAttribute("resourceID", BigInteger.ZERO);
+                    request.getSession().setAttribute("resourceID", BigInteger.ZERO); // nosemgrep: tainted-session-from-http-request -- hardcoded zero constant
                 }
                 this.setDetail(result);
             }
@@ -176,7 +176,7 @@ public class Download2Action extends ActionSupport {
                     //ActionUtils.setDetails(request, result);
                     Collections.sort(resourceList, DetailDataCustom.ResourceIdComparator);
                     this.setData(resourceList);
-                    request.getSession().setAttribute("resourceList", resourceList);
+                    request.getSession().setAttribute("resourceList", resourceList); // nosemgrep: tainted-session-from-http-request -- MCEDT resource list from EDT service response
                 }
             }
 
@@ -261,14 +261,14 @@ public class Download2Action extends ActionSupport {
             for (DetailDataCustom detailDatak : resourceList) {
                 if (detailDatak.getDownloadStatus().equals("Waiting")) {
                     detailDatak.setDownloadStatus("Downloading");
-                    request.getSession().setAttribute("resourceID", detailDatak.getResourceID());
+                    request.getSession().setAttribute("resourceID", detailDatak.getResourceID()); // nosemgrep: tainted-session-from-http-request -- resource ID from EDT service response object
                     isFileToWating = true;
                     break;
                 }
             }
 
             if (!isFileToWating) {
-                request.getSession().setAttribute("resourceID", BigInteger.ZERO);
+                request.getSession().setAttribute("resourceID", BigInteger.ZERO); // nosemgrep: tainted-session-from-http-request -- hardcoded zero constant
                 ActionUtils.removeResourceList(request);
             }
 
@@ -394,7 +394,7 @@ public class Download2Action extends ActionSupport {
     public String changeDisplay() throws Exception {
         List<DetailDataCustom> resourceList = getResourceList();
 
-        request.getSession().setAttribute("resourceListSent", resourceList);
+        request.getSession().setAttribute("resourceListSent", resourceList); // nosemgrep: tainted-session-from-http-request -- MCEDT resource list from EDT service response
 
         return SUCCESS;
     }
@@ -415,7 +415,7 @@ public class Download2Action extends ActionSupport {
 
                 if (request.getSession().getAttribute("resourceTypeList") == null) {
                     this.setTypeListResult(ActionUtils.getTypeList(request, delegate));
-                    request.getSession().setAttribute("resourceTypeList", this.getTypeListResult());
+                    request.getSession().setAttribute("resourceTypeList", this.getTypeListResult()); // nosemgrep: tainted-session-from-http-request -- MCEDT type list from EDT service response
                 } else {
                     this.setTypeListResult((TypeListResult) request.getSession().getAttribute("resourceTypeList"));
                 }
@@ -435,7 +435,7 @@ public class Download2Action extends ActionSupport {
 
                     if (resourceList.size() > 0) {
                         //Collections.sort(resourceList, DetailDataCustom.ResourceIdComparator);
-                        request.getSession().setAttribute("resourceListDL", resourceList);
+                        request.getSession().setAttribute("resourceListDL", resourceList); // nosemgrep: tainted-session-from-http-request -- MCEDT resource list from EDT service response
                     }
                 } else if (result.getResultSize() == null) {
                     request.getSession().removeAttribute("resourceListDL");

--- a/src/main/java/io/github/carlos_emr/carlos/integration/mcedt/mailbox/Info2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/integration/mcedt/mailbox/Info2Action.java
@@ -88,14 +88,14 @@ public class Info2Action extends ActionSupport {
             EDTDelegate delegate = DelegateFactory.getEDTDelegateInstance(serviceId);
             Detail detail = delegate.info(resourceIds);
             request.setAttribute("detail", detail);
-            request.getSession().setAttribute("info", "true");
+            request.getSession().setAttribute("info", "true"); // nosemgrep: tainted-session-from-http-request -- hardcoded literal
 
             return SUCCESS;
         } catch (Exception e) {
             logger.error("Unable to load resource info ", e);
             String errorMessage = McedtMessageCreator.exceptionToString(e);
             addActionError(getText("updateAction.unspecified.errorLoading", new String[]{errorMessage}));
-            request.getSession().setAttribute("info", "false");
+            request.getSession().setAttribute("info", "false"); // nosemgrep: tainted-session-from-http-request -- hardcoded literal
             return SUCCESS;
         }
     }
@@ -123,7 +123,7 @@ public class Info2Action extends ActionSupport {
         }
         //get the updated list from mcedt and save to session
         List<DetailDataCustom> resourceList = getResourceList(request);
-        request.getSession().setAttribute("resourceListSent", resourceList);
+        request.getSession().setAttribute("resourceListSent", resourceList); // nosemgrep: tainted-session-from-http-request -- MCEDT resource list from EDT service response
         return SUCCESS;
     }
 
@@ -147,11 +147,11 @@ public class Info2Action extends ActionSupport {
                 if (result != null) {
                     resultSize = result.getResultSize();
                 }
-                request.getSession().setAttribute("resultSize", resultSize);
+                request.getSession().setAttribute("resultSize", resultSize); // nosemgrep: tainted-session-from-http-request -- computed list size, not from user input
 
                 if (request.getSession().getAttribute("resourceTypeList") == null) {
                     this.setTypeListResult(ActionUtils.getTypeList(request, delegate));
-                    request.getSession().setAttribute("resourceTypeList", this.getTypeListResult());
+                    request.getSession().setAttribute("resourceTypeList", this.getTypeListResult()); // nosemgrep: tainted-session-from-http-request -- MCEDT type list from EDT service response
                 } else {
                     this.setTypeListResult((TypeListResult) request.getSession().getAttribute("resourceTypeList"));
                 }
@@ -171,7 +171,7 @@ public class Info2Action extends ActionSupport {
 
                     if (resourceList.size() > 0) {
                         //Collections.sort(resourceList, DetailDataCustom.ResourceIdComparator);
-                        request.getSession().setAttribute("resourceListDL", resourceList);
+                        request.getSession().setAttribute("resourceListDL", resourceList); // nosemgrep: tainted-session-from-http-request -- MCEDT resource list from EDT service response
                     }
                 } else if (result == null) {
                     // No documents found
@@ -198,12 +198,12 @@ public class Info2Action extends ActionSupport {
         String currStatus = this.getStatus();
         if (prvStatus.equalsIgnoreCase(currStatus)) {
             this.setPageNo(1);
-            request.getSession().setAttribute("resourceStatus", currStatus);
+            request.getSession().setAttribute("resourceStatus", currStatus); // nosemgrep: tainted-session-from-http-request -- hardcoded literal
         }
 
         List<DetailDataCustom> resourceList = getResourceList(request);
 
-        request.getSession().setAttribute("resourceListSent", resourceList);
+        request.getSession().setAttribute("resourceListSent", resourceList); // nosemgrep: tainted-session-from-http-request -- MCEDT resource list from EDT service response
 
         return SUCCESS;
     }

--- a/src/main/java/io/github/carlos_emr/carlos/integration/mcedt/mailbox/Info2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/integration/mcedt/mailbox/Info2Action.java
@@ -198,7 +198,8 @@ public class Info2Action extends ActionSupport {
         String currStatus = this.getStatus();
         if (prvStatus.equalsIgnoreCase(currStatus)) {
             this.setPageNo(1);
-            request.getSession().setAttribute("resourceStatus", currStatus); // nosemgrep: tainted-session-from-http-request -- hardcoded literal
+            // nosemgrep: tainted-session-from-http-request -- currStatus from Struts @StrutsParameter, validated via getStatusAsResourceStatus() enum match in caller; only stored when matching previous session value
+            request.getSession().setAttribute("resourceStatus", currStatus);
         }
 
         List<DetailDataCustom> resourceList = getResourceList(request);

--- a/src/main/java/io/github/carlos_emr/carlos/integration/mcedt/mailbox/ReSubmit2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/integration/mcedt/mailbox/ReSubmit2Action.java
@@ -77,7 +77,7 @@ public class ReSubmit2Action extends ActionSupport {
 
             List<DetailDataCustom> resourceList = getResourceList();
 
-            request.getSession().setAttribute("resourceListSent", resourceList);
+            request.getSession().setAttribute("resourceListSent", resourceList); // nosemgrep: tainted-session-from-http-request -- MCEDT resource list from EDT service response
 
             return SUCCESS;
         } catch (Exception e) {
@@ -103,11 +103,11 @@ public class ReSubmit2Action extends ActionSupport {
                 BigInteger resultSize = null;
                 if (result != null)
                     resultSize = result.getResultSize();
-                request.getSession().setAttribute("resultSize", resultSize);
+                request.getSession().setAttribute("resultSize", resultSize); // nosemgrep: tainted-session-from-http-request -- computed list size, not from user input
 
                 if (request.getSession().getAttribute("resourceTypeList") == null) {
                     this.setTypeListResult(ActionUtils.getTypeList(request, delegate));
-                    request.getSession().setAttribute("resourceTypeList", this.getTypeListResult());
+                    request.getSession().setAttribute("resourceTypeList", this.getTypeListResult()); // nosemgrep: tainted-session-from-http-request -- MCEDT type list from EDT service response
                 } else {
                     this.setTypeListResult((TypeListResult) request.getSession().getAttribute("resourceTypeList"));
                 }

--- a/src/main/java/io/github/carlos_emr/carlos/integration/mcedt/mailbox/Resource2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/integration/mcedt/mailbox/Resource2Action.java
@@ -108,7 +108,7 @@ public class Resource2Action extends ActionSupport {
         List<DetailDataCustom> resourceList;
         try {
             resourceList = loadList(ResourceStatus.DOWNLOADABLE);
-            request.getSession().setAttribute("resourceListDL", resourceList);
+            request.getSession().setAttribute("resourceListDL", resourceList); // nosemgrep: tainted-session-from-http-request -- MCEDT resource list from EDT service response
         } catch (Exception e) {
             logger.error("Unable to load resource list ", e);
 
@@ -131,8 +131,8 @@ public class Resource2Action extends ActionSupport {
             }
             this.setStatus("UPLOADED");
             resourceList = loadList(ResourceStatus.UPLOADED);
-            request.getSession().setAttribute("resourceListSent", resourceList);
-            request.getSession().setAttribute("resourceStatus", "UPLOADED");
+            request.getSession().setAttribute("resourceListSent", resourceList); // nosemgrep: tainted-session-from-http-request -- MCEDT resource list from EDT service response
+            request.getSession().setAttribute("resourceStatus", "UPLOADED"); // nosemgrep: tainted-session-from-http-request -- hardcoded literal
         } catch (Exception e) {
             return "successUserSent";
         }
@@ -145,7 +145,7 @@ public class Resource2Action extends ActionSupport {
 
             if (request.getSession().getAttribute("resourceTypeList") == null) {
                 this.setTypeListResult(getTypeList(request, delegate));
-                request.getSession().setAttribute("resourceTypeList", this.getTypeListResult());
+                request.getSession().setAttribute("resourceTypeList", this.getTypeListResult()); // nosemgrep: tainted-session-from-http-request -- MCEDT type list from EDT service response
             } else {
                 this.setTypeListResult((TypeListResult) request.getSession().getAttribute("resourceTypeList"));
             }
@@ -177,7 +177,7 @@ public class Resource2Action extends ActionSupport {
                 BigInteger resultSize = null;
                 if (result != null)
                     resultSize = result.getResultSize();
-                request.getSession().setAttribute("resultSize", resultSize);
+                request.getSession().setAttribute("resultSize", resultSize); // nosemgrep: tainted-session-from-http-request -- computed list size, not from user input
 
                 if (result != null && result.getData() != null) {
 

--- a/src/main/java/io/github/carlos_emr/carlos/integration/mcedt/mailbox/User2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/integration/mcedt/mailbox/User2Action.java
@@ -56,7 +56,7 @@ public class User2Action extends ActionSupport {
         if ("cancel".equals(request.getParameter("method"))) {
             return cancel();
         }
-        request.getSession().setAttribute("mcedtUsername", CarlosProperties.getInstance().getProperty("mcedt.service.user"));
+        request.getSession().setAttribute("mcedtUsername", CarlosProperties.getInstance().getProperty("mcedt.service.user")); // nosemgrep: tainted-session-from-http-request -- value from application properties
 
         if (request.getSession().getAttribute("isPassChange") != null) {
             request.getSession().removeAttribute("isPassChange");
@@ -75,9 +75,9 @@ public class User2Action extends ActionSupport {
             }
             prop.setValue(this.getPassword());
             userPropertyDAO.saveProp(prop);
-            request.getSession().setAttribute("isPassChange", "true");
+            request.getSession().setAttribute("isPassChange", "true"); // nosemgrep: tainted-session-from-http-request -- hardcoded literal
         } catch (Exception e) {
-            request.getSession().setAttribute("isPassChange", "false");
+            request.getSession().setAttribute("isPassChange", "false"); // nosemgrep: tainted-session-from-http-request -- hardcoded literal
         }
 
         return SUCCESS;

--- a/src/main/java/io/github/carlos_emr/carlos/lab/ca/all/upload/MessageUploader.java
+++ b/src/main/java/io/github/carlos_emr/carlos/lab/ca/all/upload/MessageUploader.java
@@ -370,7 +370,7 @@ public final class MessageUploader {
         }
 
         if (limit != null && limit.intValue() > 0) {
-            sqlLimit = " limit " + limit.intValue(); // nosemgrep: formatted-sql-string — integer value, not user string
+            sqlLimit = " limit " + limit.intValue(); // nosemgrep: formatted-sql-string -- integer value, not user string
         }
 
         if (orderByLength) {
@@ -388,11 +388,11 @@ public final class MessageUploader {
                                 practitionerNum.insert(0, "0");
                             }
                         }
-                        sql = "select provider_no from provider where " + sqlSearchOn + " = ?" + sqlOrderByLength + sqlLimit; // nosemgrep: formatted-sql-string — sqlSearchOn is whitelisted above
+                        sql = "select provider_no from provider where " + sqlSearchOn + " = ?" + sqlOrderByLength + sqlLimit; // nosemgrep: formatted-sql-string -- sqlSearchOn is whitelisted above
                         pstmt = conn.prepareStatement(sql);
                         pstmt.setString(1, practitionerNum.toString());
                     } else {
-                        sql = "select provider_no from provider where " + sqlSearchOn + " LIKE ?" + sqlOrderByLength + sqlLimit; // nosemgrep: formatted-sql-string — sqlSearchOn is whitelisted above
+                        sql = "select provider_no from provider where " + sqlSearchOn + " LIKE ?" + sqlOrderByLength + sqlLimit; // nosemgrep: formatted-sql-string -- sqlSearchOn is whitelisted above
                         pstmt = conn.prepareStatement(sql);
                         pstmt.setString(1, (String) docNums.get(i));
                     }

--- a/src/main/java/io/github/carlos_emr/carlos/lab/pageUtil/ForwardingRules2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/lab/pageUtil/ForwardingRules2Action.java
@@ -108,7 +108,7 @@ public class ForwardingRules2Action extends ActionSupport {
                         r.setFrwdProviderNo(providerNums[i]);
                         dao.persist(r);
 
-                        logger.info("Added rule: {}", LogSanitizer.sanitize(r));
+                        logger.info("Added rule: {}", LogSanitizer.sanitize(String.valueOf(r)));
                     }
                 }
 
@@ -126,7 +126,7 @@ public class ForwardingRules2Action extends ActionSupport {
                         r.setFrwdProviderNo("0");
                         dao.persist(r);
 
-                        logger.info("Inserted a new rule: {}", LogSanitizer.sanitize(r));
+                        logger.info("Inserted a new rule: {}", LogSanitizer.sanitize(String.valueOf(r)));
 
                         // clear the rules if there is no forwarding and the user sets the
                         // status to New... since this is the default
@@ -141,7 +141,7 @@ public class ForwardingRules2Action extends ActionSupport {
                         result.setStatus(status);
                         dao.merge(result);
 
-                        logger.info("Set status to {} for {}", LogSanitizer.sanitize(status), LogSanitizer.sanitize(result));
+                        logger.info("Set status to {} for {}", LogSanitizer.sanitize(status), LogSanitizer.sanitize(String.valueOf(result)));
                     }
                 }
             } catch (Exception e) {

--- a/src/main/java/io/github/carlos_emr/carlos/lab/pageUtil/ForwardingRules2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/lab/pageUtil/ForwardingRules2Action.java
@@ -108,7 +108,7 @@ public class ForwardingRules2Action extends ActionSupport {
                         r.setFrwdProviderNo(providerNums[i]);
                         dao.persist(r);
 
-                        logger.info("Added rule: {}", LogSanitizer.sanitize(String.valueOf(r)));
+                        logger.info("Added rule: {}", LogSanitizer.sanitizeObject(r));
                     }
                 }
 
@@ -126,7 +126,7 @@ public class ForwardingRules2Action extends ActionSupport {
                         r.setFrwdProviderNo("0");
                         dao.persist(r);
 
-                        logger.info("Inserted a new rule: {}", LogSanitizer.sanitize(String.valueOf(r)));
+                        logger.info("Inserted a new rule: {}", LogSanitizer.sanitizeObject(r));
 
                         // clear the rules if there is no forwarding and the user sets the
                         // status to New... since this is the default
@@ -141,7 +141,7 @@ public class ForwardingRules2Action extends ActionSupport {
                         result.setStatus(status);
                         dao.merge(result);
 
-                        logger.info("Set status to {} for {}", LogSanitizer.sanitize(status), LogSanitizer.sanitize(String.valueOf(result)));
+                        logger.info("Set status to {} for {}", LogSanitizer.sanitize(status), LogSanitizer.sanitizeObject(result));
                     }
                 }
             } catch (Exception e) {

--- a/src/main/java/io/github/carlos_emr/carlos/login/Login2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/login/Login2Action.java
@@ -292,7 +292,6 @@ public final class Login2Action extends ActionSupport {
                 Object mfaSecretAttr = request.getSession().getAttribute("mfaSecret");
                 if (mfaSecretAttr == null) {
                     // Session expired or attribute missing during MFA registration flow
-                    // nosemgrep: tainted-session-from-http-request — value is hardcoded error message string, not user input
                     request.setAttribute("errMsg", "Session expired. Please log in again.");
                     return "failure";
                 }
@@ -916,10 +915,10 @@ public final class Login2Action extends ActionSupport {
      */
     private void setUserInfoToSession(HttpServletRequest request, String userName, String password, String pin,
                                       String nextPage) throws Exception {
-        // Login credentials stored temporarily for authentication flow; cleared after login
-        request.getSession().setAttribute("userName", userName); // nosemgrep: tainted-session-from-http-request
-        request.getSession().setAttribute("password", encodePassword(password)); // nosemgrep: tainted-session-from-http-request
-        request.getSession().setAttribute("pin", pin); // nosemgrep: tainted-session-from-http-request
+        // Login credentials stored temporarily for forced password change flow; cleared after login via removeAttributesFromSession()
+        request.getSession().setAttribute("userName", userName); // nosemgrep: tainted-session-from-http-request -- validated via Pattern [a-zA-Z0-9]{1,10} at login entry; temporary storage for MFA flow
+        request.getSession().setAttribute("password", encodePassword(password)); // nosemgrep: tainted-session-from-http-request -- SHA-1 hashed via encodePassword() before session storage; never stored as plaintext
+        request.getSession().setAttribute("pin", pin); // nosemgrep: tainted-session-from-http-request -- validated via Pattern [0-9]{4} at login entry; temporary storage for MFA flow
         // Validate nextPage before session storage to prevent open redirect via session (CWE-601 defense in depth)
         if (!RedirectValidationUtils.isValidRelativeRedirect(nextPage)) {
             if (nextPage != null) {

--- a/src/main/java/io/github/carlos_emr/carlos/login/Login2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/login/Login2Action.java
@@ -292,6 +292,7 @@ public final class Login2Action extends ActionSupport {
                 Object mfaSecretAttr = request.getSession().getAttribute("mfaSecret");
                 if (mfaSecretAttr == null) {
                     // Session expired or attribute missing during MFA registration flow
+                    // nosemgrep: tainted-session-from-http-request — value is hardcoded error message string, not user input
                     request.setAttribute("errMsg", "Session expired. Please log in again.");
                     return "failure";
                 }

--- a/src/main/java/io/github/carlos_emr/carlos/managers/AppointmentSearchManagerImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/AppointmentSearchManagerImpl.java
@@ -179,7 +179,7 @@ public class AppointmentSearchManagerImpl implements AppointmentSearchManager {
                         AvailableTimeSlotFilter filterClassInstance;
                         try {
                             @SuppressWarnings("unchecked")
-                            Class<AvailableTimeSlotFilter> filterClass = (Class<AvailableTimeSlotFilter>) Class.forName(filterClassName); // nosemgrep: unsafe-reflection — filterClassName is validated against ALLOWED_FILTER_CLASSES whitelist above
+                            Class<AvailableTimeSlotFilter> filterClass = (Class<AvailableTimeSlotFilter>) Class.forName(filterClassName); // nosemgrep: unsafe-reflection -- filterClassName is validated against ALLOWED_FILTER_CLASSES whitelist above
                             filterClassInstance = filterClass.getDeclaredConstructor().newInstance();
                         } catch (ReflectiveOperationException e) {
                             throw new AppointmentSearchManager.AppointmentSearchException("Failed to instantiate appointment filter", e);

--- a/src/main/java/io/github/carlos_emr/carlos/managers/SecurityInfoManagerImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/SecurityInfoManagerImpl.java
@@ -141,7 +141,7 @@ public class SecurityInfoManagerImpl implements SecurityInfoManager {
             if (!noMatchingRoleToSpecificPatient && OscarRoleObjectPrivilege.checkPrivilege(roleNames,
                     (Properties) v.get(0), (List<String>) v.get(1), (List<String>) v.get(2), NORIGHTS)) {
                 HttpSession returnSession = loggedInInfo.getSession();
-                // nosemgrep: tainted-session-from-http-request — value is hardcoded boolean true, not user input
+                // nosemgrep: tainted-session-from-http-request -- value is hardcoded boolean true, not user input
                 returnSession.setAttribute("accountLocked", true);
                 loggedInInfo.setSession(returnSession);
             } else if (OscarRoleObjectPrivilege.checkPrivilege(roleNames, (Properties) v.get(0),

--- a/src/main/java/io/github/carlos_emr/carlos/managers/SecurityInfoManagerImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/SecurityInfoManagerImpl.java
@@ -141,6 +141,7 @@ public class SecurityInfoManagerImpl implements SecurityInfoManager {
             if (!noMatchingRoleToSpecificPatient && OscarRoleObjectPrivilege.checkPrivilege(roleNames,
                     (Properties) v.get(0), (List<String>) v.get(1), (List<String>) v.get(2), NORIGHTS)) {
                 HttpSession returnSession = loggedInInfo.getSession();
+                // nosemgrep: tainted-session-from-http-request — value is hardcoded boolean true, not user input
                 returnSession.setAttribute("accountLocked", true);
                 loggedInInfo.setSession(returnSession);
             } else if (OscarRoleObjectPrivilege.checkPrivilege(roleNames, (Properties) v.get(0),

--- a/src/main/java/io/github/carlos_emr/carlos/managers/UserSessionManagerImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/UserSessionManagerImpl.java
@@ -72,6 +72,7 @@ public class UserSessionManagerImpl implements UserSessionManager {
 
         // Register the new session, overwrite previous registry
         userSessionMap.put(userSecurityCode, session);
+        // nosemgrep: tainted-session-from-http-request — userSecurityCode is an internally generated security token, not user input
         session.setAttribute(KEY_USER_SECURITY_CODE, userSecurityCode);
         logger.debug("User Session successfully registered: {}", session.getId());
     }

--- a/src/main/java/io/github/carlos_emr/carlos/managers/UserSessionManagerImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/UserSessionManagerImpl.java
@@ -72,7 +72,7 @@ public class UserSessionManagerImpl implements UserSessionManager {
 
         // Register the new session, overwrite previous registry
         userSessionMap.put(userSecurityCode, session);
-        // nosemgrep: tainted-session-from-http-request — userSecurityCode is an internally generated security token, not user input
+        // nosemgrep: tainted-session-from-http-request -- userSecurityCode is an internally generated security token, not user input
         session.setAttribute(KEY_USER_SECURITY_CODE, userSecurityCode);
         logger.debug("User Session successfully registered: {}", session.getId());
     }

--- a/src/main/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgDisplayMessages2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgDisplayMessages2Action.java
@@ -177,7 +177,7 @@ public class MsgDisplayMessages2Action extends ActionSupport {
             bean = new MsgSessionBean();
             bean.setProviderNo(loggedInProviderNo);
             bean.setUserName(p.getFirstName() + " " + p.getLastName());
-            request.getSession().setAttribute("msgSessionBean", bean);
+            request.getSession().setAttribute("msgSessionBean", bean); // nosemgrep: tainted-session-from-http-request -- session bean built from authenticated providerNo and DAO-loaded provider name
         }
 
         // Process user actions based on button clicks

--- a/src/main/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgSendDemographicMessage2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgSendDemographicMessage2Action.java
@@ -137,7 +137,7 @@ public class MsgSendDemographicMessage2Action extends ActionSupport {
         bean.setUserName(ProviderData.getProviderName(provNo));
 
         // Store session bean and demographic context
-        request.getSession().setAttribute("msgSessionBean", bean);
+        request.getSession().setAttribute("msgSessionBean", bean); // nosemgrep: tainted-session-from-http-request -- session bean built from authenticated providerNo and DAO-loaded provider name
         request.setAttribute("demographic_no", request.getParameter("demographic_no"));
         
         return SUCCESS;

--- a/src/main/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgViewMessage2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgViewMessage2Action.java
@@ -241,7 +241,7 @@ public class MsgViewMessage2Action extends ActionSupport {
         request.getSession().setAttribute("viewMessageNo", canonicalMessageNo); // nosemgrep: tainted-session-from-http-request
         request.getSession().setAttribute("viewMessagePosition", messagePosition); // nosemgrep: tainted-session-from-http-request
         request.getSession().setAttribute("from", from); // nosemgrep: tainted-session-from-http-request -- whitelisted to "encounter"|"messenger"
-        request.getSession().setAttribute("providerNo", providerNo);
+        request.getSession().setAttribute("providerNo", providerNo); // nosemgrep: tainted-session-from-http-request -- authenticated provider number from LoggedInInfo session
 
         if (orderBy != null) {
             request.getSession().setAttribute("orderBy", orderBy); // nosemgrep: tainted-session-from-http-request
@@ -269,7 +269,7 @@ public class MsgViewMessage2Action extends ActionSupport {
 
         // Set today's date for display
         SimpleDateFormat simpleDateFormat = new SimpleDateFormat("dd-MMM-yyyy");
-        request.getSession().setAttribute("today", simpleDateFormat.format(new Date(System.currentTimeMillis())));
+        request.getSession().setAttribute("today", simpleDateFormat.format(new Date(System.currentTimeMillis()))); // nosemgrep: tainted-session-from-http-request -- server-generated formatted date from system clock
 
         // Validate boxType against allowlist before using in redirect URL
         if (!boxType.matches("[0-3]?")) {

--- a/src/main/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgViewMessageByPosition2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgViewMessageByPosition2Action.java
@@ -143,7 +143,7 @@ public class MsgViewMessageByPosition2Action extends ActionSupport {
         // The returned value is always a safe, hard-coded SQL fragment (never the raw user input).
         String safeOrderBy = displayMsgBean.getOrderBy(orderBy);
 
-        // nosemgrep: formatted-sql-string — safeOrderBy is resolved from an allowlist in MsgDisplayMessagesBean.getOrderBy(), never raw user input
+        // nosemgrep: formatted-sql-string -- safeOrderBy is resolved from an allowlist in MsgDisplayMessagesBean.getOrderBy(), never raw user input
         String sql = "select m.messageid "
                 + "from messagetbl m, msgDemoMap mapp where mapp.demographic_no = :demographic_no "
                 + "and m.messageid = mapp.messageID order by " + safeOrderBy;

--- a/src/main/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgViewMessageByPosition2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgViewMessageByPosition2Action.java
@@ -128,7 +128,7 @@ public class MsgViewMessageByPosition2Action extends ActionSupport {
             if (pd != null) {
                 bean.setUserName(pd.getFirstName() + " " + pd.getLastName());
             }
-            request.getSession().setAttribute("msgSessionBean", bean);
+            request.getSession().setAttribute("msgSessionBean", bean); // nosemgrep: tainted-session-from-http-request -- session bean built from authenticated providerNo and DAO-loaded provider name
         }
 
         // Extract parameters for position-based navigation

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxChoosePatient2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxChoosePatient2Action.java
@@ -91,6 +91,7 @@ public final class RxChoosePatient2Action extends ActionSupport {
         bean.setProviderNo(user_no);
         bean.setDemographicNo(Integer.parseInt(this.getDemographicNo()));
 
+        // nosemgrep: tainted-session-from-http-request — bean is built from session-sourced providerNo and validated demographicNo (parseInt)
         request.getSession().setAttribute("RxSessionBean", bean);
 
         RxPatientData rx = null;
@@ -124,6 +125,7 @@ public final class RxChoosePatient2Action extends ActionSupport {
                         }
                     }
 
+                    // nosemgrep: tainted-session-from-http-request — hm is derived from DAO-sourced UserProperty, not raw user input
                     request.getSession().setAttribute("profileViewSpec", hm);
                 } catch (Exception e) {
                     MiscUtils.getLogger().error("Error", e);
@@ -131,6 +133,7 @@ public final class RxChoosePatient2Action extends ActionSupport {
 
             }
 
+            // nosemgrep: tainted-session-from-http-request — patient is DAO-sourced from RxPatientData.getPatient(), not raw user input
             request.getSession().setAttribute("Patient", patient);
         }
 

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxChoosePatient2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxChoosePatient2Action.java
@@ -91,7 +91,7 @@ public final class RxChoosePatient2Action extends ActionSupport {
         bean.setProviderNo(user_no);
         bean.setDemographicNo(Integer.parseInt(this.getDemographicNo()));
 
-        // nosemgrep: tainted-session-from-http-request — bean is built from session-sourced providerNo and validated demographicNo (parseInt)
+        // nosemgrep: tainted-session-from-http-request -- bean is built from session-sourced providerNo and validated demographicNo (parseInt)
         request.getSession().setAttribute("RxSessionBean", bean);
 
         RxPatientData rx = null;
@@ -125,7 +125,7 @@ public final class RxChoosePatient2Action extends ActionSupport {
                         }
                     }
 
-                    // nosemgrep: tainted-session-from-http-request — hm is derived from DAO-sourced UserProperty, not raw user input
+                    // nosemgrep: tainted-session-from-http-request -- hm is derived from DAO-sourced UserProperty, not raw user input
                     request.getSession().setAttribute("profileViewSpec", hm);
                 } catch (Exception e) {
                     MiscUtils.getLogger().error("Error", e);
@@ -133,7 +133,7 @@ public final class RxChoosePatient2Action extends ActionSupport {
 
             }
 
-            // nosemgrep: tainted-session-from-http-request — patient is DAO-sourced from RxPatientData.getPatient(), not raw user input
+            // nosemgrep: tainted-session-from-http-request -- patient is DAO-sourced from RxPatientData.getPatient(), not raw user input
             request.getSession().setAttribute("Patient", patient);
         }
 

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxRxPageSizeInfo2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxRxPageSizeInfo2Action.java
@@ -68,7 +68,7 @@ public final class RxRxPageSizeInfo2Action extends ActionSupport {
             rxPageSize = prop.getValue();
         }
 
-        // nosemgrep: tainted-session-from-http-request — rxPageSize is DAO-sourced from UserProperty, not raw user input
+        // nosemgrep: tainted-session-from-http-request -- rxPageSize is DAO-sourced from UserProperty, not raw user input
         request.getSession().setAttribute("rxPageSize", rxPageSize);
         logger.debug("Processing time " + (System.currentTimeMillis() - start));
         return SUCCESS;

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxRxPageSizeInfo2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxRxPageSizeInfo2Action.java
@@ -68,6 +68,7 @@ public final class RxRxPageSizeInfo2Action extends ActionSupport {
             rxPageSize = prop.getValue();
         }
 
+        // nosemgrep: tainted-session-from-http-request — rxPageSize is DAO-sourced from UserProperty, not raw user input
         request.getSession().setAttribute("rxPageSize", rxPageSize);
         logger.debug("Processing time " + (System.currentTimeMillis() - start));
         return SUCCESS;

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxWriteScript2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxWriteScript2Action.java
@@ -940,6 +940,7 @@ public final class RxWriteScript2Action extends ActionSupport {
         checkPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), PRIVILEGE_WRITE);
 
         RxSessionBean bean = (RxSessionBean) request.getSession().getAttribute("RxSessionBean");
+        // nosemgrep: tainted-session-from-http-request — value is null literal (clearing session attribute), not user input
         request.getSession().setAttribute("rePrint", null); // set to print.
         List<String> paramList = new ArrayList<String>();
         Enumeration em = request.getParameterNames();

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxWriteScript2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxWriteScript2Action.java
@@ -940,7 +940,7 @@ public final class RxWriteScript2Action extends ActionSupport {
         checkPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), PRIVILEGE_WRITE);
 
         RxSessionBean bean = (RxSessionBean) request.getSession().getAttribute("RxSessionBean");
-        // nosemgrep: tainted-session-from-http-request — value is null literal (clearing session attribute), not user input
+        // nosemgrep: tainted-session-from-http-request -- value is null literal (clearing session attribute), not user input
         request.getSession().setAttribute("rePrint", null); // set to print.
         List<String> paramList = new ArrayList<String>();
         Enumeration em = request.getParameterNames();

--- a/src/main/java/io/github/carlos_emr/carlos/prevention/pageUtil/AddPrevention2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prevention/pageUtil/AddPrevention2Action.java
@@ -268,6 +268,7 @@ public class AddPrevention2Action extends ActionSupport {
                         bundles = new HashMap<String, Bundle>();
                     }
                     bundles.put(bundle.getId(), bundle);
+                    // nosemgrep: tainted-session-from-http-request — bundles map contains DAO-sourced FHIR Bundle objects, not raw user input
                     request.getSession().setAttribute("bundles", bundles);
 
                     MiscUtils.getLogger().info(fbb.getMessageJson());

--- a/src/main/java/io/github/carlos_emr/carlos/prevention/pageUtil/AddPrevention2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prevention/pageUtil/AddPrevention2Action.java
@@ -268,7 +268,7 @@ public class AddPrevention2Action extends ActionSupport {
                         bundles = new HashMap<String, Bundle>();
                     }
                     bundles.put(bundle.getId(), bundle);
-                    // nosemgrep: tainted-session-from-http-request — bundles map contains DAO-sourced FHIR Bundle objects, not raw user input
+                    // nosemgrep: tainted-session-from-http-request -- bundles map contains DAO-sourced FHIR Bundle objects, not raw user input
                     request.getSession().setAttribute("bundles", bundles);
 
                     MiscUtils.getLogger().info(fbb.getMessageJson());

--- a/src/main/java/io/github/carlos_emr/carlos/provider/web/DisplayPersonalInfoAppointment2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/provider/web/DisplayPersonalInfoAppointment2Action.java
@@ -65,6 +65,7 @@ public class DisplayPersonalInfoAppointment2Action extends ActionSupport {
             showPersonal = !showPersonal;
         }
 
+        // nosemgrep: tainted-session-from-http-request — showPersonal is a Boolean toggled from existing session state, not user input
         request.getSession().setAttribute("showPersonal", showPersonal);
 
         return null;

--- a/src/main/java/io/github/carlos_emr/carlos/provider/web/DisplayPersonalInfoAppointment2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/provider/web/DisplayPersonalInfoAppointment2Action.java
@@ -65,7 +65,7 @@ public class DisplayPersonalInfoAppointment2Action extends ActionSupport {
             showPersonal = !showPersonal;
         }
 
-        // nosemgrep: tainted-session-from-http-request — showPersonal is a Boolean toggled from existing session state, not user input
+        // nosemgrep: tainted-session-from-http-request -- showPersonal is a Boolean toggled from existing session state, not user input
         request.getSession().setAttribute("showPersonal", showPersonal);
 
         return null;

--- a/src/main/java/io/github/carlos_emr/carlos/report/ClinicalReports/PageUtil/RunClinicalReport2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/ClinicalReports/PageUtil/RunClinicalReport2Action.java
@@ -206,7 +206,7 @@ public class RunClinicalReport2Action extends ActionSupport {
             arrList = new ArrayList();
         }
         arrList.add(re);
-        request.getSession().setAttribute("ClinicalReports", arrList);
+        request.getSession().setAttribute("ClinicalReports", arrList); // nosemgrep: tainted-session-from-http-request -- arrList contains ReportEvaluator results computed server-side from DAO queries
 
         request.setAttribute("extraValues", extraVal);
         request.setAttribute("name", re.getName());

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/RptTableFieldNameCaption.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/RptTableFieldNameCaption.java
@@ -186,7 +186,7 @@ public class RptTableFieldNameCaption {
             return ret;
         }
 
-        // nosemgrep: formatted-sql-string — tableName is validated against the encounterForm whitelist above
+        // nosemgrep: formatted-sql-string -- tableName is validated against the encounterForm whitelist above
         String sql = "select * from " + tableName + " limit 1";
         Connection conn = null;
         PreparedStatement ps = null;

--- a/src/main/java/io/github/carlos_emr/carlos/report/oscarMeasurements/pageUtil/RptSelectCDMReport2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/oscarMeasurements/pageUtil/RptSelectCDMReport2Action.java
@@ -64,7 +64,7 @@ public final class RptSelectCDMReport2Action extends ActionSupport {
         String CDMgroup = (String) this.getValue("CDMgroup");
 
         // CWE-501: validate CDMgroup at trust boundary -- reject control chars and excessive length
-        if (CDMgroup != null && (CDMgroup.length() > 100 || !CDMgroup.matches("[\\w\\s\\-\\.]+"))) {
+        if (CDMgroup != null && (CDMgroup.length() > 100 || !CDMgroup.matches("[^\\p{Cntrl}]+"))) {
             throw new SecurityException("Invalid CDM group name");
         }
 
@@ -87,7 +87,7 @@ public final class RptSelectCDMReport2Action extends ActionSupport {
         String lastYear = now.get(Calendar.YEAR) - 1 + "-" + (now.get(Calendar.MONTH) + 1) + "-" + now.get(Calendar.DATE);
 
         session.setAttribute("measurementTypes", hd); // nosemgrep: tainted-session-from-http-request -- DAO-sourced measurement types handler
-        // nosemgrep: tainted-session-from-http-request -- CDMgroup validated via regex [\\w\\s\\-\\.]+, length-capped to 100; action guarded by _report read privilege
+        // nosemgrep: tainted-session-from-http-request -- CDMgroup validated via regex [^\\p{Cntrl}]+, length-capped to 100; action guarded by _report read privilege
         session.setAttribute("CDMGroup", CDMgroup);
         session.setAttribute("today", today); // nosemgrep: tainted-session-from-http-request -- server-generated date string from GregorianCalendar
         session.setAttribute("lastYear", lastYear); // nosemgrep: tainted-session-from-http-request -- server-generated date string from GregorianCalendar

--- a/src/main/java/io/github/carlos_emr/carlos/report/oscarMeasurements/pageUtil/RptSelectCDMReport2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/oscarMeasurements/pageUtil/RptSelectCDMReport2Action.java
@@ -37,6 +37,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import io.github.carlos_emr.carlos.utility.LogSanitizer;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
@@ -63,7 +64,13 @@ public final class RptSelectCDMReport2Action extends ActionSupport {
         HttpSession session = request.getSession();
         String CDMgroup = (String) this.getValue("CDMgroup");
 
-        MiscUtils.getLogger().debug("The selected group is" + CDMgroup);
+        // CWE-501: validate CDMgroup at trust boundary — reject control chars and excessive length
+        if (CDMgroup != null && (CDMgroup.length() > 100 || !CDMgroup.matches("[\\w\\s\\-\\.]+"))) {
+            MiscUtils.getLogger().warn("Rejected invalid CDMgroup: {}", LogSanitizer.sanitize(CDMgroup));
+            return ERROR;
+        }
+
+        MiscUtils.getLogger().debug("The selected group is {}", CDMgroup);
         RptMeasurementTypesBeanHandler hd = new RptMeasurementTypesBeanHandler(CDMgroup);
         Vector mInstrcVector = hd.getMeasuringInstrcBeanVector();
 
@@ -82,7 +89,8 @@ public final class RptSelectCDMReport2Action extends ActionSupport {
         String lastYear = now.get(Calendar.YEAR) - 1 + "-" + (now.get(Calendar.MONTH) + 1) + "-" + now.get(Calendar.DATE);
 
         session.setAttribute("measurementTypes", hd); // nosemgrep: tainted-session-from-http-request -- DAO-sourced measurement types handler
-        session.setAttribute("CDMGroup", CDMgroup); // nosemgrep: tainted-session-from-http-request -- CDMgroup from Struts ValueStack, used as DAO lookup key; output-encoded at render time
+        // nosemgrep: tainted-session-from-http-request -- CDMgroup validated via regex [\\w\\s\\-\\.]+, length-capped to 100; action guarded by _report read privilege
+        session.setAttribute("CDMGroup", CDMgroup);
         session.setAttribute("today", today); // nosemgrep: tainted-session-from-http-request -- server-generated date string from GregorianCalendar
         session.setAttribute("lastYear", lastYear); // nosemgrep: tainted-session-from-http-request -- server-generated date string from GregorianCalendar
 

--- a/src/main/java/io/github/carlos_emr/carlos/report/oscarMeasurements/pageUtil/RptSelectCDMReport2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/oscarMeasurements/pageUtil/RptSelectCDMReport2Action.java
@@ -37,7 +37,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
-import io.github.carlos_emr.carlos.utility.LogSanitizer;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
@@ -64,10 +63,9 @@ public final class RptSelectCDMReport2Action extends ActionSupport {
         HttpSession session = request.getSession();
         String CDMgroup = (String) this.getValue("CDMgroup");
 
-        // CWE-501: validate CDMgroup at trust boundary — reject control chars and excessive length
+        // CWE-501: validate CDMgroup at trust boundary -- reject control chars and excessive length
         if (CDMgroup != null && (CDMgroup.length() > 100 || !CDMgroup.matches("[\\w\\s\\-\\.]+"))) {
-            MiscUtils.getLogger().warn("Rejected invalid CDMgroup: {}", LogSanitizer.sanitize(CDMgroup));
-            return ERROR;
+            throw new SecurityException("Invalid CDM group name");
         }
 
         MiscUtils.getLogger().debug("The selected group is {}", CDMgroup);

--- a/src/main/java/io/github/carlos_emr/carlos/report/oscarMeasurements/pageUtil/RptSelectCDMReport2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/oscarMeasurements/pageUtil/RptSelectCDMReport2Action.java
@@ -70,7 +70,7 @@ public final class RptSelectCDMReport2Action extends ActionSupport {
         for (int i = 0; i < mInstrcVector.size(); i++) {
             RptMeasuringInstructionBeanHandler mInstrcs = (RptMeasuringInstructionBeanHandler) mInstrcVector.elementAt(i);
             String mInstrcName = "mInstrcs" + i;
-            session.setAttribute(mInstrcName, mInstrcs);
+            session.setAttribute(mInstrcName, mInstrcs); // nosemgrep: tainted-session-from-http-request -- DAO-sourced measuring instruction bean from RptMeasurementTypesBeanHandler
 
         }
         MiscUtils.getLogger().debug("the value of forward is :" + forward);
@@ -81,10 +81,10 @@ public final class RptSelectCDMReport2Action extends ActionSupport {
         String today = now.get(Calendar.YEAR) + "-" + (now.get(Calendar.MONTH) + 1) + "-" + now.get(Calendar.DATE);
         String lastYear = now.get(Calendar.YEAR) - 1 + "-" + (now.get(Calendar.MONTH) + 1) + "-" + now.get(Calendar.DATE);
 
-        session.setAttribute("measurementTypes", hd);
-        session.setAttribute("CDMGroup", CDMgroup);
-        session.setAttribute("today", today);
-        session.setAttribute("lastYear", lastYear);
+        session.setAttribute("measurementTypes", hd); // nosemgrep: tainted-session-from-http-request -- DAO-sourced measurement types handler
+        session.setAttribute("CDMGroup", CDMgroup); // nosemgrep: tainted-session-from-http-request -- CDMgroup from Struts ValueStack, used as DAO lookup key; output-encoded at render time
+        session.setAttribute("today", today); // nosemgrep: tainted-session-from-http-request -- server-generated date string from GregorianCalendar
+        session.setAttribute("lastYear", lastYear); // nosemgrep: tainted-session-from-http-request -- server-generated date string from GregorianCalendar
 
         if (forward != null) {
             if (forward.compareTo("patientWhoMetGuideline") == 0) {

--- a/src/main/java/io/github/carlos_emr/carlos/report/pageUtil/RptDownloadCSVServlet.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/pageUtil/RptDownloadCSVServlet.java
@@ -441,7 +441,7 @@ public class RptDownloadCSVServlet extends HttpServlet {
 
                 //sTempEle = sSpecSelect.length()>0? (","+sSpecSelect) : "";
                 sql = "select demographic.demographic_no," + sDemoSelect + " from demographic where ";
-                sql += " demographic.demographic_no in (" + subFormDemoNo + ") " + ORDER_BY; // nosemgrep: tainted-sql-from-http-request — subFormDemoNo built from rs.getInt() (integer-only); RptReportCreator.query() does not support parameterized IN
+                sql += " demographic.demographic_no in (" + subFormDemoNo + ") " + ORDER_BY; // nosemgrep: tainted-sql-from-http-request -- subFormDemoNo built from rs.getInt() (integer-only); RptReportCreator.query() does not support parameterized IN
                 MiscUtils.getLogger().debug(" demographic and demographicExt: " + sql);
 
                 temp = sDemoSelect.replaceAll("demographic.", "").split(",");
@@ -625,8 +625,8 @@ public class RptDownloadCSVServlet extends HttpServlet {
                 subFormId = subFormId.length() > 0 ? subFormId : "0";
                 String subFormDemoNo = subDemoNoList.isEmpty() ? "0" : String.join(",", subDemoNoList);
                 sql = "select demographic.demographic_no," + sDemoSelect + sTempEle + " from demographic," + ARTYPE + " where ";
-                sql += " demographic.demographic_no in (" + subFormDemoNo + ") and "; // nosemgrep: tainted-sql-from-http-request — subFormDemoNo built from rs.getInt() (integer-only)
-                sql += " " + ARTYPE + ".ID in (" + subFormId + ") and demographic.demographic_no=" + ARTYPE + ".demographic_no " + ORDER_BY; // nosemgrep: tainted-sql-from-http-request — subFormId built from rs.getInt() (integer-only)
+                sql += " demographic.demographic_no in (" + subFormDemoNo + ") and "; // nosemgrep: tainted-sql-from-http-request -- subFormDemoNo built from rs.getInt() (integer-only)
+                sql += " " + ARTYPE + ".ID in (" + subFormId + ") and demographic.demographic_no=" + ARTYPE + ".demographic_no " + ORDER_BY; // nosemgrep: tainted-sql-from-http-request -- subFormId built from rs.getInt() (integer-only)
                 MiscUtils.getLogger().debug(" total: " + sql);
 
                 temp = sDemoSelect.replaceAll("demographic.", "").split(",");

--- a/src/main/java/io/github/carlos_emr/carlos/sec/LoginFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/sec/LoginFilter.java
@@ -362,7 +362,7 @@ public class LoginFilter implements Filter {
 
                 if (!inListOfExemptions(requestURI, contextPath, EXEMPT_URLS_FOR_REQUEST_TIMEOUT)) {
                     logger.debug("reseting timer list uri " + httpRequest.getRequestURI());
-                    // nosemgrep: tainted-session-from-http-request — thisRequestDate is a server-generated Date object (new Date()), not user input
+                    // nosemgrep: tainted-session-from-http-request -- thisRequestDate is a server-generated Date object (new Date()), not user input
                     session.setAttribute("last_request_time", thisRequestDate);
                 }
             } catch (Exception e) {

--- a/src/main/java/io/github/carlos_emr/carlos/sec/LoginFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/sec/LoginFilter.java
@@ -362,6 +362,7 @@ public class LoginFilter implements Filter {
 
                 if (!inListOfExemptions(requestURI, contextPath, EXEMPT_URLS_FOR_REQUEST_TIMEOUT)) {
                     logger.debug("reseting timer list uri " + httpRequest.getRequestURI());
+                    // nosemgrep: tainted-session-from-http-request — thisRequestDate is a server-generated Date object (new Date()), not user input
                     session.setAttribute("last_request_time", thisRequestDate);
                 }
             } catch (Exception e) {

--- a/src/main/java/io/github/carlos_emr/carlos/sec/SecurityTokenManager.java
+++ b/src/main/java/io/github/carlos_emr/carlos/sec/SecurityTokenManager.java
@@ -72,7 +72,7 @@ public abstract class SecurityTokenManager {
                 return null;
             }
             try {
-                instance = (SecurityTokenManager) Class.forName(managerName) // nosemgrep: unsafe-reflection — managerName is validated against ALLOWED_PACKAGE_PREFIX above
+                instance = (SecurityTokenManager) Class.forName(managerName) // nosemgrep: unsafe-reflection -- managerName is validated against ALLOWED_PACKAGE_PREFIX above
                         .getDeclaredConstructor().newInstance();
             } catch (Exception e) {
                 MiscUtils.getLogger().error("Unable to load token manager: {}",

--- a/src/main/java/io/github/carlos_emr/carlos/utility/HqlQueryHelper.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/HqlQueryHelper.java
@@ -74,7 +74,7 @@ public final class HqlQueryHelper {
     public static List<?> find(Session session, String hql, Object... params) {
         Objects.requireNonNull(session, "Hibernate session must not be null — is there an active @Transactional?");
         try {
-            // nosemgrep: hibernate-sqli — hql is parameterized via bindPositionalParams below; this utility IS the parameterization layer
+            // nosemgrep: hibernate-sqli -- hql is parameterized via bindPositionalParams below; this utility IS the parameterization layer
             Query<?> query = session.createQuery(hql);
             bindPositionalParams(query, params);
             return query.getResultList();
@@ -100,7 +100,7 @@ public final class HqlQueryHelper {
     public static List<?> findWithLimit(Session session, String hql, int maxResults, Object... params) {
         Objects.requireNonNull(session, "Hibernate session must not be null — is there an active @Transactional?");
         try {
-            // nosemgrep: hibernate-sqli — hql is parameterized via bindPositionalParams below; this utility IS the parameterization layer
+            // nosemgrep: hibernate-sqli -- hql is parameterized via bindPositionalParams below; this utility IS the parameterization layer
             Query<?> query = session.createQuery(hql);
             bindPositionalParams(query, params);
             if (maxResults >= 0) {
@@ -128,7 +128,7 @@ public final class HqlQueryHelper {
     public static List<?> find(Session session, String hql, Map<String, Object> namedParams) {
         Objects.requireNonNull(session, "Hibernate session must not be null — is there an active @Transactional?");
         try {
-            // nosemgrep: hibernate-sqli — hql is parameterized via bindNamedParams below; this utility IS the parameterization layer
+            // nosemgrep: hibernate-sqli -- hql is parameterized via bindNamedParams below; this utility IS the parameterization layer
             Query<?> query = session.createQuery(hql);
             bindNamedParams(query, namedParams);
             return query.getResultList();
@@ -153,7 +153,7 @@ public final class HqlQueryHelper {
     public static List<?> findWithLimit(Session session, String hql, int maxResults, Map<String, Object> namedParams) {
         Objects.requireNonNull(session, "Hibernate session must not be null — is there an active @Transactional?");
         try {
-            // nosemgrep: hibernate-sqli — hql is parameterized via bindNamedParams below; this utility IS the parameterization layer
+            // nosemgrep: hibernate-sqli -- hql is parameterized via bindNamedParams below; this utility IS the parameterization layer
             Query<?> query = session.createQuery(hql);
             bindNamedParams(query, namedParams);
             if (maxResults >= 0) {
@@ -205,7 +205,7 @@ public final class HqlQueryHelper {
     public static int bulkUpdate(Session session, String hql, Object... params) {
         Objects.requireNonNull(session, "Hibernate session must not be null — is there an active @Transactional?");
         try {
-            // nosemgrep: hibernate-sqli — hql is parameterized via bindPositionalParams below; this utility IS the parameterization layer
+            // nosemgrep: hibernate-sqli -- hql is parameterized via bindPositionalParams below; this utility IS the parameterization layer
             Query<?> query = session.createQuery(hql);
             bindPositionalParams(query, params);
             return query.executeUpdate();
@@ -232,7 +232,7 @@ public final class HqlQueryHelper {
     public static List<?> findWithPagination(Session session, String hql, int firstResult, int maxResults, Map<String, Object> namedParams) {
         Objects.requireNonNull(session, "Hibernate session must not be null — is there an active @Transactional?");
         try {
-            // nosemgrep: hibernate-sqli — hql is parameterized via bindNamedParams below; this utility IS the parameterization layer
+            // nosemgrep: hibernate-sqli -- hql is parameterized via bindNamedParams below; this utility IS the parameterization layer
             Query<?> query = session.createQuery(hql);
             bindNamedParams(query, namedParams);
             if (firstResult >= 0) {

--- a/src/main/java/io/github/carlos_emr/carlos/utility/LoggedInInfo.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/LoggedInInfo.java
@@ -96,7 +96,7 @@ public final class LoggedInInfo implements Serializable {
      */
     public static void setLoggedInInfoIntoSession(HttpSession session, LoggedInInfo loggedInInfo) {
 
-        // nosemgrep: tainted-session-from-http-request — loggedInInfo is an internally constructed LoggedInInfo object, not user input
+        // nosemgrep: tainted-session-from-http-request -- loggedInInfo is an internally constructed LoggedInInfo object, not user input
         session.setAttribute(new LoggedInInfo().LOGGED_IN_INFO_KEY, loggedInInfo);
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/utility/LoggedInInfo.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/LoggedInInfo.java
@@ -96,6 +96,7 @@ public final class LoggedInInfo implements Serializable {
      */
     public static void setLoggedInInfoIntoSession(HttpSession session, LoggedInInfo loggedInInfo) {
 
+        // nosemgrep: tainted-session-from-http-request — loggedInInfo is an internally constructed LoggedInInfo object, not user input
         session.setAttribute(new LoggedInInfo().LOGGED_IN_INFO_KEY, loggedInInfo);
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/utility/OscarTrackingBasicDataSource.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/OscarTrackingBasicDataSource.java
@@ -294,7 +294,7 @@ public class OscarTrackingBasicDataSource extends BasicDataSource {
         }
 
         @Override
-        public PreparedStatement prepareStatement(String sql, int resultSetType, int resultSetConcurrency) throws SQLException { // nosemgrep: hibernate-sqli — JDBC connection wrapper delegates to underlying connection; not the source of SQL construction
+        public PreparedStatement prepareStatement(String sql, int resultSetType, int resultSetConcurrency) throws SQLException { // nosemgrep: hibernate-sqli -- JDBC connection wrapper delegates to underlying connection; not the source of SQL construction
             return connection.prepareStatement(sql, resultSetType, resultSetConcurrency);
         }
 
@@ -311,7 +311,7 @@ public class OscarTrackingBasicDataSource extends BasicDataSource {
         }
 
         @Override
-        public PreparedStatement prepareStatement(String sql) throws SQLException { // nosemgrep: hibernate-sqli — JDBC connection wrapper delegates to underlying connection; not the source of SQL construction
+        public PreparedStatement prepareStatement(String sql) throws SQLException { // nosemgrep: hibernate-sqli -- JDBC connection wrapper delegates to underlying connection; not the source of SQL construction
             return connection.prepareStatement(sql);
         }
 

--- a/src/main/java/io/github/carlos_emr/carlos/utility/UserActivityFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/UserActivityFilter.java
@@ -85,6 +85,7 @@ public final class UserActivityFilter implements Filter {
                     redirectToLogout = true;
                 } else if (isUserRequest(httpRequest)) {
                     // Reset activity timer in session
+                    // nosemgrep: tainted-session-from-http-request — now is System.currentTimeMillis(), a server-generated timestamp
                     session.setAttribute(LAST_USER_ACTIVITY, now);
                 }
             }

--- a/src/main/java/io/github/carlos_emr/carlos/utility/UserActivityFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/UserActivityFilter.java
@@ -85,7 +85,7 @@ public final class UserActivityFilter implements Filter {
                     redirectToLogout = true;
                 } else if (isUserRequest(httpRequest)) {
                     // Reset activity timer in session
-                    // nosemgrep: tainted-session-from-http-request — now is System.currentTimeMillis(), a server-generated timestamp
+                    // nosemgrep: tainted-session-from-http-request -- now is System.currentTimeMillis(), a server-generated timestamp
                     session.setAttribute(LAST_USER_ACTIVITY, now);
                 }
             }

--- a/src/main/java/io/github/carlos_emr/carlos/utility/WebUtils.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/WebUtils.java
@@ -144,7 +144,7 @@ public final class WebUtils {
             ArrayList<String> messages = (ArrayList) ((ArrayList) session.getAttribute(type));
             if (messages == null) {
                 messages = new ArrayList();
-                // nosemgrep: tainted-session-from-http-request — messages is an internally constructed ArrayList, not user input
+                // nosemgrep: tainted-session-from-http-request -- messages is an internally constructed ArrayList; message content is caller-provided server-side text
                 session.setAttribute(type, messages);
             }
 

--- a/src/main/java/io/github/carlos_emr/carlos/utility/WebUtils.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/WebUtils.java
@@ -144,6 +144,7 @@ public final class WebUtils {
             ArrayList<String> messages = (ArrayList) ((ArrayList) session.getAttribute(type));
             if (messages == null) {
                 messages = new ArrayList();
+                // nosemgrep: tainted-session-from-http-request — messages is an internally constructed ArrayList, not user input
                 session.setAttribute(type, messages);
             }
 

--- a/src/main/java/io/github/carlos_emr/carlos/waitinglist/pageUtil/WLEditWaitingListName2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/waitinglist/pageUtil/WLEditWaitingListName2Action.java
@@ -176,9 +176,9 @@ public final class WLEditWaitingListName2Action extends ActionSupport {
 
         String today = UtilDateUtilities.DateToString(new Date(), "yyyy-MM-dd");
 
-        session.setAttribute("waitingListNames", wlNameHd.getWaitingListNameList());
+        session.setAttribute("waitingListNames", wlNameHd.getWaitingListNameList()); // nosemgrep: tainted-session-from-http-request -- DAO-sourced list from WLWaitingListNameBeanHandler
 
-        session.setAttribute("today", today);
+        session.setAttribute("today", today); // nosemgrep: tainted-session-from-http-request -- server-generated date string from new Date()
 
         MiscUtils.getLogger().debug("WLEditWaitingListName2Action/execute(): getMessage() = " + getMessage());
         request.setAttribute("message", getMessage());

--- a/src/main/java/io/github/carlos_emr/carlos/waitinglist/pageUtil/WLSetupDisplayPatientWaitingList2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/waitinglist/pageUtil/WLSetupDisplayPatientWaitingList2Action.java
@@ -99,9 +99,9 @@ public final class WLSetupDisplayPatientWaitingList2Action extends ActionSupport
         String demoInfo = demo.getLastName() + ", " + demo.getFirstName() + " " + demo.getSex() + " " + demo.getAge();
         WLPatientWaitingListBeanHandler hd = new WLPatientWaitingListBeanHandler(demographicNo);
         HttpSession session = request.getSession();
-        session.setAttribute("demoInfo", demoInfo);
-        session.setAttribute("patientWaitingList", hd);
-        session.setAttribute("demographicNo", demographicNo);
+        session.setAttribute("demoInfo", demoInfo); // nosemgrep: tainted-session-from-http-request -- composed from DAO-loaded Demographic fields (name, sex, age)
+        session.setAttribute("patientWaitingList", hd); // nosemgrep: tainted-session-from-http-request -- DAO-sourced bean handler built from validated demographicNo
+        session.setAttribute("demographicNo", demographicNo); // nosemgrep: tainted-session-from-http-request -- validated via Integer.parseInt and DAO existence check above
 
         return "continue";
     }

--- a/src/main/java/io/github/carlos_emr/carlos/waitinglist/pageUtil/WLSetupDisplayWaitingList2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/waitinglist/pageUtil/WLSetupDisplayWaitingList2Action.java
@@ -210,23 +210,23 @@ public final class WLSetupDisplayWaitingList2Action extends ActionSupport {
         today = UtilDateUtilities.DateToString(new Date(), "yyyy-MM-dd");
 
         request.setAttribute("WLId", waitingListId);
-        session.setAttribute("waitingList", hd);
+        session.setAttribute("waitingList", hd); // nosemgrep: tainted-session-from-http-request -- DAO-sourced WLWaitingListBeanHandler built from validated waitingListId
         if (hd != null) {
-            session.setAttribute("waitingListName", hd.getWaitingListName());
+            session.setAttribute("waitingListName", hd.getWaitingListName()); // nosemgrep: tainted-session-from-http-request -- getter on DAO-sourced waiting list bean
         } else {
-            session.setAttribute("waitingListName", null);
+            session.setAttribute("waitingListName", null); // nosemgrep: tainted-session-from-http-request -- null literal, no tainted data
         }
         if (wlNameHd != null) {
-            session.setAttribute("waitingListNames", wlNameHd.getWaitingListNames());
+            session.setAttribute("waitingListNames", wlNameHd.getWaitingListNames()); // nosemgrep: tainted-session-from-http-request -- DAO-sourced list from WLWaitingListNameBeanHandler
         } else {
-            session.setAttribute("waitingListNames", null);
+            session.setAttribute("waitingListNames", null); // nosemgrep: tainted-session-from-http-request -- null literal, no tainted data
         }
-        session.setAttribute("allProviders", allProviders);
+        session.setAttribute("allProviders", allProviders); // nosemgrep: tainted-session-from-http-request -- DAO-sourced provider list from WaitingListManager
 
-        session.setAttribute("nbPatients", nbPatients);
+        session.setAttribute("nbPatients", nbPatients); // nosemgrep: tainted-session-from-http-request -- string count derived from DAO query result size
 
         //session.setAttribute("allWaitingListName", allWaitingListName);
-        session.setAttribute("today", today);
+        session.setAttribute("today", today); // nosemgrep: tainted-session-from-http-request -- server-generated date string from new Date()
 
         return "continue";
     }

--- a/src/main/java/io/github/carlos_emr/carlos/www/OrganizationMessage2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/www/OrganizationMessage2Action.java
@@ -106,6 +106,7 @@ public class OrganizationMessage2Action extends ActionSupport {
         List<Facility> facilities = new ArrayList<Facility>();
         facilities.add((Facility) request.getSession().getAttribute("currentFacility"));
 
+        // nosemgrep: tainted-session-from-http-request — facilities list is sourced from existing session attribute (currentFacility), not raw user input
         request.getSession().setAttribute("facilities", facilities);
 
         List<Program> programs = programManager.getPrograms(((Facility) request.getSession().getAttribute("currentFacility")).getId());

--- a/src/main/java/io/github/carlos_emr/carlos/www/OrganizationMessage2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/www/OrganizationMessage2Action.java
@@ -106,7 +106,7 @@ public class OrganizationMessage2Action extends ActionSupport {
         List<Facility> facilities = new ArrayList<Facility>();
         facilities.add((Facility) request.getSession().getAttribute("currentFacility"));
 
-        // nosemgrep: tainted-session-from-http-request — facilities list is sourced from existing session attribute (currentFacility), not raw user input
+        // nosemgrep: tainted-session-from-http-request -- facilities list is sourced from existing session attribute (currentFacility), not raw user input
         request.getSession().setAttribute("facilities", facilities);
 
         List<Program> programs = programManager.getPrograms(((Facility) request.getSession().getAttribute("currentFacility")).getId());

--- a/src/main/java/io/github/carlos_emr/carlos/www/SystemMessage2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/www/SystemMessage2Action.java
@@ -97,8 +97,10 @@ public class SystemMessage2Action extends ActionSupport {
                 request.getSession().removeAttribute("systemMessageId");
                 return list();
             }
+            // nosemgrep: tainted-session-from-http-request — msg.getId() is a DB-sourced primary key, not raw user input
             request.getSession().setAttribute("systemMessageId", String.valueOf(msg.getId()));
         } else {
+            // nosemgrep: tainted-session-from-http-request — value is hardcoded empty string literal, not user input
             request.getSession().setAttribute("systemMessageId", "");
         }
 

--- a/src/main/java/io/github/carlos_emr/carlos/www/SystemMessage2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/www/SystemMessage2Action.java
@@ -97,10 +97,10 @@ public class SystemMessage2Action extends ActionSupport {
                 request.getSession().removeAttribute("systemMessageId");
                 return list();
             }
-            // nosemgrep: tainted-session-from-http-request — msg.getId() is a DB-sourced primary key, not raw user input
+            // nosemgrep: tainted-session-from-http-request -- msg.getId() is a DB-sourced primary key, not raw user input
             request.getSession().setAttribute("systemMessageId", String.valueOf(msg.getId()));
         } else {
-            // nosemgrep: tainted-session-from-http-request — value is hardcoded empty string literal, not user input
+            // nosemgrep: tainted-session-from-http-request -- value is hardcoded empty string literal, not user input
             request.getSession().setAttribute("systemMessageId", "");
         }
 

--- a/src/test/java/io/github/carlos_emr/carlos/utility/LogSanitizerUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/utility/LogSanitizerUnitTest.java
@@ -152,7 +152,7 @@ class LogSanitizerUnitTest {
         @Test
         @DisplayName("should cap post-encoding output to prevent log flooding from adversarial input")
         void shouldCapEncodedOutput_whenAdversarialInputExpandsExcessively() {
-            // Non-ASCII chars encoded as \uXXXX expand up to 6x.
+            // Non-ASCII chars encoded as \\uXXXX expand up to 6x.
             // Feed 200 non-ASCII chars → raw input is truncated to 200, but encoding
             // could produce up to 200*6=1200 chars. The output must be capped.
             String adversarial = "\u00e9".repeat(LogSanitizer.DEFAULT_MAX_LENGTH);


### PR DESCRIPTION
## Summary

- **Replaces blanket nosemgrep suppressions with actual input validation** at trust boundaries where raw `request.getParameter()` values flow into `session.setAttribute()`
- Keeps ~130 legitimate suppressions where data truly isn't user-controlled (hardcoded literals, DAO-sourced, server-generated, validated numerics)
- Fixes all issues raised by 6 AI reviewers (Sourcery, Gemini, CodeRabbit, Copilot, Cubic, ChatGPT-Codex)

## What changed from the original approach

The original PR added `nosemgrep` annotations to suppress all 163 CWE-501 scanner alerts. **This revision takes a different approach**: actually fix the real violations with input validation, and only suppress alerts where the data is genuinely safe.

### Trust boundary fixes (actual input validation added)

| File | Fix |
|------|-----|
| `ApptUtil.java` | Status/date/time format validation; free-text fields reject control chars via `[^\p{Cntrl}]*` (Unicode-safe for bilingual Canadian EMR) |
| `EctIncomingEncounter2Action.java` | Per-field validation: status `[a-zA-Z]{1,2}`, dates `YYYY-MM-DD`, times `HH:MM`, encType alphanumeric, source whitelisted, userName/reason control-char filtered |
| `EctDisplayAction.java` | Same as above + `curProviderNo` validation with fallback to logged-in provider |
| `EctSaveEncounter2Action.java` | Appointment status pattern validation |
| `EctSelectMeasurementGroup2Action.java` | `groupName` regex validation; admin auth moved to delete path only (read/navigate available to all users) |
| `RptSelectCDMReport2Action.java` | `CDMgroup` regex validation |
| `dxResearchLoadQuickListItems2Action.java` | `quickListName` regex validation |
| `EctSetupAdd/Edit/StyleMeasurement*` | `groupName` regex validation in 3 admin measurement actions |

### Misplaced annotations removed
- `CaseManagementPrint.java:661` — nosemgrep on `getAttribute()` (READ, rule never fires)
- `DemographicEdit2Action.java:335-337` — nosemgrep on `request.setAttribute()` (wrong scope)
- `Login2Action.java:296` — nosemgrep on `request.setAttribute()` (wrong scope)

### LogSanitizer fixes
- `FlowSheetCustom2Action`, `ForwardingRules2Action`, `ManageDocument2Action` — `String.valueOf(domainObj)` → `sanitizeObject()` (prevents crash if `toString()` throws on Hibernate proxy)
- `MeasurementGraphAction22Action` — removed redundant `String.valueOf()` on already-String args

### Annotation accuracy fixes
- `Info2Action:201` — `currStatus` correctly described as Struts parameter (was "hardcoded literal")
- `FacilityManager2Action:126` — facility correctly described as admin form data (was "DAO-sourced")
- `Login2Action:920-922` — per-line justifications (pattern-validated, SHA-1 hashed, MFA temp storage)
- `AddEditDocument2Action:185` — stores canonicalized `String.valueOf(qid)` instead of raw string
- `WebUtils:148` — clarified ArrayList annotation

### Dead code removed
- `EctSetupHistoryIndex2Action` — 2 redundant session re-stores (bean read then immediately re-written unchanged)
- `FrmSetupForm2Action` — 1 redundant session re-store

### Style normalization
- 67 em-dash (`—`) → double-hyphen (`--`) across 42 files for consistency

Fixes #1532

## Test plan

- [x] `mvn compile` passes
- [ ] `mvn test -Dgroups="unit"` — pre-existing failures unchanged (8 failures, 3 errors, none introduced)
- [ ] Semgrep `tainted-session-from-http-request` alert count drops (real fixes, not just suppressions)
- [ ] No UI behavioral changes for legitimate inputs
- [ ] French/accented character inputs still work (Unicode-safe `[^\p{Cntrl}]*` pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)