### PR TITLE
[Fix] Add missing _admin.schedule privilege

### DIFF
--- a/database/mysql/oscardata.sql
+++ b/database/mysql/oscardata.sql
@@ -1749,6 +1749,7 @@ insert into `secObjPrivilege` values('admin','_admin.flowsheet','x',0,'999998');
 insert into `secObjPrivilege` values('admin','_admin.eformreporttool','x',0,'999998');
 insert into `secObjPrivilege` values('admin','_admin.billing','x',0,'999998');
 insert into `secObjPrivilege` values('admin','_admin.misc','x',0,'999998');
+insert into `secObjPrivilege` values('admin','_admin.schedule','x',0,'999998');
 insert into `secObjPrivilege` values('admin','_appointment','x',0,'999998');
 insert into `secObjPrivilege` values('admin','_appointment.doctorLink','x',0,'999998');
 insert into `secObjPrivilege` values('admin','_pmm.addProgram','x',0,'999998');

--- a/database/mysql/updates/update-2026-05-09-admin-schedule-privilege.sql
+++ b/database/mysql/updates/update-2026-05-09-admin-schedule-privilege.sql
@@ -1,0 +1,14 @@
+-- Fix missing _admin.schedule privilege that left all schedule admin pages
+-- inaccessible, including TemplateSetting, TemplateCodeSetting,
+-- TemplateApplying, HolidaySetting, EditTemplate, and CreateDate.
+--
+-- secObjectName row for _admin.schedule was added in oscardata.sql (line 1510)
+-- but the matching secObjPrivilege row for the admin role was never inserted,
+-- so hasPrivilege() returned false for every user including carlosdoc, causing
+-- a SecurityException on every schedule administration page.
+--
+-- References: Bug #2121
+
+INSERT IGNORE INTO `secObjectName` (`objectName`) VALUES ('_admin.schedule');
+INSERT IGNORE INTO `secObjPrivilege` (`roleUserGroup`, `objectName`, `privilege`, `priority`, `provider_no`)
+    VALUES ('admin', '_admin.schedule', 'x', 0, '999998');


### PR DESCRIPTION
The _admin.schedule object was defined in
secObjectName
but the corresponding secObjPrivilege row granting it to the admin role was simply never inserted
Signed-off-by: phc007 <phc007@users.noreply.github.com>

<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description

<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues
Fixes #2121 
<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?

<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Grant the `_admin.schedule` privilege to the admin role so schedule administration pages are accessible and safely backfill this privilege in existing databases.

Bug Fixes:
- Add the missing `_admin.schedule` privilege entry for the admin role to restore access to schedule administration pages.

Enhancements:
- Introduce a migration script that idempotently inserts the `_admin.schedule` secObjectName and corresponding admin privilege for existing installations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Grant `_admin.schedule` to the `admin` role to restore access to schedule administration pages. Fixes #2121 where schedule settings were inaccessible due to a missing privilege.

- **Bug Fixes**
  - Seeded `secObjPrivilege` for `admin` → `_admin.schedule` with `x`.
  - Added update script to `INSERT IGNORE` missing `secObjectName` and privilege for safe migration.

<sup>Written for commit 76eea7bf339461a5dbc0c0bc2abf9efe9ac057cb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

