### PR TITLE
Update security error redirect type in HistoryIndex.jsp

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/HistoryIndex.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/HistoryIndex.jsp
@@ -37,7 +37,7 @@
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <security:oscarSec roleName="<%=roleName$%>" objectName="_measurements" rights="r" reverse="<%=true%>">
     <%authed = false; %>
-    <%response.sendRedirect(request.getContextPath() + "/securityError?type=_eChart");%>
+    <%response.sendRedirect(request.getContextPath() + "/securityError?type=_measurements");%>
 </security:oscarSec>
 
 <%

--- a/src/main/webapp/WEB-INF/jsp/lab/CumulativeLabValues3.jsp
+++ b/src/main/webapp/WEB-INF/jsp/lab/CumulativeLabValues3.jsp
@@ -52,7 +52,7 @@
 <%@ taglib uri="jakarta.tags.core"      prefix="c"   %>
 <%@ taglib uri="jakarta.tags.fmt"       prefix="fmt" %>
 <%@ taglib uri="jakarta.tags.functions" prefix="fn"  %>
-<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
+<%@ taglib uri="carlos" prefix="carlos" %>
 <%@ taglib uri="/WEB-INF/oscar-tag.tld"  prefix="oscar"    %>
 <%@ taglib uri="/WEB-INF/security.tld"   prefix="security" %>
 
@@ -245,7 +245,7 @@
 
 <div class="d-flex align-items-center justify-content-between mb-2 pb-2 border-bottom">
     <span class="fw-semibold small">
-        <oscar:nameage demographicNo="${e:forHtmlAttribute(demographicNo)}"/>
+        <oscar:nameage demographicNo="${carlos:forHtmlAttribute(demographicNo)}"/>
     </span>
     <span class="small text-muted">
         <a href="javascript:popupStart(300,400,'About.jsp')"><fmt:message key="global.about"/></a>
@@ -264,10 +264,10 @@
                 <c:forEach items="${dateList}" var="dateEntry">
                     <th>
                         <a href="#"
-                           data-seg-id="${e:forHtmlAttribute(dateEntry['id'])}"
-                           data-provider-no="${e:forHtmlAttribute(providerNo)}"
-                           onclick="reportWindow('${e:forJavaScriptAttribute(ctx)}/lab/CA/ALL/ViewLabDisplay?segmentID=' + this.dataset.segId + '&amp;providerNo=' + this.dataset.providerNo); return false;">
-                            ${e:forHtml(dateEntry['formattedDate'])}
+                           data-seg-id="${carlos:forHtmlAttribute(dateEntry['id'])}"
+                           data-provider-no="${carlos:forHtmlAttribute(providerNo)}"
+                           onclick="reportWindow('${carlos:forJavaScriptAttribute(ctx)}/lab/CA/ALL/ViewLabDisplay?segmentID=' + this.dataset.segId + '&amp;providerNo=' + this.dataset.providerNo); return false;">
+                            ${carlos:forHtml(dateEntry['formattedDate'])}
                         </a>
                     </th>
                 </c:forEach>
@@ -285,18 +285,18 @@
                             </c:when>
                             <c:otherwise>
                                 <tr class="lab-section-header">
-                                    <td colspan="${3 + fn:length(dateList)}">${e:forHtml(row['testName'])}</td>
+                                    <td colspan="${3 + fn:length(dateList)}">${carlos:forHtml(row['testName'])}</td>
                                 </tr>
                             </c:otherwise>
                         </c:choose>
                     </c:when>
                     <c:otherwise>
                         <tr>
-                            <td>${e:forHtml(row['testName'])}</td>
-                            <td class="abn-${e:forHtmlAttribute(row['latestAbn'])}">${e:forHtml(row['latestVal'])}</td>
-                            <td>${e:forHtml(row['latestDate'])}</td>
+                            <td>${carlos:forHtml(row['testName'])}</td>
+                            <td class="abn-${carlos:forHtmlAttribute(row['latestAbn'])}">${carlos:forHtml(row['latestVal'])}</td>
+                            <td>${carlos:forHtml(row['latestDate'])}</td>
                             <c:forEach items="${row['cells']}" var="cell">
-                                <td class="abn-${e:forHtmlAttribute(cell['abn'])}">${e:forHtml(cell['val'])}</td>
+                                <td class="abn-${carlos:forHtmlAttribute(cell['abn'])}">${carlos:forHtml(cell['val'])}</td>
                             </c:forEach>
                         </tr>
                     </c:otherwise>


### PR DESCRIPTION
_measurements is what we are looking for

<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description
the error shows _eChart but the actual permission is _measurements
.... not helpful
<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues

<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?

<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the security error redirect in `HistoryIndex.jsp` to use `_measurements` instead of `_eChart`, so denied users see the correct permission context. Also migrates `CumulativeLabValues3.jsp` from legacy `e:` encoder calls to `carlos:` helpers for consistent and safe output encoding.

<sup>Written for commit 8babdd9896ab66ffd5042ce8cf4c09e568757750. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

