### PR TITLE
[Fix] fixes country loading and logic errors for saving a DOB in carlos/demographic/DemographicAdd

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/demographic/add-form-personal.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/add-form-personal.jsp
@@ -84,7 +84,10 @@
     String prefillYearOfBirth   = io.github.carlos_emr.carlos.util.StringUtils.noNull(request.getParameter("prefill_year_of_birth"));
     String prefillMonthOfBirth  = io.github.carlos_emr.carlos.util.StringUtils.noNull(request.getParameter("prefill_month_of_birth"));
     String prefillDateOfBirth   = io.github.carlos_emr.carlos.util.StringUtils.noNull(request.getParameter("prefill_date_of_birth"));
-    String prefillDOB           = (!prefillYearOfBirth.equals("") && !prefillMonthOfBirth.equals("") && !prefillDateOfBirth.equals("")) ? prefillYearOfBirth + "-" + prefillMonthOfBirth + "-" + prefillDateOfBirth : "";
+    String prefillDOB           = (!prefillYearOfBirth.equals("") && !prefillMonthOfBirth.equals("") && !prefillDateOfBirth.equals(""))
+            ? prefillYearOfBirth + "-" + org.apache.commons.lang3.StringUtils.leftPad(prefillMonthOfBirth, 2, '0')
+            + "-" + org.apache.commons.lang3.StringUtils.leftPad(prefillDateOfBirth, 2, '0')
+            : "";
     String prefillHin           = io.github.carlos_emr.carlos.util.StringUtils.noNull(request.getParameter("prefill_hin"));
     String prefillVer           = io.github.carlos_emr.carlos.util.StringUtils.noNull(request.getParameter("prefill_ver"));
     String prefillHcType        = io.github.carlos_emr.carlos.util.StringUtils.noNull(request.getParameter("prefill_hc_type"));

--- a/src/main/webapp/WEB-INF/jsp/demographic/add-form-personal.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/add-form-personal.jsp
@@ -84,6 +84,7 @@
     String prefillYearOfBirth   = io.github.carlos_emr.carlos.util.StringUtils.noNull(request.getParameter("prefill_year_of_birth"));
     String prefillMonthOfBirth  = io.github.carlos_emr.carlos.util.StringUtils.noNull(request.getParameter("prefill_month_of_birth"));
     String prefillDateOfBirth   = io.github.carlos_emr.carlos.util.StringUtils.noNull(request.getParameter("prefill_date_of_birth"));
+    String prefillDOB           = (!prefillYearOfBirth.equals("") && !prefillMonthOfBirth.equals("") && !prefillDateOfBirth.equals("")) ? prefillYearOfBirth + "-" + prefillMonthOfBirth + "-" + prefillDateOfBirth : "";
     String prefillHin           = io.github.carlos_emr.carlos.util.StringUtils.noNull(request.getParameter("prefill_hin"));
     String prefillVer           = io.github.carlos_emr.carlos.util.StringUtils.noNull(request.getParameter("prefill_ver"));
     String prefillHcType        = io.github.carlos_emr.carlos.util.StringUtils.noNull(request.getParameter("prefill_hc_type"));
@@ -757,14 +758,14 @@
                                            name="inputDOB" id="inputDOB"
                                            class="form-control"
                                            size="12" required
-                                           onchange="parsedob_date();" value="<carlos:encode value='<%= prefillYearOfBirth %>' context="htmlAttribute"/>-<carlos:encode value='<%= prefillMonthOfBirth %>' context="htmlAttribute"/>-<carlos:encode value='<%= prefillDateOfBirth %>' context="htmlAttribute"/>">
+                                           onchange="syncInputDobParts();" value="<carlos:encode value='<%= prefillDOB %>' context="htmlAttribute"/>">
                                     <img src="<%= request.getContextPath() %>/images/cal.gif" id="inputDOB_cal">
                                     <div class="invalid-feedback">
                                            <fmt:message key="demographic.add.msgInvalidDOB"/>
                                     </div>
-                                    <input type="hidden" name="year_of_birth" value="<carlos:encode value='<%= prefillYearOfBirth %>' context="htmlAttribute"/>">
-                                    <input type="hidden" name="month_of_birth" value="<carlos:encode value='<%= prefillMonthOfBirth %>' context="htmlAttribute"/>">
-                                    <input type="hidden" name="date_of_birth" value="<carlos:encode value='<%= prefillDateOfBirth %>' context="htmlAttribute"/>">
+                                    <input type="hidden" name="year_of_birth" id="year_of_birth" value="<carlos:encode value='<%= prefillYearOfBirth %>' context="htmlAttribute"/>">
+                                    <input type="hidden" name="month_of_birth" id="month_of_birth" value="<carlos:encode value='<%= prefillMonthOfBirth %>' context="htmlAttribute"/>">
+                                    <input type="hidden" name="date_of_birth" id="date_of_birth" value="<carlos:encode value='<%= prefillDateOfBirth %>' context="htmlAttribute"/>">
                                 </div>
                             </div>
                             <div class="col-sm-2 text-end">

--- a/src/main/webapp/WEB-INF/jsp/demographic/add.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/add.jsp
@@ -272,7 +272,7 @@
                 var mm = document.adddemographic.month_of_birth.value;
                 var dd = document.adddemographic.date_of_birth.value;
 
-                return checkDate(yyyy, mm, dd, i18n.msgWrongDOB);
+                return checkDate(yyyy, mm, dd, i18n.msgInvalidDOB);
             }
 
             function checkDate(yyyy, mm, dd, err_msg) {
@@ -281,15 +281,11 @@
 
                 if (checkTypeNum(yyyy) && checkTypeNum(mm) && checkTypeNum(dd)) {
                     var check_date = new Date(yyyy, (mm - 1), dd);
-                    var now = new Date();
-                    var year = now.getFullYear();
-                    var month = now.getMonth() + 1;
-                    var date = now.getDate();
-                    //alert(yyyy + " | " + mm + " | " + dd + " " + year + " " + month + " " +date);
 
-                    var young = new Date(year, month, date);
-                    var old = new Date(1800, 1, 1);
-                    //alert(check_date.getTime() + " | " + young.getTime() + " | " + old.getTime());
+                    var young = new Date();
+                    young.setDate(young.getDate() + 1); // allow to register newborns born today
+                    var old = new Date(1900, 0, 1);
+
                     if (check_date.getTime() <= young.getTime() && check_date.getTime() >= old.getTime() && yyyy.length == 4) {
                         typeInOK = true;
                     }

--- a/src/main/webapp/WEB-INF/jsp/demographic/add.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/add.jsp
@@ -130,6 +130,7 @@
             };
 
             function aSubmit() {
+                syncInputDobParts();
                 if (document.getElementById("eform_iframe") != null) {
                     document.getElementById("eform_iframe").contentWindow.document.forms[0].submit();
                 }
@@ -265,12 +266,18 @@
             }
 
             function checkDob() {
+                syncInputDobParts(); // ensure hidden part-fields reflect current visible input
                 var typeInOK = false;
                 var yyyy = document.adddemographic.year_of_birth.value;
-                var selectBox = document.adddemographic.month_of_birth;
-                var mm = selectBox.options[selectBox.selectedIndex].value;
-                selectBox = document.adddemographic.date_of_birth;
-                var dd = selectBox.options[selectBox.selectedIndex].value;
+                var mm = document.adddemographic.month_of_birth.value;
+                var dd = document.adddemographic.date_of_birth.value;
+
+                return checkDate(yyyy, mm, dd, i18n.msgWrongDOB);
+            }
+
+            function checkDate(yyyy, mm, dd, err_msg) {
+
+                var typeInOK = false;
 
                 if (checkTypeNum(yyyy) && checkTypeNum(mm) && checkTypeNum(dd)) {
                     var check_date = new Date(yyyy, (mm - 1), dd);
@@ -278,9 +285,11 @@
                     var year = now.getFullYear();
                     var month = now.getMonth() + 1;
                     var date = now.getDate();
+                    //alert(yyyy + " | " + mm + " | " + dd + " " + year + " " + month + " " +date);
 
                     var young = new Date(year, month, date);
                     var old = new Date(1800, 1, 1);
+                    //alert(check_date.getTime() + " | " + young.getTime() + " | " + old.getTime());
                     if (check_date.getTime() <= young.getTime() && check_date.getTime() >= old.getTime() && yyyy.length == 4) {
                         typeInOK = true;
                     }
@@ -289,12 +298,8 @@
                     }
                 }
 
-                if (!typeInOK) {
-                    alert(i18n.msgInvalidDOB);
-                }
-
-                if (!isValidDate(dd, mm, yyyy)) {
-                    alert(i18n.msgInvalidDOBDate);
+                if (!isValidDate(dd, mm, yyyy) || !typeInOK) {
+                    showAlert(err_msg + '<br>' + i18n.msgWrongDate);
                     typeInOK = false;
                 }
 
@@ -514,22 +519,6 @@
                 }
             }
 
-            function parsedob_date(){
-                const input=document.getElementById('inputDOB').value;
-                let year="";
-                let month="";
-                let day="";
-                if (input) {
-                    const [y, m, d] = input.split("-");
-                    year = y || "";
-                    month = m || "";
-                    day = d || "";
-                }
-                document.getElementById('year_of_birth').value = year
-                document.getElementById('month_of_birth').value = month
-                document.getElementById('date_of_birth').value = day
-            }
-
             function parseDateField(fieldId) {
                 const input = document.getElementById(fieldId).value;
             
@@ -683,6 +672,7 @@
         // Loop over them and prevent submission
         Array.from(forms).forEach(form => {
           form.addEventListener('submit', event => {
+            syncInputDobParts();
             if (!form.checkValidity()) {
               event.preventDefault()
               event.stopPropagation()
@@ -692,7 +682,12 @@
         })
       })
 
-
+        /* -------------------------------------------------------
+         * DOB single-input: calendar picker + hidden-field sync
+         * The server expects separate year_of_birth / month_of_birth /
+         * date_of_birth parameters; we derive them from the one visible
+         * yyyy-mm-dd field every time it changes or the calendar selects.
+         * ------------------------------------------------------- */
         Calendar.setup({
             inputField: "inputDOB",
             ifFormat: "%Y-%m-%d",
@@ -700,8 +695,31 @@
             button: "inputDOB_cal",
             singleClick: true,
             step: 1,
-            onUpdate: function() { parsedob_date(); }
+            onUpdate: function() { syncInputDobParts(); }
         });
+        function syncInputDobParts() {
+            var dobEl = document.getElementById('inputDOB');
+            var yearEl = document.getElementById('year_of_birth');
+            var monthEl = document.getElementById('month_of_birth');
+            var dayEl = document.getElementById('date_of_birth');
+            var val = dobEl ? dobEl.value.trim() : '';
+
+            if (!yearEl || !monthEl || !dayEl) {
+                return;
+            }
+
+            yearEl.value = '';
+            monthEl.value = '';
+            dayEl.value = '';
+
+            var parts = val.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+            if (parts) {
+                yearEl.value = parts[1];
+                monthEl.value = parts[2];
+                dayEl.value = parts[3];
+
+            }
+        }
         Calendar.setup({
             inputField: "waiting_list_referral_date",
             ifFormat: "%Y-%m-%d",

--- a/src/main/webapp/WEB-INF/jsp/demographic/add.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/add.jsp
@@ -655,7 +655,7 @@
 
                 <jsp:include page="/demographic/ViewZdemographicFullTitleSearch" />
 
-                <form method="post" id="adddemographic" name="adddemographic" action="DemographicAddRecord" novalidate class="needs-validation" onsubmit="return aSubmit()" autocomplete="off">
+                <form method="post" id="adddemographic" name="adddemographic" action="${ctx}/demographic/DemographicAddRecord" novalidate class="needs-validation" onsubmit="return aSubmit()" autocomplete="off">
 
                     <jsp:include page="add-form-personal.jsp"/>
                     <jsp:include page="add-form-clinical.jsp"/>


### PR DESCRIPTION
<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description
Mostly fixes country loading and logic errors for saving a DOB
the missing token issue will be covered by another PR by @yingbull
<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues

<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?

<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DOB parsing/validation so the single `inputDOB` stays in sync with hidden fields and saves correctly. Also allows registering newborns born today and updates the form action to include context/token.

- **Bug Fixes**
  - Sync `inputDOB` (yyyy-mm-dd) to hidden `year_of_birth`/`month_of_birth`/`date_of_birth` on change, calendar pick, and submit via `syncInputDobParts()`.
  - Prepopulate `inputDOB` from existing year/month/day with zero padding.
  - Centralize validation in `checkDate(yyyy, mm, dd, err)`; allow dates up to today (newborns), require year ≥ 1900, and show a combined error message.
  - Update form action to `${ctx}/demographic/DemographicAddRecord` to include context/token.

<sup>Written for commit b0642b8121af96f9f1fcc037650f87b6c82c8bd1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



