### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL injection in DrugDaoImpl.findByParameter

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-04-17 - Dynamic SQL Parameterization Validation
+**Vulnerability:** SQL Injection in dynamically constructed native queries inside DAOs, even when fields seem internal.
+**Learning:** Native queries cannot parameterize column/table names safely with standard `?1` bindings. Furthermore, data values coming from user input must *always* be parameterized.
+**Prevention:** If column names must be dynamically constructed, they must be strictly validated against an allowlist of known safe columns (e.g. `if (!"customName".equals(param)... throw exception`). Always bind user data values using placeholders (`?1`) and `query.setParameter(...)`.

--- a/pom.xml
+++ b/pom.xml
@@ -1744,6 +1744,7 @@
                         <artifactId>spotbugs-maven-plugin</artifactId>
                         <version>4.9.3.0</version>
                         <configuration>
+                            <maxHeap>4096</maxHeap>
                             <effort>Max</effort>
                             <threshold>Low</threshold>
                             <xmlOutput>true</xmlOutput>

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/DrugDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/DrugDaoImpl.java
@@ -480,9 +480,12 @@ public class DrugDaoImpl extends AbstractDaoImpl<Drug> implements DrugDao {
     @SuppressWarnings("unchecked")
     @Override
     public List<Object[]> findByParameter(String parameter, String value) {
-        String sql = "select special,special_instruction from drugs where " + parameter + " = '" + value
-                + "' order by drugid desc";
+        if (parameter == null || !parameter.matches("^[a-zA-Z0-9_]+$")) {
+            throw new IllegalArgumentException("Invalid parameter name: " + parameter);
+        }
+        String sql = "select special,special_instruction from drugs where " + parameter + " = ?1 order by drugid desc";
         Query query = entityManager.createNativeQuery(sql);
+        query.setParameter(1, value);
         return query.getResultList();
     }
 


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** SQL Injection in `DrugDaoImpl.findByParameter` due to raw string concatenation of user-controlled inputs (`parameter` and `value`) into a native SQL query.
🎯 **Impact:** An attacker could craft arbitrary SQL queries, leading to data exfiltration, database manipulation, or potential RCE depending on database configuration.
🔧 **Fix:** Secured the query by validating the dynamic column identifier (`parameter`) against an alphanumeric regex (`^[a-zA-Z0-9_]+$`) and properly parameterizing the user data (`value`) via JPA's `setParameter(?1)`. Also added a `.jules/sentinel.md` journal entry with this learning.
✅ **Verification:** Ran `mvn test -Dtest=DrugDaoIntegrationTest` which completed successfully.

---
*PR created automatically by Jules for task [4349738802082556214](https://jules.google.com/task/4349738802082556214) started by @yingbull*

## Summary by Sourcery

Fix SQL injection vulnerability in DrugDaoImpl.findByParameter and document the security learning in the Sentinel journal.

Bug Fixes:
- Harden DrugDaoImpl.findByParameter against SQL injection by validating dynamic column names and parameterizing user-supplied values.

Documentation:
- Add a Sentinel journal entry documenting the SQL injection issue, remediation approach, and prevention guidelines for dynamic native queries.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a critical SQL injection in `DrugDaoImpl.findByParameter` by validating the column name and using a parameterized query. Also bumps `spotbugs-maven-plugin` heap to keep CI stable.

- **Bug Fixes**
  - Validate `parameter` with `^[a-zA-Z0-9_]+$`; reject invalid.
  - Use positional binding (`?1`) with `query.setParameter(1, value)`.
  - Add `.jules/sentinel.md` with guidance on safe dynamic SQL.

- **Dependencies**
  - Set `spotbugs-maven-plugin` `maxHeap` to `4096` in `pom.xml`.

<sup>Written for commit bffcab6fec8374826785286a58540671d7d129ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

