### PR TITLE
[Fix] 2103 Enhance code description display and attributes, deprecate Dx link BillingON.jsp

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingON.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingON.jsp
@@ -885,7 +885,7 @@ var _billingForms = [<c:forEach var="bf" items="${formModel.billForm.forms}" var
                                         <table
                                                 style="width: 100%;">
                                             <tr>
-                                                <td colspan=2 style="white-space:nowrap;">
+                                                <td colspan="2" style="white-space:nowrap;">
                                                     <div id="code_desc" style="width:210px; overflow:hidden; text-overflow: ellipsis;"></div>
                                                 </td>
                                             </tr>

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingON.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingON.jsp
@@ -568,8 +568,9 @@
                 dataType: "html",
                 data: pars,
                 success: function (returnData) {
-                    jQuery("#code_desc").html(returnData);
-                    jQuery("#code_desc").attr("title", returnData.trim());
+                    var text = (returnData || '').toString().trim();
+                    jQuery("#code_desc").html(text);
+                    jQuery("#code_desc").attr("title", text);
                 },
                 error: function (e) {
                     alert(e);

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingON.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingON.jsp
@@ -569,6 +569,7 @@
                 data: pars,
                 success: function (returnData) {
                     jQuery("#code_desc").html(returnData);
+                    jQuery("#code_desc").attr("title", returnData.trim());
                 },
                 error: function (e) {
                     alert(e);
@@ -796,33 +797,7 @@ var _billingForms = [<c:forEach var="bf" items="${formModel.billForm.forms}" var
             </td>
         </tr>
     </table>
-    <c:forEach var="dxEntry" items="${formModel.serviceGrid.dxCodesByServiceType}">
-    <%-- The assembler already runs sanitizeIdToken on service-type codes, so
-         dxEntry.key is alphanumeric+underscore. The fn:replace here is
-         defense-in-depth — if a future code path ever bypasses the sanitizer,
-         the rendered HTML id remains valid (no spaces, which would otherwise
-         split the id attribute and break the JS lookup-by-id). --%>
-    <div id="dxCodeSearchDiv_<carlos:encode value='${fn:replace(dxEntry.key, " ", "_")}' context='htmlAttribute'/>" style="display: none;">
-        <c:forEach var="dx" items="${dxEntry.value}">
-        <table style="width: 98%; margin:auto;" class="table-striped table-hover">
-            <tr>
-                <td style="width: 10%">
-                    <a href="javascript:void(0);"
-                       onclick="document.forms[0].dxCode.value='<carlos:encode value='${dx.diagnosticCode}' context='javaScriptAttribute'/>';showHideLayers('Layer2','','hide');changeCodeDesc();return false;">
-                        <carlos:encode value='${dx.diagnosticCode}' context='html'/>
-                    </a>
-                </td>
-                <td>
-                    <a href="javascript:void(0);"
-                       onclick="document.forms[0].dxCode.value='<carlos:encode value='${dx.diagnosticCode}' context='javaScriptAttribute'/>';showHideLayers('Layer2','','hide');changeCodeDesc();return false;">
-                        <carlos:encode value='${fn:length(dx.description) lt 56 ? dx.description : fn:substring(dx.description, 0, 55)}' context='html'/>
-                    </a>
-                </td>
-            </tr>
-        </table>
-        </c:forEach>
-    </div>
-    </c:forEach>
+
 
 </div>
 
@@ -909,14 +884,12 @@ var _billingForms = [<c:forEach var="bf" items="${formModel.billForm.forms}" var
                                         <table
                                                 style="width: 100%;">
                                             <tr>
-                                                <td style="width: 15%">&nbsp;</td>
-                                                <td style="white-space:nowrap">
-                                                    <div id="code_desc"></div>
+                                                <td colspan=2 style="white-space:nowrap;">
+                                                    <div id="code_desc" style="width:210px; overflow:hidden; text-overflow: ellipsis;"></div>
                                                 </td>
                                             </tr>
                                             <tr>
-                                                <td><a href="javascript:void(0);"
-                                                       onclick="showHideLayers('Layer2','','show','Layer1','','hide'); return false;"><fmt:message key="oscar.billing.ca.on.billingON.dx"/></a>
+                                                <td style="width: 15%"><fmt:message key="oscar.billing.ca.on.billingON.dx"/>
                                                 </td>
                                                 <td><input type="text" name="dxCode" class="form-control form-control-sm d-inline-block w-auto"
                                                            maxlength="5"


### PR DESCRIPTION
Updated the code description element to include a title attribute and modified the layout of the code description display.

<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description
- Fixes some formatting issues
- Adds tool tip to give extended information on the diagnosis label
- Deprecates and Deletes the Dx link that used synchronous java loading of billing codes 
(now that Dx lookup by asynchronous javascript is provided)

<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues
Fixes #2103 
<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?

<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots
BEFORE
<img width="1200" height="1228" alt="Screenshot 2026-05-06 at 09-49-05 Facturation Ontario" src="https://github.com/user-attachments/assets/2dad14d6-abe5-4434-8564-11b1019c67e8" />

AFTER
<img width="1200" height="1089" alt="Screenshot 2026-05-06 at 10-22-40 Facturation Ontario" src="https://github.com/user-attachments/assets/af3d0fc0-50e4-42ba-a3f0-198fd02c3c0d" />

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Improve the Ontario billing diagnosis code display and remove the deprecated synchronous Dx lookup UI.

New Features:
- Add tooltip support to the diagnosis code description by setting the title attribute from the loaded description text.

Enhancements:
- Update the diagnosis code description layout to use a single, fixed-width ellipsized field for cleaner display.
- Remove the legacy Dx link-based diagnosis lookup panel that relied on synchronous Java-driven billing code loading, in favor of the existing asynchronous lookup.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved the billing code description display with a tooltip and a 210px ellipsized field, and removed the deprecated Dx link that used synchronous loading. Fixes #2103.

- **Bug Fixes**
  - Coerced and trimmed the AJAX response before updating `#code_desc` to avoid whitespace and non-string values.
  - Fixed `colspan` on the `#code_desc` container so the description spans both columns.

<sup>Written for commit b2a2955507737f92948360dd42e80361a501718a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



