### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL Injection in DemographicDaoImpl ORDER BY clause

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - [SQL Injection in ORDER BY clause via string concatenation]
+**Vulnerability:** A SQL Injection vulnerability existed in `DemographicDaoImpl.java` where the `orderBy` argument was directly concatenated into a native query via `orderBy = "de." + orderBy` inside the `getOrderField(String orderBy, boolean nativeQuery)` method.
+**Learning:** `ORDER BY` clauses cannot be parameterized with placeholders like standard data values (`?` or `:name`). When dynamically constructing `ORDER BY` statements in JPA/Hibernate or Native SQL queries, string concatenation exposes the system to injection attacks if user inputs are directly passed into the query structure.
+**Prevention:** Always validate dynamic order columns against an explicit and strict allowlist mapping (e.g. mapping "last_name" explicitly to "de.last_name, de.first_name") rather than directly concatenating user input to form the `ORDER BY` clause.

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDaoImpl.java
@@ -1514,10 +1514,27 @@ public class DemographicDaoImpl extends AbstractHibernateDao implements Applicat
         if (!nativeQuery) {
             orderBy = getOrderField(orderBy);
         } else {
-            if (orderBy.equals("dob")) {
-                orderBy = "de.year_of_birth, de.month_of_birth, de.date_of_birth ";
+            if (orderBy.equals("last_name") || orderBy.equals("last_name, first_name")) {
+                orderBy = "de.last_name, de.first_name";
+            } else if (orderBy.equals("demographic_no")) {
+                orderBy = "de.demographic_no";
+            } else if (orderBy.equals("chart_no")) {
+                orderBy = "de.chart_no";
+            } else if (orderBy.equals("sex")) {
+                orderBy = "de.sex";
+            } else if (orderBy.equals("dob")) {
+                orderBy = "de.year_of_birth, de.month_of_birth, de.date_of_birth";
+            } else if (orderBy.equals("provider_no")) {
+                orderBy = "de.provider_no";
+            } else if (orderBy.equals("roster_status")) {
+                orderBy = "de.roster_status";
+            } else if (orderBy.equals("patient_status")) {
+                orderBy = "de.patient_status";
+            } else if (orderBy.equals("phone")) {
+                orderBy = "de.phone";
             } else {
-                orderBy = "de." + orderBy;
+                // Default to a safe fallback or throw exception to prevent SQL injection on unknown fields
+                orderBy = "de.last_name, de.first_name";
             }
         }
 


### PR DESCRIPTION
Fixes a critical SQL injection vulnerability in `DemographicDaoImpl.java` where unvalidated user input was directly appended into the `ORDER BY` clause of a native SQL query. The code now securely maps specific safe inputs to their corresponding native column names using a strict allowlist.

Also documented this learning in `.jules/sentinel.md` as per the Sentinel guidelines.

---
*PR created automatically by Jules for task [9449810687334885583](https://jules.google.com/task/9449810687334885583) started by @yingbull*

## Summary by Sourcery

Address SQL injection risk in demographic ordering logic and document the mitigation approach.

Bug Fixes:
- Prevent SQL injection in native demographic queries by restricting ORDER BY fields to a strict allowlist with a safe fallback.

Documentation:
- Add Sentinel security note describing the ORDER BY SQL injection issue, root cause, and recommended allowlist-based prevention.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a critical SQL injection in `DemographicDaoImpl` by replacing user-controlled `ORDER BY` concatenation with a strict allowlist of known fields. Adds a Sentinel note in `.jules/sentinel.md` on safe dynamic sorting.

- **Bug Fixes**
  - Map allowed sort keys to exact native columns (e.g., "dob" -> `de.year_of_birth, de.month_of_birth, de.date_of_birth`; "last_name" -> `de.last_name, de.first_name`).
  - Use a safe default (`de.last_name, de.first_name`) for unknown inputs to block injection.
  - Documented the issue and prevention steps in `.jules/sentinel.md`.

<sup>Written for commit f3338dccaf451dea415c33ad30f9c803594f14f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

