### PR TITLE
[Fix] Attach demographic and autocomplete in CreateMessage.jsp

### DIFF
--- a/src/main/webapp/demographic/demographicsearchresults.jsp
+++ b/src/main/webapp/demographic/demographicsearchresults.jsp
@@ -254,7 +254,7 @@
                     if (window.opener && !window.opener.closed) {
                         window.opener.document.forms[0].demographic_no.value = demoNo;
                         window.opener.document.forms[0].selectedDemo.value = keyword;
-                        window.opener.document.forms[0].keyword.value = '';
+                        window.opener.document.forms[0].keyword.value = keyword;
                     }
                 } catch (e) {
                     // cross-window DOM access failed; popup will still close

--- a/src/main/webapp/demographic/demographicsearchresults.jsp
+++ b/src/main/webapp/demographic/demographicsearchresults.jsp
@@ -237,14 +237,14 @@
                 }
             }
 
-            <% if (fromMessenger) { %>
             /**
              * Writes the selected patient back to the messenger compose/view form in the
              * opener window and closes this search popup.
              *
              * Uses direct DOM access (same pattern as the appointment search popup) rather
-             * than a server-side redirect through DemographicLinkMsg.do, which is unreliable
-             * after multi-hop popup navigation.
+             * than a server-side redirect through DemographicLinkMsg.do, which was unreliable
+             * after multi-hop popup navigation. Always defined; only called from onclick
+             * links rendered when fromMessenger=true, so harmless in non-messenger contexts.
              *
              * @param {string} keyword   - Patient display name (Last, First)
              * @param {string} demoNo    - Patient demographic number
@@ -261,7 +261,6 @@
                 }
                 window.close();
             }
-            <% } %>
         </SCRIPT>
     </head>
 

--- a/src/main/webapp/demographic/demographicsearchresults.jsp
+++ b/src/main/webapp/demographic/demographicsearchresults.jsp
@@ -236,6 +236,32 @@
                     popup.focus();
                 }
             }
+
+            <% if (fromMessenger) { %>
+            /**
+             * Writes the selected patient back to the messenger compose/view form in the
+             * opener window and closes this search popup.
+             *
+             * Uses direct DOM access (same pattern as the appointment search popup) rather
+             * than a server-side redirect through DemographicLinkMsg.do, which is unreliable
+             * after multi-hop popup navigation.
+             *
+             * @param {string} keyword   - Patient display name (Last, First)
+             * @param {string} demoNo    - Patient demographic number
+             */
+            function selectForMessenger(keyword, demoNo) {
+                try {
+                    if (window.opener && !window.opener.closed) {
+                        window.opener.document.forms[0].demographic_no.value = demoNo;
+                        window.opener.document.forms[0].selectedDemo.value = keyword;
+                        window.opener.document.forms[0].keyword.value = '';
+                    }
+                } catch (e) {
+                    // cross-window DOM access failed; popup will still close
+                }
+                window.close();
+            }
+            <% } %>
         </SCRIPT>
     </head>
 
@@ -407,8 +433,10 @@
                         <%
 
                             if (fromMessenger) {
+                                String messengerPatientName = Misc.toUpperLowerCase(demo.getLastName() + ", " + demo.getFirstName());
                         %>
-                        <a href="DemographicLinkMsg.do?keyword=<%=Encode.forUriComponent(Misc.toUpperLowerCase(demo.getLastName()+", "+demo.getFirstName()))%>&demographic_no=<%= Encode.forUriComponent(dem_no) %>"><%=Encode.forHtml(demo.getDemographicNo().toString())%>
+                        <a href="javascript:void(0)"
+                           onclick="selectForMessenger('<%=Encode.forJavaScriptAttribute(messengerPatientName)%>','<%=Encode.forJavaScriptAttribute(dem_no)%>')"><%=Encode.forHtml(demo.getDemographicNo().toString())%>
                         </a></td>
                     <%
                     } else {

--- a/src/main/webapp/messenger/CreateMessage.jsp
+++ b/src/main/webapp/messenger/CreateMessage.jsp
@@ -419,6 +419,14 @@ function validateFields() {
             document.forms[0].demographic_no.value = "<%=Encode.forJavaScript(demographic_no)%>";
         }
 
+        // Initialize keyword autocomplete for inline demographic search
+        initDemographicAutocomplete(
+            '<%=request.getContextPath()%>',
+            document.forms[0].keyword,
+            document.forms[0].demographic_no,
+            document.forms[0].selectedDemo
+        );
+
 	});
 </script>
 </head>

--- a/src/main/webapp/messenger/CreateMessage.jsp
+++ b/src/main/webapp/messenger/CreateMessage.jsp
@@ -594,7 +594,7 @@ function validateFields() {
 				<tr>
 					<td><br><br>&nbsp;</td>
 					<td style="width: 40%;">
-                      <input type="text" name="keyword" class="form-control"> <input type="hidden" name="demographic_no" value="<%=Encode.forHtmlAttribute(demographic_no)%>" >
+                      <input type="text" name="keyword" id="keyword" class="form-control"> <input type="hidden" name="demographic_no" value="<%=Encode.forHtmlAttribute(demographic_no)%>" >
                     </td>
 	                <td>
                       <input type="button" class="btn btn-outline-secondary" name="searchDemo" value="<fmt:message key="messenger.CreateMessage.msgSearchDemographic" />" onclick="popupSearchDemo(document.forms[0].keyword.value)" >

--- a/src/main/webapp/messenger/ViewMessage.jsp
+++ b/src/main/webapp/messenger/ViewMessage.jsp
@@ -706,12 +706,15 @@ function fmtOscarMsg() {
 </script>
 <script>
     // Initialize keyword autocomplete for inline demographic search
-    initDemographicAutocomplete(
-        '<%=request.getContextPath()%>',
-        document.forms[0].keyword,
-        document.forms[0].demographic_no,
-        document.forms[0].selectedDemo
-    );
+    // Only run when the demographic form fields exist (not in encounter view)
+    if (document.forms[0] && document.forms[0].keyword && document.forms[0].demographic_no && document.forms[0].selectedDemo) {
+        initDemographicAutocomplete(
+            '<%=request.getContextPath()%>',
+            document.forms[0].keyword,
+            document.forms[0].demographic_no,
+            document.forms[0].selectedDemo
+        );
+    }
 </script>
 </body>
 </html>

--- a/src/main/webapp/messenger/ViewMessage.jsp
+++ b/src/main/webapp/messenger/ViewMessage.jsp
@@ -554,7 +554,7 @@ function fmtOscarMsg() {
 
 						<tr class="DoNotPrint">
 							<td></td>
-							<td><input type="text" name="keyword"
+							<td><input type="text" name="keyword" id="keyword"
 								class="form-control" />
 							</td>
 							<td>
@@ -703,6 +703,15 @@ function fmtOscarMsg() {
         document.getElementById('viewer').parentNode.insertBefore(warning, document.getElementById('viewer'));
     }
 
+</script>
+<script>
+    // Initialize keyword autocomplete for inline demographic search
+    initDemographicAutocomplete(
+        '<%=request.getContextPath()%>',
+        document.forms[0].keyword,
+        document.forms[0].demographic_no,
+        document.forms[0].selectedDemo
+    );
 </script>
 </body>
 </html>

--- a/src/main/webapp/messenger/messenger-common.js
+++ b/src/main/webapp/messenger/messenger-common.js
@@ -145,6 +145,11 @@ function initDemographicAutocomplete(contextPath, keywordInput, demoNoInput, sel
 
     keywordInput.addEventListener('input', function () {
         var term = keywordInput.value;
+        // Clear any previously selected demographic when user edits the keyword
+        demoNoInput.value = '';
+        if (selectedDemoInput) {
+            selectedDemoInput.value = '';
+        }
         if (term.length < minLength) {
             closeDropdown();
             return;
@@ -152,13 +157,14 @@ function initDemographicAutocomplete(contextPath, keywordInput, demoNoInput, sel
         if (currentXhr) {
             currentXhr.abort();
         }
-        currentXhr = new XMLHttpRequest();
-        currentXhr.open('POST', searchUrl, true);
-        currentXhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
-        currentXhr.onload = function () {
-            if (currentXhr.status >= 200 && currentXhr.status < 300) {
+        var xhr = new XMLHttpRequest();
+        currentXhr = xhr;
+        var searchUrlWithQuery = searchUrl + '?jqueryJSON=true&activeOnly=true&term=' + encodeURIComponent(term);
+        xhr.open('GET', searchUrlWithQuery, true);
+        xhr.onload = function () {
+            if (xhr.status >= 200 && xhr.status < 300) {
                 try {
-                    renderItems(JSON.parse(currentXhr.responseText));
+                    renderItems(JSON.parse(xhr.responseText));
                 } catch (e) {
                     closeDropdown();
                 }
@@ -166,8 +172,8 @@ function initDemographicAutocomplete(contextPath, keywordInput, demoNoInput, sel
                 closeDropdown();
             }
         };
-        currentXhr.onerror = function () { closeDropdown(); };
-        currentXhr.send('jqueryJSON=true&activeOnly=true&term=' + encodeURIComponent(term));
+        xhr.onerror = function () { closeDropdown(); };
+        xhr.send(null);
     });
 
     // Delay closing so a mousedown on a list item fires before input blur closes the dropdown.

--- a/src/main/webapp/messenger/messenger-common.js
+++ b/src/main/webapp/messenger/messenger-common.js
@@ -61,3 +61,124 @@ function popupSearchDemo(keyword) {
         popUp.focus();
     }
 }
+
+/**
+ * Initializes a demographic keyword autocomplete on messenger pages.
+ *
+ * Posts to SearchDemographic.do via XMLHttpRequest so that CSRFGuard's XHR
+ * override automatically injects the session token. Renders an inline dropdown
+ * of matching patient records beneath the keyword input.
+ *
+ * Selecting an item:
+ *   - Sets keywordInput to the patient's formatted name
+ *   - Sets demoNoInput (hidden) to the patient's demographic number
+ *   - Optionally sets selectedDemoInput (read-only display) to the formatted name
+ *
+ * @param {string}           contextPath       - Application context path (e.g. "/carlos")
+ * @param {HTMLInputElement} keywordInput      - Visible keyword search text input
+ * @param {HTMLInputElement} demoNoInput       - Hidden demographic_no input
+ * @param {HTMLInputElement} [selectedDemoInput] - Optional read-only selected-name display input
+ */
+function initDemographicAutocomplete(contextPath, keywordInput, demoNoInput, selectedDemoInput) {
+    var searchUrl = contextPath + '/demographic/SearchDemographic.do';
+    var minLength = 2;
+    var currentXhr = null;
+
+    // Wrap the keyword input in a relatively-positioned container so the dropdown
+    // can be absolutely positioned directly beneath it.
+    var wrapper = document.createElement('div');
+    wrapper.style.cssText = 'position:relative; display:block;';
+    keywordInput.parentNode.insertBefore(wrapper, keywordInput);
+    wrapper.appendChild(keywordInput);
+
+    var dropdown = document.createElement('ul');
+    dropdown.className = 'demographic-autocomplete-list';
+    dropdown.style.cssText = 'position:absolute; z-index:9999; background:#fff;'
+        + ' border:1px solid #ced4da; border-radius:0 0 .25rem .25rem; margin:0; padding:0;'
+        + ' list-style:none; width:100%; max-height:220px; overflow-y:auto; display:none;'
+        + ' box-shadow:0 4px 8px rgba(0,0,0,.15);';
+    wrapper.appendChild(dropdown);
+
+    function closeDropdown() {
+        dropdown.style.display = 'none';
+        dropdown.innerHTML = '';
+    }
+
+    function selectItem(item) {
+        var name = item.formattedName || item.label || '';
+        keywordInput.value = name;
+        demoNoInput.value = item.value || item.demographicNo || '';
+        if (selectedDemoInput) {
+            selectedDemoInput.value = name;
+        }
+        closeDropdown();
+    }
+
+    function renderItems(items) {
+        dropdown.innerHTML = '';
+        if (!items || items.length === 0) {
+            closeDropdown();
+            return;
+        }
+        items.forEach(function (item) {
+            var li = document.createElement('li');
+            li.style.cssText = 'padding:6px 10px; cursor:pointer; border-bottom:1px solid #f0f0f0; font-size:0.9em;';
+            var bold = document.createElement('b');
+            bold.textContent = item.label || item.formattedName || '';
+            li.appendChild(bold);
+            if (item.provider) {
+                li.appendChild(document.createElement('br'));
+                li.appendChild(document.createTextNode(item.provider));
+            }
+            li.addEventListener('mouseover', function () { li.style.backgroundColor = '#e9ecef'; });
+            li.addEventListener('mouseout', function () { li.style.backgroundColor = ''; });
+            // mousedown fires before blur so the item click is not swallowed by the
+            // input losing focus first.
+            li.addEventListener('mousedown', function (e) {
+                e.preventDefault();
+                selectItem(item);
+            });
+            dropdown.appendChild(li);
+        });
+        dropdown.style.display = 'block';
+    }
+
+    keywordInput.addEventListener('input', function () {
+        var term = keywordInput.value;
+        if (term.length < minLength) {
+            closeDropdown();
+            return;
+        }
+        if (currentXhr) {
+            currentXhr.abort();
+        }
+        currentXhr = new XMLHttpRequest();
+        currentXhr.open('POST', searchUrl, true);
+        currentXhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
+        currentXhr.onload = function () {
+            if (currentXhr.status >= 200 && currentXhr.status < 300) {
+                try {
+                    renderItems(JSON.parse(currentXhr.responseText));
+                } catch (e) {
+                    closeDropdown();
+                }
+            } else {
+                closeDropdown();
+            }
+        };
+        currentXhr.onerror = function () { closeDropdown(); };
+        currentXhr.send('jqueryJSON=true&activeOnly=true&term=' + encodeURIComponent(term));
+    });
+
+    // Delay closing so a mousedown on a list item fires before input blur closes the dropdown.
+    keywordInput.addEventListener('blur', function () {
+        setTimeout(closeDropdown, 200);
+    });
+
+    // Close if user clicks anywhere outside the autocomplete wrapper.
+    document.addEventListener('click', function (e) {
+        if (!wrapper.contains(e.target)) {
+            closeDropdown();
+        }
+    });
+}


### PR DESCRIPTION
<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description
the search buttons in CreateMessage.jsp and ViewMessage.jsp, do not work, they seem to go to src/main/webapp/messenger/msgSearchDemo.jsp then to carlos/demographic/DemographicSearch.do when you select a demo it goes to DemographicLinkMsg.do?keyword=Test%2C Patient&demographic_no=1 and never return to the original page either CreateMessage.jsp or ViewMessage.jsp
<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues
FIxes #1604 
<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?
yesterdays build
<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Enhancements:
- Add an id attribute to the keyword text input in the Create Message JSP to facilitate DOM access or styling.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes demographic attachment in Messenger by replacing the popup flow with direct write-back to the opener and adding inline autocomplete to the `keyword` field on Create/View Message. Ensures the popup closes reliably and repopulates `keyword` and the selected patient; fulfills Linear 1604.

- **New Features & Fixes**
  - Added initDemographicAutocomplete() in messenger-common.js; enabled on both pages. Selection fills `keyword`, `demographic_no`, and `selectedDemo`. Added id="keyword".
  - In demographicsearchresults.jsp, replaced DemographicLinkMsg.do with selectForMessenger() to write back values (including `keyword`) and close the popup; defined unconditionally to resolve a JSP scope error.

<sup>Written for commit d65327075aa46bb473f2b1d950be00b8dd291265. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





