### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL Injection in DrugDaoImpl

### DIFF
--- a/.github/workflows/spotbugs.yml
+++ b/.github/workflows/spotbugs.yml
@@ -168,6 +168,7 @@ jobs:
             echo '========================================='
             echo 'Compiling and running SpotBugs analysis'
             echo '========================================='
+            export MAVEN_OPTS="-Xmx4g"
             mvn -B compile spotbugs:spotbugs \
               -Pspotbugs,skip-dependency-lock \
               -DskipTests \

--- a/.github/workflows/spotbugs.yml
+++ b/.github/workflows/spotbugs.yml
@@ -172,6 +172,7 @@ jobs:
             mvn -B compile spotbugs:spotbugs \
               -Pspotbugs,skip-dependency-lock \
               -DskipTests \
+              -Dspotbugs.maxHeap=4096 \
               -T 1C
           "
 

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-04-17 - Prevent SQL Injection in dynamic Drug parameter queries
+**Vulnerability:** The `findByParameter` method in `DrugDaoImpl` concatenated the `parameter` (column name) and `value` arguments directly into a NativeQuery, leading to a critical SQL injection vulnerability.
+**Learning:** Native queries cannot parameterize column names. To prevent SQL injection when the column name must be dynamically generated, the column parameter must be validated against a strict allowlist of allowed columns before being used. The values themselves should always be parameterized (e.g., `?1`).
+**Prevention:** Use an allowlist to validate dynamic column inputs and always parameterize input values via `query.setParameter(...)`. Fail securely by throwing an `IllegalArgumentException` on invalid inputs.

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/DrugDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/DrugDaoImpl.java
@@ -480,9 +480,14 @@ public class DrugDaoImpl extends AbstractDaoImpl<Drug> implements DrugDao {
     @SuppressWarnings("unchecked")
     @Override
     public List<Object[]> findByParameter(String parameter, String value) {
-        String sql = "select special,special_instruction from drugs where " + parameter + " = '" + value
-                + "' order by drugid desc";
+        java.util.List<String> validColumns = java.util.Arrays.asList("customName", "regional_identifier", "BN");
+        if (parameter == null || !validColumns.contains(parameter)) {
+            throw new IllegalArgumentException("Invalid parameter name");
+        }
+        String sql = "select special,special_instruction from drugs where " + parameter + " = ?1"
+                + " order by drugid desc";
         Query query = entityManager.createNativeQuery(sql);
+        query.setParameter(1, value);
         return query.getResultList();
     }
 


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `findByParameter` method in `DrugDaoImpl` constructed a native SQL query using direct string concatenation for both the column name (`parameter`) and the search value (`value`). This created a severe SQL injection vulnerability.
🎯 **Impact:** An attacker could craft a malicious payload through the column name or value parameter to execute arbitrary SQL commands, potentially reading, modifying, or deleting sensitive medical database records.
🔧 **Fix:** 
- Modified the native SQL query to parameterize the `value` argument using `?1`.
- Introduced a strict allowlist validation for the dynamically supplied `parameter` argument (since SQL column names cannot be parameterized). It now throws an `IllegalArgumentException` if an invalid column name is requested.
✅ **Verification:** Ran `DrugDaoIntegrationTest` to ensure that logic remains intact and syntax errors are avoided. Checked that SQL injections are safely mitigated.

---
*PR created automatically by Jules for task [3236128988505148013](https://jules.google.com/task/3236128988505148013) started by @yingbull*

## Summary by Sourcery

Harden dynamic drug lookup queries against SQL injection and document the applied security fix.

Bug Fixes:
- Eliminate SQL injection risk in DrugDaoImpl.findByParameter by validating allowed column names and parameterizing the search value.

Documentation:
- Add a Sentinel security note documenting the SQL injection vulnerability in DrugDaoImpl and the mitigation strategy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a critical SQL injection in `DrugDaoImpl.findByParameter` and stabilizes SpotBugs CI by setting `MAVEN_OPTS=-Xmx4g` and `-Dspotbugs.maxHeap=4096` to avoid OOM.

- **Bug Fixes**
  - Harden query: parameterize `value` with `?1`; allowlist `parameter` to `["customName", "regional_identifier", "BN"]` and throw `IllegalArgumentException` if invalid.

<sup>Written for commit 9fb7c21c1e4f9c6273780196112f6c69369daec9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

