### PR TITLE
Fix security check for _measurement in JSP

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/HistoryIndex.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/HistoryIndex.jsp
@@ -29,23 +29,6 @@
 
 --%>
 
-<%
-    String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
-    boolean authed = true;
-%>
-
-<%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
-<security:oscarSec roleName="<%=roleName$%>" objectName="_measurement" rights="r" reverse="<%=true%>">
-    <%authed = false; %>
-    <%response.sendRedirect(request.getContextPath() + "/securityError?type=_measurement"); return;%>
-</security:oscarSec>
-
-<%
-    if (!authed) {
-        return;
-    }
-%>
-
 <%@page import="io.github.carlos_emr.carlos.utility.WebUtils"%>
 
 <%

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/HistoryIndex.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/HistoryIndex.jsp
@@ -35,9 +35,9 @@
 %>
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
-<security:oscarSec roleName="<%=roleName$%>" objectName="_measurements" rights="r" reverse="<%=true%>">
+<security:oscarSec roleName="<%=roleName$%>" objectName="_measurement" rights="r" reverse="<%=true%>">
     <%authed = false; %>
-    <%response.sendRedirect(request.getContextPath() + "/securityError?type=_measurements");%>
+    <%response.sendRedirect(request.getContextPath() + "/securityError?type=_measurement"); return;%>
 </security:oscarSec>
 
 <%


### PR DESCRIPTION
<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description
typo _measurements != _measurement
and the latter is the correct security object to use
AND is already being used in EctSetupHistoryIndex2Action.java to guard this page
<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues
#2073 
<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?
develop
<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots
<img width="1000" height="600" alt="Old Measurements" src="https://github.com/user-attachments/assets/639e13b3-a9c0-418c-a855-4052d7597bad" />

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed redundant security checks from HistoryIndex.jsp and rely on server-side checks in EctSetupHistoryIndex2Action. Prevents false security errors for measurements and addresses #2073.

- **Bug Fixes**
  - Deleted the `security:oscarSec` block and redirect logic; authorization is handled in `EctSetupHistoryIndex2Action.java`.
  - Removes the incorrect `_measurements` object usage and avoids duplicate checks.

<sup>Written for commit a2a972b799ba285973030cd9149cef38b0117753. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



