### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL injection in FrmForm2Action

### DIFF
--- a/.github/workflows/spotbugs.yml
+++ b/.github/workflows/spotbugs.yml
@@ -168,9 +168,11 @@ jobs:
             echo '========================================='
             echo 'Compiling and running SpotBugs analysis'
             echo '========================================='
+            export MAVEN_OPTS='-Xmx4g'
             mvn -B compile spotbugs:spotbugs \
               -Pspotbugs,skip-dependency-lock \
               -DskipTests \
+              -Dspotbugs.maxHeap=4096 \
               -T 1C
           "
 

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-04-22 - [Refactor dynamic SQL from concatenation to parameters]
+**Vulnerability:** A SQL injection vulnerability was found in FrmForm2Action where `demographicNo` was directly concatenated into the SQL query string `String sql = "SELECT * FROM form" + formName + " WHERE demographic_no='" + demographicNo + "' AND ID=0";`.
+**Learning:** String concatenation of variables into a SQL string can lead to SQL injection attacks even when input variables are somewhat sanitized or assumed safe.
+**Prevention:** Always use parameterized SQL when building dynamic queries, such as `String sql = "SELECT * FROM form" + formName + " WHERE demographic_no=? AND ID=0";`, and pass the variable via the appropriate parameterized function argument.

--- a/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FrmForm2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FrmForm2Action.java
@@ -269,10 +269,10 @@ public class FrmForm2Action extends ActionSupport {
             // Store the the form table for keeping the current record
             logger.debug("current mem 8 " + currentMem());
             try {
-                String sql = "SELECT * FROM form" + formName + " WHERE demographic_no='" + demographicNo + "' AND ID=0";
+                String sql = "SELECT * FROM form" + formName + " WHERE demographic_no=? AND ID=0";
                 FrmRecordHelp frh = new FrmRecordHelp();
                 frh.setDateFormat(_dateFormat);
-                (frh).saveFormRecord(props, sql);
+                (frh).saveFormRecord(props, sql, demographicNo);
             } catch (SQLException e) {
                 logger.error("Error", e);
             }

--- a/src/main/webapp/WEB-INF/jsp/messenger/ViewAttachment.jsp
+++ b/src/main/webapp/WEB-INF/jsp/messenger/ViewAttachment.jsp
@@ -85,7 +85,7 @@
 <%@ page import="java.util.*, org.w3c.dom.*" %>
 <%@ page import="io.github.carlos_emr.carlos.messenger.docxfer.util.MsgCommxml" %>
 <%@ page import="io.github.carlos_emr.carlos.util.UtilXML" %>
-<%@ page import="org.owasp.encoder.Encode" %>
+<%@ page import="io.github.carlos_emr.carlos.utility.SafeEncode" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
 <fmt:setBundle basename="oscarResources"/>
@@ -281,7 +281,7 @@
         void DrawDoc(Element root, JspWriter out, String rootLabel)
                 throws jakarta.servlet.jsp.JspException, java.io.IOException {
             String safeRootLabel = rootLabel == null ? "" : rootLabel;
-            out.print(spanStartRoot + Encode.forHtml(safeRootLabel) + spanEnd);
+            out.print(spanStartRoot + SafeEncode.forHtml(safeRootLabel) + spanEnd);
             out.print(tblStartRoot);
 
             NodeList lst = root.getChildNodes();
@@ -296,7 +296,7 @@
 
         void DrawTable(Element tbl, JspWriter out)
                 throws jakarta.servlet.jsp.JspException, java.io.IOException {
-            out.print(spanStart + Encode.forHtml(tbl.getAttribute("name")) + spanEnd);
+            out.print(spanStart + SafeEncode.forHtml(tbl.getAttribute("name")) + spanEnd);
             out.print(tblStart);
 
             NodeList lst = tbl.getChildNodes();
@@ -315,8 +315,8 @@
                 // String sName = "item" + item.getAttribute("itemId");
                 // out.print("<input type=checkbox name='" + sName + "' onclick='javascript:chkClick();'/>");
             }
-            out.print(Encode.forHtml(item.getAttribute("name")) + ": "
-                    + Encode.forHtml(item.getAttribute("value")) + spanEnd);
+            out.print(SafeEncode.forHtml(item.getAttribute("name")) + ": "
+                    + SafeEncode.forHtml(item.getAttribute("value")) + spanEnd);
             out.print(tblStartContent);
 
             NodeList lst = item.getChildNodes();
@@ -338,9 +338,9 @@
                     Element fld = (Element) lst.item(i);
                     if (fld.getTagName().equals("fld")) {
                         out.print("<tr><td style='font-weight:bold'>");
-                        out.print(Encode.forHtml(fld.getAttribute("name")) + ": ");
+                        out.print(SafeEncode.forHtml(fld.getAttribute("name")) + ": ");
                         out.print("</td><td>");
-                        out.print(Encode.forHtml(fld.getAttribute("value")));
+                        out.print(SafeEncode.forHtml(fld.getAttribute("value")));
                         out.print("</td></tr>");
                     }
                 }
@@ -394,15 +394,15 @@
         <div class="mb-2">
             <button type="button"
                     class="btn btn-outline-secondary btn-sm"
-                    onclick="if (confirm('<%= Encode.forJavaScript((String) pageContext.getAttribute("closeConfirmMsg")) %>')) { top.window.close(); }">
+                    onclick="if (confirm('<%= SafeEncode.forJavaScript((String) pageContext.getAttribute("closeConfirmMsg")) %>')) { top.window.close(); }">
                 <i class="fa-regular fa-circle-xmark" aria-hidden="true"></i>
                 <fmt:message key="messenger.generatePreviewPDF.btnClose"/>
             </button>
         </div>
             <form method="POST" action="<%= request.getContextPath() %>/messenger/AdjustAttachments"><input
                     type="hidden" name="xmlDoc"
-                    value="<%= Encode.forHtmlAttribute(MsgCommxml.encode64(MsgCommxml.toXML(root))) %>"/> <input
-                    type="hidden" name="id" value="<%= Encode.forHtmlAttribute(String.valueOf(request.getAttribute("attId"))) %>"/>
+                    value="<%= SafeEncode.forHtmlAttribute(MsgCommxml.encode64(MsgCommxml.toXML(root))) %>"/> <input
+                    type="hidden" name="id" value="<%= SafeEncode.forHtmlAttribute(String.valueOf(request.getAttribute("attId"))) %>"/>
 
 <table class="MainTable" id="scrollNumber1" name="encounterTable">
 

--- a/src/main/webapp/WEB-INF/jsp/messenger/ViewPDFAttachment.jsp
+++ b/src/main/webapp/WEB-INF/jsp/messenger/ViewPDFAttachment.jsp
@@ -74,7 +74,7 @@
 <%@ page import="java.util.*" %>
 <%@ page import="org.w3c.dom.*" %>
 <%@ page import="io.github.carlos_emr.carlos.util.Doc2PDF" %>
-<%@ page import="org.owasp.encoder.Encode" %>
+<%@ page import="io.github.carlos_emr.carlos.utility.SafeEncode" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
 <%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
@@ -174,7 +174,7 @@
                             %>
                             <% for ( int i = 0 ; i < attVector.size(); i++) { %>
                     <tr>
-                        <td><%= Encode.forHtml((String) attVector.get(i)) %>
+                        <td><%= SafeEncode.forHtml((String) attVector.get(i)) %>
                         </td>
                         <td>
                           <button type="submit"
@@ -189,7 +189,7 @@
                             <% }  %>
                     </table>
                         <input type="hidden" name="file_id" id="file_id"/>
-                        <input type="hidden" name="attachment" id="attachment" value="<%= Encode.forHtmlAttribute(pdfAttch) %>"/>
+                        <input type="hidden" name="attachment" id="attachment" value="<%= SafeEncode.forHtmlAttribute(pdfAttch) %>"/>
 
         </form>
     </div>

--- a/src/main/webapp/WEB-INF/jsp/messenger/attachmentFrameset.jsp
+++ b/src/main/webapp/WEB-INF/jsp/messenger/attachmentFrameset.jsp
@@ -50,14 +50,14 @@
 --%>
 
 <%@ page import="io.github.carlos_emr.carlos.util.*" %>
-<%@ page import="org.owasp.encoder.Encode" %>
+<%@ page import="io.github.carlos_emr.carlos.utility.SafeEncode" %>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
-<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
+<%@ taglib uri="/WEB-INF/carlos.tld" prefix="carlos" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <!DOCTYPE html>
-<html lang="${e:forHtmlAttribute(pageContext.request.locale.language)}">
+<html lang="${carlos:forHtmlAttribute(pageContext.request.locale.language)}">
 <head>
     <script type="text/javascript" src="<%= request.getContextPath() %>/js/global.js"></script>
         <%
@@ -72,7 +72,7 @@ String demographic_no = request.getParameter("demographic_no");
     <frameset rows="300,0">
         <%-- Main frame: Shows the PDF preview via the gated Struts action. --%>
         <frame name="main"
-               src="<%= request.getContextPath() %>/messenger/PreviewPDF?demographic_no=<%= Encode.forUriComponent(demographic_no) %>"
+               src="<%= request.getContextPath() %>/messenger/PreviewPDF?demographic_no=<%= SafeEncode.forUriComponent(demographic_no) %>"
                noresize scrolling=auto marginheight=5 marginwidth=5>
         <%-- Hidden source frame: Used for background processing --%>
         <frame name="srcFrame" src="">

--- a/src/main/webapp/WEB-INF/jsp/messenger/attachmentFrameset.jsp
+++ b/src/main/webapp/WEB-INF/jsp/messenger/attachmentFrameset.jsp
@@ -53,7 +53,7 @@
 <%@ page import="io.github.carlos_emr.carlos.utility.SafeEncode" %>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
-<%@ taglib uri="/WEB-INF/carlos.tld" prefix="carlos" %>
+<%@ taglib uri="/WEB-INF/carlos-tag.tld" prefix="carlos" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <!DOCTYPE html>

--- a/src/main/webapp/WEB-INF/jsp/messenger/generatePreviewPDF.jsp
+++ b/src/main/webapp/WEB-INF/jsp/messenger/generatePreviewPDF.jsp
@@ -77,13 +77,12 @@
 <%@ page import="io.github.carlos_emr.carlos.util.*" %>
 <%@ page import="io.github.carlos_emr.carlos.demographic.data.DemographicData" %>
 <%@ page import="io.github.carlos_emr.carlos.commn.model.Demographic" %>
-<%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="io.github.carlos_emr.carlos.utility.SafeEncode" %>
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
-<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
+<%@ taglib uri="/WEB-INF/carlos.tld" prefix="carlos" %>
 <fmt:setBundle basename="oscarResources"/>
 <fmt:message key="messenger.generatePreviewPDF.information" var="informationLabel"/>
 <fmt:message key="messenger.generatePreviewPDF.encounter" var="encounterLabel"/>
@@ -198,7 +197,7 @@
 %>
 
 <!DOCTYPE html>
-<html lang="${e:forHtmlAttribute(pageContext.request.locale.language)}">
+<html lang="${carlos:forHtmlAttribute(pageContext.request.locale.language)}">
 <head>
     <meta charset="UTF-8">
     <title>CARLOS - <fmt:message key="messenger.generatePreviewPDF.title"/></title>
@@ -207,7 +206,7 @@
     <script>
         // i18n message strings for JavaScript dialogs
         var MSGS = {
-            exitConfirm: '${e:forJavaScript(exitConfirmMsg)}'
+            exitConfirm: '${carlos:forJavaScript(exitConfirmMsg)}'
         };
 
         /**
@@ -349,7 +348,7 @@
         <div class="d-flex align-items-center gap-3">
             <span class="text-muted small">
                 <fmt:message key="messenger.generatePreviewPDF.attachDocFor"/>
-                ${e:forHtml(demoName)}
+                ${carlos:forHtml(demoName)}
             </span>
             <a href="javascript:popupStart(300,400,'About.jsp')" class="small text-decoration-none">
                 <fmt:message key="global.about"/>
@@ -385,25 +384,25 @@
                 <tr>
                     <td class="align-middle" style="width:2rem;">
                         <input type="checkbox" name="uriArray"
-                               value="<%=Encode.forHtmlAttribute(demoUri)%>"
+                               value="<%=SafeEncode.forHtmlAttribute(demoUri)%>"
                                style="display:none"/>
                         <% String demoIndex = Integer.toString(indexCount++); %>
                         <input type="checkbox" name="indexArray"
                                value="<%= demoIndex %>"
                                <%= selectedIndexes.contains(demoIndex) ? "checked" : "" %>/>
                         <input type="checkbox" name="titleArray"
-                               value="${e:forHtmlAttribute(demoTitleValue)}"
+                               value="${carlos:forHtmlAttribute(demoTitleValue)}"
                                style="display:none"/>
                     </td>
                     <td class="align-middle">
-                        ${e:forHtml(demoName)}
+                        ${carlos:forHtml(demoName)}
                         <fmt:message key="messenger.generatePreviewPDF.information"/>
                     </td>
                     <td class="align-middle" style="width:8rem;">
                         <% if (request.getParameter("isAttaching") == null) { %>
                         <button type="button"
                                 class="btn btn-outline-secondary btn-sm"
-                                data-preview-uri="<%=Encode.forHtmlAttribute(demoUri)%>"
+                                data-preview-uri="<%=SafeEncode.forHtmlAttribute(demoUri)%>"
                                 onclick="PreviewPDF(this.dataset.previewUri)">
                             <fmt:message key="messenger.generatePreviewPDF.btnPreview"/>
                         </button>
@@ -421,22 +420,22 @@
                 <tr>
                     <td class="align-middle">
                         <input type="checkbox" name="uriArray"
-                               value="<%=Encode.forHtmlAttribute(ecUri)%>"
+                               value="<%=SafeEncode.forHtmlAttribute(ecUri)%>"
                                style="display:none"/>
                         <% String encounterIndex = Integer.toString(indexCount++); %>
                         <input type="checkbox" name="indexArray"
                                value="<%= encounterIndex %>"
                                <%= selectedIndexes.contains(encounterIndex) ? "checked" : "" %>/>
                         <input type="checkbox" name="titleArray"
-                               value="${e:forHtmlAttribute(ecTitleValue)}"
+                               value="${carlos:forHtmlAttribute(ecTitleValue)}"
                                style="display:none"/>
                     </td>
-                    <td class="align-middle">${e:forHtml(ecTimestamp)}</td>
+                    <td class="align-middle">${carlos:forHtml(ecTimestamp)}</td>
                     <td class="align-middle">
                         <% if (request.getParameter("isAttaching") == null) { %>
                         <button type="button"
                                 class="btn btn-outline-secondary btn-sm"
-                                data-preview-uri="<%=Encode.forHtmlAttribute(ecUri)%>"
+                                data-preview-uri="<%=SafeEncode.forHtmlAttribute(ecUri)%>"
                                 onclick="PreviewPDF(this.dataset.previewUri)">
                             <fmt:message key="messenger.generatePreviewPDF.btnPreview"/>
                         </button>
@@ -454,14 +453,14 @@
                 <tr>
                     <td class="align-middle">
                         <input type="checkbox" name="uriArray"
-                               value="<%=Encode.forHtmlAttribute(rxUri)%>"
+                               value="<%=SafeEncode.forHtmlAttribute(rxUri)%>"
                                style="display:none"/>
                         <% String prescriptionIndex = Integer.toString(indexCount++); %>
                         <input type="checkbox" name="indexArray"
                                value="<%= prescriptionIndex %>"
                                <%= selectedIndexes.contains(prescriptionIndex) ? "checked" : "" %>/>
                         <input type="checkbox" name="titleArray"
-                               value="${e:forHtmlAttribute(currentPrescTitle)}"
+                               value="${carlos:forHtmlAttribute(currentPrescTitle)}"
                                style="display:none"/>
                     </td>
                     <td class="align-middle">
@@ -471,7 +470,7 @@
                         <% if (request.getParameter("isAttaching") == null) { %>
                         <button type="button"
                                 class="btn btn-outline-secondary btn-sm"
-                                data-preview-uri="<%=Encode.forHtmlAttribute(rxUri)%>"
+                                data-preview-uri="<%=SafeEncode.forHtmlAttribute(rxUri)%>"
                                 onclick="PreviewPDF(this.dataset.previewUri)">
                             <fmt:message key="messenger.generatePreviewPDF.btnPreview"/>
                         </button>
@@ -502,13 +501,13 @@
                     <td colspan="3" class="d-none">
                         <input type="hidden" name="srcText" id="srcText" value=""/>
                         <input type="hidden" name="attachmentCount" id="attachmentCount"
-                               value="<%=Encode.forHtmlAttribute(request.getParameter("attachmentCount") == null ? "0" : request.getParameter("attachmentCount"))%>"/>
+                               value="<%=SafeEncode.forHtmlAttribute(request.getParameter("attachmentCount") == null ? "0" : request.getParameter("attachmentCount"))%>"/>
                         <input type="hidden" name="demographic_no" id="demographic_no"
-                               value="<%=Encode.forHtmlAttribute(demographic_no != null ? demographic_no : "")%>"/>
+                               value="<%=SafeEncode.forHtmlAttribute(demographic_no != null ? demographic_no : "")%>"/>
                         <input type="hidden" name="isPreview" id="isPreview"
-                               value="<%=Encode.forHtmlAttribute(request.getParameter("isPreview") == null ? "false" : request.getParameter("isPreview"))%>"/>
+                               value="<%=SafeEncode.forHtmlAttribute(request.getParameter("isPreview") == null ? "false" : request.getParameter("isPreview"))%>"/>
                         <input type="hidden" name="isAttaching" id="isAttaching"
-                               value="<%=Encode.forHtmlAttribute(request.getParameter("isAttaching") == null ? "false" : request.getParameter("isAttaching"))%>"/>
+                               value="<%=SafeEncode.forHtmlAttribute(request.getParameter("isAttaching") == null ? "false" : request.getParameter("isAttaching"))%>"/>
                         <input type="hidden" name="isNew" id="isNew" value="true"/>
                         <input type="hidden" name="attachmentTitle" id="attachmentTitle" value=""/>
                     </td>
@@ -529,7 +528,7 @@
                     j++;
                 }
             }
-            var attachingTemplate = '${e:forJavaScript(jsAttachingTemplate)}';
+            var attachingTemplate = '${carlos:forJavaScript(jsAttachingTemplate)}';
             document.forms[0].status.value = attachingTemplate
                 .replace('{0}', <%=(msgSessionBean != null ? msgSessionBean.getCurrentAttachmentCount() + 1 : 1)%>)
                 .replace('{1}', j);

--- a/src/main/webapp/WEB-INF/jsp/messenger/generatePreviewPDF.jsp
+++ b/src/main/webapp/WEB-INF/jsp/messenger/generatePreviewPDF.jsp
@@ -82,7 +82,7 @@
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
-<%@ taglib uri="/WEB-INF/carlos.tld" prefix="carlos" %>
+<%@ taglib uri="/WEB-INF/carlos-tag.tld" prefix="carlos" %>
 <fmt:setBundle basename="oscarResources"/>
 <fmt:message key="messenger.generatePreviewPDF.information" var="informationLabel"/>
 <fmt:message key="messenger.generatePreviewPDF.encounter" var="encounterLabel"/>


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A SQL injection vulnerability was found in FrmForm2Action where `demographicNo` was directly concatenated into the SQL query string `String sql = "SELECT * FROM form" + formName + " WHERE demographic_no='" + demographicNo + "' AND ID=0";`.
🎯 Impact: An attacker could manipulate `demographicNo` to bypass checks or exfiltrate data, though the risk is somewhat mitigated by it being fetched from the session bean. However, string concatenation is always risky.
🔧 Fix: Replaced the dynamic string concatenation with parameterized SQL query `?` placeholders, and passed the variable `demographicNo` using the varargs parameter of `saveFormRecord`. Note that `formName` cannot be parameterized but is validated against an allowlist pattern by `isValidFormName` in the controller.
✅ Verification: Ran `mvn compile` and `mvn test` to ensure successful compilation and no test regressions.

---
*PR created automatically by Jules for task [1533228894955544787](https://jules.google.com/task/1533228894955544787) started by @yingbull*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a critical SQL injection in `FrmForm2Action` and standardizes output encoding in Messenger JSPs using `io.github.carlos_emr.carlos.utility.SafeEncode` and the `carlos` taglib. This blocks malicious input and reduces XSS risk; CI memory for SpotBugs is increased for more reliable analysis.

- **Bug Fixes**
  - Parameterized the `demographicNo` filter and pass it to `saveFormRecord`; `formName` stays dynamic but is validated by `isValidFormName`.
  - Replaced `org.owasp.encoder.Encode`/taglib with `SafeEncode` and the `carlos` taglib in Messenger views for consistent HTML/JS/URI encoding.

- **Performance**
  - Increased SpotBugs heap in CI (`MAVEN_OPTS=-Xmx4g`, `-Dspotbugs.maxHeap=4096`) to stabilize analysis.

<sup>Written for commit 6b904dd0908b822d30d5901ab8cc2d191e1d4b30. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

