### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL Injection in EFormReportToolDaoImpl

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## YYYY-MM-DD - Sentinel SQL Injection Findings
+**Vulnerability:** SQL injection vulnerabilities exist in dynamic table name logic within EFormReportToolDaoImpl, and more crucially, parameter binding is not used in multiple native queries.
+**Learning:** Legacy codebase patterns heavily rely on string concatenation for SQL queries using `entityManager.createNativeQuery`.
+**Prevention:** Always parameterize user inputs in SQL and use an allowlist/regex validation for dynamic table and column names that cannot be parameterized.

--- a/fix_jsp.sh
+++ b/fix_jsp.sh
@@ -1,0 +1,18 @@
+cat << 'DIFF' > jsp.diff
+--- src/main/java/io/github/carlos_emr/carlos/commn/dao/EFormReportToolDaoImpl.java
++++ src/main/java/io/github/carlos_emr/carlos/commn/dao/EFormReportToolDaoImpl.java
+@@ -50,11 +50,11 @@
+         super(EFormReportTool.class);
+     }
+
+-    private static final java.util.regex.Pattern INVALID_SQL_IDENTIFIER = java.util.regex.Pattern.compile(".*[`].*");
++    private static final java.util.regex.Pattern INVALID_SQL_IDENTIFIER = java.util.regex.Pattern.compile(".*[\`].*");
+
+     private void validateIdentifier(String identifier) {
+         if (identifier == null || INVALID_SQL_IDENTIFIER.matcher(identifier).matches()) {
+-            throw new IllegalArgumentException("Invalid SQL identifier: " + identifier);
++            throw new IllegalArgumentException("Invalid SQL identifier");
+         }
+     }
+DIFF
+patch -p0 < jsp.diff

--- a/fix_spotbugs.sh
+++ b/fix_spotbugs.sh
@@ -1,0 +1,14 @@
+cat << 'DIFF' > spotbugs.diff
+--- src/main/java/io/github/carlos_emr/carlos/commn/dao/EFormReportToolDaoImpl.java
++++ src/main/java/io/github/carlos_emr/carlos/commn/dao/EFormReportToolDaoImpl.java
+@@ -50,7 +50,7 @@
+         super(EFormReportTool.class);
+     }
+
+-    private static final java.util.regex.Pattern INVALID_SQL_IDENTIFIER = java.util.regex.Pattern.compile(".*[\`].*");
++    private static final java.util.regex.Pattern INVALID_SQL_IDENTIFIER = java.util.regex.Pattern.compile(".*\`.*");
+
+     private void validateIdentifier(String identifier) {
+         if (identifier == null || INVALID_SQL_IDENTIFIER.matcher(identifier).matches() || identifier.contains(";")) {
+DIFF
+patch -p0 < spotbugs.diff

--- a/jsp.diff
+++ b/jsp.diff
@@ -1,0 +1,15 @@
+--- src/main/java/io/github/carlos_emr/carlos/commn/dao/EFormReportToolDaoImpl.java
++++ src/main/java/io/github/carlos_emr/carlos/commn/dao/EFormReportToolDaoImpl.java
+@@ -50,11 +50,11 @@
+         super(EFormReportTool.class);
+     }
+
+-    private static final java.util.regex.Pattern INVALID_SQL_IDENTIFIER = java.util.regex.Pattern.compile(".*[`].*");
++    private static final java.util.regex.Pattern INVALID_SQL_IDENTIFIER = java.util.regex.Pattern.compile(".*[\`].*");
+
+     private void validateIdentifier(String identifier) {
+         if (identifier == null || INVALID_SQL_IDENTIFIER.matcher(identifier).matches()) {
+-            throw new IllegalArgumentException("Invalid SQL identifier: " + identifier);
++            throw new IllegalArgumentException("Invalid SQL identifier");
+         }
+     }

--- a/spotbugs.diff
+++ b/spotbugs.diff
@@ -1,0 +1,11 @@
+--- src/main/java/io/github/carlos_emr/carlos/commn/dao/EFormReportToolDaoImpl.java
++++ src/main/java/io/github/carlos_emr/carlos/commn/dao/EFormReportToolDaoImpl.java
+@@ -50,7 +50,7 @@
+         super(EFormReportTool.class);
+     }
+
+-    private static final java.util.regex.Pattern INVALID_SQL_IDENTIFIER = java.util.regex.Pattern.compile(".*[\`].*");
++    private static final java.util.regex.Pattern INVALID_SQL_IDENTIFIER = java.util.regex.Pattern.compile(".*\`.*");
+
+     private void validateIdentifier(String identifier) {
+         if (identifier == null || INVALID_SQL_IDENTIFIER.matcher(identifier).matches() || identifier.contains(";")) {

--- a/spotbugs.log
+++ b/spotbugs.log
@@ -1,0 +1,26 @@
+[INFO] Scanning for projects...
+Downloading from local_repo: file:///app/local_repo/se/vandmo/maven-metadata.xml
+Downloading from local_repo: file:///app/local_repo/org/jacoco/maven-metadata.xml
+Downloading from local_repo: file:///app/local_repo/org/apache/maven/plugins/maven-metadata.xml
+Downloading from local_repo: file:///app/local_repo/org/codehaus/mojo/maven-metadata.xml
+Downloading from central: https://repo.maven.apache.org/maven2/org/jacoco/maven-metadata.xml
+Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/mojo/maven-metadata.xml
+Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-metadata.xml
+Downloading from central: https://repo.maven.apache.org/maven2/se/vandmo/maven-metadata.xml
+Progress (1): 237 BProgress (2): 237 B | 426 BProgress (3): 237 B | 426 B | 4.6 kBProgress (3): 237 B | 426 B | 9.7 kBProgress (3): 237 B | 426 B | 14 kB Progress (4): 237 B | 426 B | 14 kB | 3.3 kBProgress (4): 237 B | 426 B | 14 kB | 7.9 kBProgress (4): 237 B | 426 B | 14 kB | 12 kB                                            Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-metadata.xml (14 kB at 27 kB/s)
+Progress (3): 237 B | 426 B | 16 kB                                   Downloaded from central: https://repo.maven.apache.org/maven2/org/jacoco/maven-metadata.xml (237 B at 443 B/s)
+Downloaded from central: https://repo.maven.apache.org/maven2/se/vandmo/maven-metadata.xml (426 B at 797 B/s)
+Progress (1): 20 kBProgress (1): 21 kB                   Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/mojo/maven-metadata.xml (21 kB at 36 kB/s)
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD FAILURE
+[INFO] ------------------------------------------------------------------------
+[INFO] Total time:  1.515 s
+[INFO] Finished at: 2026-04-16T17:03:55Z
+[INFO] ------------------------------------------------------------------------
+[ERROR] No plugin found for prefix 'spotbugs' in the current project and in the plugin groups [org.jacoco, se.vandmo, org.apache.maven.plugins, org.codehaus.mojo] available from the repositories [local (/home/jules/.m2/repository), local_repo (file:///app/local_repo), central (https://repo.maven.apache.org/maven2)] -> [Help 1]
+[ERROR]
+[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
+[ERROR] Re-run Maven using the -X switch to enable full debug logging.
+[ERROR]
+[ERROR] For more information about the errors and possible solutions, please read the following articles:
+[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/NoPluginFoundForPrefixException

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/EFormReportToolDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/EFormReportToolDaoImpl.java
@@ -38,7 +38,6 @@ import java.util.List;
 
 import jakarta.persistence.Query;
 
-import org.apache.commons.lang3.time.DateFormatUtils;
 import io.github.carlos_emr.carlos.commn.model.EForm;
 import io.github.carlos_emr.carlos.commn.model.EFormReportTool;
 import io.github.carlos_emr.carlos.commn.model.EFormValue;
@@ -51,20 +50,33 @@ public class EFormReportToolDaoImpl extends AbstractDaoImpl<EFormReportTool> imp
         super(EFormReportTool.class);
     }
 
+    private static final java.util.regex.Pattern INVALID_SQL_IDENTIFIER = java.util.regex.Pattern.compile(".*[`].*");
+
+    private void validateIdentifier(String identifier) {
+        if (identifier == null || INVALID_SQL_IDENTIFIER.matcher(identifier).matches()) {
+            throw new IllegalArgumentException("Invalid SQL identifier: " + identifier);
+        }
+    }
+
     @SuppressWarnings("unchecked")
     public void markLatest(Integer eformReportToolId) {
         EFormReportTool eft = find(eformReportToolId);
         if (eft != null) {
+            validateIdentifier(eft.getTableName());
             //get all distinct demographicNos
             Query q = entityManager.createNativeQuery("select distinct demographicNo from  " + eft.getTableName());
             List<Integer> demoNos = q.getResultList();
             for (Integer demoNo : demoNos) {
-                Query q2 = entityManager.createNativeQuery("select id from " + eft.getTableName() + " where demographicNo = " + demoNo + " order by dateFormCreated desc,fdid desc").setMaxResults(1);
+                Query q2 = entityManager.createNativeQuery("select id from " + eft.getTableName() + " where demographicNo = ?1 order by dateFormCreated desc,fdid desc").setMaxResults(1);
+                q2.setParameter(1, demoNo);
                 List<Integer> idList = q2.getResultList();
 
                 //update the first result
-                Query q3 = entityManager.createNativeQuery("update " + eft.getTableName() + " set eft_latest=1 where id=" + idList.get(0));
-                q3.executeUpdate();
+                if (!idList.isEmpty()) {
+                    Query q3 = entityManager.createNativeQuery("update " + eft.getTableName() + " set eft_latest=1 where id=?1");
+                    q3.setParameter(1, idList.get(0));
+                    q3.executeUpdate();
+                }
             }
 
             eft.setLatestMarked(true);
@@ -75,6 +87,7 @@ public class EFormReportToolDaoImpl extends AbstractDaoImpl<EFormReportTool> imp
     public void addNew(EFormReportTool eformReportTool, EForm eform, List<String> fields, String providerNo) {
         //generate the create table statement
         String tableName = "ERT_" + eformReportTool.getName() + (new BigInteger(130, new SecureRandom()).toString(8).substring(0, 8));
+        validateIdentifier(tableName);
         StringBuilder sql = new StringBuilder("CREATE TABLE " + tableName + " (");
         sql.append("id int (10) NOT NULL auto_increment primary key,");
         sql.append("fdid int (10) NOT NULL, ");
@@ -84,6 +97,7 @@ public class EFormReportToolDaoImpl extends AbstractDaoImpl<EFormReportTool> imp
         sql.append("eft_latest tinyint(1) NOT NULL, ");
         sql.append("dateCreated timestamp NOT NULL ");
         for (String field : fields) {
+            validateIdentifier(field);
             sql.append(",`" + field + "` text");
         }
         sql.append(")");
@@ -105,6 +119,7 @@ public class EFormReportToolDaoImpl extends AbstractDaoImpl<EFormReportTool> imp
     }
 
     public void populateReportTableItem(EFormReportTool eft, List<EFormValue> values, Integer fdid, Integer demographicNo, Date dateFormCreated, String providerNo) {
+        validateIdentifier(eft.getTableName());
         //create an insert statement
         StringBuilder sb = new StringBuilder();
         sb.append("INSERT INTO ");
@@ -117,6 +132,7 @@ public class EFormReportToolDaoImpl extends AbstractDaoImpl<EFormReportTool> imp
         sb.append("eft_latest,");
         sb.append("dateCreated,");
         for (EFormValue v : values) {
+            validateIdentifier(v.getVarName());
             sb.append("`" + v.getVarName() + "`");
             sb.append(",");
         }
@@ -124,15 +140,18 @@ public class EFormReportToolDaoImpl extends AbstractDaoImpl<EFormReportTool> imp
         sb.deleteCharAt(sb.length() - 1);
 
         sb.append(" ) VALUES (");
-        sb.append(fdid + ",");
-        sb.append(demographicNo + ",");
-        sb.append("\'" + DateFormatUtils.format(dateFormCreated, "yyyy-MM-dd HH:mm:ss") + "\',");
-        sb.append("\'" + providerNo + "\',");
+        sb.append("?1,");
+        sb.append("?2,");
+        sb.append("?3,");
+        sb.append("?4,");
         sb.append("0,");
         sb.append("now(),");
+
+        int paramIndex = 5;
         for (EFormValue v : values) {
-            sb.append("\'" + v.getVarValue() + "\'");
+            sb.append("?" + paramIndex);
             sb.append(",");
+            paramIndex++;
         }
         sb.deleteCharAt(sb.length() - 1);
 
@@ -141,11 +160,23 @@ public class EFormReportToolDaoImpl extends AbstractDaoImpl<EFormReportTool> imp
         //logger.debug("sql=" + sb.toString());
 
         Query q = entityManager.createNativeQuery(sb.toString());
+        q.setParameter(1, fdid);
+        q.setParameter(2, demographicNo);
+        q.setParameter(3, dateFormCreated);
+        q.setParameter(4, providerNo);
+
+        paramIndex = 5;
+        for (EFormValue v : values) {
+            q.setParameter(paramIndex, v.getVarValue());
+            paramIndex++;
+        }
+
         q.executeUpdate();
     }
 
     public void deleteAllData(EFormReportTool eft) {
         if (eft != null) {
+            validateIdentifier(eft.getTableName());
             Query q = entityManager.createNativeQuery("delete from " + eft.getTableName());
             q.executeUpdate();
         }
@@ -153,6 +184,7 @@ public class EFormReportToolDaoImpl extends AbstractDaoImpl<EFormReportTool> imp
 
     public void drop(EFormReportTool eft) {
         if (eft != null) {
+            validateIdentifier(eft.getTableName());
             Query q = entityManager.createNativeQuery("drop table " + eft.getTableName());
             q.executeUpdate();
         }
@@ -160,6 +192,7 @@ public class EFormReportToolDaoImpl extends AbstractDaoImpl<EFormReportTool> imp
 
     public Integer getNumRecords(EFormReportTool eformReportTool) {
         if (eformReportTool != null) {
+            validateIdentifier(eformReportTool.getTableName());
             Query q = entityManager.createNativeQuery("select count(*) from " + eformReportTool.getTableName());
             List<BigInteger> results = q.getResultList();
             if (!results.isEmpty()) {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/EFormReportToolDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/EFormReportToolDaoImpl.java
@@ -50,10 +50,10 @@ public class EFormReportToolDaoImpl extends AbstractDaoImpl<EFormReportTool> imp
         super(EFormReportTool.class);
     }
 
-    private static final java.util.regex.Pattern INVALID_SQL_IDENTIFIER = java.util.regex.Pattern.compile(".*[`].*");
+    private static final java.util.regex.Pattern INVALID_SQL_IDENTIFIER = java.util.regex.Pattern.compile(".*[`';].*");
 
     private void validateIdentifier(String identifier) {
-        if (identifier == null || INVALID_SQL_IDENTIFIER.matcher(identifier).matches() || identifier.contains(";")) {
+        if (identifier == null || INVALID_SQL_IDENTIFIER.matcher(identifier).matches()) {
             throw new IllegalArgumentException("Invalid SQL identifier");
         }
     }
@@ -149,7 +149,8 @@ public class EFormReportToolDaoImpl extends AbstractDaoImpl<EFormReportTool> imp
 
         int paramIndex = 5;
         for (EFormValue v : values) {
-            sb.append("?" + paramIndex);
+            sb.append("?");
+            sb.append(paramIndex);
             sb.append(",");
             paramIndex++;
         }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/EFormReportToolDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/EFormReportToolDaoImpl.java
@@ -53,8 +53,8 @@ public class EFormReportToolDaoImpl extends AbstractDaoImpl<EFormReportTool> imp
     private static final java.util.regex.Pattern INVALID_SQL_IDENTIFIER = java.util.regex.Pattern.compile(".*[`].*");
 
     private void validateIdentifier(String identifier) {
-        if (identifier == null || INVALID_SQL_IDENTIFIER.matcher(identifier).matches()) {
-            throw new IllegalArgumentException("Invalid SQL identifier: " + identifier);
+        if (identifier == null || INVALID_SQL_IDENTIFIER.matcher(identifier).matches() || identifier.contains(";")) {
+            throw new IllegalArgumentException("Invalid SQL identifier");
         }
     }
 


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix SQL Injection in EFormReportToolDaoImpl

🚨 Severity: CRITICAL
💡 Vulnerability: EFormReportToolDaoImpl constructs native SQL queries via raw string concatenation (`createNativeQuery(...)`), exposing it to SQL Injection attacks via user-provided eForm data.
🎯 Impact: Attackers could inject arbitrary SQL queries, leading to data extraction, modification, or deletion.
🔧 Fix: Refactored the queries to use proper parameterized placeholders (`?1`, `?2`, etc.) for values and added a blocklist-based validation (`INVALID_SQL_IDENTIFIER`) for table and column names that cannot be parameterized. Also included defensive checks for list bounds and natively mapped `Date` parameterization.
✅ Verification: Ran full `EForm` integration and unit tests, and validated JSP compilation via `jspc-maven-plugin`.

---
*PR created automatically by Jules for task [6390830806142442569](https://jules.google.com/task/6390830806142442569) started by @yingbull*

## Summary by Sourcery

Harden SQL handling in EFormReportToolDaoImpl to prevent SQL injection and improve safety of dynamic report table operations.

Bug Fixes:
- Replace string-concatenated native SQL queries with parameterized queries for dynamic values in EFormReportToolDaoImpl.
- Add validation for dynamically constructed table and column identifiers to block unsafe SQL identifiers and prevent injection via metadata-driven names.
- Guard latest-record update logic against empty result sets to avoid runtime errors.

Enhancements:
- Introduce a reusable identifier validation helper using a regex-based blocklist for SQL identifiers used in dynamic DDL and DML.
- Document Sentinel security findings and remediation guidance for SQL injection risks in a new .jules/sentinel.md note.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a critical SQL injection in `EFormReportToolDaoImpl` by parameterizing native SQL and validating dynamic identifiers. Hardens report table creation, inserts, latest marking, and admin ops.

- **Bug Fixes**
  - Parameterize dynamic values across select/update/insert (`?1`, `?2`, ...), including `Date` and `providerNo`; bind var values in order.
  - Validate dynamic table/column identifiers; block backticks, semicolons, and apostrophes across create, populate, mark-latest, delete/drop/count.
  - Guard `markLatest` against empty results; parameterize `demographicNo` and `id`.
  - Avoid echoing untrusted identifiers in errors; tighten invalid-identifier regex for static analysis; add a security note in `.jules/sentinel.md`.

<sup>Written for commit 0a6872139ccf8ecfbde44ae199e1d9fb11067d9a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

