### PR TITLE
fix: clear path-injection false positives + fix 3 true-positive bugs

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -9,6 +9,22 @@
 
 name: "CARLOS EMR CodeQL Configuration"
 
+# Custom CodeQL model packs for CARLOS-specific sanitizers.
+#
+# carlos-java-models registers PathValidationUtils, LogSanitizer callers, and
+# OWASP Encoder methods as explicit summaryModel / neutralModel entries so
+# CodeQL recognises them as sanitizers and does not raise false positives on
+# code paths that pass through them.
+#
+# Pack location: .github/codeql/extensions/carlos-java-models/
+#
+# Note: Local pack references may require the repository to use CodeQL's
+# advanced setup. If the pack is silently ignored under default setup,
+# convert to advanced setup with a workflow file that passes this config via
+# `github/codeql-action/init@v4`'s `config-file` input.
+packs:
+  - carlos-emr/carlos-java-models
+
 # Exclude bundled third-party JavaScript libraries from JavaScript/TypeScript analysis.
 #
 # These directories contain unmodified copies of external libraries (Bootstrap,

--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,15 @@
+# Snyk policy file — see https://docs.snyk.io/manage-risk/policies/the-.snyk-file
+version: v1.25.0
+
+# Exclude developer-only tooling from Snyk Code (SAST).
+# These paths are NOT deployed in the WAR and are invoked only by developers
+# with CLI arguments they control themselves. Production code is out of scope
+# here and must remain covered by Snyk Code — do not add src/main/** patterns.
+exclude:
+  code:
+    - scripts/**
+    - .claude/hooks/**
+    - database/mysql/importCasemgmt.java
+    - database/mysql/importCPP.java
+    - release/**
+    - .devcontainer/**

--- a/docs/security-scanning-notes.md
+++ b/docs/security-scanning-notes.md
@@ -28,7 +28,7 @@ Location: `.github/codeql/extensions/carlos-java-models/`
 
 Models `PathValidationUtils` methods as `summaryModel` entries (safe argument → return value, user-controlled argument omitted), and `LogSanitizer` / guard methods as `neutralModel` entries. CodeQL's dataflow engine cuts taint at each sanitizer boundary.
 
-Wired into `.github/codeql/codeql-config.yml` via the `packs:` key. If default-setup silently ignores local pack references, the repo must convert to advanced-setup with a dedicated workflow file — see "Open" below.
+Wired into `.github/codeql/codeql-config.yml` via the `packs:` key. If default-setup silently ignores local pack references, the repo must convert to advanced-setup with a dedicated workflow file — see "CodeQL default-setup vs advanced-setup" in the Known follow-ups section of PR #1592, or the follow-up issue once filed.
 
 **Precision property**: the model entries name specific method signatures. A new file sink that does not pass through one of these methods still raises a fresh CodeQL alert. Adding new wrappers requires editing `models/path-validation-sanitizers.yml`.
 

--- a/docs/security-scanning-notes.md
+++ b/docs/security-scanning-notes.md
@@ -1,0 +1,99 @@
+# Security scanning — suppression notes
+
+This document explains how false positives from CodeQL, SonarCloud, and Snyk Code are handled in CARLOS EMR. It exists so a future reviewer can verify a suppression in one hop: read the note, follow the reference to the sanitizer, check the canary test is green.
+
+## Overarching principle
+
+**Every suppression is an in-repo artifact**, not a platform-metadata dismissal. Suppressions travel with the code, show up in PR review, and future scanner re-runs reproduce the same state without out-of-band actions. No per-alert UI "dismiss as false positive" is used in this codebase.
+
+## Canary tests (regression tripwire)
+
+The in-repo suppressions trust two sanitizers:
+
+- `io.github.carlos_emr.carlos.utility.PathValidationUtils` — path-traversal defence (`validatePath`, `validateExistingPath`, `validateUpload`, `isInAllowedTempDirectory`).
+- `io.github.carlos_emr.carlos.utility.LogSanitizer` — log-injection defence (`sanitize(String)`, `sanitize(String, int)`, `sanitizeObject(Object)`).
+
+Both have unit-test coverage that exercises the traversal / injection paths directly:
+
+- `src/test/java/io/github/carlos_emr/carlos/utility/PathValidationUtilsTest.java`
+- `src/test/java/io/github/carlos_emr/carlos/utility/LogSanitizerUnitTest.java`
+
+If either sanitizer is ever weakened, the unit tests must fail. Every downstream suppression is only as trustworthy as these tests staying green. Both files are flagged for security review; any PR that modifies them must be reviewed with the canaries in mind.
+
+## Per-tool suppression mechanism
+
+### CodeQL — model pack
+
+Location: `.github/codeql/extensions/carlos-java-models/`
+
+Models `PathValidationUtils` methods as `summaryModel` entries (safe argument → return value, user-controlled argument omitted), and `LogSanitizer` / guard methods as `neutralModel` entries. CodeQL's dataflow engine cuts taint at each sanitizer boundary.
+
+Wired into `.github/codeql/codeql-config.yml` via the `packs:` key. If default-setup silently ignores local pack references, the repo must convert to advanced-setup with a dedicated workflow file — see "Open" below.
+
+**Precision property**: the model entries name specific method signatures. A new file sink that does not pass through one of these methods still raises a fresh CodeQL alert. Adding new wrappers requires editing `models/path-validation-sanitizers.yml`.
+
+### SonarCloud — `@SuppressWarnings("java:S5145")` on specific methods
+
+Used for log-injection findings where the logged value goes through `LogSanitizer.sanitize(...)` but SonarCloud does not recognise the custom sanitizer.
+
+- Applied **per method**, never at class level. A new log statement in a sibling method without `LogSanitizer` still alerts.
+- Annotation carries a short comment naming the reason: `// all logged user input goes through LogSanitizer.sanitize()`.
+
+Some existing code uses the inline `// NOSONAR javasecurity:S5145 — sanitized with LogSanitizer` form instead; both are valid. For new code, prefer the method-level annotation — it is explicit about which rule it suppresses (`// NOSONAR` alone suppresses all Sonar rules on that line).
+
+Not every log-injection false positive has been annotated yet. The remaining unresolved S5145 alerts sit in the following files and are tracked as residual:
+
+- `FrmPDFServlet.java`, `FrmRecordFactory.java`
+- `ImageRenderingServlet.java`
+- `EctDisplayAction.java`
+- `EventService.java`
+- `BillingCorrectionPrep.java`
+- `EFormPDFServlet.java`
+- JSPs (`select_facility.jsp`, `forwardname.jsp`, `forwardshortcutname.jsp`) — JSPs cannot carry `@SuppressWarnings`; these should be refactored so the logging happens in an annotated Java helper.
+
+Follow-up PRs should add `@SuppressWarnings("java:S5145")` per method as they are touched.
+
+### Snyk Code — `.snyk exclude.code` for dev-only paths
+
+Location: `.snyk` at repo root.
+
+Scoped to developer-only scripts that are not deployed in the WAR:
+
+- `scripts/**`
+- `.claude/hooks/**`
+- `database/mysql/importCasemgmt.java`, `database/mysql/importCPP.java`
+- `release/**`
+- `.devcontainer/**`
+
+**Scope discipline**: this file must not contain patterns matching `src/main/**`. Production-code Snyk Code findings are resolved by code refactor or left as a documented residual (see below) — not by `.snyk` exclude.
+
+### Snyk Open Source — `.snyk ignore:` block
+
+Not currently used. When needed, use the documented `ignore:` block keyed by `SNYK-XXX` vulnerability ID with a `reason:` and `expires:` date.
+
+## Residual Snyk Code `java/PT` alerts on production code
+
+A residual set of Snyk Code path-injection alerts on production code (`src/main/**`) is accepted as known noise. They cannot be cleared by:
+
+- `.snyk exclude` (scoped to dev-only paths by policy above).
+- Inline comments (`// deepcode ignore java/PT: …` is a deprecated legacy feature; Snyk strips it from results).
+- Per-alert UI dismissal (not used — see overarching principle).
+
+Options when one of these alerts is encountered:
+
+1. **Refactor the caller** to use `PathValidationUtils` in a shape Snyk Code's dataflow engine recognises. Snyk Code respects `FilenameUtils.getName()` + fixed-directory `new File(baseDir, name)`; adding a local variable pass-through sometimes breaks its over-approximation.
+2. **Leave it.** CodeQL + SonarCloud still cover the same defect class, so Snyk Code becomes a lower-signal third opinion on these files.
+3. **Escalate to Snyk.** Enterprise customers can register custom sanitizers at org level through Snyk support.
+
+No action is taken in this repo. If a given file's alerts become too noisy to review, open an issue titled `Refactor <file> for Snyk Code dataflow` and handle case-by-case.
+
+## How to add a new suppression
+
+1. Confirm the finding is genuinely safe. Trace the dataflow by hand; do not trust the scanner's first-guess sanitizer list.
+2. Identify the sanitizer that makes it safe. If it's `PathValidationUtils` or `LogSanitizer`, confirm the canary tests still cover the property you rely on.
+3. Pick the narrowest in-repo suppression mechanism:
+   - CodeQL: add a model entry for the specific method signature in `path-validation-sanitizers.yml`.
+   - SonarCloud: `@SuppressWarnings("java:S<number>")` on the single method (or `// NOSONAR java:S<number> — <reason>` on the specific line).
+   - Snyk Code: refactor first; `.snyk exclude` only for non-deployed paths.
+4. Do not disable a rule at the project/profile level. Do not use class-level `@SuppressWarnings`. Do not dismiss via the tool's UI.
+5. Reference this file in the PR description so reviewers know where to look.

--- a/src/main/java/io/github/carlos_emr/carlos/billing/CA/ON/util/EDTFolder.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billing/CA/ON/util/EDTFolder.java
@@ -34,7 +34,7 @@ public enum EDTFolder {
                 return f;
             }
         }
-        return INBOX;
+        return null;
     }
 
     public boolean providesAccessToFiles() {

--- a/src/main/java/io/github/carlos_emr/carlos/billing/CA/ON/util/EDTFolder.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billing/CA/ON/util/EDTFolder.java
@@ -28,6 +28,14 @@ public enum EDTFolder {
         return path;
     }
 
+    /**
+     * Returns the {@link EDTFolder} enum constant whose name matches {@code name}
+     * (case-insensitive).
+     *
+     * @param name String the folder name to look up (e.g., {@code "inbox"}, {@code "OUTBOX"})
+     * @return EDTFolder the matching enum constant, or {@code null} if no constant
+     *         matches {@code name}
+     */
     public static EDTFolder getFolder(String name) {
         for (EDTFolder f : EDTFolder.values()) {
             if (f.name().equalsIgnoreCase(name)) {

--- a/src/main/java/io/github/carlos_emr/carlos/billing/CA/ON/web/MoveMOHFiles2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billing/CA/ON/web/MoveMOHFiles2Action.java
@@ -134,24 +134,28 @@ public class MoveMOHFiles2Action extends ActionSupport {
 
         if (isValid) {
             String folderPath = getFolderPath(folderParam);
-            File folderFile = new File(folderPath);
-            for (String fileName : fileNames) {
-                File file;
-                try {
-                    String decodedName = URLDecoder.decode(fileName, StandardCharsets.UTF_8);
-                    file = PathValidationUtils.validatePath(decodedName, folderFile);
-                } catch (SecurityException e) {
-                    logger.warn("Invalid file location {}", LogSanitizer.sanitize(fileName)); // NOSONAR javasecurity:S5145 — sanitized with LogSanitizer
-                    errors.append("File is not in a valid location: ").append(Encode.forHtml(fileName)).append(".<br/>");
-                    continue;
-                }
+            if (folderPath == null) {
+                errors.append("Unrecognized folder: ").append(Encode.forHtml(folderParam)).append(".<br/>");
+            } else {
+                File folderFile = new File(folderPath);
+                for (String fileName : fileNames) {
+                    File file;
+                    try {
+                        String decodedName = URLDecoder.decode(fileName, StandardCharsets.UTF_8);
+                        file = PathValidationUtils.validatePath(decodedName, folderFile);
+                    } catch (IllegalArgumentException | SecurityException e) {
+                        logger.warn("Invalid file location {}", LogSanitizer.sanitize(fileName)); // NOSONAR javasecurity:S5145 — sanitized with LogSanitizer
+                        errors.append("File is not in a valid location: ").append(Encode.forHtml(fileName)).append(".<br/>");
+                        continue;
+                    }
 
-                if (file.exists()) {
-                    boolean isMoved = moveFile(file);
-                    if (isMoved) {
-                        messages.append("Archived file ").append(Encode.forHtml(file.getName())).append(" successfully.<br/>");
-                    } else {
-                        errors.append("Unable to archive ").append(Encode.forHtml(file.getName()));
+                    if (file.exists()) {
+                        boolean isMoved = moveFile(file);
+                        if (isMoved) {
+                            messages.append("Archived file ").append(Encode.forHtml(file.getName())).append(" successfully.<br/>");
+                        } else {
+                            errors.append("Unable to archive ").append(Encode.forHtml(file.getName()));
+                        }
                     }
                 }
             }
@@ -206,7 +210,7 @@ public class MoveMOHFiles2Action extends ActionSupport {
      * @return String representing the absolute filesystem path for the specified EDT folder
      */
     private String getFolderPath(String folderName) {
-    EDTFolder folder = EDTFolder.getFolder(folderName);
-    return folder.getPath();
+        EDTFolder folder = EDTFolder.getFolder(folderName);
+        return folder != null ? folder.getPath() : null;
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/billing/CA/ON/web/MoveMOHFiles2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billing/CA/ON/web/MoveMOHFiles2Action.java
@@ -28,8 +28,8 @@ import org.apache.struts2.ActionSupport;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.struts2.ServletActionContext;
@@ -134,19 +134,14 @@ public class MoveMOHFiles2Action extends ActionSupport {
 
         if (isValid) {
             String folderPath = getFolderPath(folderParam);
+            File folderFile = new File(folderPath);
             for (String fileName : fileNames) {
-                File file = getFile(folderPath, fileName);
-                if (file == null) {
-                    logger.warn("Unable to get file {}{}{}", LogSanitizer.sanitize(folderPath), File.separator, LogSanitizer.sanitize(fileName)); // NOSONAR javasecurity:S5145 — sanitized with LogSanitizer
-
-                    errors.append("Unable to find file ").append(Encode.forHtml(fileName)).append(".<br/>");
-                    continue;
-                }
-
-                boolean isValidFileLocation = validateFileLocation(file);
-                if (!isValidFileLocation) {
+                File file;
+                try {
+                    String decodedName = URLDecoder.decode(fileName, StandardCharsets.UTF_8);
+                    file = PathValidationUtils.validatePath(decodedName, folderFile);
+                } catch (SecurityException e) {
                     logger.warn("Invalid file location {}", LogSanitizer.sanitize(fileName)); // NOSONAR javasecurity:S5145 — sanitized with LogSanitizer
-
                     errors.append("File is not in a valid location: ").append(Encode.forHtml(fileName)).append(".<br/>");
                     continue;
                 }
@@ -166,72 +161,6 @@ public class MoveMOHFiles2Action extends ActionSupport {
         WebUtils.addInfoMessage(request.getSession(), messages.toString());
 
         return "Success";
-    }
-
-    /**
-     * Validates that a file resides within an authorized EDT folder location.
-     *
-     * <p>This security method ensures that the specified file is located within one of the
-     * authorized Electronic Data Transfer (EDT) folder paths. It iterates through all defined
-     * EDT folders and uses {@link PathValidationUtils#validateExistingPath(File, File)} to
-     * verify the file's location against each authorized directory.</p>
-     *
-     * <p>This validation is critical for preventing path traversal attacks and ensuring that
-     * only files within approved MOH billing directories can be archived. The method uses a
-     * try-each-folder approach, accepting the file if it validates against any of the authorized
-     * EDT folder locations.</p>
-     *
-     * <p><strong>Security:</strong> Uses {@link PathValidationUtils} to perform secure path
-     * validation, preventing directory traversal attacks and unauthorized file access. Any
-     * validation failures are caught and the method continues checking other authorized folders.</p>
-     *
-     * @param file File object representing the file to validate (must not be null)
-     * @return boolean true if the file is within an authorized EDT folder, false otherwise
-     */
-    private boolean validateFileLocation(File file) {
-        boolean result = false;
-        try {
-            for (EDTFolder folder : EDTFolder.values()) {
-                File edtFolderFile = new File(folder.getPath());
-                try {
-                    file = PathValidationUtils.validateExistingPath(file, edtFolderFile);
-                    result = true;
-                    break;
-                } catch (SecurityException e) {
-                    // File not in this folder, try next
-                }
-            }
-        } catch (Exception e) {
-            logger.error("Unable to validate file location", e);
-        }
-        return result;
-    }
-
-    /**
-     * Retrieves a File object for the specified filename within the given folder path.
-     *
-     * <p>This method creates a File object by combining the folder path and filename. It includes
-     * URL decoding of the filename parameter to handle filenames that may have been URL-encoded
-     * during HTTP transmission. This is necessary because filenames from web forms may contain
-     * special characters that are URL-encoded.</p>
-     *
-     * <p><strong>Error Handling:</strong> If the filename cannot be decoded using UTF-8 encoding,
-     * an error is logged and null is returned. The calling method should check for null and handle
-     * the error appropriately.</p>
-     *
-     * @param folderPath String representing the absolute path to the folder containing the file
-     * @param fileName String representing the URL-encoded filename to retrieve
-     * @return File object representing the file at the specified path, or null if filename decoding fails
-     */
-    private File getFile(String folderPath, String fileName) {
-    try {
-        fileName = URLDecoder.decode(fileName, "UTF-8");
-    } catch (UnsupportedEncodingException e) {
-        logger.error("Unable to decode {}", LogSanitizer.sanitize(fileName), e);
-        return null;
-    }
-
-    return new File(folderPath, fileName);
     }
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/billing/CA/ON/web/MoveMOHFiles2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billing/CA/ON/web/MoveMOHFiles2Action.java
@@ -207,7 +207,8 @@ public class MoveMOHFiles2Action extends ActionSupport {
      * which EDT folder category (e.g., inbox, outbox, error) the user is working with.</p>
      *
      * @param folderName String identifier for the EDT folder (e.g., "INBOX", "OUTBOX", "ERROR")
-     * @return String representing the absolute filesystem path for the specified EDT folder
+     * @return String the absolute filesystem path for the specified EDT folder,
+     *         or {@code null} if {@code folderName} does not match any known EDT folder
      */
     private String getFolderPath(String folderName) {
         EDTFolder folder = EDTFolder.getFolder(folderName);

--- a/src/main/java/io/github/carlos_emr/carlos/demographic/PrintDemoChartLabel2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/PrintDemoChartLabel2Action.java
@@ -48,6 +48,7 @@ import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.utility.DbConnectionFilter;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
+import io.github.carlos_emr.carlos.utility.PathValidationUtils;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 
 import io.github.carlos_emr.OscarDocumentCreator;
@@ -215,8 +216,12 @@ public class PrintDemoChartLabel2Action extends ActionSupport {
 
         try {
             try {
-                ins = new FileInputStream(System.getProperty("user.home") + File.separator + labelFile);
-            } catch (FileNotFoundException ex1) {
+                // labelFile is always a value from a hardcoded map (Chartlabel.xml or
+                // SexualHealthClinicLabel.xml), never user-controlled. validatePath()
+                // makes the safety explicit to scanners and provides defence-in-depth.
+                File validatedLabel = PathValidationUtils.validatePath(labelFile, new File(System.getProperty("user.home")));
+                ins = new FileInputStream(validatedLabel);
+            } catch (SecurityException | FileNotFoundException ex1) {
                 logger.warn(labelFile + " not found in user's home directory. Using default instead (classpath)", ex1);
             }
 

--- a/src/main/java/io/github/carlos_emr/carlos/demographic/PrintDemoChartLabel2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/PrintDemoChartLabel2Action.java
@@ -219,8 +219,11 @@ public class PrintDemoChartLabel2Action extends ActionSupport {
                 // labelFile is always a value from a hardcoded map (Chartlabel.xml or
                 // SexualHealthClinicLabel.xml), never user-controlled. validatePath()
                 // makes the safety explicit to scanners and provides defence-in-depth.
-                File validatedLabel = PathValidationUtils.validatePath(labelFile, new File(System.getProperty("user.home")));
-                ins = new FileInputStream(validatedLabel);
+                String userHome = System.getProperty("user.home");
+                if (userHome != null) {
+                    File validatedLabel = PathValidationUtils.validatePath(labelFile, new File(userHome));
+                    ins = new FileInputStream(validatedLabel);
+                }
             } catch (SecurityException | FileNotFoundException ex1) {
                 logger.warn(labelFile + " not found in user's home directory. Using default instead (classpath)", ex1);
             }

--- a/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/DemographicUpdate2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/DemographicUpdate2Action.java
@@ -38,6 +38,7 @@ import io.github.carlos_emr.carlos.commn.model.DemographicCust;
 import io.github.carlos_emr.carlos.commn.model.DemographicExt;
 import io.github.carlos_emr.carlos.commn.model.DemographicExtArchive;
 import io.github.carlos_emr.carlos.commn.model.WaitingList;
+import io.github.carlos_emr.carlos.utility.LogSanitizer;
 import io.github.carlos_emr.carlos.demographic.data.DemographicNameAgeString;
 import io.github.carlos_emr.carlos.log.LogAction;
 import io.github.carlos_emr.carlos.log.LogConst;
@@ -126,14 +127,14 @@ public class DemographicUpdate2Action extends ActionSupport {
         try {
             demographicNo = Integer.parseInt(demoNo);
         } catch (NumberFormatException e) {
-            logger.warn("DemographicUpdate2Action: invalid demographic_no={}", demoNo);
+            logger.warn("DemographicUpdate2Action: invalid demographic_no={}", LogSanitizer.sanitize(demoNo));
             addActionError("Invalid patient record identifier");
             return ERROR;
         }
 
         Demographic demographic = demographicDao.getDemographic(demoNo);
         if (demographic == null) {
-            logger.warn("DemographicUpdate2Action: demographic_no={} not found", demoNo);
+            logger.warn("DemographicUpdate2Action: demographic_no={} not found", demographicNo);
             addActionError("Patient record not found");
             return ERROR;
         }

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/ManageDocument2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/ManageDocument2Action.java
@@ -779,6 +779,7 @@ public class ManageDocument2Action extends ActionSupport {
      *
      * @throws SecurityException if the user lacks _edoc read privilege
      */
+    @SuppressWarnings("java:S5145") // all logged user input goes through LogSanitizer.sanitize()
     public void viewDocPage() {
         if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_edoc", "r", null)) {
             throw new SecurityException("missing required sec object (_edoc)");
@@ -1051,6 +1052,7 @@ public class ManageDocument2Action extends ActionSupport {
      * @throws Exception if parameter validation or file operations fail
      * @throws SecurityException if the user lacks _edoc write privilege or path traversal is detected
      */
+    @SuppressWarnings("java:S5145") // all logged user input goes through LogSanitizer.sanitize()
     public String addIncomingDocument() throws Exception {
 
         String pdfDir = request.getParameter("pdfDir");
@@ -1425,6 +1427,7 @@ public class ManageDocument2Action extends ActionSupport {
      * @throws Exception if path validation, rendering, or I/O fails
      * @throws SecurityException if the user lacks _edoc read privilege or path traversal is detected
      */
+    @SuppressWarnings("java:S5145") // all logged user input goes through LogSanitizer.sanitize()
     public void viewIncomingDocPageAsImage() throws Exception {
 
 
@@ -1503,6 +1506,7 @@ public class ManageDocument2Action extends ActionSupport {
      * @throws Exception if parameter validation fails
      * @throws SecurityException if path traversal is detected or file type is not PDF
      */
+    @SuppressWarnings("java:S5145") // all logged user input goes through LogSanitizer.sanitize()
     public File createIncomingCacheVersion(String queueId, String pdfDir, String pdfName, Integer pageNum) throws Exception {
         
         // Validate input parameters to prevent path traversal

--- a/src/main/java/io/github/carlos_emr/carlos/eform/EFormExportZip.java
+++ b/src/main/java/io/github/carlos_emr/carlos/eform/EFormExportZip.java
@@ -35,6 +35,7 @@
 
 package io.github.carlos_emr.carlos.eform;
 
+import org.apache.commons.io.FilenameUtils;
 import org.apache.logging.log4j.Logger;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.CarlosProperties;
@@ -201,9 +202,16 @@ public class EFormExportZip {
         Hashtable<String, File> tempFiles = new Hashtable<String, File>(); //references extracted files in the temp folder
         //first runthrough, get the properties files, construct eforms, cache files
         while ((ze = zis.getNextEntry()) != null) {
-            File file = new File(ze.getName());
-            _log.info("Unzipping..." + LogSanitizer.sanitize(file.getName()));
-            if (file.getName().equalsIgnoreCase("eform.properties")) {
+            // Zip Slip defence: strip any path components from the zip entry name.
+            // A malicious zip entry like "../../etc/passwd" becomes just "passwd".
+            String entryBaseName = FilenameUtils.getName(ze.getName());
+            if (entryBaseName == null || entryBaseName.isEmpty() || entryBaseName.startsWith(".")) {
+                _log.warn("Skipping invalid zip entry: {}", LogSanitizer.sanitize(ze.getName())); // NOSONAR javasecurity:S5145 — sanitized with LogSanitizer
+                zis.closeEntry();
+                continue;
+            }
+            _log.info("Unzipping..." + LogSanitizer.sanitize(entryBaseName));
+            if (entryBaseName.equalsIgnoreCase("eform.properties")) {
                 Properties properties = new Properties();
                 properties.load(zis);
                 EForm newEForm = this.createEFormFromProperties(properties);
@@ -229,10 +237,10 @@ public class EFormExportZip {
                 _log.debug("going in eform table >" + newEForm.getFormFileName() + "<");
             } else {
                 //store temp files on HD
-                File tempFile = new File(imageTempFolderDir, file.getName());
-                // Zip Slip prevention: ensure extracted file stays within the temp extraction directory
-                tempFile = PathValidationUtils.validateExistingPath(tempFile, imageTempFolderDir);
-                tempFiles.put(file.getName(), tempFile); //reference so we can find it later
+                // Zip Slip prevention: validatePath() sanitizes the name and enforces
+                // containment within imageTempFolderDir.
+                File tempFile = PathValidationUtils.validatePath(entryBaseName, imageTempFolderDir);
+                tempFiles.put(entryBaseName, tempFile); //reference so we can find it later
                 FileOutputStream fos = new FileOutputStream(tempFile);
                 inputToOutput(zis, fos);
                 fos.close();
@@ -262,9 +270,10 @@ public class EFormExportZip {
                 //do not save file if eform fails
             } else {
                 FileInputStream fis = new FileInputStream(tempFile.getValue());
-                File imageFile = new File(ImageUpload2Action.getImageFolder(), tempFile.getKey());
-                // Zip Slip prevention: ensure the image destination stays within the image folder
-                imageFile = PathValidationUtils.validateExistingPath(imageFile, ImageUpload2Action.getImageFolder());
+                // Zip Slip prevention: validatePath() sanitizes the key and enforces
+                // containment within the image folder. The key is already basename-only
+                // from the extraction loop above, but validatePath() provides defence-in-depth.
+                File imageFile = PathValidationUtils.validatePath(tempFile.getKey(), ImageUpload2Action.getImageFolder());
                 if (imageFile.exists()) {
                     errors.add("Image '" + tempFile.getKey() + "' already exists, skipping image, but the form may still be uploaded.  Please resolve.");
                     _log.info("EForm Import: Image with name '" + tempFile.getKey() + "' already exists, skipping image, but the form may still be uploaded.  Please resolve.");

--- a/src/main/java/io/github/carlos_emr/carlos/eform/EFormExportZip.java
+++ b/src/main/java/io/github/carlos_emr/carlos/eform/EFormExportZip.java
@@ -202,6 +202,10 @@ public class EFormExportZip {
         Hashtable<String, File> tempFiles = new Hashtable<String, File>(); //references extracted files in the temp folder
         //first runthrough, get the properties files, construct eforms, cache files
         while ((ze = zis.getNextEntry()) != null) {
+            if (ze.isDirectory()) {
+                zis.closeEntry();
+                continue;
+            }
             // Zip Slip defence: strip any path components from the zip entry name.
             // A malicious zip entry like "../../etc/passwd" becomes just "passwd".
             String entryBaseName = FilenameUtils.getName(ze.getName());
@@ -241,9 +245,9 @@ public class EFormExportZip {
                 // containment within imageTempFolderDir.
                 File tempFile = PathValidationUtils.validatePath(entryBaseName, imageTempFolderDir);
                 tempFiles.put(entryBaseName, tempFile); //reference so we can find it later
-                FileOutputStream fos = new FileOutputStream(tempFile);
-                inputToOutput(zis, fos);
-                fos.close();
+                try (FileOutputStream fos = new FileOutputStream(tempFile)) {
+                    inputToOutput(zis, fos);
+                }
                 //store temp files in memory
                 /*ByteArrayOutputStream baos = new ByteArrayOutputStream();
                 inputToOutput(zis, baos);
@@ -278,11 +282,11 @@ public class EFormExportZip {
                     errors.add("Image '" + tempFile.getKey() + "' already exists, skipping image, but the form may still be uploaded.  Please resolve.");
                     _log.info("EForm Import: Image with name '" + tempFile.getKey() + "' already exists, skipping image, but the form may still be uploaded.  Please resolve.");
                 }
-                OutputStream os = new FileOutputStream(imageFile);
-                inputToOutput(fis, os);
+                try (OutputStream os = new FileOutputStream(imageFile)) {
+                    inputToOutput(fis, os);
+                }
                 _log.info("Loaded eform file: " + tempFile.getKey());
                 fis.close();
-                os.close();
             }
         }
         _log.info("Registering: " + eformTable.values().size() + " eforms");
@@ -296,8 +300,11 @@ public class EFormExportZip {
     }
 
     private void deleteDirectory(File directory) {
-        for (File file : directory.listFiles()) {
-            file.delete();
+        File[] files = directory.listFiles();
+        if (files != null) {
+            for (File file : files) {
+                file.delete();
+            }
         }
         directory.delete();
     }

--- a/src/main/java/io/github/carlos_emr/carlos/eform/EFormExportZip.java
+++ b/src/main/java/io/github/carlos_emr/carlos/eform/EFormExportZip.java
@@ -43,6 +43,7 @@ import io.github.carlos_emr.carlos.eform.data.EForm;
 import io.github.carlos_emr.carlos.eform.upload.ImageUpload2Action;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.Map.Entry;
@@ -262,31 +263,30 @@ public class EFormExportZip {
         for (Entry<String, File> tempFile : tempFiles.entrySet()) {
             _log.info("looking at " + tempFile.getKey());
             if (eformTable.containsKey(tempFile.getKey())) {  //if file name matches eform
-                FileInputStream fis = new FileInputStream(tempFile.getValue());
-                ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                inputToOutput(fis, baos);
-                String html = new String(baos.toByteArray());
-                _log.debug("THIS IS WHAT THE HTML is" + html);
-                eformTable.get(tempFile.getKey()).setFormHtml(html);
-                fis.close();
-                baos.close();
+                try (FileInputStream fis = new FileInputStream(tempFile.getValue());
+                     ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+                    inputToOutput(fis, baos);
+                    String html = new String(baos.toByteArray(), StandardCharsets.UTF_8);
+                    _log.debug("THIS IS WHAT THE HTML is" + html);
+                    eformTable.get(tempFile.getKey()).setFormHtml(html);
+                }
             } else if (eformTableFailed.containsKey(tempFile.getKey())) {
                 //do not save file if eform fails
             } else {
-                FileInputStream fis = new FileInputStream(tempFile.getValue());
                 // Zip Slip prevention: validatePath() sanitizes the key and enforces
                 // containment within the image folder. The key is already basename-only
                 // from the extraction loop above, but validatePath() provides defence-in-depth.
                 File imageFile = PathValidationUtils.validatePath(tempFile.getKey(), ImageUpload2Action.getImageFolder());
                 if (imageFile.exists()) {
-                    errors.add("Image '" + tempFile.getKey() + "' already exists, skipping image, but the form may still be uploaded.  Please resolve.");
-                    _log.info("EForm Import: Image with name '" + tempFile.getKey() + "' already exists, skipping image, but the form may still be uploaded.  Please resolve.");
+                    errors.add("Image '" + tempFile.getKey() + "' already exists, skipping image, but the form may still be uploaded. Please resolve.");
+                    _log.info("EForm Import: Image with name '" + tempFile.getKey() + "' already exists, skipping image, but the form may still be uploaded. Please resolve.");
+                    continue;
                 }
-                try (OutputStream os = new FileOutputStream(imageFile)) {
+                try (FileInputStream fis = new FileInputStream(tempFile.getValue());
+                     OutputStream os = new FileOutputStream(imageFile)) {
                     inputToOutput(fis, os);
                 }
                 _log.info("Loaded eform file: " + tempFile.getKey());
-                fis.close();
             }
         }
         _log.info("Registering: " + eformTable.values().size() + " eforms");

--- a/src/main/webapp/billing/CA/ON/viewMOHFiles.jsp
+++ b/src/main/webapp/billing/CA/ON/viewMOHFiles.jsp
@@ -28,6 +28,10 @@
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean bodd = false;
     EDTFolder folder = EDTFolder.getFolder(request.getParameter("folder"));
+    if (folder == null) {
+        response.sendError(400, "Unrecognized folder parameter");
+        return;
+    }
     String folderPath = folder.getPath();
 %>
 <security:oscarSec roleName="<%=roleName$%>" objectName="_admin,_admin.backup,_admin.billing" rights="r" reverse="<%=true%>">

--- a/src/test/java/io/github/carlos_emr/carlos/utility/PathValidationUtilsTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/utility/PathValidationUtilsTest.java
@@ -476,7 +476,7 @@ public class PathValidationUtilsTest {
         @DisplayName("should return file when existing path is inside allowed directory")
         void shouldReturnFile_whenExistingPathInsideAllowedDir() throws IOException {
             File inside = tempDir.resolve("inside.txt").toFile();
-            inside.createNewFile();
+            assertThat(inside.createNewFile()).isTrue();
 
             File result = PathValidationUtils.validateExistingPath(inside, allowedDir);
 
@@ -503,7 +503,7 @@ public class PathValidationUtilsTest {
         @DisplayName("should throw SecurityException when allowedDir is null")
         void shouldThrowSecurityException_whenExistingPathAllowedDirIsNull() throws IOException {
             File inside = tempDir.resolve("inside.txt").toFile();
-            inside.createNewFile();
+            assertThat(inside.createNewFile()).isTrue();
 
             assertThatThrownBy(() -> PathValidationUtils.validateExistingPath(inside, null))
                 .isInstanceOf(SecurityException.class);

--- a/src/test/java/io/github/carlos_emr/carlos/utility/PathValidationUtilsTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/utility/PathValidationUtilsTest.java
@@ -465,6 +465,52 @@ public class PathValidationUtilsTest {
     }
 
     // ========================================================================
+    // EXISTING PATH VALIDATION - validateExistingPath(File, File)
+    // ========================================================================
+
+    @Nested
+    @DisplayName("validateExistingPath Tests")
+    class ValidateExistingPathTests {
+
+        @Test
+        @DisplayName("should return file when existing path is inside allowed directory")
+        void shouldReturnFile_whenExistingPathInsideAllowedDir() throws IOException {
+            File inside = tempDir.resolve("inside.txt").toFile();
+            inside.createNewFile();
+
+            File result = PathValidationUtils.validateExistingPath(inside, allowedDir);
+
+            assertThat(result).isEqualTo(inside);
+        }
+
+        @Test
+        @DisplayName("should throw SecurityException when existing path escapes allowed directory")
+        void shouldThrowSecurityException_whenExistingPathEscapesAllowedDir() {
+            File outside = new File("/etc/passwd");
+
+            assertThatThrownBy(() -> PathValidationUtils.validateExistingPath(outside, allowedDir))
+                .isInstanceOf(SecurityException.class);
+        }
+
+        @Test
+        @DisplayName("should throw SecurityException when existing path is null")
+        void shouldThrowSecurityException_whenExistingPathIsNull() {
+            assertThatThrownBy(() -> PathValidationUtils.validateExistingPath(null, allowedDir))
+                .isInstanceOf(SecurityException.class);
+        }
+
+        @Test
+        @DisplayName("should throw SecurityException when allowedDir is null")
+        void shouldThrowSecurityException_whenExistingPathAllowedDirIsNull() throws IOException {
+            File inside = tempDir.resolve("inside.txt").toFile();
+            inside.createNewFile();
+
+            assertThatThrownBy(() -> PathValidationUtils.validateExistingPath(inside, null))
+                .isInstanceOf(SecurityException.class);
+        }
+    }
+
+    // ========================================================================
     // SYMLINK HANDLING (Platform Dependent)
     // ========================================================================
 


### PR DESCRIPTION
## Summary

Bundles tasks 0–4 from the path-injection audit into a single PR. Clears the bulk of 110 open path-injection alerts across CodeQL / SonarCloud / Snyk Code by **fixing true positives** and using **durable, in-repo suppression mechanisms** — no per-alert platform dismissals.

Closes #1589, #1590.

## What changed

### Fixes (3 true-positive bugs)
- **`MoveMOHFiles2Action`** — replace stale `getFile()` + `validateFileLocation()` pattern with direct `PathValidationUtils.validatePath()` so the filename is sanitized before `File` construction.
- **`EFormExportZip`** — `FilenameUtils.getName()` + `PathValidationUtils.validatePath()` on ZipEntry names for explicit Zip Slip defence (both temp-extract and image-write paths).
- **`PrintDemoChartLabel2Action`** — wrap `user.home + labelFile` with `validatePath()` to make scanner-visible that `labelFile` is always a hardcoded map value.
- **`DemographicUpdate2Action`** — log parsed `int demographicNo` (not raw string) at the "not found" log; `LogSanitizer.sanitize()` the parse-failure log.

### Suppression infrastructure
- **CodeQL**: wire the pre-existing `carlos-emr/carlos-java-models` pack into `.github/codeql/codeql-config.yml`. The pack already models `PathValidationUtils`, `LogSanitizer`-adjacent guards, and `OWASP Encoder` as sanitizers — it just wasn't referenced from the config, so none of its entries were loaded.
- **Snyk Code**: new `.snyk` with `exclude.code` for dev-only paths (`scripts/`, `.claude/hooks/`, `release/`, `.devcontainer/`, `database/mysql/import*.java`). Scoped strictly to non-deployed paths; `src/main/**` remains covered.
- **SonarCloud**: `@SuppressWarnings("java:S5145")` on 4 `ManageDocument2Action` methods where all logged input already goes through `LogSanitizer`. Per-method (never class-level) to preserve regression detection for sibling methods.

### Canary tests (regression tripwire)
- `PathValidationUtilsTest` — add direct `validateExistingPath(File, File)` tests (inside-dir positive, outside-dir reject, null inputs). Every downstream suppression is only as trustworthy as these tests staying green.

### Docs
- `docs/security-scanning-notes.md` — per-tool suppression strategy, canary tests, no-platform-UI-dismissals policy, residual Snyk Code production-code FPs.

## Why not per-alert UI dismissal?

- Platform dismissals live in GitHub/Snyk metadata, not the repo — they do not travel with code, are invisible in PR review, and must be re-applied if the repo is forked or the alert state is reset.
- In-repo suppressions (model entries, `@SuppressWarnings`, `.snyk exclude`) are diff-visible and CODEOWNERS-reviewable.
- Per CodeQL docs, inline suppression comments are not supported; model-pack entries are the sanctioned mechanism.

## Test plan

- [ ] `make install --run-unit-tests` — green (covers canary tests for `PathValidationUtils` and `LogSanitizer`)
- [ ] CI CodeQL run on PR branch — confirm `java/path-injection` alert count drops (target ~0) once the model pack loads
  - If default-setup silently ignores `packs:` entries, convert to advanced-setup with a workflow file — see open question below
- [ ] CI Snyk Code run on PR branch — confirm 8 dev-script `java/PT` / `python/PT` alerts drop off; `src/main/**` scan unchanged
- [ ] CI SonarCloud run on PR branch — `javasecurity:S5145` count drops by 9 (`ManageDocument2Action`'s four methods)
- [ ] Review that no suppression pattern hides a real regression — inspect the `docs/security-scanning-notes.md` mechanism summary

## Known follow-ups (not in this PR)

- **S5145 residual**: `FrmPDFServlet`, `FrmRecordFactory`, `ImageRenderingServlet`, `EctDisplayAction`, `EventService`, `BillingCorrectionPrep`, `EFormPDFServlet`, and 3 JSPs still have un-annotated S5145 findings. Add `@SuppressWarnings("java:S5145")` per method as those files are touched. The JSPs need a small refactor (move logging into an annotated Java helper).
- **Snyk Code production-code FPs**: ~55 residual `java/PT` alerts on `src/main/**` that cannot be cleared by `.snyk exclude` or inline comments. Options documented in `docs/security-scanning-notes.md` §"Residual Snyk Code `java/PT` alerts".
- **CODEOWNERS**: add `/.github/codeql/**`, `PathValidationUtils.java`, `LogSanitizer.java`, `.snyk` to CODEOWNERS under the security reviewer handle (not added here — needs the correct user/team name).
- **CodeQL default-setup vs advanced-setup**: if default-setup silently ignores the `packs:` entry, create `.github/workflows/codeql.yml` with `github/codeql-action/init@v4` + `config-file: .github/codeql/codeql-config.yml`, then disable default setup in repo Settings → Code security.

## Testing note

Regression coverage for the three true-positive fixes is provided by the `PathValidationUtils` canary tests (which exercise the sanitizer the fixes delegate to), not by per-action unit tests. Adding Struts2 action-level tests for each fix would be mostly framework-mocking boilerplate over the security property the canary already covers. If PR review disagrees, action tests can be added in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three real path traversal issues and adds durable, in-repo suppressions so scanners stop flagging safe paths. Also hardens zip import, folder validation, and error handling.

- **Bug Fixes**
  - `MoveMOHFiles2Action`: use `PathValidationUtils.validatePath()` on decoded names; catch `IllegalArgumentException` for bad encodings; handle unknown EDT folders safely (`EDTFolder.getFolder()` now returns null) and show a clear error (`viewMOHFiles.jsp` returns 400 on invalid folder).
  - `EFormExportZip`: strip entry paths with `FilenameUtils.getName()`, validate with `PathValidationUtils.validatePath()`, skip directory entries, use try-with-resources for reads and writes, decode eForm HTML as UTF-8, do not overwrite existing images (skip with message), and null-guard `deleteDirectory()` listing.
  - `PrintDemoChartLabel2Action`: validate `user.home + labelFile` with `validatePath()` and null-guard `user.home` before `new File(...)`.
  - `DemographicUpdate2Action`: sanitize the parse-failure log and log parsed `int demographicNo` in the "not found" path.

- **Refactors**
  - CodeQL: reference `carlos-emr/carlos-java-models` in `.github/codeql/codeql-config.yml` so `PathValidationUtils` and `LogSanitizer` are modeled as sanitizers.
  - Snyk Code: add `.snyk` excludes for dev-only paths; production `src/main/**` stays covered.
  - SonarCloud: add `@SuppressWarnings("java:S5145")` on four `ManageDocument2Action` methods where logged input is sanitized.
  - Tests & Docs: add `validateExistingPath` canary tests in `PathValidationUtilsTest`; document the suppression strategy in `docs/security-scanning-notes.md`.

<sup>Written for commit 5a7be5b23502c4fd8854ac022cb8189db2d566a8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

