### PR TITLE
Harden path handling for remaining file-path traversal alert paths

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/integration/mcedt/mailbox/Upload2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/integration/mcedt/mailbox/Upload2Action.java
@@ -245,6 +245,11 @@ public class Upload2Action extends ActionSupport implements UploadedFilesAware {
             List<String> successSubmits = new ArrayList<String>();
             List<String> failSubmits = new ArrayList<String>();
             List<UploadData> uploads = toUploadMultipe();
+            CarlosProperties props = CarlosProperties.getInstance();
+            File sent = new File(props.getProperty("ONEDT_SENT", ""));
+            File outboxDir = new File(props.getProperty("ONEDT_OUTBOX", ""));
+            if (!sent.exists())
+                FileUtils.mkDir(sent);
             for (UploadData upload : uploads) {
                 List<UploadData> uploadData = new ArrayList<UploadData>();
                 uploadData.add(upload);
@@ -262,14 +267,9 @@ public class Upload2Action extends ActionSupport implements UploadedFilesAware {
                 }
 
                 List<BigInteger> ids = new ArrayList<BigInteger>();
-                CarlosProperties props = CarlosProperties.getInstance();
-                File sent = new File(props.getProperty("ONEDT_SENT", ""));
-                if (!sent.exists())
-                    FileUtils.mkDir(sent);
                 for (ResponseResult edtResponse : result.getResponse()) {
                     if (edtResponse.getResult().getCode().equals("IEDTS0001")) {
                         ids.add(edtResponse.getResourceID());
-                        File outboxDir = new File(props.getProperty("ONEDT_OUTBOX", ""));
                         File file = PathValidationUtils.validatePath(edtResponse.getDescription(), outboxDir);
                         ActionUtils.moveFileToDirectory(file, sent, false, true);
                         successUploads.add(McedtMessageCreator.resourceResultToString(result));

--- a/src/main/java/io/github/carlos_emr/carlos/integration/mcedt/mailbox/Upload2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/integration/mcedt/mailbox/Upload2Action.java
@@ -174,7 +174,8 @@ public class Upload2Action extends ActionSupport implements UploadedFilesAware {
                 if (result.getResponse().get(0).getResult().getCode().equals("IEDTS0001")) {
                     ActionUtils.setUploadResourceId(request, result.getResponse().get(0).getResourceID());
                     CarlosProperties props = CarlosProperties.getInstance();
-                    File file = new File(props.getProperty("ONEDT_OUTBOX", "") + this.getFileName());
+                    File outboxDir = new File(props.getProperty("ONEDT_OUTBOX", ""));
+                    File file = PathValidationUtils.validatePath(this.getFileName(), outboxDir);
                     ActionUtils.setSuccessfulUploads(request, file);
                 } else {
                     ActionUtils.setUploadResourceId(request, new BigInteger("-2"));
@@ -268,7 +269,8 @@ public class Upload2Action extends ActionSupport implements UploadedFilesAware {
                 for (ResponseResult edtResponse : result.getResponse()) {
                     if (edtResponse.getResult().getCode().equals("IEDTS0001")) {
                         ids.add(edtResponse.getResourceID());
-                        File file = new File(props.getProperty("ONEDT_OUTBOX", "") + edtResponse.getDescription());
+                        File outboxDir = new File(props.getProperty("ONEDT_OUTBOX", ""));
+                        File file = PathValidationUtils.validatePath(edtResponse.getDescription(), outboxDir);
                         ActionUtils.moveFileToDirectory(file, sent, false, true);
                         successUploads.add(McedtMessageCreator.resourceResultToString(result));
                     } else {

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingLreport.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingLreport.jsp
@@ -22,6 +22,7 @@
 
 <%@ page import="java.util.*,io.github.carlos_emr.*,java.io.*,java.net.*,io.github.carlos_emr.carlos.util.*,org.apache.commons.io.FileUtils"
          errorPage="/errorpage.jsp" %>
+<%@ page import="io.github.carlos_emr.carlos.utility.PathValidationUtils" %>
 <%@ page import="io.github.carlos_emr.CarlosProperties" %>
 <jsp:useBean id="oscarVariables" class="java.util.Properties" scope="session"/>
 
@@ -41,9 +42,9 @@
             }
 
             String fileContents = null;
-            if (!filename.matches(".*\\.\\..*")) {
-
-                File file = new File(INBOX + "/" + filename);
+            if (filename != null && !filename.trim().isEmpty()) {
+                File inboxDir = new File(INBOX);
+                File file = PathValidationUtils.validatePath(filename, inboxDir);
                 fileContents = FileUtils.readFileToString(file, "UTF-8");
             } else {
                 fileContents = "";
@@ -142,4 +143,3 @@
 
     </body>
 </html>
-


### PR DESCRIPTION
### Motivation
- Static scanners reported "uncontrolled data in path expression" findings where filenames from external sources were concatenated into filesystem paths.
- The project centralizes path-traversal prevention in `PathValidationUtils`, so remaining code paths should use that utility to remove alerts and enforce canonical containment.

### Description
- Replaced raw `ONEDT_OUTBOX + filename` and similar concatenations in `Upload2Action` with `PathValidationUtils.validatePath(...)` to validate filenames against the configured outbox directory before using them. (file: `src/main/java/io/github/carlos_emr/carlos/integration/mcedt/mailbox/Upload2Action.java`)
- Updated the MOH report JSP to import `PathValidationUtils` and call `PathValidationUtils.validatePath(filename, new File(INBOX))` before reading file contents, replacing a brittle `..` regex check. (file: `src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingLreport.jsp`)
- The changes centralize canonical path validation so downstream file operations are only performed on paths proven to be within allowed directories.

### Testing
- Ran a build check with `mvn -q -DskipTests compile` which failed due to external dependency resolution errors from an external Shibboleth repository (HTTP 403) and not due to code syntax in the changed files.

## Summary by Sourcery

Harden file path handling by routing user-supplied filenames through centralized path validation utilities before performing file operations.

Bug Fixes:
- Prevent potential path traversal in MOH report JSP by validating filenames against the inbox directory instead of relying on a regex check.
- Prevent potential path traversal in MCEDT upload actions by validating outbound filenames against the configured outbox directory before use.

Enhancements:
- Centralize file path construction in JSP and MCEDT upload logic around PathValidationUtils to ensure paths remain within allowed directories.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened file path handling by validating user-supplied filenames against allowed directories using `PathValidationUtils`. Prevents path traversal in MCEDT uploads and the MOH report view, and removes redundant directory init in MCEDT submit.

- **Bug Fixes**
  - MCEDT `Upload2Action`: validate filenames with `PathValidationUtils.validatePath(...)` against `ONEDT_OUTBOX` before file operations.
  - MCEDT `uploadSubmitToMcedt`: initialize `ONEDT_OUTBOX` and `ONEDT_SENT` once outside the response loop, ensure `ONEDT_SENT` exists, and reuse the shared `outboxDir` for validated file moves.
  - MOH `billingLreport.jsp`: use `PathValidationUtils` to validate filenames against `INBOX`, replacing the `..` regex check.

<sup>Written for commit f9f07ac16588df600a75e37c40e29f8530e9e347. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

