### PR TITLE
[Fix] Prevent UI cutoff (esp bp and date)  add metric conversions to Measurements.jsp

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/Measurements.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/Measurements.jsp
@@ -376,19 +376,20 @@
         }
 
         function htEnglish2Metric(obj) {
+            // allow for conversio of inputs 5' 5'0" 5'0 60" - 152.4cm
             const val = obj.value.trim();
             const tickIdx = val.indexOf("'");
-            if (tickIdx <= 0) return;
-
-            const feet = parseFloat(val.substring(0, tickIdx));
-            let inchStr = val.substring(tickIdx + 1);
+            const quotIdx = val.indexOf('"');
+            if (tickIdx <= 0 && quotIdx <= 0) return;
+            let feet = 0;
+            if (tickIdx > 0 ) feet = parseFloat(val.substring(0, tickIdx));
+            let inchStr = val;
+            if (tickIdx > 0 ) inchStr = val.substring(tickIdx + 1);
             if (inchStr.endsWith('"')) {
                 inchStr = inchStr.substring(0, inchStr.length - 1);
             }
             const inch = parseFloat(inchStr) || 0;
-
             if (isNaN(feet)) return;
-
             const heightM = Math.round((feet * 30.48 + inch * 2.54) * 10) / 10;
             if (confirm("Are you sure you want to change " + feet + " feet " + inch + " inch(es) to " + heightM + "cm?")) {
                 obj.value = heightM;
@@ -404,6 +405,7 @@
             if (rowWT) {
                 const wtInput = rowWT.querySelectorAll('td')[2]?.querySelector('input');
                 if (wtInput) {
+                    wtInput.title = "Double click to convert lb to kg";
                     wtInput.style.backgroundColor = "#d9e6f2";
                     wtInput.addEventListener('dblclick', function () {
                         wtEnglish2Metric(this);
@@ -414,6 +416,7 @@
             if (rowHT) {
                 const htInput = rowHT.querySelectorAll('td')[2]?.querySelector('input');
                 if (htInput) {
+                    htInput.title = "Double click to convert feet and inches (5'2\") to cm";
                     htInput.style.backgroundColor = "#d9e6f2";
                     htInput.addEventListener('dblclick', function () {
                         htEnglish2Metric(this);

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/Measurements.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/Measurements.jsp
@@ -256,11 +256,11 @@
                                                         </th>
                                                         <th style="width:160px"><fmt:message key="encounter.oscarMeasurements.Measurements.headingMeasuringInstrc"/>
                                                         </th>
-                                                        <th style="width:30px"><fmt:message key="encounter.oscarMeasurements.Measurements.headingValue"/>
+                                                        <th style="width:80px"><fmt:message key="encounter.oscarMeasurements.Measurements.headingValue"/>
                                                         </th>
-                                                        <th style="width:40px"><fmt:message key="encounter.oscarMeasurements.Measurements.headingObservationDate"/>
+                                                        <th style="width:120px"><fmt:message key="encounter.oscarMeasurements.Measurements.headingObservationDate"/>
                                                         </th>
-                                                        <th style="width:80px"><fmt:message key="encounter.oscarMeasurements.Measurements.headingComments"/>
+                                                        <th style="width:240px"><fmt:message key="encounter.oscarMeasurements.Measurements.headingComments"/>
                                                         </th>
                                                         <th style="width:10px"></th>
                                                     </tr>
@@ -365,22 +365,69 @@
     </form>
 
     <script>
+
+        function wtEnglish2Metric(obj) {
+      			weight = obj.value;
+      			weightM = Math.round(weight * 10 * 0.4536) / 10 ;
+      			if(confirm("Are you sure you want to change " + weight + " pounds to " + weightM +"kg?") ) {
+      				obj.value = weightM;
+      			}
+    		  }
+
+        function htEnglish2Metric(obj) {
+      		height = obj.value;
+      		if(height.length > 1 && height.indexOf("'") > 0 ) {
+      			feet = height.substring(0, height.indexOf("'"));
+      			inch = height.substring(height.indexOf("'"));
+      			if(inch.length == 1) {
+      				inch = 0;
+      			} else {
+      				inch = inch.charAt(inch.length-1)=='"' ? inch.substring(0, inch.length-1) : inch;
+      				inch = inch.substring(1);
+      			}
+      			height = Math.round((feet * 30.48 + inch * 2.54) * 10) / 10 ;
+      			if(confirm("Are you sure you want to change " + feet + " feet " + inch + " inch(es) to " + height +"cm?") ) {
+      				obj.value = height;
+      			}
+      		}
+        }
+
         document.addEventListener('DOMContentLoaded', function () {
             // If WT, HT and BMI exists then allow the link
             const rowWT = document.getElementById('row-WT');
             const rowHT = document.getElementById('row-HT');
             const rowBMI = document.getElementById('row-BMI');
 
+            if (rowWT) {
+                const wtInput = rowWT.querySelectorAll('td')[2]?.querySelector('input');
+                if (wtInput) {
+                    wtInput.style.backgroundColor = "#d9e6f2";
+                    wtInput.addEventListener('dblclick', function () {
+                        wtEnglish2Metric(this);
+                    });
+                }
+            }
+
+            if (rowHT) {
+                const htInput = rowHT.querySelectorAll('td')[2]?.querySelector('input');
+                if (htInput) {
+                    htInput.style.backgroundColor = "#d9e6f2";
+                    htInput.addEventListener('dblclick', function () {
+                        htEnglish2Metric(this);
+                    });
+                }
+            }
+
             if (rowWT && rowHT && rowBMI) {
                 const wtInput = rowWT.querySelectorAll('td')[2]?.querySelector('input');
                 const htInput = rowHT.querySelectorAll('td')[2]?.querySelector('input');
 
                 if (wtInput && htInput) {
-                    wtInput.addEventListener('keyup', function () {
+                    wtInput.addEventListener('blur', function () {
                         calcBMI(this.value, htInput.value);
                     });
 
-                    htInput.addEventListener('keyup', function () {
+                    htInput.addEventListener('blur', function () {
                         calcBMI(wtInput.value, this.value);
                     });
                 }
@@ -406,13 +453,13 @@
                         bmiInput.value = b;
                     }
                     if (rowBMI) {
-                        rowBMI.style.backgroundColor = "#d9e6f2";
+                        bmiInput.style.backgroundColor = "#d9e6f2";
                     }
                 }
             }
         }
-    </script>
 
+    </script>
 
     </body>
 </html>

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/Measurements.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/Measurements.jsp
@@ -367,29 +367,32 @@
     <script>
 
         function wtEnglish2Metric(obj) {
-      			weight = obj.value;
-      			weightM = Math.round(weight * 10 * 0.4536) / 10 ;
-      			if(confirm("Are you sure you want to change " + weight + " pounds to " + weightM +"kg?") ) {
-      				obj.value = weightM;
-      			}
-    		  }
+            const weight = parseFloat(obj.value);
+            if (isNaN(weight)) return;
+            const weightM = Math.round(weight * 0.4536 * 10) / 10;
+            if (confirm("Are you sure you want to change " + weight + " pounds to " + weightM + "kg?")) {
+                obj.value = weightM;
+            }
+        }
 
         function htEnglish2Metric(obj) {
-      		height = obj.value;
-      		if(height.length > 1 && height.indexOf("'") > 0 ) {
-      			feet = height.substring(0, height.indexOf("'"));
-      			inch = height.substring(height.indexOf("'"));
-      			if(inch.length == 1) {
-      				inch = 0;
-      			} else {
-      				inch = inch.charAt(inch.length-1)=='"' ? inch.substring(0, inch.length-1) : inch;
-      				inch = inch.substring(1);
-      			}
-      			height = Math.round((feet * 30.48 + inch * 2.54) * 10) / 10 ;
-      			if(confirm("Are you sure you want to change " + feet + " feet " + inch + " inch(es) to " + height +"cm?") ) {
-      				obj.value = height;
-      			}
-      		}
+            const val = obj.value.trim();
+            const tickIdx = val.indexOf("'");
+            if (tickIdx <= 0) return;
+
+            const feet = parseFloat(val.substring(0, tickIdx));
+            let inchStr = val.substring(tickIdx + 1);
+            if (inchStr.endsWith('"')) {
+                inchStr = inchStr.substring(0, inchStr.length - 1);
+            }
+            const inch = parseFloat(inchStr) || 0;
+
+            if (isNaN(feet)) return;
+
+            const heightM = Math.round((feet * 30.48 + inch * 2.54) * 10) / 10;
+            if (confirm("Are you sure you want to change " + feet + " feet " + inch + " inch(es) to " + heightM + "cm?")) {
+                obj.value = heightM;
+            }
         }
 
         document.addEventListener('DOMContentLoaded', function () {
@@ -451,8 +454,6 @@
                     
                     if (bmiInput) {
                         bmiInput.value = b;
-                    }
-                    if (rowBMI) {
                         bmiInput.style.backgroundColor = "#d9e6f2";
                     }
                 }


### PR DESCRIPTION
Updated table column widths  and added metric conversion functions for weight and height.

<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description
Existing cuts off BP so that the entire BP is not visible leading to errors
Changes input width not to truncate standard BP ranges and date ranges
Date cut off is less of an issue as flatpick is used to fill

if WT or HT detected then change background to alert user.  Tooltip gives instructions to double click for metric conversion
Change BMI calcuation to on blur events to prevent flickering.  The background changes for the BMI when filled to indicate that it is a calculated value
<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues

<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?

<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->
<img width="1000" height="467" alt="Screenshot 2026-04-24 at 10-48-46 Vital Measurements" src="https://github.com/user-attachments/assets/d93dc94a-a789-4f14-9c88-ea532b9fcae2" />

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resized the measurements table so BP and dates are fully visible (Value 80px, Observation Date 120px, Comments 240px). Added double‑click conversions for WT (lb→kg) and HT (ft′in″/inches→cm) with confirm prompts; BMI now recalculates on blur.

- **Refactors**
  - Fixed HT parsing to accept 5', 5'0", 5'0, and 60" inputs; added tooltips and a subtle input highlight on WT/HT to signal conversion.

<sup>Written for commit 19ef2513787e1ead684dfbff60d5bdf6318cd386. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

