### PR TITLE
Fix middleNames value handling in edit form

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/demographic/edit-form-personal.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/edit-form-personal.jsp
@@ -267,7 +267,7 @@
                                                         <td align="left"><input type="text"
                                                                                 name="middleNames" <%=getDisabled("middleNames")%>
                                                                                 size="30"
-                                                                                value="<carlos:encode value='<%= demographic.getMiddleNames() %>' context="htmlAttribute"/>"
+                                                                                value="<carlos:encode value='<%=(demographic.getMiddleNames()==null||demographic.getMiddleNames().equals("null"))?"":demographic.getMiddleNames()%>' context="htmlAttribute"/>"
                                                                                 onBlur="upCaseCtrl(this)"></td>
                                                         <td align="right"><b><fmt:message key="demographic.demographiceditdemographic.msgDemoTitle"/>: </b>
                                                         </td>


### PR DESCRIPTION
null and "null" handling

<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description

<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues

<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?

<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->

## Checklist

- [ ] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [ ] I have not included any patient data (PHI) in this PR
- [ ] I have added tests for new functionality, or this change doesn't need new tests
- [ ] I have read the [contributing guide](CONTRIBUTING.md)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the middle name field in the demographic edit form so it no longer displays the literal "null". Null or "null" values are now converted to an empty string before HTML-attribute encoding.

<sup>Written for commit 52e72d35a8c2cb0acdf521c60662cd0f33cce5dc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

