### PR TITLE
chore: fix dev credential regression and remove dep on drugref from startup

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -25,8 +25,6 @@ services:
     depends_on:
       db:
         condition: service_healthy
-      drugref:
-        condition: service_healthy
 
   drugref:
     container_name: carlos-drugref-dev

--- a/database/mysql/oscardata.sql
+++ b/database/mysql/oscardata.sql
@@ -1421,7 +1421,7 @@ INSERT INTO scheduletemplatecode (code,description,duration,color,confirm,bookin
 -- Dumping data for table 'security'
 --
 
-INSERT INTO security(security_no,user_name,password,provider_no,pin,forcePasswordReset) VALUES (128,'carlosdoc','{bcrypt}$2b$10$hznRKLQEhHbNIUdr5jDjRuBvIQffgkSsXBI.Tn7n5r0Se/Zlc/GLS','999998','1117',1);
+INSERT INTO security(security_no,user_name,password,provider_no,pin,forcePasswordReset) VALUES (128,'carlosdoc','{bcrypt}$2a$10$RcoNeqhcLzkfBzAoTQ5C5.nnsOs15iOasQCp0/smjDAuTtkMQ.Uju','999998','2026',0);
 
 --
 -- Dumping data for table 'specialistsJavascript'


### PR DESCRIPTION
This pull request updates the seed data for the `security` table in both the development and production database scripts, specifically for the user `carlosdoc`. The changes modify the password hash, PIN, and the `forcePasswordReset` flag. Additionally, a minor cleanup is made to the development Docker Compose configuration.

Database seed updates:

* Updated the `security` table insert for user `carlosdoc` in both `.devcontainer/db/scripts/development.sql` and `database/mysql/oscardata.sql`:
  - Changed the password hash value
  - Updated the PIN from `2026` (dev) and `1117` (prod) to `2026` in both
  - Set `forcePasswordReset` from `1` (true) to `0` (false) [[1]](diffhunk://#diff-210bbb9632f1875634b7ce9d79f8ee470052e08fc3a236f9ccd4d924a7d039ffL489-R489) [[2]](diffhunk://#diff-0dd6009a9ebc93a2f6802cb4d127d74c3bdd261072b12584649ef9f69c5cd6bbL1424-R1424)

Development environment configuration:

* Removed unnecessary `depends_on` condition for `drugref` service in `.devcontainer/docker-compose.yml` to simplify service dependencies

## Summary by Sourcery

Update seeded credentials for the `carlosdoc` user and simplify dev container startup dependencies.

Bug Fixes:
- Align `carlosdoc` seeded credentials across development and production databases to resolve a dev credential regression.

Enhancements:
- Disable forced password reset for the seeded `carlosdoc` user in both development and production data sets.
- Remove the `drugref` service health dependency from the `oscar` service in the devcontainer Docker Compose to decouple startup.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the dev login regression for `carlosdoc` and lets the app start without `drugref` in the dev container to avoid boot failures.

- **Bug Fixes**
  - Synced `security` seed for `carlosdoc` in both dev and prod SQL: updated bcrypt hash, set PIN to `2026`, and set `forcePasswordReset=0`.
  - Removed `depends_on` on `drugref` from `.devcontainer/docker-compose.yml` so the app can start independently while MySQL health checks are refined.

<sup>Written for commit 832c308dcca1ad4a23daa6bf0fc1771b65a6c48e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

