### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL injection in EFormReportToolDaoImpl

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-11-20 - Prevent SQL Injection in Dynamic EForm Report Table Insertion
+**Vulnerability:** The `populateReportTableItem` method in `EFormReportToolDaoImpl.java` used raw string concatenation to insert dynamic EForm values directly into a native SQL query (`sb.append("\'" + v.getVarValue() + "\'")`), which creates a severe SQL injection vulnerability.
+**Learning:** Dynamic table interactions and complex form data require parameterized queries even when the number of columns is unknown beforehand. Building a dynamic values clause with `?` placeholders and subsequently iterating to bind values with `setParameter` is a safe pattern.
+**Prevention:** Always construct parameterized queries. For dynamically generated SQL inserting a variable number of fields, iterate to append positional `?` placeholders (or named parameters), and then iterate again to bind the user data utilizing `Query.setParameter()`. Never concatenate user input directly into SQL strings.

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/EFormReportToolDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/EFormReportToolDaoImpl.java
@@ -124,15 +124,18 @@ public class EFormReportToolDaoImpl extends AbstractDaoImpl<EFormReportTool> imp
         sb.deleteCharAt(sb.length() - 1);
 
         sb.append(" ) VALUES (");
-        sb.append(fdid + ",");
-        sb.append(demographicNo + ",");
-        sb.append("\'" + DateFormatUtils.format(dateFormCreated, "yyyy-MM-dd HH:mm:ss") + "\',");
-        sb.append("\'" + providerNo + "\',");
+        sb.append("?1,");
+        sb.append("?2,");
+        sb.append("?3,");
+        sb.append("?4,");
         sb.append("0,");
         sb.append("now(),");
+
+        int paramIndex = 5;
         for (EFormValue v : values) {
-            sb.append("\'" + v.getVarValue() + "\'");
+            sb.append("?" + paramIndex);
             sb.append(",");
+            paramIndex++;
         }
         sb.deleteCharAt(sb.length() - 1);
 
@@ -141,6 +144,17 @@ public class EFormReportToolDaoImpl extends AbstractDaoImpl<EFormReportTool> imp
         //logger.debug("sql=" + sb.toString());
 
         Query q = entityManager.createNativeQuery(sb.toString());
+        q.setParameter(1, fdid);
+        q.setParameter(2, demographicNo);
+        q.setParameter(3, dateFormCreated);
+        q.setParameter(4, providerNo);
+
+        paramIndex = 5;
+        for (EFormValue v : values) {
+            q.setParameter(paramIndex, v.getVarValue());
+            paramIndex++;
+        }
+
         q.executeUpdate();
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/EFormReportToolDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/EFormReportToolDaoImpl.java
@@ -38,7 +38,6 @@ import java.util.List;
 
 import jakarta.persistence.Query;
 
-import org.apache.commons.lang3.time.DateFormatUtils;
 import io.github.carlos_emr.carlos.commn.model.EForm;
 import io.github.carlos_emr.carlos.commn.model.EFormReportTool;
 import io.github.carlos_emr.carlos.commn.model.EFormValue;


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: The `populateReportTableItem` method in `EFormReportToolDaoImpl.java` used raw string concatenation to insert dynamic EForm values directly into a native SQL query, leading to SQL injection vulnerabilities.
🎯 **Impact**: An attacker who can control form data or variables being saved to EForms could inject malicious SQL commands, potentially reading, modifying, or destroying database records.
🔧 **Fix**: Refactored the native query generation logic. Now iterates through user inputs twice: first to append standard `?` positional parameters into the `VALUES` block string, and then a second loop to properly bind those values against the `Query` object via `setParameter`. The date formatting to string was also removed in favor of parameterized date objects safely bound directly to the query.
✅ **Verification**: Compiled successfully and passed targeted test checks for `EFormData` functionalities. No new regressions were introduced, and static analysis principles now confirm parameterized safe bindings.

---
*PR created automatically by Jules for task [15337736148884603742](https://jules.google.com/task/15337736148884603742) started by @yingbull*

## Summary by Sourcery

Secure dynamic EForm report insertion by parameterizing the native SQL query used in populateReportTableItem.

Bug Fixes:
- Eliminate SQL injection risk in EFormReportToolDaoImpl by replacing string-concatenated values with bound query parameters for all inserted fields.

Documentation:
- Add a Sentinel security notes file documenting the SQL injection vulnerability, its fix, and guidance for preventing similar issues in dynamic SQL.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a critical SQL injection in `EFormReportToolDaoImpl.populateReportTableItem` by switching to a parameterized native INSERT. Base columns and dynamic EForm values are now safely bound.

- **Bug Fixes**
  - Replaced string concatenation with positional `?` placeholders and `Query.setParameter` for all values, including dynamic fields.
  - Bound `fdid`, `demographicNo`, `dateFormCreated` (as a Date), and `providerNo`; removed `DateFormatUtils` and manual quoting.
  - Added `.jules/sentinel.md` documenting the vulnerability and the safe parameterization pattern.

<sup>Written for commit 616c46fb2f519f80bcab28df059e016c5d007a5b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

