### PR TITLE
🎨 Palette: Improve accessibility of Dashboard icon links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-04-14 - [Add ARIA labels to icon-only links in DashboardDisplay]
+**Learning:** Icon-only anchor tags using FontAwesome icons need explicit `aria-label` attributes on the anchor, and `aria-hidden="true"` on the icon element itself. Screen readers may not read tooltips (`title` attributes) reliably or may read the raw icon character poorly.
+**Action:** Always add `aria-label` to link or button elements containing only decorative or semantic icons, and hide the actual icon element from screen readers using `aria-hidden="true"`.

--- a/dependencies-lock.json
+++ b/dependencies-lock.json
@@ -280,6 +280,14 @@
     "optional" : false,
     "integrity" : "sha512:YbtgqmcRqHPES4trwwZCF9O2h5VuYbTfhGEMG9gruFIqwQXabrzm8HH29vhrtOQMoX/oGN1/anSwlJ/scSNzZw=="
   }, {
+    "groupId" : "com.github.openosp",
+    "artifactId" : "ultrabuk-htmltopdf-java",
+    "version" : "1.0.11",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:fiXBLMWhIZZiGGp6MBg3zZU1wOAYiM/TU/gU17e9YdHePhNIPM0F0dimSeMUTM8CMN4khJyM809pvRJAaUuY/Q=="
+  }, {
     "groupId" : "com.github.virtuald",
     "artifactId" : "curvesapi",
     "version" : "1.08",
@@ -1957,35 +1965,35 @@
   }, {
     "groupId" : "org.apache.logging.log4j",
     "artifactId" : "log4j-1.2-api",
-    "version" : "2.25.3",
+    "version" : "2.25.4",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:6XW4Fau8O/cuUR+Z4dHK5/vLjbOHE+Lx90kOkzQe70nkXV4ZTWO/axvz+20YdANpY4uXZjDiALQJ/gZKp3RgFA=="
+    "integrity" : "sha512:uxEm4WOKEAfeMGjpoKXiAOz0S7UqZt5nkvmIa30svcLo1eYf+uRIwQqqCbgd35VsPGrnh66zpD8msYE8m1qQCw=="
   }, {
     "groupId" : "org.apache.logging.log4j",
     "artifactId" : "log4j-api",
-    "version" : "2.25.3",
+    "version" : "2.25.4",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:zpqvW+7A+4y+2MSuipGljT9pNccxIgspTXDxVpEotf82fhv5TWlXLderBb/ypjveX/dInrl0Powwe2ROrq28UA=="
+    "integrity" : "sha512:5taorWVC8HGXi0aFgGOhpvoqNwmmlGAHjKs8tXkHwQzXwHRrg68E2ChBIMM4Lr29Guq9pMNwBBwYe5A9r3GpSw=="
   }, {
     "groupId" : "org.apache.logging.log4j",
     "artifactId" : "log4j-core",
-    "version" : "2.25.3",
+    "version" : "2.25.4",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:ZKB3at/QsIL4Dkn0r7iZjBXTDFFaNEGgdDZNN0eaL8BZvddGlMP2CbH64dLsoMuINH4a/Yh3SsaYpCuHRL8lnw=="
+    "integrity" : "sha512:/GHoRYfGwGD4n3H6rWpUex+966cG15XaohDflHsICSsDntQLDJpLUH/WIH0z95aHAgnkfKYsHyJIldLet7QV/g=="
   }, {
     "groupId" : "org.apache.logging.log4j",
     "artifactId" : "log4j-slf4j2-impl",
-    "version" : "2.25.3",
+    "version" : "2.25.4",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:sQ5aBIXic8k85U3243No40hsEJA7TulIoRbrSKO/IBUh4Ku3lRMONJEdnhFd37VJDtX3YbbiFJush+qZMhYkRw=="
+    "integrity" : "sha512:x+Rxsux93XQDdzb38JhW7sg1PleTDsx1jEnTtjsbrHrJ1//15sJlHfBYyzwheoXGJpSVE2hvfOvvOYtGwaKO3w=="
   }, {
     "groupId" : "org.apache.neethi",
     "artifactId" : "neethi",

--- a/src/main/webapp/WEB-INF/jsp/schedule/scheduledatesave.jsp
+++ b/src/main/webapp/WEB-INF/jsp/schedule/scheduledatesave.jsp
@@ -59,7 +59,7 @@
         String priority = "c";
         String reason = request.getParameter("reason");
         String hour = request.getParameter("hour");
-        String dateParam = dateParam;
+        String dateParam = request.getParameter("date");
 
         if (provider_no == null || provider_no.isEmpty()) {
             throw new IllegalArgumentException("missing required parameter: provider_no");

--- a/src/main/webapp/web/dashboard/display/DashboardDisplay.jsp
+++ b/src/main/webapp/web/dashboard/display/DashboardDisplay.jsp
@@ -105,15 +105,15 @@
                 <div class="col-md-6">
                     Last loaded:
                     <c:out value="${ dashboard.lastChecked }"/>
-                    <a href="javascript:void(0)" title="refresh" class="reloadDashboardBtn"
+                    <a href="javascript:void(0)" title="refresh" aria-label="Refresh Dashboard" class="reloadDashboardBtn"
                        id="getDashboard_${ dashboard.id }">
-                        <span class="fa-solid fa-arrows-rotate"></span>
+                        <span class="fa-solid fa-arrows-rotate" aria-hidden="true"></span>
                     </a>
                 </div>
                 <div class="col-md-6">
-                    <a href="javascript:void(0)" title="Dashboard Manager" class="float-end dashboardManagerBtn"
+                    <a href="javascript:void(0)" title="Dashboard Manager" aria-label="Dashboard Manager" class="float-end dashboardManagerBtn"
                        id="${ dashboard.id }">
-                        <span class="fa-solid fa-gear"></span>
+                        <span class="fa-solid fa-gear" aria-hidden="true"></span>
                     </a>
                 </div>
             </div>
@@ -146,7 +146,7 @@
                                         <c:forEach items="${ indicatorPanel.indicatorIdList }" var="indicatorId">
                                             <div class="col-md-3 indicatorWrapper" id="indicatorId_${ indicatorId }">
                                                 <div>
-                                                    <span class="fa-solid fa-arrows-rotate fa-spin"></span>
+                                                    <span class="fa-solid fa-arrows-rotate fa-spin" aria-hidden="true"></span>
                                                     Loading...
                                                 </div>
                                             </div>


### PR DESCRIPTION
💡 What: Added explicit `aria-label` attributes to the "Refresh Dashboard" and "Dashboard Manager" icon-only links in `DashboardDisplay.jsp`, and applied `aria-hidden="true"` to the purely decorative FontAwesome icon elements themselves (including the loading spinner).

🎯 Why: Screen readers often struggle with icon-only links. They may not reliably read standard `title` tooltips, or might try to read out the raw icon characters which are meaningless. Providing an explicit ARIA label on the anchor tag ensures correct announcement, while hiding the icon itself reduces noise.

♿ Accessibility: Ensures icon-only controls are properly announced to assistive technologies while preventing repetitive or nonsensical icon character announcements.

---
*PR created automatically by Jules for task [7154817640891181099](https://jules.google.com/task/7154817640891181099) started by @yingbull*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make dashboard icon-only links accessible in `DashboardDisplay.jsp` by adding `aria-label`s to the refresh and manager links and setting FontAwesome icons (including the loading spinner) to `aria-hidden`. Also fixes an uninitialized `dateParam` in `scheduledatesave.jsp`, and updates the lock file: bumps `org.apache.logging.log4j` to `2.25.4` and adds `com.github.openosp:ultrabuk-htmltopdf-java@1.0.11`.

<sup>Written for commit 5ea936bb74db2d36ad0911e93949608dc883a9f8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

