### PR TITLE
🎨 Palette: Add alt attributes to UI images for accessibility

### DIFF
--- a/src/main/webapp/demographic/demographiceditdemographic.jsp
+++ b/src/main/webapp/demographic/demographiceditdemographic.jsp
@@ -4293,7 +4293,7 @@
                                                                    name="paper_chart_archived_date"
                                                                    id="paper_chart_archived_date"
                                                                    value="<%=paperChartIndicatorDate%>">
-                                                            <img src="<%= request.getContextPath() %>/images/cal.gif" id="archive_date_cal">
+                                                            <img src="<%= request.getContextPath() %>/images/cal.gif" alt="Calendar" id="archive_date_cal">
 
                                                             <input type="hidden" name="paper_chart_archived_program"
                                                                    id="paper_chart_archived_program"
@@ -4759,7 +4759,7 @@
                                                                                                 id="waiting_list_referral_date"
                                                                                                 size="11"
                                                                                                 value="<%=wlReferralDate%>" <%=wLReadonly%>><img
-                                                                                src="<%= request.getContextPath() %>/images/cal.gif"
+                                                                                src="<%= request.getContextPath() %>/images/cal.gif" alt="Calendar"
                                                                                 id="referral_date_cal">
                                                                         </td>
                                                                         <td><!-- padding --></td>

--- a/src/main/webapp/demographic/demographicsearch2reportresults.jsp
+++ b/src/main/webapp/demographic/demographicsearch2reportresults.jsp
@@ -346,7 +346,7 @@
     </form>
 </CENTER>
 <a href="#" onClick="history.go(-1);return false;">
-    <img src="<%= request.getContextPath() %>/images/leftarrow.gif" border="0" width="25" height="20" align="absmiddle"> Back
+    <img src="<%= request.getContextPath() %>/images/leftarrow.gif" alt="" border="0" width="25" height="20" align="absmiddle"> Back
 </a>
 </body>
 </html>

--- a/src/main/webapp/demographic/footer.jsp
+++ b/src/main/webapp/demographic/footer.jsp
@@ -38,7 +38,7 @@
 <table border="0" cellspacing="0" cellpadding="0" width="100%">
     <tr>
         <td><a href="search.jsp"> <img src="<%= request.getContextPath() %>/images/leftarrow.gif"
-                                       border="0" width="25" height="20" align="absmiddle"> <fmt:message key="demographic.footer.btnBack"/></a></td>
+                                       alt="" border="0" width="25" height="20" align="absmiddle"> <fmt:message key="demographic.footer.btnBack"/></a></td>
 
         <td align="right">
             <caisi:isModuleLoad moduleName="caisi">
@@ -48,7 +48,7 @@
                 <a href="#" onClick="self.close();">
                     </caisi:isModuleLoad>
                     <fmt:message key="demographic.footer.btnClose"/><img
-                        src="<%= request.getContextPath() %>/images/rightarrow.gif" border="0" width="25" height="20"
+                        src="<%= request.getContextPath() %>/images/rightarrow.gif" alt="" border="0" width="25" height="20"
                         align="absmiddle"></a>
 
         </td>


### PR DESCRIPTION
💡 What: Added missing `alt` attributes to image icons in demographic JSPs.
🎯 Why: Improves screen reader accessibility. Directional icons received empty `alt` attributes to be ignored since adjacent text is present, while calendar icons received descriptive `alt` tags.
📸 Before/After: Visuals remain unchanged, but screen readers will better navigate the page.
♿ Accessibility: Ensures decorative images are hidden from screen readers and functional ones are described.

---
*PR created automatically by Jules for task [14880454769178116470](https://jules.google.com/task/14880454769178116470) started by @yingbull*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added missing alt attributes to UI images across demographic JSPs to improve screen reader accessibility. Decorative left/right arrows now use empty alt so they’re ignored, and calendar icons use alt="Calendar"; visuals unchanged.

<sup>Written for commit 49f0e0d4642b068e3586a6bceb3c434d11b4af43. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

