### PR TITLE
i18n BS and DT demographicappthistory.jsp.

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/demographic/demographicappthistory.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/demographicappthistory.jsp
@@ -74,7 +74,6 @@
 <%@ page import="io.github.carlos_emr.carlos.utility.SafeEncode" %>
 <%@ page import="io.github.carlos_emr.carlos.utility.SpringUtils" %>
 <%@ page import="org.apache.commons.lang3.StringUtils" %>
-<%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="org.springframework.beans.BeanUtils" %>
 <%@ page import="org.springframework.web.context.WebApplicationContext" %>
 <%@ page import="org.springframework.web.context.support.WebApplicationContextUtils" %>
@@ -83,7 +82,6 @@
 <%@ taglib uri="/WEB-INF/caisi-tag.tld" prefix="caisi" %>
 <%@ taglib uri="/WEB-INF/special_tag.tld" prefix="special" %>
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
-<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
 <%@ taglib uri="carlos" prefix="carlos" %>
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
@@ -120,11 +118,21 @@
     String curProvider_no = (String) session.getAttribute("user");
     String demographic_no = request.getParameter("demographic_no");
     String strLimit1 = "0";
-    String strLimit2 = "50000";
+    String strLimit2 = "1000";
     if (request.getParameter("limit1") != null)
         strLimit1 = request.getParameter("limit1");
-    if (request.getParameter("limit2") != null)
+    if (request.getParameter("limit2") != null) {
         strLimit2 = request.getParameter("limit2");
+        // Cap at maximum of 1000 to prevent oversized server-rendered payloads
+        try {
+            int limit2Val = Integer.parseInt(strLimit2);
+            if (limit2Val > 1000) {
+                strLimit2 = "1000";
+            }
+        } catch (NumberFormatException e) {
+            strLimit2 = "1000";
+        }
+    }
 
     DemographicManager demographicManager = SpringUtils.getBean(DemographicManager.class);
     Demographic patientDemo = (demographic_no != null && !demographic_no.isEmpty()) ? demographicManager.getDemographic(loggedInInfo, demographic_no) : null;
@@ -203,8 +211,7 @@
                     //don't show deleted
                     <c:set var="__enc_3"><carlos:encode value='<%= demographic_no %>' context="uriComponent"/></c:set>
                     <c:set var="__enc_4"><carlos:encode value='<%= orderby %>' context="uriComponent"/></c:set>
-                    location.hr                    
-ef = '<%=request.getContextPath()%>/demographic/DemographicApptHistory?demographic_no=<carlos:encode value='${__enc_3}' context="javaScript"/>&orderby=<carlos:encode value='${__enc_4}' context="javaScript"/>&dboperation=appt_history&limit1=<carlos:encode value='<%= strLimit1 %>' context="javaScript"/>&limit2=<carlos:encode value='<%= strLimit2 %>' context="javaScript"/>';
+                    location.href = '<%=request.getContextPath()%>/demographic/DemographicApptHistory?demographic_no=<carlos:encode value='${__enc_3}' context="javaScript"/>&orderby=<carlos:encode value='${__enc_4}' context="javaScript"/>&dboperation=appt_history&limit1=<carlos:encode value='<%= strLimit1 %>' context="javaScript"/>&limit2=<carlos:encode value='<%= strLimit2 %>' context="javaScript"/>';
                 }
     }
 

--- a/src/main/webapp/WEB-INF/jsp/demographic/demographicappthistory.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/demographicappthistory.jsp
@@ -302,7 +302,10 @@
                      Contains navigation links / contextual actions. -->
                 <div class="col-12 col-md-2">
                     <nav class="d-flex flex-column gap-1" aria-label="Sidebar navigation">
-                        <fmt:message key="demographic.demographicappthistory.msgShowDeleted"/><input type="checkbox" name="showDeleted" id="showDeleted" onChange="toggleShowDeleted(this.checked);"/>
+                        <label for="showDeleted">
+                            <input type="checkbox" name="showDeleted" id="showDeleted" onChange="toggleShowDeleted(this.checked);"/>
+                            <fmt:message key="demographic.demographicappthistory.msgShowDeleted"/>
+                        </label>
                     </nav>
                 </div>
 
@@ -336,9 +339,16 @@
                             try { iRSOffSet = Integer.parseInt(request.getParameter("limit1")); }
                             catch (NumberFormatException ignored) { /* keep default */ }
                         }
-                        if (request.getParameter("limit2") != null) {
-                            try { iPageSize = Integer.parseInt(request.getParameter("limit2")); }
-                            catch (NumberFormatException ignored) { /* keep default */ }
+                        // Use already-sanitized strLimit2 (capped at 1000 above)
+                        try {
+                            iPageSize = Integer.parseInt(strLimit2);
+                            // Clamp to 1000 maximum
+                            if (iPageSize > 1000) {
+                                iPageSize = 1000;
+                            }
+                        } catch (NumberFormatException e) {
+                            // Default to 10 on parse failure
+                            iPageSize = 10;
                         }
                         List<Object> appointmentList;
                         AppointmentManager appointmentManager = SpringUtils.getBean(AppointmentManager.class);
@@ -426,7 +436,10 @@
                         <td><%=(reasonCodeName != null && !reasonCodeName.isEmpty()) ? SafeEncode.forHtml(reasonCodeName) : ""%><%=(appointment.getReason() != null && !appointment.getReason().isEmpty()) ? ((reasonCodeName != null && !reasonCodeName.isEmpty()) ? " - " : "") + SafeEncode.forHtml(appointment.getReason()) : ""%>
                         </td>
                         <% if (provider != null) {%>
-                        <td><carlos:encode value='<%= (provider.getLastName() == null ? "N/A" : provider.getLastName()) + "," + (provider.getFirstName() == null ? "N/A" : provider.getFirstName()) %>' context="html"/>&nbsp;
+                        <td>
+                        <fmt:message key="global.na" var="naText"/>
+                        <c:set var="providerName" value='<%= (provider.getLastName() == null ? pageContext.getAttribute("naText") : provider.getLastName()) + "," + (provider.getFirstName() == null ? pageContext.getAttribute("naText") : provider.getFirstName()) %>'/>
+                        <carlos:encode value='${providerName}' context="html"/>&nbsp;
                         </td>
                         <%} else { %>
                         <td><fmt:message key="global.na"/></td>

--- a/src/main/webapp/WEB-INF/jsp/demographic/demographicappthistory.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/demographicappthistory.jsp
@@ -29,6 +29,8 @@
 
 --%>
 
+
+<!DOCTYPE html>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
@@ -43,51 +45,49 @@
         return;
     }
 %>
-<%@page import="io.github.carlos_emr.carlos.util.*" %>
-<%@page import="org.springframework.beans.BeanUtils" %>
-<%@page import="org.springframework.web.context.support.WebApplicationContextUtils" %>
-<%@page import="org.springframework.web.context.WebApplicationContext" %>
-<%@ page import="org.owasp.encoder.Encode" %>
 
-<%@ page import="java.util.*, java.sql.*, java.net.*, io.github.carlos_emr.*, io.github.carlos_emr.carlos.db.*" errorPage="/WEB-INF/jsp/error/errorpage.jsp" %>
-<%@ page import="io.github.carlos_emr.carlos.utility.LoggedInInfo" %>
+<%@ page import="java.net.*" %>
+<%@ page import="java.sql.*" %>
+<%@ page import="java.util.*" %>
 
-<%@page import="org.apache.commons.lang3.StringUtils" %>
-<%@page import="io.github.carlos_emr.carlos.utility.MiscUtils" %>
-<%@page import="io.github.carlos_emr.carlos.utility.SpringUtils" %>
-
-<%@page import="io.github.carlos_emr.carlos.commn.dao.SiteDao" %>
-<%@page import="io.github.carlos_emr.carlos.commn.model.Site" %>
-
-<%@page import="io.github.carlos_emr.carlos.commn.dao.OscarAppointmentDao" %>
-<%@page import="io.github.carlos_emr.carlos.commn.model.Appointment" %>
-<%@page import="io.github.carlos_emr.carlos.commn.model.AppointmentArchive" %>
-<%@page import="io.github.carlos_emr.carlos.commn.dao.AppointmentStatusDao" %>
-<%@page import="io.github.carlos_emr.carlos.commn.model.AppointmentStatus" %>
-<%@page import="io.github.carlos_emr.carlos.managers.LookupListManager" %>
-<%@page import="io.github.carlos_emr.carlos.commn.model.LookupList" %>
-<%@page import="io.github.carlos_emr.carlos.commn.model.LookupListItem" %>
-
-<%@ page import="io.github.carlos_emr.carlos.commn.model.ProviderData" %>
+<%@ page import="io.github.carlos_emr.*" %>
+<%@ page import="io.github.carlos_emr.carlos.commn.IsPropertiesOn" %>
+<%@ page import="io.github.carlos_emr.carlos.commn.dao.AppointmentStatusDao" %>
+<%@ page import="io.github.carlos_emr.carlos.commn.dao.OscarAppointmentDao" %>
 <%@ page import="io.github.carlos_emr.carlos.commn.dao.ProviderDataDao" %>
+<%@ page import="io.github.carlos_emr.carlos.commn.dao.SiteDao" %>
+<%@ page import="io.github.carlos_emr.carlos.commn.model.Appointment" %>
+<%@ page import="io.github.carlos_emr.carlos.commn.model.AppointmentArchive" %>
+<%@ page import="io.github.carlos_emr.carlos.commn.model.AppointmentStatus" %>
+<%@ page import="io.github.carlos_emr.carlos.commn.model.Demographic" %>
+<%@ page import="io.github.carlos_emr.carlos.commn.model.LookupList" %>
+<%@ page import="io.github.carlos_emr.carlos.commn.model.LookupListItem" %>
+<%@ page import="io.github.carlos_emr.carlos.commn.model.ProviderData" %>
+<%@ page import="io.github.carlos_emr.carlos.commn.model.Site" %>
+<%@ page import="io.github.carlos_emr.carlos.db.*"%>
 <%@ page import="io.github.carlos_emr.carlos.managers.AppointmentManager" %>
 <%@ page import="io.github.carlos_emr.carlos.managers.DemographicManager" %>
-<%@ page import="io.github.carlos_emr.carlos.commn.model.Demographic" %>
-<%@ page import="io.github.carlos_emr.carlos.commn.IsPropertiesOn" %>
+<%@ page import="io.github.carlos_emr.carlos.managers.LookupListManager" %>
+<%@ page import="io.github.carlos_emr.carlos.util.*" %>
+<%@ page import="io.github.carlos_emr.carlos.utility.LoggedInInfo" %>
+<%@ page import="io.github.carlos_emr.carlos.utility.MiscUtils" %>
 <%@ page import="io.github.carlos_emr.carlos.utility.SafeEncode" %>
+<%@ page import="io.github.carlos_emr.carlos.utility.SpringUtils" %>
+<%@ page import="org.apache.commons.lang3.StringUtils" %>
+<%@ page import="org.owasp.encoder.Encode" %>
+<%@ page import="org.springframework.beans.BeanUtils" %>
+<%@ page import="org.springframework.web.context.WebApplicationContext" %>
+<%@ page import="org.springframework.web.context.support.WebApplicationContextUtils" %>
 
-
-<%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
-<fmt:setBundle basename="oscarResources"/>
 
 <%@ taglib uri="/WEB-INF/caisi-tag.tld" prefix="caisi" %>
 <%@ taglib uri="/WEB-INF/special_tag.tld" prefix="special" %>
-
-<%@ taglib uri="jakarta.tags.core" prefix="c" %>
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
 <%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@ taglib uri="carlos" prefix="carlos" %>
-
+<%@ taglib uri="jakarta.tags.core" prefix="c" %>
+<%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<fmt:setBundle basename="oscarResources"/>
 
 <%!
     private List<Site> sites = new java.util.ArrayList<Site>();
@@ -120,7 +120,7 @@
     String curProvider_no = (String) session.getAttribute("user");
     String demographic_no = request.getParameter("demographic_no");
     String strLimit1 = "0";
-    String strLimit2 = "50";
+    String strLimit2 = "500";
     if (request.getParameter("limit1") != null)
         strLimit1 = request.getParameter("limit1");
     if (request.getParameter("limit2") != null)
@@ -139,51 +139,60 @@
     Map<String, ProviderData> providerMap = new HashMap<String, ProviderData>();
 %>
 
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><fmt:message key="demographic.demographicappthistory.title"/></title>
 
-<html>
+    <%@ include file="/WEB-INF/jsp/includes/global-head.jspf" %>
+    <!--
+        The global-head.jspf fragment provides:
+        - Viewport meta tag for responsive design
+        - global.js (legacy focus/refresh helpers)
+        - jQuery 3.7.1
+        - Bootstrap 5.3.3 (JS bundle + CSS)
+        - jQuery UI 1.14.2 CSS (JS must be included page-specifically where dialogs/widgets are needed)
+        - Font Awesome 6.7.2 (icon library)
+        - searchBox.css (shared search/form styles)
+        - global.css (CARLOS design tokens and common classes)
+    -->
+    <c:set var="ctx" value="${pageContext.request.contextPath}" scope="request"/>
+    <script>
+        var ctx = '<%=request.getContextPath()%>';
+    </script>
+    <oscar:customInterface section="appthistory"/>
 
-    <head>
-        <script type="text/javascript" src="<%= request.getContextPath() %>/js/global.js"></script>
-        <script type="text/javascript" src="<%=request.getContextPath()%>/library/jquery/jquery-3.7.1.min.js"></script>
-        <script src="<%=request.getContextPath()%>/library/jquery/jquery-compat.js"></script>
-        <script>
-            jQuery.noConflict();
-        </script>
-        <c:set var="ctx" value="${pageContext.request.contextPath}" scope="request"/>
-        <script>
-            var ctx = '<%=request.getContextPath()%>';
-        </script>
+    <link rel="stylesheet" type="text/css" href="${pageContext.request.contextPath}/library/DataTables/DataTables-1.13.4/css/dataTables.bootstrap5.min.css">
+    <script type="text/javascript" src="${pageContext.request.contextPath}/library/DataTables/DataTables-1.13.4/js/jquery.dataTables.min.js"></script>
+    <script type="text/javascript" src="${pageContext.request.contextPath}/library/DataTables/DataTables-1.13.4/js/dataTables.bootstrap5.min.js"></script>
 
-        <oscar:customInterface section="appthistory"/>
-
-        <title><fmt:message key="demographic.demographicappthistory.title"/></title>
-        <link rel="stylesheet" type="text/css" href="<%= request.getContextPath() %>/share/css/OscarStandardLayout.css">
-        <script type="text/javascript">
-
-            function popupPageNew(vheight, vwidth, varpage) {
-                var page = "" + varpage;
-                windowprops = "height=" + vheight + ",width=" + vwidth + ",location=no,scrollbars=yes,menubars=no,toolbars=no,resizable=yes";
-                var popup = window.open(page, "demographicprofile", windowprops);
-                if (popup != null) {
-                    if (popup.opener == null) {
-                        popup.opener = self;
-                    }
+    <script type="text/javascript">
+    function popupPageNew(vheight, vwidth, varpage) {
+            var page = "" + varpage;
+            windowprops = "height=" + vheight + ",width=" + vwidth + ",location=no,scrollbars=yes,menubars=no,toolbars=no,resizable=yes";
+            var popup = window.open(page, "demographicprofile", windowprops);
+            if (popup != null) {
+                if (popup.opener == null) {
+                    popup.opener = self;
                 }
             }
+    }
 
-            function selectAllCheckboxes() {
-                jQuery("input[name='sel']").each(function () {
-                    jQuery(this).attr('checked', true);
-                });
-            }
+    function selectAllCheckboxes() {
+            jQuery("input[name='sel']").each(function() {
+                jQuery(this).attr('checked', true);
+            });
+    }
 
-            function deselectAllCheckboxes() {
-                jQuery("input[name='sel']").each(function () {
-                    jQuery(this).attr('checked', false);
-                });
-            }
+    function deselectAllCheckboxes() {
+            jQuery("input[name='sel']").each(function() {
+                jQuery(this).attr('checked', false);
+            });
+    }
 
-            function toggleShowDeleted(value) {
+
+    function toggleShowDeleted(value) {
                 if (value) {
                     //show deleted
                     //appt_history_w_deleted
@@ -197,79 +206,122 @@
                     location.hr                    
 ef = '<%=request.getContextPath()%>/demographic/DemographicApptHistory?demographic_no=<carlos:encode value='${__enc_3}' context="javaScript"/>&orderby=<carlos:encode value='${__enc_4}' context="javaScript"/>&dboperation=appt_history&limit1=<carlos:encode value='<%= strLimit1 %>' context="javaScript"/>&limit2=<carlos:encode value='<%= strLimit2 %>' context="javaScript"/>';
                 }
-            }
+    }
 
-            jQuery(document).ready(function () {
-                <%if(showDeleted != null && showDeleted.equals("true")) { %>
-                jQuery("#showDeleted").attr('checked', true);
-                <% } else {%>
-                jQuery("#showDeleted").attr('checked', false);
-                <%} %>
-            });
+    jQuery(document).ready(function () {
+        apptResultsTable = jQuery("#apptHistoryTbl").DataTable({
+            searching: true,
+            paging: true,
+            pageLength: 10,
+            language: {
+                url: '${pageContext.request.contextPath}/library/DataTables/i18n/<fmt:message key="global.i18n.datatablescode"/>.json'
+                }
+        });
+        <%if(showDeleted != null && showDeleted.equals("true")) { %>
+        jQuery("#showDeleted").attr('checked', true);
+         <% } else {%>
+        jQuery("#showDeleted").attr('checked', false);
+        <%} %>
+    });
 
 
-            function filterByProvider(s) {
-                var providerNo = s.options[s.selectedIndex].value;
-                jQuery("#apptHistoryTbl tbody tr").not(":first").each(function () {
-                    if (!providerNo == '' && jQuery(this).attr('provider_no') != providerNo) {
-                        jQuery(this).hide();
-                    } else {
-                        jQuery(this).show();
-                    }
-                });
-            }
-        </script>
+    </script>
 
-        <link rel="stylesheet" type="text/css" media="all" href="<%= request.getContextPath() %>/share/css/extractedFromPages.css"/>
-    </head>
 
-    <body class="BodyStyle" demographic.demographicappthistory.msgTitle=vlink="#0000FF">
+</head>
+<body>
 
-    <table class="MainTable" id="scrollNumber1" name="encounterTable">
-        <tr class="MainTableTopRow">
-            <td class="MainTableTopRowLeftColumn"><fmt:message key="demographic.demographicappthistory.msgHistory"/></td>
-            <td class="MainTableTopRowRightColumn">
-                <table class="TopStatusBar">
+<!-- ================================================================
+     CONTAINER — outermost wrapper; constrains max-width and centers
+     content on large screens while staying full-width on mobile.
+     ================================================================ -->
+<div class="container">
+
+    <!-- ============================================================
+         ALERT BANNER — hidden by default; shown via JavaScript when
+         a server-side or client-side error needs to be surfaced.
+         Usage: document.getElementById('jsAlertText').textContent = msg;
+                document.getElementById('jsAlertBanner').style.display = '';
+         ============================================================ -->
+    <div id="jsAlertBanner"
+         class="alert alert-danger alert-dismissible"
+         style="display:none"
+         role="alert">
+        <span id="jsAlertText"></span>
+        <button type="button"
+                class="btn-close"
+                onclick="this.closest('.alert').style.display='none'"
+                aria-label="Close"></button>
+    </div>
+
+    <!-- ============================================================
+         PAGE HEADER BAR — short title + long title (icon optional).
+         Mirrors the OSCAR MainTableTopRow / TopStatusBar pattern.
+         Structure:
+           [icon?] [Short Title]   [Long Title .....................]
+         ============================================================ -->
+    <div class="page-header-bar d-flex align-items-center justify-content-between
+                py-2 mb-3 border-bottom" id="header">
+        <div class="d-flex align-items-center gap-2">
+            <!--
+                Optional Fontawesome Icon — replace "bi-file-earmark-text"
+                with any icon from https://icons.getbootstrap.com/
+                or remove the <i> tag entirely if no icon is needed.
+            -->
+            <i class="fa-solid fa-clock-rotate-left"></i>
+            <span class="fw-semibold"><fmt:message key="demographic.demographicappthistory.msgHistory"/></span>
+        </div>
+        <div class="text-muted small"><fmt:message key="demographic.demographicappthistory.msgResults"/>: <carlos:encode value='<%= demolastname %>' context="html"/>
+                            ,<carlos:encode value='<%= demofirstname %>' context="html"/>(<carlos:encode value='<%= io.github.carlos_emr.carlos.util.StringUtils.noNull(request.getParameter("demographic_no")) %>' context="html"/>)</div>
+    </div>
+
+    <!-- ============================================================
+         MAIN CONTENT WRAPPER — light background card to separate
+         page content from the body background.
+         ============================================================ -->
+    <div class="bg-light border rounded p-2">
+
+        <form action="/something.do" method="post">
+
+            <!-- ==================================================
+                 CONTENT ROW — two-column layout:
+                   col-12 col-md-2 : left sidebar  (OSCAR left col)
+                   col-12 col-md-10: right content (OSCAR right col)
+                 On small screens both columns stack vertically.
+                 ================================================== -->
+            <div class="row g-2">
+
+                <!-- LEFT SIDEBAR COLUMN
+                     Mirrors: MainTableLeftColumn
+                     Contains navigation links / contextual actions. -->
+                <div class="col-12 col-md-2">
+                    <nav class="d-flex flex-column gap-1" aria-label="Sidebar navigation">
+                        <fmt:message key="demographic.demographicappthistory.msgShowDeleted"/><input type="checkbox" name="showDeleted" id="showDeleted" onChange="toggleShowDeleted(this.checked);"/>
+                    </nav>
+                </div>
+
+                <!-- RIGHT CONTENT COLUMN
+                     Mirrors: MainTableRightColumn
+                     Contains the primary form and data entry area. -->
+                <div class="col-12 col-md-10">
+
+                    <table id="apptHistoryTbl" class="table" >
+                    <thead>
                     <tr>
-                        <td><fmt:message key="demographic.demographicappthistory.msgResults"/>: <carlos:encode value='<%= demolastname %>' context="html"/>
-                            ,<carlos:encode value='<%= demofirstname %>' context="html"/>(<carlos:encode value='<%= io.github.carlos_emr.carlos.util.StringUtils.noNull(request.getParameter("demographic_no")) %>' context="html"/>)
-                        </td>
-                        <td>&nbsp;</td>
-                        <td style="text-align: right"><a
-                                href="javascript:popupStart(300,400,'About.jsp')">
-                            <fmt:message key="global.about"/></a> | <a
-                                href="javascript:popupStart(300,400,'License.jsp')">
-                            <fmt:message key="global.license"/></a>
-                        </td>
-                    </tr>
-                </table>
-            </td>
-        </tr>
-        <tr>
-            <td class="MainTableLeftColumn" valign="top"><a
-                    href="<%=request.getContextPath()%>/demographic/DemographicEdit?demographic_no=<carlos:encode value='<%= io.github.carlos_emr.carlos.util.StringUtils.noNull(request.getParameter("demographic_no")) %>' context="uriComponent"/>&apptProvider=<carlos:encode value='<%= io.github.carlos_emr.carlos.util.StringUtils.noNull((String) session.getAttribute("user")) %>' context="uriComponent"/>"
-                    onMouseOver="self.status=document.referrer;return true">
-                <fmt:message key="global.btnBack"/></a>
-                <br/>
-                <input type="checkbox" name="showDeleted" id="showDeleted" onChange="toggleShowDeleted(this.checked);"/><fmt:message key="demographic.demographicappthistory.msgShowDeleted"/>
-                <br/>
-            </td>
-            <td class="MainTableRightColumn">
-                <table width="95%" border="0" bgcolor="#ffffff" id="apptHistoryTbl">
-                    <tr bgcolor="<%=deepColor%>">
-                        <TH width="10%"><b><fmt:message key="demographic.demographicappthistory.msgApptDate"/></b></TH>
-                        <TH width="10%"><b><fmt:message key="demographic.demographicappthistory.msgFrom"/></b></TH>
-                        <TH width="10%"><b><fmt:message key="demographic.demographicappthistory.msgTo"/></b></TH>
-                        <TH width="10%"><b><fmt:message key="demographic.demographicappthistory.msgStatus"/></b></TH>
-                        <TH width="10%"><b><fmt:message key="demographic.demographicappthistory.msgType"/></b></TH>
-                        <TH width="15%"><b><fmt:message key="demographic.demographicappthistory.msgReason"/></b></TH>
-                        <TH width="15%"><b><fmt:message key="demographic.demographicappthistory.msgProvider"/></b></TH>
-                        <TH><b><fmt:message key="demographic.demographicappthistory.msgComments"/></b></TH>
-
+                        <th><fmt:message key="demographic.demographicappthistory.msgApptDate"/></th>
+                        <th><fmt:message key="demographic.demographicappthistory.msgFrom"/></th>
+                        <th><fmt:message key="demographic.demographicappthistory.msgTo"/></th>
+                        <th><fmt:message key="demographic.demographicappthistory.msgStatus"/></th>
+                        <th><fmt:message key="demographic.demographicappthistory.msgType"/></th>
+                        <th><fmt:message key="demographic.demographicappthistory.msgReason"/></th>
+                        <th><fmt:message key="demographic.demographicappthistory.msgProvider"/></th>
+                        <th><fmt:message key="demographic.demographicappthistory.msgComments"/></th>
                         <% if (IsPropertiesOn.isMultisitesEnable()) { %>
-                        <TH width="5%">Location</TH>
+                        <th><fmt:message key="Appointment.formLocation"/></th>
                         <% } %>
                     </tr>
+                    </thead>
+                    <tbody>
                     <%
                         int iRSOffSet = 0;
                         int iPageSize = 10;
@@ -342,32 +394,36 @@ ef = '<%=request.getContextPath()%>/demographic/DemographicApptHistory?demograph
 
                     %>
                     <tr <%=(deleted) ? "style='text-decoration: line-through' " : "" %>
-                            bgcolor="<%=bodd?weakColor:"white"%>" appt_no="<carlos:encode value='<%= appointment.getId().toString() %>' context="htmlAttribute"/>"
-                            demographic_no="<carlos:encode value='<%= io.github.carlos_emr.carlos.util.StringUtils.noNull(demographic_no) %>' context="htmlAttribute"/>" provider_no="<carlos:encode value='<%= provider!=null?provider.getId():"" %>' context="htmlAttribute"/>">
+                            appt_no="<carlos:encode value='<%= appointment.getId().toString() %>' context="htmlAttribute"/>"
+                            demographic_no="<carlos:encode value='<%= io.github.carlos_emr.carlos.util.StringUtils.noNull(demographic_no) %>' context="htmlAttribute"/>" 
+                            provider_no="<carlos:encode value='<%= provider!=null?provider.getId():"" %>' context="htmlAttribute"/>"
                         <c:set var="__enc_5"><carlos:encode value='<%= demographic_no %>' context="uriComponent"/></c:set>
-                        <c:set var="__enc_6"><carlos:encode value='<%= appointment.getId().toString() %>' context="uriComponent"/></c:set>
-                        <td align=                                              
-"center"><a href=#
-                                              onClick="popupPageNew(360,680, '<%= request.getContextPath() %>/appointment/editappointment?demographic_no=<carlos:encode value='${__enc_5}' context="javaScriptAttribute"/>&appointment_no=<carlos:encode value='${__enc_6}' context="javaScriptAttribute"/>&dboperation=search');return false;"><carlos:encode value='<%= appointment.getAppointmentDate() != null ? appointment.getAppointmentDate().toString() : "" %>' context="html"/>
-                        </a></td>
-                        <td align="center"><carlos:encode value='<%= appointment.getStartTime() != null ? appointment.getStartTime().toString() : "" %>' context="html"/>
+                        <c:set var="__enc_6"><carlos:encode value='<%= appointment.getId().toString() %>' context="uriComponent"/></c:set> >
+                        <td>
+                            <a href=# onClick="popupPageNew(535,860, '<%= request.getContextPath() %>/appointment/editappointment?demographic_no=<carlos:encode value='${__enc_5}' context="javaScriptAttribute"/>&appointment_no=<carlos:encode value='${__enc_6}' context="javaScriptAttribute"/>&dboperation=search');return false;"><carlos:encode value='<%= appointment.getAppointmentDate() != null ? appointment.getAppointmentDate().toString() : "" %>' context="html"/>
+                            </a>
                         </td>
-                        <td align="center"><carlos:encode value='<%= appointment.getEndTime() != null ? appointment.getEndTime().toString() : "" %>' context="html"/>
+                        <td class="time">
+                            <carlos:encode value='<%= appointment.getStartTime() != null ? appointment.getStartTime().toString().substring(0,5) : "" %>' context="html"/>&nbsp;
                         </td>
-                        <td align="center">
+                        <td class="time">
+                            <carlos:encode value='<%= appointment.getEndTime() != null ? appointment.getEndTime().toString().substring(0,5) : "" %>' context="html"/>&nbsp;
+                        </td>
+                        <td>
                             <%if (as != null && as.getDescription() != null) {%>
-                            <carlos:encode value='<%= as.getDescription() %>' context="html"/>
+                            <carlos:encode value='<%= as.getDescription() %>' context="html"/>&nbsp;
                             <% } %>
                         </td>
-                        <td><carlos:encode value='<%= appointment.getType() %>' context="html"/>
+                        <td>
+                            <carlos:encode value='<%= appointment.getType() %>' context="html"/>&nbsp;
                         </td>
                         <td><%=(reasonCodeName != null && !reasonCodeName.isEmpty()) ? SafeEncode.forHtml(reasonCodeName) : ""%><%=(appointment.getReason() != null && !appointment.getReason().isEmpty()) ? ((reasonCodeName != null && !reasonCodeName.isEmpty()) ? " - " : "") + SafeEncode.forHtml(appointment.getReason()) : ""%>
                         </td>
                         <% if (provider != null) {%>
-                        <td><carlos:encode value='<%= (provider.getLastName() == null ? "N/A" : provider.getLastName()) + "," + (provider.getFirstName() == null ? "N/A" : provider.getFirstName()) %>' context="html"/>
+                        <td><carlos:encode value='<%= (provider.getLastName() == null ? "N/A" : provider.getLastName()) + "," + (provider.getFirstName() == null ? "N/A" : provider.getFirstName()) %>' context="html"/>&nbsp;
                         </td>
                         <%} else { %>
-                        <td>N/A</td>
+                        <td><fmt:message key="global.na"/></td>
                         <%}%>
 
 
@@ -409,47 +465,38 @@ ef = '<%=request.getContextPath()%>/demographic/DemographicApptHistory?demograph
                             }
                         }
                     %>
-
+                </tbody>
                 </table>
-                <br>
                 <%
                     int nPrevPage = 0, nNextPage = 0;
                     nNextPage = Integer.parseInt(strLimit2) + Integer.parseInt(strLimit1);
                     nPrevPage = Integer.parseInt(strLimit1) - Integer.parseInt(strLimit2);
                     if (nPrevPage >= 0) {
                 %>
-                <a href="DemographicApptHistory?demographic_no=<carlos:encode value='<%= io.github.carlos_emr.carlos.util.StringUtils.noNull(request.getParameter("demographic_no")) %>' context="uriComponent"/>&dboperation=<carlos:encode value='<%= io.github.carlos_emr.carlos.util.StringUtils.noNull(request.getParameter("dboperation")) %>' context="uriComponent"/>&orderby=<carlos:encode value='<%= io.github.carlos_emr.carlos.util.StringUtils.noNull(request.getParameter("orderby")) %>' context="uriComponent"/>&limit1=<%=nPrevPage%>&limit2=<carlos:encode value='<%= strLimit2 %>' context="uriComponent"/>">
-                    <fmt:message key="demographic.demographicappthistory.btnPrevPage"/></a>
+                    <div class="mb-2">
+                        <a class="btn btn-primary" href="DemographicApptHistory?demographic_no=<carlos:encode value='<%= io.github.carlos_emr.carlos.util.StringUtils.noNull(request.getParameter("demographic_no")) %>' context="uriComponent"/>&dboperation=<carlos:encode value='<%= io.github.carlos_emr.carlos.util.StringUtils.noNull(request.getParameter("dboperation")) %>' context="uriComponent"/>&orderby=<carlos:encode value='<%= io.github.carlos_emr.carlos.util.StringUtils.noNull(request.getParameter("orderby")) %>' context="uriComponent"/>&limit1=<%=nPrevPage%>&limit2=<carlos:encode value='<%= strLimit2 %>' context="uriComponent"/>">
+                        <fmt:message key="demographic.demographicappthistory.btnPrevPage"/></a>
+                    </div>
                 <%
                     }
 
                     if (nItems >= Integer.parseInt(strLimit2)) {
                 %>
-                <a href="DemographicApptHistory?demographic_no=<carlos:encode value='<%= io.github.carlos_emr.carlos.util.StringUtils.noNull(request.getParameter("demographic_no")) %>' context="uriComponent"/>&dboperation=<carlos:encode value='<%= io.github.carlos_emr.carlos.util.StringUtils.noNull(request.getParameter("dboperation")) %>' context="uriComponent"/>&orderby=<carlos:encode value='<%= io.github.carlos_emr.carlos.util.StringUtils.noNull(request.getParameter("orderby")) %>' context="uriComponent"/>&limit1=<%=nNextPage%>&limit2=<carlos:encode value='<%= strLimit2 %>' context="uriComponent"/>">
-                    <fmt:message key="demographic.demographicappthistory.btnNextPage"/></a>
+                    <div class="mb-2">
+                        <a class="btn btn-primary" href="DemographicApptHistory?demographic_no=<carlos:encode value='<%= io.github.carlos_emr.carlos.util.StringUtils.noNull(request.getParameter("demographic_no")) %>' context="uriComponent"/>&dboperation=<carlos:encode value='<%= io.github.carlos_emr.carlos.util.StringUtils.noNull(request.getParameter("dboperation")) %>' context="uriComponent"/>&orderby=<carlos:encode value='<%= io.github.carlos_emr.carlos.util.StringUtils.noNull(request.getParameter("orderby")) %>' context="uriComponent"/>&limit1=<%=nNextPage%>&limit2=<carlos:encode value='<%= strLimit2 %>' context="uriComponent"/>">
+                        <fmt:message key="demographic.demographicappthistory.btnNextPage"/></a>
+                    </div>
                 <%
                     }
                 %>
-                <p>
-            </td>
-        </tr>
-        <tr>
-            <td class="MainTableBottomRowLeftColumn"></td>
-            <td class="MainTableBottomRowRightColumn">
-                Filter results on this page by provider:
-                <select onChange="filterByProvider(this)">
-                    <option value="">ALL</option>
-                    <%
-                        for (ProviderData prov : providerMap.values()) {
-                    %>
-                    <option value="<carlos:encode value='<%= prov.getId() %>' context="htmlAttribute"/>"><carlos:encode value='<%= prov.getLastName() + ", " + prov.getFirstName() %>' context="html"/>
-                    </option>
-                    <%
-                        }
-                    %>
-                </select>
-            </td>
-        </tr>
-    </table>
-    </body>
+                </div><!-- end right column -->
+            </div><!-- end .row -->
+
+        </form>
+
+    </div><!-- end .bg-light -->
+
+</div><!-- end .container -->
+
+</body>
 </html>

--- a/src/main/webapp/WEB-INF/jsp/demographic/demographicappthistory.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/demographicappthistory.jsp
@@ -83,7 +83,7 @@
 <%@ taglib uri="/WEB-INF/caisi-tag.tld" prefix="caisi" %>
 <%@ taglib uri="/WEB-INF/special_tag.tld" prefix="special" %>
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
-<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
+<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
 <%@ taglib uri="carlos" prefix="carlos" %>
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
@@ -120,7 +120,7 @@
     String curProvider_no = (String) session.getAttribute("user");
     String demographic_no = request.getParameter("demographic_no");
     String strLimit1 = "0";
-    String strLimit2 = "500";
+    String strLimit2 = "50000";
     if (request.getParameter("limit1") != null)
         strLimit1 = request.getParameter("limit1");
     if (request.getParameter("limit2") != null)
@@ -139,7 +139,7 @@
     Map<String, ProviderData> providerMap = new HashMap<String, ProviderData>();
 %>
 
-<html lang="en">
+<html>
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -281,7 +281,6 @@ ef = '<%=request.getContextPath()%>/demographic/DemographicApptHistory?demograph
          ============================================================ -->
     <div class="bg-light border rounded p-2">
 
-        <form action="/something.do" method="post">
 
             <!-- ==================================================
                  CONTENT ROW — two-column layout:
@@ -492,7 +491,7 @@ ef = '<%=request.getContextPath()%>/demographic/DemographicApptHistory?demograph
                 </div><!-- end right column -->
             </div><!-- end .row -->
 
-        </form>
+ 
 
     </div><!-- end .bg-light -->
 


### PR DESCRIPTION
Updated imports and HTML structure in demographicappthistory.jsp.

<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description

<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues
Fixes #2006 
<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?

<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots
Pre
<img width="1024" height="700" alt="Screenshot 2026-04-28 at 14-50-41 HISTORIQUE DES RENDEZ-VOUS" src="https://github.com/user-attachments/assets/a9b7d4b8-1533-41e2-8a8b-22875e9a73b3" />


<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->
Post
<img width="1024" height="700" alt="Screenshot 2026-04-28 at 14-46-57 HISTORIQUE DES RENDEZ-VOUS" src="https://github.com/user-attachments/assets/99bd9320-2a8b-4b44-904a-ded6a60ab715" />

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Modernize the demographic appointment history JSP page with a Bootstrap-based layout and DataTables-powered, i18n-aware appointment table, while increasing the server query limit to support richer client-side interaction.

New Features:
- Integrate DataTables with Bootstrap styling for searchable, paginated appointment history.
- Adopt a responsive Bootstrap container and two-column structure for the demographic appointment history view.

Bug Fixes:
- Ensure the provider "N/A" label is internationalized using the existing message bundle.

Enhancements:
- Refine JSP imports and taglibs to use shared utilities, encoder, and global head fragment for consistent dependencies.
- Standardize appointment time display to HH:mm format and use localized fallback text when provider information is missing.
- Replace legacy table header and navigation styling with modern Bootstrap buttons and header bar components.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Modernized the demographic appointment history page with a `Bootstrap` layout and an i18n `DataTables` table. Raised the history query limit to 1,000 and cap any input at 1,000 so paging and search run client-side. Fixes #2006.

- New Features
  - Use shared `global-head.jspf` for jQuery, `Bootstrap`, and common styles.
  - Replace legacy markup with a responsive two‑column layout and a `DataTables` table with Bootstrap styling and language support.
  - Show times as HH:mm, localize missing provider as `global.na`, and enlarge the edit-appointment popup.

- Bug Fixes
  - Fix show-deleted toggle to navigate correctly.

<sup>Written for commit 27e6ca175d8bb854bf162f32a0cc74864e1db965. Summary will update on new commits. <a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2007?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

