### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL Injection in EFormReportToolDaoImpl

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-04-17 - SQL Injection in EFormReportToolDaoImpl
+**Vulnerability:** SQL injection vulnerability in `EFormReportToolDaoImpl.populateReportTableItem` due to unparameterized string concatenation for `EFormValue` values and other fields in `INSERT INTO` dynamic queries.
+**Learning:** Even though column names might need dynamic generation or are verified, data values being inserted MUST be parameterized to prevent SQL injection.
+**Prevention:** Use JPA native queries with sequential parameters (`?1`, `?2`, etc.) and iterate over dynamic collections, matching them up with `setParameter()` calls.

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/EFormReportToolDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/EFormReportToolDaoImpl.java
@@ -39,7 +39,6 @@ import java.util.regex.Pattern;
 
 import jakarta.persistence.Query;
 
-import org.apache.commons.lang3.time.DateFormatUtils;
 import io.github.carlos_emr.carlos.commn.model.EForm;
 import io.github.carlos_emr.carlos.commn.model.EFormReportTool;
 import io.github.carlos_emr.carlos.commn.model.EFormValue;

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/EFormReportToolDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/EFormReportToolDaoImpl.java
@@ -164,14 +164,14 @@ public class EFormReportToolDaoImpl extends AbstractDaoImpl<EFormReportTool> imp
         sb.deleteCharAt(sb.length() - 1);
 
         sb.append(" ) VALUES (");
-        sb.append(fdid + ",");
-        sb.append(demographicNo + ",");
-        sb.append("\'" + DateFormatUtils.format(dateFormCreated, "yyyy-MM-dd HH:mm:ss") + "\',");
-        sb.append("\'" + persistedProviderNo + "\',");
+        sb.append("?1,");
+        sb.append("?2,");
+        sb.append("?3,");
+        sb.append("?4,");
         sb.append("0,");
         sb.append("now(),");
-        for (EFormValue v : values) {
-            sb.append("\'" + v.getVarValue() + "\'");
+        for (int i = 0; i < values.size(); i++) {
+            sb.append("?").append(i + 5);
             sb.append(",");
         }
         sb.deleteCharAt(sb.length() - 1);
@@ -181,6 +181,13 @@ public class EFormReportToolDaoImpl extends AbstractDaoImpl<EFormReportTool> imp
         //logger.debug("sql=" + sb.toString());
 
         Query q = entityManager.createNativeQuery(sb.toString());
+        q.setParameter(1, fdid);
+        q.setParameter(2, demographicNo);
+        q.setParameter(3, dateFormCreated);
+        q.setParameter(4, persistedProviderNo);
+        for (int i = 0; i < values.size(); i++) {
+            q.setParameter(i + 5, values.get(i).getVarValue());
+        }
         q.executeUpdate();
     }
 

--- a/src/test/java/io/github/carlos_emr/carlos/commn/dao/EFormReportToolDaoImplTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/commn/dao/EFormReportToolDaoImplTest.java
@@ -118,7 +118,9 @@ class EFormReportToolDaoImplTest {
 
         ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
         verify(mockEntityManager).createNativeQuery(sqlCaptor.capture());
-        assertThat(sqlCaptor.getValue()).contains(",'null',0,now(),");
+        assertThat(sqlCaptor.getValue()).contains("?1,?2,?3,?4,0,now(),?5");
+        verify(mockQuery).setParameter(4, "null");
+        verify(mockQuery).setParameter(5, "value-one");
     }
 
     @Test
@@ -135,8 +137,9 @@ class EFormReportToolDaoImplTest {
 
         ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
         verify(mockEntityManager).createNativeQuery(sqlCaptor.capture());
-        assertThat(sqlCaptor.getValue()).contains(",'P12345',0,now(),");
-        assertThat(sqlCaptor.getValue()).doesNotContain(",'null',0,now(),");
+        assertThat(sqlCaptor.getValue()).contains("?1,?2,?3,?4,0,now(),?5");
+        verify(mockQuery).setParameter(4, "P12345");
+        verify(mockQuery).setParameter(5, "value-one");
     }
 
     private static EFormValue buildValue(String varName, String varValue) {


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** SQL Injection in `EFormReportToolDaoImpl.populateReportTableItem` due to unparameterized string concatenation for `EFormValue` values and other fields in `INSERT INTO` dynamic queries.
🎯 **Impact:** An attacker could inject arbitrary SQL commands via the dynamically concatenated strings, leading to potential data compromise or corruption.
🔧 **Fix:** Replaced the string concatenations with positional parameters (`?1`, `?2`, etc.) and mapped them correctly using `q.setParameter()`. Also updated the `EFormReportToolDaoImplTest.java` test cases to verify the new parameterization correctly. Added `.jules/sentinel.md` journal entry.
✅ **Verification:** Ran the test cases with `mvn test -Dtest=EFormReportToolDaoImplTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dcheckstyle.skip=true`. All passed properly.

---
*PR created automatically by Jules for task [9818502900692218617](https://jules.google.com/task/9818502900692218617) started by @yingbull*

## Summary by Sourcery

Parameterize dynamic INSERT query construction in EFormReportToolDaoImpl to eliminate SQL injection risk and adjust tests and internal security documentation accordingly.

Bug Fixes:
- Fix SQL injection vulnerability in EFormReportToolDaoImpl.populateReportTableItem by replacing string-concatenated values with positional query parameters.

Documentation:
- Add a Sentinel journal entry documenting the SQL injection vulnerability, its root cause, and recommended prevention practices.

Tests:
- Update EFormReportToolDaoImplTest expectations to assert use of positional parameters and correct parameter values in generated SQL.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a critical SQL injection in `EFormReportToolDaoImpl.populateReportTableItem` by parameterizing the dynamic INSERT query to block arbitrary SQL and protect report data.

- **Bug Fixes**
  - Replaced concatenated values (`fdid`, `demographicNo`, `dateFormCreated`, `persistedProviderNo`, each `EFormValue`) with positional params (`?1...`) and bound them with `q.setParameter(...)`; `dateFormCreated` is now passed as a param (no manual formatting).
  - Preserved legacy `'null'` provider number behavior.
  - Updated `EFormReportToolDaoImplTest` to assert placeholders and parameter binding; added `.jules/sentinel.md` with vulnerability notes.

<sup>Written for commit 6076a847498767990dce37c28bd5cf996d004296. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

