### PR TITLE
chore: remove dead showRxChartNo preference and related code

### DIFF
--- a/.devcontainer/development/config/shared/volumes/carlos.properties
+++ b/.devcontainer/development/config/shared/volumes/carlos.properties
@@ -265,8 +265,6 @@ showRxHin=true
 RXFAX=yes
 ### Enable Renal Dosing
 RENAL_DOSING_DS=yes
-### Display Chart No on Prescription
-showRxChartNo=false
 ### Integrated Prescription Faxing
 ## True if fax should be enabled in the prescript module and false otherwise.
 rx_fax_enabled=true

--- a/src/main/resources/carlos.properties
+++ b/src/main/resources/carlos.properties
@@ -955,9 +955,6 @@ born18m_upload_hour=01
 #lab_req_billing_no=654321
 
 
-#Display Chart No on prescription
-showRxChartNo=false
-
 #Default info for redirect study site
 redirectstudysite_default_baseURL = http://competeii.mcmaster.ca/PDSsecurity/login.asp
 redirectstudysite_default_username = yilee18

--- a/src/main/webapp/WEB-INF/jsp/rx/Preview2.jsp
+++ b/src/main/webapp/WEB-INF/jsp/rx/Preview2.jsp
@@ -414,18 +414,11 @@
                                             check == 3 ? ", " : check == 2 ? "" : " ",
                                             patientProvince,
                                             patientPostal);
-
-                                    String ptChartNo = "";
-                                    if (props.getProperty("showRxChartNo", "").equalsIgnoreCase("true")) {
-                                        ptChartNo = patient.getChartNo() == null ? "" : patient.getChartNo();
-                                    }
                                 %>
                                 <input type="hidden" name="patientCityPostal"
                                        value="<carlos:encode value='<%= patientCityPostal %>' context="htmlAttribute"/>"/>
                                 <input type="hidden" name="patientHIN"
                                        value="<carlos:encode value='<%= patientHin %>' context="htmlAttribute"/>"/>
-                                <input type="hidden" name="patientChartNo"
-                                       value="<carlos:encode value='<%= ptChartNo %>' context="htmlAttribute"/>"/>
                                 <input type="hidden" name="bandNumber" value="${ bandNumber }"/>
                                 <input type="hidden" name="patientPhone"
                                        value="<fmt:message key="RxPreview.msgTel"/>: <carlos:encode value='<%= patientPhone %>' context="html"/>"/>
@@ -523,9 +516,6 @@
 												<fmt:message key="io.github.carlos_emr.carlos.rx.hin"/><carlos:encode value='<%= patientHin %>' context="html"/>
 											<% } %>
 										</b><br>
-										<% if (props.getProperty("showRxChartNo", "").equalsIgnoreCase("true")) { %>
-											<fmt:message key="io.github.carlos_emr.carlos.rx.chartNo"/><%=ptChartNo%>
-										<% } %>
 								</span>
                                 <span style="float:right">
 									<%= RxUtil.DateToString(rxDate, "MMMM d, yyyy", request.getLocale()) %>


### PR DESCRIPTION
The showRxChartNo preference had no admin UI to toggle it and shipped
defaulted to false. Remove the preference from carlos.properties (both
main and devcontainer copies) along with the JSP scriptlet that read it,
the ptChartNo variable it populated, the hidden patientChartNo input
that submitted to FrmCustomedPDFServlet, and the display block in
Preview2.jsp that rendered the chart number.

Behavior is preserved: FrmCustomedPDFServlet still reads patientChartNo
from the request, defaults null to empty, and skips rendering when
empty — equivalent to the prior showRxChartNo=false default.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed dead `showRxChartNo` preference and the related chart number UI in Rx preview. Behavior remains the same: chart number is omitted unless provided to `FrmCustomedPDFServlet`.

- **Refactors**
  - Deleted `showRxChartNo` from `src/main/resources/carlos.properties` and `.devcontainer/development/config/shared/volumes/carlos.properties`.
  - Removed scriptlet, `ptChartNo`, hidden `patientChartNo` field, and the chart number display block in `src/main/webapp/WEB-INF/jsp/rx/Preview2.jsp`.

<sup>Written for commit efba6b6b7434069f3cd7cafe0c809e1c8b4c3aaa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

