### PR TITLE
Fix vaccine brands JSON 404

### DIFF
--- a/src/main/webapp/prevention/vaccine-brands.json
+++ b/src/main/webapp/prevention/vaccine-brands.json
@@ -1,3 +1,4 @@
+<%@ page contentType="application/json; charset=UTF-8" %>
 [
 {"name":"OtherA","value":"IXCHIQ 3 log10 TCID50 per 0.5ml powder for solution","manufacture":"Valneva Austria GmbH","dose":"0.5","units":"mL","route":"IM","din":"2548984"},
 {"name":"Chol-Ecol-O","value":"DUKORAL oral","manufacture":"Valneva Sweden AB","dose":"","units":"DOSE","route":"PO","din":"2247208"},


### PR DESCRIPTION
Fixes #1991.

Adds the JSP contentType directive to the bundled vaccine catalog JSON so it is served through the existing *.json JSP mapping with Content-Type: application/json instead of returning 404.

Validation:
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix 404s when requesting /prevention/vaccine-brands.json by adding a JSP contentType directive to the file. It now serves through the existing *.json JSP mapping with Content-Type: application/json.

<sup>Written for commit 2cd5be417bd188a485d5d8bc9c9e8e0345165300. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

