### PR TITLE
Escape user input when building dynamic regexes in RX search JSPs

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/rx/SearchDrug3.jsp
+++ b/src/main/webapp/WEB-INF/jsp/rx/SearchDrug3.jsp
@@ -1900,13 +1900,12 @@ function popForm2(scriptId){
 
 			}
 
+			function escapeRegExp(searchTerm) {
+				return String(searchTerm || "").replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+			}
+
 			function replaceAll(str, keyword) {
-				var matcher;
-				var lastkeyword;
-				if (keyword !== lastkeyword) {
-					matcher = new RegExp("(" + keyword + ")", "ig");
-					lastkeyword = keyword;
-				}
+				var matcher = new RegExp("(" + escapeRegExp(keyword) + ")", "ig");
 				return str.replace(matcher, "<span class='drugKeyword' >$1</span>");
 			}
 

--- a/src/main/webapp/WEB-INF/jsp/rx/SelectPharmacy2.jsp
+++ b/src/main/webapp/WEB-INF/jsp/rx/SelectPharmacy2.jsp
@@ -244,12 +244,20 @@
                             HideSpin(true);
                         }, "json");
 					}
-                    var pharmacyNameKey = new RegExp($("#pharmacySearch").val(), "i");
-                    var pharmacyCityKey = new RegExp($("#pharmacyCitySearch").val(), "i");
-                    var pharmacyPostalCodeKey = new RegExp($("#pharmacyPostalCodeSearch").val(), "i");
-                    var pharmacyFaxKey = new RegExp($("#pharmacyFaxSearch").val(), "i");
-                    var pharmacyPhoneKey = new RegExp($("#pharmacyPhoneSearch").val(), "i");
-                    var pharmacyAddressKey = new RegExp($("#pharmacyAddressSearch").val(), "i");
+                    function escapeRegExp(searchTerm) {
+                        return String(searchTerm || "").replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+                    }
+
+                    function buildSafeSearchRegex(searchTerm) {
+                        return new RegExp(escapeRegExp(searchTerm), "i");
+                    }
+
+                    var pharmacyNameKey = buildSafeSearchRegex($("#pharmacySearch").val());
+                    var pharmacyCityKey = buildSafeSearchRegex($("#pharmacyCitySearch").val());
+                    var pharmacyPostalCodeKey = buildSafeSearchRegex($("#pharmacyPostalCodeSearch").val());
+                    var pharmacyFaxKey = buildSafeSearchRegex($("#pharmacyFaxSearch").val());
+                    var pharmacyPhoneKey = buildSafeSearchRegex($("#pharmacyPhoneSearch").val());
+                    var pharmacyAddressKey = buildSafeSearchRegex($("#pharmacyAddressSearch").val());
 
                     $("#pharmacySearch").keyup(function () {
                         updateSearchKeys();
@@ -405,12 +413,12 @@
 
 
                     function updateSearchKeys() {
-                        pharmacyNameKey = new RegExp($("#pharmacySearch").val(), "i");
-                        pharmacyCityKey = new RegExp($("#pharmacyCitySearch").val(), "i");
-                        pharmacyPostalCodeKey = new RegExp($("#pharmacyPostalCodeSearch").val(), "i");
-                        pharmacyFaxKey = new RegExp($("#pharmacyFaxSearch").val(), "i");
-                        pharmacyPhoneKey = new RegExp($("#pharmacyPhoneSearch").val(), "i");
-                        pharmacyAddressKey = new RegExp($("#pharmacyAddressSearch").val(), "i");
+                        pharmacyNameKey = buildSafeSearchRegex($("#pharmacySearch").val());
+                        pharmacyCityKey = buildSafeSearchRegex($("#pharmacyCitySearch").val());
+                        pharmacyPostalCodeKey = buildSafeSearchRegex($("#pharmacyPostalCodeSearch").val());
+                        pharmacyFaxKey = buildSafeSearchRegex($("#pharmacyFaxSearch").val());
+                        pharmacyPhoneKey = buildSafeSearchRegex($("#pharmacyPhoneSearch").val());
+                        pharmacyAddressKey = buildSafeSearchRegex($("#pharmacyAddressSearch").val());
                     }
                 })
             })(jQuery);


### PR DESCRIPTION
### Motivation

- Prevent regular-expression injection (CWE-730 / ReDoS) where user-controlled search terms were used directly to construct `RegExp` objects in RX search and pharmacy filter UI code.

### Description

- Added an `escapeRegExp` helper and `buildSafeSearchRegex` helper in `src/main/webapp/WEB-INF/jsp/rx/SelectPharmacy2.jsp` and replaced all direct `new RegExp($(...).val(), "i")` constructions with safe, escaped regex builders.
- Updated the keyword-highlighting path in `src/main/webapp/WEB-INF/jsp/rx/SearchDrug3.jsp` to escape the user-provided keyword before creating the dynamic `RegExp` used for wrapping matches, preserving the original case-insensitive behavior.
- Changes are restricted to the two JSP files that previously constructed regexes from raw user input and do not alter server-side logic or behavior beyond safer regex construction.

### Testing

- Ran a project grep search for unsafe `new RegExp(` sites in the edited JSPs to confirm the edited locations now use the escaping helper, and the search returned only the updated, escaped calls (success).
- Ran a whitespace/format check (`git diff --check`) to ensure no trailing/formatting issues were introduced (success).
- Verified the modified JSP files contain the new `escapeRegExp` / `buildSafeSearchRegex` usages and that the dynamic regex creation sites were updated accordingly (manual automated checks, success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df112b2354832891d3389889abea36)

## Summary by Sourcery

Escape user-controlled search terms before constructing dynamic regular expressions in RX search JSPs to prevent regex injection vulnerabilities.

Bug Fixes:
- Sanitize pharmacy search input fields in SelectPharmacy2.jsp by introducing helpers that escape user input before creating case-insensitive RegExp objects.
- Sanitize drug keyword highlighting in SearchDrug3.jsp by escaping the user-provided keyword before building the dynamic RegExp used for markup.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Escapes user input when building dynamic regexes in RX search and keyword highlighting to prevent regex injection/ReDoS. Keeps existing behavior and case-insensitive matching.

- **Bug Fixes**
  - In `src/main/webapp/WEB-INF/jsp/rx/SelectPharmacy2.jsp`, added `escapeRegExp` and `buildSafeSearchRegex` and replaced all direct `new RegExp(...)` calls for name, city, postal code, fax, phone, and address, including in `updateSearchKeys`.
  - In `src/main/webapp/WEB-INF/jsp/rx/SearchDrug3.jsp`, updated `replaceAll` to escape the keyword before creating the matcher used for highlighting.

<sup>Written for commit da2df1104774bd818c7cef7402e65f890878b741. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

