### PR TITLE
1783 bug innacurate description of relationship and timeline for oscar

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -61,7 +61,3 @@ The presence of copyright notices from these organizations reflects the
 open-source heritage of the code and compliance with GPL requirements to
 preserve attribution, not any current organizational relationship.
 
-## License
-
-CARLOS is open source licensed.
-See COPYING.md for the full license text.

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -11,7 +11,7 @@ maintained by the CARLOS community.
 This codebase has evolved through multiple open-source projects:
 - **CARLOS** (2026-present) - Current independent project
 - **OpenO EMR** - Intermediate fork
-- **OSCAR McMaster** - Original project (2001-2012)
+- **OSCAR McMaster** - Original project (2001-2020)
 
 ## 2025-2026 Fork Transition
 
@@ -27,24 +27,26 @@ rather than functional modifications of individual files.
 
 This software contains code from multiple contributors over 20+ years:
 
-- Department of Family Medicine, McMaster University (2001-2002)
+- Department of Family Medicine, McMaster University (2001-2020)
 - Centre for Research on Inner City Health, St. Michael's Hospital, Toronto (2005-2012)
+- OSCARservice, OpenSoft System (2006-2016)
+- Peter Hutten-Czapski (2007-2026+)
 - Indivica Inc. (2008-2012)
-- OSCARservice, OpenSoft System (2006+)
 - PeaceWorks Technology Solutions (2011-2012)
 - University of Victoria, Department of Computer Science (2013-2015)
-- The Pharmacists Clinic, University of British Columbia (2015-2019)
 - KAI Innovations Inc. (2014-2015)
+- The Pharmacists Clinic, University of British Columbia (2015-2019)
 - Magenta Health (2024+)
 - CARLOS Contributors (2026+)
-- And many individual contributors
+- And many other contributors
 
+Dates are mostly taken from the copyright notices and may not reflect contribution spans.
 All original copyright notices are preserved in source files as required by
 the GNU General Public License.
 
 ## Trademark Notice
 
-"OSCAR" is a registered trademark of McMaster University. Any references to
+"OSCAR" is an official mark of McMaster University. Any references to
 OSCAR in this codebase are for historical and descriptive purposes only and
 do not imply endorsement by or affiliation with McMaster University.
 
@@ -61,5 +63,5 @@ preserve attribution, not any current organizational relationship.
 
 ## License
 
-CARLOS is licensed under the GNU General Public License v2 or later (GPL-2.0+).
+CARLOS is open source licensed.
 See COPYING.md for the full license text.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ CARLOS is forked from the OpenO EMR project, which itself was forked from OSCAR 
 **Important Disclaimers:**
 - This project has **no affiliation** with OpenOSP, the organization that developed OpenO EMR
 - This project has **no affiliation** with McMaster University
-- OSCAR is a registered official mark of McMaster University
+- OSCAR is an official mark of McMaster University
 - The OSCAR name is used in this project solely for descriptive and historical purposes
 
 For detailed copyright attribution and project heritage information, see [NOTICE.md](NOTICE.md).

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ CARLOS is forked from the OpenO EMR project, which itself was forked from OSCAR 
 **Important Disclaimers:**
 - This project has **no affiliation** with OpenOSP, the organization that developed OpenO EMR
 - This project has **no affiliation** with McMaster University
-- The OSCAR name and related trademarks remain the property of McMaster University and are used in this project solely for descriptive and historical purposes
-- OSCAR is a registered trademark of McMaster University
+- OSCAR is a registered official mark of McMaster University
+- The OSCAR name is used in this project solely for descriptive and historical purposes
 
 For detailed copyright attribution and project heritage information, see [NOTICE.md](NOTICE.md).
 


### PR DESCRIPTION
<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description
Minor edits and corrections mostly to accurately reflect McMaster official mark and contributions
<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues
Fixes #1783 
<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?

<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [ ] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Update project notices to accurately describe OSCAR McMaster’s timeline, contributor attributions, trademark status, and licensing wording.

Bug Fixes:
- Correct OSCAR McMaster project and McMaster Department of Family Medicine contribution dates to reflect activity through 2020.
- Clarify that OSCAR is an official mark of McMaster University and that references are descriptive and historical only.

Enhancements:
- Refine contributor list ordering and wording in NOTICE to better represent long-term contributors and acknowledge additional contributors.
- Simplify license description in NOTICE and direct readers to the full license text in COPYING.md.

Documentation:
- Adjust README disclaimers to accurately describe OSCAR’s official mark status and how the OSCAR name is used in this project.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects docs to accurately reflect OSCAR’s timeline and contributors, and clarifies that OSCAR is an official mark of McMaster. Fixes #1783.

- **Bug Fixes**
  - Set OSCAR McMaster timeline to 2001–2020 in `NOTICE.md`.
  - Clarified trademark language in `NOTICE.md` and `README.md`: OSCAR is an official mark; the name is used only for descriptive and historical purposes.
  - Refined contributor attributions and date ranges; added a brief note on how dates were sourced.
  - Removed the license section from `NOTICE.md`.

<sup>Written for commit cae412efdf3e35baf2f3fa7ac8d2bee326ffd85b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

