### PR TITLE
chore: remove dead cr_security property

### DIFF
--- a/.devcontainer/development/config/shared/volumes/carlos.properties
+++ b/.devcontainer/development/config/shared/volumes/carlos.properties
@@ -455,10 +455,6 @@ BC_MSP_OPTOUT_PROVIDER_NUMBER=
 ### ———————————————————————————————————————————————————————————————————————————————————————————————————————————————————
 ### insert description here 
 ### ——————————————————————————————————————————————————————————————————————————————————————————————————————————————————— ###
-### Cookie-revolver sec framework
-## off: turn off cookie-revolver sec framework
-## on: turn on cookie-revolver sec framework
-cr_security=off
 ### Login info
 login_local_ip=192.168
 login_max_failed_times=10

--- a/src/main/resources/carlos.properties
+++ b/src/main/resources/carlos.properties
@@ -557,11 +557,6 @@ CMESort=UP
 # your host server's IP
 host=127.0.0.1
 
-## Cookie-revolver sec framework
-## off: turn off cookie-revolver sec framework
-## on: turn on cookie-revolver sec framework
-cr_security=off
-
 ## Load CAISI Application Context
 #plugins=on
 #caisi=on

--- a/src/main/webapp/WEB-INF/QuatroShelter.properties
+++ b/src/main/webapp/WEB-INF/QuatroShelter.properties
@@ -141,9 +141,6 @@ inactive_statuses = 'IN','DE','IC','ID','MO','FI'
 pmm.refer.temporaryAdmission.enabled=true
 #pmm.client.search.outside.of.domain.enabled=true
 
-# Cookie-revolver sec framework
-cr_security=off
-
 #Load CAISI Application Context
 plugins=on
 


### PR DESCRIPTION
The cr_security cookie-revolver framework toggle is dead code - no Java,
JSP, XML, or other source reads this property. Removing the unused entry
and its surrounding comments from all three property files.

The cr_securityquestion database table (in database/mysql/caisi/) is a
separate schema artifact left in place; the database/ directory is
protected and table removal would require a coordinated migration.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the dead cr_security “cookie-revolver” toggle and comments from all properties files; no code reads this property, so there is no behavior change.
The cr_securityquestion DB table remains; dropping it will require a separate migration.

<sup>Written for commit 475c4df9ecca6e1c2fd772d516d2dbc713b6787a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

