### PR TITLE
[Fix] mojibake error â€” by addition of meta charset tag to errorpage.jsp

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/error/errorpage.jsp
+++ b/src/main/webapp/WEB-INF/jsp/error/errorpage.jsp
@@ -39,7 +39,7 @@
     - LoginResourceBean.supportText: Support contact descriptive text or HTML (optional)
   @since 2026-03
 --%>
-<%@ page isErrorPage="true" %>
+<%@ page isErrorPage="true" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <%-- Log the captured exception so JSP-render failures don't disappear into a
      generic "CARLOS Error" page with nothing in catalina.out. The logic
      lives in ErrorPageLogger so it can be unit-tested without a JSP
@@ -88,7 +88,6 @@
 <%@ taglib uri='jakarta.tags.core' prefix="c" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <fmt:setBundle basename="oscarResources"/>
-<%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <%@ taglib uri="carlos" prefix="carlos" %>
 <fmt:message key="messenger.config.MessengerAdmin.goBack" var="btnBackTitle"/>
 <fmt:message key="provider.appointmentProviderAdminDay.schedView" var="btnExitTitle"/>

--- a/src/main/webapp/WEB-INF/jsp/error/errorpage.jsp
+++ b/src/main/webapp/WEB-INF/jsp/error/errorpage.jsp
@@ -88,14 +88,15 @@
 <%@ taglib uri='jakarta.tags.core' prefix="c" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <fmt:setBundle basename="oscarResources"/>
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ taglib uri="carlos" prefix="carlos" %>
 <fmt:message key="messenger.config.MessengerAdmin.goBack" var="btnBackTitle"/>
 <fmt:message key="provider.appointmentProviderAdminDay.schedView" var="btnExitTitle"/>
 <jsp:useBean id="LoginResourceBean" beanName="io.github.carlos_emr.carlos.login.LoginResourceBean" type="io.github.carlos_emr.carlos.login.LoginResourceBean"/>
 <!DOCTYPE html>
 <html>
-
 <head>
+  <meta charset="UTF-8">
     <title>
         <fmt:message key="error.description"/>
     </title>

--- a/src/main/webapp/WEB-INF/jsp/error/errorpage.jsp
+++ b/src/main/webapp/WEB-INF/jsp/error/errorpage.jsp
@@ -88,7 +88,7 @@
 <%@ taglib uri='jakarta.tags.core' prefix="c" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <fmt:setBundle basename="oscarResources"/>
-<%@ page contentType="text/html; charset=UTF-8" %>
+<%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <%@ taglib uri="carlos" prefix="carlos" %>
 <fmt:message key="messenger.config.MessengerAdmin.goBack" var="btnBackTitle"/>
 <fmt:message key="provider.appointmentProviderAdminDay.schedView" var="btnExitTitle"/>


### PR DESCRIPTION
<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description
Fixes #2175
<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues

<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?

<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots
mojibake error â€”
<img width="1361" height="422" alt="mojibakeError" src="https://github.com/user-attachments/assets/a9e20377-e192-4f20-bcc7-a3a6c4f9e69e" />

Fixed -
<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->
<img width="1099" height="495" alt="correctedErrorPage" src="https://github.com/user-attachments/assets/b7035a15-4404-410a-b862-44d6e1b307ee" />


## Checklist

- [X] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [ ] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Bug Fixes:
- Fix incorrect character rendering (mojibake) on the error page by specifying UTF-8 encoding in the JSP and HTML head.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure UTF-8 on `errorpage.jsp` by consolidating the JSP page directive with UTF-8 `contentType`/`pageEncoding` and adding a meta charset tag, fixing mojibake and rendering special characters correctly. Fixes #2175.

<sup>Written for commit f8cfbaf40f8498f08ff10cd0acac27052a4d5406. Summary will update on new commits. <a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2177?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

