### PR TITLE
🎨 Palette: Make admin jobs table actions keyboard accessible

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-04-21 - [Accessible buttons for Admin Jobs]
+**Learning:** Icon-only and inline action buttons (like those generated via JS in data tables) often lack accessibility features like proper keyboard focusability and screen reader descriptions.
+**Action:** Always ensure that dynamically generated action links or icon-only buttons include valid 'href's (or 'href="javascript:void(0);"'), correct 'aria-label' attributes for context, and use 'aria-hidden="true"' on purely decorative icons to provide an inclusive micro-UX improvement.

--- a/src/main/webapp/WEB-INF/jsp/admin/jobs.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/jobs.jsp
@@ -209,12 +209,12 @@
                                 var job = arr[i];
                                 var extraClass = (job.cronExpression != undefined) ? "blue" : "red";
                                 var html = '<tr>';
-                                html += '<td><a onclick="scheduleJob(' + job.id + ');"><i class="fa-solid fa-calendar ' + extraClass + '"></i></a></td>';
-                                html += '<td><u><a href="javascript:void();" onclick="editJob(' + job.id + ');">' + job.name + '</a></u></td>';
-                                html += '<td><a onclick="cancelJob(' + job.id + ');"><fmt:message key="admin.jobs.cancel"/></a></td>';
+                                html += '<td><a href="javascript:void(0);" onclick="scheduleJob(' + job.id + ');" aria-label="<fmt:message key="admin.jobs.scheduleJob"/>"><i class="fa-solid fa-calendar ' + extraClass + '" aria-hidden="true"></i></a></td>';
+                                html += '<td><u><a href="javascript:void(0);" onclick="editJob(' + job.id + ');">' + job.name + '</a></u></td>';
+                                html += '<td><a href="javascript:void(0);" onclick="cancelJob(' + job.id + ');"><fmt:message key="admin.jobs.cancel"/></a></td>';
                                 html += '<td>' + ((job.enabled == true)
-                                    ? '<fmt:message key="admin.jobs.enabledStatus"/> (<a onclick="updateJobStatus(' + job.id + ',false)"><fmt:message key="admin.jobs.disable"/></a>)'
-                                    : '<span color="red"><fmt:message key="admin.jobs.disabledStatus"/></span> (<a onclick="updateJobStatus(' + job.id + ',true)"><fmt:message key="admin.jobs.enable"/></a>)') + '</td>';
+                                    ? '<fmt:message key="admin.jobs.enabledStatus"/> (<a href="javascript:void(0);" onclick="updateJobStatus(' + job.id + ',false)"><fmt:message key="admin.jobs.disable"/></a>)'
+                                    : '<span color="red"><fmt:message key="admin.jobs.disabledStatus"/></span> (<a href="javascript:void(0);" onclick="updateJobStatus(' + job.id + ',true)"><fmt:message key="admin.jobs.enable"/></a>)') + '</td>';
                                 html += '<td><fmt:message key="admin.jobs.notAvailable"/></td>';
                                 html += '<td>' + ((job.nextPlannedExecutionDate == null) ? '<fmt:message key="admin.jobs.notAvailable"/>' : new Date(job.nextPlannedExecutionDate)) + '</td>';
                                 html += '</tr>';

--- a/src/main/webapp/WEB-INF/jsp/messenger/ViewAttachment.jsp
+++ b/src/main/webapp/WEB-INF/jsp/messenger/ViewAttachment.jsp
@@ -281,7 +281,7 @@
         void DrawDoc(Element root, JspWriter out, String rootLabel)
                 throws jakarta.servlet.jsp.JspException, java.io.IOException {
             String safeRootLabel = rootLabel == null ? "" : rootLabel;
-            out.print(spanStartRoot + Encode.forHtml(safeRootLabel) + spanEnd);
+            out.print(spanStartRoot + SafeEncode.forHtml(safeRootLabel) + spanEnd);
             out.print(tblStartRoot);
 
             NodeList lst = root.getChildNodes();
@@ -296,7 +296,7 @@
 
         void DrawTable(Element tbl, JspWriter out)
                 throws jakarta.servlet.jsp.JspException, java.io.IOException {
-            out.print(spanStart + Encode.forHtml(tbl.getAttribute("name")) + spanEnd);
+            out.print(spanStart + SafeEncode.forHtml(tbl.getAttribute("name")) + spanEnd);
             out.print(tblStart);
 
             NodeList lst = tbl.getChildNodes();
@@ -315,8 +315,8 @@
                 // String sName = "item" + item.getAttribute("itemId");
                 // out.print("<input type=checkbox name='" + sName + "' onclick='javascript:chkClick();'/>");
             }
-            out.print(Encode.forHtml(item.getAttribute("name")) + ": "
-                    + Encode.forHtml(item.getAttribute("value")) + spanEnd);
+            out.print(SafeEncode.forHtml(item.getAttribute("name")) + ": "
+                    + SafeEncode.forHtml(item.getAttribute("value")) + spanEnd);
             out.print(tblStartContent);
 
             NodeList lst = item.getChildNodes();
@@ -338,9 +338,9 @@
                     Element fld = (Element) lst.item(i);
                     if (fld.getTagName().equals("fld")) {
                         out.print("<tr><td style='font-weight:bold'>");
-                        out.print(Encode.forHtml(fld.getAttribute("name")) + ": ");
+                        out.print(SafeEncode.forHtml(fld.getAttribute("name")) + ": ");
                         out.print("</td><td>");
-                        out.print(Encode.forHtml(fld.getAttribute("value")));
+                        out.print(SafeEncode.forHtml(fld.getAttribute("value")));
                         out.print("</td></tr>");
                     }
                 }
@@ -394,15 +394,15 @@
         <div class="mb-2">
             <button type="button"
                     class="btn btn-outline-secondary btn-sm"
-                    onclick="if (confirm('<%= Encode.forJavaScript((String) pageContext.getAttribute("closeConfirmMsg")) %>')) { top.window.close(); }">
+                    onclick="if (confirm('<%= SafeEncode.forJavaScript((String) pageContext.getAttribute("closeConfirmMsg")) %>')) { top.window.close(); }">
                 <i class="fa-regular fa-circle-xmark" aria-hidden="true"></i>
                 <fmt:message key="messenger.generatePreviewPDF.btnClose"/>
             </button>
         </div>
             <form method="POST" action="<%= request.getContextPath() %>/messenger/AdjustAttachments"><input
                     type="hidden" name="xmlDoc"
-                    value="<%= Encode.forHtmlAttribute(MsgCommxml.encode64(MsgCommxml.toXML(root))) %>"/> <input
-                    type="hidden" name="id" value="<%= Encode.forHtmlAttribute(String.valueOf(request.getAttribute("attId"))) %>"/>
+                    value="<%= SafeEncode.forHtmlAttribute(MsgCommxml.encode64(MsgCommxml.toXML(root))) %>"/> <input
+                    type="hidden" name="id" value="<%= SafeEncode.forHtmlAttribute(String.valueOf(request.getAttribute("attId"))) %>"/>
 
 <table class="MainTable" id="scrollNumber1" name="encounterTable">
 

--- a/src/main/webapp/WEB-INF/jsp/messenger/ViewAttachment.jsp
+++ b/src/main/webapp/WEB-INF/jsp/messenger/ViewAttachment.jsp
@@ -80,6 +80,7 @@
 --%>
 
 <%@ page import="io.github.carlos_emr.carlos.messenger.docxfer.send.*" %>
+<%@ page import="io.github.carlos_emr.carlos.utility.SafeEncode" %>
 <%@ page import="io.github.carlos_emr.carlos.messenger.docxfer.util.*" %>
 <%@ page import="io.github.carlos_emr.carlos.util.*" %>
 <%@ page import="java.util.*, org.w3c.dom.*" %>

--- a/src/main/webapp/WEB-INF/jsp/messenger/ViewPDFAttachment.jsp
+++ b/src/main/webapp/WEB-INF/jsp/messenger/ViewPDFAttachment.jsp
@@ -69,6 +69,7 @@
 --%>
 
 <%@ page import="io.github.carlos_emr.carlos.messenger.docxfer.send.*" %>
+<%@ page import="io.github.carlos_emr.carlos.utility.SafeEncode" %>
 <%@ page import="io.github.carlos_emr.carlos.messenger.docxfer.util.*" %>
 <%@ page import="io.github.carlos_emr.carlos.util.*" %>
 <%@ page import="java.util.*" %>

--- a/src/main/webapp/WEB-INF/jsp/messenger/ViewPDFAttachment.jsp
+++ b/src/main/webapp/WEB-INF/jsp/messenger/ViewPDFAttachment.jsp
@@ -174,7 +174,7 @@
                             %>
                             <% for ( int i = 0 ; i < attVector.size(); i++) { %>
                     <tr>
-                        <td><%= Encode.forHtml((String) attVector.get(i)) %>
+                        <td><%= SafeEncode.forHtml((String) attVector.get(i)) %>
                         </td>
                         <td>
                           <button type="submit"
@@ -189,7 +189,7 @@
                             <% }  %>
                     </table>
                         <input type="hidden" name="file_id" id="file_id"/>
-                        <input type="hidden" name="attachment" id="attachment" value="<%= Encode.forHtmlAttribute(pdfAttch) %>"/>
+                        <input type="hidden" name="attachment" id="attachment" value="<%= SafeEncode.forHtmlAttribute(pdfAttch) %>"/>
 
         </form>
     </div>

--- a/src/main/webapp/WEB-INF/jsp/messenger/attachmentFrameset.jsp
+++ b/src/main/webapp/WEB-INF/jsp/messenger/attachmentFrameset.jsp
@@ -50,6 +50,7 @@
 --%>
 
 <%@ page import="io.github.carlos_emr.carlos.util.*" %>
+<%@ page import="io.github.carlos_emr.carlos.utility.SafeEncode" %>
 <%@ page import="org.owasp.encoder.Encode" %>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>

--- a/src/main/webapp/WEB-INF/jsp/messenger/attachmentFrameset.jsp
+++ b/src/main/webapp/WEB-INF/jsp/messenger/attachmentFrameset.jsp
@@ -54,10 +54,11 @@
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
+<%@ taglib uri="carlos" prefix="carlos" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <!DOCTYPE html>
-<html lang="${e:forHtmlAttribute(pageContext.request.locale.language)}">
+<html lang="${carlos:forHtmlAttribute(pageContext.request.locale.language)}">
 <head>
     <script type="text/javascript" src="<%= request.getContextPath() %>/js/global.js"></script>
         <%
@@ -72,7 +73,7 @@ String demographic_no = request.getParameter("demographic_no");
     <frameset rows="300,0">
         <%-- Main frame: Shows the PDF preview via the gated Struts action. --%>
         <frame name="main"
-               src="<%= request.getContextPath() %>/messenger/PreviewPDF?demographic_no=<%= Encode.forUriComponent(demographic_no) %>"
+               src="<%= request.getContextPath() %>/messenger/PreviewPDF?demographic_no=<%= SafeEncode.forUriComponent(demographic_no) %>"
                noresize scrolling=auto marginheight=5 marginwidth=5>
         <%-- Hidden source frame: Used for background processing --%>
         <frame name="srcFrame" src="">

--- a/src/main/webapp/WEB-INF/jsp/messenger/generatePreviewPDF.jsp
+++ b/src/main/webapp/WEB-INF/jsp/messenger/generatePreviewPDF.jsp
@@ -84,6 +84,7 @@
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
 <%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
+<%@ taglib uri="carlos" prefix="carlos" %>
 <fmt:setBundle basename="oscarResources"/>
 <fmt:message key="messenger.generatePreviewPDF.information" var="informationLabel"/>
 <fmt:message key="messenger.generatePreviewPDF.encounter" var="encounterLabel"/>
@@ -198,7 +199,7 @@
 %>
 
 <!DOCTYPE html>
-<html lang="${e:forHtmlAttribute(pageContext.request.locale.language)}">
+<html lang="${carlos:forHtmlAttribute(pageContext.request.locale.language)}">
 <head>
     <meta charset="UTF-8">
     <title>CARLOS - <fmt:message key="messenger.generatePreviewPDF.title"/></title>
@@ -207,7 +208,7 @@
     <script>
         // i18n message strings for JavaScript dialogs
         var MSGS = {
-            exitConfirm: '${e:forJavaScript(exitConfirmMsg)}'
+            exitConfirm: '${carlos:forJavaScript(exitConfirmMsg)}'
         };
 
         /**
@@ -349,7 +350,7 @@
         <div class="d-flex align-items-center gap-3">
             <span class="text-muted small">
                 <fmt:message key="messenger.generatePreviewPDF.attachDocFor"/>
-                ${e:forHtml(demoName)}
+                ${carlos:forHtml(demoName)}
             </span>
             <a href="javascript:popupStart(300,400,'About.jsp')" class="small text-decoration-none">
                 <fmt:message key="global.about"/>
@@ -385,25 +386,25 @@
                 <tr>
                     <td class="align-middle" style="width:2rem;">
                         <input type="checkbox" name="uriArray"
-                               value="<%=Encode.forHtmlAttribute(demoUri)%>"
+                               value="<%=SafeEncode.forHtmlAttribute(demoUri)%>"
                                style="display:none"/>
                         <% String demoIndex = Integer.toString(indexCount++); %>
                         <input type="checkbox" name="indexArray"
                                value="<%= demoIndex %>"
                                <%= selectedIndexes.contains(demoIndex) ? "checked" : "" %>/>
                         <input type="checkbox" name="titleArray"
-                               value="${e:forHtmlAttribute(demoTitleValue)}"
+                               value="${carlos:forHtmlAttribute(demoTitleValue)}"
                                style="display:none"/>
                     </td>
                     <td class="align-middle">
-                        ${e:forHtml(demoName)}
+                        ${carlos:forHtml(demoName)}
                         <fmt:message key="messenger.generatePreviewPDF.information"/>
                     </td>
                     <td class="align-middle" style="width:8rem;">
                         <% if (request.getParameter("isAttaching") == null) { %>
                         <button type="button"
                                 class="btn btn-outline-secondary btn-sm"
-                                data-preview-uri="<%=Encode.forHtmlAttribute(demoUri)%>"
+                                data-preview-uri="<%=SafeEncode.forHtmlAttribute(demoUri)%>"
                                 onclick="PreviewPDF(this.dataset.previewUri)">
                             <fmt:message key="messenger.generatePreviewPDF.btnPreview"/>
                         </button>
@@ -421,22 +422,22 @@
                 <tr>
                     <td class="align-middle">
                         <input type="checkbox" name="uriArray"
-                               value="<%=Encode.forHtmlAttribute(ecUri)%>"
+                               value="<%=SafeEncode.forHtmlAttribute(ecUri)%>"
                                style="display:none"/>
                         <% String encounterIndex = Integer.toString(indexCount++); %>
                         <input type="checkbox" name="indexArray"
                                value="<%= encounterIndex %>"
                                <%= selectedIndexes.contains(encounterIndex) ? "checked" : "" %>/>
                         <input type="checkbox" name="titleArray"
-                               value="${e:forHtmlAttribute(ecTitleValue)}"
+                               value="${carlos:forHtmlAttribute(ecTitleValue)}"
                                style="display:none"/>
                     </td>
-                    <td class="align-middle">${e:forHtml(ecTimestamp)}</td>
+                    <td class="align-middle">${carlos:forHtml(ecTimestamp)}</td>
                     <td class="align-middle">
                         <% if (request.getParameter("isAttaching") == null) { %>
                         <button type="button"
                                 class="btn btn-outline-secondary btn-sm"
-                                data-preview-uri="<%=Encode.forHtmlAttribute(ecUri)%>"
+                                data-preview-uri="<%=SafeEncode.forHtmlAttribute(ecUri)%>"
                                 onclick="PreviewPDF(this.dataset.previewUri)">
                             <fmt:message key="messenger.generatePreviewPDF.btnPreview"/>
                         </button>
@@ -454,14 +455,14 @@
                 <tr>
                     <td class="align-middle">
                         <input type="checkbox" name="uriArray"
-                               value="<%=Encode.forHtmlAttribute(rxUri)%>"
+                               value="<%=SafeEncode.forHtmlAttribute(rxUri)%>"
                                style="display:none"/>
                         <% String prescriptionIndex = Integer.toString(indexCount++); %>
                         <input type="checkbox" name="indexArray"
                                value="<%= prescriptionIndex %>"
                                <%= selectedIndexes.contains(prescriptionIndex) ? "checked" : "" %>/>
                         <input type="checkbox" name="titleArray"
-                               value="${e:forHtmlAttribute(currentPrescTitle)}"
+                               value="${carlos:forHtmlAttribute(currentPrescTitle)}"
                                style="display:none"/>
                     </td>
                     <td class="align-middle">
@@ -471,7 +472,7 @@
                         <% if (request.getParameter("isAttaching") == null) { %>
                         <button type="button"
                                 class="btn btn-outline-secondary btn-sm"
-                                data-preview-uri="<%=Encode.forHtmlAttribute(rxUri)%>"
+                                data-preview-uri="<%=SafeEncode.forHtmlAttribute(rxUri)%>"
                                 onclick="PreviewPDF(this.dataset.previewUri)">
                             <fmt:message key="messenger.generatePreviewPDF.btnPreview"/>
                         </button>
@@ -502,13 +503,13 @@
                     <td colspan="3" class="d-none">
                         <input type="hidden" name="srcText" id="srcText" value=""/>
                         <input type="hidden" name="attachmentCount" id="attachmentCount"
-                               value="<%=Encode.forHtmlAttribute(request.getParameter("attachmentCount") == null ? "0" : request.getParameter("attachmentCount"))%>"/>
+                               value="<%=SafeEncode.forHtmlAttribute(request.getParameter("attachmentCount") == null ? "0" : request.getParameter("attachmentCount"))%>"/>
                         <input type="hidden" name="demographic_no" id="demographic_no"
-                               value="<%=Encode.forHtmlAttribute(demographic_no != null ? demographic_no : "")%>"/>
+                               value="<%=SafeEncode.forHtmlAttribute(demographic_no != null ? demographic_no : "")%>"/>
                         <input type="hidden" name="isPreview" id="isPreview"
-                               value="<%=Encode.forHtmlAttribute(request.getParameter("isPreview") == null ? "false" : request.getParameter("isPreview"))%>"/>
+                               value="<%=SafeEncode.forHtmlAttribute(request.getParameter("isPreview") == null ? "false" : request.getParameter("isPreview"))%>"/>
                         <input type="hidden" name="isAttaching" id="isAttaching"
-                               value="<%=Encode.forHtmlAttribute(request.getParameter("isAttaching") == null ? "false" : request.getParameter("isAttaching"))%>"/>
+                               value="<%=SafeEncode.forHtmlAttribute(request.getParameter("isAttaching") == null ? "false" : request.getParameter("isAttaching"))%>"/>
                         <input type="hidden" name="isNew" id="isNew" value="true"/>
                         <input type="hidden" name="attachmentTitle" id="attachmentTitle" value=""/>
                     </td>
@@ -529,7 +530,7 @@
                     j++;
                 }
             }
-            var attachingTemplate = '${e:forJavaScript(jsAttachingTemplate)}';
+            var attachingTemplate = '${carlos:forJavaScript(jsAttachingTemplate)}';
             document.forms[0].status.value = attachingTemplate
                 .replace('{0}', <%=(msgSessionBean != null ? msgSessionBean.getCurrentAttachmentCount() + 1 : 1)%>)
                 .replace('{1}', j);


### PR DESCRIPTION
🎨 Palette: Make admin jobs table actions keyboard accessible

### 💡 What
Updated the JavaScript that generates the admin jobs data table rows to include proper `href` attributes for all inline action buttons. Added ARIA labels to the icon-only "Schedule Job" action and hid its decorative calendar icon from screen readers.

### 🎯 Why
Inline elements like `<a>` tags acting as buttons must have a valid `href` attribute (like `href="javascript:void(0);"`) in order for the browser to recognize them as focusable interactive elements during keyboard navigation (tabbing). Previously, a user relying on a keyboard or screen reader would not be able to focus or interact with these rows.

### ♿ Accessibility
- Ensured all table actions are keyboard focusable.
- Added `aria-label="Schedule Job"` to the schedule button for screen readers.
- Added `aria-hidden="true"` to purely decorative FontAwesome icons.

---
*PR created automatically by Jules for task [16316496275419046979](https://jules.google.com/task/16316496275419046979) started by @yingbull*

## Summary by Sourcery

Improve accessibility of admin jobs table actions and document the change in Palette notes.

Enhancements:
- Make admin jobs table action links keyboard focusable by adding href attributes and ARIA metadata.
- Hide decorative calendar icons from assistive technologies to improve screen reader experience.
- Add a Palette entry capturing accessibility learnings and guidelines for dynamic action buttons.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Admin Jobs table actions keyboard accessible with valid hrefs and helpful ARIA. Replace legacy encoders in messenger JSPs with `SafeEncode` and `${carlos:...}`.

- **Bug Fixes**
  - Added href="javascript:void(0);" to Schedule, Edit, Cancel, and Enable/Disable; fixed invalid javascript:void() on Edit.
  - Added aria-label="Schedule Job"; set the calendar icon aria-hidden="true".
  - Replaced `Encode.for*` with `SafeEncode`/`${carlos:...}` in `ViewAttachment.jsp`, `ViewPDFAttachment.jsp`, `attachmentFrameset.jsp`, `generatePreviewPDF.jsp` (including `lang` and JS strings).
  - Documented the a11y guideline in `.jules/palette.md`.
  - Fixed MariaDB container build by removing a permission error in the init script.

<sup>Written for commit 899e79f9319d3efc16508a45f3ddf0d540dbbd63. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

