### PR TITLE
Fix for Missing variable declaration

### DIFF
--- a/src/main/webapp/library/eforms/editControl.js
+++ b/src/main/webapp/library/eforms/editControl.js
@@ -398,7 +398,7 @@ function loadTemplate(selectname) {
 function parseTemplate() {
     //replace template placeholders with database pulls
     var temp = new Array();
-    contents = editControlContents(cfg_editorname);
+    var contents = editControlContents(cfg_editorname);
     temp = contents.split('##'); //parse for template place holders identified by ##value##
     contents = '';
     var keys = [];
@@ -433,7 +433,7 @@ function parseTemplate() {
 function populateTemplate() {
     //replace template placeholders with database pulls
     var temp = new Array();
-    contents = editControlContents(cfg_editorname);
+    var contents = editControlContents(cfg_editorname);
     temp = contents.split('##'); //parse for template place holders identified by ##value##
     contents = '';
     var x;


### PR DESCRIPTION
Declare `contents` as a local variable inside each function where it is used as temporary state.

Best fix (no functional change):
- In `parseTemplate()` (around line 401), change `contents = editControlContents(cfg_editorname);` to `var contents = editControlContents(cfg_editorname);`.
- In `populateTemplate()` (around line 436), change `contents = editControlContents(cfg_editorname);` to `var contents = editControlContents(cfg_editorname);`.

This keeps behavior identical within each function while preventing accidental implicit global creation. No imports, new methods, or external dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Prevent accidental creation of a global `contents` variable by declaring it locally in `parseTemplate` and `populateTemplate`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scope `contents` to each function to stop implicit global creation in `parseTemplate` and `populateTemplate`. This prevents accidental state leakage across calls with no behavior change.

<sup>Written for commit ba83e450738214cbb7ba23abe0264b63e63e284e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

