### PR TITLE
Fix NPE's when generating OHIP billing files

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/assembler/BillingOnMriViewModelAssembler.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/assembler/BillingOnMriViewModelAssembler.java
@@ -237,7 +237,7 @@ public class BillingOnMriViewModelAssembler {
                 // Map.copyOf() in BillingOnMriViewModel.Builder rejects null values —
                 // coerce to empty string so a provider with an unset bill-center code
                 // does not cause a NullPointerException when the view model is built.
-                map.put(providerNo, nullToEmpty(pbc.getBillCenterCode()));
+                map.put(providerNo, pbc.getBillCenterCode() == null ? "" : pbc.getBillCenterCode());
             }
         }
         return map;

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/assembler/BillingOnMriViewModelAssembler.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/assembler/BillingOnMriViewModelAssembler.java
@@ -21,8 +21,10 @@
  */
 package io.github.carlos_emr.carlos.billings.ca.on.assembler;
 
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Enumeration;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
@@ -31,7 +33,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.ArrayList;
 import jakarta.servlet.http.HttpServletRequest;
 
 import io.github.carlos_emr.CarlosProperties;
@@ -233,7 +234,10 @@ public class BillingOnMriViewModelAssembler {
             String providerNo = p.getProviderNo();
             ProviderBillCenter pbc = providerBillCenterDao.find(providerNo);
             if (pbc != null) {
-                map.put(providerNo, pbc.getBillCenterCode());
+                // Map.copyOf() in BillingOnMriViewModel.Builder rejects null values —
+                // coerce to empty string so a provider with an unset bill-center code
+                // does not cause a NullPointerException when the view model is built.
+                map.put(providerNo, nullToEmpty(pbc.getBillCenterCode()));
             }
         }
         return map;
@@ -316,13 +320,14 @@ public class BillingOnMriViewModelAssembler {
             }
         }
 
-        java.util.Date startDate = ConversionUtils.fromDateString(selectedYear + "-01-01 00:00:00");
-        java.util.Date endDate = ConversionUtils.fromDateString(selectedYear + "-12-31 23:59:59");
+        java.util.Date startDate = ConversionUtils.fromTimestampString(selectedYear + "-01-01 00:00:00");
+        java.util.Date endDate = ConversionUtils.fromTimestampString(selectedYear + "-12-31 23:59:59");
         List<BillActivity> bas = billActivityDao.findCurrentByDateRange(startDate, endDate);
         if (bas == null) {
             return Collections.emptyList();
         }
-        Collections.sort(bas, BillActivity.UpdateDateTimeComparator);
+        // Use a null-safe comparator — updateDateTime can be null for in-progress claims.
+        bas.sort(Comparator.comparing(BillActivity::getUpdateDateTime, Comparator.nullsLast(Comparator.reverseOrder())));
 
         List<BillingOnMriViewModel.BillActivityRow> rows = new ArrayList<>();
         int count = 0;

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/ViewBillingOnMri2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/ViewBillingOnMri2Action.java
@@ -31,6 +31,7 @@ import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import org.apache.struts2.ActionSupport;
 import org.apache.struts2.ServletActionContext;
 import io.github.carlos_emr.carlos.billings.ca.on.assembler.BillingOnMriViewModelAssembler;
+import io.github.carlos_emr.carlos.billings.ca.on.service.BillingDataLoadException;
 
 /**
  * View gate for {@code billing/CA/ON/billingONMRI.jsp}, the "Generate OHIP
@@ -68,7 +69,14 @@ public class ViewBillingOnMri2Action extends ActionSupport {
             throw new SecurityException("missing required sec object (_billing)");
         }
 
-        BillingOnMriViewModel model = billingONMRIAssembler.assemble(request, loggedInInfo);
+        BillingOnMriViewModel model;
+        try {
+            model = billingONMRIAssembler.assemble(request, loggedInInfo);
+        } catch (BillingDataLoadException e) {
+            throw e;
+        } catch (RuntimeException e) {
+            throw new BillingDataLoadException("Failed to load OHIP report view model", e);
+        }
         request.setAttribute("mriModel", model);
 
         // Replicates the legacy session-attribute the JSP scriptlet set so the

--- a/src/test/java/io/github/carlos_emr/carlos/billings/ca/on/web/ViewBillingOnMri2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/billings/ca/on/web/ViewBillingOnMri2ActionUnitTest.java
@@ -114,7 +114,7 @@ class ViewBillingOnMri2ActionUnitTest extends CarlosUnitTestBase {
     }
 
     private ViewBillingOnMri2Action newAction() {
-        return new ViewBillingOnMri2Action();
+        return new ViewBillingOnMri2Action(mockSecurityInfoManager, mockAssembler);
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/billings/ca/on/web/ViewBillingOnMri2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/billings/ca/on/web/ViewBillingOnMri2ActionUnitTest.java
@@ -1,0 +1,170 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.billings.ca.on.web;
+
+import io.github.carlos_emr.carlos.billings.ca.on.assembler.BillingOnMriViewModelAssembler;
+import io.github.carlos_emr.carlos.billings.ca.on.service.BillingDataLoadException;
+import io.github.carlos_emr.carlos.billings.ca.on.viewmodel.BillingOnMriViewModel;
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
+import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.apache.struts2.ActionSupport;
+import org.apache.struts2.ServletActionContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link ViewBillingOnMri2Action}.
+ *
+ * @since 2026-05-10
+ */
+@DisplayName("ViewBillingOnMri2Action")
+@Tag("unit")
+@Tag("billing")
+class ViewBillingOnMri2ActionUnitTest extends CarlosUnitTestBase {
+
+    private MockedStatic<ServletActionContext> servletActionContextMock;
+    private MockedStatic<LoggedInInfo> loggedInInfoMock;
+    private AutoCloseable mockitoCloseable;
+
+    @Mock
+    private SecurityInfoManager mockSecurityInfoManager;
+
+    @Mock
+    private LoggedInInfo mockLoggedInInfo;
+
+    @Mock
+    private BillingOnMriViewModelAssembler mockAssembler;
+
+    private MockHttpServletRequest mockRequest;
+    private MockHttpServletResponse mockResponse;
+
+    private static final BillingOnMriViewModel STUB_MODEL =
+            BillingOnMriViewModel.builder().selectedYear("2026").build();
+
+    @BeforeEach
+    void setUp() {
+        mockitoCloseable = MockitoAnnotations.openMocks(this);
+
+        mockRequest = new MockHttpServletRequest();
+        mockResponse = new MockHttpServletResponse();
+        mockRequest.setMethod("GET");
+
+        registerMock(SecurityInfoManager.class, mockSecurityInfoManager);
+
+        servletActionContextMock = mockStatic(ServletActionContext.class);
+        servletActionContextMock.when(ServletActionContext::getRequest).thenReturn(mockRequest);
+        servletActionContextMock.when(ServletActionContext::getResponse).thenReturn(mockResponse);
+
+        loggedInInfoMock = mockStatic(LoggedInInfo.class);
+        loggedInInfoMock.when(() -> LoggedInInfo.getLoggedInInfoFromSession(any(HttpServletRequest.class)))
+                .thenReturn(mockLoggedInInfo);
+
+        when(mockSecurityInfoManager.hasPrivilege(any(LoggedInInfo.class), eq("_billing"), eq("r"), isNull()))
+                .thenReturn(true);
+        when(mockAssembler.assemble(any(), any())).thenReturn(STUB_MODEL);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (loggedInInfoMock != null) loggedInInfoMock.close();
+        if (servletActionContextMock != null) servletActionContextMock.close();
+        if (mockitoCloseable != null) mockitoCloseable.close();
+    }
+
+    private ViewBillingOnMri2Action newAction() {
+        return new ViewBillingOnMri2Action(mockSecurityInfoManager, mockAssembler);
+    }
+
+    @Test
+    void shouldReturnSuccess_whenAssemblerSucceeds() throws Exception {
+        assertThat(newAction().execute()).isEqualTo(ActionSupport.SUCCESS);
+    }
+
+    @Test
+    void shouldExposeModel_asRequestAttribute() throws Exception {
+        newAction().execute();
+        assertThat(mockRequest.getAttribute("mriModel")).isSameAs(STUB_MODEL);
+    }
+
+    @Test
+    void shouldThrowSecurityException_whenSessionMissing() {
+        loggedInInfoMock.when(() -> LoggedInInfo.getLoggedInInfoFromSession(any(HttpServletRequest.class)))
+                .thenReturn(null);
+
+        assertThatThrownBy(newAction()::execute)
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("missing session");
+        verify(mockSecurityInfoManager, never()).hasPrivilege(any(), any(), any(), any());
+    }
+
+    @Test
+    void shouldThrowSecurityException_whenLacksBillingReadPrivilege() {
+        when(mockSecurityInfoManager.hasPrivilege(any(LoggedInInfo.class), eq("_billing"), eq("r"), isNull()))
+                .thenReturn(false);
+
+        assertThatThrownBy(newAction()::execute)
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("_billing");
+    }
+
+    @Test
+    void shouldWrapRuntimeException_asBillingDataLoadException() {
+        RuntimeException cause = new NullPointerException("null bill center");
+        when(mockAssembler.assemble(any(), any())).thenThrow(cause);
+
+        assertThatThrownBy(newAction()::execute)
+                .isInstanceOf(BillingDataLoadException.class)
+                .hasMessageContaining("OHIP report view model")
+                .hasCause(cause);
+    }
+
+    @Test
+    void shouldRethrowBillingDataLoadException_unchanged() {
+        BillingDataLoadException original = new BillingDataLoadException("disk error");
+        when(mockAssembler.assemble(any(), any())).thenThrow(original);
+
+        assertThatThrownBy(newAction()::execute)
+                .isSameAs(original);
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/billings/ca/on/web/ViewBillingOnMri2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/billings/ca/on/web/ViewBillingOnMri2ActionUnitTest.java
@@ -91,6 +91,7 @@ class ViewBillingOnMri2ActionUnitTest extends CarlosUnitTestBase {
         mockRequest.setMethod("GET");
 
         registerMock(SecurityInfoManager.class, mockSecurityInfoManager);
+        registerMock(BillingOnMriViewModelAssembler.class, mockAssembler);
 
         servletActionContextMock = mockStatic(ServletActionContext.class);
         servletActionContextMock.when(ServletActionContext::getRequest).thenReturn(mockRequest);

--- a/src/test/java/io/github/carlos_emr/carlos/billings/ca/on/web/ViewBillingOnMri2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/billings/ca/on/web/ViewBillingOnMri2ActionUnitTest.java
@@ -135,7 +135,7 @@ class ViewBillingOnMri2ActionUnitTest extends CarlosUnitTestBase {
 
         assertThatThrownBy(newAction()::execute)
                 .isInstanceOf(SecurityException.class)
-                .hasMessageContaining("missing session");
+                .hasMessageContaining("_billing");
         verify(mockSecurityInfoManager, never()).hasPrivilege(any(), any(), any(), any());
     }
 

--- a/src/test/java/io/github/carlos_emr/carlos/billings/ca/on/web/ViewBillingOnMri2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/billings/ca/on/web/ViewBillingOnMri2ActionUnitTest.java
@@ -113,7 +113,7 @@ class ViewBillingOnMri2ActionUnitTest extends CarlosUnitTestBase {
     }
 
     private ViewBillingOnMri2Action newAction() {
-        return new ViewBillingOnMri2Action(mockSecurityInfoManager, mockAssembler);
+        return new ViewBillingOnMri2Action();
     }
 
     @Test


### PR DESCRIPTION
Changes to be committed:
	modified:   src/main/java/io/github/carlos_emr/carlos/billings/ca/on/assembler/BillingOnMriViewModelAssembler.java
	modified:   src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/ViewBillingOnMri2Action.java
	new file:   src/test/java/io/github/carlos_emr/carlos/billings/ca/on/web/ViewBillingOnMri2ActionUnitTest.java

<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description

- Null-safe bill center code in loadProviderBillCenterMap() to prevent Map.copyOf() NPE
- Null-safe sort in loadBillActivityRows() to prevent UpdateDateTimeComparator NPE
- Use fromTimestampString() instead of fromDateString() for correct date range
- Wrap assembler exceptions in ViewBillingOnMri2Action as BillingDataLoadException — this converts any silent 500 into a logged, mapped exception that shows a proper error page

<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues
Fixes #2123 
<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?
it hasn't yet, the NPE and error logging needed dealing with in any case which will help debug if this doesn't cover
<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Handle null data and errors more robustly when generating OHIP MRI billing views and reports.

Bug Fixes:
- Prevent NullPointerExceptions when building provider bill-center maps by tolerating missing bill-center codes.
- Ensure billing activity queries use timestamp-based date parsing for the selected year range and sort results with a null-safe update-time ordering.

Enhancements:
- Wrap unexpected assembler runtime errors in a dedicated BillingDataLoadException in the OHIP MRI billing action for clearer, mapped error handling.

Tests:
- Add unit tests for ViewBillingOnMri2Action covering successful execution, security checks, and error-wrapping behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes NPEs in the OHIP MRI billing flow and converts silent 500s into logged, mapped errors. Addresses #2123.

- **Bug Fixes**
  - Coerce null bill-center codes to "" in `loadProviderBillCenterMap` to prevent `Map.copyOf` NPEs.
  - Use `ConversionUtils.fromTimestampString` for full-year date ranges.
  - Sort `BillActivity` by `updateDateTime` with a null-safe comparator (nulls last, descending).
  - In `ViewBillingOnMri2Action`, wrap runtime assembler errors as `BillingDataLoadException` (rethrow if already that type); tests cover success, auth checks, and wrapping, and now pass mocked deps via the constructor.

<sup>Written for commit 0ed951364a8b5572e85bd6cb46954d3c6fdd114b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

