### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL injection in DemographicDaoImpl

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-01-30 - Prevent SQL Injection in DemographicDaoImpl ORDER BY clause
+**Vulnerability:** The `getOrderField` method in `DemographicDaoImpl` concatenated the `orderBy` string directly into the query when `nativeQuery` was true (`orderBy = "de." + orderBy;`), creating a SQL injection vulnerability if the `orderBy` parameter was user-controlled.
+**Learning:** Order by clauses cannot be parameterized with placeholders in JPA/Hibernate. Dynamic order by columns must be strictly validated against an allowlist to prevent SQL injection.
+**Prevention:** Always use an allowlist mapping approach for dynamic column names or order by directions, and provide a safe default fallback.

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDaoImpl.java
@@ -1512,16 +1512,30 @@ public class DemographicDaoImpl extends AbstractHibernateDao implements Applicat
     @Override
     public String getOrderField(String orderBy, boolean nativeQuery) {
         if (!nativeQuery) {
-            orderBy = getOrderField(orderBy);
+            return getOrderField(orderBy);
         } else {
-            if (orderBy.equals("dob")) {
-                orderBy = "de.year_of_birth, de.month_of_birth, de.date_of_birth ";
+            if ("dob".equals(orderBy)) {
+                return "de.year_of_birth, de.month_of_birth, de.date_of_birth ";
+            } else if ("last_name".equals(orderBy) || "last_name, first_name".equals(orderBy)) {
+                return "de.last_name, de.first_name";
+            } else if ("demographic_no".equals(orderBy)) {
+                return "de.demographic_no";
+            } else if ("chart_no".equals(orderBy)) {
+                return "de.chart_no";
+            } else if ("sex".equals(orderBy)) {
+                return "de.sex";
+            } else if ("provider_no".equals(orderBy)) {
+                return "de.provider_no";
+            } else if ("roster_status".equals(orderBy)) {
+                return "de.roster_status";
+            } else if ("patient_status".equals(orderBy)) {
+                return "de.patient_status";
+            } else if ("phone".equals(orderBy)) {
+                return "de.phone";
             } else {
-                orderBy = "de." + orderBy;
+                return "de.last_name, de.first_name";
             }
         }
-
-        return orderBy;
     }
 
     @Override


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix SQL injection in DemographicDaoImpl

🚨 Severity: CRITICAL
💡 Vulnerability: The `getOrderField` method in `DemographicDaoImpl` concatenated the `orderBy` string directly into a native SQL query when `nativeQuery` was true (`orderBy = "de." + orderBy;`). This created a SQL injection vulnerability if the `orderBy` parameter was controlled by user input.
🎯 Impact: A malicious user could inject arbitrary SQL commands into the `ORDER BY` clause, leading to data exfiltration or potential remote code execution via database specific features.
🔧 Fix: Replaced the unsafe string concatenation with a strict mapping (allowlist) that checks expected inputs (like `"dob"`, `"last_name"`) and returns hardcoded safe values for the `ORDER BY` clause. Added a safe default fallback.
✅ Verification: Ran `mvn test -Dtest=DemographicDaoModernTest` successfully and verified code using read_file. Also added a journal entry to `.jules/sentinel.md` noting the vulnerability and prevention.

---
*PR created automatically by Jules for task [14138780481457133059](https://jules.google.com/task/14138780481457133059) started by @yingbull*

## Summary by Sourcery

Harden DemographicDaoImpl native ORDER BY handling to prevent SQL injection and document the remediation in the security journal.

Bug Fixes:
- Eliminate SQL injection risk in DemographicDaoImpl.getOrderField by replacing dynamic concatenation with a strict allowlist of supported ORDER BY fields and a safe default.

Documentation:
- Add a Sentinel security journal entry describing the ORDER BY SQL injection vulnerability, its root cause, and the adopted prevention strategy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a SQL injection vector in `DemographicDaoImpl.getOrderField` when building native ORDER BY clauses. Replaces dynamic string concatenation with a strict allowlist of supported columns and a safe default.

<sup>Written for commit fa3e1cc70795042e7778ee2231854de68d43bdeb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

