### PR TITLE
Fix/falsepositivetaint

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/admin/web/AdminNewGroup2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/admin/web/AdminNewGroup2Action.java
@@ -38,7 +38,6 @@ import org.apache.struts2.ServletActionContext;
  * POSTs to the separate {@code AdminSaveMyGroup.do} action endpoint.</p>
  *
  * @since 2026-04-05
- * @throws SecurityException if the logged-in user lacks the required admin privilege
  */
 public class AdminNewGroup2Action extends ActionSupport {
 

--- a/src/main/java/io/github/carlos_emr/carlos/admin/web/AdminSaveMyGroup2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/admin/web/AdminSaveMyGroup2Action.java
@@ -39,7 +39,6 @@ import org.apache.struts2.ServletActionContext;
  * All group save logic is handled by the JSP.</p>
  *
  * @since 2026-04-05
- * @throws SecurityException if the logged-in user lacks the required admin privilege
  */
 public class AdminSaveMyGroup2Action extends ActionSupport {
 

--- a/src/main/java/io/github/carlos_emr/carlos/admin/web/BillingSettings2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/admin/web/BillingSettings2Action.java
@@ -37,7 +37,6 @@ import org.apache.struts2.ServletActionContext;
  * POST enforcement for save operations is handled by the JSP itself.</p>
  *
  * @since 2026-04-05
- * @throws SecurityException if the logged-in user lacks the required admin privilege
  */
 public class BillingSettings2Action extends ActionSupport {
 

--- a/src/main/java/io/github/carlos_emr/carlos/admin/web/DemographicMergeRecord2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/admin/web/DemographicMergeRecord2Action.java
@@ -37,7 +37,6 @@ import org.apache.struts2.ServletActionContext;
  * The JSP handles search, display, and initiates merge/unmerge operations via a downstream {@code MergeRecords.do} action endpoint.</p>
  *
  * @since 2026-04-05
- * @throws SecurityException if the logged-in user lacks the required admin privilege
  */
 public class DemographicMergeRecord2Action extends ActionSupport {
 

--- a/src/main/java/io/github/carlos_emr/carlos/admin/web/DisplayDocumentDescriptionTemplate2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/admin/web/DisplayDocumentDescriptionTemplate2Action.java
@@ -38,7 +38,6 @@ import org.apache.struts2.ServletActionContext;
  * action endpoints.</p>
  *
  * @since 2026-04-05
- * @throws SecurityException if the logged-in user lacks the required admin privilege
  */
 public class DisplayDocumentDescriptionTemplate2Action extends ActionSupport {
 

--- a/src/main/java/io/github/carlos_emr/carlos/admin/web/GroupNoAcl2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/admin/web/GroupNoAcl2Action.java
@@ -38,7 +38,6 @@ import org.apache.struts2.ServletActionContext;
  * existed, leaving the page accessible to any authenticated user.</p>
  *
  * @since 2026-04-05
- * @throws SecurityException if the logged-in user lacks the required admin privilege
  */
 public class GroupNoAcl2Action extends ActionSupport {
 

--- a/src/main/java/io/github/carlos_emr/carlos/admin/web/LogReport2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/admin/web/LogReport2Action.java
@@ -76,7 +76,6 @@ import org.owasp.encoder.Encode;
  * </ul>
  *
  * @since 2026-04-05
- * @throws SecurityException if the logged-in user lacks the required admin privilege
  */
 public class LogReport2Action extends ActionSupport {
 

--- a/src/main/java/io/github/carlos_emr/carlos/admin/web/LotNrAddRecord2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/admin/web/LotNrAddRecord2Action.java
@@ -42,7 +42,6 @@ import org.apache.struts2.ServletActionContext;
  * duplicate active record, or creates a new {@link PreventionsLotNrs} entry otherwise.</p>
  *
  * @since 2026-04-05
- * @throws SecurityException if the logged-in user lacks the required admin privilege
  */
 public class LotNrAddRecord2Action extends ActionSupport {
 

--- a/src/main/java/io/github/carlos_emr/carlos/admin/web/LotNrDeleteRecord2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/admin/web/LotNrDeleteRecord2Action.java
@@ -42,7 +42,6 @@ import org.apache.struts2.ServletActionContext;
  * and merging the change.</p>
  *
  * @since 2026-04-05
- * @throws SecurityException if the logged-in user lacks the required admin privilege
  */
 public class LotNrDeleteRecord2Action extends ActionSupport {
 

--- a/src/main/java/io/github/carlos_emr/carlos/admin/web/LotNrSearchResults2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/admin/web/LotNrSearchResults2Action.java
@@ -37,7 +37,6 @@ import org.apache.struts2.ServletActionContext;
  * All search and display logic is handled by the JSP.</p>
  *
  * @since 2026-04-05
- * @throws SecurityException if the logged-in user lacks the required admin privilege
  */
 public class LotNrSearchResults2Action extends ActionSupport {
 

--- a/src/main/java/io/github/carlos_emr/carlos/admin/web/ManageFlowsheets2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/admin/web/ManageFlowsheets2Action.java
@@ -42,7 +42,6 @@ import org.apache.struts2.ServletActionContext;
  * then redirects (PRG pattern). GET requests return SUCCESS to render the list view.</p>
  *
  * @since 2026-04-05
- * @throws SecurityException if the logged-in user lacks the required admin privilege
  */
 public class ManageFlowsheets2Action extends ActionSupport {
 

--- a/src/main/java/io/github/carlos_emr/carlos/admin/web/ManageFlowsheetsUpload2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/admin/web/ManageFlowsheetsUpload2Action.java
@@ -40,7 +40,6 @@ import org.apache.struts2.ServletActionContext;
  * (PRG pattern).</p>
  *
  * @since 2026-04-05
- * @throws SecurityException if the logged-in user lacks the required admin privilege
  */
 public class ManageFlowsheetsUpload2Action extends ActionSupport {
 

--- a/src/main/java/io/github/carlos_emr/carlos/admin/web/ProviderAddARecord2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/admin/web/ProviderAddARecord2Action.java
@@ -39,7 +39,6 @@ import org.apache.struts2.ServletActionContext;
  * All record creation logic is handled by the JSP.</p>
  *
  * @since 2026-04-05
- * @throws SecurityException if the logged-in user lacks the required admin privilege
  */
 public class ProviderAddARecord2Action extends ActionSupport {
 

--- a/src/main/java/io/github/carlos_emr/carlos/admin/web/ProviderAddRole2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/admin/web/ProviderAddRole2Action.java
@@ -39,7 +39,6 @@ import org.apache.struts2.ServletActionContext;
  * All role add/search business logic is handled by the JSP.</p>
  *
  * @since 2026-04-05
- * @throws SecurityException if the logged-in user lacks the required admin privilege
  */
 public class ProviderAddRole2Action extends ActionSupport {
 

--- a/src/main/java/io/github/carlos_emr/carlos/admin/web/ProviderPrivilege2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/admin/web/ProviderPrivilege2Action.java
@@ -39,7 +39,6 @@ import org.apache.struts2.ServletActionContext;
  * present); non-POST requests for those operations receive HTTP 405.</p>
  *
  * @since 2026-04-05
- * @throws SecurityException if the logged-in user lacks the required admin privilege
  */
 public class ProviderPrivilege2Action extends ActionSupport {
 

--- a/src/main/java/io/github/carlos_emr/carlos/admin/web/ProviderRole2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/admin/web/ProviderRole2Action.java
@@ -41,7 +41,6 @@ import org.apache.struts2.ServletActionContext;
  * forwarded directly to the JSP.</p>
  *
  * @since 2026-04-05
- * @throws SecurityException if the logged-in user lacks the required admin privilege
  */
 public class ProviderRole2Action extends ActionSupport {
 

--- a/src/main/java/io/github/carlos_emr/carlos/admin/web/ProviderTemplate2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/admin/web/ProviderTemplate2Action.java
@@ -45,7 +45,6 @@ import org.apache.struts2.ServletActionContext;
  * and requires {@code _newCasemgmt.templates w} privilege.</p>
  *
  * @since 2026-04-05
- * @throws SecurityException if the logged-in user lacks the required admin privilege
  */
 public class ProviderTemplate2Action extends ActionSupport {
 

--- a/src/main/java/io/github/carlos_emr/carlos/admin/web/ProviderUpdate2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/admin/web/ProviderUpdate2Action.java
@@ -39,7 +39,6 @@ import org.apache.struts2.ServletActionContext;
  * All provider update logic is handled by the JSP.</p>
  *
  * @since 2026-04-05
- * @throws SecurityException if the logged-in user lacks the required admin privilege
  */
 public class ProviderUpdate2Action extends ActionSupport {
 

--- a/src/main/java/io/github/carlos_emr/carlos/admin/web/ResourceBaseUrl2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/admin/web/ResourceBaseUrl2Action.java
@@ -40,7 +40,6 @@ import org.apache.struts2.ServletActionContext;
  * forwarded directly to the JSP.</p>
  *
  * @since 2026-04-05
- * @throws SecurityException if the logged-in user lacks the required admin privilege
  */
 public class ResourceBaseUrl2Action extends ActionSupport {
 

--- a/src/main/java/io/github/carlos_emr/carlos/admin/web/SecurityAddSecurity2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/admin/web/SecurityAddSecurity2Action.java
@@ -39,7 +39,6 @@ import org.apache.struts2.ServletActionContext;
  * All add-security logic is handled by the JSP.</p>
  *
  * @since 2026-04-05
- * @throws SecurityException if the logged-in user lacks the required admin privilege
  */
 public class SecurityAddSecurity2Action extends ActionSupport {
 

--- a/src/main/java/io/github/carlos_emr/carlos/admin/web/SecurityDelete2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/admin/web/SecurityDelete2Action.java
@@ -43,7 +43,6 @@ import org.apache.struts2.ServletActionContext;
  * Performs a hard delete via {@link SecurityDao} and logs the action for the audit trail.</p>
  *
  * @since 2026-04-05
- * @throws SecurityException if the logged-in user lacks the required admin privilege
  */
 public class SecurityDelete2Action extends ActionSupport {
 

--- a/src/main/java/io/github/carlos_emr/carlos/admin/web/SecuritySearchResults2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/admin/web/SecuritySearchResults2Action.java
@@ -37,7 +37,6 @@ import org.apache.struts2.ServletActionContext;
  * All search and display logic is handled by the JSP.</p>
  *
  * @since 2026-04-05
- * @throws SecurityException if the logged-in user lacks the required admin privilege
  */
 public class SecuritySearchResults2Action extends ActionSupport {
 

--- a/src/main/java/io/github/carlos_emr/carlos/admin/web/SecurityUpdate2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/admin/web/SecurityUpdate2Action.java
@@ -39,7 +39,6 @@ import org.apache.struts2.ServletActionContext;
  * All update logic is handled by the JSP.</p>
  *
  * @since 2026-04-05
- * @throws SecurityException if the logged-in user lacks the required admin privilege
  */
 public class SecurityUpdate2Action extends ActionSupport {
 

--- a/src/main/java/io/github/carlos_emr/carlos/admin/web/UnLock2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/admin/web/UnLock2Action.java
@@ -43,7 +43,6 @@ import org.apache.struts2.ServletActionContext;
  * Always loads the current lock list into the {@code lockList} request attribute.</p>
  *
  * @since 2026-04-05
- * @throws SecurityException if the logged-in user lacks the required admin privilege
  */
 public class UnLock2Action extends ActionSupport {
 

--- a/src/main/java/io/github/carlos_emr/carlos/admin/web/UpdateDemographicProvider2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/admin/web/UpdateDemographicProvider2Action.java
@@ -37,7 +37,6 @@ import org.apache.struts2.ServletActionContext;
  * All provider reassignment logic is handled by the JSP.</p>
  *
  * @since 2026-04-05
- * @throws SecurityException if the logged-in user lacks the required admin privilege
  */
 public class UpdateDemographicProvider2Action extends ActionSupport {
 

--- a/src/main/java/io/github/carlos_emr/carlos/app/CsrfGuardScriptInjectionFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/app/CsrfGuardScriptInjectionFilter.java
@@ -275,14 +275,14 @@ public class CsrfGuardScriptInjectionFilter implements Filter {
             // count from content.getBytes(encoding) may differ from what the writer sends if
             // the response encoding changes, causing client-side truncation from a mismatched
             // header. The container computes the correct length via chunked transfer encoding.
-            response.getWriter().write(content); // nosemgrep: no-direct-response-writer -- trusted CSRF framework content
+            response.getWriter().write(content); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer, java.servlets.security.servletresponse-writer-xss.servletresponse-writer-xss, java.servlets.security.servletresponse-writer-xss-deepsemgrep.servletresponse-writer-xss-deepsemgrep -- trusted CSRF framework content
             response.getWriter().flush();
         } catch (IllegalStateException e) {
             // getWriter() failed because getOutputStream() was already called — use byte stream.
             // Content-Length is safe here since we write the exact same bytes array.
             byte[] bytes = content.getBytes(encoding);
             response.setContentLength(bytes.length);
-            response.getOutputStream().write(bytes); // nosemgrep: no-direct-response-writer -- trusted CSRF framework content
+            response.getOutputStream().write(bytes); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- trusted CSRF framework content
             response.getOutputStream().flush();
         }
     }

--- a/src/main/java/io/github/carlos_emr/carlos/billings/MSP/DocumentTeleplanReportUploadServlet.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/MSP/DocumentTeleplanReportUploadServlet.java
@@ -146,7 +146,7 @@ public class DocumentTeleplanReportUploadServlet extends HttpServlet {
                 for (int i = 0; i < 2; i++) enddata[i] = 0;
             }
             if (bwri) {
-                dest.write(data, 0, count); // nosemgrep: no-direct-response-writer -- binary file upload processing
+                dest.write(data, 0, count); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- binary file upload processing
                 for (int i = 0; i < BUFFER; i++) data[i] = 0;
             }
         } //end while

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/TeleplanSubmission.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/TeleplanSubmission.java
@@ -225,7 +225,7 @@ public class TeleplanSubmission {
         FileOutputStream out = new FileOutputStream(file);
         BufferedOutputStream bufout = new BufferedOutputStream(out);
         PrintStream p = new PrintStream(bufout);
-        p.println(fileValue); // nosemgrep: no-direct-response-writer -- MSP billing data stream
+        p.println(fileValue); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- MSP billing data stream
         p.close();
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/BillingEditCode2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/BillingEditCode2Action.java
@@ -84,7 +84,7 @@ public final class BillingEditCode2Action extends ActionSupport {
         jsonObject.put("id", id);
         MiscUtils.getLogger().debug(jsonObject.toString());
         response.setContentType("application/json;charset=UTF-8");
-        response.getOutputStream().write(jsonObject.toString().getBytes(StandardCharsets.UTF_8)); // nosemgrep: no-direct-response-writer -- JSON API response with application/json content-type
+        response.getOutputStream().write(jsonObject.toString().getBytes(StandardCharsets.UTF_8)); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- JSON API response with application/json content-type
         return null;
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/pageUtil/PaymentType2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/pageUtil/PaymentType2Action.java
@@ -115,7 +115,7 @@ public class PaymentType2Action extends ActionSupport {
                 json = objectMapper.valueToTree(retMap);
                 response.setContentType("application/json");
                 response.setCharacterEncoding("UTF-8");
-                response.getWriter().write(json.toString()); // nosemgrep: servletresponse-writer-xss, servletresponse-writer-xss-deepsemgrep -- JSON API response with application/json content-type
+                response.getWriter().write(json.toString()); // nosemgrep: java.servlets.security.servletresponse-writer-xss.servletresponse-writer-xss, java.servlets.security.servletresponse-writer-xss-deepsemgrep.servletresponse-writer-xss-deepsemgrep -- JSON API response with application/json content-type
             } catch (IOException e) {
                 // TODO Auto-generated catch block
                 MiscUtils.getLogger().info(e.toString());
@@ -157,7 +157,7 @@ public class PaymentType2Action extends ActionSupport {
                 json = objectMapper.valueToTree(retMap);
                 response.setContentType("application/json");
                 response.setCharacterEncoding("UTF-8");
-                response.getWriter().write(json.toString()); // nosemgrep: servletresponse-writer-xss, servletresponse-writer-xss-deepsemgrep -- JSON API response with application/json content-type
+                response.getWriter().write(json.toString()); // nosemgrep: java.servlets.security.servletresponse-writer-xss.servletresponse-writer-xss, java.servlets.security.servletresponse-writer-xss-deepsemgrep.servletresponse-writer-xss-deepsemgrep -- JSON API response with application/json content-type
             } catch (IOException e) {
                 // TODO Auto-generated catch block
                 MiscUtils.getLogger().info(e.toString());

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementEntry2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementEntry2Action.java
@@ -1255,7 +1255,7 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
         if (f != null && f.equals("none")) {
             response.setContentType("text/plain");
             response.setCharacterEncoding("UTF-8");
-            response.getWriter().println(note.getId());
+            response.getWriter().println(note.getId()); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- text/plain response writing numeric note id
             return null;
         }
 

--- a/src/main/java/io/github/carlos_emr/carlos/commn/web/BillingInvoice2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/web/BillingInvoice2Action.java
@@ -144,7 +144,7 @@ public class BillingInvoice2Action extends ActionSupport {
                 } catch (Exception e) {
                     MiscUtils.getLogger().error("Error", e);
                 } finally {
-                    if (fos != null) fos.close(); // nosemgrep: no-direct-response-writer -- PDF file stream close
+                    if (fos != null) fos.close(); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- PDF file stream close
                 }
             }
         }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/web/BillingONReview2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/web/BillingONReview2Action.java
@@ -87,7 +87,7 @@ public class BillingONReview2Action extends ActionSupport {
 
         String json = objectMapper.writeValueAsString(demographic);
         response.setContentType("application/json;charset=UTF-8");
-        response.getOutputStream().write(json.getBytes(StandardCharsets.UTF_8)); // nosemgrep: no-direct-response-writer -- JSON API response with application/json content-type
+        response.getOutputStream().write(json.getBytes(StandardCharsets.UTF_8)); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- JSON API response with application/json content-type
         return null;
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/commn/web/BillingreferralEdit2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/web/BillingreferralEdit2Action.java
@@ -177,7 +177,7 @@ public class BillingreferralEdit2Action extends ActionSupport {
         ArrayNode arr = objectMapper.valueToTree(checkedSpecs);
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
-        response.getWriter().print(arr); // nosemgrep: no-direct-response-writer -- JSON API response with application/json content-type
+        response.getWriter().print(arr); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- JSON API response with application/json content-type
 
         return null;
     }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/web/CodeSearchService2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/web/CodeSearchService2Action.java
@@ -70,7 +70,7 @@ public class CodeSearchService2Action extends ActionSupport {
         }
         response.setContentType("application/json");
         ArrayNode jsonArray = objectMapper.valueToTree(results);
-        response.getWriter().write(jsonArray.toString()); // nosemgrep: servletresponse-writer-xss, servletresponse-writer-xss-deepsemgrep -- JSON API response with application/json content-type
+        response.getWriter().write(jsonArray.toString()); // nosemgrep: java.servlets.security.servletresponse-writer-xss.servletresponse-writer-xss, java.servlets.security.servletresponse-writer-xss-deepsemgrep.servletresponse-writer-xss-deepsemgrep -- JSON API response with application/json content-type
 
         return null;
     }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/web/Pregnancy2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/web/Pregnancy2Action.java
@@ -379,7 +379,7 @@ public class Pregnancy2Action extends ActionSupport {
         ObjectNode json = objectMapper.valueToTree(new LabelValueBean("allergies", output.toString().trim()));
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
-        response.getWriter().println(json); // nosemgrep: no-direct-response-writer -- JSON API response with application/json content-type
+        response.getWriter().println(json); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- JSON API response with application/json content-type
         return null;
     }
 
@@ -413,7 +413,7 @@ public class Pregnancy2Action extends ActionSupport {
         ObjectNode json = objectMapper.valueToTree(new LabelValueBean("meds", output.toString().trim()));
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
-        response.getWriter().println(json); // nosemgrep: no-direct-response-writer -- JSON API response with application/json content-type
+        response.getWriter().println(json); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- JSON API response with application/json content-type
         return null;
     }
 
@@ -493,7 +493,7 @@ public class Pregnancy2Action extends ActionSupport {
 
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
-        response.getWriter().print(jsonObj.toString()); // nosemgrep: no-direct-response-writer -- JSON API response with application/json content-type
+        response.getWriter().print(jsonObj.toString()); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- JSON API response with application/json content-type
 
         return null;
     }
@@ -511,7 +511,7 @@ public class Pregnancy2Action extends ActionSupport {
         ArrayNode json = objectMapper.valueToTree(m);
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
-        response.getWriter().print(json.toString()); // nosemgrep: no-direct-response-writer -- JSON API response with application/json content-type
+        response.getWriter().print(json.toString()); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- JSON API response with application/json content-type
 
         return null;
     }
@@ -871,7 +871,7 @@ Repeat antibody screen
         ArrayNode json = objectMapper.valueToTree(results);
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
-        response.getWriter().print(json.toString()); // nosemgrep: no-direct-response-writer -- JSON API response with application/json content-type
+        response.getWriter().print(json.toString()); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- JSON API response with application/json content-type
         return null;
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/web/SearchProviderAutoComplete2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/web/SearchProviderAutoComplete2Action.java
@@ -78,7 +78,7 @@ public class SearchProviderAutoComplete2Action extends ActionSupport {
 
         response.setContentType("application/json");
         ObjectNode jsonArray = objectMapper.valueToTree(d);
-        response.getWriter().write(jsonArray.toString()); // nosemgrep: servletresponse-writer-xss, servletresponse-writer-xss-deepsemgrep -- JSON API response with application/json content-type
+        response.getWriter().write(jsonArray.toString()); // nosemgrep: java.servlets.security.servletresponse-writer-xss.servletresponse-writer-xss, java.servlets.security.servletresponse-writer-xss-deepsemgrep.servletresponse-writer-xss-deepsemgrep -- JSON API response with application/json content-type
         return null;
 
     }
@@ -111,7 +111,7 @@ public class SearchProviderAutoComplete2Action extends ActionSupport {
         }
 
         response.setContentType("application/json");
-        response.getWriter().write(objectMapper.writeValueAsString(results)); // nosemgrep: servletresponse-writer-xss, servletresponse-writer-xss-deepsemgrep -- JSON API response with application/json content-type
+        response.getWriter().write(objectMapper.writeValueAsString(results)); // nosemgrep: java.servlets.security.servletresponse-writer-xss.servletresponse-writer-xss, java.servlets.security.servletresponse-writer-xss-deepsemgrep.servletresponse-writer-xss-deepsemgrep -- JSON API response with application/json content-type
 
         return null;
     }

--- a/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/ImportLogDownload2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/ImportLogDownload2Action.java
@@ -123,7 +123,7 @@ public class ImportLogDownload2Action extends ActionSupport {
                 byte[] buffer = new byte[8192];
                 int bytesRead;
                 while ((bytesRead = in.read(buffer)) != -1) {
-                    out.write(buffer, 0, bytesRead); // nosemgrep: no-direct-response-writer -- application/octet-stream file download
+                    out.write(buffer, 0, bytesRead); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- application/octet-stream file download
                 }
                 out.flush();
             }

--- a/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/Util.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/Util.java
@@ -299,7 +299,7 @@ public class Util {
                 byte[] buf = new byte[8192];
                 int len;
                 while ((len = in.read(buf)) > 0) {
-                    out.write(buf, 0, len); // nosemgrep: no-direct-response-writer -- application/octet-stream file download
+                    out.write(buf, 0, len); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- application/octet-stream file download
                 }
             }
         } catch (IOException ex) {

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentPreview2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentPreview2Action.java
@@ -331,7 +331,7 @@ public class DocumentPreview2Action extends ActionSupport {
 
                 int data;
                 while ((data = bfis.read()) != -1) {
-                    outs.write(data); // nosemgrep: no-direct-response-writer -- application/pdf binary document preview
+                    outs.write(data); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- application/pdf binary document preview
                 }
 
                 outs.flush();

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/ManageDocument2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/ManageDocument2Action.java
@@ -320,7 +320,7 @@ public class ManageDocument2Action extends ActionSupport {
         ObjectNode jsonObject = objectMapper.valueToTree(hm);
         try {
             response.setContentType("application/json;charset=UTF-8");
-            // nosemgrep: no-direct-response-writer -- JSON API response with application/json content-type; patientId is validated numeric
+            // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- JSON API response with application/json content-type; patientId is validated numeric
             response.getOutputStream().write(jsonObject.toString().getBytes(StandardCharsets.UTF_8));
         } catch (IOException e) {
             MiscUtils.getLogger().error("IOException writing JSON response in documentUpdateAjax", e);
@@ -353,7 +353,7 @@ public class ManageDocument2Action extends ActionSupport {
         ObjectNode jsonObject = objectMapper.valueToTree(hm);
         try {
             response.setContentType("application/json;charset=UTF-8");
-            // nosemgrep: no-direct-response-writer -- JSON API response with application/json content-type and Jackson serialization
+            // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- JSON API response with application/json content-type and Jackson serialization
             response.getOutputStream().write(jsonObject.toString().getBytes(StandardCharsets.UTF_8)); // CodeQL[java/xss] JSON response — application/json content-type with Jackson serialization
         } catch (IOException e) {
             MiscUtils.getLogger().error("IOException writing JSON response in getDemoNameAjax", e);
@@ -937,7 +937,7 @@ public class ManageDocument2Action extends ActionSupport {
         response.setHeader("Content-Disposition", "inline; filename=\"" + sanitizeHeaderValue(filename) + "\"");
         log.debug("about to Print to stream");
         try (ServletOutputStream outs = response.getOutputStream()) {
-            outs.write(contentBytes); // nosemgrep: no-direct-response-writer -- binary document download with validated content-type
+            outs.write(contentBytes); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- binary document download with validated content-type
             outs.flush();
         }
     }

--- a/src/main/java/io/github/carlos_emr/carlos/dxresearch/pageUtil/dxCodeSearchJSON2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/dxresearch/pageUtil/dxCodeSearchJSON2Action.java
@@ -206,7 +206,7 @@ public class dxCodeSearchJSON2Action extends ActionSupport {
         }
 
         try (PrintWriter pout = response.getWriter()) {
-            pout.write(jsonstring); // nosemgrep: servletresponse-writer-xss, servletresponse-writer-xss-deepsemgrep -- JSON API response with application/json content-type
+            pout.write(jsonstring); // nosemgrep: java.servlets.security.servletresponse-writer-xss.servletresponse-writer-xss, java.servlets.security.servletresponse-writer-xss-deepsemgrep.servletresponse-writer-xss-deepsemgrep -- JSON API response with application/json content-type
         }
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/eform/util/EFormSignatureViewForPdfGenerationServlet.java
+++ b/src/main/java/io/github/carlos_emr/carlos/eform/util/EFormSignatureViewForPdfGenerationServlet.java
@@ -69,7 +69,7 @@ public final class EFormSignatureViewForPdfGenerationServlet extends HttpServlet
                 response.setContentType("image/" + imageType);
                 response.setContentLength(image.length);
                 BufferedOutputStream bos = new BufferedOutputStream(response.getOutputStream());
-                bos.write(image); // nosemgrep: no-direct-response-writer -- image/jpeg binary write
+                bos.write(image); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- image/jpeg binary write
                 bos.flush();
 
                 return;

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oceanEReferal/pageUtil/ERefer2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oceanEReferal/pageUtil/ERefer2Action.java
@@ -158,7 +158,7 @@ public class ERefer2Action extends ActionSupport {
         response.setContentType("text/plain");
         response.setCharacterEncoding("UTF-8");
         try (PrintWriter writer = response.getWriter()) {
-            writer.write(eReferAttachment.getId().toString()); // nosemgrep: servletresponse-writer-xss -- text/plain response writing numeric database ID
+            writer.write(eReferAttachment.getId().toString()); // nosemgrep: java.servlets.security.servletresponse-writer-xss.servletresponse-writer-xss -- text/plain response writing numeric database ID
         } catch (IOException e) {
             logger.error("Failed to write the eReferAttachment ID to the response", e);
         }

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctAddShortMeasurement2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctAddShortMeasurement2Action.java
@@ -99,7 +99,7 @@ public class EctAddShortMeasurement2Action extends ActionSupport {
             String encodedFollowupValue = URLEncoder.encode(followUpValue != null ? followUpValue : "", "UTF-8");
             String encodedDate = URLEncoder.encode(UtilDateUtilities.DateToString(new Date()), "UTF-8");
             
-            response.getWriter().print("id=" + encodedId + // nosemgrep: no-direct-response-writer -- text/plain response with URLEncoder.encode()
+            response.getWriter().print("id=" + encodedId + // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- text/plain response with URLEncoder.encode()
                                       "&followupValue=" + encodedFollowupValue + 
                                       "&Date=" + encodedDate);
         }

--- a/src/main/java/io/github/carlos_emr/carlos/fax/action/Fax2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/fax/action/Fax2Action.java
@@ -333,7 +333,7 @@ public class Fax2Action extends ActionSupport {
 
                 int data;
                 while ((data = bfis.read()) != -1) {
-                    outs.write(data); // nosemgrep: no-direct-response-writer -- binary fax document download
+                    outs.write(data); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- binary fax document download
                 }
                 outs.flush();
             } catch (IOException e) {

--- a/src/main/java/io/github/carlos_emr/carlos/form/JSONUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/JSONUtil.java
@@ -48,7 +48,7 @@ public abstract class JSONUtil {
         try (PrintWriter out = response.getWriter()) {
             response.setContentType(CONTENT_TYPE);
             response.setCharacterEncoding(ENCODING);
-            out.print(jsonObject.toString()); // nosemgrep: no-direct-response-writer -- JSON API response with application/json content-type
+            out.print(jsonObject.toString()); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- JSON API response with application/json content-type
             out.flush();
         } catch (IOException e) {
             logger.error("Error while creating JSON response", e);
@@ -59,7 +59,7 @@ public abstract class JSONUtil {
         try (PrintWriter out = response.getWriter()) {
             response.setContentType(CONTENT_TYPE);
             response.setCharacterEncoding(ENCODING);
-            out.print(jsonString); // nosemgrep: no-direct-response-writer -- JSON API response with application/json content-type
+            out.print(jsonString); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- JSON API response with application/json content-type
             out.flush();
         } catch (IOException e) {
             logger.error("Error while creating JSON response", e);

--- a/src/main/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServlet.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServlet.java
@@ -149,9 +149,8 @@ public class FrmCustomedPDFServlet extends HttpServlet {
                     Path filepath = validatedPdfFile.toPath();
 
                     if (!Files.exists(filepath)) {
-                        // nosemgrep: no-direct-response-writer -- PDF bytes written to file, not HTTP response
                         try (java.io.OutputStream fileOut = Files.newOutputStream(filepath)) {
-                            baosPDF.writeTo(fileOut);
+                            baosPDF.writeTo(fileOut); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- PDF bytes written to file, not HTTP response
                         }
                     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/hospitalReportManager/HRMPDFCreator.java
+++ b/src/main/java/io/github/carlos_emr/carlos/hospitalReportManager/HRMPDFCreator.java
@@ -223,10 +223,10 @@ public class HRMPDFCreator extends PdfPageEventHelper {
                 outputStream.write(Files.readAllBytes(path));
             } else {
                 logger.info("HRM Report is binary, only printing the attachment");
-                outputStream.write(hrmReport.getBinaryContent()); // nosemgrep: no-direct-response-writer -- binary PDF bytes to OutputStream
+                outputStream.write(hrmReport.getBinaryContent()); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- binary PDF bytes to OutputStream
             }
 
-            outputStream.flush(); // nosemgrep: no-direct-response-writer -- binary PDF bytes to OutputStream
+            outputStream.flush(); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- binary PDF bytes to OutputStream
         } catch (IOException e) {
             logger.error("An I/O Exception has occurred while either getting a PDFWriter Instance or creating the BaseFont", e);
         } catch (DocumentException e) {

--- a/src/main/java/io/github/carlos_emr/carlos/hospitalReportManager/PrintHRMReport2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/hospitalReportManager/PrintHRMReport2Action.java
@@ -130,8 +130,8 @@ public class PrintHRMReport2Action extends ActionSupport {
             return "error";
         } finally {
             if (osTemp != null) {
-                osTemp.flush(); // nosemgrep: no-direct-response-writer -- binary PDF stream
-                osTemp.close(); // nosemgrep: no-direct-response-writer -- binary PDF stream
+                osTemp.flush(); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- binary PDF stream
+                osTemp.close(); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- binary PDF stream
             }
             if (fileTemp != null) {
                 fileTemp.delete();

--- a/src/main/java/io/github/carlos_emr/carlos/integration/mcedt/Resource2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/integration/mcedt/Resource2Action.java
@@ -179,8 +179,8 @@ public class Resource2Action extends ActionSupport {
             ze.setComment(d.getDescription());
             ze.setSize(inputBytes.length);
 
-            zos.putNextEntry(ze);
-            zos.write(inputBytes); // nosemgrep: no-direct-response-writer -- application/zip binary stream
+            zos.putNextEntry(ze); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- application/zip binary stream, ZipEntry header only
+            zos.write(inputBytes); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- application/zip binary stream
             zos.closeEntry();
             zos.flush();
         }

--- a/src/main/java/io/github/carlos_emr/carlos/lab/ca/all/pageUtil/DownloadEmbeddedDocumentFromLab2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/lab/ca/all/pageUtil/DownloadEmbeddedDocumentFromLab2Action.java
@@ -85,7 +85,7 @@ public class DownloadEmbeddedDocumentFromLab2Action extends ActionSupport {
 
         // Write file to response.
         OutputStream output = response.getOutputStream();
-        output.write(decodedData); // nosemgrep: no-direct-response-writer -- application/pdf binary write
+        output.write(decodedData); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- application/pdf binary write
         output.close();
 
 

--- a/src/main/java/io/github/carlos_emr/carlos/lab/ca/all/pageUtil/LabPDFCreator.java
+++ b/src/main/java/io/github/carlos_emr/carlos/lab/ca/all/pageUtil/LabPDFCreator.java
@@ -276,7 +276,7 @@ public class LabPDFCreator extends PdfPageEventHelper {
             }
         }
 
-        os.flush(); // nosemgrep: no-direct-response-writer -- binary PDF stream flush
+        os.flush(); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- binary PDF stream flush
     }
 
     public void addEmbeddedDocuments(File currentPDF, OutputStream os) {

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxDeleteRx2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxDeleteRx2Action.java
@@ -400,7 +400,7 @@ public final class RxDeleteRx2Action extends ActionSupport {
         d.put("reason", reason);
         response.setContentType("application/json");
         ObjectNode jsonArray = (ObjectNode) objectMapper.valueToTree(d);
-        response.getWriter().write(jsonArray.toString()); // nosemgrep: servletresponse-writer-xss, servletresponse-writer-xss-deepsemgrep -- JSON API response with application/json content-type
+        response.getWriter().write(jsonArray.toString()); // nosemgrep: java.servlets.security.servletresponse-writer-xss.servletresponse-writer-xss, java.servlets.security.servletresponse-writer-xss-deepsemgrep.servletresponse-writer-xss-deepsemgrep -- JSON API response with application/json content-type
 
         return null;
     }

--- a/src/main/java/io/github/carlos_emr/carlos/provider/web/ProviderSignatureStamp2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/provider/web/ProviderSignatureStamp2Action.java
@@ -382,7 +382,7 @@ public class ProviderSignatureStamp2Action extends ActionSupport implements Uplo
         resp.setHeader("X-Content-Type-Options", "nosniff");
         try {
             PrintWriter writer = resp.getWriter();
-            writer.write(json); // nosemgrep: servletresponse-writer-xss, servletresponse-writer-xss-deepsemgrep -- JSON API response with application/json content-type
+            writer.write(json); // nosemgrep: java.servlets.security.servletresponse-writer-xss.servletresponse-writer-xss, java.servlets.security.servletresponse-writer-xss-deepsemgrep.servletresponse-writer-xss-deepsemgrep -- JSON API response with application/json content-type
             writer.flush();
         } catch (IOException e) {
             MiscUtils.getLogger().debug("Failed to write JSON response (client may have disconnected)", e);

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/ManageLetters.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/ManageLetters.java
@@ -122,7 +122,7 @@ public class ManageLetters {
 
         if (r != null) {
             try {
-                // nosemgrep: no-direct-response-writer -- binary report file bytes written to stream, not HTML response
+                // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- binary report file bytes written to stream, not HTML response
                 out.write(r.getReportFile(), 0, r.getReportFile().length);
             } catch (IOException e) {
                 logger.error("Error", e);

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/PatientListByAppt.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/PatientListByAppt.java
@@ -88,17 +88,20 @@ public class PatientListByAppt extends HttpServlet {
                     Appointment a = (Appointment) o[1];
                     Provider p = (Provider) o[2];
 
-                    // nosemgrep: no-direct-response-writer -- text/plain CSV download with Content-Disposition: attachment, not HTML
-                    pw.print(escapeCsv(d.getLastName()) + ",");
-                    pw.print(escapeCsv(d.getFirstName()) + ",");
-                    pw.print(escapeCsv(d.getPhone()) + ",");
-                    pw.print(escapeCsv(d.getPhone2()) + ",");
-                    pw.print(ConversionUtils.toTimeString(a.getStartTime()) + ",");
-                    pw.print(ConversionUtils.toDateString(a.getAppointmentDate()) + ",");
-                    pw.print(escapeCsv(a.getType().replaceAll("\r\n", "")) + ",");
-                    pw.print(escapeCsv(p.getFirstName() + " " + p.getLastName()) + ",");
-                    pw.print(escapeCsv(a.getLocation()));
-                    pw.print("\n");
+                    // CSV export rows — each pw.print() carries a full-id nosemgrep because
+                    // Semgrep Cloud does not honor preceding-line suppressions for this rule.
+                    // Content-Type is set to text/plain with Content-Disposition: attachment,
+                    // values pass through escapeCsv(), not an HTML context.
+                    pw.print(escapeCsv(d.getLastName()) + ","); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download, escapeCsv applied
+                    pw.print(escapeCsv(d.getFirstName()) + ","); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download, escapeCsv applied
+                    pw.print(escapeCsv(d.getPhone()) + ","); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download, escapeCsv applied
+                    pw.print(escapeCsv(d.getPhone2()) + ","); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download, escapeCsv applied
+                    pw.print(ConversionUtils.toTimeString(a.getStartTime()) + ","); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download, formatted time
+                    pw.print(ConversionUtils.toDateString(a.getAppointmentDate()) + ","); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download, formatted date
+                    pw.print(escapeCsv(a.getType().replaceAll("\r\n", "")) + ","); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download, escapeCsv applied
+                    pw.print(escapeCsv(p.getFirstName() + " " + p.getLastName()) + ","); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download, escapeCsv applied
+                    pw.print(escapeCsv(a.getLocation())); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download, escapeCsv applied
+                    pw.print("\n"); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download literal newline
                 }
                 pw.println("");
             }

--- a/src/main/java/io/github/carlos_emr/carlos/report/reportByTemplate/actions/GenerateOutFiles2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/reportByTemplate/actions/GenerateOutFiles2Action.java
@@ -76,7 +76,7 @@ public class GenerateOutFiles2Action extends ActionSupport {
             response.setContentType("application/octet-stream");
             response.setHeader("Content-Disposition", "attachment; filename=\"oscarReport.csv\"");
             try {
-                response.getWriter().write(csv); // nosemgrep: no-direct-response-writer -- application/octet-stream CSV export from session data
+                response.getWriter().write(csv); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer, java.servlets.security.servletresponse-writer-xss.servletresponse-writer-xss, java.servlets.security.servletresponse-writer-xss-deepsemgrep.servletresponse-writer-xss-deepsemgrep -- application/octet-stream CSV export from session data
             } catch (Exception ioe) {
                 MiscUtils.getLogger().error("Error", ioe);
             }

--- a/src/main/java/io/github/carlos_emr/carlos/ui/servlet/ImageRenderingServlet.java
+++ b/src/main/java/io/github/carlos_emr/carlos/ui/servlet/ImageRenderingServlet.java
@@ -112,7 +112,7 @@ public final class ImageRenderingServlet extends HttpServlet {
             response.setContentLength(image.length);
         BufferedOutputStream bos = new BufferedOutputStream(response.getOutputStream());
         if (image != null)
-            bos.write(image); // nosemgrep: no-direct-response-writer -- binary image stream
+            bos.write(image); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- binary image stream
         bos.flush();
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/util/GenericDownload.java
+++ b/src/main/java/io/github/carlos_emr/carlos/util/GenericDownload.java
@@ -130,7 +130,7 @@ public class GenericDownload extends HttpServlet {
         byte[] buffer = new byte[BUFFER_SIZE];
 
         while ((bufferSize = fis.read(buffer)) != -1) {
-            stream.write(buffer, 0, bufferSize); // nosemgrep: no-direct-response-writer -- binary file download buffer copy
+            stream.write(buffer, 0, bufferSize); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- binary file download buffer copy
 
         }
         fis.close();

--- a/src/main/resources/spring_jpa.xml
+++ b/src/main/resources/spring_jpa.xml
@@ -48,7 +48,10 @@
 	</bean>
 
 	<!-- JPA -->
-	<bean id="entityManagerFactory" class="org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean">
+	<!-- primary="true" resolves ambiguity: Hibernate 7's SessionFactory also implements
+	     EntityManagerFactory, so @PersistenceContext without unitName would otherwise
+	     match both this bean and the 'sessionFactory' bean in spring_hibernate.xml. -->
+	<bean id="entityManagerFactory" primary="true" class="org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean">
 		<property name="dataSource" ref="dataSource" />
 		<!-- Hibernate 7 requires the EMF to know about ALL entity types referenced
 		     by JPA associations. packagesToScan discovers @Entity classes;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reduce false-positive XSS taint alerts in Semgrep Cloud by upgrading `nosemgrep` rule IDs to fully qualified paths and adding a few missing suppressions; no runtime behavior changes. Also mark the JPA `entityManagerFactory` bean as primary to resolve Hibernate 7 ambiguity with `@PersistenceContext`.

- **Bug Fixes**
  - Replaced short-form suppressions with fully qualified IDs: `no-direct-response-writer` → `java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer`, `servletresponse-writer-xss` → `java.servlets.security.servletresponse-writer-xss.servletresponse-writer-xss`, `servletresponse-writer-xss-deepsemgrep` → `java.servlets.security.servletresponse-writer-xss-deepsemgrep.servletresponse-writer-xss-deepsemgrep`.
  - Added missing suppressions for CSV exports, ZIP entry write, PDF file write, and text/plain numeric IDs.
  - Cleaned up Javadoc by removing incorrect `@throws SecurityException` lines in several actions.
  - Set `primary="true"` on the `entityManagerFactory` bean in `spring_jpa.xml` to ensure `@PersistenceContext` selects the correct EMF with Hibernate 7.

<sup>Written for commit df549f8a6665c7a9f827cd2cf73dd9c9824b8dd7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

