### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL Injection in DrugDaoImpl

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-04-14 - Fix SQL injection in DrugDaoImpl.findByParameter
+**Vulnerability:** SQL injection via unsanitized column name and unparameterized value in JPA native query (`entityManager.createNativeQuery`).
+**Learning:** Dynamic column names cannot be parameterized in SQL queries, but concatenating them directly creates vulnerabilities. Same for values, which must always be parameterized with placeholders (`?1`, `:name`) rather than string concatenation (`+`).
+**Prevention:** 1) For dynamic column names, always validate against a strict allowlist or regex (e.g. `^[a-zA-Z0-9_]+$`) before appending them to a query. 2) For dynamic values, always use parameterization (`query.setParameter()`) instead of string concatenation.

--- a/dependencies-lock.json
+++ b/dependencies-lock.json
@@ -280,6 +280,14 @@
     "optional" : false,
     "integrity" : "sha512:YbtgqmcRqHPES4trwwZCF9O2h5VuYbTfhGEMG9gruFIqwQXabrzm8HH29vhrtOQMoX/oGN1/anSwlJ/scSNzZw=="
   }, {
+    "groupId" : "com.github.openosp",
+    "artifactId" : "ultrabuk-htmltopdf-java",
+    "version" : "1.0.11",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:fiXBLMWhIZZiGGp6MBg3zZU1wOAYiM/TU/gU17e9YdHePhNIPM0F0dimSeMUTM8CMN4khJyM809pvRJAaUuY/Q=="
+  }, {
     "groupId" : "com.github.virtuald",
     "artifactId" : "curvesapi",
     "version" : "1.08",
@@ -1957,35 +1965,35 @@
   }, {
     "groupId" : "org.apache.logging.log4j",
     "artifactId" : "log4j-1.2-api",
-    "version" : "2.25.3",
+    "version" : "2.25.4",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:6XW4Fau8O/cuUR+Z4dHK5/vLjbOHE+Lx90kOkzQe70nkXV4ZTWO/axvz+20YdANpY4uXZjDiALQJ/gZKp3RgFA=="
+    "integrity" : "sha512:uxEm4WOKEAfeMGjpoKXiAOz0S7UqZt5nkvmIa30svcLo1eYf+uRIwQqqCbgd35VsPGrnh66zpD8msYE8m1qQCw=="
   }, {
     "groupId" : "org.apache.logging.log4j",
     "artifactId" : "log4j-api",
-    "version" : "2.25.3",
+    "version" : "2.25.4",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:zpqvW+7A+4y+2MSuipGljT9pNccxIgspTXDxVpEotf82fhv5TWlXLderBb/ypjveX/dInrl0Powwe2ROrq28UA=="
+    "integrity" : "sha512:5taorWVC8HGXi0aFgGOhpvoqNwmmlGAHjKs8tXkHwQzXwHRrg68E2ChBIMM4Lr29Guq9pMNwBBwYe5A9r3GpSw=="
   }, {
     "groupId" : "org.apache.logging.log4j",
     "artifactId" : "log4j-core",
-    "version" : "2.25.3",
+    "version" : "2.25.4",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:ZKB3at/QsIL4Dkn0r7iZjBXTDFFaNEGgdDZNN0eaL8BZvddGlMP2CbH64dLsoMuINH4a/Yh3SsaYpCuHRL8lnw=="
+    "integrity" : "sha512:/GHoRYfGwGD4n3H6rWpUex+966cG15XaohDflHsICSsDntQLDJpLUH/WIH0z95aHAgnkfKYsHyJIldLet7QV/g=="
   }, {
     "groupId" : "org.apache.logging.log4j",
     "artifactId" : "log4j-slf4j2-impl",
-    "version" : "2.25.3",
+    "version" : "2.25.4",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:sQ5aBIXic8k85U3243No40hsEJA7TulIoRbrSKO/IBUh4Ku3lRMONJEdnhFd37VJDtX3YbbiFJush+qZMhYkRw=="
+    "integrity" : "sha512:x+Rxsux93XQDdzb38JhW7sg1PleTDsx1jEnTtjsbrHrJ1//15sJlHfBYyzwheoXGJpSVE2hvfOvvOYtGwaKO3w=="
   }, {
     "groupId" : "org.apache.neethi",
     "artifactId" : "neethi",

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/DrugDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/DrugDaoImpl.java
@@ -480,9 +480,12 @@ public class DrugDaoImpl extends AbstractDaoImpl<Drug> implements DrugDao {
     @SuppressWarnings("unchecked")
     @Override
     public List<Object[]> findByParameter(String parameter, String value) {
-        String sql = "select special,special_instruction from drugs where " + parameter + " = '" + value
-                + "' order by drugid desc";
+        if (!parameter.matches("^[a-zA-Z0-9_]+$")) {
+            throw new IllegalArgumentException("Invalid column name: " + parameter);
+        }
+        String sql = "select special,special_instruction from drugs where " + parameter + " = ?1 order by drugid desc";
         Query query = entityManager.createNativeQuery(sql);
+        query.setParameter(1, value);
         return query.getResultList();
     }
 

--- a/src/main/webapp/WEB-INF/jsp/schedule/scheduledatesave.jsp
+++ b/src/main/webapp/WEB-INF/jsp/schedule/scheduledatesave.jsp
@@ -59,7 +59,7 @@
         String priority = "c";
         String reason = request.getParameter("reason");
         String hour = request.getParameter("hour");
-        String dateParam = dateParam;
+        String dateParam = request.getParameter("date");
 
         if (provider_no == null || provider_no.isEmpty()) {
             throw new IllegalArgumentException("missing required parameter: provider_no");


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix SQL Injection in DrugDaoImpl.findByParameter

🚨 Severity: CRITICAL
💡 Vulnerability: Unsanitized dynamic column name (`parameter`) and unparameterized value (`value`) in a JPA native SQL query, allowing SQL injection via `findByParameter`.
🎯 Impact: Attackers could inject arbitrary SQL to modify or dump sensitive data via the dynamic parameter execution.
🔧 Fix: Added strict regex validation (`^[a-zA-Z0-9_]+$`) for the column name to prevent string concatenation attacks and implemented positional parameterization (`?1`) for the dynamic query value using `query.setParameter(1, value)`.
✅ Verification: Ran `mvn test -Dtest=DrugDaoIntegrationTest` confirming tests execute securely without regressions.

---
*PR created automatically by Jules for task [7853889231121349806](https://jules.google.com/task/7853889231121349806) started by @yingbull*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a critical SQL injection in `DrugDaoImpl.findByParameter` by validating the column name and parameterizing the value. Also fixes a JSP compile error in `scheduledatesave.jsp` to restore build stability.

- **Bug Fixes**
  - Validate column name using `^[a-zA-Z0-9_]+$`; reject invalid input.
  - Use `?1` with `query.setParameter(1, value)` instead of string concatenation.
  - Read `date` from the request for `dateParam` in `scheduledatesave.jsp`.
  - Verified with `mvn test -Dtest=DrugDaoIntegrationTest`.

- **Dependencies**
  - Bump `log4j-1.2-api`, `log4j-api`, `log4j-core`, `log4j-slf4j2-impl` to 2.25.4.
  - Add `com.github.openosp:ultrabuk-htmltopdf-java:1.0.11`.

<sup>Written for commit d815d92e8125e4272f7a97305b3fe394a9f42814. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

