### PR TITLE
fix: create configured eform image directory

### DIFF
--- a/.devcontainer/development/Dockerfile
+++ b/.devcontainer/development/Dockerfile
@@ -22,6 +22,7 @@ ARG DOCS_PATH='/home/oscar/development/volumes'
 ARG OSCAR_DOCUMENT="${DOCS_PATH}/OscarDocument"
 ARG DB_DOCS="/db-data/documents"
 ARG DOCS_DEST="/var/lib/OscarDocument/oscar/document"
+ARG EFORM_IMAGES_DEST="/var/lib/OscarDocument/oscar/eform/images"
 
 WORKDIR /workspace
 
@@ -175,7 +176,8 @@ RUN mkdir -p $OSCAR_DOCUMENT/oscar/document \
     $OSCAR_DOCUMENT/oscar/incomingdocs \
     $OSCAR_DOCUMENT/oscar/export \
     $DB_DOCS \
-    $DOCS_DEST
+    $DOCS_DEST \
+    $EFORM_IMAGES_DEST
 
 # Set up GPG for PGP encryption (used by demographic export)
 # Create the GNUPGHOME directory and generate a test key for development


### PR DESCRIPTION
Closes #2182.

Summary:
- add an explicit `EFORM_IMAGES_DEST` build arg for `/var/lib/OscarDocument/oscar/eform/images`
- create that configured eForm image directory in the development image bootstrap `mkdir -p` block

Validation:
- confirmed `.devcontainer/development/config/shared/volumes/carlos.properties` sets `EFORM_IMAGES_DIR=/var/lib/OscarDocument/oscar/eform/images/` and the Dockerfile now creates the same path
- `git diff --check`
- `git diff --cached --check`
- `gitleaks protect --staged --redact --verbose` (no leaks found)

Not run:
- `docker compose -f .devcontainer/docker-compose.yml config --quiet` (local `docker` command is unavailable in this Mac mini session)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Creates /var/lib/OscarDocument/oscar/eform/images in the dev container to match `EFORM_IMAGES_DIR`, preventing missing-path errors. Adds `EFORM_IMAGES_DEST` build arg and includes it in the `mkdir -p` bootstrap.

<sup>Written for commit 51830dd899477ad8da0344c6fd3213accaaa28aa. Summary will update on new commits. <a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2191?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

