### PR TITLE
Fix build and test failures

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDaoImpl.java
@@ -2228,35 +2228,35 @@ public class DemographicDaoImpl extends AbstractJpaDao implements ApplicationEve
         int paramIndex = 1;
 
         if (firstName.trim().length() > 0) {
-            whereClause.append("FirstName=?" + paramIndex++);
+            whereClause.append("firstName=?" + paramIndex++);
             params.add(firstName.trim());
         }
         if (lastName.trim().length() > 0) {
             if (params.size() > 0) {
                 whereClause.append(" AND ");
             }
-            whereClause.append("LastName=?" + paramIndex++);
+            whereClause.append("lastName=?" + paramIndex++);
             params.add(lastName.trim());
         }
         if (hPhone.trim().length() > 0) {
             if (params.size() > 0) {
                 whereClause.append(" AND ");
             }
-            whereClause.append("Phone=?" + paramIndex++);
+            whereClause.append("phone=?" + paramIndex++);
             params.add(hPhone.trim());
         }
         if (wPhone.trim().length() > 0) {
             if (params.size() > 0) {
                 whereClause.append(" AND ");
             }
-            whereClause.append("Phone2=?" + paramIndex++);
+            whereClause.append("phone2=?" + paramIndex++);
             params.add(wPhone.trim());
         }
         if (email.trim().length() > 0) {
             if (params.size() > 0) {
                 whereClause.append(" AND ");
             }
-            whereClause.append("Email=?" + paramIndex++);
+            whereClause.append("email=?" + paramIndex++);
             params.add(email.trim());
         }
 
@@ -2290,21 +2290,21 @@ public class DemographicDaoImpl extends AbstractJpaDao implements ApplicationEve
     public List<Demographic> getDemographicWithLastFirstDOB(String lastname, String firstname, String year_of_birth,
                                                             String month_of_birth, String date_of_birth) {
         List<String> params = new ArrayList<String>();
-        String sql = "FROM Demographic " + " WHERE LastName like ?1 and FirstName like ?2";
+        String sql = "FROM Demographic " + " WHERE lastName like ?1 and firstName like ?2";
         params.add(lastname + "%");
         params.add(firstname + "%");
 
         int paramIndex = 3;
         if (year_of_birth != null) {
-            sql += " AND YearOfBirth = ?" + paramIndex++;
+            sql += " AND yearOfBirth = ?" + paramIndex++;
             params.add(year_of_birth);
         }
         if (month_of_birth != null) {
-            sql += " AND MonthOfBirth = ?" + paramIndex++;
+            sql += " AND monthOfBirth = ?" + paramIndex++;
             params.add(month_of_birth);
         }
         if (date_of_birth != null) {
-            sql += " AND DateOfBirth = ?" + paramIndex++;
+            sql += " AND dateOfBirth = ?" + paramIndex++;
             params.add(date_of_birth);
         }
 
@@ -2316,21 +2316,21 @@ public class DemographicDaoImpl extends AbstractJpaDao implements ApplicationEve
     public List<Demographic> getDemographicWithLastFirstDOBExact(String lastname, String firstname,
                                                                  String year_of_birth, String month_of_birth, String date_of_birth) {
         List<String> params = new ArrayList<String>();
-        String sql = "FROM Demographic " + " WHERE LastName = ?1 and FirstName = ?2";
+        String sql = "FROM Demographic " + " WHERE lastName = ?1 and firstName = ?2";
         params.add(lastname);
         params.add(firstname);
 
         int paramIndex = 3;
         if (year_of_birth != null) {
-            sql += " AND YearOfBirth = ?" + paramIndex++;
+            sql += " AND yearOfBirth = ?" + paramIndex++;
             params.add(year_of_birth);
         }
         if (month_of_birth != null) {
-            sql += " AND MonthOfBirth = ?" + paramIndex++;
+            sql += " AND monthOfBirth = ?" + paramIndex++;
             params.add(month_of_birth);
         }
         if (date_of_birth != null) {
-            sql += " AND DateOfBirth = ?" + paramIndex++;
+            sql += " AND dateOfBirth = ?" + paramIndex++;
             params.add(date_of_birth);
         }
 
@@ -2346,7 +2346,7 @@ public class DemographicDaoImpl extends AbstractJpaDao implements ApplicationEve
      */
     @Override
     public boolean existsByFirstAndLastName(String firstName, String lastName) {
-        String sql = "SELECT COUNT(*) FROM Demographic WHERE FirstName = ?1 AND LastName = ?2";
+        String sql = "SELECT COUNT(*) FROM Demographic WHERE firstName = ?1 AND lastName = ?2";
         Long count = (Long) JpqlQueryHelper.find(entityManager(), sql, firstName, lastName).get(0);
         return count > 0;
     }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDaoImpl.java
@@ -2290,25 +2290,25 @@ public class DemographicDaoImpl extends AbstractJpaDao implements ApplicationEve
     public List<Demographic> getDemographicWithLastFirstDOB(String lastname, String firstname, String year_of_birth,
                                                             String month_of_birth, String date_of_birth) {
         List<String> params = new ArrayList<String>();
-        String sql = "FROM Demographic " + " WHERE lastName like ?1 and firstName like ?2";
+        StringBuilder sql = new StringBuilder("FROM Demographic WHERE lastName like ?1 and firstName like ?2");
         params.add(lastname + "%");
         params.add(firstname + "%");
 
         int paramIndex = 3;
         if (year_of_birth != null) {
-            sql += " AND yearOfBirth = ?" + paramIndex++;
+            sql.append(" AND yearOfBirth = ?").append(paramIndex++);
             params.add(year_of_birth);
         }
         if (month_of_birth != null) {
-            sql += " AND monthOfBirth = ?" + paramIndex++;
+            sql.append(" AND monthOfBirth = ?").append(paramIndex++);
             params.add(month_of_birth);
         }
         if (date_of_birth != null) {
-            sql += " AND dateOfBirth = ?" + paramIndex++;
+            sql.append(" AND dateOfBirth = ?").append(paramIndex++);
             params.add(date_of_birth);
         }
 
-        return (List<Demographic>) JpqlQueryHelper.find(entityManager(), sql, (Object[]) params.toArray(new String[params.size()]));
+        return (List<Demographic>) JpqlQueryHelper.find(entityManager(), sql.toString(), (Object[]) params.toArray(new String[params.size()]));
     }
 
     @SuppressWarnings("unchecked")
@@ -2316,25 +2316,25 @@ public class DemographicDaoImpl extends AbstractJpaDao implements ApplicationEve
     public List<Demographic> getDemographicWithLastFirstDOBExact(String lastname, String firstname,
                                                                  String year_of_birth, String month_of_birth, String date_of_birth) {
         List<String> params = new ArrayList<String>();
-        String sql = "FROM Demographic " + " WHERE lastName = ?1 and firstName = ?2";
+        StringBuilder sql = new StringBuilder("FROM Demographic WHERE lastName = ?1 and firstName = ?2");
         params.add(lastname);
         params.add(firstname);
 
         int paramIndex = 3;
         if (year_of_birth != null) {
-            sql += " AND yearOfBirth = ?" + paramIndex++;
+            sql.append(" AND yearOfBirth = ?").append(paramIndex++);
             params.add(year_of_birth);
         }
         if (month_of_birth != null) {
-            sql += " AND monthOfBirth = ?" + paramIndex++;
+            sql.append(" AND monthOfBirth = ?").append(paramIndex++);
             params.add(month_of_birth);
         }
         if (date_of_birth != null) {
-            sql += " AND dateOfBirth = ?" + paramIndex++;
+            sql.append(" AND dateOfBirth = ?").append(paramIndex++);
             params.add(date_of_birth);
         }
 
-        return (List<Demographic>) JpqlQueryHelper.find(entityManager(), sql, (Object[]) params.toArray(new String[params.size()]));
+        return (List<Demographic>) JpqlQueryHelper.find(entityManager(), sql.toString(), (Object[]) params.toArray(new String[params.size()]));
     }
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/TicklerDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/TicklerDaoImpl.java
@@ -118,6 +118,11 @@ public class TicklerDaoImpl extends AbstractDaoImpl<Tickler> implements TicklerD
     }
 
     @Override
+    public Tickler find(int id) {
+        return find(Integer.valueOf(id));
+    }
+
+    @Override
     public List<Tickler> findActiveByMessageForPatients(List<Integer> demographicNos, String remString) {
 
         //weird logic here, beware.

--- a/src/test/java/io/github/carlos_emr/carlos/appointment/AppointmentJspRoutingTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/appointment/AppointmentJspRoutingTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 class AppointmentJspRoutingTest {
 
     private static final Pattern FORCE_WINDOW_PATHS_PATTERN = Pattern.compile(
-            "(?:window\\.)?forceWindowPaths\\s*=\\s*(?:(?:window\\.)?forceWindowPaths\\s*\\|\\|\\s*)?\\[(?<body>[\\s\\S]*?)]\\s*;?");
+            "(?:(?:var|let|const)\\s+)?(?:window\\.)?forceWindowPaths\\s*=\\s*(?:(?:window\\.)?forceWindowPaths\\s*\\|\\|\\s*)?\\[(?<body>[\\s\\S]*?)]\\s*;?");
 
     @Test
     void shouldRouteLiveAppointmentCallers_directlyToFinalTargets() throws IOException {

--- a/src/test/java/io/github/carlos_emr/carlos/appointment/AppointmentJspRoutingTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/appointment/AppointmentJspRoutingTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 class AppointmentJspRoutingTest {
 
     private static final Pattern FORCE_WINDOW_PATHS_PATTERN = Pattern.compile(
-            "(?:window\\.)?forceWindowPaths\\s*=\\s*(?:window\\.forceWindowPaths\\s*\\|\\|\\s*)?\\[(?<body>[\\s\\S]*?)]\\s*;?");
+            "(?:window\\.)?forceWindowPaths\\s*=\\s*(?:(?:window\\.)?forceWindowPaths\\s*\\|\\|\\s*)?\\[(?<body>[\\s\\S]*?)]\\s*;?");
 
     @Test
     void shouldRouteLiveAppointmentCallers_directlyToFinalTargets() throws IOException {

--- a/src/test/java/io/github/carlos_emr/carlos/appointment/AppointmentJspRoutingTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/appointment/AppointmentJspRoutingTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 class AppointmentJspRoutingTest {
 
     private static final Pattern FORCE_WINDOW_PATHS_PATTERN = Pattern.compile(
-            "(?:var|let|const)\\s+forceWindowPaths\\s*=\\s*\\[(?<body>[\\s\\S]*?)]\\s*;?");
+            "(?:window\\.)?forceWindowPaths\\s*=\\s*(?:window\\.forceWindowPaths\\s*\\|\\|\\s*)?\\[(?<body>[\\s\\S]*?)]\\s*;?");
 
     @Test
     void shouldRouteLiveAppointmentCallers_directlyToFinalTargets() throws IOException {

--- a/src/test/java/io/github/carlos_emr/carlos/commn/dao/MeasurementDaoIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/commn/dao/MeasurementDaoIntegrationTest.java
@@ -123,6 +123,15 @@ public class MeasurementDaoIntegrationTest extends CarlosTestBase {
         return m;
     }
 
+    private Measurement createAndPersistWithCreateDate(int demoNo, String type, String dataField,
+                                                        Date dateObserved, Date createDate) {
+        Measurement m = createMeasurement(demoNo, type, dataField, dateObserved);
+        m.setCreateDate(createDate);
+        entityManager.persist(m);
+        entityManager.flush();
+        return m;
+    }
+
     private Measurement createAndPersistWithInstruction(int demoNo, String type, String dataField,
                                                          Date dateObserved, String instruction) {
         Measurement m = createMeasurement(demoNo, type, dataField, dateObserved);
@@ -477,8 +486,8 @@ public class MeasurementDaoIntegrationTest extends CarlosTestBase {
         @DisplayName("should return most recently entered measurement for demo and type")
         void shouldReturnLastEntered_forDemoAndType() {
             // Given
-            createAndPersist(DEMO_NO, "BP", "110/70", yesterday);
-            createAndPersist(DEMO_NO, "BP", "120/80", today);
+            createAndPersistWithCreateDate(DEMO_NO, "BP", "110/70", today, yesterday);
+            createAndPersistWithCreateDate(DEMO_NO, "BP", "120/80", yesterday, today);
 
             // When
             Measurement result = measurementDao.findLastEntered(DEMO_NO, "BP");

--- a/src/test/java/io/github/carlos_emr/carlos/commn/dao/OntarioMDSpec4DataIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/commn/dao/OntarioMDSpec4DataIntegrationTest.java
@@ -144,16 +144,7 @@ public class OntarioMDSpec4DataIntegrationTest extends CarlosTestBase {
                 .executeUpdate();
         entityManager.flush();
 
-        Provider provider = new Provider();
-        provider.setProviderNo(providerNo);
-        provider.setFirstName(firstName);
-        provider.setLastName(lastName);
-        provider.setSpecialty(specialty);
-        provider.setProviderType("doctor");
-        provider.setSex("M");
-        provider.setSignedConfidentiality(new Date());
-        provider.setStatus("1");
-        return provider;
+        return providerDao.getProvider(providerNo);
     }
 
     private Demographic createDemographic(String lastName, String firstName, String providerNo) {

--- a/src/test/java/io/github/carlos_emr/carlos/commn/dao/OntarioMDSpec4DataIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/commn/dao/OntarioMDSpec4DataIntegrationTest.java
@@ -128,16 +128,31 @@ public class OntarioMDSpec4DataIntegrationTest extends CarlosTestBase {
     }
 
     private Provider createProvider(String firstName, String lastName, String providerNo, String specialty) {
+        entityManager.createNativeQuery("""
+                MERGE INTO provider (
+                    provider_no, first_name, last_name, specialty, provider_type,
+                    sex, signed_confidentiality, status
+                ) KEY(provider_no) VALUES (
+                    :providerNo, :firstName, :lastName, :specialty, 'doctor',
+                    'M', CURRENT_TIMESTAMP, '1'
+                )
+                """)
+                .setParameter("providerNo", providerNo)
+                .setParameter("firstName", firstName)
+                .setParameter("lastName", lastName)
+                .setParameter("specialty", specialty)
+                .executeUpdate();
+        entityManager.flush();
+
         Provider provider = new Provider();
+        provider.setProviderNo(providerNo);
         provider.setFirstName(firstName);
         provider.setLastName(lastName);
-        provider.setProviderNo(providerNo);
         provider.setSpecialty(specialty);
         provider.setProviderType("doctor");
         provider.setSex("M");
         provider.setSignedConfidentiality(new Date());
         provider.setStatus("1");
-        providerDao.saveProvider(provider);
         return provider;
     }
 

--- a/src/test/java/io/github/carlos_emr/carlos/commn/dao/ProviderSiteDaoIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/commn/dao/ProviderSiteDaoIntegrationTest.java
@@ -65,7 +65,7 @@ public class ProviderSiteDaoIntegrationTest extends CarlosTestBase {
      * Creates a provider record in the database to satisfy FK constraints on providersite.
      */
     private void ensureProviderExists(String providerNo) {
-        String sql = "MERGE INTO provider (provider_no, first_name, last_name, specialty, status) KEY(provider_no) VALUES (?, 'Test', 'Provider', 'GP', '1')";
+        String sql = "MERGE INTO provider (provider_no, first_name, last_name, provider_type, sex, specialty, status) KEY(provider_no) VALUES (?, 'Test', 'Provider', 'doctor', 'M', 'GP', '1')";
         entityManager.createNativeQuery(sql)
                 .setParameter(1, providerNo)
                 .executeUpdate();

--- a/src/test/java/io/github/carlos_emr/carlos/daos/security/SecObjectNameDaoIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/daos/security/SecObjectNameDaoIntegrationTest.java
@@ -173,8 +173,7 @@ public class SecObjectNameDaoIntegrationTest extends CarlosTestBase {
         Object[] row = (Object[]) results.get(0);
         assertThat(row[0]).isEqualTo("_testObject1");
         assertThat(row[1]).isEqualTo("Test security object");
-        // Cast to Number first because H2 may return different integer subtypes
-        assertThat(((Number) row[2]).intValue()).isEqualTo(1);
+        assertThat(orgApplicableValue(row[2])).isEqualTo(1);
     }
 
     /**
@@ -229,7 +228,7 @@ public class SecObjectNameDaoIntegrationTest extends CarlosTestBase {
         // Description should reflect the updated value, not "Original description"
         assertThat(row[1]).isEqualTo("Updated description");
         // orgapplicable should be updated from 0 to 1
-        assertThat(((Number) row[2]).intValue()).isEqualTo(1);
+        assertThat(orgApplicableValue(row[2])).isEqualTo(1);
     }
 
     /**
@@ -318,6 +317,13 @@ public class SecObjectNameDaoIntegrationTest extends CarlosTestBase {
         Object[] row = (Object[]) results.get(0);
         assertThat(row[0]).isEqualTo("_testObject4");
         assertThat(row[1]).isEqualTo("Full constructor test");
-        assertThat(((Number) row[2]).intValue()).isEqualTo(1);
+        assertThat(orgApplicableValue(row[2])).isEqualTo(1);
+    }
+
+    private static int orgApplicableValue(Object value) {
+        if (value instanceof Boolean booleanValue) {
+            return booleanValue ? 1 : 0;
+        }
+        return ((Number) value).intValue();
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/daos/security/SecProviderDaoCacheIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/daos/security/SecProviderDaoCacheIntegrationTest.java
@@ -22,9 +22,9 @@
 package io.github.carlos_emr.carlos.daos.security;
 
 import com.github.benmanes.caffeine.cache.Cache;
-import io.github.carlos_emr.carlos.PMmodule.dao.ProviderDao;
 import io.github.carlos_emr.carlos.commn.dao.ProviderDataDao;
 import io.github.carlos_emr.carlos.commn.model.ProviderData;
+import io.github.carlos_emr.carlos.config.CacheConfig;
 import io.github.carlos_emr.carlos.model.security.SecProvider;
 import io.github.carlos_emr.carlos.test.base.CarlosTestBase;
 import org.junit.jupiter.api.AfterEach;
@@ -50,7 +50,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * <p>{@code SecProvider} and {@code Provider} map to the same {@code provider} table
  * (see CLAUDE.md "Dual Entity Mappings to Same Table"). Writes via {@link SecProviderDao}
- * must therefore evict the provider caches that {@link ProviderDao} populates, otherwise
+ * must therefore evict the provider caches that provider DAO reads populate, otherwise
  * admin updates through the security UI would leave stale data in the provider caches.</p>
  */
 @DisplayName("SecProviderDao cache invalidation")
@@ -63,9 +63,6 @@ class SecProviderDaoCacheIntegrationTest extends CarlosTestBase {
 
     @Autowired
     private SecProviderDao secProviderDao;
-
-    @Autowired
-    private ProviderDao providerDao;
 
     @Autowired
     private ProviderDataDao providerDataDao;
@@ -168,19 +165,10 @@ class SecProviderDaoCacheIntegrationTest extends CarlosTestBase {
     }
 
     private void seedProviderCaches() {
-        // Create a concrete provider so the DAO read path itself populates the providerNames
-        // cache — proves the eviction wipes realistic caching-path entries, not just entries
-        // we stuffed in directly with cache.put.
-        String seedProviderNo = uniquePrefix + "SE";
-        providerNosToCleanUp.add(seedProviderNo);
-        SecProvider seed = buildSecProvider(seedProviderNo, "CacheSeed", "Provider");
-        transactionTemplate.executeWithoutResult(status -> secProviderDao.save(seed));
-
-        transactionTemplate.executeWithoutResult(status -> {
-            providerDao.getActiveProviders();
-            providerDao.getActiveProviderSummaries();
-            providerDao.getProviderName(seedProviderNo);
-        });
+        putCacheEntry(CacheConfig.PROVIDER_NAMES, "name:" + uniquePrefix, "CacheSeed Provider");
+        putCacheEntry(CacheConfig.ACTIVE_PROVIDERS, "filter:true",
+                List.of(buildSecProvider(uniquePrefix + "SE", "CacheSeed", "Provider")));
+        putCacheEntry(CacheConfig.ACTIVE_PROVIDER_SUMMARIES, uniquePrefix, List.of());
     }
 
     private void assertAllThreeCachesPopulated() {
@@ -216,6 +204,12 @@ class SecProviderDaoCacheIntegrationTest extends CarlosTestBase {
                     .isNotNull();
             cache.clear();
         }
+    }
+
+    private void putCacheEntry(String cacheName, Object key, Object value) {
+        org.springframework.cache.Cache cache = cacheManager.getCache(cacheName);
+        assertThat(cache).isNotNull();
+        cache.put(key, value);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/io/github/carlos_emr/carlos/daos/security/SecProviderDaoCacheIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/daos/security/SecProviderDaoCacheIntegrationTest.java
@@ -22,9 +22,9 @@
 package io.github.carlos_emr.carlos.daos.security;
 
 import com.github.benmanes.caffeine.cache.Cache;
+import io.github.carlos_emr.carlos.PMmodule.dao.ProviderDao;
 import io.github.carlos_emr.carlos.commn.dao.ProviderDataDao;
 import io.github.carlos_emr.carlos.commn.model.ProviderData;
-import io.github.carlos_emr.carlos.config.CacheConfig;
 import io.github.carlos_emr.carlos.model.security.SecProvider;
 import io.github.carlos_emr.carlos.test.base.CarlosTestBase;
 import org.junit.jupiter.api.AfterEach;
@@ -66,6 +66,9 @@ class SecProviderDaoCacheIntegrationTest extends CarlosTestBase {
 
     @Autowired
     private ProviderDataDao providerDataDao;
+
+    @Autowired
+    private ProviderDao providerDao;
 
     @Autowired
     private CacheManager cacheManager;
@@ -165,10 +168,14 @@ class SecProviderDaoCacheIntegrationTest extends CarlosTestBase {
     }
 
     private void seedProviderCaches() {
-        putCacheEntry(CacheConfig.PROVIDER_NAMES, "name:" + uniquePrefix, "CacheSeed Provider");
-        putCacheEntry(CacheConfig.ACTIVE_PROVIDERS, "filter:true",
-                List.of(buildSecProvider(uniquePrefix + "SE", "CacheSeed", "Provider")));
-        putCacheEntry(CacheConfig.ACTIVE_PROVIDER_SUMMARIES, uniquePrefix, List.of());
+        String providerNo = uniquePrefix + "SE";
+        providerNosToCleanUp.add(providerNo);
+        transactionTemplate.executeWithoutResult(status -> secProviderDao.save(buildSecProvider(providerNo, "CacheSeed", "Provider")));
+        clearProviderCaches();
+
+        providerDao.getProviderName(providerNo);
+        providerDao.getActiveProviders();
+        providerDao.getActiveProviderSummaries();
     }
 
     private void assertAllThreeCachesPopulated() {
@@ -204,12 +211,6 @@ class SecProviderDaoCacheIntegrationTest extends CarlosTestBase {
                     .isNotNull();
             cache.clear();
         }
-    }
-
-    private void putCacheEntry(String cacheName, Object key, Object value) {
-        org.springframework.cache.Cache cache = cacheManager.getCache(cacheName);
-        assertThat(cache).isNotNull();
-        cache.put(key, value);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/io/github/carlos_emr/carlos/test/support/IntegrationTestSeedData.java
+++ b/src/test/java/io/github/carlos_emr/carlos/test/support/IntegrationTestSeedData.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.test.support;
+
+import jakarta.persistence.EntityManager;
+
+/**
+ * Shared seed-data helpers for integration tests that need core provider and
+ * demographic rows before exercising higher-level CARLOS EMR services.
+ *
+ * @since 2026-05-20
+ */
+public final class IntegrationTestSeedData {
+
+    private IntegrationTestSeedData() {
+    }
+
+    /**
+     * Ensures an active test provider row exists without flushing the caller's
+     * persistence context.
+     *
+     * @param entityManager EntityManager used by the integration test
+     * @param providerNo String provider number to upsert
+     */
+    public static void ensureProviderExists(EntityManager entityManager, String providerNo) {
+        entityManager.createNativeQuery("""
+                MERGE INTO provider (provider_no, first_name, last_name, provider_type, sex, specialty, status)
+                KEY(provider_no)
+                VALUES (:providerNo, 'Test', 'Provider', 'doctor', 'M', 'GP', '1')
+                """)
+                .setParameter("providerNo", providerNo)
+                .executeUpdate();
+    }
+
+    /**
+     * Ensures an active test demographic row exists without flushing the
+     * caller's persistence context.
+     *
+     * @param entityManager EntityManager used by the integration test
+     * @param demographicNo Integer demographic number to upsert
+     */
+    public static void ensureDemographicExists(EntityManager entityManager, Integer demographicNo) {
+        entityManager.createNativeQuery("""
+                MERGE INTO demographic (demographic_no, first_name, last_name, sex, patient_status)
+                KEY(demographic_no)
+                VALUES (:demographicNo, 'Test', 'Patient', 'M', 'AC')
+                """)
+                .setParameter("demographicNo", demographicNo)
+                .executeUpdate();
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/test/support/IntegrationTestSeedService.java
+++ b/src/test/java/io/github/carlos_emr/carlos/test/support/IntegrationTestSeedService.java
@@ -29,9 +29,9 @@ import jakarta.persistence.EntityManager;
  *
  * @since 2026-05-20
  */
-public final class IntegrationTestSeedData {
+public final class IntegrationTestSeedService {
 
-    private IntegrationTestSeedData() {
+    private IntegrationTestSeedService() {
     }
 
     /**

--- a/src/test/java/io/github/carlos_emr/carlos/tickler/TicklerPopupRoutingRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/tickler/TicklerPopupRoutingRegressionTest.java
@@ -51,7 +51,7 @@ class TicklerPopupRoutingRegressionTest {
     // Oscar.js keeps forceWindowPaths as a flat array of string literals; this
     // regression test intentionally matches that simple structure.
     private static final Pattern FORCE_WINDOW_PATHS_PATTERN = Pattern.compile(
-            "(?:window\\.)?forceWindowPaths\\s*=\\s*(?:(?:window\\.)?forceWindowPaths\\s*\\|\\|\\s*)?\\[(?<body>[\\s\\S]*?)]\\s*;?");
+            "(?:(?:var|let|const)\\s+)?(?:window\\.)?forceWindowPaths\\s*=\\s*(?:(?:window\\.)?forceWindowPaths\\s*\\|\\|\\s*)?\\[(?<body>[\\s\\S]*?)]\\s*;?");
     private static final Pattern VIEW_ADD_TICKLER_PATTERN = Pattern.compile("['\"`]ViewAddTickler['\"`]");
     private static final Pattern FORWARD_DEMOGRAPHIC_TICKLER_PATTERN =
             Pattern.compile("['\"`]ForwardDemographicTickler['\"`]");

--- a/src/test/java/io/github/carlos_emr/carlos/tickler/TicklerPopupRoutingRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/tickler/TicklerPopupRoutingRegressionTest.java
@@ -51,7 +51,7 @@ class TicklerPopupRoutingRegressionTest {
     // Oscar.js keeps forceWindowPaths as a flat array of string literals; this
     // regression test intentionally matches that simple structure.
     private static final Pattern FORCE_WINDOW_PATHS_PATTERN = Pattern.compile(
-            "(?:var|let|const)\\s+forceWindowPaths\\s*=\\s*\\[(?<body>[\\s\\S]*?)]\\s*;?");
+            "(?:window\\.)?forceWindowPaths\\s*=\\s*(?:window\\.forceWindowPaths\\s*\\|\\|\\s*)?\\[(?<body>[\\s\\S]*?)]\\s*;?");
     private static final Pattern VIEW_ADD_TICKLER_PATTERN = Pattern.compile("['\"`]ViewAddTickler['\"`]");
     private static final Pattern FORWARD_DEMOGRAPHIC_TICKLER_PATTERN =
             Pattern.compile("['\"`]ForwardDemographicTickler['\"`]");

--- a/src/test/java/io/github/carlos_emr/carlos/tickler/TicklerPopupRoutingRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/tickler/TicklerPopupRoutingRegressionTest.java
@@ -51,7 +51,7 @@ class TicklerPopupRoutingRegressionTest {
     // Oscar.js keeps forceWindowPaths as a flat array of string literals; this
     // regression test intentionally matches that simple structure.
     private static final Pattern FORCE_WINDOW_PATHS_PATTERN = Pattern.compile(
-            "(?:window\\.)?forceWindowPaths\\s*=\\s*(?:window\\.forceWindowPaths\\s*\\|\\|\\s*)?\\[(?<body>[\\s\\S]*?)]\\s*;?");
+            "(?:window\\.)?forceWindowPaths\\s*=\\s*(?:(?:window\\.)?forceWindowPaths\\s*\\|\\|\\s*)?\\[(?<body>[\\s\\S]*?)]\\s*;?");
     private static final Pattern VIEW_ADD_TICKLER_PATTERN = Pattern.compile("['\"`]ViewAddTickler['\"`]");
     private static final Pattern FORWARD_DEMOGRAPHIC_TICKLER_PATTERN =
             Pattern.compile("['\"`]ForwardDemographicTickler['\"`]");

--- a/src/test/java/io/github/carlos_emr/carlos/tickler/dao/TicklerDaoBaseIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/tickler/dao/TicklerDaoBaseIntegrationTest.java
@@ -82,8 +82,12 @@ public abstract class TicklerDaoBaseIntegrationTest extends CarlosTestBase {
      */
     @BeforeEach
     protected void setUp() {
+        ensureProviderExists("999998");
+        ensureProviderExists("999999");
+
         // Create test ticklers with varying statuses and assignments
         for (int i = 1; i <= 5; i++) {
+            ensureDemographicExists(1000 + i);
             Tickler tickler = new Tickler();
             tickler.setDemographicNo(1000 + i);
             tickler.setMessage("Test tickler " + i);
@@ -97,6 +101,26 @@ public abstract class TicklerDaoBaseIntegrationTest extends CarlosTestBase {
         entityManager.flush();
     }
 
+    private void ensureProviderExists(String providerNo) {
+        entityManager.createNativeQuery("""
+                MERGE INTO provider (provider_no, first_name, last_name, provider_type, sex, specialty, status)
+                KEY(provider_no)
+                VALUES (:providerNo, 'Test', 'Provider', 'doctor', 'M', 'GP', '1')
+                """)
+                .setParameter("providerNo", providerNo)
+                .executeUpdate();
+    }
+
+    protected void ensureDemographicExists(Integer demographicNo) {
+        entityManager.createNativeQuery("""
+                MERGE INTO demographic (demographic_no, first_name, last_name, sex, patient_status)
+                KEY(demographic_no)
+                VALUES (:demographicNo, 'Test', 'Patient', 'M', 'AC')
+                """)
+                .setParameter("demographicNo", demographicNo)
+                .executeUpdate();
+    }
+
     /**
      * Helper method to create and persist a tickler with specified attributes.
      *
@@ -106,6 +130,8 @@ public abstract class TicklerDaoBaseIntegrationTest extends CarlosTestBase {
      * @return Tickler the created and persisted tickler instance
      */
     protected Tickler createTickler(Integer demoNo, String message, Tickler.STATUS status) {
+        ensureDemographicExists(demoNo);
+
         Tickler tickler = new Tickler();
         tickler.setDemographicNo(demoNo);
         tickler.setMessage(message);
@@ -126,6 +152,7 @@ public abstract class TicklerDaoBaseIntegrationTest extends CarlosTestBase {
      */
     protected void createBulkTestData(int count, Integer baseDemo) {
         for (int i = 0; i < count; i++) {
+            ensureDemographicExists(baseDemo + i);
             Tickler tickler = new Tickler();
             tickler.setDemographicNo(baseDemo + i);
             tickler.setMessage("Bulk test tickler " + i);

--- a/src/test/java/io/github/carlos_emr/carlos/tickler/dao/TicklerDaoBaseIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/tickler/dao/TicklerDaoBaseIntegrationTest.java
@@ -24,7 +24,7 @@ package io.github.carlos_emr.carlos.tickler.dao;
 import io.github.carlos_emr.carlos.test.base.CarlosTestBase;
 import io.github.carlos_emr.carlos.commn.dao.TicklerDao;
 import io.github.carlos_emr.carlos.commn.model.Tickler;
-import io.github.carlos_emr.carlos.test.support.IntegrationTestSeedData;
+import io.github.carlos_emr.carlos.test.support.IntegrationTestSeedService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -103,11 +103,11 @@ public abstract class TicklerDaoBaseIntegrationTest extends CarlosTestBase {
     }
 
     private void ensureProviderExists(String providerNo) {
-        IntegrationTestSeedData.ensureProviderExists(entityManager, providerNo);
+        IntegrationTestSeedService.ensureProviderExists(entityManager, providerNo);
     }
 
     protected void ensureDemographicExists(Integer demographicNo) {
-        IntegrationTestSeedData.ensureDemographicExists(entityManager, demographicNo);
+        IntegrationTestSeedService.ensureDemographicExists(entityManager, demographicNo);
     }
 
     /**

--- a/src/test/java/io/github/carlos_emr/carlos/tickler/dao/TicklerDaoBaseIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/tickler/dao/TicklerDaoBaseIntegrationTest.java
@@ -24,6 +24,7 @@ package io.github.carlos_emr.carlos.tickler.dao;
 import io.github.carlos_emr.carlos.test.base.CarlosTestBase;
 import io.github.carlos_emr.carlos.commn.dao.TicklerDao;
 import io.github.carlos_emr.carlos.commn.model.Tickler;
+import io.github.carlos_emr.carlos.test.support.IntegrationTestSeedData;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -102,23 +103,11 @@ public abstract class TicklerDaoBaseIntegrationTest extends CarlosTestBase {
     }
 
     private void ensureProviderExists(String providerNo) {
-        entityManager.createNativeQuery("""
-                MERGE INTO provider (provider_no, first_name, last_name, provider_type, sex, specialty, status)
-                KEY(provider_no)
-                VALUES (:providerNo, 'Test', 'Provider', 'doctor', 'M', 'GP', '1')
-                """)
-                .setParameter("providerNo", providerNo)
-                .executeUpdate();
+        IntegrationTestSeedData.ensureProviderExists(entityManager, providerNo);
     }
 
     protected void ensureDemographicExists(Integer demographicNo) {
-        entityManager.createNativeQuery("""
-                MERGE INTO demographic (demographic_no, first_name, last_name, sex, patient_status)
-                KEY(demographic_no)
-                VALUES (:demographicNo, 'Test', 'Patient', 'M', 'AC')
-                """)
-                .setParameter("demographicNo", demographicNo)
-                .executeUpdate();
+        IntegrationTestSeedData.ensureDemographicExists(entityManager, demographicNo);
     }
 
     /**

--- a/src/test/java/io/github/carlos_emr/carlos/tickler/dao/TicklerDaoFindIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/tickler/dao/TicklerDaoFindIntegrationTest.java
@@ -58,6 +58,7 @@ public class TicklerDaoFindIntegrationTest extends TicklerDaoBaseIntegrationTest
         @DisplayName("should return tickler when valid ID is provided")
         void shouldReturnTickler_whenValidIdProvided() {
             // Given: Create and persist a new tickler
+            ensureDemographicExists(2001);
             Tickler newTickler = new Tickler();
             newTickler.setDemographicNo(2001);
             newTickler.setMessage("Find by ID test");

--- a/src/test/java/io/github/carlos_emr/carlos/tickler/dao/TicklerDaoUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/tickler/dao/TicklerDaoUnitTest.java
@@ -121,7 +121,8 @@ public class TicklerDaoUnitTest extends TicklerUnitTestBase {
         // Given
         Integer ticklerId = 789;
         Tickler mockTickler = mock(Tickler.class);
-        TypedQuery<Tickler> mockTypedQuery = mock(TypedQuery.class);
+        @SuppressWarnings("unchecked")
+        TypedQuery<Tickler> mockTypedQuery = (TypedQuery<Tickler>) mock(TypedQuery.class);
         Set<TicklerUpdate> mockUpdates = new HashSet<>();
         mockUpdates.add(new TicklerUpdate());
 

--- a/src/test/java/io/github/carlos_emr/carlos/tickler/dao/TicklerDaoUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/tickler/dao/TicklerDaoUnitTest.java
@@ -30,6 +30,7 @@ import jakarta.persistence.TypedQuery;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.*;
@@ -117,16 +118,15 @@ public class TicklerDaoUnitTest extends TicklerUnitTestBase {
 
     @Test
     @DisplayName("should eagerly load tickler updates when finding by ID")
-    void shouldEagerlyLoadUpdates_whenFindingById() {
+    void shouldEagerlyLoadUpdates_whenFindingById(@Mock TypedQuery<Tickler> mockTypedQuery) {
         // Given
         Integer ticklerId = 789;
         Tickler mockTickler = mock(Tickler.class);
-        @SuppressWarnings("unchecked")
-        TypedQuery<Tickler> mockTypedQuery = (TypedQuery<Tickler>) mock(TypedQuery.class);
         Set<TicklerUpdate> mockUpdates = new HashSet<>();
         mockUpdates.add(new TicklerUpdate());
+        ArgumentCaptor<String> queryCaptor = ArgumentCaptor.forClass(String.class);
 
-        when(mockEntityManager.createQuery(anyString(), eq(Tickler.class))).thenReturn(mockTypedQuery);
+        when(mockEntityManager.createQuery(queryCaptor.capture(), eq(Tickler.class))).thenReturn(mockTypedQuery);
         when(mockTypedQuery.setParameter("id", ticklerId)).thenReturn(mockTypedQuery);
         when(mockTypedQuery.getResultList()).thenReturn(List.of(mockTickler));
         when(mockTickler.getUpdates()).thenReturn(mockUpdates);
@@ -136,6 +136,11 @@ public class TicklerDaoUnitTest extends TicklerUnitTestBase {
 
         // Then - Verify eager loading pattern
         assertThat(result).isEqualTo(mockTickler);
+        assertThat(queryCaptor.getValue())
+            .contains("left join fetch t.comments")
+            .contains("left join fetch t.demographic")
+            .contains("where t.id = :id")
+            .doesNotContain("left join fetch t.updates");
         verify(mockTickler).getUpdates();
         // The DAO calls .size() to force eager loading
         assertThat(mockUpdates.size()).isEqualTo(1);

--- a/src/test/java/io/github/carlos_emr/carlos/tickler/dao/TicklerDaoUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/tickler/dao/TicklerDaoUnitTest.java
@@ -26,6 +26,7 @@ import io.github.carlos_emr.carlos.commn.model.Tickler;
 import io.github.carlos_emr.carlos.commn.model.TicklerUpdate;
 import io.github.carlos_emr.carlos.tickler.TicklerUnitTestBase;
 
+import jakarta.persistence.TypedQuery;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -120,10 +121,13 @@ public class TicklerDaoUnitTest extends TicklerUnitTestBase {
         // Given
         Integer ticklerId = 789;
         Tickler mockTickler = mock(Tickler.class);
+        TypedQuery<Tickler> mockTypedQuery = mock(TypedQuery.class);
         Set<TicklerUpdate> mockUpdates = new HashSet<>();
         mockUpdates.add(new TicklerUpdate());
 
-        when(mockEntityManager.find(Tickler.class, ticklerId)).thenReturn(mockTickler);
+        when(mockEntityManager.createQuery(anyString(), eq(Tickler.class))).thenReturn(mockTypedQuery);
+        when(mockTypedQuery.setParameter("id", ticklerId)).thenReturn(mockTypedQuery);
+        when(mockTypedQuery.getResultList()).thenReturn(List.of(mockTickler));
         when(mockTickler.getUpdates()).thenReturn(mockUpdates);
 
         // When

--- a/src/test/java/io/github/carlos_emr/carlos/tickler/dao/TicklerDaoWriteIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/tickler/dao/TicklerDaoWriteIntegrationTest.java
@@ -65,6 +65,7 @@ public class TicklerDaoWriteIntegrationTest extends TicklerDaoBaseIntegrationTes
         @DisplayName("should persist new tickler and successfully merge updates")
         void shouldPersistNewTicklerAndMergeUpdates_whenValidDataProvided() {
             // Given
+            ensureDemographicExists(5001);
             Tickler tickler = new Tickler();
             tickler.setDemographicNo(5001);
             tickler.setMessage("Persist test");

--- a/src/test/java/io/github/carlos_emr/carlos/tickler/manager/SimpleTicklerManagerTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/tickler/manager/SimpleTicklerManagerTest.java
@@ -38,6 +38,9 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.test.context.ContextConfiguration;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -65,6 +68,9 @@ class SimpleTicklerManagerTest extends CarlosTestBase {
     @Autowired
     private DemographicDao demographicDao;
 
+    @PersistenceContext(unitName = "entityManagerFactory")
+    private EntityManager entityManager;
+
     @Test
     @DisplayName("should load Spring context with all required beans")
     void shouldLoadSpringContextWithAllRequiredBeans() {
@@ -90,6 +96,9 @@ class SimpleTicklerManagerTest extends CarlosTestBase {
     @Test
     @DisplayName("should add tickler successfully when valid data provided")
     void shouldAddTicklerSuccessfully_whenValidDataProvided() {
+        ensureProviderExists("999998");
+        ensureDemographicExists(12345);
+
         // Given: Create a new tickler with required fields
         Tickler tickler = new Tickler();
         tickler.setDemographicNo(12345);
@@ -111,5 +120,27 @@ class SimpleTicklerManagerTest extends CarlosTestBase {
         // Then
         assertTrue(result);
         assertThat(tickler.getId()).isNotNull();
+    }
+
+    private void ensureProviderExists(String providerNo) {
+        entityManager.createNativeQuery("""
+                MERGE INTO provider (provider_no, first_name, last_name, provider_type, sex, specialty, status)
+                KEY(provider_no)
+                VALUES (:providerNo, 'Test', 'Provider', 'doctor', 'M', 'GP', '1')
+                """)
+                .setParameter("providerNo", providerNo)
+                .executeUpdate();
+        entityManager.flush();
+    }
+
+    private void ensureDemographicExists(Integer demographicNo) {
+        entityManager.createNativeQuery("""
+                MERGE INTO demographic (demographic_no, first_name, last_name, sex, patient_status)
+                KEY(demographic_no)
+                VALUES (:demographicNo, 'Test', 'Patient', 'M', 'AC')
+                """)
+                .setParameter("demographicNo", demographicNo)
+                .executeUpdate();
+        entityManager.flush();
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/tickler/manager/SimpleTicklerManagerTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/tickler/manager/SimpleTicklerManagerTest.java
@@ -27,7 +27,7 @@ import io.github.carlos_emr.carlos.commn.dao.TicklerDao;
 import io.github.carlos_emr.carlos.commn.dao.DemographicDao;
 import io.github.carlos_emr.carlos.commn.model.Tickler;
 import io.github.carlos_emr.carlos.commn.model.Provider;
-import io.github.carlos_emr.carlos.test.support.IntegrationTestSeedData;
+import io.github.carlos_emr.carlos.test.support.IntegrationTestSeedService;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 
 import org.junit.jupiter.api.*;
@@ -97,8 +97,8 @@ class SimpleTicklerManagerTest extends CarlosTestBase {
     @Test
     @DisplayName("should add tickler successfully when valid data provided")
     void shouldAddTicklerSuccessfully_whenValidDataProvided() {
-        IntegrationTestSeedData.ensureProviderExists(entityManager, "999998");
-        IntegrationTestSeedData.ensureDemographicExists(entityManager, 12345);
+        IntegrationTestSeedService.ensureProviderExists(entityManager, "999998");
+        IntegrationTestSeedService.ensureDemographicExists(entityManager, 12345);
         entityManager.flush();
 
         // Given: Create a new tickler with required fields

--- a/src/test/java/io/github/carlos_emr/carlos/tickler/manager/SimpleTicklerManagerTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/tickler/manager/SimpleTicklerManagerTest.java
@@ -27,6 +27,7 @@ import io.github.carlos_emr.carlos.commn.dao.TicklerDao;
 import io.github.carlos_emr.carlos.commn.dao.DemographicDao;
 import io.github.carlos_emr.carlos.commn.model.Tickler;
 import io.github.carlos_emr.carlos.commn.model.Provider;
+import io.github.carlos_emr.carlos.test.support.IntegrationTestSeedData;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 
 import org.junit.jupiter.api.*;
@@ -96,8 +97,9 @@ class SimpleTicklerManagerTest extends CarlosTestBase {
     @Test
     @DisplayName("should add tickler successfully when valid data provided")
     void shouldAddTicklerSuccessfully_whenValidDataProvided() {
-        ensureProviderExists("999998");
-        ensureDemographicExists(12345);
+        IntegrationTestSeedData.ensureProviderExists(entityManager, "999998");
+        IntegrationTestSeedData.ensureDemographicExists(entityManager, 12345);
+        entityManager.flush();
 
         // Given: Create a new tickler with required fields
         Tickler tickler = new Tickler();
@@ -122,25 +124,4 @@ class SimpleTicklerManagerTest extends CarlosTestBase {
         assertThat(tickler.getId()).isNotNull();
     }
 
-    private void ensureProviderExists(String providerNo) {
-        entityManager.createNativeQuery("""
-                MERGE INTO provider (provider_no, first_name, last_name, provider_type, sex, specialty, status)
-                KEY(provider_no)
-                VALUES (:providerNo, 'Test', 'Provider', 'doctor', 'M', 'GP', '1')
-                """)
-                .setParameter("providerNo", providerNo)
-                .executeUpdate();
-        entityManager.flush();
-    }
-
-    private void ensureDemographicExists(Integer demographicNo) {
-        entityManager.createNativeQuery("""
-                MERGE INTO demographic (demographic_no, first_name, last_name, sex, patient_status)
-                KEY(demographic_no)
-                VALUES (:demographicNo, 'Test', 'Patient', 'M', 'AC')
-                """)
-                .setParameter("demographicNo", demographicNo)
-                .executeUpdate();
-        entityManager.flush();
-    }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/tickler/model/TicklerLazyFetchMigrationUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/tickler/model/TicklerLazyFetchMigrationUnitTest.java
@@ -178,7 +178,7 @@ class TicklerLazyFetchMigrationUnitTest extends CarlosUnitTestBase {
         ticklerDao.find(123);
 
         ArgumentCaptor<String> queryCaptor = ArgumentCaptor.forClass(String.class);
-        verify(entityManager).createQuery(queryCaptor.capture());
+        verify(entityManager).createQuery(queryCaptor.capture(), eq(Tickler.class));
         assertThat(queryCaptor.getValue())
                 .contains("left join fetch t.comments")
                 .contains("left join fetch t.demographic")

--- a/src/test/java/io/github/carlos_emr/carlos/web/RemovedJspReferenceRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/web/RemovedJspReferenceRegressionTest.java
@@ -92,7 +92,7 @@ class RemovedJspReferenceRegressionTest {
 
         assertThat(oscarJs)
                 .as("legacy JSPs can still include Oscar.js more than once on the same page")
-                .contains("var forceWindowPaths = [")
+                .contains("window.forceWindowPaths = window.forceWindowPaths || [")
                 .doesNotContain("const forceWindowPaths = [")
                 .doesNotContain("let forceWindowPaths = [");
     }


### PR DESCRIPTION
## Summary
- Fix Hibernate JPQL property references in demographic DAO queries
- Route TicklerDao primitive ID lookup through the eager-loading find path
- Update failing tests and fixtures for current schema, H2 behavior, and JSP routing expectations

## Verification
- `make install --run-tests`: Tests run: 7242, Failures: 0, Errors: 0, Skipped: 51
- `git diff --check`
- `npm run test:schedule-links-playwright`
- `npm run test:echart-playwright`
- `npm run test:browser-surfaces-playwright`
- `node scripts/demographic-master-crud-smoke.js`
- `npm run test:login-playwright`: 14 checks, 0 failures; dev user security row restored

Note: `.devcontainer/docker-compose.yml` has unrelated pre-existing local changes and was not included in this commit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores a green build by fixing JPQL field names and enforcing a typed, eager-load Tickler find path. Updates tests for H2 seeding, JSP routing, date semantics, and cache eviction.

- Bug Fixes
  - Use lowerCamel JPQL properties in `DemographicDaoImpl` (including COUNT query).
  - Add `find(int)` delegating to typed join-fetch `find(Integer)` in `TicklerDaoImpl`; tests verify `createQuery(..., Tickler.class)`.
  - “Last entered” measurement now compares `createDate`.
  - JSP routing regex accepts `window.forceWindowPaths = window.forceWindowPaths || [...]`, optional `window.` prefix, and no var/let/const redeclaration.
  - Handle H2 boolean vs integer for org applicability in security object tests.

- Refactors
  - Introduced `IntegrationTestSeedService` for shared H2 `MERGE` seeding of `provider`/`demographic`; updated Tickler DAO, manager, and related integration tests to use it.
  - Cache invalidation tests now populate caches via Provider DAO reads after clearing caches, matching real usage.

<sup>Written for commit fe916e9b39208bc16f403f5d5cd3cacb2f8d4cd5. Summary will update on new commits. <a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2204?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

