### PR TITLE
fix: inject csrfguard.js on extensionless Struts URLs

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/app/CsrfGuardScriptInjectionFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/app/CsrfGuardScriptInjectionFilter.java
@@ -172,6 +172,12 @@ public class CsrfGuardScriptInjectionFilter implements Filter {
             return;
         }
 
+        if (wrapper.isWriterPassthrough()) {
+            LOGGER.debug("CsrfGuard: writer passthrough for {} contentType={}",
+                    httpRequest.getRequestURI(), wrapper.getContentType());
+            return;
+        }
+
         String contentType = wrapper.getContentType();
         if (contentType == null || !contentType.toLowerCase(Locale.ROOT).startsWith("text/html")) {
             // Not HTML — write captured content through without modification
@@ -294,6 +300,7 @@ public class CsrfGuardScriptInjectionFilter implements Filter {
         private PrintWriter writer;
         private boolean usingOutputStream;
         private boolean usingWriter;
+        private boolean writerPassthrough;
         private boolean committed;
         private Integer deferredContentLength;
         private Long deferredContentLengthLong;
@@ -314,14 +321,7 @@ public class CsrfGuardScriptInjectionFilter implements Filter {
             usingOutputStream = true;
             // Apply any Content-Length that was set before we knew the response mode.
             // For output-stream passthrough, the header must reach the underlying response.
-            if (deferredContentLength != null) {
-                super.setContentLength(deferredContentLength);
-                deferredContentLength = null;
-            }
-            if (deferredContentLengthLong != null) {
-                super.setContentLengthLong(deferredContentLengthLong);
-                deferredContentLengthLong = null;
-            }
+            applyDeferredContentLength();
             return super.getOutputStream();
         }
 
@@ -332,8 +332,14 @@ public class CsrfGuardScriptInjectionFilter implements Filter {
             }
             usingWriter = true;
             if (writer == null) {
-                captureWriter = new CharArrayWriter();
-                writer = new PrintWriter(captureWriter);
+                if (isKnownNonHtmlContentType()) {
+                    writerPassthrough = true;
+                    applyDeferredContentLength();
+                    writer = super.getWriter();
+                } else {
+                    captureWriter = new CharArrayWriter();
+                    writer = new PrintWriter(captureWriter);
+                }
             }
             return writer;
         }
@@ -342,6 +348,10 @@ public class CsrfGuardScriptInjectionFilter implements Filter {
         public void setContentLength(int len) {
             if (usingOutputStream) {
                 // Output-stream passthrough: the real response owns the content, so pass through
+                super.setContentLength(len);
+                return;
+            }
+            if (writerPassthrough) {
                 super.setContentLength(len);
                 return;
             }
@@ -357,6 +367,10 @@ public class CsrfGuardScriptInjectionFilter implements Filter {
         public void setContentLengthLong(long len) {
             if (usingOutputStream) {
                 // Output-stream passthrough: the real response owns the content, so pass through
+                super.setContentLengthLong(len);
+                return;
+            }
+            if (writerPassthrough) {
                 super.setContentLengthLong(len);
                 return;
             }
@@ -398,6 +412,10 @@ public class CsrfGuardScriptInjectionFilter implements Filter {
                 super.flushBuffer();
                 return;
             }
+            if (writerPassthrough) {
+                super.flushBuffer();
+                return;
+            }
             // Suppress flushing to prevent captured content from being committed to the client
             // before script injection.
             if (LOGGER.isDebugEnabled()) {
@@ -418,6 +436,9 @@ public class CsrfGuardScriptInjectionFilter implements Filter {
          */
         @Override
         public boolean isCommitted() {
+            if (writerPassthrough) {
+                return committed || super.isCommitted();
+            }
             if (usingWriter && !committed) {
                 return false;
             }
@@ -432,11 +453,31 @@ public class CsrfGuardScriptInjectionFilter implements Filter {
             return usingWriter;
         }
 
+        public boolean isWriterPassthrough() {
+            return writerPassthrough;
+        }
+
         public String getCapturedContent() {
             if (writer != null) {
                 writer.flush();
             }
             return captureWriter != null ? captureWriter.toString() : "";
+        }
+
+        private boolean isKnownNonHtmlContentType() {
+            String contentType = getContentType();
+            return contentType != null && !contentType.toLowerCase(Locale.ROOT).startsWith("text/html");
+        }
+
+        private void applyDeferredContentLength() {
+            if (deferredContentLength != null) {
+                super.setContentLength(deferredContentLength);
+                deferredContentLength = null;
+            }
+            if (deferredContentLengthLong != null) {
+                super.setContentLengthLong(deferredContentLengthLong);
+                deferredContentLengthLong = null;
+            }
         }
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/app/CsrfGuardScriptInjectionFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/app/CsrfGuardScriptInjectionFilter.java
@@ -499,7 +499,6 @@ public class CsrfGuardScriptInjectionFilter implements Filter {
         /**
          * Defers choosing capture vs. passthrough until the first write, when Content-Type
          * may be known even if it was not set when getWriter() was called.
-         *
          */
         private class LazyCaptureWriter extends Writer {
             private Writer target;

--- a/src/main/java/io/github/carlos_emr/carlos/app/CsrfGuardScriptInjectionFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/app/CsrfGuardScriptInjectionFilter.java
@@ -38,6 +38,7 @@ import jakarta.servlet.http.HttpServletResponseWrapper;
 import java.io.CharArrayWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.io.Writer;
 import java.util.Locale;
 import java.util.regex.Pattern;
 
@@ -179,7 +180,7 @@ public class CsrfGuardScriptInjectionFilter implements Filter {
         }
 
         String contentType = wrapper.getContentType();
-        if (contentType == null || !contentType.toLowerCase(Locale.ROOT).startsWith("text/html")) {
+        if (!isHtmlContentType(contentType)) {
             // Not HTML — write captured content through without modification
             writeToResponse(httpResponse, wrapper.getCapturedContent());
             return;
@@ -282,6 +283,10 @@ public class CsrfGuardScriptInjectionFilter implements Filter {
         }
     }
 
+    private static boolean isHtmlContentType(String contentType) {
+        return contentType != null && contentType.toLowerCase(Locale.ROOT).startsWith("text/html");
+    }
+
     @Override
     public void destroy() {
         // No cleanup required
@@ -337,8 +342,7 @@ public class CsrfGuardScriptInjectionFilter implements Filter {
                     applyDeferredContentLength();
                     writer = super.getWriter();
                 } else {
-                    captureWriter = new CharArrayWriter();
-                    writer = new PrintWriter(captureWriter);
+                    writer = new PrintWriter(new LazyCaptureWriter());
                 }
             }
             return writer;
@@ -466,7 +470,7 @@ public class CsrfGuardScriptInjectionFilter implements Filter {
 
         private boolean isKnownNonHtmlContentType() {
             String contentType = getContentType();
-            return contentType != null && !contentType.toLowerCase(Locale.ROOT).startsWith("text/html");
+            return contentType != null && !isHtmlContentType(contentType);
         }
 
         private void applyDeferredContentLength() {
@@ -477,6 +481,43 @@ public class CsrfGuardScriptInjectionFilter implements Filter {
             if (deferredContentLengthLong != null) {
                 super.setContentLengthLong(deferredContentLengthLong);
                 deferredContentLengthLong = null;
+            }
+        }
+
+        private class LazyCaptureWriter extends Writer {
+            private Writer target;
+
+            @Override
+            public void write(char[] chars, int offset, int length) throws IOException {
+                getTarget().write(chars, offset, length);
+            }
+
+            @Override
+            public void flush() throws IOException {
+                if (target != null) {
+                    target.flush();
+                }
+            }
+
+            @Override
+            public void close() throws IOException {
+                if (target != null) {
+                    target.close();
+                }
+            }
+
+            private Writer getTarget() throws IOException {
+                if (target == null) {
+                    if (isKnownNonHtmlContentType()) {
+                        writerPassthrough = true;
+                        applyDeferredContentLength();
+                        target = CaptureResponseWrapper.super.getWriter();
+                    } else {
+                        captureWriter = new CharArrayWriter();
+                        target = captureWriter;
+                    }
+                }
+                return target;
             }
         }
     }

--- a/src/main/java/io/github/carlos_emr/carlos/app/CsrfGuardScriptInjectionFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/app/CsrfGuardScriptInjectionFilter.java
@@ -499,13 +499,26 @@ public class CsrfGuardScriptInjectionFilter implements Filter {
         /**
          * Defers choosing capture vs. passthrough until the first write, when Content-Type
          * may be known even if it was not set when getWriter() was called.
+         *
+         * <p>Servlet responses are request-scoped and written by one request thread in this
+         * filter path, so the lazy target selection intentionally avoids synchronization.</p>
          */
         private class LazyCaptureWriter extends Writer {
             private Writer target;
 
             @Override
+            public void write(int character) throws IOException {
+                getTarget().write(character);
+            }
+
+            @Override
             public void write(char[] chars, int offset, int length) throws IOException {
                 getTarget().write(chars, offset, length);
+            }
+
+            @Override
+            public void write(String string, int offset, int length) throws IOException {
+                getTarget().write(string, offset, length);
             }
 
             @Override

--- a/src/main/java/io/github/carlos_emr/carlos/app/CsrfGuardScriptInjectionFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/app/CsrfGuardScriptInjectionFilter.java
@@ -500,11 +500,9 @@ public class CsrfGuardScriptInjectionFilter implements Filter {
          * Defers choosing capture vs. passthrough until the first write, when Content-Type
          * may be known even if it was not set when getWriter() was called.
          *
-         * <p>Servlet responses are request-scoped and written by one request thread in this
-         * filter path, so the lazy target selection intentionally avoids synchronization.</p>
          */
         private class LazyCaptureWriter extends Writer {
-            private volatile Writer target;
+            private Writer target;
 
             @Override
             public void write(int character) throws IOException {
@@ -535,7 +533,7 @@ public class CsrfGuardScriptInjectionFilter implements Filter {
                 }
             }
 
-            private Writer getTarget() throws IOException {
+            private synchronized Writer getTarget() throws IOException {
                 if (target == null) {
                     if (isKnownNonHtmlContentType()) {
                         writerPassthrough = true;

--- a/src/main/java/io/github/carlos_emr/carlos/app/CsrfGuardScriptInjectionFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/app/CsrfGuardScriptInjectionFilter.java
@@ -283,6 +283,9 @@ public class CsrfGuardScriptInjectionFilter implements Filter {
         }
     }
 
+    /**
+     * Returns whether the supplied Content-Type represents an HTML response.
+     */
     private static boolean isHtmlContentType(String contentType) {
         return contentType != null && contentType.toLowerCase(Locale.ROOT).startsWith("text/html");
     }
@@ -457,6 +460,9 @@ public class CsrfGuardScriptInjectionFilter implements Filter {
             return usingWriter;
         }
 
+        /**
+         * Returns whether writer output has been delegated directly to the underlying response.
+         */
         public boolean isWriterPassthrough() {
             return writerPassthrough;
         }
@@ -468,11 +474,17 @@ public class CsrfGuardScriptInjectionFilter implements Filter {
             return captureWriter != null ? captureWriter.toString() : "";
         }
 
+        /**
+         * Returns true only when Content-Type is known and not HTML.
+         */
         private boolean isKnownNonHtmlContentType() {
             String contentType = getContentType();
             return contentType != null && !isHtmlContentType(contentType);
         }
 
+        /**
+         * Applies Content-Length values deferred while the response mode was still unknown.
+         */
         private void applyDeferredContentLength() {
             if (deferredContentLength != null) {
                 super.setContentLength(deferredContentLength);
@@ -484,6 +496,10 @@ public class CsrfGuardScriptInjectionFilter implements Filter {
             }
         }
 
+        /**
+         * Defers choosing capture vs. passthrough until the first write, when Content-Type
+         * may be known even if it was not set when getWriter() was called.
+         */
         private class LazyCaptureWriter extends Writer {
             private Writer target;
 

--- a/src/main/java/io/github/carlos_emr/carlos/app/CsrfGuardScriptInjectionFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/app/CsrfGuardScriptInjectionFilter.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Writer;
 import java.util.Locale;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 
 /**
@@ -501,7 +502,8 @@ public class CsrfGuardScriptInjectionFilter implements Filter {
          * may be known even if it was not set when getWriter() was called.
          */
         private class LazyCaptureWriter extends Writer {
-            private volatile Writer target;
+            private final AtomicReference<Writer> target = new AtomicReference<>();
+            private final Object targetLock = new Object();
 
             @Override
             public void write(int character) throws IOException {
@@ -520,26 +522,28 @@ public class CsrfGuardScriptInjectionFilter implements Filter {
 
             @Override
             public void flush() throws IOException {
-                if (target != null) {
-                    target.flush();
+                Writer currentTarget = target.get();
+                if (currentTarget != null) {
+                    currentTarget.flush();
                 }
             }
 
             @Override
             public void close() throws IOException {
-                if (target != null) {
-                    target.close();
+                Writer currentTarget = target.get();
+                if (currentTarget != null) {
+                    currentTarget.close();
                 }
             }
 
             private Writer getTarget() throws IOException {
-                Writer currentTarget = target;
+                Writer currentTarget = target.get();
                 if (currentTarget == null) {
-                    synchronized (this) {
-                        currentTarget = target;
+                    synchronized (targetLock) {
+                        currentTarget = target.get();
                         if (currentTarget == null) {
                             currentTarget = createTarget();
-                            target = currentTarget;
+                            target.set(currentTarget);
                         }
                     }
                 }

--- a/src/main/java/io/github/carlos_emr/carlos/app/CsrfGuardScriptInjectionFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/app/CsrfGuardScriptInjectionFilter.java
@@ -501,7 +501,7 @@ public class CsrfGuardScriptInjectionFilter implements Filter {
          * may be known even if it was not set when getWriter() was called.
          */
         private class LazyCaptureWriter extends Writer {
-            private Writer target;
+            private volatile Writer target;
 
             @Override
             public void write(int character) throws IOException {
@@ -532,18 +532,28 @@ public class CsrfGuardScriptInjectionFilter implements Filter {
                 }
             }
 
-            private synchronized Writer getTarget() throws IOException {
-                if (target == null) {
-                    if (isKnownNonHtmlContentType()) {
-                        writerPassthrough = true;
-                        applyDeferredContentLength();
-                        target = CaptureResponseWrapper.super.getWriter();
-                    } else {
-                        captureWriter = new CharArrayWriter();
-                        target = captureWriter;
+            private Writer getTarget() throws IOException {
+                Writer currentTarget = target;
+                if (currentTarget == null) {
+                    synchronized (this) {
+                        currentTarget = target;
+                        if (currentTarget == null) {
+                            currentTarget = createTarget();
+                            target = currentTarget;
+                        }
                     }
                 }
-                return target;
+                return currentTarget;
+            }
+
+            private Writer createTarget() throws IOException {
+                if (isKnownNonHtmlContentType()) {
+                    writerPassthrough = true;
+                    applyDeferredContentLength();
+                    return CaptureResponseWrapper.super.getWriter();
+                }
+                captureWriter = new CharArrayWriter();
+                return captureWriter;
             }
         }
     }

--- a/src/main/java/io/github/carlos_emr/carlos/app/CsrfGuardScriptInjectionFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/app/CsrfGuardScriptInjectionFilter.java
@@ -125,18 +125,6 @@ public class CsrfGuardScriptInjectionFilter implements Filter {
             }
         }
 
-        // Skip outer Struts action requests — Tomcat 11's RequestDispatcher.forward()
-        // closes the output stream after the first buffer flush, truncating responses
-        // > 8KB. The filter-mapping includes FORWARD dispatcher so this filter also
-        // runs when Struts forwards to the JSP, wrapping it there to prevent
-        // truncation. AJAX sidebar calls use EctDisplayAction.include() which bypasses
-        // Struts results entirely.
-        String servletPath = httpRequest.getServletPath();
-        if (HttpMethodGuardFilter.isActionPath(servletPath)) {
-            chain.doFilter(request, response);
-            return;
-        }
-
         // Skip if CsrfGuard is disabled
         CsrfGuard csrfGuard;
         try {

--- a/src/main/java/io/github/carlos_emr/carlos/app/CsrfGuardScriptInjectionFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/app/CsrfGuardScriptInjectionFilter.java
@@ -504,7 +504,7 @@ public class CsrfGuardScriptInjectionFilter implements Filter {
          * filter path, so the lazy target selection intentionally avoids synchronization.</p>
          */
         private class LazyCaptureWriter extends Writer {
-            private Writer target;
+            private volatile Writer target;
 
             @Override
             public void write(int character) throws IOException {

--- a/src/test/java/io/github/carlos_emr/carlos/app/CsrfGuardScriptInjectionFilterUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/app/CsrfGuardScriptInjectionFilterUnitTest.java
@@ -173,9 +173,10 @@ class CsrfGuardScriptInjectionFilterUnitTest {
             csrfGuardMock.when(CsrfGuard::getInstance).thenReturn(csrfGuard);
             try {
                 executable.execute();
-            } catch (Exception e) {
-                throw e;
             } catch (Throwable t) {
+                if (t instanceof Exception e) {
+                    throw e;
+                }
                 throw new AssertionError(t);
             }
         }

--- a/src/test/java/io/github/carlos_emr/carlos/app/CsrfGuardScriptInjectionFilterUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/app/CsrfGuardScriptInjectionFilterUnitTest.java
@@ -61,7 +61,7 @@ class CsrfGuardScriptInjectionFilterUnitTest {
 
     @Test
     @DisplayName("should inject CSRFGuard script for extensionless request to forwarded JSP")
-    void shouldInjectCsrfguardScript_forExtensionlessRequestToForwardedJsp() throws Exception {
+    void shouldInjectCsrfGuardScript_forExtensionlessRequestToForwardedJsp() throws Exception {
         // DemographicAdd is a representative extensionless Struts route from struts-demographic.xml.
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/demographic/DemographicAdd");
         request.setContextPath("/carlos");
@@ -89,7 +89,7 @@ class CsrfGuardScriptInjectionFilterUnitTest {
 
     @Test
     @DisplayName("should not inject duplicate CSRFGuard script")
-    void shouldNotInjectDuplicateCsrfguardScript_whenScriptAlreadyExists() throws Exception {
+    void shouldNotInjectDuplicateCsrfGuardScript_whenScriptAlreadyExists() throws Exception {
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/encounter/IncomingEncounter");
         request.setContextPath("/carlos");
         MockHttpServletResponse response = new MockHttpServletResponse();

--- a/src/test/java/io/github/carlos_emr/carlos/app/CsrfGuardScriptInjectionFilterUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/app/CsrfGuardScriptInjectionFilterUnitTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 import org.mockito.MockedStatic;
 import org.owasp.csrfguard.CsrfGuard;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -165,12 +166,18 @@ class CsrfGuardScriptInjectionFilterUnitTest {
         assertThat(response.getContentLength()).isEqualTo(body.getBytes(StandardCharsets.UTF_8).length);
     }
 
-    private void withEnabledCsrfGuard(ThrowingRunnable runnable) throws Exception {
+    private void withEnabledCsrfGuard(Executable executable) throws Exception {
         CsrfGuard csrfGuard = mock(CsrfGuard.class);
         when(csrfGuard.isEnabled()).thenReturn(true);
         try (MockedStatic<CsrfGuard> csrfGuardMock = mockStatic(CsrfGuard.class)) {
             csrfGuardMock.when(CsrfGuard::getInstance).thenReturn(csrfGuard);
-            runnable.run();
+            try {
+                executable.execute();
+            } catch (Exception e) {
+                throw e;
+            } catch (Throwable t) {
+                throw new AssertionError(t);
+            }
         }
     }
 
@@ -182,10 +189,5 @@ class CsrfGuardScriptInjectionFilterUnitTest {
             index += needle.length();
         }
         return count;
-    }
-
-    @FunctionalInterface
-    private interface ThrowingRunnable {
-        void run() throws Exception;
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/app/CsrfGuardScriptInjectionFilterUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/app/CsrfGuardScriptInjectionFilterUnitTest.java
@@ -24,6 +24,7 @@ package io.github.carlos_emr.carlos.app;
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.FilterConfig;
+import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -131,9 +132,10 @@ class CsrfGuardScriptInjectionFilterUnitTest {
         String body = "{\"status\":\"ok\"}";
 
         FilterChain chain = (servletRequest, servletResponse) -> {
-            servletResponse.setContentType("application/json;charset=UTF-8");
             servletResponse.setContentLength(body.getBytes(StandardCharsets.UTF_8).length);
-            servletResponse.getWriter().write(body);
+            PrintWriter writer = servletResponse.getWriter();
+            servletResponse.setContentType("application/json;charset=UTF-8");
+            writer.write(body);
         };
 
         withEnabledCsrfGuard(() -> filter.doFilter(request, response, chain));

--- a/src/test/java/io/github/carlos_emr/carlos/app/CsrfGuardScriptInjectionFilterUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/app/CsrfGuardScriptInjectionFilterUnitTest.java
@@ -61,6 +61,7 @@ class CsrfGuardScriptInjectionFilterUnitTest {
     @Test
     @DisplayName("should inject CSRFGuard script for extensionless request to forwarded JSP")
     void shouldInjectCsrfguardScript_forExtensionlessRequestToForwardedJsp() throws Exception {
+        // DemographicAdd is a representative extensionless Struts route from struts-demographic.xml.
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/demographic/DemographicAdd");
         request.setContextPath("/carlos");
         request.setDispatcherType(DispatcherType.REQUEST);
@@ -124,8 +125,27 @@ class CsrfGuardScriptInjectionFilterUnitTest {
     }
 
     @Test
-    @DisplayName("should pass through non-HTML writer responses")
-    void shouldPassThrough_whenWriterResponseIsNonHtml() throws Exception {
+    @DisplayName("should pass through non-HTML writer responses when content type is set before writer")
+    void shouldPassThrough_whenNonHtmlContentTypePrecedesWriter() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/clinical/JsonEndpoint");
+        request.setContextPath("/carlos");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        String body = "{\"status\":\"ok\"}";
+
+        FilterChain chain = (servletRequest, servletResponse) -> {
+            servletResponse.setContentType("application/json;charset=UTF-8");
+            servletResponse.getWriter().write(body);
+        };
+
+        withEnabledCsrfGuard(() -> filter.doFilter(request, response, chain));
+
+        assertThat(response.getContentAsString()).isEqualTo(body);
+        assertThat(response.getContentAsString()).doesNotContain("/csrfguard");
+    }
+
+    @Test
+    @DisplayName("should pass through non-HTML writer responses when content type follows writer")
+    void shouldPassThrough_whenNonHtmlContentTypeFollowsWriter() throws Exception {
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/clinical/JsonEndpoint");
         request.setContextPath("/carlos");
         MockHttpServletResponse response = new MockHttpServletResponse();

--- a/src/test/java/io/github/carlos_emr/carlos/app/CsrfGuardScriptInjectionFilterUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/app/CsrfGuardScriptInjectionFilterUnitTest.java
@@ -1,0 +1,169 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.app;
+
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.owasp.csrfguard.CsrfGuard;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link CsrfGuardScriptInjectionFilter}.
+ *
+ * @since 2026-05-08
+ */
+@Tag("unit")
+@Tag("security")
+@DisplayName("CsrfGuardScriptInjectionFilter")
+class CsrfGuardScriptInjectionFilterUnitTest {
+
+    private CsrfGuardScriptInjectionFilter filter;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        filter = new CsrfGuardScriptInjectionFilter();
+        filter.init(mock(FilterConfig.class));
+    }
+
+    @Test
+    @DisplayName("should inject CSRFGuard script for extensionless request to forwarded JSP")
+    void shouldInjectCsrfguardScript_forExtensionlessRequestToForwardedJsp() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/demographic/DemographicAdd");
+        request.setContextPath("/carlos");
+        request.setDispatcherType(DispatcherType.REQUEST);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        FilterChain chain = (servletRequest, servletResponse) -> {
+            MockHttpServletRequest forwardRequest = new MockHttpServletRequest("GET",
+                    "/WEB-INF/jsp/demographic/demographicadd.jsp");
+            forwardRequest.setContextPath("/carlos");
+            forwardRequest.setDispatcherType(DispatcherType.FORWARD);
+
+            filter.doFilter(forwardRequest, servletResponse, (forwardServletRequest, forwardServletResponse) -> {
+                forwardServletResponse.setContentType("text/html;charset=UTF-8");
+                forwardServletResponse.getWriter().write("<html><head><title>Add</title></head><body></body></html>");
+            });
+        };
+
+        withEnabledCsrfGuard(() -> filter.doFilter(request, response, chain));
+
+        String content = response.getContentAsString();
+        assertThat(content).contains("<script src=\"/carlos/csrfguard\"></script>\n</head>");
+        assertThat(countOccurrences(content, "/csrfguard")).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("should not inject duplicate CSRFGuard script")
+    void shouldNotInjectDuplicateCsrfguardScript_whenScriptAlreadyExists() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/encounter/IncomingEncounter");
+        request.setContextPath("/carlos");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        FilterChain chain = (servletRequest, servletResponse) -> {
+            servletResponse.setContentType("text/html;charset=UTF-8");
+            servletResponse.getWriter().write("<html><head><script src=\"/carlos/csrfguard\"></script></head>"
+                    + "<body></body></html>");
+        };
+
+        withEnabledCsrfGuard(() -> filter.doFilter(request, response, chain));
+
+        String content = response.getContentAsString();
+        assertThat(countOccurrences(content, "/csrfguard")).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("should pass through output-stream responses")
+    void shouldPassThrough_whenResponseUsesOutputStream() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/OscarChartPrint");
+        request.setContextPath("/carlos");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        byte[] body = "%PDF-1.7".getBytes(StandardCharsets.UTF_8);
+
+        FilterChain chain = (servletRequest, servletResponse) -> {
+            servletResponse.setContentType("application/pdf");
+            servletResponse.getOutputStream().write(body);
+        };
+
+        withEnabledCsrfGuard(() -> filter.doFilter(request, response, chain));
+
+        assertThat(response.getContentAsByteArray()).isEqualTo(body);
+        assertThat(response.getContentAsString()).doesNotContain("/csrfguard");
+    }
+
+    @Test
+    @DisplayName("should pass through non-HTML writer responses")
+    void shouldPassThrough_whenWriterResponseIsNonHtml() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/clinical/JsonEndpoint");
+        request.setContextPath("/carlos");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        String body = "{\"status\":\"ok\"}";
+
+        FilterChain chain = (servletRequest, servletResponse) -> {
+            servletResponse.setContentType("application/json;charset=UTF-8");
+            servletResponse.setContentLength(body.getBytes(StandardCharsets.UTF_8).length);
+            servletResponse.getWriter().write(body);
+        };
+
+        withEnabledCsrfGuard(() -> filter.doFilter(request, response, chain));
+
+        assertThat(response.getContentAsString()).isEqualTo(body);
+        assertThat(response.getContentAsString()).doesNotContain("/csrfguard");
+        assertThat(response.getContentLength()).isEqualTo(body.getBytes(StandardCharsets.UTF_8).length);
+    }
+
+    private void withEnabledCsrfGuard(ThrowingRunnable runnable) throws Exception {
+        CsrfGuard csrfGuard = mock(CsrfGuard.class);
+        when(csrfGuard.isEnabled()).thenReturn(true);
+        try (MockedStatic<CsrfGuard> csrfGuardMock = mockStatic(CsrfGuard.class)) {
+            csrfGuardMock.when(CsrfGuard::getInstance).thenReturn(csrfGuard);
+            runnable.run();
+        }
+    }
+
+    private int countOccurrences(String content, String needle) {
+        int count = 0;
+        int index = 0;
+        while ((index = content.indexOf(needle, index)) >= 0) {
+            count++;
+            index += needle.length();
+        }
+        return count;
+    }
+
+    @FunctionalInterface
+    private interface ThrowingRunnable {
+        void run() throws Exception;
+    }
+}


### PR DESCRIPTION
The filter previously skipped wrapping for any path with no '.' in the
last segment (HttpMethodGuardFilter.isActionPath), expecting the FORWARD
dispatch on the rendered JSP to inject the script. In practice, pages
reached via extensionless Struts routes (/demographic/DemographicAdd,
/casemgmt/*, /encounter/*, /OscarChartPrint, ...) end up without
csrfguard.js, so CSRFGuard never injects the hidden CSRF-TOKEN input
into their forms. Form POSTs and AJAX submissions then fail token
validation with the visible 'Error: 0' on catalina.

Drop the action-path skip. The filter now wraps on REQUEST for every
path; the existing CaptureResponseWrapper safeguards still apply:

  - getOutputStream() delegates straight to the underlying response and
    sets usingOutputStream, so binary streamers (PDFs, ZIPs, PNGs, CSVs
    on /lab/CA/ALL/PrintPDF, /OscarChartPrint, /encounter/GraphMeasurements,
    etc.) bail at line 161 without injection.
  - The text/html content-type check skips the 108 application/json
    actions and other non-HTML responses.
  - The CSRFGUARD_SCRIPT_PATTERN idempotency check prevents double-
    injection in the nested REQUEST-wrap + FORWARD-wrap case.
  - flushBuffer() suppression and isCommitted() override remain to
    fight the Tomcat 11 forward truncation issue PR #1959 was guarding
    against.

## Summary by Sourcery

Bug Fixes:
- Fix missing csrfguard.js injection on extensionless Struts routes whose responses were previously not wrapped by the CSRFGuard script injection filter.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Injects csrfguard.js on extensionless Struts URLs by wrapping all REQUEST dispatches. Adds a lazy writer passthrough so non-HTML writer responses aren’t buffered and keep Content-Length, even if Content-Type is set before or after getWriter().

- **Bug Fixes**
  - Wrap every REQUEST; extensionless routes now get `csrfguard.js`; output-stream passthrough unchanged; writer-passthrough short-circuits non-HTML after first write.
  - Lazy writer defers and atomically selects capture vs passthrough; for non-HTML, delegates directly and applies deferred Content-Length; passthrough honors flush/isCommitted.
  - Safeguards: HTML-only via `isHtmlContentType`, duplicate-script check, Tomcat forward truncation protection; tests cover injection/no-duplicates, PDF/JSON passthrough, writer ordering, and Content-Length.

<sup>Written for commit 9cf72e96f65312bb791570a3980ba817a3927940. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

