### PR TITLE
feat: DTO projection layer for 9 entities (mirror of #1569)

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/allergy/dto/AllergyListItemDTO.java
+++ b/src/main/java/io/github/carlos_emr/carlos/allergy/dto/AllergyListItemDTO.java
@@ -45,7 +45,7 @@ public class AllergyListItemDTO implements Serializable {
     private Date entryDate;
     private String description;
     private String reaction;
-    private boolean archived;
+    private Boolean archived;
     private Boolean nonDrug;
     private Integer typeCode;
     private Date startDate;
@@ -55,14 +55,31 @@ public class AllergyListItemDTO implements Serializable {
     private String reactionType;
     private String providerNo;
 
+    /** Default constructor for serialization/framework binding. */
     public AllergyListItemDTO() {
     }
 
     /**
      * Projection constructor for JPQL constructor expressions.
+     *
+     * @param id Integer the allergy record ID
+     * @param demographicNo Integer the patient demographic number
+     * @param entryDate Date the date the allergy was entered
+     * @param description String the allergy description
+     * @param reaction String the reaction description
+     * @param archived Boolean whether the allergy is archived (null-safe for projections)
+     * @param nonDrug Boolean whether this is a non-drug allergy
+     * @param typeCode Integer the allergy type code
+     * @param startDate Date the allergy start date
+     * @param severityOfReaction String the severity of reaction
+     * @param onsetOfReaction String the onset of reaction
+     * @param lifeStage String the life stage
+     * @param reactionType String the reaction type
+     * @param providerNo String the provider number
+     * @since 2026-04-11
      */
     public AllergyListItemDTO(Integer id, Integer demographicNo, Date entryDate, String description,
-                              String reaction, boolean archived, Boolean nonDrug, Integer typeCode,
+                              String reaction, Boolean archived, Boolean nonDrug, Integer typeCode,
                               Date startDate, String severityOfReaction, String onsetOfReaction,
                               String lifeStage, String reactionType, String providerNo) {
         this.id = id;
@@ -107,8 +124,8 @@ public class AllergyListItemDTO implements Serializable {
     public void setDescription(String description) { this.description = description; }
     public String getReaction() { return reaction; }
     public void setReaction(String reaction) { this.reaction = reaction; }
-    public boolean isArchived() { return archived; }
-    public void setArchived(boolean archived) { this.archived = archived; }
+    public Boolean getArchived() { return archived; }
+    public void setArchived(Boolean archived) { this.archived = archived; }
     public Boolean getNonDrug() { return nonDrug; }
     public void setNonDrug(Boolean nonDrug) { this.nonDrug = nonDrug; }
     public Integer getTypeCode() { return typeCode; }

--- a/src/main/java/io/github/carlos_emr/carlos/allergy/dto/AllergyListItemDTO.java
+++ b/src/main/java/io/github/carlos_emr/carlos/allergy/dto/AllergyListItemDTO.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ * <p>
+ * Now maintained by the CARLOS EMR Project (2026+).
+ * https://github.com/carlos-emr/carlos
+ * CARLOS has no affiliation with OSCAR or McMaster University.
+ */
+package io.github.carlos_emr.carlos.allergy.dto;
+
+import java.io.Serializable;
+import java.util.Date;
+import java.util.Objects;
+
+import io.github.carlos_emr.carlos.commn.model.Allergy;
+
+/**
+ * Lightweight DTO for allergy list views. Carries the 14 fields needed for
+ * medication safety display out of Allergy's 91 fields.
+ *
+ * <p>Omits: HICL/HIC/AGCSP/AGCCS internal codes, ATC, regional identifier,
+ * drug ref ID, position, transient pharmacological/chemical/substance fields.</p>
+ *
+ * @since 2026-04-11
+ */
+public class AllergyListItemDTO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private Integer id;
+    private Integer demographicNo;
+    private Date entryDate;
+    private String description;
+    private String reaction;
+    private boolean archived;
+    private Boolean nonDrug;
+    private Integer typeCode;
+    private Date startDate;
+    private String severityOfReaction;
+    private String onsetOfReaction;
+    private String lifeStage;
+    private String reactionType;
+    private String providerNo;
+
+    public AllergyListItemDTO() {
+    }
+
+    /**
+     * Projection constructor for JPQL constructor expressions.
+     */
+    public AllergyListItemDTO(Integer id, Integer demographicNo, Date entryDate, String description,
+                              String reaction, boolean archived, Boolean nonDrug, Integer typeCode,
+                              Date startDate, String severityOfReaction, String onsetOfReaction,
+                              String lifeStage, String reactionType, String providerNo) {
+        this.id = id;
+        this.demographicNo = demographicNo;
+        this.entryDate = entryDate;
+        this.description = description;
+        this.reaction = reaction;
+        this.archived = archived;
+        this.nonDrug = nonDrug;
+        this.typeCode = typeCode;
+        this.startDate = startDate;
+        this.severityOfReaction = severityOfReaction;
+        this.onsetOfReaction = onsetOfReaction;
+        this.lifeStage = lifeStage;
+        this.reactionType = reactionType;
+        this.providerNo = providerNo;
+    }
+
+    /**
+     * Creates an AllergyListItemDTO from a full Allergy entity.
+     *
+     * @param a Allergy the entity to convert; must not be null
+     * @return AllergyListItemDTO a lightweight projection
+     */
+    public static AllergyListItemDTO fromEntity(Allergy a) {
+        Objects.requireNonNull(a, "Allergy entity must not be null for DTO conversion");
+        return new AllergyListItemDTO(
+                a.getId(), a.getDemographicNo(), a.getEntryDate(), a.getDescription(),
+                a.getReaction(), a.getArchived(), a.isNonDrug(), a.getTypeCode(),
+                a.getStartDate(), a.getSeverityOfReaction(), a.getOnsetOfReaction(),
+                a.getLifeStage(), a.getReactionType(), a.getProviderNo()
+        );
+    }
+
+    public Integer getId() { return id; }
+    public void setId(Integer id) { this.id = id; }
+    public Integer getDemographicNo() { return demographicNo; }
+    public void setDemographicNo(Integer demographicNo) { this.demographicNo = demographicNo; }
+    public Date getEntryDate() { return entryDate; }
+    public void setEntryDate(Date entryDate) { this.entryDate = entryDate; }
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+    public String getReaction() { return reaction; }
+    public void setReaction(String reaction) { this.reaction = reaction; }
+    public boolean isArchived() { return archived; }
+    public void setArchived(boolean archived) { this.archived = archived; }
+    public Boolean getNonDrug() { return nonDrug; }
+    public void setNonDrug(Boolean nonDrug) { this.nonDrug = nonDrug; }
+    public Integer getTypeCode() { return typeCode; }
+    public void setTypeCode(Integer typeCode) { this.typeCode = typeCode; }
+    public Date getStartDate() { return startDate; }
+    public void setStartDate(Date startDate) { this.startDate = startDate; }
+    public String getSeverityOfReaction() { return severityOfReaction; }
+    public void setSeverityOfReaction(String severityOfReaction) { this.severityOfReaction = severityOfReaction; }
+    public String getOnsetOfReaction() { return onsetOfReaction; }
+    public void setOnsetOfReaction(String onsetOfReaction) { this.onsetOfReaction = onsetOfReaction; }
+    public String getLifeStage() { return lifeStage; }
+    public void setLifeStage(String lifeStage) { this.lifeStage = lifeStage; }
+    public String getReactionType() { return reactionType; }
+    public void setReactionType(String reactionType) { this.reactionType = reactionType; }
+    public String getProviderNo() { return providerNo; }
+    public void setProviderNo(String providerNo) { this.providerNo = providerNo; }
+}

--- a/src/main/java/io/github/carlos_emr/carlos/appointment/dto/AppointmentListItemDTO.java
+++ b/src/main/java/io/github/carlos_emr/carlos/appointment/dto/AppointmentListItemDTO.java
@@ -50,7 +50,7 @@ public class AppointmentListItemDTO implements Serializable {
     private Date startTime;
     private Date endTime;
     private String name;
-    private int demographicNo;
+    private Integer demographicNo;
     private String status;
     private String type;
     private String reason;
@@ -63,6 +63,7 @@ public class AppointmentListItemDTO implements Serializable {
     private String patientLastName;
     private String patientFirstName;
 
+    /** Default constructor for serialization/framework binding. */
     public AppointmentListItemDTO() {
     }
 
@@ -75,7 +76,7 @@ public class AppointmentListItemDTO implements Serializable {
      * @param startTime Date the start time
      * @param endTime Date the end time
      * @param name String the appointment name/label
-     * @param demographicNo int the patient demographic number
+     * @param demographicNo Integer the patient demographic number
      * @param status String the appointment status
      * @param type String the appointment type
      * @param reason String the appointment reason
@@ -88,7 +89,7 @@ public class AppointmentListItemDTO implements Serializable {
      * @param patientFirstName String the patient's first name (from LEFT JOIN)
      */
     public AppointmentListItemDTO(Integer id, String providerNo, Date appointmentDate,
-                                  Date startTime, Date endTime, String name, int demographicNo,
+                                  Date startTime, Date endTime, String name, Integer demographicNo,
                                   String status, String type, String reason, String location,
                                   String notes, String urgency, String remarks, Integer reasonCode,
                                   String patientLastName, String patientFirstName) {
@@ -150,8 +151,8 @@ public class AppointmentListItemDTO implements Serializable {
     public void setEndTime(Date endTime) { this.endTime = endTime; }
     public String getName() { return name; }
     public void setName(String name) { this.name = name; }
-    public int getDemographicNo() { return demographicNo; }
-    public void setDemographicNo(int demographicNo) { this.demographicNo = demographicNo; }
+    public Integer getDemographicNo() { return demographicNo; }
+    public void setDemographicNo(Integer demographicNo) { this.demographicNo = demographicNo; }
     public String getStatus() { return status; }
     public void setStatus(String status) { this.status = status; }
     public String getType() { return type; }

--- a/src/main/java/io/github/carlos_emr/carlos/appointment/dto/AppointmentListItemDTO.java
+++ b/src/main/java/io/github/carlos_emr/carlos/appointment/dto/AppointmentListItemDTO.java
@@ -1,0 +1,175 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ * <p>
+ * Now maintained by the CARLOS EMR Project (2026+).
+ * https://github.com/carlos-emr/carlos
+ * CARLOS has no affiliation with OSCAR or McMaster University.
+ */
+package io.github.carlos_emr.carlos.appointment.dto;
+
+import java.io.Serializable;
+import java.util.Date;
+import java.util.Objects;
+
+import io.github.carlos_emr.carlos.commn.model.Appointment;
+import io.github.carlos_emr.carlos.utility.DtoFormatUtils;
+
+/**
+ * Lightweight data transfer object for daily schedule and appointment list views,
+ * optimized for JPQL constructor expression projection with a LEFT JOIN to
+ * Demographic for patient name. Carries only the 17 fields needed for schedule display
+ * out of Appointment's 37 fields.
+ *
+ * <p>Omits: {@code programId}, {@code style}, {@code billing}, {@code importedStatus},
+ * {@code createDateTime}, {@code updateDateTime}, {@code creator}, {@code lastUpdateUser},
+ * {@code creatorSecurityId}, {@code bookingSource}, {@code resources}.</p>
+ *
+ * @since 2026-04-11
+ */
+public class AppointmentListItemDTO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private Integer id;
+    private String providerNo;
+    private Date appointmentDate;
+    private Date startTime;
+    private Date endTime;
+    private String name;
+    private int demographicNo;
+    private String status;
+    private String type;
+    private String reason;
+    private String location;
+    private String notes;
+    private String urgency;
+    private String remarks;
+    private Integer reasonCode;
+    // Pre-joined from Demographic via LEFT JOIN
+    private String patientLastName;
+    private String patientFirstName;
+
+    public AppointmentListItemDTO() {
+    }
+
+    /**
+     * Projection constructor for JPQL constructor expressions.
+     *
+     * @param id Integer the appointment number
+     * @param providerNo String the provider number
+     * @param appointmentDate Date the appointment date
+     * @param startTime Date the start time
+     * @param endTime Date the end time
+     * @param name String the appointment name/label
+     * @param demographicNo int the patient demographic number
+     * @param status String the appointment status
+     * @param type String the appointment type
+     * @param reason String the appointment reason
+     * @param location String the appointment location
+     * @param notes String the appointment notes
+     * @param urgency String the urgency level
+     * @param remarks String the remarks
+     * @param reasonCode Integer the reason code
+     * @param patientLastName String the patient's last name (from LEFT JOIN)
+     * @param patientFirstName String the patient's first name (from LEFT JOIN)
+     */
+    public AppointmentListItemDTO(Integer id, String providerNo, Date appointmentDate,
+                                  Date startTime, Date endTime, String name, int demographicNo,
+                                  String status, String type, String reason, String location,
+                                  String notes, String urgency, String remarks, Integer reasonCode,
+                                  String patientLastName, String patientFirstName) {
+        this.id = id;
+        this.providerNo = providerNo;
+        this.appointmentDate = appointmentDate;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.name = name;
+        this.demographicNo = demographicNo;
+        this.status = status;
+        this.type = type;
+        this.reason = reason;
+        this.location = location;
+        this.notes = notes;
+        this.urgency = urgency;
+        this.remarks = remarks;
+        this.reasonCode = reasonCode;
+        this.patientLastName = patientLastName;
+        this.patientFirstName = patientFirstName;
+    }
+
+    /**
+     * Creates an AppointmentListItemDTO from a full Appointment entity.
+     * Patient name fields are not populated (they require a Demographic join).
+     *
+     * @param a Appointment the entity to convert; must not be null
+     * @return AppointmentListItemDTO a lightweight projection (without patient name)
+     */
+    public static AppointmentListItemDTO fromEntity(Appointment a) {
+        Objects.requireNonNull(a, "Appointment entity must not be null for DTO conversion");
+        return new AppointmentListItemDTO(
+                a.getId(), a.getProviderNo(), a.getAppointmentDate(),
+                a.getStartTime(), a.getEndTime(), a.getName(), a.getDemographicNo(),
+                a.getStatus(), a.getType(), a.getReason(), a.getLocation(),
+                a.getNotes(), a.getUrgency(), a.getRemarks(), a.getReasonCode(),
+                null, null
+        );
+    }
+
+    /**
+     * Returns the patient's formatted name as "LastName, FirstName".
+     *
+     * @return String the formatted patient name, or empty string if not joined
+     */
+    public String getPatientName() {
+        return DtoFormatUtils.formatName(patientLastName, patientFirstName, "");
+    }
+
+    public Integer getId() { return id; }
+    public void setId(Integer id) { this.id = id; }
+    public String getProviderNo() { return providerNo; }
+    public void setProviderNo(String providerNo) { this.providerNo = providerNo; }
+    public Date getAppointmentDate() { return appointmentDate; }
+    public void setAppointmentDate(Date appointmentDate) { this.appointmentDate = appointmentDate; }
+    public Date getStartTime() { return startTime; }
+    public void setStartTime(Date startTime) { this.startTime = startTime; }
+    public Date getEndTime() { return endTime; }
+    public void setEndTime(Date endTime) { this.endTime = endTime; }
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public int getDemographicNo() { return demographicNo; }
+    public void setDemographicNo(int demographicNo) { this.demographicNo = demographicNo; }
+    public String getStatus() { return status; }
+    public void setStatus(String status) { this.status = status; }
+    public String getType() { return type; }
+    public void setType(String type) { this.type = type; }
+    public String getReason() { return reason; }
+    public void setReason(String reason) { this.reason = reason; }
+    public String getLocation() { return location; }
+    public void setLocation(String location) { this.location = location; }
+    public String getNotes() { return notes; }
+    public void setNotes(String notes) { this.notes = notes; }
+    public String getUrgency() { return urgency; }
+    public void setUrgency(String urgency) { this.urgency = urgency; }
+    public String getRemarks() { return remarks; }
+    public void setRemarks(String remarks) { this.remarks = remarks; }
+    public Integer getReasonCode() { return reasonCode; }
+    public void setReasonCode(Integer reasonCode) { this.reasonCode = reasonCode; }
+    public String getPatientLastName() { return patientLastName; }
+    public void setPatientLastName(String patientLastName) { this.patientLastName = patientLastName; }
+    public String getPatientFirstName() { return patientFirstName; }
+    public void setPatientFirstName(String patientFirstName) { this.patientFirstName = patientFirstName; }
+}

--- a/src/main/java/io/github/carlos_emr/carlos/billings/dto/BillingONCListItemDTO.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/dto/BillingONCListItemDTO.java
@@ -56,11 +56,29 @@ public class BillingONCListItemDTO implements Serializable {
     private String clinic;
     private String demographicName;
 
+    /** Default constructor for serialization/framework binding. */
     public BillingONCListItemDTO() {
     }
 
     /**
      * Projection constructor for JPQL constructor expressions.
+     *
+     * @param id Integer billing header identifier
+     * @param demographicNo Integer demographic primary key
+     * @param providerNo String provider identifier
+     * @param appointmentNo Integer appointment identifier
+     * @param billingDate String billing date string
+     * @param billingTime String billing time string
+     * @param status String billing status code
+     * @param payProgram String payment program
+     * @param visitType String visit type code
+     * @param admissionDate String admission date string
+     * @param faciltyNum String facility number
+     * @param total BigDecimal billed total
+     * @param paid BigDecimal paid amount
+     * @param timestamp Date record timestamp
+     * @param clinic String clinic identifier/name
+     * @param demographicName String patient display name
      */
     public BillingONCListItemDTO(Integer id, Integer demographicNo, String providerNo,
                                  Integer appointmentNo, String billingDate, String billingTime,

--- a/src/main/java/io/github/carlos_emr/carlos/billings/dto/BillingONCListItemDTO.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/dto/BillingONCListItemDTO.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ * <p>
+ * Now maintained by the CARLOS EMR Project (2026+).
+ * https://github.com/carlos-emr/carlos
+ * CARLOS has no affiliation with OSCAR or McMaster University.
+ */
+package io.github.carlos_emr.carlos.billings.dto;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.Date;
+
+/**
+ * Lightweight DTO for Ontario billing list views. Eliminates the EAGER-loaded
+ * BillingONItem collection (with CascadeType.ALL) that is fetched on every
+ * BillingONCHeader1 entity access. Carries 16 fields vs 113 on the entity.
+ *
+ * <p>Omits: full BillingONItem EAGER collection, HIN/ver/DOB (PHI), internal
+ * transaction codes, reference numbers, provider OHIP/RMA numbers, etc.</p>
+ *
+ * @since 2026-04-11
+ */
+public class BillingONCListItemDTO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private Integer id;
+    private Integer demographicNo;
+    private String providerNo;
+    private Integer appointmentNo;
+    private String billingDate;
+    private String billingTime;
+    private String status;
+    private String payProgram;
+    private String visitType;
+    private String admissionDate;
+    private String faciltyNum;
+    private BigDecimal total;
+    private BigDecimal paid;
+    private Date timestamp;
+    private String clinic;
+    private String demographicName;
+
+    public BillingONCListItemDTO() {
+    }
+
+    /**
+     * Projection constructor for JPQL constructor expressions.
+     */
+    public BillingONCListItemDTO(Integer id, Integer demographicNo, String providerNo,
+                                 Integer appointmentNo, String billingDate, String billingTime,
+                                 String status, String payProgram, String visitType,
+                                 String admissionDate, String faciltyNum, BigDecimal total,
+                                 BigDecimal paid, Date timestamp, String clinic,
+                                 String demographicName) {
+        this.id = id;
+        this.demographicNo = demographicNo;
+        this.providerNo = providerNo;
+        this.appointmentNo = appointmentNo;
+        this.billingDate = billingDate;
+        this.billingTime = billingTime;
+        this.status = status;
+        this.payProgram = payProgram;
+        this.visitType = visitType;
+        this.admissionDate = admissionDate;
+        this.faciltyNum = faciltyNum;
+        this.total = total;
+        this.paid = paid;
+        this.timestamp = timestamp;
+        this.clinic = clinic;
+        this.demographicName = demographicName;
+    }
+
+    public Integer getId() { return id; }
+    public void setId(Integer id) { this.id = id; }
+    public Integer getDemographicNo() { return demographicNo; }
+    public void setDemographicNo(Integer demographicNo) { this.demographicNo = demographicNo; }
+    public String getProviderNo() { return providerNo; }
+    public void setProviderNo(String providerNo) { this.providerNo = providerNo; }
+    public Integer getAppointmentNo() { return appointmentNo; }
+    public void setAppointmentNo(Integer appointmentNo) { this.appointmentNo = appointmentNo; }
+    public String getBillingDate() { return billingDate; }
+    public void setBillingDate(String billingDate) { this.billingDate = billingDate; }
+    public String getBillingTime() { return billingTime; }
+    public void setBillingTime(String billingTime) { this.billingTime = billingTime; }
+    public String getStatus() { return status; }
+    public void setStatus(String status) { this.status = status; }
+    public String getPayProgram() { return payProgram; }
+    public void setPayProgram(String payProgram) { this.payProgram = payProgram; }
+    public String getVisitType() { return visitType; }
+    public void setVisitType(String visitType) { this.visitType = visitType; }
+    public String getAdmissionDate() { return admissionDate; }
+    public void setAdmissionDate(String admissionDate) { this.admissionDate = admissionDate; }
+    public String getFaciltyNum() { return faciltyNum; }
+    public void setFaciltyNum(String faciltyNum) { this.faciltyNum = faciltyNum; }
+    public BigDecimal getTotal() { return total; }
+    public void setTotal(BigDecimal total) { this.total = total; }
+    public BigDecimal getPaid() { return paid; }
+    public void setPaid(BigDecimal paid) { this.paid = paid; }
+    public Date getTimestamp() { return timestamp; }
+    public void setTimestamp(Date timestamp) { this.timestamp = timestamp; }
+    public String getClinic() { return clinic; }
+    public void setClinic(String clinic) { this.clinic = clinic; }
+    public String getDemographicName() { return demographicName; }
+    public void setDemographicName(String demographicName) { this.demographicName = demographicName; }
+}

--- a/src/main/java/io/github/carlos_emr/carlos/billings/dto/BillingONCListItemDTO.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/dto/BillingONCListItemDTO.java
@@ -33,6 +33,15 @@ import java.util.Date;
  * <p>Omits: full BillingONItem EAGER collection, HIN/ver/DOB (PHI), internal
  * transaction codes, reference numbers, provider OHIP/RMA numbers, etc.</p>
  *
+ * <p><b>No {@code fromEntity(...)} helper:</b> {@code BillingONCHeader1} stores
+ * {@code billingDate}, {@code billingTime}, and {@code admissionDate} as
+ * {@code String} fields but exposes them only through {@code Date}-returning
+ * getters (one of which declares a checked {@code ParseException}). Matching
+ * the JPQL field-access projection from an in-memory entity would require a
+ * fragile {@code SimpleDateFormat} round-trip. Construct this DTO via the
+ * JPQL {@code SELECT NEW} projection (the only supported path in practice)
+ * rather than from an entity instance.</p>
+ *
  * @since 2026-04-11
  */
 public class BillingONCListItemDTO implements Serializable {

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/dao/CaseManagementIssueDAO.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/dao/CaseManagementIssueDAO.java
@@ -35,6 +35,7 @@ import java.util.Date;
 import java.util.List;
 
 import io.github.carlos_emr.carlos.PMmodule.model.Program;
+import io.github.carlos_emr.carlos.casemgmt.dto.CaseManagementIssueListDTO;
 import io.github.carlos_emr.carlos.casemgmt.model.CaseManagementIssue;
 import io.github.carlos_emr.carlos.casemgmt.model.Issue;
 
@@ -63,4 +64,14 @@ public interface CaseManagementIssueDAO {
     public List<Integer> getIssuesByProgramsSince(Date date, List<Program> programs);
 
     public List<CaseManagementIssue> getIssuesByDemographicSince(String demographic_no, Date date);
+
+    /**
+     * Returns lightweight issue DTOs with pre-joined Issue code/description,
+     * eliminating the EAGER Issue entity load (lazy=false in HBM).
+     *
+     * @param demographicNo String the patient demographic number
+     * @return List of CaseManagementIssueListDTO
+     * @since 2026-04-11
+     */
+    public List<CaseManagementIssueListDTO> findIssueDTOsByDemographicNo(String demographicNo);
 }

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/dao/CaseManagementIssueDAOImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/dao/CaseManagementIssueDAOImpl.java
@@ -201,17 +201,26 @@ public class CaseManagementIssueDAOImpl extends AbstractHibernateDao implements 
      * Returns lightweight case management issue DTOs for a demographic, ordered by
      * update date descending. Pre-joins issue code and description via LEFT JOIN.
      *
-     * @param demographicNo String the demographic number (converted to Integer for binding)
-     * @return List&lt;CaseManagementIssueListDTO&gt; ordered by update_date descending
+     * @param demographicNo String the demographic number (parsed to Integer for binding)
+     * @return List&lt;CaseManagementIssueListDTO&gt; ordered by update_date descending;
+     *         empty list if {@code demographicNo} is not a valid integer
+     * @throws org.hibernate.HibernateException if the underlying query fails
      * @since 2026-04-11
      */
     @SuppressWarnings("unchecked")
     @Override
     public List<CaseManagementIssueListDTO> findIssueDTOsByDemographicNo(String demographicNo) {
+        Integer demoNoInt;
+        try {
+            demoNoInt = Integer.valueOf(demographicNo);
+        } catch (NumberFormatException e) {
+            log.warn("findIssueDTOsByDemographicNo: invalid demographicNo '{}'", LogSanitizer.sanitize(demographicNo));
+            return new ArrayList<>();
+        }
         org.hibernate.query.Query<CaseManagementIssueListDTO> query = currentSession().createQuery(
                 "SELECT NEW io.github.carlos_emr.carlos.casemgmt.dto.CaseManagementIssueListDTO(cmi.id, cmi.demographic_no, cmi.issue_id, cmi.type, cmi.acute, cmi.certain, cmi.major, cmi.resolved, cmi.update_date, cmi.program_id, i.code, i.description) FROM CaseManagementIssue cmi LEFT JOIN cmi.issue i WHERE cmi.demographic_no = :demoNo ORDER BY cmi.update_date DESC",
                 CaseManagementIssueListDTO.class);
-        query.setParameter("demoNo", Integer.valueOf(demographicNo));
+        query.setParameter("demoNo", demoNoInt);
         return query.list();
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/dao/CaseManagementIssueDAOImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/dao/CaseManagementIssueDAOImpl.java
@@ -40,6 +40,7 @@ import java.util.Map;
 
 import org.apache.logging.log4j.Logger;
 import io.github.carlos_emr.carlos.PMmodule.model.Program;
+import io.github.carlos_emr.carlos.casemgmt.dto.CaseManagementIssueListDTO;
 import io.github.carlos_emr.carlos.casemgmt.model.CaseManagementIssue;
 import io.github.carlos_emr.carlos.casemgmt.model.Issue;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
@@ -194,6 +195,16 @@ public class CaseManagementIssueDAOImpl extends AbstractHibernateDao implements 
         return (List<CaseManagementIssue>) HqlQueryHelper.find(currentSession(),
                 "from CaseManagementIssue cmi where cmi.demographic_no = ?1 and cmi.update_date > ?2",
                 Integer.valueOf(demographic_no), date);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public List<CaseManagementIssueListDTO> findIssueDTOsByDemographicNo(String demographicNo) {
+        org.hibernate.query.Query<CaseManagementIssueListDTO> query = currentSession().createQuery(
+                "SELECT NEW io.github.carlos_emr.carlos.casemgmt.dto.CaseManagementIssueListDTO(cmi.id, cmi.demographic_no, cmi.issue_id, cmi.type, cmi.acute, cmi.certain, cmi.major, cmi.resolved, cmi.update_date, cmi.program_id, i.code, i.description) FROM CaseManagementIssue cmi LEFT JOIN cmi.issue i WHERE cmi.demographic_no = :demoNo ORDER BY cmi.update_date DESC",
+                CaseManagementIssueListDTO.class);
+        query.setParameter("demoNo", demographicNo);
+        return query.list();
     }
 
 }

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/dao/CaseManagementIssueDAOImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/dao/CaseManagementIssueDAOImpl.java
@@ -217,8 +217,17 @@ public class CaseManagementIssueDAOImpl extends AbstractHibernateDao implements 
             log.warn("findIssueDTOsByDemographicNo: invalid demographicNo '{}'", LogSanitizer.sanitize(demographicNo));
             return new ArrayList<>();
         }
-        org.hibernate.query.Query<CaseManagementIssueListDTO> query = currentSession().createQuery(
-                "SELECT NEW io.github.carlos_emr.carlos.casemgmt.dto.CaseManagementIssueListDTO(cmi.id, cmi.demographic_no, cmi.issue_id, cmi.type, cmi.acute, cmi.certain, cmi.major, cmi.resolved, cmi.update_date, cmi.program_id, i.code, i.description) FROM CaseManagementIssue cmi LEFT JOIN cmi.issue i WHERE cmi.demographic_no = :demoNo ORDER BY cmi.update_date DESC",
+        org.hibernate.query.Query<CaseManagementIssueListDTO> query = currentSession().createQuery("""
+                SELECT NEW io.github.carlos_emr.carlos.casemgmt.dto.CaseManagementIssueListDTO(
+                    cmi.id, cmi.demographic_no, cmi.issue_id, cmi.type,
+                    cmi.acute, cmi.certain, cmi.major, cmi.resolved,
+                    cmi.update_date, cmi.program_id,
+                    i.code, i.description)
+                FROM CaseManagementIssue cmi
+                LEFT JOIN cmi.issue i
+                WHERE cmi.demographic_no = :demoNo
+                ORDER BY cmi.update_date DESC
+                """,
                 CaseManagementIssueListDTO.class);
         query.setParameter("demoNo", demoNoInt);
         return query.list();

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/dao/CaseManagementIssueDAOImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/dao/CaseManagementIssueDAOImpl.java
@@ -197,13 +197,21 @@ public class CaseManagementIssueDAOImpl extends AbstractHibernateDao implements 
                 Integer.valueOf(demographic_no), date);
     }
 
+    /**
+     * Returns lightweight case management issue DTOs for a demographic, ordered by
+     * update date descending. Pre-joins issue code and description via LEFT JOIN.
+     *
+     * @param demographicNo String the demographic number (converted to Integer for binding)
+     * @return List&lt;CaseManagementIssueListDTO&gt; ordered by update_date descending
+     * @since 2026-04-11
+     */
     @SuppressWarnings("unchecked")
     @Override
     public List<CaseManagementIssueListDTO> findIssueDTOsByDemographicNo(String demographicNo) {
         org.hibernate.query.Query<CaseManagementIssueListDTO> query = currentSession().createQuery(
                 "SELECT NEW io.github.carlos_emr.carlos.casemgmt.dto.CaseManagementIssueListDTO(cmi.id, cmi.demographic_no, cmi.issue_id, cmi.type, cmi.acute, cmi.certain, cmi.major, cmi.resolved, cmi.update_date, cmi.program_id, i.code, i.description) FROM CaseManagementIssue cmi LEFT JOIN cmi.issue i WHERE cmi.demographic_no = :demoNo ORDER BY cmi.update_date DESC",
                 CaseManagementIssueListDTO.class);
-        query.setParameter("demoNo", demographicNo);
+        query.setParameter("demoNo", Integer.valueOf(demographicNo));
         return query.list();
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/dao/CaseManagementNoteDAO.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/dao/CaseManagementNoteDAO.java
@@ -45,6 +45,7 @@ import java.util.Map;
 import jakarta.persistence.PersistenceException;
 
 import io.github.carlos_emr.carlos.PMmodule.model.Program;
+import io.github.carlos_emr.carlos.casemgmt.dto.CaseManagementNoteListDTO;
 import io.github.carlos_emr.carlos.casemgmt.model.CaseManagementNote;
 import io.github.carlos_emr.carlos.casemgmt.model.CaseManagementSearchBean;
 import io.github.carlos_emr.carlos.commn.model.Provider;
@@ -310,4 +311,14 @@ public interface CaseManagementNoteDAO {
             SqlUtils.closeResources(c, null, null);
         }
     }
+
+    /**
+     * Returns lightweight note DTOs with pre-joined provider name, eliminating
+     * 3 lazy=false HBM relationships (provider, issues, extend).
+     *
+     * @param demographicNo String the patient demographic number
+     * @return List of CaseManagementNoteListDTO
+     * @since 2026-04-11
+     */
+    public List<CaseManagementNoteListDTO> findNoteDTOsByDemographicNo(String demographicNo);
 }

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/dao/CaseManagementNoteDAOImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/dao/CaseManagementNoteDAOImpl.java
@@ -737,6 +737,7 @@ public class CaseManagementNoteDAOImpl extends AbstractHibernateDao implements C
      *
      * @param demographicNo String the demographic number
      * @return List&lt;CaseManagementNoteListDTO&gt; ordered by observation_date descending; empty if none found
+     * @throws org.hibernate.HibernateException if the underlying query fails
      * @since 2026-04-11
      */
     @SuppressWarnings("unchecked")

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/dao/CaseManagementNoteDAOImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/dao/CaseManagementNoteDAOImpl.java
@@ -729,6 +729,16 @@ public class CaseManagementNoteDAOImpl extends AbstractHibernateDao implements C
         return issueIdList;
     }
 
+    /**
+     * Returns lightweight case management note list DTOs for a demographic, ordered by
+     * observation date descending. Pre-joins provider name (HBM PascalCase:
+     * {@code p.LastName}, {@code p.FirstName}) via LEFT JOIN. Eliminates 3 {@code lazy=false}
+     * collections on the full {@code CaseManagementNote} entity.
+     *
+     * @param demographicNo String the demographic number
+     * @return List&lt;CaseManagementNoteListDTO&gt; ordered by observation_date descending; empty if none found
+     * @since 2026-04-11
+     */
     @SuppressWarnings("unchecked")
     @Override
     public List<CaseManagementNoteListDTO> findNoteDTOsByDemographicNo(String demographicNo) {

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/dao/CaseManagementNoteDAOImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/dao/CaseManagementNoteDAOImpl.java
@@ -743,8 +743,20 @@ public class CaseManagementNoteDAOImpl extends AbstractHibernateDao implements C
     @SuppressWarnings("unchecked")
     @Override
     public List<CaseManagementNoteListDTO> findNoteDTOsByDemographicNo(String demographicNo) {
-        Query<CaseManagementNoteListDTO> query = currentSession().createQuery(
-                "SELECT NEW io.github.carlos_emr.carlos.casemgmt.dto.CaseManagementNoteListDTO(cmn.id, cmn.update_date, cmn.observation_date, cmn.demographic_no, cmn.signed, cmn.providerNo, cmn.signing_provider_no, cmn.encounter_type, cmn.billing_code, cmn.program_no, cmn.uuid, cmn.locked, cmn.archived, cmn.appointmentNo, p.LastName, p.FirstName) FROM CaseManagementNote cmn LEFT JOIN Provider p ON p.ProviderNo = cmn.providerNo WHERE cmn.demographic_no = :demoNo ORDER BY cmn.observation_date DESC",
+        // HBM-mapped Provider uses PascalCase property names (ProviderNo, LastName,
+        // FirstName) per Provider.hbm.xml; HQL must reference the HBM name attribute.
+        Query<CaseManagementNoteListDTO> query = currentSession().createQuery("""
+                SELECT NEW io.github.carlos_emr.carlos.casemgmt.dto.CaseManagementNoteListDTO(
+                    cmn.id, cmn.update_date, cmn.observation_date, cmn.demographic_no,
+                    cmn.signed, cmn.providerNo, cmn.signing_provider_no, cmn.encounter_type,
+                    cmn.billing_code, cmn.program_no, cmn.uuid,
+                    cmn.locked, cmn.archived, cmn.appointmentNo,
+                    p.LastName, p.FirstName)
+                FROM CaseManagementNote cmn
+                LEFT JOIN Provider p ON p.ProviderNo = cmn.providerNo
+                WHERE cmn.demographic_no = :demoNo
+                ORDER BY cmn.observation_date DESC
+                """,
                 CaseManagementNoteListDTO.class);
         query.setParameter("demoNo", demographicNo);
         return query.list();

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/dao/CaseManagementNoteDAOImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/dao/CaseManagementNoteDAOImpl.java
@@ -52,6 +52,7 @@ import org.hibernate.query.NativeQuery;
 import org.hibernate.query.Query;
 
 import io.github.carlos_emr.carlos.PMmodule.model.Program;
+import io.github.carlos_emr.carlos.casemgmt.dto.CaseManagementNoteListDTO;
 import io.github.carlos_emr.carlos.casemgmt.model.CaseManagementNote;
 import io.github.carlos_emr.carlos.casemgmt.model.CaseManagementSearchBean;
 import io.github.carlos_emr.carlos.commn.model.Provider;
@@ -726,5 +727,15 @@ public class CaseManagementNoteDAOImpl extends AbstractHibernateDao implements C
             issueIdList.add(Long.parseLong(id.trim()));
         }
         return issueIdList;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public List<CaseManagementNoteListDTO> findNoteDTOsByDemographicNo(String demographicNo) {
+        Query<CaseManagementNoteListDTO> query = currentSession().createQuery(
+                "SELECT NEW io.github.carlos_emr.carlos.casemgmt.dto.CaseManagementNoteListDTO(cmn.id, cmn.update_date, cmn.observation_date, cmn.demographic_no, cmn.signed, cmn.providerNo, cmn.signing_provider_no, cmn.encounter_type, cmn.billing_code, cmn.program_no, cmn.uuid, cmn.locked, cmn.archived, cmn.appointmentNo, p.LastName, p.FirstName) FROM CaseManagementNote cmn LEFT JOIN Provider p ON p.ProviderNo = cmn.providerNo WHERE cmn.demographic_no = :demoNo ORDER BY cmn.observation_date DESC",
+                CaseManagementNoteListDTO.class);
+        query.setParameter("demoNo", demographicNo);
+        return query.list();
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/dto/CaseManagementIssueListDTO.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/dto/CaseManagementIssueListDTO.java
@@ -23,6 +23,10 @@ package io.github.carlos_emr.carlos.casemgmt.dto;
 
 import java.io.Serializable;
 import java.util.Date;
+import java.util.Objects;
+
+import io.github.carlos_emr.carlos.casemgmt.model.CaseManagementIssue;
+import io.github.carlos_emr.carlos.casemgmt.model.Issue;
 
 /**
  * Lightweight DTO for case management issue list views. Eliminates the
@@ -92,6 +96,27 @@ public class CaseManagementIssueListDTO implements Serializable {
         this.programId = programId;
         this.issueCode = issueCode;
         this.issueDescription = issueDescription;
+    }
+
+    /**
+     * Creates a DTO from a full {@link CaseManagementIssue} entity. Pulls
+     * {@code issue.code}/{@code issue.description} via the already-loaded
+     * {@code Issue} relationship when present; otherwise leaves them null.
+     *
+     * @param cmi CaseManagementIssue the entity to convert; must not be null
+     * @return CaseManagementIssueListDTO a lightweight projection
+     * @since 2026-04-12
+     */
+    public static CaseManagementIssueListDTO fromEntity(CaseManagementIssue cmi) {
+        Objects.requireNonNull(cmi, "CaseManagementIssue entity must not be null for DTO conversion");
+        Issue issue = cmi.getIssue();
+        return new CaseManagementIssueListDTO(
+                cmi.getId(), cmi.getDemographic_no(), cmi.getIssue_id(), cmi.getType(),
+                cmi.isAcute(), cmi.isCertain(), cmi.isMajor(), cmi.isResolved(),
+                cmi.getUpdate_date(), cmi.getProgram_id(),
+                issue == null ? null : issue.getCode(),
+                issue == null ? null : issue.getDescription()
+        );
     }
 
     public Long getId() { return id; }

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/dto/CaseManagementIssueListDTO.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/dto/CaseManagementIssueListDTO.java
@@ -54,12 +54,27 @@ public class CaseManagementIssueListDTO implements Serializable {
     private String issueCode;
     private String issueDescription;
 
+    /** Default constructor for serialization/framework binding. */
     public CaseManagementIssueListDTO() {
     }
 
     /**
      * Projection constructor for HQL constructor expressions.
      * Parameter order must match the SELECT NEW clause exactly.
+     *
+     * @param id Long issue row identifier
+     * @param demographicNo String demographic surrogate key
+     * @param issueId Long issue identifier
+     * @param type String issue type
+     * @param acute boolean acute flag
+     * @param certain boolean certainty flag
+     * @param major boolean major flag
+     * @param resolved boolean resolved flag
+     * @param updateDate Date update timestamp
+     * @param programId Integer program identifier
+     * @param issueCode String joined issue code (from Issue entity)
+     * @param issueDescription String joined issue description (from Issue entity)
+     * @since 2026-04-11
      */
     public CaseManagementIssueListDTO(Long id, String demographicNo, Long issueId, String type,
                                       boolean acute, boolean certain, boolean major, boolean resolved,

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/dto/CaseManagementIssueListDTO.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/dto/CaseManagementIssueListDTO.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ * <p>
+ * Now maintained by the CARLOS EMR Project (2026+).
+ * https://github.com/carlos-emr/carlos
+ * CARLOS has no affiliation with OSCAR or McMaster University.
+ */
+package io.github.carlos_emr.carlos.casemgmt.dto;
+
+import java.io.Serializable;
+import java.util.Date;
+
+/**
+ * Lightweight DTO for case management issue list views. Eliminates the
+ * EAGER-loaded Issue entity relationship (lazy=false in HBM). Pre-joins
+ * issue code and description via LEFT JOIN.
+ *
+ * <p>HBM property names (camelCase with underscores): {@code id},
+ * {@code demographic_no}, {@code issue_id}, {@code type}, {@code acute},
+ * {@code certain}, {@code major}, {@code resolved}, {@code update_date},
+ * {@code program_id}.</p>
+ *
+ * @since 2026-04-11
+ */
+public class CaseManagementIssueListDTO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private Long id;
+    private String demographicNo;
+    private Long issueId;
+    private String type;
+    private boolean acute;
+    private boolean certain;
+    private boolean major;
+    private boolean resolved;
+    private Date updateDate;
+    private Integer programId;
+    // Pre-joined from Issue entity
+    private String issueCode;
+    private String issueDescription;
+
+    public CaseManagementIssueListDTO() {
+    }
+
+    /**
+     * Projection constructor for HQL constructor expressions.
+     * Parameter order must match the SELECT NEW clause exactly.
+     */
+    public CaseManagementIssueListDTO(Long id, String demographicNo, Long issueId, String type,
+                                      boolean acute, boolean certain, boolean major, boolean resolved,
+                                      Date updateDate, Integer programId,
+                                      String issueCode, String issueDescription) {
+        this.id = id;
+        this.demographicNo = demographicNo;
+        this.issueId = issueId;
+        this.type = type;
+        this.acute = acute;
+        this.certain = certain;
+        this.major = major;
+        this.resolved = resolved;
+        this.updateDate = updateDate;
+        this.programId = programId;
+        this.issueCode = issueCode;
+        this.issueDescription = issueDescription;
+    }
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public String getDemographicNo() { return demographicNo; }
+    public void setDemographicNo(String demographicNo) { this.demographicNo = demographicNo; }
+    public Long getIssueId() { return issueId; }
+    public void setIssueId(Long issueId) { this.issueId = issueId; }
+    public String getType() { return type; }
+    public void setType(String type) { this.type = type; }
+    public boolean isAcute() { return acute; }
+    public void setAcute(boolean acute) { this.acute = acute; }
+    public boolean isCertain() { return certain; }
+    public void setCertain(boolean certain) { this.certain = certain; }
+    public boolean isMajor() { return major; }
+    public void setMajor(boolean major) { this.major = major; }
+    public boolean isResolved() { return resolved; }
+    public void setResolved(boolean resolved) { this.resolved = resolved; }
+    public Date getUpdateDate() { return updateDate; }
+    public void setUpdateDate(Date updateDate) { this.updateDate = updateDate; }
+    public Integer getProgramId() { return programId; }
+    public void setProgramId(Integer programId) { this.programId = programId; }
+    public String getIssueCode() { return issueCode; }
+    public void setIssueCode(String issueCode) { this.issueCode = issueCode; }
+    public String getIssueDescription() { return issueDescription; }
+    public void setIssueDescription(String issueDescription) { this.issueDescription = issueDescription; }
+}

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/dto/CaseManagementIssueListDTO.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/dto/CaseManagementIssueListDTO.java
@@ -41,7 +41,7 @@ public class CaseManagementIssueListDTO implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private Long id;
-    private String demographicNo;
+    private Integer demographicNo;
     private Long issueId;
     private String type;
     private boolean acute;
@@ -63,7 +63,7 @@ public class CaseManagementIssueListDTO implements Serializable {
      * Parameter order must match the SELECT NEW clause exactly.
      *
      * @param id Long issue row identifier
-     * @param demographicNo String demographic surrogate key
+     * @param demographicNo Integer demographic surrogate key
      * @param issueId Long issue identifier
      * @param type String issue type
      * @param acute boolean acute flag
@@ -76,7 +76,7 @@ public class CaseManagementIssueListDTO implements Serializable {
      * @param issueDescription String joined issue description (from Issue entity)
      * @since 2026-04-11
      */
-    public CaseManagementIssueListDTO(Long id, String demographicNo, Long issueId, String type,
+    public CaseManagementIssueListDTO(Long id, Integer demographicNo, Long issueId, String type,
                                       boolean acute, boolean certain, boolean major, boolean resolved,
                                       Date updateDate, Integer programId,
                                       String issueCode, String issueDescription) {
@@ -96,8 +96,8 @@ public class CaseManagementIssueListDTO implements Serializable {
 
     public Long getId() { return id; }
     public void setId(Long id) { this.id = id; }
-    public String getDemographicNo() { return demographicNo; }
-    public void setDemographicNo(String demographicNo) { this.demographicNo = demographicNo; }
+    public Integer getDemographicNo() { return demographicNo; }
+    public void setDemographicNo(Integer demographicNo) { this.demographicNo = demographicNo; }
     public Long getIssueId() { return issueId; }
     public void setIssueId(Long issueId) { this.issueId = issueId; }
     public String getType() { return type; }

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/dto/CaseManagementNoteListDTO.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/dto/CaseManagementNoteListDTO.java
@@ -50,6 +50,12 @@ public class CaseManagementNoteListDTO implements Serializable {
     private Long id;
     private Date updateDate;
     private Date observationDate;
+    /**
+     * Demographic number as stored on the underlying entity. {@code CaseManagementNote.demographic_no}
+     * is typed as {@code String} in the HBM mapping (unlike most other demographic-linked
+     * entities which use {@code Integer}), so this field mirrors that type to avoid
+     * an unnecessary parse at the DAO boundary.
+     */
     private String demographicNo;
     private boolean signed;
     private String providerNo;

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/dto/CaseManagementNoteListDTO.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/dto/CaseManagementNoteListDTO.java
@@ -23,7 +23,10 @@ package io.github.carlos_emr.carlos.casemgmt.dto;
 
 import java.io.Serializable;
 import java.util.Date;
+import java.util.Objects;
 
+import io.github.carlos_emr.carlos.casemgmt.model.CaseManagementNote;
+import io.github.carlos_emr.carlos.commn.model.Provider;
 import io.github.carlos_emr.carlos.utility.DtoFormatUtils;
 
 /**
@@ -71,12 +74,31 @@ public class CaseManagementNoteListDTO implements Serializable {
     private String providerLastName;
     private String providerFirstName;
 
+    /** Default constructor for serialization/framework binding. */
     public CaseManagementNoteListDTO() {
     }
 
     /**
      * Projection constructor for HQL constructor expressions.
      * Parameter order must match the SELECT NEW clause exactly.
+     *
+     * @param id Long note row identifier
+     * @param updateDate Date last-update timestamp
+     * @param observationDate Date clinical observation date
+     * @param demographicNo String demographic surrogate key (String per HBM mapping)
+     * @param signed boolean signature flag
+     * @param providerNo String authoring provider number
+     * @param signingProviderNo String signing provider number (may differ from authoring provider)
+     * @param encounterType String encounter type code
+     * @param billingCode String billing code
+     * @param programNo String program number
+     * @param uuid String note UUID used for history linkage
+     * @param locked boolean locked flag
+     * @param archived boolean archived flag
+     * @param appointmentNo Integer associated appointment id (nullable)
+     * @param providerLastName String authoring provider last name (from LEFT JOIN)
+     * @param providerFirstName String authoring provider first name (from LEFT JOIN)
+     * @since 2026-04-11
      */
     public CaseManagementNoteListDTO(Long id, Date updateDate, Date observationDate,
                                      String demographicNo, boolean signed, String providerNo,
@@ -100,6 +122,29 @@ public class CaseManagementNoteListDTO implements Serializable {
         this.appointmentNo = appointmentNo;
         this.providerLastName = providerLastName;
         this.providerFirstName = providerFirstName;
+    }
+
+    /**
+     * Creates a DTO from a full {@link CaseManagementNote} entity. Pulls provider
+     * name from the already-loaded {@code Provider} relationship when present;
+     * otherwise leaves it null.
+     *
+     * @param cmn CaseManagementNote the entity to convert; must not be null
+     * @return CaseManagementNoteListDTO a lightweight projection
+     * @since 2026-04-12
+     */
+    public static CaseManagementNoteListDTO fromEntity(CaseManagementNote cmn) {
+        Objects.requireNonNull(cmn, "CaseManagementNote entity must not be null for DTO conversion");
+        Provider provider = cmn.getProvider();
+        return new CaseManagementNoteListDTO(
+                cmn.getId(), cmn.getUpdate_date(), cmn.getObservation_date(),
+                cmn.getDemographic_no(), cmn.isSigned(), cmn.getProviderNo(),
+                cmn.getSigning_provider_no(), cmn.getEncounter_type(),
+                cmn.getBilling_code(), cmn.getProgram_no(), cmn.getUuid(),
+                cmn.isLocked(), cmn.isArchived(), cmn.getAppointmentNo(),
+                provider == null ? null : provider.getLastName(),
+                provider == null ? null : provider.getFirstName()
+        );
     }
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/dto/CaseManagementNoteListDTO.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/dto/CaseManagementNoteListDTO.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ * <p>
+ * Now maintained by the CARLOS EMR Project (2026+).
+ * https://github.com/carlos-emr/carlos
+ * CARLOS has no affiliation with OSCAR or McMaster University.
+ */
+package io.github.carlos_emr.carlos.casemgmt.dto;
+
+import java.io.Serializable;
+import java.util.Date;
+
+import io.github.carlos_emr.carlos.utility.DtoFormatUtils;
+
+/**
+ * Lightweight DTO for clinical note list views. Eliminates the 3 EAGER/lazy=false
+ * relationships in the HBM mapping (provider, issues set, extend set) and avoids
+ * loading the full note text, history, and formula-computed properties.
+ *
+ * <p>Pre-joins provider name via LEFT JOIN to Provider. Omits: note text (LOB),
+ * history, issues set, editors list, extend set, password, formula columns
+ * (roleName, programName, revision, create_date).</p>
+ *
+ * <p>HBM property names used in HQL: {@code id}, {@code update_date},
+ * {@code observation_date}, {@code demographic_no}, {@code signed},
+ * {@code providerNo}, {@code signing_provider_no}, {@code encounter_type},
+ * {@code billing_code}, {@code program_no}, {@code uuid}, {@code locked},
+ * {@code archived}, {@code appointmentNo}.</p>
+ *
+ * @since 2026-04-11
+ */
+public class CaseManagementNoteListDTO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private Long id;
+    private Date updateDate;
+    private Date observationDate;
+    private String demographicNo;
+    private boolean signed;
+    private String providerNo;
+    private String signingProviderNo;
+    private String encounterType;
+    private String billingCode;
+    private String programNo;
+    private String uuid;
+    private boolean locked;
+    private boolean archived;
+    private Integer appointmentNo;
+    // Pre-joined from Provider
+    private String providerLastName;
+    private String providerFirstName;
+
+    public CaseManagementNoteListDTO() {
+    }
+
+    /**
+     * Projection constructor for HQL constructor expressions.
+     * Parameter order must match the SELECT NEW clause exactly.
+     */
+    public CaseManagementNoteListDTO(Long id, Date updateDate, Date observationDate,
+                                     String demographicNo, boolean signed, String providerNo,
+                                     String signingProviderNo, String encounterType,
+                                     String billingCode, String programNo, String uuid,
+                                     boolean locked, boolean archived, Integer appointmentNo,
+                                     String providerLastName, String providerFirstName) {
+        this.id = id;
+        this.updateDate = updateDate;
+        this.observationDate = observationDate;
+        this.demographicNo = demographicNo;
+        this.signed = signed;
+        this.providerNo = providerNo;
+        this.signingProviderNo = signingProviderNo;
+        this.encounterType = encounterType;
+        this.billingCode = billingCode;
+        this.programNo = programNo;
+        this.uuid = uuid;
+        this.locked = locked;
+        this.archived = archived;
+        this.appointmentNo = appointmentNo;
+        this.providerLastName = providerLastName;
+        this.providerFirstName = providerFirstName;
+    }
+
+    /**
+     * Returns the provider's formatted name as "LastName, FirstName".
+     *
+     * @return String the formatted provider name
+     */
+    public String getProviderName() {
+        return DtoFormatUtils.formatName(providerLastName, providerFirstName, "");
+    }
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public Date getUpdateDate() { return updateDate; }
+    public void setUpdateDate(Date updateDate) { this.updateDate = updateDate; }
+    public Date getObservationDate() { return observationDate; }
+    public void setObservationDate(Date observationDate) { this.observationDate = observationDate; }
+    public String getDemographicNo() { return demographicNo; }
+    public void setDemographicNo(String demographicNo) { this.demographicNo = demographicNo; }
+    public boolean isSigned() { return signed; }
+    public void setSigned(boolean signed) { this.signed = signed; }
+    public String getProviderNo() { return providerNo; }
+    public void setProviderNo(String providerNo) { this.providerNo = providerNo; }
+    public String getSigningProviderNo() { return signingProviderNo; }
+    public void setSigningProviderNo(String signingProviderNo) { this.signingProviderNo = signingProviderNo; }
+    public String getEncounterType() { return encounterType; }
+    public void setEncounterType(String encounterType) { this.encounterType = encounterType; }
+    public String getBillingCode() { return billingCode; }
+    public void setBillingCode(String billingCode) { this.billingCode = billingCode; }
+    public String getProgramNo() { return programNo; }
+    public void setProgramNo(String programNo) { this.programNo = programNo; }
+    public String getUuid() { return uuid; }
+    public void setUuid(String uuid) { this.uuid = uuid; }
+    public boolean isLocked() { return locked; }
+    public void setLocked(boolean locked) { this.locked = locked; }
+    public boolean isArchived() { return archived; }
+    public void setArchived(boolean archived) { this.archived = archived; }
+    public Integer getAppointmentNo() { return appointmentNo; }
+    public void setAppointmentNo(Integer appointmentNo) { this.appointmentNo = appointmentNo; }
+    public String getProviderLastName() { return providerLastName; }
+    public void setProviderLastName(String providerLastName) { this.providerLastName = providerLastName; }
+    public String getProviderFirstName() { return providerFirstName; }
+    public void setProviderFirstName(String providerFirstName) { this.providerFirstName = providerFirstName; }
+}

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/service/CaseManagementManager.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/service/CaseManagementManager.java
@@ -391,12 +391,13 @@ public interface CaseManagementManager {
     /**
      * Returns lightweight case management issue DTOs for a demographic.
      * Enforces {@code _demographic} read privilege scoped to the patient
-     * and writes a synchronous audit log entry.
+     * and writes a synchronous audit log entry. The underlying DAO guards
+     * against non-numeric input — see
+     * {@link CaseManagementIssueDAO#findIssueDTOsByDemographicNo(String)}.
      *
      * @param loggedInInfo LoggedInInfo the logged-in user context
      * @param demographicNo String the patient demographic number
-     * @return List&lt;CaseManagementIssueListDTO&gt; ordered by update_date descending;
-     *         empty list if {@code demographicNo} is not a valid integer
+     * @return List&lt;CaseManagementIssueListDTO&gt; ordered by update_date descending
      * @throws SecurityException if the caller lacks {@code _demographic} read privilege
      * @since 2026-04-12
      */

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/service/CaseManagementManager.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/service/CaseManagementManager.java
@@ -32,6 +32,8 @@
 package io.github.carlos_emr.carlos.casemgmt.service;
 
 import io.github.carlos_emr.carlos.casemgmt.dao.*;
+import io.github.carlos_emr.carlos.casemgmt.dto.CaseManagementIssueListDTO;
+import io.github.carlos_emr.carlos.casemgmt.dto.CaseManagementNoteListDTO;
 import io.github.carlos_emr.carlos.casemgmt.model.*;
 import io.github.carlos_emr.carlos.commn.dao.*;
 import io.github.carlos_emr.carlos.commn.model.*;
@@ -385,5 +387,32 @@ public interface CaseManagementManager {
     public void setCPPMedicalHistory(CaseManagementCPP cpp, String providerNo, List accessRight);
 
     public String listNotes(String code, String providerNo, String demoNo);
+
+    /**
+     * Returns lightweight case management issue DTOs for a demographic.
+     * Enforces {@code _demographic} read privilege scoped to the patient
+     * and writes a synchronous audit log entry.
+     *
+     * @param loggedInInfo LoggedInInfo the logged-in user context
+     * @param demographicNo String the patient demographic number
+     * @return List&lt;CaseManagementIssueListDTO&gt; ordered by update_date descending;
+     *         empty list if {@code demographicNo} is not a valid integer
+     * @throws SecurityException if the caller lacks {@code _demographic} read privilege
+     * @since 2026-04-12
+     */
+    List<CaseManagementIssueListDTO> getIssueDTOs(LoggedInInfo loggedInInfo, String demographicNo);
+
+    /**
+     * Returns lightweight case management note DTOs for a demographic.
+     * Enforces {@code _demographic} read privilege scoped to the patient
+     * and writes a synchronous audit log entry.
+     *
+     * @param loggedInInfo LoggedInInfo the logged-in user context
+     * @param demographicNo String the patient demographic number
+     * @return List&lt;CaseManagementNoteListDTO&gt; ordered by observation_date descending
+     * @throws SecurityException if the caller lacks {@code _demographic} read privilege
+     * @since 2026-04-12
+     */
+    List<CaseManagementNoteListDTO> getNoteDTOs(LoggedInInfo loggedInInfo, String demographicNo);
 
 }

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/service/CaseManagementManagerImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/service/CaseManagementManagerImpl.java
@@ -34,6 +34,8 @@ package io.github.carlos_emr.carlos.casemgmt.service;
 import io.github.carlos_emr.carlos.PMmodule.model.*;
 import io.github.carlos_emr.carlos.appt.ApptStatusData;
 import io.github.carlos_emr.carlos.casemgmt.dao.*;
+import io.github.carlos_emr.carlos.casemgmt.dto.CaseManagementIssueListDTO;
+import io.github.carlos_emr.carlos.casemgmt.dto.CaseManagementNoteListDTO;
 import io.github.carlos_emr.carlos.casemgmt.model.*;
 import io.github.carlos_emr.carlos.commn.dao.*;
 import io.github.carlos_emr.carlos.commn.model.*;
@@ -2562,6 +2564,28 @@ public class CaseManagementManagerImpl implements CaseManagementManager {
             logger.warn("Invalid role format: '" + roleIdStr + "' - not a valid Long");
         }
         return "";
+    }
+
+    @Override
+    public List<CaseManagementIssueListDTO> getIssueDTOs(LoggedInInfo loggedInInfo, String demographicNo) {
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_demographic", SecurityInfoManager.READ, demographicNo)) {
+            throw new SecurityException("missing required sec object (_demographic)");
+        }
+        List<CaseManagementIssueListDTO> results = caseManagementIssueDAO.findIssueDTOsByDemographicNo(demographicNo);
+        LogAction.addLogSynchronous(loggedInInfo, "CaseManagementManager.getIssueDTOs",
+                "demographicNo=" + demographicNo);
+        return results;
+    }
+
+    @Override
+    public List<CaseManagementNoteListDTO> getNoteDTOs(LoggedInInfo loggedInInfo, String demographicNo) {
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_demographic", SecurityInfoManager.READ, demographicNo)) {
+            throw new SecurityException("missing required sec object (_demographic)");
+        }
+        List<CaseManagementNoteListDTO> results = caseManagementNoteDAO.findNoteDTOsByDemographicNo(demographicNo);
+        LogAction.addLogSynchronous(loggedInInfo, "CaseManagementManager.getNoteDTOs",
+                "demographicNo=" + demographicNo);
+        return results;
     }
 
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/AllergyDao.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/AllergyDao.java
@@ -34,6 +34,7 @@ package io.github.carlos_emr.carlos.commn.dao;
 import java.util.Date;
 import java.util.List;
 
+import io.github.carlos_emr.carlos.allergy.dto.AllergyListItemDTO;
 import io.github.carlos_emr.carlos.commn.model.Allergy;
 
 public interface AllergyDao extends AbstractDao<Allergy> {
@@ -54,4 +55,13 @@ public interface AllergyDao extends AbstractDao<Allergy> {
                                                                  Date updatedAfterThisDateExclusive, int itemsToReturn);
 
     public List<Allergy> findAllCustomAllergiesWithNullNonDrugFlag(int start, int limit);
+
+    /**
+     * Returns lightweight allergy DTOs for a demographic (14 fields vs 91).
+     *
+     * @param demographicNo Integer the patient demographic number
+     * @return List of AllergyListItemDTO
+     * @since 2026-04-11
+     */
+    public List<AllergyListItemDTO> findAllergyDTOsByDemographicNo(Integer demographicNo);
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/AllergyDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/AllergyDaoImpl.java
@@ -31,6 +31,7 @@
 
 package io.github.carlos_emr.carlos.commn.dao;
 
+import io.github.carlos_emr.carlos.allergy.dto.AllergyListItemDTO;
 import io.github.carlos_emr.carlos.commn.model.Allergy;
 
 import jakarta.persistence.Query;
@@ -162,5 +163,13 @@ public class AllergyDaoImpl extends AbstractDaoImpl<Allergy> implements AllergyD
         @SuppressWarnings("unchecked")
         List<Allergy> results = query.getResultList();
         return (results);
+    }
+
+    @Override
+    public List<AllergyListItemDTO> findAllergyDTOsByDemographicNo(Integer demographicNo) {
+        Query query = entityManager.createQuery(
+                "SELECT NEW io.github.carlos_emr.carlos.allergy.dto.AllergyListItemDTO(a.id, a.demographicNo, a.entryDate, a.description, a.reaction, a.archived, a.nonDrug, a.typeCode, a.startDate, a.severityOfReaction, a.onsetOfReaction, a.lifeStage, a.reactionType, a.providerNo) FROM Allergy a WHERE a.demographicNo = :demoNo ORDER BY a.entryDate DESC");
+        query.setParameter("demoNo", demographicNo);
+        return query.getResultList();
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/AllergyDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/AllergyDaoImpl.java
@@ -174,8 +174,15 @@ public class AllergyDaoImpl extends AbstractDaoImpl<Allergy> implements AllergyD
      */
     @Override
     public List<AllergyListItemDTO> findAllergyDTOsByDemographicNo(Integer demographicNo) {
-        Query query = entityManager.createQuery(
-                "SELECT NEW io.github.carlos_emr.carlos.allergy.dto.AllergyListItemDTO(a.id, a.demographicNo, a.entryDate, a.description, a.reaction, a.archived, a.nonDrug, a.typeCode, a.startDate, a.severityOfReaction, a.onsetOfReaction, a.lifeStage, a.reactionType, a.providerNo) FROM Allergy a WHERE a.demographicNo = :demoNo ORDER BY a.entryDate DESC");
+        Query query = entityManager.createQuery("""
+                SELECT NEW io.github.carlos_emr.carlos.allergy.dto.AllergyListItemDTO(
+                    a.id, a.demographicNo, a.entryDate, a.description, a.reaction,
+                    a.archived, a.nonDrug, a.typeCode, a.startDate, a.severityOfReaction,
+                    a.onsetOfReaction, a.lifeStage, a.reactionType, a.providerNo)
+                FROM Allergy a
+                WHERE a.demographicNo = :demoNo
+                ORDER BY a.entryDate DESC
+                """);
         query.setParameter("demoNo", demographicNo);
         return query.getResultList();
     }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/AllergyDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/AllergyDaoImpl.java
@@ -165,6 +165,13 @@ public class AllergyDaoImpl extends AbstractDaoImpl<Allergy> implements AllergyD
         return (results);
     }
 
+    /**
+     * Returns lightweight allergy list DTOs for a demographic, ordered by entry date descending.
+     *
+     * @param demographicNo Integer the demographic identifier
+     * @return List&lt;AllergyListItemDTO&gt; ordered by entry date descending; empty if none found
+     * @since 2026-04-11
+     */
     @Override
     public List<AllergyListItemDTO> findAllergyDTOsByDemographicNo(Integer demographicNo) {
         Query query = entityManager.createQuery(

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/AllergyMergedDemographicDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/AllergyMergedDemographicDaoImpl.java
@@ -93,6 +93,12 @@ public class AllergyMergedDemographicDaoImpl extends AllergyDaoImpl implements A
         return template.findMerged(demographicId, result);
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Merges allergy DTOs from the target demographic with those from any
+     * demographics merged into it.</p>
+     */
     @Override
     public List<AllergyListItemDTO> findAllergyDTOsByDemographicNo(Integer demographicNo) {
         List<AllergyListItemDTO> result = super.findAllergyDTOsByDemographicNo(demographicNo);

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/AllergyMergedDemographicDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/AllergyMergedDemographicDaoImpl.java
@@ -36,6 +36,7 @@ import java.util.List;
 
 import io.github.carlos_emr.carlos.commn.merge.MergedDemographicTemplate;
 import io.github.carlos_emr.carlos.commn.model.Allergy;
+import io.github.carlos_emr.carlos.allergy.dto.AllergyListItemDTO;
 import org.springframework.stereotype.Repository;
 
 @Repository("AllergyDao")
@@ -90,5 +91,17 @@ public class AllergyMergedDemographicDaoImpl extends AllergyDaoImpl implements A
             }
         };
         return template.findMerged(demographicId, result);
+    }
+
+    @Override
+    public List<AllergyListItemDTO> findAllergyDTOsByDemographicNo(Integer demographicNo) {
+        List<AllergyListItemDTO> result = super.findAllergyDTOsByDemographicNo(demographicNo);
+        MergedDemographicTemplate<AllergyListItemDTO> template = new MergedDemographicTemplate<AllergyListItemDTO>() {
+            @Override
+            protected List<AllergyListItemDTO> findById(Integer demographic_no) {
+                return AllergyMergedDemographicDaoImpl.super.findAllergyDTOsByDemographicNo(demographic_no);
+            }
+        };
+        return template.findMerged(demographicNo, result);
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/BillingONCHeader1Dao.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/BillingONCHeader1Dao.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import io.github.carlos_emr.carlos.billings.dto.BillingONCListItemDTO;
 import io.github.carlos_emr.carlos.commn.model.BillingONCHeader1;
 import io.github.carlos_emr.carlos.commn.model.BillingONItem;
 import io.github.carlos_emr.carlos.commn.model.Provider;
@@ -141,4 +142,13 @@ public interface BillingONCHeader1Dao extends AbstractDao<BillingONCHeader1> {
 
     public List<BillingONCHeader1> findAllByPayProgram(String payProgram, int startIndex, int limit);
 
+    /**
+     * Returns lightweight billing DTOs for a demographic, bypassing the EAGER
+     * BillingONItem collection (CascadeType.ALL). 16 fields vs 113.
+     *
+     * @param demographicNo Integer the patient demographic number
+     * @return List of BillingONCListItemDTO
+     * @since 2026-04-11
+     */
+    public List<BillingONCListItemDTO> findBillingDTOsByDemographicNo(Integer demographicNo);
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/BillingONCHeader1DaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/BillingONCHeader1DaoImpl.java
@@ -917,10 +917,18 @@ public class BillingONCHeader1DaoImpl extends AbstractDaoImpl<BillingONCHeader1>
         return results;
     }
 
+    /**
+     * Returns lightweight Ontario billing header DTOs for a demographic, excluding
+     * soft-deleted records ({@code status = 'D'}), ordered by billing date descending.
+     *
+     * @param demographicNo Integer the patient demographic number
+     * @return List&lt;BillingONCListItemDTO&gt; of active billing records ordered by billing date descending
+     * @since 2026-04-11
+     */
     @Override
     public List<BillingONCListItemDTO> findBillingDTOsByDemographicNo(Integer demographicNo) {
         Query query = entityManager.createQuery(
-                "SELECT NEW io.github.carlos_emr.carlos.billings.dto.BillingONCListItemDTO(b.id, b.demographicNo, b.providerNo, b.appointmentNo, b.billingDate, b.billingTime, b.status, b.payProgram, b.visitType, b.admissionDate, b.faciltyNum, b.total, b.paid, b.timestamp, b.clinic, b.demographicName) FROM BillingONCHeader1 b WHERE b.demographicNo = :demoNo ORDER BY b.billingDate DESC");
+                "SELECT NEW io.github.carlos_emr.carlos.billings.dto.BillingONCListItemDTO(b.id, b.demographicNo, b.providerNo, b.appointmentNo, b.billingDate, b.billingTime, b.status, b.payProgram, b.visitType, b.admissionDate, b.faciltyNum, b.total, b.paid, b.timestamp, b.clinic, b.demographicName) FROM BillingONCHeader1 b WHERE b.demographicNo = :demoNo AND b.status <> 'D' ORDER BY b.billingDate DESC");
         query.setParameter("demoNo", demographicNo);
         return query.getResultList();
     }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/BillingONCHeader1DaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/BillingONCHeader1DaoImpl.java
@@ -927,8 +927,16 @@ public class BillingONCHeader1DaoImpl extends AbstractDaoImpl<BillingONCHeader1>
      */
     @Override
     public List<BillingONCListItemDTO> findBillingDTOsByDemographicNo(Integer demographicNo) {
-        Query query = entityManager.createQuery(
-                "SELECT NEW io.github.carlos_emr.carlos.billings.dto.BillingONCListItemDTO(b.id, b.demographicNo, b.providerNo, b.appointmentNo, b.billingDate, b.billingTime, b.status, b.payProgram, b.visitType, b.admissionDate, b.faciltyNum, b.total, b.paid, b.timestamp, b.clinic, b.demographicName) FROM BillingONCHeader1 b WHERE b.demographicNo = :demoNo AND b.status <> 'D' ORDER BY b.billingDate DESC");
+        Query query = entityManager.createQuery("""
+                SELECT NEW io.github.carlos_emr.carlos.billings.dto.BillingONCListItemDTO(
+                    b.id, b.demographicNo, b.providerNo, b.appointmentNo,
+                    b.billingDate, b.billingTime, b.status, b.payProgram, b.visitType,
+                    b.admissionDate, b.faciltyNum, b.total, b.paid, b.timestamp,
+                    b.clinic, b.demographicName)
+                FROM BillingONCHeader1 b
+                WHERE b.demographicNo = :demoNo AND b.status <> 'D'
+                ORDER BY b.billingDate DESC
+                """);
         query.setParameter("demoNo", demographicNo);
         return query.getResultList();
     }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/BillingONCHeader1DaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/BillingONCHeader1DaoImpl.java
@@ -46,6 +46,7 @@ import java.util.Map.Entry;
 import jakarta.persistence.Query;
 
 import org.apache.commons.lang3.StringUtils;
+import io.github.carlos_emr.carlos.billings.dto.BillingONCListItemDTO;
 import io.github.carlos_emr.carlos.PMmodule.dao.ProviderDao;
 import io.github.carlos_emr.carlos.PMmodule.utility.DateUtils;
 import io.github.carlos_emr.carlos.billing.CA.ON.model.BillingPercLimit;
@@ -914,6 +915,14 @@ public class BillingONCHeader1DaoImpl extends AbstractDaoImpl<BillingONCHeader1>
         List<BillingONCHeader1> results = query.getResultList();
 
         return results;
+    }
+
+    @Override
+    public List<BillingONCListItemDTO> findBillingDTOsByDemographicNo(Integer demographicNo) {
+        Query query = entityManager.createQuery(
+                "SELECT NEW io.github.carlos_emr.carlos.billings.dto.BillingONCListItemDTO(b.id, b.demographicNo, b.providerNo, b.appointmentNo, b.billingDate, b.billingTime, b.status, b.payProgram, b.visitType, b.admissionDate, b.faciltyNum, b.total, b.paid, b.timestamp, b.clinic, b.demographicName) FROM BillingONCHeader1 b WHERE b.demographicNo = :demoNo ORDER BY b.billingDate DESC");
+        query.setParameter("demoNo", demographicNo);
+        return query.getResultList();
     }
 
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/ConsultationRequestDao.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/ConsultationRequestDao.java
@@ -35,6 +35,7 @@ import java.util.Date;
 import java.util.List;
 
 import io.github.carlos_emr.carlos.commn.model.ConsultationRequest;
+import io.github.carlos_emr.carlos.consultation.dto.ConsultationRequestListItemDTO;
 
 public interface ConsultationRequestDao extends AbstractDao<ConsultationRequest> {
 
@@ -63,4 +64,14 @@ public interface ConsultationRequestDao extends AbstractDao<ConsultationRequest>
     List<ConsultationRequest> findByDemographicAndServices(Integer demographicNo, List<String> serviceNameList);
 
     List<Integer> findNewConsultationsSinceDemoKey(String keyName);
+
+    /**
+     * Returns lightweight consultation request DTOs for a demographic, eliminating
+     * 3 EAGER entity joins. Pre-joins specialist name.
+     *
+     * @param demographicId Integer the patient demographic number
+     * @return List of ConsultationRequestListItemDTO
+     * @since 2026-04-11
+     */
+    List<ConsultationRequestListItemDTO> findConsultationDTOsByDemographicId(Integer demographicId);
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/ConsultationRequestDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/ConsultationRequestDaoImpl.java
@@ -39,6 +39,7 @@ import jakarta.persistence.Query;
 import org.apache.commons.lang3.time.DateFormatUtils;
 import io.github.carlos_emr.carlos.commn.NativeSql;
 import io.github.carlos_emr.carlos.commn.model.ConsultationRequest;
+import io.github.carlos_emr.carlos.consultation.dto.ConsultationRequestListItemDTO;
 
 @SuppressWarnings("unchecked")
 public class ConsultationRequestDaoImpl extends AbstractDaoImpl<ConsultationRequest> implements ConsultationRequestDao {
@@ -214,6 +215,14 @@ public class ConsultationRequestDaoImpl extends AbstractDaoImpl<ConsultationRequ
         String sql = "select distinct dr.demographicNo from consultationRequests dr,demographic d,demographicExt e where dr.demographicNo = d.demographic_no and d.demographic_no = e.demographic_no and e.key_val=?1 and dr.lastUpdateDate > e.value";
         Query query = entityManager.createNativeQuery(sql);
         query.setParameter(1, keyName);
+        return query.getResultList();
+    }
+
+    @Override
+    public List<ConsultationRequestListItemDTO> findConsultationDTOsByDemographicId(Integer demographicId) {
+        Query query = entityManager.createQuery(
+                "SELECT NEW io.github.carlos_emr.carlos.consultation.dto.ConsultationRequestListItemDTO(cr.id, cr.referralDate, cr.serviceId, cr.demographicId, cr.providerNo, cr.status, cr.statusText, cr.urgency, cr.reasonForReferral, cr.appointmentDate, cr.followUpDate, cr.sendTo, cr.siteName, cr.letterheadName, cr.source, cr.lastUpdateDate, ps.lastName, ps.firstName) FROM ConsultationRequest cr LEFT JOIN cr.professionalSpecialist ps WHERE cr.demographicId = :demoId ORDER BY cr.referralDate DESC");
+        query.setParameter("demoId", demographicId);
         return query.getResultList();
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/ConsultationRequestDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/ConsultationRequestDaoImpl.java
@@ -218,6 +218,13 @@ public class ConsultationRequestDaoImpl extends AbstractDaoImpl<ConsultationRequ
         return query.getResultList();
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Executes a JPQL {@code SELECT NEW} projection with a LEFT JOIN on
+     * {@code professionalSpecialist} to pre-populate the specialist's name,
+     * ordered by {@code referralDate} descending.</p>
+     */
     @Override
     public List<ConsultationRequestListItemDTO> findConsultationDTOsByDemographicId(Integer demographicId) {
         Query query = entityManager.createQuery(

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/ConsultationRequestDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/ConsultationRequestDaoImpl.java
@@ -227,8 +227,18 @@ public class ConsultationRequestDaoImpl extends AbstractDaoImpl<ConsultationRequ
      */
     @Override
     public List<ConsultationRequestListItemDTO> findConsultationDTOsByDemographicId(Integer demographicId) {
-        Query query = entityManager.createQuery(
-                "SELECT NEW io.github.carlos_emr.carlos.consultation.dto.ConsultationRequestListItemDTO(cr.id, cr.referralDate, cr.serviceId, cr.demographicId, cr.providerNo, cr.status, cr.statusText, cr.urgency, cr.reasonForReferral, cr.appointmentDate, cr.followUpDate, cr.sendTo, cr.siteName, cr.letterheadName, cr.source, cr.lastUpdateDate, ps.lastName, ps.firstName) FROM ConsultationRequest cr LEFT JOIN cr.professionalSpecialist ps WHERE cr.demographicId = :demoId ORDER BY cr.referralDate DESC");
+        Query query = entityManager.createQuery("""
+                SELECT NEW io.github.carlos_emr.carlos.consultation.dto.ConsultationRequestListItemDTO(
+                    cr.id, cr.referralDate, cr.serviceId, cr.demographicId,
+                    cr.providerNo, cr.status, cr.statusText, cr.urgency,
+                    cr.reasonForReferral, cr.appointmentDate, cr.followUpDate,
+                    cr.sendTo, cr.siteName, cr.letterheadName, cr.source, cr.lastUpdateDate,
+                    ps.lastName, ps.firstName)
+                FROM ConsultationRequest cr
+                LEFT JOIN cr.professionalSpecialist ps
+                WHERE cr.demographicId = :demoId
+                ORDER BY cr.referralDate DESC
+                """);
         query.setParameter("demoId", demographicId);
         return query.getResultList();
     }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/ConsultationRequestMergedDemographicDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/ConsultationRequestMergedDemographicDaoImpl.java
@@ -65,6 +65,12 @@ public class ConsultationRequestMergedDemographicDaoImpl extends ConsultationReq
         return template.findMerged(demographicNo, result);
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Merges consultation request DTOs from the target demographic with those
+     * from any demographics merged into it.</p>
+     */
     @Override
     public List<ConsultationRequestListItemDTO> findConsultationDTOsByDemographicId(Integer demographicId) {
         List<ConsultationRequestListItemDTO> result = super.findConsultationDTOsByDemographicId(demographicId);

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/ConsultationRequestMergedDemographicDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/ConsultationRequestMergedDemographicDaoImpl.java
@@ -35,6 +35,7 @@ import java.util.List;
 
 import io.github.carlos_emr.carlos.commn.merge.MergedDemographicTemplate;
 import io.github.carlos_emr.carlos.commn.model.ConsultationRequest;
+import io.github.carlos_emr.carlos.consultation.dto.ConsultationRequestListItemDTO;
 import org.springframework.stereotype.Repository;
 
 @Repository("consultationRequestDao")
@@ -62,6 +63,18 @@ public class ConsultationRequestMergedDemographicDaoImpl extends ConsultationReq
             }
         };
         return template.findMerged(demographicNo, result);
+    }
+
+    @Override
+    public List<ConsultationRequestListItemDTO> findConsultationDTOsByDemographicId(Integer demographicId) {
+        List<ConsultationRequestListItemDTO> result = super.findConsultationDTOsByDemographicId(demographicId);
+        MergedDemographicTemplate<ConsultationRequestListItemDTO> template = new MergedDemographicTemplate<ConsultationRequestListItemDTO>() {
+            @Override
+            protected List<ConsultationRequestListItemDTO> findById(Integer demographic_no) {
+                return ConsultationRequestMergedDemographicDaoImpl.super.findConsultationDTOsByDemographicId(demographic_no);
+            }
+        };
+        return template.findMerged(demographicId, result);
     }
 
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/DocumentDao.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/DocumentDao.java
@@ -190,9 +190,9 @@ public interface DocumentDao extends AbstractDao<Document> {
      * Returns lightweight document DTOs for a demographic, bypassing the EAGER
      * DocumentReview collection load. Uses JPQL constructor expression projection.
      *
-     * @param demographicNo String the patient demographic number
-     * @return List of DocumentListItemDTO for the patient's documents
+     * @param demographicNo Integer the patient demographic number
+     * @return List of DocumentListItemDTO for the patient's documents ordered by observation date descending
      * @since 2026-04-11
      */
-    public List<DocumentListItemDTO> findDocumentDTOsByDemographicNo(String demographicNo);
+    public List<DocumentListItemDTO> findDocumentDTOsByDemographicNo(Integer demographicNo);
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/DocumentDao.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/DocumentDao.java
@@ -37,6 +37,7 @@ import java.util.List;
 
 import io.github.carlos_emr.carlos.commn.model.Demographic;
 import io.github.carlos_emr.carlos.commn.model.Document;
+import io.github.carlos_emr.carlos.documentManager.dto.DocumentListItemDTO;
 
 import io.github.carlos_emr.carlos.documentManager.EDocUtil.EDocSort;
 
@@ -184,4 +185,14 @@ public interface DocumentDao extends AbstractDao<Document> {
      * @return List&lt;String&gt; list of distinct matching document descriptions
      */
     public List<String> findDocumentDescriptions(String keyword);
+
+    /**
+     * Returns lightweight document DTOs for a demographic, bypassing the EAGER
+     * DocumentReview collection load. Uses JPQL constructor expression projection.
+     *
+     * @param demographicNo String the patient demographic number
+     * @return List of DocumentListItemDTO for the patient's documents
+     * @since 2026-04-11
+     */
+    public List<DocumentListItemDTO> findDocumentDTOsByDemographicNo(String demographicNo);
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/DocumentDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/DocumentDaoImpl.java
@@ -507,22 +507,15 @@ public class DocumentDaoImpl extends AbstractDaoImpl<Document> implements Docume
      * traverse the {@code @EmbeddedId} on {@code CtlDocument}. Active (non-deleted)
      * documents only.</p>
      *
-     * @param demographicNo String the demographic number (must be a valid integer string)
-     * @return List&lt;DocumentListItemDTO&gt; ordered by observation date descending,
-     *         or an empty list if {@code demographicNo} is not a valid integer
+     * @param demographicNo Integer the patient demographic number
+     * @return List&lt;DocumentListItemDTO&gt; ordered by observation date descending
      * @since 2026-04-11
      */
     @Override
-    public List<DocumentListItemDTO> findDocumentDTOsByDemographicNo(String demographicNo) {
-        int demoNoInt;
-        try {
-            demoNoInt = Integer.parseInt(demographicNo);
-        } catch (NumberFormatException e) {
-            return java.util.Collections.emptyList();
-        }
+    public List<DocumentListItemDTO> findDocumentDTOsByDemographicNo(Integer demographicNo) {
         Query query = entityManager.createQuery(
                 "SELECT NEW io.github.carlos_emr.carlos.documentManager.dto.DocumentListItemDTO(d.documentNo, d.doctype, d.docClass, d.docSubClass, d.docdesc, d.docfilename, d.doccreator, d.responsible, d.source, d.status, d.contenttype, d.contentdatetime, d.observationdate, d.reviewer, d.reviewdatetime, d.numberofpages, d.appointmentNo, d.abnormal) FROM Document d WHERE d.documentNo IN (SELECT c.id.documentNo FROM CtlDocument c WHERE c.id.module = 'demographic' AND c.id.moduleId = :demoNo) AND d.status != 'D' ORDER BY d.observationdate DESC");
-        query.setParameter("demoNo", demoNoInt);
+        query.setParameter("demoNo", demographicNo);
         return query.getResultList();
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/DocumentDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/DocumentDaoImpl.java
@@ -46,6 +46,7 @@ import io.github.carlos_emr.carlos.commn.model.ConsultDocs;
 import io.github.carlos_emr.carlos.commn.model.Demographic;
 import io.github.carlos_emr.carlos.commn.model.Document;
 import io.github.carlos_emr.carlos.commn.model.EFormDocs;
+import io.github.carlos_emr.carlos.documentManager.dto.DocumentListItemDTO;
 import org.springframework.stereotype.Repository;
 
 import io.github.carlos_emr.carlos.documentManager.EDocUtil;
@@ -497,5 +498,13 @@ public class DocumentDaoImpl extends AbstractDaoImpl<Document> implements Docume
         query.setParameter(2, demographicId);
 
         return getSingleResultOrNull(query);
+    }
+
+    @Override
+    public List<DocumentListItemDTO> findDocumentDTOsByDemographicNo(String demographicNo) {
+        Query query = entityManager.createQuery(
+                "SELECT NEW io.github.carlos_emr.carlos.documentManager.dto.DocumentListItemDTO(d.documentNo, d.doctype, d.docClass, d.docSubClass, d.docdesc, d.docfilename, d.doccreator, d.responsible, d.source, d.status, d.contenttype, d.contentdatetime, d.observationdate, d.reviewer, d.reviewdatetime, d.numberofpages, d.appointmentNo, d.abnormal) FROM Document d WHERE d.documentNo IN (SELECT c.documentNo FROM CtlDocument c WHERE c.module = 'demographic' AND c.moduleId = :demoNo) AND d.status != 'D' ORDER BY d.observationdate DESC");
+        query.setParameter("demoNo", Integer.parseInt(demographicNo));
+        return query.getResultList();
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/DocumentDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/DocumentDaoImpl.java
@@ -513,8 +513,19 @@ public class DocumentDaoImpl extends AbstractDaoImpl<Document> implements Docume
      */
     @Override
     public List<DocumentListItemDTO> findDocumentDTOsByDemographicNo(Integer demographicNo) {
-        Query query = entityManager.createQuery(
-                "SELECT NEW io.github.carlos_emr.carlos.documentManager.dto.DocumentListItemDTO(d.documentNo, d.doctype, d.docClass, d.docSubClass, d.docdesc, d.docfilename, d.doccreator, d.responsible, d.source, d.status, d.contenttype, d.contentdatetime, d.observationdate, d.reviewer, d.reviewdatetime, d.numberofpages, d.appointmentNo, d.abnormal) FROM Document d WHERE d.documentNo IN (SELECT c.id.documentNo FROM CtlDocument c WHERE c.id.module = 'demographic' AND c.id.moduleId = :demoNo) AND d.status != 'D' ORDER BY d.observationdate DESC");
+        Query query = entityManager.createQuery("""
+                SELECT NEW io.github.carlos_emr.carlos.documentManager.dto.DocumentListItemDTO(
+                    d.documentNo, d.doctype, d.docClass, d.docSubClass, d.docdesc,
+                    d.docfilename, d.doccreator, d.responsible, d.source, d.status,
+                    d.contenttype, d.contentdatetime, d.observationdate, d.reviewer,
+                    d.reviewdatetime, d.numberofpages, d.appointmentNo, d.abnormal)
+                FROM Document d
+                WHERE d.documentNo IN (
+                    SELECT c.id.documentNo FROM CtlDocument c
+                    WHERE c.id.module = 'demographic' AND c.id.moduleId = :demoNo)
+                AND d.status != 'D'
+                ORDER BY d.observationdate DESC
+                """);
         query.setParameter("demoNo", demographicNo);
         return query.getResultList();
     }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/DocumentDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/DocumentDaoImpl.java
@@ -500,11 +500,29 @@ public class DocumentDaoImpl extends AbstractDaoImpl<Document> implements Docume
         return getSingleResultOrNull(query);
     }
 
+    /**
+     * Returns lightweight document list DTOs for a demographic number.
+     *
+     * <p>Uses {@code c.id.documentNo}, {@code c.id.module}, {@code c.id.moduleId} to
+     * traverse the {@code @EmbeddedId} on {@code CtlDocument}. Active (non-deleted)
+     * documents only.</p>
+     *
+     * @param demographicNo String the demographic number (must be a valid integer string)
+     * @return List&lt;DocumentListItemDTO&gt; ordered by observation date descending,
+     *         or an empty list if {@code demographicNo} is not a valid integer
+     * @since 2026-04-11
+     */
     @Override
     public List<DocumentListItemDTO> findDocumentDTOsByDemographicNo(String demographicNo) {
+        int demoNoInt;
+        try {
+            demoNoInt = Integer.parseInt(demographicNo);
+        } catch (NumberFormatException e) {
+            return java.util.Collections.emptyList();
+        }
         Query query = entityManager.createQuery(
-                "SELECT NEW io.github.carlos_emr.carlos.documentManager.dto.DocumentListItemDTO(d.documentNo, d.doctype, d.docClass, d.docSubClass, d.docdesc, d.docfilename, d.doccreator, d.responsible, d.source, d.status, d.contenttype, d.contentdatetime, d.observationdate, d.reviewer, d.reviewdatetime, d.numberofpages, d.appointmentNo, d.abnormal) FROM Document d WHERE d.documentNo IN (SELECT c.documentNo FROM CtlDocument c WHERE c.module = 'demographic' AND c.moduleId = :demoNo) AND d.status != 'D' ORDER BY d.observationdate DESC");
-        query.setParameter("demoNo", Integer.parseInt(demographicNo));
+                "SELECT NEW io.github.carlos_emr.carlos.documentManager.dto.DocumentListItemDTO(d.documentNo, d.doctype, d.docClass, d.docSubClass, d.docdesc, d.docfilename, d.doccreator, d.responsible, d.source, d.status, d.contenttype, d.contentdatetime, d.observationdate, d.reviewer, d.reviewdatetime, d.numberofpages, d.appointmentNo, d.abnormal) FROM Document d WHERE d.documentNo IN (SELECT c.id.documentNo FROM CtlDocument c WHERE c.id.module = 'demographic' AND c.id.moduleId = :demoNo) AND d.status != 'D' ORDER BY d.observationdate DESC");
+        query.setParameter("demoNo", demoNoInt);
         return query.getResultList();
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/DrugDao.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/DrugDao.java
@@ -34,6 +34,7 @@ import java.util.Date;
 import java.util.List;
 
 import io.github.carlos_emr.carlos.commn.model.Drug;
+import io.github.carlos_emr.carlos.prescript.dto.DrugListItemDTO;
 
 public interface DrugDao extends AbstractDao<Drug> {
 
@@ -120,4 +121,13 @@ public interface DrugDao extends AbstractDao<Drug> {
 
     public List<Drug> findLongTermDrugsByDemographic(Integer demographicId);
 
+    /**
+     * Returns lightweight drug DTOs for a demographic, ordered by date descending.
+     * Uses JPQL constructor expression projection (20 fields vs 101 on entity).
+     *
+     * @param demographicId Integer the patient demographic number
+     * @return List of DrugListItemDTO for the patient's prescriptions
+     * @since 2026-04-11
+     */
+    public List<DrugListItemDTO> findDrugDTOsByDemographicId(Integer demographicId);
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/DrugDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/DrugDaoImpl.java
@@ -40,6 +40,7 @@ import jakarta.persistence.TypedQuery;
 import org.apache.commons.lang3.StringUtils;
 import io.github.carlos_emr.carlos.commn.NativeSql;
 import io.github.carlos_emr.carlos.commn.model.Drug;
+import io.github.carlos_emr.carlos.prescript.dto.DrugListItemDTO;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 
 public class DrugDaoImpl extends AbstractDaoImpl<Drug> implements DrugDao {
@@ -629,6 +630,15 @@ public class DrugDaoImpl extends AbstractDaoImpl<Drug> implements DrugDao {
         typedQuery.setParameter("searchString", "%" + spInstructQuery + "%");
 
         return typedQuery.getResultList();
+    }
+
+    @Override
+    public List<DrugListItemDTO> findDrugDTOsByDemographicId(Integer demographicId) {
+        TypedQuery<DrugListItemDTO> query = entityManager.createQuery(
+                "SELECT NEW io.github.carlos_emr.carlos.prescript.dto.DrugListItemDTO(d.id, d.demographicId, d.brandName, d.genericName, d.customName, d.dosage, d.route, d.freqCode, d.duration, d.durUnit, d.quantity, d.repeat, d.rxDate, d.endDate, d.lastRefillDate, d.archived, d.longTerm, d.providerNo, d.special, d.scriptNo) FROM Drug d WHERE d.demographicId = :demoId ORDER BY d.rxDate DESC",
+                DrugListItemDTO.class);
+        query.setParameter("demoId", demographicId);
+        return query.getResultList();
     }
 
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/DrugDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/DrugDaoImpl.java
@@ -632,6 +632,14 @@ public class DrugDaoImpl extends AbstractDaoImpl<Drug> implements DrugDao {
         return typedQuery.getResultList();
     }
 
+    /**
+     * Returns lightweight drug/prescription list DTOs for a demographic, ordered by
+     * prescription date descending. Carries 20 fields vs 101 on the full Drug entity.
+     *
+     * @param demographicId Integer the patient demographic identifier
+     * @return List&lt;DrugListItemDTO&gt; ordered by rxDate descending; empty if none found
+     * @since 2026-04-11
+     */
     @Override
     public List<DrugListItemDTO> findDrugDTOsByDemographicId(Integer demographicId) {
         TypedQuery<DrugListItemDTO> query = entityManager.createQuery(

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/DrugDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/DrugDaoImpl.java
@@ -643,8 +643,16 @@ public class DrugDaoImpl extends AbstractDaoImpl<Drug> implements DrugDao {
      */
     @Override
     public List<DrugListItemDTO> findDrugDTOsByDemographicId(Integer demographicId) {
-        TypedQuery<DrugListItemDTO> query = entityManager.createQuery(
-                "SELECT NEW io.github.carlos_emr.carlos.prescript.dto.DrugListItemDTO(d.id, d.demographicId, d.brandName, d.genericName, d.customName, d.dosage, d.route, d.freqCode, d.duration, d.durUnit, d.quantity, d.repeat, d.rxDate, d.endDate, d.lastRefillDate, d.archived, d.longTerm, d.providerNo, d.special, d.scriptNo) FROM Drug d WHERE d.demographicId = :demoId ORDER BY d.rxDate DESC",
+        TypedQuery<DrugListItemDTO> query = entityManager.createQuery("""
+                SELECT NEW io.github.carlos_emr.carlos.prescript.dto.DrugListItemDTO(
+                    d.id, d.demographicId, d.brandName, d.genericName, d.customName,
+                    d.dosage, d.route, d.freqCode, d.duration, d.durUnit, d.quantity,
+                    d.repeat, d.rxDate, d.endDate, d.lastRefillDate, d.archived,
+                    d.longTerm, d.providerNo, d.special, d.scriptNo)
+                FROM Drug d
+                WHERE d.demographicId = :demoId
+                ORDER BY d.rxDate DESC
+                """,
                 DrugListItemDTO.class);
         query.setParameter("demoId", demographicId);
         return query.getResultList();

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/DrugDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/DrugDaoImpl.java
@@ -638,6 +638,7 @@ public class DrugDaoImpl extends AbstractDaoImpl<Drug> implements DrugDao {
      *
      * @param demographicId Integer the patient demographic identifier
      * @return List&lt;DrugListItemDTO&gt; ordered by rxDate descending; empty if none found
+     * @throws jakarta.persistence.PersistenceException if the underlying query fails
      * @since 2026-04-11
      */
     @Override

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/DrugMergedDemographicDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/DrugMergedDemographicDaoImpl.java
@@ -291,6 +291,12 @@ public class DrugMergedDemographicDaoImpl extends DrugDaoImpl implements DrugMer
 
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Merges drug DTOs from the target demographic with those from any
+     * demographics merged into it.</p>
+     */
     @Override
     public List<DrugListItemDTO> findDrugDTOsByDemographicId(Integer demographicId) {
         List<DrugListItemDTO> result = super.findDrugDTOsByDemographicId(demographicId);

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/DrugMergedDemographicDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/DrugMergedDemographicDaoImpl.java
@@ -37,6 +37,7 @@ import java.util.List;
 import io.github.carlos_emr.carlos.commn.merge.MergedDemographicSingleResultTemplate;
 import io.github.carlos_emr.carlos.commn.merge.MergedDemographicTemplate;
 import io.github.carlos_emr.carlos.commn.model.Drug;
+import io.github.carlos_emr.carlos.prescript.dto.DrugListItemDTO;
 import org.springframework.stereotype.Repository;
 
 import io.github.carlos_emr.carlos.util.ConversionUtils;
@@ -288,5 +289,17 @@ public class DrugMergedDemographicDaoImpl extends DrugDaoImpl implements DrugMer
         };
         return template.findMerged(demographicNo, result);
 
+    }
+
+    @Override
+    public List<DrugListItemDTO> findDrugDTOsByDemographicId(Integer demographicId) {
+        List<DrugListItemDTO> result = super.findDrugDTOsByDemographicId(demographicId);
+        MergedDemographicTemplate<DrugListItemDTO> template = new MergedDemographicTemplate<DrugListItemDTO>() {
+            @Override
+            protected List<DrugListItemDTO> findById(Integer demographic_no) {
+                return DrugMergedDemographicDaoImpl.super.findDrugDTOsByDemographicId(demographic_no);
+            }
+        };
+        return template.findMerged(demographicId, result);
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/OscarAppointmentDao.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/OscarAppointmentDao.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Set;
 
 import io.github.carlos_emr.carlos.PMmodule.model.Program;
+import io.github.carlos_emr.carlos.appointment.dto.AppointmentListItemDTO;
 import io.github.carlos_emr.carlos.commn.model.Appointment;
 import io.github.carlos_emr.carlos.commn.model.AppointmentArchive;
 
@@ -152,4 +153,15 @@ public interface OscarAppointmentDao extends AbstractDao<Appointment> {
 
     public List<Object[]> listProviderAppointmentCounts(Date sDate, Date eDate);
 
+    /**
+     * Returns lightweight appointment DTOs for a provider on a given date, with
+     * pre-joined patient names from Demographic. Uses JPQL constructor expression
+     * projection (17 fields vs 37 on entity).
+     *
+     * @param date Date the appointment date
+     * @param providerNo String the provider number
+     * @return List of AppointmentListItemDTO for the provider's daily schedule
+     * @since 2026-04-11
+     */
+    public List<AppointmentListItemDTO> findDayAppointmentDTOs(Date date, String providerNo);
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/OscarAppointmentDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/OscarAppointmentDaoImpl.java
@@ -34,6 +34,7 @@ package io.github.carlos_emr.carlos.commn.dao;
 import org.apache.commons.lang3.StringUtils;
 import io.github.carlos_emr.carlos.PMmodule.model.Program;
 import io.github.carlos_emr.carlos.commn.NativeSql;
+import io.github.carlos_emr.carlos.appointment.dto.AppointmentListItemDTO;
 import io.github.carlos_emr.carlos.commn.model.Appointment;
 import io.github.carlos_emr.carlos.commn.model.AppointmentArchive;
 import io.github.carlos_emr.carlos.commn.model.Facility;
@@ -818,6 +819,15 @@ public class OscarAppointmentDaoImpl extends AbstractDaoImpl<Appointment> implem
         Query query = entityManager.createNativeQuery(sql);
         query.setParameter(1, sDate == null ? new Date(Long.MIN_VALUE) : sDate);
         query.setParameter(2, eDate == null ? new Date(Long.MIN_VALUE) : eDate);
+        return query.getResultList();
+    }
+
+    @Override
+    public List<AppointmentListItemDTO> findDayAppointmentDTOs(Date date, String providerNo) {
+        Query query = entityManager.createQuery(
+                "SELECT NEW io.github.carlos_emr.carlos.appointment.dto.AppointmentListItemDTO(a.id, a.providerNo, a.appointmentDate, a.startTime, a.endTime, a.name, a.demographicNo, a.status, a.type, a.reason, a.location, a.notes, a.urgency, a.remarks, a.reasonCode, d.LastName, d.FirstName) FROM Appointment a LEFT JOIN Demographic d ON d.DemographicNo = a.demographicNo WHERE a.appointmentDate = :date AND a.providerNo = :providerNo ORDER BY a.startTime");
+        query.setParameter("date", date);
+        query.setParameter("providerNo", providerNo);
         return query.getResultList();
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/OscarAppointmentDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/OscarAppointmentDaoImpl.java
@@ -822,6 +822,16 @@ public class OscarAppointmentDaoImpl extends AbstractDaoImpl<Appointment> implem
         return query.getResultList();
     }
 
+    /**
+     * Returns lightweight appointment list DTOs for a provider's day schedule.
+     * Uses HBM-mapped PascalCase property names ({@code d.DemographicNo}, {@code d.LastName},
+     * {@code d.FirstName}) as defined in {@code Demographic.hbm.xml}.
+     *
+     * @param date Date the appointment date to query
+     * @param providerNo String the provider number to filter by
+     * @return List&lt;AppointmentListItemDTO&gt; ordered by start time ascending; empty if none found
+     * @since 2026-04-11
+     */
     @Override
     public List<AppointmentListItemDTO> findDayAppointmentDTOs(Date date, String providerNo) {
         Query query = entityManager.createQuery(

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/OscarAppointmentDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/OscarAppointmentDaoImpl.java
@@ -834,8 +834,19 @@ public class OscarAppointmentDaoImpl extends AbstractDaoImpl<Appointment> implem
      */
     @Override
     public List<AppointmentListItemDTO> findDayAppointmentDTOs(Date date, String providerNo) {
-        Query query = entityManager.createQuery(
-                "SELECT NEW io.github.carlos_emr.carlos.appointment.dto.AppointmentListItemDTO(a.id, a.providerNo, a.appointmentDate, a.startTime, a.endTime, a.name, a.demographicNo, a.status, a.type, a.reason, a.location, a.notes, a.urgency, a.remarks, a.reasonCode, d.LastName, d.FirstName) FROM Appointment a LEFT JOIN Demographic d ON d.DemographicNo = a.demographicNo WHERE a.appointmentDate = :date AND a.providerNo = :providerNo ORDER BY a.startTime");
+        // HBM-mapped Demographic uses PascalCase property names (DemographicNo, LastName,
+        // FirstName) per Demographic.hbm.xml; HQL must reference the HBM name attribute.
+        Query query = entityManager.createQuery("""
+                SELECT NEW io.github.carlos_emr.carlos.appointment.dto.AppointmentListItemDTO(
+                    a.id, a.providerNo, a.appointmentDate, a.startTime, a.endTime,
+                    a.name, a.demographicNo, a.status, a.type, a.reason, a.location,
+                    a.notes, a.urgency, a.remarks, a.reasonCode,
+                    d.LastName, d.FirstName)
+                FROM Appointment a
+                LEFT JOIN Demographic d ON d.DemographicNo = a.demographicNo
+                WHERE a.appointmentDate = :date AND a.providerNo = :providerNo
+                ORDER BY a.startTime
+                """);
         query.setParameter("date", date);
         query.setParameter("providerNo", providerNo);
         return query.getResultList();

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/PreventionDao.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/PreventionDao.java
@@ -34,6 +34,7 @@ import java.util.Date;
 import java.util.List;
 
 import io.github.carlos_emr.carlos.commn.model.Prevention;
+import io.github.carlos_emr.carlos.prevention.dto.PreventionListItemDTO;
 
 public interface PreventionDao extends AbstractDao<Prevention> {
     List<Prevention> findByDemographicId(Integer demographicId);
@@ -63,4 +64,14 @@ public interface PreventionDao extends AbstractDao<Prevention> {
     List<Prevention> findUniqueByDemographicId(Integer demographicId);
 
     List<Integer> findNewPreventionsSinceDemoKey(String keyName);
+
+    /**
+     * Returns lightweight prevention DTOs for a demographic, bypassing the EAGER
+     * PreventionExt collection load. Uses JPQL constructor expression projection.
+     *
+     * @param demographicId Integer the patient demographic number
+     * @return List of PreventionListItemDTO for the patient's immunizations
+     * @since 2026-04-11
+     */
+    List<PreventionListItemDTO> findPreventionDTOsByDemographicId(Integer demographicId);
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/PreventionDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/PreventionDaoImpl.java
@@ -232,6 +232,14 @@ public class PreventionDaoImpl extends AbstractDaoImpl<Prevention> implements Pr
         return query.getResultList();
     }
 
+    /**
+     * Returns lightweight prevention/immunization list DTOs for a demographic, ordered by
+     * prevention date descending. Eliminates the EAGER-loaded {@code PreventionExt} collection.
+     *
+     * @param demographicId Integer the patient demographic identifier
+     * @return List&lt;PreventionListItemDTO&gt; ordered by preventionDate descending; empty if none found
+     * @since 2026-04-11
+     */
     @Override
     public List<PreventionListItemDTO> findPreventionDTOsByDemographicId(Integer demographicId) {
         Query query = entityManager.createQuery(

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/PreventionDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/PreventionDaoImpl.java
@@ -37,6 +37,7 @@ import jakarta.persistence.Query;
 
 import io.github.carlos_emr.carlos.commn.NativeSql;
 import io.github.carlos_emr.carlos.commn.model.Prevention;
+import io.github.carlos_emr.carlos.prevention.dto.PreventionListItemDTO;
 
 public class PreventionDaoImpl extends AbstractDaoImpl<Prevention> implements PreventionDao {
 
@@ -231,5 +232,12 @@ public class PreventionDaoImpl extends AbstractDaoImpl<Prevention> implements Pr
         return query.getResultList();
     }
 
+    @Override
+    public List<PreventionListItemDTO> findPreventionDTOsByDemographicId(Integer demographicId) {
+        Query query = entityManager.createQuery(
+                "SELECT NEW io.github.carlos_emr.carlos.prevention.dto.PreventionListItemDTO(p.id, p.demographicId, p.preventionType, p.preventionDate, p.creationDate, p.providerNo, p.creatorProviderNo, p.deleted, p.refused, p.never, p.nextDate, p.lastUpdateDate) FROM Prevention p WHERE p.demographicId = :demoId ORDER BY p.preventionDate DESC");
+        query.setParameter("demoId", demographicId);
+        return query.getResultList();
+    }
 
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/PreventionDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/PreventionDaoImpl.java
@@ -242,8 +242,16 @@ public class PreventionDaoImpl extends AbstractDaoImpl<Prevention> implements Pr
      */
     @Override
     public List<PreventionListItemDTO> findPreventionDTOsByDemographicId(Integer demographicId) {
-        Query query = entityManager.createQuery(
-                "SELECT NEW io.github.carlos_emr.carlos.prevention.dto.PreventionListItemDTO(p.id, p.demographicId, p.preventionType, p.preventionDate, p.creationDate, p.providerNo, p.creatorProviderNo, p.deleted, p.refused, p.never, p.nextDate, p.lastUpdateDate) FROM Prevention p WHERE p.demographicId = :demoId ORDER BY p.preventionDate DESC");
+        Query query = entityManager.createQuery("""
+                SELECT NEW io.github.carlos_emr.carlos.prevention.dto.PreventionListItemDTO(
+                    p.id, p.demographicId, p.preventionType, p.preventionDate,
+                    p.creationDate, p.providerNo, p.creatorProviderNo,
+                    p.deleted, p.refused, p.never,
+                    p.nextDate, p.lastUpdateDate)
+                FROM Prevention p
+                WHERE p.demographicId = :demoId
+                ORDER BY p.preventionDate DESC
+                """);
         query.setParameter("demoId", demographicId);
         return query.getResultList();
     }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/PreventionMergedDemographicDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/PreventionMergedDemographicDaoImpl.java
@@ -90,6 +90,12 @@ public class PreventionMergedDemographicDaoImpl extends PreventionDaoImpl implem
         return template.findMerged(demoNo, result);
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Merges prevention DTOs from the target demographic with those from any
+     * demographics merged into it.</p>
+     */
     @Override
     public List<PreventionListItemDTO> findPreventionDTOsByDemographicId(Integer demographicId) {
         List<PreventionListItemDTO> result = super.findPreventionDTOsByDemographicId(demographicId);

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/PreventionMergedDemographicDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/PreventionMergedDemographicDaoImpl.java
@@ -36,6 +36,7 @@ import java.util.List;
 
 import io.github.carlos_emr.carlos.commn.merge.MergedDemographicTemplate;
 import io.github.carlos_emr.carlos.commn.model.Prevention;
+import io.github.carlos_emr.carlos.prevention.dto.PreventionListItemDTO;
 import org.springframework.stereotype.Repository;
 
 @Repository("preventionDaoImpl")
@@ -87,5 +88,17 @@ public class PreventionMergedDemographicDaoImpl extends PreventionDaoImpl implem
             }
         };
         return template.findMerged(demoNo, result);
+    }
+
+    @Override
+    public List<PreventionListItemDTO> findPreventionDTOsByDemographicId(Integer demographicId) {
+        List<PreventionListItemDTO> result = super.findPreventionDTOsByDemographicId(demographicId);
+        MergedDemographicTemplate<PreventionListItemDTO> template = new MergedDemographicTemplate<PreventionListItemDTO>() {
+            @Override
+            protected List<PreventionListItemDTO> findById(Integer demographic_no) {
+                return PreventionMergedDemographicDaoImpl.super.findPreventionDTOsByDemographicId(demographic_no);
+            }
+        };
+        return template.findMerged(demographicId, result);
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/consultation/dto/ConsultationRequestListItemDTO.java
+++ b/src/main/java/io/github/carlos_emr/carlos/consultation/dto/ConsultationRequestListItemDTO.java
@@ -43,7 +43,7 @@ public class ConsultationRequestListItemDTO implements Serializable {
     private Integer id;
     private Date referralDate;
     private Integer serviceId;
-    private Integer demographicId;
+    private Integer demographicNo;
     private String providerNo;
     private String status;
     private String statusText;
@@ -69,7 +69,7 @@ public class ConsultationRequestListItemDTO implements Serializable {
      * @param id Integer the consultation request ID
      * @param referralDate Date the referral date
      * @param serviceId Integer the consultation service ID
-     * @param demographicId Integer the patient demographic number
+     * @param demographicNo Integer the patient demographic number
      * @param providerNo String the referring provider number
      * @param status String the status code
      * @param statusText String the status display text
@@ -87,7 +87,7 @@ public class ConsultationRequestListItemDTO implements Serializable {
      * @since 2026-04-11
      */
     public ConsultationRequestListItemDTO(Integer id, Date referralDate, Integer serviceId,
-                                          Integer demographicId, String providerNo,
+                                          Integer demographicNo, String providerNo,
                                           String status, String statusText, String urgency,
                                           String reasonForReferral, Date appointmentDate,
                                           Date followUpDate, String sendTo, String siteName,
@@ -96,7 +96,7 @@ public class ConsultationRequestListItemDTO implements Serializable {
         this.id = id;
         this.referralDate = referralDate;
         this.serviceId = serviceId;
-        this.demographicId = demographicId;
+        this.demographicNo = demographicNo;
         this.providerNo = providerNo;
         this.status = status;
         this.statusText = statusText;
@@ -128,8 +128,8 @@ public class ConsultationRequestListItemDTO implements Serializable {
     public void setReferralDate(Date referralDate) { this.referralDate = referralDate; }
     public Integer getServiceId() { return serviceId; }
     public void setServiceId(Integer serviceId) { this.serviceId = serviceId; }
-    public Integer getDemographicId() { return demographicId; }
-    public void setDemographicId(Integer demographicId) { this.demographicId = demographicId; }
+    public Integer getDemographicNo() { return demographicNo; }
+    public void setDemographicNo(Integer demographicNo) { this.demographicNo = demographicNo; }
     public String getProviderNo() { return providerNo; }
     public void setProviderNo(String providerNo) { this.providerNo = providerNo; }
     public String getStatus() { return status; }

--- a/src/main/java/io/github/carlos_emr/carlos/consultation/dto/ConsultationRequestListItemDTO.java
+++ b/src/main/java/io/github/carlos_emr/carlos/consultation/dto/ConsultationRequestListItemDTO.java
@@ -59,11 +59,32 @@ public class ConsultationRequestListItemDTO implements Serializable {
     private String specialistLastName;
     private String specialistFirstName;
 
+    /** Default constructor for serialization/framework binding. */
     public ConsultationRequestListItemDTO() {
     }
 
     /**
      * Projection constructor for JPQL constructor expressions.
+     *
+     * @param id Integer the consultation request ID
+     * @param referralDate Date the referral date
+     * @param serviceId Integer the consultation service ID
+     * @param demographicId Integer the patient demographic number
+     * @param providerNo String the referring provider number
+     * @param status String the status code
+     * @param statusText String the status display text
+     * @param urgency String the urgency code
+     * @param reasonForReferral String the referral reason
+     * @param appointmentDate Date the appointment date
+     * @param followUpDate Date the follow-up date
+     * @param sendTo String the destination/team
+     * @param siteName String the site name
+     * @param letterheadName String the letterhead name
+     * @param source String the source system
+     * @param lastUpdateDate Date the last update timestamp
+     * @param specialistLastName String the specialist last name (from LEFT JOIN)
+     * @param specialistFirstName String the specialist first name (from LEFT JOIN)
+     * @since 2026-04-11
      */
     public ConsultationRequestListItemDTO(Integer id, Date referralDate, Integer serviceId,
                                           Integer demographicId, String providerNo,

--- a/src/main/java/io/github/carlos_emr/carlos/consultation/dto/ConsultationRequestListItemDTO.java
+++ b/src/main/java/io/github/carlos_emr/carlos/consultation/dto/ConsultationRequestListItemDTO.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ * <p>
+ * Now maintained by the CARLOS EMR Project (2026+).
+ * https://github.com/carlos-emr/carlos
+ * CARLOS has no affiliation with OSCAR or McMaster University.
+ */
+package io.github.carlos_emr.carlos.consultation.dto;
+
+import java.io.Serializable;
+import java.util.Date;
+
+import io.github.carlos_emr.carlos.utility.DtoFormatUtils;
+
+/**
+ * Lightweight DTO for consultation request list views. Eliminates the 3 EAGER
+ * relationships (ProfessionalSpecialist, DemographicContact, LookupListItem)
+ * that are loaded on every ConsultationRequest entity fetch.
+ *
+ * <p>Pre-joins specialist name via LEFT JOIN. Omits: full entity relationships,
+ * clinicalInfo, currentMeds, allergies, signature, letterhead details.</p>
+ *
+ * @since 2026-04-11
+ */
+public class ConsultationRequestListItemDTO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private Integer id;
+    private Date referralDate;
+    private Integer serviceId;
+    private Integer demographicId;
+    private String providerNo;
+    private String status;
+    private String statusText;
+    private String urgency;
+    private String reasonForReferral;
+    private Date appointmentDate;
+    private Date followUpDate;
+    private String sendTo;
+    private String siteName;
+    private String letterheadName;
+    private String source;
+    private Date lastUpdateDate;
+    private String specialistLastName;
+    private String specialistFirstName;
+
+    public ConsultationRequestListItemDTO() {
+    }
+
+    /**
+     * Projection constructor for JPQL constructor expressions.
+     */
+    public ConsultationRequestListItemDTO(Integer id, Date referralDate, Integer serviceId,
+                                          Integer demographicId, String providerNo,
+                                          String status, String statusText, String urgency,
+                                          String reasonForReferral, Date appointmentDate,
+                                          Date followUpDate, String sendTo, String siteName,
+                                          String letterheadName, String source, Date lastUpdateDate,
+                                          String specialistLastName, String specialistFirstName) {
+        this.id = id;
+        this.referralDate = referralDate;
+        this.serviceId = serviceId;
+        this.demographicId = demographicId;
+        this.providerNo = providerNo;
+        this.status = status;
+        this.statusText = statusText;
+        this.urgency = urgency;
+        this.reasonForReferral = reasonForReferral;
+        this.appointmentDate = appointmentDate;
+        this.followUpDate = followUpDate;
+        this.sendTo = sendTo;
+        this.siteName = siteName;
+        this.letterheadName = letterheadName;
+        this.source = source;
+        this.lastUpdateDate = lastUpdateDate;
+        this.specialistLastName = specialistLastName;
+        this.specialistFirstName = specialistFirstName;
+    }
+
+    /**
+     * Returns the specialist's formatted name as "LastName, FirstName".
+     *
+     * @return String the formatted specialist name, or empty string if not joined
+     */
+    public String getSpecialistName() {
+        return DtoFormatUtils.formatName(specialistLastName, specialistFirstName, "");
+    }
+
+    public Integer getId() { return id; }
+    public void setId(Integer id) { this.id = id; }
+    public Date getReferralDate() { return referralDate; }
+    public void setReferralDate(Date referralDate) { this.referralDate = referralDate; }
+    public Integer getServiceId() { return serviceId; }
+    public void setServiceId(Integer serviceId) { this.serviceId = serviceId; }
+    public Integer getDemographicId() { return demographicId; }
+    public void setDemographicId(Integer demographicId) { this.demographicId = demographicId; }
+    public String getProviderNo() { return providerNo; }
+    public void setProviderNo(String providerNo) { this.providerNo = providerNo; }
+    public String getStatus() { return status; }
+    public void setStatus(String status) { this.status = status; }
+    public String getStatusText() { return statusText; }
+    public void setStatusText(String statusText) { this.statusText = statusText; }
+    public String getUrgency() { return urgency; }
+    public void setUrgency(String urgency) { this.urgency = urgency; }
+    public String getReasonForReferral() { return reasonForReferral; }
+    public void setReasonForReferral(String reasonForReferral) { this.reasonForReferral = reasonForReferral; }
+    public Date getAppointmentDate() { return appointmentDate; }
+    public void setAppointmentDate(Date appointmentDate) { this.appointmentDate = appointmentDate; }
+    public Date getFollowUpDate() { return followUpDate; }
+    public void setFollowUpDate(Date followUpDate) { this.followUpDate = followUpDate; }
+    public String getSendTo() { return sendTo; }
+    public void setSendTo(String sendTo) { this.sendTo = sendTo; }
+    public String getSiteName() { return siteName; }
+    public void setSiteName(String siteName) { this.siteName = siteName; }
+    public String getLetterheadName() { return letterheadName; }
+    public void setLetterheadName(String letterheadName) { this.letterheadName = letterheadName; }
+    public String getSource() { return source; }
+    public void setSource(String source) { this.source = source; }
+    public Date getLastUpdateDate() { return lastUpdateDate; }
+    public void setLastUpdateDate(Date lastUpdateDate) { this.lastUpdateDate = lastUpdateDate; }
+    public String getSpecialistLastName() { return specialistLastName; }
+    public void setSpecialistLastName(String specialistLastName) { this.specialistLastName = specialistLastName; }
+    public String getSpecialistFirstName() { return specialistFirstName; }
+    public void setSpecialistFirstName(String specialistFirstName) { this.specialistFirstName = specialistFirstName; }
+}

--- a/src/main/java/io/github/carlos_emr/carlos/consultation/dto/ConsultationRequestListItemDTO.java
+++ b/src/main/java/io/github/carlos_emr/carlos/consultation/dto/ConsultationRequestListItemDTO.java
@@ -23,7 +23,10 @@ package io.github.carlos_emr.carlos.consultation.dto;
 
 import java.io.Serializable;
 import java.util.Date;
+import java.util.Objects;
 
+import io.github.carlos_emr.carlos.commn.model.ConsultationRequest;
+import io.github.carlos_emr.carlos.commn.model.ProfessionalSpecialist;
 import io.github.carlos_emr.carlos.utility.DtoFormatUtils;
 
 /**
@@ -111,6 +114,29 @@ public class ConsultationRequestListItemDTO implements Serializable {
         this.lastUpdateDate = lastUpdateDate;
         this.specialistLastName = specialistLastName;
         this.specialistFirstName = specialistFirstName;
+    }
+
+    /**
+     * Creates a DTO from a full {@link ConsultationRequest} entity. Pulls
+     * specialist name from the already-loaded {@code ProfessionalSpecialist}
+     * relationship when present; otherwise leaves it null.
+     *
+     * @param cr ConsultationRequest the entity to convert; must not be null
+     * @return ConsultationRequestListItemDTO a lightweight projection
+     * @since 2026-04-12
+     */
+    public static ConsultationRequestListItemDTO fromEntity(ConsultationRequest cr) {
+        Objects.requireNonNull(cr, "ConsultationRequest entity must not be null for DTO conversion");
+        ProfessionalSpecialist ps = cr.getProfessionalSpecialist();
+        return new ConsultationRequestListItemDTO(
+                cr.getId(), cr.getReferralDate(), cr.getServiceId(), cr.getDemographicId(),
+                cr.getProviderNo(), cr.getStatus(), cr.getStatusText(), cr.getUrgency(),
+                cr.getReasonForReferral(), cr.getAppointmentDate(), cr.getFollowUpDate(),
+                cr.getSendTo(), cr.getSiteName(), cr.getLetterheadName(), cr.getSource(),
+                cr.getLastUpdateDate(),
+                ps == null ? null : ps.getLastName(),
+                ps == null ? null : ps.getFirstName()
+        );
     }
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/dto/DocumentListItemDTO.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/dto/DocumentListItemDTO.java
@@ -1,0 +1,177 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ * <p>
+ * Now maintained by the CARLOS EMR Project (2026+).
+ * https://github.com/carlos-emr/carlos
+ * CARLOS has no affiliation with OSCAR or McMaster University.
+ */
+package io.github.carlos_emr.carlos.documentManager.dto;
+
+import java.io.Serializable;
+import java.util.Date;
+import java.util.Objects;
+
+import io.github.carlos_emr.carlos.commn.model.Document;
+
+/**
+ * Lightweight data transfer object for document inbox and list views,
+ * optimized for JPQL constructor expression projection. Eliminates the
+ * EAGER-loaded DocumentReview collection and the LOB docxml field that
+ * are loaded on every Document entity fetch.
+ *
+ * <p>Omits: {@code docxml} (LOB), {@code base64Binary} (transient),
+ * {@code reviews} (EAGER collection), {@code reportMedia}, {@code sentDateTime},
+ * {@code restrictToProgram}, {@code receivedDate}, {@code sourceFacility}.</p>
+ *
+ * @since 2026-04-11
+ */
+public class DocumentListItemDTO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private Integer documentNo;
+    private String doctype;
+    private String docClass;
+    private String docSubClass;
+    private String docdesc;
+    private String docfilename;
+    private String doccreator;
+    private String responsible;
+    private String source;
+    private char status;
+    private String contenttype;
+    private Date contentdatetime;
+    private Date observationdate;
+    private String reviewer;
+    private Date reviewdatetime;
+    private Integer numberofpages;
+    private Integer appointmentNo;
+    private boolean abnormal;
+
+    public DocumentListItemDTO() {
+    }
+
+    /**
+     * Projection constructor for JPQL constructor expressions.
+     *
+     * @param documentNo Integer the document number (primary key)
+     * @param doctype String the document type
+     * @param docClass String the document class
+     * @param docSubClass String the document sub-class
+     * @param docdesc String the document description
+     * @param docfilename String the document filename
+     * @param doccreator String the creator provider number
+     * @param responsible String the responsible provider number
+     * @param source String the document source
+     * @param status char the document status ('A' active, 'D' deleted)
+     * @param contenttype String the MIME content type
+     * @param contentdatetime Date the content date/time
+     * @param observationdate Date the observation date
+     * @param reviewer String the reviewer provider number
+     * @param reviewdatetime Date the review date/time
+     * @param numberofpages Integer the page count
+     * @param appointmentNo Integer the linked appointment number
+     * @param abnormal boolean whether the document is flagged abnormal
+     */
+    public DocumentListItemDTO(Integer documentNo, String doctype, String docClass, String docSubClass,
+                               String docdesc, String docfilename, String doccreator, String responsible,
+                               String source, char status, String contenttype, Date contentdatetime,
+                               Date observationdate, String reviewer, Date reviewdatetime,
+                               Integer numberofpages, Integer appointmentNo, boolean abnormal) {
+        this.documentNo = documentNo;
+        this.doctype = doctype;
+        this.docClass = docClass;
+        this.docSubClass = docSubClass;
+        this.docdesc = docdesc;
+        this.docfilename = docfilename;
+        this.doccreator = doccreator;
+        this.responsible = responsible;
+        this.source = source;
+        this.status = status;
+        this.contenttype = contenttype;
+        this.contentdatetime = contentdatetime;
+        this.observationdate = observationdate;
+        this.reviewer = reviewer;
+        this.reviewdatetime = reviewdatetime;
+        this.numberofpages = numberofpages;
+        this.appointmentNo = appointmentNo;
+        this.abnormal = abnormal;
+    }
+
+    /**
+     * Creates a DocumentListItemDTO from a full Document entity.
+     *
+     * @param d Document the entity to convert; must not be null
+     * @return DocumentListItemDTO a lightweight projection
+     */
+    public static DocumentListItemDTO fromEntity(Document d) {
+        Objects.requireNonNull(d, "Document entity must not be null for DTO conversion");
+        return new DocumentListItemDTO(
+                d.getDocumentNo(), d.getDoctype(), d.getDocClass(), d.getDocSubClass(),
+                d.getDocdesc(), d.getDocfilename(), d.getDoccreator(), d.getResponsible(),
+                d.getSource(), d.getStatus(), d.getContenttype(), d.getContentdatetime(),
+                d.getObservationdate(), d.getReviewer(), d.getReviewdatetime(),
+                d.getNumberofpages(), d.getAppointmentNo(), d.isAbnormal()
+        );
+    }
+
+    /**
+     * Returns whether this document has been reviewed.
+     *
+     * @return boolean true if a reviewer is assigned
+     */
+    public boolean isReviewed() {
+        return reviewer != null && !reviewer.trim().isEmpty();
+    }
+
+    public Integer getDocumentNo() { return documentNo; }
+    public void setDocumentNo(Integer documentNo) { this.documentNo = documentNo; }
+    public String getDoctype() { return doctype; }
+    public void setDoctype(String doctype) { this.doctype = doctype; }
+    public String getDocClass() { return docClass; }
+    public void setDocClass(String docClass) { this.docClass = docClass; }
+    public String getDocSubClass() { return docSubClass; }
+    public void setDocSubClass(String docSubClass) { this.docSubClass = docSubClass; }
+    public String getDocdesc() { return docdesc; }
+    public void setDocdesc(String docdesc) { this.docdesc = docdesc; }
+    public String getDocfilename() { return docfilename; }
+    public void setDocfilename(String docfilename) { this.docfilename = docfilename; }
+    public String getDoccreator() { return doccreator; }
+    public void setDoccreator(String doccreator) { this.doccreator = doccreator; }
+    public String getResponsible() { return responsible; }
+    public void setResponsible(String responsible) { this.responsible = responsible; }
+    public String getSource() { return source; }
+    public void setSource(String source) { this.source = source; }
+    public char getStatus() { return status; }
+    public void setStatus(char status) { this.status = status; }
+    public String getContenttype() { return contenttype; }
+    public void setContenttype(String contenttype) { this.contenttype = contenttype; }
+    public Date getContentdatetime() { return contentdatetime; }
+    public void setContentdatetime(Date contentdatetime) { this.contentdatetime = contentdatetime; }
+    public Date getObservationdate() { return observationdate; }
+    public void setObservationdate(Date observationdate) { this.observationdate = observationdate; }
+    public String getReviewer() { return reviewer; }
+    public void setReviewer(String reviewer) { this.reviewer = reviewer; }
+    public Date getReviewdatetime() { return reviewdatetime; }
+    public void setReviewdatetime(Date reviewdatetime) { this.reviewdatetime = reviewdatetime; }
+    public Integer getNumberofpages() { return numberofpages; }
+    public void setNumberofpages(Integer numberofpages) { this.numberofpages = numberofpages; }
+    public Integer getAppointmentNo() { return appointmentNo; }
+    public void setAppointmentNo(Integer appointmentNo) { this.appointmentNo = appointmentNo; }
+    public boolean isAbnormal() { return abnormal; }
+    public void setAbnormal(boolean abnormal) { this.abnormal = abnormal; }
+}

--- a/src/main/java/io/github/carlos_emr/carlos/managers/AllergyManager.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/AllergyManager.java
@@ -36,6 +36,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 
+import io.github.carlos_emr.carlos.allergy.dto.AllergyListItemDTO;
 import io.github.carlos_emr.carlos.commn.model.Allergy;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 
@@ -53,4 +54,14 @@ public interface AllergyManager {
 
     public List<Allergy> getAllergiesByProgramProviderDemographicDate(LoggedInInfo loggedInInfo, Integer programId,
                                                                       String providerNo, Integer demographicId, Calendar updatedAfterThisDateInclusive, int itemsToReturn);
+
+    /**
+     * Returns lightweight allergy DTOs for a demographic.
+     *
+     * @param loggedInInfo LoggedInInfo the logged-in user context
+     * @param demographicNo Integer the patient demographic number
+     * @return List of AllergyListItemDTO
+     * @since 2026-04-11
+     */
+    List<AllergyListItemDTO> getAllergyDTOs(LoggedInInfo loggedInInfo, Integer demographicNo);
 }

--- a/src/main/java/io/github/carlos_emr/carlos/managers/AllergyManager.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/AllergyManager.java
@@ -61,6 +61,7 @@ public interface AllergyManager {
      * @param loggedInInfo LoggedInInfo the logged-in user context
      * @param demographicNo Integer the patient demographic number
      * @return List of AllergyListItemDTO
+     * @throws SecurityException if the caller lacks {@code _allergy} read privilege
      * @since 2026-04-11
      */
     List<AllergyListItemDTO> getAllergyDTOs(LoggedInInfo loggedInInfo, Integer demographicNo);

--- a/src/main/java/io/github/carlos_emr/carlos/managers/AllergyManagerImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/AllergyManagerImpl.java
@@ -125,6 +125,9 @@ public class AllergyManagerImpl implements AllergyManager {
         return (results);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public List<AllergyListItemDTO> getAllergyDTOs(LoggedInInfo loggedInInfo, Integer demographicNo) {
         if (!securityInfoManager.hasPrivilege(loggedInInfo, "_allergy", "r", null)) {

--- a/src/main/java/io/github/carlos_emr/carlos/managers/AllergyManagerImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/AllergyManagerImpl.java
@@ -37,6 +37,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 
+import io.github.carlos_emr.carlos.allergy.dto.AllergyListItemDTO;
 import io.github.carlos_emr.carlos.commn.dao.AllergyDao;
 import io.github.carlos_emr.carlos.commn.model.Allergy;
 import io.github.carlos_emr.carlos.commn.model.ConsentType;
@@ -119,5 +120,15 @@ public class AllergyManagerImpl implements AllergyManager {
                         + ", updatedAfterThisDateInclusive=" + updatedAfterThisDateInclusive.getTime());
 
         return (results);
+    }
+
+    @Override
+    public List<AllergyListItemDTO> getAllergyDTOs(LoggedInInfo loggedInInfo, Integer demographicNo) {
+        List<AllergyListItemDTO> results = allergyDao.findAllergyDTOsByDemographicNo(demographicNo);
+
+        LogAction.addLogSynchronous(loggedInInfo, "AllergyManager.getAllergyDTOs",
+                "demographicNo=" + demographicNo);
+
+        return results;
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/managers/AllergyManagerImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/AllergyManagerImpl.java
@@ -55,6 +55,9 @@ public class AllergyManagerImpl implements AllergyManager {
     @Autowired
     private PatientConsentManager patientConsentManager;
 
+    @Autowired
+    private SecurityInfoManager securityInfoManager;
+
     @Override
     public Allergy getAllergy(LoggedInInfo loggedInInfo, Integer id) {
         Allergy result = allergyDao.find(id);
@@ -124,6 +127,9 @@ public class AllergyManagerImpl implements AllergyManager {
 
     @Override
     public List<AllergyListItemDTO> getAllergyDTOs(LoggedInInfo loggedInInfo, Integer demographicNo) {
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_allergy", "r", null)) {
+            throw new SecurityException("missing required sec object (_allergy)");
+        }
         List<AllergyListItemDTO> results = allergyDao.findAllergyDTOsByDemographicNo(demographicNo);
 
         LogAction.addLogSynchronous(loggedInInfo, "AllergyManager.getAllergyDTOs",

--- a/src/main/java/io/github/carlos_emr/carlos/managers/AppointmentManager.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/AppointmentManager.java
@@ -31,8 +31,10 @@
  */
 package io.github.carlos_emr.carlos.managers;
 
+import java.util.Date;
 import java.util.List;
 
+import io.github.carlos_emr.carlos.appointment.dto.AppointmentListItemDTO;
 import io.github.carlos_emr.carlos.commn.model.Appointment;
 import io.github.carlos_emr.carlos.commn.model.AppointmentStatus;
 import io.github.carlos_emr.carlos.commn.model.LookupListItem;
@@ -72,4 +74,16 @@ public interface AppointmentManager {
     public List<Appointment> findMonthlyAppointments(LoggedInInfo loggedInInfo, String providerNo, int year, int month);
 
     public String getNextAppointmentDate(Integer demographicNo);
+
+    /**
+     * Returns lightweight appointment DTOs for a provider's daily schedule with
+     * pre-joined patient names. Enforces read privilege check.
+     *
+     * @param loggedInInfo LoggedInInfo the logged-in user context
+     * @param date Date the appointment date
+     * @param providerNo String the provider number
+     * @return List of AppointmentListItemDTO for the provider's daily schedule
+     * @since 2026-04-11
+     */
+    List<AppointmentListItemDTO> getDayAppointmentDTOs(LoggedInInfo loggedInInfo, Date date, String providerNo);
 }

--- a/src/main/java/io/github/carlos_emr/carlos/managers/AppointmentManager.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/AppointmentManager.java
@@ -83,6 +83,7 @@ public interface AppointmentManager {
      * @param date Date the appointment date
      * @param providerNo String the provider number
      * @return List of AppointmentListItemDTO for the provider's daily schedule
+     * @throws SecurityException if the caller lacks the {@code _appointment} read privilege
      * @since 2026-04-11
      */
     List<AppointmentListItemDTO> getDayAppointmentDTOs(LoggedInInfo loggedInInfo, Date date, String providerNo);

--- a/src/main/java/io/github/carlos_emr/carlos/managers/AppointmentManagerImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/AppointmentManagerImpl.java
@@ -332,11 +332,16 @@ public class AppointmentManagerImpl implements AppointmentManager {
         return appointmentString;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public List<AppointmentListItemDTO> getDayAppointmentDTOs(LoggedInInfo loggedInInfo, Date date, String providerNo) {
         if (!securityInfoManager.hasPrivilege(loggedInInfo, "_appointment", "r", null)) {
-            throw new RuntimeException("missing required sec object (_appointment)");
+            throw new SecurityException("missing required sec object (_appointment)");
         }
+        LogAction.addLogSynchronous(loggedInInfo, "AppointmentManager.getDayAppointmentDTOs",
+                "date=" + date + ", providerNo=" + providerNo);
         return appointmentDao.findDayAppointmentDTOs(date, providerNo);
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/managers/AppointmentManagerImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/AppointmentManagerImpl.java
@@ -43,6 +43,7 @@ import io.github.carlos_emr.carlos.commn.dao.AppointmentArchiveDao;
 import io.github.carlos_emr.carlos.commn.dao.AppointmentStatusDao;
 import io.github.carlos_emr.carlos.commn.dao.LookupListDao;
 import io.github.carlos_emr.carlos.commn.dao.OscarAppointmentDao;
+import io.github.carlos_emr.carlos.appointment.dto.AppointmentListItemDTO;
 import io.github.carlos_emr.carlos.commn.model.Appointment;
 import io.github.carlos_emr.carlos.commn.model.AppointmentArchive;
 import io.github.carlos_emr.carlos.commn.model.AppointmentStatus;
@@ -329,6 +330,14 @@ public class AppointmentManagerImpl implements AppointmentManager {
             }
         }
         return appointmentString;
+    }
+
+    @Override
+    public List<AppointmentListItemDTO> getDayAppointmentDTOs(LoggedInInfo loggedInInfo, Date date, String providerNo) {
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_appointment", "r", null)) {
+            throw new RuntimeException("missing required sec object (_appointment)");
+        }
+        return appointmentDao.findDayAppointmentDTOs(date, providerNo);
     }
 
 }

--- a/src/main/java/io/github/carlos_emr/carlos/managers/BillingONManager.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/BillingONManager.java
@@ -28,13 +28,16 @@
  */
 package io.github.carlos_emr.carlos.managers;
 
+import io.github.carlos_emr.carlos.billings.dto.BillingONCListItemDTO;
 import io.github.carlos_emr.carlos.commn.dao.BillingONCHeader1Dao;
 import io.github.carlos_emr.carlos.commn.dao.BillingONExtDao;
 import io.github.carlos_emr.carlos.commn.dao.ClinicDAO;
 import io.github.carlos_emr.carlos.commn.dao.DemographicDao;
 import io.github.carlos_emr.carlos.commn.model.BillingONCHeader1;
 import io.github.carlos_emr.carlos.commn.web.BillingInvoice2Action;
+import io.github.carlos_emr.carlos.log.LogAction;
 import io.github.carlos_emr.carlos.utility.LocaleUtils;
+import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -42,6 +45,7 @@ import io.github.carlos_emr.carlos.util.DateUtils;
 
 import java.io.InputStream;
 import java.util.Date;
+import java.util.List;
 import java.util.Locale;
 import java.util.Properties;
 
@@ -65,6 +69,9 @@ public class BillingONManager {
 
     @Autowired
     private DemographicDao demographicDao;
+
+    @Autowired
+    private SecurityInfoManager securityInfoManager;
 
     protected static Properties emailProperties = getBillingEmailProperties();
 
@@ -180,6 +187,26 @@ public class BillingONManager {
     public void addEmailedBillingComment(Integer invoiceNo, Locale locale) {
         String emailedMsg = LocaleUtils.getMessage(locale, "billing.billing3rdInv.msgEmailed");
         addBillingComment(emailedMsg, invoiceNo, locale);
+    }
+
+    /**
+     * Returns lightweight Ontario billing DTOs for a demographic. Enforces
+     * {@code _billing} read privilege and writes a synchronous audit log entry.
+     *
+     * @param loggedInInfo LoggedInInfo the logged-in user context
+     * @param demographicNo Integer the patient demographic number
+     * @return List&lt;BillingONCListItemDTO&gt; of active billing records ordered by billing date descending
+     * @throws SecurityException if the caller lacks {@code _billing} read privilege
+     * @since 2026-04-12
+     */
+    public List<BillingONCListItemDTO> getBillingDTOs(LoggedInInfo loggedInInfo, Integer demographicNo) {
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_billing", SecurityInfoManager.READ, null)) {
+            throw new SecurityException("missing required sec object (_billing)");
+        }
+        List<BillingONCListItemDTO> results = billingONCHeader1Dao.findBillingDTOsByDemographicNo(demographicNo);
+        LogAction.addLogSynchronous(loggedInInfo, "BillingONManager.getBillingDTOs",
+                "demographicNo=" + demographicNo);
+        return results;
     }
 
     private void addBillingComment(String comment, Integer invoiceNo, Locale locale) {

--- a/src/main/java/io/github/carlos_emr/carlos/managers/ConsultationManager.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/ConsultationManager.java
@@ -388,7 +388,7 @@ public interface ConsultationManager {
      * @param loggedInInfo LoggedInInfo the session context used for privilege checking
      * @param demographicId Integer the patient demographic number
      * @return List&lt;ConsultationRequestListItemDTO&gt; ordered by referral date descending
-     * @throws RuntimeException if the caller lacks the {@code _con} read privilege
+     * @throws SecurityException if the caller lacks the {@code _con} read privilege
      * @since 2026-04-11
      */
     List<ConsultationRequestListItemDTO> getConsultationDTOs(LoggedInInfo loggedInInfo, Integer demographicId);

--- a/src/main/java/io/github/carlos_emr/carlos/managers/ConsultationManager.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/ConsultationManager.java
@@ -41,6 +41,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import io.github.carlos_emr.carlos.commn.model.ConsultDocs;
+import io.github.carlos_emr.carlos.consultation.dto.ConsultationRequestListItemDTO;
 import io.github.carlos_emr.carlos.commn.model.ConsultResponseDoc;
 import io.github.carlos_emr.carlos.commn.model.ConsultationRequest;
 import io.github.carlos_emr.carlos.commn.model.ConsultationRequestExt;
@@ -379,4 +380,14 @@ public interface ConsultationManager {
      * @return Map mapping extension key to its String value
      */
     public Map<String, String> getExtValuesAsMap(List<ConsultationRequestExt> extras);
+
+    /**
+     * Returns lightweight consultation request DTOs for a demographic, eliminating
+     * 3 EAGER entity joins.
+     *
+     * @param demographicId Integer the patient demographic number
+     * @return List of ConsultationRequestListItemDTO
+     * @since 2026-04-11
+     */
+    List<ConsultationRequestListItemDTO> getConsultationDTOs(Integer demographicId);
 }

--- a/src/main/java/io/github/carlos_emr/carlos/managers/ConsultationManager.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/ConsultationManager.java
@@ -383,11 +383,13 @@ public interface ConsultationManager {
 
     /**
      * Returns lightweight consultation request DTOs for a demographic, eliminating
-     * 3 EAGER entity joins.
+     * 3 EAGER entity joins. Enforces {@code _con} read privilege.
      *
+     * @param loggedInInfo LoggedInInfo the session context used for privilege checking
      * @param demographicId Integer the patient demographic number
-     * @return List of ConsultationRequestListItemDTO
+     * @return List&lt;ConsultationRequestListItemDTO&gt; ordered by referral date descending
+     * @throws RuntimeException if the caller lacks the {@code _con} read privilege
      * @since 2026-04-11
      */
-    List<ConsultationRequestListItemDTO> getConsultationDTOs(Integer demographicId);
+    List<ConsultationRequestListItemDTO> getConsultationDTOs(LoggedInInfo loggedInInfo, Integer demographicId);
 }

--- a/src/main/java/io/github/carlos_emr/carlos/managers/ConsultationManagerImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/ConsultationManagerImpl.java
@@ -51,6 +51,8 @@ import org.apache.logging.log4j.Logger;
 import io.github.carlos_emr.carlos.commn.dao.ClinicDAO;
 import io.github.carlos_emr.carlos.commn.dao.ConsultDocsDao;
 import io.github.carlos_emr.carlos.commn.dao.ConsultRequestDao;
+import io.github.carlos_emr.carlos.commn.dao.ConsultationRequestDao;
+import io.github.carlos_emr.carlos.consultation.dto.ConsultationRequestListItemDTO;
 import io.github.carlos_emr.carlos.commn.dao.ConsultResponseDao;
 import io.github.carlos_emr.carlos.commn.dao.ConsultResponseDocDao;
 import io.github.carlos_emr.carlos.commn.dao.ConsultationRequestArchiveDao;
@@ -119,6 +121,8 @@ public class ConsultationManagerImpl implements ConsultationManager {
 
     @Autowired
     ConsultRequestDao consultationRequestDao;
+    @Autowired
+    ConsultationRequestDao consultationRequestDtoDao;
     @Autowired
     ConsultResponseDao consultationResponseDao;
     @Autowired
@@ -818,5 +822,10 @@ public class ConsultationManagerImpl implements ConsultationManager {
         }
 
         return extraMap;
+    }
+
+    @Override
+    public List<ConsultationRequestListItemDTO> getConsultationDTOs(Integer demographicId) {
+        return consultationRequestDtoDao.findConsultationDTOsByDemographicId(demographicId);
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/managers/ConsultationManagerImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/ConsultationManagerImpl.java
@@ -829,7 +829,9 @@ public class ConsultationManagerImpl implements ConsultationManager {
      */
     @Override
     public List<ConsultationRequestListItemDTO> getConsultationDTOs(LoggedInInfo loggedInInfo, Integer demographicId) {
-        checkPrivilege(loggedInInfo, SecurityInfoManager.READ);
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_con", SecurityInfoManager.READ, null)) {
+            throw new SecurityException("missing required sec object (_con)");
+        }
         List<ConsultationRequestListItemDTO> results = consultationRequestDtoDao.findConsultationDTOsByDemographicId(demographicId);
         LogAction.addLogSynchronous(loggedInInfo, "ConsultationManager.getConsultationDTOs",
                 "demographicId=" + demographicId);

--- a/src/main/java/io/github/carlos_emr/carlos/managers/ConsultationManagerImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/ConsultationManagerImpl.java
@@ -824,8 +824,15 @@ public class ConsultationManagerImpl implements ConsultationManager {
         return extraMap;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
-    public List<ConsultationRequestListItemDTO> getConsultationDTOs(Integer demographicId) {
-        return consultationRequestDtoDao.findConsultationDTOsByDemographicId(demographicId);
+    public List<ConsultationRequestListItemDTO> getConsultationDTOs(LoggedInInfo loggedInInfo, Integer demographicId) {
+        checkPrivilege(loggedInInfo, SecurityInfoManager.READ);
+        List<ConsultationRequestListItemDTO> results = consultationRequestDtoDao.findConsultationDTOsByDemographicId(demographicId);
+        LogAction.addLogSynchronous(loggedInInfo, "ConsultationManager.getConsultationDTOs",
+                "demographicId=" + demographicId);
+        return results;
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/managers/ConsultationManagerImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/ConsultationManagerImpl.java
@@ -829,7 +829,7 @@ public class ConsultationManagerImpl implements ConsultationManager {
      */
     @Override
     public List<ConsultationRequestListItemDTO> getConsultationDTOs(LoggedInInfo loggedInInfo, Integer demographicId) {
-        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_con", SecurityInfoManager.READ, null)) {
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_con", SecurityInfoManager.READ, demographicId)) {
             throw new SecurityException("missing required sec object (_con)");
         }
         List<ConsultationRequestListItemDTO> results = consultationRequestDtoDao.findConsultationDTOsByDemographicId(demographicId);

--- a/src/main/java/io/github/carlos_emr/carlos/managers/DocumentManager.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/DocumentManager.java
@@ -125,6 +125,7 @@ public interface DocumentManager {
      * @param loggedInInfo LoggedInInfo the logged-in user context
      * @param demographicNo Integer the patient demographic number
      * @return List of DocumentListItemDTO for the patient's documents
+     * @throws SecurityException if the caller lacks {@code _edoc} read privilege
      * @since 2026-04-11
      */
     List<DocumentListItemDTO> getDocumentDTOs(LoggedInInfo loggedInInfo, Integer demographicNo);

--- a/src/main/java/io/github/carlos_emr/carlos/managers/DocumentManager.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/DocumentManager.java
@@ -41,6 +41,7 @@ import java.util.List;
 import io.github.carlos_emr.carlos.commn.dao.DocumentDao;
 import io.github.carlos_emr.carlos.commn.model.CtlDocument;
 import io.github.carlos_emr.carlos.commn.model.Document;
+import io.github.carlos_emr.carlos.documentManager.dto.DocumentListItemDTO;
 
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.PDFGenerationException;
@@ -116,4 +117,15 @@ public interface DocumentManager {
     public Path renderDocument(LoggedInInfo loggedInInfo, String documentId) throws PDFGenerationException;
 
      public Integer addDocumentToQueue(LoggedInInfo loggedInInfo, Integer documentId, Integer queueId);
+
+    /**
+     * Returns lightweight document DTOs for a demographic, bypassing the EAGER
+     * DocumentReview collection. Enforces read privilege check.
+     *
+     * @param loggedInInfo LoggedInInfo the logged-in user context
+     * @param demographicNo Integer the patient demographic number
+     * @return List of DocumentListItemDTO for the patient's documents
+     * @since 2026-04-11
+     */
+    List<DocumentListItemDTO> getDocumentDTOs(LoggedInInfo loggedInInfo, Integer demographicNo);
 }

--- a/src/main/java/io/github/carlos_emr/carlos/managers/DocumentManagerImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/DocumentManagerImpl.java
@@ -591,7 +591,7 @@ public class DocumentManagerImpl implements DocumentManager {
      */
     @Override
     public List<DocumentListItemDTO> getDocumentDTOs(LoggedInInfo loggedInInfo, Integer demographicNo) {
-        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_edoc", "r", "")) {
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_edoc", "r", null)) {
             throw new SecurityException("missing required sec object (_edoc)");
         }
         List<DocumentListItemDTO> results = documentDao.findDocumentDTOsByDemographicNo(demographicNo);

--- a/src/main/java/io/github/carlos_emr/carlos/managers/DocumentManagerImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/DocumentManagerImpl.java
@@ -594,9 +594,9 @@ public class DocumentManagerImpl implements DocumentManager {
         if (!securityInfoManager.hasPrivilege(loggedInInfo, "_edoc", "r", "")) {
             throw new SecurityException("missing required sec object (_edoc)");
         }
-        List<DocumentListItemDTO> results = documentDao.findDocumentDTOsByDemographicNo(String.valueOf(demographicNo));
-        LogAction.addLog(loggedInInfo, "DocumentManager.getDocumentDTOs",
-                "demographicNo=" + demographicNo, "", "", "");
+        List<DocumentListItemDTO> results = documentDao.findDocumentDTOsByDemographicNo(demographicNo);
+        LogAction.addLogSynchronous(loggedInInfo, "DocumentManager.getDocumentDTOs",
+                "demographicNo=" + demographicNo);
         return results;
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/managers/DocumentManagerImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/DocumentManagerImpl.java
@@ -44,6 +44,7 @@ import java.util.List;
 
 import io.github.carlos_emr.carlos.commn.dao.*;
 import io.github.carlos_emr.carlos.commn.model.*;
+import io.github.carlos_emr.carlos.documentManager.dto.DocumentListItemDTO;
 import org.openpdf.text.DocumentException;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -584,4 +585,12 @@ public class DocumentManagerImpl implements DocumentManager {
 		}
 		return null;
 	}
+
+    @Override
+    public List<DocumentListItemDTO> getDocumentDTOs(LoggedInInfo loggedInInfo, Integer demographicNo) {
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_edoc", "r", "")) {
+            throw new RuntimeException("missing required sec object (_edoc)");
+        }
+        return documentDao.findDocumentDTOsByDemographicNo(String.valueOf(demographicNo));
+    }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/managers/DocumentManagerImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/DocumentManagerImpl.java
@@ -586,11 +586,17 @@ public class DocumentManagerImpl implements DocumentManager {
 		return null;
 	}
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public List<DocumentListItemDTO> getDocumentDTOs(LoggedInInfo loggedInInfo, Integer demographicNo) {
         if (!securityInfoManager.hasPrivilege(loggedInInfo, "_edoc", "r", "")) {
-            throw new RuntimeException("missing required sec object (_edoc)");
+            throw new SecurityException("missing required sec object (_edoc)");
         }
-        return documentDao.findDocumentDTOsByDemographicNo(String.valueOf(demographicNo));
+        List<DocumentListItemDTO> results = documentDao.findDocumentDTOsByDemographicNo(String.valueOf(demographicNo));
+        LogAction.addLog(loggedInInfo, "DocumentManager.getDocumentDTOs",
+                "demographicNo=" + demographicNo, "", "", "");
+        return results;
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/managers/PrescriptionManager.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/PrescriptionManager.java
@@ -33,6 +33,7 @@ package io.github.carlos_emr.carlos.managers;
 
 import io.github.carlos_emr.carlos.commn.model.Drug;
 import io.github.carlos_emr.carlos.commn.model.Prescription;
+import io.github.carlos_emr.carlos.prescript.dto.DrugListItemDTO;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 
 import java.util.Date;
@@ -74,4 +75,14 @@ public interface PrescriptionManager {
     public boolean print(LoggedInInfo loggedInInfo, int scriptNo);
 
     boolean setPrescriptionSignature(LoggedInInfo loggedInInfo, int scriptNo, Integer digitalSignatureId);
+
+    /**
+     * Returns lightweight drug DTOs for a demographic. Enforces read privilege check.
+     *
+     * @param loggedInInfo LoggedInInfo the logged-in user context
+     * @param demographicNo Integer the patient demographic number
+     * @return List of DrugListItemDTO for the patient's prescriptions
+     * @since 2026-04-11
+     */
+    List<DrugListItemDTO> getDrugDTOs(LoggedInInfo loggedInInfo, Integer demographicNo);
 }

--- a/src/main/java/io/github/carlos_emr/carlos/managers/PrescriptionManager.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/PrescriptionManager.java
@@ -82,6 +82,7 @@ public interface PrescriptionManager {
      * @param loggedInInfo LoggedInInfo the logged-in user context
      * @param demographicNo Integer the patient demographic number
      * @return List of DrugListItemDTO for the patient's prescriptions
+     * @throws org.springframework.security.access.AccessDeniedException if the caller lacks {@code _demographic} read privilege for this patient
      * @since 2026-04-11
      */
     List<DrugListItemDTO> getDrugDTOs(LoggedInInfo loggedInInfo, Integer demographicNo);

--- a/src/main/java/io/github/carlos_emr/carlos/managers/PrescriptionManager.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/PrescriptionManager.java
@@ -31,6 +31,7 @@
  */
 package io.github.carlos_emr.carlos.managers;
 
+import io.github.carlos_emr.carlos.commn.exception.AccessDeniedException;
 import io.github.carlos_emr.carlos.commn.model.Drug;
 import io.github.carlos_emr.carlos.commn.model.Prescription;
 import io.github.carlos_emr.carlos.prescript.dto.DrugListItemDTO;
@@ -82,7 +83,7 @@ public interface PrescriptionManager {
      * @param loggedInInfo LoggedInInfo the logged-in user context
      * @param demographicNo Integer the patient demographic number
      * @return List of DrugListItemDTO for the patient's prescriptions
-     * @throws org.springframework.security.access.AccessDeniedException if the caller lacks {@code _demographic} read privilege for this patient
+     * @throws AccessDeniedException if the caller lacks {@code _demographic} read privilege for this patient
      * @since 2026-04-11
      */
     List<DrugListItemDTO> getDrugDTOs(LoggedInInfo loggedInInfo, Integer demographicNo);

--- a/src/main/java/io/github/carlos_emr/carlos/managers/PrescriptionManagerImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/PrescriptionManagerImpl.java
@@ -402,7 +402,15 @@ public class PrescriptionManagerImpl implements PrescriptionManager {
     }
 
     /**
-     * {@inheritDoc}
+     * Returns lightweight drug list DTOs for a demographic after enforcing read access.
+     * Enforces {@code _demographic} read privilege via {@code SecurityInfoManager}
+     * and logs the access via {@code LogAction}.
+     *
+     * @param loggedInInfo LoggedInInfo logged-in provider/session context for authorization and auditing
+     * @param demographicNo Integer the patient demographic identifier
+     * @return List&lt;DrugListItemDTO&gt; ordered by prescription date descending
+     * @throws AccessDeniedException if the caller lacks {@code _demographic} read privilege
+     * @since 2026-04-11
      */
     @Override
     public List<DrugListItemDTO> getDrugDTOs(LoggedInInfo loggedInInfo, Integer demographicNo) {

--- a/src/main/java/io/github/carlos_emr/carlos/managers/PrescriptionManagerImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/PrescriptionManagerImpl.java
@@ -401,11 +401,16 @@ public class PrescriptionManagerImpl implements PrescriptionManager {
         return true;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public List<DrugListItemDTO> getDrugDTOs(LoggedInInfo loggedInInfo, Integer demographicNo) {
         if (!securityInfoManager.hasPrivilege(loggedInInfo, "_demographic", "r", demographicNo)) {
-            throw new RuntimeException("missing required sec object (_demographic)");
+            throw new AccessDeniedException("_demographic", "r", demographicNo);
         }
+        LogAction.addLogSynchronous(loggedInInfo, "PrescriptionManager.getDrugDTOs",
+                "demographicNo=" + demographicNo);
         return drugDao.findDrugDTOsByDemographicId(demographicNo);
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/managers/PrescriptionManagerImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/PrescriptionManagerImpl.java
@@ -35,6 +35,7 @@ import io.github.carlos_emr.carlos.prescript.util.RxUtil;
 import org.apache.logging.log4j.Logger;
 import io.github.carlos_emr.carlos.commn.dao.DrugDao;
 import io.github.carlos_emr.carlos.commn.dao.PrescriptionDao;
+import io.github.carlos_emr.carlos.prescript.dto.DrugListItemDTO;
 import io.github.carlos_emr.carlos.commn.exception.AccessDeniedException;
 import io.github.carlos_emr.carlos.commn.model.ConsentType;
 import io.github.carlos_emr.carlos.commn.model.Drug;
@@ -398,6 +399,14 @@ public class PrescriptionManagerImpl implements PrescriptionManager {
         prescriptionDao.merge(prescription);
 
         return true;
-}
+    }
+
+    @Override
+    public List<DrugListItemDTO> getDrugDTOs(LoggedInInfo loggedInInfo, Integer demographicNo) {
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_demographic", "r", demographicNo)) {
+            throw new RuntimeException("missing required sec object (_demographic)");
+        }
+        return drugDao.findDrugDTOsByDemographicId(demographicNo);
+    }
 
 }

--- a/src/main/java/io/github/carlos_emr/carlos/managers/PreventionManager.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/PreventionManager.java
@@ -36,6 +36,7 @@ import java.util.*;
 
 import io.github.carlos_emr.carlos.commn.model.Prevention;
 import io.github.carlos_emr.carlos.commn.model.PreventionExt;
+import io.github.carlos_emr.carlos.prevention.dto.PreventionListItemDTO;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 
 public interface PreventionManager {
@@ -87,4 +88,14 @@ public interface PreventionManager {
 
     public String getCustomPreventionItems();
 
+    /**
+     * Returns lightweight prevention DTOs for a demographic, bypassing the EAGER
+     * PreventionExt collection. Enforces read privilege check.
+     *
+     * @param loggedInInfo LoggedInInfo the logged-in user context
+     * @param demographicNo Integer the patient demographic number
+     * @return List of PreventionListItemDTO for the patient's immunizations
+     * @since 2026-04-11
+     */
+    List<PreventionListItemDTO> getPreventionDTOs(LoggedInInfo loggedInInfo, Integer demographicNo);
 }

--- a/src/main/java/io/github/carlos_emr/carlos/managers/PreventionManager.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/PreventionManager.java
@@ -95,6 +95,7 @@ public interface PreventionManager {
      * @param loggedInInfo LoggedInInfo the logged-in user context
      * @param demographicNo Integer the patient demographic number
      * @return List of PreventionListItemDTO for the patient's immunizations
+     * @throws SecurityException if the caller lacks {@code _prevention} read privilege
      * @since 2026-04-11
      */
     List<PreventionListItemDTO> getPreventionDTOs(LoggedInInfo loggedInInfo, Integer demographicNo);

--- a/src/main/java/io/github/carlos_emr/carlos/managers/PreventionManagerImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/PreventionManagerImpl.java
@@ -491,11 +491,16 @@ public class PreventionManagerImpl implements Serializable, PreventionManager {
         return immunizations;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public List<PreventionListItemDTO> getPreventionDTOs(LoggedInInfo loggedInInfo, Integer demographicNo) {
         if (!securityInfoManager.hasPrivilege(loggedInInfo, "_prevention", SecurityInfoManager.READ, demographicNo)) {
-            throw new RuntimeException("missing required sec object (_prevention)");
+            throw new SecurityException("missing required sec object (_prevention)");
         }
+        LogAction.addLogSynchronous(loggedInInfo, "PreventionManager.getPreventionDTOs",
+                "demographicNo=" + demographicNo);
         return preventionDao.findPreventionDTOsByDemographicId(demographicNo);
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/managers/PreventionManagerImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/PreventionManagerImpl.java
@@ -44,6 +44,7 @@ import io.github.carlos_emr.carlos.commn.interfaces.Immunization.ImmunizationPro
 import io.github.carlos_emr.carlos.commn.model.Prevention;
 import io.github.carlos_emr.carlos.commn.model.PreventionExt;
 import io.github.carlos_emr.carlos.commn.model.Property;
+import io.github.carlos_emr.carlos.prevention.dto.PreventionListItemDTO;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
@@ -488,6 +489,14 @@ public class PreventionManagerImpl implements Serializable, PreventionManager {
                 "demographicNo=" + demographicNo);
 
         return immunizations;
+    }
+
+    @Override
+    public List<PreventionListItemDTO> getPreventionDTOs(LoggedInInfo loggedInInfo, Integer demographicNo) {
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_prevention", SecurityInfoManager.READ, demographicNo)) {
+            throw new RuntimeException("missing required sec object (_prevention)");
+        }
+        return preventionDao.findPreventionDTOsByDemographicId(demographicNo);
     }
 
 }

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/dto/DrugListItemDTO.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/dto/DrugListItemDTO.java
@@ -1,0 +1,189 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ * <p>
+ * Now maintained by the CARLOS EMR Project (2026+).
+ * https://github.com/carlos-emr/carlos
+ * CARLOS has no affiliation with OSCAR or McMaster University.
+ */
+package io.github.carlos_emr.carlos.prescript.dto;
+
+import java.io.Serializable;
+import java.util.Date;
+import java.util.Objects;
+
+import io.github.carlos_emr.carlos.commn.model.Drug;
+
+/**
+ * Lightweight data transfer object for prescription list and history views,
+ * optimized for JPQL constructor expression projection. Carries only the 20
+ * fields needed for medication display out of Drug's 101 fields.
+ *
+ * <p>Omits: ATC codes, regional identifiers, GCN sequence numbers, renal dosing,
+ * compliance tracking, protocol fields, pharmacy IDs, and other internal data.</p>
+ *
+ * @since 2026-04-11
+ */
+public class DrugListItemDTO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private Integer id;
+    private Integer demographicId;
+    private String brandName;
+    private String genericName;
+    private String customName;
+    private String dosage;
+    private String route;
+    private String freqCode;
+    private String duration;
+    private String durUnit;
+    private String quantity;
+    private Integer repeat;
+    private Date rxDate;
+    private Date endDate;
+    private Date lastRefillDate;
+    private boolean archived;
+    private Boolean longTerm;
+    private String providerNo;
+    private String special;
+    private Integer scriptNo;
+
+    public DrugListItemDTO() {
+    }
+
+    /**
+     * Projection constructor for JPQL constructor expressions.
+     *
+     * @param id Integer the drug/prescription ID
+     * @param demographicId Integer the patient demographic number
+     * @param brandName String the brand name (BN)
+     * @param genericName String the generic name (GN)
+     * @param customName String the custom/compound name
+     * @param dosage String the dosage
+     * @param route String the route of administration
+     * @param freqCode String the frequency code
+     * @param duration String the duration
+     * @param durUnit String the duration unit
+     * @param quantity String the quantity
+     * @param repeat Integer the number of repeats/refills
+     * @param rxDate Date the prescription date
+     * @param endDate Date the end date
+     * @param lastRefillDate Date the last refill date
+     * @param archived boolean whether the prescription is archived
+     * @param longTerm Boolean whether this is a long-term medication
+     * @param providerNo String the prescribing provider number
+     * @param special String the special instructions
+     * @param scriptNo Integer the script number
+     */
+    public DrugListItemDTO(Integer id, Integer demographicId, String brandName, String genericName,
+                           String customName, String dosage, String route, String freqCode,
+                           String duration, String durUnit, String quantity, Integer repeat,
+                           Date rxDate, Date endDate, Date lastRefillDate, boolean archived,
+                           Boolean longTerm, String providerNo, String special, Integer scriptNo) {
+        this.id = id;
+        this.demographicId = demographicId;
+        this.brandName = brandName;
+        this.genericName = genericName;
+        this.customName = customName;
+        this.dosage = dosage;
+        this.route = route;
+        this.freqCode = freqCode;
+        this.duration = duration;
+        this.durUnit = durUnit;
+        this.quantity = quantity;
+        this.repeat = repeat;
+        this.rxDate = rxDate;
+        this.endDate = endDate;
+        this.lastRefillDate = lastRefillDate;
+        this.archived = archived;
+        this.longTerm = longTerm;
+        this.providerNo = providerNo;
+        this.special = special;
+        this.scriptNo = scriptNo;
+    }
+
+    /**
+     * Creates a DrugListItemDTO from a full Drug entity.
+     *
+     * @param d Drug the entity to convert; must not be null
+     * @return DrugListItemDTO a lightweight projection
+     */
+    public static DrugListItemDTO fromEntity(Drug d) {
+        Objects.requireNonNull(d, "Drug entity must not be null for DTO conversion");
+        return new DrugListItemDTO(
+                d.getId(), d.getDemographicId(), d.getBrandName(), d.getGenericName(),
+                d.getCustomName(), d.getDosage(), d.getRoute(), d.getFreqCode(),
+                d.getDuration(), d.getDurUnit(), d.getQuantity(), d.getRepeat(),
+                d.getRxDate(), d.getEndDate(), d.getLastRefillDate(), d.isArchived(),
+                d.getLongTerm(), d.getProviderNo(), d.getSpecial(), d.getScriptNo()
+        );
+    }
+
+    /**
+     * Returns the best available display name for this medication: brand name
+     * first, then generic name, then custom name.
+     *
+     * @return String the display name, or empty string if all names are null
+     */
+    public String getDisplayName() {
+        if (brandName != null && !brandName.trim().isEmpty()) return brandName;
+        if (genericName != null && !genericName.trim().isEmpty()) return genericName;
+        if (customName != null && !customName.trim().isEmpty()) return customName;
+        return "";
+    }
+
+    public Integer getId() { return id; }
+    public void setId(Integer id) { this.id = id; }
+    public Integer getDemographicId() { return demographicId; }
+    public void setDemographicId(Integer demographicId) { this.demographicId = demographicId; }
+    public String getBrandName() { return brandName; }
+    public void setBrandName(String brandName) { this.brandName = brandName; }
+    public String getGenericName() { return genericName; }
+    public void setGenericName(String genericName) { this.genericName = genericName; }
+    public String getCustomName() { return customName; }
+    public void setCustomName(String customName) { this.customName = customName; }
+    public String getDosage() { return dosage; }
+    public void setDosage(String dosage) { this.dosage = dosage; }
+    public String getRoute() { return route; }
+    public void setRoute(String route) { this.route = route; }
+    public String getFreqCode() { return freqCode; }
+    public void setFreqCode(String freqCode) { this.freqCode = freqCode; }
+    public String getDuration() { return duration; }
+    public void setDuration(String duration) { this.duration = duration; }
+    public String getDurUnit() { return durUnit; }
+    public void setDurUnit(String durUnit) { this.durUnit = durUnit; }
+    public String getQuantity() { return quantity; }
+    public void setQuantity(String quantity) { this.quantity = quantity; }
+    public Integer getRepeat() { return repeat; }
+    public void setRepeat(Integer repeat) { this.repeat = repeat; }
+    public Date getRxDate() { return rxDate; }
+    public void setRxDate(Date rxDate) { this.rxDate = rxDate; }
+    public Date getEndDate() { return endDate; }
+    public void setEndDate(Date endDate) { this.endDate = endDate; }
+    public Date getLastRefillDate() { return lastRefillDate; }
+    public void setLastRefillDate(Date lastRefillDate) { this.lastRefillDate = lastRefillDate; }
+    public boolean isArchived() { return archived; }
+    public void setArchived(boolean archived) { this.archived = archived; }
+    public Boolean getLongTerm() { return longTerm; }
+    public void setLongTerm(Boolean longTerm) { this.longTerm = longTerm; }
+    public String getProviderNo() { return providerNo; }
+    public void setProviderNo(String providerNo) { this.providerNo = providerNo; }
+    public String getSpecial() { return special; }
+    public void setSpecial(String special) { this.special = special; }
+    public Integer getScriptNo() { return scriptNo; }
+    public void setScriptNo(Integer scriptNo) { this.scriptNo = scriptNo; }
+}

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/dto/DrugListItemDTO.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/dto/DrugListItemDTO.java
@@ -42,7 +42,7 @@ public class DrugListItemDTO implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private Integer id;
-    private Integer demographicId;
+    private Integer demographicNo;
     private String brandName;
     private String genericName;
     private String customName;
@@ -69,7 +69,7 @@ public class DrugListItemDTO implements Serializable {
      * Projection constructor for JPQL constructor expressions.
      *
      * @param id Integer the drug/prescription ID
-     * @param demographicId Integer the patient demographic number
+     * @param demographicNo Integer the patient demographic number
      * @param brandName String the brand name (BN)
      * @param genericName String the generic name (GN)
      * @param customName String the custom/compound name
@@ -89,13 +89,13 @@ public class DrugListItemDTO implements Serializable {
      * @param special String the special instructions
      * @param scriptNo Integer the script number
      */
-    public DrugListItemDTO(Integer id, Integer demographicId, String brandName, String genericName,
+    public DrugListItemDTO(Integer id, Integer demographicNo, String brandName, String genericName,
                            String customName, String dosage, String route, String freqCode,
                            String duration, String durUnit, String quantity, Integer repeat,
                            Date rxDate, Date endDate, Date lastRefillDate, boolean archived,
                            Boolean longTerm, String providerNo, String special, Integer scriptNo) {
         this.id = id;
-        this.demographicId = demographicId;
+        this.demographicNo = demographicNo;
         this.brandName = brandName;
         this.genericName = genericName;
         this.customName = customName;
@@ -148,8 +148,8 @@ public class DrugListItemDTO implements Serializable {
 
     public Integer getId() { return id; }
     public void setId(Integer id) { this.id = id; }
-    public Integer getDemographicId() { return demographicId; }
-    public void setDemographicId(Integer demographicId) { this.demographicId = demographicId; }
+    public Integer getDemographicNo() { return demographicNo; }
+    public void setDemographicNo(Integer demographicNo) { this.demographicNo = demographicNo; }
     public String getBrandName() { return brandName; }
     public void setBrandName(String brandName) { this.brandName = brandName; }
     public String getGenericName() { return genericName; }

--- a/src/main/java/io/github/carlos_emr/carlos/prevention/dto/PreventionListItemDTO.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prevention/dto/PreventionListItemDTO.java
@@ -23,6 +23,9 @@ package io.github.carlos_emr.carlos.prevention.dto;
 
 import java.io.Serializable;
 import java.util.Date;
+import java.util.Objects;
+
+import io.github.carlos_emr.carlos.commn.model.Prevention;
 
 /**
  * Lightweight data transfer object for immunization/prevention history list views,
@@ -87,6 +90,31 @@ public class PreventionListItemDTO implements Serializable {
         this.never = never;
         this.nextDate = nextDate;
         this.lastUpdateDate = lastUpdateDate;
+    }
+
+    /**
+     * Creates a DTO from a full {@link Prevention} entity. Preserves the raw
+     * multi-valued {@code refused} status ('0'..'3') via {@code getRefusedRawValue()}
+     * — the boolean accessor {@code isRefused()} would collapse '2' (ineligible) and
+     * '3' (completed externally) back to '0', which this helper avoids.
+     *
+     * @param p Prevention the entity to convert; must not be null
+     * @return PreventionListItemDTO a lightweight projection
+     * @since 2026-04-12
+     */
+    public static PreventionListItemDTO fromEntity(Prevention p) {
+        Objects.requireNonNull(p, "Prevention entity must not be null for DTO conversion");
+        int refusedRaw = p.getRefusedRawValue();
+        char refused = (refusedRaw >= 0 && refusedRaw <= 3) ? (char) ('0' + refusedRaw) : '0';
+        return new PreventionListItemDTO(
+                p.getId(), p.getDemographicId(), p.getPreventionType(),
+                p.getPreventionDate(), p.getCreationDate(), p.getProviderNo(),
+                p.getCreatorProviderNo(),
+                p.isDeleted() ? '1' : '0',
+                refused,
+                p.isNever() ? '1' : '0',
+                p.getNextDate(), p.getLastUpdateDate()
+        );
     }
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/prevention/dto/PreventionListItemDTO.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prevention/dto/PreventionListItemDTO.java
@@ -39,7 +39,7 @@ public class PreventionListItemDTO implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private Integer id;
-    private Integer demographicId;
+    private Integer demographicNo;
     private String preventionType;
     private Date preventionDate;
     private Date creationDate;
@@ -59,7 +59,7 @@ public class PreventionListItemDTO implements Serializable {
      * Projection constructor for JPQL constructor expressions.
      *
      * @param id Integer the prevention record ID
-     * @param demographicId Integer the patient demographic number
+     * @param demographicNo Integer the patient demographic number
      * @param preventionType String the prevention/vaccine type name
      * @param preventionDate Date the date the prevention was administered
      * @param creationDate Date the record creation date
@@ -71,12 +71,12 @@ public class PreventionListItemDTO implements Serializable {
      * @param nextDate Date the next scheduled date
      * @param lastUpdateDate Date the last update timestamp
      */
-    public PreventionListItemDTO(Integer id, Integer demographicId, String preventionType,
+    public PreventionListItemDTO(Integer id, Integer demographicNo, String preventionType,
                                  Date preventionDate, Date creationDate, String providerNo,
                                  String creatorProviderNo, char deleted, char refused, char never,
                                  Date nextDate, Date lastUpdateDate) {
         this.id = id;
-        this.demographicId = demographicId;
+        this.demographicNo = demographicNo;
         this.preventionType = preventionType;
         this.preventionDate = preventionDate;
         this.creationDate = creationDate;
@@ -100,8 +100,8 @@ public class PreventionListItemDTO implements Serializable {
 
     public Integer getId() { return id; }
     public void setId(Integer id) { this.id = id; }
-    public Integer getDemographicId() { return demographicId; }
-    public void setDemographicId(Integer demographicId) { this.demographicId = demographicId; }
+    public Integer getDemographicNo() { return demographicNo; }
+    public void setDemographicNo(Integer demographicNo) { this.demographicNo = demographicNo; }
     public String getPreventionType() { return preventionType; }
     public void setPreventionType(String preventionType) { this.preventionType = preventionType; }
     public Date getPreventionDate() { return preventionDate; }

--- a/src/main/java/io/github/carlos_emr/carlos/prevention/dto/PreventionListItemDTO.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prevention/dto/PreventionListItemDTO.java
@@ -23,9 +23,6 @@ package io.github.carlos_emr.carlos.prevention.dto;
 
 import java.io.Serializable;
 import java.util.Date;
-import java.util.Objects;
-
-import io.github.carlos_emr.carlos.commn.model.Prevention;
 
 /**
  * Lightweight data transfer object for immunization/prevention history list views,
@@ -48,12 +45,13 @@ public class PreventionListItemDTO implements Serializable {
     private Date creationDate;
     private String providerNo;
     private String creatorProviderNo;
-    private char deleted;
-    private char refused;
-    private char never;
+    private char deleted = '0';
+    private char refused = '0';
+    private char never = '0';
     private Date nextDate;
     private Date lastUpdateDate;
 
+    /** Default constructor for serialization/framework binding. */
     public PreventionListItemDTO() {
     }
 
@@ -67,9 +65,9 @@ public class PreventionListItemDTO implements Serializable {
      * @param creationDate Date the record creation date
      * @param providerNo String the administering provider number
      * @param creatorProviderNo String the record creator provider number
-     * @param deleted char deletion flag ('0' or '1')
-     * @param refused char refusal flag ('0' or '1')
-     * @param never char never-administer flag ('0' or '1')
+     * @param deleted char deletion flag ('0'=active, '1'=deleted)
+     * @param refused char refusal/status flag ('0'=active, '1'=refused, '2'=ineligible, '3'=completedExternally)
+     * @param never char never-administer flag ('0'=active, '1'=never)
      * @param nextDate Date the next scheduled date
      * @param lastUpdateDate Date the last update timestamp
      */
@@ -89,25 +87,6 @@ public class PreventionListItemDTO implements Serializable {
         this.never = never;
         this.nextDate = nextDate;
         this.lastUpdateDate = lastUpdateDate;
-    }
-
-    /**
-     * Creates a PreventionListItemDTO from a full Prevention entity.
-     *
-     * @param p Prevention the entity to convert; must not be null
-     * @return PreventionListItemDTO a lightweight projection
-     */
-    public static PreventionListItemDTO fromEntity(Prevention p) {
-        Objects.requireNonNull(p, "Prevention entity must not be null for DTO conversion");
-        return new PreventionListItemDTO(
-                p.getId(), p.getDemographicId(), p.getPreventionType(),
-                p.getPreventionDate(), p.getCreationDate(), p.getProviderNo(),
-                p.getCreatorProviderNo(),
-                p.isDeleted() ? '1' : '0',
-                p.isRefused() ? '1' : '0',
-                p.isNever() ? '1' : '0',
-                p.getNextDate(), p.getLastUpdateDate()
-        );
     }
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/prevention/dto/PreventionListItemDTO.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prevention/dto/PreventionListItemDTO.java
@@ -1,0 +1,146 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ * <p>
+ * Now maintained by the CARLOS EMR Project (2026+).
+ * https://github.com/carlos-emr/carlos
+ * CARLOS has no affiliation with OSCAR or McMaster University.
+ */
+package io.github.carlos_emr.carlos.prevention.dto;
+
+import java.io.Serializable;
+import java.util.Date;
+import java.util.Objects;
+
+import io.github.carlos_emr.carlos.commn.model.Prevention;
+
+/**
+ * Lightweight data transfer object for immunization/prevention history list views,
+ * optimized for JPQL constructor expression projection. Eliminates the EAGER-loaded
+ * PreventionExt collection that is fetched on every Prevention entity load.
+ *
+ * <p>Omits: entire {@code preventionExts} EAGER collection (lot number, route,
+ * dose, site, comments), {@code snomedId}, transient {@code preventionExtendedProperties}.</p>
+ *
+ * @since 2026-04-11
+ */
+public class PreventionListItemDTO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private Integer id;
+    private Integer demographicId;
+    private String preventionType;
+    private Date preventionDate;
+    private Date creationDate;
+    private String providerNo;
+    private String creatorProviderNo;
+    private char deleted;
+    private char refused;
+    private char never;
+    private Date nextDate;
+    private Date lastUpdateDate;
+
+    public PreventionListItemDTO() {
+    }
+
+    /**
+     * Projection constructor for JPQL constructor expressions.
+     *
+     * @param id Integer the prevention record ID
+     * @param demographicId Integer the patient demographic number
+     * @param preventionType String the prevention/vaccine type name
+     * @param preventionDate Date the date the prevention was administered
+     * @param creationDate Date the record creation date
+     * @param providerNo String the administering provider number
+     * @param creatorProviderNo String the record creator provider number
+     * @param deleted char deletion flag ('0' or '1')
+     * @param refused char refusal flag ('0' or '1')
+     * @param never char never-administer flag ('0' or '1')
+     * @param nextDate Date the next scheduled date
+     * @param lastUpdateDate Date the last update timestamp
+     */
+    public PreventionListItemDTO(Integer id, Integer demographicId, String preventionType,
+                                 Date preventionDate, Date creationDate, String providerNo,
+                                 String creatorProviderNo, char deleted, char refused, char never,
+                                 Date nextDate, Date lastUpdateDate) {
+        this.id = id;
+        this.demographicId = demographicId;
+        this.preventionType = preventionType;
+        this.preventionDate = preventionDate;
+        this.creationDate = creationDate;
+        this.providerNo = providerNo;
+        this.creatorProviderNo = creatorProviderNo;
+        this.deleted = deleted;
+        this.refused = refused;
+        this.never = never;
+        this.nextDate = nextDate;
+        this.lastUpdateDate = lastUpdateDate;
+    }
+
+    /**
+     * Creates a PreventionListItemDTO from a full Prevention entity.
+     *
+     * @param p Prevention the entity to convert; must not be null
+     * @return PreventionListItemDTO a lightweight projection
+     */
+    public static PreventionListItemDTO fromEntity(Prevention p) {
+        Objects.requireNonNull(p, "Prevention entity must not be null for DTO conversion");
+        return new PreventionListItemDTO(
+                p.getId(), p.getDemographicId(), p.getPreventionType(),
+                p.getPreventionDate(), p.getCreationDate(), p.getProviderNo(),
+                p.getCreatorProviderNo(),
+                p.isDeleted() ? '1' : '0',
+                p.isRefused() ? '1' : '0',
+                p.isNever() ? '1' : '0',
+                p.getNextDate(), p.getLastUpdateDate()
+        );
+    }
+
+    /**
+     * Returns whether this prevention record is active (not deleted, not refused, not never).
+     *
+     * @return boolean true if the record is active
+     */
+    public boolean isActive() {
+        return deleted == '0' && refused == '0' && never == '0';
+    }
+
+    public Integer getId() { return id; }
+    public void setId(Integer id) { this.id = id; }
+    public Integer getDemographicId() { return demographicId; }
+    public void setDemographicId(Integer demographicId) { this.demographicId = demographicId; }
+    public String getPreventionType() { return preventionType; }
+    public void setPreventionType(String preventionType) { this.preventionType = preventionType; }
+    public Date getPreventionDate() { return preventionDate; }
+    public void setPreventionDate(Date preventionDate) { this.preventionDate = preventionDate; }
+    public Date getCreationDate() { return creationDate; }
+    public void setCreationDate(Date creationDate) { this.creationDate = creationDate; }
+    public String getProviderNo() { return providerNo; }
+    public void setProviderNo(String providerNo) { this.providerNo = providerNo; }
+    public String getCreatorProviderNo() { return creatorProviderNo; }
+    public void setCreatorProviderNo(String creatorProviderNo) { this.creatorProviderNo = creatorProviderNo; }
+    public char getDeleted() { return deleted; }
+    public void setDeleted(char deleted) { this.deleted = deleted; }
+    public char getRefused() { return refused; }
+    public void setRefused(char refused) { this.refused = refused; }
+    public char getNever() { return never; }
+    public void setNever(char never) { this.never = never; }
+    public Date getNextDate() { return nextDate; }
+    public void setNextDate(Date nextDate) { this.nextDate = nextDate; }
+    public Date getLastUpdateDate() { return lastUpdateDate; }
+    public void setLastUpdateDate(Date lastUpdateDate) { this.lastUpdateDate = lastUpdateDate; }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/casemgmt/dao/CaseManagementIssueDAOIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/casemgmt/dao/CaseManagementIssueDAOIntegrationTest.java
@@ -542,4 +542,60 @@ public class CaseManagementIssueDAOIntegrationTest extends CarlosTestBase {
             ).isInstanceOf(IllegalArgumentException.class);
         }
     }
+
+    /**
+     * Tests for {@link CaseManagementIssueDAO#findIssueDTOsByDemographicNo(String)}
+     * including the NumberFormatException guard that returns an empty list on
+     * non-numeric input (rather than propagating the NFE or silently blowing up
+     * during JPQL parameter binding).
+     */
+    @Nested
+    @DisplayName("findIssueDTOsByDemographicNo — DTO projection + NFE guard")
+    @Tag("read")
+    class FindIssueDTOsByDemographicNo {
+
+        @Test
+        @DisplayName("should return empty list when demographicNo is not a valid integer")
+        void shouldReturnEmptyList_whenDemographicNoIsNonNumeric() {
+            // Locks in the NFE-guard contract at CaseManagementIssueDAOImpl:214-218.
+            // Regression target: removing the try/catch would cause a
+            // NumberFormatException to propagate here, breaking callers that
+            // expect a benign empty result for bad URL/form input.
+            assertThat(caseManagementIssueDAO.findIssueDTOsByDemographicNo("not-a-number"))
+                    .isEmpty();
+            assertThat(caseManagementIssueDAO.findIssueDTOsByDemographicNo(""))
+                    .isEmpty();
+        }
+
+        @Test
+        @DisplayName("should return empty list when demographic has no issues")
+        void shouldReturnEmptyList_whenDemographicHasNoIssues() {
+            assertThat(caseManagementIssueDAO.findIssueDTOsByDemographicNo("99999"))
+                    .isEmpty();
+        }
+
+        @Test
+        @DisplayName("should return DTOs ordered by update_date descending when demographic has issues")
+        void shouldReturnDTOsOrderedByUpdateDateDesc_whenDemographicHasIssues() {
+            // Given two issues for the same demographic with distinct update_dates
+            CaseManagementIssue older = createCaseManagementIssue("21000", testIssue1);
+            Calendar cal = Calendar.getInstance();
+            cal.add(Calendar.DAY_OF_MONTH, -7);
+            older.setUpdate_date(cal.getTime());
+            hibernateTemplate.update(older);
+
+            CaseManagementIssue newer = createCaseManagementIssue("21000", testIssue2);
+            newer.setUpdate_date(new Date());
+            hibernateTemplate.update(newer);
+            hibernateTemplate.flush();
+
+            // When
+            var dtos = caseManagementIssueDAO.findIssueDTOsByDemographicNo("21000");
+
+            // Then — both returned, newer first, with joined Issue code/description
+            assertThat(dtos).hasSize(2);
+            assertThat(dtos.get(0).getUpdateDate()).isAfterOrEqualTo(dtos.get(1).getUpdateDate());
+            assertThat(dtos).extracting("issueCode").contains("TEST001", "TEST002");
+        }
+    }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/commn/dao/DtoProjectionSmokeIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/commn/dao/DtoProjectionSmokeIntegrationTest.java
@@ -1,0 +1,162 @@
+/**
+ * Copyright (c) 2026 CARLOS EMR Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.commn.dao;
+
+import io.github.carlos_emr.carlos.casemgmt.dao.CaseManagementNoteDAO;
+import io.github.carlos_emr.carlos.test.base.CarlosTestBase;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Parse-and-execute smoke tests for the 8 DAO DTO projection methods added in
+ * the DTO projection layer. Each test invokes the DAO method against an empty
+ * H2 database and asserts:
+ *
+ * <ul>
+ *   <li>The JPQL {@code SELECT NEW} query parses successfully — catches HBM
+ *       property-name typos (including the PascalCase HBM quirk for Demographic
+ *       and Provider), constructor arity mismatches, and type incompatibilities.
+ *   <li>Execution against an empty table returns a non-null empty list, not
+ *       an exception.
+ * </ul>
+ *
+ * <p><b>What this does NOT catch:</b> field reorders within same-typed argument
+ * sequences (e.g., swapping two adjacent {@code String} columns). Those require
+ * per-DAO round-trip tests with populated data — the {@code CaseManagementIssueDAOIntegrationTest}
+ * FindIssueDTOsByDemographicNo nested class is the prototype for that deeper
+ * coverage and can be replicated per DAO as a follow-up.</p>
+ *
+ * <p>This file is the cheap-but-broad safety net that catches the class of bugs
+ * Hibernate would throw at query-execution time rather than at deploy time.</p>
+ *
+ * @since 2026-04-12
+ */
+@DisplayName("DTO Projection Smoke Tests — 8 DAOs")
+@Tag("integration")
+@Tag("dao")
+@Tag("dto")
+@Transactional
+public class DtoProjectionSmokeIntegrationTest extends CarlosTestBase {
+
+    @Autowired
+    private AllergyDao allergyDao;
+
+    @Autowired
+    private OscarAppointmentDao appointmentDao;
+
+    @Autowired
+    private BillingONCHeader1Dao billingONCHeader1Dao;
+
+    @Autowired
+    private ConsultationRequestDao consultationRequestDao;
+
+    @Autowired
+    private DocumentDao documentDao;
+
+    @Autowired
+    private DrugDao drugDao;
+
+    @Autowired
+    private PreventionDao preventionDao;
+
+    @Autowired
+    @Qualifier("CaseManagementNoteDAO")
+    private CaseManagementNoteDAO caseManagementNoteDAO;
+
+    private static final Integer NON_EXISTENT_DEMO = 999_999;
+    private static final String NON_EXISTENT_DEMO_STR = "999999";
+    private static final String PROVIDER_NO = "999990";
+
+    @Test
+    @DisplayName("AllergyDao.findAllergyDTOsByDemographicNo should parse and return empty for unknown demographic")
+    void allergyDao_projectionShouldParseAndExecute() {
+        assertThatCode(() ->
+                assertThat(allergyDao.findAllergyDTOsByDemographicNo(NON_EXISTENT_DEMO)).isEmpty()
+        ).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("OscarAppointmentDao.findDayAppointmentDTOs should parse and return empty for unknown provider/date")
+    void appointmentDao_projectionShouldParseAndExecute() {
+        assertThatCode(() ->
+                assertThat(appointmentDao.findDayAppointmentDTOs(new Date(), PROVIDER_NO)).isEmpty()
+        ).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("BillingONCHeader1Dao.findBillingDTOsByDemographicNo should parse and return empty for unknown demographic")
+    void billingDao_projectionShouldParseAndExecute() {
+        assertThatCode(() ->
+                assertThat(billingONCHeader1Dao.findBillingDTOsByDemographicNo(NON_EXISTENT_DEMO)).isEmpty()
+        ).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("ConsultationRequestDao.findConsultationDTOsByDemographicId should parse and return empty for unknown demographic")
+    void consultationDao_projectionShouldParseAndExecute() {
+        assertThatCode(() ->
+                assertThat(consultationRequestDao.findConsultationDTOsByDemographicId(NON_EXISTENT_DEMO)).isEmpty()
+        ).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("DocumentDao.findDocumentDTOsByDemographicNo should parse and return empty for unknown demographic")
+    void documentDao_projectionShouldParseAndExecute() {
+        assertThatCode(() ->
+                assertThat(documentDao.findDocumentDTOsByDemographicNo(NON_EXISTENT_DEMO)).isEmpty()
+        ).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("DrugDao.findDrugDTOsByDemographicId should parse and return empty for unknown demographic")
+    void drugDao_projectionShouldParseAndExecute() {
+        assertThatCode(() ->
+                assertThat(drugDao.findDrugDTOsByDemographicId(NON_EXISTENT_DEMO)).isEmpty()
+        ).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("PreventionDao.findPreventionDTOsByDemographicId should parse and return empty for unknown demographic")
+    void preventionDao_projectionShouldParseAndExecute() {
+        assertThatCode(() ->
+                assertThat(preventionDao.findPreventionDTOsByDemographicId(NON_EXISTENT_DEMO)).isEmpty()
+        ).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("CaseManagementNoteDAO.findNoteDTOsByDemographicNo should parse and return empty for unknown demographic")
+    void noteDao_projectionShouldParseAndExecute() {
+        assertThatCode(() ->
+                assertThat(caseManagementNoteDAO.findNoteDTOsByDemographicNo(NON_EXISTENT_DEMO_STR)).isEmpty()
+        ).doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/managers/DtoManagerSecurityUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/managers/DtoManagerSecurityUnitTest.java
@@ -60,6 +60,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.never;
@@ -274,7 +275,8 @@ public class DtoManagerSecurityUnitTest extends CarlosUnitTestBase {
         assertThat(result).isSameAs(expected);
         verify(dao).findAllergyDTOsByDemographicNo(DEMO_NO);
         logActionMock.verify(() -> LogAction.addLogSynchronous(
-                eq(mockLoggedInInfo), eq("AllergyManager.getAllergyDTOs"), anyString()));
+                eq(mockLoggedInInfo), eq("AllergyManager.getAllergyDTOs"),
+                contains("demographicNo=" + DEMO_NO)));
     }
 
     @Test
@@ -294,7 +296,8 @@ public class DtoManagerSecurityUnitTest extends CarlosUnitTestBase {
         assertThat(result).isSameAs(expected);
         verify(dao).findDayAppointmentDTOs(date, PROVIDER_NO);
         logActionMock.verify(() -> LogAction.addLogSynchronous(
-                eq(mockLoggedInInfo), eq("AppointmentManager.getDayAppointmentDTOs"), anyString()));
+                eq(mockLoggedInInfo), eq("AppointmentManager.getDayAppointmentDTOs"),
+                contains("providerNo=" + PROVIDER_NO)));
     }
 
     @Test
@@ -313,7 +316,8 @@ public class DtoManagerSecurityUnitTest extends CarlosUnitTestBase {
         assertThat(result).isSameAs(expected);
         verify(dao).findConsultationDTOsByDemographicId(DEMO_NO);
         logActionMock.verify(() -> LogAction.addLogSynchronous(
-                eq(mockLoggedInInfo), eq("ConsultationManager.getConsultationDTOs"), anyString()));
+                eq(mockLoggedInInfo), eq("ConsultationManager.getConsultationDTOs"),
+                contains("demographicId=" + DEMO_NO)));
     }
 
     @Test
@@ -332,7 +336,8 @@ public class DtoManagerSecurityUnitTest extends CarlosUnitTestBase {
         assertThat(result).isSameAs(expected);
         verify(dao).findDocumentDTOsByDemographicNo(DEMO_NO);
         logActionMock.verify(() -> LogAction.addLogSynchronous(
-                eq(mockLoggedInInfo), eq("DocumentManager.getDocumentDTOs"), anyString()));
+                eq(mockLoggedInInfo), eq("DocumentManager.getDocumentDTOs"),
+                contains("demographicNo=" + DEMO_NO)));
     }
 
     @Test
@@ -351,7 +356,8 @@ public class DtoManagerSecurityUnitTest extends CarlosUnitTestBase {
         assertThat(result).isSameAs(expected);
         verify(dao).findDrugDTOsByDemographicId(DEMO_NO);
         logActionMock.verify(() -> LogAction.addLogSynchronous(
-                eq(mockLoggedInInfo), eq("PrescriptionManager.getDrugDTOs"), anyString()));
+                eq(mockLoggedInInfo), eq("PrescriptionManager.getDrugDTOs"),
+                contains("demographicNo=" + DEMO_NO)));
     }
 
     @Test
@@ -370,7 +376,8 @@ public class DtoManagerSecurityUnitTest extends CarlosUnitTestBase {
         assertThat(result).isSameAs(expected);
         verify(dao).findPreventionDTOsByDemographicId(DEMO_NO);
         logActionMock.verify(() -> LogAction.addLogSynchronous(
-                eq(mockLoggedInInfo), eq("PreventionManager.getPreventionDTOs"), anyString()));
+                eq(mockLoggedInInfo), eq("PreventionManager.getPreventionDTOs"),
+                contains("demographicNo=" + DEMO_NO)));
     }
 
     @Test
@@ -389,7 +396,8 @@ public class DtoManagerSecurityUnitTest extends CarlosUnitTestBase {
         assertThat(result).isSameAs(expected);
         verify(dao).findBillingDTOsByDemographicNo(DEMO_NO);
         logActionMock.verify(() -> LogAction.addLogSynchronous(
-                eq(mockLoggedInInfo), eq("BillingONManager.getBillingDTOs"), anyString()));
+                eq(mockLoggedInInfo), eq("BillingONManager.getBillingDTOs"),
+                contains("demographicNo=" + DEMO_NO)));
     }
 
     @Test
@@ -408,7 +416,8 @@ public class DtoManagerSecurityUnitTest extends CarlosUnitTestBase {
         assertThat(result).isSameAs(expected);
         verify(dao).findIssueDTOsByDemographicNo(DEMO_NO_STR);
         logActionMock.verify(() -> LogAction.addLogSynchronous(
-                eq(mockLoggedInInfo), eq("CaseManagementManager.getIssueDTOs"), anyString()));
+                eq(mockLoggedInInfo), eq("CaseManagementManager.getIssueDTOs"),
+                contains("demographicNo=" + DEMO_NO_STR)));
     }
 
     @Test
@@ -427,6 +436,7 @@ public class DtoManagerSecurityUnitTest extends CarlosUnitTestBase {
         assertThat(result).isSameAs(expected);
         verify(dao).findNoteDTOsByDemographicNo(DEMO_NO_STR);
         logActionMock.verify(() -> LogAction.addLogSynchronous(
-                eq(mockLoggedInInfo), eq("CaseManagementManager.getNoteDTOs"), anyString()));
+                eq(mockLoggedInInfo), eq("CaseManagementManager.getNoteDTOs"),
+                contains("demographicNo=" + DEMO_NO_STR)));
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/managers/DtoManagerSecurityUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/managers/DtoManagerSecurityUnitTest.java
@@ -21,8 +21,13 @@
  */
 package io.github.carlos_emr.carlos.managers;
 
+import io.github.carlos_emr.carlos.allergy.dto.AllergyListItemDTO;
+import io.github.carlos_emr.carlos.appointment.dto.AppointmentListItemDTO;
+import io.github.carlos_emr.carlos.billings.dto.BillingONCListItemDTO;
 import io.github.carlos_emr.carlos.casemgmt.dao.CaseManagementIssueDAO;
 import io.github.carlos_emr.carlos.casemgmt.dao.CaseManagementNoteDAO;
+import io.github.carlos_emr.carlos.casemgmt.dto.CaseManagementIssueListDTO;
+import io.github.carlos_emr.carlos.casemgmt.dto.CaseManagementNoteListDTO;
 import io.github.carlos_emr.carlos.casemgmt.service.CaseManagementManagerImpl;
 import io.github.carlos_emr.carlos.commn.dao.AllergyDao;
 import io.github.carlos_emr.carlos.commn.dao.BillingONCHeader1Dao;
@@ -32,6 +37,11 @@ import io.github.carlos_emr.carlos.commn.dao.DrugDao;
 import io.github.carlos_emr.carlos.commn.dao.OscarAppointmentDao;
 import io.github.carlos_emr.carlos.commn.dao.PreventionDao;
 import io.github.carlos_emr.carlos.commn.exception.AccessDeniedException;
+import io.github.carlos_emr.carlos.consultation.dto.ConsultationRequestListItemDTO;
+import io.github.carlos_emr.carlos.documentManager.dto.DocumentListItemDTO;
+import io.github.carlos_emr.carlos.log.LogAction;
+import io.github.carlos_emr.carlos.prescript.dto.DrugListItemDTO;
+import io.github.carlos_emr.carlos.prevention.dto.PreventionListItemDTO;
 import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 
@@ -41,26 +51,38 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
  * Verifies that every Manager DTO method added in the DTO projection layer
- * throws on privilege denial rather than silently returning an empty list.
+ * behaves correctly on both the denial and the allow path.
  *
- * <p>A copy-paste regression (wrong sec-object string, missing privilege check,
- * or swallowed denial) would silently leak PHI. These tests lock in the contract
- * that denial surfaces as an exception and that the backing DAO is not consulted.</p>
+ * <p>Denial tests lock in that a missing privilege surfaces as an exception and
+ * that the backing DAO is NOT consulted — preventing a silent PHI leak if a
+ * sec-object string or privilege mode regresses.</p>
+ *
+ * <p>Allow tests lock in the opposite half of the contract: granted privilege
+ * must reach the DAO, return the DAO's result unchanged, and record a
+ * synchronous audit log entry. A typo on the allow branch (wrong sec-object
+ * string that the user happens to have) would pass all denial tests but be
+ * caught here.</p>
  *
  * @since 2026-04-12
  */
-@DisplayName("DTO Manager Security — privilege-denial contract")
+@DisplayName("DTO Manager Security — privilege contract (denial + allow)")
 @Tag("unit")
 @Tag("fast")
 @Tag("manager")
@@ -84,7 +106,14 @@ public class DtoManagerSecurityUnitTest extends CarlosUnitTestBase {
     }
 
     private void denyAllPrivileges() {
-        when(mockSecurityInfoManager.hasPrivilege(any(LoggedInInfo.class), anyString(), anyString(), any()))
+        // SecurityInfoManager has both int and String overloads for the scoped arg.
+        // Stub both so primitive-int call sites (Prescription/Prevention) hit a stub
+        // rather than Mockito's default-false (which would pass by coincidence).
+        when(mockSecurityInfoManager.hasPrivilege(any(LoggedInInfo.class), anyString(), anyString(), anyString()))
+                .thenReturn(false);
+        when(mockSecurityInfoManager.hasPrivilege(any(LoggedInInfo.class), anyString(), anyString(), anyInt()))
+                .thenReturn(false);
+        when(mockSecurityInfoManager.hasPrivilege(any(LoggedInInfo.class), anyString(), anyString(), isNull()))
                 .thenReturn(false);
     }
 
@@ -211,5 +240,193 @@ public class DtoManagerSecurityUnitTest extends CarlosUnitTestBase {
                 .isInstanceOf(SecurityException.class)
                 .hasMessageContaining("_demographic");
         verify(noteDao, never()).findNoteDTOsByDemographicNo(anyString());
+    }
+
+    // ---------------------------------------------------------------------
+    // Allow-path tests — privilege granted ⇒ DAO called, result returned,
+    // audit entry written. These catch regressions where a sec-object string
+    // typo makes the check pass against the wrong object, or where audit
+    // logging is accidentally removed.
+    // ---------------------------------------------------------------------
+
+    private void grantPrivilege(String secObject) {
+        when(mockSecurityInfoManager.hasPrivilege(any(LoggedInInfo.class), eq(secObject), anyString(), anyString()))
+                .thenReturn(true);
+        when(mockSecurityInfoManager.hasPrivilege(any(LoggedInInfo.class), eq(secObject), anyString(), anyInt()))
+                .thenReturn(true);
+        when(mockSecurityInfoManager.hasPrivilege(any(LoggedInInfo.class), eq(secObject), anyString(), isNull()))
+                .thenReturn(true);
+    }
+
+    @Test
+    @DisplayName("AllergyManagerImpl.getAllergyDTOs should call DAO and log when _allergy granted")
+    void allergyManager_shouldCallDaoAndLog_whenAllergyReadGranted() {
+        AllergyDao dao = Mockito.mock(AllergyDao.class);
+        List<AllergyListItemDTO> expected = Collections.singletonList(new AllergyListItemDTO());
+        when(dao.findAllergyDTOsByDemographicNo(DEMO_NO)).thenReturn(expected);
+        AllergyManagerImpl manager = new AllergyManagerImpl();
+        injectDependency(manager, "allergyDao", dao);
+        injectDependency(manager, "securityInfoManager", mockSecurityInfoManager);
+        grantPrivilege("_allergy");
+
+        List<AllergyListItemDTO> result = manager.getAllergyDTOs(mockLoggedInInfo, DEMO_NO);
+
+        assertThat(result).isSameAs(expected);
+        verify(dao).findAllergyDTOsByDemographicNo(DEMO_NO);
+        logActionMock.verify(() -> LogAction.addLogSynchronous(
+                eq(mockLoggedInInfo), eq("AllergyManager.getAllergyDTOs"), anyString()));
+    }
+
+    @Test
+    @DisplayName("AppointmentManagerImpl.getDayAppointmentDTOs should call DAO and log when _appointment granted")
+    void appointmentManager_shouldCallDaoAndLog_whenAppointmentReadGranted() {
+        OscarAppointmentDao dao = Mockito.mock(OscarAppointmentDao.class);
+        Date date = new Date();
+        List<AppointmentListItemDTO> expected = Collections.singletonList(new AppointmentListItemDTO());
+        when(dao.findDayAppointmentDTOs(date, PROVIDER_NO)).thenReturn(expected);
+        AppointmentManagerImpl manager = new AppointmentManagerImpl();
+        injectDependency(manager, "appointmentDao", dao);
+        injectDependency(manager, "securityInfoManager", mockSecurityInfoManager);
+        grantPrivilege("_appointment");
+
+        List<AppointmentListItemDTO> result = manager.getDayAppointmentDTOs(mockLoggedInInfo, date, PROVIDER_NO);
+
+        assertThat(result).isSameAs(expected);
+        verify(dao).findDayAppointmentDTOs(date, PROVIDER_NO);
+        logActionMock.verify(() -> LogAction.addLogSynchronous(
+                eq(mockLoggedInInfo), eq("AppointmentManager.getDayAppointmentDTOs"), anyString()));
+    }
+
+    @Test
+    @DisplayName("ConsultationManagerImpl.getConsultationDTOs should call DAO and log when _con granted")
+    void consultationManager_shouldCallDaoAndLog_whenConReadGranted() {
+        ConsultationRequestDao dao = Mockito.mock(ConsultationRequestDao.class);
+        List<ConsultationRequestListItemDTO> expected = Collections.singletonList(new ConsultationRequestListItemDTO());
+        when(dao.findConsultationDTOsByDemographicId(DEMO_NO)).thenReturn(expected);
+        ConsultationManagerImpl manager = new ConsultationManagerImpl();
+        injectDependency(manager, "consultationRequestDtoDao", dao);
+        injectDependency(manager, "securityInfoManager", mockSecurityInfoManager);
+        grantPrivilege("_con");
+
+        List<ConsultationRequestListItemDTO> result = manager.getConsultationDTOs(mockLoggedInInfo, DEMO_NO);
+
+        assertThat(result).isSameAs(expected);
+        verify(dao).findConsultationDTOsByDemographicId(DEMO_NO);
+        logActionMock.verify(() -> LogAction.addLogSynchronous(
+                eq(mockLoggedInInfo), eq("ConsultationManager.getConsultationDTOs"), anyString()));
+    }
+
+    @Test
+    @DisplayName("DocumentManagerImpl.getDocumentDTOs should call DAO and log when _edoc granted")
+    void documentManager_shouldCallDaoAndLog_whenEdocReadGranted() {
+        DocumentDao dao = Mockito.mock(DocumentDao.class);
+        List<DocumentListItemDTO> expected = Collections.singletonList(new DocumentListItemDTO());
+        when(dao.findDocumentDTOsByDemographicNo(DEMO_NO)).thenReturn(expected);
+        DocumentManagerImpl manager = new DocumentManagerImpl();
+        injectDependency(manager, "documentDao", dao);
+        injectDependency(manager, "securityInfoManager", mockSecurityInfoManager);
+        grantPrivilege("_edoc");
+
+        List<DocumentListItemDTO> result = manager.getDocumentDTOs(mockLoggedInInfo, DEMO_NO);
+
+        assertThat(result).isSameAs(expected);
+        verify(dao).findDocumentDTOsByDemographicNo(DEMO_NO);
+        logActionMock.verify(() -> LogAction.addLogSynchronous(
+                eq(mockLoggedInInfo), eq("DocumentManager.getDocumentDTOs"), anyString()));
+    }
+
+    @Test
+    @DisplayName("PrescriptionManagerImpl.getDrugDTOs should call DAO and log when _demographic granted")
+    void prescriptionManager_shouldCallDaoAndLog_whenDemographicReadGranted() {
+        DrugDao dao = Mockito.mock(DrugDao.class);
+        List<DrugListItemDTO> expected = Collections.singletonList(new DrugListItemDTO());
+        when(dao.findDrugDTOsByDemographicId(DEMO_NO)).thenReturn(expected);
+        PrescriptionManagerImpl manager = new PrescriptionManagerImpl();
+        injectDependency(manager, "drugDao", dao);
+        injectDependency(manager, "securityInfoManager", mockSecurityInfoManager);
+        grantPrivilege("_demographic");
+
+        List<DrugListItemDTO> result = manager.getDrugDTOs(mockLoggedInInfo, DEMO_NO);
+
+        assertThat(result).isSameAs(expected);
+        verify(dao).findDrugDTOsByDemographicId(DEMO_NO);
+        logActionMock.verify(() -> LogAction.addLogSynchronous(
+                eq(mockLoggedInInfo), eq("PrescriptionManager.getDrugDTOs"), anyString()));
+    }
+
+    @Test
+    @DisplayName("PreventionManagerImpl.getPreventionDTOs should call DAO and log when _prevention granted")
+    void preventionManager_shouldCallDaoAndLog_whenPreventionReadGranted() {
+        PreventionDao dao = Mockito.mock(PreventionDao.class);
+        List<PreventionListItemDTO> expected = Collections.singletonList(new PreventionListItemDTO());
+        when(dao.findPreventionDTOsByDemographicId(DEMO_NO)).thenReturn(expected);
+        PreventionManagerImpl manager = new PreventionManagerImpl();
+        injectDependency(manager, "preventionDao", dao);
+        injectDependency(manager, "securityInfoManager", mockSecurityInfoManager);
+        grantPrivilege("_prevention");
+
+        List<PreventionListItemDTO> result = manager.getPreventionDTOs(mockLoggedInInfo, DEMO_NO);
+
+        assertThat(result).isSameAs(expected);
+        verify(dao).findPreventionDTOsByDemographicId(DEMO_NO);
+        logActionMock.verify(() -> LogAction.addLogSynchronous(
+                eq(mockLoggedInInfo), eq("PreventionManager.getPreventionDTOs"), anyString()));
+    }
+
+    @Test
+    @DisplayName("BillingONManager.getBillingDTOs should call DAO and log when _billing granted")
+    void billingONManager_shouldCallDaoAndLog_whenBillingReadGranted() {
+        BillingONCHeader1Dao dao = Mockito.mock(BillingONCHeader1Dao.class);
+        List<BillingONCListItemDTO> expected = Collections.singletonList(new BillingONCListItemDTO());
+        when(dao.findBillingDTOsByDemographicNo(DEMO_NO)).thenReturn(expected);
+        BillingONManager manager = new BillingONManager();
+        injectDependency(manager, "billingONCHeader1Dao", dao);
+        injectDependency(manager, "securityInfoManager", mockSecurityInfoManager);
+        grantPrivilege("_billing");
+
+        List<BillingONCListItemDTO> result = manager.getBillingDTOs(mockLoggedInInfo, DEMO_NO);
+
+        assertThat(result).isSameAs(expected);
+        verify(dao).findBillingDTOsByDemographicNo(DEMO_NO);
+        logActionMock.verify(() -> LogAction.addLogSynchronous(
+                eq(mockLoggedInInfo), eq("BillingONManager.getBillingDTOs"), anyString()));
+    }
+
+    @Test
+    @DisplayName("CaseManagementManagerImpl.getIssueDTOs should call DAO and log when _demographic granted")
+    void caseManagementManager_getIssueDTOs_shouldCallDaoAndLog_whenDemographicReadGranted() {
+        CaseManagementIssueDAO dao = Mockito.mock(CaseManagementIssueDAO.class);
+        List<CaseManagementIssueListDTO> expected = Collections.singletonList(new CaseManagementIssueListDTO());
+        when(dao.findIssueDTOsByDemographicNo(DEMO_NO_STR)).thenReturn(expected);
+        CaseManagementManagerImpl manager = new CaseManagementManagerImpl();
+        injectDependency(manager, "caseManagementIssueDAO", dao);
+        injectDependency(manager, "securityInfoManager", mockSecurityInfoManager);
+        grantPrivilege("_demographic");
+
+        List<CaseManagementIssueListDTO> result = manager.getIssueDTOs(mockLoggedInInfo, DEMO_NO_STR);
+
+        assertThat(result).isSameAs(expected);
+        verify(dao).findIssueDTOsByDemographicNo(DEMO_NO_STR);
+        logActionMock.verify(() -> LogAction.addLogSynchronous(
+                eq(mockLoggedInInfo), eq("CaseManagementManager.getIssueDTOs"), anyString()));
+    }
+
+    @Test
+    @DisplayName("CaseManagementManagerImpl.getNoteDTOs should call DAO and log when _demographic granted")
+    void caseManagementManager_getNoteDTOs_shouldCallDaoAndLog_whenDemographicReadGranted() {
+        CaseManagementNoteDAO dao = Mockito.mock(CaseManagementNoteDAO.class);
+        List<CaseManagementNoteListDTO> expected = Collections.singletonList(new CaseManagementNoteListDTO());
+        when(dao.findNoteDTOsByDemographicNo(DEMO_NO_STR)).thenReturn(expected);
+        CaseManagementManagerImpl manager = new CaseManagementManagerImpl();
+        injectDependency(manager, "caseManagementNoteDAO", dao);
+        injectDependency(manager, "securityInfoManager", mockSecurityInfoManager);
+        grantPrivilege("_demographic");
+
+        List<CaseManagementNoteListDTO> result = manager.getNoteDTOs(mockLoggedInInfo, DEMO_NO_STR);
+
+        assertThat(result).isSameAs(expected);
+        verify(dao).findNoteDTOsByDemographicNo(DEMO_NO_STR);
+        logActionMock.verify(() -> LogAction.addLogSynchronous(
+                eq(mockLoggedInInfo), eq("CaseManagementManager.getNoteDTOs"), anyString()));
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/managers/DtoManagerSecurityUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/managers/DtoManagerSecurityUnitTest.java
@@ -1,0 +1,215 @@
+/**
+ * Copyright (c) 2026 CARLOS EMR Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.managers;
+
+import io.github.carlos_emr.carlos.casemgmt.dao.CaseManagementIssueDAO;
+import io.github.carlos_emr.carlos.casemgmt.dao.CaseManagementNoteDAO;
+import io.github.carlos_emr.carlos.casemgmt.service.CaseManagementManagerImpl;
+import io.github.carlos_emr.carlos.commn.dao.AllergyDao;
+import io.github.carlos_emr.carlos.commn.dao.BillingONCHeader1Dao;
+import io.github.carlos_emr.carlos.commn.dao.ConsultationRequestDao;
+import io.github.carlos_emr.carlos.commn.dao.DocumentDao;
+import io.github.carlos_emr.carlos.commn.dao.DrugDao;
+import io.github.carlos_emr.carlos.commn.dao.OscarAppointmentDao;
+import io.github.carlos_emr.carlos.commn.dao.PreventionDao;
+import io.github.carlos_emr.carlos.commn.exception.AccessDeniedException;
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
+import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies that every Manager DTO method added in the DTO projection layer
+ * throws on privilege denial rather than silently returning an empty list.
+ *
+ * <p>A copy-paste regression (wrong sec-object string, missing privilege check,
+ * or swallowed denial) would silently leak PHI. These tests lock in the contract
+ * that denial surfaces as an exception and that the backing DAO is not consulted.</p>
+ *
+ * @since 2026-04-12
+ */
+@DisplayName("DTO Manager Security — privilege-denial contract")
+@Tag("unit")
+@Tag("fast")
+@Tag("manager")
+@Tag("security")
+public class DtoManagerSecurityUnitTest extends CarlosUnitTestBase {
+
+    private static final Integer DEMO_NO = 12345;
+    private static final String DEMO_NO_STR = "12345";
+    private static final String PROVIDER_NO = "999990";
+
+    private SecurityInfoManager mockSecurityInfoManager;
+    private LoggedInInfo mockLoggedInInfo;
+
+    @BeforeEach
+    void setUpSecurityMocks() {
+        mockSecurityInfoManager = Mockito.mock(SecurityInfoManager.class);
+        mockLoggedInInfo = Mockito.mock(LoggedInInfo.class);
+        Mockito.lenient().when(mockLoggedInInfo.getLoggedInProviderNo()).thenReturn(PROVIDER_NO);
+        registerMock(SecurityInfoManager.class, mockSecurityInfoManager);
+        denyAllPrivileges();
+    }
+
+    private void denyAllPrivileges() {
+        when(mockSecurityInfoManager.hasPrivilege(any(LoggedInInfo.class), anyString(), anyString(), any()))
+                .thenReturn(false);
+    }
+
+    @Test
+    @DisplayName("AllergyManagerImpl.getAllergyDTOs should throw SecurityException and skip DAO when _allergy denied")
+    void allergyManager_shouldThrow_whenAllergyReadDenied() {
+        AllergyDao dao = Mockito.mock(AllergyDao.class);
+        AllergyManagerImpl manager = new AllergyManagerImpl();
+        injectDependency(manager, "allergyDao", dao);
+        injectDependency(manager, "securityInfoManager", mockSecurityInfoManager);
+
+        assertThatThrownBy(() -> manager.getAllergyDTOs(mockLoggedInInfo, DEMO_NO))
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("_allergy");
+        verify(dao, never()).findAllergyDTOsByDemographicNo(any());
+    }
+
+    @Test
+    @DisplayName("AppointmentManagerImpl.getDayAppointmentDTOs should throw SecurityException and skip DAO when _appointment denied")
+    void appointmentManager_shouldThrow_whenAppointmentReadDenied() {
+        OscarAppointmentDao dao = Mockito.mock(OscarAppointmentDao.class);
+        AppointmentManagerImpl manager = new AppointmentManagerImpl();
+        injectDependency(manager, "appointmentDao", dao);
+        injectDependency(manager, "securityInfoManager", mockSecurityInfoManager);
+
+        assertThatThrownBy(() -> manager.getDayAppointmentDTOs(mockLoggedInInfo, new Date(), PROVIDER_NO))
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("_appointment");
+        verify(dao, never()).findDayAppointmentDTOs(any(), anyString());
+    }
+
+    @Test
+    @DisplayName("ConsultationManagerImpl.getConsultationDTOs should throw SecurityException and skip DAO when _con denied")
+    void consultationManager_shouldThrow_whenConReadDenied() {
+        ConsultationRequestDao dao = Mockito.mock(ConsultationRequestDao.class);
+        ConsultationManagerImpl manager = new ConsultationManagerImpl();
+        injectDependency(manager, "consultationRequestDtoDao", dao);
+        injectDependency(manager, "securityInfoManager", mockSecurityInfoManager);
+
+        assertThatThrownBy(() -> manager.getConsultationDTOs(mockLoggedInInfo, DEMO_NO))
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("_con");
+        verify(dao, never()).findConsultationDTOsByDemographicId(any());
+    }
+
+    @Test
+    @DisplayName("DocumentManagerImpl.getDocumentDTOs should throw SecurityException and skip DAO when _edoc denied")
+    void documentManager_shouldThrow_whenEdocReadDenied() {
+        DocumentDao dao = Mockito.mock(DocumentDao.class);
+        DocumentManagerImpl manager = new DocumentManagerImpl();
+        injectDependency(manager, "documentDao", dao);
+        injectDependency(manager, "securityInfoManager", mockSecurityInfoManager);
+
+        assertThatThrownBy(() -> manager.getDocumentDTOs(mockLoggedInInfo, DEMO_NO))
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("_edoc");
+        verify(dao, never()).findDocumentDTOsByDemographicNo(any());
+    }
+
+    @Test
+    @DisplayName("PrescriptionManagerImpl.getDrugDTOs should throw AccessDeniedException (scoped) and skip DAO when _demographic denied")
+    void prescriptionManager_shouldThrow_whenDemographicReadDenied() {
+        DrugDao dao = Mockito.mock(DrugDao.class);
+        PrescriptionManagerImpl manager = new PrescriptionManagerImpl();
+        injectDependency(manager, "drugDao", dao);
+        injectDependency(manager, "securityInfoManager", mockSecurityInfoManager);
+
+        assertThatThrownBy(() -> manager.getDrugDTOs(mockLoggedInInfo, DEMO_NO))
+                .isInstanceOf(AccessDeniedException.class);
+        verify(dao, never()).findDrugDTOsByDemographicId(any());
+    }
+
+    @Test
+    @DisplayName("PreventionManagerImpl.getPreventionDTOs should throw SecurityException and skip DAO when _prevention denied")
+    void preventionManager_shouldThrow_whenPreventionReadDenied() {
+        PreventionDao dao = Mockito.mock(PreventionDao.class);
+        PreventionManagerImpl manager = new PreventionManagerImpl();
+        injectDependency(manager, "preventionDao", dao);
+        injectDependency(manager, "securityInfoManager", mockSecurityInfoManager);
+
+        assertThatThrownBy(() -> manager.getPreventionDTOs(mockLoggedInInfo, DEMO_NO))
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("_prevention");
+        verify(dao, never()).findPreventionDTOsByDemographicId(any());
+    }
+
+    @Test
+    @DisplayName("BillingONManager.getBillingDTOs should throw SecurityException and skip DAO when _billing denied")
+    void billingONManager_shouldThrow_whenBillingReadDenied() {
+        BillingONCHeader1Dao dao = Mockito.mock(BillingONCHeader1Dao.class);
+        BillingONManager manager = new BillingONManager();
+        injectDependency(manager, "billingONCHeader1Dao", dao);
+        injectDependency(manager, "securityInfoManager", mockSecurityInfoManager);
+
+        assertThatThrownBy(() -> manager.getBillingDTOs(mockLoggedInInfo, DEMO_NO))
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("_billing");
+        verify(dao, never()).findBillingDTOsByDemographicNo(any());
+    }
+
+    @Test
+    @DisplayName("CaseManagementManagerImpl.getIssueDTOs should throw SecurityException and skip DAO when _demographic denied")
+    void caseManagementManager_getIssueDTOs_shouldThrow_whenDemographicReadDenied() {
+        CaseManagementIssueDAO issueDao = Mockito.mock(CaseManagementIssueDAO.class);
+        CaseManagementManagerImpl manager = new CaseManagementManagerImpl();
+        injectDependency(manager, "caseManagementIssueDAO", issueDao);
+        injectDependency(manager, "securityInfoManager", mockSecurityInfoManager);
+
+        assertThatThrownBy(() -> manager.getIssueDTOs(mockLoggedInInfo, DEMO_NO_STR))
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("_demographic");
+        verify(issueDao, never()).findIssueDTOsByDemographicNo(anyString());
+    }
+
+    @Test
+    @DisplayName("CaseManagementManagerImpl.getNoteDTOs should throw SecurityException and skip DAO when _demographic denied")
+    void caseManagementManager_getNoteDTOs_shouldThrow_whenDemographicReadDenied() {
+        CaseManagementNoteDAO noteDao = Mockito.mock(CaseManagementNoteDAO.class);
+        CaseManagementManagerImpl manager = new CaseManagementManagerImpl();
+        injectDependency(manager, "caseManagementNoteDAO", noteDao);
+        injectDependency(manager, "securityInfoManager", mockSecurityInfoManager);
+
+        assertThatThrownBy(() -> manager.getNoteDTOs(mockLoggedInInfo, DEMO_NO_STR))
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("_demographic");
+        verify(noteDao, never()).findNoteDTOsByDemographicNo(anyString());
+    }
+}


### PR DESCRIPTION
## Summary

Mirror of PR #1569 on a fresh branch (`fix-dto-review`) at the same HEAD (510e583ac1). Contents and diff are identical.

Adds a DTO projection layer for 9 entities (Drug, Document, Prevention, Appointment, Allergy, ConsultationRequest, BillingONC, CaseManagementIssue, CaseManagementNote) with DAO + Manager integration, privilege enforcement, synchronous audit logging, merged-demographic support, and 46 tests (9 denial + 9 allow unit tests, 20 CaseMgmtIssue integration tests, 8 DAO projection smoke tests).

**See #1569 for full review history** — this branch has the same commits and addresses the same review findings across 5+ review rounds.

## Related

- Parent PR: #1569
- Spike: #1612 (DTO type-design — records/immutability/enums)
- Spike: #1614 (audit logging order — log on attempt vs success)

## Test plan
- [x] `mvn test -Dtest=DtoManagerSecurityUnitTest` — 18/18 pass
- [x] `mvn test -Dtest=CaseManagementIssueDAOIntegrationTest` — 20/20 pass
- [x] `mvn test -Dtest=DtoProjectionSmokeIntegrationTest` — 8/8 pass
- [ ] `/ui-tests:test4` — prescriptions/allergies
- [ ] `/ui-tests:test3` — appointments
- [ ] `/ui-tests:test9` — prevention/immunization
- [ ] `/ui-tests:test6` — encounter/e-chart (case management)
- [ ] `/ui-tests:test7` — Ontario billing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a DTO projection layer for 9 entities to return lightweight list DTOs and avoid EAGER loads, improving read performance. Adds Manager wrappers with privilege checks and synchronous audit logs; includes merged-demographic support and comprehensive tests.

- **New Features**
  - List DTOs for Drug, Document, Prevention, Appointment, Allergy, ConsultationRequest, BillingONC, CaseManagementIssue, CaseManagementNote.
  - DAO `SELECT NEW` projections with pre-joined fields (e.g., patient/provider names), ordered by recent dates; entity-returning methods unchanged.
  - Manager methods enforce privileges (`_demographic`, `_edoc`, `_prevention`, `_appointment`, `_allergy`, `_con`) via `SecurityInfoManager` and log via `LogAction`.
  - Merged-demographic overrides added for Drug, Prevention, Allergy, ConsultationRequest.
  - Added 46 tests, including unit allow/deny checks and projection smoke tests.

- **Bug Fixes**
  - `DocumentDaoImpl`: correct `CtlDocument` embedded-id path; guard non-numeric demographic input (return empty list).
  - `CaseManagementIssueDAO`: bind demographic as `Integer`; add NumberFormatException guard.
  - `BillingONCHeader1DaoImpl`: exclude soft-deleted records (`status != 'D'`) in DTOs.
  - Scope `_con` per patient and add missing Manager privilege checks; use synchronous audit logging across DTO entry points.
  - Normalize DTO types (e.g., `Integer` demographicNo, `Boolean` archived) and safe defaults for char flags.

<sup>Written for commit 510e583ac1f5b5a10a58891ce8d609cf86a61044. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

