### PR TITLE
feat: migrate 28 DAOs from Hibernate Session to JPA EntityManager

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/AgencyDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/AgencyDaoImpl.java
@@ -37,18 +37,18 @@ import org.apache.logging.log4j.Logger;
 import io.github.carlos_emr.carlos.PMmodule.model.Agency;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import org.springframework.transaction.annotation.Transactional;
-import io.github.carlos_emr.carlos.dao.AbstractHibernateDao;
-import io.github.carlos_emr.carlos.utility.HqlQueryHelper;
+import io.github.carlos_emr.carlos.dao.AbstractJpaDao;
+import io.github.carlos_emr.carlos.utility.JpqlQueryHelper;
 
 @Transactional
-public class AgencyDaoImpl extends AbstractHibernateDao implements AgencyDao {
+public class AgencyDaoImpl extends AbstractJpaDao implements AgencyDao {
 
     private Logger log = MiscUtils.getLogger();
 
     public Agency getLocalAgency() {
         Agency agency = null;
 
-        List results = HqlQueryHelper.find(currentSession(), "from Agency a");
+        List results = JpqlQueryHelper.find(entityManager(), "from Agency a");
 
         if (!results.isEmpty()) {
             agency = (Agency) results.get(0);
@@ -63,9 +63,9 @@ public class AgencyDaoImpl extends AbstractHibernateDao implements AgencyDao {
         }
 
         if (agency.getId() == null) {
-            currentSession().persist(agency);
+            entityManager().persist(agency);
         } else {
-            currentSession().merge(agency);
+            entityManager().merge(agency);
         }
 
         if (log.isDebugEnabled()) {

--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/ClientReferralDAOImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/ClientReferralDAOImpl.java
@@ -39,18 +39,18 @@ import io.github.carlos_emr.carlos.PMmodule.model.ClientReferral;
 import io.github.carlos_emr.carlos.PMmodule.model.Program;
 import io.github.carlos_emr.carlos.commn.model.Admission;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
-import io.github.carlos_emr.carlos.dao.AbstractHibernateDao;
+import io.github.carlos_emr.carlos.dao.AbstractJpaDao;
 import org.springframework.transaction.annotation.Transactional;
-import io.github.carlos_emr.carlos.utility.HqlQueryHelper;
+import io.github.carlos_emr.carlos.utility.JpqlQueryHelper;
 
 @Transactional
-public class ClientReferralDAOImpl extends AbstractHibernateDao implements ClientReferralDAO {
+public class ClientReferralDAOImpl extends AbstractJpaDao implements ClientReferralDAO {
 
     private Logger log = MiscUtils.getLogger();
 
     public List<ClientReferral> getReferrals() {
         @SuppressWarnings("unchecked")
-        List<ClientReferral> results = (List<ClientReferral>) HqlQueryHelper.find(currentSession(), "from ClientReferral");
+        List<ClientReferral> results = (List<ClientReferral>) JpqlQueryHelper.find(entityManager(), "from ClientReferral");
 
         if (log.isDebugEnabled()) {
             log.debug("getReferrals: # of results=" + results.size());
@@ -67,7 +67,7 @@ public class ClientReferralDAOImpl extends AbstractHibernateDao implements Clien
         }
         
         String sSQL = "from ClientReferral cr where cr.ClientId = ?1";
-        List<ClientReferral> results = (List<ClientReferral>) HqlQueryHelper.find(currentSession(), sSQL, clientId);
+        List<ClientReferral> results = (List<ClientReferral>) JpqlQueryHelper.find(entityManager(), sSQL, clientId);
 
         if (log.isDebugEnabled()) {
             log.debug("getReferrals: clientId=" + clientId + ",# of results=" + results.size());
@@ -96,7 +96,7 @@ public class ClientReferralDAOImpl extends AbstractHibernateDao implements Clien
             facilityId,
             facilityId
         };
-        List<ClientReferral> results = (List<ClientReferral>) HqlQueryHelper.find(currentSession(), sSQL, param);
+        List<ClientReferral> results = (List<ClientReferral>) JpqlQueryHelper.find(entityManager(), sSQL, param);
 
         if (log.isDebugEnabled()) {
             log.debug("getReferralsByFacility: clientId=" + clientId + ",# of results=" + results.size());
@@ -120,7 +120,7 @@ public class ClientReferralDAOImpl extends AbstractHibernateDao implements Clien
             String sSQL = "from ClientReferral r where r.ClientId = ?1 and r.Id < ?2 order by r.Id desc";
             Object[] param = new Object[]{cr.getClientId(), cr.getId()};
             @SuppressWarnings("unchecked")
-            List<ClientReferral> results = (List<ClientReferral>) HqlQueryHelper.find(currentSession(), sSQL, param);
+            List<ClientReferral> results = (List<ClientReferral>) JpqlQueryHelper.find(entityManager(), sSQL, param);
 
             // temp - completionNotes/Referring program/agency, notes/External
             String completionNotes = "";
@@ -158,7 +158,7 @@ public class ClientReferralDAOImpl extends AbstractHibernateDao implements Clien
 
         String queryStr = "FROM Program p WHERE p.id = ?1 AND p.type = 'external'";
         @SuppressWarnings("unchecked")
-        List<Program> rs = (List<Program>) HqlQueryHelper.find(currentSession(), queryStr, programId);
+        List<Program> rs = (List<Program>) JpqlQueryHelper.find(entityManager(), queryStr, programId);
 
         if (!rs.isEmpty()) {
             result = true;
@@ -178,7 +178,7 @@ public class ClientReferralDAOImpl extends AbstractHibernateDao implements Clien
 
         String queryStr = "FROM Admission a WHERE a.clientId=?1 ORDER BY a.admissionDate DESC";
         @SuppressWarnings("unchecked")
-        List<Admission> rs = (List<Admission>) HqlQueryHelper.find(currentSession(), queryStr, demographicNo);
+        List<Admission> rs = (List<Admission>) JpqlQueryHelper.find(entityManager(), queryStr, demographicNo);
         return rs;
     }
     // end of change
@@ -198,7 +198,7 @@ public class ClientReferralDAOImpl extends AbstractHibernateDao implements Clien
                 ClientReferral.STATUS_PENDING,
                 ClientReferral.STATUS_UNKNOWN
             };
-            results = (List<ClientReferral>) HqlQueryHelper.find(currentSession(), resultQuery, param);
+            results = (List<ClientReferral>) JpqlQueryHelper.find(entityManager(), resultQuery, param);
         } else {
             String sSQL = "from ClientReferral cr where cr.ClientId = ?1 and (cr.Status = ?2 or cr.Status = ?3 or cr.Status = ?4) and ((cr.FacilityId=?5) or (cr.ProgramId in (select s.id from Program s where s.facilityId=?6)))";
             Object params[] = new Object[] {
@@ -209,7 +209,7 @@ public class ClientReferralDAOImpl extends AbstractHibernateDao implements Clien
                 facilityId,
                 facilityId
             };
-            results = (List<ClientReferral>) HqlQueryHelper.find(currentSession(), sSQL, params);
+            results = (List<ClientReferral>) JpqlQueryHelper.find(entityManager(), sSQL, params);
         }
 
         if (log.isDebugEnabled()) {
@@ -237,7 +237,7 @@ public class ClientReferralDAOImpl extends AbstractHibernateDao implements Clien
             ClientReferral.STATUS_ACTIVE,
             ClientReferral.STATUS_CURRENT
         };
-        results = (List<ClientReferral>) HqlQueryHelper.find(currentSession(), sSQL, params);
+        results = (List<ClientReferral>) JpqlQueryHelper.find(entityManager(), sSQL, params);
 
         if (log.isDebugEnabled()) {
             log.debug("getActiveReferralsByClientAndProgram: clientId=" + clientId + "programId " + programId + ", # of results=" + results.size());
@@ -251,7 +251,7 @@ public class ClientReferralDAOImpl extends AbstractHibernateDao implements Clien
             throw new IllegalArgumentException();
         }
 
-        ClientReferral result = currentSession().find(ClientReferral.class, id);
+        ClientReferral result = entityManager().find(ClientReferral.class, id);
 
         if (log.isDebugEnabled()) {
             log.debug("getClientReferral: id=" + id + ",found=" + (result != null));
@@ -266,9 +266,9 @@ public class ClientReferralDAOImpl extends AbstractHibernateDao implements Clien
         }
 
         if (referral.getId() == null) {
-            currentSession().persist(referral);
+            entityManager().persist(referral);
         } else {
-            currentSession().merge(referral);
+            entityManager().merge(referral);
         }
 
         if (log.isDebugEnabled()) {
@@ -280,15 +280,15 @@ public class ClientReferralDAOImpl extends AbstractHibernateDao implements Clien
     @SuppressWarnings("unchecked")
     public List<ClientReferral> search(ClientReferral referral) {
         if (referral != null && referral.getProgramId() != null && referral.getProgramId() > 0) {
-            return (List<ClientReferral>) HqlQueryHelper.find(currentSession(),
+            return (List<ClientReferral>) JpqlQueryHelper.find(entityManager(),
                     "from ClientReferral cr where cr.ProgramId = ?1", referral.getProgramId());
         }
-        return (List<ClientReferral>) HqlQueryHelper.find(currentSession(), "from ClientReferral");
+        return (List<ClientReferral>) JpqlQueryHelper.find(entityManager(), "from ClientReferral");
     }
 
     public List<ClientReferral> getClientReferralsByProgram(int programId) {
         @SuppressWarnings("unchecked")
-        List<ClientReferral> results = (List<ClientReferral>) HqlQueryHelper.find(currentSession(), "from ClientReferral cr where cr.ProgramId = ?1", Long.valueOf(programId));
+        List<ClientReferral> results = (List<ClientReferral>) JpqlQueryHelper.find(entityManager(), "from ClientReferral cr where cr.ProgramId = ?1", Long.valueOf(programId));
 
         return results;
     }

--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/DefaultRoleAccessDAOImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/DefaultRoleAccessDAOImpl.java
@@ -34,41 +34,41 @@ package io.github.carlos_emr.carlos.PMmodule.dao;
 import java.util.List;
 
 import io.github.carlos_emr.carlos.PMmodule.model.DefaultRoleAccess;
-import io.github.carlos_emr.carlos.dao.AbstractHibernateDao;
+import io.github.carlos_emr.carlos.dao.AbstractJpaDao;
 import org.springframework.transaction.annotation.Transactional;
-import io.github.carlos_emr.carlos.utility.HqlQueryHelper;
+import io.github.carlos_emr.carlos.utility.JpqlQueryHelper;
 
 @Transactional
 @SuppressWarnings("unchecked")
-public class DefaultRoleAccessDAOImpl extends AbstractHibernateDao implements DefaultRoleAccessDAO {
+public class DefaultRoleAccessDAOImpl extends AbstractJpaDao implements DefaultRoleAccessDAO {
 
     public void deleteDefaultRoleAccess(Long id) {
-        currentSession().remove(getDefaultRoleAccess(id));
+        entityManager().remove(getDefaultRoleAccess(id));
     }
 
     public DefaultRoleAccess getDefaultRoleAccess(Long id) {
-        return currentSession().find(DefaultRoleAccess.class, id);
+        return entityManager().find(DefaultRoleAccess.class, id);
     }
 
     public List<DefaultRoleAccess> getDefaultRoleAccesses() {
-        return (List<DefaultRoleAccess>) HqlQueryHelper.find(currentSession(), "from DefaultRoleAccess dra ORDER BY role_id");
+        return (List<DefaultRoleAccess>) JpqlQueryHelper.find(entityManager(), "from DefaultRoleAccess dra ORDER BY role_id");
     }
 
     public List<DefaultRoleAccess> findAll() {
-        return (List<DefaultRoleAccess>) HqlQueryHelper.find(currentSession(), "from DefaultRoleAccess dra");
+        return (List<DefaultRoleAccess>) JpqlQueryHelper.find(entityManager(), "from DefaultRoleAccess dra");
     }
 
     public void saveDefaultRoleAccess(DefaultRoleAccess dra) {
         if (dra.getId() == null) {
-            currentSession().persist(dra);
+            entityManager().persist(dra);
         } else {
-            currentSession().merge(dra);
+            entityManager().merge(dra);
         }
     }
 
     public DefaultRoleAccess find(Long roleId, Long accessTypeId) {
         String sSQL = "from DefaultRoleAccess dra where dra.roleId=?1 and dra.accessTypeId=?2";
-        List results = HqlQueryHelper.find(currentSession(), sSQL, roleId, accessTypeId);
+        List results = JpqlQueryHelper.find(entityManager(), sSQL, roleId, accessTypeId);
 
         if (!results.isEmpty()) {
             return (DefaultRoleAccess) results.get(0);
@@ -77,7 +77,7 @@ public class DefaultRoleAccessDAOImpl extends AbstractHibernateDao implements De
     }
 
     public List<Object[]> findAllRolesAndAccessTypes() {
-        return (List<Object[]>) HqlQueryHelper.find(currentSession(), "SELECT a, b FROM DefaultRoleAccess a, AccessType b WHERE a.id = b.Id");
+        return (List<Object[]>) JpqlQueryHelper.find(entityManager(), "SELECT a, b FROM DefaultRoleAccess a, AccessType b WHERE a.id = b.Id");
     }
 
 }

--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/FormsDAOImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/FormsDAOImpl.java
@@ -43,17 +43,17 @@ import jakarta.persistence.criteria.Root;
 import org.apache.logging.log4j.Logger;
 import io.github.carlos_emr.carlos.PMmodule.model.FormInfo;
 import io.github.carlos_emr.carlos.commn.model.Provider;
-import io.github.carlos_emr.carlos.dao.AbstractHibernateDao;
+import io.github.carlos_emr.carlos.dao.AbstractJpaDao;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
-public class FormsDAOImpl extends AbstractHibernateDao implements FormsDAO {
+public class FormsDAOImpl extends AbstractJpaDao implements FormsDAO {
 
     private Logger log = MiscUtils.getLogger();
 
     public void saveForm(Object o) {
-        currentSession().persist(o);
+        entityManager().persist(o);
 
         if (log.isDebugEnabled()) {
             log.debug("saveForm:" + o);
@@ -67,11 +67,11 @@ public class FormsDAOImpl extends AbstractHibernateDao implements FormsDAO {
             throw new IllegalArgumentException();
         }
 
-        CriteriaBuilder cb = currentSession().getCriteriaBuilder();
+        CriteriaBuilder cb = entityManager().getCriteriaBuilder();
         CriteriaQuery<?> cq = cb.createQuery(clazz);
         Root<?> root = cq.from(clazz);
         cq.where(cb.equal(root.get("demographicNo"), Integer.parseInt(clientId)));
-        List<?> results = currentSession().createQuery(cq).getResultList();
+        List<?> results = entityManager().createQuery(cq).getResultList();
         if (results.size() > 0) {
             result = results.get(0);
         }
@@ -90,20 +90,20 @@ public class FormsDAOImpl extends AbstractHibernateDao implements FormsDAO {
 
         List<FormInfo> formInfos = new ArrayList<FormInfo>();
 
-        CriteriaBuilder cb = currentSession().getCriteriaBuilder();
+        CriteriaBuilder cb = entityManager().getCriteriaBuilder();
         CriteriaQuery<Object[]> cq = cb.createQuery(Object[].class);
         Root<?> root = cq.from(clazz);
         cq.multiselect(root.get("id"), root.get("providerNo"), root.get("formEdited"));
         cq.where(cb.equal(root.get("demographicNo"), Integer.parseInt(clientId)));
         cq.orderBy(cb.desc(root.get("formEdited")));
-        List results = currentSession().createQuery(cq).getResultList();
+        List results = entityManager().createQuery(cq).getResultList();
         for (Iterator iter = results.iterator(); iter.hasNext(); ) {
             FormInfo fi = new FormInfo();
             Object[] values = (Object[]) iter.next();
             Integer id = (Integer) values[0];
             String providerNo = (String) values[1];
             Date dateEdited = (Date) values[2];
-            Provider provider = currentSession().find(Provider.class, providerNo);
+            Provider provider = entityManager().find(Provider.class, providerNo);
             fi.setFormId(id.longValue());
             fi.setProviderNo(Long.parseLong(providerNo));
             fi.setFormDate(dateEdited);

--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/ProgramClientRestrictionDAOImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/ProgramClientRestrictionDAOImpl.java
@@ -37,9 +37,9 @@ import java.util.List;
 import io.github.carlos_emr.carlos.PMmodule.model.ProgramClientRestriction;
 import io.github.carlos_emr.carlos.commn.dao.DemographicDao;
 import org.springframework.beans.factory.annotation.Autowired;
-import io.github.carlos_emr.carlos.dao.AbstractHibernateDao;
+import io.github.carlos_emr.carlos.dao.AbstractJpaDao;
 import org.springframework.transaction.annotation.Transactional;
-import io.github.carlos_emr.carlos.utility.HqlQueryHelper;
+import io.github.carlos_emr.carlos.utility.JpqlQueryHelper;
 
 /**
  * DAO implementation for managing {@link ProgramClientRestriction} records.
@@ -56,7 +56,7 @@ import io.github.carlos_emr.carlos.utility.HqlQueryHelper;
  * @see ProgramClientRestriction
  */
 @Transactional
-public class ProgramClientRestrictionDAOImpl extends AbstractHibernateDao implements ProgramClientRestrictionDAO {
+public class ProgramClientRestrictionDAOImpl extends AbstractJpaDao implements ProgramClientRestrictionDAO {
     private DemographicDao demographicDao;
     private ProgramDao programDao;
     private ProviderDao providerDao;
@@ -64,7 +64,7 @@ public class ProgramClientRestrictionDAOImpl extends AbstractHibernateDao implem
     public Collection<ProgramClientRestriction> find(int programId, int demographicNo) {
 
         String sSQL = "from ProgramClientRestriction pcr where pcr.enabled = true and pcr.programId = ?1 and pcr.demographicNo = ?2 order by pcr.startDate";
-        List<ProgramClientRestriction> pcrs = (List<ProgramClientRestriction>) HqlQueryHelper.find(currentSession(), sSQL, programId, demographicNo);
+        List<ProgramClientRestriction> pcrs = (List<ProgramClientRestriction>) JpqlQueryHelper.find(entityManager(), sSQL, programId, demographicNo);
         for (ProgramClientRestriction pcr : pcrs) {
             setRelationships(pcr);
         }
@@ -73,19 +73,19 @@ public class ProgramClientRestrictionDAOImpl extends AbstractHibernateDao implem
 
     public void save(ProgramClientRestriction restriction) {
         if (restriction.getId() == null || restriction.getId() == 0) {
-            currentSession().persist(restriction);
+            entityManager().persist(restriction);
         } else {
-            currentSession().merge(restriction);
+            entityManager().merge(restriction);
         }
     }
 
     public ProgramClientRestriction find(int restrictionId) {
-        return setRelationships(currentSession().find(ProgramClientRestriction.class, restrictionId));
+        return setRelationships(entityManager().find(ProgramClientRestriction.class, restrictionId));
     }
 
     public Collection<ProgramClientRestriction> findForProgram(int programId) {
         String sSQL = "from ProgramClientRestriction pcr where pcr.enabled = true and pcr.programId = ?1 order by pcr.demographicNo";
-        Collection<ProgramClientRestriction> pcrs = (Collection<ProgramClientRestriction>) HqlQueryHelper.find(currentSession(), sSQL, programId);
+        Collection<ProgramClientRestriction> pcrs = (Collection<ProgramClientRestriction>) JpqlQueryHelper.find(entityManager(), sSQL, programId);
         for (ProgramClientRestriction pcr : pcrs) {
             setRelationships(pcr);
         }
@@ -94,7 +94,7 @@ public class ProgramClientRestrictionDAOImpl extends AbstractHibernateDao implem
 
     public Collection<ProgramClientRestriction> findDisabledForProgram(int programId) {
         String sSQL = "from ProgramClientRestriction pcr where pcr.enabled = false and pcr.programId = ?1 order by pcr.demographicNo";
-        Collection<ProgramClientRestriction> pcrs = (Collection<ProgramClientRestriction>) HqlQueryHelper.find(currentSession(), sSQL, programId);
+        Collection<ProgramClientRestriction> pcrs = (Collection<ProgramClientRestriction>) JpqlQueryHelper.find(entityManager(), sSQL, programId);
         for (ProgramClientRestriction pcr : pcrs) {
             setRelationships(pcr);
         }
@@ -103,7 +103,7 @@ public class ProgramClientRestrictionDAOImpl extends AbstractHibernateDao implem
 
     public Collection<ProgramClientRestriction> findForClient(int demographicNo) {
         String sSQL = "from ProgramClientRestriction pcr where pcr.enabled = true and pcr.demographicNo = ?1 order by pcr.programId";
-        Collection<ProgramClientRestriction> pcrs = (Collection<ProgramClientRestriction>) HqlQueryHelper.find(currentSession(), sSQL, demographicNo);
+        Collection<ProgramClientRestriction> pcrs = (Collection<ProgramClientRestriction>) JpqlQueryHelper.find(entityManager(), sSQL, demographicNo);
         for (ProgramClientRestriction pcr : pcrs) {
             setRelationships(pcr);
         }
@@ -112,7 +112,7 @@ public class ProgramClientRestrictionDAOImpl extends AbstractHibernateDao implem
 
     public Collection<ProgramClientRestriction> findForClient(int demographicNo, int facilityId) {
         String sSQL = "from ProgramClientRestriction pcr where pcr.enabled = true and pcr.demographicNo = ?1 and pcr.programId in (select s.id from Program s where s.facilityId = ?2 or s.facilityId is null) order by pcr.programId";
-        Collection<ProgramClientRestriction> pcrs = (Collection<ProgramClientRestriction>) HqlQueryHelper.find(currentSession(), sSQL, Integer.valueOf(demographicNo), facilityId);
+        Collection<ProgramClientRestriction> pcrs = (Collection<ProgramClientRestriction>) JpqlQueryHelper.find(entityManager(), sSQL, Integer.valueOf(demographicNo), facilityId);
         for (ProgramClientRestriction pcr : pcrs) {
             setRelationships(pcr);
         }
@@ -121,7 +121,7 @@ public class ProgramClientRestrictionDAOImpl extends AbstractHibernateDao implem
 
     public Collection<ProgramClientRestriction> findDisabledForClient(int demographicNo) {
         String sSQL = "from ProgramClientRestriction pcr where pcr.enabled = false and pcr.demographicNo = ?1 order by pcr.programId";
-        Collection<ProgramClientRestriction> pcrs = (Collection<ProgramClientRestriction>) HqlQueryHelper.find(currentSession(), sSQL, demographicNo);
+        Collection<ProgramClientRestriction> pcrs = (Collection<ProgramClientRestriction>) JpqlQueryHelper.find(entityManager(), sSQL, demographicNo);
         for (ProgramClientRestriction pcr : pcrs) {
             setRelationships(pcr);
         }

--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/ProgramClientStatusDAOImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/ProgramClientStatusDAOImpl.java
@@ -36,25 +36,25 @@ import org.apache.logging.log4j.Logger;
 import io.github.carlos_emr.carlos.PMmodule.model.ProgramClientStatus;
 import io.github.carlos_emr.carlos.commn.model.Admission;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
-import io.github.carlos_emr.carlos.dao.AbstractHibernateDao;
-import io.github.carlos_emr.carlos.utility.HqlQueryHelper;
+import io.github.carlos_emr.carlos.dao.AbstractJpaDao;
+import io.github.carlos_emr.carlos.utility.JpqlQueryHelper;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
-public class ProgramClientStatusDAOImpl extends AbstractHibernateDao implements ProgramClientStatusDAO {
+public class ProgramClientStatusDAOImpl extends AbstractJpaDao implements ProgramClientStatusDAO {
 
     private Logger log = MiscUtils.getLogger();
 
     public List<ProgramClientStatus> getProgramClientStatuses(Integer programId) {
         String sSQL = "from ProgramClientStatus pcs where pcs.programId=?1";
-        return (List<ProgramClientStatus>) HqlQueryHelper.find(currentSession(), sSQL, programId);
+        return (List<ProgramClientStatus>) JpqlQueryHelper.find(entityManager(), sSQL, programId);
     }
 
     public void saveProgramClientStatus(ProgramClientStatus status) {
         if (status.getId() == null) {
-            currentSession().persist(status);
+            entityManager().persist(status);
         } else {
-            currentSession().merge(status);
+            entityManager().merge(status);
         }
     }
 
@@ -64,13 +64,13 @@ public class ProgramClientStatusDAOImpl extends AbstractHibernateDao implements 
         }
 
         ProgramClientStatus pcs = null;
-        pcs = currentSession().find(ProgramClientStatus.class, Integer.valueOf(id));
+        pcs = entityManager().find(ProgramClientStatus.class, Integer.valueOf(id));
         if (pcs != null) return pcs;
         else return null;
     }
 
     public void deleteProgramClientStatus(String id) {
-        currentSession().remove(getProgramClientStatus(id));
+        entityManager().remove(getProgramClientStatus(id));
     }
 
     public boolean clientStatusNameExists(Integer programId, String statusName) {
@@ -82,7 +82,7 @@ public class ProgramClientStatusDAOImpl extends AbstractHibernateDao implements 
             throw new IllegalArgumentException();
         }
 
-        List<?> results = HqlQueryHelper.find(currentSession(),
+        List<?> results = JpqlQueryHelper.find(entityManager(),
                 "from ProgramClientStatus pt where pt.programId = ?1 and pt.name = ?2",
                 programId, statusName);
 
@@ -102,7 +102,7 @@ public class ProgramClientStatusDAOImpl extends AbstractHibernateDao implements 
         }
 
         String sSQL = "from Admission a where a.programId = ?1 and a.teamId = ?2 and a.admissionStatus='current'";
-        List<Admission> results = (List<Admission>) HqlQueryHelper.find(currentSession(), sSQL, programId, statusId);
+        List<Admission> results = (List<Admission>) JpqlQueryHelper.find(entityManager(), sSQL, programId, statusId);
 
         if (log.isDebugEnabled()) {
             log.debug("getAllClientsInStatus: programId= " + programId + ",statusId=" + statusId + ",# results=" + results.size());

--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/ProgramClientStatusDAOImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/ProgramClientStatusDAOImpl.java
@@ -65,8 +65,7 @@ public class ProgramClientStatusDAOImpl extends AbstractJpaDao implements Progra
 
         ProgramClientStatus pcs = null;
         pcs = entityManager().find(ProgramClientStatus.class, Integer.valueOf(id));
-        if (pcs != null) return pcs;
-        else return null;
+        return pcs;
     }
 
     public void deleteProgramClientStatus(String id) {

--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/ProgramFunctionalUserDAOImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/ProgramFunctionalUserDAOImpl.java
@@ -37,19 +37,19 @@ import org.apache.logging.log4j.Logger;
 import io.github.carlos_emr.carlos.PMmodule.model.FunctionalUserType;
 import io.github.carlos_emr.carlos.PMmodule.model.ProgramFunctionalUser;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
-import io.github.carlos_emr.carlos.dao.AbstractHibernateDao;
+import io.github.carlos_emr.carlos.dao.AbstractJpaDao;
 import org.springframework.transaction.annotation.Transactional;
-import io.github.carlos_emr.carlos.utility.HqlQueryHelper;
+import io.github.carlos_emr.carlos.utility.JpqlQueryHelper;
 
 @Transactional
-public class ProgramFunctionalUserDAOImpl extends AbstractHibernateDao implements ProgramFunctionalUserDAO {
+public class ProgramFunctionalUserDAOImpl extends AbstractJpaDao implements ProgramFunctionalUserDAO {
 
     private static Logger log = MiscUtils.getLogger();
 
     @Override
     public List<FunctionalUserType> getFunctionalUserTypes() {
         String sSQL = "from FunctionalUserType";
-        List<FunctionalUserType> results = (List<FunctionalUserType>) HqlQueryHelper.find(currentSession(), sSQL);
+        List<FunctionalUserType> results = (List<FunctionalUserType>) JpqlQueryHelper.find(entityManager(), sSQL);
 
         if (log.isDebugEnabled()) {
             log.debug("getFunctionalUserTypes: # of results=" + results.size());
@@ -63,7 +63,7 @@ public class ProgramFunctionalUserDAOImpl extends AbstractHibernateDao implement
             throw new IllegalArgumentException();
         }
 
-        FunctionalUserType result = currentSession().find(FunctionalUserType.class, id);
+        FunctionalUserType result = entityManager().find(FunctionalUserType.class, id);
 
         if (log.isDebugEnabled()) {
             log.debug("getFunctionalUserType: id=" + id + ",found=" + (result != null));
@@ -79,9 +79,9 @@ public class ProgramFunctionalUserDAOImpl extends AbstractHibernateDao implement
         }
 
         if (fut.getId() == null) {
-            currentSession().persist(fut);
+            entityManager().persist(fut);
         } else {
-            currentSession().merge(fut);
+            entityManager().merge(fut);
         }
 
         if (log.isDebugEnabled()) {
@@ -95,7 +95,7 @@ public class ProgramFunctionalUserDAOImpl extends AbstractHibernateDao implement
             throw new IllegalArgumentException();
         }
 
-        currentSession().remove(getFunctionalUserType(id));
+        entityManager().remove(getFunctionalUserType(id));
 
         if (log.isDebugEnabled()) {
             log.debug("deleteFunctionalUserType:" + id);
@@ -109,7 +109,7 @@ public class ProgramFunctionalUserDAOImpl extends AbstractHibernateDao implement
         }
 
         String sSQL = "from ProgramFunctionalUser pfu where pfu.ProgramId = ?1";
-        List<FunctionalUserType> results = (List<FunctionalUserType>) HqlQueryHelper.find(currentSession(), sSQL, programId);
+        List<FunctionalUserType> results = (List<FunctionalUserType>) JpqlQueryHelper.find(entityManager(), sSQL, programId);
 
         if (log.isDebugEnabled()) {
             log.debug("getFunctionalUsers: programId=" + programId + ",# of results=" + results.size());
@@ -123,7 +123,7 @@ public class ProgramFunctionalUserDAOImpl extends AbstractHibernateDao implement
             throw new IllegalArgumentException();
         }
 
-        ProgramFunctionalUser result = currentSession().find(ProgramFunctionalUser.class, id);
+        ProgramFunctionalUser result = entityManager().find(ProgramFunctionalUser.class, id);
 
         if (log.isDebugEnabled()) {
             log.debug("getFunctionalUser: id=" + id + ",found=" + (result != null));
@@ -139,9 +139,9 @@ public class ProgramFunctionalUserDAOImpl extends AbstractHibernateDao implement
         }
 
         if (pfu.getId() == null) {
-            currentSession().persist(pfu);
+            entityManager().persist(pfu);
         } else {
-            currentSession().merge(pfu);
+            entityManager().merge(pfu);
         }
 
         if (log.isDebugEnabled()) {
@@ -155,7 +155,7 @@ public class ProgramFunctionalUserDAOImpl extends AbstractHibernateDao implement
             throw new IllegalArgumentException();
         }
 
-        currentSession().remove(getFunctionalUser(id));
+        entityManager().remove(getFunctionalUser(id));
 
         if (log.isDebugEnabled()) {
             log.debug("deleteFunctionalUser:" + id);
@@ -186,7 +186,7 @@ public class ProgramFunctionalUserDAOImpl extends AbstractHibernateDao implement
 
         String sSQL = "select pfu.Id from ProgramFunctionalUser pfu where pfu.ProgramId = ?1 and pfu.UserTypeId = ?2";
         @SuppressWarnings("unchecked")
-        List<Long> results = (List<Long>) HqlQueryHelper.find(currentSession(), sSQL, programId, userTypeId);
+        List<Long> results = (List<Long>) JpqlQueryHelper.find(entityManager(), sSQL, programId, userTypeId);
 
         if (!results.isEmpty()) {
             result = results.get(0);

--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/ProgramProviderDAOImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/ProgramProviderDAOImpl.java
@@ -37,17 +37,17 @@ import io.github.carlos_emr.carlos.PMmodule.model.ProgramProvider;
 import io.github.carlos_emr.carlos.commn.model.Facility;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.QueueCache;
-import io.github.carlos_emr.carlos.dao.AbstractHibernateDao;
+import io.github.carlos_emr.carlos.dao.AbstractJpaDao;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import io.github.carlos_emr.carlos.utility.HqlQueryHelper;
+import io.github.carlos_emr.carlos.utility.JpqlQueryHelper;
 
 @Transactional
-public class ProgramProviderDAOImpl extends AbstractHibernateDao implements ProgramProviderDAO {
+public class ProgramProviderDAOImpl extends AbstractJpaDao implements ProgramProviderDAO {
 
     private Logger log = MiscUtils.getLogger();
 
@@ -67,7 +67,7 @@ public class ProgramProviderDAOImpl extends AbstractHibernateDao implements Prog
 
         if (results == null) {
             String q = "select pp from ProgramProvider pp where pp.ProgramId=?1 and pp.ProviderNo=?2";
-            results = (List<ProgramProvider>) HqlQueryHelper.find(currentSession(), q, programId, providerNo);
+            results = (List<ProgramProvider>) JpqlQueryHelper.find(entityManager(), q, programId, providerNo);
             if (results != null)
                 programProviderByProviderProgramIdCache.put(cacheKey, results);
         }
@@ -78,14 +78,14 @@ public class ProgramProviderDAOImpl extends AbstractHibernateDao implements Prog
     @SuppressWarnings("unchecked")
     @Override
     public List<ProgramProvider> getAllProgramProviders() {
-        return (List<ProgramProvider>) HqlQueryHelper.find(currentSession(), "FROM ProgramProvider");
+        return (List<ProgramProvider>) JpqlQueryHelper.find(entityManager(), "FROM ProgramProvider");
     }
 
     @SuppressWarnings("unchecked")
     @Override
     public List<ProgramProvider> getProgramProviderByProviderNo(String providerNo) {
         String q = "select pp from ProgramProvider pp where pp.ProviderNo=?1";
-        return (List<ProgramProvider>) HqlQueryHelper.find(currentSession(), q, providerNo);
+        return (List<ProgramProvider>) JpqlQueryHelper.find(entityManager(), q, providerNo);
     }
 
     @Override
@@ -95,7 +95,7 @@ public class ProgramProviderDAOImpl extends AbstractHibernateDao implements Prog
         }
 
         @SuppressWarnings("unchecked")
-        List<ProgramProvider> results = (List<ProgramProvider>) HqlQueryHelper.find(currentSession(),
+        List<ProgramProvider> results = (List<ProgramProvider>) JpqlQueryHelper.find(entityManager(),
                 "from ProgramProvider pp where pp.ProgramId = ?1", programId);
 
         if (log.isDebugEnabled()) {
@@ -111,7 +111,7 @@ public class ProgramProviderDAOImpl extends AbstractHibernateDao implements Prog
         }
 
         String sSQL = "from ProgramProvider pp where pp.ProviderNo = ?1";
-        List<ProgramProvider> results = (List<ProgramProvider>) HqlQueryHelper.find(currentSession(), sSQL, providerNo);
+        List<ProgramProvider> results = (List<ProgramProvider>) JpqlQueryHelper.find(entityManager(), sSQL, providerNo);
 
         if (log.isDebugEnabled()) {
             log.debug("getProgramProvidersByProvider: providerNo=" + providerNo + ",# of results=" + results.size());
@@ -129,7 +129,7 @@ public class ProgramProviderDAOImpl extends AbstractHibernateDao implements Prog
         Map<String, Object> params = new HashMap<>();
         params.put("providerNo", providerNo);
         params.put("facilityId", facilityId);
-        List results = HqlQueryHelper.find(currentSession(), hql, params);
+        List results = JpqlQueryHelper.find(entityManager(), hql, params);
 
         if (log.isDebugEnabled()) {
             log.debug("getProgramProvidersByProviderAndFacility: providerNo=" + providerNo + ",# of results="
@@ -144,7 +144,7 @@ public class ProgramProviderDAOImpl extends AbstractHibernateDao implements Prog
             throw new IllegalArgumentException();
         }
 
-        ProgramProvider result = currentSession().find(ProgramProvider.class, id);
+        ProgramProvider result = entityManager().find(ProgramProvider.class, id);
 
         if (log.isDebugEnabled()) {
             log.debug("getProgramProvider: id=" + id + ",found=" + (result != null));
@@ -168,7 +168,7 @@ public class ProgramProviderDAOImpl extends AbstractHibernateDao implements Prog
 
         ProgramProvider result = null;
         String queryStr = "from ProgramProvider pp where pp.ProviderNo = ?1 and pp.ProgramId = ?2 and pp.RoleId = ?3";
-        List results = HqlQueryHelper.find(currentSession(), queryStr, providerNo, programId, roleId);
+        List results = JpqlQueryHelper.find(entityManager(), queryStr, providerNo, programId, roleId);
 
         if (!results.isEmpty()) {
             result = (ProgramProvider) results.get(0);
@@ -194,7 +194,7 @@ public class ProgramProviderDAOImpl extends AbstractHibernateDao implements Prog
 
         ProgramProvider result = null;
         String sSQL = "from ProgramProvider pp where pp.ProviderNo = ?1 and pp.ProgramId = ?2";
-        List results = HqlQueryHelper.find(currentSession(), sSQL, providerNo, programId);
+        List results = JpqlQueryHelper.find(entityManager(), sSQL, providerNo, programId);
         if (!results.isEmpty()) {
             result = (ProgramProvider) results.get(0);
         }
@@ -215,7 +215,7 @@ public class ProgramProviderDAOImpl extends AbstractHibernateDao implements Prog
         }
 
         programProviderByProviderProgramIdCache.remove(makeCacheKey(pp.getProviderNo(), pp.getProgramId()));
-        currentSession().merge(pp);
+        entityManager().merge(pp);
 
         if (log.isDebugEnabled()) {
             log.debug("saveProgramProvider: id=" + pp.getId());
@@ -232,7 +232,7 @@ public class ProgramProviderDAOImpl extends AbstractHibernateDao implements Prog
         ProgramProvider pp = getProgramProvider(id);
         if (pp != null) {
             programProviderByProviderProgramIdCache.remove(makeCacheKey(pp.getProviderNo(), pp.getProgramId()));
-            currentSession().remove(pp);
+            entityManager().remove(pp);
         }
 
         if (log.isDebugEnabled()) {
@@ -252,7 +252,7 @@ public class ProgramProviderDAOImpl extends AbstractHibernateDao implements Prog
             while (it.hasNext()) {
                 ProgramProvider pp = (ProgramProvider) it.next();
                 programProviderByProviderProgramIdCache.remove(makeCacheKey(pp.getProviderNo(), pp.getProgramId()));
-                currentSession().remove(pp);
+                entityManager().remove(pp);
             }
         }
 
@@ -272,7 +272,7 @@ public class ProgramProviderDAOImpl extends AbstractHibernateDao implements Prog
         Long pId = programId.longValue();
 
         String sSQL = "select pp from ProgramProvider pp left join pp.teams as team where pp.ProgramId = ?1 and team.id = ?2";
-        List<ProgramProvider> results = (List<ProgramProvider>) HqlQueryHelper.find(currentSession(), sSQL, pId, teamId);
+        List<ProgramProvider> results = (List<ProgramProvider>) JpqlQueryHelper.find(entityManager(), sSQL, pId, teamId);
 
         if (log.isDebugEnabled()) {
             log.debug("getProgramProvidersInTeam: programId=" + programId + ",teamId=" + teamId + ",# of results="
@@ -290,7 +290,7 @@ public class ProgramProviderDAOImpl extends AbstractHibernateDao implements Prog
         }
 
         String sSQL = "from ProgramProvider pp where pp.ProviderNo = ?1";
-        List results = HqlQueryHelper.find(currentSession(), sSQL, providerNo);
+        List results = JpqlQueryHelper.find(entityManager(), sSQL, providerNo);
 
         if (log.isDebugEnabled()) {
             log.debug("getProgramDomain: providerNo=" + providerNo + ",# of results=" + results.size());
@@ -305,7 +305,7 @@ public class ProgramProviderDAOImpl extends AbstractHibernateDao implements Prog
         }
 
         String sSQL = "select pp from ProgramProvider pp, Program p where pp.ProgramId=p.id and p.programStatus='active' and pp.ProviderNo = ?1";
-        List results = HqlQueryHelper.find(currentSession(), sSQL, providerNo);
+        List results = JpqlQueryHelper.find(entityManager(), sSQL, providerNo);
 
         if (log.isDebugEnabled()) {
             log.debug("getProgramDomain: providerNo=" + providerNo + ",# of results=" + results.size());
@@ -323,7 +323,7 @@ public class ProgramProviderDAOImpl extends AbstractHibernateDao implements Prog
         Map<String, Object> params = new HashMap<>();
         params.put("providerNo", providerNo);
         params.put("facilityId", facilityId);
-        List results = HqlQueryHelper.find(currentSession(), hql, params);
+        List results = JpqlQueryHelper.find(entityManager(), hql, params);
 
         if (log.isDebugEnabled()) {
             log.debug("getProgramDomainByFacility: providerNo=" + providerNo + ",# of results=" + results.size());
@@ -338,7 +338,7 @@ public class ProgramProviderDAOImpl extends AbstractHibernateDao implements Prog
         }
 
         String queryStr = "from ProgramProvider pp where pp.ProviderNo = ?1 and pp.ProgramId = ?2";
-        List results = HqlQueryHelper.find(currentSession(), queryStr,
+        List results = JpqlQueryHelper.find(entityManager(), queryStr,
                 providerNo, Long.valueOf(programId.longValue()));
         if (results != null && results.size() > 0) {
             return true;
@@ -355,7 +355,7 @@ public class ProgramProviderDAOImpl extends AbstractHibernateDao implements Prog
             throw new IllegalArgumentException();
         }
         String sSQL = "select distinct f from Facility f, Program p, ProgramProvider pp where pp.ProgramId = p.id and f.id = p.facilityId and pp.ProviderNo = ?1";
-        List results = HqlQueryHelper.find(currentSession(), sSQL, providerNo);
+        List results = JpqlQueryHelper.find(entityManager(), sSQL, providerNo);
 
         return results;
     }
@@ -364,6 +364,6 @@ public class ProgramProviderDAOImpl extends AbstractHibernateDao implements Prog
     @Override
     public void updateProviderRole(ProgramProvider pp, Long roleId) {
         pp.setRoleId(roleId);
-        currentSession().merge(pp);
+        entityManager().merge(pp);
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/ProgramQueueDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/ProgramQueueDaoImpl.java
@@ -36,12 +36,12 @@ import java.util.List;
 import org.apache.logging.log4j.Logger;
 import io.github.carlos_emr.carlos.PMmodule.model.ProgramQueue;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
-import io.github.carlos_emr.carlos.dao.AbstractHibernateDao;
+import io.github.carlos_emr.carlos.dao.AbstractJpaDao;
 import org.springframework.transaction.annotation.Transactional;
-import io.github.carlos_emr.carlos.utility.HqlQueryHelper;
+import io.github.carlos_emr.carlos.utility.JpqlQueryHelper;
 
 @Transactional
-public class ProgramQueueDaoImpl extends AbstractHibernateDao implements ProgramQueueDao {
+public class ProgramQueueDaoImpl extends AbstractJpaDao implements ProgramQueueDao {
 
     private Logger log = MiscUtils.getLogger();
 
@@ -51,7 +51,7 @@ public class ProgramQueueDaoImpl extends AbstractHibernateDao implements Program
             throw new IllegalArgumentException();
         }
 
-        ProgramQueue result = currentSession().find(ProgramQueue.class, queueId);
+        ProgramQueue result = entityManager().find(ProgramQueue.class, queueId);
 
         if (log.isDebugEnabled()) {
             log.debug("getProgramQueue: queueId=" + queueId + ", found=" + (result != null));
@@ -67,7 +67,7 @@ public class ProgramQueueDaoImpl extends AbstractHibernateDao implements Program
         }
 
         String queryStr = " FROM ProgramQueue q WHERE q.ProgramId=?1 ORDER BY  q.Id  ";
-        List results = HqlQueryHelper.find(currentSession(), queryStr, programId);
+        List results = JpqlQueryHelper.find(entityManager(), queryStr, programId);
 
         if (log.isDebugEnabled()) {
             log.debug("getProgramQueue: programId=" + programId + ", # of results=" + results.size());
@@ -82,7 +82,7 @@ public class ProgramQueueDaoImpl extends AbstractHibernateDao implements Program
             throw new IllegalArgumentException();
         }
 
-        List results = HqlQueryHelper.find(currentSession(),
+        List results = JpqlQueryHelper.find(entityManager(),
                 "from ProgramQueue pq where pq.ProgramId = ?1 and pq.Status = 'active' order by pq.ReferralDate",
                 Long.valueOf(programId));
 
@@ -100,9 +100,9 @@ public class ProgramQueueDaoImpl extends AbstractHibernateDao implements Program
         }
 
         if (programQueue.getId() == null) {
-            currentSession().persist(programQueue);
+            entityManager().persist(programQueue);
         } else {
-            currentSession().merge(programQueue);
+            entityManager().merge(programQueue);
         }
 
         if (log.isDebugEnabled()) {
@@ -122,7 +122,7 @@ public class ProgramQueueDaoImpl extends AbstractHibernateDao implements Program
 
         ProgramQueue result = null;
         String sSQL = "from ProgramQueue pq where pq.ProgramId = ?1 and pq.ClientId = ?2";
-        List results = HqlQueryHelper.find(currentSession(), sSQL, Long.valueOf(programId), Long.valueOf(clientId));
+        List results = JpqlQueryHelper.find(entityManager(), sSQL, Long.valueOf(programId), Long.valueOf(clientId));
 
         if (!results.isEmpty()) {
             result = (ProgramQueue) results.get(0);
@@ -147,7 +147,7 @@ public class ProgramQueueDaoImpl extends AbstractHibernateDao implements Program
         ProgramQueue result = null;
 
         String sSQL = "from ProgramQueue pq where pq.ProgramId = ?1 and pq.ClientId = ?2 and pq.Status='active'";
-        List results = HqlQueryHelper.find(currentSession(), sSQL, programId, demographicNo);
+        List results = JpqlQueryHelper.find(entityManager(), sSQL, programId, demographicNo);
         if (!results.isEmpty()) {
             result = (ProgramQueue) results.get(0);
         }

--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/ProgramSignatureDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/ProgramSignatureDaoImpl.java
@@ -37,12 +37,12 @@ import java.util.List;
 import org.apache.logging.log4j.Logger;
 import io.github.carlos_emr.carlos.PMmodule.model.ProgramSignature;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
-import io.github.carlos_emr.carlos.dao.AbstractHibernateDao;
+import io.github.carlos_emr.carlos.dao.AbstractJpaDao;
 import org.springframework.transaction.annotation.Transactional;
-import io.github.carlos_emr.carlos.utility.HqlQueryHelper;
+import io.github.carlos_emr.carlos.utility.JpqlQueryHelper;
 
 @Transactional
-public class ProgramSignatureDaoImpl extends AbstractHibernateDao implements ProgramSignatureDao {
+public class ProgramSignatureDaoImpl extends AbstractJpaDao implements ProgramSignatureDao {
 
     private static final Logger log = MiscUtils.getLogger();
 
@@ -53,7 +53,7 @@ public class ProgramSignatureDaoImpl extends AbstractHibernateDao implements Pro
             return null;
         }
         String sSQL = "FROM ProgramSignature ps where ps.programId = ?1 ORDER BY ps.updateDate ASC";
-        List ps = HqlQueryHelper.find(currentSession(), sSQL, programId);
+        List ps = JpqlQueryHelper.find(entityManager(), sSQL, programId);
 
         if (!ps.isEmpty()) {
             programSignature = (ProgramSignature) ps.get(0);
@@ -72,7 +72,7 @@ public class ProgramSignatureDaoImpl extends AbstractHibernateDao implements Pro
         }
 
         String sSQL = "FROM ProgramSignature ps WHERE ps.programId = ?1 ORDER BY ps.updateDate ASC";
-        List rs = HqlQueryHelper.find(currentSession(), sSQL, programId);
+        List rs = JpqlQueryHelper.find(entityManager(), sSQL, programId);
 
         if (log.isDebugEnabled()) {
             log.debug("getProgramSignatures: # of programs: " + rs.size());
@@ -87,11 +87,11 @@ public class ProgramSignatureDaoImpl extends AbstractHibernateDao implements Pro
         }
         programSignature.setUpdateDate(new Date());
         if (programSignature.getId() == null) {
-            currentSession().persist(programSignature);
+            entityManager().persist(programSignature);
         } else {
-            currentSession().merge(programSignature);
+            entityManager().merge(programSignature);
         }
-        currentSession().flush();
+        entityManager().flush();
 
         if (log.isDebugEnabled()) {
             log.debug("saveAdmission: id= " + programSignature.getId());

--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/ProgramTeamDAOImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/ProgramTeamDAOImpl.java
@@ -37,12 +37,12 @@ import org.apache.logging.log4j.Logger;
 import io.github.carlos_emr.carlos.PMmodule.model.ProgramTeam;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import org.springframework.dao.EmptyResultDataAccessException;
-import io.github.carlos_emr.carlos.dao.AbstractHibernateDao;
-import io.github.carlos_emr.carlos.utility.HqlQueryHelper;
+import io.github.carlos_emr.carlos.dao.AbstractJpaDao;
+import io.github.carlos_emr.carlos.utility.JpqlQueryHelper;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
-public class ProgramTeamDAOImpl extends AbstractHibernateDao implements ProgramTeamDAO {
+public class ProgramTeamDAOImpl extends AbstractJpaDao implements ProgramTeamDAO {
 
     private Logger log = MiscUtils.getLogger();
 
@@ -57,7 +57,7 @@ public class ProgramTeamDAOImpl extends AbstractHibernateDao implements ProgramT
             log.debug("teamExists: called with null teamId, returning false");
             return false;
         }
-        boolean exists = currentSession().find(ProgramTeam.class, teamId) != null;
+        boolean exists = entityManager().find(ProgramTeam.class, teamId) != null;
         log.debug("teamExists: " + exists);
 
         return exists;
@@ -77,7 +77,7 @@ public class ProgramTeamDAOImpl extends AbstractHibernateDao implements ProgramT
         if (teamName == null || teamName.length() <= 0) {
             throw new IllegalArgumentException();
         }
-        List teams = HqlQueryHelper.find(currentSession(),
+        List teams = JpqlQueryHelper.find(entityManager(),
                 "from ProgramTeam pt where pt.programId = ?1 and pt.name = ?2",
                 programId, teamName);
 
@@ -99,7 +99,7 @@ public class ProgramTeamDAOImpl extends AbstractHibernateDao implements ProgramT
             throw new IllegalArgumentException();
         }
 
-        ProgramTeam result = currentSession().find(ProgramTeam.class, id);
+        ProgramTeam result = entityManager().find(ProgramTeam.class, id);
 
         if (log.isDebugEnabled()) {
             log.debug("getProgramTeam: id=" + id + ",found=" + (result != null));
@@ -120,7 +120,7 @@ public class ProgramTeamDAOImpl extends AbstractHibernateDao implements ProgramT
         }
 
         String sSQL = "from ProgramTeam tp where tp.programId = ?1";
-        List<ProgramTeam> results = (List<ProgramTeam>) HqlQueryHelper.find(currentSession(), sSQL, programId);
+        List<ProgramTeam> results = (List<ProgramTeam>) JpqlQueryHelper.find(entityManager(), sSQL, programId);
 
         if (log.isDebugEnabled()) {
             log.debug("getProgramTeams: programId=" + programId + ",# of results=" + results.size());
@@ -141,9 +141,9 @@ public class ProgramTeamDAOImpl extends AbstractHibernateDao implements ProgramT
         }
 
         if (team.getId() == null) {
-            currentSession().persist(team);
+            entityManager().persist(team);
         } else {
-            currentSession().merge(team);
+            entityManager().merge(team);
         }
 
         if (log.isDebugEnabled()) {
@@ -167,7 +167,7 @@ public class ProgramTeamDAOImpl extends AbstractHibernateDao implements ProgramT
             throw new EmptyResultDataAccessException("No ProgramTeam found with id=" + id, 1);
         }
 
-        currentSession().remove(team);
+        entityManager().remove(team);
 
         if (log.isDebugEnabled()) {
             log.debug("deleteProgramTeam: id=" + id);

--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/ProviderDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/ProviderDaoImpl.java
@@ -44,6 +44,7 @@ import org.apache.logging.log4j.Logger;
 import jakarta.persistence.Query;
 import jakarta.persistence.TypedQuery;
 import io.github.carlos_emr.carlos.commn.NativeSql;
+import io.github.carlos_emr.carlos.utility.LogSanitizer;
 import io.github.carlos_emr.carlos.commn.dao.ProviderFacilityDao;
 import io.github.carlos_emr.carlos.commn.model.Provider;
 import io.github.carlos_emr.carlos.commn.model.ProviderFacility;
@@ -202,7 +203,8 @@ public class ProviderDaoImpl extends AbstractJpaDao implements ProviderDao {
             } catch (NumberFormatException e) {
                 // Caller asked for providers in a specific program but passed a non-numeric id.
                 // Return empty rather than silently widening the result to all active providers.
-                log.warn("getActiveProviders: non-numeric programId '{}', returning empty list", programId);
+                log.warn("getActiveProviders: non-numeric programId '{}', returning empty list",
+                        LogSanitizer.sanitize(programId));
                 return Collections.emptyList();
             }
         } else if (facilityId != null && "0".equals(facilityId) == false) {

--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/ProviderDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/ProviderDaoImpl.java
@@ -200,9 +200,10 @@ public class ProviderDaoImpl extends AbstractJpaDao implements ProviderDao {
             try {
                 rs = (List<Provider>) JpqlQueryHelper.find(entityManager(), sSQL, Long.valueOf(programId));
             } catch (NumberFormatException e) {
-                log.warn("getActiveProviders: invalid programId '{}', returning all active providers", programId);
-                rs = (List<Provider>) JpqlQueryHelper.find(entityManager(),
-                        "FROM  Provider p where p.Status='1' ORDER BY p.LastName");
+                // Caller asked for providers in a specific program but passed a non-numeric id.
+                // Return empty rather than silently widening the result to all active providers.
+                log.warn("getActiveProviders: non-numeric programId '{}', returning empty list", programId);
+                return Collections.emptyList();
             }
         } else if (facilityId != null && "0".equals(facilityId) == false) {
             sSQL = "FROM  Provider p where p.Status='1' and p.ProviderNo in "

--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/ProviderDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/ProviderDaoImpl.java
@@ -197,7 +197,13 @@ public class ProviderDaoImpl extends AbstractJpaDao implements ProviderDao {
         if (programId != null && "0".equals(programId) == false) {
             sSQL = "FROM  Provider p where p.Status='1' and p.ProviderNo in "
                     + "(select c.ProviderNo from ProgramProvider c where c.ProgramId =?1) ORDER BY p.LastName";
-            rs = (List<Provider>) JpqlQueryHelper.find(entityManager(), sSQL, Long.valueOf(programId));
+            try {
+                rs = (List<Provider>) JpqlQueryHelper.find(entityManager(), sSQL, Long.valueOf(programId));
+            } catch (NumberFormatException e) {
+                log.warn("getActiveProviders: invalid programId '{}', returning all active providers", programId);
+                rs = (List<Provider>) JpqlQueryHelper.find(entityManager(),
+                        "FROM  Provider p where p.Status='1' ORDER BY p.LastName");
+            }
         } else if (facilityId != null && "0".equals(facilityId) == false) {
             sSQL = "FROM  Provider p where p.Status='1' and p.ProviderNo in "
                     + "(select c.ProviderNo from ProgramProvider c where c.ProgramId in "

--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/ProviderDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/ProviderDaoImpl.java
@@ -41,14 +41,14 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.logging.log4j.Logger;
-import org.hibernate.query.NativeQuery;
-import org.hibernate.query.Query;
+import jakarta.persistence.Query;
+import jakarta.persistence.TypedQuery;
 import io.github.carlos_emr.carlos.commn.NativeSql;
 import io.github.carlos_emr.carlos.commn.dao.ProviderFacilityDao;
 import io.github.carlos_emr.carlos.commn.model.Provider;
 import io.github.carlos_emr.carlos.commn.model.ProviderFacility;
 import io.github.carlos_emr.carlos.commn.model.ProviderFacilityPK;
-import io.github.carlos_emr.carlos.dao.AbstractHibernateDao;
+import io.github.carlos_emr.carlos.dao.AbstractJpaDao;
 import io.github.carlos_emr.carlos.provider.dto.ProviderSummaryDTO;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
@@ -56,17 +56,17 @@ import io.github.carlos_emr.carlos.utility.SpringUtils;
 import org.springframework.transaction.annotation.Transactional;
 
 import io.github.carlos_emr.carlos.model.security.SecProvider;
-import io.github.carlos_emr.carlos.utility.HqlQueryHelper;
+import io.github.carlos_emr.carlos.utility.JpqlQueryHelper;
 
 @SuppressWarnings("unchecked")
 @Transactional
-public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao {
+public class ProviderDaoImpl extends AbstractJpaDao implements ProviderDao {
 
 
     private static Logger log = MiscUtils.getLogger();
 
     public boolean providerExists(String providerNo) {
-        return currentSession().find(Provider.class, providerNo) != null;
+        return entityManager().find(Provider.class, providerNo) != null;
     }
 
     @Override
@@ -75,7 +75,7 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
             return null;
         }
 
-        Provider provider = currentSession().find(Provider.class, providerNo);
+        Provider provider = entityManager().find(Provider.class, providerNo);
 
         if (log.isDebugEnabled()) {
             log.debug("getProvider: providerNo=" + providerNo + ",found=" + (provider != null));
@@ -136,7 +136,7 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
     @Override
     public List<Provider> getProviders() {
 
-        List<Provider> rs = (List<Provider>) HqlQueryHelper.find(currentSession(),
+        List<Provider> rs = (List<Provider>) JpqlQueryHelper.find(entityManager(),
                 "FROM  Provider p ORDER BY p.LastName");
 
         if (log.isDebugEnabled()) {
@@ -150,7 +150,7 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
         String sSQL = "FROM Provider p WHERE p.providerNumber IN (:providers)";
         Map<String, Object> params = new HashMap<>();
         params.put("providers", Arrays.asList(providers));
-        return (List<Provider>) HqlQueryHelper.find(currentSession(), sSQL, params);
+        return (List<Provider>) JpqlQueryHelper.find(entityManager(), sSQL, params);
     }
 
     @Override
@@ -158,7 +158,7 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
         firstname = firstname.trim();
         lastname = lastname.trim();
         String s = "From Provider p where p.FirstName=?1 and p.LastName=?2";
-        return (List<Provider>) HqlQueryHelper.find(currentSession(), s, firstname, lastname);
+        return (List<Provider>) JpqlQueryHelper.find(entityManager(), s, firstname, lastname);
     }
 
     @Override
@@ -166,7 +166,7 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
         firstname = firstname.trim();
         lastname = lastname.trim();
         String s = "From Provider p where p.FirstName like ?1 and p.LastName like ?2";
-        return (List<Provider>) HqlQueryHelper.find(currentSession(), s, firstname, lastname);
+        return (List<Provider>) JpqlQueryHelper.find(entityManager(), s, firstname, lastname);
     }
 
     @Override
@@ -174,7 +174,7 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
         firstname = firstname.trim();
         lastname = lastname.trim();
         String s = "From Provider p where p.FirstName like ?1 and p.LastName like ?2 and p.Status='1'";
-        return (List<Provider>) HqlQueryHelper.find(currentSession(), s, firstname, lastname);
+        return (List<Provider>) JpqlQueryHelper.find(entityManager(), s, firstname, lastname);
     }
 
     @Override
@@ -185,7 +185,7 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
                 " and o.codecsv  like '%' || sr.orgcd || ',%' " +
                 " and not (sr.orgcd like 'R%' or sr.orgcd like 'O%'))" +
                 " ORDER BY p.lastName";
-        return (List<SecProvider>) HqlQueryHelper.find(currentSession(), sSQL, programId);
+        return (List<SecProvider>) JpqlQueryHelper.find(entityManager(), sSQL, programId);
     }
 
     @Override
@@ -197,7 +197,7 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
         if (programId != null && "0".equals(programId) == false) {
             sSQL = "FROM  Provider p where p.Status='1' and p.ProviderNo in "
                     + "(select c.ProviderNo from ProgramProvider c where c.ProgramId =?1) ORDER BY p.LastName";
-            rs = (List<Provider>) HqlQueryHelper.find(currentSession(), sSQL, Long.valueOf(programId));
+            rs = (List<Provider>) JpqlQueryHelper.find(entityManager(), sSQL, Long.valueOf(programId));
         } else if (facilityId != null && "0".equals(facilityId) == false) {
             sSQL = "FROM  Provider p where p.Status='1' and p.ProviderNo in "
                     + "(select c.ProviderNo from ProgramProvider c where c.ProgramId in "
@@ -205,10 +205,10 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
             // JS 2192700 - string facilityId seems to be throwing class cast
             // exception
             Integer intFacilityId = Integer.valueOf(facilityId);
-            rs = (List<Provider>) HqlQueryHelper.find(currentSession(), sSQL, intFacilityId);
+            rs = (List<Provider>) JpqlQueryHelper.find(entityManager(), sSQL, intFacilityId);
         } else {
             sSQL = "FROM  Provider p where p.Status='1' ORDER BY p.LastName";
-            rs = (List<Provider>) HqlQueryHelper.find(currentSession(), sSQL);
+            rs = (List<Provider>) JpqlQueryHelper.find(entityManager(), sSQL);
         }
 
         return rs;
@@ -217,7 +217,7 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
     @Override
     public List<Provider> getActiveProviders() {
 
-        List<Provider> rs = (List<Provider>) HqlQueryHelper.find(currentSession(),
+        List<Provider> rs = (List<Provider>) JpqlQueryHelper.find(entityManager(),
                 "FROM  Provider p where p.Status='1' AND p.ProviderNo NOT LIKE '-%'  ORDER BY p.LastName");
 
         if (log.isDebugEnabled()) {
@@ -232,10 +232,10 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
         List<Provider> rs = null;
 
         if (!filterOutSystemAndImportedProviders) {
-            rs = (List<Provider>) HqlQueryHelper.find(currentSession(),
+            rs = (List<Provider>) JpqlQueryHelper.find(entityManager(),
                     "FROM  Provider p where p.Status='1' ORDER BY p.LastName");
         } else {
-            rs = (List<Provider>) HqlQueryHelper.find(currentSession(),
+            rs = (List<Provider>) JpqlQueryHelper.find(entityManager(),
                     "FROM  Provider p where p.Status='1' AND p.ProviderNo NOT LIKE '-%' ORDER BY p.LastName");
         }
 
@@ -250,7 +250,7 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
         if (role == null) return Collections.emptyList();
         String sSQL = "select p FROM Provider p, SecUserRole s where p.ProviderNo = s.ProviderNo and p.Status='1' " +
         "and s.RoleName = ?1 order by p.LastName, p.FirstName";
-        List<Provider> rs = (List<Provider>) HqlQueryHelper.find(currentSession(), sSQL, role);
+        List<Provider> rs = (List<Provider>) JpqlQueryHelper.find(entityManager(), sSQL, role);
 
         if (log.isDebugEnabled()) {
             log.debug("getActiveProvidersByRole: # of results=" + rs.size());
@@ -260,7 +260,7 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
 
     @Override
     public List<Provider> getDoctorsWithOhip() {
-        return (List<Provider>) HqlQueryHelper.find(currentSession(),
+        return (List<Provider>) JpqlQueryHelper.find(entityManager(),
                 "FROM Provider p " +
                         "WHERE p.ProviderType = 'doctor' " +
                         "AND p.Status = '1' " +
@@ -270,7 +270,7 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
 
     @Override
     public List<Provider> getBillableProviders() {
-        List<Provider> rs = (List<Provider>) HqlQueryHelper.find(currentSession(),
+        List<Provider> rs = (List<Provider>) JpqlQueryHelper.find(entityManager(),
                 "FROM Provider p where p.OhipNo != '' and p.Status = '1' order by p.LastName");
         return rs;
     }
@@ -289,7 +289,7 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
     public List<Provider> getBillableProvidersInBC(LoggedInInfo loggedInInfo) {
         String sSQL = "FROM Provider p where (p.OhipNo <> '' or p.RmaNo <> ''  or p.BillingNo <> '' or p.HsoNo <> '') " +
                 "and p.Status = '1' and p.ProviderNo not like ?1 order by p.LastName";
-        return (List<Provider>) HqlQueryHelper.find(currentSession(), sSQL, loggedInInfo.getLoggedInProviderNo());
+        return (List<Provider>) JpqlQueryHelper.find(entityManager(), sSQL, loggedInInfo.getLoggedInProviderNo());
     }
 
     @SuppressWarnings("unchecked")
@@ -297,14 +297,14 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
     public List<Provider> getBillableProvidersInBC() {
         String sSQL = "FROM Provider p where (p.OhipNo <> '' or p.RmaNo <> ''  or p.BillingNo <> '' or p.HsoNo <> '') " +
         "and p.Status = '1' order by p.LastName";
-        List<Provider> rs = (List<Provider>) HqlQueryHelper.find(currentSession(), sSQL);
+        List<Provider> rs = (List<Provider>) JpqlQueryHelper.find(entityManager(), sSQL);
         return rs;
     }
 
     @Override
     public List<Provider> getProviders(boolean active) {
         String hql = "FROM Provider p where p.Status = ?1 order by p.LastName";
-        return (List<Provider>) HqlQueryHelper.find(currentSession(), hql, active ? "1" : "0");
+        return (List<Provider>) JpqlQueryHelper.find(entityManager(), hql, active ? "1" : "0");
     }
 
     @Override
@@ -330,7 +330,7 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
         }
 
         Object params[] = paramList.toArray(new Object[paramList.size()]);
-        List<Provider> rs = (List<Provider>) HqlQueryHelper.find(currentSession(), sql, params);
+        List<Provider> rs = (List<Provider>) JpqlQueryHelper.find(entityManager(), sql, params);
 
         if (log.isDebugEnabled()) {
             log.debug("getProviders: # of results=" + rs.size());
@@ -342,7 +342,7 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
     public List<Provider> getActiveProvider(String providerNo) {
 
         String sql = "FROM Provider p where p.Status='1' and p.ProviderNo =?1";
-        List<Provider> rs = (List<Provider>) HqlQueryHelper.find(currentSession(), sql, providerNo);
+        List<Provider> rs = (List<Provider>) JpqlQueryHelper.find(entityManager(), sql, providerNo);
 
         if (log.isDebugEnabled()) {
             log.debug("getProvider: # of results=" + rs.size());
@@ -353,7 +353,7 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
     @Override
     public List<Provider> search(String name) {
         String hql = "FROM Provider p WHERE p.FirstName LIKE ?1 OR p.LastName LIKE ?2 ORDER BY p.ProviderNo";
-        List<Provider> results = (List<Provider>) HqlQueryHelper.find(currentSession(), hql, name + "%", name + "%");
+        List<Provider> results = (List<Provider>) JpqlQueryHelper.find(entityManager(), hql, name + "%", name + "%");
 
         if (log.isDebugEnabled()) {
             log.debug("search: # of results=" + results.size());
@@ -364,7 +364,7 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
     @Override
     public List<Provider> getProvidersByTypeWithNonEmptyOhipNo(String type) {
         String sSQL = "from Provider p where p.ProviderType = ?1 and p.OhipNo <> ''";
-        List<Provider> results = (List<Provider>) HqlQueryHelper.find(currentSession(), sSQL, type);
+        List<Provider> results = (List<Provider>) JpqlQueryHelper.find(entityManager(), sSQL, type);
         return results;
     }
 
@@ -372,7 +372,7 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
     public List<Provider> getProvidersByType(String type) {
 
         String sSQL = "from Provider p where p.ProviderType = ?1";
-        List<Provider> results = (List<Provider>) HqlQueryHelper.find(currentSession(), sSQL, type);
+        List<Provider> results = (List<Provider>) JpqlQueryHelper.find(entityManager(), sSQL, type);
 
         if (log.isDebugEnabled()) {
             log.debug("getProvidersByType: type=" + type + ",# of results="
@@ -386,7 +386,7 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
     public List<Provider> getProvidersByTypePattern(String typePattern) {
 
         String sSQL = "from Provider p where p.ProviderType like ?1";
-        List<Provider> results = (List<Provider>) HqlQueryHelper.find(currentSession(), sSQL, typePattern);
+        List<Provider> results = (List<Provider>) JpqlQueryHelper.find(entityManager(), sSQL, typePattern);
         return results;
     }
 
@@ -421,10 +421,10 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
     @SuppressWarnings("unchecked")
     @Override
     public List<Integer> getFacilityIds(String provider_no) {
-        NativeQuery<?> query = currentSession().createNativeQuery(
+        Query query = entityManager().createNativeQuery(
                 "SELECT facility_id FROM provider_facility, Facility WHERE Facility.id = provider_facility.facility_id AND Facility.disabled = 0 AND provider_no = :providerNo");
         query.setParameter("providerNo", provider_no);
-        return (List<Integer>) query.list();
+        return (List<Integer>) query.getResultList();
     }
 
     @SuppressWarnings("unchecked")
@@ -433,20 +433,20 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
      * Retrieves a list of provider IDs associated with the specified facility ID.
      */
     public List<String> getProviderIds(int facilityId) {
-        NativeQuery<?> query = currentSession().createNativeQuery(
+        Query query = entityManager().createNativeQuery(
                 "SELECT provider_no FROM provider_facility WHERE facility_id = :facilityId");
         query.setParameter("facilityId", facilityId);
-        return (List<String>) query.list();
+        return (List<String>) query.getResultList();
     }
 
     @Override
     public void updateProvider(Provider provider) {
-        currentSession().merge(provider);
+        entityManager().merge(provider);
     }
 
     @Override
     public void saveProvider(Provider provider) {
-        currentSession().persist(provider);
+        entityManager().persist(provider);
     }
 
     @Override
@@ -456,7 +456,7 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
         }
 
         String sSQL = "From Provider p where p.practitionerNo=?1";
-        List<Provider> providerList = (List<Provider>) HqlQueryHelper.find(currentSession(), sSQL, practitionerNo);
+        List<Provider> providerList = (List<Provider>) JpqlQueryHelper.find(entityManager(), sSQL, practitionerNo);
 
         if (providerList.size() > 1) {
             log.warn("Found more than 1 providers with practitionerNo=" + practitionerNo);
@@ -485,7 +485,7 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
         Map<String, Object> params = new HashMap<>();
         params.put("types", Arrays.asList(practitionerNoTypes));
         params.put("practNo", practitionerNo);
-        List<Provider> providerList = (List<Provider>) HqlQueryHelper.find(currentSession(), sSQL, params);
+        List<Provider> providerList = (List<Provider>) JpqlQueryHelper.find(entityManager(), sSQL, params);
 
         if (providerList.size() > 1) {
             log.warn("Found more than 1 providers with practitionerNo=" + practitionerNo);
@@ -499,7 +499,7 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
     @Override
     public List<String> getUniqueTeams() {
 
-        List<String> providerList = (List<String>) HqlQueryHelper.find(currentSession(),
+        List<String> providerList = (List<String>) JpqlQueryHelper.find(entityManager(),
                 "select distinct p.Team From Provider p");
 
         return providerList;
@@ -510,7 +510,7 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
         String team = p.getTeam();
         if (team == null) return Collections.emptyList();
         String sSQL = "from Provider p where p.Status='1' and p.OhipNo!='' and p.Team=?1 order by p.LastName, p.FirstName";
-        List<Provider> providers = (List<Provider>) HqlQueryHelper.find(currentSession(), sSQL, team);
+        List<Provider> providers = (List<Provider>) JpqlQueryHelper.find(entityManager(), sSQL, team);
 
         return providers;
     }
@@ -522,7 +522,7 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
         }
 
         String sSQL = "from Provider p where p.OhipNo like ?1 order by p.LastName, p.FirstName";
-        List<Provider> providers = (List<Provider>) HqlQueryHelper.find(currentSession(), sSQL, ohipNo);
+        List<Provider> providers = (List<Provider>) JpqlQueryHelper.find(entityManager(), sSQL, ohipNo);
 
         if (providers.size() > 1) {
             log.warn("Found more than 1 providers with the given ohipNo");
@@ -536,7 +536,7 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
     @Override
     public List<Provider> getProvidersWithNonEmptyOhip(LoggedInInfo loggedInInfo) {
         String sSQL = "FROM Provider p WHERE p.OhipNo != '' and p.ProviderNo not like ?1 order by p.LastName, p.FirstName";
-        return (List<Provider>) HqlQueryHelper.find(currentSession(), sSQL, loggedInInfo.getLoggedInProviderNo());
+        return (List<Provider>) JpqlQueryHelper.find(entityManager(), sSQL, loggedInInfo.getLoggedInProviderNo());
     }
 
     /**
@@ -546,7 +546,7 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
      */
     @Override
     public List<Provider> getProvidersWithNonEmptyOhip() {
-        return (List<Provider>) HqlQueryHelper.find(currentSession(),
+        return (List<Provider>) JpqlQueryHelper.find(entityManager(),
                 "FROM Provider p WHERE p.OhipNo != '' order by p.LastName, p.FirstName");
     }
 
@@ -554,12 +554,12 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
     public List<Provider> getCurrentTeamProviders(String providerNo) {
         String hql = "SELECT p FROM Provider p WHERE p.Status='1' and p.OhipNo != '' AND (p.ProviderNo=?1 or p.Team=(SELECT p2.Team FROM Provider p2 where p2.ProviderNo=?2)) ORDER BY p.LastName, p.FirstName";
 
-        return (List<Provider>) HqlQueryHelper.find(currentSession(), hql, providerNo, providerNo);
+        return (List<Provider>) JpqlQueryHelper.find(entityManager(), hql, providerNo, providerNo);
     }
 
     @Override
     public List<String> getActiveTeams() {
-        List<String> providerList = (List<String>) HqlQueryHelper.find(currentSession(),
+        List<String> providerList = (List<String>) JpqlQueryHelper.find(entityManager(),
                 "select distinct p.Team From Provider p where p.Status = '1' and p.Team != '' order by p.Team");
         return providerList;
     }
@@ -571,16 +571,16 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
      * Retrieves a list of active teams associated with a given provider number.
      */
     public List<String> getActiveTeamsViaSites(String providerNo) {
-        NativeQuery<?> query = currentSession().createNativeQuery(
+        Query query = entityManager().createNativeQuery(
                 "SELECT DISTINCT team FROM provider p INNER JOIN providersite s ON s.provider_no = p.provider_no WHERE s.site_id IN (SELECT site_id FROM providersite WHERE provider_no = :providerNo) ORDER BY team");
         query.setParameter("providerNo", providerNo);
-        return (List<String>) query.list();
+        return (List<String>) query.getResultList();
     }
 
     @Override
     public List<Provider> getProviderByPatientId(Integer patientId) {
         String hql = "SELECT p FROM Provider p, Demographic d WHERE d.ProviderNo = p.ProviderNo AND d.DemographicNo = ?1";
-        return (List<Provider>) HqlQueryHelper.find(currentSession(), hql, patientId);
+        return (List<Provider>) JpqlQueryHelper.find(entityManager(), hql, patientId);
     }
 
     @Override
@@ -590,7 +590,7 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
                 "AND p.OhipNo IS NOT NULL " +
                 "AND p.OhipNo != '' " +
                 "ORDER BY p.LastName, p.FirstName";
-        return (List<Provider>) HqlQueryHelper.find(currentSession(), sql);
+        return (List<Provider>) JpqlQueryHelper.find(entityManager(), sql);
     }
 
     @Override
@@ -599,20 +599,20 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
                 "AND p.OhipNo IS NOT NULL " +
                 "AND p.OhipNo != '' " +
                 "ORDER BY p.LastName, p.FirstName";
-        return (List<Provider>) HqlQueryHelper.find(currentSession(), sql);
+        return (List<Provider>) JpqlQueryHelper.find(entityManager(), sql);
     }
 
     @Override
     public List<String> getProvidersInTeam(String teamName) {
         if (teamName == null) return Collections.emptyList();
         String sSQL = "select distinct p.ProviderNo from Provider p  where p.Team = ?1";
-        List<String> providerList = (List<String>) HqlQueryHelper.find(currentSession(), sSQL, teamName);
+        List<String> providerList = (List<String>) JpqlQueryHelper.find(entityManager(), sSQL, teamName);
         return providerList;
     }
 
     @Override
     public List<Object[]> getDistinctProviders() {
-        List<Object[]> providerList = (List<Object[]>) HqlQueryHelper.find(currentSession(),
+        List<Object[]> providerList = (List<Object[]>) JpqlQueryHelper.find(entityManager(),
                 "select distinct p.ProviderNo, p.ProviderType from Provider p ORDER BY p.LastName");
         return providerList;
     }
@@ -621,7 +621,7 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
     public List<String> getRecordsAddedAndUpdatedSinceTime(Date date) {
         String sSQL = "select distinct p.ProviderNo From Provider p where p.lastUpdateDate > ?1 ";
         @SuppressWarnings("unchecked")
-        List<String> providers = (List<String>) HqlQueryHelper.find(currentSession(), sSQL, date);
+        List<String> providers = (List<String>) JpqlQueryHelper.find(entityManager(), sSQL, date);
 
         return providers;
     }
@@ -652,7 +652,7 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
 
         }
 
-        Query<Provider> q = currentSession().createQuery(sqlCommand, Provider.class);
+        TypedQuery<Provider> q = entityManager().createQuery(sqlCommand, Provider.class);
         if (searchString != null) {
             q.setParameter("ln", "%" + searchString.split(",")[0] + "%");
             if (searchString.indexOf(",") != -1 && searchString.split(",").length > 1
@@ -662,7 +662,7 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
         }
         q.setFirstResult(startIndex);
         q.setMaxResults(itemsToReturn);
-        return q.list();
+        return q.getResultList();
     }
 
     @SuppressWarnings("unchecked")
@@ -689,14 +689,14 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
 
         sqlCommand += " ORDER BY x.LastName,x.FirstName";
 
-        Query<Provider> q = currentSession().createQuery(sqlCommand, Provider.class);
+        TypedQuery<Provider> q = entityManager().createQuery(sqlCommand, Provider.class);
         q.setParameter("status", active ? "1" : "0");
         if (term != null && term.length() > 0) {
             q.setParameter("term", term + "%");
         }
         q.setFirstResult(startIndex);
         q.setMaxResults(itemsToReturn);
-        return q.list();
+        return q.getResultList();
     }
 
     @SuppressWarnings("unchecked")
@@ -706,10 +706,10 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
      * Retrieves a list of provider numbers with appointments on the specified date.
      */
     public List<String> getProviderNosWithAppointmentsOnDate(Date appointmentDate) {
-        NativeQuery<?> query = currentSession().createNativeQuery(
+        Query query = entityManager().createNativeQuery(
                 "SELECT p.provider_no FROM provider p WHERE p.provider_no IN (SELECT DISTINCT a.provider_no FROM appointment a WHERE a.appointment_date = :appointmentDate) AND p.Status = '1'");
         query.setParameter("appointmentDate", new java.sql.Date(appointmentDate.getTime()));
-        return (List<String>) query.list();
+        return (List<String>) query.getResultList();
     }
 
     /**
@@ -722,10 +722,10 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
      */
     @Override
     public List<Provider> getProvidersByIds(List<String> providerNumbers) {
-        Query<Provider> query = currentSession().createQuery(
+        TypedQuery<Provider> query = entityManager().createQuery(
                 "FROM Provider p WHERE p.ProviderNo IN (:providerNumbers)", Provider.class);
-        query.setParameterList("providerNumbers", providerNumbers);
-        return query.list();
+        query.setParameter("providerNumbers", providerNumbers);
+        return query.getResultList();
     }
 
     /**
@@ -760,9 +760,9 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
 
     @Override
     public List<ProviderSummaryDTO> getActiveProviderSummaries() {
-        Query<ProviderSummaryDTO> query = currentSession().createQuery(
+        TypedQuery<ProviderSummaryDTO> query = entityManager().createQuery(
                 ACTIVE_PROVIDER_SUMMARIES_HQL, ProviderSummaryDTO.class);
-        return query.list();
+        return query.getResultList();
     }
 
     @Override
@@ -770,11 +770,11 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
         if (providerNo == null || providerNo.isEmpty()) {
             return null;
         }
-        Query<ProviderSummaryDTO> query = currentSession().createQuery(
+        TypedQuery<ProviderSummaryDTO> query = entityManager().createQuery(
                 PROVIDER_SUMMARY_BY_ID_HQL, ProviderSummaryDTO.class);
         query.setParameter("providerNo", providerNo);
         query.setMaxResults(1);
-        List<ProviderSummaryDTO> results = query.list();
+        List<ProviderSummaryDTO> results = query.getResultList();
         return results.isEmpty() ? null : results.get(0);
     }
 
@@ -784,10 +784,10 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
         if (providerNumbers == null || providerNumbers.isEmpty()) {
             return map;
         }
-        Query<ProviderSummaryDTO> query = currentSession().createQuery(
+        TypedQuery<ProviderSummaryDTO> query = entityManager().createQuery(
                 PROVIDER_SUMMARIES_BY_IDS_HQL, ProviderSummaryDTO.class);
-        query.setParameterList("providerNumbers", providerNumbers);
-        for (ProviderSummaryDTO dto : query.list()) {
+        query.setParameter("providerNumbers", providerNumbers);
+        for (ProviderSummaryDTO dto : query.getResultList()) {
             map.put(dto.getProviderNo(), dto);
         }
         return map;

--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/SecUserRoleDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/SecUserRoleDaoImpl.java
@@ -37,12 +37,12 @@ import java.util.List;
 import org.apache.logging.log4j.Logger;
 import io.github.carlos_emr.carlos.PMmodule.model.SecUserRole;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
-import io.github.carlos_emr.carlos.dao.AbstractHibernateDao;
+import io.github.carlos_emr.carlos.dao.AbstractJpaDao;
 import org.springframework.transaction.annotation.Transactional;
-import io.github.carlos_emr.carlos.utility.HqlQueryHelper;
+import io.github.carlos_emr.carlos.utility.JpqlQueryHelper;
 
 @Transactional
-public class SecUserRoleDaoImpl extends AbstractHibernateDao implements SecUserRoleDao {
+public class SecUserRoleDaoImpl extends AbstractJpaDao implements SecUserRoleDao {
 
     private static Logger log = MiscUtils.getLogger();
 
@@ -54,7 +54,7 @@ public class SecUserRoleDaoImpl extends AbstractHibernateDao implements SecUserR
 
         String sSQL = "from SecUserRole s where s.ProviderNo = ?1";
         @SuppressWarnings("unchecked")
-        List<SecUserRole> results = (List<SecUserRole>) HqlQueryHelper.find(currentSession(), sSQL, providerNo);
+        List<SecUserRole> results = (List<SecUserRole>) JpqlQueryHelper.find(entityManager(), sSQL, providerNo);
 
         if (log.isDebugEnabled()) {
             log.debug("getUserRoles: providerNo=" + providerNo + ",# of results=" + results.size());
@@ -67,7 +67,7 @@ public class SecUserRoleDaoImpl extends AbstractHibernateDao implements SecUserR
     public List<SecUserRole> getSecUserRolesByRoleName(String roleName) {
         String sSQL = "from SecUserRole s where s.RoleName = ?1";
         @SuppressWarnings("unchecked")
-        List<SecUserRole> results = (List<SecUserRole>) HqlQueryHelper.find(currentSession(), sSQL, roleName);
+        List<SecUserRole> results = (List<SecUserRole>) JpqlQueryHelper.find(entityManager(), sSQL, roleName);
 
         return results;
     }
@@ -76,7 +76,7 @@ public class SecUserRoleDaoImpl extends AbstractHibernateDao implements SecUserR
     public List<SecUserRole> findByRoleNameAndProviderNo(String roleName, String providerNo) {
         String sSQL = "from SecUserRole s where s.RoleName = ?1 and s.ProviderNo=?2";
         @SuppressWarnings("unchecked")
-        List<SecUserRole> results = (List<SecUserRole>) HqlQueryHelper.find(currentSession(), sSQL, roleName, providerNo);
+        List<SecUserRole> results = (List<SecUserRole>) JpqlQueryHelper.find(entityManager(), sSQL, roleName, providerNo);
 
         return results;
     }
@@ -90,7 +90,7 @@ public class SecUserRoleDaoImpl extends AbstractHibernateDao implements SecUserR
         boolean result = false;
         String sSQL = "from SecUserRole s where s.ProviderNo = ?1 and s.RoleName = 'admin'";
         @SuppressWarnings("unchecked")
-        List<SecUserRole> results = (List<SecUserRole>) HqlQueryHelper.find(currentSession(), sSQL, providerNo);
+        List<SecUserRole> results = (List<SecUserRole>) JpqlQueryHelper.find(entityManager(), sSQL, providerNo);
         if (!results.isEmpty()) {
             result = true;
         }
@@ -104,20 +104,20 @@ public class SecUserRoleDaoImpl extends AbstractHibernateDao implements SecUserR
 
     @Override
     public SecUserRole find(Long id) {
-        return currentSession().find(SecUserRole.class, id);
+        return entityManager().find(SecUserRole.class, id);
     }
 
     @Override
     public void save(SecUserRole sur) {
         sur.setLastUpdateDate(new Date());
-        currentSession().persist(sur);
+        entityManager().persist(sur);
     }
 
     @Override
     public List<String> getRecordsAddedAndUpdatedSinceTime(Date date) {
         String sSQL = "select p.ProviderNo From SecUserRole p WHERE p.lastUpdateDate > ?1";
         @SuppressWarnings("unchecked")
-        List<String> records = (List<String>) HqlQueryHelper.find(currentSession(), sSQL, date);
+        List<String> records = (List<String>) JpqlQueryHelper.find(entityManager(), sSQL, date);
 
         return records;
     }

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/dao/CaseManagementCPPDAOImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/dao/CaseManagementCPPDAOImpl.java
@@ -37,21 +37,21 @@ import java.util.List;
 import org.apache.logging.log4j.Logger;
 import io.github.carlos_emr.carlos.casemgmt.model.CaseManagementCPP;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
-import io.github.carlos_emr.carlos.dao.AbstractHibernateDao;
+import io.github.carlos_emr.carlos.dao.AbstractJpaDao;
 import org.springframework.transaction.annotation.Transactional;
-import io.github.carlos_emr.carlos.utility.HqlQueryHelper;
+import io.github.carlos_emr.carlos.utility.JpqlQueryHelper;
 
 /*
  * Updated by Eugene Petruhin on 09 jan 2009 while fixing #2482832 & #2494061
  */
 @Transactional
-public class CaseManagementCPPDAOImpl extends AbstractHibernateDao implements CaseManagementCPPDAO {
+public class CaseManagementCPPDAOImpl extends AbstractJpaDao implements CaseManagementCPPDAO {
 
     private Logger log = MiscUtils.getLogger();
 
     @Override
     public CaseManagementCPP getCPP(String demographic_no) {
-        List results = HqlQueryHelper.find(currentSession(),
+        List results = JpqlQueryHelper.find(entityManager(),
                 "from CaseManagementCPP cpp where cpp.demographic_no = ?1 order by update_date desc",
                 demographic_no);
         return (results.size() != 0) ? (CaseManagementCPP) results.get(0) : null;
@@ -84,9 +84,9 @@ public class CaseManagementCPPDAOImpl extends AbstractHibernateDao implements Ca
         }
 
         if (cpp.getId() == null) {
-            currentSession().persist(cpp);
+            entityManager().persist(cpp);
         } else {
-            currentSession().merge(cpp);
+            entityManager().merge(cpp);
         }
 
     }

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/dao/CaseManagementIssueDAOImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/dao/CaseManagementIssueDAOImpl.java
@@ -43,20 +43,20 @@ import io.github.carlos_emr.carlos.PMmodule.model.Program;
 import io.github.carlos_emr.carlos.casemgmt.model.CaseManagementIssue;
 import io.github.carlos_emr.carlos.casemgmt.model.Issue;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
-import io.github.carlos_emr.carlos.dao.AbstractHibernateDao;
+import io.github.carlos_emr.carlos.dao.AbstractJpaDao;
 import org.springframework.transaction.annotation.Transactional;
-import io.github.carlos_emr.carlos.utility.HqlQueryHelper;
+import io.github.carlos_emr.carlos.utility.JpqlQueryHelper;
 import io.github.carlos_emr.carlos.utility.LogSanitizer;
 
 @Transactional
-public class CaseManagementIssueDAOImpl extends AbstractHibernateDao implements CaseManagementIssueDAO {
+public class CaseManagementIssueDAOImpl extends AbstractJpaDao implements CaseManagementIssueDAO {
 
     private static Logger log = MiscUtils.getLogger();
 
     @SuppressWarnings("unchecked")
     @Override
     public List<CaseManagementIssue> getIssuesByDemographic(String demographic_no) {
-        return (List<CaseManagementIssue>) HqlQueryHelper.find(currentSession(),
+        return (List<CaseManagementIssue>) JpqlQueryHelper.find(entityManager(),
                 "from CaseManagementIssue cmi where cmi.demographic_no = ?1",
                 Integer.valueOf(demographic_no));
     }
@@ -65,11 +65,11 @@ public class CaseManagementIssueDAOImpl extends AbstractHibernateDao implements 
     @Override
     public List<CaseManagementIssue> getIssuesByDemographicOrderActive(Integer demographic_no, Boolean resolved) {
         if (resolved != null) {
-            return (List<CaseManagementIssue>) HqlQueryHelper.find(currentSession(),
+            return (List<CaseManagementIssue>) JpqlQueryHelper.find(entityManager(),
                     "from CaseManagementIssue cmi where cmi.demographic_no = ?1 and cmi.resolved = ?2 order by cmi.resolved",
                     demographic_no, resolved);
         } else {
-            return (List<CaseManagementIssue>) HqlQueryHelper.find(currentSession(),
+            return (List<CaseManagementIssue>) JpqlQueryHelper.find(entityManager(),
                     "from CaseManagementIssue cmi where cmi.demographic_no = ?1 order by cmi.resolved",
                     demographic_no);
         }
@@ -79,11 +79,11 @@ public class CaseManagementIssueDAOImpl extends AbstractHibernateDao implements 
     @Override
     public List<CaseManagementIssue> getIssuesByNote(Integer noteId, Boolean resolved) {
         if (resolved != null) {
-            return (List<CaseManagementIssue>) HqlQueryHelper.find(currentSession(),
+            return (List<CaseManagementIssue>) JpqlQueryHelper.find(entityManager(),
                     "from CaseManagementIssue cmi where cmi.notes.id = ?1 and cmi.resolved = ?2 order by cmi.resolved",
                     noteId, resolved);
         } else {
-            return (List<CaseManagementIssue>) HqlQueryHelper.find(currentSession(),
+            return (List<CaseManagementIssue>) JpqlQueryHelper.find(entityManager(),
                     "from CaseManagementIssue cmi where cmi.notes.id = ?1 order by cmi.resolved",
                     noteId);
         }
@@ -92,7 +92,7 @@ public class CaseManagementIssueDAOImpl extends AbstractHibernateDao implements 
     @SuppressWarnings("unchecked")
     @Override
     public Issue getIssueByCmnId(Integer cmnIssueId) {
-        List<Issue> result = (List<Issue>) HqlQueryHelper.find(currentSession(),
+        List<Issue> result = (List<Issue>) JpqlQueryHelper.find(entityManager(),
                 "select issue from CaseManagementIssue cmi where cmi.id = ?1",
                 Long.valueOf(cmnIssueId));
         if (result.size() > 0)
@@ -103,7 +103,7 @@ public class CaseManagementIssueDAOImpl extends AbstractHibernateDao implements 
     @Override
     public CaseManagementIssue getIssuebyId(String demo, String id) {
         @SuppressWarnings("unchecked")
-        List<CaseManagementIssue> list = (List<CaseManagementIssue>) HqlQueryHelper.find(currentSession(),
+        List<CaseManagementIssue> list = (List<CaseManagementIssue>) JpqlQueryHelper.find(entityManager(),
                 "from CaseManagementIssue cmi where cmi.issue_id = ?1 and cmi.demographic_no = ?2",
                 Long.parseLong(id), Integer.valueOf(demo));
         if (list != null && list.size() == 1)
@@ -115,7 +115,7 @@ public class CaseManagementIssueDAOImpl extends AbstractHibernateDao implements 
     @Override
     public CaseManagementIssue getIssuebyIssueCode(String demo, String issueCode) {
         @SuppressWarnings("unchecked")
-        List<CaseManagementIssue> list = (List<CaseManagementIssue>) HqlQueryHelper.find(currentSession(),
+        List<CaseManagementIssue> list = (List<CaseManagementIssue>) JpqlQueryHelper.find(entityManager(),
                 "select cmi from CaseManagementIssue cmi, Issue issue where cmi.issue_id=issue.id and issue.code = ?1 and cmi.demographic_no = ?2",
                 issueCode, Integer.valueOf(demo));
 
@@ -131,7 +131,7 @@ public class CaseManagementIssueDAOImpl extends AbstractHibernateDao implements 
 
     @Override
     public void deleteIssueById(CaseManagementIssue issue) {
-        currentSession().remove(issue);
+        entityManager().remove(issue);
         return;
 
     }
@@ -143,9 +143,9 @@ public class CaseManagementIssueDAOImpl extends AbstractHibernateDao implements 
             CaseManagementIssue cmi = itr.next();
             cmi.setUpdate_date(new Date());
             if (cmi.getId() != null && cmi.getId().longValue() > 0) {
-                currentSession().merge(cmi);
+                entityManager().merge(cmi);
             } else {
-                currentSession().persist(cmi);
+                entityManager().persist(cmi);
             }
         }
 
@@ -154,16 +154,16 @@ public class CaseManagementIssueDAOImpl extends AbstractHibernateDao implements 
     public void saveIssue(CaseManagementIssue issue) {
         issue.setUpdate_date(new Date());
         if (issue.getId() == null || issue.getId() <= 0) {
-            currentSession().persist(issue);
+            entityManager().persist(issue);
         } else {
-            currentSession().merge(issue);
+            entityManager().merge(issue);
         }
     }
 
     @SuppressWarnings("unchecked")
     @Override
     public List<CaseManagementIssue> getAllCertainIssues() {
-        return (List<CaseManagementIssue>) HqlQueryHelper.find(currentSession(),
+        return (List<CaseManagementIssue>) JpqlQueryHelper.find(entityManager(),
                 "from CaseManagementIssue cmi where cmi.certain = true");
     }
 
@@ -183,7 +183,7 @@ public class CaseManagementIssueDAOImpl extends AbstractHibernateDao implements 
         Map<String, Object> params = new HashMap<>();
         params.put("updateDate", date);
         params.put("programIds", programIds);
-        List<Integer> results = (List<Integer>) HqlQueryHelper.find(currentSession(), hql, params);
+        List<Integer> results = (List<Integer>) JpqlQueryHelper.find(entityManager(), hql, params);
 
         return results;
     }
@@ -191,7 +191,7 @@ public class CaseManagementIssueDAOImpl extends AbstractHibernateDao implements 
     @SuppressWarnings("unchecked")
     @Override
     public List<CaseManagementIssue> getIssuesByDemographicSince(String demographic_no, Date date) {
-        return (List<CaseManagementIssue>) HqlQueryHelper.find(currentSession(),
+        return (List<CaseManagementIssue>) JpqlQueryHelper.find(entityManager(),
                 "from CaseManagementIssue cmi where cmi.demographic_no = ?1 and cmi.update_date > ?2",
                 Integer.valueOf(demographic_no), date);
     }

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/dao/CaseManagementNoteDAOImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/dao/CaseManagementNoteDAOImpl.java
@@ -376,6 +376,9 @@ public class CaseManagementNoteDAOImpl extends AbstractJpaDao implements CaseMan
             query.setParameter("demographicNo", demographic_no);
 
             if (issueCodes != null && issueCodes.length > 0) {
+                // Hibernate 7 extension: setParameter with a List on a native query expands the collection
+                // into the IN clause — this is not guaranteed by the JPA spec but is supported by Hibernate
+                // as NativeQueryImplementor (replaces the pre-migration setParameterList() call).
                 query.setParameter("issueCodes", Arrays.asList(issueCodes));
             }
 
@@ -607,7 +610,7 @@ public class CaseManagementNoteDAOImpl extends AbstractJpaDao implements CaseMan
                 log.debug("Could not find issueCode: " + issueCode);
                 return 0;
             }
-            Integer issueId = ((Number) issueResults.get(0)).intValue();
+            int issueId = ((Number) issueResults.get(0)).intValue();
 
             log.debug("issue Code " + issueCode + " id :" + issueId);
 

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/dao/CaseManagementNoteDAOImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/dao/CaseManagementNoteDAOImpl.java
@@ -45,24 +45,25 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.UUID;
 
+import java.util.Arrays;
+
 import org.apache.logging.log4j.Logger;
 import org.hibernate.Hibernate;
-import org.hibernate.Session;
-import org.hibernate.query.NativeQuery;
-import org.hibernate.query.Query;
+
+import jakarta.persistence.Query;
 
 import io.github.carlos_emr.carlos.PMmodule.model.Program;
 import io.github.carlos_emr.carlos.casemgmt.model.CaseManagementNote;
 import io.github.carlos_emr.carlos.casemgmt.model.CaseManagementSearchBean;
 import io.github.carlos_emr.carlos.commn.model.Provider;
-import io.github.carlos_emr.carlos.dao.AbstractHibernateDao;
+import io.github.carlos_emr.carlos.dao.AbstractJpaDao;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import org.springframework.transaction.annotation.Transactional;
 
-import io.github.carlos_emr.carlos.utility.HqlQueryHelper;
+import io.github.carlos_emr.carlos.utility.JpqlQueryHelper;
 
 @Transactional
-public class CaseManagementNoteDAOImpl extends AbstractHibernateDao implements CaseManagementNoteDAO {
+public class CaseManagementNoteDAOImpl extends AbstractJpaDao implements CaseManagementNoteDAO {
 
     private static Logger log = MiscUtils.getLogger();
 
@@ -71,7 +72,7 @@ public class CaseManagementNoteDAOImpl extends AbstractHibernateDao implements C
     public List<CaseManagementNote> findAll() {
         log.warn(
                 "A METHOD THAT IS LIKELY TO CAUSE A CRASH HAS BEEN INVOKED. PLEASE LIMIT THE USE OF THIS METHOD, AS IT'S LIKELY TO EXHAUST MEMORY AND MAY LEAD TO A SERVER CRASH. CONSIDER PAGINATING THE INVOCATION INSTEAD");
-        return (List<CaseManagementNote>) HqlQueryHelper.find(currentSession(), "FROM CaseManagementNote");
+        return (List<CaseManagementNote>) JpqlQueryHelper.find(entityManager(), "FROM CaseManagementNote");
     }
 
     @SuppressWarnings("unchecked")
@@ -80,7 +81,7 @@ public class CaseManagementNoteDAOImpl extends AbstractHibernateDao implements C
         String uuid = note.getUuid();
         if (uuid == null) return Collections.emptyList();
         String hql = "select distinct p from Provider p, CaseManagementNote cmn where p.ProviderNo = cmn.providerNo and cmn.uuid = ?1";
-        return (List<Provider>) HqlQueryHelper.find(currentSession(), hql, uuid);
+        return (List<Provider>) JpqlQueryHelper.find(entityManager(), hql, uuid);
     }
 
     @SuppressWarnings("unchecked")
@@ -88,7 +89,7 @@ public class CaseManagementNoteDAOImpl extends AbstractHibernateDao implements C
     public List<Provider> getAllEditors(String demographicNo) {
         if (demographicNo == null) return Collections.emptyList();
         String hql = "select distinct p from Provider p, CaseManagementNote cmn where p.ProviderNo = cmn.providerNo and cmn.demographic_no = ?1";
-        return (List<Provider>) HqlQueryHelper.find(currentSession(), hql, demographicNo);
+        return (List<Provider>) JpqlQueryHelper.find(entityManager(), hql, demographicNo);
     }
 
     @SuppressWarnings("unchecked")
@@ -96,7 +97,7 @@ public class CaseManagementNoteDAOImpl extends AbstractHibernateDao implements C
     public List<CaseManagementNote> getHistory(CaseManagementNote note) {
         String uuid = note.getUuid();
         if (uuid == null) return Collections.emptyList();
-        return (List<CaseManagementNote>) HqlQueryHelper.find(currentSession(),
+        return (List<CaseManagementNote>) JpqlQueryHelper.find(entityManager(),
                 "from CaseManagementNote cmn where cmn.uuid = ?1 order by cmn.update_date asc", uuid);
     }
 
@@ -112,10 +113,10 @@ public class CaseManagementNoteDAOImpl extends AbstractHibernateDao implements C
         params.put("demoNo", demoNo);
 
         String hql = "select cmn from CaseManagementNote cmn join cmn.issues i where i.issue_id in (:issueIds) and cmn.demographic_no = :demoNo ORDER BY cmn.observation_date asc";
-        List<CaseManagementNote> issueList = (List<CaseManagementNote>) HqlQueryHelper.find(currentSession(), hql, params);
+        List<CaseManagementNote> issueList = (List<CaseManagementNote>) JpqlQueryHelper.find(entityManager(), hql, params);
 
         hql = "select max(cmn.id) from CaseManagementNote cmn join cmn.issues i where i.issue_id in (:issueIds) and cmn.demographic_no = :demoNo group by cmn.uuid order by max(cmn.id)";
-        List<Long> currNoteList = (List<Long>) HqlQueryHelper.find(currentSession(), hql, params);
+        List<Long> currNoteList = (List<Long>) JpqlQueryHelper.find(entityManager(), hql, params);
 
         for (CaseManagementNote issueNote : issueList) {
             if (currNoteList.contains(issueNote.getId())) {
@@ -128,8 +129,8 @@ public class CaseManagementNoteDAOImpl extends AbstractHibernateDao implements C
 
     @Override
     public CaseManagementNote getNote(Long id) {
-        CaseManagementNote note = currentSession().find(CaseManagementNote.class, id);
-        // currentSession().find() returns null when no record exists for the given id;
+        CaseManagementNote note = entityManager().find(CaseManagementNote.class, id);
+        // entityManager().find() returns null when no record exists for the given id;
         // guard prevents NPE on lazy-collection initialization for deleted or missing notes
         if (note != null) {
             Hibernate.initialize(note.getIssues());
@@ -145,7 +146,7 @@ public class CaseManagementNoteDAOImpl extends AbstractHibernateDao implements C
         Map<String, Object> params = new HashMap<>();
         params.put("ids", ids);
         @SuppressWarnings("unchecked")
-        List<CaseManagementNote> notes = (List<CaseManagementNote>) HqlQueryHelper.find(currentSession(), hql, params);
+        List<CaseManagementNote> notes = (List<CaseManagementNote>) JpqlQueryHelper.find(entityManager(), hql, params);
         return notes;
     }
 
@@ -158,7 +159,7 @@ public class CaseManagementNoteDAOImpl extends AbstractHibernateDao implements C
         Map<String, Object> params = new HashMap<>();
         params.put("uuid", uuid);
         @SuppressWarnings("unchecked")
-        List<CaseManagementNote> tmp = (List<CaseManagementNote>) HqlQueryHelper.find(currentSession(), hql, params);
+        List<CaseManagementNote> tmp = (List<CaseManagementNote>) JpqlQueryHelper.find(entityManager(), hql, params);
 
         if (tmp == null || tmp.isEmpty())
             return null;
@@ -170,7 +171,7 @@ public class CaseManagementNoteDAOImpl extends AbstractHibernateDao implements C
     public List<CaseManagementNote> getNotesByUUID(String uuid) {
         String hql = "select cmn from CaseManagementNote cmn where cmn.uuid = ?1 order by cmn.id";
         @SuppressWarnings("unchecked")
-        List<CaseManagementNote> ret = (List<CaseManagementNote>) HqlQueryHelper.find(currentSession(), hql, uuid);
+        List<CaseManagementNote> ret = (List<CaseManagementNote>) JpqlQueryHelper.find(entityManager(), hql, uuid);
         return ret;
     }
 
@@ -194,7 +195,7 @@ public class CaseManagementNoteDAOImpl extends AbstractHibernateDao implements C
         String hql = "select distinct cmn from CaseManagementNote cmn join cmn.issues i where i.issue_id = ?1 and cmn.demographic_no = ?2 and cmn.observation_date >= ?3  and cmn.id in (select max(cmn2.id) from CaseManagementNote cmn2 where cmn2.demographic_no = ?4 GROUP BY cmn2.uuid) ORDER BY cmn.observation_date asc";
 
         @SuppressWarnings("unchecked")
-        List<CaseManagementNote> result = (List<CaseManagementNote>) HqlQueryHelper.find(currentSession(), hql,
+        List<CaseManagementNote> result = (List<CaseManagementNote>) JpqlQueryHelper.find(entityManager(), hql,
                 issueId, demoNo, d, demoNo);
         return result;
     }
@@ -224,17 +225,17 @@ public class CaseManagementNoteDAOImpl extends AbstractHibernateDao implements C
         params.put("staleDate", d);
 
         @SuppressWarnings("unchecked")
-        List<CaseManagementNote> result = (List<CaseManagementNote>) HqlQueryHelper.find(currentSession(), hql, params);
+        List<CaseManagementNote> result = (List<CaseManagementNote>) JpqlQueryHelper.find(entityManager(), hql, params);
         return result;
     }
 
     @SuppressWarnings("unchecked")
     @Override
     public List<CaseManagementNote> getNotesByDemographic(String demographic_no, String staleDate) {
-        Query<?> q = currentSession().createNamedQuery("mostRecentTime");
+        Query q = entityManager().createNamedQuery("mostRecentTime");
         q.setParameter("demographicNo", demographic_no);
         q.setParameter("staleDate", staleDate);
-        return (List<CaseManagementNote>) q.list();
+        return (List<CaseManagementNote>) q.getResultList();
     }
 
     // This was created by OSCAR. if all notes' UUID are same like null, it will
@@ -243,48 +244,48 @@ public class CaseManagementNoteDAOImpl extends AbstractHibernateDao implements C
     @Override
     public List<CaseManagementNote> getNotesByDemographic(String demographic_no) {
         String hql = "select cmn from CaseManagementNote cmn where cmn.demographic_no = ?1 and cmn.id = (select max(cmn2.id) from CaseManagementNote cmn2 where cmn2.uuid = cmn.uuid) order by cmn.observation_date";
-        return (List<CaseManagementNote>) HqlQueryHelper.find(currentSession(), hql, demographic_no);
+        return (List<CaseManagementNote>) JpqlQueryHelper.find(entityManager(), hql, demographic_no);
     }
 
     @Override
     public List<CaseManagementNote> getNotesByDemographicSince(String demographic_no, Date date) {
         if (demographic_no == null || date == null) return Collections.emptyList();
         String hql = "select cmn from CaseManagementNote cmn where cmn.demographic_no = ?1 and cmn.update_date > ?2 and cmn.locked = false and cmn.id = (select max(cmn2.id) from CaseManagementNote cmn2 where cmn2.uuid = cmn.uuid) order by cmn.observation_date";
-        return (List<CaseManagementNote>) HqlQueryHelper.find(currentSession(), hql, demographic_no, date);
+        return (List<CaseManagementNote>) JpqlQueryHelper.find(entityManager(), hql, demographic_no, date);
     }
 
     @Override
     public long getNotesCountByDemographicId(String demographic_no) {
         String hql = "select count(*) from CaseManagementNote cmm where cmm.demographic_no = ?1";
-        return ((Long) HqlQueryHelper.find(currentSession(), hql, demographic_no).get(0)).longValue();
+        return ((Long) JpqlQueryHelper.find(entityManager(), hql, demographic_no).get(0)).longValue();
     }
 
     @SuppressWarnings("unchecked")
     @Override
     public List<Object[]> getRawNoteInfoByDemographic(String demographic_no) {
         String hql = "select cmn.id,cmn.observation_date,cmn.providerNo,cmn.program_no,cmn.reporter_caisi_role,cmn.uuid from CaseManagementNote cmn where cmn.demographic_no = ?1 order by cmn.update_date DESC";
-        return (List<Object[]>) HqlQueryHelper.find(currentSession(), hql, demographic_no);
+        return (List<Object[]>) JpqlQueryHelper.find(entityManager(), hql, demographic_no);
     }
 
     @SuppressWarnings("unchecked")
     @Override
     public List<Map<String, Object>> getRawNoteInfoMapByDemographic(String demographic_no) {
         String hql = "select new map(cmn.id as id,cmn.observation_date as observation_date,cmn.providerNo as providerNo,cmn.program_no as program_no,cmn.reporter_caisi_role as reporter_caisi_role,cmn.uuid as uuid, cmn.update_date as update_date) from CaseManagementNote cmn where cmn.demographic_no = ?1 order by cmn.update_date DESC";
-        return (List<Map<String, Object>>) HqlQueryHelper.find(currentSession(), hql, demographic_no);
+        return (List<Map<String, Object>>) JpqlQueryHelper.find(entityManager(), hql, demographic_no);
     }
 
     @SuppressWarnings("unchecked")
     @Override
     public List<Map<String, Object>> getUnsignedRawNoteInfoMapByDemographic(String demographic_no) {
         String hql = "select new map(cmn.id as id,cmn.observation_date as observation_date,cmn.providerNo as providerNo,cmn.program_no as program_no,cmn.reporter_caisi_role as reporter_caisi_role,cmn.uuid as uuid, cmn.update_date as update_date) from CaseManagementNote cmn where cmn.demographic_no = ?1 and cmn.signed=?2 and cmn.id = (select max(cmn2.id) from CaseManagementNote cmn2 where cmn2.uuid = cmn.uuid) order by cmn.update_date DESC";
-        return (List<Map<String, Object>>) HqlQueryHelper.find(currentSession(), hql, demographic_no, false);
+        return (List<Map<String, Object>>) JpqlQueryHelper.find(entityManager(), hql, demographic_no, false);
     }
 
     @SuppressWarnings("unchecked")
     @Override
     public List<CaseManagementNote> getNotesByDemographic(String demographic_no, Integer maxNotes) {
         String hql = "select cmn from CaseManagementNote cmn where cmn.demographic_no = ?1 and cmn.id = (select max(cmn2.id) from CaseManagementNote cmn2 where cmn2.uuid = cmn.uuid) order by cmn.observation_date desc";
-        return (List<CaseManagementNote>) HqlQueryHelper.findWithLimit(currentSession(), hql, maxNotes, demographic_no);
+        return (List<CaseManagementNote>) JpqlQueryHelper.findWithLimit(entityManager(), hql, maxNotes, demographic_no);
     }
 
     @SuppressWarnings("unchecked")
@@ -302,7 +303,7 @@ public class CaseManagementNoteDAOImpl extends AbstractHibernateDao implements C
             Map<String, Object> params = new HashMap<>();
             params.put("issueIds", issueIdList);
             params.put("demoNo", demographic_no);
-            return (List<CaseManagementNote>) HqlQueryHelper.find(currentSession(), hql, params);
+            return (List<CaseManagementNote>) JpqlQueryHelper.find(entityManager(), hql, params);
 
         } else {
             long id = Long.parseLong(issues[0]);
@@ -311,12 +312,12 @@ public class CaseManagementNoteDAOImpl extends AbstractHibernateDao implements C
             Map<String, Object> params = new HashMap<>();
             params.put("issueId", id);
             params.put("demoNo", demographic_no);
-            List<CaseManagementNote> issueList = (List<CaseManagementNote>) HqlQueryHelper.find(currentSession(), hql, params);
+            List<CaseManagementNote> issueList = (List<CaseManagementNote>) JpqlQueryHelper.find(entityManager(), hql, params);
 
             hql = "select max(cmn.id) from CaseManagementNote cmn where cmn.demographic_no = :demoNo group by cmn.uuid order by max(cmn.id)";
             Map<String, Object> params2 = new HashMap<>();
             params2.put("demoNo", demographic_no);
-            List<Long> currNoteList = (List<Long>) HqlQueryHelper.find(currentSession(), hql, params2);
+            List<Long> currNoteList = (List<Long>) JpqlQueryHelper.find(entityManager(), hql, params2);
 
             for (CaseManagementNote issueNote : issueList) {
                 if (currNoteList.contains(issueNote.getId())) {
@@ -339,7 +340,7 @@ public class CaseManagementNoteDAOImpl extends AbstractHibernateDao implements C
         Map<String, Object> params = new HashMap<>();
         params.put("issueIds", issueIdList);
         params.put("demoNo", demographic_no);
-        return (List<CaseManagementNote>) HqlQueryHelper.findWithLimit(currentSession(), hql, maxNotes, params);
+        return (List<CaseManagementNote>) JpqlQueryHelper.findWithLimit(entityManager(), hql, maxNotes, params);
     }
 
     @SuppressWarnings("unchecked")
@@ -354,13 +355,12 @@ public class CaseManagementNoteDAOImpl extends AbstractHibernateDao implements C
         Map<String, Object> params = new HashMap<>();
         params.put("issueIds", issueIdList);
         params.put("demoNo", demographic_no);
-        return (List<CaseManagementNote>) HqlQueryHelper.find(currentSession(), hql, params);
+        return (List<CaseManagementNote>) JpqlQueryHelper.find(entityManager(), hql, params);
     }
 
     @Override
     public Collection<CaseManagementNote> findNotesByDemographicAndIssueCode(Integer demographic_no,
                                                                              String[] issueCodes) {
-        Session session = currentSession();
         List<CaseManagementNote> notes = new ArrayList<CaseManagementNote>();
         StringBuilder sqlCommand = new StringBuilder(
                 "select distinct casemgmt_note.note_id from issue,casemgmt_issue,casemgmt_issue_notes,casemgmt_note " +
@@ -372,15 +372,15 @@ public class CaseManagementNoteDAOImpl extends AbstractHibernateDao implements C
             
             sqlCommand.append("and casemgmt_issue_notes.id=casemgmt_issue.id and casemgmt_issue_notes.note_id=casemgmt_note.note_id");
             
-            NativeQuery<?> query = session.createNativeQuery(sqlCommand.toString());
+            Query query = entityManager().createNativeQuery(sqlCommand.toString());
             query.setParameter("demographicNo", demographic_no);
 
             if (issueCodes != null && issueCodes.length > 0) {
-                query.setParameterList("issueCodes", issueCodes);
+                query.setParameter("issueCodes", Arrays.asList(issueCodes));
             }
 
             @SuppressWarnings("unchecked")
-            List<?> ids = query.list();
+            List<?> ids = query.getResultList();
             for (Object id : ids) {
                 if (id instanceof Number) {
                     notes.add(getNote(((Number) id).longValue()));
@@ -411,30 +411,30 @@ public class CaseManagementNoteDAOImpl extends AbstractHibernateDao implements C
     @Override
     public List<CaseManagementNote> getNotesByDemographicDateRange(String demographic_no, Date startDate,
                                                                    Date endDate) {
-        Query<?> q = currentSession().createNamedQuery("mostRecentDateRange");
+        Query q = entityManager().createNamedQuery("mostRecentDateRange");
         q.setParameter("demographicNo", demographic_no);
         q.setParameter("startDate", startDate);
         q.setParameter("endDate", endDate);
-        return (List<CaseManagementNote>) q.list();
+        return (List<CaseManagementNote>) q.getResultList();
     }
 
     @SuppressWarnings("unchecked")
     @Override
     public List<CaseManagementNote> getNotesByDemographicLimit(String demographic_no, Integer offset,
                                                                Integer numToReturn) {
-        Query<?> q = currentSession().createNamedQuery("mostRecentLimit");
+        Query q = entityManager().createNamedQuery("mostRecentLimit");
         q.setParameter("demographicNo", demographic_no);
         q.setFirstResult(offset);
         q.setMaxResults(numToReturn);
-        return (List<CaseManagementNote>) q.list();
+        return (List<CaseManagementNote>) q.getResultList();
     }
 
     @Override
     @Transactional(readOnly = false)
     public void updateNote(CaseManagementNote note) {
         note.setUpdate_date(new Date());
-        currentSession().merge(note);
-        currentSession().flush();
+        entityManager().merge(note);
+        entityManager().flush();
     }
 
     /**
@@ -460,11 +460,11 @@ public class CaseManagementNoteDAOImpl extends AbstractHibernateDao implements C
         // existing IDs — merge reattaches them. persist is for new notes only.
         // updateNote() also exists but callers historically use saveNote for both.
         if (note.getId() != null && note.getId() > 0) {
-            currentSession().merge(note);
+            entityManager().merge(note);
         } else {
-            currentSession().persist(note);
+            entityManager().persist(note);
         }
-        currentSession().flush();
+        entityManager().flush();
     }
 
     /**
@@ -488,9 +488,9 @@ public class CaseManagementNoteDAOImpl extends AbstractHibernateDao implements C
             note.setUpdate_date(new Date());
         }
         if (note.getId() != null && note.getId() > 0) {
-            return currentSession().merge(note);
+            return entityManager().merge(note);
         } else {
-            currentSession().persist(note);
+            entityManager().persist(note);
             return note;
         }
     }
@@ -533,8 +533,8 @@ public class CaseManagementNoteDAOImpl extends AbstractHibernateDao implements C
             hql += " ORDER BY cmn.update_date DESC";
 
             @SuppressWarnings("unchecked")
-            List<CaseManagementNote> results = (List<CaseManagementNote>) HqlQueryHelper.find(
-                    currentSession(), hql, params);
+            List<CaseManagementNote> results = (List<CaseManagementNote>) JpqlQueryHelper.find(
+                    entityManager(), hql, params);
             return results;
 
         } catch (ParseException e) {
@@ -546,26 +546,26 @@ public class CaseManagementNoteDAOImpl extends AbstractHibernateDao implements C
     @Override
     public List<Long> getAllNoteIds() {
         @SuppressWarnings("unchecked")
-        List<Long> results = (List<Long>) HqlQueryHelper.find(currentSession(), "select n.id from CaseManagementNote n");
+        List<Long> results = (List<Long>) JpqlQueryHelper.find(entityManager(), "select n.id from CaseManagementNote n");
         return results;
     }
 
     @Override
     public boolean haveIssue(Long issid, String demoNo) {
-        NativeQuery<?> query = currentSession().createNativeQuery(
+        Query query = entityManager().createNativeQuery(
                 "SELECT * FROM casemgmt_issue_notes WHERE id = :issId");
         query.setParameter("issId", issid);
-        List<?> results = query.list();
+        List<?> results = query.getResultList();
         return !results.isEmpty();
     }
 
     @Override
     public boolean haveIssue(String issueCode, Integer demographicId) {
-        NativeQuery<?> query = currentSession().createNativeQuery(
+        Query query = entityManager().createNativeQuery(
                 "SELECT casemgmt_issue.id FROM casemgmt_issue_notes, casemgmt_issue, issue WHERE issue.issue_id = casemgmt_issue.issue_id AND casemgmt_issue.id = casemgmt_issue_notes.id AND demographic_no = :demographicId AND issue.code = :issueCode");
         query.setParameter("demographicId", demographicId);
         query.setParameter("issueCode", issueCode);
-        List<?> results = query.list();
+        List<?> results = query.getResultList();
         return !results.isEmpty();
     }
 
@@ -576,16 +576,14 @@ public class CaseManagementNoteDAOImpl extends AbstractHibernateDao implements C
     @Override
     public int getNoteCountForProviderForDateRange(String providerNo, Date startDate, Date endDate) {
         try {
-            Session session = currentSession();
             String sqlCommand = "select count(distinct uuid) from casemgmt_note where provider_no = :providerNo and observation_date >= :startDate and observation_date <= :endDate";
 
-            @SuppressWarnings("unchecked")
-            NativeQuery<Number> query = session.createNativeQuery(sqlCommand);
+            Query query = entityManager().createNativeQuery(sqlCommand);
             query.setParameter("providerNo", providerNo);
             query.setParameter("startDate", new Timestamp(startDate.getTime()));
             query.setParameter("endDate", new Timestamp(endDate.getTime()));
 
-            Number result = (Number) query.uniqueResultOptional().orElse(null);
+            Number result = (Number) query.getSingleResult();
             return result != null ? result.intValue() : 0;
         } catch (RuntimeException e) {
             log.error("getNoteCountForProviderForDateRange failed for providerNo={}", providerNo, e);
@@ -597,21 +595,19 @@ public class CaseManagementNoteDAOImpl extends AbstractHibernateDao implements C
     public int getNoteCountForProviderForDateRangeWithIssueId(String providerNo, Date startDate, Date endDate,
                                                               String issueCode) {
         try {
-            Session session = currentSession();
-
             // Step 1: Get issue_id from issue code
             String getIssueIdSql = "SELECT issue_id FROM issue WHERE code = :issueCode";
             log.debug(getIssueIdSql);
 
-            @SuppressWarnings("unchecked")
-            NativeQuery<Integer> issueQuery = session.createNativeQuery(getIssueIdSql);
+            Query issueQuery = entityManager().createNativeQuery(getIssueIdSql);
             issueQuery.setParameter("issueCode", issueCode);
 
-            Integer issueId = (Integer) issueQuery.uniqueResultOptional().orElse(null);
-            if (issueId == null) {
+            List<?> issueResults = issueQuery.getResultList();
+            if (issueResults.isEmpty()) {
                 log.debug("Could not find issueCode: " + issueCode);
                 return 0;
             }
+            Integer issueId = ((Number) issueResults.get(0)).intValue();
 
             log.debug("issue Code " + issueCode + " id :" + issueId);
 
@@ -619,14 +615,13 @@ public class CaseManagementNoteDAOImpl extends AbstractHibernateDao implements C
             String sqlCommand = "select count(distinct uuid) from casemgmt_issue c, casemgmt_issue_notes cin, casemgmt_note cn where c.issue_id = :issueId and c.id = cin.id and cin.note_id = cn.note_id and cn.provider_no = :providerNo and observation_date >= :startDate and observation_date <= :endDate";
             log.debug(sqlCommand);
 
-            @SuppressWarnings("unchecked")
-            NativeQuery<Number> countQuery = session.createNativeQuery(sqlCommand);
+            Query countQuery = entityManager().createNativeQuery(sqlCommand);
             countQuery.setParameter("issueId", issueId);
             countQuery.setParameter("providerNo", providerNo);
             countQuery.setParameter("startDate", new Timestamp(startDate.getTime()));
             countQuery.setParameter("endDate", new Timestamp(endDate.getTime()));
 
-            Number result = (Number) countQuery.uniqueResultOptional().orElse(null);
+            Number result = (Number) countQuery.getSingleResult();
             int finalCount = result != null ? result.intValue() : 0;
             return finalCount;
         } catch (RuntimeException e) {
@@ -641,7 +636,7 @@ public class CaseManagementNoteDAOImpl extends AbstractHibernateDao implements C
         String hql = "select distinct cmn from CaseManagementNote cmn where cmn.id in (select max(cmn2.id) from CaseManagementNote cmn2 where cmn2.demographic_no = ?1 GROUP BY cmn2.uuid) and cmn.demographic_no = ?2 and cmn.note like ?3 and cmn.archived = false";
 
         @SuppressWarnings("unchecked")
-        List<CaseManagementNote> result = (List<CaseManagementNote>) HqlQueryHelper.find(currentSession(), hql,
+        List<CaseManagementNote> result = (List<CaseManagementNote>) JpqlQueryHelper.find(entityManager(), hql,
                 demographic_no, demographic_no, searchString);
         return result;
     }
@@ -652,7 +647,7 @@ public class CaseManagementNoteDAOImpl extends AbstractHibernateDao implements C
         String queryStr = "FROM CaseManagementNote x WHERE x.program_no=?1 and x.observation_date>=?2 and x.observation_date<=?3";
 
         @SuppressWarnings("unchecked")
-        List<CaseManagementNote> rs = (List<CaseManagementNote>) HqlQueryHelper.find(currentSession(), queryStr,
+        List<CaseManagementNote> rs = (List<CaseManagementNote>) JpqlQueryHelper.find(entityManager(), queryStr,
                 programId.toString(), minObservationDate, maxObservationDate);
 
         return rs;
@@ -662,7 +657,7 @@ public class CaseManagementNoteDAOImpl extends AbstractHibernateDao implements C
     public List<CaseManagementNote> getMostRecentNotesByAppointmentNo(int appointmentNo) {
         String hql = "select distinct cmn.uuid from CaseManagementNote cmn where cmn.appointmentNo = ?1";
         @SuppressWarnings("unchecked")
-        List<String> tmp = (List<String>) HqlQueryHelper.find(currentSession(), hql, appointmentNo);
+        List<String> tmp = (List<String>) JpqlQueryHelper.find(entityManager(), hql, appointmentNo);
         List<CaseManagementNote> mostRecents = new ArrayList<CaseManagementNote>();
         for (String uuid : tmp) {
             mostRecents.add(this.getMostRecentNote(uuid));
@@ -674,7 +669,7 @@ public class CaseManagementNoteDAOImpl extends AbstractHibernateDao implements C
     public List<CaseManagementNote> getMostRecentNotes(Integer demographicNo) {
         String hql = "select distinct cmn.uuid from CaseManagementNote cmn where cmn.demographic_no = ?1";
         @SuppressWarnings("unchecked")
-        List<String> tmp = (List<String>) HqlQueryHelper.find(currentSession(), hql,
+        List<String> tmp = (List<String>) JpqlQueryHelper.find(entityManager(), hql,
                 String.valueOf(demographicNo));
         List<CaseManagementNote> mostRecents = new ArrayList<CaseManagementNote>();
         for (String uuid : tmp) {
@@ -687,7 +682,7 @@ public class CaseManagementNoteDAOImpl extends AbstractHibernateDao implements C
     public Long findMaxNoteId() {
         String sql = "select max(c.id) from CaseManagementNote c";
         @SuppressWarnings("unchecked")
-        List<Object> r = (List<Object>) HqlQueryHelper.find(currentSession(), sql);
+        List<Object> r = (List<Object>) JpqlQueryHelper.find(entityManager(), sql);
         if (r.isEmpty()) {
             return 0L;
         }
@@ -711,7 +706,7 @@ public class CaseManagementNoteDAOImpl extends AbstractHibernateDao implements C
         Map<String, Object> params = new HashMap<>();
         params.put("programIds", programIds);
         params.put("updateDate", date);
-        List<String> results = (List<String>) HqlQueryHelper.find(currentSession(), hql, params);
+        List<String> results = (List<String>) JpqlQueryHelper.find(entityManager(), hql, params);
 
         List<Integer> results2 = new ArrayList<Integer>();
         for (String r : results) {

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/dao/CaseManagementNoteExtDAOImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/dao/CaseManagementNoteExtDAOImpl.java
@@ -36,16 +36,16 @@ import java.util.Date;
 import java.util.List;
 
 import io.github.carlos_emr.carlos.casemgmt.model.CaseManagementNoteExt;
-import io.github.carlos_emr.carlos.dao.AbstractHibernateDao;
+import io.github.carlos_emr.carlos.dao.AbstractJpaDao;
 import org.springframework.transaction.annotation.Transactional;
-import io.github.carlos_emr.carlos.utility.HqlQueryHelper;
+import io.github.carlos_emr.carlos.utility.JpqlQueryHelper;
 
 @Transactional
-public class CaseManagementNoteExtDAOImpl extends AbstractHibernateDao implements CaseManagementNoteExtDAO {
+public class CaseManagementNoteExtDAOImpl extends AbstractJpaDao implements CaseManagementNoteExtDAO {
 
     @Override
     public CaseManagementNoteExt getNoteExt(Long id) {
-        CaseManagementNoteExt noteExt = currentSession().find(CaseManagementNoteExt.class, id);
+        CaseManagementNoteExt noteExt = entityManager().find(CaseManagementNoteExt.class, id);
         return noteExt;
     }
 
@@ -53,44 +53,44 @@ public class CaseManagementNoteExtDAOImpl extends AbstractHibernateDao implement
     @Override
     public List<CaseManagementNoteExt> getExtByNote(Long noteId) {
         String hql = "from CaseManagementNoteExt cExt where cExt.noteId = ?1 order by cExt.id desc";
-        return (List<CaseManagementNoteExt>) HqlQueryHelper.find(currentSession(), hql, noteId);
+        return (List<CaseManagementNoteExt>) JpqlQueryHelper.find(entityManager(), hql, noteId);
     }
 
     @Override
     public List getExtByKeyVal(String keyVal) {
         if (keyVal == null) return Collections.emptyList();
         String hql = "from CaseManagementNoteExt cExt where cExt.keyVal = ?1";
-        return HqlQueryHelper.find(currentSession(), hql, keyVal);
+        return JpqlQueryHelper.find(entityManager(), hql, keyVal);
     }
 
     @Override
     public List getExtByValue(String keyVal, String value) {
         if (keyVal == null || value == null) return Collections.emptyList();
         String hql = "from CaseManagementNoteExt cExt where cExt.keyVal = ?1 and cExt.value like ?2";
-        return HqlQueryHelper.find(currentSession(), hql, keyVal, value);
+        return JpqlQueryHelper.find(entityManager(), hql, keyVal, value);
     }
 
     @Override
     public List getExtBeforeDate(String keyVal, Date dateValue) {
         if (keyVal == null || dateValue == null) return Collections.emptyList();
         String hql = "from CaseManagementNoteExt cExt where cExt.keyVal = ?1 and cExt.dateValue <= ?2";
-        return HqlQueryHelper.find(currentSession(), hql, keyVal, dateValue);
+        return JpqlQueryHelper.find(entityManager(), hql, keyVal, dateValue);
     }
 
     @Override
     public List getExtAfterDate(String keyVal, Date dateValue) {
         if (keyVal == null || dateValue == null) return Collections.emptyList();
         String hql = "from CaseManagementNoteExt cExt where cExt.keyVal = ?1 and cExt.dateValue >= ?2";
-        return HqlQueryHelper.find(currentSession(), hql, keyVal, dateValue);
+        return JpqlQueryHelper.find(entityManager(), hql, keyVal, dateValue);
     }
 
     @Override
     public void save(CaseManagementNoteExt cExt) {
-        currentSession().persist(cExt);
+        entityManager().persist(cExt);
     }
 
     @Override
     public void update(CaseManagementNoteExt cExt) {
-        currentSession().merge(cExt);
+        entityManager().merge(cExt);
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/dao/CaseManagementNoteLinkDAOImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/dao/CaseManagementNoteLinkDAOImpl.java
@@ -34,16 +34,16 @@ package io.github.carlos_emr.carlos.casemgmt.dao;
 import java.util.List;
 
 import io.github.carlos_emr.carlos.casemgmt.model.CaseManagementNoteLink;
-import io.github.carlos_emr.carlos.dao.AbstractHibernateDao;
+import io.github.carlos_emr.carlos.dao.AbstractJpaDao;
 import org.springframework.transaction.annotation.Transactional;
-import io.github.carlos_emr.carlos.utility.HqlQueryHelper;
+import io.github.carlos_emr.carlos.utility.JpqlQueryHelper;
 
 @Transactional
-public class CaseManagementNoteLinkDAOImpl extends AbstractHibernateDao implements CaseManagementNoteLinkDAO {
+public class CaseManagementNoteLinkDAOImpl extends AbstractJpaDao implements CaseManagementNoteLinkDAO {
 
     @Override
     public CaseManagementNoteLink getNoteLink(Long id) {
-        CaseManagementNoteLink noteLink = currentSession().find(CaseManagementNoteLink.class, id);
+        CaseManagementNoteLink noteLink = entityManager().find(CaseManagementNoteLink.class, id);
         return noteLink;
     }
 
@@ -51,35 +51,35 @@ public class CaseManagementNoteLinkDAOImpl extends AbstractHibernateDao implemen
     @Override
     public List<CaseManagementNoteLink> getLinkByTableId(Integer tableName, Long tableId) {
         String hql = "from CaseManagementNoteLink cLink where cLink.tableName = ?1 and cLink.tableId = ?2 order by cLink.id";
-        return (List<CaseManagementNoteLink>) HqlQueryHelper.find(currentSession(), hql, tableName, tableId);
+        return (List<CaseManagementNoteLink>) JpqlQueryHelper.find(entityManager(), hql, tableName, tableId);
     }
 
     @SuppressWarnings("unchecked")
     @Override
     public List<CaseManagementNoteLink> getLinkByTableId(Integer tableName, Long tableId, String otherId) {
         String hql = "from CaseManagementNoteLink cLink where cLink.tableName = ?1 and cLink.tableId = ?2 and cLink.otherId=?3 order by cLink.id";
-        return (List<CaseManagementNoteLink>) HqlQueryHelper.find(currentSession(), hql, tableName, tableId, otherId);
+        return (List<CaseManagementNoteLink>) JpqlQueryHelper.find(entityManager(), hql, tableName, tableId, otherId);
     }
 
     @SuppressWarnings("unchecked")
     @Override
     public List<CaseManagementNoteLink> getLinkByTableIdDesc(Integer tableName, Long tableId) {
         String hql = "from CaseManagementNoteLink cLink where cLink.tableName = ?1 and cLink.tableId = ?2 order by cLink.id desc";
-        return (List<CaseManagementNoteLink>) HqlQueryHelper.find(currentSession(), hql, tableName, tableId);
+        return (List<CaseManagementNoteLink>) JpqlQueryHelper.find(entityManager(), hql, tableName, tableId);
     }
 
     @SuppressWarnings("unchecked")
     @Override
     public List<CaseManagementNoteLink> getLinkByTableIdDesc(Integer tableName, Long tableId, String otherId) {
         String hql = "from CaseManagementNoteLink cLink where cLink.tableName = ?1 and cLink.tableId = ?2 and cLink.otherId=?3 order by cLink.id desc";
-        return (List<CaseManagementNoteLink>) HqlQueryHelper.find(currentSession(), hql, tableName, tableId, otherId);
+        return (List<CaseManagementNoteLink>) JpqlQueryHelper.find(entityManager(), hql, tableName, tableId, otherId);
     }
 
     @SuppressWarnings("unchecked")
     @Override
     public List<CaseManagementNoteLink> getLinkByNote(Long noteId) {
         String hql = "from CaseManagementNoteLink cLink where cLink.noteId = ?1 order by cLink.id";
-        return (List<CaseManagementNoteLink>) HqlQueryHelper.find(currentSession(), hql, noteId);
+        return (List<CaseManagementNoteLink>) JpqlQueryHelper.find(entityManager(), hql, noteId);
     }
 
     @Override
@@ -105,11 +105,11 @@ public class CaseManagementNoteLinkDAOImpl extends AbstractHibernateDao implemen
 
     @Override
     public void save(CaseManagementNoteLink cLink) {
-        currentSession().persist(cLink);
+        entityManager().persist(cLink);
     }
 
     @Override
     public void update(CaseManagementNoteLink cLink) {
-        currentSession().merge(cLink);
+        entityManager().merge(cLink);
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/dao/ClientImageDAOImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/dao/ClientImageDAOImpl.java
@@ -39,16 +39,16 @@ import org.apache.logging.log4j.Logger;
 import io.github.carlos_emr.carlos.casemgmt.model.ClientImage;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.QueueCache;
-import io.github.carlos_emr.carlos.dao.AbstractHibernateDao;
+import io.github.carlos_emr.carlos.dao.AbstractJpaDao;
 import org.springframework.transaction.annotation.Transactional;
-import io.github.carlos_emr.carlos.utility.HqlQueryHelper;
+import io.github.carlos_emr.carlos.utility.JpqlQueryHelper;
 
 /**
  * Anyone modifying get and set methods should take note of the dataCache and
  * add/remove items as appropriate.
  */
 @Transactional
-public class ClientImageDAOImpl extends AbstractHibernateDao implements ClientImageDAO {
+public class ClientImageDAOImpl extends AbstractJpaDao implements ClientImageDAO {
 
     private static final Logger logger = MiscUtils.getLogger();
 
@@ -67,9 +67,9 @@ public class ClientImageDAOImpl extends AbstractHibernateDao implements ClientIm
             existing.setImage_data(clientImage.getImage_data());
             existing.setImage_type(clientImage.getImage_type());
             existing.setUpdate_date(new Date());
-            currentSession().merge(existing);
+            entityManager().merge(existing);
         } else {
-            currentSession().persist(clientImage);
+            entityManager().persist(clientImage);
         }
 
         // update cache
@@ -80,7 +80,7 @@ public class ClientImageDAOImpl extends AbstractHibernateDao implements ClientIm
     public void deleteClientImage(Integer clientId) {
         ClientImage clientImage = getClientImage(clientId);
         if (clientImage != null) {
-            currentSession().remove(clientImage);
+            entityManager().remove(clientImage);
             dataCache.remove(clientId);
         }
     }
@@ -95,8 +95,8 @@ public class ClientImageDAOImpl extends AbstractHibernateDao implements ClientIm
 
             // get from database
             @SuppressWarnings("unchecked")
-            List<ClientImage> results = (List<ClientImage>) HqlQueryHelper
-                    .find(currentSession(), "from ClientImage i where i.demographic_no=?1 order by update_date desc", clientId);
+            List<ClientImage> results = (List<ClientImage>) JpqlQueryHelper
+                    .find(entityManager(), "from ClientImage i where i.demographic_no=?1 order by update_date desc", clientId);
             if (results.size() > 0) {
                 clientImage = results.get(0);
 

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/dao/IssueDAOImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/dao/IssueDAOImpl.java
@@ -41,24 +41,24 @@ import org.apache.logging.log4j.Logger;
 import io.github.carlos_emr.carlos.casemgmt.model.Issue;
 import io.github.carlos_emr.carlos.commn.dao.AbstractDaoImpl;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
-import io.github.carlos_emr.carlos.dao.AbstractHibernateDao;
+import io.github.carlos_emr.carlos.dao.AbstractJpaDao;
 import org.springframework.transaction.annotation.Transactional;
 
 import io.github.carlos_emr.carlos.model.security.Secrole;
-import io.github.carlos_emr.carlos.utility.HqlQueryHelper;
+import io.github.carlos_emr.carlos.utility.JpqlQueryHelper;
 
 @Transactional
-public class IssueDAOImpl extends AbstractHibernateDao implements IssueDAO {
+public class IssueDAOImpl extends AbstractJpaDao implements IssueDAO {
     private static Logger logger = MiscUtils.getLogger();
 
     @Override
     public Issue getIssue(Long id) {
-        return currentSession().find(Issue.class, id);
+        return entityManager().find(Issue.class, id);
     }
 
     @Override
     public List<Issue> getIssues() {
-        return (List<Issue>) HqlQueryHelper.find(currentSession(), "from Issue");
+        return (List<Issue>) JpqlQueryHelper.find(entityManager(), "from Issue");
     }
 
     @Override
@@ -69,12 +69,12 @@ public class IssueDAOImpl extends AbstractHibernateDao implements IssueDAO {
         String hql = "from Issue i where i.code in (:codes)";
         Map<String, Object> params = new HashMap<>();
         params.put("codes", Arrays.asList(codes));
-        return (List<Issue>) HqlQueryHelper.find(currentSession(), hql, params);
+        return (List<Issue>) JpqlQueryHelper.find(entityManager(), hql, params);
     }
 
     @Override
     public Issue findIssueByCode(String code) {
-        List<Issue> list = (List<Issue>) HqlQueryHelper.find(currentSession(), "from Issue i where i.code = ?1",
+        List<Issue> list = (List<Issue>) JpqlQueryHelper.find(entityManager(), "from Issue i where i.code = ?1",
                 code);
         if (list.size() > 0)
             return list.get(0);
@@ -84,7 +84,7 @@ public class IssueDAOImpl extends AbstractHibernateDao implements IssueDAO {
 
     @Override
     public Issue findIssueByTypeAndCode(String type, String code) {
-        List<Issue> list = (List<Issue>) HqlQueryHelper.find(currentSession(), "from Issue i where i.type=?1 and i.code = ?2",
+        List<Issue> list = (List<Issue>) JpqlQueryHelper.find(entityManager(), "from Issue i where i.type=?1 and i.code = ?2",
                 type, code);
         if (list.size() > 0)
             return list.get(0);
@@ -95,16 +95,16 @@ public class IssueDAOImpl extends AbstractHibernateDao implements IssueDAO {
     @Override
     public void saveIssue(Issue issue) {
         if (issue.getId() == null) {
-            currentSession().persist(issue);
+            entityManager().persist(issue);
         } else {
-            currentSession().merge(issue);
+            entityManager().merge(issue);
         }
     }
 
     @Deprecated
     @Override
     public void delete(Long issueId) {
-        currentSession().remove(getIssue(issueId));
+        entityManager().remove(getIssue(issueId));
     }
 
     @SuppressWarnings("unchecked")
@@ -113,7 +113,7 @@ public class IssueDAOImpl extends AbstractHibernateDao implements IssueDAO {
         search = "%" + search + "%";
         search = search.toLowerCase();
         String sql = "from Issue i where lower(i.code) like ?1 or lower(i.description) like ?2";
-        return (List<Issue>) HqlQueryHelper.find(currentSession(), sql, search, search);
+        return (List<Issue>) JpqlQueryHelper.find(entityManager(), sql, search, search);
     }
 
     @Override
@@ -130,7 +130,7 @@ public class IssueDAOImpl extends AbstractHibernateDao implements IssueDAO {
         String sql = "select i.id from Issue i where i.role in (:roleNames) order by sortOrderId";
         Map<String, Object> params = new HashMap<>();
         params.put("roleNames", roleNames);
-        return (List<Long>) HqlQueryHelper.find(currentSession(), sql, params);
+        return (List<Long>) JpqlQueryHelper.find(entityManager(), sql, params);
     }
 
     @SuppressWarnings("unchecked")
@@ -152,7 +152,7 @@ public class IssueDAOImpl extends AbstractHibernateDao implements IssueDAO {
         Map<String, Object> params = new HashMap<>();
         params.put("search", search);
         params.put("roleNames", roleNames);
-        return (List<Issue>) HqlQueryHelper.findWithPagination(currentSession(), hql, startIndex,
+        return (List<Issue>) JpqlQueryHelper.findWithPagination(entityManager(), hql, startIndex,
                 Math.min(numToReturn, AbstractDaoImpl.MAX_LIST_RETURN_SIZE), params);
     }
 
@@ -176,7 +176,7 @@ public class IssueDAOImpl extends AbstractHibernateDao implements IssueDAO {
         Map<String, Object> params = new HashMap<>();
         params.put("search", search);
         params.put("roleNames", roleNames);
-        List<Long> result = (List<Long>) HqlQueryHelper.find(currentSession(), hql, params);
+        List<Long> result = (List<Long>) JpqlQueryHelper.find(entityManager(), hql, params);
 
         if (result.size() > 0) {
             return result.get(0).intValue();
@@ -191,7 +191,7 @@ public class IssueDAOImpl extends AbstractHibernateDao implements IssueDAO {
         search = search.toLowerCase();
         String sql = "from Issue i where (lower(i.code) like ?1 or lower(i.description) like ?2)";
         logger.debug(sql);
-        return HqlQueryHelper.find(currentSession(), sql, search, search);
+        return JpqlQueryHelper.find(entityManager(), sql, search, search);
     }
 
     /**
@@ -208,7 +208,7 @@ public class IssueDAOImpl extends AbstractHibernateDao implements IssueDAO {
         if (type == null || type.equals("")) {
             codes = new ArrayList<String>();
         } else {
-            codes = (List<String>) HqlQueryHelper.find(currentSession(), "SELECT i.code FROM Issue i WHERE i.type = ?1",
+            codes = (List<String>) JpqlQueryHelper.find(entityManager(), "SELECT i.code FROM Issue i WHERE i.type = ?1",
                     type.toLowerCase());
         }
         return codes;

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/dao/RoleProgramAccessDAOImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/dao/RoleProgramAccessDAOImpl.java
@@ -35,19 +35,19 @@ import java.util.Collections;
 import java.util.List;
 
 import io.github.carlos_emr.carlos.PMmodule.model.DefaultRoleAccess;
-import io.github.carlos_emr.carlos.dao.AbstractHibernateDao;
+import io.github.carlos_emr.carlos.dao.AbstractJpaDao;
 import org.springframework.transaction.annotation.Transactional;
-import io.github.carlos_emr.carlos.utility.HqlQueryHelper;
+import io.github.carlos_emr.carlos.utility.JpqlQueryHelper;
 
 @Transactional
-public class RoleProgramAccessDAOImpl extends AbstractHibernateDao implements RoleProgramAccessDAO {
+public class RoleProgramAccessDAOImpl extends AbstractJpaDao implements RoleProgramAccessDAO {
 
     @SuppressWarnings("unchecked")
     @Override
     public List<DefaultRoleAccess> getDefaultAccessRightByRole(Long roleId) {
         if (roleId == null) return Collections.emptyList();
         String q = "from DefaultRoleAccess da where da.caisi_role.id=?1";
-        return (List<DefaultRoleAccess>) HqlQueryHelper.find(currentSession(), q, roleId);
+        return (List<DefaultRoleAccess>) JpqlQueryHelper.find(entityManager(), q, roleId);
     }
 
     @SuppressWarnings("unchecked")
@@ -55,13 +55,13 @@ public class RoleProgramAccessDAOImpl extends AbstractHibernateDao implements Ro
     public List<DefaultRoleAccess> getDefaultSpecificAccessRightByRole(Long roleId, String accessType) {
         if (roleId == null || accessType == null) return Collections.emptyList();
         String q = "from DefaultRoleAccess da where da.caisi_role.id=?1 and da.access_type.Name like ?2";
-        return (List<DefaultRoleAccess>) HqlQueryHelper.find(currentSession(), q, roleId, accessType);
+        return (List<DefaultRoleAccess>) JpqlQueryHelper.find(entityManager(), q, roleId, accessType);
     }
 
     @Override
     public boolean hasAccess(String accessName, Long roleId) {
         if (accessName == null || roleId == null) return false;
         String q = "from DefaultRoleAccess da where da.caisi_role.id=?1 and da.access_type.Name=?2";
-        return !HqlQueryHelper.find(currentSession(), q, roleId, accessName).isEmpty();
+        return !JpqlQueryHelper.find(entityManager(), q, roleId, accessName).isEmpty();
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/dao/AbstractJpaDao.java
+++ b/src/main/java/io/github/carlos_emr/carlos/dao/AbstractJpaDao.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2026. CARLOS EMR. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+package io.github.carlos_emr.carlos.dao;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+/**
+ * Minimal base class for DAOs migrated from {@link AbstractHibernateDao} to JPA
+ * {@link EntityManager}.
+ *
+ * <p>Provides {@link #entityManager()} as the JPA counterpart to
+ * {@code AbstractHibernateDao.currentSession()}, enabling a mechanical
+ * migration: replace {@code currentSession()} calls with {@code entityManager()}
+ * and {@code HqlQueryHelper} calls with {@code JpqlQueryHelper}.</p>
+ *
+ * <p>Compatible with {@code autowire="byName"} in {@code applicationContext.xml}:
+ * since this class has no {@code setSessionFactory} setter, Spring's byName
+ * autowiring harmlessly finds no match for the {@code "sessionFactory"} bean.
+ * The {@link EntityManager} is injected independently via
+ * {@link PersistenceContext}.</p>
+ *
+ * @since 2026-04-11
+ * @see AbstractHibernateDao
+ * @see io.github.carlos_emr.carlos.utility.JpqlQueryHelper
+ */
+public abstract class AbstractJpaDao {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    /**
+     * Returns the JPA {@link EntityManager} bound to the active transaction.
+     *
+     * <p>Drop-in replacement for {@code AbstractHibernateDao.currentSession()}.
+     * The EntityManager lifecycle is managed by Spring's transaction
+     * infrastructure — no explicit close is needed.</p>
+     *
+     * @return the current transactional EntityManager
+     */
+    protected EntityManager entityManager() {
+        return entityManager;
+    }
+}

--- a/src/main/java/io/github/carlos_emr/carlos/dao/AbstractJpaDao.java
+++ b/src/main/java/io/github/carlos_emr/carlos/dao/AbstractJpaDao.java
@@ -1,6 +1,7 @@
 /**
- * Copyright (c) 2026. CARLOS EMR. All rights reserved.
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
  *
+ * This software is published under the GPL GNU General Public License.
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; either version 2
@@ -14,6 +15,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
  */
 package io.github.carlos_emr.carlos.dao;
 

--- a/src/main/java/io/github/carlos_emr/carlos/daos/ProviderDAOImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/daos/ProviderDAOImpl.java
@@ -34,28 +34,28 @@ package io.github.carlos_emr.carlos.daos;
 import java.util.List;
 
 import io.github.carlos_emr.carlos.commn.model.Provider;
-import io.github.carlos_emr.carlos.dao.AbstractHibernateDao;
+import io.github.carlos_emr.carlos.dao.AbstractJpaDao;
 import org.springframework.transaction.annotation.Transactional;
-import io.github.carlos_emr.carlos.utility.HqlQueryHelper;
+import io.github.carlos_emr.carlos.utility.JpqlQueryHelper;
 
 /**
  * DAO implementation for provider data access.
  */
 @Transactional
-public class ProviderDAOImpl extends AbstractHibernateDao implements ProviderDAO {
+public class ProviderDAOImpl extends AbstractJpaDao implements ProviderDAO {
 
     @SuppressWarnings("unchecked")
     public List<Provider> getProviders() {
-        return (List<Provider>) HqlQueryHelper.find(currentSession(), "from Provider p order by p.LastName");
+        return (List<Provider>) JpqlQueryHelper.find(entityManager(), "from Provider p order by p.LastName");
     }
 
     public Provider getProvider(String provider_no) {
-        return currentSession().find(Provider.class, provider_no);
+        return entityManager().find(Provider.class, provider_no);
     }
 
     @SuppressWarnings("unchecked")
     public Provider getProviderByName(String lastName, String firstName) {
-        List<Provider> results = (List<Provider>) HqlQueryHelper.find(currentSession(), "from Provider p where p.FirstName = ?1 and p.LastName = ?2", firstName, lastName);
+        List<Provider> results = (List<Provider>) JpqlQueryHelper.find(entityManager(), "from Provider p where p.FirstName = ?1 and p.LastName = ?2", firstName, lastName);
         return results.isEmpty() ? null : results.get(0);
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/daos/security/SecObjectNameDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/daos/security/SecObjectNameDaoImpl.java
@@ -32,7 +32,7 @@
 
 package io.github.carlos_emr.carlos.daos.security;
 
-import io.github.carlos_emr.carlos.dao.AbstractHibernateDao;
+import io.github.carlos_emr.carlos.dao.AbstractJpaDao;
 
 import io.github.carlos_emr.carlos.model.security.Secobjectname;
 import org.springframework.transaction.annotation.Transactional;
@@ -40,14 +40,14 @@ import org.springframework.transaction.annotation.Transactional;
  * @author jackson
  */
 @Transactional
-public class SecObjectNameDaoImpl extends AbstractHibernateDao implements SecObjectNameDao {
+public class SecObjectNameDaoImpl extends AbstractJpaDao implements SecObjectNameDao {
 
     @Override
     public void saveOrUpdate(Secobjectname t) {
         if (t.getObjectname() == null) {
-            currentSession().persist(t);
+            entityManager().persist(t);
         } else {
-            currentSession().merge(t);
+            entityManager().merge(t);
         }
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/daos/security/SecProviderDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/daos/security/SecProviderDaoImpl.java
@@ -82,7 +82,13 @@ public class SecProviderDaoImpl extends AbstractJpaDao implements SecProviderDao
     public void delete(SecProvider persistentInstance) {
         logger.debug("deleting Provider instance");
         try {
-            entityManager().remove(persistentInstance);
+            // Pre-migration Hibernate Session.delete() accepted detached entities.
+            // JPA EntityManager.remove() requires a managed instance, so reattach via
+            // merge() first when the caller passes a detached entity.
+            SecProvider managed = entityManager().contains(persistentInstance)
+                    ? persistentInstance
+                    : entityManager().merge(persistentInstance);
+            entityManager().remove(managed);
             logger.debug("delete successful");
         } catch (RuntimeException re) {
             logger.error("delete failed", re);

--- a/src/main/java/io/github/carlos_emr/carlos/daos/security/SecProviderDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/daos/security/SecProviderDaoImpl.java
@@ -270,10 +270,15 @@ public class SecProviderDaoImpl extends AbstractJpaDao implements SecProviderDao
     public void attachClean(SecProviderDao instance) {
         logger.debug("attaching clean Provider instance");
         try {
-            // JPA equivalent of Hibernate Session.lock(LockMode.NONE): re-attach without acquiring a database lock.
-            // Note: attachClean() parameter type should be SecProvider (the entity), not SecProviderDao (the interface).
-            // This pre-existing interface design bug is tracked for a separate fix.
-            entityManager().merge(instance);
+            // JPA has no direct equivalent of Hibernate Session.lock(entity, LockMode.NONE) for reattach.
+            // If the entity is already managed, there is nothing to do. If it is detached, merge() is
+            // the only JPA-standard reattach path — unlike lock(NONE), merge may trigger UPDATE on flush
+            // if the detached state differs from the database row. Callers relying on the old "clean"
+            // (no-UPDATE) semantics must ensure the instance is not dirty before calling.
+            // Pre-existing: parameter type should be SecProvider (entity), not SecProviderDao (interface).
+            if (!entityManager().contains(instance)) {
+                entityManager().merge(instance);
+            }
             logger.debug("attach successful");
         } catch (RuntimeException re) {
             logger.error("attach failed", re);

--- a/src/main/java/io/github/carlos_emr/carlos/daos/security/SecProviderDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/daos/security/SecProviderDaoImpl.java
@@ -33,18 +33,17 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.logging.log4j.Logger;
-import org.hibernate.LockMode;
-import org.hibernate.Session;
-import org.hibernate.query.Query;
-import io.github.carlos_emr.carlos.dao.AbstractHibernateDao;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.TypedQuery;
+import io.github.carlos_emr.carlos.dao.AbstractJpaDao;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import org.springframework.transaction.annotation.Transactional;
 
 import io.github.carlos_emr.carlos.model.security.SecProvider;
-import io.github.carlos_emr.carlos.utility.HqlQueryHelper;
+import io.github.carlos_emr.carlos.utility.JpqlQueryHelper;
 
 @Transactional
-public class SecProviderDaoImpl extends AbstractHibernateDao implements SecProviderDao {
+public class SecProviderDaoImpl extends AbstractJpaDao implements SecProviderDao {
     private static final Logger logger = MiscUtils.getLogger();
 
     private static final Set<String> ALLOWED_PROPERTIES = Set.of(
@@ -56,7 +55,7 @@ public class SecProviderDaoImpl extends AbstractHibernateDao implements SecProvi
     public void save(SecProvider transientInstance) {
         logger.debug("saving Provider instance");
         try {
-            currentSession().persist(transientInstance);
+            entityManager().persist(transientInstance);
             logger.debug("save successful");
         } catch (RuntimeException re) {
             logger.error("save failed", re);
@@ -69,9 +68,9 @@ public class SecProviderDaoImpl extends AbstractHibernateDao implements SecProvi
         logger.debug("saving Provider instance");
         try {
             if (transientInstance.getProviderNo() == null) {
-                currentSession().persist(transientInstance);
+                entityManager().persist(transientInstance);
             } else {
-                currentSession().merge(transientInstance);
+                entityManager().merge(transientInstance);
             }
             logger.debug("save successful");
         } catch (RuntimeException re) {
@@ -84,7 +83,7 @@ public class SecProviderDaoImpl extends AbstractHibernateDao implements SecProvi
     public void delete(SecProvider persistentInstance) {
         logger.debug("deleting Provider instance");
         try {
-            currentSession().remove(persistentInstance);
+            entityManager().remove(persistentInstance);
             logger.debug("delete successful");
         } catch (RuntimeException re) {
             logger.error("delete failed", re);
@@ -96,7 +95,7 @@ public class SecProviderDaoImpl extends AbstractHibernateDao implements SecProvi
     public SecProvider findById(java.lang.String id) {
         logger.debug("getting Provider instance with id: " + id);
         try {
-            SecProvider instance = currentSession().find(SecProvider.class, id);
+            SecProvider instance = entityManager().find(SecProvider.class, id);
             return instance;
         } catch (RuntimeException re) {
             logger.error("get failed", re);
@@ -109,7 +108,7 @@ public class SecProviderDaoImpl extends AbstractHibernateDao implements SecProvi
         logger.debug("getting Provider instance with id: " + id);
         try {
             String sql = "from SecProvider where id=?1 and status=?2";
-            List lst = HqlQueryHelper.find(currentSession(), sql, id, status);
+            List lst = JpqlQueryHelper.find(entityManager(), sql, id, status);
             if (lst.size() == 0)
                 return null;
             else
@@ -140,7 +139,7 @@ public class SecProviderDaoImpl extends AbstractHibernateDao implements SecProvi
             if (!ALLOWED_PROPERTIES.contains(propertyName)) {
                 throw new IllegalArgumentException("Invalid property name: " + propertyName);
             }
-            return HqlQueryHelper.find(currentSession(),
+            return JpqlQueryHelper.find(entityManager(),
                     "FROM SecProvider WHERE " + propertyName + " = ?1", value);
         } catch (RuntimeException re) {
             logger.error("find by property name failed", re);
@@ -235,8 +234,8 @@ public class SecProviderDaoImpl extends AbstractHibernateDao implements SecProvi
     public List findAll() {
         logger.debug("finding all Provider instances");
         try {
-            Query<SecProvider> queryObject = currentSession().createQuery("from SecProvider", SecProvider.class);
-            return queryObject.list();
+            TypedQuery<SecProvider> queryObject = entityManager().createQuery("from SecProvider", SecProvider.class);
+            return queryObject.getResultList();
         } catch (RuntimeException re) {
             logger.error("find all failed", re);
             throw re;
@@ -246,9 +245,8 @@ public class SecProviderDaoImpl extends AbstractHibernateDao implements SecProvi
     @Override
     public SecProviderDao merge(SecProviderDao detachedInstance) {
         logger.debug("merging Provider instance");
-        Session session = currentSession();
         try {
-            SecProviderDao result = (SecProviderDao) session.merge(detachedInstance);
+            SecProviderDao result = (SecProviderDao) entityManager().merge(detachedInstance);
             logger.debug("merge successful");
             return result;
         } catch (RuntimeException re) {
@@ -260,9 +258,8 @@ public class SecProviderDaoImpl extends AbstractHibernateDao implements SecProvi
     @Override
     public void attachDirty(SecProviderDao instance) {
         logger.debug("attaching dirty Provider instance");
-        Session session = currentSession();
         try {
-            session.merge(instance);
+            entityManager().merge(instance);
             logger.debug("attach successful");
         } catch (RuntimeException re) {
             logger.error("attach failed", re);
@@ -274,7 +271,7 @@ public class SecProviderDaoImpl extends AbstractHibernateDao implements SecProvi
     public void attachClean(SecProviderDao instance) {
         logger.debug("attaching clean Provider instance");
         try {
-            currentSession().lock(instance, LockMode.NONE);
+            entityManager().lock(instance, LockModeType.NONE);
             logger.debug("attach successful");
         } catch (RuntimeException re) {
             logger.error("attach failed", re);

--- a/src/main/java/io/github/carlos_emr/carlos/daos/security/SecProviderDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/daos/security/SecProviderDaoImpl.java
@@ -33,7 +33,6 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.logging.log4j.Logger;
-import jakarta.persistence.LockModeType;
 import jakarta.persistence.TypedQuery;
 import io.github.carlos_emr.carlos.dao.AbstractJpaDao;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
@@ -271,7 +270,10 @@ public class SecProviderDaoImpl extends AbstractJpaDao implements SecProviderDao
     public void attachClean(SecProviderDao instance) {
         logger.debug("attaching clean Provider instance");
         try {
-            entityManager().lock(instance, LockModeType.NONE);
+            // JPA equivalent of Hibernate Session.lock(LockMode.NONE): re-attach without acquiring a database lock.
+            // Note: attachClean() parameter type should be SecProvider (the entity), not SecProviderDao (the interface).
+            // This pre-existing interface design bug is tracked for a separate fix.
+            entityManager().merge(instance);
             logger.debug("attach successful");
         } catch (RuntimeException re) {
             logger.error("attach failed", re);

--- a/src/main/java/io/github/carlos_emr/carlos/daos/security/SecobjprivilegeDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/daos/security/SecobjprivilegeDaoImpl.java
@@ -39,16 +39,16 @@ import java.util.Map;
 
 import org.apache.logging.log4j.Logger;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
-import io.github.carlos_emr.carlos.dao.AbstractHibernateDao;
+import io.github.carlos_emr.carlos.dao.AbstractJpaDao;
 import org.springframework.transaction.annotation.Transactional;
 
 import io.github.carlos_emr.carlos.model.security.Secobjprivilege;
-import io.github.carlos_emr.carlos.utility.HqlQueryHelper;
+import io.github.carlos_emr.carlos.utility.JpqlQueryHelper;
 
 import java.util.Set;
 
 @Transactional
-public class SecobjprivilegeDaoImpl extends AbstractHibernateDao implements SecobjprivilegeDao {
+public class SecobjprivilegeDaoImpl extends AbstractJpaDao implements SecobjprivilegeDao {
 
     private Logger logger = MiscUtils.getLogger();
 
@@ -62,9 +62,9 @@ public class SecobjprivilegeDaoImpl extends AbstractHibernateDao implements Seco
         }
 
         if (secobjprivilege.getRoleusergroup() == null || secobjprivilege.getObjectname_code() == null) {
-            currentSession().persist(secobjprivilege);
+            entityManager().persist(secobjprivilege);
         } else {
-            currentSession().merge(secobjprivilege);
+            entityManager().merge(secobjprivilege);
         }
 
         if (logger.isDebugEnabled()) {
@@ -107,7 +107,7 @@ public class SecobjprivilegeDaoImpl extends AbstractHibernateDao implements Seco
         try {
             String queryString = "update Secobjprivilege as model set model.providerNo = ?1 where model.objectname_code = ?2 and model.privilege_code = ?3 and model.roleusergroup = ?4";
 
-            return HqlQueryHelper.bulkUpdate(currentSession(), queryString,
+            return JpqlQueryHelper.bulkUpdate(entityManager(), queryString,
                     instance.getProviderNo(), instance.getObjectname_code(),
                     instance.getPrivilege_code(), instance.getRoleusergroup());
 
@@ -122,7 +122,7 @@ public class SecobjprivilegeDaoImpl extends AbstractHibernateDao implements Seco
         logger.debug("deleting Secobjprivilege by roleName");
         try {
 
-            return HqlQueryHelper.bulkUpdate(currentSession(), "delete Secobjprivilege as model where model.roleusergroup =?1",
+            return JpqlQueryHelper.bulkUpdate(entityManager(), "delete Secobjprivilege as model where model.roleusergroup =?1",
                     roleName);
 
         } catch (RuntimeException re) {
@@ -135,7 +135,7 @@ public class SecobjprivilegeDaoImpl extends AbstractHibernateDao implements Seco
     public void delete(Secobjprivilege persistentInstance) {
         logger.debug("deleting Secobjprivilege instance");
         try {
-            currentSession().remove(persistentInstance);
+            entityManager().remove(persistentInstance);
             logger.debug("delete successful");
         } catch (RuntimeException re) {
             logger.error("delete failed", re);
@@ -148,7 +148,7 @@ public class SecobjprivilegeDaoImpl extends AbstractHibernateDao implements Seco
         try {
             String queryString = "select description from Secobjectname obj where obj.objectname=?1";
 
-            List lst = HqlQueryHelper.find(currentSession(), queryString, function_code);
+            List lst = JpqlQueryHelper.find(entityManager(), queryString, function_code);
             if (lst.size() > 0 && lst.get(0) != null)
                 return lst.get(0).toString();
             else
@@ -164,7 +164,7 @@ public class SecobjprivilegeDaoImpl extends AbstractHibernateDao implements Seco
         try {
             String queryString = "select description from Secprivilege obj where obj.privilege=?1";
 
-            List lst = HqlQueryHelper.find(currentSession(), queryString, accessType_code);
+            List lst = JpqlQueryHelper.find(entityManager(), queryString, accessType_code);
             if (lst.size() > 0 && lst.get(0) != null)
                 return lst.get(0).toString();
             else
@@ -198,7 +198,7 @@ public class SecobjprivilegeDaoImpl extends AbstractHibernateDao implements Seco
             }
             String queryString = "from Secobjprivilege as model where model."
                     + propertyName + "= ?1 order by objectname_code";
-            return HqlQueryHelper.find(currentSession(), queryString, value);
+            return JpqlQueryHelper.find(entityManager(), queryString, value);
         } catch (RuntimeException re) {
             logger.error("find by property name failed", re);
             throw re;
@@ -211,7 +211,7 @@ public class SecobjprivilegeDaoImpl extends AbstractHibernateDao implements Seco
         List<Secobjprivilege> results = new ArrayList<Secobjprivilege>();
 
         @SuppressWarnings("unchecked")
-        List<Secobjprivilege> lst = (List<Secobjprivilege>) HqlQueryHelper.find(currentSession(), queryString, o);
+        List<Secobjprivilege> lst = (List<Secobjprivilege>) JpqlQueryHelper.find(entityManager(), queryString, o);
 
         for (Secobjprivilege p : lst) {
             if (roles.contains(p.getRoleusergroup())) {
@@ -227,6 +227,6 @@ public class SecobjprivilegeDaoImpl extends AbstractHibernateDao implements Seco
         String hql = "from Secobjprivilege obj where obj.roleusergroup IN (:roles)";
         Map<String, Object> params = new HashMap<>();
         params.put("roles", roles);
-        return (List<Secobjprivilege>) HqlQueryHelper.find(currentSession(), hql, params);
+        return (List<Secobjprivilege>) JpqlQueryHelper.find(entityManager(), hql, params);
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/daos/security/SecroleDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/daos/security/SecroleDaoImpl.java
@@ -35,21 +35,21 @@ import java.util.List;
 
 import org.apache.logging.log4j.Logger;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
-import io.github.carlos_emr.carlos.dao.AbstractHibernateDao;
-import io.github.carlos_emr.carlos.utility.HqlQueryHelper;
+import io.github.carlos_emr.carlos.dao.AbstractJpaDao;
+import io.github.carlos_emr.carlos.utility.JpqlQueryHelper;
 
 import org.springframework.transaction.annotation.Transactional;
 import io.github.carlos_emr.carlos.model.security.Secrole;
 
 @Transactional
-public class SecroleDaoImpl extends AbstractHibernateDao implements SecroleDao {
+public class SecroleDaoImpl extends AbstractJpaDao implements SecroleDao {
 
     private Logger logger = MiscUtils.getLogger();
 
     @Override
     public List<Secrole> getRoles() {
         @SuppressWarnings("unchecked")
-        List<Secrole> results = (List<Secrole>) HqlQueryHelper.find(currentSession(), "from Secrole r order by roleName");
+        List<Secrole> results = (List<Secrole>) JpqlQueryHelper.find(entityManager(), "from Secrole r order by roleName");
 
         logger.debug("getRoles: # of results=" + results.size());
 
@@ -62,7 +62,7 @@ public class SecroleDaoImpl extends AbstractHibernateDao implements SecroleDao {
             throw new IllegalArgumentException();
         }
 
-        Secrole result = currentSession().find(Secrole.class, Long.valueOf(id));
+        Secrole result = entityManager().find(Secrole.class, Long.valueOf(id));
 
         logger.debug("getRole: id=" + id + ",found=" + (result != null));
 
@@ -76,7 +76,7 @@ public class SecroleDaoImpl extends AbstractHibernateDao implements SecroleDao {
             throw new IllegalArgumentException();
         }
 
-        List lst = HqlQueryHelper.find(currentSession(), "from Secrole r where r.roleName = ?1", roleName);
+        List lst = JpqlQueryHelper.find(entityManager(), "from Secrole r where r.roleName = ?1", roleName);
         if (lst != null && lst.size() > 0)
             result = (Secrole) lst.get(0);
 
@@ -87,7 +87,7 @@ public class SecroleDaoImpl extends AbstractHibernateDao implements SecroleDao {
 
     @Override
     public List getDefaultRoles() {
-        return HqlQueryHelper.find(currentSession(), "from Secrole r where r.userDefined=0");
+        return JpqlQueryHelper.find(entityManager(), "from Secrole r where r.userDefined=0");
     }
 
     @Override
@@ -97,9 +97,9 @@ public class SecroleDaoImpl extends AbstractHibernateDao implements SecroleDao {
         }
 
         if (secrole.getId() == null) {
-            currentSession().persist(secrole);
+            entityManager().persist(secrole);
         } else {
-            currentSession().merge(secrole);
+            entityManager().merge(secrole);
         }
 
     }

--- a/src/main/java/io/github/carlos_emr/carlos/daos/security/SecuserroleDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/daos/security/SecuserroleDaoImpl.java
@@ -357,8 +357,14 @@ public class SecuserroleDaoImpl extends AbstractJpaDao implements SecuserroleDao
     public void attachClean(Secuserrole instance) {
         logger.debug("attaching clean Secuserrole instance");
         try {
-            // JPA equivalent of Hibernate Session.lock(LockMode.NONE): re-attach without acquiring a database lock
-            entityManager().merge(instance);
+            // JPA has no direct equivalent of Hibernate Session.lock(entity, LockMode.NONE) for reattach.
+            // If the entity is already managed, there is nothing to do. If it is detached, merge() is
+            // the only JPA-standard reattach path — unlike lock(NONE), merge may trigger UPDATE on flush
+            // if the detached state differs from the database row. Callers relying on the old "clean"
+            // (no-UPDATE) semantics must ensure the instance is not dirty before calling.
+            if (!entityManager().contains(instance)) {
+                entityManager().merge(instance);
+            }
             logger.debug("attach successful");
         } catch (RuntimeException re) {
             logger.error("attach failed", re);

--- a/src/main/java/io/github/carlos_emr/carlos/daos/security/SecuserroleDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/daos/security/SecuserroleDaoImpl.java
@@ -118,7 +118,13 @@ public class SecuserroleDaoImpl extends AbstractJpaDao implements SecuserroleDao
     public void delete(Secuserrole persistentInstance) {
         logger.debug("deleting Secuserrole instance");
         try {
-            entityManager().remove(persistentInstance);
+            // Pre-migration Hibernate Session.delete() accepted detached entities.
+            // JPA EntityManager.remove() requires a managed instance, so reattach via
+            // merge() first when the caller passes a detached entity.
+            Secuserrole managed = entityManager().contains(persistentInstance)
+                    ? persistentInstance
+                    : entityManager().merge(persistentInstance);
+            entityManager().remove(managed);
             logger.debug("delete successful");
         } catch (RuntimeException re) {
             logger.error("delete failed", re);

--- a/src/main/java/io/github/carlos_emr/carlos/daos/security/SecuserroleDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/daos/security/SecuserroleDaoImpl.java
@@ -36,7 +36,6 @@ import java.util.Map;
 
 import org.apache.logging.log4j.Logger;
 import jakarta.persistence.EntityManager;
-import jakarta.persistence.LockModeType;
 import io.github.carlos_emr.carlos.PMmodule.web.formbean.StaffForm;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.dao.AbstractJpaDao;
@@ -175,7 +174,7 @@ public class SecuserroleDaoImpl extends AbstractJpaDao implements SecuserroleDao
             return 0;
         }
         try {
-            String queryString = "update Secuserrole as model set model.activeyn = ?1, lastUpdateDate=now() where model.providerNo = ?2 and model.roleName = ?3 and model.orgcd = ?4";
+            String queryString = "update Secuserrole as model set model.activeyn = ?1, model.lastUpdateDate=now() where model.providerNo = ?2 and model.roleName = ?3 and model.orgcd = ?4";
 
             return JpqlQueryHelper.bulkUpdate(entityManager(), queryString,
                     instance.getActiveyn(), instance.getProviderNo(),
@@ -358,7 +357,8 @@ public class SecuserroleDaoImpl extends AbstractJpaDao implements SecuserroleDao
     public void attachClean(Secuserrole instance) {
         logger.debug("attaching clean Secuserrole instance");
         try {
-            entityManager().lock(instance, LockModeType.NONE);
+            // JPA equivalent of Hibernate Session.lock(LockMode.NONE): re-attach without acquiring a database lock
+            entityManager().merge(instance);
             logger.debug("attach successful");
         } catch (RuntimeException re) {
             logger.error("attach failed", re);

--- a/src/main/java/io/github/carlos_emr/carlos/daos/security/SecuserroleDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/daos/security/SecuserroleDaoImpl.java
@@ -35,15 +35,15 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.logging.log4j.Logger;
-import org.hibernate.LockMode;
-import org.hibernate.Session;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.LockModeType;
 import io.github.carlos_emr.carlos.PMmodule.web.formbean.StaffForm;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
-import io.github.carlos_emr.carlos.dao.AbstractHibernateDao;
+import io.github.carlos_emr.carlos.dao.AbstractJpaDao;
 
 import io.github.carlos_emr.carlos.model.security.Secuserrole;
 import org.springframework.transaction.annotation.Transactional;
-import io.github.carlos_emr.carlos.utility.HqlQueryHelper;
+import io.github.carlos_emr.carlos.utility.JpqlQueryHelper;
 
 import java.util.Set;
 
@@ -58,7 +58,7 @@ import java.util.Set;
  * @see Secuserrole
  */
 @Transactional
-public class SecuserroleDaoImpl extends AbstractHibernateDao implements SecuserroleDao {
+public class SecuserroleDaoImpl extends AbstractJpaDao implements SecuserroleDao {
     private static final Logger logger = MiscUtils.getLogger();
 
     private static final Set<String> ALLOWED_PROPERTIES = Set.of(
@@ -67,7 +67,7 @@ public class SecuserroleDaoImpl extends AbstractHibernateDao implements Secuserr
     @Override
     public void saveAll(List list) {
         logger.debug("saving ALL Secuserrole instances");
-        Session session = currentSession();
+        EntityManager em = entityManager();
         try {
             for (int i = 0; i < list.size(); i++) {
                 Secuserrole obj = (Secuserrole) list.get(i);
@@ -75,7 +75,7 @@ public class SecuserroleDaoImpl extends AbstractHibernateDao implements Secuserr
                 int rowcount = update(obj);
 
                 if (rowcount <= 0) {
-                    session.persist(obj);
+                    em.persist(obj);
                 }
 
             }
@@ -89,13 +89,13 @@ public class SecuserroleDaoImpl extends AbstractHibernateDao implements Secuserr
     @Override
     public void save(Secuserrole transientInstance) {
         logger.debug("saving Secuserrole instance");
-        Session session = currentSession();
+        EntityManager em = entityManager();
         try {
             transientInstance.setLastUpdateDate(new Date());
             if (transientInstance.getId() == null) {
-                session.persist(transientInstance);
+                em.persist(transientInstance);
             } else {
-                session.merge(transientInstance);
+                em.merge(transientInstance);
             }
             logger.debug("save successful");
         } catch (RuntimeException re) {
@@ -106,20 +106,20 @@ public class SecuserroleDaoImpl extends AbstractHibernateDao implements Secuserr
 
     @Override
     public void updateRoleName(Integer id, String roleName) {
-        Secuserrole sur = currentSession().find(Secuserrole.class, id);
+        EntityManager em = entityManager();
+        Secuserrole sur = em.find(Secuserrole.class, id);
         if (sur != null) {
             sur.setRoleName(roleName);
             sur.setLastUpdateDate(new Date());
-            currentSession().merge(sur);
+            em.merge(sur);
         }
     }
 
     @Override
     public void delete(Secuserrole persistentInstance) {
         logger.debug("deleting Secuserrole instance");
-        Session session = currentSession();
         try {
-            session.remove(persistentInstance);
+            entityManager().remove(persistentInstance);
             logger.debug("delete successful");
         } catch (RuntimeException re) {
             logger.error("delete failed", re);
@@ -132,7 +132,7 @@ public class SecuserroleDaoImpl extends AbstractHibernateDao implements Secuserr
         logger.debug("deleting Secuserrole by orgcd");
         try {
 
-            return HqlQueryHelper.bulkUpdate(currentSession(), "delete Secuserrole as model where model.orgcd =?1", orgcd);
+            return JpqlQueryHelper.bulkUpdate(entityManager(), "delete Secuserrole as model where model.orgcd =?1", orgcd);
 
         } catch (RuntimeException re) {
             logger.error("delete failed", re);
@@ -145,7 +145,7 @@ public class SecuserroleDaoImpl extends AbstractHibernateDao implements Secuserr
         logger.debug("deleting Secuserrole by providerNo");
         try {
 
-            return HqlQueryHelper.bulkUpdate(currentSession(), "delete Secuserrole as model where model.providerNo =?1",
+            return JpqlQueryHelper.bulkUpdate(entityManager(), "delete Secuserrole as model where model.providerNo =?1",
                     providerNo);
 
         } catch (RuntimeException re) {
@@ -159,7 +159,7 @@ public class SecuserroleDaoImpl extends AbstractHibernateDao implements Secuserr
         logger.debug("deleting Secuserrole by ID");
         try {
 
-            return HqlQueryHelper.bulkUpdate(currentSession(), "delete Secuserrole as model where model.id =?1", id);
+            return JpqlQueryHelper.bulkUpdate(entityManager(), "delete Secuserrole as model where model.id =?1", id);
 
         } catch (RuntimeException re) {
             logger.error("delete failed", re);
@@ -177,7 +177,7 @@ public class SecuserroleDaoImpl extends AbstractHibernateDao implements Secuserr
         try {
             String queryString = "update Secuserrole as model set model.activeyn = ?1, lastUpdateDate=now() where model.providerNo = ?2 and model.roleName = ?3 and model.orgcd = ?4";
 
-            return HqlQueryHelper.bulkUpdate(currentSession(), queryString,
+            return JpqlQueryHelper.bulkUpdate(entityManager(), queryString,
                     instance.getActiveyn(), instance.getProviderNo(),
                     instance.getRoleName(), instance.getOrgcd());
 
@@ -190,9 +190,8 @@ public class SecuserroleDaoImpl extends AbstractHibernateDao implements Secuserr
     @Override
     public Secuserrole findById(java.lang.Integer id) {
         logger.debug("getting Secuserrole instance with id: " + id);
-        Session session = currentSession();
         try {
-            Secuserrole instance = session.find(Secuserrole.class, id);
+            Secuserrole instance = entityManager().find(Secuserrole.class, id);
             return instance;
         } catch (RuntimeException re) {
             logger.error("get failed", re);
@@ -223,7 +222,7 @@ public class SecuserroleDaoImpl extends AbstractHibernateDao implements Secuserr
                 hql.append(" and s.activeyn = :activeyn");
                 params.put("activeyn", instance.getActiveyn());
             }
-            List results = HqlQueryHelper.find(currentSession(), hql.toString(), params);
+            List results = JpqlQueryHelper.find(entityManager(), hql.toString(), params);
             logger.debug("find by example successful, result size: "
                     + results.size());
             return results;
@@ -243,7 +242,7 @@ public class SecuserroleDaoImpl extends AbstractHibernateDao implements Secuserr
             }
             String queryString = "from Secuserrole as model where model."
                     + propertyName + "= ?1";
-            return HqlQueryHelper.find(currentSession(), queryString, value);
+            return JpqlQueryHelper.find(entityManager(), queryString, value);
         } catch (RuntimeException re) {
             logger.error("find by property name failed", re);
             throw re;
@@ -272,7 +271,7 @@ public class SecuserroleDaoImpl extends AbstractHibernateDao implements Secuserr
                 queryString = "select a from Secuserrole a, LstOrgcd b, SecProvider p where a.providerNo=p.providerNo and b.code =?1 and b.codecsv like '%' || a.orgcd || ',%' and not (a.orgcd like 'R%' or a.orgcd like 'O%')";
             }
 
-            return HqlQueryHelper.find(currentSession(), queryString, orgcd);
+            return JpqlQueryHelper.find(entityManager(), queryString, orgcd);
 
         } catch (RuntimeException re) {
             logger.error("Find staff failed", re);
@@ -303,7 +302,7 @@ public class SecuserroleDaoImpl extends AbstractHibernateDao implements Secuserr
             if (hasFname) params.put("fname", "%" + fname.toLowerCase() + "%");
             if (hasLname) params.put("lname", "%" + lname.toLowerCase() + "%");
 
-            return HqlQueryHelper.find(currentSession(), hql, params);
+            return JpqlQueryHelper.find(entityManager(), hql, params);
 
         } catch (RuntimeException re) {
             logger.error("Search staff failed", re);
@@ -320,7 +319,7 @@ public class SecuserroleDaoImpl extends AbstractHibernateDao implements Secuserr
     public List findAll() {
         logger.debug("finding all Secuserrole instances");
         try {
-            return HqlQueryHelper.find(currentSession(), "from Secuserrole");
+            return JpqlQueryHelper.find(entityManager(), "from Secuserrole");
         } catch (RuntimeException re) {
             logger.error("find all failed", re);
             throw re;
@@ -330,10 +329,9 @@ public class SecuserroleDaoImpl extends AbstractHibernateDao implements Secuserr
     @Override
     public Secuserrole merge(Secuserrole detachedInstance) {
         logger.debug("merging Secuserrole instance");
-        Session session = currentSession();
         try {
             detachedInstance.setLastUpdateDate(new Date());
-            Secuserrole result = (Secuserrole) session.merge(
+            Secuserrole result = (Secuserrole) entityManager().merge(
                     detachedInstance);
             logger.debug("merge successful");
             return result;
@@ -346,10 +344,9 @@ public class SecuserroleDaoImpl extends AbstractHibernateDao implements Secuserr
     @Override
     public void attachDirty(Secuserrole instance) {
         logger.debug("attaching dirty Secuserrole instance");
-        Session session = currentSession();
         try {
             instance.setLastUpdateDate(new Date());
-            session.merge(instance);
+            entityManager().merge(instance);
             logger.debug("attach successful");
         } catch (RuntimeException re) {
             logger.error("attach failed", re);
@@ -360,9 +357,8 @@ public class SecuserroleDaoImpl extends AbstractHibernateDao implements Secuserr
     @Override
     public void attachClean(Secuserrole instance) {
         logger.debug("attaching clean Secuserrole instance");
-        Session session = currentSession();
         try {
-            session.lock(instance, LockMode.NONE);
+            entityManager().lock(instance, LockModeType.NONE);
             logger.debug("attach successful");
         } catch (RuntimeException re) {
             logger.error("attach failed", re);

--- a/src/main/java/io/github/carlos_emr/carlos/daos/security/UserAccessDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/daos/security/UserAccessDaoImpl.java
@@ -32,12 +32,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import io.github.carlos_emr.carlos.dao.AbstractHibernateDao;
+import io.github.carlos_emr.carlos.dao.AbstractJpaDao;
 import org.springframework.transaction.annotation.Transactional;
-import io.github.carlos_emr.carlos.utility.HqlQueryHelper;
+import io.github.carlos_emr.carlos.utility.JpqlQueryHelper;
 
 @Transactional
-public class UserAccessDaoImpl extends AbstractHibernateDao implements UserAccessDao {
+public class UserAccessDaoImpl extends AbstractJpaDao implements UserAccessDao {
 
     @SuppressWarnings("unchecked")
     @Override
@@ -48,10 +48,10 @@ public class UserAccessDaoImpl extends AbstractHibernateDao implements UserAcces
             Map<String, Object> params = new HashMap<>();
             params.put("providerNo", providerNo);
             params.put("shelterPattern", shelterPattern);
-            return HqlQueryHelper.find(currentSession(), hql, params);
+            return JpqlQueryHelper.find(entityManager(), hql, params);
         } else {
             String sSQL = "from UserAccessValue s where s.providerNo= ?1 order by s.functionCd, s.privilege desc, s.orgCd";
-            return HqlQueryHelper.find(currentSession(), sSQL, providerNo);
+            return JpqlQueryHelper.find(entityManager(), sSQL, providerNo);
         }
     }
 
@@ -64,10 +64,10 @@ public class UserAccessDaoImpl extends AbstractHibernateDao implements UserAcces
             Map<String, Object> params = new HashMap<>();
             params.put("providerNo", providerNo);
             params.put("shelterPattern", shelterPattern);
-            return HqlQueryHelper.find(currentSession(), hql, params);
+            return JpqlQueryHelper.find(entityManager(), hql, params);
         } else {
             String sSQL = "select distinct o.codecsv from UserAccessValue s, LstOrgcd o where s.providerNo= ?1 and s.privilege>='r' and s.orgCd=o.code order by o.codecsv";
-            return HqlQueryHelper.find(currentSession(), sSQL, providerNo);
+            return JpqlQueryHelper.find(entityManager(), sSQL, providerNo);
         }
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/utility/JpqlQueryHelper.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/JpqlQueryHelper.java
@@ -73,8 +73,7 @@ public final class JpqlQueryHelper {
     public static List<?> find(EntityManager em, String jpql, Object... params) {
         Objects.requireNonNull(em, "EntityManager must not be null — is there an active @Transactional?");
         try {
-            // nosemgrep: hibernate-sqli — this IS the parameterization utility; params bound via bindPositionalParams below
-            Query query = em.createQuery(jpql);
+            Query query = em.createQuery(jpql); // nosemgrep: java.lang.security.audit.sqli.jpa-sqli.jpa-sqli
             bindPositionalParams(query, params);
             return query.getResultList();
         } catch (PersistenceException e) {
@@ -99,8 +98,7 @@ public final class JpqlQueryHelper {
     public static List<?> findWithLimit(EntityManager em, String jpql, int maxResults, Object... params) {
         Objects.requireNonNull(em, "EntityManager must not be null — is there an active @Transactional?");
         try {
-            // nosemgrep: hibernate-sqli — this IS the parameterization utility; params bound below
-            Query query = em.createQuery(jpql);
+            Query query = em.createQuery(jpql); // nosemgrep: java.lang.security.audit.sqli.jpa-sqli.jpa-sqli
             bindPositionalParams(query, params);
             if (maxResults >= 0) {
                 query.setMaxResults(maxResults);
@@ -128,8 +126,7 @@ public final class JpqlQueryHelper {
     public static List<?> find(EntityManager em, String jpql, Map<String, Object> namedParams) {
         Objects.requireNonNull(em, "EntityManager must not be null — is there an active @Transactional?");
         try {
-            // nosemgrep: hibernate-sqli — this IS the parameterization utility; named params bound below
-            Query query = em.createQuery(jpql);
+            Query query = em.createQuery(jpql); // nosemgrep: java.lang.security.audit.sqli.jpa-sqli.jpa-sqli
             bindNamedParams(query, namedParams);
             return query.getResultList();
         } catch (PersistenceException e) {
@@ -153,8 +150,7 @@ public final class JpqlQueryHelper {
     public static List<?> findWithLimit(EntityManager em, String jpql, int maxResults, Map<String, Object> namedParams) {
         Objects.requireNonNull(em, "EntityManager must not be null — is there an active @Transactional?");
         try {
-            // nosemgrep: hibernate-sqli — this IS the parameterization utility; named params bound below
-            Query query = em.createQuery(jpql);
+            Query query = em.createQuery(jpql); // nosemgrep: java.lang.security.audit.sqli.jpa-sqli.jpa-sqli
             bindNamedParams(query, namedParams);
             if (maxResults >= 0) {
                 query.setMaxResults(maxResults);
@@ -180,8 +176,7 @@ public final class JpqlQueryHelper {
     public static int bulkUpdate(EntityManager em, String jpql, Object... params) {
         Objects.requireNonNull(em, "EntityManager must not be null — is there an active @Transactional?");
         try {
-            // nosemgrep: hibernate-sqli — this IS the parameterization utility; params bound below
-            Query query = em.createQuery(jpql);
+            Query query = em.createQuery(jpql); // nosemgrep: java.lang.security.audit.sqli.jpa-sqli.jpa-sqli
             bindPositionalParams(query, params);
             return query.executeUpdate();
         } catch (PersistenceException e) {
@@ -207,8 +202,7 @@ public final class JpqlQueryHelper {
     public static List<?> findWithPagination(EntityManager em, String jpql, int firstResult, int maxResults, Map<String, Object> namedParams) {
         Objects.requireNonNull(em, "EntityManager must not be null — is there an active @Transactional?");
         try {
-            // nosemgrep: hibernate-sqli — this IS the parameterization utility; named params bound below
-            Query query = em.createQuery(jpql);
+            Query query = em.createQuery(jpql); // nosemgrep: java.lang.security.audit.sqli.jpa-sqli.jpa-sqli
             bindNamedParams(query, namedParams);
             if (firstResult >= 0) {
                 query.setFirstResult(firstResult);

--- a/src/main/java/io/github/carlos_emr/carlos/utility/JpqlQueryHelper.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/JpqlQueryHelper.java
@@ -250,7 +250,8 @@ public final class JpqlQueryHelper {
      * hierarchy, preserving the same contract as {@link HqlQueryHelper}.
      *
      * <p>Checks JPA-standard subtypes first, then unwraps Hibernate-specific
-     * exceptions from the cause chain for finer-grained translation.</p>
+     * exceptions from the immediate cause ({@code e.getCause()} — one level only)
+     * for finer-grained translation.</p>
      */
     private static DataAccessException translatePersistenceException(PersistenceException e) {
         // JPA-standard exception subtypes
@@ -273,7 +274,7 @@ public final class JpqlQueryHelper {
             return new InvalidDataAccessApiUsageException(e.getMessage(), e);
         }
 
-        // Unwrap Hibernate-specific exceptions from the cause chain
+        // Unwrap Hibernate-specific exceptions from the immediate cause (e.getCause() — one level only)
         Throwable cause = e.getCause();
         if (cause instanceof org.hibernate.exception.ConstraintViolationException) {
             return new DataIntegrityViolationException(e.getMessage(), e);

--- a/src/main/java/io/github/carlos_emr/carlos/utility/JpqlQueryHelper.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/JpqlQueryHelper.java
@@ -1,6 +1,7 @@
 /**
- * Copyright (c) 2026. CARLOS EMR. All rights reserved.
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
  *
+ * This software is published under the GPL GNU General Public License.
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; either version 2
@@ -14,6 +15,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
  */
 package io.github.carlos_emr.carlos.utility;
 

--- a/src/main/java/io/github/carlos_emr/carlos/utility/JpqlQueryHelper.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/JpqlQueryHelper.java
@@ -1,0 +1,312 @@
+/**
+ * Copyright (c) 2026. CARLOS EMR. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+package io.github.carlos_emr.carlos.utility;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceException;
+import jakarta.persistence.Query;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.CannotAcquireLockException;
+import org.springframework.dao.IncorrectResultSizeDataAccessException;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.dao.InvalidDataAccessResourceUsageException;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.dao.QueryTimeoutException;
+
+/**
+ * JPA counterpart to {@link HqlQueryHelper} that uses {@link EntityManager}
+ * instead of Hibernate {@code Session}.
+ *
+ * <p>Provides the same six method signatures as {@code HqlQueryHelper},
+ * enabling a mechanical migration: replace
+ * {@code HqlQueryHelper.find(currentSession(), hql, params)} with
+ * {@code JpqlQueryHelper.find(entityManager(), hql, params)}.</p>
+ *
+ * <p>All JPQL strings from the Hibernate-based DAOs work unchanged because
+ * Hibernate is the JPA provider. JPA exceptions are translated to Spring's
+ * {@code DataAccessException} hierarchy to preserve the same contract.</p>
+ *
+ * @since 2026-04-11
+ * @see HqlQueryHelper
+ * @see io.github.carlos_emr.carlos.dao.AbstractJpaDao
+ */
+public final class JpqlQueryHelper {
+
+    private JpqlQueryHelper() {
+    }
+
+    /**
+     * Execute a JPQL query with 1-based positional parameter binding.
+     *
+     * <p>Returns {@code List<?>} to match {@code HqlQueryHelper.find()} signature,
+     * allowing existing {@code (List<SomeType>)} casts to work unchanged.</p>
+     *
+     * @param em the EntityManager from {@code entityManager()}
+     * @param jpql the JPQL query string using 1-based positional parameters ({@code ?1}, {@code ?2}, etc.)
+     * @param params the parameter values, bound to {@code ?1}, {@code ?2}, etc. in order
+     * @return a non-null list of query results (empty if no matches)
+     * @throws org.springframework.dao.DataAccessException if the query execution fails
+     * @throws IllegalArgumentException if any positional parameter value is null
+     */
+    public static List<?> find(EntityManager em, String jpql, Object... params) {
+        Objects.requireNonNull(em, "EntityManager must not be null — is there an active @Transactional?");
+        try {
+            // nosemgrep: hibernate-sqli — this IS the parameterization utility; params bound via bindPositionalParams below
+            Query query = em.createQuery(jpql);
+            bindPositionalParams(query, params);
+            return query.getResultList();
+        } catch (PersistenceException e) {
+            throw translatePersistenceException(e);
+        }
+    }
+
+    /**
+     * Execute a JPQL query with 1-based positional parameter binding and a row limit.
+     *
+     * <p>Use this method when the query needs {@code setMaxResults()} (e.g., "top N" queries).
+     * Pass {@code -1} for {@code maxResults} to return all rows.</p>
+     *
+     * @param em the EntityManager from {@code entityManager()}
+     * @param jpql the JPQL query string using 1-based positional parameters ({@code ?1}, {@code ?2}, etc.)
+     * @param maxResults maximum number of rows to return, or {@code -1} for unlimited
+     * @param params the parameter values, bound to {@code ?1}, {@code ?2}, etc. in order
+     * @return a non-null list of query results (empty if no matches)
+     * @throws org.springframework.dao.DataAccessException if the query execution fails
+     * @throws IllegalArgumentException if any positional parameter value is null
+     */
+    public static List<?> findWithLimit(EntityManager em, String jpql, int maxResults, Object... params) {
+        Objects.requireNonNull(em, "EntityManager must not be null — is there an active @Transactional?");
+        try {
+            // nosemgrep: hibernate-sqli — this IS the parameterization utility; params bound below
+            Query query = em.createQuery(jpql);
+            bindPositionalParams(query, params);
+            if (maxResults >= 0) {
+                query.setMaxResults(maxResults);
+            }
+            return query.getResultList();
+        } catch (PersistenceException e) {
+            throw translatePersistenceException(e);
+        }
+    }
+
+    /**
+     * Execute a JPQL query with named parameter binding.
+     *
+     * <p>Use this method for queries with named parameters ({@code :paramName}).
+     * Collection values are bound with {@code setParameter} for IN clauses
+     * (Hibernate 7 JPA mode supports Collection binding via {@code setParameter}).</p>
+     *
+     * @param em the EntityManager from {@code entityManager()}
+     * @param jpql the JPQL query string using named parameters ({@code :param1}, {@code :param2}, etc.)
+     * @param namedParams map of parameter names to values
+     * @return a non-null list of query results (empty if no matches)
+     * @throws org.springframework.dao.DataAccessException if the query execution fails
+     * @throws IllegalArgumentException if any named parameter value is null or a Collection parameter is empty
+     */
+    public static List<?> find(EntityManager em, String jpql, Map<String, Object> namedParams) {
+        Objects.requireNonNull(em, "EntityManager must not be null — is there an active @Transactional?");
+        try {
+            // nosemgrep: hibernate-sqli — this IS the parameterization utility; named params bound below
+            Query query = em.createQuery(jpql);
+            bindNamedParams(query, namedParams);
+            return query.getResultList();
+        } catch (PersistenceException e) {
+            throw translatePersistenceException(e);
+        }
+    }
+
+    /**
+     * Execute a JPQL query with named parameter binding and a row limit.
+     *
+     * <p>Pass {@code -1} for {@code maxResults} to return all rows.</p>
+     *
+     * @param em the EntityManager from {@code entityManager()}
+     * @param jpql the JPQL query string using named parameters ({@code :param1}, {@code :param2}, etc.)
+     * @param maxResults maximum number of rows to return, or {@code -1} for unlimited
+     * @param namedParams map of parameter names to values
+     * @return a non-null list of query results (empty if no matches)
+     * @throws org.springframework.dao.DataAccessException if the query execution fails
+     * @throws IllegalArgumentException if any named parameter value is null or a Collection parameter is empty
+     */
+    public static List<?> findWithLimit(EntityManager em, String jpql, int maxResults, Map<String, Object> namedParams) {
+        Objects.requireNonNull(em, "EntityManager must not be null — is there an active @Transactional?");
+        try {
+            // nosemgrep: hibernate-sqli — this IS the parameterization utility; named params bound below
+            Query query = em.createQuery(jpql);
+            bindNamedParams(query, namedParams);
+            if (maxResults >= 0) {
+                query.setMaxResults(maxResults);
+            }
+            return query.getResultList();
+        } catch (PersistenceException e) {
+            throw translatePersistenceException(e);
+        }
+    }
+
+    /**
+     * Execute a JPQL bulk update/delete with 1-based positional parameter binding.
+     *
+     * <p>Drop-in replacement for {@code HqlQueryHelper.bulkUpdate()}.</p>
+     *
+     * @param em the EntityManager from {@code entityManager()}
+     * @param jpql the JPQL update/delete string using 1-based positional parameters ({@code ?1}, {@code ?2}, etc.)
+     * @param params the parameter values, bound to {@code ?1}, {@code ?2}, etc. in order
+     * @return the number of entity instances updated or deleted (&gt;= 0)
+     * @throws org.springframework.dao.DataAccessException if the query execution fails
+     * @throws IllegalArgumentException if any positional parameter value is null
+     */
+    public static int bulkUpdate(EntityManager em, String jpql, Object... params) {
+        Objects.requireNonNull(em, "EntityManager must not be null — is there an active @Transactional?");
+        try {
+            // nosemgrep: hibernate-sqli — this IS the parameterization utility; params bound below
+            Query query = em.createQuery(jpql);
+            bindPositionalParams(query, params);
+            return query.executeUpdate();
+        } catch (PersistenceException e) {
+            throw translatePersistenceException(e);
+        }
+    }
+
+    /**
+     * Execute a JPQL query with named parameter binding, pagination, and a row limit.
+     *
+     * <p>Use this method when the query needs both {@code setFirstResult()} and
+     * {@code setMaxResults()} (e.g., paginated search results).</p>
+     *
+     * @param em the EntityManager from {@code entityManager()}
+     * @param jpql the JPQL query string using named parameters ({@code :param1}, {@code :param2}, etc.)
+     * @param firstResult the 0-based index of the first result to return, or {@code -1} to start from the beginning
+     * @param maxResults maximum number of rows to return, or {@code -1} for unlimited
+     * @param namedParams map of parameter names to values
+     * @return a non-null list of query results (empty if no matches)
+     * @throws org.springframework.dao.DataAccessException if the query execution fails
+     * @throws IllegalArgumentException if any named parameter value is null or a Collection parameter is empty
+     */
+    public static List<?> findWithPagination(EntityManager em, String jpql, int firstResult, int maxResults, Map<String, Object> namedParams) {
+        Objects.requireNonNull(em, "EntityManager must not be null — is there an active @Transactional?");
+        try {
+            // nosemgrep: hibernate-sqli — this IS the parameterization utility; named params bound below
+            Query query = em.createQuery(jpql);
+            bindNamedParams(query, namedParams);
+            if (firstResult >= 0) {
+                query.setFirstResult(firstResult);
+            }
+            if (maxResults >= 0) {
+                query.setMaxResults(maxResults);
+            }
+            return query.getResultList();
+        } catch (PersistenceException e) {
+            throw translatePersistenceException(e);
+        }
+    }
+
+    private static void bindNamedParams(Query query, Map<String, Object> namedParams) {
+        if (namedParams == null) {
+            return;
+        }
+        for (Map.Entry<String, Object> entry : namedParams.entrySet()) {
+            Object value = entry.getValue();
+            if (value == null) {
+                throw new IllegalArgumentException(
+                        "Null value for named parameter '" + entry.getKey()
+                        + "'. Use IS NULL in JPQL instead of binding a null value.");
+            }
+            if (value instanceof Collection) {
+                Collection<?> coll = (Collection<?>) value;
+                if (coll.isEmpty()) {
+                    throw new IllegalArgumentException(
+                            "Empty collection for named parameter '" + entry.getKey()
+                            + "'. IN clause requires at least one value.");
+                }
+            }
+            query.setParameter(entry.getKey(), value);
+        }
+    }
+
+    /**
+     * Translates a {@link PersistenceException} to Spring's {@link DataAccessException}
+     * hierarchy, preserving the same contract as {@link HqlQueryHelper}.
+     *
+     * <p>Checks JPA-standard subtypes first, then unwraps Hibernate-specific
+     * exceptions from the cause chain for finer-grained translation.</p>
+     */
+    private static DataAccessException translatePersistenceException(PersistenceException e) {
+        // JPA-standard exception subtypes
+        if (e instanceof jakarta.persistence.EntityExistsException) {
+            return new DataIntegrityViolationException(e.getMessage(), e);
+        }
+        if (e instanceof jakarta.persistence.NonUniqueResultException) {
+            return new IncorrectResultSizeDataAccessException(e.getMessage(), 1, e);
+        }
+        if (e instanceof jakarta.persistence.OptimisticLockException) {
+            return new OptimisticLockingFailureException(e.getMessage(), e);
+        }
+        if (e instanceof jakarta.persistence.PessimisticLockException) {
+            return new CannotAcquireLockException(e.getMessage(), e);
+        }
+        if (e instanceof jakarta.persistence.QueryTimeoutException) {
+            return new QueryTimeoutException(e.getMessage(), e);
+        }
+        if (e instanceof jakarta.persistence.TransactionRequiredException) {
+            return new InvalidDataAccessApiUsageException(e.getMessage(), e);
+        }
+
+        // Unwrap Hibernate-specific exceptions from the cause chain
+        Throwable cause = e.getCause();
+        if (cause instanceof org.hibernate.exception.ConstraintViolationException) {
+            return new DataIntegrityViolationException(e.getMessage(), e);
+        }
+        if (cause instanceof org.hibernate.exception.DataException) {
+            return new DataIntegrityViolationException(e.getMessage(), e);
+        }
+        if (cause instanceof org.hibernate.exception.LockAcquisitionException) {
+            return new CannotAcquireLockException(e.getMessage(), e);
+        }
+        if (cause instanceof org.hibernate.exception.SQLGrammarException) {
+            return new InvalidDataAccessResourceUsageException(e.getMessage(), e);
+        }
+        if (cause instanceof org.hibernate.exception.JDBCConnectionException) {
+            return new DataAccessResourceFailureException(e.getMessage(), e);
+        }
+        if (cause instanceof org.hibernate.QueryException) {
+            return new InvalidDataAccessResourceUsageException(e.getMessage(), e);
+        }
+
+        return new InvalidDataAccessResourceUsageException(e.getMessage(), e);
+    }
+
+    private static void bindPositionalParams(Query query, Object[] params) {
+        if (params != null) {
+            for (int i = 0; i < params.length; i++) {
+                if (params[i] == null) {
+                    throw new IllegalArgumentException(
+                            "Null value for positional parameter ?" + (i + 1)
+                            + ". Use IS NULL in JPQL instead of binding a null value.");
+                }
+                query.setParameter(i + 1, params[i]);
+            }
+        }
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/PMmodule/dao/ProviderDaoIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/PMmodule/dao/ProviderDaoIntegrationTest.java
@@ -685,6 +685,27 @@ public class ProviderDaoIntegrationTest extends CarlosTestBase {
                 .contains("T001", "T002", "T003")
                 .doesNotContain("T004");
         }
+
+        @Test
+        @Tag("query")
+        @DisplayName("should return empty list for non-numeric programId")
+        void shouldReturnEmptyList_forNonNumericProgramId() {
+            // Regression guard: non-numeric programId must NOT silently widen
+            // to all active providers (which was the pre-fix behavior).
+            List<Provider> results = providerDao.getActiveProviders(null, "not-a-number");
+
+            assertThat(results).isEmpty();
+        }
+
+        @Test
+        @Tag("query")
+        @DisplayName("should return empty list for empty-string programId")
+        void shouldReturnEmptyList_forEmptyStringProgramId() {
+            // Empty string hits the NumberFormatException branch (Long.valueOf("") throws).
+            List<Provider> results = providerDao.getActiveProviders(null, "");
+
+            assertThat(results).isEmpty();
+        }
     }
 
     /** Tests for getProviderName and getProviderNameLastFirst edge cases. */

--- a/src/test/java/io/github/carlos_emr/carlos/casemgmt/dao/CaseManagementNoteDaoIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/casemgmt/dao/CaseManagementNoteDaoIntegrationTest.java
@@ -1313,10 +1313,13 @@ public class CaseManagementNoteDaoIntegrationTest extends CaseManagementNoteDaoB
                 .findNotesByDemographicAndIssueCode(DEMO_NO,
                     new String[]{"FNDIC001", "FNDIC002"});
 
-            // Then - both requested codes returned; third is excluded
+            // Then - exactly the two requested notes, third excluded. Size check
+            // guards against the IN clause being dropped entirely (which would
+            // return every note for the demographic).
             assertThat(results)
+                .hasSize(2)
                 .extracting(CaseManagementNote::getId)
-                .contains(n1.getId(), n2.getId())
+                .containsExactlyInAnyOrder(n1.getId(), n2.getId())
                 .doesNotContain(excluded.getId());
         }
 

--- a/src/test/java/io/github/carlos_emr/carlos/casemgmt/dao/CaseManagementNoteDaoIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/casemgmt/dao/CaseManagementNoteDaoIntegrationTest.java
@@ -1288,6 +1288,40 @@ public class CaseManagementNoteDaoIntegrationTest extends CaseManagementNoteDaoB
 
         @Test
         @Tag("query")
+        @DisplayName("should expand IN clause for multiple issue codes")
+        void shouldExpandInClause_forMultipleIssueCodes() {
+            // Regression guard for Hibernate's native-query Collection expansion on IN clauses.
+            // Pre-migration used setParameterList(); JPA migration relies on
+            // NativeQueryImplementor auto-expanding a List via setParameter (not guaranteed by
+            // the JPA spec). If that behavior breaks, this test fails rather than surfacing
+            // as a runtime SQL error.
+            Issue issue2 = createIssue("FNDIC002", "FindByCode Issue 2");
+            Issue issue3 = createIssue("FNDIC003", "FindByCode Issue 3");
+            CaseManagementIssue cmi2 = createCaseManagementIssue(String.valueOf(DEMO_NO), issue2);
+            CaseManagementIssue cmi3 = createCaseManagementIssue(String.valueOf(DEMO_NO), issue3);
+
+            CaseManagementNote n1 = createNoteWithIssue(String.valueOf(DEMO_NO), "Multi-code note 1",
+                createDate(2024, 10, 1), cmi1);
+            CaseManagementNote n2 = createNoteWithIssue(String.valueOf(DEMO_NO), "Multi-code note 2",
+                createDate(2024, 10, 2), cmi2);
+            CaseManagementNote excluded = createNoteWithIssue(String.valueOf(DEMO_NO), "Excluded note",
+                createDate(2024, 10, 3), cmi3);
+            hibernateTemplate.flush();
+
+            // When - filter on two of three codes
+            Collection<CaseManagementNote> results = caseManagementNoteDAO
+                .findNotesByDemographicAndIssueCode(DEMO_NO,
+                    new String[]{"FNDIC001", "FNDIC002"});
+
+            // Then - both requested codes returned; third is excluded
+            assertThat(results)
+                .extracting(CaseManagementNote::getId)
+                .contains(n1.getId(), n2.getId())
+                .doesNotContain(excluded.getId());
+        }
+
+        @Test
+        @Tag("query")
         @DisplayName("should de-duplicate notes with same UUID keeping most recent")
         void shouldDeduplicateByUuid_keepingMostRecent() {
             // Given - two revisions of the same note (same UUID)

--- a/src/test/java/io/github/carlos_emr/carlos/daos/security/SecuserroleDaoIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/daos/security/SecuserroleDaoIntegrationTest.java
@@ -768,22 +768,24 @@ public class SecuserroleDaoIntegrationTest extends CarlosTestBase {
         }
 
         /**
-         * Verifies that {@code attachClean()} throws when called with a detached
-         * entity. In Hibernate 7, {@code session.lock()} rejects detached instances
-         * with a {@code DetachedObjectException} wrapped in {@code IllegalArgumentException}.
+         * Verifies that {@code attachClean()} reattaches a detached entity via JPA
+         * {@code merge()}. JPA has no direct equivalent of Hibernate
+         * {@code Session.lock(entity, LockMode.NONE)} for detached entities, so the
+         * implementation falls through to {@code merge()} (guarded by
+         * {@code entityManager().contains(instance)} to preserve the no-op contract
+         * for already-managed instances).
          */
         @Test
         @Tag("read")
-        @DisplayName("should throw when attaching clean on detached entity")
-        void shouldThrow_whenAttachingCleanOnDetachedEntity() {
+        @DisplayName("should reattach detached entity without throwing")
+        void shouldReattachDetachedEntity_viaMerge() {
             // Given - create, flush, then evict to make it detached
             Secuserrole role = createSecuserrole("AC200", "nurse", "ORG1");
             hibernateTemplate.flush();
             hibernateTemplate.evict(role);
 
-            // When / Then - Hibernate 7 rejects lock() on detached entities
-            assertThatThrownBy(() -> secuserroleDao.attachClean(role))
-                .isInstanceOf(RuntimeException.class);
+            // When / Then - attachClean must NOT throw for a detached entity
+            secuserroleDao.attachClean(role);
         }
     }
 

--- a/src/test/resources/test-context-full.xml
+++ b/src/test/resources/test-context-full.xml
@@ -620,13 +620,11 @@
     <bean id="secUserRoleDao" class="io.github.carlos_emr.carlos.daos.security.SecuserroleDaoImpl" autowire="byName" />
     <bean id="userAccessDao" class="io.github.carlos_emr.carlos.daos.security.UserAccessDaoImpl" autowire="byName" />
     <bean id="secObjectNameDao" class="io.github.carlos_emr.carlos.daos.security.SecObjectNameDaoImpl" autowire="byName" />
-    <bean id="secProviderDao" class="io.github.carlos_emr.carlos.daos.security.SecProviderDaoImpl" autowire="byName">
-        <property name="sessionFactory" ref="sessionFactory" />
-    </bean>
+    <bean id="secProviderDao" class="io.github.carlos_emr.carlos.daos.security.SecProviderDaoImpl" autowire="byName" />
     <bean id="providerDAO" class="io.github.carlos_emr.carlos.daos.ProviderDAOImpl" autowire="byName" />
     <bean id="lookupDao" class="io.github.carlos_emr.carlos.daos.LookupDaoImpl" autowire="byName" />
 
-    <!-- PMmodule DAOs (no @Repository, extends AbstractHibernateDao) -->
+    <!-- PMmodule DAOs (no @Repository) -->
     <bean id="programDao" class="io.github.carlos_emr.carlos.PMmodule.dao.ProgramDaoImpl" autowire="byName" />
     <bean id="programQueueDao" class="io.github.carlos_emr.carlos.PMmodule.dao.ProgramQueueDaoImpl" autowire="byName" />
     <bean id="clientReferralDAO" class="io.github.carlos_emr.carlos.PMmodule.dao.ClientReferralDAOImpl" autowire="byName" />
@@ -639,26 +637,15 @@
     <bean id="programTeamDAO" class="io.github.carlos_emr.carlos.PMmodule.dao.ProgramTeamDAOImpl" autowire="byName" />
     <bean id="programSignatureDao" class="io.github.carlos_emr.carlos.PMmodule.dao.ProgramSignatureDaoImpl" autowire="byName" />
     <bean id="programClientRestrictionDAO" class="io.github.carlos_emr.carlos.PMmodule.dao.ProgramClientRestrictionDAOImpl" autowire="byName">
-        <property name="sessionFactory" ref="sessionFactory" />
         <property name="demographicDao" ref="demographicDao" />
         <property name="programDao" ref="programDao" />
         <property name="providerDao" ref="providerDao" />
     </bean>
-    <bean id="defaultRoleAccessDAO" class="io.github.carlos_emr.carlos.PMmodule.dao.DefaultRoleAccessDAOImpl" autowire="byName">
-        <property name="sessionFactory" ref="sessionFactory" />
-    </bean>
-    <bean id="formsDAO" class="io.github.carlos_emr.carlos.PMmodule.dao.FormsDAOImpl" autowire="byName">
-        <property name="sessionFactory" ref="sessionFactory" />
-    </bean>
-    <bean id="pmSecUserRoleDao" class="io.github.carlos_emr.carlos.PMmodule.dao.SecUserRoleDaoImpl" autowire="byName">
-        <property name="sessionFactory" ref="sessionFactory" />
-    </bean>
-    <bean id="programFunctionalUserDAO" class="io.github.carlos_emr.carlos.PMmodule.dao.ProgramFunctionalUserDAOImpl" autowire="byName">
-        <property name="sessionFactory" ref="sessionFactory" />
-    </bean>
-    <bean id="programClientStatusDAO" class="io.github.carlos_emr.carlos.PMmodule.dao.ProgramClientStatusDAOImpl" autowire="byName">
-        <property name="sessionFactory" ref="sessionFactory" />
-    </bean>
+    <bean id="defaultRoleAccessDAO" class="io.github.carlos_emr.carlos.PMmodule.dao.DefaultRoleAccessDAOImpl" autowire="byName" />
+    <bean id="formsDAO" class="io.github.carlos_emr.carlos.PMmodule.dao.FormsDAOImpl" autowire="byName" />
+    <bean id="pmSecUserRoleDao" class="io.github.carlos_emr.carlos.PMmodule.dao.SecUserRoleDaoImpl" autowire="byName" />
+    <bean id="programFunctionalUserDAO" class="io.github.carlos_emr.carlos.PMmodule.dao.ProgramFunctionalUserDAOImpl" autowire="byName" />
+    <bean id="programClientStatusDAO" class="io.github.carlos_emr.carlos.PMmodule.dao.ProgramClientStatusDAOImpl" autowire="byName" />
 
     <!-- ===================================================================== -->
     <!-- Managers and Services (not discovered by @Repository scan)            -->

--- a/src/test/resources/test-context-full.xml
+++ b/src/test/resources/test-context-full.xml
@@ -112,8 +112,11 @@
         </property>
     </bean>
 
-    <!-- JPA EntityManagerFactory - creates schema for all HBM mappings -->
-    <bean id="entityManagerFactory" class="org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean">
+    <!-- JPA EntityManagerFactory - creates schema for all HBM mappings.
+         primary="true" disambiguates from sessionFactory (Hibernate SessionFactory
+         also implements EntityManagerFactory), so @PersistenceContext injections
+         from AbstractJpaDao resolve cleanly in the dual-context test setup. -->
+    <bean id="entityManagerFactory" primary="true" class="org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean">
         <property name="dataSource" ref="dataSource" />
         <property name="persistenceProvider">
             <bean class="org.hibernate.jpa.HibernatePersistenceProvider" />


### PR DESCRIPTION
Add AbstractJpaDao and JpqlQueryHelper as JPA counterparts to the
existing AbstractHibernateDao and HqlQueryHelper infrastructure.
Migrate all 21 Simple and 7 Medium DAOs to use EntityManager instead
of Hibernate Session, unifying persistence on a single JPA contract.

Infrastructure:
- AbstractJpaDao: minimal base class with @PersistenceContext EntityManager
- JpqlQueryHelper: 6 query methods matching HqlQueryHelper signatures,
  with PersistenceException → Spring DataAccessException translation

Special migration patterns handled:
- LockMode.NONE → LockModeType.NONE (SecProviderDaoImpl, SecuserroleDaoImpl)
- NativeQuery → entityManager().createNativeQuery() (ProviderDaoImpl, CaseManagementNoteDAOImpl)
- Hibernate.initialize() retained for zero-risk (CaseManagementNoteDAOImpl)
- createNamedQuery, typed queries, DTO projections, setParameterList → setParameter
- Session.flush() → entityManager().flush()

The 4 Complex DAOs (DemographicDaoImpl, PopulationReportDaoImpl,
LookupDaoImpl, AbstractQueryHandler) remain on AbstractHibernateDao
for a separate issue. No Spring XML changes needed.

Fixes #1558

https://claude.ai/code/session_01LwxnxiTDRPxSYxnvnxigyM

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated 28 DAOs from Hibernate `Session` to JPA `EntityManager` using a shared JPA base and JPQL helper, unifying persistence and removing Hibernate-specific code; fixes #1558. Also hardens deletes and logging.

- **Refactors**
  - Added `AbstractJpaDao` with `@PersistenceContext` `EntityManager`.
  - Added `JpqlQueryHelper` mirroring `HqlQueryHelper` with `PersistenceException` → Spring `DataAccessException` translation.
  - Replaced `Session` APIs with `EntityManager` across 21 simple + 7 medium DAOs; updated parameters, native queries via `entityManager().createNativeQuery()`, kept `Hibernate.initialize()` where safe, and replaced `Session.flush()` with `entityManager().flush()`; left 4 complex DAOs for follow-up.
  - Aligned copyright headers in `AbstractJpaDao` and `JpqlQueryHelper` to the CARLOS Contributors format.

- **Bug Fixes**
  - `SecProviderDaoImpl` and `SecuserroleDaoImpl`: reattach entities via `merge()` only when not managed; for `delete()`, `merge()` before `remove()` to match pre-migration semantics.
  - `ProviderDaoImpl`: on non-numeric or empty `programId`, return an empty list; sanitize `programId` in logs with `LogSanitizer`.
  - Tests/config: added IN-clause regression test for `CaseManagementNoteDao`, added tests for bad `programId`, updated attachClean test to expect merge-based reattach, and marked `entityManagerFactory` as primary in `test-context-full.xml` (also removed stale `sessionFactory` properties).
  - `JpqlQueryHelper`: corrected Semgrep rule id to stop false-positive alerts.

<sup>Written for commit 30736b393194a4a922fade028d405a1560764169. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

