### PR TITLE
Sanitize dynamic HTML in floating toolbar, popup and alerts to prevent XSS

### DIFF
--- a/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
+++ b/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
@@ -677,6 +677,64 @@ function hideElements() {
     }
 }
 
+const TOOLBAR_ALLOWED_TAGS = new Set([
+    "DIV", "NAV", "FORM", "SPAN", "INPUT", "BUTTON", "I", "IMG"
+]);
+
+const TOOLBAR_ALLOWED_ATTRIBUTES = new Set([
+    "id", "class", "name", "type", "value", "title", "placeholder", "required",
+    "disabled", "style", "data-bs-theme", "data-poload", "aria-label", "alt", "src"
+]);
+
+const TOOLBAR_ALLOWED_ONCLICK = new Set([
+    "remoteSave()", "remotePrint()", "remoteDownload()", "remoteFax()", "remoteEdocument()",
+    "remoteEmail()", "remoteClose()", "closeToolbar()", "openToolbar()"
+]);
+
+function isSafeToolbarUri(uri) {
+    const value = String(uri || "").trim().toLowerCase();
+    return !(value.startsWith("javascript:") || value.startsWith("data:") || value.startsWith("vbscript:"));
+}
+
+function sanitizeToolbarFragment(fragment) {
+    const walker = document.createTreeWalker(fragment, NodeFilter.SHOW_ELEMENT);
+    const elements = [];
+    while (walker.nextNode()) {
+        elements.push(walker.currentNode);
+    }
+
+    elements.forEach((element) => {
+        if (!TOOLBAR_ALLOWED_TAGS.has(element.tagName)) {
+            element.remove();
+            return;
+        }
+
+        Array.from(element.attributes).forEach((attr) => {
+            const attrName = attr.name.toLowerCase();
+            const attrValue = attr.value || "";
+
+            if (attrName === "onclick") {
+                if (!TOOLBAR_ALLOWED_ONCLICK.has(attrValue.trim())) {
+                    element.removeAttribute(attr.name);
+                }
+                return;
+            }
+
+            if (attrName.startsWith("on") || !TOOLBAR_ALLOWED_ATTRIBUTES.has(attrName)) {
+                element.removeAttribute(attr.name);
+                return;
+            }
+
+            if ((attrName === "src" || attrName === "href") && !isSafeToolbarUri(attrValue)) {
+                element.removeAttribute(attr.name);
+            }
+        });
+    });
+
+    const rootToolbar = fragment.querySelector("#eform_floating_toolbar");
+    return rootToolbar ? fragment : null;
+}
+
 /**
  * A javascript includes method
  * @returns
@@ -691,9 +749,20 @@ function includeHTML(elmnt) {
                 let toolbarWrapper = document.createElement("div");
                 toolbarWrapper.setAttribute("id", "toolbarWrapper");
                 toolbarWrapper.setAttribute("class", "hidden-print DoNotPrint no-print");
-                // Same-origin JSP fragment (eform_floating_toolbar.jspf) with server-defined
-                // event handlers — innerHTML is required for toolbar functionality.
-                toolbarWrapper.innerHTML = this.responseText; // nosemgrep: javascript.browser.security.insecure-document-method.insecure-document-method
+                const parser = new DOMParser();
+                const parsed = parser.parseFromString(this.responseText, "text/html");
+                const fragment = document.createDocumentFragment();
+                while (parsed.body.firstChild) {
+                    fragment.appendChild(parsed.body.firstChild);
+                }
+
+                const sanitizedFragment = sanitizeToolbarFragment(fragment);
+                if (!sanitizedFragment) {
+                    elmnt.append("eForm tool bar rejected by sanitizer.");
+                    return;
+                }
+
+                toolbarWrapper.appendChild(sanitizedFragment);
                 elmnt.append(toolbarWrapper);
 
                 // After adding floating toolbar update number of attachments

--- a/src/main/webapp/js/oscar-alert.js
+++ b/src/main/webapp/js/oscar-alert.js
@@ -29,24 +29,6 @@
 let oscarAlert;
 
 /**
- * Escapes a string for safe insertion into HTML body text to prevent XSS.
- * Uses a temporary DOM text node so the browser's own escaping is applied,
- * encoding <, >, and & but NOT quotes (" or ').
- *
- * WARNING: The output is NOT safe for HTML attribute contexts.
- *
- * @param {string} text - the raw string to escape
- * @returns {string} HTML-encoded string safe for use as HTML body text content
- */
-function escapeHtml(text) {
-    if (text == null) return '';
-    const node = document.createTextNode(String(text));
-    const div = document.createElement('div');
-    div.appendChild(node);
-    return div.innerHTML;
-}
-
-/**
  * Create and display a Bootstrap alert with the given message, type, and duration
  * @param {string} alertId - unique identifier for the alert div
  * @param {string} message - the message to display inside the alert
@@ -105,9 +87,7 @@ class OscarAlert {
         this.alertDiv.className = `alert alert-${alertType} alert-dismissible fade oscar-alert`;
         this.alertDiv.role = 'alert';
 
-        // Safe: getInnerHTML() escapes message via escapeHtml(); alertType is from trusted string literals
-        this.alertDiv.innerHTML = this.getInnerHTML(message); // nosemgrep: javascript.browser.security.insecure-document-method.insecure-document-method
-
+        this.renderAlert(message);
         this.alertDiv.querySelector('.btn-close').addEventListener('click', () => this.dismissAlert());
     }
 
@@ -172,13 +152,31 @@ class OscarAlert {
         }
     }
 
-    getInnerHTML(message) {
-        const safeMessage = escapeHtml(message);
-        return `
-            <strong>${this.getLabel()}</strong> ${safeMessage}
-            <br> <small>${this.getDismissalMessage()}<span id="countdown-${this.alertDiv.id}">${this.countdown}</span> seconds.</small>
-            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close" ></button>
-        `;
+    renderAlert(message) {
+        this.alertDiv.replaceChildren();
+
+        const label = document.createElement('strong');
+        label.textContent = this.getLabel();
+
+        const messageText = document.createTextNode(` ${String(message ?? '')}`);
+        const lineBreak = document.createElement('br');
+
+        const small = document.createElement('small');
+        small.append(document.createTextNode(this.getDismissalMessage()));
+
+        const countdown = document.createElement('span');
+        countdown.id = `countdown-${this.alertDiv.id}`;
+        countdown.textContent = this.countdown.toString();
+        small.append(countdown);
+        small.append(document.createTextNode(' seconds.'));
+
+        const closeButton = document.createElement('button');
+        closeButton.type = 'button';
+        closeButton.className = 'btn-close';
+        closeButton.setAttribute('data-bs-dismiss', 'alert');
+        closeButton.setAttribute('aria-label', 'Close');
+
+        this.alertDiv.append(label, messageText, lineBreak, document.createTextNode(' '), small, closeButton);
     }
 
     getDismissalMessage() {

--- a/src/main/webapp/js/popup.js
+++ b/src/main/webapp/js/popup.js
@@ -7,10 +7,8 @@
  *   <span onmouseover="nhpup.popup(htmlVar, {'width': 350})">hover me</span>
  *   <span onmouseover="nhpup.popup('content'); nhpup.attachHideHandler(event);">hover me</span>
  *
- * Security note: popup() sets innerHTML because callers pass pre-built HTML
- * table markup from same-origin JavaScript variables (e.g., phone/address
- * history tables, healthcare team detail tables). The content originates from
- * server-side OWASP-encoded data, not direct user input.
+ * Security note: popup() sanitizes caller-provided markup before rendering.
+ * Scriptable tags and event-handler attributes are removed to prevent XSS.
  */
 var nhpup = (function () {
     "use strict";
@@ -18,6 +16,40 @@ var nhpup = (function () {
     var pup = null;
     var minMargin = 15;
     var defaultWidth = 200;
+    var blockedTags = new Set(["SCRIPT", "STYLE", "IFRAME", "OBJECT", "EMBED", "LINK", "META"]);
+
+    function sanitizeFragment(markup) {
+        var parser = new DOMParser();
+        var parsed = parser.parseFromString(String(markup == null ? "" : markup), "text/html");
+        var fragment = document.createDocumentFragment();
+        while (parsed.body.firstChild) {
+            fragment.appendChild(parsed.body.firstChild);
+        }
+
+        var walker = document.createTreeWalker(fragment, NodeFilter.SHOW_ELEMENT);
+        var nodes = [];
+        while (walker.nextNode()) {
+            nodes.push(walker.currentNode);
+        }
+
+        nodes.forEach(function (el) {
+            if (blockedTags.has(el.tagName)) {
+                el.remove();
+                return;
+            }
+
+            Array.from(el.attributes).forEach(function (attr) {
+                var name = attr.name.toLowerCase();
+                var value = attr.value || "";
+                var normalized = value.replace(/[\u0000-\u001f\u007f\s]+/g, "").toLowerCase();
+                if (name.startsWith("on") || name === "srcdoc" || normalized.startsWith("javascript:")) {
+                    el.removeAttribute(attr.name);
+                }
+            });
+        });
+
+        return fragment;
+    }
 
     function ensureElement() {
         if (pup) return;
@@ -66,9 +98,8 @@ var nhpup = (function () {
                 if (config.width) pup.style.width = config.width + "px";
             }
 
-            // innerHTML is intentional — callers pass pre-built HTML tables
-            // from same-origin server-rendered data (see security note above)
-            pup.innerHTML = msg;  // nosemgrep: javascript.browser.security.insecure-document-method.insecure-document-method
+            // Render sanitized HTML to prevent script/event-handler injection.
+            pup.replaceChildren(sanitizeFragment(msg));
             pup.style.display = "block";
 
         },


### PR DESCRIPTION
### Motivation
- Reduce XSS risk by avoiding unchecked `innerHTML` for server-provided fragments and UI messages and by stripping scriptable tags and event handlers.
- Ensure the floating toolbar only renders an expected DOM subtree and allowed attributes to prevent injection via toolbar JSP fragments.

### Description
- Replace direct `innerHTML` usage in the floating toolbar loader with `DOMParser` + `DocumentFragment` and add `sanitizeToolbarFragment()` that enforces allowed tags, attributes, allowed `onclick` handlers, and rejects unsafe URIs; the toolbar is rejected if the expected `#eform_floating_toolbar` root is missing.
- Add `TOOLBAR_ALLOWED_TAGS`, `TOOLBAR_ALLOWED_ATTRIBUTES`, `TOOLBAR_ALLOWED_ONCLICK`, and `isSafeToolbarUri()` to centralize toolbar whitelist logic.
- Tighten popup markup rendering by adding `sanitizeFragment()` to remove blocked tags and strip `on*` event attributes and dangerous `javascript:`-style URIs, and render the sanitized fragment with `replaceChildren()` instead of `innerHTML`.
- Rework `OscarAlert` to build DOM nodes safely (text nodes and elements) in `renderAlert()` instead of composing HTML strings and using `innerHTML`, and remove the old `escapeHtml()` helper.

### Testing
- Ran linting and static checks (`eslint`) against modified JS files and fixed issues; no lint errors reported.
- Executed frontend unit tests (`npm test`) covering popup and alert components and all tests passed.
- Ran automated integration/smoke tests that exercise the floating toolbar load path and they passed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df0fd7bca883289a1555f32db4f41c)

## Summary by Sourcery

Harden client-side rendering of dynamic HTML in the floating toolbar, popup, and alert components to reduce XSS risk.

Bug Fixes:
- Sanitize floating toolbar fragments before insertion, enforcing allowed tags, attributes, onclick handlers, and safe URIs, and reject unexpected toolbar roots.
- Sanitize popup HTML content by stripping scriptable tags, event handlers, and dangerous javascript-style URIs before rendering.
- Render OscarAlert content via DOM node construction instead of innerHTML, removing reliance on string-built HTML and the old escapeHtml helper.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitizes dynamic HTML in the eForm floating toolbar, popups, and OscarAlert to block XSS. Replaces unsafe `innerHTML` paths with DOM parsing, whitelisting, and safe node construction.

- **Bug Fixes**
  - Floating toolbar: parse with `DOMParser`, whitelist tags/attrs, allow only known `onclick` values, strip unsafe URIs, and reject fragments missing `#eform_floating_toolbar`.
  - Popups: remove scriptable tags and `on*` attributes, block `javascript:`-style URIs, and render via `replaceChildren()` with a sanitized fragment.
  - OscarAlert: build content with elements and text nodes instead of `innerHTML`; removed `escapeHtml()` without changing the public API.

<sup>Written for commit 43e71bf45664c4ef32bcb609e24a8b94d6f8b686. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

