### PR TITLE
chore: fix build and jsp compile issues from recent merges

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentPreview2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentPreview2Action.java
@@ -524,7 +524,7 @@ public class DocumentPreview2Action extends ActionSupport {
 		request.setAttribute("allForms", allForms);
     }
 
-    private boolean hasPrivilege(LoggedInInfo loggedInInfo, String securityObjectName, String privilege, Object target) {
+    private boolean hasPrivilege(LoggedInInfo loggedInInfo, String securityObjectName, String privilege, String target) {
         return securityInfoManager.hasPrivilege(loggedInInfo, securityObjectName, privilege, target);
     }
 

--- a/src/main/webapp/WEB-INF/jsp/admin/logReport.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/logReport.jsp
@@ -75,6 +75,7 @@
 <%@page import="io.github.carlos_emr.Misc" %>
 <%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="io.github.carlos_emr.CarlosProperties" %>
+<%@ page import="io.github.carlos_emr.carlos.utility.SafeEncode" %>
 <html>
     <head>
 

--- a/src/main/webapp/WEB-INF/jsp/messenger/generatePreviewPDF.jsp
+++ b/src/main/webapp/WEB-INF/jsp/messenger/generatePreviewPDF.jsp
@@ -202,7 +202,7 @@
 <head>
     <meta charset="UTF-8">
     <title>CARLOS - <fmt:message key="messenger.generatePreviewPDF.title"/></title>
-    <%@ include file="/includes/global-head.jspf" %>
+    <%@ include file="/WEB-INF/jsp/includes/global-head.jspf" %>
 
     <script>
         // i18n message strings for JavaScript dialogs

--- a/src/test/java/io/github/carlos_emr/carlos/billings/ca/bc/data/BillingCodeDataUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/billings/ca/bc/data/BillingCodeDataUnitTest.java
@@ -84,7 +84,7 @@ class BillingCodeDataUnitTest extends CarlosUnitTestBase {
     @Test
     void shouldDeleteBillingCode_whenBillingCodeExists() {
         BillingService billingService = new BillingService();
-        billingService.setId(123);
+        billingService.setBillingserviceNo(123);
         when(mockBillingServiceDao.find(123)).thenReturn(billingService);
 
         assertThat(billingCodeData.deleteBillingCode("123")).isTrue();

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentPreview2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentPreview2ActionTest.java
@@ -319,7 +319,7 @@ class DocumentPreview2ActionTest extends CarlosUnitTestBase {
 
     @Test
     @DisplayName("should return bad request when render edoc pdf id is invalid")
-    void shouldReturnBadRequest_whenRenderEdocPdfIdIsInvalid() {
+    void shouldReturnBadRequest_whenRenderEdocPdfIdIsInvalid() throws Exception {
         request.setParameter("method", "renderEDocPDF");
         request.setParameter("eDocId", "invalid");
 


### PR DESCRIPTION
This pull request contains several small but important changes across the codebase, focusing on bug fixes, improvements to imports, and test corrections. Here are the most significant updates:

**Bug Fixes and Refactoring:**

* Updated the `hasPrivilege` method in `DocumentPreview2Action.java` to require a `String` type for the `target` parameter instead of `Object`, ensuring type safety and consistency with the underlying privilege check.
* Corrected the setter method used in the `shouldDeleteBillingCode_whenBillingCodeExists` test to use `setBillingserviceNo` instead of `setId`, aligning with the actual property in `BillingService`.

**Test Improvements:**

* Added `throws Exception` to the `shouldReturnBadRequest_whenRenderEdocPdfIdIsInvalid` test method signature in `DocumentPreview2ActionTest.java` to properly handle potential checked exceptions during test execution.

**Import and Include Path Updates:**

* Added an import for `SafeEncode` in `logReport.jsp` to improve encoding and security practices in JSP rendering.
* Updated the include path for `global-head.jspf` in `generatePreviewPDF.jsp` to use an absolute path, ensuring the correct file is included during JSP compilation.

## Summary by Sourcery

Fix compilation and test issues introduced by recent merges to restore a clean build.

Bug Fixes:
- Align DocumentPreview2Action privilege checks with the underlying security API by requiring a String target parameter.
- Correct BillingCodeDataUnitTest to use the actual BillingService identifier field when setting up deletable entities.

Enhancements:
- Adjust generatePreviewPDF.jsp to include the global head JSP fragment via the correct absolute path for reliable JSP compilation.
- Import SafeEncode in logReport.jsp to support safer output encoding in the admin log report view.

Tests:
- Allow DocumentPreview2ActionTest invalid eDoc PDF ID test to declare checked exceptions so it can execute without compilation errors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes build failures and JSP compile errors introduced by recent merges. Updates a privilege check, corrects tests, and fixes JSP imports/includes to restore a clean build.

- **Bug Fixes**
  - Require String `target` in `hasPrivilege` in DocumentPreview2Action to match the security API.
  - Import `io.github.carlos_emr.carlos.utility.SafeEncode` in `admin/logReport.jsp` for safe output encoding.
  - Include `/WEB-INF/jsp/includes/global-head.jspf` in `messenger/generatePreviewPDF.jsp` to fix JSP compile paths.
  - Use `setBillingserviceNo` in `BillingCodeDataUnitTest` when preparing `BillingService`.
  - Add `throws Exception` to the invalid eDoc PDF ID test in DocumentPreview2ActionTest.

<sup>Written for commit f070e2660a3252cd5694eb370d4bb633f70966fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

