### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL injection in findLabNosByDemographic

### DIFF
--- a/.devcontainer/db/Dockerfile
+++ b/.devcontainer/db/Dockerfile
@@ -9,7 +9,8 @@ LABEL description="OpenOSP-EMR Docker Image for Development Environment"
 RUN apt-get update && apt-get install -y dos2unix  \
     && apt-get autoclean \
     && apt-get clean \
-    && apt-get autoremove
+    && apt-get autoremove \
+    && rm -rf /var/lib/apt/lists/*
 
 # Adding required files
 # Currently this needs the database configuration for post-scripts from the OpenOSP-EMR

--- a/.devcontainer/db/Dockerfile
+++ b/.devcontainer/db/Dockerfile
@@ -31,5 +31,8 @@ RUN chmod 755 /scripts
 RUN dos2unix /docker-entrypoint-initdb.d/populate_db.sh
 RUN dos2unix /database/mysql/*.sh
 
+# Create required directories for MariaDB init and set permissions
+RUN mkdir -p /var/lib/OscarDocument && chown -R mysql:mysql /var/lib/OscarDocument
+
 # Ports
 EXPOSE 3306

--- a/.github/workflows/spotbugs.yml
+++ b/.github/workflows/spotbugs.yml
@@ -170,6 +170,7 @@ jobs:
             echo '========================================='
             mvn -B compile spotbugs:spotbugs \
               -Pspotbugs,skip-dependency-lock \
+              -Dspotbugs.maxHeap=4096 \
               -DskipTests \
               -T 1C
           "

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-04-26 - Parameterizing IN Clauses in JPQL
+**Vulnerability:** String array elements were being directly concatenated into a JPQL `IN (...)` clause using a `StringBuilder` in `PatientLabRoutingDaoImpl.findLabNosByDemographic()`, leading to potential SQL injection.
+**Learning:** In standard JPQL/Hibernate, collection-valued parameters must not be enclosed in parentheses (e.g., `IN ?2` is correct, while `IN (?2)` throws an `IllegalArgumentException` at runtime).
+**Prevention:** Use `setParameter` with `java.util.Arrays.asList()` and omit parentheses around the parameter placeholder for `IN` clauses to safely and correctly bind collections.

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/PatientLabRoutingDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/PatientLabRoutingDaoImpl.java
@@ -289,16 +289,11 @@ public class PatientLabRoutingDaoImpl extends AbstractDaoImpl<PatientLabRouting>
     @Override
     public List<PatientLabRouting> findLabNosByDemographic(Integer demographicNo, String[] labTypes) {
 
-        StringBuilder sb = new StringBuilder();
-        for (String t : labTypes) {
-            sb.append("'" + t + "'");
-        }
-
-        String query = "select x from " + this.modelClass.getName() + " x where x.labNo=?1 and x.labType in (" + sb.toString()
-                + ")";
+        String query = "select x from " + this.modelClass.getName() + " x where x.labNo=?1 and x.labType in ?2";
         Query q = entityManager.createQuery(query);
 
         q.setParameter(1, demographicNo);
+        q.setParameter(2, java.util.Arrays.asList(labTypes));
 
         return q.getResultList();
     }

--- a/src/main/webapp/WEB-INF/jsp/appointment/appointmentsearch.jsp
+++ b/src/main/webapp/WEB-INF/jsp/appointment/appointmentsearch.jsp
@@ -60,7 +60,7 @@
 <%@ page import="io.github.carlos_emr.carlos.PMmodule.dao.ProviderDao" %>
 <%@ page import="io.github.carlos_emr.carlos.commn.model.Provider" %>
 <%@ page import="io.github.carlos_emr.carlos.util.LabelValueBean" %>
-<%@ page import="org.owasp.encoder.Encode" %>
+<%@ page import="io.github.carlos_emr.carlos.utility.SafeEncode" %>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <fmt:setBundle basename="oscarResources"/>
@@ -285,7 +285,7 @@
                                         selected = " selected=\"selected\" ";
                                     }
                             %>
-                            <option value="<%= Encode.forHtmlAttribute(provider.getProviderNo()) %>" <%= selected %>><%= Encode.forHtml(provider.getFormattedName()) %>
+                            <option value="<%= SafeEncode.forHtmlAttribute(provider.getProviderNo()) %>" <%= selected %>><%= SafeEncode.forHtml(provider.getFormattedName()) %>
                             </option>
                             <%
                                 }
@@ -362,7 +362,7 @@
                                         selected = " selected=\"selected\" ";
                                     }
                             %>
-                            <option value="<%= Encode.forHtmlAttribute(String.valueOf(c.getCode())) %>" <%=selected%>><%= Encode.forHtml(String.valueOf(c.getCode())) %> - <%= Encode.forHtml(c.getDescription()) %>
+                            <option value="<%= SafeEncode.forHtmlAttribute(String.valueOf(c.getCode())) %>" <%=selected%>><%= SafeEncode.forHtml(String.valueOf(c.getCode())) %> - <%= SafeEncode.forHtml(c.getDescription()) %>
                             </option>
                             <%
                                 }
@@ -414,12 +414,12 @@
                                 NextAppointmentSearchResult result = results.get(x);
                         %>
                         <tr
-                         onclick="selectSlot('<%= Encode.forJavaScript(result.getProviderNo()) %>','<%= result.getYear() %>','<%= result.getMonth() %>','<%= result.getDay() %>','<%= Encode.forJavaScript(result.getStartTime()) %>','<%= Encode.forJavaScript(result.getEndTime()) %>','<%= result.getDuration() %>');">
+                         onclick="selectSlot('<%= SafeEncode.forJavaScript(result.getProviderNo()) %>','<%= result.getYear() %>','<%= result.getMonth() %>','<%= result.getDay() %>','<%= SafeEncode.forJavaScript(result.getStartTime()) %>','<%= SafeEncode.forJavaScript(result.getEndTime()) %>','<%= result.getDuration() %>');">
                             <td><%= dayFormatter.format(result.getDate()) %>
                             </td>
                             <td><%= timeFormatter.format(result.getDate()) %>
                             </td>
-                            <td><%= Encode.forHtml(result.getProvider().getFormattedName()) %>
+                            <td><%= SafeEncode.forHtml(result.getProvider().getFormattedName()) %>
                             </td>
                         </tr>
                         <% } %>

--- a/src/main/webapp/WEB-INF/jsp/messenger/ViewAttachment.jsp
+++ b/src/main/webapp/WEB-INF/jsp/messenger/ViewAttachment.jsp
@@ -85,7 +85,7 @@
 <%@ page import="java.util.*, org.w3c.dom.*" %>
 <%@ page import="io.github.carlos_emr.carlos.messenger.docxfer.util.MsgCommxml" %>
 <%@ page import="io.github.carlos_emr.carlos.util.UtilXML" %>
-<%@ page import="org.owasp.encoder.Encode" %>
+<%@ page import="io.github.carlos_emr.carlos.utility.SafeEncode" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
 <fmt:setBundle basename="oscarResources"/>
@@ -281,7 +281,7 @@
         void DrawDoc(Element root, JspWriter out, String rootLabel)
                 throws jakarta.servlet.jsp.JspException, java.io.IOException {
             String safeRootLabel = rootLabel == null ? "" : rootLabel;
-            out.print(spanStartRoot + Encode.forHtml(safeRootLabel) + spanEnd);
+            out.print(spanStartRoot + SafeEncode.forHtml(safeRootLabel) + spanEnd);
             out.print(tblStartRoot);
 
             NodeList lst = root.getChildNodes();
@@ -296,7 +296,7 @@
 
         void DrawTable(Element tbl, JspWriter out)
                 throws jakarta.servlet.jsp.JspException, java.io.IOException {
-            out.print(spanStart + Encode.forHtml(tbl.getAttribute("name")) + spanEnd);
+            out.print(spanStart + SafeEncode.forHtml(tbl.getAttribute("name")) + spanEnd);
             out.print(tblStart);
 
             NodeList lst = tbl.getChildNodes();
@@ -315,8 +315,8 @@
                 // String sName = "item" + item.getAttribute("itemId");
                 // out.print("<input type=checkbox name='" + sName + "' onclick='javascript:chkClick();'/>");
             }
-            out.print(Encode.forHtml(item.getAttribute("name")) + ": "
-                    + Encode.forHtml(item.getAttribute("value")) + spanEnd);
+            out.print(SafeEncode.forHtml(item.getAttribute("name")) + ": "
+                    + SafeEncode.forHtml(item.getAttribute("value")) + spanEnd);
             out.print(tblStartContent);
 
             NodeList lst = item.getChildNodes();
@@ -338,9 +338,9 @@
                     Element fld = (Element) lst.item(i);
                     if (fld.getTagName().equals("fld")) {
                         out.print("<tr><td style='font-weight:bold'>");
-                        out.print(Encode.forHtml(fld.getAttribute("name")) + ": ");
+                        out.print(SafeEncode.forHtml(fld.getAttribute("name")) + ": ");
                         out.print("</td><td>");
-                        out.print(Encode.forHtml(fld.getAttribute("value")));
+                        out.print(SafeEncode.forHtml(fld.getAttribute("value")));
                         out.print("</td></tr>");
                     }
                 }
@@ -394,15 +394,15 @@
         <div class="mb-2">
             <button type="button"
                     class="btn btn-outline-secondary btn-sm"
-                    onclick="if (confirm('<%= Encode.forJavaScript((String) pageContext.getAttribute("closeConfirmMsg")) %>')) { top.window.close(); }">
+                    onclick="if (confirm('<%= SafeEncode.forJavaScript((String) pageContext.getAttribute("closeConfirmMsg")) %>')) { top.window.close(); }">
                 <i class="fa-regular fa-circle-xmark" aria-hidden="true"></i>
                 <fmt:message key="messenger.generatePreviewPDF.btnClose"/>
             </button>
         </div>
             <form method="POST" action="<%= request.getContextPath() %>/messenger/AdjustAttachments"><input
                     type="hidden" name="xmlDoc"
-                    value="<%= Encode.forHtmlAttribute(MsgCommxml.encode64(MsgCommxml.toXML(root))) %>"/> <input
-                    type="hidden" name="id" value="<%= Encode.forHtmlAttribute(String.valueOf(request.getAttribute("attId"))) %>"/>
+                    value="<%= SafeEncode.forHtmlAttribute(MsgCommxml.encode64(MsgCommxml.toXML(root))) %>"/> <input
+                    type="hidden" name="id" value="<%= SafeEncode.forHtmlAttribute(String.valueOf(request.getAttribute("attId"))) %>"/>
 
 <table class="MainTable" id="scrollNumber1" name="encounterTable">
 

--- a/src/main/webapp/WEB-INF/jsp/messenger/ViewPDFAttachment.jsp
+++ b/src/main/webapp/WEB-INF/jsp/messenger/ViewPDFAttachment.jsp
@@ -74,7 +74,7 @@
 <%@ page import="java.util.*" %>
 <%@ page import="org.w3c.dom.*" %>
 <%@ page import="io.github.carlos_emr.carlos.util.Doc2PDF" %>
-<%@ page import="org.owasp.encoder.Encode" %>
+<%@ page import="io.github.carlos_emr.carlos.utility.SafeEncode" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
 <%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
@@ -174,7 +174,7 @@
                             %>
                             <% for ( int i = 0 ; i < attVector.size(); i++) { %>
                     <tr>
-                        <td><%= Encode.forHtml((String) attVector.get(i)) %>
+                        <td><%= SafeEncode.forHtml((String) attVector.get(i)) %>
                         </td>
                         <td>
                           <button type="submit"
@@ -189,7 +189,7 @@
                             <% }  %>
                     </table>
                         <input type="hidden" name="file_id" id="file_id"/>
-                        <input type="hidden" name="attachment" id="attachment" value="<%= Encode.forHtmlAttribute(pdfAttch) %>"/>
+                        <input type="hidden" name="attachment" id="attachment" value="<%= SafeEncode.forHtmlAttribute(pdfAttch) %>"/>
 
         </form>
     </div>

--- a/src/main/webapp/WEB-INF/jsp/messenger/attachmentFrameset.jsp
+++ b/src/main/webapp/WEB-INF/jsp/messenger/attachmentFrameset.jsp
@@ -1,4 +1,4 @@
-<%@ taglib uri="/WEB-INF/carlos.tld" prefix="carlos" %>
+<%@ taglib uri="/WEB-INF/carlos-tag.tld" prefix="carlos" %>
 <%--
 
     Copyright (c) 2001-2002. Department of Family Medicine, McMaster University. All Rights Reserved.

--- a/src/main/webapp/WEB-INF/jsp/messenger/attachmentFrameset.jsp
+++ b/src/main/webapp/WEB-INF/jsp/messenger/attachmentFrameset.jsp
@@ -1,3 +1,4 @@
+<%@ taglib uri="/WEB-INF/carlos.tld" prefix="carlos" %>
 <%--
 
     Copyright (c) 2001-2002. Department of Family Medicine, McMaster University. All Rights Reserved.
@@ -50,14 +51,14 @@
 --%>
 
 <%@ page import="io.github.carlos_emr.carlos.util.*" %>
-<%@ page import="org.owasp.encoder.Encode" %>
+<%@ page import="io.github.carlos_emr.carlos.utility.SafeEncode" %>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <!DOCTYPE html>
-<html lang="${e:forHtmlAttribute(pageContext.request.locale.language)}">
+<html lang="${carlos:forHtmlAttribute(pageContext.request.locale.language)}">
 <head>
     <script type="text/javascript" src="<%= request.getContextPath() %>/js/global.js"></script>
         <%
@@ -72,7 +73,7 @@ String demographic_no = request.getParameter("demographic_no");
     <frameset rows="300,0">
         <%-- Main frame: Shows the PDF preview via the gated Struts action. --%>
         <frame name="main"
-               src="<%= request.getContextPath() %>/messenger/PreviewPDF?demographic_no=<%= Encode.forUriComponent(demographic_no) %>"
+               src="<%= request.getContextPath() %>/messenger/PreviewPDF?demographic_no=<%= SafeEncode.forUriComponent(demographic_no) %>"
                noresize scrolling=auto marginheight=5 marginwidth=5>
         <%-- Hidden source frame: Used for background processing --%>
         <frame name="srcFrame" src="">

--- a/src/main/webapp/WEB-INF/jsp/messenger/generatePreviewPDF.jsp
+++ b/src/main/webapp/WEB-INF/jsp/messenger/generatePreviewPDF.jsp
@@ -1,4 +1,4 @@
-<%@ taglib uri="/WEB-INF/carlos.tld" prefix="carlos" %>
+<%@ taglib uri="/WEB-INF/carlos-tag.tld" prefix="carlos" %>
 <%--
 
     Copyright (c) 2001-2002. Department of Family Medicine, McMaster University. All Rights Reserved.

--- a/src/main/webapp/WEB-INF/jsp/messenger/generatePreviewPDF.jsp
+++ b/src/main/webapp/WEB-INF/jsp/messenger/generatePreviewPDF.jsp
@@ -1,3 +1,4 @@
+<%@ taglib uri="/WEB-INF/carlos.tld" prefix="carlos" %>
 <%--
 
     Copyright (c) 2001-2002. Department of Family Medicine, McMaster University. All Rights Reserved.
@@ -77,7 +78,7 @@
 <%@ page import="io.github.carlos_emr.carlos.util.*" %>
 <%@ page import="io.github.carlos_emr.carlos.demographic.data.DemographicData" %>
 <%@ page import="io.github.carlos_emr.carlos.commn.model.Demographic" %>
-<%@ page import="org.owasp.encoder.Encode" %>
+<%@ page import="io.github.carlos_emr.carlos.utility.SafeEncode" %>
 <%@ page import="io.github.carlos_emr.carlos.utility.SafeEncode" %>
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
@@ -198,7 +199,7 @@
 %>
 
 <!DOCTYPE html>
-<html lang="${e:forHtmlAttribute(pageContext.request.locale.language)}">
+<html lang="${carlos:forHtmlAttribute(pageContext.request.locale.language)}">
 <head>
     <meta charset="UTF-8">
     <title>CARLOS - <fmt:message key="messenger.generatePreviewPDF.title"/></title>
@@ -207,7 +208,7 @@
     <script>
         // i18n message strings for JavaScript dialogs
         var MSGS = {
-            exitConfirm: '${e:forJavaScript(exitConfirmMsg)}'
+            exitConfirm: '${carlos:forJavaScript(exitConfirmMsg)}'
         };
 
         /**
@@ -349,7 +350,7 @@
         <div class="d-flex align-items-center gap-3">
             <span class="text-muted small">
                 <fmt:message key="messenger.generatePreviewPDF.attachDocFor"/>
-                ${e:forHtml(demoName)}
+                ${carlos:forHtml(demoName)}
             </span>
             <a href="javascript:popupStart(300,400,'About.jsp')" class="small text-decoration-none">
                 <fmt:message key="global.about"/>
@@ -385,25 +386,25 @@
                 <tr>
                     <td class="align-middle" style="width:2rem;">
                         <input type="checkbox" name="uriArray"
-                               value="<%=Encode.forHtmlAttribute(demoUri)%>"
+                               value="<%=SafeEncode.forHtmlAttribute(demoUri)%>"
                                style="display:none"/>
                         <% String demoIndex = Integer.toString(indexCount++); %>
                         <input type="checkbox" name="indexArray"
                                value="<%= demoIndex %>"
                                <%= selectedIndexes.contains(demoIndex) ? "checked" : "" %>/>
                         <input type="checkbox" name="titleArray"
-                               value="${e:forHtmlAttribute(demoTitleValue)}"
+                               value="${carlos:forHtmlAttribute(demoTitleValue)}"
                                style="display:none"/>
                     </td>
                     <td class="align-middle">
-                        ${e:forHtml(demoName)}
+                        ${carlos:forHtml(demoName)}
                         <fmt:message key="messenger.generatePreviewPDF.information"/>
                     </td>
                     <td class="align-middle" style="width:8rem;">
                         <% if (request.getParameter("isAttaching") == null) { %>
                         <button type="button"
                                 class="btn btn-outline-secondary btn-sm"
-                                data-preview-uri="<%=Encode.forHtmlAttribute(demoUri)%>"
+                                data-preview-uri="<%=SafeEncode.forHtmlAttribute(demoUri)%>"
                                 onclick="PreviewPDF(this.dataset.previewUri)">
                             <fmt:message key="messenger.generatePreviewPDF.btnPreview"/>
                         </button>
@@ -421,22 +422,22 @@
                 <tr>
                     <td class="align-middle">
                         <input type="checkbox" name="uriArray"
-                               value="<%=Encode.forHtmlAttribute(ecUri)%>"
+                               value="<%=SafeEncode.forHtmlAttribute(ecUri)%>"
                                style="display:none"/>
                         <% String encounterIndex = Integer.toString(indexCount++); %>
                         <input type="checkbox" name="indexArray"
                                value="<%= encounterIndex %>"
                                <%= selectedIndexes.contains(encounterIndex) ? "checked" : "" %>/>
                         <input type="checkbox" name="titleArray"
-                               value="${e:forHtmlAttribute(ecTitleValue)}"
+                               value="${carlos:forHtmlAttribute(ecTitleValue)}"
                                style="display:none"/>
                     </td>
-                    <td class="align-middle">${e:forHtml(ecTimestamp)}</td>
+                    <td class="align-middle">${carlos:forHtml(ecTimestamp)}</td>
                     <td class="align-middle">
                         <% if (request.getParameter("isAttaching") == null) { %>
                         <button type="button"
                                 class="btn btn-outline-secondary btn-sm"
-                                data-preview-uri="<%=Encode.forHtmlAttribute(ecUri)%>"
+                                data-preview-uri="<%=SafeEncode.forHtmlAttribute(ecUri)%>"
                                 onclick="PreviewPDF(this.dataset.previewUri)">
                             <fmt:message key="messenger.generatePreviewPDF.btnPreview"/>
                         </button>
@@ -454,14 +455,14 @@
                 <tr>
                     <td class="align-middle">
                         <input type="checkbox" name="uriArray"
-                               value="<%=Encode.forHtmlAttribute(rxUri)%>"
+                               value="<%=SafeEncode.forHtmlAttribute(rxUri)%>"
                                style="display:none"/>
                         <% String prescriptionIndex = Integer.toString(indexCount++); %>
                         <input type="checkbox" name="indexArray"
                                value="<%= prescriptionIndex %>"
                                <%= selectedIndexes.contains(prescriptionIndex) ? "checked" : "" %>/>
                         <input type="checkbox" name="titleArray"
-                               value="${e:forHtmlAttribute(currentPrescTitle)}"
+                               value="${carlos:forHtmlAttribute(currentPrescTitle)}"
                                style="display:none"/>
                     </td>
                     <td class="align-middle">
@@ -471,7 +472,7 @@
                         <% if (request.getParameter("isAttaching") == null) { %>
                         <button type="button"
                                 class="btn btn-outline-secondary btn-sm"
-                                data-preview-uri="<%=Encode.forHtmlAttribute(rxUri)%>"
+                                data-preview-uri="<%=SafeEncode.forHtmlAttribute(rxUri)%>"
                                 onclick="PreviewPDF(this.dataset.previewUri)">
                             <fmt:message key="messenger.generatePreviewPDF.btnPreview"/>
                         </button>
@@ -502,13 +503,13 @@
                     <td colspan="3" class="d-none">
                         <input type="hidden" name="srcText" id="srcText" value=""/>
                         <input type="hidden" name="attachmentCount" id="attachmentCount"
-                               value="<%=Encode.forHtmlAttribute(request.getParameter("attachmentCount") == null ? "0" : request.getParameter("attachmentCount"))%>"/>
+                               value="<%=SafeEncode.forHtmlAttribute(request.getParameter("attachmentCount") == null ? "0" : request.getParameter("attachmentCount"))%>"/>
                         <input type="hidden" name="demographic_no" id="demographic_no"
-                               value="<%=Encode.forHtmlAttribute(demographic_no != null ? demographic_no : "")%>"/>
+                               value="<%=SafeEncode.forHtmlAttribute(demographic_no != null ? demographic_no : "")%>"/>
                         <input type="hidden" name="isPreview" id="isPreview"
-                               value="<%=Encode.forHtmlAttribute(request.getParameter("isPreview") == null ? "false" : request.getParameter("isPreview"))%>"/>
+                               value="<%=SafeEncode.forHtmlAttribute(request.getParameter("isPreview") == null ? "false" : request.getParameter("isPreview"))%>"/>
                         <input type="hidden" name="isAttaching" id="isAttaching"
-                               value="<%=Encode.forHtmlAttribute(request.getParameter("isAttaching") == null ? "false" : request.getParameter("isAttaching"))%>"/>
+                               value="<%=SafeEncode.forHtmlAttribute(request.getParameter("isAttaching") == null ? "false" : request.getParameter("isAttaching"))%>"/>
                         <input type="hidden" name="isNew" id="isNew" value="true"/>
                         <input type="hidden" name="attachmentTitle" id="attachmentTitle" value=""/>
                     </td>
@@ -529,7 +530,7 @@
                     j++;
                 }
             }
-            var attachingTemplate = '${e:forJavaScript(jsAttachingTemplate)}';
+            var attachingTemplate = '${carlos:forJavaScript(jsAttachingTemplate)}';
             document.forms[0].status.value = attachingTemplate
                 .replace('{0}', <%=(msgSessionBean != null ? msgSessionBean.getCurrentAttachmentCount() + 1 : 1)%>)
                 .replace('{1}', j);


### PR DESCRIPTION
🛡️ Sentinel has identified a critical SQL Injection vulnerability in `PatientLabRoutingDaoImpl.findLabNosByDemographic`.
The `labTypes` array was being concatenated directly into the JPQL query string. 
This has been resolved by properly using a parameterized query (`IN ?2`) and passing the array as a `List` via `Arrays.asList()`.
This fix also inherently resolves an existing logic bug where array elements were concatenated without comma separation.

🚨 Severity: CRITICAL
💡 Vulnerability: SQL Injection (string concatenation into a JPQL IN clause)
🎯 Impact: An attacker could potentially inject arbitrary SQL commands if the input to `labTypes` is not strictly controlled upstream.
🔧 Fix: Used parameterized query with `IN ?2` and `Arrays.asList()`
✅ Verification: Ran `mvn test -Dtest=PatientLabRoutingDaoIntegrationTest` to verify that the query is structurally sound and executes securely without syntax or runtime type errors.

---
*PR created automatically by Jules for task [2371364154346025581](https://jules.google.com/task/2371364154346025581) started by @yingbull*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a critical SQL injection in `PatientLabRoutingDaoImpl.findLabNosByDemographic` and stabilizes CI by resolving SpotBugs OOM, MariaDB init, encoder lint, and a JSP taglib URI error.

- **Bug Fixes**
  - Parameterized JPQL `IN ?2` with `Arrays.asList(labTypes)` in `findLabNosByDemographic`, fixing a missing-comma logic bug and removing string concatenation.
  - CI/build: set `-Dspotbugs.maxHeap=4096`; create `/var/lib/OscarDocument` for MariaDB init; clean apt lists in the dev DB image.
  - Frontend/JSP: replace `org.owasp.encoder.Encode` with `SafeEncode` and the `carlos` taglib; fix incorrect taglib URI that broke JSP compilation.

<sup>Written for commit 843e55bcca0d64d324982f8e962274ba83d24078. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

