### PR TITLE
chore: fixes for 500/0 errors from webinf migration

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/appointment/appointmentcontrol.jsp
+++ b/src/main/webapp/WEB-INF/jsp/appointment/appointmentcontrol.jsp
@@ -86,7 +86,7 @@
     String target = opToFileDict.getDef(operation, "");
     if (target.isEmpty()) {
         MiscUtils.getLogger().warn("appointmentcontrol.jsp: unrecognized displaymode: {}",
-                org.owasp.encoder.SafeEncode.forJava(operation));
+                SafeEncode.forJava(operation));
         response.sendError(HttpServletResponse.SC_BAD_REQUEST,
                 "Unrecognized appointment operation");
         return;

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/onSearch3rdBillAddr.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/onSearch3rdBillAddr.jsp
@@ -340,6 +340,6 @@
         if (d == null || d.trim().equals("")) {
             return "";
         }
-        return org.owasp.encoder.SafeEncode.forJavaScript(d);
+        return SafeEncode.forJavaScript(d);
     }
 %>


### PR DESCRIPTION
This pull request makes minor refactoring changes to improve code clarity and consistency by simplifying references to the `SafeEncode` class. The updates remove unnecessary fully-qualified class names in favor of direct references.

Code cleanup and simplification:

* Replaced fully-qualified `org.owasp.encoder.SafeEncode` with direct `SafeEncode` references in `appointmentcontrol.jsp` and `onSearch3rdBillAddr.jsp` for improved readability and maintainability. [[1]](diffhunk://#diff-aa087f970a6d9b836fc9cb39e2c0155e9bc5a9a87d71026b5307b4b305d2c37fL89-R89) [[2]](diffhunk://#diff-d6b4259d8a92139abf642f3d7ecd0e7760385a8480c1ea230035266607622164L343-R343)

## Summary by Sourcery

Enhancements:
- Replace fully qualified org.owasp.encoder.SafeEncode usages in JSPs with direct SafeEncode references for consistency and readability.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 500/0 errors after the WEB-INF migration by using the imported `SafeEncode` class instead of fully qualified `org.owasp.encoder.SafeEncode` in `appointmentcontrol.jsp` and `onSearch3rdBillAddr.jsp`. This aligns with JSP imports and simplifies the code for readability.

<sup>Written for commit 9d38baf4746b659e1fe525c867ebe886aa303f29. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

