### PR TITLE
feat: DTO projection layer for Provider and Demographic entities

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/ProviderDao.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/ProviderDao.java
@@ -31,6 +31,7 @@
 
 package io.github.carlos_emr.carlos.PMmodule.dao;
 
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -179,8 +180,8 @@ public interface ProviderDao {
      * Returns provider summaries for the given provider numbers as a map keyed
      * by provider number. Useful for batch lookups to avoid N+1 queries.
      *
-     * @param providerNumbers List of String provider numbers to look up
+     * @param providerNumbers Collection of String provider numbers to look up (List or Set both accepted)
      * @return Map of providerNo to ProviderSummaryDTO
      */
-    public Map<String, ProviderSummaryDTO> getProviderSummariesByIds(List<String> providerNumbers);
+    public Map<String, ProviderSummaryDTO> getProviderSummariesByIds(Collection<String> providerNumbers);
 }

--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/ProviderDao.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/ProviderDao.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 
 import io.github.carlos_emr.carlos.commn.model.Provider;
+import io.github.carlos_emr.carlos.provider.dto.ProviderSummaryDTO;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 
 import io.github.carlos_emr.carlos.model.security.SecProvider;
@@ -153,4 +154,33 @@ public interface ProviderDao {
     public List<Provider> getProvidersByIds(List<String> providerNumbers);
 
     public Map<String, String> getProviderNamesByIdsAsMap(List<String> providerNumbers);
+
+    // --- DTO projection methods ---
+
+    /**
+     * Returns all active providers as lightweight summary DTOs using JPQL constructor
+     * expression projection. Fetches only name, specialty, status, and team fields,
+     * ordered by last name.
+     *
+     * @return List of ProviderSummaryDTO for all active providers
+     */
+    public List<ProviderSummaryDTO> getActiveProviderSummaries();
+
+    /**
+     * Returns a single provider as a lightweight summary DTO, or null if the
+     * provider number does not exist.
+     *
+     * @param providerNo String the provider number to look up
+     * @return ProviderSummaryDTO the provider summary, or null if not found
+     */
+    public ProviderSummaryDTO getProviderSummary(String providerNo);
+
+    /**
+     * Returns provider summaries for the given provider numbers as a map keyed
+     * by provider number. Useful for batch lookups to avoid N+1 queries.
+     *
+     * @param providerNumbers List of String provider numbers to look up
+     * @return Map of providerNo to ProviderSummaryDTO
+     */
+    public Map<String, ProviderSummaryDTO> getProviderSummariesByIds(List<String> providerNumbers);
 }

--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/ProviderDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/ProviderDaoImpl.java
@@ -752,7 +752,7 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
     @Override
     public List<ProviderSummaryDTO> getActiveProviderSummaries() {
         Query<ProviderSummaryDTO> query = currentSession().createQuery(
-                "SELECT NEW io.github.carlos_emr.carlos.provider.dto.ProviderSummaryDTO(p.ProviderNo, p.LastName, p.FirstName, p.Specialty, p.Status, p.Team) FROM Provider p WHERE p.Status = '1' ORDER BY p.LastName, p.FirstName",
+                "SELECT NEW io.github.carlos_emr.carlos.provider.dto.ProviderSummaryDTO(p.ProviderNo, p.LastName, p.FirstName, p.Specialty, p.Status, p.Team) FROM Provider p WHERE p.Status = '1' AND p.ProviderNo NOT LIKE '-%' ORDER BY p.LastName, p.FirstName",
                 ProviderSummaryDTO.class);
         return query.list();
     }

--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/ProviderDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/ProviderDaoImpl.java
@@ -48,6 +48,7 @@ import io.github.carlos_emr.carlos.commn.model.Provider;
 import io.github.carlos_emr.carlos.commn.model.ProviderFacility;
 import io.github.carlos_emr.carlos.commn.model.ProviderFacilityPK;
 import io.github.carlos_emr.carlos.dao.AbstractHibernateDao;
+import io.github.carlos_emr.carlos.provider.dto.ProviderSummaryDTO;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
@@ -743,5 +744,45 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
         }
 
         return providerNameMap;
+    }
+
+    // --- DTO projection methods ---
+
+    @Override
+    public List<ProviderSummaryDTO> getActiveProviderSummaries() {
+        Query<ProviderSummaryDTO> query = currentSession().createQuery(
+                "SELECT NEW io.github.carlos_emr.carlos.provider.dto.ProviderSummaryDTO(p.ProviderNo, p.LastName, p.FirstName, p.Specialty, p.Status, p.Team) FROM Provider p WHERE p.Status = '1' ORDER BY p.LastName, p.FirstName",
+                ProviderSummaryDTO.class);
+        return query.list();
+    }
+
+    @Override
+    public ProviderSummaryDTO getProviderSummary(String providerNo) {
+        if (providerNo == null || providerNo.isEmpty()) {
+            return null;
+        }
+        Query<ProviderSummaryDTO> query = currentSession().createQuery(
+                "SELECT NEW io.github.carlos_emr.carlos.provider.dto.ProviderSummaryDTO(p.ProviderNo, p.LastName, p.FirstName, p.Specialty, p.Status, p.Team) FROM Provider p WHERE p.ProviderNo = :providerNo",
+                ProviderSummaryDTO.class);
+        query.setParameter("providerNo", providerNo);
+        query.setMaxResults(1);
+        List<ProviderSummaryDTO> results = query.list();
+        return results.isEmpty() ? null : results.get(0);
+    }
+
+    @Override
+    public Map<String, ProviderSummaryDTO> getProviderSummariesByIds(List<String> providerNumbers) {
+        Map<String, ProviderSummaryDTO> map = new HashMap<>();
+        if (providerNumbers == null || providerNumbers.isEmpty()) {
+            return map;
+        }
+        Query<ProviderSummaryDTO> query = currentSession().createQuery(
+                "SELECT NEW io.github.carlos_emr.carlos.provider.dto.ProviderSummaryDTO(p.ProviderNo, p.LastName, p.FirstName, p.Specialty, p.Status, p.Team) FROM Provider p WHERE p.ProviderNo IN (:providerNumbers)",
+                ProviderSummaryDTO.class);
+        query.setParameterList("providerNumbers", providerNumbers);
+        for (ProviderSummaryDTO dto : query.list()) {
+            map.put(dto.getProviderNo(), dto);
+        }
+        return map;
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/ProviderDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/ProviderDaoImpl.java
@@ -749,11 +749,19 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
 
     // --- DTO projection methods ---
 
+    private static final String ACTIVE_PROVIDER_SUMMARIES_HQL =
+            "SELECT NEW io.github.carlos_emr.carlos.provider.dto.ProviderSummaryDTO(p.ProviderNo, p.LastName, p.FirstName, p.Specialty, p.Status, p.Team) FROM Provider p WHERE p.Status = '1' AND p.ProviderNo NOT LIKE '-%' ORDER BY p.LastName, p.FirstName";
+
+    private static final String PROVIDER_SUMMARY_BY_ID_HQL =
+            "SELECT NEW io.github.carlos_emr.carlos.provider.dto.ProviderSummaryDTO(p.ProviderNo, p.LastName, p.FirstName, p.Specialty, p.Status, p.Team) FROM Provider p WHERE p.ProviderNo = :providerNo";
+
+    private static final String PROVIDER_SUMMARIES_BY_IDS_HQL =
+            "SELECT NEW io.github.carlos_emr.carlos.provider.dto.ProviderSummaryDTO(p.ProviderNo, p.LastName, p.FirstName, p.Specialty, p.Status, p.Team) FROM Provider p WHERE p.ProviderNo IN (:providerNumbers)";
+
     @Override
     public List<ProviderSummaryDTO> getActiveProviderSummaries() {
         Query<ProviderSummaryDTO> query = currentSession().createQuery(
-                "SELECT NEW io.github.carlos_emr.carlos.provider.dto.ProviderSummaryDTO(p.ProviderNo, p.LastName, p.FirstName, p.Specialty, p.Status, p.Team) FROM Provider p WHERE p.Status = '1' AND p.ProviderNo NOT LIKE '-%' ORDER BY p.LastName, p.FirstName",
-                ProviderSummaryDTO.class);
+                ACTIVE_PROVIDER_SUMMARIES_HQL, ProviderSummaryDTO.class);
         return query.list();
     }
 
@@ -763,8 +771,7 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
             return null;
         }
         Query<ProviderSummaryDTO> query = currentSession().createQuery(
-                "SELECT NEW io.github.carlos_emr.carlos.provider.dto.ProviderSummaryDTO(p.ProviderNo, p.LastName, p.FirstName, p.Specialty, p.Status, p.Team) FROM Provider p WHERE p.ProviderNo = :providerNo",
-                ProviderSummaryDTO.class);
+                PROVIDER_SUMMARY_BY_ID_HQL, ProviderSummaryDTO.class);
         query.setParameter("providerNo", providerNo);
         query.setMaxResults(1);
         List<ProviderSummaryDTO> results = query.list();
@@ -778,8 +785,7 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
             return map;
         }
         Query<ProviderSummaryDTO> query = currentSession().createQuery(
-                "SELECT NEW io.github.carlos_emr.carlos.provider.dto.ProviderSummaryDTO(p.ProviderNo, p.LastName, p.FirstName, p.Specialty, p.Status, p.Team) FROM Provider p WHERE p.ProviderNo IN (:providerNumbers)",
-                ProviderSummaryDTO.class);
+                PROVIDER_SUMMARIES_BY_IDS_HQL, ProviderSummaryDTO.class);
         query.setParameterList("providerNumbers", providerNumbers);
         for (ProviderSummaryDTO dto : query.list()) {
             map.put(dto.getProviderNo(), dto);

--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/ProviderDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/ProviderDaoImpl.java
@@ -33,6 +33,7 @@ package io.github.carlos_emr.carlos.PMmodule.dao;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -771,7 +772,7 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
     }
 
     @Override
-    public Map<String, ProviderSummaryDTO> getProviderSummariesByIds(List<String> providerNumbers) {
+    public Map<String, ProviderSummaryDTO> getProviderSummariesByIds(Collection<String> providerNumbers) {
         Map<String, ProviderSummaryDTO> map = new HashMap<>();
         if (providerNumbers == null || providerNumbers.isEmpty()) {
             return map;

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDao.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDao.java
@@ -456,7 +456,8 @@ public interface DemographicDao {
      * encounter/chart page display. Uses JPQL constructor expression projection.
      *
      * @param demographicNo Integer the patient demographic number
-     * @return DemographicHeaderDTO the header data, or null if not found
+     * @return DemographicHeaderDTO the header data, or {@code null} if not found or demographicNo is null
+     * @since 2026-04-11
      */
     public DemographicHeaderDTO getDemographicHeader(Integer demographicNo);
 
@@ -464,12 +465,13 @@ public interface DemographicDao {
      * Searches demographics by name and returns lightweight list item DTOs.
      * Uses JPQL constructor expression projection to avoid loading full entities.
      *
-     * @param searchString String the name search string (last,first or last first)
+     * @param searchString String the name search string in "lastName" or "lastName,firstName" format
      * @param limit int maximum number of results
      * @param offset int starting position
      * @param providerNo String the logged-in provider number for domain filtering
      * @param outOfDomain boolean whether to include out-of-domain patients
-     * @return List of DemographicListItemDTO matching the search criteria
+     * @return List of DemographicListItemDTO matching the search criteria, ordered by last name then first name
+     * @since 2026-04-11
      */
     public List<DemographicListItemDTO> searchDemographicDTOByName(String searchString, int limit, int offset,
                                                                     String providerNo, boolean outOfDomain);

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDao.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDao.java
@@ -39,6 +39,8 @@ import io.github.carlos_emr.carlos.PMmodule.web.formbean.ClientSearchFormBean;
 import io.github.carlos_emr.carlos.commn.Gender;
 import io.github.carlos_emr.carlos.commn.model.Demographic;
 import io.github.carlos_emr.carlos.commn.model.DemographicExt;
+import io.github.carlos_emr.carlos.demographic.dto.DemographicHeaderDTO;
+import io.github.carlos_emr.carlos.demographic.dto.DemographicListItemDTO;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.webserv.rest.to.model.DemographicSearchRequest;
 import io.github.carlos_emr.carlos.webserv.rest.to.model.DemographicSearchResult;
@@ -446,4 +448,29 @@ public interface DemographicDao {
     public List<Demographic> findByPhone(String phone, String start, int numToReturn);
 
     public List<Demographic> findByHin(String hin, String start, int numToReturn);
+
+    // --- DTO projection methods ---
+
+    /**
+     * Returns a demographic header DTO with pre-joined provider name for
+     * encounter/chart page display. Uses JPQL constructor expression projection.
+     *
+     * @param demographicNo Integer the patient demographic number
+     * @return DemographicHeaderDTO the header data, or null if not found
+     */
+    public DemographicHeaderDTO getDemographicHeader(Integer demographicNo);
+
+    /**
+     * Searches demographics by name and returns lightweight list item DTOs.
+     * Uses JPQL constructor expression projection to avoid loading full entities.
+     *
+     * @param searchString String the name search string (last,first or last first)
+     * @param limit int maximum number of results
+     * @param offset int starting position
+     * @param providerNo String the logged-in provider number for domain filtering
+     * @param outOfDomain boolean whether to include out-of-domain patients
+     * @return List of DemographicListItemDTO matching the search criteria
+     */
+    public List<DemographicListItemDTO> searchDemographicDTOByName(String searchString, int limit, int offset,
+                                                                    String providerNo, boolean outOfDomain);
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDaoImpl.java
@@ -65,6 +65,8 @@ import io.github.carlos_emr.carlos.commn.Gender;
 import io.github.carlos_emr.carlos.commn.NativeSql;
 import io.github.carlos_emr.carlos.commn.model.Demographic;
 import io.github.carlos_emr.carlos.commn.model.DemographicExt;
+import io.github.carlos_emr.carlos.demographic.dto.DemographicHeaderDTO;
+import io.github.carlos_emr.carlos.demographic.dto.DemographicListItemDTO;
 import io.github.carlos_emr.carlos.event.DemographicCreateEvent;
 import io.github.carlos_emr.carlos.event.DemographicUpdateEvent;
 import io.github.carlos_emr.carlos.integration.hl7.generators.HL7A04Generator;
@@ -2980,6 +2982,49 @@ public class DemographicDaoImpl extends AbstractHibernateDao implements Applicat
             startIndex,
             numToReturn,
             true);
+    }
+
+    // --- DTO projection methods ---
+
+    @Override
+    public DemographicHeaderDTO getDemographicHeader(Integer demographicNo) {
+        if (demographicNo == null) {
+            return null;
+        }
+        Query<DemographicHeaderDTO> query = currentSession().createQuery(
+                "SELECT NEW io.github.carlos_emr.carlos.demographic.dto.DemographicHeaderDTO(d.DemographicNo, d.LastName, d.FirstName, d.Sex, d.SexDesc, d.YearOfBirth, d.MonthOfBirth, d.DateOfBirth, d.Hin, d.Ver, d.HcType, d.ChartNo, d.PatientStatus, d.RosterStatus, d.ProviderNo, p.LastName, p.FirstName) FROM Demographic d LEFT JOIN Provider p ON p.ProviderNo = d.ProviderNo WHERE d.DemographicNo = :demoNo",
+                DemographicHeaderDTO.class);
+        query.setParameter("demoNo", demographicNo);
+        query.setMaxResults(1);
+        List<DemographicHeaderDTO> results = query.list();
+        return results.isEmpty() ? null : results.get(0);
+    }
+
+    @Override
+    public List<DemographicListItemDTO> searchDemographicDTOByName(String searchString, int limit, int offset,
+                                                                    String providerNo, boolean outOfDomain) {
+        String baseQuery = "SELECT NEW io.github.carlos_emr.carlos.demographic.dto.DemographicListItemDTO(d.DemographicNo, d.LastName, d.FirstName, d.Alias, d.Sex, d.YearOfBirth, d.MonthOfBirth, d.DateOfBirth, d.PatientStatus, d.RosterStatus, d.ProviderNo, d.ChartNo, d.Phone, d.Email, d.Hin, d.Address) FROM Demographic d WHERE d.LastName like :lastName";
+        String[] name = Objects.requireNonNullElse(searchString, "").split(",");
+        boolean hasFirstName = name.length == 2;
+
+        if (hasFirstName) {
+            baseQuery = baseQuery.concat(" and (d.FirstName like :firstName or d.Alias like :firstName)");
+        }
+        if (providerNo != null && !outOfDomain) {
+            baseQuery = baseQuery.concat(" AND d.id IN (select distinct a.clientId from ProgramProvider pp,Admission a WHERE pp.ProgramId=a.programId AND pp.ProviderNo=:providerNo)");
+        }
+
+        Query<DemographicListItemDTO> query = currentSession().createQuery(baseQuery, DemographicListItemDTO.class);
+        query.setParameter("lastName", name[0].trim() + "%");
+        if (hasFirstName) {
+            query.setParameter("firstName", name[1].trim() + "%");
+        }
+        if (providerNo != null && !outOfDomain) {
+            query.setParameter("providerNo", providerNo);
+        }
+        query.setFirstResult(offset);
+        query.setMaxResults(limit);
+        return query.list();
     }
 
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDaoImpl.java
@@ -3011,7 +3011,7 @@ public class DemographicDaoImpl extends AbstractHibernateDao implements Applicat
             baseQuery = baseQuery.concat(" and (d.FirstName like :firstName or d.Alias like :firstName)");
         }
         if (providerNo != null && !outOfDomain) {
-            baseQuery = baseQuery.concat(" AND d.id IN (select distinct a.clientId from ProgramProvider pp,Admission a WHERE pp.ProgramId=a.programId AND pp.ProviderNo=:providerNo)");
+            baseQuery = baseQuery.concat(" AND d.id IN (" + PROGRAM_DOMAIN_RESTRICTION + ")");
         }
 
         Query<DemographicListItemDTO> query = currentSession().createQuery(baseQuery, DemographicListItemDTO.class);

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDaoImpl.java
@@ -2986,6 +2986,14 @@ public class DemographicDaoImpl extends AbstractHibernateDao implements Applicat
 
     // --- DTO projection methods ---
 
+    /**
+     * Returns a lightweight header projection for a single demographic, including
+     * the most responsible provider's name via a LEFT JOIN.
+     *
+     * @param demographicNo Integer the demographic ID to retrieve
+     * @return DemographicHeaderDTO the header projection, or {@code null} if not found or demographicNo is null
+     * @since 2026-04-11
+     */
     @Override
     public DemographicHeaderDTO getDemographicHeader(Integer demographicNo) {
         if (demographicNo == null) {
@@ -3000,6 +3008,19 @@ public class DemographicDaoImpl extends AbstractHibernateDao implements Applicat
         return results.isEmpty() ? null : results.get(0);
     }
 
+    /**
+     * Searches demographics by name and returns lightweight list item projections.
+     * Supports "lastName" or "lastName,firstName" format. Results are ordered by
+     * last name then first name ascending.
+     *
+     * @param searchString String the search string in "lastName" or "lastName,firstName" format
+     * @param limit int maximum number of results to return
+     * @param offset int starting position for pagination
+     * @param providerNo String the provider number for program domain restriction (can be null to skip)
+     * @param outOfDomain boolean if true, skip program domain restriction even when providerNo is set
+     * @return List of DemographicListItemDTO matching demographics, ordered by name
+     * @since 2026-04-11
+     */
     @Override
     public List<DemographicListItemDTO> searchDemographicDTOByName(String searchString, int limit, int offset,
                                                                     String providerNo, boolean outOfDomain) {
@@ -3013,6 +3034,7 @@ public class DemographicDaoImpl extends AbstractHibernateDao implements Applicat
         if (providerNo != null && !outOfDomain) {
             baseQuery = baseQuery.concat(" AND d.id IN (" + PROGRAM_DOMAIN_RESTRICTION + ")");
         }
+        baseQuery = baseQuery.concat(" ORDER BY d.LastName ASC, d.FirstName ASC");
 
         Query<DemographicListItemDTO> query = currentSession().createQuery(baseQuery, DemographicListItemDTO.class);
         query.setParameter("lastName", name[0].trim() + "%");

--- a/src/main/java/io/github/carlos_emr/carlos/commn/web/SearchDemographicAutoComplete2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/web/SearchDemographicAutoComplete2Action.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -46,14 +47,14 @@ import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.commn.dao.DemographicDao;
 import io.github.carlos_emr.carlos.commn.model.Demographic;
 import io.github.carlos_emr.carlos.commn.model.DemographicCust;
+import io.github.carlos_emr.carlos.PMmodule.dao.ProviderDao;
+import io.github.carlos_emr.carlos.provider.dto.ProviderSummaryDTO;
 import io.github.carlos_emr.carlos.utility.AppointmentUtil;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 
 import io.github.carlos_emr.CarlosProperties;
-import io.github.carlos_emr.carlos.prescript.data.RxProviderData;
-import io.github.carlos_emr.carlos.prescript.data.RxProviderData.Provider;
 
 /**
  * Struts 2 action providing JSON autocomplete results for demographic (patient) searches.
@@ -102,7 +103,6 @@ public class SearchDemographicAutoComplete2Action extends ActionSupport {
         boolean activeOnly = false;
         activeOnly = request.getParameter("activeOnly") != null && request.getParameter("activeOnly").equalsIgnoreCase("true");
         boolean jqueryJSON = request.getParameter("jqueryJSON") != null && request.getParameter("jqueryJSON").equalsIgnoreCase("true");
-        RxProviderData rx = new RxProviderData();
 
 
         if (searchStr == null || searchStr.trim().isEmpty()) {
@@ -160,8 +160,34 @@ public class SearchDemographicAutoComplete2Action extends ActionSupport {
         }
 
 
-        // Hoist DAO lookup outside loop to avoid N+1 bean resolution on every iteration
+        // Hoist DAO lookups outside loop to avoid N+1 bean resolution on every iteration
         DemographicCustDao demographicCustDao = (DemographicCustDao) SpringUtils.getBean(DemographicCustDao.class);
+        ProviderDao providerDao = SpringUtils.getBean(ProviderDao.class);
+
+        // Batch-load all referenced provider numbers in a single query instead of N+1 RxProviderData lookups
+        List<String> providerNos = new ArrayList<>();
+        for (Demographic demo : list) {
+            if (demo.getProviderNo() != null && !demo.getProviderNo().isEmpty()) {
+                providerNos.add(demo.getProviderNo());
+            }
+        }
+        boolean workflowEnhance = CarlosProperties.getInstance().isPropertyActive("workflow_enhance");
+        if (workflowEnhance) {
+            for (Demographic demo : list) {
+                DemographicCust dc = demographicCustDao.find(demo.getDemographicNo());
+                if (dc != null) {
+                    String n = StringUtils.trimToNull(dc.getNurse());
+                    String r = StringUtils.trimToNull(dc.getResident());
+                    String m = StringUtils.trimToNull(dc.getMidwife());
+                    if (n != null) providerNos.add(n);
+                    if (r != null) providerNos.add(r);
+                    if (m != null) providerNos.add(m);
+                }
+            }
+        }
+        Map<String, ProviderSummaryDTO> providerMap = providerNos.isEmpty()
+                ? new HashMap<>()
+                : providerDao.getProviderSummariesByIds(providerNos);
 
         List<HashMap<String, String>> secondList = new ArrayList<HashMap<String, String>>();
         for (Demographic demo : list) {
@@ -178,13 +204,12 @@ public class SearchDemographicAutoComplete2Action extends ActionSupport {
             h.put("hin", demo.getHin() != null ? demo.getHin() : "");
             h.put("address", demo.getAddress() != null ? demo.getAddress() : "");
 
-
-            Provider p = rx.getProvider(demo.getProviderNo());
             if (demo.getProviderNo() != null) {
                 h.put("providerNo", demo.getProviderNo());
-            }
-            if (p.getSurname() != null && p.getFirstName() != null) {
-                h.put("providerName", p.getSurname() + ", " + p.getFirstName());
+                ProviderSummaryDTO prov = providerMap.get(demo.getProviderNo());
+                if (prov != null) {
+                    h.put("providerName", prov.getFormattedName());
+                }
             }
 
             DemographicCust demographicCust = demographicCustDao.find(demo.getDemographicNo());
@@ -192,7 +217,7 @@ public class SearchDemographicAutoComplete2Action extends ActionSupport {
             String alertText = (demographicCust != null && demographicCust.getAlert() != null) ? demographicCust.getAlert() : "";
             h.put("alert", alertText);
 
-            if (CarlosProperties.getInstance().isPropertyActive("workflow_enhance")) {
+            if (workflowEnhance) {
                 h.put("nextAppointment", AppointmentUtil.getNextAppointment(demo.getDemographicNo() + ""));
 
                 if (demographicCust != null) {
@@ -201,18 +226,18 @@ public class SearchDemographicAutoComplete2Action extends ActionSupport {
                     String cust4 = StringUtils.trimToNull(demographicCust.getMidwife());
                     if (cust1 != null) {
                         h.put("cust1", cust1);
-                        p = rx.getProvider(cust1);
-                        h.put("cust1Name", p.getSurname() + ", " + p.getFirstName());
+                        ProviderSummaryDTO c1 = providerMap.get(cust1);
+                        if (c1 != null) h.put("cust1Name", c1.getFormattedName());
                     }
                     if (cust2 != null) {
                         h.put("cust2", cust2);
-                        p = rx.getProvider(cust2);
-                        h.put("cust2Name", p.getSurname() + ", " + p.getFirstName());
+                        ProviderSummaryDTO c2 = providerMap.get(cust2);
+                        if (c2 != null) h.put("cust2Name", c2.getFormattedName());
                     }
                     if (cust4 != null) {
                         h.put("cust4", cust4);
-                        p = rx.getProvider(cust4);
-                        h.put("cust4Name", p.getSurname() + ", " + p.getFirstName());
+                        ProviderSummaryDTO c4 = providerMap.get(cust4);
+                        if (c4 != null) h.put("cust4Name", c4.getFormattedName());
                     }
                 }
             }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/web/SearchDemographicAutoComplete2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/web/SearchDemographicAutoComplete2Action.java
@@ -174,20 +174,18 @@ public class SearchDemographicAutoComplete2Action extends ActionSupport {
             }
         }
         boolean workflowEnhance = CarlosProperties.getInstance().isPropertyActive("workflow_enhance");
-        // Cache DemographicCust records fetched during workflow pre-pass to avoid a second query per patient in the render loop
+        // Pre-load all DemographicCust records to avoid N+1 queries in the render loop
         Map<Integer, DemographicCust> dcMap = new HashMap<>();
-        if (workflowEnhance) {
-            for (Demographic demo : list) {
-                DemographicCust dc = demographicCustDao.find(demo.getDemographicNo());
-                dcMap.put(demo.getDemographicNo(), dc);
-                if (dc != null) {
-                    String n = StringUtils.trimToNull(dc.getNurse());
-                    String r = StringUtils.trimToNull(dc.getResident());
-                    String m = StringUtils.trimToNull(dc.getMidwife());
-                    if (n != null) providerNos.add(n);
-                    if (r != null) providerNos.add(r);
-                    if (m != null) providerNos.add(m);
-                }
+        for (Demographic demo : list) {
+            DemographicCust dc = demographicCustDao.find(demo.getDemographicNo());
+            dcMap.put(demo.getDemographicNo(), dc);
+            if (workflowEnhance && dc != null) {
+                String n = StringUtils.trimToNull(dc.getNurse());
+                String r = StringUtils.trimToNull(dc.getResident());
+                String m = StringUtils.trimToNull(dc.getMidwife());
+                if (n != null) providerNos.add(n);
+                if (r != null) providerNos.add(r);
+                if (m != null) providerNos.add(m);
             }
         }
         Map<String, ProviderSummaryDTO> providerMap = providerNos.isEmpty()
@@ -217,10 +215,8 @@ public class SearchDemographicAutoComplete2Action extends ActionSupport {
                 }
             }
 
-            // Reuse cached DemographicCust from workflow pre-pass if available, otherwise fetch once
-            DemographicCust demographicCust = dcMap.containsKey(demo.getDemographicNo())
-                    ? dcMap.get(demo.getDemographicNo())
-                    : demographicCustDao.find(demo.getDemographicNo());
+            // Reuse pre-loaded DemographicCust from the cache
+            DemographicCust demographicCust = dcMap.get(demo.getDemographicNo());
 
             String alertText = (demographicCust != null && demographicCust.getAlert() != null) ? demographicCust.getAlert() : "";
             h.put("alert", alertText);

--- a/src/main/java/io/github/carlos_emr/carlos/commn/web/SearchDemographicAutoComplete2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/web/SearchDemographicAutoComplete2Action.java
@@ -232,21 +232,9 @@ public class SearchDemographicAutoComplete2Action extends ActionSupport {
                     String cust1 = StringUtils.trimToNull(demographicCust.getNurse());
                     String cust2 = StringUtils.trimToNull(demographicCust.getResident());
                     String cust4 = StringUtils.trimToNull(demographicCust.getMidwife());
-                    if (cust1 != null) {
-                        h.put("cust1", cust1);
-                        ProviderSummaryDTO c1 = providerMap.get(cust1);
-                        if (c1 != null) h.put("cust1Name", c1.getFormattedName());
-                    }
-                    if (cust2 != null) {
-                        h.put("cust2", cust2);
-                        ProviderSummaryDTO c2 = providerMap.get(cust2);
-                        if (c2 != null) h.put("cust2Name", c2.getFormattedName());
-                    }
-                    if (cust4 != null) {
-                        h.put("cust4", cust4);
-                        ProviderSummaryDTO c4 = providerMap.get(cust4);
-                        if (c4 != null) h.put("cust4Name", c4.getFormattedName());
-                    }
+                    putCustProvider(h, "cust1", cust1, providerMap);
+                    putCustProvider(h, "cust2", cust2, providerMap);
+                    putCustProvider(h, "cust4", cust4, providerMap);
                 }
             }
 
@@ -273,6 +261,14 @@ public class SearchDemographicAutoComplete2Action extends ActionSupport {
         }
         return null;
 
+    }
+
+    private static void putCustProvider(HashMap<String, String> h, String key, String providerNo,
+                                           Map<String, ProviderSummaryDTO> providerMap) {
+        if (providerNo == null) return;
+        h.put(key, providerNo);
+        ProviderSummaryDTO prov = providerMap.get(providerNo);
+        if (prov != null) h.put(key + "Name", prov.getFormattedName());
     }
 
     private String formatJSON(List<HashMap<String, String>> info) {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/web/SearchDemographicAutoComplete2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/web/SearchDemographicAutoComplete2Action.java
@@ -33,8 +33,10 @@ package io.github.carlos_emr.carlos.commn.web;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -165,16 +167,19 @@ public class SearchDemographicAutoComplete2Action extends ActionSupport {
         ProviderDao providerDao = SpringUtils.getBean(ProviderDao.class);
 
         // Batch-load all referenced provider numbers in a single query instead of N+1 RxProviderData lookups
-        List<String> providerNos = new ArrayList<>();
+        Set<String> providerNos = new LinkedHashSet<>();
         for (Demographic demo : list) {
             if (demo.getProviderNo() != null && !demo.getProviderNo().isEmpty()) {
                 providerNos.add(demo.getProviderNo());
             }
         }
         boolean workflowEnhance = CarlosProperties.getInstance().isPropertyActive("workflow_enhance");
+        // Cache DemographicCust records fetched during workflow pre-pass to avoid a second query per patient in the render loop
+        Map<Integer, DemographicCust> dcMap = new HashMap<>();
         if (workflowEnhance) {
             for (Demographic demo : list) {
                 DemographicCust dc = demographicCustDao.find(demo.getDemographicNo());
+                dcMap.put(demo.getDemographicNo(), dc);
                 if (dc != null) {
                     String n = StringUtils.trimToNull(dc.getNurse());
                     String r = StringUtils.trimToNull(dc.getResident());
@@ -204,7 +209,7 @@ public class SearchDemographicAutoComplete2Action extends ActionSupport {
             h.put("hin", demo.getHin() != null ? demo.getHin() : "");
             h.put("address", demo.getAddress() != null ? demo.getAddress() : "");
 
-            if (demo.getProviderNo() != null) {
+            if (demo.getProviderNo() != null && !demo.getProviderNo().isEmpty()) {
                 h.put("providerNo", demo.getProviderNo());
                 ProviderSummaryDTO prov = providerMap.get(demo.getProviderNo());
                 if (prov != null) {
@@ -212,7 +217,10 @@ public class SearchDemographicAutoComplete2Action extends ActionSupport {
                 }
             }
 
-            DemographicCust demographicCust = demographicCustDao.find(demo.getDemographicNo());
+            // Reuse cached DemographicCust from workflow pre-pass if available, otherwise fetch once
+            DemographicCust demographicCust = dcMap.containsKey(demo.getDemographicNo())
+                    ? dcMap.get(demo.getDemographicNo())
+                    : demographicCustDao.find(demo.getDemographicNo());
 
             String alertText = (demographicCust != null && demographicCust.getAlert() != null) ? demographicCust.getAlert() : "";
             h.put("alert", alertText);

--- a/src/main/java/io/github/carlos_emr/carlos/demographic/dto/DemographicHeaderDTO.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/dto/DemographicHeaderDTO.java
@@ -1,0 +1,313 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ * <p>
+ * Now maintained by the CARLOS EMR Project (2026+).
+ * https://github.com/carlos-emr/carlos
+ * CARLOS has no affiliation with OSCAR or McMaster University.
+ */
+package io.github.carlos_emr.carlos.demographic.dto;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.time.Period;
+
+/**
+ * Lightweight data transfer object for encounter and chart page headers.
+ * Optimized for JPQL constructor expression projection with a LEFT JOIN
+ * to Provider for the MRP name.
+ *
+ * <p>PHI minimization: this DTO omits SIN, address, phone, and email
+ * which are not displayed in encounter headers.</p>
+ *
+ * @since 2026-04-11
+ */
+public class DemographicHeaderDTO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private Integer demographicNo;
+    private String lastName;
+    private String firstName;
+    private String sex;
+    private String sexDesc;
+    private String yearOfBirth;
+    private String monthOfBirth;
+    private String dateOfBirth;
+    private String hin;
+    private String ver;
+    private String hcType;
+    private String chartNo;
+    private String patientStatus;
+    private String rosterStatus;
+    private String providerNo;
+    private String providerLastName;
+    private String providerFirstName;
+
+    /**
+     * Default constructor required by frameworks.
+     */
+    public DemographicHeaderDTO() {
+    }
+
+    /**
+     * Projection constructor for JPQL constructor expressions. Parameter order
+     * must match the SELECT NEW clause exactly.
+     *
+     * @param demographicNo Integer the patient demographic number
+     * @param lastName String the patient's last name
+     * @param firstName String the patient's first name
+     * @param sex String the patient's sex code
+     * @param sexDesc String the sex description (from formula join)
+     * @param yearOfBirth String the birth year (4 digits)
+     * @param monthOfBirth String the birth month (2 digits)
+     * @param dateOfBirth String the birth day (2 digits)
+     * @param hin String the Health Insurance Number
+     * @param ver String the HIN version code
+     * @param hcType String the health card type (province)
+     * @param chartNo String the chart number
+     * @param patientStatus String the patient status code
+     * @param rosterStatus String the roster status
+     * @param providerNo String the most responsible provider number
+     * @param providerLastName String the MRP's last name (from LEFT JOIN)
+     * @param providerFirstName String the MRP's first name (from LEFT JOIN)
+     */
+    public DemographicHeaderDTO(Integer demographicNo, String lastName, String firstName,
+                                String sex, String sexDesc,
+                                String yearOfBirth, String monthOfBirth, String dateOfBirth,
+                                String hin, String ver, String hcType,
+                                String chartNo, String patientStatus, String rosterStatus,
+                                String providerNo, String providerLastName, String providerFirstName) {
+        this.demographicNo = demographicNo;
+        this.lastName = lastName;
+        this.firstName = firstName;
+        this.sex = sex;
+        this.sexDesc = sexDesc;
+        this.yearOfBirth = yearOfBirth;
+        this.monthOfBirth = monthOfBirth;
+        this.dateOfBirth = dateOfBirth;
+        this.hin = hin;
+        this.ver = ver;
+        this.hcType = hcType;
+        this.chartNo = chartNo;
+        this.patientStatus = patientStatus;
+        this.rosterStatus = rosterStatus;
+        this.providerNo = providerNo;
+        this.providerLastName = providerLastName;
+        this.providerFirstName = providerFirstName;
+    }
+
+    /**
+     * Returns the patient's formatted name as "LastName, FirstName".
+     *
+     * @return String the formatted name
+     */
+    public String getFormattedName() {
+        StringBuilder sb = new StringBuilder();
+        if (lastName != null) sb.append(lastName);
+        sb.append(", ");
+        if (firstName != null) sb.append(firstName);
+        return sb.toString();
+    }
+
+    /**
+     * Returns the date of birth formatted as "YYYY-MM-DD", or empty string
+     * if any component is missing.
+     *
+     * @return String the formatted date of birth
+     */
+    public String getFormattedDob() {
+        if (yearOfBirth == null || monthOfBirth == null || dateOfBirth == null) {
+            return "";
+        }
+        return yearOfBirth + "-" + monthOfBirth + "-" + dateOfBirth;
+    }
+
+    /**
+     * Computes the patient's age in years based on the DOB components.
+     *
+     * @return String the age in years, or empty string if DOB is incomplete
+     */
+    public String getAge() {
+        if (yearOfBirth == null || monthOfBirth == null || dateOfBirth == null) {
+            return "";
+        }
+        try {
+            LocalDate dob = LocalDate.of(
+                    Integer.parseInt(yearOfBirth),
+                    Integer.parseInt(monthOfBirth),
+                    Integer.parseInt(dateOfBirth));
+            return String.valueOf(Period.between(dob, LocalDate.now()).getYears());
+        } catch (NumberFormatException e) {
+            return "";
+        }
+    }
+
+    /**
+     * Returns the MRP (Most Responsible Provider) formatted name as
+     * "LastName, FirstName", or empty string if no provider is assigned.
+     *
+     * @return String the formatted provider name
+     */
+    public String getProviderName() {
+        if (providerLastName == null && providerFirstName == null) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder();
+        if (providerLastName != null) sb.append(providerLastName.trim());
+        if (providerFirstName != null) {
+            if (sb.length() > 0) sb.append(", ");
+            sb.append(providerFirstName.trim());
+        }
+        return sb.toString();
+    }
+
+    public Integer getDemographicNo() {
+        return demographicNo;
+    }
+
+    public void setDemographicNo(Integer demographicNo) {
+        this.demographicNo = demographicNo;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getSex() {
+        return sex;
+    }
+
+    public void setSex(String sex) {
+        this.sex = sex;
+    }
+
+    public String getSexDesc() {
+        return sexDesc;
+    }
+
+    public void setSexDesc(String sexDesc) {
+        this.sexDesc = sexDesc;
+    }
+
+    public String getYearOfBirth() {
+        return yearOfBirth;
+    }
+
+    public void setYearOfBirth(String yearOfBirth) {
+        this.yearOfBirth = yearOfBirth;
+    }
+
+    public String getMonthOfBirth() {
+        return monthOfBirth;
+    }
+
+    public void setMonthOfBirth(String monthOfBirth) {
+        this.monthOfBirth = monthOfBirth;
+    }
+
+    public String getDateOfBirth() {
+        return dateOfBirth;
+    }
+
+    public void setDateOfBirth(String dateOfBirth) {
+        this.dateOfBirth = dateOfBirth;
+    }
+
+    public String getHin() {
+        return hin;
+    }
+
+    public void setHin(String hin) {
+        this.hin = hin;
+    }
+
+    public String getVer() {
+        return ver;
+    }
+
+    public void setVer(String ver) {
+        this.ver = ver;
+    }
+
+    public String getHcType() {
+        return hcType;
+    }
+
+    public void setHcType(String hcType) {
+        this.hcType = hcType;
+    }
+
+    public String getChartNo() {
+        return chartNo;
+    }
+
+    public void setChartNo(String chartNo) {
+        this.chartNo = chartNo;
+    }
+
+    public String getPatientStatus() {
+        return patientStatus;
+    }
+
+    public void setPatientStatus(String patientStatus) {
+        this.patientStatus = patientStatus;
+    }
+
+    public String getRosterStatus() {
+        return rosterStatus;
+    }
+
+    public void setRosterStatus(String rosterStatus) {
+        this.rosterStatus = rosterStatus;
+    }
+
+    public String getProviderNo() {
+        return providerNo;
+    }
+
+    public void setProviderNo(String providerNo) {
+        this.providerNo = providerNo;
+    }
+
+    public String getProviderLastName() {
+        return providerLastName;
+    }
+
+    public void setProviderLastName(String providerLastName) {
+        this.providerLastName = providerLastName;
+    }
+
+    public String getProviderFirstName() {
+        return providerFirstName;
+    }
+
+    public void setProviderFirstName(String providerFirstName) {
+        this.providerFirstName = providerFirstName;
+    }
+}

--- a/src/main/java/io/github/carlos_emr/carlos/demographic/dto/DemographicHeaderDTO.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/dto/DemographicHeaderDTO.java
@@ -139,10 +139,12 @@ public class DemographicHeaderDTO implements Serializable {
      * @return String the formatted date of birth
      */
     public String getFormattedDob() {
-        if (yearOfBirth == null || monthOfBirth == null || dateOfBirth == null) {
+        if (yearOfBirth == null || yearOfBirth.trim().isEmpty()
+                || monthOfBirth == null || monthOfBirth.trim().isEmpty()
+                || dateOfBirth == null || dateOfBirth.trim().isEmpty()) {
             return "";
         }
-        return yearOfBirth + "-" + monthOfBirth + "-" + dateOfBirth;
+        return yearOfBirth.trim() + "-" + monthOfBirth.trim() + "-" + dateOfBirth.trim();
     }
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/demographic/dto/DemographicHeaderDTO.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/dto/DemographicHeaderDTO.java
@@ -25,6 +25,9 @@ import java.io.Serializable;
 import java.time.LocalDate;
 import java.time.Period;
 
+import io.github.carlos_emr.carlos.utility.DtoFormatUtils;
+import io.github.carlos_emr.carlos.utility.MiscUtils;
+
 /**
  * Lightweight data transfer object for encounter and chart page headers.
  * Optimized for JPQL constructor expression projection with a LEFT JOIN
@@ -116,20 +119,7 @@ public class DemographicHeaderDTO implements Serializable {
      * @return String the formatted name
      */
     public String getFormattedName() {
-        if (lastName == null && firstName == null) {
-            return "N/A";
-        }
-        StringBuilder sb = new StringBuilder();
-        if (lastName != null) {
-            sb.append(lastName.trim());
-        }
-        if (firstName != null) {
-            if (sb.length() > 0) {
-                sb.append(", ");
-            }
-            sb.append(firstName.trim());
-        }
-        return sb.toString();
+        return DtoFormatUtils.formatName(lastName, firstName, "N/A");
     }
 
     /**
@@ -139,12 +129,7 @@ public class DemographicHeaderDTO implements Serializable {
      * @return String the formatted date of birth
      */
     public String getFormattedDob() {
-        if (yearOfBirth == null || yearOfBirth.trim().isEmpty()
-                || monthOfBirth == null || monthOfBirth.trim().isEmpty()
-                || dateOfBirth == null || dateOfBirth.trim().isEmpty()) {
-            return "";
-        }
-        return yearOfBirth.trim() + "-" + monthOfBirth.trim() + "-" + dateOfBirth.trim();
+        return DtoFormatUtils.formatDob(yearOfBirth, monthOfBirth, dateOfBirth);
     }
 
     /**
@@ -163,6 +148,8 @@ public class DemographicHeaderDTO implements Serializable {
                     Integer.parseInt(dateOfBirth));
             return String.valueOf(Period.between(dob, LocalDate.now()).getYears());
         } catch (NumberFormatException | java.time.DateTimeException e) {
+            MiscUtils.getLogger().warn("Invalid DOB components for demographic {}: year={}, month={}, day={}",
+                    demographicNo, yearOfBirth, monthOfBirth, dateOfBirth);
             return "";
         }
     }
@@ -174,16 +161,7 @@ public class DemographicHeaderDTO implements Serializable {
      * @return String the formatted provider name
      */
     public String getProviderName() {
-        if (providerLastName == null && providerFirstName == null) {
-            return "";
-        }
-        StringBuilder sb = new StringBuilder();
-        if (providerLastName != null) sb.append(providerLastName.trim());
-        if (providerFirstName != null) {
-            if (sb.length() > 0) sb.append(", ");
-            sb.append(providerFirstName.trim());
-        }
-        return sb.toString();
+        return DtoFormatUtils.formatName(providerLastName, providerFirstName, "");
     }
 
     public Integer getDemographicNo() {

--- a/src/main/java/io/github/carlos_emr/carlos/demographic/dto/DemographicHeaderDTO.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/dto/DemographicHeaderDTO.java
@@ -148,8 +148,7 @@ public class DemographicHeaderDTO implements Serializable {
                     Integer.parseInt(dateOfBirth));
             return String.valueOf(Period.between(dob, LocalDate.now()).getYears());
         } catch (NumberFormatException | java.time.DateTimeException e) {
-            MiscUtils.getLogger().warn("Invalid DOB components for demographic {}: year={}, month={}, day={}",
-                    demographicNo, yearOfBirth, monthOfBirth, dateOfBirth);
+            MiscUtils.getLogger().warn("Invalid DOB components for demographic {}", demographicNo);
             return "";
         }
     }

--- a/src/main/java/io/github/carlos_emr/carlos/demographic/dto/DemographicHeaderDTO.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/dto/DemographicHeaderDTO.java
@@ -116,10 +116,19 @@ public class DemographicHeaderDTO implements Serializable {
      * @return String the formatted name
      */
     public String getFormattedName() {
+        if (lastName == null && firstName == null) {
+            return "N/A";
+        }
         StringBuilder sb = new StringBuilder();
-        if (lastName != null) sb.append(lastName);
-        sb.append(", ");
-        if (firstName != null) sb.append(firstName);
+        if (lastName != null) {
+            sb.append(lastName.trim());
+        }
+        if (firstName != null) {
+            if (sb.length() > 0) {
+                sb.append(", ");
+            }
+            sb.append(firstName.trim());
+        }
         return sb.toString();
     }
 
@@ -151,7 +160,7 @@ public class DemographicHeaderDTO implements Serializable {
                     Integer.parseInt(monthOfBirth),
                     Integer.parseInt(dateOfBirth));
             return String.valueOf(Period.between(dob, LocalDate.now()).getYears());
-        } catch (NumberFormatException e) {
+        } catch (NumberFormatException | java.time.DateTimeException e) {
             return "";
         }
     }

--- a/src/main/java/io/github/carlos_emr/carlos/demographic/dto/DemographicListItemDTO.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/dto/DemographicListItemDTO.java
@@ -151,7 +151,7 @@ public class DemographicListItemDTO implements Serializable {
      * @return String the formatted name
      */
     public String getFormattedName() {
-        if (lastName == null && firstName == null) {
+        if (lastName == null && firstName == null && (alias == null || alias.trim().isEmpty())) {
             return "N/A";
         }
         StringBuilder sb = new StringBuilder();
@@ -177,10 +177,12 @@ public class DemographicListItemDTO implements Serializable {
      * @return String the formatted date of birth
      */
     public String getFormattedDob() {
-        if (yearOfBirth == null || monthOfBirth == null || dateOfBirth == null) {
+        if (yearOfBirth == null || yearOfBirth.trim().isEmpty()
+                || monthOfBirth == null || monthOfBirth.trim().isEmpty()
+                || dateOfBirth == null || dateOfBirth.trim().isEmpty()) {
             return "";
         }
-        return yearOfBirth + "-" + monthOfBirth + "-" + dateOfBirth;
+        return yearOfBirth.trim() + "-" + monthOfBirth.trim() + "-" + dateOfBirth.trim();
     }
 
     public Integer getDemographicNo() {

--- a/src/main/java/io/github/carlos_emr/carlos/demographic/dto/DemographicListItemDTO.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/dto/DemographicListItemDTO.java
@@ -160,6 +160,9 @@ public class DemographicListItemDTO implements Serializable {
         }
         String base = DtoFormatUtils.formatName(lastName, firstName, "");
         if (hasAlias) {
+            if (base.isEmpty()) {
+                return "(" + alias.trim() + ")";
+            }
             return base + " (" + alias.trim() + ")";
         }
         return base;

--- a/src/main/java/io/github/carlos_emr/carlos/demographic/dto/DemographicListItemDTO.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/dto/DemographicListItemDTO.java
@@ -151,12 +151,21 @@ public class DemographicListItemDTO implements Serializable {
      * @return String the formatted name
      */
     public String getFormattedName() {
+        if (lastName == null && firstName == null) {
+            return "N/A";
+        }
         StringBuilder sb = new StringBuilder();
-        if (lastName != null) sb.append(lastName);
-        sb.append(", ");
-        if (firstName != null) sb.append(firstName);
-        if (alias != null && !alias.isEmpty()) {
-            sb.append(" (").append(alias).append(")");
+        if (lastName != null) {
+            sb.append(lastName.trim());
+        }
+        if (firstName != null) {
+            if (sb.length() > 0) {
+                sb.append(", ");
+            }
+            sb.append(firstName.trim());
+        }
+        if (alias != null && !alias.trim().isEmpty()) {
+            sb.append(" (").append(alias.trim()).append(")");
         }
         return sb.toString();
     }

--- a/src/main/java/io/github/carlos_emr/carlos/demographic/dto/DemographicListItemDTO.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/dto/DemographicListItemDTO.java
@@ -22,8 +22,10 @@
 package io.github.carlos_emr.carlos.demographic.dto;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 import io.github.carlos_emr.carlos.commn.model.Demographic;
+import io.github.carlos_emr.carlos.utility.DtoFormatUtils;
 
 /**
  * Lightweight data transfer object for patient search results and autocomplete,
@@ -122,6 +124,7 @@ public class DemographicListItemDTO implements Serializable {
      * @return DemographicListItemDTO a lightweight projection
      */
     public static DemographicListItemDTO fromEntity(Demographic d) {
+        Objects.requireNonNull(d, "Demographic entity must not be null for DTO conversion");
         DemographicListItemDTO dto = new DemographicListItemDTO(
                 d.getDemographicNo(),
                 d.getLastName(),
@@ -151,23 +154,15 @@ public class DemographicListItemDTO implements Serializable {
      * @return String the formatted name
      */
     public String getFormattedName() {
-        if (lastName == null && firstName == null && (alias == null || alias.trim().isEmpty())) {
+        boolean hasAlias = alias != null && !alias.trim().isEmpty();
+        if (lastName == null && firstName == null && !hasAlias) {
             return "N/A";
         }
-        StringBuilder sb = new StringBuilder();
-        if (lastName != null) {
-            sb.append(lastName.trim());
+        String base = DtoFormatUtils.formatName(lastName, firstName, "");
+        if (hasAlias) {
+            return base + " (" + alias.trim() + ")";
         }
-        if (firstName != null) {
-            if (sb.length() > 0) {
-                sb.append(", ");
-            }
-            sb.append(firstName.trim());
-        }
-        if (alias != null && !alias.trim().isEmpty()) {
-            sb.append(" (").append(alias.trim()).append(")");
-        }
-        return sb.toString();
+        return base;
     }
 
     /**
@@ -177,12 +172,7 @@ public class DemographicListItemDTO implements Serializable {
      * @return String the formatted date of birth
      */
     public String getFormattedDob() {
-        if (yearOfBirth == null || yearOfBirth.trim().isEmpty()
-                || monthOfBirth == null || monthOfBirth.trim().isEmpty()
-                || dateOfBirth == null || dateOfBirth.trim().isEmpty()) {
-            return "";
-        }
-        return yearOfBirth.trim() + "-" + monthOfBirth.trim() + "-" + dateOfBirth.trim();
+        return DtoFormatUtils.formatDob(yearOfBirth, monthOfBirth, dateOfBirth);
     }
 
     public Integer getDemographicNo() {

--- a/src/main/java/io/github/carlos_emr/carlos/demographic/dto/DemographicListItemDTO.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/dto/DemographicListItemDTO.java
@@ -1,0 +1,312 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ * <p>
+ * Now maintained by the CARLOS EMR Project (2026+).
+ * https://github.com/carlos-emr/carlos
+ * CARLOS has no affiliation with OSCAR or McMaster University.
+ */
+package io.github.carlos_emr.carlos.demographic.dto;
+
+import java.io.Serializable;
+
+import io.github.carlos_emr.carlos.commn.model.Demographic;
+
+/**
+ * Lightweight data transfer object for patient search results and autocomplete,
+ * optimized for JPQL constructor expression projection. Carries only the fields
+ * needed for patient identification in search results.
+ *
+ * <p>PHI minimization: this DTO deliberately omits SIN (Social Insurance Number)
+ * which is never displayed in search results.</p>
+ *
+ * <p>The {@code cellPhone} field is not part of the JPQL projection constructor
+ * because it comes from the {@code demographic_ext} table. It can be populated
+ * post-query via {@link #setCellPhone(String)} if needed.</p>
+ *
+ * @since 2026-04-11
+ */
+public class DemographicListItemDTO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private Integer demographicNo;
+    private String lastName;
+    private String firstName;
+    private String alias;
+    private String sex;
+    private String yearOfBirth;
+    private String monthOfBirth;
+    private String dateOfBirth;
+    private String patientStatus;
+    private String rosterStatus;
+    private String providerNo;
+    private String chartNo;
+    private String phone;
+    private String email;
+    private String hin;
+    private String address;
+
+    // Not part of JPQL projection — populated post-query from DemographicExt
+    private String cellPhone;
+
+    /**
+     * Default constructor required by frameworks.
+     */
+    public DemographicListItemDTO() {
+    }
+
+    /**
+     * Projection constructor for JPQL constructor expressions. Parameter order
+     * must match the SELECT NEW clause exactly. Does not include cellPhone
+     * (loaded from demographic_ext, not the demographic table).
+     *
+     * @param demographicNo Integer the patient demographic number
+     * @param lastName String the patient's last name
+     * @param firstName String the patient's first name
+     * @param alias String the patient's alias/preferred name
+     * @param sex String the patient's sex code
+     * @param yearOfBirth String the birth year (4 digits)
+     * @param monthOfBirth String the birth month (2 digits)
+     * @param dateOfBirth String the birth day (2 digits)
+     * @param patientStatus String the patient status code (AC, IN, DE, etc.)
+     * @param rosterStatus String the roster status
+     * @param providerNo String the most responsible provider number
+     * @param chartNo String the chart number
+     * @param phone String the primary phone number
+     * @param email String the email address
+     * @param hin String the Health Insurance Number
+     * @param address String the primary address
+     */
+    public DemographicListItemDTO(Integer demographicNo, String lastName, String firstName,
+                                  String alias, String sex,
+                                  String yearOfBirth, String monthOfBirth, String dateOfBirth,
+                                  String patientStatus, String rosterStatus,
+                                  String providerNo, String chartNo,
+                                  String phone, String email, String hin, String address) {
+        this.demographicNo = demographicNo;
+        this.lastName = lastName;
+        this.firstName = firstName;
+        this.alias = alias;
+        this.sex = sex;
+        this.yearOfBirth = yearOfBirth;
+        this.monthOfBirth = monthOfBirth;
+        this.dateOfBirth = dateOfBirth;
+        this.patientStatus = patientStatus;
+        this.rosterStatus = rosterStatus;
+        this.providerNo = providerNo;
+        this.chartNo = chartNo;
+        this.phone = phone;
+        this.email = email;
+        this.hin = hin;
+        this.address = address;
+    }
+
+    /**
+     * Creates a DemographicListItemDTO from a full Demographic entity.
+     *
+     * @param d Demographic the entity to convert; must not be null
+     * @return DemographicListItemDTO a lightweight projection
+     */
+    public static DemographicListItemDTO fromEntity(Demographic d) {
+        DemographicListItemDTO dto = new DemographicListItemDTO(
+                d.getDemographicNo(),
+                d.getLastName(),
+                d.getFirstName(),
+                d.getAlias(),
+                d.getSex(),
+                d.getYearOfBirth(),
+                d.getMonthOfBirth(),
+                d.getDateOfBirth(),
+                d.getPatientStatus(),
+                d.getRosterStatus(),
+                d.getProviderNo(),
+                d.getChartNo(),
+                d.getPhone(),
+                d.getEmail(),
+                d.getHin(),
+                d.getAddress()
+        );
+        dto.setCellPhone(d.getCellPhone());
+        return dto;
+    }
+
+    /**
+     * Returns the patient's formatted name as "LastName, FirstName" with alias
+     * appended in parentheses if present.
+     *
+     * @return String the formatted name
+     */
+    public String getFormattedName() {
+        StringBuilder sb = new StringBuilder();
+        if (lastName != null) sb.append(lastName);
+        sb.append(", ");
+        if (firstName != null) sb.append(firstName);
+        if (alias != null && !alias.isEmpty()) {
+            sb.append(" (").append(alias).append(")");
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Returns the date of birth formatted as "YYYY-MM-DD", or empty string
+     * if any component is missing.
+     *
+     * @return String the formatted date of birth
+     */
+    public String getFormattedDob() {
+        if (yearOfBirth == null || monthOfBirth == null || dateOfBirth == null) {
+            return "";
+        }
+        return yearOfBirth + "-" + monthOfBirth + "-" + dateOfBirth;
+    }
+
+    public Integer getDemographicNo() {
+        return demographicNo;
+    }
+
+    public void setDemographicNo(Integer demographicNo) {
+        this.demographicNo = demographicNo;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getAlias() {
+        return alias;
+    }
+
+    public void setAlias(String alias) {
+        this.alias = alias;
+    }
+
+    public String getSex() {
+        return sex;
+    }
+
+    public void setSex(String sex) {
+        this.sex = sex;
+    }
+
+    public String getYearOfBirth() {
+        return yearOfBirth;
+    }
+
+    public void setYearOfBirth(String yearOfBirth) {
+        this.yearOfBirth = yearOfBirth;
+    }
+
+    public String getMonthOfBirth() {
+        return monthOfBirth;
+    }
+
+    public void setMonthOfBirth(String monthOfBirth) {
+        this.monthOfBirth = monthOfBirth;
+    }
+
+    public String getDateOfBirth() {
+        return dateOfBirth;
+    }
+
+    public void setDateOfBirth(String dateOfBirth) {
+        this.dateOfBirth = dateOfBirth;
+    }
+
+    public String getPatientStatus() {
+        return patientStatus;
+    }
+
+    public void setPatientStatus(String patientStatus) {
+        this.patientStatus = patientStatus;
+    }
+
+    public String getRosterStatus() {
+        return rosterStatus;
+    }
+
+    public void setRosterStatus(String rosterStatus) {
+        this.rosterStatus = rosterStatus;
+    }
+
+    public String getProviderNo() {
+        return providerNo;
+    }
+
+    public void setProviderNo(String providerNo) {
+        this.providerNo = providerNo;
+    }
+
+    public String getChartNo() {
+        return chartNo;
+    }
+
+    public void setChartNo(String chartNo) {
+        this.chartNo = chartNo;
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public void setPhone(String phone) {
+        this.phone = phone;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getHin() {
+        return hin;
+    }
+
+    public void setHin(String hin) {
+        this.hin = hin;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public String getCellPhone() {
+        return cellPhone;
+    }
+
+    public void setCellPhone(String cellPhone) {
+        this.cellPhone = cellPhone;
+    }
+}

--- a/src/main/java/io/github/carlos_emr/carlos/managers/DemographicManager.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/DemographicManager.java
@@ -236,18 +236,23 @@ public interface DemographicManager {
      * @param loggedInInfo LoggedInInfo the logged-in user context
      * @param demographicId Integer the patient demographic number
      * @return DemographicHeaderDTO the header data, or null if not found
+     * @throws RuntimeException if the logged-in user lacks read privilege on _demographic
+     * @since 2026-04-11
      */
     public DemographicHeaderDTO getDemographicHeader(LoggedInInfo loggedInInfo, Integer demographicId);
 
     /**
      * Searches demographics by name and returns lightweight list item DTOs.
-     * Enforces read privilege check.
+     * Enforces read privilege check. Results are restricted to the logged-in
+     * provider's program domain.
      *
      * @param loggedInInfo LoggedInInfo the logged-in user context
-     * @param searchString String the name search string
-     * @param startIndex int starting position
-     * @param itemsToReturn int maximum results
-     * @return List of DemographicListItemDTO matching the search
+     * @param searchString String the name search string in "lastName" or "lastName,firstName" format
+     * @param startIndex int starting position for pagination
+     * @param itemsToReturn int maximum number of results to return
+     * @return List of DemographicListItemDTO matching the search within the provider's domain
+     * @throws RuntimeException if the logged-in user lacks read privilege on _demographic
+     * @since 2026-04-11
      */
     public List<DemographicListItemDTO> searchDemographicDTOs(LoggedInInfo loggedInInfo, String searchString,
                                                               int startIndex, int itemsToReturn);

--- a/src/main/java/io/github/carlos_emr/carlos/managers/DemographicManager.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/DemographicManager.java
@@ -35,6 +35,8 @@ package io.github.carlos_emr.carlos.managers;
 import io.github.carlos_emr.carlos.commn.Gender;
 import io.github.carlos_emr.carlos.commn.exception.PatientDirectiveException;
 import io.github.carlos_emr.carlos.commn.model.*;
+import io.github.carlos_emr.carlos.demographic.dto.DemographicHeaderDTO;
+import io.github.carlos_emr.carlos.demographic.dto.DemographicListItemDTO;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.webserv.rest.to.model.DemographicSearchRequest;
 import io.github.carlos_emr.carlos.webserv.rest.to.model.DemographicSearchResult;
@@ -224,4 +226,29 @@ public interface DemographicManager {
     public String getNextAppointmentDate(LoggedInInfo loggedInInfo, Integer demographicNo);
 
     public String getNextAppointmentDate(LoggedInInfo loggedInInfo, Demographic demographic);
+
+    // --- DTO projection methods ---
+
+    /**
+     * Returns a lightweight demographic header for encounter/chart display.
+     * Includes pre-joined provider name. Enforces read privilege check.
+     *
+     * @param loggedInInfo LoggedInInfo the logged-in user context
+     * @param demographicId Integer the patient demographic number
+     * @return DemographicHeaderDTO the header data, or null if not found
+     */
+    public DemographicHeaderDTO getDemographicHeader(LoggedInInfo loggedInInfo, Integer demographicId);
+
+    /**
+     * Searches demographics by name and returns lightweight list item DTOs.
+     * Enforces read privilege check.
+     *
+     * @param loggedInInfo LoggedInInfo the logged-in user context
+     * @param searchString String the name search string
+     * @param startIndex int starting position
+     * @param itemsToReturn int maximum results
+     * @return List of DemographicListItemDTO matching the search
+     */
+    public List<DemographicListItemDTO> searchDemographicDTOs(LoggedInInfo loggedInInfo, String searchString,
+                                                              int startIndex, int itemsToReturn);
 }

--- a/src/main/java/io/github/carlos_emr/carlos/managers/DemographicManagerImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/DemographicManagerImpl.java
@@ -1279,13 +1279,14 @@ public class DemographicManagerImpl implements DemographicManager {
 
     // --- DTO projection methods ---
 
+    /** {@inheritDoc} */
     @Override
     public DemographicHeaderDTO getDemographicHeader(LoggedInInfo loggedInInfo, Integer demographicId) {
-        if (demographicId != null) {
-            checkPrivilege(loggedInInfo, SecurityInfoManager.READ, demographicId);
-        } else {
+        if (demographicId == null) {
             checkPrivilege(loggedInInfo, SecurityInfoManager.READ);
+            return null;
         }
+        checkPrivilege(loggedInInfo, SecurityInfoManager.READ, demographicId);
         DemographicHeaderDTO result = demographicDao.getDemographicHeader(demographicId);
         if (result != null) {
             LogAction.addLogSynchronous(loggedInInfo, "DemographicManager.getDemographicHeader",
@@ -1294,6 +1295,7 @@ public class DemographicManagerImpl implements DemographicManager {
         return result;
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<DemographicListItemDTO> searchDemographicDTOs(LoggedInInfo loggedInInfo, String searchString,
                                                               int startIndex, int itemsToReturn) {

--- a/src/main/java/io/github/carlos_emr/carlos/managers/DemographicManagerImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/DemographicManagerImpl.java
@@ -127,7 +127,11 @@ public class DemographicManagerImpl implements DemographicManager {
 	 */
      @Override
      public Demographic getDemographic(LoggedInInfo loggedInInfo, Integer demographicId) throws PatientDirectiveException {
-        checkPrivilege(loggedInInfo, SecurityInfoManager.READ, (demographicId != null) ? demographicId : null); 
+        if (demographicId != null) {
+            checkPrivilege(loggedInInfo, SecurityInfoManager.READ, demographicId);
+        } else {
+            checkPrivilege(loggedInInfo, SecurityInfoManager.READ);
+        }
         Demographic demographic = demographicDao.getDemographicById(demographicId); 
         if (demographic != null) {
 			this.getMRP(loggedInInfo, demographic);
@@ -1277,7 +1281,11 @@ public class DemographicManagerImpl implements DemographicManager {
 
     @Override
     public DemographicHeaderDTO getDemographicHeader(LoggedInInfo loggedInInfo, Integer demographicId) {
-        checkPrivilege(loggedInInfo, SecurityInfoManager.READ, (demographicId != null) ? demographicId : null);
+        if (demographicId != null) {
+            checkPrivilege(loggedInInfo, SecurityInfoManager.READ, demographicId);
+        } else {
+            checkPrivilege(loggedInInfo, SecurityInfoManager.READ);
+        }
         return demographicDao.getDemographicHeader(demographicId);
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/managers/DemographicManagerImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/DemographicManagerImpl.java
@@ -40,6 +40,8 @@ import io.github.carlos_emr.carlos.commn.Gender;
 import io.github.carlos_emr.carlos.commn.exception.PatientDirectiveException;
 import io.github.carlos_emr.carlos.commn.model.Demographic.PatientStatus;
 import io.github.carlos_emr.carlos.commn.model.enumerator.DemographicExtKey;
+import io.github.carlos_emr.carlos.demographic.dto.DemographicHeaderDTO;
+import io.github.carlos_emr.carlos.demographic.dto.DemographicListItemDTO;
 import io.github.carlos_emr.carlos.utility.DemographicContactCreator;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
@@ -1269,6 +1271,22 @@ public class DemographicManagerImpl implements DemographicManager {
         String appointmentString = getNextAppointmentDate(loggedInInfo, demographic.getDemographicNo());
         demographic.setNextAppointment(appointmentString);
         return appointmentString;
+    }
+
+    // --- DTO projection methods ---
+
+    @Override
+    public DemographicHeaderDTO getDemographicHeader(LoggedInInfo loggedInInfo, Integer demographicId) {
+        checkPrivilege(loggedInInfo, SecurityInfoManager.READ, (demographicId != null) ? demographicId : null);
+        return demographicDao.getDemographicHeader(demographicId);
+    }
+
+    @Override
+    public List<DemographicListItemDTO> searchDemographicDTOs(LoggedInInfo loggedInInfo, String searchString,
+                                                              int startIndex, int itemsToReturn) {
+        checkPrivilege(loggedInInfo, SecurityInfoManager.READ);
+        String providerNo = loggedInInfo.getLoggedInProviderNo();
+        return demographicDao.searchDemographicDTOByName(searchString, itemsToReturn, startIndex, providerNo, false);
     }
 
 }

--- a/src/main/java/io/github/carlos_emr/carlos/managers/DemographicManagerImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/DemographicManagerImpl.java
@@ -1286,7 +1286,12 @@ public class DemographicManagerImpl implements DemographicManager {
         } else {
             checkPrivilege(loggedInInfo, SecurityInfoManager.READ);
         }
-        return demographicDao.getDemographicHeader(demographicId);
+        DemographicHeaderDTO result = demographicDao.getDemographicHeader(demographicId);
+        if (result != null) {
+            LogAction.addLogSynchronous(loggedInInfo, "DemographicManager.getDemographicHeader",
+                    "demographicId=" + result.getDemographicNo());
+        }
+        return result;
     }
 
     @Override
@@ -1294,7 +1299,16 @@ public class DemographicManagerImpl implements DemographicManager {
                                                               int startIndex, int itemsToReturn) {
         checkPrivilege(loggedInInfo, SecurityInfoManager.READ);
         String providerNo = loggedInInfo.getLoggedInProviderNo();
-        return demographicDao.searchDemographicDTOByName(searchString, itemsToReturn, startIndex, providerNo, false);
+        List<DemographicListItemDTO> results = demographicDao.searchDemographicDTOByName(
+                searchString, itemsToReturn, startIndex, providerNo, false);
+
+        // --- log action ---
+        for (DemographicListItemDTO dto : results) {
+            LogAction.addLogSynchronous(loggedInInfo, "DemographicManager.searchDemographicDTOs result",
+                    "demographicId=" + dto.getDemographicNo());
+        }
+
+        return results;
     }
 
 }

--- a/src/main/java/io/github/carlos_emr/carlos/provider/dto/ProviderSummaryDTO.java
+++ b/src/main/java/io/github/carlos_emr/carlos/provider/dto/ProviderSummaryDTO.java
@@ -22,8 +22,10 @@
 package io.github.carlos_emr.carlos.provider.dto;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 import io.github.carlos_emr.carlos.commn.model.Provider;
+import io.github.carlos_emr.carlos.utility.DtoFormatUtils;
 
 /**
  * Lightweight data transfer object for provider name lookups and list display,
@@ -81,6 +83,7 @@ public class ProviderSummaryDTO implements Serializable {
      * @return ProviderSummaryDTO a lightweight projection of the provider
      */
     public static ProviderSummaryDTO fromEntity(Provider provider) {
+        Objects.requireNonNull(provider, "Provider entity must not be null for DTO conversion");
         return new ProviderSummaryDTO(
                 provider.getProviderNo(),
                 provider.getLastName(),
@@ -97,20 +100,7 @@ public class ProviderSummaryDTO implements Serializable {
      * @return String the formatted name, or "N/A" if both names are null
      */
     public String getFormattedName() {
-        if (lastName == null && firstName == null) {
-            return "N/A";
-        }
-        StringBuilder sb = new StringBuilder();
-        if (lastName != null) {
-            sb.append(lastName.trim());
-        }
-        if (firstName != null) {
-            if (sb.length() > 0) {
-                sb.append(", ");
-            }
-            sb.append(firstName.trim());
-        }
-        return sb.toString();
+        return DtoFormatUtils.formatName(lastName, firstName, "N/A");
     }
 
     public String getProviderNo() {

--- a/src/main/java/io/github/carlos_emr/carlos/provider/dto/ProviderSummaryDTO.java
+++ b/src/main/java/io/github/carlos_emr/carlos/provider/dto/ProviderSummaryDTO.java
@@ -1,0 +1,163 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ * <p>
+ * Now maintained by the CARLOS EMR Project (2026+).
+ * https://github.com/carlos-emr/carlos
+ * CARLOS has no affiliation with OSCAR or McMaster University.
+ */
+package io.github.carlos_emr.carlos.provider.dto;
+
+import java.io.Serializable;
+
+import io.github.carlos_emr.carlos.commn.model.Provider;
+
+/**
+ * Lightweight data transfer object for provider name lookups and list display,
+ * optimized for JPQL constructor expression projection. Carries only the fields
+ * needed for provider identification in dropdowns, autocomplete, and list views.
+ *
+ * <p>Omits billing numbers, phone, address, DOB, email, and other fields that
+ * are only relevant on the provider admin/edit page.</p>
+ *
+ * @since 2026-04-11
+ */
+public class ProviderSummaryDTO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private String providerNo;
+    private String lastName;
+    private String firstName;
+    private String specialty;
+    private String status;
+    private String team;
+
+    /**
+     * Default constructor required by frameworks.
+     */
+    public ProviderSummaryDTO() {
+    }
+
+    /**
+     * Projection constructor for JPQL constructor expressions. Parameter order
+     * must match the SELECT NEW clause exactly.
+     *
+     * @param providerNo String the provider number
+     * @param lastName String the provider's last name
+     * @param firstName String the provider's first name
+     * @param specialty String the provider's specialty
+     * @param status String the provider's active status ("1" = active, "0" = inactive)
+     * @param team String the provider's team assignment
+     */
+    public ProviderSummaryDTO(String providerNo, String lastName, String firstName,
+                              String specialty, String status, String team) {
+        this.providerNo = providerNo;
+        this.lastName = lastName;
+        this.firstName = firstName;
+        this.specialty = specialty;
+        this.status = status;
+        this.team = team;
+    }
+
+    /**
+     * Creates a ProviderSummaryDTO from a full Provider entity, copying only the
+     * summary fields.
+     *
+     * @param provider Provider the entity to convert; must not be null
+     * @return ProviderSummaryDTO a lightweight projection of the provider
+     */
+    public static ProviderSummaryDTO fromEntity(Provider provider) {
+        return new ProviderSummaryDTO(
+                provider.getProviderNo(),
+                provider.getLastName(),
+                provider.getFirstName(),
+                provider.getSpecialty(),
+                provider.getStatus(),
+                provider.getTeam()
+        );
+    }
+
+    /**
+     * Returns the provider's formatted name as "LastName, FirstName".
+     *
+     * @return String the formatted name, or "N/A" if both names are null
+     */
+    public String getFormattedName() {
+        if (lastName == null && firstName == null) {
+            return "N/A";
+        }
+        StringBuilder sb = new StringBuilder();
+        if (lastName != null) {
+            sb.append(lastName.trim());
+        }
+        if (firstName != null) {
+            if (sb.length() > 0) {
+                sb.append(", ");
+            }
+            sb.append(firstName.trim());
+        }
+        return sb.toString();
+    }
+
+    public String getProviderNo() {
+        return providerNo;
+    }
+
+    public void setProviderNo(String providerNo) {
+        this.providerNo = providerNo;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getSpecialty() {
+        return specialty;
+    }
+
+    public void setSpecialty(String specialty) {
+        this.specialty = specialty;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getTeam() {
+        return team;
+    }
+
+    public void setTeam(String team) {
+        this.team = team;
+    }
+}

--- a/src/main/java/io/github/carlos_emr/carlos/utility/DtoFormatUtils.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/DtoFormatUtils.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ * <p>
+ * Now maintained by the CARLOS EMR Project (2026+).
+ * https://github.com/carlos-emr/carlos
+ * CARLOS has no affiliation with OSCAR or McMaster University.
+ */
+package io.github.carlos_emr.carlos.utility;
+
+/**
+ * Shared formatting utilities for DTO display methods. Centralizes the
+ * "LastName, FirstName" and "YYYY-MM-DD" formatting logic used across
+ * Provider and Demographic DTOs.
+ *
+ * @since 2026-04-11
+ */
+public final class DtoFormatUtils {
+
+    private DtoFormatUtils() {
+    }
+
+    /**
+     * Formats a name as "LastName, FirstName", handling nulls gracefully.
+     *
+     * @param lastName String the last name (may be null)
+     * @param firstName String the first name (may be null)
+     * @param fallback String the value to return when both names are null
+     * @return String the formatted name, or fallback if both names are null
+     */
+    public static String formatName(String lastName, String firstName, String fallback) {
+        if (lastName == null && firstName == null) {
+            return fallback;
+        }
+        StringBuilder sb = new StringBuilder();
+        if (lastName != null) {
+            sb.append(lastName.trim());
+        }
+        if (firstName != null) {
+            if (sb.length() > 0) {
+                sb.append(", ");
+            }
+            sb.append(firstName.trim());
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Formats a date of birth from separate components as "YYYY-MM-DD".
+     * Returns empty string if any component is null or blank.
+     *
+     * @param yearOfBirth String the year component (may be null)
+     * @param monthOfBirth String the month component (may be null)
+     * @param dateOfBirth String the day component (may be null)
+     * @return String the formatted date, or empty string if any component is missing
+     */
+    public static String formatDob(String yearOfBirth, String monthOfBirth, String dateOfBirth) {
+        if (yearOfBirth == null || yearOfBirth.trim().isEmpty()
+                || monthOfBirth == null || monthOfBirth.trim().isEmpty()
+                || dateOfBirth == null || dateOfBirth.trim().isEmpty()) {
+            return "";
+        }
+        return yearOfBirth.trim() + "-" + monthOfBirth.trim() + "-" + dateOfBirth.trim();
+    }
+}

--- a/src/main/java/io/github/carlos_emr/carlos/utility/DtoFormatUtils.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/DtoFormatUtils.java
@@ -42,20 +42,30 @@ public final class DtoFormatUtils {
      * @return String the formatted name, or fallback if both names are null
      */
     public static String formatName(String lastName, String firstName, String fallback) {
-        if (lastName == null && firstName == null) {
+        String trimmedLast = trimToNull(lastName);
+        String trimmedFirst = trimToNull(firstName);
+        if (trimmedLast == null && trimmedFirst == null) {
             return fallback;
         }
         StringBuilder sb = new StringBuilder();
-        if (lastName != null) {
-            sb.append(lastName.trim());
+        if (trimmedLast != null) {
+            sb.append(trimmedLast);
         }
-        if (firstName != null) {
+        if (trimmedFirst != null) {
             if (sb.length() > 0) {
                 sb.append(", ");
             }
-            sb.append(firstName.trim());
+            sb.append(trimmedFirst);
         }
         return sb.toString();
+    }
+
+    private static String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
     }
 
     /**


### PR DESCRIPTION
## Summary
- Introduces lightweight DTO classes with JPQL `SELECT NEW` constructor expression projections to replace full entity loading in the web/view layer
- **ProviderSummaryDTO** (6 fields vs 20+ on entity) with batch lookup, eliminating N+1 `RxProviderData.getProvider()` calls in patient autocomplete
- **DemographicListItemDTO** (16 fields, omits SIN for PHI minimization) and **DemographicHeaderDTO** (17 fields with pre-joined provider name and computed age)
- All existing entity-returning DAO/Manager methods are untouched — zero breaking changes
- Follows the established `TicklerListDTO` / `SELECT NEW` pattern from `tickler/dto/`

## Test plan
- [x] `make install` builds successfully
- [x] 198 ProviderDao tests pass (0 failures)
- [x] 310 DemographicDao/DemographicManager tests pass (0 failures)
- [ ] `/ui-tests:test1` — smoke test (login, search, patient records)
- [ ] `/ui-tests:test2` — demographics (create, edit, search, filters)
- [ ] Verify autocomplete JSON response shape is identical before/after

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a lightweight DTO projection layer for Provider and Demographic using JPQL SELECT NEW to return only needed fields. This reduces DB load and removes N+1 provider lookups in patient autocomplete without breaking existing APIs or changing JSON response shape.

- **New Features**
  - Added ProviderSummaryDTO with DAO projections: getActiveProviderSummaries, getProviderSummary, getProviderSummariesByIds.
  - Added DemographicListItemDTO (search, omits SIN) and DemographicHeaderDTO (pre-joined provider name, computed age) with matching DemographicDao/DemographicManager methods and read checks.
  - searchDemographicDTOByName now orders results by last name, then first name.

- **Bug Fixes**
  - Autocomplete: batch provider summaries; dedup provider IDs; preload all DemographicCust; widened getProviderSummariesByIds(Collection<String>); skip empty providerNo.
  - Null-safety: fixed NPE in privilege checks when demographicId is null and early-return in header lookup; DemographicHeaderDTO.getAge() catches DateTimeException.
  - Output correctness: name formatting avoids stray commas and preserves alias; alias-only names render as "(alias)"; whitespace-only names are treated as null; provider name is raw (no "Dr."); getFormattedDob() handles blank components; getActiveProviderSummaries() excludes system providers.
  - Privacy: removed DOB components from warn logs in DemographicHeaderDTO.getAge().

<sup>Written for commit 3cc2405947fc317482994f81b0bdfedf036e6828. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

