### PR TITLE
[Fix] declutter DisplayMessages.jsp

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/messenger/DisplayMessages.jsp
+++ b/src/main/webapp/WEB-INF/jsp/messenger/DisplayMessages.jsp
@@ -254,6 +254,36 @@
                     // Set title attribute
                     element.setAttribute("title", text);
                 });
+
+                // Show bulk action controls only when one or more message checkboxes are selected.
+                // Skip control groups that have no actionable buttons (e.g. demographic view, pageType == 3)
+                // so an empty strip never appears.
+                const controlGroups = Array.from(document.querySelectorAll('.action-controls'))
+                        .filter(function (el) { return el.querySelector('button'); });
+                if (controlGroups.length > 0) {
+                    const selectAll = document.getElementById('checkA');
+                    function updateControlsVisibility() {
+                        // Count only per-message checkboxes, not the select-all toggle,
+                        // so controls stay hidden when the list is empty or all rows are unchecked.
+                        const anyChecked = document.querySelectorAll('input[name="messageNo"]:checked').length > 0;
+                        const displayStyle = anyChecked ? 'inline-block' : 'none';
+                        controlGroups.forEach(function (el) { el.style.display = displayStyle; });
+                    }
+                    // 'change' is the idiomatic event for checkbox state and also covers keyboard toggling.
+                    document.addEventListener('change', function (e) {
+                        if (e.target && e.target.classList && e.target.classList.contains('chk')) {
+                            updateControlsVisibility();
+                        }
+                    });
+                    // checkAll() programmatically sets .checked without firing 'change', so re-sync
+                    // after the inline onclick handler has propagated the state to per-message checkboxes.
+                    if (selectAll) {
+                        selectAll.addEventListener('click', function () {
+                            updateControlsVisibility();
+                        });
+                    }
+                    updateControlsVisibility();
+                }
             });
 
         </script>
@@ -374,7 +404,15 @@
                         }   //messageid
 %>
                     <tr>
-                        <td style="padding: 10px;" >
+                        <td style="padding: 10px;" ><span class="action-controls" style="display: none;">
+                            <%if (pageType == 0){%>
+                                    <button name="btnDelete" type="submit" class="btn btn-light" title="<fmt:message key="messenger.DisplayMessages.formArchive"/>"><i class="fa-solid fa-box-archive"></i>&nbsp;<fmt:message key="messenger.DisplayMessages.formArchive"/></button>
+                                    <button name="btnRead" type="submit" class="btn btn-light" title="<fmt:message key="messenger.DisplayMessages.markRead"/>"><i class="fa-solid fa-envelope-open-text"></i>&nbsp;<fmt:message key="messenger.DisplayMessages.markRead"/></button>
+                                    <button name="btnUnread" type="submit" class="btn btn-light" title="<fmt:message key="messenger.DisplayMessages.markUnRead"/>"><i class="fa-solid fa-envelope"></i>&nbsp;<fmt:message key="messenger.DisplayMessages.markUnRead"/></button>
+                            <%}else if (pageType == 2){%>
+                                    <button name="btnUnarchive" type="submit" class="btn btn-light" title="<fmt:message key="messenger.DisplayMessages.formUnarchive"/>"><i class="fa-solid fa-box-open"></i>&nbsp;<fmt:message key="messenger.DisplayMessages.formUnarchive"/></button>
+                            <%}%>
+                            &nbsp;</span>
                         <span class="float-end">
 		                    <%
 		                    int recordsToDisplay = 25;
@@ -422,7 +460,7 @@
                                 <thead><tr>
                                     <th style="text-align: left;">
                                     <%if( pageType!=1 ) {%>
-                                       <input type="checkbox" name="checkA" class="chk" onclick="checkAll('msgList'); " id="checkA" style="margin-bottom: 10px;" title="<fmt:message key="messenger.DisplayMessages.msgAllMessage"/>">
+                                       <input type="checkbox" name="checkA" onclick="checkAll('msgList'); " id="checkA" style="margin-bottom: 10px;" title="<fmt:message key="messenger.DisplayMessages.msgAllMessage"/>">
                                     <%} %>
                                     </th>
                                     <th style="text-align: left; width:120px;">
@@ -554,7 +592,7 @@
                             <%}%>
 
                             <tr><td colspan="6">
-                            <span id="controls" style="visibility: hidden;">
+                            <span class="action-controls" style="display: none;">
                             <%if (pageType == 0){%>
                                     <button name="btnDelete" type="submit" class="btn btn-light" title="<fmt:message key="messenger.DisplayMessages.formArchive"/>"><i class="fa-solid fa-box-archive"></i>&nbsp;<fmt:message key="messenger.DisplayMessages.formArchive"/></button>
                                     <button name="btnRead" type="submit" class="btn btn-light" title="<fmt:message key="messenger.DisplayMessages.markRead"/>"><i class="fa-solid fa-envelope-open-text"></i>&nbsp;<fmt:message key="messenger.DisplayMessages.markRead"/></button>
@@ -584,24 +622,5 @@
         </tr>
     </table>
 </form>
-<script>
-  document.addEventListener('DOMContentLoaded', function () {
-    const controls = document.getElementById('controls');
-  
-    function updateControlsVisibility() {
-      const anyChecked = document.querySelectorAll('.chk:checked').length > 0;
-      controls.style.visibility = anyChecked ? 'visible' : 'hidden';
-    }
-  
-    document.addEventListener('click', function (e) {
-      if (e.target.matches('.chk')) {
-        updateControlsVisibility();
-      }
-    });
-  
-    updateControlsVisibility();
-  });
-</script>
-
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/jsp/messenger/DisplayMessages.jsp
+++ b/src/main/webapp/WEB-INF/jsp/messenger/DisplayMessages.jsp
@@ -76,9 +76,6 @@
 <%@ page import="java.util.ResourceBundle" %>
 <%@ page import="io.github.carlos_emr.carlos.utility.MiscUtils" %>
 <%@ page import="io.github.carlos_emr.carlos.utility.SafeEncode" %>
-
- 
-	
  
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
@@ -212,7 +209,8 @@
         </style>
 
         <script type="text/javascript" src="<%= request.getContextPath() %>/messenger/messenger-common.js"></script>
-        <script type="text/javascript">
+
+        <script>
             function uload() {
                 if (opener && opener.callRefreshTabAlerts) {
                     opener.callRefreshTabAlerts("oscar_new_msg");
@@ -376,15 +374,7 @@
                         }   //messageid
 %>
                     <tr>
-                        <td style="padding: 10px;" ><span>
-                            <%if (pageType == 0){%>
-                                    <button name="btnDelete" type="submit" class="btn btn-light" title="<fmt:message key="messenger.DisplayMessages.formArchive"/>"><i class="fa-solid fa-box-archive"></i>&nbsp;<fmt:message key="messenger.DisplayMessages.formArchive"/></button>
-                                    <button name="btnRead" type="submit" class="btn btn-light" title="<fmt:message key="messenger.DisplayMessages.markRead"/>"><i class="fa-solid fa-envelope-open-text"></i>&nbsp;<fmt:message key="messenger.DisplayMessages.markRead"/></button>
-                                    <button name="btnUnread" type="submit" class="btn btn-light" title="<fmt:message key="messenger.DisplayMessages.markUnRead"/>"><i class="fa-solid fa-envelope"></i>&nbsp;<fmt:message key="messenger.DisplayMessages.markUnRead"/></button>
-                            <%}else if (pageType == 2){%>
-                                    <button name="btnUnarchive" type="submit" class="btn btn-light" title="<fmt:message key="messenger.DisplayMessages.formUnarchive"/>"><i class="fa-solid fa-box-open"></i>&nbsp;<fmt:message key="messenger.DisplayMessages.formUnarchive"/></button>
-                            <%}%>
-                            &nbsp;</span>
+                        <td style="padding: 10px;" >
                         <span class="float-end">
 		                    <%
 		                    int recordsToDisplay = 25;
@@ -432,7 +422,7 @@
                                 <thead><tr>
                                     <th style="text-align: left;">
                                     <%if( pageType!=1 ) {%>
-                                       <input type="checkbox" name="checkA" onclick="checkAll('msgList')" id="checkA" style="margin-bottom: 10px;" title="<fmt:message key="messenger.DisplayMessages.msgAllMessage"/>">
+                                       <input type="checkbox" name="checkA" class="chk" onclick="checkAll('msgList'); " id="checkA" style="margin-bottom: 10px;" title="<fmt:message key="messenger.DisplayMessages.msgAllMessage"/>">
                                     <%} %>
                                     </th>
                                     <th style="text-align: left; width:120px;">
@@ -512,7 +502,7 @@
                                 <tr class="<%=rowClass%>">
                                     <td style="width:25px;">
                                     <%if (pageType != 1){%>
-                                       <input type="checkbox" name="messageNo" value="<carlos:encode value='<%= dm.getMessageId() %>' context="htmlAttribute"/>">
+                                       <input type="checkbox" class="chk" name="messageNo" value="<carlos:encode value='<%= dm.getMessageId() %>' context="htmlAttribute"/>">
                                      <% } %>
 
                                     </td>
@@ -564,7 +554,7 @@
                             <%}%>
 
                             <tr><td colspan="6">
-                        <span>
+                            <span id="controls" style="visibility: hidden;">
                             <%if (pageType == 0){%>
                                     <button name="btnDelete" type="submit" class="btn btn-light" title="<fmt:message key="messenger.DisplayMessages.formArchive"/>"><i class="fa-solid fa-box-archive"></i>&nbsp;<fmt:message key="messenger.DisplayMessages.formArchive"/></button>
                                     <button name="btnRead" type="submit" class="btn btn-light" title="<fmt:message key="messenger.DisplayMessages.markRead"/>"><i class="fa-solid fa-envelope-open-text"></i>&nbsp;<fmt:message key="messenger.DisplayMessages.markRead"/></button>
@@ -594,5 +584,24 @@
         </tr>
     </table>
 </form>
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    const controls = document.getElementById('controls');
+  
+    function updateControlsVisibility() {
+      const anyChecked = document.querySelectorAll('.chk:checked').length > 0;
+      controls.style.visibility = anyChecked ? 'visible' : 'hidden';
+    }
+  
+    document.addEventListener('click', function (e) {
+      if (e.target.matches('.chk')) {
+        updateControlsVisibility();
+      }
+    });
+  
+    updateControlsVisibility();
+  });
+</script>
+
 </body>
 </html>


### PR DESCRIPTION
hide controls until needed

<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description
context sensitive display of UI to prevent button display that will not work outside of their context
<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues
Fixes #1852
<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?
dev
<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots
<img width="1024" height="337" alt="cleanerDisplayMessages" src="https://github.com/user-attachments/assets/66189fc9-da76-4178-a26e-63b428f9cf66" />

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->

<img width="1007" height="600" alt="Afficher les messages" src="https://github.com/user-attachments/assets/c8e106ef-cb56-4081-9243-edb5556a471c" />
<img width="1007" height="804" alt="checkedAfficher les messages" src="https://github.com/user-attachments/assets/7b931475-7758-4cfe-ae90-72ede71cb81b" />

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Declutter the messenger message list UI by showing bulk action controls only when applicable.

Enhancements:
- Hide bulk message action controls by default and display them only when one or more messages are selected.
- Add client-side logic to track message selection checkboxes and toggle the visibility of the bulk action controls accordingly.
- Assign a shared CSS class to relevant checkboxes to simplify selection state handling and visibility updates for controls.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide bulk action buttons in the messenger until at least one message is selected, decluttering the UI and preventing non-functional actions. Fixes #1852.

- **Bug Fixes**
  - Wrapped action toolbars in `.action-controls`, hidden by default and shown only when any message checkbox is checked.
  - Added `.chk` to per-message checkboxes and a `change` listener; also sync visibility when using “select all” (`#checkA`) to catch programmatic toggles.
  - Only toggle control groups that contain buttons to avoid showing empty strips in views without actions.

<sup>Written for commit 439361654a4d381d030dbefec516b7fac4565053. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



