### PR TITLE
Fix JSP include path in bootstrap layout example

### DIFF
--- a/docs/CARLOS_bootstrap_layout_Example.html
+++ b/docs/CARLOS_bootstrap_layout_Example.html
@@ -41,7 +41,7 @@
         When converting this template to a JSP page, replace the Bootstrap CDN links above
         with a single JSP include fragment:
 
-            <%@ include file="/includes/global-head.jspf" %>
+            <%@ include file="/WEB-INF/jsp/includes/global-head.jspf" %>
 
         The global-head.jspf fragment provides:
         - Viewport meta tag for responsive design


### PR DESCRIPTION
include file="/WEB-INF/jsp/includes/global-head.jspf
is the correct path

## Summary by Sourcery

Documentation:
- Update the documented JSP include snippet to reference /WEB-INF/jsp/includes/global-head.jspf instead of the outdated /includes path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the JSP include path in the Bootstrap layout example so developers copy the correct directive. The path now points to `/WEB-INF/jsp/includes/global-head.jspf`.

<sup>Written for commit 340f35621a18bc0113b978d4b0907639dbda2fe1. Summary will update on new commits. <a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2036?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

