### PR TITLE
chore: swap devcontainer DrugRef to carlos-emr/drugref2026

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -34,8 +34,8 @@ services:
       context: ./drugref
       dockerfile: Dockerfile
       args:
-        DRUGREF_REPO: ${DRUGREF_REPO:-https://github.com/open-osp/Open-Drugref.git}
-        DRUGREF_BRANCH: ${DRUGREF_BRANCH:-main}
+        DRUGREF_REPO: ${DRUGREF_REPO:-https://github.com/carlos-emr/drugref2026.git}
+        DRUGREF_BRANCH: ${DRUGREF_BRANCH:-v1.0.0-rc2}
     ports:
       - "8180:8080"
     volumes:
@@ -48,7 +48,7 @@ services:
       db:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/drugref2/DrugrefService?wsdl"]
+      test: ["CMD", "curl", "-fs", "-o", "/dev/null", "http://localhost:8080/drugref2/"]
       timeout: 10s
       retries: 5
       interval: 30s

--- a/.devcontainer/drugref/Dockerfile
+++ b/.devcontainer/drugref/Dockerfile
@@ -1,12 +1,12 @@
 # =============================================================================
 # Build stage - contains build tools (git, maven)
 # =============================================================================
-FROM tomcat:9.0.97-jdk11-temurin AS builder
+FROM tomcat:11.0-jdk21-temurin AS builder
 
 # Note: DRUGREF_BRANCH accepts branch names or tags, but not commit SHAs
 # (shallow clone with --depth 1 doesn't support checking out by SHA)
-ARG DRUGREF_REPO=https://github.com/open-osp/Open-Drugref.git
-ARG DRUGREF_BRANCH=main
+ARG DRUGREF_REPO=https://github.com/carlos-emr/drugref2026.git
+ARG DRUGREF_BRANCH=v1.0.0-rc2
 
 RUN apt-get update && apt-get install -y --no-install-recommends git maven \
     && rm -rf /var/lib/apt/lists/*
@@ -20,11 +20,11 @@ RUN mvn -DskipTests clean package
 # =============================================================================
 # Final stage - minimal runtime image (no build tools)
 # =============================================================================
-FROM tomcat:9.0.97-jdk11-temurin
+FROM tomcat:11.0-jdk21-temurin
 
-LABEL author="OpenOSP" \
+LABEL author="carlos-emr" \
       version="1.0.0" \
-      description="OpenOSP DrugRef2 Container - Java 11 for legacy dependency compatibility"
+      description="CARLOS DrugRef2026 Container - Java 21 / Tomcat 11"
 
 # Install curl for healthcheck
 RUN apt-get update && apt-get install -y --no-install-recommends curl \


### PR DESCRIPTION
Migrate the DrugRef sidecar from the legacy open-osp/Open-Drugref
build (Java 11 / Tomcat 9 / javax.*) to carlos-emr/drugref2026
(Java 21 / Tomcat 11 / Jakarta EE), which aligns the sidecar with
the main CARLOS stack and removes the last Java 11 image from the
dev environment.

- docker-compose.yml: default DRUGREF_REPO to
  carlos-emr/drugref2026.git and pin DRUGREF_BRANCH to the
  v1.0.0-rc2 tag for reproducible builds (shallow clone supports
  tags). Replace the healthcheck, which fetched
  /drugref2/DrugrefService?wsdl (never valid - DrugRef is XML-RPC,
  not SOAP, and the endpoint rejects GET on the new stack), with
  a GET on /drugref2/.
- drugref/Dockerfile: bump both build and runtime stages to
  tomcat:11.0-jdk21-temurin; refresh default ARGs and LABEL to
  match the new upstream.

XML-RPC compatibility was traced end-to-end: every method
RxDrugRef calls on live code paths (list_search_element*,
get_drug_by_DIN, get_allergy_warnings, identify, version,
interaction_by_regional_identifier, ...) exists in drugref2026's
Drugref.java. The 16 methods CARLOS wraps that are absent
(atc, interaction, drug2atclist, getStrengths, ...) are only
reachable through @Deprecated helpers in RxDrugData with no
callers; they remain for a follow-up cleanup PR.

Schema: the 17 tables in database/mysql/development-drugref.sql
cover every table drugref2026's data-model documents, so the
seeded dump is reusable unchanged.

https://claude.ai/code/session_0119rnLD43ELbvXLQ3S1M82h

## Summary by Sourcery

Update the devcontainer DrugRef sidecar to use the CARLOS-aligned DrugRef2026 image on Java 21 / Tomcat 11 and point the default repo/branch to a tagged, reproducible upstream build.

Enhancements:
- Switch the DrugRef devcontainer Dockerfile from Tomcat 9 / Java 11 to Tomcat 11 / Java 21 and refresh image metadata for the DrugRef2026 stack.
- Update devcontainer docker-compose defaults to use the carlos-emr/drugref2026 repository at the v1.0.0-rc2 tag for reproducible DrugRef builds.
- Adjust the DrugRef service healthcheck to target the base /drugref2/ endpoint instead of the legacy WSDL URL.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Swapped the devcontainer DrugRef sidecar from `open-osp/Open-Drugref` (Java 11/Tomcat 9) to `carlos-emr/drugref2026` (Java 21/Tomcat 11). This aligns with the CARLOS stack and removes the last Java 11 image.

- **Refactors**
  - Default `DRUGREF_REPO` to `https://github.com/carlos-emr/drugref2026.git` and pin `DRUGREF_BRANCH` to `v1.0.0-rc2` for reproducible builds.
  - Update build/runtime base image to `tomcat:11.0-jdk21-temurin`; refresh default args and labels.
  - Fix healthcheck to GET `/drugref2/` (DrugRef is XML-RPC, not SOAP).

- **Migration**
  - No app changes needed; rebuild the devcontainer.
  - Existing `development-drugref.sql` seed remains compatible.

<sup>Written for commit 4a02f9d52c86715f97ca78146aa5ad531d930f3d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

