### PR TITLE
fix: return 204 instead of 404 for missing clinic/support logos

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/login/LoginResourceAction.java
+++ b/src/main/java/io/github/carlos_emr/carlos/login/LoginResourceAction.java
@@ -65,6 +65,10 @@ public class LoginResourceAction extends HttpServlet {
         this.images = oscarDocument + File.separator + "login";
     }
 
+    protected String getImagesDir() {
+        return this.images;
+    }
+
     protected void doGet(HttpServletRequest request,
                          HttpServletResponse response) throws ServletException, IOException {
         try {
@@ -94,7 +98,7 @@ public class LoginResourceAction extends HttpServlet {
                 
                 // Construct and validate the file path using PathValidationUtils
                 try {
-                    File imagesDir = new File(images);
+                    File imagesDir = new File(getImagesDir());
                     image = PathValidationUtils.validatePath(sanitizedFilename, imagesDir);
                 } catch (SecurityException e) {
                     log.warn("Path validation rejected for filename: {}", sanitizedFilename);
@@ -104,8 +108,12 @@ public class LoginResourceAction extends HttpServlet {
             }
 
             // Send 404 if no valid image path was provided or file doesn't exist
-            if (image == null || !image.exists()) {
+            if (image == null) {
                 response.sendError(HttpServletResponse.SC_NOT_FOUND);
+                return;
+            }
+            if (!image.exists()) {
+                response.setStatus(HttpServletResponse.SC_NO_CONTENT);
                 return;
             }
 

--- a/src/test/java/io/github/carlos_emr/carlos/login/LoginResourceActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/login/LoginResourceActionUnitTest.java
@@ -99,7 +99,7 @@ class LoginResourceActionUnitTest {
 
     @Test
     @DisplayName("should return 400 when filename is empty after sanitization")
-    void shouldReturn400_whenPathContainsDirectoryTraversal() throws Exception {
+    void shouldReturn400_whenFilenameIsEmptyAfterSanitization() throws Exception {
         // A path that results in an empty filename after sanitization
         when(request.getPathInfo()).thenReturn("/");
 

--- a/src/test/java/io/github/carlos_emr/carlos/login/LoginResourceActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/login/LoginResourceActionUnitTest.java
@@ -128,7 +128,7 @@ class LoginResourceActionUnitTest {
         servlet.doGet(request, response);
 
         verify(response).setContentType("image/png");
-        verify(response, never()).sendError(anyInt(), anyString());
+        verify(response, never()).sendError(anyInt());
         verify(response, never()).setStatus(HttpServletResponse.SC_NO_CONTENT);
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/login/LoginResourceActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/login/LoginResourceActionUnitTest.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.login;
+
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.Path;
+
+import static org.mockito.Mockito.*;
+
+@Tag("unit")
+@DisplayName("LoginResourceAction")
+class LoginResourceActionUnitTest {
+
+    private LoginResourceAction servlet;
+    private HttpServletRequest request;
+    private HttpServletResponse response;
+    private ServletConfig servletConfig;
+    private ServletContext servletContext;
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        servletContext = mock(ServletContext.class);
+        servletConfig = mock(ServletConfig.class);
+        when(servletConfig.getServletContext()).thenReturn(servletContext);
+
+        servlet = new LoginResourceAction() {
+            @Override
+            public ServletContext getServletContext() {
+                return servletContext;
+            }
+
+            @Override
+            protected String getImagesDir() {
+                return tempDir.toFile().getAbsolutePath();
+            }
+        };
+
+        servlet.init(servletConfig);
+
+        request = mock(HttpServletRequest.class);
+        response = mock(HttpServletResponse.class);
+    }
+
+    @Test
+    @DisplayName("should return 204 when logo file does not exist")
+    void shouldReturn204_whenLogoFileDoesNotExist() throws Exception {
+        when(request.getPathInfo()).thenReturn("/clinicLogo.png");
+
+        servlet.doGet(request, response);
+
+        verify(response).setStatus(HttpServletResponse.SC_NO_CONTENT);
+        verify(response, never()).sendError(eq(HttpServletResponse.SC_NOT_FOUND), anyString());
+    }
+
+    @Test
+    @DisplayName("should return 404 when path info is null")
+    void shouldReturn404_whenPathInfoIsNull() throws Exception {
+        when(request.getPathInfo()).thenReturn(null);
+
+        servlet.doGet(request, response);
+
+        verify(response).sendError(HttpServletResponse.SC_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("should return 400 when filename is empty after sanitization")
+    void shouldReturn400_whenPathContainsDirectoryTraversal() throws Exception {
+        // A path that results in an empty filename after sanitization
+        when(request.getPathInfo()).thenReturn("/");
+
+        servlet.doGet(request, response);
+
+        verify(response).sendError(eq(HttpServletResponse.SC_BAD_REQUEST), anyString());
+    }
+
+    @Test
+    @DisplayName("should serve image when logo file exists")
+    void shouldServeImage_whenLogoFileExists() throws Exception {
+        // Create a real temp image file
+        File logoFile = tempDir.resolve("clinicLogo.png").toFile();
+        logoFile.createNewFile();
+
+        when(request.getPathInfo()).thenReturn("/clinicLogo.png");
+        when(servletContext.getMimeType("clinicLogo.png")).thenReturn("image/png");
+
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        when(response.getWriter()).thenReturn(pw);
+
+        jakarta.servlet.ServletOutputStream sos = mock(jakarta.servlet.ServletOutputStream.class);
+        when(response.getOutputStream()).thenReturn(sos);
+
+        servlet.doGet(request, response);
+
+        verify(response).setContentType("image/png");
+        verify(response, never()).sendError(anyInt(), anyString());
+        verify(response, never()).setStatus(HttpServletResponse.SC_NO_CONTENT);
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/login/LoginResourceActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/login/LoginResourceActionUnitTest.java
@@ -84,7 +84,7 @@ class LoginResourceActionUnitTest {
         servlet.doGet(request, response);
 
         verify(response).setStatus(HttpServletResponse.SC_NO_CONTENT);
-        verify(response, never()).sendError(eq(HttpServletResponse.SC_NOT_FOUND), anyString());
+        verify(response, never()).sendError(HttpServletResponse.SC_NOT_FOUND);
     }
 
     @Test


### PR DESCRIPTION
## Summary
Fixes the two 404 console errors on the login page when no clinic or 
support logo has been uploaded by the admin.

## Root Cause
`LoginResourceAction` was returning 404 when the optional branding 
images (clinicLogo.png, supportLogo.png) were not configured. 
Although the existing onerror fallback in the JSP hid the visual 
impact, the browser still logged 404 errors on every login page load.

## Fix
Returns 204 No Content instead of 404 when the requested logo file 
does not exist. The browser treats 204 the same as a missing image 
and fires the existing onerror handler, so no visual change occurs.

## Testing
Added unit tests covering:
- 204 returned when logo file does not exist
- 404 returned when path info is null
- 400 returned when filename is empty after sanitization
- Image served correctly when file exists

Closes #1824

## Summary by Sourcery

Adjust login branding image handling to avoid 404s for missing optional logos and add unit coverage for the servlet behavior.

Bug Fixes:
- Return HTTP 204 No Content instead of 404 when optional clinic/support logo files are not present, eliminating spurious console errors on the login page.

Enhancements:
- Expose the login images directory via a protected accessor to allow overriding in tests.

Tests:
- Add unit tests for LoginResourceAction covering missing-logo 204 responses, null path 404 responses, bad filename 400 responses, and successful image serving when the file exists.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the login logo endpoints to return 204 No Content when clinic/support logos aren’t configured, removing 404 console errors without changing the existing image fallback. Adds unit tests and exposes an overridable `getImagesDir()` for cleaner testing.

- **Bug Fixes**
  - Return 204 when the logo file is absent; keep 404 for null path and 400 for empty/invalid filenames.
  - Add tests for missing/existing files; expose `getImagesDir()` and fix test assertion overloads.

<sup>Written for commit f565836cbbd91194e8140ba75c67ec697f2e034d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

