### PR TITLE
Fixinboxlink

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/oscarMDS/documentsInQueues.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarMDS/documentsInQueues.jsp
@@ -28,6 +28,41 @@
     CARLOS has no affiliation with OSCAR or McMaster University.
 
 --%>
+<%--
+    documentsInQueues.jsp — "Pending Docs" inbox sub-page.
+
+    Renders the two-column queue review UI: a list of inbox queues on the
+    left, and (lazily) the documents/labs assigned to the selected queue
+    on the right. From the right pane the provider can preview a document
+    image, paginate, rotate, remove the first page, split, file or force-
+    file the document, acknowledge it, forward it, and re-assign it to a
+    patient. Each mutation hits a JSON endpoint (DocumentJSON, etc.) via
+    Prototype/jQuery AJAX and updates global JS lookup tables in place so
+    the queue counts stay in sync without a full reload.
+
+    Wrapped in `.container` so the popup (opened by InboxhubTopbar at
+    height=800, width=1000) shares the same Bootstrap lg-breakpoint
+    gutter as Doc Upload and the other inbox sub-pages.
+
+    Required request attributes (set by DmsInboxManage2Action#execute when
+    method=getDocumentsInQueues):
+      queueIdNames         Map<Integer,String>  — queue id → display name
+      queueDocNos          Map<Integer,List>    — queue id → doc/lab ids
+      providerNo           String               — viewing provider
+      searchProviderNo     String               — provider filter applied
+      patientIdNamesStr    String               — ";id=last,first;..." packed list
+      patientIdStr         String               — packed patient id list
+      patientDocs          Map<Integer,List>    — patient id → doc/lab ids
+      docStatus            Map<Integer,String>  — doc/lab id → status flag (N/A/I/...)
+      docType              Map<Integer,String>  — doc/lab id → "DOC" or "HL7"
+      typeDocLab           Map<String,List>     — type → ids of that type
+      normals / abnormals  List<String>         — flag categorisation for display
+
+    Required privilege: _lab read (enforced by <security:oscarSec> at the
+    top of the page; missing privilege redirects to /securityError).
+
+    @since 2010-11-06
+--%>
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%
@@ -337,6 +372,16 @@
         var nowMultiple = 1;
         var queueID;
 
+        /**
+         * Switch the right pane to show the documents/labs belonging to the given queue.
+         *
+         * Side effects: clears the right pane, resets the global lazy-render state
+         * (`nowChildId`, `nowMultiple`, `nowDocLabIds`), records the active queue in
+         * `queueID`, then triggers `showFirstTime()` which renders the first batch.
+         * The id list is reversed because the renderer pops from the end.
+         *
+         * @param {number|string} qid queue id (key into the global `queueDocNos` map)
+         */
         function showDocInQueue(qid) {
             var docsDiv = $('docs');
             while (docsDiv.firstChild) {
@@ -413,6 +458,15 @@
             return initList(s);
         }
 
+        /**
+         * Parse the packed patient-name string the action serialises into the page.
+         *
+         * Format: `;<id>=<lastName>,<firstName>;<id>=<lastName>,<firstName>;...`
+         * Leading semicolon and empty trailing segments are tolerated.
+         *
+         * @param {string} s packed string, e.g. ";1=Doe,Jane;2=Roe,John"
+         * @returns {Object<string,string>} id → "lastName,firstName"
+         */
         function initPatientIdNames(s) {//;1=abc,def;2=dksi,skal;3=dks,eiw
             var ar = s.split(';');
             var r = new Object();
@@ -430,6 +484,15 @@
             return r;
         }
 
+        /**
+         * Parse the toString() of a Java HashMap whose values are Lists.
+         *
+         * Input format: `{key1=[v1, v2, v3], key2=[v4, v5], ...}`. Used for
+         * `typeDocLab` (type → ids) and `patientDocs` (patient id → doc ids).
+         *
+         * @param {string} s Java Map.toString() output
+         * @returns {Object<string,string[]>} key → array of stringified values
+         */
         function initHashtblWithList(s) {//for typeDocLab,patientDocs
             s = s.replace('{', '');
             s = s.replace('}', '');
@@ -457,6 +520,15 @@
 
         }
 
+        /**
+         * Parse the toString() of a Java HashMap whose values are scalar Strings.
+         *
+         * Input format: `{key1=val1, key2=val2, ...}`. Used for `docStatus`
+         * (doc/lab id → status flag) and `docType` (doc/lab id → "DOC"/"HL7").
+         *
+         * @param {string} s Java Map.toString() output
+         * @returns {Object<string,string>} key → scalar value
+         */
         function initHashtblWithString(s) {//for docStatus,docType
             s = s.replace('{', '');
             s = s.replace('}', '');
@@ -757,6 +829,20 @@
             }
         }
 
+        /**
+         * Local override of the global `reportWindow` (defined in
+         * /share/javascript/oscarMDSIndex.js).
+         *
+         * Quirk: the `height` argument is ignored — the popup is always opened
+         * at height 660, with only `width` honoured. Pre-existing legacy
+         * behaviour; preserved to avoid regressing callers within this page
+         * that were authored against it. Do not "fix" the height handling
+         * without auditing every callsite below.
+         *
+         * @param {string} page absolute or context-relative URL to open
+         * @param {number} height accepted for signature compatibility but ignored
+         * @param {number} width popup width in px
+         */
         function reportWindow(page, height, width) {
             //console.log(page);
             if (height && width) {

--- a/src/main/webapp/WEB-INF/jsp/oscarMDS/documentsInQueues.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarMDS/documentsInQueues.jsp
@@ -2407,6 +2407,7 @@
 
 %>
 
+<div class="container">
 <div class="page-header-bar" style="font-size:14px !important;">
     <h4 class="page-header-title" style="font-size:18px !important;font-weight:normal !important;"><fmt:message key="inboxmanager.documentsInQueues"/></h4>
     <input type="hidden" name="providerNo" value="<carlos:encode value='<%= providerNo %>' context="htmlAttribute"/>">
@@ -2464,5 +2465,6 @@
 
 </script>
 <jsp:include page="/images/spinner.jsp"/>
+</div><%-- close container --%>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/jsp/oscarMDS/documentsInQueues.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarMDS/documentsInQueues.jsp
@@ -831,20 +831,18 @@
          * Local override of the global `reportWindow` (defined in
          * /share/javascript/oscarMDSIndex.js).
          *
-         * Quirk: the `height` argument is ignored — the popup is always opened
-         * at height 660, with only `width` honoured. Pre-existing legacy
-         * behaviour; preserved to avoid regressing callers within this page
-         * that were authored against it. Do not "fix" the height handling
-         * without auditing every callsite below.
+         * Uses caller-provided dimensions when present, matching the global
+         * helper while retaining the legacy 660x960 fallback for callers that
+         * omit dimensions.
          *
          * @param {string} page absolute or context-relative URL to open
-         * @param {number} height accepted for signature compatibility but ignored
+         * @param {number} height popup height in px
          * @param {number} width popup width in px
          */
         function reportWindow(page, height, width) {
             //console.log(page);
             if (height && width) {
-                windowprops = "height=" + 660 + ", width=" + width + ", location=no, scrollbars=yes, menubars=no, toolbars=no, resizable=yes, top=0, left=0";
+                windowprops = "height=" + height + ", width=" + width + ", location=no, scrollbars=yes, menubars=no, toolbars=no, resizable=yes, top=0, left=0";
             } else {
                 windowprops = "height=660, width=960, location=no, scrollbars=yes, menubars=no, toolbars=no, resizable=yes, top=0, left=0";
             }

--- a/src/main/webapp/WEB-INF/jsp/oscarMDS/documentsInQueues.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarMDS/documentsInQueues.jsp
@@ -465,7 +465,7 @@
          * @param {string} s packed string, e.g. ";1=Doe,Jane;2=Roe,John"
          * @returns {Object<string,string>} id → "lastName,firstName"
          */
-        function initPatientIdNames(s) {//;1=abc,def;2=dksi,skal;3=dks,eiw
+        function initPatientIdNames(s) {
             var ar = s.split(';');
             var r = new Object();
             for (var i = 0; i < ar.length; i++) {
@@ -491,7 +491,7 @@
          * @param {string} s Java Map.toString() output
          * @returns {Object<string,string[]>} key → array of stringified values
          */
-        function initHashtblWithList(s) {//for typeDocLab,patientDocs
+        function initHashtblWithList(s) {
             s = s.replace('{', '');
             s = s.replace('}', '');
             if (s.length > 0) {
@@ -527,7 +527,7 @@
          * @param {string} s Java Map.toString() output
          * @returns {Object<string,string>} key → scalar value
          */
-        function initHashtblWithString(s) {//for docStatus,docType
+        function initHashtblWithString(s) {
             s = s.replace('{', '');
             s = s.replace('}', '');
             s = s.replace(/\s/g, '');
@@ -847,7 +847,12 @@
                 windowprops = "height=660, width=960, location=no, scrollbars=yes, menubars=no, toolbars=no, resizable=yes, top=0, left=0";
             }
             var popup = window.open(page, "labreport", windowprops);
-            popup.focus();
+            if (popup != null) {
+                if (popup.opener == null) {
+                    popup.opener = self;
+                }
+                popup.focus();
+            }
         }
 
 

--- a/src/main/webapp/WEB-INF/jsp/oscarMDS/documentsInQueues.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarMDS/documentsInQueues.jsp
@@ -831,16 +831,16 @@
          * Local override of the global `reportWindow` (defined in
          * /share/javascript/oscarMDSIndex.js).
          *
-         * Uses caller-provided dimensions when present, matching the global
-         * helper while retaining the legacy 660x960 fallback for callers that
-         * omit dimensions.
+         * Uses caller-provided dimensions when both height and width are
+         * provided; falls back to the legacy 660x960 defaults when either
+         * dimension is absent or zero.
          *
          * @param {string} page absolute or context-relative URL to open
          * @param {number} height popup height in px
          * @param {number} width popup width in px
          */
         function reportWindow(page, height, width) {
-            //console.log(page);
+            var windowprops;
             if (height && width) {
                 windowprops = "height=" + height + ", width=" + width + ", location=no, scrollbars=yes, menubars=no, toolbars=no, resizable=yes, top=0, left=0";
             } else {

--- a/src/main/webapp/WEB-INF/jsp/oscarMDS/documentsInQueues.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarMDS/documentsInQueues.jsp
@@ -79,9 +79,7 @@
     }
 %>
 
-<%@page import="org.owasp.encoder.Encode" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
-<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@ taglib uri="carlos" prefix="carlos" %>
 <fmt:setBundle basename="oscarResources"/>
 <%@ page import="java.util.*, io.github.carlos_emr.carlos.util.*, io.github.carlos_emr.CarlosProperties" %>

--- a/src/main/webapp/WEB-INF/jsp/web/inboxhub/InboxhubTopbar.jsp
+++ b/src/main/webapp/WEB-INF/jsp/web/inboxhub/InboxhubTopbar.jsp
@@ -22,8 +22,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA
     in /share/javascript/oscarMDSIndex.js.
 
     Inputs:
-      providerNo — provider number of the logged-in user, read from
-        sessionScope.user; passed to the Forwarding Rules popup so the
+      providerNo — provider number of the logged-in user; set below from
+        sessionScope.user and passed to the Forwarding Rules popup so the
         rules editor scopes to that provider.
 
     Conditional rendering:
@@ -35,9 +35,11 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA
 
     Popup sizing:
       reportWindow's signature is (page, height, width). The popup args
-      are intentionally height=800, width=1000 for the sub-pages
-      that share a Bootstrap `.container` wrapper (Pending Docs, HL7 Lab
-      Upload, Create Lab, Forwarding Rules, Doc Upload). At
+      are intentionally height=800, width=1000 for the sub-pages that
+      share a Bootstrap `.container` wrapper (Pending Docs, HL7 Lab
+      Upload, Create Lab, Forwarding Rules, Doc Upload). Incoming Docs
+      keeps width=1200 because it uses a full-width `container-fluid`
+      layout for queue triage. At
       width=1000 the container hits Bootstrap's lg breakpoint (>=992px)
       and resolves to a 960px max-width — producing the same ~20px page
       gutter on every popup. Diverging widths land on different
@@ -58,14 +60,17 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA
 <c:set var="contextPath" value="${pageContext.request.contextPath}" />
 
 <%-- Ordered by workflow: incoming → pending → uploads → create → config --%>
+<%-- Incoming Docs uses container-fluid, so it intentionally keeps a wider popup. --%>
 <a href="javascript:reportWindow('${carlos:forJavaScript(contextPath)}/documentManager/ViewIncomingDocs',800,1200)" class="nav-link"><fmt:message key="inboxmanager.document.incomingDocs"/></a>
 <a href="javascript:reportWindow('${carlos:forJavaScript(contextPath)}/documentManager/inboxManage?method=getDocumentsInQueues',800,1000)" class="nav-link"><fmt:message key="inboxmanager.document.pendingDocs"/></a>
-<c:if test="${CarlosProperties.getInstance().getBooleanProperty('legacy_document_upload_enabled', 'true')}">
-    <a href="javascript:reportWindow('${carlos:forJavaScript(contextPath)}/documentManager/ViewHtml5AddDocuments',800,1000)" class="nav-link"><fmt:message key="inboxmanager.document.uploadDoc"/></a>
-</c:if>
-<c:if test="${!CarlosProperties.getInstance().getBooleanProperty('legacy_document_upload_enabled', 'true')}">
-    <a href="javascript:reportWindow('${carlos:forJavaScript(contextPath)}/documentManager/ViewDocumentUploader',800,1000)" class="nav-link"><fmt:message key="inboxmanager.document.uploadDoc"/></a>
-</c:if>
+<c:choose>
+    <c:when test="${CarlosProperties.getInstance().getBooleanProperty('legacy_document_upload_enabled', 'true')}">
+        <a href="javascript:reportWindow('${carlos:forJavaScript(contextPath)}/documentManager/ViewHtml5AddDocuments',800,1000)" class="nav-link"><fmt:message key="inboxmanager.document.uploadDoc"/></a>
+    </c:when>
+    <c:otherwise>
+        <a href="javascript:reportWindow('${carlos:forJavaScript(contextPath)}/documentManager/ViewDocumentUploader',800,1000)" class="nav-link"><fmt:message key="inboxmanager.document.uploadDoc"/></a>
+    </c:otherwise>
+</c:choose>
 <a href="javascript:reportWindow('${carlos:forJavaScript(contextPath)}/lab/CA/ALL/insideLabUpload',800,1000)" class="nav-link"><fmt:message key="admin.admin.hl7LabUpload"/></a>
 <a href="javascript:reportWindow('${carlos:forJavaScript(contextPath)}/oscarMDS/ViewCreateLab',800,1000)" class="nav-link"><fmt:message key="global.createLab" /></a>
 <a href="javascript:reportWindow('${carlos:forJavaScript(contextPath)}/oscarMDS/ForwardingRules?providerNo=${carlos:forJavaScript(carlos:forUriComponent(providerNo))}',800,1000);" class="nav-link"><fmt:message key="inboxhub.topbar.forwardingRules"/></a>

--- a/src/main/webapp/WEB-INF/jsp/web/inboxhub/InboxhubTopbar.jsp
+++ b/src/main/webapp/WEB-INF/jsp/web/inboxhub/InboxhubTopbar.jsp
@@ -37,8 +37,10 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA
       reportWindow's signature is (page, height, width). The popup args
       are intentionally height=800, width=1000 for the sub-pages that
       share a Bootstrap `.container` wrapper (Pending Docs, HL7 Lab
-      Upload, Create Lab, Forwarding Rules, Doc Upload). Incoming Docs
-      keeps width=1200 because it uses a full-width `container-fluid`
+      Upload, Create Lab, Forwarding Rules, modern Doc Upload). Legacy
+      Doc Upload keeps its compact 600x500 popup because it uses a fixed
+      legacy layout rather than Bootstrap's container gutter. Incoming
+      Docs keeps width=1200 because it uses a full-width `container-fluid`
       layout for queue triage. At
       width=1000 the container hits Bootstrap's lg breakpoint (>=992px)
       and resolves to a 960px max-width — producing the same ~20px page
@@ -65,7 +67,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA
 <a href="javascript:reportWindow('${carlos:forJavaScript(contextPath)}/documentManager/inboxManage?method=getDocumentsInQueues',800,1000)" class="nav-link"><fmt:message key="inboxmanager.document.pendingDocs"/></a>
 <c:choose>
     <c:when test="${CarlosProperties.getInstance().getBooleanProperty('legacy_document_upload_enabled', 'true')}">
-        <a href="javascript:reportWindow('${carlos:forJavaScript(contextPath)}/documentManager/ViewHtml5AddDocuments',800,1000)" class="nav-link"><fmt:message key="inboxmanager.document.uploadDoc"/></a>
+        <a href="javascript:reportWindow('${carlos:forJavaScript(contextPath)}/documentManager/ViewHtml5AddDocuments',600,500)" class="nav-link"><fmt:message key="inboxmanager.document.uploadDoc"/></a>
     </c:when>
     <c:otherwise>
         <a href="javascript:reportWindow('${carlos:forJavaScript(contextPath)}/documentManager/ViewDocumentUploader',800,1000)" class="nav-link"><fmt:message key="inboxmanager.document.uploadDoc"/></a>

--- a/src/main/webapp/WEB-INF/jsp/web/inboxhub/InboxhubTopbar.jsp
+++ b/src/main/webapp/WEB-INF/jsp/web/inboxhub/InboxhubTopbar.jsp
@@ -21,7 +21,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA
     list view. Each link opens a feature popup via reportWindow(...) defined
     in /share/javascript/oscarMDSIndex.js.
 
-    Inputs (request scope):
+    Inputs (session scope):
       sessionScope.user — provider number of the logged-in user; passed to
         the Forwarding Rules popup so the rules editor scopes to that
         provider.
@@ -51,7 +51,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA
 <%@ page contentType="text/html;charset=UTF-8" pageEncoding="UTF-8" language="java" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <fmt:setBundle basename="oscarResources"/>
-<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@ taglib uri="carlos" prefix="carlos" %>
 
 
@@ -69,4 +68,4 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA
 </c:if>
 <a href="javascript:reportWindow('${carlos:forJavaScript(contextPath)}/lab/CA/ALL/insideLabUpload',800,1000)" class="nav-link"><fmt:message key="admin.admin.hl7LabUpload"/></a>
 <a href="javascript:reportWindow('${carlos:forJavaScript(contextPath)}/oscarMDS/ViewCreateLab',800,1000)" class="nav-link"><fmt:message key="global.createLab" /></a>
-<a href="javascript:reportWindow('${carlos:forJavaScript(contextPath)}/oscarMDS/ForwardingRules?providerNo=${carlos:forJavaScript(providerNo)}',800,1000);" class="nav-link"><fmt:message key="inboxhub.topbar.forwardingRules"/></a>
+<a href="javascript:reportWindow('${carlos:forJavaScript(contextPath)}/oscarMDS/ForwardingRules?providerNo=${carlos:forJavaScript(carlos:forUriComponent(providerNo))}',800,1000);" class="nav-link"><fmt:message key="inboxhub.topbar.forwardingRules"/></a>

--- a/src/main/webapp/WEB-INF/jsp/web/inboxhub/InboxhubTopbar.jsp
+++ b/src/main/webapp/WEB-INF/jsp/web/inboxhub/InboxhubTopbar.jsp
@@ -16,6 +16,35 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA
 -->
+<%--
+    InboxhubTopbar — secondary navigation strip rendered above the inbox hub
+    list view. Each link opens a feature popup via reportWindow(...) defined
+    in /share/javascript/oscarMDSIndex.js.
+
+    Inputs (request scope):
+      sessionScope.user — provider number of the logged-in user; passed to
+        the Forwarding Rules popup so the rules editor scopes to that
+        provider.
+
+    Conditional rendering:
+      The "Doc Upload" link toggles between two endpoints based on the
+      Carlos property `legacy_document_upload_enabled` (default true). When
+      true, the legacy `ViewHtml5AddDocuments` popup is rendered; when
+      false, the modern `ViewDocumentUploader` popup is rendered. Both
+      branches render the same i18n label.
+
+    Popup sizing:
+      reportWindow's signature is (page, height, width). The popup args
+      are intentionally height=800, width=1000 for the four sub-pages
+      that share a Bootstrap `.container` wrapper (Pending Docs, HL7 Lab
+      Upload, Create Lab, Forwarding Rules, plus modern Doc Upload). At
+      width=1000 the container hits Bootstrap's lg breakpoint (>=992px)
+      and resolves to a 960px max-width — producing the same ~20px page
+      gutter on every popup. Diverging widths land on different
+      breakpoints and visually drift apart.
+
+    @since 2025-02-12
+--%>
 <%@ page import="io.github.carlos_emr.CarlosProperties" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>

--- a/src/main/webapp/WEB-INF/jsp/web/inboxhub/InboxhubTopbar.jsp
+++ b/src/main/webapp/WEB-INF/jsp/web/inboxhub/InboxhubTopbar.jsp
@@ -35,9 +35,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA
 
     Popup sizing:
       reportWindow's signature is (page, height, width). The popup args
-      are intentionally height=800, width=1000 for the four sub-pages
+      are intentionally height=800, width=1000 for the sub-pages
       that share a Bootstrap `.container` wrapper (Pending Docs, HL7 Lab
-      Upload, Create Lab, Forwarding Rules, plus modern Doc Upload). At
+      Upload, Create Lab, Forwarding Rules, Doc Upload). At
       width=1000 the container hits Bootstrap's lg breakpoint (>=992px)
       and resolves to a 960px max-width — producing the same ~20px page
       gutter on every popup. Diverging widths land on different
@@ -61,7 +61,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA
 <a href="javascript:reportWindow('${carlos:forJavaScript(contextPath)}/documentManager/ViewIncomingDocs',800,1200)" class="nav-link"><fmt:message key="inboxmanager.document.incomingDocs"/></a>
 <a href="javascript:reportWindow('${carlos:forJavaScript(contextPath)}/documentManager/inboxManage?method=getDocumentsInQueues',800,1000)" class="nav-link"><fmt:message key="inboxmanager.document.pendingDocs"/></a>
 <c:if test="${CarlosProperties.getInstance().getBooleanProperty('legacy_document_upload_enabled', 'true')}">
-    <a href="javascript:reportWindow('${carlos:forJavaScript(contextPath)}/documentManager/ViewHtml5AddDocuments',600,500)" class="nav-link"><fmt:message key="inboxmanager.document.uploadDoc"/></a>
+    <a href="javascript:reportWindow('${carlos:forJavaScript(contextPath)}/documentManager/ViewHtml5AddDocuments',800,1000)" class="nav-link"><fmt:message key="inboxmanager.document.uploadDoc"/></a>
 </c:if>
 <c:if test="${!CarlosProperties.getInstance().getBooleanProperty('legacy_document_upload_enabled', 'true')}">
     <a href="javascript:reportWindow('${carlos:forJavaScript(contextPath)}/documentManager/ViewDocumentUploader',800,1000)" class="nav-link"><fmt:message key="inboxmanager.document.uploadDoc"/></a>

--- a/src/main/webapp/WEB-INF/jsp/web/inboxhub/InboxhubTopbar.jsp
+++ b/src/main/webapp/WEB-INF/jsp/web/inboxhub/InboxhubTopbar.jsp
@@ -21,10 +21,10 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA
     list view. Each link opens a feature popup via reportWindow(...) defined
     in /share/javascript/oscarMDSIndex.js.
 
-    Inputs (session scope):
-      sessionScope.user — provider number of the logged-in user; passed to
-        the Forwarding Rules popup so the rules editor scopes to that
-        provider.
+    Inputs:
+      providerNo — provider number of the logged-in user, read from
+        sessionScope.user; passed to the Forwarding Rules popup so the
+        rules editor scopes to that provider.
 
     Conditional rendering:
       The "Doc Upload" link toggles between two endpoints based on the

--- a/src/main/webapp/WEB-INF/jsp/web/inboxhub/InboxhubTopbar.jsp
+++ b/src/main/webapp/WEB-INF/jsp/web/inboxhub/InboxhubTopbar.jsp
@@ -31,7 +31,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA
 
 <%-- Ordered by workflow: incoming → pending → uploads → create → config --%>
 <a href="javascript:reportWindow('${carlos:forJavaScript(contextPath)}/documentManager/ViewIncomingDocs',800,1200)" class="nav-link"><fmt:message key="inboxmanager.document.incomingDocs"/></a>
-<a href="javascript:reportWindow('${carlos:forJavaScript(contextPath)}/documentManager/inboxManage?method=getDocumentsInQueues',700,1100)" class="nav-link"><fmt:message key="inboxmanager.document.pendingDocs"/></a>
+<a href="javascript:reportWindow('${carlos:forJavaScript(contextPath)}/documentManager/inboxManage?method=getDocumentsInQueues',800,1000)" class="nav-link"><fmt:message key="inboxmanager.document.pendingDocs"/></a>
 <c:if test="${CarlosProperties.getInstance().getBooleanProperty('legacy_document_upload_enabled', 'true')}">
     <a href="javascript:reportWindow('${carlos:forJavaScript(contextPath)}/documentManager/ViewHtml5AddDocuments',600,500)" class="nav-link"><fmt:message key="inboxmanager.document.uploadDoc"/></a>
 </c:if>
@@ -40,4 +40,4 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA
 </c:if>
 <a href="javascript:reportWindow('${carlos:forJavaScript(contextPath)}/lab/CA/ALL/insideLabUpload',800,1000)" class="nav-link"><fmt:message key="admin.admin.hl7LabUpload"/></a>
 <a href="javascript:reportWindow('${carlos:forJavaScript(contextPath)}/oscarMDS/ViewCreateLab',800,1000)" class="nav-link"><fmt:message key="global.createLab" /></a>
-<a href="javascript:reportWindow('${carlos:forJavaScript(contextPath)}/oscarMDS/ForwardingRules?providerNo=${carlos:forJavaScript(providerNo)}');" class="nav-link"><fmt:message key="inboxhub.topbar.forwardingRules"/></a>
+<a href="javascript:reportWindow('${carlos:forJavaScript(contextPath)}/oscarMDS/ForwardingRules?providerNo=${carlos:forJavaScript(providerNo)}',800,1000);" class="nav-link"><fmt:message key="inboxhub.topbar.forwardingRules"/></a>


### PR DESCRIPTION
Issue 2100.  Also standardized indent of page across all the pages in inbox.  Ran review code.

<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description

<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues

<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?

<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->

## Checklist

- [ ] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [ ] I have not included any patient data (PHI) in this PR
- [ ] I have added tests for new functionality, or this change doesn't need new tests
- [ ] I have read the [contributing guide](CONTRIBUTING.md)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes inbox popup widths so Bootstrap `.container` gutters align: Pending Docs, HL7 Upload, Create Lab, Forwarding Rules, and modern Doc Upload open at 800x1000; Incoming Docs stays 800x1200 and legacy Doc Upload remains 600x500. Wraps Pending Docs in a `.container`, fixes `providerNo` encoding, and hardens popup behavior. Fixes #2100.

- **Bug Fixes**
  - Set Pending Docs, modern Doc Upload, HL7 Lab Upload, Create Lab, and Forwarding Rules to 800x1000; keep Incoming Docs at 800x1200 and legacy Doc Upload at 600x500.
  - Wrapped `documentsInQueues.jsp` in a `.container` to match gutters with other inbox pages.
  - Local `reportWindow` now uses provided height/width (fallback 660x960), scopes `windowprops`, and guards popup focus.
  - Forwarding Rules link encodes `providerNo` correctly (URI component → JS string) and passes 800x1000; removed unused encoder taglibs, consolidated upload-link flag with `c:choose`, and added JSP header blocks and JSDoc on key functions.

<sup>Written for commit ea5892ce037c18bc9c700fede62aaeba524e8801. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

