### PR TITLE
chore: remove dead appt_intake_form preference

### DIFF
--- a/.devcontainer/development/config/shared/volumes/carlos.properties
+++ b/.devcontainer/development/config/shared/volumes/carlos.properties
@@ -929,8 +929,6 @@ new_flowsheet_enabled=false
 # RMA Billing
 rma_enabled=false
 indivica_hc_read_enabled=false
-#Indivica contributed intake form.
-appt_intake_form=off
 #size of quick chart in eChart. default is 20 if not specified
 #quick_chart_size=20
 #CAISI should not search for duplicates outside your program domain when true.

--- a/release/config
+++ b/release/config
@@ -57,7 +57,6 @@ billregion=ON
 billcenter=G
 signature_tablet=no
 ENABLE_EDIT_APPT_STATUS=yes
-appt_intake_form=off
 new_flowsheet_enabled=true
 NEW_CONTACTS_UI=true
 enableFax=false
@@ -373,8 +372,6 @@ echo "For a new install from console so probe for some settings" >>$LOG_FILE
 	db_reset carlos-emr/eyeform || true
 	db_set carlos-emr/eyeform false || true
 	eyeform=false
-	db_set carlos-emr/appt_intake_form true || true
-	appt_intake_form="on"
 
 	db_go || true
 
@@ -472,7 +469,6 @@ else
 	-e 's/\(^billcenter =\)/#\1/' \
 	-e 's/\(^SINGLE_PAGE_CHART\)/#\1/' \
 	-e 's/\(^signature_tablet\)/#\1/' \
-	-e 's/\(^appt_intake_form\)/#\1/' \
 	-e 's/\(^new_flowsheet_enabled\)/#\1/' \
 	-e 's/\(^enableFax\)/#\1/' \
 	-e 's/\(^HL7_COMPLETED_DIR\)/#\1/' \

--- a/release/postinst
+++ b/release/postinst
@@ -51,7 +51,6 @@ UPGRADE=false
 INSTALL_SSL=true
 signature_tablet=no
 ENABLE_EDIT_APPT_STATUS=yes
-appt_intake_form=off
 NEW_CONTACTS_UI=false
 indivica_rx_enhance=false
 enableFax=false

--- a/release/templates
+++ b/release/templates
@@ -45,13 +45,7 @@ Default: false
 Description: Do you want to install the eyeform version?
  An optional version of carlos is designed for Ophthalmology.
 
-Template: carlos-emr/appt_intake_form
-Type: boolean
-Default: true
-Description: Do you want to use the intake form?
- The intake form allows for users to add common vitals and other measurements from the schedule.
-
-Template: carlos-emr/NEW_CONTACTS_UI 
+Template: carlos-emr/NEW_CONTACTS_UI
 Type: boolean
 Default: false
 Description: Do you want to use the new contacts interface?

--- a/src/main/resources/carlos.properties
+++ b/src/main/resources/carlos.properties
@@ -773,8 +773,6 @@ rma_enabled=false
 workflow_enhance=false
 
 indivica_hc_read_enabled=false
-#Indivica contributed intake form.
-appt_intake_form=off
 
 # appt status value for Here or Arrived
 #appt_status_here=H


### PR DESCRIPTION
The appt_intake_form property (Indivica-contributed intake form feature
flag) was defined in properties files and Debian packaging, but had no
Java/JSP code reading it. Removed all traces:

- src/main/resources/carlos.properties
- .devcontainer/development/config/shared/volumes/carlos.properties
- release/config (default value, debconf set, sed comment-out)
- release/postinst (default value)
- release/templates (debconf template definition)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused appt_intake_form feature flag from properties and Debian packaging to reduce dead config. No runtime behavior change.

- **Refactors**
  - Removed appt_intake_form from `src/main/resources/carlos.properties` and `.devcontainer/development/config/shared/volumes/carlos.properties`.
  - Removed defaults and debconf entries in `release/config`, `release/postinst`, and `release/templates`.
  - Dropped the related sed comment-out rule in `release/config`.

<sup>Written for commit 734399a39f831b9170bd96ed954b2cbaa66d52d8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

