### PR TITLE
[Fix] Encoding fix and moved hint from placeholder as the input was too small to display and inconsistent with rest of the design

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingONfavourite.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingONfavourite.jsp
@@ -31,7 +31,7 @@
 --%>
 <%@ page errorPage="/WEB-INF/jsp/error/errorpage.jsp" %>
 <%@ page import="java.util.ResourceBundle" %>
-<%@ page contentType="text/html; charset=UTF-8" %>
+<%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <%@ taglib uri="carlos" prefix="carlos" %>

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingONfavourite.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/ON/billingONfavourite.jsp
@@ -31,7 +31,7 @@
 --%>
 <%@ page errorPage="/WEB-INF/jsp/error/errorpage.jsp" %>
 <%@ page import="java.util.ResourceBundle" %>
-
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <%@ taglib uri="carlos" prefix="carlos" %>
@@ -186,8 +186,8 @@
                     <div class="d-flex align-items-center gap-1 flex-wrap">
                         <input class="form-control form-control-sm fav-dx" type="text" name="dx"
                                value="<carlos:encode value='${favouriteModel.formFields[\"dx\"]}' context='htmlAttribute'/>"
-                               maxlength="4"
-                               placeholder="<fmt:message key='billing.billingOnFavourite.dxHint'/>"/>
+                               maxlength="4"/>
+                        <span class="text-muted small"><fmt:message key="billing.billingOnFavourite.dxHint"/></span>
                         <label class="fw-semibold mb-0 ms-2">
                             <fmt:message key="billing.billingOnFavourite.labelDx1"/>
                         </label>


### PR DESCRIPTION
Fixed mojibake and moved hint from placeholder as the input was too small to display and inconsistent with rest of the design

<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description
visual
<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues

<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?

<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots

after
<img width="700" height="685" alt="fixedAdd_EditBillingFav" src="https://github.com/user-attachments/assets/13b868f4-3eea-4f8e-ab31-ea808b7d34f7" />


## Checklist

- [X] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mojibake in ON billing favourites by serving the page as UTF-8. Also moves the DX hint from the input placeholder to inline text for clarity and consistency. Addresses Linear 2180 (mojibake in Billing Supercodes).

- **Bug Fixes**
  - Set JSP `contentType="text/html; charset=UTF-8"` and `pageEncoding="UTF-8"` to resolve encoding issues.
  - Moved `billing.billingOnFavourite.dxHint` from the input placeholder to a small muted span next to the field.

<sup>Written for commit 3701c6e9f502c1338a1d4ac7531b202dab7beef9. Summary will update on new commits. <a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2186?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

