### PR TITLE
docs: add missing javadoc to 40 classes

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/administration/GstReport.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/administration/GstReport.java
@@ -18,6 +18,9 @@ import io.github.carlos_emr.carlos.util.ConversionUtils;
 import java.util.Properties;
 import java.util.Vector;
 
+/**
+ * Represents the GST report for billing administration in British Columbia.
+ */
 public class GstReport {
 
     public Vector<Properties> getGST(LoggedInInfo loggedInInfo, String[] providerNos, String startDate, String endDate) {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/EReferAttachment.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/EReferAttachment.java
@@ -12,6 +12,9 @@ import jakarta.persistence.Table;
 import java.util.Date;
 import java.util.List;
 
+/**
+ * Entity representing metadata for an eReferral attachment.
+ */
 @Entity
 @Table(name = "erefer_attachment")
 public class EReferAttachment extends AbstractModel<Integer> {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/EReferAttachmentData.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/EReferAttachmentData.java
@@ -8,6 +8,9 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
+/**
+ * Entity representing binary data of an eReferral attachment.
+ */
 @Entity
 @IdClass(EReferAttachmentDataCompositeKey.class)
 @Table(name = "erefer_attachment_data")

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/EmailAttachment.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/EmailAttachment.java
@@ -5,6 +5,9 @@ import jakarta.persistence.*;
 
 import io.github.carlos_emr.carlos.commn.model.enumerator.DocumentType;
 
+/**
+ * Entity representing a file attachment sent via email.
+ */
 @Entity
 @Table(name = "emailAttachment")
 public class EmailAttachment extends AbstractModel<Integer> {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/EmailConfig.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/EmailConfig.java
@@ -5,6 +5,9 @@ import io.github.carlos_emr.carlos.commn.model.converter.EmailConfigTypeConverte
 import jakarta.persistence.*;
 import java.util.List;
 
+/**
+ * Entity representing the configuration settings for sending emails.
+ */
 @Entity
 @Table(name = "emailConfig")
 public class EmailConfig extends AbstractModel<Integer> {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/JSONAction.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/JSONAction.java
@@ -12,6 +12,9 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
 
+/**
+ * Base action class for processing Struts requests and returning JSON responses.
+ */
 public class JSONAction extends ActionSupport {
 
     private final String ENCODING = "UTF-8";

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/AppointmentBookingSourceConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/AppointmentBookingSourceConverter.java
@@ -3,6 +3,9 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.Appointment.BookingSource;
 import jakarta.persistence.Converter;
 
+/**
+ * JPA converter for translating Appointment Booking sources.
+ */
 @Converter
 public class AppointmentBookingSourceConverter extends NullSafeEnumConverter<BookingSource> {
     public AppointmentBookingSourceConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/ClientLinkTypeConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/ClientLinkTypeConverter.java
@@ -3,6 +3,9 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.ClientLink.Type;
 import jakarta.persistence.Converter;
 
+/**
+ * JPA converter for translating Client Link types.
+ */
 @Converter
 public class ClientLinkTypeConverter extends NullSafeEnumConverter<Type> {
     public ClientLinkTypeConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/DigitalSignatureModuleTypeConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/DigitalSignatureModuleTypeConverter.java
@@ -3,6 +3,9 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.enumerator.ModuleType;
 import jakarta.persistence.Converter;
 
+/**
+ * JPA converter for translating Digital Signature module types.
+ */
 @Converter
 public class DigitalSignatureModuleTypeConverter extends NullSafeEnumConverter<ModuleType> {
     public DigitalSignatureModuleTypeConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailAttachmentDocumentTypeConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailAttachmentDocumentTypeConverter.java
@@ -3,6 +3,9 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.enumerator.DocumentType;
 import jakarta.persistence.Converter;
 
+/**
+ * JPA converter for translating Email Attachment document types.
+ */
 @Converter
 public class EmailAttachmentDocumentTypeConverter extends NullSafeEnumConverter<DocumentType> {
     public EmailAttachmentDocumentTypeConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailConfigProviderConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailConfigProviderConverter.java
@@ -3,6 +3,9 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.EmailConfig.EmailProvider;
 import jakarta.persistence.Converter;
 
+/**
+ * JPA converter for translating Email Configuration provider options.
+ */
 @Converter
 public class EmailConfigProviderConverter extends NullSafeEnumConverter<EmailProvider> {
     public EmailConfigProviderConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailConfigTypeConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailConfigTypeConverter.java
@@ -3,6 +3,9 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.EmailConfig.EmailType;
 import jakarta.persistence.Converter;
 
+/**
+ * JPA converter for translating Email Configuration types.
+ */
 @Converter
 public class EmailConfigTypeConverter extends NullSafeEnumConverter<EmailType> {
     public EmailConfigTypeConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailLogChartDisplayOptionConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailLogChartDisplayOptionConverter.java
@@ -3,6 +3,9 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.EmailLog.ChartDisplayOption;
 import jakarta.persistence.Converter;
 
+/**
+ * JPA converter for translating Email Log chart display options.
+ */
 @Converter
 public class EmailLogChartDisplayOptionConverter extends NullSafeEnumConverter<ChartDisplayOption> {
     public EmailLogChartDisplayOptionConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailLogStatusConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailLogStatusConverter.java
@@ -3,6 +3,9 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.EmailLog.EmailStatus;
 import jakarta.persistence.Converter;
 
+/**
+ * JPA converter for translating Email Log status values.
+ */
 @Converter
 public class EmailLogStatusConverter extends NullSafeEnumConverter<EmailStatus> {
     public EmailLogStatusConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailLogTransactionTypeConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailLogTransactionTypeConverter.java
@@ -3,6 +3,9 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.EmailLog.TransactionType;
 import jakarta.persistence.Converter;
 
+/**
+ * JPA converter for translating Email Log transaction types.
+ */
 @Converter
 public class EmailLogTransactionTypeConverter extends NullSafeEnumConverter<TransactionType> {
     public EmailLogTransactionTypeConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/FaxConfigProviderTypeConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/FaxConfigProviderTypeConverter.java
@@ -3,6 +3,9 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.FaxConfig.ProviderType;
 import jakarta.persistence.Converter;
 
+/**
+ * JPA converter for translating Fax provider types between database and entity.
+ */
 @Converter
 public class FaxConfigProviderTypeConverter extends NullSafeEnumConverter<ProviderType> {
     public FaxConfigProviderTypeConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/FaxJobStatusConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/FaxJobStatusConverter.java
@@ -3,6 +3,9 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.FaxJob.STATUS;
 import jakarta.persistence.Converter;
 
+/**
+ * JPA converter for translating Fax Job status values.
+ */
 @Converter
 public class FaxJobStatusConverter extends NullSafeEnumConverter<STATUS> {
     public FaxJobStatusConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/HnrDataValidationTypeConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/HnrDataValidationTypeConverter.java
@@ -3,6 +3,9 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.HnrDataValidation.Type;
 import jakarta.persistence.Converter;
 
+/**
+ * JPA converter for translating HNR data validation types.
+ */
 @Converter
 public class HnrDataValidationTypeConverter extends NullSafeEnumConverter<Type> {
     public HnrDataValidationTypeConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/TicklerPriorityConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/TicklerPriorityConverter.java
@@ -3,6 +3,9 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.Tickler.PRIORITY;
 import jakarta.persistence.Converter;
 
+/**
+ * JPA converter for translating Tickler priorities between database and entity.
+ */
 @Converter
 public class TicklerPriorityConverter extends NullSafeEnumConverter<PRIORITY> {
     public TicklerPriorityConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/TicklerStatusConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/TicklerStatusConverter.java
@@ -3,6 +3,9 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.Tickler.STATUS;
 import jakarta.persistence.Converter;
 
+/**
+ * JPA converter for translating Tickler status values.
+ */
 @Converter
 public class TicklerStatusConverter extends NullSafeEnumConverter<STATUS> {
     public TicklerStatusConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/enumerator/CppCode.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/enumerator/CppCode.java
@@ -3,6 +3,9 @@ package io.github.carlos_emr.carlos.commn.model.enumerator;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Enumeration representing Clinical Practice Profile (CPP) coding standards.
+ */
 public enum CppCode {
     OMEDS("OMeds"),
     SOC_HISTORY("SocHistory"),

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/enumerator/DocumentType.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/enumerator/DocumentType.java
@@ -1,5 +1,8 @@
 package io.github.carlos_emr.carlos.commn.model.enumerator;
 
+/**
+ * Enumeration representing the various types of documents stored in the system.
+ */
 public enum DocumentType {
     EFORM("E", "eForm"),
     DOC("D", "doc"),

--- a/src/main/java/io/github/carlos_emr/carlos/config/ServletContextConfig.java
+++ b/src/main/java/io/github/carlos_emr/carlos/config/ServletContextConfig.java
@@ -7,6 +7,9 @@ import jakarta.servlet.ServletContext;
 
 import org.springframework.web.context.ServletContextAware;
 
+/**
+ * Spring configuration class to initialize and provide the ServletContext.
+ */
 @Configuration
 public class ServletContextConfig implements ServletContextAware {
 

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oceanEReferal/pageUtil/OceanEReferralAttachmentUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oceanEReferal/pageUtil/OceanEReferralAttachmentUtil.java
@@ -10,6 +10,9 @@ import io.github.carlos_emr.carlos.commn.model.EReferAttachment;
 import io.github.carlos_emr.carlos.commn.model.EReferAttachmentData;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 
+/**
+ * Utility methods for handling file attachments in Ocean eReferrals.
+ */
 public class OceanEReferralAttachmentUtil {
     private static EReferAttachmentDataDaoImpl eReferAttachmentDataDao = SpringUtils.getBean(EReferAttachmentDataDaoImpl.class);
     private static EReferAttachmentDaoImpl eReferAttachmentDao = SpringUtils.getBean(EReferAttachmentDaoImpl.class);

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/config/data/ConsultationServiceDto.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/config/data/ConsultationServiceDto.java
@@ -1,5 +1,8 @@
 package io.github.carlos_emr.carlos.encounter.oscarConsultationRequest.config.data;
 
+/**
+ * Data transfer object representing a service provided by a consultant.
+ */
 public class ConsultationServiceDto {
     private Integer serviceId;
     private String serviceDesc;

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/config/data/SpecialistDto.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/config/data/SpecialistDto.java
@@ -1,5 +1,8 @@
 package io.github.carlos_emr.carlos.encounter.oscarConsultationRequest.config.data;
 
+/**
+ * Data transfer object representing a specialist in consultation requests.
+ */
 public class SpecialistDto {
     private Integer specId;
     private String name;

--- a/src/main/java/io/github/carlos_emr/carlos/integration/ebs/App.java
+++ b/src/main/java/io/github/carlos_emr/carlos/integration/ebs/App.java
@@ -1,5 +1,8 @@
 package io.github.carlos_emr.carlos.integration.ebs;
 
+/**
+ * Main entry point or utility app for the EBS integration module.
+ */
 public class App
 {
     public static void main(final String[] args) {

--- a/src/main/java/io/github/carlos_emr/carlos/utility/EmailSendingException.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/EmailSendingException.java
@@ -1,5 +1,8 @@
 package io.github.carlos_emr.carlos.utility;
 
+/**
+ * Exception thrown when an email fails to send due to network or configuration issues.
+ */
 public class EmailSendingException extends Exception {
     public EmailSendingException() {
         super();

--- a/src/main/java/io/github/carlos_emr/carlos/utility/JsDateSerializer.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/JsDateSerializer.java
@@ -6,6 +6,9 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import java.io.IOException;
 import java.util.Calendar;
 
+/**
+ * Custom JSON serializer for formatting dates into a JavaScript-compatible format.
+ */
 public class JsDateSerializer extends JsonSerializer<java.sql.Date> {
     @Override
     public void serialize(java.sql.Date value, JsonGenerator gen, SerializerProvider serializers) 

--- a/src/main/java/io/github/carlos_emr/carlos/utility/PDFEncryptionUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/PDFEncryptionUtil.java
@@ -9,6 +9,9 @@ import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.encryption.AccessPermission;
 import org.apache.pdfbox.pdmodel.encryption.StandardProtectionPolicy;
 
+/**
+ * Utility class for encrypting PDF documents securely.
+ */
 public class PDFEncryptionUtil {
     public static Path encryptPDF(Path pdfPath, String password) throws IOException {
         try (PDDocument pdDocument = Loader.loadPDF(pdfPath.toFile())) {

--- a/src/main/java/io/github/carlos_emr/carlos/ws/DuplicateHinException.java
+++ b/src/main/java/io/github/carlos_emr/carlos/ws/DuplicateHinException.java
@@ -5,6 +5,9 @@ import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import java.io.Serializable;
 
+/**
+ * Exception thrown when a duplicate Health Insurance Number (HIN) is detected.
+ */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "DuplicateHinException")
 public class DuplicateHinException implements Serializable

--- a/src/main/java/io/github/carlos_emr/carlos/ws/Gender.java
+++ b/src/main/java/io/github/carlos_emr/carlos/ws/Gender.java
@@ -3,6 +3,9 @@ package io.github.carlos_emr.carlos.ws;
 import jakarta.xml.bind.annotation.XmlEnum;
 import jakarta.xml.bind.annotation.XmlType;
 
+/**
+ * Enumeration representing gender options in web service data models.
+ */
 @XmlType(name = "gender")
 @XmlEnum
 public enum Gender

--- a/src/main/java/io/github/carlos_emr/carlos/ws/HelloWorld.java
+++ b/src/main/java/io/github/carlos_emr/carlos/ws/HelloWorld.java
@@ -5,6 +5,9 @@ import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import java.io.Serializable;
 
+/**
+ * Primary HelloWorld web service endpoint for testing connectivity.
+ */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "helloWorld")
 public class HelloWorld implements Serializable

--- a/src/main/java/io/github/carlos_emr/carlos/ws/HelloWorld2.java
+++ b/src/main/java/io/github/carlos_emr/carlos/ws/HelloWorld2.java
@@ -5,6 +5,9 @@ import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import java.io.Serializable;
 
+/**
+ * Secondary HelloWorld web service endpoint for integration testing.
+ */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "helloWorld2", propOrder = { "arg0" })
 public class HelloWorld2 implements Serializable

--- a/src/main/java/io/github/carlos_emr/carlos/ws/HelloWorld2Response.java
+++ b/src/main/java/io/github/carlos_emr/carlos/ws/HelloWorld2Response.java
@@ -6,6 +6,9 @@ import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import java.io.Serializable;
 
+/**
+ * Response wrapper for the secondary HelloWorld web service endpoint.
+ */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "helloWorld2Response", propOrder = { "_return" })
 public class HelloWorld2Response implements Serializable

--- a/src/main/java/io/github/carlos_emr/carlos/ws/HelloWorldResponse.java
+++ b/src/main/java/io/github/carlos_emr/carlos/ws/HelloWorldResponse.java
@@ -6,6 +6,9 @@ import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import java.io.Serializable;
 
+/**
+ * Response wrapper for the primary HelloWorld web service endpoint.
+ */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "helloWorldResponse", propOrder = { "_return" })
 public class HelloWorldResponse implements Serializable

--- a/src/main/java/io/github/carlos_emr/carlos/ws/InvalidHinException.java
+++ b/src/main/java/io/github/carlos_emr/carlos/ws/InvalidHinException.java
@@ -5,6 +5,9 @@ import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import java.io.Serializable;
 
+/**
+ * Exception thrown when an invalid Health Insurance Number (HIN) is provided.
+ */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "InvalidHinException")
 public class InvalidHinException implements Serializable

--- a/src/main/java/io/github/carlos_emr/carlos/ws/MatchingClientParameters.java
+++ b/src/main/java/io/github/carlos_emr/carlos/ws/MatchingClientParameters.java
@@ -10,6 +10,9 @@ import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import java.io.Serializable;
 
+/**
+ * Parameters used to match client demographics during web service integrations.
+ */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "matchingClientParameters", propOrder = { "maxEntriesToReturn", "minScore", "firstName", "lastName", "birthDate", "hin" })
 public class MatchingClientParameters implements Serializable

--- a/src/main/java/io/github/carlos_emr/carlos/ws/MatchingClientScore.java
+++ b/src/main/java/io/github/carlos_emr/carlos/ws/MatchingClientScore.java
@@ -5,6 +5,9 @@ import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import java.io.Serializable;
 
+/**
+ * Score object representing the confidence level of a client demographic match.
+ */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "matchingClientScore", propOrder = { "client", "score" })
 public class MatchingClientScore implements Serializable

--- a/src/main/java/io/github/carlos_emr/carlos/ws/ObjectFactory.java
+++ b/src/main/java/io/github/carlos_emr/carlos/ws/ObjectFactory.java
@@ -5,6 +5,9 @@ import jakarta.xml.bind.JAXBElement;
 import javax.xml.namespace.QName;
 import jakarta.xml.bind.annotation.XmlRegistry;
 
+/**
+ * Factory class to create instances of XML or web service objects.
+ */
 @XmlRegistry
 public class ObjectFactory
 {


### PR DESCRIPTION
Adding missing javadoc to 40 classes to improve documentation coverage across the codebase.

---
*PR created automatically by Jules for task [17015174504698984303](https://jules.google.com/task/17015174504698984303) started by @yingbull*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add missing class-level Javadoc to 40 classes to improve API clarity and in-IDE documentation. Touches entities/enums, JPA converters, web-service DTOs/exceptions, utilities, and Spring config with no functional changes.

<sup>Written for commit 3651207f42c0028ba16005cf7010d29132444186. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

