### PR TITLE
chore: remove dead TRANSPORTATION_TIME_MANDATORY property

### DIFF
--- a/archive/release/config
+++ b/archive/release/config
@@ -493,11 +493,10 @@ if [ "${UPGRADE}" = "true" ] ; then
             ENCOUNTER_TIME_MANDATORY=$(sed '/^\#/d' ${C_HOME}${PROGRAM}.properties | grep 'ENCOUNTER_TIME_MANDATORY'  | tail -n 1 | cut -d "=" -f2 | sed 's/^[[:space:]]*//;s/[[:space:]]*$//') 2>>$LOG_FILE
             if [ "${ENCOUNTER_TIME_MANDATORY}" = "" ]; then
                 echo "adding end block"  >>$LOG_FILE
-                echo "ENCOUNTER_TIME_MANDATORY=false" >> ${C_HOME}${PROGRAM}.properties 
-                echo "TRANSPORTATION_TIME_MANDATORY=false" >> ${C_HOME}${PROGRAM}.properties 
-                echo "" >> ${C_HOME}${PROGRAM}.properties 
-                echo "#this will make patient search have a wildcard at front of it" >> ${C_HOME}${PROGRAM}.properties 
-                echo "search.searchName.addLeadingWildcard=false" >> ${C_HOME}${PROGRAM}.properties 
+                echo "ENCOUNTER_TIME_MANDATORY=false" >> ${C_HOME}${PROGRAM}.properties
+                echo "" >> ${C_HOME}${PROGRAM}.properties
+                echo "#this will make patient search have a wildcard at front of it" >> ${C_HOME}${PROGRAM}.properties
+                echo "search.searchName.addLeadingWildcard=false" >> ${C_HOME}${PROGRAM}.properties
                 echo "" >> ${C_HOME}${PROGRAM}.properties 
                 echo "## A new patient consent module in a nice versatile and compact package. " >> ${C_HOME}${PROGRAM}.properties 
                 echo "## View instruction documentation." >> ${C_HOME}${PROGRAM}.properties 

--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/model/Program.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/model/Program.java
@@ -115,7 +115,6 @@ public class Program extends AbstractModel<Integer> {
     private LookupCodeValue shelter;
     private String siteSpecificField;
     private Boolean enableEncounterTime = false;
-    private Boolean enableEncounterTransportationTime = false;
     private String emailNotificationAddressesCsv = null;
     private Date lastReferralNotification = null;
     //these are all transient - these need to be removed, we shouldn't be having fields like this in JPA model objects.
@@ -1085,33 +1084,6 @@ public class Program extends AbstractModel<Integer> {
      */
     public void setEnableEncounterTime(Boolean enableEncounterTime) {
         this.enableEncounterTime = enableEncounterTime;
-    }
-    
-    /**
-     * Checks if encounter transportation time tracking is enabled for this program.
-     * 
-     * @return true if encounter transportation time tracking is enabled, false otherwise
-     */
-    public Boolean isEnableEncounterTransportationTime() {
-        return enableEncounterTransportationTime;
-    }
-
-    /**
-     * Gets the flag indicating if encounter transportation time tracking is enabled for this program.
-     * 
-     * @return the enableEncounterTransportationTime flag
-     */
-    public Boolean getEnableEncounterTransportationTime() {
-        return enableEncounterTransportationTime;
-    }
-
-    /**
-     * Sets the flag indicating if encounter transportation time tracking is enabled for this program.
-     * 
-     * @param enableEncounterTransportationTime the enableEncounterTransportationTime flag to set
-     */
-    public void setEnableEncounterTransportationTime(Boolean enableEncounterTransportationTime) {
-        this.enableEncounterTransportationTime = enableEncounterTransportationTime;
     }
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/web/admin/FacilityManager2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/web/admin/FacilityManager2Action.java
@@ -264,7 +264,6 @@ public class FacilityManager2Action extends ActionSupport {
             facility.setEnablePhoneEncounter(WebUtils.isChecked(request, "facility.enablePhoneEncounter"));
             facility.setEnableGroupNotes(WebUtils.isChecked(request, "facility.enableGroupNotes"));
             facility.setEnableEncounterTime(WebUtils.isChecked(request, "facility.enableEncounterTime"));
-            facility.setEnableEncounterTransportationTime(WebUtils.isChecked(request, "facility.enableEncounterTransportationTime"));
             if (facility.getRegistrationIntake() != null && facility.getRegistrationIntake() < 0)
                 facility.setRegistrationIntake(null);
 

--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/web/admin/ProgramManager2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/web/admin/ProgramManager2Action.java
@@ -869,8 +869,6 @@ public class ProgramManager2Action extends ActionSupport {
         if (request.getParameter("program.mentalHealth") == null) program.setMentalHealth(false);
         if (request.getParameter("program.housing") == null) program.setHousing(false);
         if (request.getParameter("program.enableEncounterTime") == null) program.setEnableEncounterTime(false);
-        if (request.getParameter("program.enableEncounterTransportationTime") == null)
-            program.setEnableEncounterTransportationTime(false);
 
         request.setAttribute("oldProgram", program);
 
@@ -944,7 +942,6 @@ public class ProgramManager2Action extends ActionSupport {
         oldProgram.setHousing(getParameterAsBoolean(request, "old_housing"));
         oldProgram.setFacilityId(getParameterAsInteger(request, "old_facility_id", 0));
         oldProgram.setEnableEncounterTime(getParameterAsBoolean(request, "old_enableEncounterTime"));
-        oldProgram.setEnableEncounterTransportationTime(getParameterAsBoolean(request, "old_enableEncounterTransportationTime"));
 
         if (isChanged(program, oldProgram)) {
             ProgramSignature programSignature = new ProgramSignature();

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/model/CaseManagementNote.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/model/CaseManagementNote.java
@@ -84,8 +84,6 @@ public class CaseManagementNote extends BaseObject {
     private int appointmentNo;
     private Integer hourOfEncounterTime;
     private Integer minuteOfEncounterTime;
-    private Integer hourOfEncTransportationTime;
-    private Integer minuteOfEncTransportationTime;
 
     CaseManagementNoteLinkDAO caseManagementNoteLinkDao = (CaseManagementNoteLinkDAO) SpringUtils.getBean(CaseManagementNoteLinkDAO.class);
 
@@ -569,22 +567,6 @@ public class CaseManagementNote extends BaseObject {
 
     public void setMinuteOfEncounterTime(Integer minuteOfEncounterTime) {
         this.minuteOfEncounterTime = minuteOfEncounterTime;
-    }
-
-    public Integer getHourOfEncTransportationTime() {
-        return hourOfEncTransportationTime;
-    }
-
-    public void setHourOfEncTransportationTime(Integer hourOfEncTransportationTime) {
-        this.hourOfEncTransportationTime = hourOfEncTransportationTime;
-    }
-
-    public Integer getMinuteOfEncTransportationTime() {
-        return minuteOfEncTransportationTime;
-    }
-
-    public void setMinuteOfEncTransportationTime(Integer minuteOfEncTransportationTime) {
-        this.minuteOfEncTransportationTime = minuteOfEncTransportationTime;
     }
 
 

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementEntry2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementEntry2Action.java
@@ -1334,16 +1334,6 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
             note.setMinuteOfEncounterTime(Integer.valueOf(minuteOfEncounterTime));
         }
 
-        String hourOfEncTransportationTime = request.getParameter("hourOfEncTransportationTime");
-        if (StringUtils.isNotEmpty(hourOfEncTransportationTime)) {
-            note.setHourOfEncTransportationTime(Integer.valueOf(hourOfEncTransportationTime));
-        }
-
-        String minuteOfEncTransportationTime = request.getParameter("minuteOfEncTransportationTime");
-        if (StringUtils.isNotEmpty(minuteOfEncTransportationTime)) {
-            note.setMinuteOfEncTransportationTime(Integer.valueOf(minuteOfEncTransportationTime));
-        }
-
         String sign = request.getParameter("sign");
         if (sign == null) {
             note.setSigning_provider_no("");
@@ -1830,14 +1820,6 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
         if (minuteOfEncounterTime != null) {
             note.setMinuteOfEncounterTime(Integer.valueOf(minuteOfEncounterTime));
         }
-        String hourOfEncTransportationTime = request.getParameter("hourOfEncTransportationTime");
-        if (minuteOfEncounterTime != null) {
-            note.setHourOfEncTransportationTime(Integer.valueOf(hourOfEncTransportationTime));
-        }
-        String minuteOfEncTransportationTime = request.getParameter("minuteOfEncTransportationTime");
-        if (minuteOfEncounterTime != null) {
-            note.setMinuteOfEncTransportationTime(Integer.valueOf(minuteOfEncTransportationTime));
-        }
 
         // check if previous note is doc note.
         Long prevNoteId = note.getId();
@@ -2245,10 +2227,6 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
                 sessionFrm.getCaseNote().setMinuteOfEncounterTime(this.getMinuteOfEncounterTime());
             if (this.getHourOfEncounterTime() != null)
                 sessionFrm.getCaseNote().setHourOfEncounterTime(this.getHourOfEncounterTime());
-            if (this.getMinuteOfEncTransportationTime() != null)
-                sessionFrm.getCaseNote().setMinuteOfEncTransportationTime(this.getMinuteOfEncTransportationTime());
-            if (this.getHourOfEncTransportationTime() != null)
-                sessionFrm.getCaseNote().setHourOfEncTransportationTime(this.getHourOfEncTransportationTime());
         }
 
         // add checked new issues to client's issue list
@@ -3482,8 +3460,6 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
 
     private Integer hourOfEncounterTime;
     private Integer minuteOfEncounterTime;
-    private Integer hourOfEncTransportationTime;
-    private Integer minuteOfEncTransportationTime;
 
     private String reloadUrl;
 
@@ -3818,24 +3794,6 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
     @StrutsParameter
     public void setMinuteOfEncounterTime(Integer minuteOfEncounterTime) {
         this.minuteOfEncounterTime = minuteOfEncounterTime;
-    }
-
-    public Integer getHourOfEncTransportationTime() {
-        return hourOfEncTransportationTime;
-    }
-
-    @StrutsParameter
-    public void setHourOfEncTransportationTime(Integer hourOfEncTransportationTime) {
-        this.hourOfEncTransportationTime = hourOfEncTransportationTime;
-    }
-
-    public Integer getMinuteOfEncTransportationTime() {
-        return minuteOfEncTransportationTime;
-    }
-
-    @StrutsParameter
-    public void setMinuteOfEncTransportationTime(Integer minuteOfEncTransportationTime) {
-        this.minuteOfEncTransportationTime = minuteOfEncTransportationTime;
     }
 
     public String getReloadUrl() {

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/NoteDisplay.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/NoteDisplay.java
@@ -149,7 +149,5 @@ public interface NoteDisplay {
 
     public String getEncounterTime();
 
-    public String getEncounterTransportationTime();
-
     public Integer getAppointmentNo();
 }

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/NoteDisplayLocal.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/NoteDisplayLocal.java
@@ -223,22 +223,6 @@ public class NoteDisplayLocal implements NoteDisplay {
         return et.toString();
     }
 
-    @Override
-    public String getEncounterTransportationTime() {
-        StringBuilder et = new StringBuilder();
-
-        if (caseManagementNote.getHourOfEncTransportationTime() != null) {
-            et.append(caseManagementNote.getHourOfEncTransportationTime());
-            et.append(":");
-        }
-
-        if (caseManagementNote.getMinuteOfEncTransportationTime() != null) {
-            et.append(caseManagementNote.getMinuteOfEncTransportationTime());
-        }
-
-        return et.toString();
-    }
-
 
     public ArrayList<String> getIssueDescriptions() {
         ArrayList<String> issueDescriptions = new ArrayList<String>();

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/NoteDisplayNonNote.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/NoteDisplayNonNote.java
@@ -290,12 +290,6 @@ public class NoteDisplayNonNote implements NoteDisplay {
         return null;
     }
 
-    @Override
-    public String getEncounterTransportationTime() {
-        // TODO Auto-generated method stub
-        return null;
-    }
-
     public boolean isInvoice() {
         return isInvoice;
     }

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/formbeans/CaseManagementEntryFormBean.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/formbeans/CaseManagementEntryFormBean.java
@@ -73,8 +73,6 @@ public class CaseManagementEntryFormBean {
 
     private Integer hourOfEncounterTime;
     private Integer minuteOfEncounterTime;
-    private Integer hourOfEncTransportationTime;
-    private Integer minuteOfEncTransportationTime;
 
     public CaseManagementEntryFormBean() {
         super();
@@ -359,22 +357,6 @@ public class CaseManagementEntryFormBean {
 
     public void setMinuteOfEncounterTime(Integer minuteOfEncounterTime) {
         this.minuteOfEncounterTime = minuteOfEncounterTime;
-    }
-
-    public Integer getHourOfEncTransportationTime() {
-        return hourOfEncTransportationTime;
-    }
-
-    public void setHourOfEncTransportationTime(Integer hourOfEncTransportationTime) {
-        this.hourOfEncTransportationTime = hourOfEncTransportationTime;
-    }
-
-    public Integer getMinuteOfEncTransportationTime() {
-        return minuteOfEncTransportationTime;
-    }
-
-    public void setMinuteOfEncTransportationTime(Integer minuteOfEncTransportationTime) {
-        this.minuteOfEncTransportationTime = minuteOfEncTransportationTime;
     }
 
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/Facility.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/Facility.java
@@ -67,7 +67,6 @@ public class Facility extends AbstractModel<Integer> implements Serializable {
     private int ocanServiceOrgNumber = 0;
     private boolean enableGroupNotes = false;
     private boolean enableEncounterTime = false;
-    private boolean enableEncounterTransportationTime = false;
     private int rxInteractionWarningLevel = 0;
     private String vacancyWithdrawnTicklerProvider = null;
     private Integer vacancyWithdrawnTicklerDemographic = null;
@@ -256,14 +255,6 @@ public class Facility extends AbstractModel<Integer> implements Serializable {
 
     public void setEnableEncounterTime(boolean enableEncounterTime) {
         this.enableEncounterTime = enableEncounterTime;
-    }
-
-    public boolean isEnableEncounterTransportationTime() {
-        return enableEncounterTransportationTime;
-    }
-
-    public void setEnableEncounterTransportationTime(boolean enableEncounterTransportationTime) {
-        this.enableEncounterTransportationTime = enableEncounterTransportationTime;
     }
 
     public int getRxInteractionWarningLevel() {

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/NotesService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/NotesService.java
@@ -281,7 +281,6 @@ public class NotesService extends AbstractServiceImpl {
             note.setGroupNote(nd.isGroupNote());
             note.setCpp(nd.isCpp());
             note.setEncounterTime(nd.getEncounterTime());
-            note.setEncounterTransportationTime(nd.getEncounterTransportationTime());
 
             noteList.add(note);
         }
@@ -417,18 +416,6 @@ public class NotesService extends AbstractServiceImpl {
 			note.setMinuteOfEncounterTime(Integer.valueOf(minuteOfEncounterTime));
 		}*/
 
-        logger.debug("this is what the encounter time was " + note.getEncounterTransportationTime());
-		/*
-		String hourOfEncTransportationTime = request.getParameter("hourOfEncTransportationTime");
-		if (hourOfEncTransportationTime != null && !"".equals(hourOfEncTransportationTime)) {
-			note.setHourOfEncTransportationTime(Integer.valueOf(hourOfEncTransportationTime));
-		}
-
-		String minuteOfEncTransportationTime = request.getParameter("minuteOfEncTransportationTime");
-		if (minuteOfEncTransportationTime != null && !"".equals(minuteOfEncTransportationTime)) {
-			note.setMinuteOfEncTransportationTime(Integer.valueOf(minuteOfEncTransportationTime));
-		}
-		*/
         //Need to check some how that if a note is signed that it must stay signed, currently this is done in the interface where the save button is not available.
         if (note.getIsSigned()) {
             caseMangementNote.setSigning_provider_no(providerNo);
@@ -925,7 +912,7 @@ public class NotesService extends AbstractServiceImpl {
          * demographic_no, provider_no, note, signed,
          * include_issue_innote, signing_provider_no, encounter_type, billing_code,
          * program_no, reporter_caisi_role, reporter_program_team, history,
-         *  uuid, password, locked, archived, appointmentNo, hourOfEncounterTime, minuteOfEncounterTime, hourOfEncTransportationTime, minuteOfEncTransportationTime
+         *  uuid, password, locked, archived, appointmentNo, hourOfEncounterTime, minuteOfEncounterTime
          *
          */
 
@@ -1376,7 +1363,6 @@ public class NotesService extends AbstractServiceImpl {
         returnNote.setGroupNote(nd.isGroupNote());
         returnNote.setCpp(nd.isCpp());
         returnNote.setEncounterTime(nd.getEncounterTime());
-        returnNote.setEncounterTransportationTime(nd.getEncounterTransportationTime());
         returnNote.setAppointmentNo(nd.getAppointmentNo());
 
         return returnNote;

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/to/model/NoteTo1.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/to/model/NoteTo1.java
@@ -80,7 +80,6 @@ public class NoteTo1 implements Serializable {
     private boolean isGroupNote;
     private boolean isCpp;
     private String encounterTime;
-    private String encounterTransportationTime;
 
     private Integer position;
 
@@ -344,14 +343,6 @@ public class NoteTo1 implements Serializable {
 
     public void setEncounterTime(String encounterTime) {
         this.encounterTime = encounterTime;
-    }
-
-    public String getEncounterTransportationTime() {
-        return encounterTransportationTime;
-    }
-
-    public void setEncounterTransportationTime(String encounterTransportationTime) {
-        this.encounterTransportationTime = encounterTransportationTime;
     }
 
     public Boolean isEditable() {

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/to/model/ProgramTo1.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/to/model/ProgramTo1.java
@@ -91,7 +91,6 @@ public class ProgramTo1 implements Serializable {
     private LookupCodeValue shelter;
     private String siteSpecificField;
     private Boolean enableEncounterTime = false;
-    private Boolean enableEncounterTransportationTime = false;
     private String emailNotificationAddressesCsv = null;
     private Date lastReferralNotification = null;
 
@@ -488,14 +487,6 @@ public class ProgramTo1 implements Serializable {
 
     public void setEnableEncounterTime(Boolean enableEncounterTime) {
         this.enableEncounterTime = enableEncounterTime;
-    }
-
-    public Boolean getEnableEncounterTransportationTime() {
-        return enableEncounterTransportationTime;
-    }
-
-    public void setEnableEncounterTransportationTime(Boolean enableEncounterTransportationTime) {
-        this.enableEncounterTransportationTime = enableEncounterTransportationTime;
     }
 
     public String getEmailNotificationAddressesCsv() {

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/transfer_objects/FacilityTransfer.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/transfer_objects/FacilityTransfer.java
@@ -54,7 +54,6 @@ public final class FacilityTransfer {
     private boolean enableAnonymous;
     private boolean enableGroupNotes;
     private boolean enableEncounterTime;
-    private boolean enableEncounterTransportationTime;
     private int rxInteractionWarningLevel;
     private Date lastUpdated;
 
@@ -176,14 +175,6 @@ public final class FacilityTransfer {
 
     public void setEnableEncounterTime(boolean enableEncounterTime) {
         this.enableEncounterTime = enableEncounterTime;
-    }
-
-    public boolean isEnableEncounterTransportationTime() {
-        return (enableEncounterTransportationTime);
-    }
-
-    public void setEnableEncounterTransportationTime(boolean enableEncounterTransportationTime) {
-        this.enableEncounterTransportationTime = enableEncounterTransportationTime;
     }
 
     public int getRxInteractionWarningLevel() {

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/transfer_objects/ProgramTransfer.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/transfer_objects/ProgramTransfer.java
@@ -84,7 +84,6 @@ public final class ProgramTransfer {
     private Date lastUpdateDate;
     private String siteSpecificField;
     private Boolean enableEncounterTime = false;
-    private Boolean enableEncounterTransportationTime = false;
     private String emailNotificationAddressesCsv = null;
     private Date lastReferralNotification = null;
 
@@ -449,14 +448,6 @@ public final class ProgramTransfer {
 
     public void setEnableEncounterTime(Boolean enableEncounterTime) {
         this.enableEncounterTime = enableEncounterTime;
-    }
-
-    public Boolean getEnableEncounterTransportationTime() {
-        return (enableEncounterTransportationTime);
-    }
-
-    public void setEnableEncounterTransportationTime(Boolean enableEncounterTransportationTime) {
-        this.enableEncounterTransportationTime = enableEncounterTransportationTime;
     }
 
     public String getEmailNotificationAddressesCsv() {

--- a/src/main/resources/carlos.properties
+++ b/src/main/resources/carlos.properties
@@ -1280,7 +1280,6 @@ hsfo_job_run_as_provider=999998
 
 
 ENCOUNTER_TIME_MANDATORY=false
-TRANSPORTATION_TIME_MANDATORY=false
 
 #this will make patient search have a wildcard at front of it
 search.searchName.addLeadingWildcard=false

--- a/src/main/resources/io/github/carlos_emr/carlos/PMmodule/model/Program.hbm.xml
+++ b/src/main/resources/io/github/carlos_emr/carlos/PMmodule/model/Program.hbm.xml
@@ -67,7 +67,6 @@
 		<property name="lastUpdateUser" column="lastupdateuser"></property>
 		<property name="siteSpecificField" />
 		<property name="enableEncounterTime" column="enableEncounterTime" type="boolean" length="1" />
-		<property name="enableEncounterTransportationTime" column="enableEncounterTransportationTime" type="boolean" length="1" />
 		<property name="emailNotificationAddressesCsv" />
 		<property name="lastReferralNotification" />
     </class>

--- a/src/main/resources/io/github/carlos_emr/carlos/casemgmt/model/casemgmt_note.hbm.xml
+++ b/src/main/resources/io/github/carlos_emr/carlos/casemgmt/model/casemgmt_note.hbm.xml
@@ -69,8 +69,6 @@
 
 		<property name="hourOfEncounterTime" type="integer" column="hourOfEncounterTime"/>
 		<property name="minuteOfEncounterTime" type="integer" column="minuteOfEncounterTime"/>
-		<property name="hourOfEncTransportationTime" type="integer" column="hourOfEncTransportationTime"/>
-		<property name="minuteOfEncTransportationTime" type="integer" column="minuteOfEncTransportationTime"/>
 
 	</class>
 
@@ -89,8 +87,6 @@
 		uuid as {cmn.uuid}, locked as {cmn.locked}, archived as {cmn.archived},
 		position as {cmn.position}, appointmentNo as {cmn.appointmentNo},
 		hourOfEncounterTime as {cmn.hourOfEncounterTime}, minuteOfEncounterTime as {cmn.minuteOfEncounterTime},
-		hourOfEncTransportationTime as {cmn.hourOfEncTransportationTime},
-		minuteOfEncTransportationTime as {cmn.minuteOfEncTransportationTime},
 		(select r.role_name from secRole r where r.role_no =
 		reporter_caisi_role) as {cmn.roleName},
 		(select p.name from program p where p.id = program_no) as {cmn.programName},
@@ -119,8 +115,6 @@
 		uuid as {cmn.uuid}, locked as {cmn.locked}, archived as {cmn.archived},
 		position as {cmn.position}, appointmentNo as {cmn.appointmentNo},
 		hourOfEncounterTime as {cmn.hourOfEncounterTime}, minuteOfEncounterTime as {cmn.minuteOfEncounterTime},
-		hourOfEncTransportationTime as {cmn.hourOfEncTransportationTime},
-		minuteOfEncTransportationTime as {cmn.minuteOfEncTransportationTime},
 		(select r.role_name from secRole r where r.role_no =
 		reporter_caisi_role) as {cmn.roleName},
 		(select p.name from program p where p.id = program_no) as {cmn.programName},
@@ -150,8 +144,6 @@
 		uuid as {cmn.uuid}, locked as {cmn.locked}, archived as {cmn.archived},
 		position as {cmn.position}, appointmentNo as {cmn.appointmentNo},
 		hourOfEncounterTime as {cmn.hourOfEncounterTime}, minuteOfEncounterTime as {cmn.minuteOfEncounterTime},
-		hourOfEncTransportationTime as {cmn.hourOfEncTransportationTime},
-		minuteOfEncTransportationTime as {cmn.minuteOfEncTransportationTime},
 		(select r.role_name from secRole r where r.role_no =
 		reporter_caisi_role) as {cmn.roleName},
 		(select p.name from program p where p.id = program_no) as {cmn.programName},

--- a/src/main/resources/oscarResources_en.properties
+++ b/src/main/resources/oscarResources_en.properties
@@ -1169,7 +1169,6 @@ encounter.assignedIssues.title = Assigned Issues
 encounter.date.title = Date
 encounter.encounterDate.title = Encounter Date
 encounter.encounterTime.title = Encounter Time (hour:min)
-encounter.encounterTransportation.title = Encounter Transportation Time (hour:min)
 encounter.encType.title = Enc Type
 encounter.faceToFaceEnc.title = face to face encounter with client
 encounter.telephoneEnc.title = telephone encounter with client

--- a/src/main/resources/oscarResources_es.properties
+++ b/src/main/resources/oscarResources_es.properties
@@ -1109,7 +1109,6 @@ encounter.assignedIssues.title = Problemas asignados
 encounter.date.title = Fecha
 encounter.encounterDate.title = Fecha de consulta
 encounter.encounterTime.title = Hora de consulta (hora:min)
-encounter.encounterTransportation.title = Hora de transporte a la consulta (hora:min)
 encounter.encType.title = Tipo cons
 encounter.faceToFaceEnc.title = cara a cara con paciente
 encounter.telephoneEnc.title = telefonica con paciente

--- a/src/main/resources/oscarResources_fr.properties
+++ b/src/main/resources/oscarResources_fr.properties
@@ -989,7 +989,6 @@ encounter.assignedIssues.title=Sujets assign\u00e9s
 encounter.date.title=Date
 encounter.encounterDate.title = Rencontre date de
 encounter.encounterTime.title = Rencontre heure (heure:min)
-encounter.encounterTransportation.title = Temps de transport (heure:min)
 encounter.encType.title=Rencontre de type
 encounter.faceToFaceEnc.title=En personne
 encounter.telephoneEnc.title=Par t\u00e9l\u00e9phone

--- a/src/main/resources/oscarResources_pl.properties
+++ b/src/main/resources/oscarResources_pl.properties
@@ -1016,7 +1016,6 @@ encounter.assignedIssues.title=okre&#X15b;lony cel problemy
 encounter.date.title=Data
 encounter.encounterDate.title = Encounter Date
 encounter.encounterTime.title = Encounter Time (hour:min)
-encounter.encounterTransportation.title = Transportation Time (hour:min)
 encounter.encType.title=Encounter Type
 encounter.faceToFaceEnc.title=spotkania twarz&#X105; w twarz z klientem
 encounter.telephoneEnc.title=spotkanie telefonicznie z klientem

--- a/src/main/resources/oscarResources_pt_BR.properties
+++ b/src/main/resources/oscarResources_pt_BR.properties
@@ -1241,7 +1241,6 @@ encounter.assignedIssues.title = Problemas atribu\u00EDdos
 encounter.date.title = Data
 encounter.encounterDate.title =  Data da consulta
 encounter.encounterTime.title = Tempo da consulta (hora:min)
-encounter.encounterTransportation.title = Tempo de transporte da consulta (hour:min)
 encounter.encType.title = Tipo de encaixe
 encounter.faceToFaceEnc.title = consulta presencial com o paciente
 encounter.telephoneEnc.title = contato telef\u00F4nico com o paciente

--- a/src/main/webapp/WEB-INF/jsp/PMmodule/Admin/Facility/EditFacility.jsp
+++ b/src/main/webapp/WEB-INF/jsp/PMmodule/Admin/Facility/EditFacility.jsp
@@ -236,10 +236,6 @@
             <td width="20%">Enable Mandatory Encounter Time in Encounter:</td>
             <td><input type="checkbox" name="facility.enableEncounterTime" <c:if test="${facility.enableEncounterTime}">checked</c:if>/></td>
         </tr>
-        <tr class="b">
-            <td width="20%">Enable Mandatory Transportation Time in Encounter:</td>
-            <td><input type="checkbox" name="facility.enableEncounterTransportationTime" <c:if test="${facility.enableEncounterTransportationTime}">checked</c:if>/></td>
-        </tr>
 
         <tr class="b">
             <td width="20%">Rx Interaction Warning Level:</td>

--- a/src/main/webapp/WEB-INF/jsp/PMmodule/Admin/ProgramEdit/general.jsp
+++ b/src/main/webapp/WEB-INF/jsp/PMmodule/Admin/ProgramEdit/general.jsp
@@ -89,7 +89,6 @@
     <input type="hidden" name="old_housing" value="${carlos:forHtmlAttribute(program.housing)}"/>
     <input type="hidden" name="old_facility_id" value="${carlos:forHtmlAttribute(empty program.facilityId ? 0 : program.facilityId)}"/>
     <input type="hidden" name="old_enableEncounterTime" value="${carlos:forHtmlAttribute(program.enableEncounterTime)}"/>
-    <input type="hidden" name="old_enableEncounterTransportationTime" value="${carlos:forHtmlAttribute(program.enableEncounterTransportationTime)}"/>
 
     <div class="tabs">
         <table cellpadding="3" cellspacing="0" border="0">
@@ -269,10 +268,6 @@
         <tr class="b">
             <td width="20%">Enable Mandatory Encounter Time in Encounter:</td>
             <td><input type="checkbox" name="program.enableEncounterTime" <c:if test="${program.enableEncounterTime}">checked</c:if>/></td>
-        </tr>
-        <tr class="b">
-            <td width="20%">Enable Mandatory Transportation Time in Encounter:</td>
-            <td><input type="checkbox" name="program.enableEncounterTransportationTime" <c:if test="${program.enableEncounterTransportationTime}">checked</c:if>/></td>
         </tr>
         <tr>
             <td colspan="2">

--- a/src/main/webapp/WEB-INF/jsp/casemgmt/ChartNotesAjax.jsp
+++ b/src/main/webapp/WEB-INF/jsp/casemgmt/ChartNotesAjax.jsp
@@ -751,14 +751,6 @@ EmailComposeManager emailComposeManager = SpringUtils.getBean(EmailComposeManage
                             id="encTime<%=globalNoteId%>"><carlos:encode value='<%= note.getEncounterTime() %>' context="html"/></span>
                     </div>
                     <% } %>
-                    <%
-                        if (facility.isEnableEncounterTransportationTime() || (program != null && program.isEnableEncounterTransportationTime())) {
-                    %>
-                    <div style="clear: right; margin-right: 3px; float: right;">
-                        <fmt:message key="encounter.encounterTransportation.title"/>:&nbsp;<span
-                            id="encTransTime<%=globalNoteId%>"><carlos:encode value='<%= note.getEncounterTransportationTime() %>' context="html"/></span>
-                    </div>
-                    <% } %>
 
 									<%if (!note.isEmailNote()) {%>
                     <div style="clear: right; margin-right: 3px; float: right;">

--- a/src/main/webapp/WEB-INF/jsp/casemgmt/noteIssueList.jsp
+++ b/src/main/webapp/WEB-INF/jsp/casemgmt/noteIssueList.jsp
@@ -173,34 +173,6 @@
 </span></div>
 <%}%>
 
-<%
-    if (currentFacility.isEnableEncounterTransportationTime() || (currentProgram != null && currentProgram.isEnableEncounterTransportationTime())) {
-%>
-<div style="clear: right; margin: 0 30px 0 0; float: right;"><span>
-    <c:choose>
-        <c:when test="${not empty ajaxsave}">
-            <fmt:message key="encounter.encounterTransportation.title"/>:&nbsp;
-            <span id="encTransTimeHr${caseManagementEntryForm.caseNote.id}">
-                ${caseManagementEntryForm.caseNote.hourOfEncTransportationTime}
-            </span>:
-            <span id="encTransTimeMin${caseManagementEntryForm.caseNote.id}">
-                ${caseManagementEntryForm.caseNote.minuteOfEncTransportationTime}
-            </span>
-        </c:when>
-        <c:otherwise>
-            <fmt:message key="encounter.encounterTransportation.title"/>:&nbsp;
-            <input type="text" tabindex="13" id="hourOfEncTransportationTime" name="hourOfEncTransportationTime" maxlength="2"
-                   style="border: 1px; width: 20px; height:12px;"
-                   value="${caseManagementEntryForm.caseNote.hourOfEncTransportationTime}">&nbsp;<b>:</b>&nbsp;
-            <input type="text" tabindex="14" id="minuteOfEncTransportationTime" name="minuteOfEncTransportationTime" maxlength="2"
-                   style="border: 1px; width: 20px; height:12px;"
-                   value="${caseManagementEntryForm.caseNote.minuteOfEncTransportationTime}">
-        </c:otherwise>
-    </c:choose>
-
-</span></div>
-<%}%>
-
 <div id="current_note_addon"></div>
 
 <c:set var="encSelect" value="${encSelect}${noteIndex}" />

--- a/src/main/webapp/js/newCaseManagementView.js.jsp
+++ b/src/main/webapp/js/newCaseManagementView.js.jsp
@@ -2218,18 +2218,6 @@ function updateCPPNote() {
                 alert(assignEncTypeError);
                 return false;
             }
-            if (document.getElementById("hourOfEncTransportationTime") != null) {
-                if (isNaN(document.getElementById("hourOfEncTransportationTime").value) ||
-                    isNaN(document.getElementById("minuteOfEncTransportationTime").value)) {
-                    alert(encTimeError);
-                    return false;
-                }
-                if (!isNaN(document.getElementById("minuteOfEncTransportationTime").value) &&
-                    parseInt(document.getElementById("minuteOfEncTransportationTime").value) > 59) {
-                    alert(encMinError);
-                    return false;
-                }
-            }
             if (document.getElementById("hourOfEncounterTime") != null) {
                 if (isNaN(document.getElementById("hourOfEncounterTime").value) ||
                     isNaN(document.getElementById("minuteOfEncounterTime").value)) {
@@ -2243,9 +2231,7 @@ function updateCPPNote() {
                 }
 
 
-                if (parseInt(document.getElementById("minuteOfEncTransportationTime").value) == 0 &&
-                    parseInt(document.getElementById("hourOfEncTransportationTime").value) == 0 &&
-                    parseInt(document.getElementById("minuteOfEncounterTime").value) == 0 &&
+                if (parseInt(document.getElementById("minuteOfEncounterTime").value) == 0 &&
                     parseInt(document.getElementById("hourOfEncounterTime").value) == 0) {
 
                     if (encTimeMandatory) {
@@ -2325,18 +2311,6 @@ function updateCPPNote() {
                 alert(assignEncTypeError);
                 return false;
             }
-            if (document.getElementById("hourOfEncTransportationTime") != null) {
-                if (isNaN(document.getElementById("hourOfEncTransportationTime").value) ||
-                    isNaN(document.getElementById("minuteOfEncTransportationTime").value)) {
-                    alert(encTimeError);
-                    return false;
-                }
-                if (!isNaN(document.getElementById("minuteOfEncTransportationTime").value) &&
-                    parseInt(document.getElementById("minuteOfEncTransportationTime").value) > 59) {
-                    alert(encMinError);
-                    return false;
-                }
-            }
             if (document.getElementById("hourOfEncounterTime") != null) {
                 if (isNaN(document.getElementById("hourOfEncounterTime").value) ||
                     isNaN(document.getElementById("minuteOfEncounterTime").value)) {
@@ -2350,9 +2324,7 @@ function updateCPPNote() {
                 }
 
 
-                if (parseInt(document.getElementById("minuteOfEncTransportationTime").value) == 0 &&
-                    parseInt(document.getElementById("hourOfEncTransportationTime").value) == 0 &&
-                    parseInt(document.getElementById("minuteOfEncounterTime").value) == 0 &&
+                if (parseInt(document.getElementById("minuteOfEncounterTime").value) == 0 &&
                     parseInt(document.getElementById("hourOfEncounterTime").value) == 0) {
 
                     if (encTimeMandatory) {
@@ -2431,17 +2403,13 @@ function updateCPPNote() {
                 alert(assignEncTypeError);
                 return false;
             }
-            if (document.getElementById("hourOfEncTransportationTime") != null) {
-                if (isNaN(document.getElementById("hourOfEncTransportationTime").value) ||
-                    isNaN(document.getElementById("minuteOfEncTransportationTime").value) ||
-                    isNaN(document.getElementById("hourOfEncounterTime").value) ||
+            if (document.getElementById("hourOfEncounterTime") != null) {
+                if (isNaN(document.getElementById("hourOfEncounterTime").value) ||
                     isNaN(document.getElementById("minuteOfEncounterTime").value)) {
                     alert(encTimeError);
                     return false;
                 }
-                if (parseInt(document.getElementById("minuteOfEncTransportationTime").value) == 0 &&
-                    parseInt(document.getElementById("hourOfEncTransportationTime").value) == 0 &&
-                    parseInt(document.getElementById("minuteOfEncounterTime").value) == 0 &&
+                if (parseInt(document.getElementById("minuteOfEncounterTime").value) == 0 &&
                     parseInt(document.getElementById("hourOfEncounterTime").value) == 0) {
 
                     if (encTimeMandatory) {
@@ -3568,18 +3536,6 @@ function autoSave() {
             if ($("encTypeSelect0") != null && $("encTypeSelect0").options[$("encTypeSelect0").selectedIndex].value.length == 0) {
                 alert(assignEncTypeError);
                 return false;
-            }
-            if (document.getElementById("hourOfEncTransportationTime") != null) {
-                if (isNaN(document.getElementById("hourOfEncTransportationTime").value) ||
-                    isNaN(document.getElementById("minuteOfEncTransportationTime").value)) {
-                    alert(encTimeError);
-                    return false;
-                }
-                if (!isNaN(document.getElementById("minuteOfEncTransportationTime").value) &&
-                    parseInt(document.getElementById("minuteOfEncTransportationTime").value) > 59) {
-                    alert(encMinError);
-                    return false;
-                }
             }
             if (document.getElementById("hourOfEncounterTime") != null) {
                 if (isNaN(document.getElementById("hourOfEncounterTime").value) ||


### PR DESCRIPTION
The TRANSPORTATION_TIME_MANDATORY property was defined in
carlos.properties but never read by any Java, JSP, or JavaScript
code. The legacy Debian packaging script in archive/release/config
also seeded this property into installed carlos.properties files.
Removed both since no code consumes the flag.

Unlike the still-active ENCOUNTER_TIME_MANDATORY property (read by
newEncounterLayout.jsp), TRANSPORTATION_TIME_MANDATORY has no
consumers, so this is a pure dead-code cleanup with no behavioural
change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused TRANSPORTATION_TIME_MANDATORY property and the defunct “encounter transportation time” feature (flags, fields, DTOs, UI, and validation). ENCOUNTER_TIME_MANDATORY remains; no functional changes to encounter time.

- **Refactors**
  - Removed TRANSPORTATION_TIME_MANDATORY from `carlos.properties` and `archive/release/config`.
  - Deleted transportation-time code across models, REST DTOs/services, and UI (admin checkboxes, encounter forms, client-side validation).
  - Removed related i18n keys and unused method signatures.

- **Migration**
  - No action required.
  - DB columns for transportation time remain but are unmapped; can be dropped in a future migration.

<sup>Written for commit 6647b038e83fb53406f7b5df0613c34ff074df26. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

