### PR TITLE
chore: migration bug fixes

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/app/HttpMethodGuardFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/app/HttpMethodGuardFilter.java
@@ -134,7 +134,7 @@ public class HttpMethodGuardFilter implements Filter {
      */
     private static final Set<String> READ_ONLY_ACTION_NAMES = Set.of(
             "createbillingreportaction",  // PDF/CSV download — GET is correct for file downloads
-            "createdate"                  // ScheduleCreateDate2Action (schedule bulk-date editor):
+            "createdate",                 // ScheduleCreateDate2Action (schedule bulk-date editor):
                                           // GET serves month-navigation reloads (bFirstDisp=0);
                                           // ScheduleCreateDate2Action.execute() enforces POST for
                                           // real mutations (bFirstDisp null or "1") internally.
@@ -145,6 +145,11 @@ public class HttpMethodGuardFilter implements Filter {
                                           // action name 'createdate' matches the unconditional
                                           // "create" mutator prefix, so we exempt it here and rely
                                           // on the action's own POST check for mutations.
+            "addappointment"              // ViewAppointmentWrite2Action — view gate that loads the
+                                          // add-appointment form. The name starts with "add" so it
+                                          // matches MUTATOR_ACTION_PREFIXES, but the action itself
+                                          // only renders a JSP — the actual write goes through
+                                          // appointment/AddRecord (which IS a POST-only mutator).
     );
 
     /**

--- a/src/main/webapp/WEB-INF/classes/struts-integration.xml
+++ b/src/main/webapp/WEB-INF/classes/struts-integration.xml
@@ -136,6 +136,15 @@
         <action name="administration/index" class="io.github.carlos_emr.carlos.administration.gate.ViewAdministrationIndex2Action">
             <result name="success">/WEB-INF/jsp/administration/index.jsp</result>
         </action>
+        <!-- Compatibility mapping: /administration is the clean section-root URL used
+             by the main menu, left nav, and popup targets. Maps the same auth gate
+             action directly so the browser URL stays clean (no visible /index suffix).
+             Note: callers must use the extensionless form '/administration' without a
+             trailing slash — Tomcat does not strip trailing slashes before Struts
+             matching, and '/administration/' does not route cleanly under this setup. -->
+        <action name="administration" class="io.github.carlos_emr.carlos.administration.gate.ViewAdministrationIndex2Action">
+            <result name="success">/WEB-INF/jsp/administration/index.jsp</result>
+        </action>
         <action name="common/OntarioMDRedirect" class="io.github.carlos_emr.carlos.common.gate.ViewOntarioMDRedirect2Action">
             <result name="success">/WEB-INF/jsp/common/OntarioMDRedirect.jsp</result>
         </action>

--- a/src/main/webapp/WEB-INF/classes/struts.xml
+++ b/src/main/webapp/WEB-INF/classes/struts.xml
@@ -37,7 +37,7 @@
     <constant name="struts.actionConfig.fallbackToEmptyNamespace" value="true" />
     <constant name="struts.serve.static" value="true" />
     <constant name="struts.serve.static.browserCache" value="true" />
-    <constant name="struts.action.excludePattern" value=".*\.(css|js|png|jpg|gif|svg|ico|map|woff|woff2|ttf|eot|html|htm)$|^(/[^/]+)?/WEB-INF/.*|^/ws/.*|^/servlet/.*" />
+    <constant name="struts.action.excludePattern" value=".*\.(css|js|png|jpg|gif|svg|ico|map|woff|woff2|ttf|eot|html|htm|jsp|jspf)$|^(/[^/]+)?/WEB-INF/.*|^/ws/.*|^/servlet/.*|^/csrfguard$" />
     <constant name="struts.custom.i18n.resources" value="oscarResources,MessageResources_mcedt"/>
     <constant name="struts.multipart.maxSize" value="524288000" />
     <!-- Use stream-based multipart parser (reads from getInputStream()) instead of the default

--- a/src/main/webapp/WEB-INF/jsp/admin/UsageReport.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/UsageReport.jsp
@@ -30,6 +30,7 @@
 --%>
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/admin/billingreferralAdmin.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/billingreferralAdmin.jsp
@@ -28,6 +28,7 @@
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <fmt:setBundle basename="oscarResources"/>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     if (session.getAttribute("userrole") == null) response.sendRedirect(request.getContextPath() + "/logoutPage");
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");

--- a/src/main/webapp/WEB-INF/jsp/admin/clinicAdmin.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/clinicAdmin.jsp
@@ -50,6 +50,7 @@
 <%@ page import="io.github.carlos_emr.carlos.report.reportByTemplate.*" %>
 <%@ page import="io.github.carlos_emr.carlos.commn.model.Clinic" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 <%
     Clinic clinic = (Clinic) request.getAttribute("clinicForm");

--- a/src/main/webapp/WEB-INF/jsp/admin/demographicmergerecord.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/demographicmergerecord.jsp
@@ -35,6 +35,7 @@
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <fmt:setBundle basename="oscarResources"/>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/admin/oscarLogging.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/oscarLogging.jsp
@@ -33,6 +33,7 @@
 <c:set var="ctx" value="${pageContext.request.contextPath}"
        scope="request"/>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/admin/providerPrivilege.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/providerPrivilege.jsp
@@ -77,6 +77,7 @@
 <%@ page import="io.github.carlos_emr.carlos.log.LogConst" %>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <%

--- a/src/main/webapp/WEB-INF/jsp/admin/providerRole.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/providerRole.jsp
@@ -58,6 +58,7 @@
 <%@ page import="io.github.carlos_emr.carlos.commn.IsPropertiesOn" %>
 <%@ page import="io.github.carlos_emr.CarlosProperties" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 <%
     ProgramDao programDao = SpringUtils.getBean(ProgramDao.class);

--- a/src/main/webapp/WEB-INF/jsp/admin/providerupdateprovider.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/providerupdateprovider.jsp
@@ -36,6 +36,7 @@
 <fmt:setBundle basename="oscarResources"/>
 <%@ taglib uri="/WEB-INF/caisi-tag.tld" prefix="caisi" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = session.getAttribute("userrole") + "," + session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/admin/unLock.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/unLock.jsp
@@ -90,6 +90,7 @@
 %>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">

--- a/src/main/webapp/WEB-INF/jsp/admin/updatedemographicprovider.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/updatedemographicprovider.jsp
@@ -65,6 +65,7 @@
 <fmt:setBundle basename="oscarResources"/>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <html>
     <head>
         <title><fmt:message key="admin.admin.btnUpdatePatientProvider"/></title>

--- a/src/main/webapp/WEB-INF/jsp/administration/index.jsp
+++ b/src/main/webapp/WEB-INF/jsp/administration/index.jsp
@@ -75,6 +75,7 @@
 <fmt:setBundle basename="oscarResources"/>
 <%@ taglib uri="/WEB-INF/caisi-tag.tld" prefix="caisi" %>
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <%
     if (session.getAttribute("userrole") == null) response.sendRedirect(request.getContextPath() + "/logoutPage");

--- a/src/main/webapp/WEB-INF/jsp/administration/leftNav.jspf
+++ b/src/main/webapp/WEB-INF/jsp/administration/leftNav.jspf
@@ -33,6 +33,7 @@
 <%@ page import="io.github.carlos_emr.carlos.commn.IsPropertiesOn" %>
 <%@ taglib uri="jakarta.tags.core" prefix="c"%>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <%
 String curProvider_no = (String)session.getAttribute("user");
@@ -48,7 +49,7 @@ String curProvider_no = (String)session.getAttribute("user");
 	<div class="accordion" id="adminNav">
 
 		<div class="p-2" style="margin-bottom:0px;color:#000">
-		<a href="${ctx}/administration/"><i class="fa-solid fa-gear"></i> <fmt:message key="admin.admin.page.title"/></a>
+		<a href="${ctx}/administration"><i class="fa-solid fa-gear"></i> <fmt:message key="admin.admin.page.title"/></a>
 		</div>
 
 <!-- #USER MANAGEMENT -->

--- a/src/main/webapp/WEB-INF/jsp/appointment/appointmentaddrecordcard.jsp
+++ b/src/main/webapp/WEB-INF/jsp/appointment/appointmentaddrecordcard.jsp
@@ -52,6 +52,7 @@
         import="java.sql.*, java.util.*, io.github.carlos_emr.MyDateFormat, io.github.carlos_emr.carlos.commn.OtherIdManager, io.github.carlos_emr.carlos.util.ConversionUtils" %>
 <%@ page import="io.github.carlos_emr.carlos.event.EventService, io.github.carlos_emr.carlos.utility.SpringUtils" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <%@page import="io.github.carlos_emr.carlos.commn.dao.AppointmentArchiveDao" %>

--- a/src/main/webapp/WEB-INF/jsp/appointment/appointmentaddrecordprint.jsp
+++ b/src/main/webapp/WEB-INF/jsp/appointment/appointmentaddrecordprint.jsp
@@ -53,6 +53,7 @@
         import="java.sql.*, java.util.*, io.github.carlos_emr.MyDateFormat, io.github.carlos_emr.carlos.commn.OtherIdManager,io.github.carlos_emr.carlos.demographic.data.*,java.text.SimpleDateFormat,io.github.carlos_emr.carlos.utility.SpringUtils" %>
 <%@ page import="io.github.carlos_emr.carlos.event.EventService" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <%@page import="io.github.carlos_emr.carlos.commn.dao.OscarAppointmentDao" %>

--- a/src/main/webapp/WEB-INF/jsp/appointment/appointmentviewrecordcard.jsp
+++ b/src/main/webapp/WEB-INF/jsp/appointment/appointmentviewrecordcard.jsp
@@ -56,6 +56,7 @@
 <%@ page import="io.github.carlos_emr.carlos.commn.model.UserProperty" %>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <%@ include file="/WEB-INF/jsp/common/webAppContextAndSuperMgr.jsp" %>

--- a/src/main/webapp/WEB-INF/jsp/appointment/printappointment.jsp
+++ b/src/main/webapp/WEB-INF/jsp/appointment/printappointment.jsp
@@ -29,6 +29,7 @@
 --%>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <%@ page import="io.github.carlos_emr.carlos.commn.dao.UserPropertyDAO" %>

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/adjustBill.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/adjustBill.jsp
@@ -50,6 +50,7 @@
 
 <%@ taglib uri="/WEB-INF/rewrite-tag.tld" prefix="rewrite" %>
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@page import="io.github.carlos_emr.carlos.billing.ca.bc.data.*,io.github.carlos_emr.*,io.github.carlos_emr.carlos.commn.model.*" %>
 <%@page import="java.math.*, java.util.*, java.sql.*, io.github.carlos_emr.*, java.net.*,io.github.carlos_emr.carlos.billing.ca.bc.MSP.*" %>
 <%@page import="org.springframework.web.context.WebApplicationContext,org.springframework.web.context.support.WebApplicationContextUtils, io.github.carlos_emr.carlos.entities.*" %>

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billStatus.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billStatus.jsp
@@ -50,6 +50,7 @@
 <fmt:setBundle basename="oscarResources"/>
 
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <%@page import="io.github.carlos_emr.carlos.utility.SpringUtils" %>
 <%@page import="io.github.carlos_emr.carlos.commn.dao.ReportProviderDao" %>

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingAccountReports.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingAccountReports.jsp
@@ -1,5 +1,6 @@
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingCalendarPopup.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingCalendarPopup.jsp
@@ -32,6 +32,7 @@
 Use returnForm and returnItem request params and this page will fill in that input item on that page
 -->
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 
 

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingCodeAdjust.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingCodeAdjust.jsp
@@ -31,6 +31,7 @@
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingCodeNewSearch.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingCodeNewSearch.jsp
@@ -38,6 +38,7 @@
 <%@ page import="io.github.carlos_emr.carlos.billings.ca.bc.pageUtil.ServiceCodeAssociation" %>
 <%@ page import="io.github.carlos_emr.carlos.billings.ca.bc.pageUtil.BillingAssociationPersistence" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingCodeNewUpdate.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingCodeNewUpdate.jsp
@@ -30,6 +30,7 @@
 --%>
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingCorrection.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingCorrection.jsp
@@ -30,6 +30,7 @@
 --%>
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingCreated.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingCreated.jsp
@@ -54,6 +54,7 @@
 
 
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <%@ page import="io.github.carlos_emr.carlos.billing.ca.bc.data.*,io.github.carlos_emr.carlos.billing.ca.bc.pageUtil.*" %>
 <%@page import="io.github.carlos_emr.carlos.utility.SpringUtils" %>

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingDigNewSearch.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingDigNewSearch.jsp
@@ -33,6 +33,7 @@
 <%@ page import="io.github.carlos_emr.carlos.utility.SpringUtils" %>
 <%@ page import="io.github.carlos_emr.carlos.commn.model.DiagnosticCode" %>
 <%@ page import="io.github.carlos_emr.carlos.commn.dao.DiagnosticCodeDao" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     DiagnosticCodeDao diagnosticCodeDao = SpringUtils.getBean(DiagnosticCodeDao.class);
 %>

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingDigNewUpdate.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingDigNewUpdate.jsp
@@ -30,6 +30,7 @@ b<%--
 --%>
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingEditCode.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingEditCode.jsp
@@ -45,6 +45,7 @@
 %>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <%@ page import="java.util.*,io.github.carlos_emr.carlos.billings.ca.bc.data.BillingCodeData,io.github.carlos_emr.carlos.billing.ca.bc.pageUtil.*" %>

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingGetPriceCode.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingGetPriceCode.jsp
@@ -37,6 +37,7 @@
 <%@page import="io.github.carlos_emr.carlos.utility.SpringUtils" %>
 <%@page import="io.github.carlos_emr.carlos.commn.dao.BillingServiceDao" %>
 <%@page import="io.github.carlos_emr.carlos.commn.model.BillingService" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 
 <%

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingManageReferralDoc.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingManageReferralDoc.jsp
@@ -46,6 +46,7 @@
 %>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <%@ page

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingPreferences.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingPreferences.jsp
@@ -1,5 +1,6 @@
 <%@ taglib prefix="oscar" uri="/oscarPropertiestag" %>
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@page import="java.util.*,io.github.carlos_emr.carlos.util.*" %>
 <%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="io.github.carlos_emr.carlos.commn.model.SystemPreferences" %>

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingReferCodeSearch.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingReferCodeSearch.jsp
@@ -38,6 +38,7 @@
 <%@page import="io.github.carlos_emr.carlos.utility.SpringUtils" %>
 <%@page import="io.github.carlos_emr.carlos.commn.model.Billingreferral" %>
 <%@page import="io.github.carlos_emr.carlos.commn.dao.BillingreferralDao" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     BillingreferralDao billingReferralDao = (BillingreferralDao) SpringUtils.getBean(BillingreferralDao.class);
 %>

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingReferCodeUpdate.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingReferCodeUpdate.jsp
@@ -30,6 +30,7 @@
 --%>
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingReportCenter.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingReportCenter.jsp
@@ -30,6 +30,7 @@
 --%>
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingReportControl.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingReportControl.jsp
@@ -33,6 +33,7 @@
 
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingSim.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingSim.jsp
@@ -25,6 +25,7 @@
 
 <%@page import="java.nio.charset.StandardCharsets" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingTeleplanGroupReport.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingTeleplanGroupReport.jsp
@@ -30,6 +30,7 @@
 --%>
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingView.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingView.jsp
@@ -50,6 +50,7 @@
         response.sendRedirect(request.getContextPath() + "/logoutPage");
 %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/checkEligibility.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/checkEligibility.jsp
@@ -1,4 +1,5 @@
 <%@ page import="io.github.carlos_emr.Misc" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%--
 
     Copyright (c) 2001-2002. Department of Family Medicine, McMaster University. All Rights Reserved.

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/formwcb.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/formwcb.jsp
@@ -59,6 +59,7 @@
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
 
 <%@ taglib uri="/WEB-INF/rewrite-tag.tld" prefix="rewrite" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <%
     boolean readonly = false;

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/genTA.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/genTA.jsp
@@ -30,6 +30,7 @@
 --%>
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/genTAS00.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/genTAS00.jsp
@@ -29,6 +29,7 @@
 
 --%>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/genTAS00ByOfficeNo.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/genTAS00ByOfficeNo.jsp
@@ -29,6 +29,7 @@
 
 --%>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/genTAS01.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/genTAS01.jsp
@@ -29,6 +29,7 @@
 
 --%>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/genTAS22.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/genTAS22.jsp
@@ -29,6 +29,7 @@
 
 --%>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/onAddEdit3rdAddr.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/onAddEdit3rdAddr.jsp
@@ -165,6 +165,7 @@
 
 %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <html>

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/onSearch3rdBillAddr.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/onSearch3rdBillAddr.jsp
@@ -121,6 +121,7 @@
 
 <%@ page import="org.apache.commons.text.WordUtils" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/privateBilling/printPreview.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/privateBilling/printPreview.jsp
@@ -22,6 +22,7 @@
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     if (session.getAttribute("user") == null)
         response.sendRedirect(request.getContextPath() + "/logoutPage");

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/support/billingcodes.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/support/billingcodes.jsp
@@ -32,6 +32,7 @@
 
 <%@page import="io.github.carlos_emr.carlos.utility.SpringUtils" %>
 <%@page import="io.github.carlos_emr.carlos.commn.dao.BillingServiceDao" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     if (session.getAttribute("user") == null) {
         response.sendRedirect(request.getContextPath() + "/logoutPage");

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/support/billingfeeitem.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/support/billingfeeitem.jsp
@@ -35,6 +35,7 @@
 <%@ page import="io.github.carlos_emr.carlos.util.UtilDateUtilities" %>
 <%@ page import="io.github.carlos_emr.carlos.commn.model.BillingService" %>
 <%@ page import="io.github.carlos_emr.Misc" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     if (session.getAttribute("user") == null) {
         response.sendRedirect(request.getContextPath() + "/logoutPage");

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/support/bodypart.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/support/bodypart.jsp
@@ -32,6 +32,7 @@
 <%@page import="io.github.carlos_emr.carlos.utility.SpringUtils" %>
 <%@page import="io.github.carlos_emr.carlos.billing.CA.dao.WcbBpCodeDao" %>
 <%@ page import="io.github.carlos_emr.Misc" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <%
     if (session.getAttribute("user") == null) {

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/support/icd9.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/support/icd9.jsp
@@ -32,6 +32,7 @@
 <%@ page import="io.github.carlos_emr.carlos.commn.model.DiagnosticCode" %>
 <%@ page import="io.github.carlos_emr.carlos.commn.dao.DiagnosticCodeDao" %>
 <%@ page import="io.github.carlos_emr.Misc" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <%
     DiagnosticCodeDao diagnosticCodeDao = SpringUtils.getBean(DiagnosticCodeDao.class);

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/support/natureinjury.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/support/natureinjury.jsp
@@ -33,6 +33,7 @@
 <%@page import="io.github.carlos_emr.carlos.utility.SpringUtils" %>
 <%@page import="io.github.carlos_emr.carlos.billing.CA.BC.dao.WcbNoiCodeDao" %>
 <%@ page import="io.github.carlos_emr.Misc" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <html>
     <head>

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/teleplan/ManageTeleplan.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/teleplan/ManageTeleplan.jsp
@@ -38,6 +38,7 @@
 
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
 <%@ taglib uri="/WEB-INF/rewrite-tag.tld" prefix="rewrite" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <% TeleplanUserPassDAO dao = new TeleplanUserPassDAO();
     String superUser = (String) session.getAttribute("user");
 %>

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/viewReconcileReports.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/viewReconcileReports.jsp
@@ -29,6 +29,7 @@
 
 --%>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/wcbForms.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/wcbForms.jsp
@@ -55,6 +55,7 @@
 <%@ page import="io.github.carlos_emr.carlos.util.StringUtils" %>
 <%@taglib uri="jakarta.tags.core" prefix="c" %>
 <%@taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 <%
     String demographicNo = request.getParameter("demographicNo");

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/ON/addEditServiceCode.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/ON/addEditServiceCode.jsp
@@ -300,6 +300,7 @@
 
 %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <html>

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/ON/batchBilling.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/ON/batchBilling.jsp
@@ -43,6 +43,7 @@
 <%@page import="io.github.carlos_emr.carlos.utility.SpringUtils" %>
 <%@page import="io.github.carlos_emr.carlos.commn.dao.ClinicLocationDao, io.github.carlos_emr.carlos.PMmodule.dao.ProviderDao, io.github.carlos_emr.carlos.commn.dao.BatchBillingDAO, io.github.carlos_emr.carlos.commn.dao.DemographicDao" %>
 <%@page import="io.github.carlos_emr.carlos.commn.model.ClinicLocation, io.github.carlos_emr.carlos.commn.model.Provider, io.github.carlos_emr.carlos.commn.model.BatchBilling, io.github.carlos_emr.carlos.commn.model.Demographic" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <c:set var="ctx" value="${pageContext.request.contextPath}" scope="request"/>
 <%
     ClinicLocationDao clinicLocationDao = (ClinicLocationDao) SpringUtils.getBean(ClinicLocationDao.class);

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingCalendarPopup.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingCalendarPopup.jsp
@@ -31,6 +31,7 @@
         errorPage="/WEB-INF/jsp/error/errorpage.jsp" %>
 <%@ page import="io.github.carlos_emr.DateInMonthTable" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingCodeSearch.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingCodeSearch.jsp
@@ -31,6 +31,7 @@
 <%@ page import="io.github.carlos_emr.carlos.util.StringUtils" %>
 <%@ page import="io.github.carlos_emr.carlos.commn.dao.BillingServiceDao" %>
 <%@ page import="io.github.carlos_emr.carlos.commn.model.BillingService" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <%
     BillingServiceDao billingServiceDao = SpringUtils.getBean(BillingServiceDao.class);

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingCodeUpdate.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingCodeUpdate.jsp
@@ -31,6 +31,7 @@
 <%@page import="io.github.carlos_emr.carlos.utility.SpringUtils" %>
 <%@page import="io.github.carlos_emr.carlos.commn.dao.BillingServiceDao" %>
 <%@page import="io.github.carlos_emr.carlos.commn.model.BillingService" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     BillingServiceDao billingServiceDao = SpringUtils.getBean(BillingServiceDao.class);
 %>

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingDigSearch.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingDigSearch.jsp
@@ -69,6 +69,7 @@
 %>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <html>

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingEditWithApptNo.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingEditWithApptNo.jsp
@@ -42,6 +42,7 @@
 <%@ page import="io.github.carlos_emr.carlos.billings.ca.on.data.BillingClaimHeader1Data" %>
 <%@ page import="io.github.carlos_emr.carlos.util.ConversionUtils" %>
 <%@ page import="io.github.carlos_emr.CarlosProperties" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String prov = request.getParameter("billRegion");
     String billForm = request.getParameter("billForm");

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingLreport.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingLreport.jsp
@@ -16,6 +16,7 @@
 <%@page import="java.nio.charset.Charset" %>
 <%@ page language="java" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingOHIPsimulation.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingOHIPsimulation.jsp
@@ -29,6 +29,7 @@
 <%@ page import="io.github.carlos_emr.carlos.utility.DateRange" %>
 <%! boolean bMultisites = IsPropertiesOn.isMultisitesEnable(); %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@ page import="java.math.*, java.util.*, io.github.carlos_emr.carlos.util.*" %>
 <%
     if (session.getAttribute("userrole") == null) response.sendRedirect(request.getContextPath() + "/logoutPage");

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingON.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingON.jsp
@@ -34,6 +34,7 @@
 
 
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@ page errorPage="/WEB-INF/jsp/error/errorpage.jsp"%>
 
 <%@page import="java.util.*,java.net.*,java.sql.*" %>

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingON3rdInv.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingON3rdInv.jsp
@@ -48,6 +48,7 @@
 <%@ page import="org.owasp.encoder.Encode" %>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingONCorrection.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingONCorrection.jsp
@@ -63,6 +63,7 @@
 <%@taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <% if (session.getAttribute("user") == null)

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingONDisplay.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingONDisplay.jsp
@@ -86,6 +86,7 @@
 %>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <html>

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingONEditPrivateCode.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingONEditPrivateCode.jsp
@@ -159,6 +159,7 @@
     }
 %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingONHistorySpec.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingONHistorySpec.jsp
@@ -33,6 +33,7 @@
 <%@ page import="io.github.carlos_emr.carlos.billings.ca.on.data.BillingDataHlp" %>
 <%@ page import="io.github.carlos_emr.MyDateFormat" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     if (session.getAttribute("user") == null)
         response.sendRedirect(request.getContextPath() + "/logout.htm");

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingONMRI.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingONMRI.jsp
@@ -41,6 +41,7 @@
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <fmt:setBundle basename="oscarResources"/>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <%@ include file="/WEB-INF/jsp/admin/dbconnection.jsp" %>
 

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingONNewReport.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingONNewReport.jsp
@@ -63,6 +63,7 @@
 <%@ page import="org.owasp.encoder.Encode" %>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <%

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingONPayment.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingONPayment.jsp
@@ -32,6 +32,7 @@
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <%@page import="io.github.carlos_emr.carlos.utility.SpringUtils,io.github.carlos_emr.carlos.utility.LocaleUtils,io.github.carlos_emr.carlos.utility.MiscUtils, io.github.carlos_emr.carlos.util.DateUtils" %>

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingONSave.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingONSave.jsp
@@ -13,6 +13,7 @@
     @since 2026
 --%>
 <%@ page contentType="text/html;charset=UTF-8" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <!DOCTYPE html>
 <html>
 <head>

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingONSaveWorkloadRedirect.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingONSaveWorkloadRedirect.jsp
@@ -13,6 +13,7 @@
     @since 2026
 --%>
 <%@ page contentType="text/html;charset=UTF-8" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String workloadUrlBack = (String) request.getAttribute("workloadUrlBack");
 %>

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingONStatus.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingONStatus.jsp
@@ -53,6 +53,7 @@
     <%@taglib uri="jakarta.tags.core" prefix="c"%>
     --%>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     if (session.getAttribute("userrole") == null) response.sendRedirect(request.getContextPath() + "/logoutPage");
     String roleName$ = session.getAttribute("userrole") + "," + session.getAttribute("user");

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingONfavourite.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingONfavourite.jsp
@@ -222,6 +222,7 @@
     }
 %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <html>

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingReportCenter.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingReportCenter.jsp
@@ -43,6 +43,7 @@
 <%@ page import="io.github.carlos_emr.carlos.commn.model.ReportProvider" %>
 <%@ page import="io.github.carlos_emr.carlos.commn.model.Provider" %>
 <%@ page import="io.github.carlos_emr.carlos.commn.dao.ReportProviderDao" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     ReportProviderDao reportProviderDao = SpringUtils.getBean(ReportProviderDao.class);
 %>

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingReportControl.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingReportControl.jsp
@@ -46,6 +46,7 @@
 <%@ page import="io.github.carlos_emr.carlos.commn.dao.OscarAppointmentDao" %>
 <%@ page import="io.github.carlos_emr.carlos.commn.model.Appointment" %>
 <%@ page import="io.github.carlos_emr.CarlosProperties" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     ReportProviderDao reportProviderDao = SpringUtils.getBean(ReportProviderDao.class);
     BillingDao billingDao = SpringUtils.getBean(BillingDao.class);

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingReport_unbilled.jspf
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingReport_unbilled.jspf
@@ -2,6 +2,7 @@
 <%@page import="java.util.List" %>
 <%@page import="io.github.carlos_emr.carlos.commn.model.Appointment" %>
 <%@page import="io.github.carlos_emr.carlos.commn.dao.OscarAppointmentDao" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <table width="100%" border="2" valign="top">
 	<% 
 String dateBegin = request.getParameter("xml_vdate");

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingShortcutPg2.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingShortcutPg2.jsp
@@ -44,6 +44,7 @@
     String service_form = "";
 %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 
 <%@ page errorPage="/WEB-INF/jsp/error/errorpage.jsp" import="java.util.*,java.math.*,java.net.*,java.sql.*, io.github.carlos_emr.carlos.util.*, io.github.carlos_emr.*" %>

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/ON/editBillingPaymentType.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/ON/editBillingPaymentType.jsp
@@ -31,6 +31,7 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <%@ page import="java.util.List" %>
 <%@ page import="io.github.carlos_emr.carlos.commn.model.BillingPaymentType" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html>
 

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/ON/genRADesc.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/ON/genRADesc.jsp
@@ -25,6 +25,7 @@
 
 <%@page import="io.github.carlos_emr.carlos.utility.LoggedInInfo" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <%@page import="io.github.carlos_emr.carlos.util.DateUtils" %>

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/ON/genRASummary.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/ON/genRASummary.jsp
@@ -51,6 +51,7 @@
 <%@page import="io.github.carlos_emr.carlos.utility.MiscUtils" %>
 <%@ page import="io.github.carlos_emr.carlos.util.UtilDateUtilities" %>
 <%@ page import="io.github.carlos_emr.SxmlMisc" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <html>
 <head>
     <script type="text/javascript" src="<%= request.getContextPath() %>/js/global.js"></script>

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/ON/genRASummaryDetail.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/ON/genRASummaryDetail.jsp
@@ -52,6 +52,7 @@
 <%@ page import="io.github.carlos_emr.carlos.util.UtilDateUtilities" %>
 <%@ page import="io.github.carlos_emr.carlos.util.ConversionUtils" %>
 <%@ page import="io.github.carlos_emr.SxmlMisc" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <html>
 <head>
     <script type="text/javascript" src="<%= request.getContextPath() %>/js/global.js"></script>

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/ON/inr/dbUpdateINRbilling.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/ON/inr/dbUpdateINRbilling.jsp
@@ -33,6 +33,7 @@
     @since 2026-04-05
 --%>
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <html>
 <head>
     <script language="JavaScript">

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/ON/inr/updateINRbilling.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/ON/inr/updateINRbilling.jsp
@@ -30,6 +30,7 @@
 <%@page import="io.github.carlos_emr.carlos.billing.CA.dao.BillingInrDao" %>
 <%@page import="io.github.carlos_emr.carlos.utility.SpringUtils" %>
 <%@page import="io.github.carlos_emr.carlos.util.ConversionUtils" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     DemographicDao demographicDao = SpringUtils.getBean(DemographicDao.class);
 %>

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/ON/manageBillingform_add.jspf
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/ON/manageBillingform_add.jspf
@@ -33,6 +33,7 @@
 <%@page import="io.github.carlos_emr.carlos.commn.dao.CtlBillingServiceDao" %>
 <%@ page import="io.github.carlos_emr.carlos.util.StringUtils" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <% String errorMessage = request.getParameter("errorMessage"); %>
 

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/ON/manageBillingform_dx.jspf
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/ON/manageBillingform_dx.jspf
@@ -28,6 +28,7 @@
 <%@page import="io.github.carlos_emr.carlos.commn.model.CtlDiagCode" %>
 <%@page import="io.github.carlos_emr.carlos.commn.dao.CtlDiagCodeDao" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@ page import="io.github.carlos_emr.carlos.util.StringUtils" %>
 
 <form method="post" name="form1" action="DbManageBillingformDx">

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/ON/manageBillingform_service.jspf
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/ON/manageBillingform_service.jspf
@@ -28,6 +28,7 @@
 <%@page import="io.github.carlos_emr.carlos.commn.model.CtlBillingService" %>
 <%@page import="io.github.carlos_emr.carlos.commn.dao.CtlBillingServiceDao" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@ page import="io.github.carlos_emr.carlos.util.StringUtils" %>
 
 <form method="post" name="form1"

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/ON/onAddEdit3rdAddr.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/ON/onAddEdit3rdAddr.jsp
@@ -149,6 +149,7 @@
 
 %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <html>

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/ON/onGenRAError.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/ON/onGenRAError.jsp
@@ -28,6 +28,7 @@
          errorPage="/WEB-INF/jsp/error/errorpage.jsp" %>
 <%@ page import="io.github.carlos_emr.carlos.billing.ca.on.pageUtil.*" %>
 <%@ page import="io.github.carlos_emr.carlos.billings.ca.on.pageUtil.BillingRAPrep" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <html>
 <head>
     <script type="text/javascript" src="<%= request.getContextPath() %>/js/global.js"></script>

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/ON/onGenRASummary.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/ON/onGenRASummary.jsp
@@ -38,6 +38,7 @@
 <%@ page import="io.github.carlos_emr.carlos.util.UtilDateUtilities" %>
 <%@ page import="io.github.carlos_emr.carlos.commn.IsPropertiesOn" %>
 <%@ page import="io.github.carlos_emr.SxmlMisc" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     RaHeaderDao dao = SpringUtils.getBean(RaHeaderDao.class);
 %>

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/ON/onSearch3rdBillAddr.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/ON/onSearch3rdBillAddr.jsp
@@ -84,6 +84,7 @@
 <%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="io.github.carlos_emr.carlos.util.StringUtils" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <html>

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/ON/printBillingClipboard.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/ON/printBillingClipboard.jsp
@@ -24,6 +24,7 @@
 --%>
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 <%@ page import="org.owasp.encoder.Encode" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     if (session.getAttribute("user") == null)
         response.sendRedirect(request.getContextPath() + "/logoutPage");

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/ON/searchRefDoc.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/ON/searchRefDoc.jsp
@@ -155,6 +155,7 @@
 %>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 

--- a/src/main/webapp/WEB-INF/jsp/calendar/oscarCalendarPopup.jsp
+++ b/src/main/webapp/WEB-INF/jsp/calendar/oscarCalendarPopup.jsp
@@ -36,6 +36,7 @@
 <%@ page
         import="java.util.*, java.sql.*, io.github.carlos_emr.*, java.text.*,java.net.*" %>
 <%@ page import="io.github.carlos_emr.DateInMonthTable" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     //to prepare calendar display
     String type = request.getParameter("type");

--- a/src/main/webapp/WEB-INF/jsp/casemgmt/CaseManagementView.jsp
+++ b/src/main/webapp/WEB-INF/jsp/casemgmt/CaseManagementView.jsp
@@ -47,6 +47,7 @@
 <%@ page import="io.github.carlos_emr.carlos.casemgmt.model.CaseManagementCPP" %>
 <%@ page import="io.github.carlos_emr.carlos.utility.MiscUtils" %>
 <%@ page import="io.github.carlos_emr.carlos.util.StringUtils" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     Logger logger = MiscUtils.getLogger();
 

--- a/src/main/webapp/WEB-INF/jsp/casemgmt/ChartNotes.jsp
+++ b/src/main/webapp/WEB-INF/jsp/casemgmt/ChartNotes.jsp
@@ -52,6 +52,7 @@
 <%@include file="/WEB-INF/jsp/casemgmt/taglibs.jsp" %>
 <fmt:setBundle basename="oscarResources"/>
 <%@taglib uri="/WEB-INF/caisi-tag.tld" prefix="caisi" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@page import="java.util.Enumeration" %>
 <%@page import="io.github.carlos_emr.carlos.encounter.pageUtil.NavBarDisplayDAO" %>
 <%@page import="java.util.Arrays,java.util.Properties,java.util.List,java.util.Set,java.util.ArrayList,java.util.Enumeration,java.util.HashSet,java.util.Iterator,java.text.SimpleDateFormat,java.util.Calendar,java.util.Date,java.text.ParseException" %>

--- a/src/main/webapp/WEB-INF/jsp/casemgmt/ChartNotesAjax.jsp
+++ b/src/main/webapp/WEB-INF/jsp/casemgmt/ChartNotesAjax.jsp
@@ -49,6 +49,7 @@
 <%@include file="/WEB-INF/jsp/casemgmt/taglibs.jsp" %>
 <fmt:setBundle basename="oscarResources"/>
 <%@taglib uri="/WEB-INF/caisi-tag.tld" prefix="caisi" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@page import="java.util.Enumeration" %>
 <%@page import="io.github.carlos_emr.carlos.encounter.pageUtil.NavBarDisplayDAO" %>
 <%@page import="java.util.Arrays,java.util.Properties,java.util.List,java.util.Set,java.util.ArrayList,java.util.Enumeration,java.util.HashSet,java.util.Iterator,java.text.SimpleDateFormat,java.util.Calendar,java.util.Date,java.text.ParseException" %>

--- a/src/main/webapp/WEB-INF/jsp/casemgmt/groupNoteSelect.jsp
+++ b/src/main/webapp/WEB-INF/jsp/casemgmt/groupNoteSelect.jsp
@@ -29,6 +29,7 @@
 --%>
 <%@ page import="io.github.carlos_emr.carlos.casemgmt.web.formbeans.CaseManagementEntryFormBean"%>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/casemgmt/historyview.jsp
+++ b/src/main/webapp/WEB-INF/jsp/casemgmt/historyview.jsp
@@ -27,6 +27,7 @@
     CARLOS has no affiliation with OSCAR or McMaster University.
 
 --%>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 
 <%@ include file="/WEB-INF/jsp/casemgmt/taglibs.jsp" %>

--- a/src/main/webapp/WEB-INF/jsp/casemgmt/navigation.jsp
+++ b/src/main/webapp/WEB-INF/jsp/casemgmt/navigation.jsp
@@ -37,6 +37,7 @@
 <%@ include file="/WEB-INF/jsp/casemgmt/taglibs.jsp" %>
 <%@ taglib uri="jakarta.tags.functions" prefix="fn" %>
 <%@ taglib uri="/WEB-INF/caisi-tag.tld" prefix="caisi" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@ page import="io.github.carlos_emr.carlos.encounter.oscarMeasurements.MeasurementFlowSheet" %>
 <%@ page import="io.github.carlos_emr.carlos.encounter.oscarMeasurements.MeasurementTemplateFlowSheetConfig" %>
 <%@ page import="io.github.carlos_emr.carlos.encounter.oscarMeasurements.util.MeasurementHelper" %>

--- a/src/main/webapp/WEB-INF/jsp/casemgmt/newEncounterHeader.jsp
+++ b/src/main/webapp/WEB-INF/jsp/casemgmt/newEncounterHeader.jsp
@@ -33,7 +33,7 @@
 <fmt:setBundle basename="oscarResources"/>
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
-<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@ page import="io.github.carlos_emr.carlos.utility.MiscUtils" %>
 <%@ page import="io.github.carlos_emr.carlos.utility.LoggedInInfo, io.github.carlos_emr.carlos.commn.model.Facility" %>
 <%@ page import="io.github.carlos_emr.carlos.utility.SpringUtils" %>

--- a/src/main/webapp/WEB-INF/jsp/casemgmt/newEncounterLayout.jsp
+++ b/src/main/webapp/WEB-INF/jsp/casemgmt/newEncounterLayout.jsp
@@ -29,6 +29,7 @@
 --%>
 
 <%@ taglib uri="/WEB-INF/caisi-tag.tld" prefix="caisi" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <%@ include file="/WEB-INF/jsp/casemgmt/taglibs.jsp" %>
 <fmt:setBundle basename="oscarResources"/>

--- a/src/main/webapp/WEB-INF/jsp/casemgmt/noteBrowser.jsp
+++ b/src/main/webapp/WEB-INF/jsp/casemgmt/noteBrowser.jsp
@@ -45,6 +45,7 @@
 <%@ taglib uri="/WEB-INF/oscarProperties-tag.tld" prefix="oscarProp" %>
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <jsp:useBean id="oscarVariables" class="java.util.Properties" scope="page"/>
 
 <%@page import="java.net.URLDecoder, java.net.URLEncoder,java.util.Date, java.util.List" %>
@@ -138,7 +139,7 @@
 <html>
 <head>
     <title><fmt:message key="encounter.noteBrowser.title"/> - <oscar:nameage
-            demographicNo="<e:forHtmlAttribute value='<%= demographicID %>' />"/></title>
+            demographicNo="<%= demographicID %>"/></title>
     <script type="text/javascript">
 
         function popup(vheight, vwidth, varpage) { //open a new popup window
@@ -483,7 +484,7 @@ t?editDocumentNo=' + docid + '&function=<%=module%>&functionid=<e:forJavaScript 
         <%}%>
         <tr>
             <td align="left" valign="top" width="50%">
-                <oscar:nameage demographicNo="<e:forHtmlAttribute value='<%= demographicID %>' />"/><br>
+                <oscar:nameage demographicNo="<%= demographicID %>"/><br>
 
                 <input type="hidden" name="viewstatus" value="<e:forHtmlAttribute value='<%= viewstatus %>' />">
                 <input type="hidden" name="sortorder" value="<e:forHtmlAttribute value='<%= sortorder %>' />">

--- a/src/main/webapp/WEB-INF/jsp/casemgmt/viewNotes.jsp
+++ b/src/main/webapp/WEB-INF/jsp/casemgmt/viewNotes.jsp
@@ -85,7 +85,7 @@
 	SecurityManager securityManager = new SecurityManager();
 	if(securityManager.hasWriteAccess("_" + request.getParameter("issue_code"),roleName$)) {
 %>
-<a href="javascript:void(0)" title='Add Item' onclick="return showEdit(event,'<fmt:message key="<e:forHtmlAttribute value='<%= paramTitle %>' />" />','',0,'','','','<e:forJavaScriptAttribute value='<%= (String) request.getAttribute("addUrl") %>' />0', '<e:forJavaScriptAttribute value='<%= paramCmd %>' />','<e:forJavaScriptAttribute value='<%= (String) request.getAttribute("identUrl") %>' />','<e:forJavaScriptAttribute value='<%= (String) request.getAttribute("cppIssue") %>' />','','<e:forJavaScriptAttribute value='<%= paramDemoNo %>' />');">+</a>
+<a href="javascript:void(0)" title='Add Item' onclick="return showEdit(event,'<fmt:message key="<%= paramTitle %>" />','',0,'','','','<e:forJavaScriptAttribute value='<%= (String) request.getAttribute("addUrl") %>' />0', '<e:forJavaScriptAttribute value='<%= paramCmd %>' />','<e:forJavaScriptAttribute value='<%= (String) request.getAttribute("identUrl") %>' />','<e:forJavaScriptAttribute value='<%= (String) request.getAttribute("cppIssue") %>' />','','<e:forJavaScriptAttribute value='<%= paramDemoNo %>' />');">+</a>
 <% } else { %>
 	&nbsp;
 <% } %>
@@ -94,7 +94,7 @@
 <div class="nav-menu-title">
 <h3>
 	<a href="javascript:void(0)" onclick="return showIssueHistory('<e:forJavaScriptAttribute value='<%= io.github.carlos_emr.carlos.util.StringUtils.noNull(request.getParameter("demographicNo")) %>' />','<e:forJavaScriptAttribute value='<%= String.valueOf(request.getAttribute("issueIds")) %>' />');">
-<fmt:message key="<e:forHtmlAttribute value='<%= paramTitle %>' />" /></a>
+<fmt:message key="<%= paramTitle %>" /></a>
 </h3>
 </div>
 </div>

--- a/src/main/webapp/WEB-INF/jsp/common/OntarioMDRedirect.jsp
+++ b/src/main/webapp/WEB-INF/jsp/common/OntarioMDRedirect.jsp
@@ -33,6 +33,7 @@
 <%@page import="org.springframework.web.context.WebApplicationContext,io.github.carlos_emr.carlos.commn.dao.*,io.github.carlos_emr.carlos.commn.model.*" %>
 <%@ page import="io.github.carlos_emr.carlos.commn.dao.UserPropertyDAO" %>
 <%@ page import="io.github.carlos_emr.carlos.commn.model.UserProperty" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
 
     WebApplicationContext ctx = WebApplicationContextUtils.getRequiredWebApplicationContext(getServletContext());

--- a/src/main/webapp/WEB-INF/jsp/decision/annualreview/annualreviewplanner.jsp
+++ b/src/main/webapp/WEB-INF/jsp/decision/annualreview/annualreviewplanner.jsp
@@ -77,6 +77,7 @@
 <%@ page import="org.w3c.dom.Document" %>
 <%@ page import="org.w3c.dom.Node" %>
 <%@ page import="org.w3c.dom.NodeList" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     DesAnnualReviewPlanDao desAnnualReviewPlanDao = SpringUtils.getBean(DesAnnualReviewPlanDao.class);
 %>

--- a/src/main/webapp/WEB-INF/jsp/decision/antenatal/antenatalplanner.jsp
+++ b/src/main/webapp/WEB-INF/jsp/decision/antenatal/antenatalplanner.jsp
@@ -46,6 +46,7 @@
 <%@page import="io.github.carlos_emr.carlos.commn.model.Desaprisk" %>
 <%@page import="io.github.carlos_emr.carlos.commn.dao.DesapriskDao" %>
 <%@ page import="io.github.carlos_emr.SxmlMisc" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     DesapriskDao desapriskDao = SpringUtils.getBean(DesapriskDao.class);
 %>

--- a/src/main/webapp/WEB-INF/jsp/decision/antenatal/antenatalplannerprint.jsp
+++ b/src/main/webapp/WEB-INF/jsp/decision/antenatal/antenatalplannerprint.jsp
@@ -49,6 +49,7 @@
 <%@page import="io.github.carlos_emr.carlos.commn.dao.DesapriskDao" %>
 <%@ page import="io.github.carlos_emr.carlos.db.DBHandler" %>
 <%@ page import="io.github.carlos_emr.SxmlMisc" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     DesapriskDao desapriskDao = SpringUtils.getBean(DesapriskDao.class);
 %>

--- a/src/main/webapp/WEB-INF/jsp/decision/antenatal/obarchecklistedit_99_12.jsp
+++ b/src/main/webapp/WEB-INF/jsp/decision/antenatal/obarchecklistedit_99_12.jsp
@@ -46,6 +46,7 @@
 <%@ page import="io.github.carlos_emr.carlos.managers.SecurityInfoManager" %>
 <%@ page import="io.github.carlos_emr.carlos.utility.LoggedInInfo" %>
 <%@ page import="io.github.carlos_emr.carlos.utility.SpringUtils" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <% java.util.Properties oscarVariables = CarlosProperties.getInstance(); %>
 
 <html>

--- a/src/main/webapp/WEB-INF/jsp/demographic/AddAlternateContact.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/AddAlternateContact.jsp
@@ -74,6 +74,7 @@
 <fmt:setBundle basename="oscarResources"/>
 
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <%
     CtlRelationshipsDao ctlRelationshipsDao = SpringUtils.getBean(CtlRelationshipsDao.class);

--- a/src/main/webapp/WEB-INF/jsp/demographic/ManageContacts.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/ManageContacts.jsp
@@ -33,6 +33,7 @@
 <%@ page import="io.github.carlos_emr.carlos.commn.model.Contact" %>
 <%@page import="io.github.carlos_emr.carlos.commn.model.DemographicContact" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/demographic/add-form-personal.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/add-form-personal.jsp
@@ -29,6 +29,7 @@
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
 <%@ taglib uri="/WEB-INF/caisi-tag.tld" prefix="caisi" %>
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <c:set var="ctx" value="${ pageContext.request.contextPath }"/>
 <%-- Retrieve variables from request attributes (set by DemographicAdd2Action) --%>
 <%

--- a/src/main/webapp/WEB-INF/jsp/demographic/addnewdemographicswipe.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/addnewdemographicswipe.jsp
@@ -28,6 +28,7 @@
     CARLOS has no affiliation with OSCAR or McMaster University.
 
 --%>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <html>
 <head>
     <script type="text/javascript" src="<%= request.getContextPath() %>/js/global.js"></script>

--- a/src/main/webapp/WEB-INF/jsp/demographic/contact.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/contact.jsp
@@ -34,6 +34,7 @@
 <%@page import="io.github.carlos_emr.carlos.utility.SpringUtils" %>
 <%@page import="io.github.carlos_emr.carlos.PMmodule.dao.ProviderDao" %>
 <%@page import="io.github.carlos_emr.carlos.commn.model.DemographicContact" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String id = request.getParameter("id");
     StringUtils.trimToEmpty(id);

--- a/src/main/webapp/WEB-INF/jsp/demographic/contactSearch.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/contactSearch.jsp
@@ -35,6 +35,7 @@
 <%@ page import="io.github.carlos_emr.carlos.commn.web.Contact2Action" %>
 <%@ page import="io.github.carlos_emr.carlos.commn.model.Contact" %>
 <%@ page import="org.apache.commons.text.WordUtils" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <%@ include file="/taglibs.jsp" %>
 <fmt:setBundle basename="oscarResources"/>

--- a/src/main/webapp/WEB-INF/jsp/demographic/demographicAudit.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/demographicAudit.jsp
@@ -62,6 +62,7 @@
 
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 
 <head>

--- a/src/main/webapp/WEB-INF/jsp/demographic/demographicCohort.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/demographicCohort.jsp
@@ -32,6 +32,7 @@
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%@ taglib uri="jakarta.tags.functions" prefix="fn" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/demographic/demographicaddarecord.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/demographicaddarecord.jsp
@@ -42,6 +42,7 @@
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <fmt:setBundle basename="oscarResources"/>
 <%@ taglib uri="/WEB-INF/caisi-tag.tld" prefix="caisi" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@ page import="org.owasp.encoder.Encode" %>
 <html>
 <head>

--- a/src/main/webapp/WEB-INF/jsp/demographic/demographicappthistory.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/demographicappthistory.jsp
@@ -84,6 +84,7 @@
 
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 
 <%!

--- a/src/main/webapp/WEB-INF/jsp/demographic/demographiceditdemographic.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/demographiceditdemographic.jsp
@@ -1631,7 +1631,7 @@
                                                                     %>
                                                                     <jsp:include page="<%=fieldJSP%>">
                                                                         <jsp:param name="demo"
-                                                                                   value="<e:forHtmlAttribute value='<%= demographic_no %>' />"/>
+                                                                                   value="<%= demographic_no %>"/>
                                                                     </jsp:include>
                                                                     <%}%>
 
@@ -2124,7 +2124,7 @@
                                                                     <jsp:include page="./displayFirstNationsModule.jsp"
                                                                                  flush="false">
                                                                         <jsp:param name="demo"
-                                                                                   value="<e:forHtmlAttribute value='<%= demographic_no %>' />"/>
+                                                                                   value="<%= demographic_no %>"/>
                                                                         <jsp:param name="fncommunity"
                                                                                    value="${fncommunity}"/>
                                                                     </jsp:include>
@@ -2517,7 +2517,7 @@
                                                                     value="true">
                                                                 <jsp:include page="displayHealthCareTeam.jsp">
                                                                     <jsp:param name="demographicNo"
-                                                                               value="<e:forHtmlAttribute value='<%= demographic_no %>' />"/>
+                                                                               value="<%= demographic_no %>"/>
                                                                 </jsp:include>
                                                             </oscar:oscarPropertiesCheck>
                                                                 <%-- TOGGLE OFF PATIENT CLINIC STATUS --%>
@@ -3840,7 +3840,7 @@
                                                             <td colspan="8">
                                                                 <jsp:include page="manageFirstNationsModule.jsp">
                                                                     <jsp:param name="demo"
-                                                                               value="<e:forHtmlAttribute value='<%= demographic_no %>' />"/>
+                                                                               value="<%= demographic_no %>"/>
                                                                 </jsp:include>
                                                             </td>
                                                         </tr>
@@ -4783,7 +4783,7 @@
                                                             <td colspan="4">
                                                                 <jsp:include page="manageHealthCareTeam.jsp">
                                                                     <jsp:param name="demographicNo"
-                                                                               value="<e:forHtmlAttribute value='<%= demographic_no %>' />"/>
+                                                                               value="<%= demographic_no %>"/>
                                                                 </jsp:include>
                                                             </td>
                                                         </tr>

--- a/src/main/webapp/WEB-INF/jsp/demographic/demographiclabelprintsetting.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/demographiclabelprintsetting.jsp
@@ -60,6 +60,7 @@
 
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 

--- a/src/main/webapp/WEB-INF/jsp/demographic/demographicprintdemographic.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/demographicprintdemographic.jsp
@@ -34,6 +34,7 @@
          errorPage="/WEB-INF/jsp/error/errorpage.jsp" %>
 <%@ page import="io.github.carlos_emr.carlos.util.StringUtils" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 

--- a/src/main/webapp/WEB-INF/jsp/demographic/demographicsearch2apptresults.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/demographicsearch2apptresults.jsp
@@ -50,6 +50,7 @@
 
 <%@ taglib uri="/WEB-INF/caisi-tag.tld" prefix="caisi" %>
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <c:set var="ctx" value="${pageContext.request.contextPath}"/>
 

--- a/src/main/webapp/WEB-INF/jsp/demographic/demographicsearch2reportresults.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/demographicsearch2reportresults.jsp
@@ -42,6 +42,7 @@
 <fmt:setBundle basename="oscarResources"/>
 
 <%@ taglib uri="/WEB-INF/caisi-tag.tld" prefix="caisi" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <%
     String curProvider_no = request.getParameter("provider_no");

--- a/src/main/webapp/WEB-INF/jsp/demographic/demographicsearchresults.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/demographicsearchresults.jsp
@@ -479,7 +479,7 @@
                         </a></td>
                     </caisi:isModuleLoad>
                     <caisi:isModuleLoad moduleName="caisi" reverse="true">
-                        <td class="name"><e:forHtmlContent value='<%= Misc.toUpperLowerCase(demo.getLastName() + ", " + Misc.toUpperLowerCase(demo.getFirstName()) + " " + Misc.toUpperLowerCase(demo.getMiddleNames())) %>' />
+                        <td class="name"><e:forHtmlContent value='<%= Misc.toUpperLowerCase(demo.getLastName() + ", " + Misc.toUpperLowerCase(demo.getFirstName()) + (demo.getMiddleNames() != null && !demo.getMiddleNames().isEmpty() ? " " + Misc.toUpperLowerCase(demo.getMiddleNames()) : "")) %>' />
                         </td>
                     </caisi:isModuleLoad>
                     <td class="chartNo"><e:forHtmlContent value='<%= demo.getChartNo() == null || demo.getChartNo().equals("") ? " " : demo.getChartNo() %>' />

--- a/src/main/webapp/WEB-INF/jsp/demographic/demographicupdatearecord.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/demographicupdatearecord.jsp
@@ -36,6 +36,7 @@
     @since 2026-04-04
 --%>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 <html>
 <head>

--- a/src/main/webapp/WEB-INF/jsp/demographic/edit-form-clinical.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/edit-form-clinical.jsp
@@ -1171,7 +1171,7 @@
                                                             <td colspan="4">
                                                                 <jsp:include page="/WEB-INF/jsp/demographic/manageHealthCareTeam.jsp">
                                                                     <jsp:param name="demographicNo"
-                                                                               value="<e:forHtmlAttribute value='<%= demographic_no %>' />"/>
+                                                                               value="<%= demographic_no %>"/>
                                                                 </jsp:include>
                                                             </td>
                                                         </tr>

--- a/src/main/webapp/WEB-INF/jsp/demographic/edit-form-personal.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/edit-form-personal.jsp
@@ -74,6 +74,7 @@
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
 <%@ taglib uri="/WEB-INF/special_tag.tld" prefix="special" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <c:set var="ctx" value="${ pageContext.request.contextPath }"/>
 <%-- Retrieve all variables from request attributes (set by DemographicEdit2Action) --%>
 <%
@@ -1472,7 +1473,7 @@
                                                             <td colspan="8">
                                                                 <jsp:include page="/WEB-INF/jsp/demographic/manageFirstNationsModule.jsp">
                                                                     <jsp:param name="demo"
-                                                                               value="<e:forHtmlAttribute value='<%= demographic_no %>' />"/>
+                                                                               value="<%= demographic_no %>"/>
                                                                 </jsp:include>
                                                             </td>
                                                         </tr>

--- a/src/main/webapp/WEB-INF/jsp/demographic/edit-view.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/edit-view.jsp
@@ -349,7 +349,7 @@
                                                                     %>
                                                                     <jsp:include page="<%=fieldJSP%>">
                                                                         <jsp:param name="demo"
-                                                                                   value="<e:forHtmlAttribute value='<%= demographic_no %>' />"/>
+                                                                                   value="<%= demographic_no %>"/>
                                                                     </jsp:include>
                                                                     <%}%>
 
@@ -830,7 +830,7 @@
                                                                     <jsp:include page="/WEB-INF/jsp/demographic/displayFirstNationsModule.jsp"
                                                                                  flush="false">
                                                                         <jsp:param name="demo"
-                                                                                   value="<e:forHtmlAttribute value='<%= demographic_no %>' />"/>
+                                                                                   value="<%= demographic_no %>"/>
                                                                         <jsp:param name="fncommunity"
                                                                                    value="${fncommunity}"/>
                                                                     </jsp:include>
@@ -1216,7 +1216,7 @@
                                                                     value="true">
                                                                 <jsp:include page="/WEB-INF/jsp/demographic/displayHealthCareTeam.jsp">
                                                                     <jsp:param name="demographicNo"
-                                                                               value="<e:forHtmlAttribute value='<%= demographic_no %>' />"/>
+                                                                               value="<%= demographic_no %>"/>
                                                                 </jsp:include>
                                                             </oscar:oscarPropertiesCheck>
                                                                 <%-- TOGGLE OFF PATIENT CLINIC STATUS --%>

--- a/src/main/webapp/WEB-INF/jsp/demographic/printAddressLabel.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/printAddressLabel.jsp
@@ -45,6 +45,7 @@
 
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <%@ page import="io.github.carlos_emr.carlos.commn.dao.UserPropertyDAO" %>

--- a/src/main/webapp/WEB-INF/jsp/demographic/printClientLabLabel.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/printClientLabLabel.jsp
@@ -44,6 +44,7 @@
 %>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <%@ page import="io.github.carlos_emr.carlos.commn.dao.UserPropertyDAO" %>

--- a/src/main/webapp/WEB-INF/jsp/demographic/printDemoChartLabel.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/printDemoChartLabel.jsp
@@ -45,6 +45,7 @@
 %>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <%@ page import="io.github.carlos_emr.carlos.commn.dao.UserPropertyDAO" %>

--- a/src/main/webapp/WEB-INF/jsp/demographic/printDemoLabel.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/printDemoLabel.jsp
@@ -45,6 +45,7 @@
 
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <%@ page import="io.github.carlos_emr.carlos.commn.dao.UserPropertyDAO" %>

--- a/src/main/webapp/WEB-INF/jsp/demographic/printEnvelope.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/printEnvelope.jsp
@@ -29,6 +29,7 @@
 --%>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <%@ page import="io.github.carlos_emr.carlos.commn.dao.UserPropertyDAO" %>

--- a/src/main/webapp/WEB-INF/jsp/demographic/procontact.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/procontact.jsp
@@ -37,6 +37,7 @@
 <%@page import="io.github.carlos_emr.carlos.PMmodule.dao.ProviderDao" %>
 <%@page import="io.github.carlos_emr.carlos.commn.model.DemographicContact" %>
 <%@ page import="io.github.carlos_emr.CarlosProperties" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String id = request.getParameter("id");
     ProviderDao providerDao = (ProviderDao) SpringUtils.getBean(ProviderDao.class);

--- a/src/main/webapp/WEB-INF/jsp/demographic/procontactSearch.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/procontactSearch.jsp
@@ -55,6 +55,7 @@
 <%@ page import="io.github.carlos_emr.carlos.commn.model.ProfessionalContact" %>
 <%@ page import="io.github.carlos_emr.carlos.commn.model.Contact" %>
 <%@ page import="org.apache.commons.text.WordUtils" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <%@ include file="/taglibs.jsp" %>
 <fmt:setBundle basename="oscarResources"/>

--- a/src/main/webapp/WEB-INF/jsp/demographic/professionalSpecialistSearch.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/professionalSpecialistSearch.jsp
@@ -54,6 +54,7 @@
 <%@ page import="io.github.carlos_emr.carlos.commn.web.Contact2Action" %>
 <%@ page import="io.github.carlos_emr.carlos.commn.model.ProfessionalSpecialist" %>
 <%@ page import="org.apache.commons.text.WordUtils" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <%@ include file="/taglibs.jsp" %>
 <fmt:setBundle basename="oscarResources"/>

--- a/src/main/webapp/WEB-INF/jsp/demographic/zdemographicfulltitlesearch.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/zdemographicfulltitlesearch.jsp
@@ -67,6 +67,7 @@
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%@ taglib uri="/WEB-INF/caisi-tag.tld" prefix="caisi" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <script type="application/javascript">
     /**

--- a/src/main/webapp/WEB-INF/jsp/documentManager/MultiPageDocDisplay.jsp
+++ b/src/main/webapp/WEB-INF/jsp/documentManager/MultiPageDocDisplay.jsp
@@ -55,6 +55,7 @@
 
 <%@ taglib uri="/WEB-INF/rewrite-tag.tld" prefix="rewrite" %>
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@page import="org.springframework.web.context.support.WebApplicationContextUtils,io.github.carlos_emr.carlos.lab.ca.all.*,io.github.carlos_emr.carlos.mds.data.*,io.github.carlos_emr.carlos.lab.ca.all.util.*" %>
 <%@page import="org.springframework.web.context.WebApplicationContext,io.github.carlos_emr.carlos.commn.dao.*,io.github.carlos_emr.carlos.commn.model.*, io.github.carlos_emr.carlos.PMmodule.dao.ProviderDao" %>
 <%@ page import="io.github.carlos_emr.carlos.documentManager.EDocUtil" %>

--- a/src/main/webapp/WEB-INF/jsp/documentManager/addDocument.jsp
+++ b/src/main/webapp/WEB-INF/jsp/documentManager/addDocument.jsp
@@ -47,6 +47,7 @@
 <fmt:setBundle basename="oscarResources"/>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@ page
         import="java.util.*, io.github.carlos_emr.carlos.util.*, io.github.carlos_emr.CarlosProperties, io.github.carlos_emr.carlos.utility.SpringUtils, io.github.carlos_emr.carlos.commn.dao.CtlDocClassDao" %>
 <%@ page import="io.github.carlos_emr.carlos.documentManager.data.AddEditDocument2Form" %>

--- a/src/main/webapp/WEB-INF/jsp/documentManager/addedithtmldocument.jsp
+++ b/src/main/webapp/WEB-INF/jsp/documentManager/addedithtmldocument.jsp
@@ -50,6 +50,7 @@
 %>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <%@ page

--- a/src/main/webapp/WEB-INF/jsp/documentManager/documentBrowser.jsp
+++ b/src/main/webapp/WEB-INF/jsp/documentManager/documentBrowser.jsp
@@ -52,6 +52,7 @@
 <%@page import="org.springframework.web.context.support.WebApplicationContextUtils" %>
 <%@ page import="io.github.carlos_emr.carlos.utility.SpringUtils" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/documentManager/documentReport.jsp
+++ b/src/main/webapp/WEB-INF/jsp/documentManager/documentReport.jsp
@@ -60,6 +60,7 @@
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <%@ page import="java.util.*" %>
 <%@ page import="io.github.carlos_emr.carlos.commn.dao.CtlDocClassDao" %>
@@ -404,7 +405,7 @@
         <div id="docListAlertContainer"></div>
 
         <% if ("demographic".equals(module)) { %>
-        <oscar:nameage demographicNo="<e:forHtmlAttribute value='<%= moduleid %>' />"/>
+        <oscar:nameage demographicNo="<%= moduleid %>"/>
         <%} %>
 
         <jsp:include page="addDocument.jsp">

--- a/src/main/webapp/WEB-INF/jsp/documentManager/documentUploader.jsp
+++ b/src/main/webapp/WEB-INF/jsp/documentManager/documentUploader.jsp
@@ -43,6 +43,7 @@
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <fmt:setBundle basename="oscarResources"/>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String)session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed=true;

--- a/src/main/webapp/WEB-INF/jsp/documentManager/editDocument.jsp
+++ b/src/main/webapp/WEB-INF/jsp/documentManager/editDocument.jsp
@@ -55,6 +55,7 @@
 <fmt:setBundle basename="oscarResources"/>
 
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@ page
         import="java.util.*, io.github.carlos_emr.carlos.util.*, io.github.carlos_emr.carlos.providers.data.ProviderData, io.github.carlos_emr.carlos.utility.SpringUtils, io.github.carlos_emr.carlos.commn.dao.CtlDocClassDao" %>
 <%@ page import="io.github.carlos_emr.carlos.commn.model.DocumentExtraReviewer" %>

--- a/src/main/webapp/WEB-INF/jsp/eform/efmformadd_data.jsp
+++ b/src/main/webapp/WEB-INF/jsp/eform/efmformadd_data.jsp
@@ -36,6 +36,7 @@
 <%@ page import="io.github.carlos_emr.carlos.utility.LoggedInInfo" %>
 <%@ page import="io.github.carlos_emr.carlos.eform.data.EForm" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%--
 	Addition of a floating global toolbar specifically for activation of the
 	Fax and eDocument functions.

--- a/src/main/webapp/WEB-INF/jsp/eform/efmformapconfig_lookup.jsp
+++ b/src/main/webapp/WEB-INF/jsp/eform/efmformapconfig_lookup.jsp
@@ -22,6 +22,7 @@
 <%@ page import="io.github.carlos_emr.carlos.utility.LoggedInInfo" %>
 <%@ page import="io.github.carlos_emr.carlos.utility.SpringUtils" %>
 <%@ page import="org.owasp.encoder.Encode" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     // Security: require _eform read privilege (consistent with all other eForm endpoints)
     SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);

--- a/src/main/webapp/WEB-INF/jsp/eform/efmformmanageredit.jsp
+++ b/src/main/webapp/WEB-INF/jsp/eform/efmformmanageredit.jsp
@@ -33,6 +33,7 @@
 <%@ page import="io.github.carlos_emr.carlos.eform.EFormUtil" %>
 <%@ page import="org.owasp.encoder.Encode" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <%

--- a/src/main/webapp/WEB-INF/jsp/eform/efmformslistadd.jsp
+++ b/src/main/webapp/WEB-INF/jsp/eform/efmformslistadd.jsp
@@ -54,6 +54,7 @@ Ontario, Canada
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%@ taglib uri="jakarta.tags.core" prefix="c"%>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <%

--- a/src/main/webapp/WEB-INF/jsp/eform/efmimagemanager.jsp
+++ b/src/main/webapp/WEB-INF/jsp/eform/efmimagemanager.jsp
@@ -32,6 +32,7 @@
 <%@ page import="io.github.carlos_emr.carlos.eform.data.*, io.github.carlos_emr.CarlosProperties, io.github.carlos_emr.carlos.eform.*, java.util.*" %>
 <%@ page import="io.github.carlos_emr.carlos.eform.EFormUtil" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 

--- a/src/main/webapp/WEB-INF/jsp/eform/efmmanageformgroups.jsp
+++ b/src/main/webapp/WEB-INF/jsp/eform/efmmanageformgroups.jsp
@@ -32,6 +32,7 @@
 <%@ page import="io.github.carlos_emr.carlos.eform.data.*, io.github.carlos_emr.carlos.eform.*, java.util.*" %>
 <%@ page import="io.github.carlos_emr.carlos.eform.EFormUtil" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <%

--- a/src/main/webapp/WEB-INF/jsp/eform/efmpatientformlist.jsp
+++ b/src/main/webapp/WEB-INF/jsp/eform/efmpatientformlist.jsp
@@ -39,6 +39,7 @@
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
 <%@ taglib uri="jakarta.tags.core" prefix="c"%>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <%

--- a/src/main/webapp/WEB-INF/jsp/eform/efmpatientformlistdeleted.jsp
+++ b/src/main/webapp/WEB-INF/jsp/eform/efmpatientformlistdeleted.jsp
@@ -45,6 +45,7 @@
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar"%>
 <%@ taglib uri="jakarta.tags.core" prefix="c"%>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <%

--- a/src/main/webapp/WEB-INF/jsp/eform/efmpatientformlistsingle.jsp
+++ b/src/main/webapp/WEB-INF/jsp/eform/efmpatientformlistsingle.jsp
@@ -53,6 +53,7 @@
 
 %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 

--- a/src/main/webapp/WEB-INF/jsp/eform/efmviewgroups.jsp
+++ b/src/main/webapp/WEB-INF/jsp/eform/efmviewgroups.jsp
@@ -33,6 +33,7 @@
 <%@ page import="io.github.carlos_emr.carlos.eform.EFormUtil" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 <%
     if (session.getAttribute("userrole") == null) response.sendRedirect(request.getContextPath() + "/logoutPage");

--- a/src/main/webapp/WEB-INF/jsp/eform/fieldNoteReport/fieldnotereport.jsp
+++ b/src/main/webapp/WEB-INF/jsp/eform/fieldNoteReport/fieldnotereport.jsp
@@ -33,6 +33,7 @@
 <%@ page import="java.util.*, java.text.*" %>
 <%@ page import="io.github.carlos_emr.carlos.util.StringUtils" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <%

--- a/src/main/webapp/WEB-INF/jsp/eform/fieldNoteReport/fieldnotereportdetail.jsp
+++ b/src/main/webapp/WEB-INF/jsp/eform/fieldNoteReport/fieldnotereportdetail.jsp
@@ -36,6 +36,7 @@
 <%@ page import="org.owasp.encoder.Encode" %>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <%

--- a/src/main/webapp/WEB-INF/jsp/eform/fieldNoteReport/fieldnoteselect.jsp
+++ b/src/main/webapp/WEB-INF/jsp/eform/fieldNoteReport/fieldnoteselect.jsp
@@ -34,6 +34,7 @@
 <%@ page import="io.github.carlos_emr.carlos.utility.SpringUtils" %>
 <%@ page import="java.util.*" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <%

--- a/src/main/webapp/WEB-INF/jsp/eform/partials/upload.jsp
+++ b/src/main/webapp/WEB-INF/jsp/eform/partials/upload.jsp
@@ -35,6 +35,7 @@
 <fmt:setBundle basename="oscarResources"/>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <html>
 

--- a/src/main/webapp/WEB-INF/jsp/encounter/InsertTemplate.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/InsertTemplate.jsp
@@ -29,6 +29,7 @@
 
 --%>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <%@ page import="java.lang.*,io.github.carlos_emr.carlos.encounter.oscarMeasurements.pageUtil.*" %>

--- a/src/main/webapp/WEB-INF/jsp/encounter/LeftNavBarDisplay.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/LeftNavBarDisplay.jsp
@@ -56,6 +56,7 @@
 <%@ page import="io.github.carlos_emr.carlos.services.security.SecurityManager" %>
 <%@ page import="io.github.carlos_emr.carlos.util.DateUtils" %>
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <c:set var="ctx" value="${pageContext.request.contextPath}"
        scope="request"/>
 

--- a/src/main/webapp/WEB-INF/jsp/encounter/encounterPrint.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/encounterPrint.jsp
@@ -34,6 +34,7 @@
 
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/encounter/immunization/Schedule.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/immunization/Schedule.jsp
@@ -98,6 +98,7 @@
 
 %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 

--- a/src/main/webapp/WEB-INF/jsp/encounter/immunization/ScheduleConfig.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/immunization/ScheduleConfig.jsp
@@ -53,6 +53,7 @@
 <%@ page import="io.github.carlos_emr.carlos.encounter.immunization.data.EctImmConfigData" %>
 <%@ page import="io.github.carlos_emr.carlos.commn.model.Demographic" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 

--- a/src/main/webapp/WEB-INF/jsp/encounter/immunization/ScheduleEdit.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/immunization/ScheduleEdit.jsp
@@ -49,6 +49,7 @@
 <%@ page import="io.github.carlos_emr.carlos.encounter.pageUtil.EctSessionBean" %>
 <%@ page import="org.owasp.encoder.Encode" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 
 <link rel="stylesheet" type="text/css" href="<%= request.getContextPath() %>/encounterStyles.css">

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConfirmConsultationRequest.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConfirmConsultationRequest.jsp
@@ -34,6 +34,7 @@
 <fmt:setBundle basename="oscarResources"/>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/DisplayDemographicConsultationRequests.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/DisplayDemographicConsultationRequests.jsp
@@ -76,6 +76,7 @@
 <%@ page import="io.github.carlos_emr.carlos.encounter.oscarConsultationRequest.pageUtil.EctViewConsultationRequestsUtil" %>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <%
     String demo = request.getParameter("de");

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ViewConsultationRequests.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ViewConsultationRequests.jsp
@@ -85,6 +85,7 @@
 <%@ page import="org.owasp.encoder.Encode" %>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <%
@@ -673,9 +674,11 @@
                             }
                         }%>
                     <fmt:message key="encounter.oscarConsultationRequest.ViewConsultationRequests.msgAddTicklerConfirm" var="addTicklerConfirmVar"/>
-                    <%  String addTicklerConfirmJs = Encode.forJavaScript((String)pageContext.getAttribute("addTicklerConfirmVar")); %>
+                    <%  String addTicklerConfirmJs = Encode.forJavaScript((String)pageContext.getAttribute("addTicklerConfirmVar"));
+                        String addTicklerUrl = request.getContextPath() + "/tickler/ViewAddTickler?" + queryStr
+                            + "&message=" + java.net.URLEncoder.encode("Patient has Consultation Letter with a status of 'Nothing Done' for over one week", "UTF-8"); %>
                     <a class="btn btn-link btn-sm" target="_blank"
-                       href="<e:forHtmlAttribute value='<%= request.getContextPath() + "/tickler/ViewAddTickler?" + queryStr + "&message=" + java.net.URLEncoder.encode("Patient has Consultation Letter with a status of 'Nothing Done' for over one week","UTF-8") %>' />"
+                       href="<%= Encode.forHtmlAttribute(addTicklerUrl) %>"
                        onclick="return confirm('<%=addTicklerConfirmJs%>');">
                         <i class="fas fa-bell me-1"></i><fmt:message key="encounter.oscarConsultationRequest.ViewConsultationRequests.msgAddTicklerBtn"/>
                     </a>

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/config/AddService.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/config/AddService.jsp
@@ -33,6 +33,7 @@
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <fmt:setBundle basename="oscarResources"/>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/config/DeleteServices.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/config/DeleteServices.jsp
@@ -46,6 +46,7 @@
 
 <%@ page import="io.github.carlos_emr.carlos.encounter.oscarConsultationRequest.config.pageUtil.EctConTitlebar" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <!DOCTYPE html>

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/config/DisplayInstitution.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/config/DisplayInstitution.jsp
@@ -45,6 +45,7 @@
 %>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <%@page import="java.util.List" %>
 <%@page import="io.github.carlos_emr.carlos.utility.SpringUtils" %>

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/config/DisplayService.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/config/DisplayService.jsp
@@ -46,6 +46,7 @@
 <%@ page import="io.github.carlos_emr.carlos.encounter.oscarConsultationRequest.config.pageUtil.EctConTitlebar" %>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <!DOCTYPE html>

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/config/EditDepartments.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/config/EditDepartments.jsp
@@ -45,6 +45,7 @@
 %>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <%@page import="io.github.carlos_emr.carlos.utility.SpringUtils" %>

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/config/EditInstitutions.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/config/EditInstitutions.jsp
@@ -45,6 +45,7 @@
 %>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <%@page import="io.github.carlos_emr.carlos.utility.SpringUtils" %>

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/config/EditSpecialists.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/config/EditSpecialists.jsp
@@ -31,6 +31,7 @@
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <fmt:setBundle basename="oscarResources"/>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@ page import="java.util.List" %>
 <%@ page import="io.github.carlos_emr.carlos.encounter.oscarConsultationRequest.config.pageUtil.EctConTitlebar" %>
 <%

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/config/ShowAllInstitutions.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/config/ShowAllInstitutions.jsp
@@ -30,6 +30,7 @@
 --%>
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/config/ShowAllServices.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/config/ShowAllServices.jsp
@@ -66,6 +66,7 @@
 <%@ page import="org.owasp.encoder.Encode" %>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/AddMeasurementData.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/AddMeasurementData.jsp
@@ -49,6 +49,7 @@
 <fmt:setBundle basename="oscarResources"/>
 
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     if (session.getAttribute("user") == null) response.sendRedirect(request.getContextPath() + "/logoutPage");
     String demographic_no = request.getParameter("demographic_no");

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/TemplateFlowSheetPage.jspf
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/TemplateFlowSheetPage.jspf
@@ -47,6 +47,7 @@
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
 <%@ taglib uri="/WEB-INF/rewrite-tag.tld" prefix="rewrite" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security"%>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@page import="io.github.carlos_emr.CarlosProperties"%>
 <%@ page import="org.owasp.encoder.Encode" %>
 <%-- CARLOS StringUtils used via FQ name to avoid conflict with apache commons lang3 StringUtils --%>

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/TemplateFlowSheetPrint.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/TemplateFlowSheetPrint.jsp
@@ -57,6 +57,7 @@
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
 <%@ taglib uri="/WEB-INF/rewrite-tag.tld" prefix="rewrite" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     if (session.getAttribute("user") == null) response.sendRedirect(request.getContextPath() + "/logoutPage");
     if (session.getAttribute("userrole") == null) response.sendRedirect(request.getContextPath() + "/logoutPage");

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/addMeasurementMap.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/addMeasurementMap.jsp
@@ -31,6 +31,7 @@
 
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/addMeasurementMap2.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/addMeasurementMap2.jsp
@@ -30,6 +30,7 @@
 --%>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/adminFlowsheet/FlowsheetAddTarget.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/adminFlowsheet/FlowsheetAddTarget.jsp
@@ -49,6 +49,7 @@
 
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 
 <%@ page import="io.github.carlos_emr.carlos.utility.SpringUtils" %>

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/adminFlowsheet/FlowsheetAddWarning.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/adminFlowsheet/FlowsheetAddWarning.jsp
@@ -50,6 +50,7 @@
 
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 
 <%@ page import="io.github.carlos_emr.carlos.utility.SpringUtils" %>

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/adminFlowsheet/FlowsheetEditor.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/adminFlowsheet/FlowsheetEditor.jsp
@@ -49,6 +49,7 @@
 
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 
 <%@ page import="io.github.carlos_emr.carlos.utility.SpringUtils" %>

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/adminFlowsheet/FlowsheetItemEditor.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/adminFlowsheet/FlowsheetItemEditor.jsp
@@ -51,6 +51,7 @@
 
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 
 <%@ page import="io.github.carlos_emr.carlos.utility.SpringUtils" %>

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/adminFlowsheet/UpdateFlowsheet.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/adminFlowsheet/UpdateFlowsheet.jsp
@@ -65,6 +65,7 @@
 
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
 <%@ taglib uri="/WEB-INF/rewrite-tag.tld" prefix="rewrite" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 
 <%

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/remapMeasurementMap.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/remapMeasurementMap.jsp
@@ -30,6 +30,7 @@
 --%>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/removeMeasurementMap.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/removeMeasurementMap.jsp
@@ -30,6 +30,7 @@
 --%>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 

--- a/src/main/webapp/WEB-INF/jsp/episode/success.jsp
+++ b/src/main/webapp/WEB-INF/jsp/episode/success.jsp
@@ -28,6 +28,7 @@
     CARLOS has no affiliation with OSCAR or McMaster University.
 
 --%>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <html>
 <head>
     <title></title>

--- a/src/main/webapp/WEB-INF/jsp/error/failure.jsp
+++ b/src/main/webapp/WEB-INF/jsp/error/failure.jsp
@@ -29,6 +29,7 @@
 
 --%>
 <%@ page session="true" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <html>
 
     <html>

--- a/src/main/webapp/WEB-INF/jsp/error/securityError.jsp
+++ b/src/main/webapp/WEB-INF/jsp/error/securityError.jsp
@@ -29,6 +29,7 @@
 
 --%>
 <%@ page import="java.util.List" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <html>
 <head>

--- a/src/main/webapp/WEB-INF/jsp/form/addRhInjection.jsp
+++ b/src/main/webapp/WEB-INF/jsp/form/addRhInjection.jsp
@@ -55,6 +55,7 @@
 <%@ page import="io.github.carlos_emr.carlos.form.FrmRecord" %>
 <%@ page import="io.github.carlos_emr.carlos.form.FrmRecordFactory" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 

--- a/src/main/webapp/WEB-INF/jsp/form/formRourke2020p1.jsp
+++ b/src/main/webapp/WEB-INF/jsp/form/formRourke2020p1.jsp
@@ -55,6 +55,7 @@
 <%@ page import="io.github.carlos_emr.carlos.form.FrmRecord" %>
 <%@ page import="io.github.carlos_emr.carlos.form.FrmRourke2020Record" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 <%
     LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);

--- a/src/main/webapp/WEB-INF/jsp/form/formRourke2020p2.jsp
+++ b/src/main/webapp/WEB-INF/jsp/form/formRourke2020p2.jsp
@@ -57,6 +57,7 @@
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <fmt:setBundle basename="oscarResources"/>
 <%@ taglib uri="/WEB-INF/rourke-tag.tld" prefix="rourke" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <%
     String formClass = "Rourke2009";

--- a/src/main/webapp/WEB-INF/jsp/form/formRourke2020p3.jsp
+++ b/src/main/webapp/WEB-INF/jsp/form/formRourke2020p3.jsp
@@ -59,6 +59,7 @@
 
 
 <%@ taglib uri="/WEB-INF/rourke-tag.tld" prefix="rourke" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <%
     LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);

--- a/src/main/webapp/WEB-INF/jsp/form/formRourke2020p4.jsp
+++ b/src/main/webapp/WEB-INF/jsp/form/formRourke2020p4.jsp
@@ -56,6 +56,7 @@
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <fmt:setBundle basename="oscarResources"/>
 <%@ taglib uri="/WEB-INF/rourke-tag.tld" prefix="rourke" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <%
     LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);

--- a/src/main/webapp/WEB-INF/jsp/form/formalpha.jsp
+++ b/src/main/webapp/WEB-INF/jsp/form/formalpha.jsp
@@ -44,6 +44,7 @@
 %>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 <%@ page import="io.github.carlos_emr.carlos.form.*" %>
 <%@page import="io.github.carlos_emr.carlos.utility.LoggedInInfo" %>

--- a/src/main/webapp/WEB-INF/jsp/form/formbcarpg1namepopup.jsp
+++ b/src/main/webapp/WEB-INF/jsp/form/formbcarpg1namepopup.jsp
@@ -33,6 +33,7 @@
     ProviderDao providerDao = SpringUtils.getBean(ProviderDao.class);
 %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 <html>
     <head>

--- a/src/main/webapp/WEB-INF/jsp/form/formlatelifedisabilityvisualAid1.jsp
+++ b/src/main/webapp/WEB-INF/jsp/form/formlatelifedisabilityvisualAid1.jsp
@@ -29,6 +29,7 @@
 
 --%>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName2$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/form/formlatelifefunctionvisualAid2.jsp
+++ b/src/main/webapp/WEB-INF/jsp/form/formlatelifefunctionvisualAid2.jsp
@@ -30,6 +30,7 @@
 --%>
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName2$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/form/formrourke2009p1.jsp
+++ b/src/main/webapp/WEB-INF/jsp/form/formrourke2009p1.jsp
@@ -52,6 +52,7 @@
 <%@ page import="io.github.carlos_emr.carlos.form.FrmRourke2009Record" %>
 <%@ page import="io.github.carlos_emr.carlos.form.data.FrmData" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 <%
     LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);

--- a/src/main/webapp/WEB-INF/jsp/form/formrourke2009p2.jsp
+++ b/src/main/webapp/WEB-INF/jsp/form/formrourke2009p2.jsp
@@ -53,6 +53,7 @@
 <%@ page import="io.github.carlos_emr.carlos.form.data.FrmData" %>
 <%@ page import="io.github.carlos_emr.carlos.util.StringUtils" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 <%
     String formClass = "Rourke2009";

--- a/src/main/webapp/WEB-INF/jsp/form/formrourke2017p1.jsp
+++ b/src/main/webapp/WEB-INF/jsp/form/formrourke2017p1.jsp
@@ -55,6 +55,7 @@
 <%@ page import="io.github.carlos_emr.carlos.form.FrmRecord" %>
 <%@ page import="io.github.carlos_emr.carlos.form.FrmRourke2017Record" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 <%
     LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);

--- a/src/main/webapp/WEB-INF/jsp/form/formrourke2017p2.jsp
+++ b/src/main/webapp/WEB-INF/jsp/form/formrourke2017p2.jsp
@@ -60,6 +60,7 @@
 
 
 <%@ taglib uri="/WEB-INF/rourke-tag.tld" prefix="rourke" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <%
     //    String formClass = "Rourke2009";

--- a/src/main/webapp/WEB-INF/jsp/form/formrourke2017p3.jsp
+++ b/src/main/webapp/WEB-INF/jsp/form/formrourke2017p3.jsp
@@ -57,6 +57,7 @@
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <fmt:setBundle basename="oscarResources"/>
 <%@ taglib uri="/WEB-INF/rourke-tag.tld" prefix="rourke" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <%
     LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);

--- a/src/main/webapp/WEB-INF/jsp/form/formrourke2017p4.jsp
+++ b/src/main/webapp/WEB-INF/jsp/form/formrourke2017p4.jsp
@@ -57,6 +57,7 @@
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <fmt:setBundle basename="oscarResources"/>
 <%@ taglib uri="/WEB-INF/rourke-tag.tld" prefix="rourke" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <%
     LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);

--- a/src/main/webapp/WEB-INF/jsp/hospitalReportManager/displayHRMDocList.jsp
+++ b/src/main/webapp/WEB-INF/jsp/hospitalReportManager/displayHRMDocList.jsp
@@ -23,6 +23,7 @@
 <fmt:setBundle basename="oscarResources"/>
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/hospitalReportManager/displayHRMReport.jsp
+++ b/src/main/webapp/WEB-INF/jsp/hospitalReportManager/displayHRMReport.jsp
@@ -23,6 +23,7 @@
 
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/hospitalReportManager/hospitalReportManager.jsp
+++ b/src/main/webapp/WEB-INF/jsp/hospitalReportManager/hospitalReportManager.jsp
@@ -59,6 +59,7 @@
 
 
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <html>
     <head>

--- a/src/main/webapp/WEB-INF/jsp/lab/CA/ALL/labDisplayAjax.jsp
+++ b/src/main/webapp/WEB-INF/jsp/lab/CA/ALL/labDisplayAjax.jsp
@@ -70,6 +70,7 @@
 <%@ taglib uri="/WEB-INF/oscarProperties-tag.tld" prefix="oscarProperties" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/lab/CA/BC/demo_select.jsp
+++ b/src/main/webapp/WEB-INF/jsp/lab/CA/BC/demo_select.jsp
@@ -54,6 +54,7 @@
 <%@ page import="java.net.URLEncoder" %>
 <%@ page import="java.nio.charset.StandardCharsets" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 <%
 

--- a/src/main/webapp/WEB-INF/jsp/lab/CA/BC/labDisplay.jsp
+++ b/src/main/webapp/WEB-INF/jsp/lab/CA/BC/labDisplay.jsp
@@ -49,6 +49,7 @@
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <fmt:setBundle basename="oscarResources"/>
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
 
 

--- a/src/main/webapp/WEB-INF/jsp/lab/CA/BC/report.jsp
+++ b/src/main/webapp/WEB-INF/jsp/lab/CA/BC/report.jsp
@@ -30,6 +30,7 @@
 --%>
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/lab/CA/BC/searchreports.jsp
+++ b/src/main/webapp/WEB-INF/jsp/lab/CA/BC/searchreports.jsp
@@ -30,6 +30,7 @@
 --%>
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/lab/CA/ON/CMLDisplay.jsp
+++ b/src/main/webapp/WEB-INF/jsp/lab/CA/ON/CMLDisplay.jsp
@@ -53,6 +53,7 @@
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <fmt:setBundle basename="oscarResources"/>
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
 
     String segmentID = request.getParameter("segmentID");

--- a/src/main/webapp/WEB-INF/jsp/lab/CA/ON/labValues.jsp
+++ b/src/main/webapp/WEB-INF/jsp/lab/CA/ON/labValues.jsp
@@ -56,6 +56,7 @@
 <%@ page import="io.github.carlos_emr.carlos.demographic.data.DemographicData" %>
 <%@ page import="io.github.carlos_emr.carlos.lab.ca.on.CommonLabTestValues" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 <%
     String labType = request.getParameter("labType");

--- a/src/main/webapp/WEB-INF/jsp/lab/CA/ON/labValuesGraph.jsp
+++ b/src/main/webapp/WEB-INF/jsp/lab/CA/ON/labValuesGraph.jsp
@@ -48,6 +48,7 @@
 <%@ page
         import="java.util.*,io.github.carlos_emr.carlos.lab.ca.on.*,io.github.carlos_emr.carlos.demographic.data.*" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 <%
 

--- a/src/main/webapp/WEB-INF/jsp/lab/CumulativeLabValues.jsp
+++ b/src/main/webapp/WEB-INF/jsp/lab/CumulativeLabValues.jsp
@@ -39,6 +39,7 @@
 <fmt:setBundle basename="oscarResources"/>
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/lab/CumulativeLabValues2.jsp
+++ b/src/main/webapp/WEB-INF/jsp/lab/CumulativeLabValues2.jsp
@@ -39,6 +39,7 @@
 <fmt:setBundle basename="oscarResources"/>
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/lab/CumulativeLabValues3.jsp
+++ b/src/main/webapp/WEB-INF/jsp/lab/CumulativeLabValues3.jsp
@@ -35,6 +35,7 @@
 <fmt:setBundle basename="oscarResources"/>
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/lab/DemographicLab.jsp
+++ b/src/main/webapp/WEB-INF/jsp/lab/DemographicLab.jsp
@@ -43,6 +43,7 @@
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <fmt:setBundle basename="oscarResources"/>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/lab/DisplayLabValue.jsp
+++ b/src/main/webapp/WEB-INF/jsp/lab/DisplayLabValue.jsp
@@ -30,6 +30,7 @@
 --%>
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/lab/LinkReq.jsp
+++ b/src/main/webapp/WEB-INF/jsp/lab/LinkReq.jsp
@@ -41,6 +41,7 @@
 <%@page import="io.github.carlos_emr.CarlosProperties" %>
 <%@page import="io.github.carlos_emr.carlos.commn.dao.LabRequestReportLinkDao" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/login/forcepasswordreset.jsp
+++ b/src/main/webapp/WEB-INF/jsp/login/forcepasswordreset.jsp
@@ -41,6 +41,7 @@
     }
 %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 <%@ page import="org.springframework.web.util.JavaScriptUtils" %>
 <%@ page

--- a/src/main/webapp/WEB-INF/jsp/login/location.jsp
+++ b/src/main/webapp/WEB-INF/jsp/login/location.jsp
@@ -37,6 +37,7 @@
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <fmt:setBundle basename="oscarResources"/>
 <%@ taglib uri="/WEB-INF/caisi-tag.tld" prefix="caisi" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@ include file="/WEB-INF/jsp/common/webAppContextAndSuperMgr.jsp" %>
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html>

--- a/src/main/webapp/WEB-INF/jsp/login/loginfailed.jsp
+++ b/src/main/webapp/WEB-INF/jsp/login/loginfailed.jsp
@@ -30,6 +30,7 @@
 --%>
 <%@ page import="io.github.carlos_emr.CarlosProperties" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String errormsg = request.getParameter("errormsg");
 %>

--- a/src/main/webapp/WEB-INF/jsp/login/select_facility.jsp
+++ b/src/main/webapp/WEB-INF/jsp/login/select_facility.jsp
@@ -35,6 +35,7 @@
 <%@page import="io.github.carlos_emr.carlos.commn.model.Provider" %>
 <%@include file="/WEB-INF/jsp/layouts/caisi_html_top.jspf" %>
 <%@ page import="io.github.carlos_emr.carlos.login.Login2Action" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <h2>Please select which facility you would like to currently work in</h2>
 <%
     FacilityDao facilityDao = (FacilityDao) SpringUtils.getBean(FacilityDao.class);

--- a/src/main/webapp/WEB-INF/jsp/mcedt/mailbox/autoUpload.jsp
+++ b/src/main/webapp/WEB-INF/jsp/mcedt/mailbox/autoUpload.jsp
@@ -36,6 +36,7 @@
 <%@ taglib uri="http://www.oscar-emr.com/tags/integration" prefix="i" %>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <%@ page
         import="java.io.*,java.util.*, java.sql.*, io.github.carlos_emr.*, java.net.*, io.github.carlos_emr.carlos.integration.mcedt.mailbox.ActionUtils, java.math.BigInteger,ca.ontario.health.edt.ResponseResult" errorPage="/WEB-INF/jsp/error/errorpage.jsp" %>

--- a/src/main/webapp/WEB-INF/jsp/mcedt/mailbox/index.jsp
+++ b/src/main/webapp/WEB-INF/jsp/mcedt/mailbox/index.jsp
@@ -37,6 +37,7 @@
 <%@ taglib uri="jakarta.tags.functions" prefix="fn" %>
 <%@ taglib uri="http://www.oscar-emr.com/tags/integration" prefix="i" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@ page import="java.util.*,io.github.carlos_emr.carlos.integration.mcedt.mailbox.ActionUtils" %>
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>

--- a/src/main/webapp/WEB-INF/jsp/messenger/DisplayDemographicMessages.jsp
+++ b/src/main/webapp/WEB-INF/jsp/messenger/DisplayDemographicMessages.jsp
@@ -76,6 +76,7 @@
 <%@ page import="io.github.carlos_emr.carlos.commn.model.Demographic" %>
 <%@ page import="org.owasp.encoder.Encode" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     // Build role string for security check
     String userrole = (String) session.getAttribute("userrole");
@@ -314,7 +315,7 @@
                                         <td class='<%= dm.getType() == 3 ? "integratedMessage" : "normalMessage" %>'><e:forHtmlContent value='<%= dm.getThedate() %>' />
                                         </td>
                                         <td class='<%= dm.getType() == 3 ? "integratedMessage" : "normalMessage" %>'>
-                                            <oscar:nameage demographicNo="<e:forHtmlAttribute value='<%= dm.getDemographic_no() %>' />"></oscar:nameage>
+                                            <oscar:nameage demographicNo="<%= dm.getDemographic_no() %>"></oscar:nameage>
                                         </td>
                                     </tr>
                                     <%}%>

--- a/src/main/webapp/WEB-INF/jsp/messenger/DisplayMessages.jsp
+++ b/src/main/webapp/WEB-INF/jsp/messenger/DisplayMessages.jsp
@@ -84,6 +84,7 @@
 <fmt:setBundle basename="oscarResources"/>
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     // Build security role string from session attributes
     String userrole = (String) session.getAttribute("userrole");
@@ -553,7 +554,7 @@
                                     <td>
 
                                     <%if(dm.getDemographic_no() != null  && !dm.getDemographic_no().equalsIgnoreCase("null")) {%>
-                                        <oscar:nameage demographicNo="<e:forHtmlAttribute value='<%= dm.getDemographic_no() %>' />"></oscar:nameage>
+                                        <oscar:nameage demographicNo="<%= dm.getDemographic_no() %>"></oscar:nameage>
                                     <%} %>
 
                                     </td>

--- a/src/main/webapp/WEB-INF/jsp/messenger/SentMessage.jsp
+++ b/src/main/webapp/WEB-INF/jsp/messenger/SentMessage.jsp
@@ -64,6 +64,7 @@
 <fmt:setBundle basename="oscarResources"/>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     // Build role string for security validation
     String userrole = (String) session.getAttribute("userrole");

--- a/src/main/webapp/WEB-INF/jsp/messenger/attachmentFrameset.jsp
+++ b/src/main/webapp/WEB-INF/jsp/messenger/attachmentFrameset.jsp
@@ -50,6 +50,7 @@
 --%>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 
 <%@ page import="io.github.carlos_emr.carlos.util.*" %>

--- a/src/main/webapp/WEB-INF/jsp/messenger/generatePreviewPDF.jsp
+++ b/src/main/webapp/WEB-INF/jsp/messenger/generatePreviewPDF.jsp
@@ -97,6 +97,7 @@
 
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/messenger/msgSearchDemo.jsp
+++ b/src/main/webapp/WEB-INF/jsp/messenger/msgSearchDemo.jsp
@@ -104,6 +104,7 @@
 <body
         onload="<% if ( firstSearch) { %> document.forms[0].submit() <% } %>">
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 

--- a/src/main/webapp/WEB-INF/jsp/oscarMDS/CreateLab.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarMDS/CreateLab.jsp
@@ -48,6 +48,7 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
 "http://www.w3.org/TR/html4/loose.dtd">
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 

--- a/src/main/webapp/WEB-INF/jsp/oscarMDS/CreateLabTest.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarMDS/CreateLabTest.jsp
@@ -30,6 +30,7 @@
 --%>
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/oscarMDS/ForwardingRules.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarMDS/ForwardingRules.jsp
@@ -29,6 +29,7 @@
 
 --%>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 

--- a/src/main/webapp/WEB-INF/jsp/oscarMDS/OpenEChart.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarMDS/OpenEChart.jsp
@@ -30,6 +30,7 @@
 --%>
 <%@ page import="java.util.*" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@ page import="java.net.URLEncoder" %>
 <%
     // Check if demographicNo is present and valid

--- a/src/main/webapp/WEB-INF/jsp/oscarMDS/PatientSearch.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarMDS/PatientSearch.jsp
@@ -38,6 +38,7 @@
 
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/oscarMDS/Search.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarMDS/Search.jsp
@@ -29,6 +29,7 @@
 
 --%>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 <%@ page import="io.github.carlos_emr.carlos.util.StringUtils" %>
 

--- a/src/main/webapp/WEB-INF/jsp/oscarMDS/SegmentDisplay.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarMDS/SegmentDisplay.jsp
@@ -42,6 +42,7 @@
 
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/oscarMDS/documentsInQueues.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarMDS/documentsInQueues.jsp
@@ -46,6 +46,7 @@
 
 <%@page import="org.owasp.encoder.Encode" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 <%@ page import="java.util.*, io.github.carlos_emr.carlos.util.*, io.github.carlos_emr.CarlosProperties" %>
 <!DOCTYPE HTML >

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/ManageDemographicQueryFavourites.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/ManageDemographicQueryFavourites.jsp
@@ -45,6 +45,7 @@
 %>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <%@ page import="io.github.carlos_emr.carlos.report.data.RptSearchData,java.util.*" %>
 <%

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/ReportDemographicReport.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/ReportDemographicReport.jsp
@@ -45,6 +45,7 @@
 %>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <%@ page import="io.github.carlos_emr.carlos.report.data.RptSearchData,java.util.*" %>

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/cds_4_report_form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/cds_4_report_form.jsp
@@ -29,6 +29,7 @@
 --%>
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/cds_4_report_results.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/cds_4_report_results.jsp
@@ -29,6 +29,7 @@
 --%>
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/dbManageProvider.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/dbManageProvider.jsp
@@ -31,6 +31,7 @@
     @since 2026-04-05
 --%>
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <html>
 <head>
     <script type="text/javascript" src="<%= request.getContextPath() %>/js/global.js"></script>

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/editCodeDesc.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/editCodeDesc.jsp
@@ -26,6 +26,7 @@
 
 <%@ include file="/taglibs.jsp" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/manageProvider.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/manageProvider.jsp
@@ -72,6 +72,7 @@
     String last_name = "", first_name = "", mygroup = "";
 %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <html>

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/mis_report_form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/mis_report_form.jsp
@@ -30,6 +30,7 @@
 --%>
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/obec.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/obec.jsp
@@ -31,6 +31,7 @@
 
 <%@ taglib uri="/struts-tags" prefix="s" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/oscarReportAgeSex.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/oscarReportAgeSex.jsp
@@ -46,6 +46,7 @@
 
 <%@ include file="/WEB-INF/jsp/admin/dbconnection.jsp" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <%@page import="java.math.*, java.util.*, java.sql.*, io.github.carlos_emr.*, java.net.*" errorPage="/WEB-INF/jsp/error/errorpage.jsp" %>

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/oscarReportCalendarPopup.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/oscarReportCalendarPopup.jsp
@@ -52,6 +52,7 @@
 %>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/oscarReportCatchment.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/oscarReportCatchment.jsp
@@ -30,6 +30,7 @@
 --%>
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/oscarReportFluBilling.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/oscarReportFluBilling.jsp
@@ -30,6 +30,7 @@
 --%>
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/oscarReportVisitControl.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/oscarReportVisitControl.jsp
@@ -30,6 +30,7 @@
 --%>
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName2$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed2 = true;

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/oscarReportVisit_lk.jspf
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/oscarReportVisit_lk.jspf
@@ -25,6 +25,7 @@
 -->
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security"%>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
       String roleName$ = (String)session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
       boolean authed=true;

--- a/src/main/webapp/WEB-INF/jsp/oscarResearch/oscarDxResearch/dxResearchCustomization.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarResearch/oscarDxResearch/dxResearchCustomization.jsp
@@ -43,6 +43,7 @@
 --%>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 <!DOCTYPE html>
 <html>

--- a/src/main/webapp/WEB-INF/jsp/oscarWorkflow/WorkFlowList.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarWorkflow/WorkFlowList.jsp
@@ -44,6 +44,7 @@
 <fmt:setBundle basename="oscarResources"/>
 
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <%
 

--- a/src/main/webapp/WEB-INF/jsp/prevention/AddPreventionData.jsp
+++ b/src/main/webapp/WEB-INF/jsp/prevention/AddPreventionData.jsp
@@ -94,6 +94,7 @@
 
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/prevention/AddPreventionDataDisambiguate.jsp
+++ b/src/main/webapp/WEB-INF/jsp/prevention/AddPreventionDataDisambiguate.jsp
@@ -55,6 +55,7 @@
 
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/prevention/PreventionListManager.jsp
+++ b/src/main/webapp/WEB-INF/jsp/prevention/PreventionListManager.jsp
@@ -38,6 +38,7 @@
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
 <%@ taglib uri="/WEB-INF/rewrite-tag.tld" prefix="rewrite" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/prevention/PreventionReporting.jsp
+++ b/src/main/webapp/WEB-INF/jsp/prevention/PreventionReporting.jsp
@@ -51,6 +51,7 @@
 <c:set var="ctx" value="${pageContext.request.contextPath}" scope="request"/>
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/prevention/index.jsp
+++ b/src/main/webapp/WEB-INF/jsp/prevention/index.jsp
@@ -96,6 +96,7 @@
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
 <%@ taglib uri="/WEB-INF/rewrite-tag.tld" prefix="rewrite" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/provider/appointmentFormsLinks.jspf
+++ b/src/main/webapp/WEB-INF/jsp/provider/appointmentFormsLinks.jspf
@@ -10,6 +10,7 @@
 <%@page import="io.github.carlos_emr.carlos.utility.SpringUtils"%>
 <%@page import="org.owasp.encoder.Encode"%>
 <%@page import="java.net.URLEncoder"%>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <%
 	LoggedInInfo loggedInInfo3=LoggedInInfo.getLoggedInInfoFromSession(request);

--- a/src/main/webapp/WEB-INF/jsp/provider/appointmentprovideradminday.jsp
+++ b/src/main/webapp/WEB-INF/jsp/provider/appointmentprovideradminday.jsp
@@ -1055,7 +1055,7 @@
                                     <li id="admin2">
                                         <a href="javascript:void(0)" id="admin-panel"
                                            title="<fmt:message key="admin.admin.page.title"/>"
-                                       onclick="newWindow('<%=request.getContextPath()%>/administration/','admin')"><fmt:message key="provider.mainMenu.administration"/></a>
+                                       onclick="newWindow('<%=request.getContextPath()%>/administration','admin')"><fmt:message key="provider.mainMenu.administration"/></a>
                                     </li>
 
                                 </security:oscarSec>
@@ -2440,7 +2440,7 @@
                 //use (evt.altKey || evt.metaKey) for Mac if you want Apple+A, you will probably want a seperate onkeypress handler in that case to return false to prevent propagation
                 switch (evt.keyCode) {
                     case <fmt:message key="global.adminShortcut"/> :
-                        newWindow("<%= request.getContextPath() %>/administration/", "admin");
+                        newWindow("<%= request.getContextPath() %>/administration", "admin");
                         return false;  //run code for 'A'dmin
                     case <fmt:message key="global.calendarShortcut"/> :
                         popupOscarRx(425, 430, '<%= request.getContextPath() %>/share/CalendarPopup?urlfrom=<%= request.getContextPath() %>/provider/providercontrol&year=<%=strYear%>&month=<%=strMonth%>&param=<%=URLEncoder.encode("&view=0&displaymode=day&dboperation=searchappointmentday","UTF-8")%>');

--- a/src/main/webapp/WEB-INF/jsp/provider/appointmentprovideradminmonth.jsp
+++ b/src/main/webapp/WEB-INF/jsp/provider/appointmentprovideradminmonth.jsp
@@ -88,6 +88,7 @@
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <%
     String curUser_no, curProvider_no, userfirstname, userlastname, mygroupno, n_t_w_w = "";

--- a/src/main/webapp/WEB-INF/jsp/provider/editSignature.jsp
+++ b/src/main/webapp/WEB-INF/jsp/provider/editSignature.jsp
@@ -34,6 +34,7 @@
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
 <!-- add by caisi end<style>* {border:1px solid black;}</style> -->
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 

--- a/src/main/webapp/WEB-INF/jsp/provider/mainMenu.jsp
+++ b/src/main/webapp/WEB-INF/jsp/provider/mainMenu.jsp
@@ -258,7 +258,7 @@
 
                                 <li id="admin2">
                                     <a href="javascript:void(0)" id="admin-panel" TITLE='<fmt:message key="admin.admin.page.title"/>'
-                                       onclick="newWindow('<%=request.getContextPath()%>/administration/','admin')"><fmt:message key="provider.mainMenu.administration"/></a>
+                                       onclick="newWindow('<%=request.getContextPath()%>/administration','admin')"><fmt:message key="provider.mainMenu.administration"/></a>
                                 </li>
 
                             </security:oscarSec>

--- a/src/main/webapp/WEB-INF/jsp/provider/providerchangepassword.jsp
+++ b/src/main/webapp/WEB-INF/jsp/provider/providerchangepassword.jsp
@@ -52,6 +52,7 @@
 %>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <%@ page

--- a/src/main/webapp/WEB-INF/jsp/provider/providercontrol.jsp
+++ b/src/main/webapp/WEB-INF/jsp/provider/providercontrol.jsp
@@ -175,9 +175,13 @@
     // get operation name from request
     String operation = requestParamDict.getDef("displaymode", "");
 
-    // Use jsp:include instead of pageContext.forward() because Tomcat 11's
-    // response buffer handling prevents forward() from working when response
-    // wrapper filters (CSRFGuard, LogoutBroadcast) are in the filter chain.
+    // Include the target (Struts action or relative JSP). Struts filters are mapped
+    // to REQUEST, FORWARD, and INCLUDE dispatchers in web.xml so Struts action paths
+    // (like /provider/ViewAppointmentAdminDay) route through Struts on the include,
+    // and JSP file paths are resolved by the JSP servlet (`.jsp` is in
+    // struts.action.excludePattern). This keeps the browser URL as the section-root
+    // /provider/providercontrol router so bookmarks and back-stack behavior are
+    // preserved across display modes.
     out.clearBuffer();
     String includeTarget = opToFileDict.getDef(operation, "");
     request.getRequestDispatcher(includeTarget).include(request, response);

--- a/src/main/webapp/WEB-INF/jsp/provider/providerencounterhistory.jsp
+++ b/src/main/webapp/WEB-INF/jsp/provider/providerencounterhistory.jsp
@@ -37,6 +37,7 @@
 <%@page import="io.github.carlos_emr.carlos.commn.dao.EncounterDao" %>
 <%@page import="io.github.carlos_emr.carlos.commn.model.Encounter" %>
 <%@page import="io.github.carlos_emr.carlos.util.ConversionUtils" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     EncounterDao encounterDao = SpringUtils.getBean(EncounterDao.class);
     ResourceBundle bundle = ResourceBundle.getBundle("oscarResources", request.getLocale());

--- a/src/main/webapp/WEB-INF/jsp/provider/providerencounterprint.jsp
+++ b/src/main/webapp/WEB-INF/jsp/provider/providerencounterprint.jsp
@@ -32,6 +32,7 @@
 <%@ page import="java.util.*, java.sql.*, io.github.carlos_emr.*,java.net.*" errorPage="/WEB-INF/jsp/error/errorpage.jsp" %>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <%@page import="io.github.carlos_emr.carlos.utility.SpringUtils" %>

--- a/src/main/webapp/WEB-INF/jsp/provider/providerencountersingle.jsp
+++ b/src/main/webapp/WEB-INF/jsp/provider/providerencountersingle.jsp
@@ -41,6 +41,7 @@
 <%@page import="io.github.carlos_emr.carlos.util.ConversionUtils" %>
 <%@page import="io.github.carlos_emr.carlos.util.StringUtils" %>
 <%@page import="io.github.carlos_emr.SxmlMisc" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     EncounterTemplateDao encounterTemplateDao = SpringUtils.getBean(EncounterTemplateDao.class);
     EncounterDao encounterDao = SpringUtils.getBean(EncounterDao.class);

--- a/src/main/webapp/WEB-INF/jsp/provider/providernewgroup.jsp
+++ b/src/main/webapp/WEB-INF/jsp/provider/providernewgroup.jsp
@@ -34,6 +34,7 @@
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <fmt:setBundle basename="oscarResources"/>
 <%@ taglib uri="https://owasp.org/www-project-csrfguard/Owasp.CsrfGuard.tld" prefix="csrf" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <%@ page import="io.github.carlos_emr.carlos.utility.SpringUtils" %>
 <%@ page import="io.github.carlos_emr.carlos.commn.model.MyGroup" %>

--- a/src/main/webapp/WEB-INF/jsp/provider/providerupdatepreference.jsp
+++ b/src/main/webapp/WEB-INF/jsp/provider/providerupdatepreference.jsp
@@ -52,6 +52,7 @@
 
 <%@page import="io.github.carlos_emr.carlos.utility.SessionConstants" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <%@ page import="java.sql.*, java.util.*, io.github.carlos_emr.*" errorPage="/WEB-INF/jsp/error/errorpage.jsp" %>

--- a/src/main/webapp/WEB-INF/jsp/provider/receptionistfindprovider.jsp
+++ b/src/main/webapp/WEB-INF/jsp/provider/receptionistfindprovider.jsp
@@ -36,6 +36,7 @@
 
 
 <%@ taglib uri="/WEB-INF/caisi-tag.tld" prefix="caisi" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <%
     LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);

--- a/src/main/webapp/WEB-INF/jsp/provider/setLabMacroPrefs.jsp
+++ b/src/main/webapp/WEB-INF/jsp/provider/setLabMacroPrefs.jsp
@@ -112,6 +112,7 @@
 <%@page import="org.owasp.encoder.Encode"%>
 
 <%@taglib uri="jakarta.tags.fmt" prefix="fmt"%>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 <%-- Capture i18n message into page-scope variable for safe use in JavaScript with OWASP encoding --%>
 <fmt:message key="provider.labMacroPrefs.confirmDeleteAll" var="confirmDeleteAllMsg"/>

--- a/src/main/webapp/WEB-INF/jsp/report/ClinicalReports.jsp
+++ b/src/main/webapp/WEB-INF/jsp/report/ClinicalReports.jsp
@@ -63,6 +63,7 @@
 <fmt:setBundle basename="oscarResources"/>
 
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <%
     String provider = (String) session.getAttribute("user");

--- a/src/main/webapp/WEB-INF/jsp/report/GenerateLetters.jsp
+++ b/src/main/webapp/WEB-INF/jsp/report/GenerateLetters.jsp
@@ -57,6 +57,7 @@
 <fmt:setBundle basename="oscarResources"/>
 
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <jsp:useBean id="providerBean" class="java.util.Properties"
              scope="session"/>
 

--- a/src/main/webapp/WEB-INF/jsp/report/ManageLetters.jsp
+++ b/src/main/webapp/WEB-INF/jsp/report/ManageLetters.jsp
@@ -49,6 +49,7 @@
 <%@ page import="io.github.carlos_emr.carlos.report.data.ManageLetters" %>
 <%@ page import="org.apache.commons.lang3.StringUtils" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <html>

--- a/src/main/webapp/WEB-INF/jsp/report/reportFormCaption.jsp
+++ b/src/main/webapp/WEB-INF/jsp/report/reportFormCaption.jsp
@@ -59,6 +59,7 @@
     vecTableField = tableObj.getTableNameCaption(tableName);
 %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <html>
     <head>

--- a/src/main/webapp/WEB-INF/jsp/report/reportFormConfig.jsp
+++ b/src/main/webapp/WEB-INF/jsp/report/reportFormConfig.jsp
@@ -89,6 +89,7 @@
 
 %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <html>
     <head>

--- a/src/main/webapp/WEB-INF/jsp/report/reportFormDemoConfig.jsp
+++ b/src/main/webapp/WEB-INF/jsp/report/reportFormDemoConfig.jsp
@@ -81,6 +81,7 @@
     vecTableField = tableObj.getTableNameCaption(tableName);
 %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <html>
     <head>

--- a/src/main/webapp/WEB-INF/jsp/report/reportFormOrder.jsp
+++ b/src/main/webapp/WEB-INF/jsp/report/reportFormOrder.jsp
@@ -46,6 +46,7 @@
     Vector vecConfigObj = tableObj.getConfigObj(SAVE_AS, reportId);
 %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <html>
     <head>

--- a/src/main/webapp/WEB-INF/jsp/report/reportdaysheet.jsp
+++ b/src/main/webapp/WEB-INF/jsp/report/reportdaysheet.jsp
@@ -32,6 +32,7 @@
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <fmt:setBundle basename="oscarResources"/>
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = session.getAttribute("userrole") + "," + session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/report/reportecharthistory.jsp
+++ b/src/main/webapp/WEB-INF/jsp/report/reportecharthistory.jsp
@@ -45,6 +45,7 @@
 %>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 <%
 

--- a/src/main/webapp/WEB-INF/jsp/report/reportedblist.jsp
+++ b/src/main/webapp/WEB-INF/jsp/report/reportedblist.jsp
@@ -31,6 +31,7 @@
 
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/report/reportindex.jsp
+++ b/src/main/webapp/WEB-INF/jsp/report/reportindex.jsp
@@ -78,6 +78,7 @@
 <fmt:setBundle basename="oscarResources"/>
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String country = request.getLocale().getCountry();
     CarlosProperties carlosVariables = CarlosProperties.getInstance();

--- a/src/main/webapp/WEB-INF/jsp/report/reportonbilledphcp.jsp
+++ b/src/main/webapp/WEB-INF/jsp/report/reportonbilledphcp.jsp
@@ -42,6 +42,7 @@
 <%@ page import="java.sql.*" %>
 <%@ page import="java.util.ResourceBundle" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <%

--- a/src/main/webapp/WEB-INF/jsp/report/reportonbilledvisitprovider.jsp
+++ b/src/main/webapp/WEB-INF/jsp/report/reportonbilledvisitprovider.jsp
@@ -27,6 +27,7 @@
 <%@ page import="java.util.ResourceBundle" %>
 <%@ page import="org.owasp.encoder.Encode" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 <%
     SecuserroleDao secuserroleDao = (SecuserroleDao) SpringUtils.getBean(SecuserroleDao.class);

--- a/src/main/webapp/WEB-INF/jsp/rx/AddReaction2.jsp
+++ b/src/main/webapp/WEB-INF/jsp/rx/AddReaction2.jsp
@@ -35,6 +35,7 @@
 
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName2$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/rx/ChooseDrug.jsp
+++ b/src/main/webapp/WEB-INF/jsp/rx/ChooseDrug.jsp
@@ -50,6 +50,7 @@
 
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <%@ page import="java.util.*,io.github.carlos_emr.carlos.rx.data.*,io.github.carlos_emr.carlos.rx.pageUtil.*, io.github.carlos_emr.CarlosProperties" %>
 <%@ page import="io.github.carlos_emr.carlos.prescript.pageUtil.RxSessionBean" %>

--- a/src/main/webapp/WEB-INF/jsp/rx/DrugPrice.jsp
+++ b/src/main/webapp/WEB-INF/jsp/rx/DrugPrice.jsp
@@ -52,6 +52,7 @@
 <%@page import="java.util.*" %>
 <%@page import="java.text.*" %>
 <%@ page import="io.github.carlos_emr.carlos.prescript.util.DrugPriceLookup" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
 		    String din = request.getParameter("din");
 		    String randomId = request.getParameter("randomId");

--- a/src/main/webapp/WEB-INF/jsp/rx/LimitedUseCode.jsp
+++ b/src/main/webapp/WEB-INF/jsp/rx/LimitedUseCode.jsp
@@ -42,6 +42,7 @@
 <%@ page import="io.github.carlos_emr.carlos.prescript.util.LimitedUseCode" %>
 <%@ page import="io.github.carlos_emr.carlos.prescript.util.LimitedUseLookup" %>
 <%@ page import="io.github.carlos_emr.carlos.util.StringUtils" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <%
     String din = StringUtils.noNull(request.getParameter("din"));

--- a/src/main/webapp/WEB-INF/jsp/rx/ManagePharmacy2.jsp
+++ b/src/main/webapp/WEB-INF/jsp/rx/ManagePharmacy2.jsp
@@ -36,6 +36,7 @@
 
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     RxSessionBean bean = null;
     String roleName2$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");

--- a/src/main/webapp/WEB-INF/jsp/rx/PrintDrugProfile2.jsp
+++ b/src/main/webapp/WEB-INF/jsp/rx/PrintDrugProfile2.jsp
@@ -62,6 +62,7 @@
 </c:if>
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/rx/RenalDosing.jsp
+++ b/src/main/webapp/WEB-INF/jsp/rx/RenalDosing.jsp
@@ -45,6 +45,7 @@
 <%@ page import="io.github.carlos_emr.carlos.util.StringUtils" %>
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/rx/SearchDrug3.jsp
+++ b/src/main/webapp/WEB-INF/jsp/rx/SearchDrug3.jsp
@@ -1851,7 +1851,9 @@ function popForm2(scriptId){
      function callAdditionWebService(url,id){
          var contextPath = '${e:forJavaScript(ctx)}';
          if (url.indexOf(contextPath) !== 0) {
-             url = contextPath + "/rx/" + url;
+             // url typically begins with '/rx/...' (already context-relative).
+             // Only prepend contextPath; don't double-stack '/rx/'.
+             url = contextPath + (url.charAt(0) === '/' ? url : '/rx/' + url);
          }
          var ran_number=Math.round(Math.random()*1000000);
          var params = "demographicNo=<%=demoNo%>&rand="+ran_number;  //hack to get around ie caching the page
@@ -1861,7 +1863,9 @@ function popForm2(scriptId){
 			function callReplacementWebService(url, id) {
             var contextPath = '${e:forJavaScript(ctx)}';
             if (url.indexOf(contextPath) !== 0) {
-                url = contextPath + "/rx/" + url;
+                // url typically begins with '/rx/...' (already context-relative).
+                // Only prepend contextPath; don't double-stack '/rx/'.
+                url = contextPath + (url.charAt(0) === '/' ? url : '/rx/' + url);
             }
 				var ran_number = Math.round(Math.random() * 1000000);
 				// alert(url + "  " + id + "  " + ran_number);

--- a/src/main/webapp/WEB-INF/jsp/rx/SelectPharmacy2.jsp
+++ b/src/main/webapp/WEB-INF/jsp/rx/SelectPharmacy2.jsp
@@ -33,6 +33,7 @@
 <fmt:setBundle basename="oscarResources"/>
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@ page import="io.github.carlos_emr.carlos.rx.data.*,java.util.*" %>
 <%@ page import="io.github.carlos_emr.CarlosProperties" %>
 <%@ page import="io.github.carlos_emr.carlos.prescript.pageUtil.RxSessionBean" %>

--- a/src/main/webapp/WEB-INF/jsp/rx/SelectReason.jsp
+++ b/src/main/webapp/WEB-INF/jsp/rx/SelectReason.jsp
@@ -44,6 +44,7 @@
     CodingSystemManager codingSystemManager = SpringUtils.getBean(CodingSystemManager.class);
 %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/rx/ShowAllergies2.jsp
+++ b/src/main/webapp/WEB-INF/jsp/rx/ShowAllergies2.jsp
@@ -39,6 +39,7 @@
 <fmt:setBundle basename="oscarResources"/>
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <%@page import="java.util.List" %>
 <%@page import="io.github.carlos_emr.carlos.utility.SpringUtils" %>

--- a/src/main/webapp/WEB-INF/jsp/rx/SideLinksEditFavorites2.jsp
+++ b/src/main/webapp/WEB-INF/jsp/rx/SideLinksEditFavorites2.jsp
@@ -49,6 +49,7 @@
 %>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 <%
     RxSessionBean bean2 = (RxSessionBean) request.getSession().getAttribute("RxSessionBean");

--- a/src/main/webapp/WEB-INF/jsp/rx/UpdateInteractingDrugs.jsp
+++ b/src/main/webapp/WEB-INF/jsp/rx/UpdateInteractingDrugs.jsp
@@ -34,6 +34,7 @@
 <%@page import="io.github.carlos_emr.carlos.prescript.data.RxPrescriptionData" %>
 <%@ page import="io.github.carlos_emr.carlos.prescript.pageUtil.RxSessionBean" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/rx/ViewPharmacy.jsp
+++ b/src/main/webapp/WEB-INF/jsp/rx/ViewPharmacy.jsp
@@ -38,6 +38,7 @@
 <%@ page import="io.github.carlos_emr.carlos.util.StringUtils" %>
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName2$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/rx/chartDrugProfile.jsp
+++ b/src/main/webapp/WEB-INF/jsp/rx/chartDrugProfile.jsp
@@ -47,6 +47,7 @@
 <%@ page
         import="java.util.*,io.github.carlos_emr.carlos.lab.ca.on.*,io.github.carlos_emr.carlos.demographic.data.*" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 

--- a/src/main/webapp/WEB-INF/jsp/rx/updateForm.jsp
+++ b/src/main/webapp/WEB-INF/jsp/rx/updateForm.jsp
@@ -37,6 +37,7 @@
 
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;

--- a/src/main/webapp/WEB-INF/jsp/schedule/scheduleDisplayTemplate.jsp
+++ b/src/main/webapp/WEB-INF/jsp/schedule/scheduleDisplayTemplate.jsp
@@ -40,6 +40,7 @@
 <%@page import="io.github.carlos_emr.carlos.commn.model.ScheduleTemplateCode" %>
 <%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="io.github.carlos_emr.carlos.util.StringUtils" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%
     ScheduleTemplateDao scheduleTemplateDao = SpringUtils.getBean(ScheduleTemplateDao.class);
     ScheduleTemplateCodeDao scheduleTemplateCodeDao = SpringUtils.getBean(ScheduleTemplateCodeDao.class);

--- a/src/main/webapp/WEB-INF/jsp/schedule/schedulecreatedate.jsp
+++ b/src/main/webapp/WEB-INF/jsp/schedule/schedulecreatedate.jsp
@@ -61,6 +61,7 @@
         import="java.util.*, java.sql.*, io.github.carlos_emr.*, java.text.*, java.lang.*,java.net.*"
         errorPage="/WEB-INF/jsp/error/errorpage.jsp" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <jsp:useBean id="scheduleRscheduleBean" class="io.github.carlos_emr.RscheduleBean" scope="session"/>

--- a/src/main/webapp/WEB-INF/jsp/schedule/scheduledatepopup.jsp
+++ b/src/main/webapp/WEB-INF/jsp/schedule/scheduledatepopup.jsp
@@ -41,6 +41,7 @@
 %>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 

--- a/src/main/webapp/WEB-INF/jsp/schedule/scheduleedittemplate.jsp
+++ b/src/main/webapp/WEB-INF/jsp/schedule/scheduleedittemplate.jsp
@@ -39,6 +39,7 @@
         errorPage="/WEB-INF/jsp/error/errorpage.jsp" %>
 <%@ page import="io.github.carlos_emr.CarlosProperties" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 

--- a/src/main/webapp/WEB-INF/jsp/schedule/scheduleflipview.jsp
+++ b/src/main/webapp/WEB-INF/jsp/schedule/scheduleflipview.jsp
@@ -108,6 +108,7 @@
              scope="page"/>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 

--- a/src/main/webapp/WEB-INF/jsp/schedule/scheduleholidaysetting.jsp
+++ b/src/main/webapp/WEB-INF/jsp/schedule/scheduleholidaysetting.jsp
@@ -59,6 +59,7 @@
         import="java.util.*, java.sql.*, io.github.carlos_emr.*, java.text.*, java.lang.*"
         errorPage="/WEB-INF/jsp/error/errorpage.jsp" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 

--- a/src/main/webapp/WEB-INF/jsp/schedule/scheduletemplateapplying.jsp
+++ b/src/main/webapp/WEB-INF/jsp/schedule/scheduletemplateapplying.jsp
@@ -58,6 +58,7 @@
 <fmt:setBundle basename="oscarResources"/>
 <%@ taglib uri="/WEB-INF/rewrite-tag.tld" prefix="rewrite" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@ page import="java.nio.charset.StandardCharsets" %>
 <%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="io.github.carlos_emr.carlos.utility.SpringUtils" %>

--- a/src/main/webapp/WEB-INF/jsp/schedule/scheduletemplatesetting.jsp
+++ b/src/main/webapp/WEB-INF/jsp/schedule/scheduletemplatesetting.jsp
@@ -53,6 +53,7 @@
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <fmt:setBundle basename="oscarResources"/>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 
 <%

--- a/src/main/webapp/WEB-INF/jsp/scratch/index.jsp
+++ b/src/main/webapp/WEB-INF/jsp/scratch/index.jsp
@@ -39,6 +39,7 @@
 <fmt:setBundle basename="oscarResources"/>
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar"%>
 <%@ taglib uri="/WEB-INF/rewrite-tag.tld" prefix="rewrite"%>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <%
   String user_no = (String) request.getSession().getAttribute("user");

--- a/src/main/webapp/WEB-INF/jsp/scratch/version.jsp
+++ b/src/main/webapp/WEB-INF/jsp/scratch/version.jsp
@@ -35,6 +35,7 @@
 <fmt:setBundle basename="oscarResources"/>
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar"%>
 <%@ taglib uri="/WEB-INF/rewrite-tag.tld" prefix="rewrite"%>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <%
     String date = null;

--- a/src/main/webapp/WEB-INF/jsp/share/CalendarPopup.jsp
+++ b/src/main/webapp/WEB-INF/jsp/share/CalendarPopup.jsp
@@ -38,6 +38,7 @@
 --%>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 <%@ page import="java.nio.charset.StandardCharsets" %>
 <%@ page

--- a/src/main/webapp/WEB-INF/jsp/signature_pad/tabletSignature.jsp
+++ b/src/main/webapp/WEB-INF/jsp/signature_pad/tabletSignature.jsp
@@ -23,6 +23,7 @@ is hosted in an IFrame and that the IFrame's parent window implements signatureH
 <%@ page import="io.github.carlos_emr.carlos.commn.model.enumerator.ModuleType" %>
 <%@ page import="org.owasp.encoder.Encode" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 <%
     LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);

--- a/src/main/webapp/WEB-INF/jsp/tickler/ticklerAdd.jsp
+++ b/src/main/webapp/WEB-INF/jsp/tickler/ticklerAdd.jsp
@@ -92,6 +92,7 @@
 <%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");

--- a/src/main/webapp/WEB-INF/jsp/tickler/ticklerDemoMain.jsp
+++ b/src/main/webapp/WEB-INF/jsp/tickler/ticklerDemoMain.jsp
@@ -117,6 +117,7 @@
 %>
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <html>

--- a/src/main/webapp/WEB-INF/jsp/tickler/ticklerMain.jsp
+++ b/src/main/webapp/WEB-INF/jsp/tickler/ticklerMain.jsp
@@ -914,10 +914,6 @@
             </div>
         </form>
 
-        <p class="yesprint">
-            <%=CarlosProperties.getConfidentialityStatement()%>
-        </p>
-
         <div id="note-form" title="<fmt:message key='tickler.ticklerMain.noteDialogTitle'/>" style="display:none;">
             <form>
                 <input type="hidden" name="tickler_note_demographicNo" id="tickler_note_demographicNo" value=""/>

--- a/src/main/webapp/WEB-INF/jsp/tickler/ticklerSuggestedText.jsp
+++ b/src/main/webapp/WEB-INF/jsp/tickler/ticklerSuggestedText.jsp
@@ -33,6 +33,7 @@
 <%@ page import="io.github.carlos_emr.carlos.utility.SpringUtils" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -168,6 +168,7 @@
 		<url-pattern>/*</url-pattern>
 		<dispatcher>REQUEST</dispatcher>
 		<dispatcher>FORWARD</dispatcher>
+		<dispatcher>INCLUDE</dispatcher>
 	</filter-mapping>
     <!-- LoggedInUserFilter runs in the documented custom-filter gap between
          Struts prepare and execute so action requests have derived
@@ -186,6 +187,7 @@
 		<url-pattern>/*</url-pattern>
 		<dispatcher>REQUEST</dispatcher>
 		<dispatcher>FORWARD</dispatcher>
+		<dispatcher>INCLUDE</dispatcher>
 	</filter-mapping>
     <filter>
             <filter-name>WebServiceSessionInvalidatingFilter</filter-name>

--- a/src/main/webapp/billing/manageBillingform_add.jspf
+++ b/src/main/webapp/billing/manageBillingform_add.jspf
@@ -28,6 +28,7 @@
 <%@page import="io.github.carlos_emr.carlos.commn.model.CtlBillingService" %>
 <%@page import="io.github.carlos_emr.carlos.commn.dao.CtlBillingServiceDao" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <form name="servicetypeform" method="post">
 <table width="75%" border="0" height="285">

--- a/src/main/webapp/billing/manageBillingform_dx.jspf
+++ b/src/main/webapp/billing/manageBillingform_dx.jspf
@@ -28,6 +28,7 @@
 <%@page import="io.github.carlos_emr.carlos.commn.model.CtlDiagCode" %>
 <%@page import="io.github.carlos_emr.carlos.commn.dao.CtlDiagCodeDao" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@ page import="io.github.carlos_emr.carlos.util.StringUtils" %>
 
 <form method="post" name="form1" action="DbManageBillingformDx">

--- a/src/main/webapp/billing/manageBillingform_service.jspf
+++ b/src/main/webapp/billing/manageBillingform_service.jspf
@@ -28,6 +28,7 @@
 <%@page import="io.github.carlos_emr.carlos.commn.model.CtlBillingService" %>
 <%@page import="io.github.carlos_emr.carlos.commn.dao.CtlBillingServiceDao" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@ page import="io.github.carlos_emr.carlos.util.StringUtils" %>
 
 <form method="post" name="form1"


### PR DESCRIPTION
This pull request introduces several security and routing improvements to the application. The main changes include adding the OWASP encoder taglib to numerous JSP files for enhanced output encoding, updating HTTP method guard logic to exempt certain safe actions from POST enforcement, improving Struts action routing for the administration section, and refining static resource and endpoint exclusion patterns.

**Security enhancements:**

* Added the `owasp.encoder.jakarta.advanced` taglib (`e`) to a wide range of JSP files in admin, appointment, billing, and administration sections to support safer output encoding and reduce XSS risk. [[1]](diffhunk://#diff-4807499fb070860c88f5f45977f531e76e43f35325e8e6a344d742405c60cf6fR33) [[2]](diffhunk://#diff-442f422e1a829b05175640153718c9dfbc97de7671983cbd6b4f32cc8572289dR31) [[3]](diffhunk://#diff-dab389540834a348f3077b8d1f3a5b81b08df30312119d27d495301088c7d01dR53) [[4]](diffhunk://#diff-406e8db46678758819541b55e8ee4cfd1f84782ac4639cfee9fb9c99afb77e43R38) [[5]](diffhunk://#diff-e2f2e239d9c007da5a7ff9d4b19d5e180140d3aa7a2df856c28c154d57ffd0d5R36) [[6]](diffhunk://#diff-4bde35427fe12759c86facaa367cd8ac9144c90a6f6030dcb573514d1b67595aR80) [[7]](diffhunk://#diff-ef1bb04b2fd26f3c492cb35eaf25c316970a3cd4a1ac2ed8769734ea2c86361dR61) [[8]](diffhunk://#diff-2a2316ff84375087524ea9e4201c302b608db80ebaa2364d4e57aee65529bca5R39) [[9]](diffhunk://#diff-a3e8c4ea0c09e8b07cd29092fb8c4c2105fcfe4520062a67c013b45da5c21e95R93) [[10]](diffhunk://#diff-266530f7a7e4d0effdaf4ffdc544694362e2d6a6543dcee56a2ea07fd9fe3efaR68) [[11]](diffhunk://#diff-0ae177a0c1f9164ed11c853d7fb56508e97025ee7bfcf57f6f2aa4f35c6bf4b7R78) [[12]](diffhunk://#diff-92db3f949d45e7608a5006cfa073e9fd69c536193ef2fd661f08791dd4c5b74bR36) [[13]](diffhunk://#diff-b5d696922caa711545eb23a48c89945a6c1f90b273245a37a6302dbf20b1bc68R55) [[14]](diffhunk://#diff-825dbdf354ff0eddc5528b3b8eb39e3e8f92370eabad37567d18cb11af4ea48eR56) [[15]](diffhunk://#diff-ee9d9ffc302cbceaba02aa3ba99333a72f7cd93632e8bbd4224cfdcb59a2dcfaR59) [[16]](diffhunk://#diff-5cba5885f2c60aad078eb6a7b1954f56df6a864493162fcade81150a4b93af5fR32) [[17]](diffhunk://#diff-bf4d7faee4edc2c6ce8d42c90e1d3728c353755200b3b0f730baff6f263b1c4cR53)

**HTTP method guard improvements:**

* Updated `HttpMethodGuardFilter.java` to exempt the `addappointment` action from POST enforcement, since it's a view-only action that matches the "add" mutator prefix but does not perform mutations. Improved comments for clarity on action exemptions. [[1]](diffhunk://#diff-3677dd6e6c039367e58b622ac1330270ba1ebb0c414421991f7b94b19a1c5795L137-R137) [[2]](diffhunk://#diff-3677dd6e6c039367e58b622ac1330270ba1ebb0c414421991f7b94b19a1c5795R148-R152)

**Struts configuration and routing:**

* Added a clean `/administration` action mapping in `struts-integration.xml` to allow the section root to be accessed without an `/index` suffix, improving navigation and URL cleanliness.
* Updated the left navigation link to point to `/administration` instead of `/administration/`, aligning with the new routing and avoiding trailing slash issues.

**Static resource and endpoint exclusion:**

* Expanded the `struts.action.excludePattern` to exclude `.jsp`, `.jspf`, and `/csrfguard` endpoints from Struts processing, reducing unnecessary interception and improving security.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened JSP output encoding with the OWASP Encoder and fixed routing/method-guard edge cases. Added a clean `/administration` route and broadened Struts exclusions for `.jsp*` and `/csrfguard`.

- **Bug Fixes**
  - Added the `owasp.encoder.jakarta.advanced` taglib (`e`) across admin, appointment, and billing JSPs to reduce XSS risk.
  - Updated `HttpMethodGuardFilter` to exempt `addappointment` (view-only) from POST enforcement; writes still go through `appointment/AddRecord` as POST.
  - Mapped `/administration` directly to the admin index action and updated the left nav link to drop the trailing slash.
  - Expanded `struts.action.excludePattern` to exclude `.jsp`, `.jspf`, and `/csrfguard` from Struts processing.

- **Migration**
  - Update any hardcoded links to use `/administration` without a trailing slash.

<sup>Written for commit 84feb61298f186c02a3b78843a4a4fe801a11b53. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

