### PR TITLE
Use extensionless /appointment/printappointment route in add/update appointment JSPs and update routing test

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/appointment/appointmentaddarecord.jsp
+++ b/src/main/webapp/WEB-INF/jsp/appointment/appointmentaddarecord.jsp
@@ -82,7 +82,7 @@
                 <h1><fmt:message key="appointment.addappointment.msgAddSuccess"/></h1>
                 <script language="JavaScript">
                     <c:if test="${printReceipt}">
-                    popupPage(350, 750, 'printappointment.jsp?appointment_no=${carlos:forJavaScript(apptId)}');
+                    popupPage(350, 750, '${pageContext.request.contextPath}/appointment/printappointment?appointment_no=${carlos:forJavaScript(apptId)}');
                     </c:if>
                     try { self.opener.refresh(); } catch (e) { /* opener may be closed or cross-origin */ }
                     self.close();

--- a/src/main/webapp/WEB-INF/jsp/appointment/appointmentaddarecord.jsp
+++ b/src/main/webapp/WEB-INF/jsp/appointment/appointmentaddarecord.jsp
@@ -82,7 +82,7 @@
                 <h1><fmt:message key="appointment.addappointment.msgAddSuccess"/></h1>
                 <script language="JavaScript">
                     <c:if test="${printReceipt}">
-                    popupPage(350, 750, '${pageContext.request.contextPath}/appointment/printappointment?appointment_no=${carlos:forJavaScript(apptId)}');
+                    popupPage(350, 750, '${pageContext.request.contextPath}/appointment/printappointment?appointment_no=${carlos:forJavaScript(carlos:forUriComponent(apptId))}');
                     </c:if>
                     try { self.opener.refresh(); } catch (e) { /* opener may be closed or cross-origin */ }
                     self.close();

--- a/src/main/webapp/WEB-INF/jsp/appointment/appointmentupdatearecord.jsp
+++ b/src/main/webapp/WEB-INF/jsp/appointment/appointmentupdatearecord.jsp
@@ -64,7 +64,7 @@
                 <h1><fmt:message key="appointment.appointmentupdatearecord.msgUpdateSuccess"/></h1>
                 <script language="JavaScript">
                     <c:if test="${printReceipt}">
-                    popupPage(350, 750, 'printappointment.jsp?appointment_no=${carlos:forJavaScript(appointmentNo)}');
+                    popupPage(350, 750, '${pageContext.request.contextPath}/appointment/printappointment?appointment_no=${carlos:forJavaScript(appointmentNo)}');
                     </c:if>
                     try { self.opener.refresh(); } catch (e) { /* opener may be closed or cross-origin */ }
                     self.close();

--- a/src/main/webapp/WEB-INF/jsp/appointment/appointmentupdatearecord.jsp
+++ b/src/main/webapp/WEB-INF/jsp/appointment/appointmentupdatearecord.jsp
@@ -64,7 +64,7 @@
                 <h1><fmt:message key="appointment.appointmentupdatearecord.msgUpdateSuccess"/></h1>
                 <script language="JavaScript">
                     <c:if test="${printReceipt}">
-                    popupPage(350, 750, '${pageContext.request.contextPath}/appointment/printappointment?appointment_no=${carlos:forJavaScript(appointmentNo)}');
+                    popupPage(350, 750, '${pageContext.request.contextPath}/appointment/printappointment?appointment_no=${carlos:forJavaScript(carlos:forUriComponent(appointmentNo))}');
                     </c:if>
                     try { self.opener.refresh(); } catch (e) { /* opener may be closed or cross-origin */ }
                     self.close();

--- a/src/test/java/io/github/carlos_emr/carlos/appointment/AppointmentJspRoutingTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/appointment/AppointmentJspRoutingTest.java
@@ -51,9 +51,13 @@ class AppointmentJspRoutingTest {
         assertThat(groupRecords).doesNotContain("action=\"appointmentgrouprecords.jsp\"");
 
         assertThat(addRecord).contains("/appointment/printappointment?appointment_no=");
+        assertThat(addRecord).contains("pageContext.request.contextPath");
+        assertThat(addRecord).contains("carlos:forJavaScript(carlos:forUriComponent(apptId))");
         assertThat(addRecord).doesNotContain("printappointment.jsp?appointment_no=");
 
         assertThat(updateRecord).contains("/appointment/printappointment?appointment_no=");
+        assertThat(updateRecord).contains("pageContext.request.contextPath");
+        assertThat(updateRecord).contains("carlos:forJavaScript(carlos:forUriComponent(appointmentNo))");
         assertThat(updateRecord).doesNotContain("printappointment.jsp?appointment_no=");
 
         assertThat(providerDay).contains("/appointment/addappointment?");

--- a/src/test/java/io/github/carlos_emr/carlos/appointment/AppointmentJspRoutingTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/appointment/AppointmentJspRoutingTest.java
@@ -52,7 +52,6 @@ class AppointmentJspRoutingTest {
 
         assertThat(addRecord).contains("/appointment/printappointment?appointment_no=");
         assertThat(addRecord).contains("pageContext.request.contextPath");
-        assertThat(addRecord).contains("/appointment/printappointment?appointment_no=");
         assertThat(addRecord).contains("carlos:forJavaScript(carlos:forUriComponent(apptId))");
         assertThat(addRecord).doesNotContain("printappointment.jsp?appointment_no=");
 

--- a/src/test/java/io/github/carlos_emr/carlos/appointment/AppointmentJspRoutingTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/appointment/AppointmentJspRoutingTest.java
@@ -53,7 +53,7 @@ class AppointmentJspRoutingTest {
         assertThat(addRecord).contains("/appointment/printappointment?appointment_no=");
         assertThat(addRecord).contains("pageContext.request.contextPath");
         assertThat(addRecord).contains("/appointment/printappointment?appointment_no=");
-        assertThat(addRecord).containsAnyOf("request.getContextPath()", "pageContext.request.contextPath");
+        assertThat(addRecord).contains("carlos:forJavaScript(carlos:forUriComponent(apptId))");
         assertThat(addRecord).doesNotContain("printappointment.jsp?appointment_no=");
 
         assertThat(updateRecord).contains("/appointment/printappointment?appointment_no=");

--- a/src/test/java/io/github/carlos_emr/carlos/appointment/AppointmentJspRoutingTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/appointment/AppointmentJspRoutingTest.java
@@ -28,6 +28,9 @@ class AppointmentJspRoutingTest {
         String editRepeat = readJspContent("src/main/webapp/WEB-INF/jsp/appointment/appointmenteditrepeatbooking.jsp");
         String repeat = readJspContent("src/main/webapp/WEB-INF/jsp/appointment/appointmentrepeatbooking.jsp");
         String groupRecords = readJspContent("src/main/webapp/WEB-INF/jsp/appointment/appointmentgrouprecords.jsp");
+        String addRecord = readJspContent("src/main/webapp/WEB-INF/jsp/appointment/appointmentaddarecord.jsp");
+        String updateRecord = readJspContent("src/main/webapp/WEB-INF/jsp/appointment/appointmentupdatearecord.jsp");
+        String providerDay = readJspContent("src/main/webapp/WEB-INF/jsp/provider/appointmentprovideradminday.jsp");
 
         assertThat(editAppointment).contains("/appointment/appointmentcontrol");
         assertThat(editAppointment).contains("/appointment/appointmenteditrepeatbooking");
@@ -46,6 +49,16 @@ class AppointmentJspRoutingTest {
 
         assertThat(groupRecords).contains("action=\"<%=request.getContextPath() %>/appointment/appointmentgrouprecords\"");
         assertThat(groupRecords).doesNotContain("action=\"appointmentgrouprecords.jsp\"");
+
+        assertThat(addRecord).contains("/appointment/printappointment?appointment_no=");
+        assertThat(addRecord).doesNotContain("printappointment.jsp?appointment_no=");
+
+        assertThat(updateRecord).contains("/appointment/printappointment?appointment_no=");
+        assertThat(updateRecord).doesNotContain("printappointment.jsp?appointment_no=");
+
+        assertThat(providerDay).contains("/appointment/addappointment?");
+        assertThat(providerDay).contains("return ctx + '/appointment/addappointment'");
+        assertThat(providerDay).doesNotContain("/appointment/addappointment.jsp");
     }
 
     private String readJspContent(String path) throws IOException {

--- a/src/test/java/io/github/carlos_emr/carlos/appointment/AppointmentJspRoutingTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/appointment/AppointmentJspRoutingTest.java
@@ -52,10 +52,12 @@ class AppointmentJspRoutingTest {
 
         assertThat(addRecord).contains("/appointment/printappointment?appointment_no=");
         assertThat(addRecord).contains("pageContext.request.contextPath");
-        assertThat(addRecord).contains("carlos:forJavaScript(carlos:forUriComponent(apptId))");
+        assertThat(addRecord).contains("/appointment/printappointment?appointment_no=");
+        assertThat(addRecord).containsAnyOf("request.getContextPath()", "pageContext.request.contextPath");
         assertThat(addRecord).doesNotContain("printappointment.jsp?appointment_no=");
 
         assertThat(updateRecord).contains("/appointment/printappointment?appointment_no=");
+        assertThat(updateRecord).containsAnyOf("request.getContextPath()", "pageContext.request.contextPath");
         assertThat(updateRecord).contains("pageContext.request.contextPath");
         assertThat(updateRecord).contains("carlos:forJavaScript(carlos:forUriComponent(appointmentNo))");
         assertThat(updateRecord).doesNotContain("printappointment.jsp?appointment_no=");


### PR DESCRIPTION
### Motivation
- Migrate popup print links in appointment add/update result pages to use extensionless routes under the application context instead of direct JSP filenames.
- Ensure JSP routing consistency across appointment workflows and prevent direct references to `.jsp` filenames.

### Description
- Updated `appointmentaddarecord.jsp` to call `popupPage` with `${pageContext.request.contextPath}/appointment/printappointment?appointment_no=${carlos:forJavaScript(apptId)}` instead of `printappointment.jsp?...`.
- Updated `appointmentupdatearecord.jsp` to call `popupPage` with `${pageContext.request.contextPath}/appointment/printappointment?appointment_no=${carlos:forJavaScript(appointmentNo)}` instead of `printappointment.jsp?...`.
- Extended `AppointmentJspRoutingTest` to read the updated JSPs and added assertions ensuring the new extensionless `'/appointment/printappointment?appointment_no='` URLs are present and the old `printappointment.jsp` references are removed, plus added checks for provider-day add appointment routing.

### Testing
- Ran the updated unit test `AppointmentJspRoutingTest` which verifies routing string changes and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e50da0b3d483288596b94047de301e)

## Summary by Sourcery

Update appointment JSP print links to use context-relative extensionless routes and extend routing tests to cover the new URLs and provider-day add-appointment routing.

Bug Fixes:
- Align appointment add/update print receipt links with extensionless routing to avoid direct JSP filename usage.

Tests:
- Expand AppointmentJspRoutingTest to assert the new print appointment URLs, removal of legacy JSP-based links, and provider-day add appointment routing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched print receipt links on add/update appointment success pages to the extensionless, context-relative `/appointment/printappointment` route, using nested `carlos:forUriComponent` + `carlos:forJavaScript` encoding for `appointment_no`.
Tightened `AppointmentJspRoutingTest` to assert context-path usage, encoded query construction, removal of `printappointment.jsp`, and provider-day `addappointment` routing.

<sup>Written for commit b14aea15e45b4ae89aff0c566d744a59be540a63. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

