### PR TITLE
sec: suppress 20 false-positive XXE code scanning alerts

### DIFF
--- a/scripts/convert_jrxml_v6_to_v7.py
+++ b/scripts/convert_jrxml_v6_to_v7.py
@@ -573,7 +573,7 @@ def convert_jrxml(input_path):
     try:
         # Register namespace to avoid ns0: prefixes
         ET.register_namespace('', JR_NS)
-        root = ET.fromstring(content)  # deepcode ignore InsecureXmlParser: DOCTYPE stripped on line 567; Python 3.12 expat blocks external entities; build-time script only
+        root = ET.fromstring(content)  # deepcode ignore InsecureXmlParser: parses sanitized content after this function strips DOCTYPE declarations before XML parsing; build-time conversion script
     except ET.ParseError as e:
         print(f"  ERROR parsing {input_path}: {e}", file=sys.stderr)
         return None

--- a/scripts/convert_jrxml_v6_to_v7.py
+++ b/scripts/convert_jrxml_v6_to_v7.py
@@ -573,7 +573,7 @@ def convert_jrxml(input_path):
     try:
         # Register namespace to avoid ns0: prefixes
         ET.register_namespace('', JR_NS)
-        root = ET.fromstring(content)
+        root = ET.fromstring(content)  # deepcode ignore InsecureXmlParser: DOCTYPE stripped on line 567; Python 3.12 expat blocks external entities; build-time script only
     except ET.ParseError as e:
         print(f"  ERROR parsing {input_path}: {e}", file=sys.stderr)
         return None

--- a/src/main/java/io/github/carlos_emr/OBChecklist_99_12.java
+++ b/src/main/java/io/github/carlos_emr/OBChecklist_99_12.java
@@ -88,7 +88,7 @@ public class OBChecklist_99_12 {
         try {
             SAXParserFactory factory = XmlUtils.createSecureSAXParserFactory();
             SAXParser saxParser = factory.newSAXParser();
-            XMLReader reader = saxParser.getXMLReader();
+            XMLReader reader = saxParser.getXMLReader(); // nosemgrep: xmlreader-xxe, xmlreader-xxe-parameter-entities -- XXE protection applied by XmlUtils.createSecureSAXParserFactory()
 
             ContentHandler contentHandler = new OBChecklistHandler_99_12(savedar1params);
             reader.setContentHandler(contentHandler);

--- a/src/main/java/io/github/carlos_emr/OBRisks_99_12.java
+++ b/src/main/java/io/github/carlos_emr/OBRisks_99_12.java
@@ -80,7 +80,7 @@ public class OBRisks_99_12 {
         try {
             SAXParserFactory factory = XmlUtils.createSecureSAXParserFactory();
             SAXParser saxParser = factory.newSAXParser();
-            XMLReader reader = saxParser.getXMLReader();
+            XMLReader reader = saxParser.getXMLReader(); // nosemgrep: xmlreader-xxe, xmlreader-xxe-parameter-entities -- XXE protection applied by XmlUtils.createSecureSAXParserFactory()
 
             ContentHandler contentHandler = new OBRisksHandler_99_12();
             reader.setContentHandler(contentHandler);
@@ -102,7 +102,7 @@ public class OBRisks_99_12 {
         try {
             SAXParserFactory factory = XmlUtils.createSecureSAXParserFactory();
             SAXParser saxParser = factory.newSAXParser();
-            XMLReader reader = saxParser.getXMLReader();
+            XMLReader reader = saxParser.getXMLReader(); // nosemgrep: xmlreader-xxe, xmlreader-xxe-parameter-entities -- XXE protection applied by XmlUtils.createSecureSAXParserFactory()
 
             ContentHandler contentHandler = new OBRisksHandler_99_12();
             reader.setContentHandler(contentHandler);

--- a/src/main/java/io/github/carlos_emr/carlos/dashboard/handler/IndicatorTemplateHandler.java
+++ b/src/main/java/io/github/carlos_emr/carlos/dashboard/handler/IndicatorTemplateHandler.java
@@ -114,7 +114,7 @@ public class IndicatorTemplateHandler {
 
         try {
 
-            Validator validator = XmlUtils.createSecureValidator(getSchema());
+            Validator validator = XmlUtils.createSecureValidator(getSchema()); // nosemgrep: validator-xxe -- XXE protection applied by XmlUtils.createSecureValidator()
             validator.validate(new DOMSource(getIndicatorTemplateDocument()));
             setValidXML(Boolean.TRUE);
         } catch (Exception e) {

--- a/src/main/java/io/github/carlos_emr/carlos/decision/DesAntenatalPlannerChecklist_99_12.java
+++ b/src/main/java/io/github/carlos_emr/carlos/decision/DesAntenatalPlannerChecklist_99_12.java
@@ -115,7 +115,7 @@ public class DesAntenatalPlannerChecklist_99_12 {
         try {
             SAXParserFactory factory = XmlUtils.createSecureSAXParserFactory();
             SAXParser saxParser = factory.newSAXParser();
-            XMLReader reader = saxParser.getXMLReader();
+            XMLReader reader = saxParser.getXMLReader(); // nosemgrep: xmlreader-xxe, xmlreader-xxe-parameter-entities -- XXE protection applied by XmlUtils.createSecureSAXParserFactory()
 
             ContentHandler contentHandler = new DesAntenatalPlannerChecklistHandler_99_12(savedar1params);
             reader.setContentHandler(contentHandler);

--- a/src/main/java/io/github/carlos_emr/carlos/decision/DesAntenatalPlannerRisks_99_12.java
+++ b/src/main/java/io/github/carlos_emr/carlos/decision/DesAntenatalPlannerRisks_99_12.java
@@ -99,7 +99,7 @@ public class DesAntenatalPlannerRisks_99_12 {
         try {
             SAXParserFactory factory = XmlUtils.createSecureSAXParserFactory();
             SAXParser saxParser = factory.newSAXParser();
-            XMLReader reader = saxParser.getXMLReader();
+            XMLReader reader = saxParser.getXMLReader(); // nosemgrep: xmlreader-xxe, xmlreader-xxe-parameter-entities -- XXE protection applied by XmlUtils.createSecureSAXParserFactory()
 
             ContentHandler contentHandler = new DesAntenatalPlannerRisksHandler_99_12();
             reader.setContentHandler(contentHandler);
@@ -140,7 +140,7 @@ public class DesAntenatalPlannerRisks_99_12 {
         try {
             SAXParserFactory factory = XmlUtils.createSecureSAXParserFactory();
             SAXParser saxParser = factory.newSAXParser();
-            XMLReader reader = saxParser.getXMLReader();
+            XMLReader reader = saxParser.getXMLReader(); // nosemgrep: xmlreader-xxe, xmlreader-xxe-parameter-entities -- XXE protection applied by XmlUtils.createSecureSAXParserFactory()
 
             ContentHandler contentHandler = new DesAntenatalPlannerRisksHandler_99_12();
             reader.setContentHandler(contentHandler);

--- a/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/DemographicExportAction42Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/DemographicExportAction42Action.java
@@ -3690,7 +3690,7 @@ public class DemographicExportAction42Action extends ActionSupport {
         // Check whether document is valid; validation stops at first error detected.
         Validator validator;
         try {
-            validator = XmlUtils.createSecureValidator(schema);
+            validator = XmlUtils.createSecureValidator(schema); // nosemgrep: validator-xxe -- XXE protection applied by XmlUtils.createSecureValidator()
         } catch (SAXException e) {
             logger.error("Failed to create secure validator", e);
             return false;

--- a/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FrmSetupForm2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FrmSetupForm2Action.java
@@ -162,7 +162,7 @@ public final class FrmSetupForm2Action extends ActionSupport {
             File formDir = new File(formDirPath);
             File validatedForm = PathValidationUtils.validatePath(formName + ".xml", formDir);
             try (InputStream is = new FileInputStream(validatedForm)) {
-            Vector measurementTypes = EctFindMeasurementTypeUtil.checkMeasurmentTypes(is, formName); // deepcode ignore XXE: XXE protection applied internally via XmlUtils.createSecureJaxbSource()
+            Vector measurementTypes = EctFindMeasurementTypeUtil.checkMeasurmentTypes(is, formName); // deepcode ignore java/XXE: XXE protection applied internally via XmlUtils.createSecureJaxbSource()
             EctMeasurementTypesBean mt;
 
             ResultSet rs;

--- a/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FrmSetupForm2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FrmSetupForm2Action.java
@@ -162,7 +162,7 @@ public final class FrmSetupForm2Action extends ActionSupport {
             File formDir = new File(formDirPath);
             File validatedForm = PathValidationUtils.validatePath(formName + ".xml", formDir);
             try (InputStream is = new FileInputStream(validatedForm)) {
-            Vector measurementTypes = EctFindMeasurementTypeUtil.checkMeasurmentTypes(is, formName);
+            Vector measurementTypes = EctFindMeasurementTypeUtil.checkMeasurmentTypes(is, formName); // deepcode ignore XXE: XXE protection applied internally via XmlUtils.createSecureJaxbSource()
             EctMeasurementTypesBean mt;
 
             ResultSet rs;

--- a/src/main/java/io/github/carlos_emr/carlos/utility/XmlUtils.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/XmlUtils.java
@@ -312,7 +312,7 @@ public final class XmlUtils {
     public static SAXSource createSecureJaxbSource(InputStream inputStream) throws ParserConfigurationException, SAXException {
         SAXParserFactory spf = createSecureSAXParserFactory();
         spf.setNamespaceAware(true);
-        XMLReader xr = spf.newSAXParser().getXMLReader();
+        XMLReader xr = spf.newSAXParser().getXMLReader(); // nosemgrep: xmlreader-xxe, xmlreader-xxe-parameter-entities -- XXE protection applied by createSecureSAXParserFactory() above
         return new SAXSource(xr, new InputSource(inputStream));
     }
 


### PR DESCRIPTION
## Summary

- Suppresses all 20 open XXE (CWE-611) code scanning alerts across 9 files
- **All 20 are false positives** — the code already uses `XmlUtils.createSecure*()` factory methods with comprehensive XXE protections (disallow-doctype-decl, external-general-entities=false, external-parameter-entities=false, FEATURE_SECURE_PROCESSING=true)
- Semgrep PRO and SnykCode cannot trace through the factory method indirection, so they flag the downstream parser creation as vulnerable
- Zero logic changes — only inline suppression comments added

### Alert Breakdown

| Scanner | Rule | Alerts | Suppression |
|---------|------|--------|-------------|
| Semgrep PRO | `xmlreader-xxe` + `xmlreader-xxe-parameter-entities` | 14 (7 locations) | `// nosemgrep` |
| Semgrep PRO | `validator-xxe` | 2 | `// nosemgrep` |
| SnykCode | `java/XXE` | 1 | `// deepcode ignore XXE` |
| SnykCode | `python/InsecureXmlParser` | 1 | `# deepcode ignore InsecureXmlParser` |

### Files Modified

| File | Change |
|------|--------|
| `XmlUtils.java:315` | nosemgrep on `createSecureJaxbSource()` XMLReader |
| `DemographicExportAction42Action.java:3693` | nosemgrep on `createSecureValidator()` |
| `IndicatorTemplateHandler.java:117` | nosemgrep on `createSecureValidator()` |
| `DesAntenatalPlannerRisks_99_12.java:102,143` | nosemgrep on XMLReader from `createSecureSAXParserFactory()` |
| `DesAntenatalPlannerChecklist_99_12.java:118` | nosemgrep on XMLReader from `createSecureSAXParserFactory()` |
| `OBRisks_99_12.java:83,105` | nosemgrep on XMLReader from `createSecureSAXParserFactory()` |
| `OBChecklist_99_12.java:91` | nosemgrep on XMLReader from `createSecureSAXParserFactory()` |
| `FrmSetupForm2Action.java:165` | deepcode ignore (traces to `XmlUtils.createSecureJaxbSource()`) |
| `convert_jrxml_v6_to_v7.py:576` | deepcode ignore (DOCTYPE stripped; Python 3.12 safe; build script) |

### Post-merge: fallback alert dismissal

If any alerts persist after CI scans, dismiss via:
```bash
for ALERT in 6256 5787 5569 5568 5567 5566 5021 5020 5019 5018 5017 5016 4718 4717 4716 4715 4714 4713 4308 4278; do
  gh api -X PATCH /repos/carlos-emr/carlos/code-scanning/alerts/$ALERT \
    -f state=dismissed -f dismissed_reason=false_positive \
    -f dismissed_comment="False positive: XXE protection applied via XmlUtils.createSecure*() factory methods"
done
```

## Test plan

- [x] `mvn compile -q` passes clean
- [x] Python script dry-run works correctly
- [ ] CI Semgrep scan shows no new XXE alerts
- [ ] CI Snyk scan shows no new XXE alerts
- [ ] Verify 20 alerts close in GitHub Security tab after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppress 20 false‑positive XXE (CWE‑611) alerts across 9 files by adding targeted `// nosemgrep` on `XMLReader` and `Validator` creation and `deepcode ignore` notes in Java and Python. No logic changes; XML parsing already uses `XmlUtils.createSecure*()`, and the build script strips DOCTYPE and now documents the safe `ET.fromstring` call (Python 3.12 expat blocks external entities).

<sup>Written for commit 96b3caa8056c304eec1b9dbc36273a6defe219c1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

