### PR TITLE
fix: restore develop compile — JPA entityManager() in CaseMgmt DTO queries

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/dao/CaseManagementIssueDAOImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/dao/CaseManagementIssueDAOImpl.java
@@ -38,6 +38,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import jakarta.persistence.TypedQuery;
+
 import org.apache.logging.log4j.Logger;
 import io.github.carlos_emr.carlos.PMmodule.model.Program;
 import io.github.carlos_emr.carlos.casemgmt.dto.CaseManagementIssueListDTO;
@@ -217,7 +219,7 @@ public class CaseManagementIssueDAOImpl extends AbstractJpaDao implements CaseMa
             log.warn("findIssueDTOsByDemographicNo: invalid demographicNo '{}'", LogSanitizer.sanitize(demographicNo));
             return new ArrayList<>();
         }
-        org.hibernate.query.Query<CaseManagementIssueListDTO> query = currentSession().createQuery("""
+        TypedQuery<CaseManagementIssueListDTO> query = entityManager().createQuery("""
                 SELECT NEW io.github.carlos_emr.carlos.casemgmt.dto.CaseManagementIssueListDTO(
                     cmi.id, cmi.demographic_no, cmi.issue_id, cmi.type,
                     cmi.acute, cmi.certain, cmi.major, cmi.resolved,
@@ -230,7 +232,7 @@ public class CaseManagementIssueDAOImpl extends AbstractJpaDao implements CaseMa
                 """,
                 CaseManagementIssueListDTO.class);
         query.setParameter("demoNo", demoNoInt);
-        return query.list();
+        return query.getResultList();
     }
 
 }

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/dao/CaseManagementNoteDAOImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/dao/CaseManagementNoteDAOImpl.java
@@ -51,6 +51,7 @@ import org.apache.logging.log4j.Logger;
 import org.hibernate.Hibernate;
 
 import jakarta.persistence.Query;
+import jakarta.persistence.TypedQuery;
 
 import io.github.carlos_emr.carlos.PMmodule.model.Program;
 import io.github.carlos_emr.carlos.casemgmt.dto.CaseManagementNoteListDTO;
@@ -743,7 +744,7 @@ public class CaseManagementNoteDAOImpl extends AbstractJpaDao implements CaseMan
     public List<CaseManagementNoteListDTO> findNoteDTOsByDemographicNo(String demographicNo) {
         // HBM-mapped Provider uses PascalCase property names (ProviderNo, LastName,
         // FirstName) per Provider.hbm.xml; HQL must reference the HBM name attribute.
-        Query<CaseManagementNoteListDTO> query = currentSession().createQuery("""
+        TypedQuery<CaseManagementNoteListDTO> query = entityManager().createQuery("""
                 SELECT NEW io.github.carlos_emr.carlos.casemgmt.dto.CaseManagementNoteListDTO(
                     cmn.id, cmn.update_date, cmn.observation_date, cmn.demographic_no,
                     cmn.signed, cmn.providerNo, cmn.signing_provider_no, cmn.encounter_type,
@@ -757,6 +758,6 @@ public class CaseManagementNoteDAOImpl extends AbstractJpaDao implements CaseMan
                 """,
                 CaseManagementNoteListDTO.class);
         query.setParameter("demoNo", demographicNo);
-        return query.list();
+        return query.getResultList();
     }
 }


### PR DESCRIPTION
## Summary

Develop's `mvn compile` currently fails with 3 errors:

\`\`\`
CaseManagementIssueDAOImpl.java:220  cannot find symbol: currentSession()
CaseManagementNoteDAOImpl.java:746   type jakarta.persistence.Query does not take parameters
CaseManagementNoteDAOImpl.java:746   cannot find symbol: currentSession()
\`\`\`

## Root cause

PR #1569 added two DTO projection methods (`findIssueDTOsByDemographicNo`, `findNoteDTOsByDemographicNo`) that use Hibernate-native `currentSession().createQuery(...)` returning `org.hibernate.query.Query<T>`. Both DAO classes (`CaseManagementIssueDAOImpl`, `CaseManagementNoteDAOImpl`) extend `AbstractJpaDao`, which only exposes `entityManager()` — not `currentSession()`. The branch compiled on `chore/dto-phase2` because that branch had a different base class; the mismatch surfaced after the merge to develop.

## Fix

Convert both methods to JPA:
- `org.hibernate.query.Query<T>` → `jakarta.persistence.TypedQuery<T>`
- `currentSession().createQuery(...)` → `entityManager().createQuery(...)`
- `query.list()` → `query.getResultList()`

No behavioral change — both `SELECT NEW` constructor projections return the same DTO shape; JPA query semantics are equivalent for these read-only paths.

## Test plan

- [x] `make install` — BUILD SUCCESS
- [ ] Smoke-test the downstream consumers (Manager + DAO integration tests from PR #1569):
  - `mvn -o test -Dtest=DtoManagerSecurityUnitTest`
  - `mvn -o test -Dtest=CaseManagementIssueDAOIntegrationTest`
  - `mvn -o test -Dtest=DtoProjectionSmokeIntegrationTest`

## Related

- Caused by: PR #1569
- Unblocks: any branch rebased onto develop (e.g., PR #1506, #1615)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix compile failures on develop by converting Hibernate-specific DTO queries to JPA in `CaseManagementIssueDAOImpl` and `CaseManagementNoteDAOImpl`. Replaced `currentSession().createQuery(...)`/`org.hibernate.query.Query<T>` with `entityManager().createQuery(...)`/`jakarta.persistence.TypedQuery` and switched `list()` to `getResultList()`; no behavior change.

<sup>Written for commit bba7dfd14022a26879d0bb8928c9103cedb3146c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

