### PR TITLE
perf: add Spring Cache infrastructure with Caffeine for reference data

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/ProviderDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/ProviderDaoImpl.java
@@ -219,7 +219,7 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
         return rs;
     }
 
-    @Cacheable(value = "activeProviders", key = "'noFilter'")
+    @Cacheable(value = "activeProviders", key = "'filter:true'")
     @Override
     public List<Provider> getActiveProviders() {
 
@@ -229,7 +229,7 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
         if (log.isDebugEnabled()) {
             log.debug("getProviders: # of results=" + rs.size());
         }
-        return rs;
+        return Collections.unmodifiableList(new ArrayList<>(rs));
     }
 
     @Cacheable(value = "activeProviders", key = "'filter:' + #filterOutSystemAndImportedProviders")
@@ -249,7 +249,7 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
         if (log.isDebugEnabled()) {
             log.debug("getProviders: # of results=" + rs.size());
         }
-        return rs;
+        return Collections.unmodifiableList(new ArrayList<>(rs));
     }
 
     @Override
@@ -780,7 +780,7 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
     public List<ProviderSummaryDTO> getActiveProviderSummaries() {
         Query<ProviderSummaryDTO> query = currentSession().createQuery(
                 ACTIVE_PROVIDER_SUMMARIES_HQL, ProviderSummaryDTO.class);
-        return query.list();
+        return Collections.unmodifiableList(new ArrayList<>(query.list()));
     }
 
     @Override

--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/ProviderDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/ProviderDaoImpl.java
@@ -53,6 +53,9 @@ import io.github.carlos_emr.carlos.provider.dto.ProviderSummaryDTO;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.transaction.annotation.Transactional;
 
 import io.github.carlos_emr.carlos.model.security.SecProvider;
@@ -84,6 +87,7 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
         return provider;
     }
 
+    @Cacheable(value = "providerNames", key = "'name:' + #providerNo")
     @Override
     public String getProviderName(String providerNo) {
 
@@ -107,6 +111,7 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
         return providerName;
     }
 
+    @Cacheable(value = "providerNames", key = "'nameLastFirst:' + #providerNo")
     @Override
     public String getProviderNameLastFirst(String providerNo) {
         if (providerNo == null || providerNo.length() <= 0) {
@@ -214,6 +219,7 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
         return rs;
     }
 
+    @Cacheable(value = "activeProviders", key = "'noFilter'")
     @Override
     public List<Provider> getActiveProviders() {
 
@@ -226,6 +232,7 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
         return rs;
     }
 
+    @Cacheable(value = "activeProviders", key = "'filter:' + #filterOutSystemAndImportedProviders")
     @Override
     public List<Provider> getActiveProviders(boolean filterOutSystemAndImportedProviders) {
 
@@ -439,11 +446,21 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
         return (List<String>) query.list();
     }
 
+    @Caching(evict = {
+            @CacheEvict(value = "providerNames", allEntries = true),
+            @CacheEvict(value = "activeProviders", allEntries = true),
+            @CacheEvict(value = "activeProviderSummaries", allEntries = true)
+    })
     @Override
     public void updateProvider(Provider provider) {
         currentSession().merge(provider);
     }
 
+    @Caching(evict = {
+            @CacheEvict(value = "providerNames", allEntries = true),
+            @CacheEvict(value = "activeProviders", allEntries = true),
+            @CacheEvict(value = "activeProviderSummaries", allEntries = true)
+    })
     @Override
     public void saveProvider(Provider provider) {
         currentSession().persist(provider);
@@ -758,6 +775,7 @@ public class ProviderDaoImpl extends AbstractHibernateDao implements ProviderDao
     private static final String PROVIDER_SUMMARIES_BY_IDS_HQL =
             "SELECT NEW io.github.carlos_emr.carlos.provider.dto.ProviderSummaryDTO(p.ProviderNo, p.LastName, p.FirstName, p.Specialty, p.Status, p.Team) FROM Provider p WHERE p.ProviderNo IN (:providerNumbers)";
 
+    @Cacheable("activeProviderSummaries")
     @Override
     public List<ProviderSummaryDTO> getActiveProviderSummaries() {
         Query<ProviderSummaryDTO> query = currentSession().createQuery(

--- a/src/main/java/io/github/carlos_emr/carlos/appt/status/service/impl/AppointmentStatusMgrImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/appt/status/service/impl/AppointmentStatusMgrImpl.java
@@ -27,7 +27,7 @@
  */
 package io.github.carlos_emr.carlos.appt.status.service.impl;
 
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 
@@ -55,10 +55,11 @@ public class AppointmentStatusMgrImpl implements AppointmentStatusMgr {
         return cachedActiveStatuses;
     }
 
-    @SuppressWarnings("unchecked")
     public static synchronized void setCachedActiveStatuses(List<AppointmentStatus> cachedActiveStatuses) {
-        Collections.sort(cachedActiveStatuses, Comparator.comparing(AppointmentStatus::getId));
-        AppointmentStatusMgrImpl.cachedActiveStatuses = cachedActiveStatuses;
+        // Sort a defensive copy — the incoming list may be unmodifiable (e.g. from a @Cacheable DAO read)
+        List<AppointmentStatus> sorted = new ArrayList<>(cachedActiveStatuses);
+        sorted.sort(Comparator.comparing(AppointmentStatus::getId));
+        AppointmentStatusMgrImpl.cachedActiveStatuses = sorted;
     }
 
 

--- a/src/main/java/io/github/carlos_emr/carlos/appt/status/service/impl/AppointmentStatusMgrImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/appt/status/service/impl/AppointmentStatusMgrImpl.java
@@ -27,8 +27,6 @@
  */
 package io.github.carlos_emr.carlos.appt.status.service.impl;
 
-import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 
 import io.github.carlos_emr.carlos.commn.dao.AppointmentStatusDao;
@@ -45,32 +43,21 @@ public class AppointmentStatusMgrImpl implements AppointmentStatusMgr {
 
     private static AppointmentStatusDao appointStatusDao = SpringUtils.getBean(AppointmentStatusDao.class);
 
-    private static List<AppointmentStatus> cachedActiveStatuses = null;
-    private static boolean cacheIsDirty = false;
-
     public static List<AppointmentStatus> getCachedActiveStatuses() {
-        if (cachedActiveStatuses == null || cacheIsDirty) {
-            cachedActiveStatuses = appointStatusDao.findActive();
-        }
-        return cachedActiveStatuses;
+        return appointStatusDao.findActive();
     }
 
     public static synchronized void setCachedActiveStatuses(List<AppointmentStatus> cachedActiveStatuses) {
-        // Sort a defensive copy — the incoming list may be unmodifiable (e.g. from a @Cacheable DAO read)
-        List<AppointmentStatus> source =
-                (cachedActiveStatuses == null) ? java.util.Collections.emptyList() : cachedActiveStatuses;
-        List<AppointmentStatus> sorted = new ArrayList<>(source);
-        sorted.sort(Comparator.comparing(AppointmentStatus::getId));
-        AppointmentStatusMgrImpl.cachedActiveStatuses = java.util.Collections.unmodifiableList(sorted);
+        // Spring Cache now owns appointment-status caching and eviction.
     }
 
 
     public static boolean isCacheIsDirty() {
-        return cacheIsDirty;
+        return false;
     }
 
     public static void setCacheIsDirty(boolean cacheIsDirty) {
-        AppointmentStatusMgrImpl.cacheIsDirty = cacheIsDirty;
+        // Spring Cache now owns appointment-status caching and eviction.
     }
 
     public List<AppointmentStatus> getAllStatus() {
@@ -78,10 +65,6 @@ public class AppointmentStatusMgrImpl implements AppointmentStatusMgr {
     }
 
     public List<AppointmentStatus> getAllActiveStatus() {
-        if (cacheIsDirty) {
-            setCachedActiveStatuses(appointStatusDao.findActive());
-            cacheIsDirty = false;
-        }
         return appointStatusDao.findActive();
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/appt/status/service/impl/AppointmentStatusMgrImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/appt/status/service/impl/AppointmentStatusMgrImpl.java
@@ -57,9 +57,11 @@ public class AppointmentStatusMgrImpl implements AppointmentStatusMgr {
 
     public static synchronized void setCachedActiveStatuses(List<AppointmentStatus> cachedActiveStatuses) {
         // Sort a defensive copy — the incoming list may be unmodifiable (e.g. from a @Cacheable DAO read)
-        List<AppointmentStatus> sorted = new ArrayList<>(cachedActiveStatuses);
+        List<AppointmentStatus> source =
+                (cachedActiveStatuses == null) ? java.util.Collections.emptyList() : cachedActiveStatuses;
+        List<AppointmentStatus> sorted = new ArrayList<>(source);
         sorted.sort(Comparator.comparing(AppointmentStatus::getId));
-        AppointmentStatusMgrImpl.cachedActiveStatuses = sorted;
+        AppointmentStatusMgrImpl.cachedActiveStatuses = java.util.Collections.unmodifiableList(sorted);
     }
 
 

--- a/src/main/java/io/github/carlos_emr/carlos/appt/status/service/impl/AppointmentStatusMgrImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/appt/status/service/impl/AppointmentStatusMgrImpl.java
@@ -47,19 +47,6 @@ public class AppointmentStatusMgrImpl implements AppointmentStatusMgr {
         return appointStatusDao.findActive();
     }
 
-    public static synchronized void setCachedActiveStatuses(List<AppointmentStatus> cachedActiveStatuses) {
-        // Spring Cache now owns appointment-status caching and eviction.
-    }
-
-
-    public static boolean isCacheIsDirty() {
-        return false;
-    }
-
-    public static void setCacheIsDirty(boolean cacheIsDirty) {
-        // Spring Cache now owns appointment-status caching and eviction.
-    }
-
     public List<AppointmentStatus> getAllStatus() {
         return appointStatusDao.findAll();
     }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/AbstractDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/AbstractDaoImpl.java
@@ -457,6 +457,17 @@ public abstract class AbstractDaoImpl<T extends AbstractModel<?>> implements Abs
      * Saves or updates the entity based on depending if it's persistent, as
      * determined by {@link AbstractModel#isPersistent()}
      *
+     * <p><strong>Cache invalidation notice:</strong> This method delegates to
+     * {@link #merge(AbstractModel)} or {@link #persist(AbstractModel)} via a
+     * direct (self) invocation that bypasses the Spring AOP proxy. Therefore,
+     * {@code @CacheEvict} annotations on subclass overrides of {@code merge()}
+     * and {@code persist()} are <em>not</em> triggered when this method is
+     * called. Subclasses that cache their read methods (e.g. via
+     * {@code @Cacheable}) must either override this method with the appropriate
+     * {@code @CacheEvict} annotation, or callers should invoke the
+     * {@code persist()}/{@code merge()} entry points directly so that proxy
+     * interception fires.</p>
+     *
      * @param entity Entity to be saved or updated
      * @return Returns the entity
      */

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/AbstractDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/AbstractDaoImpl.java
@@ -92,6 +92,17 @@ public abstract class AbstractDaoImpl<T extends AbstractModel<?>> implements Abs
         batchPersist(oList, 25);
     }
 
+    /**
+     * Persists a list of entities in batches using a dedicated EntityManager.
+     *
+     * <p><strong>Cache invalidation notice:</strong> This method uses a separate
+     * EntityManager and bypasses Spring AOP proxying, so {@code @CacheEvict}
+     * annotations on subclass overrides of {@link #persist(AbstractModel)} are
+     * <em>not</em> triggered here. Subclasses that cache their read methods (e.g.
+     * via {@code @Cacheable}) and also expose batch-write operations must override
+     * this method and annotate it with the appropriate {@code @CacheEvict} to
+     * prevent stale cache entries after a batch persist.</p>
+     */
     @Override
     public void batchPersist(List<T> oList, int batchSize) {
         EntityManager batchEntityManager = null;
@@ -137,6 +148,17 @@ public abstract class AbstractDaoImpl<T extends AbstractModel<?>> implements Abs
         batchRemove(oList, 25);
     }
 
+    /**
+     * Removes a list of entities in batches using a dedicated EntityManager.
+     *
+     * <p><strong>Cache invalidation notice:</strong> This method uses a separate
+     * EntityManager and bypasses Spring AOP proxying, so {@code @CacheEvict}
+     * annotations on subclass overrides of {@link #remove(AbstractModel)} are
+     * <em>not</em> triggered here. Subclasses that cache their read methods (e.g.
+     * via {@code @Cacheable}) and also expose batch-write operations must override
+     * this method and annotate it with the appropriate {@code @CacheEvict} to
+     * prevent stale cache entries after a batch remove.</p>
+     */
     @Override
     public void batchRemove(List<T> oList, int batchSize) {
         EntityManager batchEntityManager = null;

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/AppointmentStatusDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/AppointmentStatusDaoImpl.java
@@ -118,6 +118,12 @@ public class AppointmentStatusDaoImpl extends AbstractDaoImpl<AppointmentStatus>
 
     @CacheEvict(value = "appointmentStatuses", allEntries = true)
     @Override
+    public AppointmentStatus saveEntity(AppointmentStatus entity) {
+        return super.saveEntity(entity);
+    }
+
+    @CacheEvict(value = "appointmentStatuses", allEntries = true)
+    @Override
     public void merge(AbstractModel<?> o) {
         super.merge(o);
     }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/AppointmentStatusDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/AppointmentStatusDaoImpl.java
@@ -31,10 +31,13 @@
  */
 package io.github.carlos_emr.carlos.commn.dao;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import jakarta.persistence.Query;
 
+import io.github.carlos_emr.carlos.commn.model.AbstractModel;
 import io.github.carlos_emr.carlos.commn.model.AppointmentStatus;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
@@ -52,7 +55,7 @@ public class AppointmentStatusDaoImpl extends AbstractDaoImpl<AppointmentStatus>
     @Override
     public List<AppointmentStatus> findAll() {
         Query query = entityManager.createQuery("FROM " + modelClass.getSimpleName());
-        return query.getResultList();
+        return Collections.unmodifiableList(new ArrayList<>(query.getResultList()));
     }
 
     @Cacheable(value = "appointmentStatuses", key = "'active'")
@@ -64,7 +67,7 @@ public class AppointmentStatusDaoImpl extends AbstractDaoImpl<AppointmentStatus>
         @SuppressWarnings("unchecked")
         List<AppointmentStatus> results = q.getResultList();
 
-        return results;
+        return Collections.unmodifiableList(new ArrayList<>(results));
     }
 
     @Cacheable(value = "appointmentStatuses", key = "'status:' + #status")
@@ -105,6 +108,30 @@ public class AppointmentStatusDaoImpl extends AbstractDaoImpl<AppointmentStatus>
         if (appts != null) {
             appts.setActive(iActive);
         }
+    }
+
+    @CacheEvict(value = "appointmentStatuses", allEntries = true)
+    @Override
+    public void persist(AbstractModel<?> o) {
+        super.persist(o);
+    }
+
+    @CacheEvict(value = "appointmentStatuses", allEntries = true)
+    @Override
+    public void merge(AbstractModel<?> o) {
+        super.merge(o);
+    }
+
+    @CacheEvict(value = "appointmentStatuses", allEntries = true)
+    @Override
+    public void remove(AbstractModel<?> o) {
+        super.remove(o);
+    }
+
+    @CacheEvict(value = "appointmentStatuses", allEntries = true)
+    @Override
+    public boolean remove(Object id) {
+        return super.remove(id);
     }
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/AppointmentStatusDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/AppointmentStatusDaoImpl.java
@@ -116,6 +116,12 @@ public class AppointmentStatusDaoImpl extends AbstractDaoImpl<AppointmentStatus>
         super.persist(o);
     }
 
+    /**
+     * Saves or updates an appointment status and invalidates all cached appointment-status lookups.
+     *
+     * @param entity AppointmentStatus the entity to persist or merge
+     * @return AppointmentStatus the saved entity
+     */
     @CacheEvict(value = "appointmentStatuses", allEntries = true)
     @Override
     public AppointmentStatus saveEntity(AppointmentStatus entity) {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/AppointmentStatusDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/AppointmentStatusDaoImpl.java
@@ -36,6 +36,8 @@ import java.util.List;
 import jakarta.persistence.Query;
 
 import io.github.carlos_emr.carlos.commn.model.AppointmentStatus;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -45,6 +47,7 @@ public class AppointmentStatusDaoImpl extends AbstractDaoImpl<AppointmentStatus>
         super(AppointmentStatus.class);
     }
 
+    @Cacheable(value = "appointmentStatuses", key = "'all'")
     @SuppressWarnings("unchecked")
     @Override
     public List<AppointmentStatus> findAll() {
@@ -52,6 +55,7 @@ public class AppointmentStatusDaoImpl extends AbstractDaoImpl<AppointmentStatus>
         return query.getResultList();
     }
 
+    @Cacheable(value = "appointmentStatuses", key = "'active'")
     @Override
     public List<AppointmentStatus> findActive() {
         Query q = entityManager.createQuery("select a from AppointmentStatus a where a.active=?1");
@@ -63,6 +67,7 @@ public class AppointmentStatusDaoImpl extends AbstractDaoImpl<AppointmentStatus>
         return results;
     }
 
+    @Cacheable(value = "appointmentStatuses", key = "'status:' + #status")
     @Override
     public AppointmentStatus findByStatus(String status) {
         if (status == null || status.length() == 0) {
@@ -84,6 +89,7 @@ public class AppointmentStatusDaoImpl extends AbstractDaoImpl<AppointmentStatus>
         return null;
     }
 
+    @CacheEvict(value = "appointmentStatuses", allEntries = true)
     @Override
     public void modifyStatus(int ID, String strDesc, String strColor) {
         AppointmentStatus appts = find(ID);
@@ -93,6 +99,7 @@ public class AppointmentStatusDaoImpl extends AbstractDaoImpl<AppointmentStatus>
         }
     }
 
+    @CacheEvict(value = "appointmentStatuses", allEntries = true)
     public void changeStatus(int ID, int iActive) {
         AppointmentStatus appts = find(ID);
         if (appts != null) {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/LookupListDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/LookupListDaoImpl.java
@@ -31,6 +31,8 @@
  */
 package io.github.carlos_emr.carlos.commn.dao;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import jakarta.persistence.Query;
@@ -57,7 +59,7 @@ public class LookupListDaoImpl extends AbstractDaoImpl<LookupList> implements Lo
         @SuppressWarnings("unchecked")
         List<LookupList> result = q.getResultList();
 
-        return result;
+        return Collections.unmodifiableList(new ArrayList<>(result));
     }
 
     @Cacheable(value = "lookupLists", key = "'name:' + #name")

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/LookupListDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/LookupListDaoImpl.java
@@ -35,7 +35,9 @@ import java.util.List;
 
 import jakarta.persistence.Query;
 
+import io.github.carlos_emr.carlos.commn.model.AbstractModel;
 import io.github.carlos_emr.carlos.commn.model.LookupList;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Repository;
 
@@ -67,5 +69,31 @@ public class LookupListDaoImpl extends AbstractDaoImpl<LookupList> implements Lo
         LookupList ll = this.getSingleResultOrNull(q);
 
         return ll;
+    }
+
+    // Defense-in-depth: evict at the DAO layer so that any future code calling
+    // these methods directly (bypassing LookupListManager) still invalidates the cache.
+    @CacheEvict(value = "lookupLists", allEntries = true)
+    @Override
+    public void persist(AbstractModel<?> o) {
+        super.persist(o);
+    }
+
+    @CacheEvict(value = "lookupLists", allEntries = true)
+    @Override
+    public void merge(AbstractModel<?> o) {
+        super.merge(o);
+    }
+
+    @CacheEvict(value = "lookupLists", allEntries = true)
+    @Override
+    public void remove(AbstractModel<?> o) {
+        super.remove(o);
+    }
+
+    @CacheEvict(value = "lookupLists", allEntries = true)
+    @Override
+    public boolean remove(Object id) {
+        return super.remove(id);
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/LookupListDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/LookupListDaoImpl.java
@@ -36,6 +36,7 @@ import java.util.List;
 import jakarta.persistence.Query;
 
 import io.github.carlos_emr.carlos.commn.model.LookupList;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -45,6 +46,7 @@ public class LookupListDaoImpl extends AbstractDaoImpl<LookupList> implements Lo
         super(LookupList.class);
     }
 
+    @Cacheable(value = "lookupLists", key = "'allActive'")
     @Override
     public List<LookupList> findAllActive() {
         Query q = entityManager.createQuery("select l from LookupList l where l.active=?1 order by l.name asc");
@@ -56,6 +58,7 @@ public class LookupListDaoImpl extends AbstractDaoImpl<LookupList> implements Lo
         return result;
     }
 
+    @Cacheable(value = "lookupLists", key = "'name:' + #name")
     @Override
     public LookupList findByName(String name) {
         Query q = entityManager.createQuery("select l from LookupList l where l.name=?1");

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/LookupListDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/LookupListDaoImpl.java
@@ -83,6 +83,12 @@ public class LookupListDaoImpl extends AbstractDaoImpl<LookupList> implements Lo
 
     @CacheEvict(value = "lookupLists", allEntries = true)
     @Override
+    public LookupList saveEntity(LookupList entity) {
+        return super.saveEntity(entity);
+    }
+
+    @CacheEvict(value = "lookupLists", allEntries = true)
+    @Override
     public void merge(AbstractModel<?> o) {
         super.merge(o);
     }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/LookupListDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/LookupListDaoImpl.java
@@ -81,6 +81,12 @@ public class LookupListDaoImpl extends AbstractDaoImpl<LookupList> implements Lo
         super.persist(o);
     }
 
+    /**
+     * Saves or updates a lookup list and invalidates all cached lookup-list reads.
+     *
+     * @param entity LookupList the entity to persist or merge
+     * @return LookupList the saved entity
+     */
     @CacheEvict(value = "lookupLists", allEntries = true)
     @Override
     public LookupList saveEntity(LookupList entity) {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/MeasurementTypeDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/MeasurementTypeDaoImpl.java
@@ -30,10 +30,14 @@
  */
 package io.github.carlos_emr.carlos.commn.dao;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import jakarta.persistence.Query;
 
+import io.github.carlos_emr.carlos.commn.model.AbstractModel;
 import io.github.carlos_emr.carlos.commn.model.MeasurementType;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Repository;
 
@@ -51,7 +55,7 @@ public class MeasurementTypeDaoImpl extends AbstractDaoImpl<MeasurementType> imp
         String sqlCommand = "select x from " + modelClass.getSimpleName() + " x order by x.type";
         Query query = entityManager.createQuery(sqlCommand);
         List<MeasurementType> results = query.getResultList();
-        return (results);
+        return Collections.unmodifiableList(new ArrayList<>(results));
     }
 
     @Cacheable(value = "measurementTypes", key = "'allByName'")
@@ -60,7 +64,7 @@ public class MeasurementTypeDaoImpl extends AbstractDaoImpl<MeasurementType> imp
         String sqlCommand = "select x from " + modelClass.getSimpleName() + " x order by x.typeDisplayName";
         Query query = entityManager.createQuery(sqlCommand);
         List<MeasurementType> results = query.getResultList();
-        return (results);
+        return Collections.unmodifiableList(new ArrayList<>(results));
     }
 
     @Cacheable(value = "measurementTypes", key = "'allById'")
@@ -69,7 +73,31 @@ public class MeasurementTypeDaoImpl extends AbstractDaoImpl<MeasurementType> imp
         String sqlCommand = "select x from " + modelClass.getSimpleName() + " x order by x.id";
         Query query = entityManager.createQuery(sqlCommand);
         List<MeasurementType> results = query.getResultList();
-        return (results);
+        return Collections.unmodifiableList(new ArrayList<>(results));
+    }
+
+    @CacheEvict(value = "measurementTypes", allEntries = true)
+    @Override
+    public void persist(AbstractModel<?> o) {
+        super.persist(o);
+    }
+
+    @CacheEvict(value = "measurementTypes", allEntries = true)
+    @Override
+    public void merge(AbstractModel<?> o) {
+        super.merge(o);
+    }
+
+    @CacheEvict(value = "measurementTypes", allEntries = true)
+    @Override
+    public void remove(AbstractModel<?> o) {
+        super.remove(o);
+    }
+
+    @CacheEvict(value = "measurementTypes", allEntries = true)
+    @Override
+    public boolean remove(Object id) {
+        return super.remove(id);
     }
 
     @Override

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/MeasurementTypeDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/MeasurementTypeDaoImpl.java
@@ -84,6 +84,12 @@ public class MeasurementTypeDaoImpl extends AbstractDaoImpl<MeasurementType> imp
 
     @CacheEvict(value = "measurementTypes", allEntries = true)
     @Override
+    public MeasurementType saveEntity(MeasurementType entity) {
+        return super.saveEntity(entity);
+    }
+
+    @CacheEvict(value = "measurementTypes", allEntries = true)
+    @Override
     public void merge(AbstractModel<?> o) {
         super.merge(o);
     }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/MeasurementTypeDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/MeasurementTypeDaoImpl.java
@@ -82,6 +82,12 @@ public class MeasurementTypeDaoImpl extends AbstractDaoImpl<MeasurementType> imp
         super.persist(o);
     }
 
+    /**
+     * Saves or updates a measurement type and invalidates all cached measurement-type lists.
+     *
+     * @param entity MeasurementType the entity to persist or merge
+     * @return MeasurementType the saved entity
+     */
     @CacheEvict(value = "measurementTypes", allEntries = true)
     @Override
     public MeasurementType saveEntity(MeasurementType entity) {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/MeasurementTypeDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/MeasurementTypeDaoImpl.java
@@ -34,6 +34,7 @@ import java.util.List;
 import jakarta.persistence.Query;
 
 import io.github.carlos_emr.carlos.commn.model.MeasurementType;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -44,6 +45,7 @@ public class MeasurementTypeDaoImpl extends AbstractDaoImpl<MeasurementType> imp
         super(MeasurementType.class);
     }
 
+    @Cacheable(value = "measurementTypes", key = "'allByType'")
     @Override
     public List<MeasurementType> findAll() {
         String sqlCommand = "select x from " + modelClass.getSimpleName() + " x order by x.type";
@@ -52,6 +54,7 @@ public class MeasurementTypeDaoImpl extends AbstractDaoImpl<MeasurementType> imp
         return (results);
     }
 
+    @Cacheable(value = "measurementTypes", key = "'allByName'")
     @Override
     public List<MeasurementType> findAllOrderByName() {
         String sqlCommand = "select x from " + modelClass.getSimpleName() + " x order by x.typeDisplayName";
@@ -60,6 +63,7 @@ public class MeasurementTypeDaoImpl extends AbstractDaoImpl<MeasurementType> imp
         return (results);
     }
 
+    @Cacheable(value = "measurementTypes", key = "'allById'")
     @Override
     public List<MeasurementType> findAllOrderById() {
         String sqlCommand = "select x from " + modelClass.getSimpleName() + " x order by x.id";

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/AppointmentStatus.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/AppointmentStatus.java
@@ -33,11 +33,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.PostPersist;
-import jakarta.persistence.PostUpdate;
 import jakarta.persistence.Table;
-
-import io.github.carlos_emr.carlos.appt.status.service.impl.AppointmentStatusMgrImpl;
 
 
 @Entity
@@ -140,11 +136,5 @@ public class AppointmentStatus extends AbstractModel<Integer> {
 
     public void setShortLetterColour(String shortLetterColour) {
         this.shortLetterColour = shortLetterColour;
-    }
-
-    @PostPersist
-    @PostUpdate
-    public void on_jpa_update() {
-        AppointmentStatusMgrImpl.setCacheIsDirty(true);
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/config/CacheConfig.java
+++ b/src/main/java/io/github/carlos_emr/carlos/config/CacheConfig.java
@@ -71,7 +71,7 @@ public class CacheConfig {
         cacheManager.setCaches(List.of(
                 buildCache("providerNames", 500, 15, TimeUnit.MINUTES),
                 buildCache("activeProviders", 10, 5, TimeUnit.MINUTES),
-                buildCache("activeProviderSummaries", 5, 5, TimeUnit.MINUTES),
+                buildCache("activeProviderSummaries", 1, 5, TimeUnit.MINUTES),
                 buildCache("appointmentStatuses", 5, 30, TimeUnit.MINUTES),
                 buildCache("measurementTypes", 10, 60, TimeUnit.MINUTES),
                 buildCache("lookupLists", 50, 30, TimeUnit.MINUTES)

--- a/src/main/java/io/github/carlos_emr/carlos/config/CacheConfig.java
+++ b/src/main/java/io/github/carlos_emr/carlos/config/CacheConfig.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.config;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configures Spring Cache abstraction backed by Caffeine for reference data caching.
+ *
+ * <p>Each cache has individually tuned TTL and max-size settings appropriate for its
+ * data volatility. Provider names change only via admin screens (15-min TTL), while
+ * active provider lists are slightly more dynamic (5-min TTL). Appointment statuses
+ * and lookup lists are admin-level configuration (30-min TTL). Measurement types
+ * are essentially static reference data (60-min TTL).</p>
+ *
+ * <p>Discovered automatically by the broad component scan in {@code spring_managers.xml}
+ * ({@code io.github.carlos_emr.carlos} base package).</p>
+ *
+ * @since 2026-04-12
+ * @see io.github.carlos_emr.carlos.PMmodule.dao.ProviderDaoImpl
+ * @see io.github.carlos_emr.carlos.commn.dao.AppointmentStatusDaoImpl
+ * @see io.github.carlos_emr.carlos.commn.dao.MeasurementTypeDaoImpl
+ * @see io.github.carlos_emr.carlos.commn.dao.LookupListDaoImpl
+ */
+@Configuration
+@EnableCaching(proxyTargetClass = true)
+public class CacheConfig {
+
+    /**
+     * Creates a {@link SimpleCacheManager} with individually configured Caffeine caches.
+     *
+     * <p>Using {@code SimpleCacheManager} rather than {@code CaffeineCacheManager} allows
+     * per-cache TTL and max-size tuning. Each cache is backed by a Caffeine instance with
+     * {@code expireAfterWrite} for time-based eviction and {@code maximumSize} for
+     * memory-bounded eviction.</p>
+     *
+     * @return CacheManager the configured cache manager
+     */
+    @Bean
+    public CacheManager cacheManager() {
+        SimpleCacheManager cacheManager = new SimpleCacheManager();
+        cacheManager.setCaches(List.of(
+                buildCache("providerNames", 500, 15, TimeUnit.MINUTES),
+                buildCache("activeProviders", 10, 5, TimeUnit.MINUTES),
+                buildCache("activeProviderSummaries", 5, 5, TimeUnit.MINUTES),
+                buildCache("appointmentStatuses", 5, 30, TimeUnit.MINUTES),
+                buildCache("measurementTypes", 10, 60, TimeUnit.MINUTES),
+                buildCache("lookupLists", 50, 30, TimeUnit.MINUTES)
+        ));
+        return cacheManager;
+    }
+
+    private CaffeineCache buildCache(String name, long maxSize, long duration, TimeUnit unit) {
+        return new CaffeineCache(name,
+                Caffeine.newBuilder()
+                        .maximumSize(maxSize)
+                        .expireAfterWrite(duration, unit)
+                        .build());
+    }
+}

--- a/src/main/java/io/github/carlos_emr/carlos/config/CacheConfig.java
+++ b/src/main/java/io/github/carlos_emr/carlos/config/CacheConfig.java
@@ -77,7 +77,9 @@ public class CacheConfig {
                 buildCache("measurementTypes", 10, 60, TimeUnit.MINUTES),
                 buildCache("lookupLists", 50, 30, TimeUnit.MINUTES)
         ));
+        // Initialize the delegate before wrapping it so the cache names are fully registered.
         cacheManager.afterPropertiesSet();
+        // Defer puts/evictions until transaction commit so rolled-back writes do not leak into the cache.
         return new TransactionAwareCacheManagerProxy(cacheManager);
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/config/CacheConfig.java
+++ b/src/main/java/io/github/carlos_emr/carlos/config/CacheConfig.java
@@ -30,6 +30,7 @@ import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.caffeine.CaffeineCache;
 import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.cache.transaction.TransactionAwareCacheManagerProxy;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -76,7 +77,8 @@ public class CacheConfig {
                 buildCache("measurementTypes", 10, 60, TimeUnit.MINUTES),
                 buildCache("lookupLists", 50, 30, TimeUnit.MINUTES)
         ));
-        return cacheManager;
+        cacheManager.afterPropertiesSet();
+        return new TransactionAwareCacheManagerProxy(cacheManager);
     }
 
     private CaffeineCache buildCache(String name, long maxSize, long duration, TimeUnit unit) {

--- a/src/main/java/io/github/carlos_emr/carlos/daos/security/SecProviderDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/daos/security/SecProviderDaoImpl.java
@@ -38,6 +38,8 @@ import org.hibernate.Session;
 import org.hibernate.query.Query;
 import io.github.carlos_emr.carlos.dao.AbstractHibernateDao;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.transaction.annotation.Transactional;
 
 import io.github.carlos_emr.carlos.model.security.SecProvider;
@@ -52,6 +54,15 @@ public class SecProviderDaoImpl extends AbstractHibernateDao implements SecProvi
             ADDRESS, PHONE, WORK_PHONE, OHIP_NO, RMA_NO, BILLING_NO,
             HSO_NO, STATUS, COMMENTS, PROVIDER_ACTIVITY);
 
+    // SecProvider and Provider both map to the same `provider` table.
+    // All write methods must evict the Provider-level caches so that
+    // ProviderDaoImpl's @Cacheable reads do not serve stale data after
+    // a SecProvider write.
+    @Caching(evict = {
+        @CacheEvict(value = "providerNames", allEntries = true),
+        @CacheEvict(value = "activeProviders", allEntries = true),
+        @CacheEvict(value = "activeProviderSummaries", allEntries = true)
+    })
     @Override
     public void save(SecProvider transientInstance) {
         logger.debug("saving Provider instance");
@@ -64,6 +75,11 @@ public class SecProviderDaoImpl extends AbstractHibernateDao implements SecProvi
         }
     }
 
+    @Caching(evict = {
+        @CacheEvict(value = "providerNames", allEntries = true),
+        @CacheEvict(value = "activeProviders", allEntries = true),
+        @CacheEvict(value = "activeProviderSummaries", allEntries = true)
+    })
     @Override
     public void saveOrUpdate(SecProvider transientInstance) {
         logger.debug("saving Provider instance");
@@ -80,6 +96,11 @@ public class SecProviderDaoImpl extends AbstractHibernateDao implements SecProvi
         }
     }
 
+    @Caching(evict = {
+        @CacheEvict(value = "providerNames", allEntries = true),
+        @CacheEvict(value = "activeProviders", allEntries = true),
+        @CacheEvict(value = "activeProviderSummaries", allEntries = true)
+    })
     @Override
     public void delete(SecProvider persistentInstance) {
         logger.debug("deleting Provider instance");
@@ -243,6 +264,11 @@ public class SecProviderDaoImpl extends AbstractHibernateDao implements SecProvi
         }
     }
 
+    @Caching(evict = {
+        @CacheEvict(value = "providerNames", allEntries = true),
+        @CacheEvict(value = "activeProviders", allEntries = true),
+        @CacheEvict(value = "activeProviderSummaries", allEntries = true)
+    })
     @Override
     public SecProviderDao merge(SecProviderDao detachedInstance) {
         logger.debug("merging Provider instance");
@@ -257,6 +283,11 @@ public class SecProviderDaoImpl extends AbstractHibernateDao implements SecProvi
         }
     }
 
+    @Caching(evict = {
+        @CacheEvict(value = "providerNames", allEntries = true),
+        @CacheEvict(value = "activeProviders", allEntries = true),
+        @CacheEvict(value = "activeProviderSummaries", allEntries = true)
+    })
     @Override
     public void attachDirty(SecProviderDao instance) {
         logger.debug("attaching dirty Provider instance");

--- a/src/main/java/io/github/carlos_emr/carlos/managers/LookupListManager.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/LookupListManager.java
@@ -36,6 +36,7 @@ import io.github.carlos_emr.carlos.commn.model.LookupList;
 import io.github.carlos_emr.carlos.commn.model.LookupListItem;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 
 import io.github.carlos_emr.carlos.log.LogAction;
@@ -58,6 +59,7 @@ public class LookupListManager {
         return lookupListDao.findByName(name);
     }
 
+    @CacheEvict(value = "lookupLists", allEntries = true)
     public LookupList addLookupList(LoggedInInfo loggedInInfo, LookupList lookupList) {
 
         if (!securityInfoManager.hasPrivilege(loggedInInfo, "_admin", SecurityInfoManager.WRITE, null)) {
@@ -75,6 +77,7 @@ public class LookupListManager {
      * Add a new lookupListItem
      * Ensure that the lookupListItem is associated to a list entry of the LookupList table.
      */
+    @CacheEvict(value = "lookupLists", allEntries = true)
     public LookupListItem addLookupListItem(LoggedInInfo loggedInInfo, LookupListItem lookupListItem) {
 
         if (!securityInfoManager.hasPrivilege(loggedInInfo, "_admin", SecurityInfoManager.WRITE, null)) {
@@ -114,6 +117,7 @@ public class LookupListManager {
     /**
      * Update a lookupListItem that has been edited.
      */
+    @CacheEvict(value = "lookupLists", allEntries = true)
     public Integer updateLookupListItem(LoggedInInfo loggedInInfo, LookupListItem lookupListItem) {
 
         if (!securityInfoManager.hasPrivilege(loggedInInfo, "_admin", SecurityInfoManager.UPDATE, null)) {
@@ -130,6 +134,7 @@ public class LookupListManager {
     /**
      * Remove a lookupListItem by it's id.
      */
+    @CacheEvict(value = "lookupLists", allEntries = true)
     public boolean removeLookupListItem(LoggedInInfo loggedInInfo, int lookupListItemId) {
 
         if (!securityInfoManager.hasPrivilege(loggedInInfo, "_admin", SecurityInfoManager.DELETE, null)) {
@@ -153,6 +158,7 @@ public class LookupListManager {
      *
      * @param lookupListItemId
      */
+    @CacheEvict(value = "lookupLists", allEntries = true)
     public boolean updateLookupListItemDisplayOrder(LoggedInInfo loggedInInfo, int lookupListItemId, int lookupListItemDisplayOrder) {
 
         if (!securityInfoManager.hasPrivilege(loggedInInfo, "_admin", SecurityInfoManager.UPDATE, null)) {


### PR DESCRIPTION
Add application-level caching backed by Caffeine for frequently accessed
reference data that was being loaded fresh from the database on every
HTTP request, eliminating thousands of redundant DB queries per hour.

Infrastructure:
- CacheConfig: @EnableCaching with SimpleCacheManager defining 6 caches
  with per-cache TTL (5-60 min) and max-size tuning via Caffeine

Cached DAOs:
- ProviderDaoImpl: getProviderName, getProviderNameLastFirst,
  getActiveProviders (2 variants), getActiveProviderSummaries
  with @CacheEvict on updateProvider/saveProvider
- AppointmentStatusDaoImpl: findAll, findActive, findByStatus
  with @CacheEvict on modifyStatus/changeStatus
- MeasurementTypeDaoImpl: findAll, findAllOrderByName, findAllOrderById
  (TTL-only eviction, no mutation methods)
- LookupListDaoImpl: findAllActive, findByName
  (TTL-only eviction, mutations via manager layer)

No breaking changes: no method signatures, interfaces, class hierarchies,
or XML configuration files were modified. Caffeine 3.2.3 and
spring-context-support were already project dependencies.

Fixes #1560

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Spring Cache with Caffeine for reference data to cut redundant DB queries and speed up common reads. Fixes #1560 with per-cache TTLs, unmodifiable return copies, and strict evictions to prevent stale data across provider, appointment status, measurement type, and lookup list reads.

- New Features
  - Added CacheConfig with Caffeine caches and per-cache TTLs: providerNames (15m), activeProviders (5m), activeProviderSummaries (5m, maxSize=1), appointmentStatuses (30m), measurementTypes (60m), lookupLists (30m).
  - Added `@Cacheable` on DAO read paths (provider names/active lists/summaries; appointment status findAll/findActive/findByStatus; measurement types findAll*; lookup lists findAllActive/findByName); return unmodifiable copies; unified `activeProviders` keys.

- Bug Fixes
  - Evict caches on writes: provider save/update; all `SecProviderDaoImpl` writes; `persist`/`merge`/`remove`/`saveEntity` in appointment status, measurement type, and lookup list DAOs; all write methods in `LookupListManager`.
  - Removed in-memory caching from `AppointmentStatusMgrImpl`; it now delegates to DAO and no longer tracks or sorts cached data.
  - Added JavaDoc warnings in `AbstractDaoImpl` that `batchPersist`/`batchRemove` and `saveEntity` bypass Spring AOP; subclasses must override with `@CacheEvict` if batch writes are used.

<sup>Written for commit 84c713558187e36310b9e1777f4e3795e26729d8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



