### PR TITLE
chore: fixes from jsp WEB-INF migration and test clreanup

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/ViewBillingOBECEA2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/ViewBillingOBECEA2Action.java
@@ -1,0 +1,15 @@
+package io.github.carlos_emr.carlos.billings.ca.on.web;
+
+import io.github.carlos_emr.carlos.providers.gate.BaseProviderViewGate2Action;
+
+public class ViewBillingOBECEA2Action extends BaseProviderViewGate2Action {
+    @Override
+    protected String getSecurityObject() {
+        return "_admin.billing";
+    }
+
+    @Override
+    protected String getAccessRight() {
+        return "w";
+    }
+}

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/ViewBillingOBECEA2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/ViewBillingOBECEA2Action.java
@@ -1,12 +1,24 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
 package io.github.carlos_emr.carlos.billings.ca.on.web;
 
 import io.github.carlos_emr.carlos.providers.gate.BaseProviderViewGate2Action;
 
 /**
- * Action for viewing the Billing OBECEA report for Ontario.
- * This action validates the required administrative billing privileges before displaying the report.
+ * View gate for {@code billing/CA/ON/billingOBECEA.jsp}. Enforces
+ * {@code _admin.billing} {@code w} privilege before forwarding to the JSP.
  *
- * @since 2026-03-25
+ * @since 2026-05-05
  */
 public class ViewBillingOBECEA2Action extends BaseProviderViewGate2Action {
     @Override

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/ViewBillingOBECEA2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/ViewBillingOBECEA2Action.java
@@ -2,6 +2,12 @@ package io.github.carlos_emr.carlos.billings.ca.on.web;
 
 import io.github.carlos_emr.carlos.providers.gate.BaseProviderViewGate2Action;
 
+/**
+ * Action for viewing the Billing OBECEA report for Ontario.
+ * This action validates the required administrative billing privileges before displaying the report.
+ *
+ * @since 2026-03-25
+ */
 public class ViewBillingOBECEA2Action extends BaseProviderViewGate2Action {
     @Override
     protected String getSecurityObject() {

--- a/src/main/java/io/github/carlos_emr/carlos/decision/gate/ViewDecision2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/decision/gate/ViewDecision2Action.java
@@ -41,10 +41,10 @@ import io.github.carlos_emr.carlos.utility.SpringUtils;
  * review and antenatal planners, checklists, risk editors).
  *
  * Every JSP in {@code /WEB-INF/jsp/decision/} is routed through this action.
- * All execution paths require {@code _forms r}. When the request carries a
+ * All execution paths require {@code _form r}. When the request carries a
  * {@code submit} parameter whose trimmed value (case-insensitive, {@link
  * Locale#ROOT}) starts with "save", the action additionally requires the
- * request be POST and {@code _forms w} -- this closes the GET-triggered
+ * request be POST and {@code _form w} -- this closes the GET-triggered
  * mutation vector the original JSPs presented, where scriptlet code would
  * persist {@code DesAnnualReviewPlan}/{@code Desaprisk} rows or overwrite
  * XML config files based solely on query-string parameters.
@@ -75,8 +75,8 @@ public final class ViewDecision2Action extends ActionSupport {
 
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
         if (loggedInInfo == null
-                || !securityInfoManager.hasPrivilege(loggedInInfo, "_forms", "r", null)) {
-            throw new SecurityException("missing required sec object (_forms r)");
+                || !securityInfoManager.hasPrivilege(loggedInInfo, "_form", "r", null)) {
+            throw new SecurityException("missing required sec object (_form r)");
         }
 
         String submit = request.getParameter("submit");
@@ -92,8 +92,8 @@ public final class ViewDecision2Action extends ActionSupport {
                 }
                 return NONE;
             }
-            if (!securityInfoManager.hasPrivilege(loggedInInfo, "_forms", "w", null)) {
-                throw new SecurityException("missing required sec object (_forms w)");
+            if (!securityInfoManager.hasPrivilege(loggedInInfo, "_form", "w", null)) {
+                throw new SecurityException("missing required sec object (_form w)");
             }
         }
 

--- a/src/main/java/io/github/carlos_emr/carlos/providers/gate/ViewProviderColourErr2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/providers/gate/ViewProviderColourErr2Action.java
@@ -1,10 +1,22 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
 package io.github.carlos_emr.carlos.providers.gate;
 
 /**
- * Action for viewing the provider color configuration error page.
- * This action validates the required appointment privileges before displaying the error view.
+ * View gate for {@code provider/providerColourErr.jsp}. Enforces
+ * {@code _appointment} {@code r} privilege before forwarding to the JSP.
  *
- * @since 2026-03-25
+ * @since 2026-05-05
  */
 public final class ViewProviderColourErr2Action extends BaseProviderViewGate2Action {
     @Override

--- a/src/main/java/io/github/carlos_emr/carlos/providers/gate/ViewProviderColourErr2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/providers/gate/ViewProviderColourErr2Action.java
@@ -1,0 +1,13 @@
+package io.github.carlos_emr.carlos.providers.gate;
+
+public final class ViewProviderColourErr2Action extends BaseProviderViewGate2Action {
+    @Override
+    protected String getSecurityObject() {
+        return "_appointment";
+    }
+
+    @Override
+    protected String getAccessRight() {
+        return "r";
+    }
+}

--- a/src/main/java/io/github/carlos_emr/carlos/providers/gate/ViewProviderColourErr2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/providers/gate/ViewProviderColourErr2Action.java
@@ -1,5 +1,11 @@
 package io.github.carlos_emr.carlos.providers.gate;
 
+/**
+ * Action for viewing the provider color configuration error page.
+ * This action validates the required appointment privileges before displaying the error view.
+ *
+ * @since 2026-03-25
+ */
 public final class ViewProviderColourErr2Action extends BaseProviderViewGate2Action {
     @Override
     protected String getSecurityObject() {

--- a/src/main/java/io/github/carlos_emr/carlos/providers/gate/ViewProviderFaxErr2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/providers/gate/ViewProviderFaxErr2Action.java
@@ -1,0 +1,13 @@
+package io.github.carlos_emr.carlos.providers.gate;
+
+public final class ViewProviderFaxErr2Action extends BaseProviderViewGate2Action {
+    @Override
+    protected String getSecurityObject() {
+        return "_appointment";
+    }
+
+    @Override
+    protected String getAccessRight() {
+        return "r";
+    }
+}

--- a/src/main/java/io/github/carlos_emr/carlos/providers/gate/ViewProviderFaxErr2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/providers/gate/ViewProviderFaxErr2Action.java
@@ -1,5 +1,11 @@
 package io.github.carlos_emr.carlos.providers.gate;
 
+/**
+ * Action for viewing the provider fax configuration error page.
+ * This action validates the required appointment privileges before displaying the error view.
+ *
+ * @since 2026-03-25
+ */
 public final class ViewProviderFaxErr2Action extends BaseProviderViewGate2Action {
     @Override
     protected String getSecurityObject() {

--- a/src/main/java/io/github/carlos_emr/carlos/providers/gate/ViewProviderFaxErr2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/providers/gate/ViewProviderFaxErr2Action.java
@@ -1,10 +1,22 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
 package io.github.carlos_emr.carlos.providers.gate;
 
 /**
- * Action for viewing the provider fax configuration error page.
- * This action validates the required appointment privileges before displaying the error view.
+ * View gate for {@code provider/providerFaxErr.jsp}. Enforces
+ * {@code _appointment} {@code r} privilege before forwarding to the JSP.
  *
- * @since 2026-03-25
+ * @since 2026-05-05
  */
 public final class ViewProviderFaxErr2Action extends BaseProviderViewGate2Action {
     @Override

--- a/src/main/java/io/github/carlos_emr/carlos/providers/gate/ViewProviderFaxErr2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/providers/gate/ViewProviderFaxErr2Action.java
@@ -1,11 +1,19 @@
 /**
- * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ * Copyright (c) 2026 CARLOS EMR
  *
- * This software is published under the GPL GNU General Public License.
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  * CARLOS EMR Project
  * https://github.com/carlos-emr/carlos

--- a/src/main/webapp/WEB-INF/classes/struts-billing.xml
+++ b/src/main/webapp/WEB-INF/classes/struts-billing.xml
@@ -453,6 +453,10 @@
             <result name="error">/WEB-INF/jsp/billing/CA/ON/billingOBECEA.jsp</result>
         </action>
 
+        <action name="billing/CA/ON/ViewBillingOBECEA" class="io.github.carlos_emr.carlos.billings.ca.on.web.ViewBillingOBECEA2Action">
+            <result name="success">/WEB-INF/jsp/billing/CA/ON/billingOBECEA.jsp</result>
+        </action>
+
         <action name="billing/CA/ON/billingLreport" class="io.github.carlos_emr.carlos.billings.ca.on.web.BillingLegacyReport2Action">
             <result name="success">/WEB-INF/jsp/billing/CA/ON/billingLreport.jsp</result>
         </action>

--- a/src/main/webapp/WEB-INF/classes/struts-provider.xml
+++ b/src/main/webapp/WEB-INF/classes/struts-provider.xml
@@ -216,5 +216,11 @@
         <action name="provider/ViewAppointmentAdminMonth" class="io.github.carlos_emr.carlos.providers.gate.ViewAppointmentAdminMonth2Action">
             <result name="success">/WEB-INF/jsp/provider/appointmentprovideradminmonth.jsp</result>
         </action>
+        <action name="provider/ViewProviderColourErr" class="io.github.carlos_emr.carlos.providers.gate.ViewProviderColourErr2Action">
+            <result name="success">/WEB-INF/jsp/provider/providerColourErr.jsp</result>
+        </action>
+        <action name="provider/ViewProviderFaxErr" class="io.github.carlos_emr.carlos.providers.gate.ViewProviderFaxErr2Action">
+            <result name="success">/WEB-INF/jsp/provider/providerFaxErr.jsp</result>
+        </action>
     </package>
 </struts>

--- a/src/main/webapp/WEB-INF/jsp/admin/admin.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/admin.jsp
@@ -360,7 +360,7 @@
                     <% } %>
                     <li><a href="#"
                            onclick='popupPage(600,900, "${pageContext.request.contextPath}<%= oscarVariables.getProperty("RA_FORWORD", "/billing/CA/ON/ViewGenRA") %>");return false;'><fmt:message key="admin.admin.btnBillingReconciliation"/></a></li>
-                    <!-- li><a href="#" onclick ='popupPage(600,1000,"${pageContext.request.contextPath}/billing/CA/ON/billingOBECEA.jsp");return false;'><fmt:message key="admin.admin.btnEDTBillingReportGenerator"/></a></li-->
+                    <!-- li><a href="#" onclick ='popupPage(600,1000,"${pageContext.request.contextPath}/billing/CA/ON/ViewBillingOBECEA");return false;'><fmt:message key="admin.admin.btnEDTBillingReportGenerator"/></a></li-->
                     <li>
                         <a href="#" onclick='popupPage(800,1000,"${pageContext.request.contextPath}/mcedt/mcedt");return false;'><fmt:message key="admin.admin.mcedt"/></a>
                     </li>
@@ -485,9 +485,7 @@
 
                     <li><a href="#"
                            onclick='popupPage(600,900,"${pageContext.request.contextPath}/oscarReport/ViewPatientlist")'><fmt:message key="admin.admin.exportPatientbyAppt"/></a></li>
-                    <caisi:isModuleLoad moduleName="caisi">
-                        <li><a href="${pageContext.request.contextPath}/PMmodule/reports/activity_report_form.jsp"><fmt:message key="admin.admin.activityRpt"/></a></li>
-                    </caisi:isModuleLoad>
+
                     <li><a href="${pageContext.request.contextPath}/oscarReport/ViewProviderServiceReportForm"><fmt:message key="admin.admin.providerServiceRpt"/></a></li>
                     <caisi:isModuleLoad moduleName="caisi">
                         <li><a href="${pageContext.request.contextPath}/PopulationReport"><fmt:message key="admin.admin.popRpt"/></a></li>

--- a/src/main/webapp/WEB-INF/jsp/admin/keygen/createKey.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/keygen/createKey.jsp
@@ -193,8 +193,8 @@
                         </td>
                         <td>&nbsp;</td>
                         <td style="text-align: right"><a
-                                href="javascript:popupStart(300,400,'About.jsp')"><fmt:message key="global.about"/></a> | <a
-                                href="javascript:popupStart(300,400,'License.jsp')"><fmt:message key="global.license"/></a></td>
+                                href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewAbout')"><fmt:message key="global.about"/></a> | <a
+                                href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewLicense')"><fmt:message key="global.license"/></a></td>
                     </tr>
                 </table>
             </td>

--- a/src/main/webapp/WEB-INF/jsp/admin/updatedemographicprovider.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/updatedemographicprovider.jsp
@@ -283,7 +283,7 @@
         <div class="card card-body bg-body-tertiary">
             <table class="table table-striped  table-sm">
                 <FORM NAME="ADDMRP" METHOD="post"
-                      ACTION="updatedemographicprovider.jsp">
+                      ACTION="<%= request.getContextPath() %>/admin/UpdateDemographicProvider">
                     <tr>
                         <td>
                             <b><fmt:message key="admin.updatedemographicprovider.msgMrp"/></b>
@@ -346,7 +346,7 @@
         <div class="card card-body bg-body-tertiary">
             <table class="table table-striped  table-sm">
                 <FORM NAME="ADDAPPT1" METHOD="post"
-                      ACTION="updatedemographicprovider.jsp">
+                      ACTION="<%= request.getContextPath() %>/admin/UpdateDemographicProvider">
                     <tr>
                         <td>
                             <b><fmt:message key="admin.updatedemographicprovider.msgNurse"/></b>
@@ -410,7 +410,7 @@
         <div class="card card-body bg-body-tertiary">
             <table class="table table-striped  table-sm">
                 <FORM NAME="ADDAPPT2" METHOD="post"
-                      ACTION="updatedemographicprovider.jsp">
+                      ACTION="<%= request.getContextPath() %>/admin/UpdateDemographicProvider">
                     <tr>
                         <td><b><fmt:message key="admin.updatedemographicprovider.msgMidwife"/></b></td>
                     </tr>
@@ -476,7 +476,7 @@
         <div class="card card-body bg-body-tertiary">
             <table class="table table-striped  table-sm">
                 <FORM NAME="ADDAPPT" METHOD="post"
-                      ACTION="updatedemographicprovider.jsp">
+                      ACTION="<%= request.getContextPath() %>/admin/UpdateDemographicProvider">
                     <tr>
                         <td><b><fmt:message key="admin.updatedemographicprovider.msgResident"/></b></td>
                     </tr>

--- a/src/main/webapp/WEB-INF/jsp/admin/uploadEntryText.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/uploadEntryText.jsp
@@ -106,8 +106,8 @@
                     <td><fmt:message key="admin.admin.uploadEntryTxt"/></td>
                     <td>&nbsp;</td>
                     <td style="text-align: right"><a
-                            href="javascript:popupStart(300,400,'About.jsp')"><fmt:message key="global.about"/></a> | <a
-                            href="javascript:popupStart(300,400,'License.jsp')"><fmt:message key="global.license"/></a></td>
+                            href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewAbout')"><fmt:message key="global.about"/></a> | <a
+                            href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewLicense')"><fmt:message key="global.license"/></a></td>
                 </tr>
             </table>
         </td>

--- a/src/main/webapp/WEB-INF/jsp/administration/leftNav.jspf
+++ b/src/main/webapp/WEB-INF/jsp/administration/leftNav.jspf
@@ -377,9 +377,6 @@ String curProvider_no = (String)session.getAttribute("user");
 						<li><a page="${pageContext.request.contextPath}/PopulationReport" class="contentLink"> <fmt:message key="admin.admin.popRpt"/></a></li>
 						<li><a href="${ctx}/oscarReport/ViewCds4ReportForm"	class="contentLink"><fmt:message key="admin.admin.cdsRpt"/></a></li>
 						<li><a href="${ctx}/oscarReport/ViewMisReportForm" class="contentLink"><fmt:message key="admin.admin.misRpt"/></a></li>
-						<li><a href="${ctx}/oscarReport/ocan_report_form.jsp" class="contentLink"><fmt:message key="admin.admin.ocanRpt"/></a></li>
-						<li><a href="${ctx}/oscarReport/ocan_iar.jsp" class="contentLink"><fmt:message key="admin.admin.ocanIarRpt"/></a></li>
-						<li><a href="javascript:void(0);" class="xlink" rel="${ctx}/oscarReport/ocan_reporting.jsp"><fmt:message key="admin.admin.ocanReporting"/></a></li>
 					</caisi:isModuleLoad>
 					
 					<li><a href="${ctx}/admin/ViewUsageReport" class="contentLink"><fmt:message key="admin.admin.usageRpt"/></a></li>

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingAddCode.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingAddCode.jsp
@@ -99,9 +99,9 @@
                         <td>Add Billing Code</td>
                         <td>&nbsp;</td>
                         <td style="text-align: right"><a
-                                href="javascript:popupStart(300,400,'Help.jsp')"><fmt:message key="global.help"/></a> | <a
-                                href="javascript:popupStart(300,400,'About.jsp')"><fmt:message key="global.about"/></a> | <a
-                                href="javascript:popupStart(300,400,'License.jsp')"><fmt:message key="global.license"/></a></td>
+                                href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewHelp')"><fmt:message key="global.help"/></a> | <a
+                                href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewAbout')"><fmt:message key="global.about"/></a> | <a
+                                href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewLicense')"><fmt:message key="global.license"/></a></td>
                     </tr>
                 </table>
             </td>

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingCodeAdjust.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingCodeAdjust.jsp
@@ -90,9 +90,9 @@
                         <td>Adjust Billing Codes</td>
                         <td>&nbsp;</td>
                         <td style="text-align: right"><a
-                                href="javascript:popupStart(300,400,'Help.jsp')"> <fmt:message key="global.help"/> </a> | <a
-                                href="javascript:popupStart(300,400,'About.jsp')"> <fmt:message key="global.about"/> </a> | <a
-                                href="javascript:popupStart(300,400,'License.jsp')"> <fmt:message key="global.license"/> </a></td>
+                                href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewHelp')"> <fmt:message key="global.help"/> </a> | <a
+                                href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewAbout')"> <fmt:message key="global.about"/> </a> | <a
+                                href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewLicense')"> <fmt:message key="global.license"/> </a></td>
                     </tr>
                 </table>
             </td>

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingEditCode.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingEditCode.jsp
@@ -90,10 +90,10 @@
                         </td>
                         <td>&nbsp;</td>
                         <td style="text-align: right">
-                            <a href="javascript:popupStart(300,400,'Help.jsp')"><fmt:message key="global.help"/></a> |
-                            <a href="javascript:popupStart(300,400,'About.jsp')"><fmt:message key="global.about"/></a>
+                            <a href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewHelp')"><fmt:message key="global.help"/></a> |
+                            <a href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewAbout')"><fmt:message key="global.about"/></a>
                             |
-                            <a href="javascript:popupStart(300,400,'License.jsp')"><fmt:message key="global.license"/></a>
+                            <a href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewLicense')"><fmt:message key="global.license"/></a>
                         </td>
                     </tr>
                 </table>

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/manageSVCDXAssoc.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/manageSVCDXAssoc.jsp
@@ -53,9 +53,9 @@
                             <h3><fmt:message key="oscar.billing.CA.BC.billingBC.manageSVCDXAssoc.title"/></h3>
                         </td>
                         <td style="text-align: right" colspan="2"><a
-                                href="javascript:popupStart(300,400,'Help.jsp')"> <fmt:message key="global.help"/> </a> | <a
-                                href="javascript:popupStart(300,400,'About.jsp')"> <fmt:message key="global.about"/> </a> | <a
-                                href="javascript:popupStart(300,400,'License.jsp')"> <fmt:message key="global.license"/> </a></td>
+                                href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewHelp')"> <fmt:message key="global.help"/> </a> | <a
+                                href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewAbout')"> <fmt:message key="global.about"/> </a> | <a
+                                href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewLicense')"> <fmt:message key="global.license"/> </a></td>
                     </tr>
                     <tr bgcolor="CCCCFF">
                         <th><fmt:message key="oscar.billing.CA.BC.billingBC.manageSVCDXAssoc.svc"/></th>

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/teleplan/ManageBillingCodes.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/teleplan/ManageBillingCodes.jsp
@@ -356,9 +356,9 @@
 
                         </td>
                         <td style="text-align:right">
-                            <a href="javascript:popupStart(300,400,'Help.jsp')"><fmt:message key="global.help"/></a> |
-                            <a href="javascript:popupStart(300,400,'About.jsp')"><fmt:message key="global.about"/></a>
-                            | <a href="javascript:popupStart(300,400,'License.jsp')"><fmt:message key="global.license"/></a>
+                            <a href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewHelp')"><fmt:message key="global.help"/></a> |
+                            <a href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewAbout')"><fmt:message key="global.about"/></a>
+                            | <a href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewLicense')"><fmt:message key="global.license"/></a>
                         </td>
                     </tr>
                 </table>

--- a/src/main/webapp/WEB-INF/jsp/calendar/oscarCalendarPopup.jsp
+++ b/src/main/webapp/WEB-INF/jsp/calendar/oscarCalendarPopup.jsp
@@ -94,11 +94,11 @@
     <table BORDER="0" CELLPADDING="0" CELLSPACING="0" WIDTH="100%">
         <tr>
             <td BGCOLOR="#FFD7C4" width="50%" align="center"><a
-                    href="oscarCalendarPopup.jsp?year=<%=year%>&month=<%=month%>&delta=-1&type=<carlos:encode value='<%= type %>' context="uriComponent"/>&openerForm=<carlos:encode value='<%= openerForm %>' context="uriComponent"/>&openerElement=<carlos:encode value='<%= openerElement %>' context="uriComponent"/>">
+                    href="<%= request.getContextPath() %>/calendar/oscarCalendarPopup?year=<%=year%>&month=<%=month%>&delta=-1&type=<carlos:encode value='<%= type %>' context="uriComponent"/>&openerForm=<carlos:encode value='<%= openerForm %>' context="uriComponent"/>&openerElement=<carlos:encode value='<%= openerElement %>' context="uriComponent"/>">
                 &nbsp;&nbsp;<img src="<%= request.getContextPath() %>/images/previous.gif" WIDTH="10" HEIGHT="9"
                                  BORDER="0" ALT="View Last Month" vspace="2"> <fmt:message key="billing.billingCalendarPopup.btnLast"/>&nbsp;&nbsp; </a> <b><span
                     CLASS=title><%=year%>-<%=month%></span></b> <a
-                    href="oscarCalendarPopup.jsp?year=<%=year%>&month=<%=month%>&delta=1&type=<carlos:encode value='<%= type %>' context="uriComponent"/>&openerForm=<carlos:encode value='<%= openerForm %>' context="uriComponent"/>&openerElement=<carlos:encode value='<%= openerElement %>' context="uriComponent"/>">
+                    href="<%= request.getContextPath() %>/calendar/oscarCalendarPopup?year=<%=year%>&month=<%=month%>&delta=1&type=<carlos:encode value='<%= type %>' context="uriComponent"/>&openerForm=<carlos:encode value='<%= openerForm %>' context="uriComponent"/>&openerElement=<carlos:encode value='<%= openerElement %>' context="uriComponent"/>">
                 &nbsp;&nbsp;<fmt:message key="billing.billingCalendarPopup.btnNext"/>
                 <img src="<%= request.getContextPath() %>/images/next.gif" WIDTH="10" HEIGHT="9" BORDER="0"
                      ALT="View Next Month" vspace="2">&nbsp;&nbsp;</a></td>

--- a/src/main/webapp/WEB-INF/jsp/demographic/AddAlternateContact.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/AddAlternateContact.jsp
@@ -115,8 +115,8 @@
                         <td><oscar:nameage demographicNo="<%=creatorDemo%>"/></td>
                         <td>&nbsp;</td>
                         <td style="text-align: right"><a
-                                href="javascript:popupStart(300,400,'About.jsp')"><fmt:message key="global.about"/></a> | <a
-                                href="javascript:popupStart(300,400,'License.jsp')"><fmt:message key="global.license"/></a></td>
+                                href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewAbout')"><fmt:message key="global.about"/></a> | <a
+                                href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewLicense')"><fmt:message key="global.license"/></a></td>
                     </tr>
                 </table>
             </td>

--- a/src/main/webapp/WEB-INF/jsp/demographic/ManageContacts.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/ManageContacts.jsp
@@ -351,8 +351,8 @@
                         <td><c:set var="__enc_1"><carlos:encode value='<%= demographic_no != null ? demographic_no : "" %>' context="htmlAttribute"/></c:set><oscar:nameage demographicNo="${__enc_1}"/></td>
                         <td>&nbsp;</td>
                         <td style="text-align: right"><a
-                                href="javascript:popupStart(300,400,'About.jsp')"><fmt:message key="global.about"/></a> | <a
-                                href="javascript:popupStart(300,400,'License.jsp')"><fmt:message key="global.license"/></a></td>
+                                href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewAbout')"><fmt:message key="global.about"/></a> | <a
+                                href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewLicense')"><fmt:message key="global.license"/></a></td>
                     </tr>
                 </table>
             </td>

--- a/src/main/webapp/WEB-INF/jsp/demographic/displayHealthCareTeam.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/displayHealthCareTeam.jsp
@@ -136,9 +136,9 @@
                         </td>
                         <td style="text-align: right">
 
-                            <a href="javascript:popupStart(300,400,'About.jsp')">
+                            <a href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewAbout')">
                                 <fmt:message key="global.about"/></a> | <a
-                                href="javascript:popupStart(300,400,'License.jsp')">
+                                href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewLicense')">
                             <fmt:message key="global.license"/></a></td>
                     </tr>
                 </table>

--- a/src/main/webapp/WEB-INF/jsp/demographic/manageHealthCareTeam.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/manageHealthCareTeam.jsp
@@ -369,9 +369,9 @@
                         </td>
                         <td style="text-align: right">
 
-                            <a href="javascript:popupStart(300,400,'About.jsp')">
+                            <a href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewAbout')">
                                 <fmt:message key="global.about"/></a> | <a
-                                href="javascript:popupStart(300,400,'License.jsp')">
+                                href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewLicense')">
                             <fmt:message key="global.license"/></a></td>
                     </tr>
                 </table>

--- a/src/main/webapp/WEB-INF/jsp/demographic/procontactSearch.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/procontactSearch.jsp
@@ -183,8 +183,8 @@
                             <td>&nbsp;</td>
                             <td>&nbsp;</td>
                             <td style="text-align: right"><a
-                                    href="javascript:popupStart(300,400,'About.jsp')"><fmt:message key="global.about"/></a> | <a
-                                    href="javascript:popupStart(300,400,'License.jsp')"><fmt:message key="global.license"/></a></td>
+                                    href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewAbout')"><fmt:message key="global.about"/></a> | <a
+                                    href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewLicense')"><fmt:message key="global.license"/></a></td>
                         </tr>
                     </table>
                 </td>
@@ -269,7 +269,7 @@
         <% } %>
 
         <tr>
-            <form method="post" name="nextform" action="searchRefDoc.jsp">
+            <form method="post" name="nextform" action="<%= request.getContextPath() %>/demographic/ViewProContactSearch">
                 <%
                     if (nLastPage >= 0) {
                 %>

--- a/src/main/webapp/WEB-INF/jsp/demographic/professionalSpecialistSearch.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/professionalSpecialistSearch.jsp
@@ -228,7 +228,7 @@
             //-->
         </SCRIPT>
 
-        <form method="post" name="nextform" action="searchRefDoc.jsp">
+        <form method="post" name="nextform" action="<%= request.getContextPath() %>/demographic/ViewProfessionalSpecialistSearch">
             <%
                 if (nLastPage >= 0) {
             %> <input type="submit" class="mbttn" name="submit"

--- a/src/main/webapp/WEB-INF/jsp/eform/efmpatientformlistsingle.jsp
+++ b/src/main/webapp/WEB-INF/jsp/eform/efmpatientformlistsingle.jsp
@@ -145,8 +145,8 @@
                         <td><fmt:message key="eform.showmyform.msgFormLybrary"/></td>
                         <td>&nbsp;</td>
                         <td style="text-align: right"><a
-                                href="javascript:popupStart(300,400,'About.jsp')"><fmt:message key="global.about"/></a> | <a
-                                href="javascript:popupStart(300,400,'License.jsp')"><fmt:message key="global.license"/></a></td>
+                                href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewAbout')"><fmt:message key="global.about"/></a> | <a
+                                href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewLicense')"><fmt:message key="global.license"/></a></td>
                     </tr>
                 </table>
             </td>

--- a/src/main/webapp/WEB-INF/jsp/encounter/calculators/CoronaryArteryDiseaseRiskPrediction.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/calculators/CoronaryArteryDiseaseRiskPrediction.jsp
@@ -29,7 +29,7 @@
 
 --%>
 
-<html lang="en">
+<html lang="${pageContext.request.locale.language}">
 
 
 <head>

--- a/src/main/webapp/WEB-INF/jsp/encounter/calculators/CoronaryArteryDiseaseRiskPrediction.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/calculators/CoronaryArteryDiseaseRiskPrediction.jsp
@@ -827,8 +827,8 @@
         </td>
         <td style="text-align: right"><a
                 href="javascript:
-                    popupStart(300,400,'About.jsp')">About</a>
-            | <a href="javascript:popupStart(300,400,'License.jsp')">License</a>
+                    popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewAbout')">About</a>
+            | <a href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewLicense')">License</a>
         </td>
     </tr>
     <tr>

--- a/src/main/webapp/WEB-INF/jsp/encounter/calculators/CoronaryArteryDiseaseRiskPrediction.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/calculators/CoronaryArteryDiseaseRiskPrediction.jsp
@@ -29,7 +29,7 @@
 
 --%>
 
-<html lang="${pageContext.request.locale.language}">
+<html lang="<%= io.github.carlos_emr.carlos.utility.SafeEncode.forHtmlAttribute(request.getLocale().getLanguage()) %>">
 
 
 <head>

--- a/src/main/webapp/WEB-INF/jsp/encounter/calculators/GeneralCalculators.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/calculators/GeneralCalculators.jsp
@@ -153,8 +153,8 @@
                         <td><fmt:message key="encounter.calculators.GeneralCalculators.msgTitle"/></td>
                         <td>&nbsp;</td>
                         <td style="text-align: right"><a
-                                href="javascript:popupStart(300,400,'About.jsp')"><fmt:message key="global.about"/></a> | <a
-                                href="javascript:popupStart(300,400,'License.jsp')"><fmt:message key="global.license"/></a></td>
+                                href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewAbout')"><fmt:message key="global.about"/></a> | <a
+                                href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewLicense')"><fmt:message key="global.license"/></a></td>
                     </tr>
                 </table>
             </td>

--- a/src/main/webapp/WEB-INF/jsp/encounter/calculators/OsteoporoticFracture.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/calculators/OsteoporoticFracture.jsp
@@ -379,8 +379,8 @@
                         <td><fmt:message key="encounter.calculators.OsteoporoticFracture.title"/></td>
                         <td>&nbsp;</td>
                         <td style="text-align: right"><a
-                                href="javascript:popupStart(300,400,'About.jsp')"><fmt:message key="global.about"/></a> | <a
-                                href="javascript:popupStart(300,400,'License.jsp')"><fmt:message key="global.license"/></a></td>
+                                href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewAbout')"><fmt:message key="global.about"/></a> | <a
+                                href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewLicense')"><fmt:message key="global.license"/></a></td>
                     </tr>
                 </table>
             </td>

--- a/src/main/webapp/WEB-INF/jsp/encounter/includes/encounter-row-three.jspf
+++ b/src/main/webapp/WEB-INF/jsp/encounter/includes/encounter-row-three.jspf
@@ -60,10 +60,7 @@
         </c:if>
     </div>
     <div class="d-flex gap-1 align-items-center">
-        <oscar:oscarPropertiesCheck property="CPP" value="yes">
-            <input type="button" class="btn btn-sm btn-secondary" value="CPP"
-                   onclick="document.forms['encForm'].btnPressed.value='Save'; popupPage(700, 960, 'cpp', 'encounterCPP.jsp'); document.forms['encForm'].submit();"/>
-        </oscar:oscarPropertiesCheck>
+
 
         <input type="button" class="btn btn-sm btn-secondary"
                value="<fmt:message key="global.btnPrint"/>"

--- a/src/main/webapp/WEB-INF/jsp/encounter/includes/encounter-row-three.jspf
+++ b/src/main/webapp/WEB-INF/jsp/encounter/includes/encounter-row-three.jspf
@@ -1,5 +1,7 @@
 <%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@ taglib uri="carlos" prefix="carlos" %>
+<%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<fmt:setBundle basename="oscarResources"/>
 <%-- Row Three: Encounter notes, template autocomplete, consumption, action buttons --%>
 <div class="encounter-card card mb-1" id="rowThree">
     <div class="card-header d-flex align-items-center">

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/AddMeasurementData.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/AddMeasurementData.jsp
@@ -346,8 +346,8 @@
                         </td>
                         <td style="text-align:right">
                             <a
-                                href="javascript:popupStart(300,400,'About.jsp')"><fmt:message key="global.about"/></a>
-                            | <a href="javascript:popupStart(300,400,'License.jsp')"><fmt:message key="global.license"/></a>
+                                href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewAbout')"><fmt:message key="global.about"/></a>
+                            | <a href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewLicense')"><fmt:message key="global.license"/></a>
                         </td>
                     </tr>
                 </table>

--- a/src/main/webapp/WEB-INF/jsp/fax/CoverPage.jsp
+++ b/src/main/webapp/WEB-INF/jsp/fax/CoverPage.jsp
@@ -205,7 +205,7 @@
                     <td id="oscarFaxHeaderCenterColumn"><carlos:encode value='${ transactionType }' context="forHtml"/></td>
                     <td id="oscarFaxHeaderRightColumn" align=right>
 						<span class="HelpAboutLogout"> 
-							<a style="font-size: 10px; font-style: normal;" href="${ ctx }encounter/About.jsp"
+							<a style="font-size: 10px; font-style: normal;" href="${ ctx }/encounter/ViewAbout"
                                target="_new">About</a>
 							<a style="font-size: 10px; font-style: normal;" target="_blank"
                                href="http://www.oscarmanual.org/search?SearchableText=&Title=Chart+Interface&portal_type%3Alist=Document">Help</a>

--- a/src/main/webapp/WEB-INF/jsp/fax/CoverPage.jsp
+++ b/src/main/webapp/WEB-INF/jsp/fax/CoverPage.jsp
@@ -205,7 +205,7 @@
                     <td id="oscarFaxHeaderCenterColumn"><carlos:encode value='${ transactionType }' context="forHtml"/></td>
                     <td id="oscarFaxHeaderRightColumn" align=right>
 						<span class="HelpAboutLogout"> 
-							<a style="font-size: 10px; font-style: normal;" href="${ ctx }/encounter/ViewAbout"
+							<a style="font-size: 10px; font-style: normal;" href="${pageContext.request.contextPath}/encounter/ViewAbout"
                                target="_new">About</a>
 							<a style="font-size: 10px; font-style: normal;" target="_blank"
                                href="http://www.oscarmanual.org/search?SearchableText=&Title=Chart+Interface&portal_type%3Alist=Document">Help</a>

--- a/src/main/webapp/WEB-INF/jsp/form/formbcarpg2.jsp
+++ b/src/main/webapp/WEB-INF/jsp/form/formbcarpg2.jsp
@@ -446,7 +446,7 @@
 */
 
             if (ret == true) {
-                popupFixedPage(650, 850, 'formbcar2wt.jsp' + param);
+                // popupFixedPage(650, 850, 'formbcar2wt.jsp' + param); // Link removed as formbcar2wt.jsp no longer exists
             }
 
         }

--- a/src/main/webapp/WEB-INF/jsp/form/formbcarpg3.jsp
+++ b/src/main/webapp/WEB-INF/jsp/form/formbcarpg3.jsp
@@ -440,7 +440,7 @@
 */
 
             if (ret == true) {
-                popupFixedPage(650, 850, 'formbcar2wt.jsp' + param);
+                // popupFixedPage(650, 850, 'formbcar2wt.jsp' + param); // Link removed as formbcar2wt.jsp no longer exists
             }
 
         }

--- a/src/main/webapp/WEB-INF/jsp/hospitalReportManager/displayHRMDocList.jsp
+++ b/src/main/webapp/WEB-INF/jsp/hospitalReportManager/displayHRMDocList.jsp
@@ -120,9 +120,9 @@
                         <td><h4><fmt:message key="hrm.displayHRMDocList.displaydocs"/></h4></td>
                         <td>&nbsp;</td>
                         <td style="text-align: right"><a
-                                href="javascript:popupStart(300,400,'Help.jsp')"><fmt:message key="global.help"/></a> | <a
-                                href="javascript:popupStart(300,400,'About.jsp')"><fmt:message key="global.about"/></a> | <a
-                                href="javascript:popupStart(300,400,'License.jsp')"><fmt:message key="global.license"/></a></td>
+                                href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewHelp')"><fmt:message key="global.help"/></a> | <a
+                                href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewAbout')"><fmt:message key="global.about"/></a> | <a
+                                href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewLicense')"><fmt:message key="global.license"/></a></td>
                     </tr>
                 </table>
             </td>

--- a/src/main/webapp/WEB-INF/jsp/lab/CA/BC/LabUpload.jsp
+++ b/src/main/webapp/WEB-INF/jsp/lab/CA/BC/LabUpload.jsp
@@ -91,9 +91,9 @@
                         <td>Upload <!--i18n--></td>
                         <td>&nbsp;</td>
                         <td style="text-align: right"><a
-                                href="javascript:popupStart(300,400,'Help.jsp')"><fmt:message key="global.help"/></a> | <a
-                                href="javascript:popupStart(300,400,'About.jsp')"><fmt:message key="global.about"/></a> | <a
-                                href="javascript:popupStart(300,400,'License.jsp')"><fmt:message key="global.license"/></a></td>
+                                href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewHelp')"><fmt:message key="global.help"/></a> | <a
+                                href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewAbout')"><fmt:message key="global.about"/></a> | <a
+                                href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewLicense')"><fmt:message key="global.license"/></a></td>
                     </tr>
                 </table>
             </td>

--- a/src/main/webapp/WEB-INF/jsp/lab/CumulativeLabValues.jsp
+++ b/src/main/webapp/WEB-INF/jsp/lab/CumulativeLabValues.jsp
@@ -194,8 +194,8 @@
                         <td><oscar:nameage demographicNo="<%=demographic_no%>"/></td>
                         <td>&nbsp;</td>
                         <td style="text-align: right"><a
-                                href="javascript:popupStart(300,400,'About.jsp')"><fmt:message key="global.about"/></a> | <a
-                                href="javascript:popupStart(300,400,'License.jsp')"><fmt:message key="global.license"/></a></td>
+                                href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewAbout')"><fmt:message key="global.about"/></a> | <a
+                                href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewLicense')"><fmt:message key="global.license"/></a></td>
                     </tr>
                 </table>
             </td>

--- a/src/main/webapp/WEB-INF/jsp/lab/CumulativeLabValues3.jsp
+++ b/src/main/webapp/WEB-INF/jsp/lab/CumulativeLabValues3.jsp
@@ -248,9 +248,9 @@
         <oscar:nameage demographicNo="${carlos:forHtmlAttribute(demographicNo)}"/>
     </span>
     <span class="small text-muted">
-        <a href="javascript:popupStart(300,400,'About.jsp')"><fmt:message key="global.about"/></a>
+        <a href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewAbout')"><fmt:message key="global.about"/></a>
         &nbsp;|&nbsp;
-        <a href="javascript:popupStart(300,400,'License.jsp')"><fmt:message key="global.license"/></a>
+        <a href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewLicense')"><fmt:message key="global.license"/></a>
     </span>
 </div>
 

--- a/src/main/webapp/WEB-INF/jsp/messenger/Transfer/SelectItems.jsp
+++ b/src/main/webapp/WEB-INF/jsp/messenger/Transfer/SelectItems.jsp
@@ -361,8 +361,8 @@
                     <td>Document Transfer</td>
                     <td></td>
                     <td style="text-align: right"><a
-                            href="javascript:popupStart(300,400,'About.jsp')">About</a> | <a
-                            href="javascript:popupStart(300,400,'License.jsp')">License</a></td>
+                            href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewAbout')">About</a> | <a
+                            href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewLicense')">License</a></td>
                 </tr>
             </table>
         </td>

--- a/src/main/webapp/WEB-INF/jsp/messenger/ViewAttachment.jsp
+++ b/src/main/webapp/WEB-INF/jsp/messenger/ViewAttachment.jsp
@@ -379,10 +379,10 @@
             <span class="text-muted small">
                 <fmt:message key="messenger.generatePreviewPDF.attachDocFor"/>
             </span>
-            <a href="javascript:popupStart(300,400,'About.jsp')" class="small text-decoration-none">
+            <a href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewAbout')" class="small text-decoration-none">
                 <fmt:message key="global.about"/>
             </a>
-            <a href="javascript:popupStart(300,400,'License.jsp')" class="small text-decoration-none">
+            <a href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewLicense')" class="small text-decoration-none">
                 <fmt:message key="global.license"/>
             </a>
         </div>

--- a/src/main/webapp/WEB-INF/jsp/messenger/ViewPDFAttachment.jsp
+++ b/src/main/webapp/WEB-INF/jsp/messenger/ViewPDFAttachment.jsp
@@ -142,10 +142,10 @@
             <span class="fw-semibold"><fmt:message key="messenger.CreateMessage.msgMessenger"/></span>
         </div>
         <div class="d-flex align-items-center gap-3">
-            <a href="javascript:popupStart(300,400,'About.jsp')" class="small text-decoration-none">
+            <a href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewAbout')" class="small text-decoration-none">
                 <fmt:message key="global.about"/>
             </a>
-            <a href="javascript:popupStart(300,400,'License.jsp')" class="small text-decoration-none">
+            <a href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewLicense')" class="small text-decoration-none">
                 <fmt:message key="global.license"/>
             </a>
         </div>

--- a/src/main/webapp/WEB-INF/jsp/messenger/attachmentFrameset.jsp
+++ b/src/main/webapp/WEB-INF/jsp/messenger/attachmentFrameset.jsp
@@ -54,11 +54,10 @@
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <%@ taglib uri="carlos" prefix="carlos" %>
-<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <!DOCTYPE html>
-<html lang="${e:forHtmlAttribute(pageContext.request.locale.language)}">
+<html lang="${carlos:forHtmlAttribute(pageContext.request.locale.language)}">
 <head>
     <script type="text/javascript" src="<%= request.getContextPath() %>/js/global.js"></script>
         <%

--- a/src/main/webapp/WEB-INF/jsp/messenger/attachmentFrameset.jsp
+++ b/src/main/webapp/WEB-INF/jsp/messenger/attachmentFrameset.jsp
@@ -54,10 +54,11 @@
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <%@ taglib uri="carlos" prefix="carlos" %>
+<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <!DOCTYPE html>
-<html lang="${carlos:forHtmlAttribute(pageContext.request.locale.language)}">
+<html lang="${e:forHtmlAttribute(pageContext.request.locale.language)}">
 <head>
     <script type="text/javascript" src="<%= request.getContextPath() %>/js/global.js"></script>
         <%

--- a/src/main/webapp/WEB-INF/jsp/messenger/generatePreviewPDF.jsp
+++ b/src/main/webapp/WEB-INF/jsp/messenger/generatePreviewPDF.jsp
@@ -83,7 +83,6 @@
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
 <%@ taglib uri="carlos" prefix="carlos" %>
-<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 <fmt:message key="messenger.generatePreviewPDF.information" var="informationLabel"/>
 <fmt:message key="messenger.generatePreviewPDF.encounter" var="encounterLabel"/>
@@ -198,7 +197,7 @@
 %>
 
 <!DOCTYPE html>
-<html lang="${e:forHtmlAttribute(pageContext.request.locale.language)}">
+<html lang="${carlos:forHtmlAttribute(pageContext.request.locale.language)}">
 <head>
     <meta charset="UTF-8">
     <title>CARLOS - <fmt:message key="messenger.generatePreviewPDF.title"/></title>

--- a/src/main/webapp/WEB-INF/jsp/messenger/generatePreviewPDF.jsp
+++ b/src/main/webapp/WEB-INF/jsp/messenger/generatePreviewPDF.jsp
@@ -83,6 +83,7 @@
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
 <%@ taglib uri="carlos" prefix="carlos" %>
+<%@ taglib uri="owasp.encoder.jakarta" prefix="e" %>
 <fmt:setBundle basename="oscarResources"/>
 <fmt:message key="messenger.generatePreviewPDF.information" var="informationLabel"/>
 <fmt:message key="messenger.generatePreviewPDF.encounter" var="encounterLabel"/>
@@ -197,7 +198,7 @@
 %>
 
 <!DOCTYPE html>
-<html lang="${carlos:forHtmlAttribute(pageContext.request.locale.language)}">
+<html lang="${e:forHtmlAttribute(pageContext.request.locale.language)}">
 <head>
     <meta charset="UTF-8">
     <title>CARLOS - <fmt:message key="messenger.generatePreviewPDF.title"/></title>
@@ -350,10 +351,10 @@
                 <fmt:message key="messenger.generatePreviewPDF.attachDocFor"/>
                 ${carlos:forHtml(demoName)}
             </span>
-            <a href="javascript:popupStart(300,400,'About.jsp')" class="small text-decoration-none">
+            <a href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewAbout')" class="small text-decoration-none">
                 <fmt:message key="global.about"/>
             </a>
-            <a href="javascript:popupStart(300,400,'License.jsp')" class="small text-decoration-none">
+            <a href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewLicense')" class="small text-decoration-none">
                 <fmt:message key="global.license"/>
             </a>
         </div>

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/oscarMeasurements/CDMReport.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/oscarMeasurements/CDMReport.jsp
@@ -97,8 +97,8 @@
                         <td><fmt:message key="oscarReport.CDMReport.msgTitle"/>: ${carlos:forHtml(CDMGroup)}</td>
                         <td></td>
                         <td style="text-align: right"><a
-                                href="javascript:popupStart(300,400,'About.jsp')"><fmt:message key="global.about"/></a> | <a
-                                href="javascript:popupStart(300,400,'License.jsp')"><fmt:message key="global.license"/></a></td>
+                                href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewAbout')"><fmt:message key="global.about"/></a> | <a
+                                href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewLicense')"><fmt:message key="global.license"/></a></td>
                     </tr>
                 </table>
             </td>

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/oscarMeasurements/InitializeFrequencyOfRelevantTestsCDMReport.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/oscarMeasurements/InitializeFrequencyOfRelevantTestsCDMReport.jsp
@@ -115,8 +115,8 @@
                             <td><fmt:message key="oscarReport.CDMReport.msgTitle"/>: ${carlos:forHtml(CDMGroup)}</td>
                             <td></td>
                             <td style="text-align: right"><a
-                                    href="javascript:popupStart(300,400,'About.jsp')"><fmt:message key="global.about"/></a> | <a
-                                    href="javascript:popupStart(300,400,'License.jsp')"><fmt:message key="global.license"/></a></td>
+                                    href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewAbout')"><fmt:message key="global.about"/></a> | <a
+                                    href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewLicense')"><fmt:message key="global.license"/></a></td>
                         </tr>
                     </table>
                 </td>

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/oscarMeasurements/InitializePatientsInAbnormalRangeCDMReport.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/oscarMeasurements/InitializePatientsInAbnormalRangeCDMReport.jsp
@@ -111,8 +111,8 @@
                             <td><fmt:message key="oscarReport.CDMReport.msgTitle"/>: ${carlos:forHtml(CDMGroup)}</td>
                             <td></td>
                             <td style="text-align: right"><a
-                                    href="javascript:popupStart(300,400,'About.jsp')"><fmt:message key="global.about"/></a> | <a
-                                    href="javascript:popupStart(300,400,'License.jsp')"><fmt:message key="global.license"/></a></td>
+                                    href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewAbout')"><fmt:message key="global.about"/></a> | <a
+                                    href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewLicense')"><fmt:message key="global.license"/></a></td>
                         </tr>
                     </table>
                 </td>

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/oscarMeasurements/InitializePatientsMetGuidelineCDMReport.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/oscarMeasurements/InitializePatientsMetGuidelineCDMReport.jsp
@@ -114,8 +114,8 @@
                             <td><fmt:message key="oscarReport.CDMReport.msgTitle"/>: ${carlos:forHtml(CDMGroup)}</td>
                             <td></td>
                             <td style="text-align: right"><a
-                                    href="javascript:popupStart(300,400,'About.jsp')"><fmt:message key="global.about"/></a> | <a
-                                    href="javascript:popupStart(300,400,'License.jsp')"><fmt:message key="global.license"/></a></td>
+                                    href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewAbout')"><fmt:message key="global.about"/></a> | <a
+                                    href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewLicense')"><fmt:message key="global.license"/></a></td>
                         </tr>
                     </table>
                 </td>

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/oscarMeasurements/SelectCDMReport.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/oscarMeasurements/SelectCDMReport.jsp
@@ -94,8 +94,8 @@
                                     </c:forEach>
                             </select></td>
                             <td style="text-align: right"><a
-                                    href="javascript:popupStart(300,400,'About.jsp')"><fmt:message key="global.about"/></a> | <a
-                                    href="javascript:popupStart(300,400,'License.jsp')"><fmt:message key="global.license"/></a></td>
+                                    href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewAbout')"><fmt:message key="global.about"/></a> | <a
+                                    href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewLicense')"><fmt:message key="global.license"/></a></td>
                         </tr>
                     </table>
                 </td>

--- a/src/main/webapp/WEB-INF/jsp/oscarWorkflow/WorkFlowList.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarWorkflow/WorkFlowList.jsp
@@ -117,8 +117,8 @@
                         </td>
                         <td>&nbsp;</td>
                         <td style="text-align: right"><a
-                                href="javascript:popupStart(300,400,'About.jsp')"><fmt:message key="global.about"/></a> | <a
-                                href="javascript:popupStart(300,400,'License.jsp')"><fmt:message key="global.license"/></a></td>
+                                href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewAbout')"><fmt:message key="global.about"/></a> | <a
+                                href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewLicense')"><fmt:message key="global.license"/></a></td>
                     </tr>
                 </table>
             </td>

--- a/src/main/webapp/WEB-INF/jsp/prevention/AddPreventionData.jsp
+++ b/src/main/webapp/WEB-INF/jsp/prevention/AddPreventionData.jsp
@@ -631,8 +631,8 @@
                         </td>
                         <td style="text-align:right; background-color:silver;">
                             <a
-                                href="javascript:popupStart(300,400,'About.jsp')"><fmt:message key="global.about"/></a>
-                            | <a href="javascript:popupStart(300,400,'License.jsp')"><fmt:message key="global.license"/></a>
+                                href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewAbout')"><fmt:message key="global.about"/></a>
+                            | <a href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewLicense')"><fmt:message key="global.license"/></a>
                         </td>
                     </tr>
                 </table>

--- a/src/main/webapp/WEB-INF/jsp/prevention/AddPreventionDataDisambiguate.jsp
+++ b/src/main/webapp/WEB-INF/jsp/prevention/AddPreventionDataDisambiguate.jsp
@@ -279,8 +279,8 @@
                         </td>
                         <td style="text-align:right">
                             <a
-                                href="javascript:popupStart(300,400,'About.jsp')"><fmt:message key="global.about"/></a>
-                            | <a href="javascript:popupStart(300,400,'License.jsp')"><fmt:message key="global.license"/></a>
+                                href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewAbout')"><fmt:message key="global.about"/></a>
+                            | <a href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewLicense')"><fmt:message key="global.license"/></a>
                         </td>
                     </tr>
                 </table>

--- a/src/main/webapp/WEB-INF/jsp/prevention/dhirSubmission.jsp
+++ b/src/main/webapp/WEB-INF/jsp/prevention/dhirSubmission.jsp
@@ -320,8 +320,8 @@
                         </td>
                         <td style="text-align:right">
                             <a
-                                href="javascript:popupStart(300,400,'About.jsp')"><fmt:message key="global.about"/></a>
-                            | <a href="javascript:popupStart(300,400,'License.jsp')"><fmt:message key="global.license"/></a>
+                                href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewAbout')"><fmt:message key="global.about"/></a>
+                            | <a href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewLicense')"><fmt:message key="global.license"/></a>
                         </td>
                     </tr>
                 </table>

--- a/src/main/webapp/WEB-INF/jsp/prevention/review.jsp
+++ b/src/main/webapp/WEB-INF/jsp/prevention/review.jsp
@@ -518,8 +518,8 @@
                         </td>
                         <td style="text-align:right">
                             <a
-                                href="javascript:popupStart(300,400,'About.jsp')"><fmt:message key="global.about"/></a>
-                            | <a href="javascript:popupStart(300,400,'License.jsp')"><fmt:message key="global.license"/></a>
+                                href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewAbout')"><fmt:message key="global.about"/></a>
+                            | <a href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewLicense')"><fmt:message key="global.license"/></a>
                         </td>
                     </tr>
                 </table>

--- a/src/main/webapp/WEB-INF/jsp/provider/editSignature.jsp
+++ b/src/main/webapp/WEB-INF/jsp/provider/editSignature.jsp
@@ -85,8 +85,8 @@
                         <td><fmt:message key="provider.editSignature.msgProviderSignature"/></td>
                         <td>&nbsp;</td>
                         <td style="text-align: right"><a
-                                href="javascript:popupStart(300,400,'About.jsp')"><fmt:message key="global.about"/></a> | <a
-                                href="javascript:popupStart(300,400,'License.jsp')"><fmt:message key="global.license"/></a></td>
+                                href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewAbout')"><fmt:message key="global.about"/></a> | <a
+                                href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewLicense')"><fmt:message key="global.license"/></a></td>
                     </tr>
                 </table>
             </td>

--- a/src/main/webapp/WEB-INF/jsp/provider/providerSignature.jsp
+++ b/src/main/webapp/WEB-INF/jsp/provider/providerSignature.jsp
@@ -70,8 +70,8 @@
                         </td>
                         <td>&nbsp;</td>
                         <td style="text-align: right"><a
-                                href="javascript:popupStart(300,400,'About.jsp')"><fmt:message key="global.about"/></a> | <a
-                                href="javascript:popupStart(300,400,'License.jsp')"><fmt:message key="global.license"/></a></td>
+                                href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewAbout')"><fmt:message key="global.about"/></a> | <a
+                                href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewLicense')"><fmt:message key="global.license"/></a></td>
                     </tr>
                 </table>
             </td>

--- a/src/main/webapp/WEB-INF/jsp/report/ClinicalReports.jsp
+++ b/src/main/webapp/WEB-INF/jsp/report/ClinicalReports.jsp
@@ -342,8 +342,8 @@
                         </td>
                         <td style="text-align:right">
                             <a
-                                href="javascript:popupStart(300,400,'About.jsp')"><fmt:message key="global.about"/></a>
-                            | <a href="javascript:popupStart(300,400,'License.jsp')"><fmt:message key="global.license"/></a>
+                                href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewAbout')"><fmt:message key="global.about"/></a>
+                            | <a href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewLicense')"><fmt:message key="global.license"/></a>
                         </td>
                     </tr>
                 </table>

--- a/src/main/webapp/WEB-INF/jsp/report/GenerateLetters.jsp
+++ b/src/main/webapp/WEB-INF/jsp/report/GenerateLetters.jsp
@@ -206,8 +206,8 @@
                         <td>&nbsp; <a href="${pageContext.request.contextPath}/report/ViewManageLetters"><fmt:message key="report.GenerateLetters.manage"/></a></td>
                         <td style="text-align: right">
                             <a
-                                    href="javascript:popupStart(300,400,'About.jsp')"><fmt:message key="global.about"/></a> | <a
-                                    href="javascript:popupStart(300,400,'License.jsp')"><fmt:message key="global.license"/></a></td>
+                                    href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewAbout')"><fmt:message key="global.about"/></a> | <a
+                                    href="javascript:popupStart(300,400,'<%=request.getContextPath()%>/encounter/ViewLicense')"><fmt:message key="global.license"/></a></td>
                     </tr>
                 </table>
             </td>

--- a/src/main/webapp/WEB-INF/jsp/rx/chartDrugProfile.jsp
+++ b/src/main/webapp/WEB-INF/jsp/rx/chartDrugProfile.jsp
@@ -151,7 +151,7 @@
 
             <fieldset>
                 <legend>Med List</legend>
-                <form action="rx/chartDrugProfile.jsp">
+                <form action="<%= request.getContextPath() %>/rx/ViewChartDrugProfile">
                     <input type="hidden" name="labType" value="<carlos:encode value='<%= labType %>' context="htmlAttribute"/>"/>
                     <input type="hidden" name="demographic_no" value="<carlos:encode value='<%= demographicNo %>' context="htmlAttribute"/>"/>
                     <input type="hidden" name="testName" value="<carlos:encode value='<%= testName %>' context="htmlAttribute"/>"/>

--- a/src/main/webapp/admin/templateConversionReview.jsp
+++ b/src/main/webapp/admin/templateConversionReview.jsp
@@ -15,7 +15,7 @@
 <fmt:setBundle basename="oscarResources"/>
 
 <!DOCTYPE html>
-<html lang="en">
+<html lang="${pageContext.request.locale.language}">
 <head>
     <meta charset="UTF-8">
     <%@ include file="/WEB-INF/jsp/includes/global-head.jspf" %>

--- a/src/main/webapp/admin/templateConversionReview.jsp
+++ b/src/main/webapp/admin/templateConversionReview.jsp
@@ -72,7 +72,7 @@
                     <td>Provider colour set error page</td>
                     <td>64</td>
                     <td>
-                        <a href="${pageContext.request.contextPath}/provider/providerColourErr.jsp"
+                        <a href="${pageContext.request.contextPath}/provider/ViewProviderColourErr"
                            target="_blank" class="btn btn-outline-primary btn-sm">Open</a>
                     </td>
                 </tr>
@@ -82,7 +82,7 @@
                     <td>Provider fax number error page</td>
                     <td>64</td>
                     <td>
-                        <a href="${pageContext.request.contextPath}/provider/providerFaxErr.jsp"
+                        <a href="${pageContext.request.contextPath}/provider/ViewProviderFaxErr"
                            target="_blank" class="btn btn-outline-primary btn-sm">Open</a>
                     </td>
                 </tr>
@@ -92,7 +92,7 @@
                     <td>Encounter save &amp; exit timeout popup</td>
                     <td>80</td>
                     <td>
-                        <a href="${pageContext.request.contextPath}/encounter/TimeOut.jsp"
+                        <a href="${pageContext.request.contextPath}/encounter/ViewTimeOut"
                            target="_blank" class="btn btn-outline-primary btn-sm">Open</a>
                     </td>
                 </tr>
@@ -102,7 +102,7 @@
                     <td>Consultation &mdash; nothing to print message</td>
                     <td>92</td>
                     <td>
-                        <a href="${pageContext.request.contextPath}/encounter/oscarConsultationRequest/nothingtoPrint.jsp"
+                        <a href="${pageContext.request.contextPath}/encounter/oscarConsultationRequest/ViewNothingtoPrint"
                            target="_blank" class="btn btn-outline-primary btn-sm">Open</a>
                     </td>
                 </tr>
@@ -112,7 +112,7 @@
                     <td>License display page</td>
                     <td>95</td>
                     <td>
-                        <a href="${pageContext.request.contextPath}/encounter/License.jsp"
+                        <a href="${pageContext.request.contextPath}/encounter/ViewLicense"
                            target="_blank" class="btn btn-outline-primary btn-sm">Open</a>
                     </td>
                 </tr>

--- a/src/main/webapp/admin/templateConversionReview.jsp
+++ b/src/main/webapp/admin/templateConversionReview.jsp
@@ -12,10 +12,11 @@
     @since 2026-04-13
 --%>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="carlos" prefix="carlos" %>
 <fmt:setBundle basename="oscarResources"/>
 
 <!DOCTYPE html>
-<html lang="${pageContext.request.locale.language}">
+<html lang="${carlos:forHtmlAttribute(pageContext.request.locale.language)}">
 <head>
     <meta charset="UTF-8">
     <%@ include file="/WEB-INF/jsp/includes/global-head.jspf" %>

--- a/src/main/webapp/css/searchDrug3.css
+++ b/src/main/webapp/css/searchDrug3.css
@@ -593,6 +593,6 @@ table.topLink span.HelpAboutLogout a {
 
 }
 
-table.topLink span.HelpAboutLogout a[href*='About.jsp'] {
+table.topLink span.HelpAboutLogout a[href*='ViewAbout'] {
 	border-right: white thin groove !important;
 }

--- a/src/main/webapp/encounter/calculators/CoronaryArteryDiseaseRiskPrediction.html
+++ b/src/main/webapp/encounter/calculators/CoronaryArteryDiseaseRiskPrediction.html
@@ -678,9 +678,9 @@
                     <td>Coronary Artery Disease Risk Prediction</td>
                     <td>&nbsp;</td>
                     <td style="text-align: right"><a
-                            href="javascript:popupStart(300,400,'Help.jsp')">Help</a> | <a
-                            href="javascript:popupStart(300,400,'About.jsp')">About</a> | <a
-                            href="javascript:popupStart(300,400,'License.jsp')">License</a></td>
+                            href="javascript:popupStart(300,400,'../ViewHelp')">Help</a> | <a
+                            href="javascript:popupStart(300,400,'../ViewAbout')">About</a> | <a
+                            href="javascript:popupStart(300,400,'../ViewLicense')">License</a></td>
                 </tr>
             </table>
         </td>

--- a/src/main/webapp/encounter/calculators/GeneralCalculators.htm
+++ b/src/main/webapp/encounter/calculators/GeneralCalculators.htm
@@ -167,9 +167,9 @@
                     <td>General Conversions</td>
                     <td>&nbsp;</td>
                     <td style="text-align: right"><a
-                            href="javascript:popupStart(300,400,'Help.jsp')">Help</a> | <a
-                            href="javascript:popupStart(300,400,'About.jsp')">About</a> | <a
-                            href="javascript:popupStart(300,400,'License.jsp')">License</a></td>
+                            href="javascript:popupStart(300,400,'../ViewHelp')">Help</a> | <a
+                            href="javascript:popupStart(300,400,'../ViewAbout')">About</a> | <a
+                            href="javascript:popupStart(300,400,'../ViewLicense')">License</a></td>
                 </tr>
             </table>
         </td>

--- a/src/main/webapp/encounter/calculators/OsteoporoticFracture.htm
+++ b/src/main/webapp/encounter/calculators/OsteoporoticFracture.htm
@@ -382,9 +382,9 @@
                     </td>
                     <td>&nbsp;</td>
                     <td style="text-align: right"><a
-                            href="javascript:popupStart(300,400,'Help.jsp')">Help</a> | <a
-                            href="javascript:popupStart(300,400,'About.jsp')">About</a> | <a
-                            href="javascript:popupStart(300,400,'License.jsp')">License</a></td>
+                            href="javascript:popupStart(300,400,'../ViewHelp')">Help</a> | <a
+                            href="javascript:popupStart(300,400,'../ViewAbout')">About</a> | <a
+                            href="javascript:popupStart(300,400,'../ViewLicense')">License</a></td>
                 </tr>
             </table>
         </td>

--- a/src/main/webapp/encounter/calculators/SimpleCalculator.htm
+++ b/src/main/webapp/encounter/calculators/SimpleCalculator.htm
@@ -258,9 +258,9 @@
                     <td>Simple Calculator</td>
                     <td>&nbsp;</td>
                     <td style="text-align: right"><a
-                            href="javascript:popupStart(300,400,'Help.jsp')">Help</a> | <a
-                            href="javascript:popupStart(300,400,'About.jsp')">About</a> | <a
-                            href="javascript:popupStart(300,400,'License.jsp')">License</a></td>
+                            href="javascript:popupStart(300,400,'../ViewHelp')">Help</a> | <a
+                            href="javascript:popupStart(300,400,'../ViewAbout')">About</a> | <a
+                            href="javascript:popupStart(300,400,'../ViewLicense')">License</a></td>
                 </tr>
             </table>
         </td>

--- a/src/test/java/io/github/carlos_emr/carlos/decision/gate/ViewDecision2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/decision/gate/ViewDecision2ActionTest.java
@@ -44,7 +44,7 @@ import static org.mockito.Mockito.*;
  * <p>Matrix covered:
  * <ul>
  *   <li>{GET, POST} × {no submit, submit=Save, submit=Print, submit=SAVE mixed case}
- *       × {_forms r only, _forms r+w, neither}</li>
+ *       × {_form r only, _form r+w, neither}</li>
  * </ul>
  *
  * @since 2026-04-14
@@ -85,8 +85,8 @@ class ViewDecision2ActionTest extends CarlosUnitTestBase {
 
         registerMock(SecurityInfoManager.class, mockSecurityInfoManager);
 
-        // Default: _forms r granted
-        when(mockSecurityInfoManager.hasPrivilege(any(LoggedInInfo.class), eq("_forms"), eq("r"), isNull()))
+        // Default: _form r granted
+        when(mockSecurityInfoManager.hasPrivilege(any(LoggedInInfo.class), eq("_form"), eq("r"), isNull()))
                 .thenReturn(true);
 
         action = new ViewDecision2Action();
@@ -107,7 +107,7 @@ class ViewDecision2ActionTest extends CarlosUnitTestBase {
     class ReadGate {
 
         @Test
-        @DisplayName("should succeed on GET with _forms r and no submit param")
+        @DisplayName("should succeed on GET with _form r and no submit param")
         void shouldSucceed_onGetWithReadAndNoSubmit() throws Exception {
             mockRequest.setMethod("GET");
 
@@ -125,19 +125,19 @@ class ViewDecision2ActionTest extends CarlosUnitTestBase {
 
             assertThatThrownBy(() -> action.execute())
                     .isInstanceOf(SecurityException.class)
-                    .hasMessageContaining("_forms r");
+                    .hasMessageContaining("_form r");
         }
 
         @Test
-        @DisplayName("should throw SecurityException when _forms r is denied")
+        @DisplayName("should throw SecurityException when _form r is denied")
         void shouldThrow_whenReadPrivilegeDenied() {
             mockRequest.setMethod("GET");
-            when(mockSecurityInfoManager.hasPrivilege(any(LoggedInInfo.class), eq("_forms"), eq("r"), isNull()))
+            when(mockSecurityInfoManager.hasPrivilege(any(LoggedInInfo.class), eq("_form"), eq("r"), isNull()))
                     .thenReturn(false);
 
             assertThatThrownBy(() -> action.execute())
                     .isInstanceOf(SecurityException.class)
-                    .hasMessageContaining("_forms r");
+                    .hasMessageContaining("_form r");
         }
     }
 
@@ -156,7 +156,7 @@ class ViewDecision2ActionTest extends CarlosUnitTestBase {
             assertThat(result).isEqualTo(ActionSupport.NONE);
             assertThat(mockResponse.getStatus()).isEqualTo(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
             verify(mockSecurityInfoManager, never())
-                    .hasPrivilege(any(LoggedInInfo.class), eq("_forms"), eq("w"), isNull());
+                    .hasPrivilege(any(LoggedInInfo.class), eq("_form"), eq("w"), isNull());
         }
 
         @Test
@@ -184,24 +184,24 @@ class ViewDecision2ActionTest extends CarlosUnitTestBase {
         }
 
         @Test
-        @DisplayName("should throw SecurityException on POST with Save when _forms w denied")
+        @DisplayName("should throw SecurityException on POST with Save when _form w denied")
         void shouldThrow_onPostSaveWithoutWritePrivilege() {
             mockRequest.setMethod("POST");
             mockRequest.setParameter("submit", " Save ");
-            when(mockSecurityInfoManager.hasPrivilege(any(LoggedInInfo.class), eq("_forms"), eq("w"), isNull()))
+            when(mockSecurityInfoManager.hasPrivilege(any(LoggedInInfo.class), eq("_form"), eq("w"), isNull()))
                     .thenReturn(false);
 
             assertThatThrownBy(() -> action.execute())
                     .isInstanceOf(SecurityException.class)
-                    .hasMessageContaining("_forms w");
+                    .hasMessageContaining("_form w");
         }
 
         @Test
-        @DisplayName("should succeed on POST with Save when _forms r and _forms w granted")
+        @DisplayName("should succeed on POST with Save when _form r and _form w granted")
         void shouldSucceed_onPostSaveWithReadAndWrite() throws Exception {
             mockRequest.setMethod("POST");
             mockRequest.setParameter("submit", " Save ");
-            when(mockSecurityInfoManager.hasPrivilege(any(LoggedInInfo.class), eq("_forms"), eq("w"), isNull()))
+            when(mockSecurityInfoManager.hasPrivilege(any(LoggedInInfo.class), eq("_form"), eq("w"), isNull()))
                     .thenReturn(true);
 
             String result = action.execute();
@@ -248,7 +248,7 @@ class ViewDecision2ActionTest extends CarlosUnitTestBase {
 
             assertThat(result).isEqualTo(ActionSupport.SUCCESS);
             verify(mockSecurityInfoManager, never())
-                    .hasPrivilege(any(LoggedInInfo.class), eq("_forms"), eq("w"), isNull());
+                    .hasPrivilege(any(LoggedInInfo.class), eq("_form"), eq("w"), isNull());
         }
 
         @Test
@@ -260,7 +260,7 @@ class ViewDecision2ActionTest extends CarlosUnitTestBase {
 
             assertThat(result).isEqualTo(ActionSupport.SUCCESS);
             verify(mockSecurityInfoManager, never())
-                    .hasPrivilege(any(LoggedInInfo.class), eq("_forms"), eq("w"), isNull());
+                    .hasPrivilege(any(LoggedInInfo.class), eq("_form"), eq("w"), isNull());
         }
 
         @Test
@@ -273,7 +273,7 @@ class ViewDecision2ActionTest extends CarlosUnitTestBase {
 
             assertThat(result).isEqualTo(ActionSupport.SUCCESS);
             verify(mockSecurityInfoManager, never())
-                    .hasPrivilege(any(LoggedInInfo.class), eq("_forms"), eq("w"), isNull());
+                    .hasPrivilege(any(LoggedInInfo.class), eq("_form"), eq("w"), isNull());
         }
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/messenger/MessengerJspRouteMigrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/messenger/MessengerJspRouteMigrationTest.java
@@ -87,8 +87,9 @@ class MessengerJspRouteMigrationTest {
         String jsp = Files.readString(ATTACHMENT_FRAMESET);
 
         assertThat(jsp)
-                .contains("<%@ taglib uri=\"owasp.encoder.jakarta\" prefix=\"e\" %>")
-                .contains("<html lang=\"${e:forHtmlAttribute(pageContext.request.locale.language)}\">")
+                .contains("<%@ taglib uri=\"carlos\" prefix=\"carlos\" %>")
+                .contains("<html lang=\"${carlos:forHtmlAttribute(pageContext.request.locale.language)}\">")
+                .doesNotContain("<%@ taglib uri=\"owasp.encoder.jakarta\" prefix=\"e\" %>")
                 .doesNotContain("<html lang=\"${pageContext.request.locale.language}\">");
     }
 
@@ -103,7 +104,8 @@ class MessengerJspRouteMigrationTest {
                 .contains("request.getParameterValues(\"indexArray\")")
                 .contains("selectedIndexes.contains(")
                 .contains("checked")
-                .contains("<html lang=\"${e:forHtmlAttribute(pageContext.request.locale.language)}\">")
+                .contains("<html lang=\"${carlos:forHtmlAttribute(pageContext.request.locale.language)}\">")
+                .doesNotContain("<%@ taglib uri=\"owasp.encoder.jakarta\" prefix=\"e\" %>")
                 .doesNotContain("pageContext.setAttribute(\"demoTitleValue\", demoName + \" information\");")
                 .doesNotContain("pageContext.setAttribute(\"ecTitleValue\", \"Encounter: \" + ec.getTimestamp().toString());")
                 .doesNotContain("<html lang=\"${pageContext.request.locale.language}\">");

--- a/src/test/resources/test-context-full.xml
+++ b/src/test/resources/test-context-full.xml
@@ -692,6 +692,12 @@
     <bean id="demographicManager" class="io.github.carlos_emr.carlos.test.mocks.MockBeanFactory">
         <property name="mockType" value="io.github.carlos_emr.carlos.managers.DemographicManager" />
     </bean>
+    <bean id="preventionManager" class="io.github.carlos_emr.carlos.test.mocks.MockBeanFactory">
+        <property name="mockType" value="io.github.carlos_emr.carlos.managers.PreventionManager" />
+    </bean>
+    <bean id="programManager2" class="io.github.carlos_emr.carlos.test.mocks.MockBeanFactory">
+        <property name="mockType" value="io.github.carlos_emr.carlos.managers.ProgramManager2" />
+    </bean>
     <bean id="defaultNoteService" class="io.github.carlos_emr.carlos.test.mocks.MockBeanFactory">
         <property name="mockType" value="io.github.carlos_emr.carlos.casemgmt.service.impl.DefaultNoteService" />
     </bean>


### PR DESCRIPTION
This pull request introduces several improvements focused on code organization, routing, and consistent use of context-aware URLs in JSP files. It adds new Java action classes for provider and billing features, updates Struts configuration to register these actions, and standardizes the way help/about/license popups are invoked throughout the application. Additionally, it updates form actions and navigation links to use more maintainable, context-based paths, and removes some legacy or unused UI elements.

The most important changes are:

**New Action Classes and Struts Configuration**
- Added `ViewBillingOBECEA2Action`, `ViewProviderColourErr2Action`, and `ViewProviderFaxErr2Action` Java classes, each specifying security and access rights for their respective features. [[1]](diffhunk://#diff-10741e264d380bb475e3a2b725a8346b2fb75159f2a32dae0459602086f82ec8R1-R15) [[2]](diffhunk://#diff-11629307618eb5f609b3e00ec72df78c80b7985a586491a303cd4b57b2df83d3R1-R13) [[3]](diffhunk://#diff-842de7ad493d434409877062a841a833e8155fd676125f46a65c182bbedaab77R1-R13)
- Registered the new action classes in `struts-billing.xml` and `struts-provider.xml`, mapping them to their corresponding JSP pages for billing and provider error views. [[1]](diffhunk://#diff-3458c885d4833c83c91dd713199cec6db8acdaa760ded8f6129fc956bbaa203dR456-R459) [[2]](diffhunk://#diff-32a1c8a39cb068de4fbe7f305fce9c3e69465f084fa3dff208f01b456a806cfcR219-R224)

**JSP URL and Form Action Standardization**
- Updated numerous JSP files to use `request.getContextPath()` for help, about, and license popup URLs, ensuring correct path resolution regardless of deployment context. [[1]](diffhunk://#diff-ffa838548652d1cf7d64957b043f10f930d35d55e3012c55ba77389a262ced1aL102-R104) [[2]](diffhunk://#diff-4b99245c483ec4e7bf674c62fd5fddba3946542b18b0a24ec9dd916a9c49d3b7L93-R95) [[3]](diffhunk://#diff-e6342586d06e389998409c9926fdd0f384caf3b1d587a14ea66887ccba186577L93-R96) [[4]](diffhunk://#diff-7a8744b9c8ef7d491c9f2ba6be094525da222f3f49144efab70ad78cba60deb4L56-R58) [[5]](diffhunk://#diff-c0c1dc5443349773c9a7f6d9581dab815db95eaad04c97e255c2535c789c4010L359-R361) [[6]](diffhunk://#diff-a5b19b328e2dc44dab92d5b5c780dc1b3190b22471540698cd535e6c9e51c387L118-R119) [[7]](diffhunk://#diff-1ea0e7ac7d5604866e5855096bb4fae4fc8ed71960b4b2520139451a0233f2b3L196-R197) [[8]](diffhunk://#diff-1af13fbf9c00e55866a235491f6a03efd99ba1877188b5f99bc582a91124b147L109-R110)
- Changed form actions in `updatedemographicprovider.jsp` to post to the `/admin/UpdateDemographicProvider` endpoint using the context path, improving maintainability and consistency. [[1]](diffhunk://#diff-266530f7a7e4d0effdaf4ffdc544694362e2d6a6543dcee56a2ea07fd9fe3efaL286-R286) [[2]](diffhunk://#diff-266530f7a7e4d0effdaf4ffdc544694362e2d6a6543dcee56a2ea07fd9fe3efaL349-R349) [[3]](diffhunk://#diff-266530f7a7e4d0effdaf4ffdc544694362e2d6a6543dcee56a2ea07fd9fe3efaL413-R413) [[4]](diffhunk://#diff-266530f7a7e4d0effdaf4ffdc544694362e2d6a6543dcee56a2ea07fd9fe3efaL479-R479)
- Updated calendar navigation links in `oscarCalendarPopup.jsp` to use context-aware URLs.

**Navigation and UI Clean-up**
- Updated or commented out navigation links in admin and left navigation JSPs, including switching the EDT Billing Report Generator link to use the new action and removing some legacy module links. [[1]](diffhunk://#diff-533dc5a0a81e31fccfcd14a745395876bf8e88df06b88010c4e9fbbf66e6ceeeL363-R363) [[2]](diffhunk://#diff-533dc5a0a81e31fccfcd14a745395876bf8e88df06b88010c4e9fbbf66e6ceeeL488-R488) [[3]](diffhunk://#diff-92db3f949d45e7608a5006cfa073e9fd69c536193ef2fd661f08791dd4c5b74bL380-L382)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized JSP routes and registered new Struts actions after the WEB-INF migration to fix broken popups/links, improve i18n, and clean up navigation. Paths now resolve via the context path and action routes, legacy UI items were removed, and Decision privilege checks were corrected.

- **Refactors**
  - Added actions for billing and provider error pages and registered them in Struts (ViewBillingOBECEA, ViewProviderColourErr, ViewProviderFaxErr).
  - Switched About/Help/License and many forms/links to context-aware action URLs (e.g., ViewAbout/ViewLicense/ViewHelp, UpdateDemographicProvider, calendar popup, Rx chart profile, professional contact/specialist search).
  - Localized pages by setting the html lang from the current locale with safe encoding (calculators and template review); removed the legacy CPP button from the encounter header.
  - Cleaned up admin/left navigation and updated template conversion review links to use the new actions (provider error/fax error, timeout, license, nothing-to-print); adjusted CSS to match the new About route.

- **Bug Fixes**
  - Fixed routes broken by the WEB-INF move (calendar month nav, Rx med list, professional search pagination) and removed the dead formbcar2wt.jsp popup.
  - Corrected Decision privilege key to `_form` and aligned tests.
  - Hardened Messenger PDF preview/attachments by switching to the `carlos` encoder taglib and correctly encoding the lang attribute; added missing test mocks (`PreventionManager`, `ProgramManager2`).

<sup>Written for commit b234e1c4a8f74414f41577a2aa5909da748fb5ac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

