### PR TITLE
fix(login): stop storing PIN/nextPage in session; validate providerNo before shared-list mutation

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/login/Login2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/login/Login2Action.java
@@ -360,6 +360,12 @@ public final class Login2Action extends ActionSupport {
         if (request.getParameter("forcedpasswordchange") != null
                 && request.getParameter("forcedpasswordchange").equalsIgnoreCase("true")) {
             // Coming back from force password change.
+            //
+            // Only userName and (hashed) password are retrieved from session; pin and
+            // nextPage are NOT stored in session (see setUserInfoToSession Javadoc).
+            // nextPage is propagated via the hidden form field carried by
+            // forcepasswordreset.jsp; pin is re-entered by the user after a successful
+            // reset via a fresh login on the login page.
             userName = (String) request.getSession().getAttribute("userName");
 
             // Username is only letters and numbers
@@ -369,17 +375,12 @@ public final class Login2Action extends ActionSupport {
 
             password = (String) request.getSession().getAttribute("password");
 
-            pin = (String) request.getSession().getAttribute("pin");
-
-            // pins are integers only
-            if (!Pattern.matches("[0-9]{4}", pin)) {
-                pin = "";
-            }
-            nextPage = (String) request.getSession().getAttribute("nextPage");
-            // Validate nextPage retrieved from session to prevent open redirect (CWE-601 defense in depth)
+            // nextPage is a request parameter (hidden form field), not a session attribute
+            nextPage = request.getParameter("nextPage");
+            // Validate nextPage to prevent open redirect (CWE-601)
             if (!RedirectValidationUtils.isValidRelativeRedirect(nextPage)) {
                 if (nextPage != null) {
-                    logger.warn("Rejected invalid nextPage from session: {}", LogSanitizer.sanitize(nextPage));
+                    logger.warn("Rejected invalid nextPage on password-reset return: {}", LogSanitizer.sanitize(nextPage));
                 }
                 nextPage = null;
             }
@@ -401,10 +402,19 @@ public final class Login2Action extends ActionSupport {
 
                 persistNewPassword(userName, newPassword);
 
-                password = newPassword;
-
-                // Remove the attributes from session
+                // Remove the stashed session attributes
                 removeAttributesFromSession(request);
+
+                // Password changed successfully. Rather than re-authenticating inline
+                // (which would require the PIN to survive the round-trip via session),
+                // redirect the user to the login page so they re-enter full credentials
+                // with their new password. nextPage is preserved as a query parameter.
+                String loginUrl = request.getContextPath() + "/index.jsp?msg=password_changed";
+                if (nextPage != null) {
+                    loginUrl = loginUrl + "&nextPage=" + Encode.forUriComponent(nextPage);
+                }
+                response.sendRedirect(loginUrl);
+                return NONE;
             } catch (Exception e) {
                 logger.error("Error", e);
                 String newURL = request.getContextPath() + "/loginfailed.jsp?errormsg=Setting values to the session.";
@@ -415,9 +425,6 @@ public final class Login2Action extends ActionSupport {
                 response.sendRedirect(newURL);
                 return NONE;
             }
-
-            // make sure this checking doesn't happen again
-            forcedpasswordchange = false;
 
         } else {
             // >> 3. Standard Login Attempt
@@ -547,10 +554,16 @@ public final class Login2Action extends ActionSupport {
                     security.isForcePasswordReset() != null && security.isForcePasswordReset()
                     && forcedpasswordchange) {
 
+                // Propagate nextPage to the reset page as a query parameter (not session);
+                // the JSP carries it forward as a hidden form field and the return path
+                // re-validates it via RedirectValidationUtils.
                 String newURL = request.getContextPath() + "/forcepasswordreset.jsp";
+                if (nextPage != null && RedirectValidationUtils.isValidRelativeRedirect(nextPage)) {
+                    newURL = newURL + "?nextPage=" + Encode.forUriComponent(nextPage);
+                }
 
                 try {
-                    setUserInfoToSession(request, userName, password, pin, nextPage);
+                    setUserInfoToSession(request, userName, password);
                 } catch (Exception e) {
                     logger.error("Error", e);
                     newURL = request.getContextPath() + "/loginfailed.jsp?errormsg=Setting values to the session.";
@@ -605,7 +618,7 @@ public final class Login2Action extends ActionSupport {
                 if (Objects.nonNull(sec) && sec.isUsingMfa()) {
                     // MFA Enabled
                     try {
-                        setUserInfoToSession(request, userName, password, pin, nextPage);
+                        setUserInfoToSession(request, userName, password);
                         request.getSession().setAttribute("cl", cl); // nosemgrep: tainted-session-from-http-request
                     } catch (Exception e) {
                         throw new RuntimeException(e);
@@ -661,8 +674,21 @@ public final class Login2Action extends ActionSupport {
                 ArrayList<String> newDocArr = (ArrayList<String>) request.getSession().getServletContext()
                         .getAttribute("CaseMgmtUsers");
                 if ("enabled".equals(providerPreference.getDefaultNewOscarCme())) {
-                    newDocArr.add(providerNo);
-                    session.setAttribute("CaseMgmtUsers", newDocArr); // nosemgrep: tainted-session-from-http-request
+                    // Re-validate providerNo before mutating the ServletContext-scoped list
+                    // (shared across all user sessions). Prevents an unvalidated value from
+                    // leaking into other users' sessions via the shared reference.
+                    if (Pattern.matches("[A-Za-z0-9_-]{1,20}", providerNo)) {
+                        synchronized (newDocArr) {
+                            if (!newDocArr.contains(providerNo)) {
+                                newDocArr.add(providerNo);
+                            }
+                        }
+                        // Store a defensive copy in the session so this user's view of the
+                        // list cannot be mutated by another user's login flow.
+                        session.setAttribute("CaseMgmtUsers", new ArrayList<>(newDocArr)); // nosemgrep: tainted-session-from-http-request -- providerNo regex-validated; defensive copy prevents shared-reference leakage
+                    } else {
+                        logger.warn("Rejected invalid providerNo for CaseMgmtUsers list: {}", LogSanitizer.sanitize(providerNo));
+                    }
                 }
             }
             session.setAttribute("starthour", providerPreference.getStartHour().toString()); // nosemgrep: tainted-session-from-http-request
@@ -871,15 +897,18 @@ public final class Login2Action extends ActionSupport {
      * <ul>
      *   <li>userName - The authenticated username</li>
      *   <li>password - The encoded password hash</li>
-     *   <li>pin - The provider PIN code</li>
-     *   <li>nextPage - The post-authentication redirect target</li>
      * </ul>
+     *
+     * <p>Also removes the legacy {@code pin} and {@code nextPage} session keys for
+     * backward-compatibility with sessions created before those fields were moved off
+     * the session entirely.
      *
      * @param request HttpServletRequest containing the session to clean
      */
     private void removeAttributesFromSession(HttpServletRequest request) {
         request.getSession().removeAttribute("userName");
         request.getSession().removeAttribute("password");
+        // Legacy keys — no longer written, but cleared for sessions that predate the change.
         request.getSession().removeAttribute("pin");
         request.getSession().removeAttribute("nextPage");
     }
@@ -887,48 +916,43 @@ public final class Login2Action extends ActionSupport {
     /**
      * Stores user authentication information in the session for forced password reset flow.
      *
-     * <p>During the forced password reset process, the user's credentials are temporarily
-     * stored in the session so they can be re-authenticated after successfully changing
-     * their password. The password is encoded before storage for security.
+     * <p>During the forced-password-change and MFA flows, the username and hashed password
+     * are temporarily stashed in the session so the user can be identified on return from
+     * the relevant prompt page. The password is SHA-1 hashed before storage.
      *
-     * <p>The {@code nextPage} parameter is validated against open redirect (CWE-601) before
-     * being stored. Any value that is absolute, protocol-relative, or contains backslash
-     * bypasses is rejected and stored as {@code null} (defense in depth).
+     * <p><strong>What is NOT stored (by design):</strong>
+     * <ul>
+     *   <li><b>PIN</b> — never written to the session. The PIN is a second authentication
+     *       factor; storing it in session even transiently expands the attack surface for
+     *       session-hijack / XSS vectors. After a successful password reset, the user is
+     *       redirected to the login page and re-enters their PIN fresh.</li>
+     *   <li><b>nextPage</b> — never written to the session. A session-stored redirect target
+     *       is a latent CWE-601 vector (the attribute can resurface outside the validation
+     *       context). Callers propagate nextPage via the URL / hidden form fields instead,
+     *       and re-validate with {@link RedirectValidationUtils} at each read.</li>
+     * </ul>
      *
      * <p>Session attributes set:
      * <ul>
      *   <li>userName - String the authenticated username (validated alphanumeric)</li>
      *   <li>password - String the SHA-encoded password hash</li>
-     *   <li>pin - String the 4-digit provider PIN</li>
-     *   <li>nextPage - String the validated relative URL, or null if invalid/absent</li>
      * </ul>
      *
      * @param request HttpServletRequest to access the session
      * @param userName String the username (must match [a-zA-Z0-9]{1,10} pattern)
-     * @param password String the plain-text password (will be encoded before storage)
-     * @param pin String the 4-digit PIN (must match [0-9]{4} pattern)
-     * @param nextPage String the relative URL to redirect to after password reset (validated before storage)
+     * @param password String the plain-text password (will be SHA-1 encoded before storage)
      * @throws Exception if password encoding fails
      * @see #encodePassword for password encoding algorithm
      * @see #removeAttributesFromSession for cleanup after password reset
-     * @see RedirectValidationUtils#isValidRelativeRedirect for redirect URL validation logic
      */
-    private void setUserInfoToSession(HttpServletRequest request, String userName, String password, String pin,
-                                      String nextPage) throws Exception {
-        // Login credentials stored temporarily for forced password change flow; cleared after login via removeAttributesFromSession()
-        request.getSession().setAttribute("userName", userName); // nosemgrep: tainted-session-from-http-request -- validated via Pattern [a-zA-Z0-9]{1,10} at login entry; temporary storage for MFA flow
-        request.getSession().setAttribute("password", encodePassword(password)); // nosemgrep: tainted-session-from-http-request -- SHA-1 hashed via encodePassword() before session storage; never stored as plaintext
-        request.getSession().setAttribute("pin", pin); // nosemgrep: tainted-session-from-http-request -- validated via Pattern [0-9]{4} at login entry; temporary storage for MFA flow
-        // Validate nextPage before session storage to prevent open redirect via session (CWE-601 defense in depth)
-        if (!RedirectValidationUtils.isValidRelativeRedirect(nextPage)) {
-            if (nextPage != null) {
-                logger.warn("Rejected invalid nextPage before session storage: {}", LogSanitizer.sanitize(nextPage));
-            }
-            nextPage = null;
-        }
-        // nextPage validated via RedirectValidationUtils above
-        request.getSession().setAttribute("nextPage", nextPage); // nosemgrep: tainted-session-from-http-request
-
+    private void setUserInfoToSession(HttpServletRequest request, String userName, String password) throws Exception {
+        // Only the username + hashed password are stashed for the forced-password-change
+        // round-trip. PIN and nextPage are NOT stored in session (CWE-601 / session-data-
+        // exposure defence — see Login2Action Javadoc on the forced-password-change flow).
+        // PIN is re-entered by the user after successful reset; nextPage is propagated
+        // as a request parameter via forcepasswordreset.jsp's hidden form field.
+        request.getSession().setAttribute("userName", userName); // nosemgrep: tainted-session-from-http-request -- validated via Pattern [a-zA-Z0-9]{1,10} at login entry
+        request.getSession().setAttribute("password", encodePassword(password)); // nosemgrep: tainted-session-from-http-request -- SHA-1 hashed via encodePassword() before session storage
     }
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/login/Login2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/login/Login2Action.java
@@ -396,6 +396,11 @@ public final class Login2Action extends ActionSupport {
                 if (errorStr != null && !errorStr.isEmpty()) {
                     String newURL = request.getContextPath() + "/forcepasswordreset.jsp";
                     newURL = newURL + errorStr;
+                    // Re-append nextPage so it is not lost when the user corrects errors and
+                    // re-submits the password-reset form. nextPage was already validated above.
+                    if (nextPage != null) {
+                        newURL = newURL + "&nextPage=" + Encode.forUriComponent(nextPage);
+                    }
                     response.sendRedirect(newURL);
                     return NONE;
                 }
@@ -677,15 +682,18 @@ public final class Login2Action extends ActionSupport {
                     // Re-validate providerNo before mutating the ServletContext-scoped list
                     // (shared across all user sessions). Prevents an unvalidated value from
                     // leaking into other users' sessions via the shared reference.
-                    if (Pattern.matches("[A-Za-z0-9_-]{1,20}", providerNo)) {
+                    if (newDocArr == null) {
+                        // CaseMgmtUsers is initialised by Startup.java; null means startup failed.
+                        logger.warn("CaseMgmtUsers list not initialised in ServletContext; skipping list update");
+                    } else if (Pattern.matches("[A-Za-z0-9_-]{1,20}", providerNo)) {
                         synchronized (newDocArr) {
                             if (!newDocArr.contains(providerNo)) {
                                 newDocArr.add(providerNo);
                             }
+                            // Store a defensive copy inside the synchronized block so the session
+                            // snapshot is consistent and cannot race with a concurrent login's add().
+                            session.setAttribute("CaseMgmtUsers", new ArrayList<>(newDocArr)); // nosemgrep: tainted-session-from-http-request -- providerNo regex-validated; defensive copy prevents shared-reference leakage
                         }
-                        // Store a defensive copy in the session so this user's view of the
-                        // list cannot be mutated by another user's login flow.
-                        session.setAttribute("CaseMgmtUsers", new ArrayList<>(newDocArr)); // nosemgrep: tainted-session-from-http-request -- providerNo regex-validated; defensive copy prevents shared-reference leakage
                     } else {
                         logger.warn("Rejected invalid providerNo for CaseMgmtUsers list: {}", LogSanitizer.sanitize(providerNo));
                     }

--- a/src/main/java/io/github/carlos_emr/carlos/login/Login2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/login/Login2Action.java
@@ -353,6 +353,8 @@ public final class Login2Action extends ActionSupport {
         String password = "";
         String pin = "";
         String nextPage = "";
+        // Destination carried from a forced-password-reset round-trip; validated before use.
+        String postLoginRedirect = null;
         boolean forcedpasswordchange = true;
         String where = "failure";
 
@@ -413,10 +415,11 @@ public final class Login2Action extends ActionSupport {
                 // Password changed successfully. Rather than re-authenticating inline
                 // (which would require the PIN to survive the round-trip via session),
                 // redirect the user to the login page so they re-enter full credentials
-                // with their new password. nextPage is preserved as a query parameter.
+                // with their new password. postLoginRedirect carries the original destination
+                // through the re-login form without colliding with the facility-selection nextPage flow.
                 String loginUrl = request.getContextPath() + "/index.jsp?msg=password_changed";
                 if (nextPage != null) {
-                    loginUrl = loginUrl + "&nextPage=" + Encode.forUriComponent(nextPage);
+                    loginUrl = loginUrl + "&postLoginRedirect=" + Encode.forUriComponent(nextPage);
                 }
                 response.sendRedirect(loginUrl);
                 return NONE;
@@ -447,6 +450,14 @@ public final class Login2Action extends ActionSupport {
                 pin = "";
             }
             nextPage = request.getParameter("nextPage");
+
+            // Post-password-reset re-login: the login form carries the original destination as
+            // postLoginRedirect (distinct from nextPage which is used for facility-selection return).
+            postLoginRedirect = request.getParameter("postLoginRedirect");
+            if (postLoginRedirect != null && !RedirectValidationUtils.isValidRelativeRedirect(postLoginRedirect)) {
+                logger.warn("Rejected invalid postLoginRedirect on login: {}", LogSanitizer.sanitize(postLoginRedirect));
+                postLoginRedirect = null;
+            }
 
             logger.debug("nextPage: {}", LogSanitizer.sanitize(nextPage));
             if (nextPage != null) {
@@ -763,6 +774,15 @@ public final class Login2Action extends ActionSupport {
                     request.getSession().setAttribute("currentFacility", facility); // nosemgrep: tainted-session-from-http-request
                     LogAction.addLog(strAuth[0], LogConst.LOGIN, LogConst.CON_LOGIN, "facilityId=" + first_id, ip);
                 }
+            }
+
+            // Post-password-reset re-login: redirect to the original destination after full
+            // session and facility setup. Only reachable here for single-facility and
+            // no-facility providers; multi-facility providers were already redirected to
+            // select_facility.jsp above and will land on the default post-login page.
+            if (postLoginRedirect != null) {
+                response.sendRedirect(postLoginRedirect);
+                return NONE;
             }
 
             if (UserRoleUtils.hasRole(request, "Patient Intake")) {

--- a/src/main/java/io/github/carlos_emr/carlos/login/Login2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/login/Login2Action.java
@@ -780,8 +780,11 @@ public final class Login2Action extends ActionSupport {
             // session and facility setup. Only reachable here for single-facility and
             // no-facility providers; multi-facility providers were already redirected to
             // select_facility.jsp above and will land on the default post-login page.
+            // postLoginRedirect is validated by RedirectValidationUtils.isValidRelativeRedirect()
+            // at line ~457 before reaching this branch (only relative, same-origin paths allowed;
+            // absolute URIs, protocol-relative URLs, backslash bypasses and path-traversal rejected).
             if (postLoginRedirect != null) {
-                response.sendRedirect(postLoginRedirect);
+                response.sendRedirect(postLoginRedirect); // nosemgrep: javasecurity.S5146, java.lang.security.audit.servlets.unvalidated-redirect.unvalidated-redirect-java -- gated by RedirectValidationUtils.isValidRelativeRedirect() before entering this branch // lgtm[java/unvalidated-url-redirection]
                 return NONE;
             }
 

--- a/src/main/resources/oscarResources_en.properties
+++ b/src/main/resources/oscarResources_en.properties
@@ -34,6 +34,7 @@ loginApplication.propertyFile=oscar_mcmaster
 loginApplication.title=CARLOS
 loginApplication.formLabel=CARLOS
 loginApplication.formFailedLabel=Login failed. Username or Password is incorrect.
+loginApplication.passwordChangedLabel=Password changed successfully. Please log in with your new password.
 loginApplication.formUserName=User Name:
 loginApplication.formPwd=Password:
 loginApplication.formCmt=for external Wide Area Network access

--- a/src/main/resources/oscarResources_es.properties
+++ b/src/main/resources/oscarResources_es.properties
@@ -36,6 +36,7 @@ loginApplication.propertyFile=oscar_mcmaster
 loginApplication.title=CARLOS
 loginApplication.formLabel=ENTRAR
 loginApplication.formFailedLabel=Usuario o clave incorrectos
+loginApplication.passwordChangedLabel=Contrase\u00f1a cambiada correctamente. Por favor, inicie sesi\u00f3n con su nueva contrase\u00f1a.
 loginApplication.formUserName=Usuario:
 loginApplication.formPwd=Clave:
 loginApplication.formCmt=para acceso externo a la red local

--- a/src/main/resources/oscarResources_fr.properties
+++ b/src/main/resources/oscarResources_fr.properties
@@ -33,6 +33,7 @@ loginApplication.propertyFile=oscar_mcmaster
 loginApplication.title=CARLOS
 loginApplication.formLabel=Connexion
 loginApplication.formFailedLabel=Nom d'utilisateur ou mot de passe incorrect
+loginApplication.passwordChangedLabel=Mot de passe modifi\u00e9 avec succ\u00e8s. Veuillez vous connecter avec votre nouveau mot de passe.
 loginApplication.formUserName=Nom d'utilisateur \:
 loginApplication.formPwd=Mot de passe \:
 loginApplication.formCmt=pour l'acc\u00e8s au r\u00e9seau \u00e9tendu externe

--- a/src/main/resources/oscarResources_pl.properties
+++ b/src/main/resources/oscarResources_pl.properties
@@ -28,6 +28,7 @@ loginApplication.propertyFile=oscar_mcmaster
 loginApplication.title=CARLOS
 loginApplication.formLabel=LOGIN
 loginApplication.formFailedLabel=Niepoprawna nazwa u&#X17c;ytkownika lub has&#X142;o
+loginApplication.passwordChangedLabel=Has\u0142o zmienione pomyslnie. Zaloguj sie uzywajac nowego has\u0142a.
 loginApplication.formUserName=Nazwa u&#X17c;ytkownika:
 loginApplication.formPwd=Has&#X142;o:
 loginApplication.formCmt=zewn&#X119;trznego dost&#X119;pu do sieci rozleg&#X142;ej

--- a/src/main/resources/oscarResources_pt_BR.properties
+++ b/src/main/resources/oscarResources_pt_BR.properties
@@ -117,6 +117,7 @@ loginApplication.propertyFile=oscar_mcmaster
 loginApplication.title=CARLOS
 loginApplication.formLabel=Login
 loginApplication.formFailedLabel=Login Incorreto
+loginApplication.passwordChangedLabel=Senha alterada com sucesso. Por favor, fa\u00e7a login com sua nova senha.
 loginApplication.formUserName= Usu\u00E1rio
 loginApplication.formPwd=Senha
 loginApplication.formCmt=Acesso remoto 

--- a/src/main/webapp/forcepasswordreset.jsp
+++ b/src/main/webapp/forcepasswordreset.jsp
@@ -29,6 +29,7 @@
 
 --%>
 
+<%@ page import="io.github.carlos_emr.carlos.utility.RedirectValidationUtils" %>
 <%
     //Make sure user has logged in first and username is in the session
 
@@ -38,6 +39,13 @@
     String errormsg = "";
     if (request.getParameter("errormsg") != null) {
         errormsg = request.getParameter("errormsg");
+    }
+    // nextPage is passed as a query parameter from Login2Action (not session) to
+    // avoid CWE-601 session-persisted redirect. Validate here before propagating as
+    // a hidden form field so a rejected value never reaches the page.
+    String nextPageParam = request.getParameter("nextPage");
+    if (nextPageParam != null && !RedirectValidationUtils.isValidRelativeRedirect(nextPageParam)) {
+        nextPageParam = null;
     }
 %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
@@ -274,6 +282,16 @@
         </table>
 
         <input type=hidden name='forcedpasswordchange' value='true'/>
+        <%
+            // nextPage carried forward as a hidden form field so it survives the
+            // password-reset round-trip without ever touching the session (CWE-601
+            // defence). Value was validated server-side above.
+            if (nextPageParam != null) {
+        %>
+        <input type="hidden" name="nextPage" value="<%= Encode.forHtmlAttribute(nextPageParam) %>"/>
+        <%
+            }
+        %>
 
     </form>
     </body>

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -32,6 +32,8 @@
 
 <%@ page import="io.github.carlos_emr.carlos.login.UAgentInfo" %>
 <%@ page import="io.github.carlos_emr.carlos.managers.MfaManager" %>
+<%@ page import="io.github.carlos_emr.carlos.utility.RedirectValidationUtils" %>
+<%@ page import="org.owasp.encoder.Encode" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <fmt:setBundle basename="oscarResources"/>
 <%@ taglib uri='jakarta.tags.core' prefix="c" %>
@@ -50,6 +52,15 @@
     // Show a success banner so the user knows why they are being asked to log in again.
     boolean passwordChangedMsg = "password_changed".equals(request.getParameter("msg"));
     pageContext.setAttribute("passwordChangedMsg", passwordChangedMsg);
+
+    // Carry postLoginRedirect through the login form for post-password-reset re-login flow.
+    // Login2Action sets this to the original destination the user was trying to reach before
+    // the forced-password-change intercepted them. Validated server-side here (CWE-601).
+    String postLoginRedirectParam = request.getParameter("postLoginRedirect");
+    if (postLoginRedirectParam != null && !RedirectValidationUtils.isValidRelativeRedirect(postLoginRedirectParam)) {
+        postLoginRedirectParam = null;
+    }
+    pageContext.setAttribute("postLoginRedirect", postLoginRedirectParam);
 %>
 
 <jsp:useBean id="LoginResourceBean" beanName="io.github.carlos_emr.carlos.login.LoginResourceBean" type="io.github.carlos_emr.carlos.login.LoginResourceBean"/>
@@ -686,6 +697,11 @@ body {
                             <input type="hidden" id="loginType" name="loginType" value="">
                             <input type=hidden name='propname'
                                    value='<fmt:message key="loginApplication.propertyFile"/>'>
+                            <%-- Carry postLoginRedirect through the login POST for post-password-reset
+                                 re-login flow. Value is validated server-side above (CWE-601). --%>
+                            <% if (postLoginRedirectParam != null) { %>
+                            <input type="hidden" name="postLoginRedirect" value="<%= Encode.forHtmlAttribute(postLoginRedirectParam) %>"/>
+                            <% } %>
 
                             <div id="buttonContainer">
                                 <c:choose>

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -45,6 +45,11 @@
     UAgentInfo userAgentInfo = new UAgentInfo(userAgent, accept);
     boolean isMobileDevice = userAgentInfo.detectMobileQuick();
     pageContext.setAttribute("isMobileDevice", isMobileDevice);
+
+    // After a forced-password-reset, Login2Action redirects here with ?msg=password_changed.
+    // Show a success banner so the user knows why they are being asked to log in again.
+    boolean passwordChangedMsg = "password_changed".equals(request.getParameter("msg"));
+    pageContext.setAttribute("passwordChangedMsg", passwordChangedMsg);
 %>
 
 <jsp:useBean id="LoginResourceBean" beanName="io.github.carlos_emr.carlos.login.LoginResourceBean" type="io.github.carlos_emr.carlos.login.LoginResourceBean"/>
@@ -619,6 +624,13 @@ body {
                     <c:set var="login_error" value="is-invalid" scope="page"/>
                     <div class="alert">
                         <fmt:message key="loginApplication.formFailedLabel"/>
+                    </div>
+                </c:if>
+
+                <%-- Password successfully changed message (shown when returning from forced-password-reset flow). --%>
+                <c:if test="${ passwordChangedMsg }">
+                    <div class="alert alert-success" role="alert">
+                        <fmt:message key="loginApplication.passwordChangedLabel"/>
                     </div>
                 </c:if>
 


### PR DESCRIPTION
## Summary

Fixes three true-positive trust-boundary findings in `Login2Action.java` flagged by the Semgrep `tainted-session-from-http-request` rule family and SnykCode `java/TrustBoundaryViolation`.

## Fixes

### 1. `CaseMgmtUsers` cross-session leakage (line 665)
The `ArrayList<String>` at `ServletContext` scope is shared across every user session. Login was mutating it in-place with an unvalidated `providerNo` and then storing the same reference into the new user's session — a concurrent login could observe another user's providerNo via the shared list.

- `providerNo` is now regex-validated `[A-Za-z0-9_-]{1,20}` before the shared list is mutated
- List mutation is synchronised on the list
- A defensive copy (`new ArrayList<>(newDocArr)`) is stored in the session so each user's session holds an independent list

### 2. PIN no longer stored in session (line 921)
The forced-password-change flow stashed the user's PIN in session with only a `[0-9]{4}` regex guard, expecting to reuse it after password reset. Sessions can live 30 min; XSS or session fixation in that window would leak a second-factor secret.

- `setUserInfoToSession` no longer writes `pin` to the session at all (both the forced-password-change and MFA callers)
- The forced-password-change return branch now short-circuits after a successful reset: redirects to the login page with a `?msg=password_changed` flag, user re-enters their PIN fresh on the normal login form
- The MFA flow already uses the session-stashed `LoginCheckLogin` object for re-auth, not the raw PIN, so dropping the PIN stash there is also safe

### 3. `nextPage` no longer stored in session (line 930)
A session-stored redirect target is a latent CWE-601 vector — the attribute can be picked up outside the validation context or survive long enough that the originating request is out of scope.

- `setUserInfoToSession` no longer writes `nextPage` to the session
- Redirect to `forcepasswordreset.jsp` carries `nextPage` as a URL query parameter (validated via `RedirectValidationUtils` before inclusion, `Encode.forUriComponent` applied)
- `forcepasswordreset.jsp` re-validates `nextPage` server-side and echoes it as a hidden form field (HTML-attribute-encoded via `Encode.forHtmlAttribute`)
- On return to `login.do`, `nextPage` is read from the request parameter and re-validated one more time before use

## Changed

- `src/main/java/io/github/carlos_emr/carlos/login/Login2Action.java`:
  - `setUserInfoToSession` signature: 4 args → 2 args (dropped `pin` and `nextPage`)
  - Both callers (forced-password-change at line 561, MFA at line 621) updated
  - Forced-password-change return branch rewired to redirect to login page after reset instead of falling through to `cl.auth`
  - Redirect to `forcepasswordreset.jsp` now includes validated `nextPage` as query param
  - `removeAttributesFromSession` keeps clearing `pin`/`nextPage` keys for backward-compat with sessions created before this change
  - `CaseMgmtUsers` handling validated + defensive-copied

- `src/main/webapp/forcepasswordreset.jsp`:
  - Reads `nextPage` from request parameter, re-validates via `RedirectValidationUtils`
  - Echoes validated value as hidden form field (HTML-attribute-encoded)

## Why not just suppress?

All three were classified as **true positives** in the security-audit review. They're not scanner noise — each one represents a real (if small-window) data-exposure risk. Suppressing would have hidden the signal.

## Test plan

- [ ] `make install --run-unit-tests` green
- [ ] Manual: trigger forced-password-change flow, confirm user is redirected to login page after reset and must re-enter credentials
- [ ] Manual: trigger forced-password-change with `nextPage=/somewhere` query param, confirm it survives the round-trip and redirects correctly after re-login
- [ ] Manual: trigger MFA flow, confirm it still works without the PIN in session
- [ ] Manual: confirm existing session attrs from before this change are cleared by `removeAttributesFromSession` (backward-compat)
- [ ] Re-scan: confirm Semgrep/Snyk trust-boundary alerts at lines 665, 921, 930 clear

## UX note

Users in the forced-password-change flow will now be prompted to log in again after resetting their password (rather than being transparently re-authenticated). This is intentional — the re-login path ensures PIN re-entry happens through the normal authenticated channel rather than via a session-stashed copy. Forced-password-change is a rare event (initial-account setup), so the extra step is acceptable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops storing PIN and nextPage in session and tightens `providerNo` and redirect handling to close trust-boundary gaps in the login flow. Adds a safe post-reset re-login via postLoginRedirect and shows a clear success message.

- **Bug Fixes**
  - Removed PIN from session; after password reset, redirect to login (`?msg=password_changed`) and require fresh PIN. Carry the original destination as validated `postLoginRedirect` through the login form and redirect to it after successful login for single/no-facility users; suppressed the CodeQL redirect alert on this validated path.
  - Stopped storing `nextPage` in session; validate it, pass via query param to `forcepasswordreset.jsp`, re-validate in the JSP, and echo as a hidden field; preserve it on validation-error redirects back to the reset page.
  - Validated `providerNo` with `[A-Za-z0-9_-]{1,20}` before mutating the shared `CaseMgmtUsers` list; handle null list, synchronize mutation, and store a defensive copy in session inside the synchronized block.
  - Simplified `setUserInfoToSession` to `(userName, password)`; password is hashed; legacy `pin`/`nextPage` keys still cleared for backward compatibility.
  - Show password-changed success banner on `index.jsp`; added i18n key `loginApplication.passwordChangedLabel` in `oscarResources_*.properties`.

<sup>Written for commit 40c7d33b4f06931d9acb678dfe94e41959af090e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

