### PR TITLE
chore: remove dead ALT_DISCHARGE_REASON nested-discharge code

### DIFF
--- a/.devcontainer/development/config/shared/volumes/carlos.properties
+++ b/.devcontainer/development/config/shared/volumes/carlos.properties
@@ -863,10 +863,6 @@ TORONTO_RFQ=no
 ## true : filter notes and programs based on the facility
 ## false : don't filter notes or programs by facility
 FILTER_ON_FACILITY=false
-## the nested discharge reasons
-## yes : use the nested discharge reasons that used in sherbourne health center
-## no : not use nested discharge reasons
-ALT_DISCHARGE_REASON=no
 ## auto generated providers no.
 ## yes or true : the providers no. auto generated
 ## no or false : the providers no. not auto generated

--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/web/ClientManager2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/web/ClientManager2Action.java
@@ -142,12 +142,8 @@ public class ClientManager2Action extends ActionSupport {
             return discharge_community();
         } else if ("discharge_community_select_program".equals(method)) {
             return discharge_community_select_program();
-        } else if ("nested_discharge_community_select_program".equals(method)) {
-            return nested_discharge_community_select_program();
         } else if ("discharge_select_program".equals(method)) {
             return discharge_select_program();
-        } else if ("nested_discharge_select_program".equals(method)) {
-            return nested_discharge_select_program();
         } else if ("getGeneralFormsReport".equals(method)) {
             return getGeneralFormsReport();
         } else if ("edit".equals(method)) {
@@ -302,11 +298,6 @@ public class ClientManager2Action extends ActionSupport {
         return "edit";
     }
 
-    public String nested_discharge_community_select_program() {
-        request.setAttribute("nestedReason", "true");
-        return discharge_community_select_program();
-    }
-
     public String discharge_select_program() {
         String id = request.getParameter("id");
         String admissionId = request.getParameter("admission.id");
@@ -324,13 +315,6 @@ public class ClientManager2Action extends ActionSupport {
             }
         }
 
-        return "edit";
-    }
-
-    public String nested_discharge_select_program() {
-        request.setAttribute("nestedReason", "true");
-        setEditAttributes(request, request.getParameter("id"));
-        request.setAttribute("do_discharge", Boolean.valueOf(true));
         return "edit";
     }
 
@@ -932,7 +916,6 @@ public class ClientManager2Action extends ActionSupport {
             request.setAttribute("temporaryAdmissions", admissionManager.getCurrentTemporaryProgramAdmission(Integer.valueOf(demographicNo)));
             request.setAttribute("current_community_program", admissionManager.getCurrentCommunityProgramAdmission(Integer.valueOf(demographicNo)));
             request.setAttribute("dischargeReasons", lookupManager.LoadCodeList("DRN", true, null, null));
-            request.setAttribute("dischargeReasons2", ""/*lookupManager.LoadCodeList("DR2", true, null, null)*/);
         }
 
         /* Relations */

--- a/src/main/resources/carlos.properties
+++ b/src/main/resources/carlos.properties
@@ -635,11 +635,6 @@ TORONTO_RFQ=no
 ## false : don't filter notes or programs by facility
 FILTER_ON_FACILITY=false
 
-## the nested discharge reasons
-## yes : use the nested discharge reasons that used in sherbourne health center
-## no : not use nested discharge reasons
-ALT_DISCHARGE_REASON=no
-
 ## auto generated providers no.
 ## yes or true : the providers no. auto generated
 ## no or false : the providers no. not auto generated


### PR DESCRIPTION
The ALT_DISCHARGE_REASON property and the "nested" discharge-reason
action methods were a Sherbourne-specific feature toggle whose entire
runtime surface is unreachable:

- ALT_DISCHARGE_REASON was defined in two carlos.properties files but
  never read by any Java/JSP/XML/JS code.
- nested_discharge_community_select_program() and
  nested_discharge_select_program() in ClientManager2Action, plus their
  routing branches, were never invoked by any UI, JSP, or Struts mapping.
- The "nestedReason" request attribute they set was never consumed.
- The dischargeReasons2 attribute was already hard-set to "" with the
  underlying LoadCodeList("DR2", ...) call commented out, and no JSP
  references it.

Removes the dead property, the two action methods and their routing,
and the dischargeReasons2 attribute. The standard discharge flow
(radioDischargeReason, processDischarge*, discharge_select_program,
discharge_community_select_program, dischargeReasons / DRN lookup) is
unchanged. The unused "needsecondary" column on lst_discharge_reason
remains in the schema; dropping it requires a separate DB migration.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove unreachable Sherbourne-specific nested discharge toggle and code paths. No changes to the standard discharge flow.

- **Refactors**
  - Removed ALT_DISCHARGE_REASON from both carlos.properties files.
  - Deleted nested_discharge_community_select_program and nested_discharge_select_program handlers and their routing in ClientManager2Action.
  - Dropped unused dischargeReasons2 request attribute.
  - Note: lst_discharge_reason.needsecondary remains; dropping it requires a separate DB migration.

<sup>Written for commit 84d1af567c8c9506877c7fb3995f79119afb00f8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

