### PR TITLE
Integrate Flatpickr for date selection

### DIFF
--- a/src/main/resources/oscarResources_pl.properties
+++ b/src/main/resources/oscarResources_pl.properties
@@ -9193,6 +9193,7 @@ consultationList.header.action=Akcja
 consultationList.header.appointmentDate=Data wizyty
 dashboard.dashboardmanager.title=Mened\u017cer pulpitu
 ddmmyyyy=(dd/mm/rrrr)
+yyyy-mm-dd=rrrr-mm-dd
 disable=Wy\u0142\u0105cz
 disabled=Wy\u0142\u0105czony
 dob=Data urodzenia

--- a/src/main/webapp/WEB-INF/jsp/tickler/ticklerMain.jsp
+++ b/src/main/webapp/WEB-INF/jsp/tickler/ticklerMain.jsp
@@ -606,8 +606,16 @@
             }
 
             function allYear() {
-                document.serviceform.xml_appointment_date.value = "8888-12-31";
-                document.serviceform.xml_vdate.value = "1900-01-01";
+                if (window._ticklerToPicker) {
+                    window._ticklerToPicker.setDate("8888-12-31", true);
+                } else {
+                    document.serviceform.xml_appointment_date.value = "8888-12-31";
+                }
+                if (window._ticklerFromPicker) {
+                    window._ticklerFromPicker.setDate("1900-01-01", true);
+                } else {
+                    document.serviceform.xml_vdate.value = "1900-01-01";
+                }
             }
 
             function Check(e) { e.checked = true; }
@@ -712,6 +720,9 @@
 
             const fromPicker = flatpickr("#xml_vdate", fromPickerOptions);
             const toPicker = flatpickr("#xml_appointment_date", toPickerOptions);
+            // Expose pickers so allYear() can update Flatpickr state, not just .value
+            window._ticklerFromPicker = fromPicker;
+            window._ticklerToPicker = toPicker;
         
             function syncFrom(selectedDates, dateStr, instance) {
               const fromDate = instance.selectedDates[0];

--- a/src/main/webapp/WEB-INF/jsp/tickler/ticklerMain.jsp
+++ b/src/main/webapp/WEB-INF/jsp/tickler/ticklerMain.jsp
@@ -778,7 +778,7 @@
                 <div class="row mb-2">
                     <label for="xml_vdate" class="col-sm-3 col-form-label"><fmt:message key="tickler.ticklerMain.formFrom"/></label>
                     <div class="col-sm-9">
-                        <input type="text" class="form-control" name="xml_vdate" id="xml_vdate"
+                        <input type="text" class="form-control" name="xml_vdate" id="xml_vdate" placeholder="<fmt:message key="yyyy-mm-dd"/>"
                                value="<carlos:encode value='<%= xml_vdate %>' context="htmlAttribute"/>">
 
                     </div>
@@ -786,7 +786,7 @@
                 <div class="row mb-2">
                     <label for="xml_appointment_date" class="col-sm-3 col-form-label"><fmt:message key="tickler.ticklerMain.formTo"/></label>
                     <div class="col-sm-9">
-                        <input type="date" class="form-control" name="xml_appointment_date" id="xml_appointment_date"
+                        <input type="text" class="form-control" name="xml_appointment_date" id="xml_appointment_date" placeholder="<fmt:message key="yyyy-mm-dd"/>"
                                value="<carlos:encode value='<%= xml_appointment_date %>' context="htmlAttribute"/>">
 
                     </div>

--- a/src/main/webapp/WEB-INF/jsp/tickler/ticklerMain.jsp
+++ b/src/main/webapp/WEB-INF/jsp/tickler/ticklerMain.jsp
@@ -153,7 +153,10 @@
     java.util.ResourceBundle oscarBundle = java.util.ResourceBundle.getBundle("oscarResources", request.getLocale());
 %>
 
-<html>
+<c:set var="flatpickrLanguage" value="${pageContext.request.locale.language}"/>
+
+<!DOCTYPE html>
+<html lang="${flatpickrLanguage}">
     <head>
         <title><fmt:message key="tickler.ticklerMain.managerHeading"/></title>
 
@@ -163,6 +166,13 @@
         <script type="text/javascript" src="${pageContext.request.contextPath}/library/DataTables/DataTables-1.13.4/js/jquery.dataTables.min.js"></script>
         <script type="text/javascript" src="${pageContext.request.contextPath}/library/DataTables/DataTables-1.13.4/js/dataTables.bootstrap5.min.js"></script>
         <link rel="stylesheet" type="text/css" media="print" href="<%= request.getContextPath() %>/css/print.css"/>
+
+        <!-- Flatpickr -->
+        <script type="text/javascript" src="${pageContext.request.contextPath}/library/flatpickr/flatpickr.min.js"></script>
+        <c:if test="${flatpickrLanguage != 'en'}">
+        <script type="text/javascript" src="${pageContext.request.contextPath}/library/flatpickr/l10n/${carlos:forHtmlAttribute(flatpickrLanguage)}.js"></script>
+        </c:if>
+        <link rel="stylesheet" type="text/css" href="${pageContext.request.contextPath}/library/flatpickr/flatpickr.min.css">
 
         <style>
             /* Comment rows */
@@ -275,6 +285,11 @@
             @media print {
                 .searchBox, .page-header-bar { display: none; }
             }
+
+            @media screen {
+                .yesprint { display: none; }
+            }
+
         </style>
         <script type="application/javascript">
 
@@ -671,7 +686,64 @@
             });
 
         </script>
+        <script>
+          document.addEventListener("DOMContentLoaded", function () {
+            const localeCode = "${carlos:forJavaScript(flatpickrLanguage)}";
+            const fromPickerOptions = {
+              dateFormat: "Y-m-d",
+              allowInput: true,
+              onChange: syncFrom,
+              onClose: syncFrom
+            };
+            const toPickerOptions = {
+              dateFormat: "Y-m-d",
+              allowInput: true,
+              onChange: syncTo,
+              onClose: syncTo
+            };
 
+            if (localeCode !== "en") {
+              fromPickerOptions.locale = localeCode;
+              toPickerOptions.locale = localeCode;
+            }
+
+            const fromPicker = flatpickr("#xml_vdate", fromPickerOptions);
+            const toPicker = flatpickr("#xml_appointment_date", toPickerOptions);
+        
+            function syncFrom(selectedDates, dateStr, instance) {
+              const fromDate = instance.selectedDates[0];
+              const toDate = toPicker.selectedDates[0];
+        
+              if (fromDate) {
+                toPicker.set("minDate", fromDate);
+        
+                // auto-correct if To < From
+                if (toDate && toDate < fromDate) {
+                  toPicker.setDate(fromDate, true);
+                }
+              } else {
+                toPicker.set("minDate", null);
+              }
+            }
+        
+            function syncTo(selectedDates, dateStr, instance) {
+              const toDate = instance.selectedDates[0];
+              const fromDate = fromPicker.selectedDates[0];
+        
+              if (toDate) {
+                fromPicker.set("maxDate", toDate);
+        
+                // auto-correct if From > To
+                if (fromDate && fromDate > toDate) {
+                  fromPicker.setDate(toDate, true);
+                }
+              } else {
+                fromPicker.set("maxDate", null);
+              }
+            }
+        
+          });
+        </script>
     </head>
 
     <body>
@@ -706,8 +778,9 @@
                 <div class="row mb-2">
                     <label for="xml_vdate" class="col-sm-3 col-form-label"><fmt:message key="tickler.ticklerMain.formFrom"/></label>
                     <div class="col-sm-9">
-                        <input type="date" class="form-control" name="xml_vdate" id="xml_vdate"
+                        <input type="text" class="form-control" name="xml_vdate" id="xml_vdate"
                                value="<carlos:encode value='<%= xml_vdate %>' context="htmlAttribute"/>">
+
                     </div>
                 </div>
                 <div class="row mb-2">
@@ -715,6 +788,7 @@
                     <div class="col-sm-9">
                         <input type="date" class="form-control" name="xml_appointment_date" id="xml_appointment_date"
                                value="<carlos:encode value='<%= xml_appointment_date %>' context="htmlAttribute"/>">
+
                     </div>
                 </div>
                 <div class="row mb-2">

--- a/src/main/webapp/WEB-INF/jsp/tickler/ticklerMain.jsp
+++ b/src/main/webapp/WEB-INF/jsp/tickler/ticklerMain.jsp
@@ -168,7 +168,7 @@
         <!-- Flatpickr -->
         <script type="text/javascript" src="${pageContext.request.contextPath}/library/flatpickr/flatpickr.min.js"></script>
         <c:if test="${flatpickrLanguage != 'en'}">
-        <script type="text/javascript" src="${pageContext.request.contextPath}/library/flatpickr/l10n/${carlos:forHtmlAttribute(flatpickrLanguage)}.js"></script>
+        <script type="text/javascript" src="${pageContext.request.contextPath}/library/flatpickr/l10n/${carlos:forUriComponent(flatpickrLanguage)}.js"></script>
         </c:if>
         <link rel="stylesheet" type="text/css" href="${pageContext.request.contextPath}/library/flatpickr/flatpickr.min.css">
 
@@ -700,10 +700,15 @@
               onClose: syncTo
             };
 
-            if (localeCode !== "en") {
-              fromPickerOptions.locale = localeCode;
-              toPickerOptions.locale = localeCode;
-            }
+            const hasRequestedLocale = localeCode !== "en"
+              && window.flatpickr
+              && flatpickr.l10ns
+              && flatpickr.l10ns[localeCode];
+
+            if (hasRequestedLocale) {
+               fromPickerOptions.locale = localeCode;
+               toPickerOptions.locale = localeCode;
+             }
 
             const fromPicker = flatpickr("#xml_vdate", fromPickerOptions);
             const toPicker = flatpickr("#xml_appointment_date", toPickerOptions);

--- a/src/main/webapp/WEB-INF/jsp/tickler/ticklerMain.jsp
+++ b/src/main/webapp/WEB-INF/jsp/tickler/ticklerMain.jsp
@@ -28,7 +28,7 @@
     CARLOS has no affiliation with OSCAR or McMaster University.
 
 --%>
-<!DOCTYPE html>
+
 <%@page import="io.github.carlos_emr.carlos.utility.LoggedInInfo" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 
@@ -152,9 +152,7 @@
     List<Provider> providers = providerDao.getActiveProviders();
     java.util.ResourceBundle oscarBundle = java.util.ResourceBundle.getBundle("oscarResources", request.getLocale());
 %>
-
-<c:set var="flatpickrLanguage" value="${pageContext.request.locale.language}"/>
-
+<c:set var="flatpickrLanguage" value="${pageContext.request.locale.language == 'es' || pageContext.request.locale.language == 'fr' || pageContext.request.locale.language == 'pl' || pageContext.request.locale.language == 'pt' ? pageContext.request.locale.language : 'en'}"/>
 <!DOCTYPE html>
 <html lang="${flatpickrLanguage}">
     <head>


### PR DESCRIPTION
Updated the HTML structure to include Flatpickr date picker functionality, allowing users to select dates with improved localization support. Hid footer for screen presentations

<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description

<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues

<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?

<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Integrate a localized Flatpickr-based date picker into the tickler search page and adjust layout for screen-only presentations.

New Features:
- Add Flatpickr-powered date pickers for the tickler From and To date fields with locale-aware configuration and date range synchronization.

Enhancements:
- Set HTML language attribute based on the request locale for better localization support.
- Hide print-only footer content during on-screen viewing via CSS media queries.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Integrates `flatpickr` for Tickler From/To date selection with locale-aware UI and automatic range syncing. Switches date inputs to text with localized `yyyy-mm-dd` placeholders and hides print-only footers on screen.

- **New Features**
  - Added `flatpickr` JS/CSS; compute `flatpickrLanguage` (`es`, `fr`, `pl`, `pt`, else `en`), set `<html lang>`, load matching locale when not `en`, and only apply it if present in `flatpickr.l10ns` (fallback to `en`).
  - Changed `#xml_vdate` and `#xml_appointment_date` to text with `yyyy-mm-dd` placeholders (i18n; added Polish key), initialized with `Y-m-d`, allow manual input, auto-sync min/max between fields, and keep `allYear()` in sync via `setDate` on both pickers.

<sup>Written for commit b8ce55a6d19621ee777c0596025a29fd188e272b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

