### PR TITLE
Fix vaccine brands JSON 404

### DIFF
--- a/src/main/webapp/prevention/vaccine-brands.json
+++ b/src/main/webapp/prevention/vaccine-brands.json
@@ -1,6 +1,8 @@
 <%@ page contentType="application/json; charset=UTF-8" trimDirectiveWhitespaces="true" %><%
-    if (!io.github.carlos_emr.carlos.utility.SpringUtils.getBean(io.github.carlos_emr.carlos.managers.SecurityInfoManager.class)
-            .hasPrivilege(io.github.carlos_emr.carlos.utility.LoggedInInfo.getLoggedInInfoFromSession(request), "_prevention", "r", null)) {
+    io.github.carlos_emr.carlos.utility.LoggedInInfo loggedInInfo =
+            io.github.carlos_emr.carlos.utility.LoggedInInfo.getLoggedInInfoFromSession(request);
+    if (loggedInInfo == null || !io.github.carlos_emr.carlos.utility.SpringUtils.getBean(io.github.carlos_emr.carlos.managers.SecurityInfoManager.class)
+            .hasPrivilege(loggedInInfo, "_prevention", "r", null)) {
         response.sendError(403);
         return;
     }

--- a/src/main/webapp/prevention/vaccine-brands.json
+++ b/src/main/webapp/prevention/vaccine-brands.json
@@ -1,3 +1,4 @@
+<%@ page contentType="application/json; charset=UTF-8" %>
 [
 {"name":"OtherA","value":"IXCHIQ 3 log10 TCID50 per 0.5ml powder for solution","manufacture":"Valneva Austria GmbH","dose":"0.5","units":"mL","route":"IM","din":"2548984"},
 {"name":"Chol-Ecol-O","value":"DUKORAL oral","manufacture":"Valneva Sweden AB","dose":"","units":"DOSE","route":"PO","din":"2247208"},

--- a/src/main/webapp/prevention/vaccine-brands.json
+++ b/src/main/webapp/prevention/vaccine-brands.json
@@ -1,5 +1,10 @@
-<%@ page contentType="application/json; charset=UTF-8" %>
-[
+<%@ page contentType="application/json; charset=UTF-8" trimDirectiveWhitespaces="true" %><%
+    if (!io.github.carlos_emr.carlos.utility.SpringUtils.getBean(io.github.carlos_emr.carlos.managers.SecurityInfoManager.class)
+            .hasPrivilege(io.github.carlos_emr.carlos.utility.LoggedInInfo.getLoggedInInfoFromSession(request), "_prevention", "r", null)) {
+        response.sendError(403);
+        return;
+    }
+%>[
 {"name":"OtherA","value":"IXCHIQ 3 log10 TCID50 per 0.5ml powder for solution","manufacture":"Valneva Austria GmbH","dose":"0.5","units":"mL","route":"IM","din":"2548984"},
 {"name":"Chol-Ecol-O","value":"DUKORAL oral","manufacture":"Valneva Sweden AB","dose":"","units":"DOSE","route":"PO","din":"2247208"},
 {"name":"Chol-O","value":"VAXCHORA 400000000 colony forming units per sachet powder","manufacture":"Bavarian Nordic AS","dose":"","units":"DOSE","route":"PO","din":"2538164"},


### PR DESCRIPTION
Fixes #1991.

This keeps vaccine-brands.json available through the existing *.json JSP mapping, with the JSON content type expected by the prevention page. It also adds the _prevention read check requested in review and trims directive whitespace so the response starts with the JSON array.

Validation:
- git diff --check
- mvn -DskipTests=true -T 1C package war:exploded -Pjspc

I left the broader JSON lint/Biome guard out of this small fix because existing webapp/**/*.json JSP endpoints use a few different directive patterns. That cleanup is better as a separate PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the 404 for vaccine-brands.json and serves it via the existing *.json JSP mapping with the correct JSON content type. Adds the `_prevention` read check (returns 403 when missing) and trims JSP directive whitespace so the response starts with the JSON array.

<sup>Written for commit cc7bc490c3a905a096d6168e71bb1668851fb84e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

