### PR TITLE
Improves error page logging + adds devel option

### DIFF
--- a/.devcontainer/development/config/shared/volumes/carlos.properties
+++ b/.devcontainer/development/config/shared/volumes/carlos.properties
@@ -1117,3 +1117,11 @@ WAF_RATE_LIMIT_EXEMPT_IPS=127.0.0.1,::1,0:0:0:0:0:0:0:1
 
 # Stale counter eviction interval in seconds (memory management)
 WAF_RATE_LIMIT_CLEANUP_INTERVAL_SECONDS=300
+
+# ---------------------------------------------------------------------------
+# Developer error display — DEVELOPMENT USE ONLY. SECURITY RISK.
+# See src/main/resources/carlos.properties for the full security warning.
+# When enabled, full exception stack traces are rendered in the browser and
+# ResponseSanitizationFilter is disabled. NEVER enable with real patient data.
+# Requires Tomcat restart to take effect.
+# DISPLAY_ERROR=true

--- a/.devcontainer/development/scripts/make
+++ b/.devcontainer/development/scripts/make
@@ -151,25 +151,46 @@ build_and_deploy() {
 
   if [ "$run_tests" = true ]; then
     # Build and run all tests
-    mvn $clean_phase -DskipTests=true -T 1C package war:exploded $jsp_profile $dev_mode_flag $checks_flag
+    if ! mvn $clean_phase -DskipTests=true -T 1C package war:exploded $jsp_profile $dev_mode_flag $checks_flag; then
+      echo "\nBuild failed during package phase."
+      return 1
+    fi
     echo ""
     echo "Running tests..."
-    mvn test
+    if ! mvn test; then
+      echo "\nTests failed."
+      return 1
+    fi
   elif [ "$run_tests" = "unit" ]; then
     # Build and run only unit tests
-    mvn $clean_phase -DskipTests=true -T 1C package war:exploded $jsp_profile $dev_mode_flag $checks_flag
+    if ! mvn $clean_phase -DskipTests=true -T 1C package war:exploded $jsp_profile $dev_mode_flag $checks_flag; then
+      echo "\nBuild failed during package phase."
+      return 1
+    fi
     echo ""
     echo "Running unit tests..."
-    mvn test -Dgroups="unit"
+    if ! mvn test -Dgroups="unit"; then
+      echo "\nUnit tests failed."
+      return 1
+    fi
   elif [ "$run_tests" = "integration" ]; then
     # Build and run only integration tests
-    mvn $clean_phase -DskipTests=true -T 1C package war:exploded $jsp_profile $dev_mode_flag $checks_flag
+    if ! mvn $clean_phase -DskipTests=true -T 1C package war:exploded $jsp_profile $dev_mode_flag $checks_flag; then
+      echo "\nBuild failed during package phase."
+      return 1
+    fi
     echo ""
     echo "Running integration tests..."
-    mvn test -Dgroups="integration"
+    if ! mvn test -Dgroups="integration"; then
+      echo "\nIntegration tests failed."
+      return 1
+    fi
   else
     # Regular build without tests
-    mvn $clean_phase -DskipTests=true -T 1C package war:exploded $jsp_profile $dev_mode_flag $checks_flag
+    if ! mvn $clean_phase -DskipTests=true -T 1C package war:exploded $jsp_profile $dev_mode_flag $checks_flag; then
+      echo "\nBuild failed during package phase."
+      return 1
+    fi
   fi
 
   # Extract the version from the pom.xml file.

--- a/src/main/java/io/github/carlos_emr/carlos/utility/ErrorPageLogger.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/ErrorPageLogger.java
@@ -118,8 +118,9 @@ public final class ErrorPageLogger {
                         ? request.getAttribute("jakarta.servlet.error.message")
                         : null;
                 if (status != null || uri != null || message != null) {
-                    boolean displayError = CarlosProperties.isPropertyActive(
-                            ResponseSanitizationFilter.DISPLAY_ERROR_PROPERTY);
+                    String sanitizationProp = CarlosProperties.getInstance().getProperty(ResponseSanitizationFilter.ENABLED_PROPERTY, "").trim();
+                    boolean sanitizationEnabled = sanitizationProp.isEmpty() || Boolean.parseBoolean(sanitizationProp);
+                    boolean displayError = !sanitizationEnabled && CarlosProperties.getInstance().isPropertyActive(ResponseSanitizationFilter.DISPLAY_ERROR_PROPERTY);
                     MiscUtils.getLogger().warn(
                             "errorpage.jsp triggered without exception "
                             + "(method={}, uri={}, status={}, message={}) "

--- a/src/main/java/io/github/carlos_emr/carlos/utility/ErrorPageLogger.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/ErrorPageLogger.java
@@ -126,7 +126,7 @@ public final class ErrorPageLogger {
                             + "(method={}, uri={}, status={}, message={}) "
                             + "— sendError() was called without propagating the exception",
                             method, uri, status,
-                            displayError ? message : (message != null ? "[present — set DISPLAY_ERROR=true to log]" : null));
+                            displayError ? message : (message != null ? "[present — set DISPLAY_ERROR=true, response.sanitization.enabled=false to log]" : null));
                 }
                 return;
             }

--- a/src/main/java/io/github/carlos_emr/carlos/utility/ErrorPageLogger.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/ErrorPageLogger.java
@@ -117,12 +117,15 @@ public final class ErrorPageLogger {
                 Object message = request != null
                         ? request.getAttribute("jakarta.servlet.error.message")
                         : null;
-                if (status != null || message != null || uri != null) {
+                if (status != null || uri != null || message != null) {
+                    boolean displayError = CarlosProperties.isPropertyActive(
+                            ResponseSanitizationFilter.DISPLAY_ERROR_PROPERTY);
                     MiscUtils.getLogger().warn(
                             "errorpage.jsp triggered without exception "
                             + "(method={}, uri={}, status={}, message={}) "
                             + "— sendError() was called without propagating the exception",
-                            method, uri, status, message);
+                            method, uri, status,
+                            displayError ? message : (message != null ? "[present — set DISPLAY_ERROR=true to log]" : null));
                 }
                 return;
             }

--- a/src/main/java/io/github/carlos_emr/carlos/utility/ErrorPageLogger.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/ErrorPageLogger.java
@@ -43,12 +43,22 @@ public final class ErrorPageLogger {
     }
 
     /**
-     * Logs the captured exception (if present) at ERROR with URI and status
-     * context. Safe to call when no exception is present (no-op).
+     * Logs a diagnostic entry for the error page invocation.
+     *
+     * <ul>
+     *   <li>If an exception is available (via {@code explicitException} or the
+     *       {@code jakarta.servlet.error.exception} request attribute), logs at ERROR
+     *       level with the full stack trace, HTTP method, sanitized URI, and status code.</li>
+     *   <li>If no exception is available but Tomcat error-dispatch attributes are present
+     *       (the common {@code sendError()} path where the exception was not propagated),
+     *       logs at WARN level with the available status, URI, and message — providing at
+     *       least a minimal trace in the absence of a stack trace.</li>
+     *   <li>If neither an exception nor any error attributes are present, this method is a
+     *       no-op — safe to call in any context.</li>
+     * </ul>
      *
      * @param explicitException the exception bound to the JSP page-context
-     *                          (i.e., {@code pageContext.exception}); may be
-     *                          {@code null}
+     *                          (i.e., {@code pageContext.exception}); may be {@code null}
      * @param request           the request from which to read the
      *                          {@code jakarta.servlet.error.*} attributes
      */
@@ -70,9 +80,7 @@ public final class ErrorPageLogger {
                     t = (Throwable) attr;
                 }
             }
-            if (t == null) {
-                return;
-            }
+
             // Strip the query string AND any path parameters (`;jsessionid=...`,
             // etc.) off the captured request_uri before logging:
             //  - billing flows pass mixed identifiers in the query; some are
@@ -82,22 +90,9 @@ public final class ErrorPageLogger {
             //    cookieless requests, which is sensitive and would let an
             //    operator with log access hijack the session.
             // Path-only is enough to diagnose the failure site.
-            Object rawUri = request != null
+            Object uri = sanitizeUri(request != null
                     ? request.getAttribute("jakarta.servlet.error.request_uri")
-                    : null;
-            Object uri = rawUri;
-            if (rawUri instanceof String) {
-                String s = (String) rawUri;
-                int q = s.indexOf('?');
-                if (q >= 0) {
-                    s = s.substring(0, q);
-                }
-                int sc = s.indexOf(';');
-                if (sc >= 0) {
-                    s = s.substring(0, sc);
-                }
-                uri = s;
-            }
+                    : null);
             Object status = request != null
                     ? request.getAttribute("jakarta.servlet.error.status_code")
                     : null;
@@ -107,6 +102,31 @@ public final class ErrorPageLogger {
             Object method = (request instanceof HttpServletRequest)
                     ? ((HttpServletRequest) request).getMethod()
                     : null;
+
+            if (t == null) {
+                // No exception is available. This happens when sendError() is called
+                // without propagating the exception object — the most common case is
+                // Struts intercepting an unmapped exception and calling sendError(500)
+                // rather than rethrowing. Tomcat does not set
+                // jakarta.servlet.error.exception in this code path.
+                //
+                // Log a WARN using whatever error attributes Tomcat DID set so that
+                // the failed request leaves at least a minimal trace in the log.
+                // When no attributes are present at all (non-error invocation of this
+                // helper) the no-op path remains quiet.
+                Object message = request != null
+                        ? request.getAttribute("jakarta.servlet.error.message")
+                        : null;
+                if (status != null || message != null || uri != null) {
+                    MiscUtils.getLogger().warn(
+                            "errorpage.jsp triggered without exception "
+                            + "(method={}, uri={}, status={}, message={}) "
+                            + "— sendError() was called without propagating the exception",
+                            method, uri, status, message);
+                }
+                return;
+            }
+
             MiscUtils.getLogger().error(
                     "errorpage.jsp captured exception (method={}, uri={}, status={})",
                     method, uri, status, t);
@@ -120,5 +140,25 @@ public final class ErrorPageLogger {
                 // truly nothing more we can do
             }
         }
+    }
+
+    /**
+     * Strips the query string and any path parameters (e.g. {@code ;jsessionid=...}) from
+     * a raw {@code jakarta.servlet.error.request_uri} value before it is written to logs.
+     */
+    private static Object sanitizeUri(Object rawUri) {
+        if (!(rawUri instanceof String)) {
+            return rawUri;
+        }
+        String s = (String) rawUri;
+        int q = s.indexOf('?');
+        if (q >= 0) {
+            s = s.substring(0, q);
+        }
+        int sc = s.indexOf(';');
+        if (sc >= 0) {
+            s = s.substring(0, sc);
+        }
+        return s;
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/utility/ErrorPageLogger.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/ErrorPageLogger.java
@@ -21,6 +21,7 @@
  */
 package io.github.carlos_emr.carlos.utility;
 
+import io.github.carlos_emr.CarlosProperties;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.http.HttpServletRequest;
 

--- a/src/main/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilter.java
@@ -155,8 +155,13 @@ public class ResponseSanitizationFilter implements Filter {
 
     /**
      * Reads the {@code response.sanitization.enabled} property from {@code carlos.properties}.
-     * If {`@code` response.sanitization.enabled} is set to {`@code` false} AND 
-     * {`@code` DISPLAY_ERROR} is set to {`@code` true} then sanitization is bypassed 
+     * Defaults to {@code true} (enabled) when the property is absent or blank.
+     *
+     * <p>When {@code response.sanitization.enabled=false} AND {@code DISPLAY_ERROR=true} are
+     * both set, this filter is disabled and a security WARN is emitted — that combination is
+     * the intended full developer error-display mode. {@code DISPLAY_ERROR=true} alone does
+     * not bypass sanitization; {@code response.sanitization.enabled} is the gating control.</p>
+     *
      * @param filterConfig FilterConfig the servlet container filter configuration
      */
     @Override
@@ -164,13 +169,12 @@ public class ResponseSanitizationFilter implements Filter {
         String propValue = CarlosProperties.getInstance().getProperty(ENABLED_PROPERTY, "").trim();
         enabled = propValue.isEmpty() || Boolean.parseBoolean(propValue);
         if (!enabled && CarlosProperties.getInstance().isPropertyActive(DISPLAY_ERROR_PROPERTY)) {
-            // DISPLAY_ERROR is a second check to disable sanitization — it is a developer-only mode
-            // that deliberately allows raw exception details to reach the browser. Disable
-            // sanitization so the full error context is visible. This must NEVER be active
-            // in production (see DISPLAY_ERROR_PROPERTY Javadoc).
-            enabled = false;
-            LOGGER.warn("DISPLAY_ERROR is active — ResponseSanitizationFilter disabled. "
-                    + "Stack traces WILL be sent to clients. "
+            // Sanitization is already disabled via response.sanitization.enabled=false.
+            // When DISPLAY_ERROR is also active the developer has opted into full error
+            // display — emit a prominent security warning so this state is never missed in logs.
+            // (enabled is already false; this block only adds the WARN.)
+            LOGGER.warn("DISPLAY_ERROR is active with sanitization disabled — "
+                    + "stack traces WILL be sent to clients. "
                     + "This is a SECURITY RISK — do not enable in production environments "
                     + "or any system with real patient data.");
         }

--- a/src/main/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilter.java
@@ -155,16 +155,17 @@ public class ResponseSanitizationFilter implements Filter {
 
     /**
      * Reads the {@code response.sanitization.enabled} property from {@code carlos.properties}.
-     * Defaults to {@code true} (enabled) when the property is absent or blank.
-     *
+     * and the {@code DISPLAY_ERROR_PROPERTY} property from {@code carlos.properties}.
+     * If {@code response.sanitization.enabled} is set to {@code false} AND 
+     * (@code DISPLAY_ERROR} is set to {@code true} then sanitization is bypassed
      * @param filterConfig FilterConfig the servlet container filter configuration
      */
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {
         String propValue = CarlosProperties.getInstance().getProperty(ENABLED_PROPERTY, "").trim();
         enabled = propValue.isEmpty() || Boolean.parseBoolean(propValue);
-        if (enabled && CarlosProperties.getInstance().isPropertyActive(DISPLAY_ERROR_PROPERTY)) {
-            // DISPLAY_ERROR overrides the sanitization flag — it is a developer-only mode
+        if (!enabled && CarlosProperties.getInstance().isPropertyActive(DISPLAY_ERROR_PROPERTY)) {
+            // DISPLAY_ERROR is a second check to disable sanitization — it is a developer-only mode
             // that deliberately allows raw exception details to reach the browser. Disable
             // sanitization so the full error context is visible. This must NEVER be active
             // in production (see DISPLAY_ERROR_PROPERTY Javadoc).

--- a/src/main/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilter.java
@@ -155,9 +155,8 @@ public class ResponseSanitizationFilter implements Filter {
 
     /**
      * Reads the {@code response.sanitization.enabled} property from {@code carlos.properties}.
-     * and the {@code DISPLAY_ERROR_PROPERTY} property from {@code carlos.properties}.
-     * If {@code response.sanitization.enabled} is set to {@code false} AND 
-     * (@code DISPLAY_ERROR} is set to {@code true} then sanitization is bypassed
+     * If {`@code` response.sanitization.enabled} is set to {`@code` false} AND 
+     * {`@code` DISPLAY_ERROR} is set to {`@code` true} then sanitization is bypassed 
      * @param filterConfig FilterConfig the servlet container filter configuration
      */
     @Override

--- a/src/main/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilter.java
@@ -101,6 +101,20 @@ public class ResponseSanitizationFilter implements Filter {
     static final String ENABLED_PROPERTY = "response.sanitization.enabled";
 
     /**
+     * Property name that activates developer error display mode. When this property is
+     * {@code true} / {@code yes} / {@code on} in {@code carlos.properties}, this filter
+     * disables itself so that raw exception details reach the browser.
+     *
+     * <p><strong>SECURITY RISK:</strong> Stack traces expose internal class names,
+     * library versions, code paths, and data structures that significantly aid attackers.
+     * Only enable in isolated devcontainer environments with synthetic test data.
+     * Never enable in any environment with real patient data or external network access.</p>
+     *
+     * @see <a href="https://owasp.org/www-project-top-ten/">OWASP A05 Security Misconfiguration</a>
+     */
+    static final String DISPLAY_ERROR_PROPERTY = "DISPLAY_ERROR";
+
+    /**
      * Maximum number of characters to buffer per response before switching to pass-through mode.
      * Responses larger than this cannot contain a stack trace header; skipping inspection
      * avoids unbounded heap growth for large encounter notes, lab reports, etc.
@@ -149,6 +163,17 @@ public class ResponseSanitizationFilter implements Filter {
     public void init(FilterConfig filterConfig) throws ServletException {
         String propValue = CarlosProperties.getInstance().getProperty(ENABLED_PROPERTY, "").trim();
         enabled = propValue.isEmpty() || Boolean.parseBoolean(propValue);
+        if (enabled && CarlosProperties.getInstance().isPropertyActive(DISPLAY_ERROR_PROPERTY)) {
+            // DISPLAY_ERROR overrides the sanitization flag — it is a developer-only mode
+            // that deliberately allows raw exception details to reach the browser. Disable
+            // sanitization so the full error context is visible. This must NEVER be active
+            // in production (see DISPLAY_ERROR_PROPERTY Javadoc).
+            enabled = false;
+            LOGGER.warn("DISPLAY_ERROR is active — ResponseSanitizationFilter disabled. "
+                    + "Stack traces WILL be sent to clients. "
+                    + "This is a SECURITY RISK — do not enable in production environments "
+                    + "or any system with real patient data.");
+        }
         LOGGER.info("ResponseSanitizationFilter initialized: enabled={}", enabled);
     }
 

--- a/src/main/resources/carlos.properties
+++ b/src/main/resources/carlos.properties
@@ -1369,3 +1369,37 @@ WAF_RATE_LIMIT_MAX_COUNTERS=50000
 # Set to false in development environments where stack traces aid debugging.
 # Default: true (enabled). Requires Tomcat restart to take effect.
 response.sanitization.enabled=true
+
+# ==============================================================================
+# DEVELOPER SETTINGS — FOR USE IN ISOLATED DEVCONTAINER ENVIRONMENTS ONLY
+# ==============================================================================
+#
+# DISPLAY_ERROR — DEVELOPMENT USE ONLY.  *** SECURITY RISK — SEE BELOW ***
+#
+# When true, full exception details (class name, message, stack trace) are
+# rendered directly in the browser on CARLOS error pages, and
+# ResponseSanitizationFilter disables itself automatically so the raw details
+# are not stripped before reaching the client.  When the exception was
+# swallowed by Struts before sendError() was called (the common case for
+# unmapped action exceptions), the detail block shows the available HTTP error
+# attributes and directs the developer to the WARN log from ErrorPageLogger.
+#
+# *** DISPLAYING EXCEPTIONS IS A SECURITY RISK ***
+# Stack traces expose internal class names, library versions, file paths, code
+# paths, and data structures that significantly aid attackers in exploiting the
+# application.  In environments subject to HIPAA/PIPEDA (all CARLOS deployments
+# with real patient data), information leakage of this kind may itself
+# constitute a reportable breach.
+#
+# This setting MUST remain commented-out / false in:
+#   - Any environment with real patient data (PHI)
+#   - Any environment reachable from an external network
+#   - Shared or multi-tenant infrastructure
+#   - QA, staging, or demo environments visible to external parties
+#
+# ONLY enable in an isolated devcontainer with synthetic/test data where
+# network access is controlled and no real PHI is present.
+# Requires Tomcat restart to take effect.
+# Default: false (property absent — isPropertyActive returns false)
+#
+# DISPLAY_ERROR=false

--- a/src/main/webapp/WEB-INF/jsp/error/errorpage.jsp
+++ b/src/main/webapp/WEB-INF/jsp/error/errorpage.jsp
@@ -46,6 +46,38 @@
      container; this scriptlet is a 1-line dispatcher. --%>
 <% io.github.carlos_emr.carlos.utility.ErrorPageLogger.logIfPresent(exception, request); %>
 <!-- only true can access exception object -->
+<%--
+  DISPLAY_ERROR — developer mode block.
+  When carlos.properties sets DISPLAY_ERROR=true, render full exception details in
+  the browser to aid local debugging. ResponseSanitizationFilter also disables itself
+  when this flag is active so raw details are not stripped before reaching the client.
+  SECURITY: this block MUST remain inactive in all production and PHI environments.
+--%>
+<%
+    boolean _displayError = io.github.carlos_emr.CarlosProperties.getInstance()
+            .isPropertyActive("DISPLAY_ERROR");
+    request.setAttribute("_displayError", _displayError);
+    if (_displayError) {
+        Throwable _t = exception;
+        if (_t == null) {
+            Object _errAttr = request.getAttribute("jakarta.servlet.error.exception");
+            if (_errAttr instanceof Throwable) {
+                _t = (Throwable) _errAttr;
+            }
+        }
+        if (_t != null) {
+            java.io.StringWriter _sw = new java.io.StringWriter();
+            _t.printStackTrace(new java.io.PrintWriter(_sw));
+            request.setAttribute("_exceptionType", _t.getClass().getName());
+            request.setAttribute("_exceptionMessage", _t.getMessage());
+            request.setAttribute("_exceptionTrace", _sw.toString());
+        }
+        Object _errMsg = request.getAttribute("jakarta.servlet.error.message");
+        if (_errMsg != null) {
+            request.setAttribute("_errorMessage", _errMsg.toString());
+        }
+    }
+%>
 <%@ taglib uri='jakarta.tags.core' prefix="c" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <fmt:setBundle basename="oscarResources"/>
@@ -161,6 +193,46 @@
                href="${carlos:forUri(pageContext.request.contextPath)}/provider/providercontrol" role="button"><fmt:message key="global.btnExit"/></a>
         </div>
     </div>
+
+    <%-- Developer error detail — visible only when DISPLAY_ERROR=true in carlos.properties.
+         SECURITY RISK: never enable this in production or any PHI environment. --%>
+    <c:if test="${_displayError}">
+        <div id="dev-error-detail" style="margin: 30px 0; text-align: left;
+             background: #fff8f0; border: 2px solid #cc4400; border-radius: 4px; padding: 16px;">
+            <h3 style="color: #cc4400; margin-top: 0; font-family: monospace;">
+                Developer Detail (DISPLAY_ERROR=true — not for production)
+            </h3>
+            <c:choose>
+                <c:when test="${not empty _exceptionType}">
+                    <p style="font-family: monospace;">
+                        <strong>Exception:</strong> <carlos:encode value="${_exceptionType}"/>
+                    </p>
+                    <c:if test="${not empty _exceptionMessage}">
+                        <p style="font-family: monospace;">
+                            <strong>Message:</strong> <carlos:encode value="${_exceptionMessage}"/>
+                        </p>
+                    </c:if>
+                    <pre style="background: #f8f8f8; padding: 10px; overflow: auto;
+                         max-height: 500px; white-space: pre-wrap; word-break: break-all;
+                         font-size: 0.85em;"><carlos:encode value="${_exceptionTrace}"/></pre>
+                </c:when>
+                <c:otherwise>
+                    <p style="font-family: monospace;">
+                        No exception details available — the error was reported via
+                        <code>sendError()</code> without propagating the exception object.
+                        <c:if test="${not empty _errorMessage}">
+                            <br/><strong>Error message:</strong>
+                            <carlos:encode value="${_errorMessage}"/>
+                        </c:if>
+                    </p>
+                    <p style="font-family: monospace; color: #666;">
+                        To locate the root cause, check the application log for WARN entries
+                        from ErrorPageLogger matching this URI and status code.
+                    </p>
+                </c:otherwise>
+            </c:choose>
+        </div>
+    </c:if>
 
     <c:if test="${ not empty LoginResourceBean.supportLink
 							or not empty LoginResourceBean.supportName

--- a/src/test/java/io/github/carlos_emr/carlos/utility/ErrorPageLoggerUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/utility/ErrorPageLoggerUnitTest.java
@@ -109,6 +109,27 @@ class ErrorPageLoggerUnitTest extends CarlosUnitTestBase {
         assertThat(appender.events()).isEmpty();
     }
 
+    @Test
+    void shouldSanitizeRequestUri_onWarnPath() {
+        // WARN path: no exception, only error attributes. URI should be sanitized (no query or jsessionid).
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setAttribute("jakarta.servlet.error.status_code", 404);
+        req.setAttribute(
+                "jakarta.servlet.error.request_uri",
+                "/some/path/with;jsessionid=ABCDEF1234567890?secret=top&foo=bar"
+        );
+
+        ErrorPageLogger.logIfPresent(null, req);
+
+        assertThat(appender.events()).hasSize(1);
+        assertThat(appender.events().get(0).getLevel()).isEqualTo(Level.WARN);
+
+        String msg = appender.events().get(0).getMessage().getFormattedMessage();
+        // URI must be reduced to the path only; no query parameters or jsessionid.
+        assertThat(msg).contains("uri=/some/path/with");
+        assertThat(msg).doesNotContain("jsessionid", "secret=top", "foo=bar", "?");
+    }
+
     /**
      * When Struts (or any code) calls {@code sendError(status)} without propagating
      * the exception object, Tomcat does not set {@code jakarta.servlet.error.exception}

--- a/src/test/java/io/github/carlos_emr/carlos/utility/ErrorPageLoggerUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/utility/ErrorPageLoggerUnitTest.java
@@ -101,11 +101,55 @@ class ErrorPageLoggerUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
-    void shouldNoOp_whenNoExceptionAvailable() {
+    void shouldNoOp_whenNoExceptionAndNoErrorAttributes() {
+        // Request with no error attributes at all (not a real error dispatch) — no-op.
         MockHttpServletRequest req = new MockHttpServletRequest();
         assertThatCode(() -> ErrorPageLogger.logIfPresent(null, req))
                 .doesNotThrowAnyException();
         assertThat(appender.events()).isEmpty();
+    }
+
+    /**
+     * When Struts (or any code) calls {@code sendError(status)} without propagating
+     * the exception object, Tomcat does not set {@code jakarta.servlet.error.exception}
+     * in the error dispatch but DOES set the status-code, message, and URI attributes.
+     * {@code logIfPresent} must emit a WARN so the error leaves a trace even without a
+     * stack trace.
+     */
+    @Test
+    void shouldWarnWithAttributes_whenNoExceptionButErrorAttributesPresent() {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setAttribute("jakarta.servlet.error.status_code", 500);
+        req.setAttribute("jakarta.servlet.error.request_uri",
+                "/carlos/billing/CA/ON/ViewBillingONMRI");
+        req.setAttribute("jakarta.servlet.error.message", "Internal Server Error");
+        req.setMethod("GET");
+
+        ErrorPageLogger.logIfPresent(null, req);
+
+        assertThat(appender.events()).hasSize(1);
+        LogEvent evt = appender.events().get(0);
+        assertThat(evt.getLevel()).isEqualTo(Level.WARN);
+        assertThat(evt.getThrown()).isNull();
+        String msg = evt.getMessage().getFormattedMessage();
+        assertThat(msg).contains("uri=/carlos/billing/CA/ON/ViewBillingONMRI");
+        assertThat(msg).contains("status=500");
+        assertThat(msg).contains("method=GET");
+        assertThat(msg).contains("sendError()");
+    }
+
+    @Test
+    void shouldWarnWithPartialAttributes_whenOnlyStatusPresent() {
+        // Minimal case: only status_code is set (sendError(sc) variant, no message).
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setAttribute("jakarta.servlet.error.status_code", 403);
+
+        ErrorPageLogger.logIfPresent(null, req);
+
+        assertThat(appender.events()).hasSize(1);
+        assertThat(appender.events().get(0).getLevel()).isEqualTo(Level.WARN);
+        assertThat(appender.events().get(0).getMessage().getFormattedMessage())
+                .contains("status=403");
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilterUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilterUnitTest.java
@@ -559,14 +559,14 @@ class ResponseSanitizationFilterUnitTest {
 
             filter.doFilter(request, response, chain);
 
-            // Stack trace must NOT be sanitized when DISPLAY_ERROR is active.
+            // Stack trace must NOT be sanitized when DISPLAY_ERROR is active and response.samitization.enabled is false.
             assertThat(response.getContentAsString()).isEqualTo(stackTraceBody);
         }
 
         @Test
-        @DisplayName("should disable itself even when response.sanitization.enabled is true")
+        @DisplayName("should not disable itself when response.sanitization.enabled is true")
         void shouldDisableItself_evenWhenSanitizationPropertyIsTrue() throws Exception {
-            // response.sanitization.enabled=true AND DISPLAY_ERROR=true → filter disables.
+            // response.sanitization.enabled=false AND DISPLAY_ERROR=true → filter disables.
             // This is verified by the pass-through behaviour: a stack trace in a 500
             // response reaches the client instead of being replaced with a generic page.
             MockHttpServletRequest request = new MockHttpServletRequest();
@@ -580,8 +580,8 @@ class ResponseSanitizationFilterUnitTest {
 
             filter.doFilter(request, response, chain);
 
-            assertThat(response.getContentAsString()).contains("RuntimeException");
-            assertThat(response.getContentAsString()).doesNotContain("Reference ID:");
+            assertThat(response.getContentAsString()).doesNotContain("RuntimeException");
+            assertThat(response.getContentAsString()).contains("Reference ID:");
         }
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilterUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilterUnitTest.java
@@ -545,7 +545,7 @@ class ResponseSanitizationFilterUnitTest {
 
         @Test
         @DisplayName("should pass through error response with stack trace unchanged")
-        void shouldPassThrough_errorWithStackTrace_whenDisplayErrorActive() throws Exception {
+        void shouldPassThrough_errorWithStackTraceWhenDisplayErrorActive() throws Exception {
             MockHttpServletRequest request = new MockHttpServletRequest();
             MockHttpServletResponse response = new MockHttpServletResponse();
             String stackTraceBody = "java.lang.NullPointerException\n"

--- a/src/test/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilterUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilterUnitTest.java
@@ -525,15 +525,19 @@ class ResponseSanitizationFilterUnitTest {
     }
 
     // -------------------------------------------------------------------------
-    // DISPLAY_ERROR — developer mode disables the filter via init()
+    // DISPLAY_ERROR — requires BOTH properties for full developer error display
+    // response.sanitization.enabled=false is the gating control; DISPLAY_ERROR
+    // alone does NOT bypass RSF sanitization.
     // -------------------------------------------------------------------------
 
     @Nested
-    @DisplayName("when DISPLAY_ERROR is active")
-    class DisplayErrorActive {
+    @DisplayName("when DISPLAY_ERROR is set but sanitization is still enabled")
+    class DisplayErrorWithSanitizationEnabled {
 
         @BeforeEach
-        void enableDisplayError() throws Exception {
+        void initWithDisplayErrorOnlyAndSanitizationOn() throws Exception {
+            // response.sanitization.enabled=true (default) AND DISPLAY_ERROR=true:
+            // sanitization is NOT bypassed — DISPLAY_ERROR alone is not sufficient.
             when(mockProperties.getProperty(ResponseSanitizationFilter.ENABLED_PROPERTY, ""))
                     .thenReturn("true");
             when(mockProperties.isPropertyActive(ResponseSanitizationFilter.DISPLAY_ERROR_PROPERTY))
@@ -544,8 +548,9 @@ class ResponseSanitizationFilterUnitTest {
         }
 
         @Test
-        @DisplayName("should pass through error response with stack trace unchanged")
-        void shouldPassThrough_errorWithStackTraceWhenDisplayErrorActive() throws Exception {
+        @DisplayName("should still sanitize stack trace when only DISPLAY_ERROR is set")
+        void shouldStillSanitize_whenOnlyDisplayErrorIsSet_withoutDisablingSanitization()
+                throws Exception {
             MockHttpServletRequest request = new MockHttpServletRequest();
             MockHttpServletResponse response = new MockHttpServletResponse();
             String stackTraceBody = "java.lang.NullPointerException\n"
@@ -559,29 +564,83 @@ class ResponseSanitizationFilterUnitTest {
 
             filter.doFilter(request, response, chain);
 
-            // Stack trace must NOT be sanitized when DISPLAY_ERROR is active and response.samitization.enabled is false.
-            assertThat(response.getContentAsString()).isEqualTo(stackTraceBody);
+            // RSF remains active — DISPLAY_ERROR alone does not bypass sanitization.
+            assertThat(response.getContentAsString()).doesNotContain("NullPointerException");
+            assertThat(response.getContentAsString()).contains("Reference ID:");
         }
 
         @Test
-        @DisplayName("should not disable itself when response.sanitization.enabled is true")
-        void shouldDisableItself_evenWhenSanitizationPropertyIsTrue() throws Exception {
-            // response.sanitization.enabled=false AND DISPLAY_ERROR=true → filter disables.
-            // This is verified by the pass-through behaviour: a stack trace in a 500
-            // response reaches the client instead of being replaced with a generic page.
+        @DisplayName("should replace stack trace body with Reference ID when only DISPLAY_ERROR is set")
+        void shouldReplaceWithReferenceId_whenOnlyDisplayErrorIsSet() throws Exception {
             MockHttpServletRequest request = new MockHttpServletRequest();
             MockHttpServletResponse response = new MockHttpServletResponse();
 
             FilterChain chain = (req, res) -> {
                 HttpServletResponse httpRes = (HttpServletResponse) res;
                 httpRes.setStatus(500);
-                httpRes.getWriter().write("java.lang.RuntimeException: raw detail");
+                httpRes.getWriter().write("java.lang.RuntimeException: sensitive detail");
             };
 
             filter.doFilter(request, response, chain);
 
             assertThat(response.getContentAsString()).doesNotContain("RuntimeException");
             assertThat(response.getContentAsString()).contains("Reference ID:");
+        }
+    }
+
+    @Nested
+    @DisplayName("when both DISPLAY_ERROR and sanitization=false are set (developer mode)")
+    class DisplayErrorWithSanitizationDisabled {
+
+        @BeforeEach
+        void initWithBothPropertiesSet() throws Exception {
+            // response.sanitization.enabled=false AND DISPLAY_ERROR=true:
+            // both must be set — this is the correct two-property developer configuration.
+            when(mockProperties.getProperty(ResponseSanitizationFilter.ENABLED_PROPERTY, ""))
+                    .thenReturn("false");
+            when(mockProperties.isPropertyActive(ResponseSanitizationFilter.DISPLAY_ERROR_PROPERTY))
+                    .thenReturn(true);
+            filter = new ResponseSanitizationFilter();
+            FilterConfig filterConfig = mock(FilterConfig.class);
+            filter.init(filterConfig);
+        }
+
+        @Test
+        @DisplayName("should pass through stack trace unchanged when both properties are set")
+        void shouldPassThrough_stackTrace_whenBothPropertiesSet() throws Exception {
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            String stackTraceBody = "java.lang.NullPointerException\n"
+                    + "\tat io.github.carlos_emr.carlos.SomeClass.method(SomeClass.java:42)";
+
+            FilterChain chain = (req, res) -> {
+                HttpServletResponse httpRes = (HttpServletResponse) res;
+                httpRes.setStatus(500);
+                httpRes.getWriter().write(stackTraceBody);
+            };
+
+            filter.doFilter(request, response, chain);
+
+            // RSF is disabled by response.sanitization.enabled=false — raw details pass through.
+            assertThat(response.getContentAsString()).isEqualTo(stackTraceBody);
+        }
+
+        @Test
+        @DisplayName("should not replace body with Reference ID when both properties are set")
+        void shouldNotReplaceWithReferenceId_whenBothPropertiesSet() throws Exception {
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            MockHttpServletResponse response = new MockHttpServletResponse();
+
+            FilterChain chain = (req, res) -> {
+                HttpServletResponse httpRes = (HttpServletResponse) res;
+                httpRes.setStatus(500);
+                httpRes.getWriter().write("java.lang.RuntimeException: raw developer detail");
+            };
+
+            filter.doFilter(request, response, chain);
+
+            assertThat(response.getContentAsString()).contains("RuntimeException");
+            assertThat(response.getContentAsString()).doesNotContain("Reference ID:");
         }
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilterUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilterUnitTest.java
@@ -523,4 +523,65 @@ class ResponseSanitizationFilterUnitTest {
             assertThat(body).contains("Reference ID:");
         }
     }
+
+    // -------------------------------------------------------------------------
+    // DISPLAY_ERROR — developer mode disables the filter via init()
+    // -------------------------------------------------------------------------
+
+    @Nested
+    @DisplayName("when DISPLAY_ERROR is active")
+    class DisplayErrorActive {
+
+        @BeforeEach
+        void enableDisplayError() throws Exception {
+            when(mockProperties.getProperty(ResponseSanitizationFilter.ENABLED_PROPERTY, ""))
+                    .thenReturn("true");
+            when(mockProperties.isPropertyActive(ResponseSanitizationFilter.DISPLAY_ERROR_PROPERTY))
+                    .thenReturn(true);
+            filter = new ResponseSanitizationFilter();
+            FilterConfig filterConfig = mock(FilterConfig.class);
+            filter.init(filterConfig);
+        }
+
+        @Test
+        @DisplayName("should pass through error response with stack trace unchanged")
+        void shouldPassThrough_errorWithStackTrace_whenDisplayErrorActive() throws Exception {
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            String stackTraceBody = "java.lang.NullPointerException\n"
+                    + "\tat io.github.carlos_emr.carlos.SomeClass.method(SomeClass.java:42)";
+
+            FilterChain chain = (req, res) -> {
+                HttpServletResponse httpRes = (HttpServletResponse) res;
+                httpRes.setStatus(500);
+                httpRes.getWriter().write(stackTraceBody);
+            };
+
+            filter.doFilter(request, response, chain);
+
+            // Stack trace must NOT be sanitized when DISPLAY_ERROR is active.
+            assertThat(response.getContentAsString()).isEqualTo(stackTraceBody);
+        }
+
+        @Test
+        @DisplayName("should disable itself even when response.sanitization.enabled is true")
+        void shouldDisableItself_evenWhenSanitizationPropertyIsTrue() throws Exception {
+            // response.sanitization.enabled=true AND DISPLAY_ERROR=true → filter disables.
+            // This is verified by the pass-through behaviour: a stack trace in a 500
+            // response reaches the client instead of being replaced with a generic page.
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            MockHttpServletResponse response = new MockHttpServletResponse();
+
+            FilterChain chain = (req, res) -> {
+                HttpServletResponse httpRes = (HttpServletResponse) res;
+                httpRes.setStatus(500);
+                httpRes.getWriter().write("java.lang.RuntimeException: raw detail");
+            };
+
+            filter.doFilter(request, response, chain);
+
+            assertThat(response.getContentAsString()).contains("RuntimeException");
+            assertThat(response.getContentAsString()).doesNotContain("Reference ID:");
+        }
+    }
 }


### PR DESCRIPTION
modified:   .devcontainer/development/config/shared/volumes/carlos.properties
	modified:   src/main/java/io/github/carlos_emr/carlos/utility/ErrorPageLogger.java
	modified:   src/main/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilter.java
	modified:   src/main/resources/carlos.properties
	modified:   src/main/webapp/WEB-INF/jsp/error/errorpage.jsp
	modified:   src/test/java/io/github/carlos_emr/carlos/utility/ErrorPageLoggerUnitTest.java
	modified:   src/test/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilterUnitTest.java

<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description

<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->
When Struts intercepts an unmapped exception it calls response.sendError(500) rather than rethrowing. Tomcat dispatches to errorpage.jsp via the ERROR mechanism but does not set jakarta.servlet.error.exception — only the status code, URI, and message attributes are present. ErrorPageLogger.logIfPresent(null, req) found no exception object and silently returned — no log entry at any level. 

This commit fixes the problem
AND for convenience adds a developer/maintainer option to display the error 
(understanding that it is not to be used in production)

## Related Issues
Fixes #2125
<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?

<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots
after with dev settings

<img width="1903" height="917" alt="devError Page" src="https://github.com/user-attachments/assets/282c3a2e-4cf4-4fa7-b43c-56f2645327a1" />


## Checklist

- [X] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Improve diagnostic logging for error-page invocations and introduce a developer-only option to surface full error details while disabling response sanitization.

New Features:
- Add a DISPLAY_ERROR configuration property that shows detailed exception information on the error page for local debugging and disables response sanitization when active.

Bug Fixes:
- Ensure ErrorPageLogger logs a warning with HTTP context when an error page is triggered via sendError() without an associated exception, so these failures leave a trace in logs.

Enhancements:
- Sanitize logged error-page URIs via a helper to strip query strings and path parameters before writing to logs.
- Extend errorpage.jsp to surface clearer diagnostic information when exceptions are unavailable, guiding developers to corresponding log entries.

Documentation:
- Document the DISPLAY_ERROR developer setting and its security implications in configuration files.

Tests:
- Add and update unit tests for ErrorPageLogger to cover no-op, warning, and error logging paths, including URI sanitization and partial attribute scenarios.
- Add tests verifying ResponseSanitizationFilter disables itself and passes through raw error responses when DISPLAY_ERROR is active.

Chores:
- Update devcontainer carlos.properties to include commented guidance for enabling DISPLAY_ERROR in isolated development environments.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves error-page diagnostics: logs a WARN with method, status, and a sanitized URI when `errorpage.jsp` is reached via `sendError(...)` without an exception, with the error message redacted by default. Adds a dev-only `DISPLAY_ERROR` option; stack traces and full messages show only when `response.sanitization.enabled=false` and `DISPLAY_ERROR=true` (fixes #2125).

- **Bug Fixes**
  - `ErrorPageLogger` now warns when no exception is present but error attributes exist; logs method, status, sanitized URI, and redacts the error message unless `DISPLAY_ERROR=true`; tests cover no-op, WARN/ERROR, partial-attribute cases, and URI sanitization.

- **New Features**
  - `DISPLAY_ERROR` in `carlos.properties` adds developer detail in `errorpage.jsp`; with `response.sanitization.enabled=false` it disables `ResponseSanitizationFilter` and shows stack traces, otherwise sanitization stays on; security warnings and devcontainer guidance updated.

<sup>Written for commit c7bd88db51f5897104a859d23370550affa17ed7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

