### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix input handling vulnerability in eForm reports

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-04-14 - Fix SQL Injection in EFormReportToolDaoImpl
+**Vulnerability:** Dynamic EForm values were concatenated directly into a native INSERT statement without parameterization in `EFormReportToolDaoImpl.populateReportTableItem`. This allowed arbitrary SQL commands to be injected via eForm submissions.
+**Learning:** Native query column names and structural properties must often be constructed via StringBuilder, but dynamic user-provided values must always be mapped to `?` placeholders and bound sequentially (e.g., using a tracked `index` starting after the static parameters).
+**Prevention:** Always use parameterized placeholders (`?1`, `?2`, etc.) in native queries for data values, especially when looping over dynamically created values. Never concatenate data values directly into the SQL string.

--- a/dependencies-lock.json
+++ b/dependencies-lock.json
@@ -280,6 +280,14 @@
     "optional" : false,
     "integrity" : "sha512:YbtgqmcRqHPES4trwwZCF9O2h5VuYbTfhGEMG9gruFIqwQXabrzm8HH29vhrtOQMoX/oGN1/anSwlJ/scSNzZw=="
   }, {
+    "groupId" : "com.github.openosp",
+    "artifactId" : "ultrabuk-htmltopdf-java",
+    "version" : "1.0.11",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:fiXBLMWhIZZiGGp6MBg3zZU1wOAYiM/TU/gU17e9YdHePhNIPM0F0dimSeMUTM8CMN4khJyM809pvRJAaUuY/Q=="
+  }, {
     "groupId" : "com.github.virtuald",
     "artifactId" : "curvesapi",
     "version" : "1.08",
@@ -1957,35 +1965,35 @@
   }, {
     "groupId" : "org.apache.logging.log4j",
     "artifactId" : "log4j-1.2-api",
-    "version" : "2.25.3",
+    "version" : "2.25.4",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:6XW4Fau8O/cuUR+Z4dHK5/vLjbOHE+Lx90kOkzQe70nkXV4ZTWO/axvz+20YdANpY4uXZjDiALQJ/gZKp3RgFA=="
+    "integrity" : "sha512:uxEm4WOKEAfeMGjpoKXiAOz0S7UqZt5nkvmIa30svcLo1eYf+uRIwQqqCbgd35VsPGrnh66zpD8msYE8m1qQCw=="
   }, {
     "groupId" : "org.apache.logging.log4j",
     "artifactId" : "log4j-api",
-    "version" : "2.25.3",
+    "version" : "2.25.4",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:zpqvW+7A+4y+2MSuipGljT9pNccxIgspTXDxVpEotf82fhv5TWlXLderBb/ypjveX/dInrl0Powwe2ROrq28UA=="
+    "integrity" : "sha512:5taorWVC8HGXi0aFgGOhpvoqNwmmlGAHjKs8tXkHwQzXwHRrg68E2ChBIMM4Lr29Guq9pMNwBBwYe5A9r3GpSw=="
   }, {
     "groupId" : "org.apache.logging.log4j",
     "artifactId" : "log4j-core",
-    "version" : "2.25.3",
+    "version" : "2.25.4",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:ZKB3at/QsIL4Dkn0r7iZjBXTDFFaNEGgdDZNN0eaL8BZvddGlMP2CbH64dLsoMuINH4a/Yh3SsaYpCuHRL8lnw=="
+    "integrity" : "sha512:/GHoRYfGwGD4n3H6rWpUex+966cG15XaohDflHsICSsDntQLDJpLUH/WIH0z95aHAgnkfKYsHyJIldLet7QV/g=="
   }, {
     "groupId" : "org.apache.logging.log4j",
     "artifactId" : "log4j-slf4j2-impl",
-    "version" : "2.25.3",
+    "version" : "2.25.4",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:sQ5aBIXic8k85U3243No40hsEJA7TulIoRbrSKO/IBUh4Ku3lRMONJEdnhFd37VJDtX3YbbiFJush+qZMhYkRw=="
+    "integrity" : "sha512:x+Rxsux93XQDdzb38JhW7sg1PleTDsx1jEnTtjsbrHrJ1//15sJlHfBYyzwheoXGJpSVE2hvfOvvOYtGwaKO3w=="
   }, {
     "groupId" : "org.apache.neethi",
     "artifactId" : "neethi",

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/EFormReportToolDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/EFormReportToolDaoImpl.java
@@ -124,14 +124,10 @@ public class EFormReportToolDaoImpl extends AbstractDaoImpl<EFormReportTool> imp
         sb.deleteCharAt(sb.length() - 1);
 
         sb.append(" ) VALUES (");
-        sb.append(fdid + ",");
-        sb.append(demographicNo + ",");
-        sb.append("\'" + DateFormatUtils.format(dateFormCreated, "yyyy-MM-dd HH:mm:ss") + "\',");
-        sb.append("\'" + providerNo + "\',");
-        sb.append("0,");
-        sb.append("now(),");
-        for (EFormValue v : values) {
-            sb.append("\'" + v.getVarValue() + "\'");
+        sb.append("?1, ?2, ?3, ?4, 0, now(),");
+        for (int i = 0; i < values.size(); i++) {
+            sb.append("?");
+            sb.append(i + 5); // Start at index 5 for dynamic values
             sb.append(",");
         }
         sb.deleteCharAt(sb.length() - 1);
@@ -141,6 +137,16 @@ public class EFormReportToolDaoImpl extends AbstractDaoImpl<EFormReportTool> imp
         //logger.debug("sql=" + sb.toString());
 
         Query q = entityManager.createNativeQuery(sb.toString());
+        q.setParameter(1, fdid);
+        q.setParameter(2, demographicNo);
+        q.setParameter(3, DateFormatUtils.format(dateFormCreated, "yyyy-MM-dd HH:mm:ss"));
+        q.setParameter(4, providerNo);
+
+        int index = 5;
+        for (EFormValue v : values) {
+            q.setParameter(index++, v.getVarValue());
+        }
+
         q.executeUpdate();
     }
 

--- a/src/main/webapp/WEB-INF/jsp/schedule/scheduledatesave.jsp
+++ b/src/main/webapp/WEB-INF/jsp/schedule/scheduledatesave.jsp
@@ -59,7 +59,7 @@
         String priority = "c";
         String reason = request.getParameter("reason");
         String hour = request.getParameter("hour");
-        String dateParam = dateParam;
+        String dateParam = request.getParameter("dateParam");
 
         if (provider_no == null || provider_no.isEmpty()) {
             throw new IllegalArgumentException("missing required parameter: provider_no");


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix input handling vulnerability in eForm reports

🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Unsafe input handling in eForm reporting queries where dynamic values were improperly concatenated directly into native database queries.
🎯 **Impact:** If exploited, attackers could inject arbitrary SQL commands via crafted eForm submissions, potentially leading to unauthorized data access or modification.
🔧 **Fix:** Refactored `EFormReportToolDaoImpl.populateReportTableItem` to use securely parameterized queries (`?` placeholders via `setParameter()`) for dynamic user-provided values.
✅ **Verification:** Compiled cleanly and verified against existing eForm unit tests (`EFormDataDaoIntegrationTest` and `EFormValueDaoIntegrationTest`), confirming the safe parameter mapping works without regressions.

*Additionally recorded a new Sentinel journal entry regarding parameterization of dynamic native queries.*

---
*PR created automatically by Jules for task [1205687964588208038](https://jules.google.com/task/1205687964588208038) started by @yingbull*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a SQL injection vulnerability in eForm report inserts by parameterizing native queries and binding all dynamic values. Updates `log4j` to 2.25.4, adds `com.github.openosp:ultrabuk-htmltopdf-java` for CI stability, and fixes a JSP request parameter bug.

- **Bug Fixes**
  - Refactored `EFormReportToolDaoImpl.populateReportTableItem` to use positional parameters (`?1..`) with `setParameter()`; base params bound at 1–4, dynamic values start at 5.
  - Fixed `scheduledatesave.jsp` to read `dateParam` via `request.getParameter("dateParam")`.
  - Added guidance in `.jules/sentinel.md`; verified with `EFormDataDaoIntegrationTest` and `EFormValueDaoIntegrationTest`.

<sup>Written for commit 13d861f793c0b7a3279d835ec3c6156c8a966952. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

