### PR TITLE
feat: add OpenAI Codex CLI to devcontainer

### DIFF
--- a/.devcontainer/development/Dockerfile
+++ b/.devcontainer/development/Dockerfile
@@ -72,6 +72,10 @@ RUN npm install -g @google/gemini-cli \
 RUN npm install -g @github/copilot && \
     echo "✅ GitHub Copilot CLI installed: $(copilot --version)"
 
+# Install OpenAI Codex CLI (standalone coding agent)
+RUN npm install -g @openai/codex && \
+    echo "✅ OpenAI Codex CLI installed: $(codex --version)"
+
 # Install Playwright globally first to ensure it's available
 # Version 1.56.0 has correct Ubuntu 24.04 t64 package names in its dependency list
 RUN npm install -g playwright@1.56.0 && \

--- a/.devcontainer/development/config/bashrc
+++ b/.devcontainer/development/config/bashrc
@@ -51,7 +51,7 @@ if [ -t 1 ]; then
     echo "  Type 'help-dev' for commands reference"
     echo "  Type 'make help' for build options"
     echo "-----------------------------------------"
-    echo "  AI: claude | copilot | gemini | aider"
+    echo "  AI: claude | copilot | codex | gemini | aider"
     echo "  copilot --model claude-opus-4-6"
     echo "========================================="
     echo ""

--- a/.devcontainer/development/scripts/help-dev
+++ b/.devcontainer/development/scripts/help-dev
@@ -34,6 +34,9 @@ MAIL MANAGEMENT:
 
 AI CODING ASSISTANTS:
   claude                  Claude Code CLI (Anthropic)
+  copilot                 GitHub Copilot CLI
+  codex                   OpenAI Codex CLI
+  gemini                  Google Gemini CLI
   aider                   AI pair programming assistant
   aider --model claude-3-5-sonnet-20241022
   aider --model gpt-4-turbo


### PR DESCRIPTION
Installs @openai/codex globally alongside the existing Claude, Copilot,
and Gemini CLIs so developers can pick between AI coding assistants in
the dev environment. Also refreshes the bashrc welcome banner and
help-dev reference to list all available AI tools.

## Summary by Sourcery

Add OpenAI Codex CLI to the devcontainer development image and update shell messaging to reflect available AI tools.

New Features:
- Install the OpenAI Codex CLI globally in the devcontainer development image.

Enhancements:
- Update the devcontainer bash welcome banner to list Codex among available AI assistants.
- Refresh the help-dev command reference to reflect the full set of AI tooling in the development environment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `@openai/codex` CLI to the devcontainer, installed globally, so you can use Codex alongside Claude, Copilot, and Gemini. Updates the bash welcome banner and `help-dev` to include the `codex` command.

<sup>Written for commit 690cfb374e508a748036d922649a38cede0f1063. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

