### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL injection in ConsultationRequestDaoImpl

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - [CRITICAL] SQL Injection in ConsultationRequestDaoImpl via HQL string concatenation
+**Vulnerability:** A critical SQL/HQL injection vulnerability was found in `ConsultationRequestDaoImpl.java` where user-provided inputs (`team`, `startDate`, `endDate`) were being directly concatenated into a dynamic JPQL query string in the `getConsults` method.
+**Learning:** Even when using ORMs like Hibernate and creating JPQL/HQL queries via `entityManager.createQuery()`, dynamically appending variables (especially user-controlled ones like `team`) directly into the query string leads to injection vulnerabilities.
+**Prevention:** Always use parameterized queries (named parameters like `:team` or positional placeholders like `?1`) and bind the values using `query.setParameter()` instead of concatenating them directly into the HQL string. This ensures the underlying ORM handles escaping correctly and prevents execution of malicious SQL commands.

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/ConsultationRequestDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/ConsultationRequestDaoImpl.java
@@ -36,6 +36,8 @@ import java.util.List;
 
 import jakarta.persistence.Query;
 
+import org.apache.commons.lang3.time.DateFormatUtils;
+
 import io.github.carlos_emr.carlos.commn.NativeSql;
 import io.github.carlos_emr.carlos.commn.model.ConsultationRequest;
 import io.github.carlos_emr.carlos.consultation.dto.ConsultationRequestListItemDTO;
@@ -138,10 +140,10 @@ public class ConsultationRequestDaoImpl extends AbstractDaoImpl<ConsultationRequ
             query.setParameter("team", team);
         }
         if (startDate != null) {
-            query.setParameter("startDate", startDate);
+            query.setParameter("startDate", DateFormatUtils.ISO_DATETIME_FORMAT.format(startDate));
         }
         if (endDate != null) {
-            query.setParameter("endDate", endDate);
+            query.setParameter("endDate", DateFormatUtils.ISO_DATETIME_FORMAT.format(endDate));
         }
 
         query.setFirstResult(offset != null ? offset : 0);

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/ConsultationRequestDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/ConsultationRequestDaoImpl.java
@@ -36,7 +36,6 @@ import java.util.List;
 
 import jakarta.persistence.Query;
 
-import org.apache.commons.lang3.time.DateFormatUtils;
 import io.github.carlos_emr.carlos.commn.NativeSql;
 import io.github.carlos_emr.carlos.commn.model.ConsultationRequest;
 import io.github.carlos_emr.carlos.consultation.dto.ConsultationRequestListItemDTO;
@@ -88,22 +87,22 @@ public class ConsultationRequestDaoImpl extends AbstractDaoImpl<ConsultationRequ
         }
 
         if (!team.isEmpty()) {
-            sql.append("and cr.sendTo = '" + team + "' ");
+            sql.append("and cr.sendTo = :team ");
         }
 
         if (startDate != null) {
             if (searchDate != null && searchDate.equals("1")) {
-                sql.append("and cr.appointmentDate >= '" + DateFormatUtils.ISO_DATETIME_FORMAT.format(startDate) + "' ");
+                sql.append("and cr.appointmentDate >= :startDate ");
             } else {
-                sql.append("and cr.referralDate >= '" + DateFormatUtils.ISO_DATETIME_FORMAT.format(startDate) + "' ");
+                sql.append("and cr.referralDate >= :startDate ");
             }
         }
 
         if (endDate != null) {
             if (searchDate != null && searchDate.equals("1")) {
-                sql.append("and cr.appointmentDate <= '" + DateFormatUtils.ISO_DATETIME_FORMAT.format(endDate) + "' ");
+                sql.append("and cr.appointmentDate <= :endDate ");
             } else {
-                sql.append("and cr.referralDate <= '" + DateFormatUtils.ISO_DATETIME_FORMAT.format(endDate) + "' ");
+                sql.append("and cr.referralDate <= :endDate ");
             }
         }
 
@@ -135,6 +134,16 @@ public class ConsultationRequestDaoImpl extends AbstractDaoImpl<ConsultationRequ
 
 
         Query query = entityManager.createQuery(sql.toString());
+        if (!team.isEmpty()) {
+            query.setParameter("team", team);
+        }
+        if (startDate != null) {
+            query.setParameter("startDate", startDate);
+        }
+        if (endDate != null) {
+            query.setParameter("endDate", endDate);
+        }
+
         query.setFirstResult(offset != null ? offset : 0);
 
         //need to never send more than MAX_LIST_RETURN_SIZE

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/ConsultationRequestDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/ConsultationRequestDaoImpl.java
@@ -36,8 +36,6 @@ import java.util.List;
 
 import jakarta.persistence.Query;
 
-import org.apache.commons.lang3.time.DateFormatUtils;
-
 import io.github.carlos_emr.carlos.commn.NativeSql;
 import io.github.carlos_emr.carlos.commn.model.ConsultationRequest;
 import io.github.carlos_emr.carlos.consultation.dto.ConsultationRequestListItemDTO;
@@ -140,10 +138,10 @@ public class ConsultationRequestDaoImpl extends AbstractDaoImpl<ConsultationRequ
             query.setParameter("team", team);
         }
         if (startDate != null) {
-            query.setParameter("startDate", DateFormatUtils.ISO_DATETIME_FORMAT.format(startDate));
+            query.setParameter("startDate", startDate);
         }
         if (endDate != null) {
-            query.setParameter("endDate", DateFormatUtils.ISO_DATETIME_FORMAT.format(endDate));
+            query.setParameter("endDate", endDate);
         }
 
         query.setFirstResult(offset != null ? offset : 0);

--- a/src/main/webapp/WEB-INF/jsp/messenger/ViewAttachment.jsp
+++ b/src/main/webapp/WEB-INF/jsp/messenger/ViewAttachment.jsp
@@ -85,7 +85,7 @@
 <%@ page import="java.util.*, org.w3c.dom.*" %>
 <%@ page import="io.github.carlos_emr.carlos.messenger.docxfer.util.MsgCommxml" %>
 <%@ page import="io.github.carlos_emr.carlos.util.UtilXML" %>
-<%@ page import="org.owasp.encoder.Encode" %>
+<%@ page import="io.github.carlos_emr.carlos.utility.SafeEncode" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
 <fmt:setBundle basename="oscarResources"/>
@@ -281,7 +281,7 @@
         void DrawDoc(Element root, JspWriter out, String rootLabel)
                 throws jakarta.servlet.jsp.JspException, java.io.IOException {
             String safeRootLabel = rootLabel == null ? "" : rootLabel;
-            out.print(spanStartRoot + Encode.forHtml(safeRootLabel) + spanEnd);
+            out.print(spanStartRoot + SafeEncode.forHtml(safeRootLabel) + spanEnd);
             out.print(tblStartRoot);
 
             NodeList lst = root.getChildNodes();
@@ -296,7 +296,7 @@
 
         void DrawTable(Element tbl, JspWriter out)
                 throws jakarta.servlet.jsp.JspException, java.io.IOException {
-            out.print(spanStart + Encode.forHtml(tbl.getAttribute("name")) + spanEnd);
+            out.print(spanStart + SafeEncode.forHtml(tbl.getAttribute("name")) + spanEnd);
             out.print(tblStart);
 
             NodeList lst = tbl.getChildNodes();
@@ -315,8 +315,8 @@
                 // String sName = "item" + item.getAttribute("itemId");
                 // out.print("<input type=checkbox name='" + sName + "' onclick='javascript:chkClick();'/>");
             }
-            out.print(Encode.forHtml(item.getAttribute("name")) + ": "
-                    + Encode.forHtml(item.getAttribute("value")) + spanEnd);
+            out.print(SafeEncode.forHtml(item.getAttribute("name")) + ": "
+                    + SafeEncode.forHtml(item.getAttribute("value")) + spanEnd);
             out.print(tblStartContent);
 
             NodeList lst = item.getChildNodes();
@@ -338,9 +338,9 @@
                     Element fld = (Element) lst.item(i);
                     if (fld.getTagName().equals("fld")) {
                         out.print("<tr><td style='font-weight:bold'>");
-                        out.print(Encode.forHtml(fld.getAttribute("name")) + ": ");
+                        out.print(SafeEncode.forHtml(fld.getAttribute("name")) + ": ");
                         out.print("</td><td>");
-                        out.print(Encode.forHtml(fld.getAttribute("value")));
+                        out.print(SafeEncode.forHtml(fld.getAttribute("value")));
                         out.print("</td></tr>");
                     }
                 }
@@ -394,15 +394,15 @@
         <div class="mb-2">
             <button type="button"
                     class="btn btn-outline-secondary btn-sm"
-                    onclick="if (confirm('<%= Encode.forJavaScript((String) pageContext.getAttribute("closeConfirmMsg")) %>')) { top.window.close(); }">
+                    onclick="if (confirm('<%= SafeEncode.forJavaScript((String) pageContext.getAttribute("closeConfirmMsg")) %>')) { top.window.close(); }">
                 <i class="fa-regular fa-circle-xmark" aria-hidden="true"></i>
                 <fmt:message key="messenger.generatePreviewPDF.btnClose"/>
             </button>
         </div>
             <form method="POST" action="<%= request.getContextPath() %>/messenger/AdjustAttachments"><input
                     type="hidden" name="xmlDoc"
-                    value="<%= Encode.forHtmlAttribute(MsgCommxml.encode64(MsgCommxml.toXML(root))) %>"/> <input
-                    type="hidden" name="id" value="<%= Encode.forHtmlAttribute(String.valueOf(request.getAttribute("attId"))) %>"/>
+                    value="<%= SafeEncode.forHtmlAttribute(MsgCommxml.encode64(MsgCommxml.toXML(root))) %>"/> <input
+                    type="hidden" name="id" value="<%= SafeEncode.forHtmlAttribute(String.valueOf(request.getAttribute("attId"))) %>"/>
 
 <table class="MainTable" id="scrollNumber1" name="encounterTable">
 

--- a/src/main/webapp/WEB-INF/jsp/messenger/ViewPDFAttachment.jsp
+++ b/src/main/webapp/WEB-INF/jsp/messenger/ViewPDFAttachment.jsp
@@ -74,7 +74,7 @@
 <%@ page import="java.util.*" %>
 <%@ page import="org.w3c.dom.*" %>
 <%@ page import="io.github.carlos_emr.carlos.util.Doc2PDF" %>
-<%@ page import="org.owasp.encoder.Encode" %>
+<%@ page import="io.github.carlos_emr.carlos.utility.SafeEncode" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
 <%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
@@ -174,7 +174,7 @@
                             %>
                             <% for ( int i = 0 ; i < attVector.size(); i++) { %>
                     <tr>
-                        <td><%= Encode.forHtml((String) attVector.get(i)) %>
+                        <td><%= SafeEncode.forHtml((String) attVector.get(i)) %>
                         </td>
                         <td>
                           <button type="submit"
@@ -189,7 +189,7 @@
                             <% }  %>
                     </table>
                         <input type="hidden" name="file_id" id="file_id"/>
-                        <input type="hidden" name="attachment" id="attachment" value="<%= Encode.forHtmlAttribute(pdfAttch) %>"/>
+                        <input type="hidden" name="attachment" id="attachment" value="<%= SafeEncode.forHtmlAttribute(pdfAttch) %>"/>
 
         </form>
     </div>

--- a/src/main/webapp/WEB-INF/jsp/messenger/attachmentFrameset.jsp
+++ b/src/main/webapp/WEB-INF/jsp/messenger/attachmentFrameset.jsp
@@ -53,7 +53,7 @@
 <%@ page import="io.github.carlos_emr.carlos.utility.SafeEncode" %>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
-<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
+<%@ taglib uri="/WEB-INF/carlos.tld" prefix="carlos" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <!DOCTYPE html>

--- a/src/main/webapp/WEB-INF/jsp/messenger/attachmentFrameset.jsp
+++ b/src/main/webapp/WEB-INF/jsp/messenger/attachmentFrameset.jsp
@@ -50,14 +50,14 @@
 --%>
 
 <%@ page import="io.github.carlos_emr.carlos.util.*" %>
-<%@ page import="org.owasp.encoder.Encode" %>
+<%@ page import="io.github.carlos_emr.carlos.utility.SafeEncode" %>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <!DOCTYPE html>
-<html lang="${e:forHtmlAttribute(pageContext.request.locale.language)}">
+<html lang="${carlos:forHtmlAttribute(pageContext.request.locale.language)}">
 <head>
     <script type="text/javascript" src="<%= request.getContextPath() %>/js/global.js"></script>
         <%
@@ -72,7 +72,7 @@ String demographic_no = request.getParameter("demographic_no");
     <frameset rows="300,0">
         <%-- Main frame: Shows the PDF preview via the gated Struts action. --%>
         <frame name="main"
-               src="<%= request.getContextPath() %>/messenger/PreviewPDF?demographic_no=<%= Encode.forUriComponent(demographic_no) %>"
+               src="<%= request.getContextPath() %>/messenger/PreviewPDF?demographic_no=<%= SafeEncode.forUriComponent(demographic_no) %>"
                noresize scrolling=auto marginheight=5 marginwidth=5>
         <%-- Hidden source frame: Used for background processing --%>
         <frame name="srcFrame" src="">

--- a/src/main/webapp/WEB-INF/jsp/messenger/generatePreviewPDF.jsp
+++ b/src/main/webapp/WEB-INF/jsp/messenger/generatePreviewPDF.jsp
@@ -77,7 +77,7 @@
 <%@ page import="io.github.carlos_emr.carlos.util.*" %>
 <%@ page import="io.github.carlos_emr.carlos.demographic.data.DemographicData" %>
 <%@ page import="io.github.carlos_emr.carlos.commn.model.Demographic" %>
-<%@ page import="org.owasp.encoder.Encode" %>
+<%@ page import="io.github.carlos_emr.carlos.utility.SafeEncode" %>
 <%@ page import="io.github.carlos_emr.carlos.utility.SafeEncode" %>
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
@@ -198,7 +198,7 @@
 %>
 
 <!DOCTYPE html>
-<html lang="${e:forHtmlAttribute(pageContext.request.locale.language)}">
+<html lang="${carlos:forHtmlAttribute(pageContext.request.locale.language)}">
 <head>
     <meta charset="UTF-8">
     <title>CARLOS - <fmt:message key="messenger.generatePreviewPDF.title"/></title>
@@ -207,7 +207,7 @@
     <script>
         // i18n message strings for JavaScript dialogs
         var MSGS = {
-            exitConfirm: '${e:forJavaScript(exitConfirmMsg)}'
+            exitConfirm: '${carlos:forJavaScript(exitConfirmMsg)}'
         };
 
         /**
@@ -349,7 +349,7 @@
         <div class="d-flex align-items-center gap-3">
             <span class="text-muted small">
                 <fmt:message key="messenger.generatePreviewPDF.attachDocFor"/>
-                ${e:forHtml(demoName)}
+                ${carlos:forHtml(demoName)}
             </span>
             <a href="javascript:popupStart(300,400,'About.jsp')" class="small text-decoration-none">
                 <fmt:message key="global.about"/>
@@ -385,25 +385,25 @@
                 <tr>
                     <td class="align-middle" style="width:2rem;">
                         <input type="checkbox" name="uriArray"
-                               value="<%=Encode.forHtmlAttribute(demoUri)%>"
+                               value="<%=SafeEncode.forHtmlAttribute(demoUri)%>"
                                style="display:none"/>
                         <% String demoIndex = Integer.toString(indexCount++); %>
                         <input type="checkbox" name="indexArray"
                                value="<%= demoIndex %>"
                                <%= selectedIndexes.contains(demoIndex) ? "checked" : "" %>/>
                         <input type="checkbox" name="titleArray"
-                               value="${e:forHtmlAttribute(demoTitleValue)}"
+                               value="${carlos:forHtmlAttribute(demoTitleValue)}"
                                style="display:none"/>
                     </td>
                     <td class="align-middle">
-                        ${e:forHtml(demoName)}
+                        ${carlos:forHtml(demoName)}
                         <fmt:message key="messenger.generatePreviewPDF.information"/>
                     </td>
                     <td class="align-middle" style="width:8rem;">
                         <% if (request.getParameter("isAttaching") == null) { %>
                         <button type="button"
                                 class="btn btn-outline-secondary btn-sm"
-                                data-preview-uri="<%=Encode.forHtmlAttribute(demoUri)%>"
+                                data-preview-uri="<%=SafeEncode.forHtmlAttribute(demoUri)%>"
                                 onclick="PreviewPDF(this.dataset.previewUri)">
                             <fmt:message key="messenger.generatePreviewPDF.btnPreview"/>
                         </button>
@@ -421,22 +421,22 @@
                 <tr>
                     <td class="align-middle">
                         <input type="checkbox" name="uriArray"
-                               value="<%=Encode.forHtmlAttribute(ecUri)%>"
+                               value="<%=SafeEncode.forHtmlAttribute(ecUri)%>"
                                style="display:none"/>
                         <% String encounterIndex = Integer.toString(indexCount++); %>
                         <input type="checkbox" name="indexArray"
                                value="<%= encounterIndex %>"
                                <%= selectedIndexes.contains(encounterIndex) ? "checked" : "" %>/>
                         <input type="checkbox" name="titleArray"
-                               value="${e:forHtmlAttribute(ecTitleValue)}"
+                               value="${carlos:forHtmlAttribute(ecTitleValue)}"
                                style="display:none"/>
                     </td>
-                    <td class="align-middle">${e:forHtml(ecTimestamp)}</td>
+                    <td class="align-middle">${carlos:forHtml(ecTimestamp)}</td>
                     <td class="align-middle">
                         <% if (request.getParameter("isAttaching") == null) { %>
                         <button type="button"
                                 class="btn btn-outline-secondary btn-sm"
-                                data-preview-uri="<%=Encode.forHtmlAttribute(ecUri)%>"
+                                data-preview-uri="<%=SafeEncode.forHtmlAttribute(ecUri)%>"
                                 onclick="PreviewPDF(this.dataset.previewUri)">
                             <fmt:message key="messenger.generatePreviewPDF.btnPreview"/>
                         </button>
@@ -454,14 +454,14 @@
                 <tr>
                     <td class="align-middle">
                         <input type="checkbox" name="uriArray"
-                               value="<%=Encode.forHtmlAttribute(rxUri)%>"
+                               value="<%=SafeEncode.forHtmlAttribute(rxUri)%>"
                                style="display:none"/>
                         <% String prescriptionIndex = Integer.toString(indexCount++); %>
                         <input type="checkbox" name="indexArray"
                                value="<%= prescriptionIndex %>"
                                <%= selectedIndexes.contains(prescriptionIndex) ? "checked" : "" %>/>
                         <input type="checkbox" name="titleArray"
-                               value="${e:forHtmlAttribute(currentPrescTitle)}"
+                               value="${carlos:forHtmlAttribute(currentPrescTitle)}"
                                style="display:none"/>
                     </td>
                     <td class="align-middle">
@@ -471,7 +471,7 @@
                         <% if (request.getParameter("isAttaching") == null) { %>
                         <button type="button"
                                 class="btn btn-outline-secondary btn-sm"
-                                data-preview-uri="<%=Encode.forHtmlAttribute(rxUri)%>"
+                                data-preview-uri="<%=SafeEncode.forHtmlAttribute(rxUri)%>"
                                 onclick="PreviewPDF(this.dataset.previewUri)">
                             <fmt:message key="messenger.generatePreviewPDF.btnPreview"/>
                         </button>
@@ -502,13 +502,13 @@
                     <td colspan="3" class="d-none">
                         <input type="hidden" name="srcText" id="srcText" value=""/>
                         <input type="hidden" name="attachmentCount" id="attachmentCount"
-                               value="<%=Encode.forHtmlAttribute(request.getParameter("attachmentCount") == null ? "0" : request.getParameter("attachmentCount"))%>"/>
+                               value="<%=SafeEncode.forHtmlAttribute(request.getParameter("attachmentCount") == null ? "0" : request.getParameter("attachmentCount"))%>"/>
                         <input type="hidden" name="demographic_no" id="demographic_no"
-                               value="<%=Encode.forHtmlAttribute(demographic_no != null ? demographic_no : "")%>"/>
+                               value="<%=SafeEncode.forHtmlAttribute(demographic_no != null ? demographic_no : "")%>"/>
                         <input type="hidden" name="isPreview" id="isPreview"
-                               value="<%=Encode.forHtmlAttribute(request.getParameter("isPreview") == null ? "false" : request.getParameter("isPreview"))%>"/>
+                               value="<%=SafeEncode.forHtmlAttribute(request.getParameter("isPreview") == null ? "false" : request.getParameter("isPreview"))%>"/>
                         <input type="hidden" name="isAttaching" id="isAttaching"
-                               value="<%=Encode.forHtmlAttribute(request.getParameter("isAttaching") == null ? "false" : request.getParameter("isAttaching"))%>"/>
+                               value="<%=SafeEncode.forHtmlAttribute(request.getParameter("isAttaching") == null ? "false" : request.getParameter("isAttaching"))%>"/>
                         <input type="hidden" name="isNew" id="isNew" value="true"/>
                         <input type="hidden" name="attachmentTitle" id="attachmentTitle" value=""/>
                     </td>
@@ -529,7 +529,7 @@
                     j++;
                 }
             }
-            var attachingTemplate = '${e:forJavaScript(jsAttachingTemplate)}';
+            var attachingTemplate = '${carlos:forJavaScript(jsAttachingTemplate)}';
             document.forms[0].status.value = attachingTemplate
                 .replace('{0}', <%=(msgSessionBean != null ? msgSessionBean.getCurrentAttachmentCount() + 1 : 1)%>)
                 .replace('{1}', j);

--- a/src/main/webapp/WEB-INF/jsp/messenger/generatePreviewPDF.jsp
+++ b/src/main/webapp/WEB-INF/jsp/messenger/generatePreviewPDF.jsp
@@ -83,7 +83,7 @@
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
-<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
+<%@ taglib uri="/WEB-INF/carlos.tld" prefix="carlos" %>
 <fmt:setBundle basename="oscarResources"/>
 <fmt:message key="messenger.generatePreviewPDF.information" var="informationLabel"/>
 <fmt:message key="messenger.generatePreviewPDF.encounter" var="encounterLabel"/>


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: In `ConsultationRequestDaoImpl.java`, the `getConsults` method was dynamically constructing an HQL/JPQL string by directly concatenating method arguments (like `team`, `startDate`, and `endDate`) using string builder logic.
🎯 **Impact**: If `team` (or other parameters) are controlled by an attacker, they can inject arbitrary SQL commands. Although this is via JPQL, HQL/JPQL injection often translates directly to underlying SQL injection, allowing an attacker to read/modify arbitrary data or bypass data restrictions.
🔧 **Fix**: Replaced the concatenated strings with named parameters (e.g. `:team`, `:startDate`) and bound the arguments using `query.setParameter()`. This leverages the ORM's built-in parameterization and escaping, eliminating the injection risk. Furthermore, passing `Date` objects directly to `setParameter()` avoids having to format them as strings (`DateFormatUtils`), which simplifies the logic and improves safety.
✅ **Verification**: Code compiles successfully. The test `ConsultationRequestDaoIntegrationTest` was run and completes with `BUILD SUCCESS`, confirming that the JPQL queries are syntactically correct and still match expected behavior. Added a finding to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [3981825145173723825](https://jules.google.com/task/3981825145173723825) started by @yingbull*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a critical JPQL injection in `ConsultationRequestDaoImpl#getConsults` by using named parameters and binding `Date` values directly. Also hardens Messenger JSPs against XSS and fixes CI lint and jspc failures.

- **Bug Fixes**
  - DAO: Use named parameters for `team`, `startDate`, and `endDate`; bind `Date` objects with `query.setParameter`; keep pagination and filters intact.
  - JSPs: Replace `org.owasp.encoder.Encode` and `${e:...}` with `io.github.carlos_emr.carlos.utility.SafeEncode` and `${carlos:...}`; update HTML/JS/URI encoders.
  - CI/Build: Remove unused `org.apache.commons.lang3.time.DateFormatUtils`; fix `check-encoder-null-safety.sh` and SpotBugs/FindSecBugs; correct TLD path to `/WEB-INF/carlos.tld` to resolve jspc errors.

<sup>Written for commit c505427ba96229241fd7fb52f84cf3e0ed0870ea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

