### PR TITLE
2106 bug edit demographic does not load province and country selects 

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/demographic/demographiceditdemographic.js.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/demographiceditdemographic.js.jsp
@@ -332,34 +332,7 @@ updateProvinces(sdCode);
 }
 
 
-function updateProvinces(province) {
-var country = jQuery("#country").val();
-console.log('country is ' + country );
-if(country == '') {
-console.log('t1');
-return;
-}
 
-jQuery.ajax({
-type: "POST",
-url: ctx + '/demographicSupport',
-data: 'method=getCountryAndProvinceCodes&country=' + country,
-dataType: 'json',
-success: function (data) {
-jQuery('#province').empty();
-jQuery.each(data, function(i, value) {
-jQuery('#province').append(jQuery('<option>').text(value.label).attr('value', value.value));
-});
-
-
-if(province != null) {
-jQuery("#province").val(province);
-}
-
-
-}
-});
-}
 
 
 function setResidentialProvince(sdCode) {
@@ -389,30 +362,3 @@ updateResidentialProvinces(sdCode);
 });
 }
 
-
-function updateResidentialProvinces(province) {
-var country = jQuery("#residentialCountry").val();
-if(country == '') {
-return;
-}
-jQuery.ajax({
-type: "POST",
-url: ctx + '/demographicSupport',
-data: 'method=getCountryAndProvinceCodes&country=' + country,
-dataType: 'json',
-success: function (data) {
-jQuery('#residentialProvince').empty();
-
-jQuery.each(data, function(i, value) {
-jQuery('#residentialProvince').append(jQuery('<option>').text(value.label).attr('value', value.value));
-});
-
-
-if(province != null) {
-jQuery("#residentialProvince").val(province);
-}
-
-
-}
-});
-}

--- a/src/main/webapp/WEB-INF/jsp/demographic/edit-form-personal.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/edit-form-personal.jsp
@@ -267,7 +267,7 @@
                                                         <td align="left"><input type="text"
                                                                                 name="middleNames" <%=getDisabled("middleNames")%>
                                                                                 size="30"
-                                                                                value="<carlos:encode value='<%= demographic.getMiddleNames() %>' context="htmlAttribute"/>"
+                                                                                value='<%=(demographic.getMiddleNames()==null||demographic.getMiddleNames().equals("null"))?"":demographic.getMiddleNames()%>' context="htmlAttribute"/>" 
                                                                                 onBlur="upCaseCtrl(this)"></td>
                                                         <td align="right"><b><fmt:message key="demographic.demographiceditdemographic.msgDemoTitle"/>: </b>
                                                         </td>

--- a/src/main/webapp/WEB-INF/jsp/demographic/edit-form-personal.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/edit-form-personal.jsp
@@ -267,7 +267,7 @@
                                                         <td align="left"><input type="text"
                                                                                 name="middleNames" <%=getDisabled("middleNames")%>
                                                                                 size="30"
-                                                                                value='<%=(demographic.getMiddleNames()==null||demographic.getMiddleNames().equals("null"))?"":demographic.getMiddleNames()%>' context="htmlAttribute"/>" 
+                                                                                value="<carlos:encode value='<%= demographic.getMiddleNames() %>' context="htmlAttribute"/>"
                                                                                 onBlur="upCaseCtrl(this)"></td>
                                                         <td align="right"><b><fmt:message key="demographic.demographiceditdemographic.msgDemoTitle"/>: </b>
                                                         </td>

--- a/src/main/webapp/WEB-INF/jsp/demographic/edit-form-personal.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/edit-form-personal.jsp
@@ -267,7 +267,7 @@
                                                         <td align="left"><input type="text"
                                                                                 name="middleNames" <%=getDisabled("middleNames")%>
                                                                                 size="30"
-                                                                                value="<carlos:encode value='<%= demographic.getMiddleNames() %>' context="htmlAttribute"/>"
+                                                                                value="<carlos:encode value='<%=(demographic.getMiddleNames()==null||demographic.getMiddleNames().equals("null"))?"":demographic.getMiddleNames()%>' context="html"/>"
                                                                                 onBlur="upCaseCtrl(this)"></td>
                                                         <td align="right"><b><fmt:message key="demographic.demographiceditdemographic.msgDemoTitle"/>: </b>
                                                         </td>

--- a/src/main/webapp/WEB-INF/jsp/demographic/edit-form-personal.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/edit-form-personal.jsp
@@ -267,7 +267,7 @@
                                                         <td align="left"><input type="text"
                                                                                 name="middleNames" <%=getDisabled("middleNames")%>
                                                                                 size="30"
-                                                                                value="<carlos:encode value='<%=(demographic.getMiddleNames()==null||demographic.getMiddleNames().equals("null"))?"":demographic.getMiddleNames()%>' context="html"/>"
+                                                                                value="<carlos:encode value='<%=(demographic.getMiddleNames()==null||demographic.getMiddleNames().equals("null"))?"":demographic.getMiddleNames()%>' context="htmlAttribute"/>"
                                                                                 onBlur="upCaseCtrl(this)"></td>
                                                         <td align="right"><b><fmt:message key="demographic.demographiceditdemographic.msgDemoTitle"/>: </b>
                                                         </td>
@@ -1039,7 +1039,7 @@
                                                         </td>
                                                         <td align="left"><input type="text" name="email"
                                                                                 size="30" <%=getDisabled("email")%>
-                                                                                value="<%=demographic.getEmail() !=null ? SafeEncode.forHtmlContent(demographic.getEmail()) : ""%>">
+                                                                                value="<%=demographic.getEmail() !=null ? SafeEncode.forHtmlAttribute(demographic.getEmail()) : ""%>">
                                                         </td>
                                                         <td style="text-align: right;">
                                                             <strong><fmt:message key="demographic.demographicaddrecordhtm.formGender"/></strong>

--- a/src/main/webapp/WEB-INF/jsp/demographic/edit-view.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/edit-view.jsp
@@ -265,7 +265,7 @@
                                                                         <span class="info"><carlos:encode value='<%= demographic.getFirstName() %>' context="html"/></span>
                                                                     </li>
                                                                     <li><span class="label"><fmt:message key="demographic.demographiceditdemographic.formMiddleNames"/>:</span>
-                                                                        <span class="info"> <carlos:encode value='<%= demographic.getMiddleNames() %>' context="html"/></span>
+                                                                        <span class="info"> <carlos:encode value='<%=(demographic.getMiddleNames()==null||demographic.getMiddleNames().equals("null"))?"":demographic.getMiddleNames()%>' context="html"/></span>
                                                                     </li>
                                                                     <li>
 														<span class="label" style="color:red;"><fmt:message key="demographic.demographicaddrecordhtm.formNameUsed"/>:

--- a/src/main/webapp/WEB-INF/jsp/demographic/edit.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/edit.jsp
@@ -958,7 +958,7 @@
                             jQuery('#country').append(jQuery('<option>').text(value.label).attr('value', value.value));
                         });
 
-                        var defaultProvince = '<%=CarlosProperties.getInstance().getProperty("demographic.default_province","")%>';
+                        var defaultProvince = '<%=org.owasp.encoder.Encode.forJavaScript(CarlosProperties.getInstance().getProperty("demographic.default_province",""))%>';
                         var defaultCountry = '';
 
                         if (defaultProvince == '' && defaultCountry == '') {
@@ -982,7 +982,7 @@
                             jQuery('#residentialCountry').append(jQuery('<option>').text(value.label).attr('value', value.value));
                         });
 
-                        var defaultProvince = '<%=CarlosProperties.getInstance().getProperty("demographic.default_province","")%>';
+                        var defaultProvince = '<%=org.owasp.encoder.Encode.forJavaScript(CarlosProperties.getInstance().getProperty("demographic.default_province",""))%>';
                         var defaultCountry = '';
 
                         if (defaultProvince == '' && defaultCountry == '') {
@@ -1035,8 +1035,8 @@
                     }
                 });
             }
-            <% } %>
         </script>
+        <% } %>
         <style>
             /* for the search buttons at the top of the page
 			this should be removed if the page is updated to bootstrap

--- a/src/main/webapp/WEB-INF/jsp/demographic/edit.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/edit.jsp
@@ -933,7 +933,110 @@
 		}
 	%>
         </script>
+            <%
+            if("true".equals(oscarProps.getProperty("iso3166.2.enabled"))) {
+            %>
+<script>
+            jQuery(document).ready(function () {
 
+                jQuery("#country").on('change', function () {
+                    updateProvinces('');
+                });
+
+                jQuery("#residentialCountry").on('change', function () {
+                    updateResidentialProvinces('');
+                });
+
+                jQuery.ajax({
+                    type: "POST",
+                    url: '<%=request.getContextPath()%>/demographicSupport',
+                    data: 'method=getCountryAndProvinceCodes',
+                    dataType: 'json',
+                    success: function (data) {
+                        jQuery('#country').append(jQuery('<option>').text('').attr('value', ''));
+                        jQuery.each(data, function (i, value) {
+                            jQuery('#country').append(jQuery('<option>').text(value.label).attr('value', value.value));
+                        });
+
+                        var defaultProvince = '<%=CarlosProperties.getInstance().getProperty("demographic.default_province","")%>';
+                        var defaultCountry = '';
+
+                        if (defaultProvince == '' && defaultCountry == '') {
+                            defaultProvince = 'CA-ON';
+                        }
+                        defaultCountry = defaultProvince.substring(0, defaultProvince.indexOf('-'));
+
+                        jQuery("#country").val(defaultCountry);
+                        updateProvinces(defaultProvince);
+                    }
+                });
+
+                jQuery.ajax({
+                    type: "POST",
+                    url: '<%=request.getContextPath()%>/demographicSupport',
+                    data: 'method=getCountryAndProvinceCodes',
+                    dataType: 'json',
+                    success: function (data) {
+                        jQuery('#residentialCountry').append(jQuery('<option>').text('').attr('value', ''));
+                        jQuery.each(data, function (i, value) {
+                            jQuery('#residentialCountry').append(jQuery('<option>').text(value.label).attr('value', value.value));
+                        });
+
+                        var defaultProvince = '<%=CarlosProperties.getInstance().getProperty("demographic.default_province","")%>';
+                        var defaultCountry = '';
+
+                        if (defaultProvince == '' && defaultCountry == '') {
+                            defaultProvince = 'CA-ON';
+                        }
+                        defaultCountry = defaultProvince.substring(0, defaultProvince.indexOf('-'));
+
+                        jQuery("#residentialCountry").val(defaultCountry);
+                        updateResidentialProvinces(defaultProvince);
+                    }
+                });
+            });
+
+            function updateProvinces(province) {
+                var country = jQuery("#country").val();
+                jQuery.ajax({
+                    type: "POST",
+                    url: '<%=request.getContextPath()%>/demographicSupport',
+                    data: 'method=getCountryAndProvinceCodes&country=' + country,
+                    dataType: 'json',
+                    success: function (data) {
+                        jQuery('#province').empty();
+                        jQuery.each(data, function (i, value) {
+                            jQuery('#province').append(jQuery('<option>').text(value.label).attr('value', value.value));
+                        });
+
+                        if (province != null) {
+                            jQuery("#province").val(province);
+                        }
+                    }
+                });
+            }
+
+            function updateResidentialProvinces(province) {
+                var country = jQuery("#residentialCountry").val();
+                jQuery.ajax({
+                    type: "POST",
+                    url: '<%=request.getContextPath()%>/demographicSupport',
+                    data: 'method=getCountryAndProvinceCodes&country=' + country,
+                    dataType: 'json',
+                    success: function (data) {
+                        jQuery('#residentialProvince').empty();
+                        jQuery.each(data, function (i, value) {
+                            jQuery('#residentialProvince').append(jQuery('<option>').text(value.label).attr('value', value.value));
+                        });
+
+                        if (province != null) {
+                            jQuery("#residentialProvince").val(province);
+                        }
+                    }
+                });
+            }
+            <% } %>
+        </script>
         <style>
             /* for the search buttons at the top of the page
 			this should be removed if the page is updated to bootstrap

--- a/src/main/webapp/WEB-INF/jsp/demographic/edit.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/edit.jsp
@@ -936,7 +936,7 @@
             <%
             if("true".equals(oscarProps.getProperty("iso3166.2.enabled"))) {
             %>
-<script>
+        <script>
             jQuery(document).ready(function () {
 
                 jQuery("#country").on('change', function () {
@@ -954,50 +954,45 @@
                     dataType: 'json',
                     success: function (data) {
                         jQuery('#country').append(jQuery('<option>').text('').attr('value', ''));
-                        jQuery.each(data, function (i, value) {
-                            jQuery('#country').append(jQuery('<option>').text(value.label).attr('value', value.value));
-                        });
-
-                        var defaultProvince = '<%=org.owasp.encoder.Encode.forJavaScript(CarlosProperties.getInstance().getProperty("demographic.default_province",""))%>';
-                        var defaultCountry = '';
-
-                        if (defaultProvince == '' && defaultCountry == '') {
-                            defaultProvince = 'CA-ON';
-                        }
-                        defaultCountry = defaultProvince.substring(0, defaultProvince.indexOf('-'));
-
-                        jQuery("#country").val(defaultCountry);
-                        updateProvinces(defaultProvince);
-                    }
-                });
-
-                jQuery.ajax({
-                    type: "POST",
-                    url: '<%=request.getContextPath()%>/demographicSupport',
-                    data: 'method=getCountryAndProvinceCodes',
-                    dataType: 'json',
-                    success: function (data) {
                         jQuery('#residentialCountry').append(jQuery('<option>').text('').attr('value', ''));
                         jQuery.each(data, function (i, value) {
+                            jQuery('#country').append(jQuery('<option>').text(value.label).attr('value', value.value));
                             jQuery('#residentialCountry').append(jQuery('<option>').text(value.label).attr('value', value.value));
                         });
 
-                        var defaultProvince = '<%=org.owasp.encoder.Encode.forJavaScript(CarlosProperties.getInstance().getProperty("demographic.default_province",""))%>';
-                        var defaultCountry = '';
+                        var demoProvince = '<carlos:encode value='<%=demographic.getProvince();%>' context="javaScriptBlock"/>';
+                        var resiProvince = '<carlos:encode value='<%=demographic.getResidentialProvince();%>' context="javaScriptBlock"/>';
+                        
+                        var defaultProvince = '<carlos:encode value='<%= CarlosProperties.getInstance().getProperty("demographic.default_province","") %>' context="javaScriptBlock"/>';
+                        // override defaultProvince with actual stored demographic's province if present
+                        if (demoProvince.length > 0) { defaultProvince = demoProvince; }
+                        if (defaultProvince.indexOf('-') < 0) {
+                            defaultProvince = 'CA-ON';
+                        } 
+                        var defaultCountry = defaultProvince.split('-')[0];
+                        jQuery("#country").val(defaultCountry);
+                        updateProvinces(defaultProvince);
 
-                        if (defaultProvince == '' && defaultCountry == '') {
+                        if (resiProvince.length > 0) { defaultProvince = resiProvince; }
+                        // override defaultProvince with actual stored demographic's residential province if present
+                        if (defaultProvince.indexOf('-') < 0) {
                             defaultProvince = 'CA-ON';
                         }
-                        defaultCountry = defaultProvince.substring(0, defaultProvince.indexOf('-'));
-
+                        defaultCountry = defaultProvince.split('-')[0];
                         jQuery("#residentialCountry").val(defaultCountry);
                         updateResidentialProvinces(defaultProvince);
                     }
                 });
             });
 
+        </script>
+        <% } %>
+        <script>
             function updateProvinces(province) {
                 var country = jQuery("#country").val();
+                if(country == '') {
+                  console.log('empty country');
+                return;
                 jQuery.ajax({
                     type: "POST",
                     url: '<%=request.getContextPath()%>/demographicSupport',
@@ -1018,6 +1013,9 @@
 
             function updateResidentialProvinces(province) {
                 var country = jQuery("#residentialCountry").val();
+                if(country == '') {
+                  console.log('empty residential country');
+                return;
                 jQuery.ajax({
                     type: "POST",
                     url: '<%=request.getContextPath()%>/demographicSupport',
@@ -1036,7 +1034,6 @@
                 });
             }
         </script>
-        <% } %>
         <style>
             /* for the search buttons at the top of the page
 			this should be removed if the page is updated to bootstrap

--- a/src/main/webapp/WEB-INF/jsp/demographic/edit.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/edit.jsp
@@ -950,7 +950,7 @@
                 jQuery.ajax({
                     type: "POST",
                     url: '<%=request.getContextPath()%>/demographicSupport',
-                    data: 'method=getCountryAndProvinceCodes',
+                    data: { method: 'getCountryAndProvinceCodes' },
                     dataType: 'json',
                     success: function (data) {
                         jQuery('#country').append(jQuery('<option>').text('').attr('value', ''));
@@ -962,13 +962,13 @@
 
                         var demoProvince = '<carlos:encode value='<%=demographic.getProvince()%>' context="javaScriptBlock"/>';
                         var resiProvince = '<carlos:encode value='<%=demographic.getResidentialProvince()%>' context="javaScriptBlock"/>';
-                        
+
                         var defaultProvince = '<carlos:encode value='<%= CarlosProperties.getInstance().getProperty("demographic.default_province","") %>' context="javaScriptBlock"/>';
                         // override defaultProvince with actual stored demographic's province if present
                         if (demoProvince.length > 0) { defaultProvince = demoProvince; }
                         if (defaultProvince.indexOf('-') < 0) {
                             defaultProvince = 'CA-ON';
-                        } 
+                        }
                         var defaultCountry = defaultProvince.split('-')[0];
                         jQuery("#country").val(defaultCountry);
                         updateProvinces(defaultProvince);
@@ -982,6 +982,11 @@
                         var resiCountry = defaultResiProvince.split('-')[0];
                         jQuery("#residentialCountry").val(resiCountry);
                         updateResidentialProvinces(defaultResiProvince);
+                    },
+                    error: function (xhr, status, error) {
+                        console.error('Failed to load country codes:', error);
+                        jQuery('#country').empty().append(jQuery('<option>').text('Unable to load countries').attr('value', ''));
+                        jQuery('#residentialCountry').empty().append(jQuery('<option>').text('Unable to load countries').attr('value', ''));
                     }
                 });
             });
@@ -998,7 +1003,7 @@
                 jQuery.ajax({
                     type: "POST",
                     url: '<%=request.getContextPath()%>/demographicSupport',
-                    data: 'method=getCountryAndProvinceCodes&country=' + country,
+                    data: { method: 'getCountryAndProvinceCodes', country: country },
                     dataType: 'json',
                     success: function (data) {
                         jQuery('#province').empty();
@@ -1009,6 +1014,10 @@
                         if (province != null) {
                             jQuery("#province").val(province);
                         }
+                    },
+                    error: function (xhr, status, error) {
+                        console.error('Failed to load provinces:', error);
+                        jQuery('#province').empty().append(jQuery('<option>').text('Unable to load provinces').attr('value', ''));
                     }
                 });
             }
@@ -1022,7 +1031,7 @@
                 jQuery.ajax({
                     type: "POST",
                     url: '<%=request.getContextPath()%>/demographicSupport',
-                    data: 'method=getCountryAndProvinceCodes&country=' + country,
+                    data: { method: 'getCountryAndProvinceCodes', country: country },
                     dataType: 'json',
                     success: function (data) {
                         jQuery('#residentialProvince').empty();
@@ -1033,6 +1042,10 @@
                         if (province != null) {
                             jQuery("#residentialProvince").val(province);
                         }
+                    },
+                    error: function (xhr, status, error) {
+                        console.error('Failed to load residential provinces:', error);
+                        jQuery('#residentialProvince').empty().append(jQuery('<option>').text('Unable to load provinces').attr('value', ''));
                     }
                 });
             }

--- a/src/main/webapp/WEB-INF/jsp/demographic/edit.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/edit.jsp
@@ -960,8 +960,8 @@
                             jQuery('#residentialCountry').append(jQuery('<option>').text(value.label).attr('value', value.value));
                         });
 
-                        var demoProvince = '<carlos:encode value='<%=demographic.getProvince();%>' context="javaScriptBlock"/>';
-                        var resiProvince = '<carlos:encode value='<%=demographic.getResidentialProvince();%>' context="javaScriptBlock"/>';
+                        var demoProvince = '<carlos:encode value='<%=demographic.getProvince()%>' context="javaScriptBlock"/>';
+                        var resiProvince = '<carlos:encode value='<%=demographic.getResidentialProvince()%>' context="javaScriptBlock"/>';
                         
                         var defaultProvince = '<carlos:encode value='<%= CarlosProperties.getInstance().getProperty("demographic.default_province","") %>' context="javaScriptBlock"/>';
                         // override defaultProvince with actual stored demographic's province if present
@@ -973,14 +973,15 @@
                         jQuery("#country").val(defaultCountry);
                         updateProvinces(defaultProvince);
 
-                        if (resiProvince.length > 0) { defaultProvince = resiProvince; }
-                        // override defaultProvince with actual stored demographic's residential province if present
-                        if (defaultProvince.indexOf('-') < 0) {
-                            defaultProvince = 'CA-ON';
+                        // initialize residential province separately to avoid overwriting demo values
+                        var defaultResiProvince = '<carlos:encode value='<%= CarlosProperties.getInstance().getProperty("demographic.default_province","") %>' context="javaScriptBlock"/>';
+                        if (resiProvince.length > 0) { defaultResiProvince = resiProvince; }
+                        if (defaultResiProvince.indexOf('-') < 0) {
+                            defaultResiProvince = 'CA-ON';
                         }
-                        defaultCountry = defaultProvince.split('-')[0];
-                        jQuery("#residentialCountry").val(defaultCountry);
-                        updateResidentialProvinces(defaultProvince);
+                        var resiCountry = defaultResiProvince.split('-')[0];
+                        jQuery("#residentialCountry").val(resiCountry);
+                        updateResidentialProvinces(defaultResiProvince);
                     }
                 });
             });
@@ -991,8 +992,9 @@
             function updateProvinces(province) {
                 var country = jQuery("#country").val();
                 if(country == '') {
-                  console.log('empty country');
-                return;
+                    console.log('empty country');
+                    return;
+                }
                 jQuery.ajax({
                     type: "POST",
                     url: '<%=request.getContextPath()%>/demographicSupport',
@@ -1014,8 +1016,9 @@
             function updateResidentialProvinces(province) {
                 var country = jQuery("#residentialCountry").val();
                 if(country == '') {
-                  console.log('empty residential country');
-                return;
+                    console.log('empty residential country');
+                    return;
+                }
                 jQuery.ajax({
                     type: "POST",
                     url: '<%=request.getContextPath()%>/demographicSupport',


### PR DESCRIPTION
<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description
fixes iso country so that the dropdowns populate
fixes bug where default province overwrites demo's province
fixed bug where "null" is displayed as middle name

<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues
Fixes #2106 
<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?

<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Ensure demographic edit form correctly initializes and updates ISO3166-2-based country and province selections for mailing and residential addresses.

Bug Fixes:
- Restore loading and updating of country and province dropdowns on the demographic edit page when ISO3166-2 support is enabled.

Enhancements:
- Align country and province initialization logic with ISO3166-2 configuration, including default province and country handling.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Edit Demographic form so country and province selects load and update correctly when ISO 3166-2 is enabled. Also treats null/"null" middle names as empty and applies attribute-safe encoding to inputs. Fixes #2106.

- **Bug Fixes**
  - Load `#country`/`#residentialCountry` and update `#province`/`#residentialProvince` via `demographicSupport?method=getCountryAndProvinceCodes` (adds a blank), with error handling. Move logic to `edit.jsp` and apply only when `iso3166.2.enabled` is true.
  - Preselect mailing/residential provinces from the demographic; else use `demographic.default_province`, fall back to `CA-ON`, and derive country from the province code.
  - Treat null/"null" middle names as empty in edit and view. Use attribute-safe encoding for inputs (e.g., email).

<sup>Written for commit 83c65432d5ab371947eee74884358161e753cedc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



