### PR TITLE
Fix case-sensitive sorting in Log Report provider dropdown

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/admin/web/LogReport2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/admin/web/LogReport2Action.java
@@ -116,8 +116,8 @@ public class LogReport2Action extends ActionSupport {
             }
 
             providers.sort(Comparator
-                    .comparing(ProviderData::getFirstName, Comparator.nullsFirst(Comparator.naturalOrder()))
-                    .thenComparing(ProviderData::getLastName, Comparator.nullsFirst(Comparator.naturalOrder())));
+                    .comparing(ProviderData::getFirstName,  Comparator.nullsFirst(String.CASE_INSENSITIVE_ORDER))
+                    .thenComparing(ProviderData::getLastName, Comparator.nullsFirst(String.CASE_INSENSITIVE_ORDER)));
 
             for (ProviderData provider : providers) {
                 String pNo = StringUtils.defaultString(provider.getId());


### PR DESCRIPTION
Fixes #1831

Replace naturalOrder() with CASE_INSENSITIVE_ORDER for first and last name.

## Summary by Sourcery

Bug Fixes:
- Fix case-sensitive sorting of providers in the Log Report dropdown by using case-insensitive string comparison for first and last names.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make provider sorting in the Log Report dropdown case-insensitive to ensure consistent alphabetical order regardless of name casing. Uses `String.CASE_INSENSITIVE_ORDER` with nulls-first for first and last names.

<sup>Written for commit b08e68215e10aec3dcada25120fa9a23fabee4a9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

