### PR TITLE
[Fix] Password reset fails 

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/login/Login2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/login/Login2Action.java
@@ -951,6 +951,7 @@ public final class Login2Action extends ActionSupport {
         }
         session.removeAttribute(LOGIN_CREDENTIALS_TOKEN_ATTR);
         session.removeAttribute("nextPage");
+        session.removeAttribute("userName");
     }
 
     /**
@@ -1023,6 +1024,7 @@ public final class Login2Action extends ActionSupport {
 
         String token = LoginCredentialCache.getInstance().store(credentials);
         session.setAttribute(LOGIN_CREDENTIALS_TOKEN_ATTR, token); // nosemgrep: tainted-session-from-http-request -- opaque random token, not user-controlled; no credential material in session
+        session.setAttribute("userName", userName); // nosemgrep: tainted-session-from-http-request -- login name only; gate checks on forcepasswordreset and MFA pages depend on this
     }
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/login/Login2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/login/Login2Action.java
@@ -1025,7 +1025,7 @@ public final class Login2Action extends ActionSupport {
         String token = LoginCredentialCache.getInstance().store(credentials);
         // Use an opaque random token, not user-controlled; no credential material in session
         session.setAttribute(LOGIN_CREDENTIALS_TOKEN_ATTR, token); // nosemgrep: tainted-session-from-http-request
-        // login name only; gate checks on forcepasswordreset and MFA pages depend on this
+        // Only add login name to sesssion; gate checks on forcepasswordreset and MFA pages depend on this
         session.setAttribute("userName", userName); // nosemgrep: tainted-session-from-http-request
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/login/Login2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/login/Login2Action.java
@@ -1025,7 +1025,7 @@ public final class Login2Action extends ActionSupport {
         String token = LoginCredentialCache.getInstance().store(credentials);
         // Use an opaque random token, not user-controlled; no credential material in session
         session.setAttribute(LOGIN_CREDENTIALS_TOKEN_ATTR, token); // nosemgrep: tainted-session-from-http-request
-        // Only add login name to sesssion; gate checks on forcepasswordreset and MFA pages depend on this
+        // (Only) add login name to sesssion; gate checks on forcepasswordreset and MFA pages depend on this
         session.setAttribute("userName", userName); // nosemgrep: tainted-session-from-http-request
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/login/Login2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/login/Login2Action.java
@@ -1025,7 +1025,7 @@ public final class Login2Action extends ActionSupport {
         String token = LoginCredentialCache.getInstance().store(credentials);
         // Use an opaque random token, not user-controlled; no credential material in session
         session.setAttribute(LOGIN_CREDENTIALS_TOKEN_ATTR, token); // nosemgrep: tainted-session-from-http-request
-        // (Only) add login name to sesssion; gate checks on forcepasswordreset and MFA pages depend on this
+        // (Only) login name in sesssion; gate checks on forcepasswordreset and MFA pages depend on this
         session.setAttribute("userName", userName); // nosemgrep: tainted-session-from-http-request
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/login/Login2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/login/Login2Action.java
@@ -1023,10 +1023,10 @@ public final class Login2Action extends ActionSupport {
         }
 
         String token = LoginCredentialCache.getInstance().store(credentials);
-        // nosemgrep: tainted-session-from-http-request -- opaque random token, not user-controlled; no credential material in session
-        session.setAttribute(LOGIN_CREDENTIALS_TOKEN_ATTR, token); 
-        // nosemgrep: tainted-session-from-http-request -- login name only; gate checks on forcepasswordreset and MFA pages depend on this
-        session.setAttribute("userName", userName);
+        // opaque random token, not user-controlled; no credential material in session
+        session.setAttribute(LOGIN_CREDENTIALS_TOKEN_ATTR, token); // nosemgrep: tainted-session-from-http-request
+        // login name only; gate checks on forcepasswordreset and MFA pages depend on this
+        session.setAttribute("userName", userName); // nosemgrep: tainted-session-from-http-request
     }
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/login/Login2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/login/Login2Action.java
@@ -1023,7 +1023,7 @@ public final class Login2Action extends ActionSupport {
         }
 
         String token = LoginCredentialCache.getInstance().store(credentials);
-        // opaque random token, not user-controlled; no credential material in session
+        // Use an opaque random token, not user-controlled; no credential material in session
         session.setAttribute(LOGIN_CREDENTIALS_TOKEN_ATTR, token); // nosemgrep: tainted-session-from-http-request
         // login name only; gate checks on forcepasswordreset and MFA pages depend on this
         session.setAttribute("userName", userName); // nosemgrep: tainted-session-from-http-request

--- a/src/main/java/io/github/carlos_emr/carlos/login/Login2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/login/Login2Action.java
@@ -1025,7 +1025,7 @@ public final class Login2Action extends ActionSupport {
         String token = LoginCredentialCache.getInstance().store(credentials);
         // Use an opaque random token, not user-controlled; no credential material in session
         session.setAttribute(LOGIN_CREDENTIALS_TOKEN_ATTR, token); // nosemgrep: tainted-session-from-http-request
-        // (Only) login name in sesssion; gate checks on forcepasswordreset and MFA pages depend on this
+        // Only login name in sesssion; gate checks on forcepasswordreset and MFA pages depend on this
         session.setAttribute("userName", userName); // nosemgrep: tainted-session-from-http-request
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/login/Login2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/login/Login2Action.java
@@ -1023,8 +1023,10 @@ public final class Login2Action extends ActionSupport {
         }
 
         String token = LoginCredentialCache.getInstance().store(credentials);
-        session.setAttribute(LOGIN_CREDENTIALS_TOKEN_ATTR, token); // nosemgrep: tainted-session-from-http-request -- opaque random token, not user-controlled; no credential material in session
-        session.setAttribute("userName", userName); // nosemgrep: tainted-session-from-http-request -- login name only; gate checks on forcepasswordreset and MFA pages depend on this
+        // nosemgrep: tainted-session-from-http-request -- opaque random token, not user-controlled; no credential material in session
+        session.setAttribute(LOGIN_CREDENTIALS_TOKEN_ATTR, token); 
+        // nosemgrep: tainted-session-from-http-request -- login name only; gate checks on forcepasswordreset and MFA pages depend on this
+        session.setAttribute("userName", userName);
     }
 
     /**


### PR DESCRIPTION
setUserInfoToSession now writes "userName" (the login name only — not a password or PIN, safe to store), and removeAttributesFromSession cleans it up. The force-password-reset page will now render correctly and the carlosdoc initial user from the Ontario init script will be able to log in and set their password.

<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description
Init script does not allow you to login
<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues
Fixes #2116 
<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?
the bug was tested on develop
the fix was tested on this branch
<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Bug Fixes:
- Fix password reset flow by persisting the login username in the session and cleaning it up when clearing session attributes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2116 by storing the login `userName` in the session during force-password-reset and clearing it during cleanup. Restores the reset flow (including the `carlosdoc` init user) and aligns `nosemgrep` suppressions and comment placement with the style guide.

<sup>Written for commit 5b216968bfaa323a0e5129b204ba927478380a2e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



