### PR TITLE
🎨 Palette: Add aria-hidden to decorative icons in SentMessage.jsp

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-01-20 - [Aria Hidden For Decorative Icons]
+**Learning:** Purely decorative inner icon elements (e.g., `<i class="fa-solid...">`) should be hidden from screen readers using `aria-hidden="true"`.
+**Action:** Always verify decorative icons have `aria-hidden="true"` attached.

--- a/src/main/webapp/WEB-INF/jsp/messenger/SentMessage.jsp
+++ b/src/main/webapp/WEB-INF/jsp/messenger/SentMessage.jsp
@@ -115,16 +115,16 @@
  <body class="BodyStyle" >
 <table class="MainTable" id="scrollNumber1" style="width:100%; margin-top: 10px;">
 	<tr class="MainTableTopRow">
-		<td class="MainTableTopRowLeftColumn"><h4>&nbsp;<i class="fa-solid fa-envelope" title='<fmt:message key="messenger.DisplayMessages.msgMessenger"/>'></i>&nbsp;<fmt:message
+		<td class="MainTableTopRowLeftColumn"><h4>&nbsp;<i class="fa-solid fa-envelope" title='<fmt:message key="messenger.DisplayMessages.msgMessenger"/>' aria-hidden="true"></i>&nbsp;<fmt:message
 			key="messenger.SentMessage.msgMessenger" />: <fmt:message
 					key="messenger.SentMessage.msgMessageSent" /></h4></td>
 		<td class="MainTableTopRowRightColumn" >
 		<table class="TopStatusBar" style="width:100%;">
 			<tr>
 				<td style="text-align: right;">
-            <i class="fa-solid fa-circle-question"></i>
+            <i class="fa-solid fa-circle-question" aria-hidden="true"></i>
             <a href="javascript:void(0)" onClick ="popupPage(700,960,''+'Messenger sent')"><fmt:message key="app.top1"/></a>
-            <i class="fa-solid fa-circle-info" style="margin-left:10px;"></i>
+            <i class="fa-solid fa-circle-info" style="margin-left:10px;" aria-hidden="true"></i>
             <a href="javascript:void(0)"  onClick="window.open('<%=request.getContextPath()%>/encounter/ViewAbout','About CARLOS','scrollbars=1,resizable=1,width=800,height=600,left=0,top=0')" ><fmt:message key="global.about" /></a>
         </td>
 			</tr>
@@ -138,11 +138,11 @@
 </div>
 <div style="width:100%; margin-left:10px; margin-top: 50px;">
 <a class="btn btn-outline-secondary" href="${pageContext.request.contextPath}/messenger/ViewCreateMessage">
-    <i class="fa-solid fa-pencil"></i>&nbsp;<fmt:message key="messenger.DisplayMessages.btnCompose"/></a>
+    <i class="fa-solid fa-pencil" aria-hidden="true"></i>&nbsp;<fmt:message key="messenger.DisplayMessages.btnCompose"/></a>
 <a class="btn btn-primary" href="${pageContext.request.contextPath}/messenger/DisplayMessages">
-    <i class="fa-solid fa-inbox"></i>&nbsp;<fmt:message key="messenger.SentMessagebtnBack" /></a>
+    <i class="fa-solid fa-inbox" aria-hidden="true"></i>&nbsp;<fmt:message key="messenger.SentMessagebtnBack" /></a>
 <a class="btn btn-outline-secondary" href="javascript:BackToCarlos()">
-    <i class="fa-solid fa-right-from-bracket"></i>&nbsp;<fmt:message key="messenger.SentMessage.btnExit" /></a>
+    <i class="fa-solid fa-right-from-bracket" aria-hidden="true"></i>&nbsp;<fmt:message key="messenger.SentMessage.btnExit" /></a>
 </div>
 </body>
 </html>


### PR DESCRIPTION
Added `aria-hidden="true"` to FontAwesome icons (`<i>`) in `SentMessage.jsp` that are purely decorative. This improves accessibility by ensuring screen readers skip the icons and rely on the adjacent localized text links/buttons, preventing them from reading out confusing generic unicode characters.

Also created `.jules/palette.md` journal file to log the critical accessibility learning.

---
*PR created automatically by Jules for task [12829503630609538239](https://jules.google.com/task/12829503630609538239) started by @yingbull*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marked decorative FontAwesome icons in `SentMessage.jsp` with `aria-hidden="true"` so screen readers skip them and use the nearby localized link/button text instead. Added `.jules/palette.md` with a brief note documenting this accessibility guideline.

<sup>Written for commit c1ac1670083d98a7259672d31d80c6bf4a2571f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

