### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL Injection in Hl7LinkDao

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - SQL Injection in Dynamic ORDER BY Clauses
+**Vulnerability:** A critical SQL injection vulnerability was found in `Hl7LinkDao.java`. Unsanitized user input (`orderby`) was concatenated into an `ORDER BY` clause, and `provider_no` was replaced into the string without parameterization.
+**Learning:** JPA/Hibernate native queries (`createNativeQuery`) cannot parameterize `ORDER BY` clauses dynamically. Direct string replacement via `replaceAll` for parameters like `provider_no` bypasses query parameterization entirely.
+**Prevention:** Always use `setParameter("paramName", value)` for values in native queries. For dynamic `ORDER BY` clauses or column names, validate user input against a strict allowlist or a targeted blocklist (e.g., `.*[`';\\-].*`) before string concatenation to prevent injection.

--- a/src/main/java/io/github/carlos_emr/carlos/billing/CA/BC/dao/Hl7LinkDao.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billing/CA/BC/dao/Hl7LinkDao.java
@@ -97,28 +97,38 @@ public class Hl7LinkDao extends AbstractDaoImpl<Hl7Link> {
 
     @NativeSql({"hl7_pid", "hl7_link", "hl7_obr", "hl7_message"})
     public List<Object[]> findReports(Date start, Date end, String provider_no, String orderby, String command) {
-        String select_reports_by_provider = "SELECT DISTINCT hl7_pid.pid_id, hl7_pid.patient_name, hl7_obr.ordering_provider, hl7_obr.result_copies_to, hl7_link.status, hl7_link.signed_on, provider.last_name, provider.first_name, hl7_message.date_time  FROM hl7_link, demographic, hl7_pid, hl7_obr, hl7_message, provider WHERE demographic.provider_no = provider.provider_no AND hl7_link.pid_id=hl7_obr.pid_id AND hl7_link.pid_id=hl7_pid.pid_id AND demographic.provider_no='@provider_no' AND hl7_message.message_id=hl7_pid.message_id AND demographic.demographic_no=hl7_link.demographic_no AND hl7_link.status!='P'";
+        String select_reports_by_provider = "SELECT DISTINCT hl7_pid.pid_id, hl7_pid.patient_name, hl7_obr.ordering_provider, hl7_obr.result_copies_to, hl7_link.status, hl7_link.signed_on, provider.last_name, provider.first_name, hl7_message.date_time  FROM hl7_link, demographic, hl7_pid, hl7_obr, hl7_message, provider WHERE demographic.provider_no = provider.provider_no AND hl7_link.pid_id=hl7_obr.pid_id AND hl7_link.pid_id=hl7_pid.pid_id AND demographic.provider_no=:providerNo AND hl7_message.message_id=hl7_pid.message_id AND demographic.demographic_no=hl7_link.demographic_no AND hl7_link.status!='P'";
         String select_reports_linked_to_providers = "SELECT DISTINCT hl7_pid.pid_id, hl7_pid.patient_name, hl7_obr.ordering_provider, hl7_obr.result_copies_to, hl7_link.status, hl7_link.signed_on, provider.last_name, provider.first_name, hl7_message.date_time  FROM hl7_link, demographic, hl7_pid, hl7_obr, hl7_message, provider WHERE demographic.provider_no = provider.provider_no AND hl7_link.pid_id=hl7_obr.pid_id AND hl7_link.pid_id=hl7_pid.pid_id AND hl7_message.message_id=hl7_pid.message_id AND demographic.demographic_no=hl7_link.demographic_no AND hl7_link.status!='P'";
         String select_unlinked_labs = "SELECT DISTINCT hl7_pid.pid_id, hl7_pid.patient_name, hl7_obr.ordering_provider, hl7_obr.result_copies_to, hl7_link.status, hl7_link.signed_on, hl7_message.date_time, '' as `last_name`, '' as `first_name` FROM hl7_pid left join hl7_link on hl7_link.pid_id=hl7_pid.pid_id left join hl7_obr on hl7_pid.pid_id=hl7_obr.pid_id left join hl7_message on hl7_message.message_id=hl7_pid.message_id WHERE hl7_link.status='P' OR hl7_link.status is null";
         String sqlWhere = (start != null ? " AND hl7_message.date_time >= '" + ConversionUtils.toDateString(start) + " 00:00:00'" : "") +
                 (end != null ? " AND hl7_message.date_time <= '" + ConversionUtils.toTimeString(end) + " 23:59:59'" : "");
-        String sqlOrderBy = " ORDER BY @orderby";
+
+        // Prevent SQL injection by verifying orderby against a blocklist for dynamic injection characters
+        if (orderby != null && orderby.matches(".*[`';\\-].*")) {
+            throw new IllegalArgumentException("Invalid orderby parameter");
+        }
+        String sqlOrderBy = " ORDER BY " + (orderby != null && !orderby.trim().isEmpty() ? orderby : "pid_id");
 
         String sql = null;
         if (command != null && !command.equals("")) {
+            boolean useProviderParam = false;
             if ("-ULL".equals(provider_no)) {
                 sql = select_unlinked_labs;
             } else if ("-APL".equals(provider_no)) {
                 sql = select_reports_linked_to_providers;
             } else if ("-UAP".equals(provider_no)) {
                 sql = select_reports_by_provider;
+                useProviderParam = true;
             } else {
                 sql = select_reports_by_provider;
+                useProviderParam = true;
             }
             sql += sqlWhere + sqlOrderBy;
-            sql = sql.replaceAll("@provider_no", provider_no.replaceAll("-UAP", "")).replaceAll("@orderby", orderby);
 
             Query query = entityManager.createNativeQuery(sql);
+            if (useProviderParam) {
+                query.setParameter("providerNo", provider_no != null ? provider_no.replace("-UAP", "") : "");
+            }
             return query.getResultList();
         }
 


### PR DESCRIPTION
This PR fixes a critical SQL injection vulnerability in `Hl7LinkDao.java`. Unsanitized user input (`orderby`) was previously concatenated into an `ORDER BY` clause, and the `provider_no` parameter was replaced into the string without parameterization.

Changes:
- Refactored `findReports` to use `query.setParameter("providerNo", ...)` for the `provider_no` parameter.
- Implemented a regex blocklist for `orderby` to throw an `IllegalArgumentException` if malicious characters are detected, defaulting to `pid_id` if empty.
- Documented findings in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [2131331390368584134](https://jules.google.com/task/2131331390368584134) started by @yingbull*

## Summary by Sourcery

Fix SQL injection risks in Hl7LinkDao report queries and document the security findings.

Bug Fixes:
- Sanitize the dynamic ORDER BY input in findReports and default to a safe column when missing.
- Parameterize the provider number in native queries instead of performing raw string replacement to prevent SQL injection.

Documentation:
- Add a Sentinel security note documenting the SQL injection vulnerability, constraints of dynamic ORDER BY in native queries, and recommended prevention patterns.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a critical SQL injection in `Hl7LinkDao.findReports` by parameterizing `providerNo` and validating the dynamic `ORDER BY`. This removes unsafe string concatenation and protects report queries.

- **Bug Fixes**
  - Use named parameter `:providerNo` with `query.setParameter("providerNo", ...)`.
  - Validate `orderby` against dangerous characters; default to `pid_id` when blank.
  - Remove unsafe `replaceAll` substitutions for `provider_no` and `orderby`.
  - Add security notes in `.jules/sentinel.md`.

<sup>Written for commit 71691117a2225657471797d6d2dacab348eea7fd. Summary will update on new commits. <a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2005?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

