### PR TITLE
fix: repair 23 post-migration test failures across DAO, cache, tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1356,6 +1356,12 @@
                 <configuration>
                     <source>21</source>
                     <target>21</target>
+                    <!-- Emit MethodParameters attribute into .class files so Spring SpEL can
+                         resolve method-argument names like #providerNo in @Cacheable conditions.
+                         Without this, Spring 6+ silently fails parameter-name discovery (legacy
+                         LocalVariableTableParameterNameDiscoverer was removed), the condition
+                         evaluates to false, and no caching occurs. -->
+                    <parameters>true</parameters>
                     <!-- Suppress framework deprecation warnings during incremental migration.
                          Override via: mvn ... -Dmaven.compiler.showDeprecation=true -->
                     <showDeprecation>${maven.compiler.showDeprecation}</showDeprecation>

--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/ProviderDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/ProviderDaoImpl.java
@@ -269,8 +269,11 @@ public class ProviderDaoImpl extends AbstractJpaDao implements ProviderDao {
     @Override
     public List<Provider> getActiveProvidersByRole(String role) {
         if (role == null) return Collections.emptyList();
-        String sSQL = "select p FROM Provider p, SecUserRole s where p.ProviderNo = s.ProviderNo and p.Status='1' " +
-        "and s.RoleName = ?1 order by p.LastName, p.FirstName";
+        // Uses Secuserrole (model.security) — the identity-PK mapping that matches the actual
+        // secUserRole table schema. The PMmodule SecUserRole composite-key mapping is
+        // intentionally absent from the test EMF and does not reflect the production DB.
+        String sSQL = "select p FROM Provider p, Secuserrole s where p.ProviderNo = s.providerNo and p.Status='1' " +
+        "and s.roleName = ?1 order by p.LastName, p.FirstName";
         List<Provider> rs = (List<Provider>) JpqlQueryHelper.find(entityManager(), sSQL, role);
 
         if (log.isDebugEnabled()) {

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/dao/CaseManagementIssueDAOImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/dao/CaseManagementIssueDAOImpl.java
@@ -134,9 +134,13 @@ public class CaseManagementIssueDAOImpl extends AbstractJpaDao implements CaseMa
 
     @Override
     public void deleteIssueById(CaseManagementIssue issue) {
-        entityManager().remove(issue);
-        return;
-
+        // Pre-migration Hibernate Session.delete() accepted detached entities. JPA
+        // EntityManager.remove() requires a managed instance, so reattach via merge()
+        // when the caller passes a detached entity (mirrors SecProviderDaoImpl.delete).
+        CaseManagementIssue managed = entityManager().contains(issue)
+                ? issue
+                : entityManager().merge(issue);
+        entityManager().remove(managed);
     }
 
     @Override

--- a/src/main/java/io/github/carlos_emr/carlos/daos/security/SecobjprivilegeDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/daos/security/SecobjprivilegeDaoImpl.java
@@ -135,7 +135,13 @@ public class SecobjprivilegeDaoImpl extends AbstractJpaDao implements Secobjpriv
     public void delete(Secobjprivilege persistentInstance) {
         logger.debug("deleting Secobjprivilege instance");
         try {
-            entityManager().remove(persistentInstance);
+            // Pre-migration Hibernate Session.delete() accepted detached entities. JPA
+            // EntityManager.remove() requires a managed instance, so reattach via merge()
+            // when the caller passes a detached entity (mirrors SecProviderDaoImpl.delete).
+            Secobjprivilege managed = entityManager().contains(persistentInstance)
+                    ? persistentInstance
+                    : entityManager().merge(persistentInstance);
+            entityManager().remove(managed);
             logger.debug("delete successful");
         } catch (RuntimeException re) {
             logger.error("delete failed", re);

--- a/src/test/java/io/github/carlos_emr/carlos/PMmodule/dao/AgencyDaoIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/PMmodule/dao/AgencyDaoIntegrationTest.java
@@ -318,9 +318,11 @@ public class AgencyDaoIntegrationTest extends CarlosTestBase {
     @DisplayName("should update agency when existing instance modified")
     void shouldUpdateAgency_whenExistingInstanceModified() {
         // Given - persist an agency with initial intake configuration
+        // AgencyDaoImpl writes via the JPA EntityManager; flush through the same context,
+        // not the Hibernate Session (which doesn't see EntityManager-managed inserts/updates).
         Agency agency = createAgency(5, "HS", 3, "AC");
         agencyDao.saveAgency(agency);
-        hibernateTemplate.flush();
+        entityManager.flush();
 
         // Capture the generated primary key to verify identity is preserved after update
         Long savedId = agency.getId();
@@ -330,12 +332,11 @@ public class AgencyDaoIntegrationTest extends CarlosTestBase {
         agency.setIntakeQuickState("ZZ");
         agencyDao.saveAgency(agency);
 
-        // Flush Hibernate Session to execute the UPDATE SQL, then clear both
-        // persistence contexts so the subsequent read performs a real database
-        // SELECT rather than returning a cached entity
-        hibernateTemplate.flush();
-        hibernateTemplate.clear();
+        // Force the UPDATE to hit the database and clear both persistence contexts so the
+        // subsequent read performs a real SELECT rather than returning a cached entity.
+        entityManager.flush();
         entityManager.clear();
+        hibernateTemplate.clear();
 
         // Then - re-read from database and verify the updated values
         Agency updated = entityManager.find(Agency.class, savedId);

--- a/src/test/java/io/github/carlos_emr/carlos/app/MultiReadHttpServletRequestUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/app/MultiReadHttpServletRequestUnitTest.java
@@ -603,7 +603,7 @@ class MultiReadHttpServletRequestUnitTest {
             mock.setContentType("multipart/form-data; boundary=----TestBoundary");
 
             MultiReadHttpServletRequest wrapper = new MultiReadHttpServletRequest(mock);
-            String expectedLimitBytes = String.valueOf(MultiReadHttpServletRequest.MAX_BODY_SIZE);
+            String expectedLimitMb = (MultiReadHttpServletRequest.MAX_BODY_SIZE / (1024 * 1024)) + " MB";
 
             assertThatThrownBy(() -> {
                 ServletInputStream inputStream = wrapper.getInputStream();
@@ -613,7 +613,7 @@ class MultiReadHttpServletRequestUnitTest {
                 }
             })
                     .isInstanceOf(IOException.class)
-                    .hasMessageContaining(expectedLimitBytes);
+                    .hasMessageContaining(expectedLimitMb);
         }
 
         @Test

--- a/src/test/java/io/github/carlos_emr/carlos/casemgmt/dao/CaseManagementIssueDAOIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/casemgmt/dao/CaseManagementIssueDAOIntegrationTest.java
@@ -24,6 +24,8 @@ import io.github.carlos_emr.carlos.test.base.CarlosTestBase;
 import io.github.carlos_emr.carlos.casemgmt.model.CaseManagementIssue;
 import io.github.carlos_emr.carlos.casemgmt.model.CaseManagementNote;
 import io.github.carlos_emr.carlos.casemgmt.model.Issue;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -61,6 +63,9 @@ public class CaseManagementIssueDAOIntegrationTest extends CarlosTestBase {
     @Autowired
     @Qualifier("CaseManagementIssueDAO")
     private CaseManagementIssueDAO caseManagementIssueDAO;
+
+    @PersistenceContext(unitName = "entityManagerFactory")
+    private EntityManager entityManager;
 
     @Autowired
     @Qualifier("IssueDAO")
@@ -181,14 +186,18 @@ public class CaseManagementIssueDAOIntegrationTest extends CarlosTestBase {
             hibernateTemplate.flush();
             Long savedId = cmi.getId();
 
-            // When
+            // When — deleteIssueById writes through the JPA EntityManager; flush and query
+            // via that same context so the DELETE is observable in the verification step
+            // (hibernateTemplate.flush/find read from the Hibernate Session, which doesn't
+            // see EntityManager-scheduled removes in the dual-context test harness).
             caseManagementIssueDAO.deleteIssueById(cmi);
-            hibernateTemplate.flush();
+            entityManager.flush();
 
-            // Then - verify via HibernateTemplate (same persistence context as DAO)
-            @SuppressWarnings("unchecked")
-            List<CaseManagementIssue> results = (List<CaseManagementIssue>) hibernateTemplate
-                .find("from CaseManagementIssue where id = ?1", savedId);
+            // Then
+            List<CaseManagementIssue> results = entityManager
+                .createQuery("from CaseManagementIssue where id = :id", CaseManagementIssue.class)
+                .setParameter("id", savedId)
+                .getResultList();
             assertThat(results).isEmpty();
         }
 

--- a/src/test/java/io/github/carlos_emr/carlos/commn/dao/GroupsDaoIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/commn/dao/GroupsDaoIntegrationTest.java
@@ -49,7 +49,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Transactional
 public class GroupsDaoIntegrationTest extends CarlosTestBase {
 
+    // Use the @Repository-scanned bean by name. Another test
+    // (MsgMessengerAdmin2ActionTest#setUp) pollutes the shared Spring context by calling
+    // CarlosWebTestBase.replaceSpringUtilsBean(GroupsDao.class, mockGroupsDao), which
+    // registers a "groupsDao" singleton alongside the real "groupsDaoImpl". That leaves two
+    // GroupsDao beans visible here and a bare @Autowired by type is ambiguous — @Qualifier
+    // pins us to the production DAO regardless of test order.
     @Autowired
+    @org.springframework.beans.factory.annotation.Qualifier("groupsDaoImpl")
     private GroupsDao dao;
 
     /**

--- a/src/test/java/io/github/carlos_emr/carlos/commn/dao/LookupListDaoIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/commn/dao/LookupListDaoIntegrationTest.java
@@ -103,9 +103,17 @@ public class LookupListDaoIntegrationTest extends CarlosTestBase {
 
             List<LookupList> result = dao.findAllActive();
 
-            assertThat(result).hasSizeGreaterThanOrEqualTo(3);
-            List<LookupList> firstThree = result.subList(0, 3);
-            assertThat(firstThree).containsExactly(ll4, ll1, ll3);
+            // Filter to just the three entries this test created — a sibling cache test
+            // (LookupListDaoCacheIntegrationTest#shouldEvictLookupListsCache_beforeBatchPersistRuns)
+            // runs in NOT_SUPPORTED propagation and can commit a row with null name when H2
+            // doesn't enforce the NOT NULL constraint production has. That row otherwise sorts
+            // ahead of "alpha" and breaks positional assertions here.
+            List<LookupList> created = result.stream()
+                    .filter(l -> l.getId().equals(ll1.getId())
+                            || l.getId().equals(ll3.getId())
+                            || l.getId().equals(ll4.getId()))
+                    .toList();
+            assertThat(created).containsExactly(ll4, ll1, ll3);
         }
     }
 

--- a/src/test/java/io/github/carlos_emr/carlos/commn/dao/LookupListDaoIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/commn/dao/LookupListDaoIntegrationTest.java
@@ -114,6 +114,7 @@ public class LookupListDaoIntegrationTest extends CarlosTestBase {
                             || l.getId().equals(ll4.getId()))
                     .toList();
             assertThat(created).containsExactly(ll4, ll1, ll3);
+            assertThat(result).doesNotContain(ll2);
         }
     }
 

--- a/src/test/java/io/github/carlos_emr/carlos/daos/security/SecProviderDaoIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/daos/security/SecProviderDaoIntegrationTest.java
@@ -1845,7 +1845,10 @@ public class SecProviderDaoIntegrationTest extends CarlosTestBase {
         @DisplayName("should merge detached SecProvider entity")
         void shouldMergeDetachedEntity_whenInvokedWithDetachedInstance() {
             SecProvider saved = createProvider(uniquePrefix + "M1", "MergeFirst", "MergeLast", "1");
-            hibernateTemplate.flush();
+            // SecProviderDao writes through the JPA EntityManager. Flushing via the Hibernate
+            // Session here confuses Hibernate 7's thread-safety assertion when merge() later
+            // forces a JPA flush — the two persistence contexts race on shared EntityInsertActions.
+            entityManager.flush();
             entityManager.detach(saved);
 
             saved.setFirstName("MergedFirst");

--- a/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequestUtilUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequestUtilUnitTest.java
@@ -21,6 +21,12 @@
  */
 package io.github.carlos_emr.carlos.encounter.oscarConsultationRequest.pageUtil;
 
+import io.github.carlos_emr.carlos.commn.dao.ConsultationRequestDao;
+import io.github.carlos_emr.carlos.commn.dao.ConsultationRequestExtDao;
+import io.github.carlos_emr.carlos.commn.dao.ConsultationServiceDao;
+import io.github.carlos_emr.carlos.commn.dao.ContactDao;
+import io.github.carlos_emr.carlos.commn.dao.FaxClientLogDao;
+import io.github.carlos_emr.carlos.commn.dao.FaxJobDao;
 import io.github.carlos_emr.carlos.commn.model.Demographic;
 import io.github.carlos_emr.carlos.commn.model.DemographicExt;
 import io.github.carlos_emr.carlos.commn.model.DemographicExt.DemographicProperty;
@@ -54,13 +60,39 @@ class EctConsultationFormRequestUtilUnitTest extends CarlosUnitTestBase {
     private DemographicManager mockDemographicManager;
 
     @Mock
+    private ConsultationRequestDao mockConsultationRequestDao;
+
+    @Mock
+    private ConsultationRequestExtDao mockConsultationRequestExtDao;
+
+    @Mock
+    private ConsultationServiceDao mockConsultationServiceDao;
+
+    @Mock
+    private ContactDao mockContactDao;
+
+    @Mock
+    private FaxJobDao mockFaxJobDao;
+
+    @Mock
+    private FaxClientLogDao mockFaxClientLogDao;
+
+    @Mock
     private LoggedInInfo mockLoggedInInfo;
 
     private EctConsultationFormRequestUtil consultationFormRequestUtil;
 
     @BeforeEach
     void setUp() {
+        // EctConsultationFormRequestUtil's field initializers call SpringUtils.getBean(...)
+        // for every collaborator — register them all before constructing it.
         registerMock(DemographicManager.class, mockDemographicManager);
+        registerMock(ConsultationRequestDao.class, mockConsultationRequestDao);
+        registerMock(ConsultationRequestExtDao.class, mockConsultationRequestExtDao);
+        registerMock(ConsultationServiceDao.class, mockConsultationServiceDao);
+        registerMock(ContactDao.class, mockContactDao);
+        registerMock(FaxJobDao.class, mockFaxJobDao);
+        registerMock(FaxClientLogDao.class, mockFaxClientLogDao);
         consultationFormRequestUtil = new EctConsultationFormRequestUtil();
     }
 

--- a/src/test/java/io/github/carlos_emr/carlos/managers/ConsultationManagerUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/managers/ConsultationManagerUnitTest.java
@@ -44,6 +44,11 @@ import io.github.carlos_emr.carlos.commn.model.Provider;
 import io.github.carlos_emr.carlos.consultations.ConsultationRequestSearchFilter;
 import io.github.carlos_emr.carlos.consultations.ConsultationResponseSearchFilter;
 import io.github.carlos_emr.carlos.hospitalReportManager.HRMUtil;
+import io.github.carlos_emr.carlos.hospitalReportManager.dao.HRMCategoryDao;
+import io.github.carlos_emr.carlos.hospitalReportManager.dao.HRMDocumentDao;
+import io.github.carlos_emr.carlos.hospitalReportManager.dao.HRMDocumentSubClassDao;
+import io.github.carlos_emr.carlos.hospitalReportManager.dao.HRMDocumentToDemographicDao;
+import io.github.carlos_emr.carlos.hospitalReportManager.dao.HRMSubClassDao;
 import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.webserv.rest.to.model.ConsultationRequestSearchResult;
@@ -188,6 +193,18 @@ public class ConsultationManagerUnitTest extends CarlosUnitTestBase {
         registerMock(DemographicManager.class, mockDemographicManager);
         registerMock(DocumentManager.class, mockDocumentManager);
         registerMock(FormsManager.class, mockFormsManager);
+
+        // HRMUtil's static initializer calls SpringUtils.getBean(...) for each DAO it holds.
+        // The shouldMatchAttachedHrmDocuments test uses Mockito.mockStatic(HRMUtil.class) which
+        // forces class load and runs <clinit>. Register stubs up front so the first load succeeds;
+        // static init runs once per JVM, so a later test that needed the same mocks would not
+        // get a chance to register them.
+        registerMock(HRMDocumentDao.class, Mockito.mock(HRMDocumentDao.class));
+        registerMock(HRMDocumentToDemographicDao.class, Mockito.mock(HRMDocumentToDemographicDao.class));
+        registerMock(HRMSubClassDao.class, Mockito.mock(HRMSubClassDao.class));
+        registerMock(HRMDocumentSubClassDao.class, Mockito.mock(HRMDocumentSubClassDao.class));
+        registerMock(HRMCategoryDao.class, Mockito.mock(HRMCategoryDao.class));
+        registerMock(NioFileManager.class, Mockito.mock(NioFileManager.class));
 
         // Security manager returns true for all privilege checks in unit tests
         lenient().when(mockSecurityInfoManager.hasPrivilege(any(), anyString(), anyString(), any()))

--- a/src/test/java/io/github/carlos_emr/carlos/managers/EFormReportToolManagerUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/managers/EFormReportToolManagerUnitTest.java
@@ -116,7 +116,9 @@ public class EFormReportToolManagerUnitTest extends CarlosUnitTestBase {
         EFormValue valueOne = createValue(10, "bp");
         EFormValue valueThree = createValue(12, "weight");
 
-        when(mockEFormReportToolDao.find(77)).thenReturn(reportTool);
+        // Production calls dao.find(Integer) which resolves to find(Object); stub must match that
+        // overload, not the find(int) overload picked by a bare int literal.
+        when(mockEFormReportToolDao.find((Object) Integer.valueOf(77))).thenReturn(reportTool);
         when(mockEFormDataDao.findMetaFieldsByFormId(500)).thenReturn(List.of(rowOne, rowTwo, rowThree));
         when(mockEFormValueDao.findByFormDataIdList(List.of(10, 11, 12))).thenReturn(List.of(valueOne, valueThree));
 
@@ -158,7 +160,7 @@ public class EFormReportToolManagerUnitTest extends CarlosUnitTestBase {
             }
         }
 
-        when(mockEFormReportToolDao.find(78)).thenReturn(reportTool);
+        when(mockEFormReportToolDao.find((Object) Integer.valueOf(78))).thenReturn(reportTool);
         when(mockEFormDataDao.findMetaFieldsByFormId(501)).thenReturn(fdidRows);
         when(mockEFormValueDao.findByFormDataIdList(firstBatch)).thenReturn(List.of(createValue(1, "bp")));
         when(mockEFormValueDao.findByFormDataIdList(secondBatch)).thenReturn(List.of(createValue(501, "weight")));
@@ -174,7 +176,9 @@ public class EFormReportToolManagerUnitTest extends CarlosUnitTestBase {
     }
 
     /**
-     * Creates an eform value fixture for a specific form-data row.
+     * Creates an eform value fixture for a specific form-data row. Sets a unique id so
+     * AbstractModel.equals — which dereferences getId() without a null guard — doesn't NPE
+     * when Mockito runs eq() comparisons during verify().
      *
      * @param formDataId Integer the form-data identifier the value belongs to
      * @param varName String the eform variable name
@@ -185,6 +189,13 @@ public class EFormReportToolManagerUnitTest extends CarlosUnitTestBase {
         value.setFormDataId(formDataId);
         value.setVarName(varName);
         value.setVarValue("value");
+        try {
+            java.lang.reflect.Field idField = EFormValue.class.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(value, formDataId);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException("failed to set id on EFormValue test fixture", e);
+        }
         return value;
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/ScheduleServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/ScheduleServiceUnitTest.java
@@ -46,7 +46,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -86,7 +88,9 @@ class ScheduleServiceUnitTest extends CarlosUnitTestBase {
         injectDependency(service, "securityInfoManager", securityInfoManager);
         injectDependency(service, "appointmentSearchDao", appointmentSearchDao);
 
-        when(securityInfoManager.hasPrivilege(any(), eq("_appointment"), eq("w"), any())).thenReturn(true);
+        // Lenient: some tests exercise paths that short-circuit before the privilege check
+        // (e.g. findUnknownFilter) or override the stub. Strict-by-default would fail those.
+        lenient().when(securityInfoManager.hasPrivilege(any(), eq("_appointment"), eq("w"), any())).thenReturn(true);
     }
 
     @Test
@@ -99,7 +103,8 @@ class ScheduleServiceUnitTest extends CarlosUnitTestBase {
         assertThat(nullIdResponse.getEntity()).isEqualTo("Invalid search configuration id");
         assertThat(zeroIdResponse.getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
         assertThat(zeroIdResponse.getEntity()).isEqualTo("Invalid search configuration id");
-        verify(securityInfoManager).hasPrivilege(eq(loggedInInfo), eq("_appointment"), eq("w"), isNull());
+        // Two saveSearchConfig invocations above → hasPrivilege is checked twice
+        verify(securityInfoManager, times(2)).hasPrivilege(eq(loggedInInfo), eq("_appointment"), eq("w"), isNull());
         verify(appointmentSearchDao, never()).find(any());
     }
 


### PR DESCRIPTION
This pull request includes several improvements and fixes across the codebase, focusing on correct JPA/Hibernate usage, enhanced test reliability, and improved Spring context handling. The most significant changes ensure proper entity management in DAO methods, address dual persistence context issues in integration tests, clarify Spring bean resolution in tests, and improve test setup to avoid subtle failures.

**JPA/Hibernate entity management and DAO correctness:**

* Updated DAO `delete` methods (e.g., `CaseManagementIssueDAOImpl.deleteIssueById`, `SecobjprivilegeDaoImpl.delete`) to reattach detached entities using `merge()` before removal, ensuring compatibility with JPA's requirement for managed instances. [[1]](diffhunk://#diff-16381a3b78be6c09b9928b74cbba6f96c87276ee760e8657ccd08c34509d4111L137-R143) [[2]](diffhunk://#diff-9ee258e2a7cc430541c287d9790f38a86a39899074e9edbe8861b11f20683295L138-R144)
* Modified `ProviderDaoImpl.getActiveProvidersByRole` to use the correct `Secuserrole` mapping and field names, matching the production database schema and avoiding test/production mismatches.

**Test reliability and persistence context handling:**

* Refactored integration tests (e.g., `AgencyDaoIntegrationTest`, `CaseManagementIssueDAOIntegrationTest`, `SecProviderDaoIntegrationTest`) to flush and query through the JPA `EntityManager` instead of the Hibernate `Session`/`hibernateTemplate`, preventing issues from dual persistence contexts and ensuring that test verifications observe the correct database state. [[1]](diffhunk://#diff-6e15f8a156b914b38eadd5e09c707ff334e1bffaaae056912b26e622ea5c43c3R321-R325) [[2]](diffhunk://#diff-6e15f8a156b914b38eadd5e09c707ff334e1bffaaae056912b26e622ea5c43c3L333-R339) [[3]](diffhunk://#diff-f6f38f05f80d2fbc550471d9c33c7e3a771ea5bfb10a95224a9525eb18db191aL184-R200) [[4]](diffhunk://#diff-a33870655174f4ee8fd4df3e9304756c691787e88e5a1348de0157a262680a1bL1848-R1851)
* Improved test assertions in `LookupListDaoIntegrationTest` to filter out unexpected rows introduced by other tests, making the test robust to side effects from shared test setup.

**Spring context and bean resolution in tests:**

* Added `@Qualifier` annotations in tests (e.g., `GroupsDaoIntegrationTest`) to disambiguate beans when multiple candidates exist due to test context pollution, ensuring the correct DAO implementation is used.
* Registered all required mock beans before constructing utility classes in unit tests (e.g., `EctConsultationFormRequestUtilUnitTest`, `ConsultationManagerUnitTest`), preventing initialization errors from missing dependencies in static initializers or field injection. [[1]](diffhunk://#diff-3d8e7482c2f73630faa1df1c47472ffce2e7e98ee7eaef8f086540b386be0c0aR24-R29) [[2]](diffhunk://#diff-3d8e7482c2f73630faa1df1c47472ffce2e7e98ee7eaef8f086540b386be0c0aR62-R95) [[3]](diffhunk://#diff-1ae66d6c65711625279512a79b35cca5c2af3fdb6b744efcc1da813f1a74e2bcR47-R51) [[4]](diffhunk://#diff-1ae66d6c65711625279512a79b35cca5c2af3fdb6b744efcc1da813f1a74e2bcR197-R208)

**Test code clarity and correctness:**

* Clarified and improved test stubbing and documentation, such as using the correct overload for DAO `find` methods in `EFormReportToolManagerUnitTest`, and ensuring fixture objects are fully initialized to avoid NPEs during Mockito argument matching. [[1]](diffhunk://#diff-faa6f5a0493f6a05051d654198c9f4584298a08a62ee3c5bf9c3eca0c53d81f2L119-R121) [[2]](diffhunk://#diff-faa6f5a0493f6a05051d654198c9f4584298a08a62ee3c5bf9c3eca0c53d81f2L161-R163) [[3]](diffhunk://#diff-faa6f5a0493f6a05051d654198c9f4584298a08a62ee3c5bf9c3eca0c53d81f2L177-R181)
* Updated error message assertions in `MultiReadHttpServletRequestUnitTest` to check for limits in MB, matching the current implementation. [[1]](diffhunk://#diff-f379ac938b7ddf5a310b08dd85776d71c556e03ef4ad14197018fa1a4a490d5aL606-R606) [[2]](diffhunk://#diff-f379ac938b7ddf5a310b08dd85776d71c556e03ef4ad14197018fa1a4a490d5aL616-R616)

**Build and configuration improvements:**

* Added `<parameters>true>` to the Maven compiler configuration in `pom.xml` to emit method parameter names in `.class` files, enabling Spring SpEL to resolve argument names for caching annotations in Spring 6+.

## Summary by Sourcery

Fix DAO delete semantics for detached JPA entities and align provider role queries with the production schema while stabilizing post-migration tests and build configuration.

Bug Fixes:
- Ensure CaseManagementIssue and Secobjprivilege delete methods reattach detached entities before removal to comply with JPA EntityManager requirements.
- Correct ProviderDaoImpl.getActiveProvidersByRole to use the appropriate Secuserrole mapping and field names consistent with the production database schema.
- Make LookupListDaoIntegrationTest resilient to extra rows created by sibling tests by asserting only on the lists created within the test.
- Align MultiReadHttpServletRequestUnitTest error message assertions with the current MB-based limit formatting.
- Avoid Hibernate/JPA dual-persistence-context issues in integration tests by flushing and verifying through the EntityManager where DAOs write via JPA.
- Prevent static initialization failures in HRMUtil- and EctConsultationFormRequestUtil-related tests by registering required Spring beans and mocks before class loading or construction.
- Fix Mockito stubbing in EFormReportToolManagerUnitTest to match the actual DAO find overload used in production and ensure fixtures have non-null ids for equality comparisons.
- Resolve Spring bean ambiguity in GroupsDaoIntegrationTest by qualifying the concrete GroupsDao bean.
- Prevent strict stubbing failures in ScheduleServiceUnitTest by making the security privilege mock lenient and adjusting invocation expectations.

Enhancements:
- Standardize integration tests such as AgencyDaoIntegrationTest, CaseManagementIssueDAOIntegrationTest, and SecProviderDaoIntegrationTest to interact with the same JPA EntityManager context as their DAOs for more reliable lifecycle verification.

Build:
- Enable Java compiler parameter metadata emission in pom.xml so Spring 6+ can resolve method parameter names for SpEL-based caching expressions.

Tests:
- Add missing DAO and service mocks in EctConsultationFormRequestUtilUnitTest and register them in setup to satisfy SpringUtils bean lookups.
- Document and adjust test setup and comments across multiple tests to clarify persistence context expectations and Mockito behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 23 post-migration test failures by making JPA deletes safe for detached entities, correcting the provider-role query, and stabilizing tests that mixed persistence contexts. Also enables method-parameter metadata so Spring cache conditions evaluate correctly; affected DAO/cache tests now pass.

- **Bug Fixes**
  - Reattach on delete: `CaseManagementIssueDAOImpl.deleteIssueById` and `SecobjprivilegeDaoImpl.delete` now `merge()` before `remove()`.
  - Correct role query: `ProviderDaoImpl.getActiveProvidersByRole` now joins `Secuserrole` with correct field names.
  - Use one persistence context in tests: flush and verify via `EntityManager` (not `HibernateTemplate`) to avoid dual-context issues and Hibernate 7 assertions.
  - Stable test wiring: add `@Qualifier` for `GroupsDao` to avoid bean ambiguity; register required mocks before constructing utilities or triggering static initializers; fix Mockito stubs and ID setup; update error message checks to MB format.
  - Robust lookup list test: filter results to the rows created by the test and assert inactive entries are excluded, handling a sibling test’s possible null-name row.

- **Dependencies**
  - `maven-compiler-plugin`: set `<parameters>true>` to include parameter names so Spring SpEL resolves args in `@Cacheable` conditions and caching works as expected.

<sup>Written for commit 6c3b32cea5686b37a1d53a6703ca9f55db548049. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

