### PR TITLE
Remove connection hard limit from PR 2092

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/utility/OscarTrackingBasicDataSource.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/OscarTrackingBasicDataSource.java
@@ -59,7 +59,6 @@ import org.apache.logging.log4j.Logger;
 public class OscarTrackingBasicDataSource extends BasicDataSource {
 
     public static final int MAX_CONNECTION_WARN_SIZE = 2;
-    public static final int MAX_CONNECTION_HARD_LIMIT = 50;
     public static final Logger logger = MiscUtils.getLogger();
     public static final Map<Connection, StackTraceElement[]> debugMap = Collections.synchronizedMap(new WeakHashMap<Connection, StackTraceElement[]>());
     private static final ThreadLocal<HashSet<Connection>> connections = new ThreadLocal<HashSet<Connection>>();
@@ -76,23 +75,6 @@ public class OscarTrackingBasicDataSource extends BasicDataSource {
         }
 
         threadConnections.add(c);
-
-        if (threadConnections.size() > MAX_CONNECTION_HARD_LIMIT) {
-            String msg = "Thread is using " + threadConnections.size() + " jdbc connections, exceeds hard limit "
-                    + MAX_CONNECTION_HARD_LIMIT;
-            logger.error(msg);
-            // This path enforces a hard cap for pathologically long requests. Remove from
-            // bookkeeping before closing so leak detectors don't report already-abandoned
-            // connections when returning this connection to the datasource.
-            threadConnections.remove(c);
-            debugMap.remove(c);
-            try {
-                c.close();
-            } catch (SQLException e) {
-                logger.error("Error closing jdbc connection during hard-limit enforcement", e);
-            }
-            throw new SQLException(msg);
-        }
 
         if (threadConnections.size() > MAX_CONNECTION_WARN_SIZE) {
             String msg = "Thread is currently using " + threadConnections.size() + " separate jdbc connections, it souldn't need more than " + MAX_CONNECTION_WARN_SIZE;


### PR DESCRIPTION
This is a small stacked PR against PR #2092.

It removes the per-thread JDBC connection hard limit added during cleanup, while keeping the existing warning/debug tracking behavior. The hard cap changes global runtime behavior outside the filename/path-validation scope, so it is better handled separately if needed.

Verification:
- `git diff --check`
- `mvn -q -Pskip-dependency-lock -DskipTests compile`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the per-thread JDBC connection hard cap to avoid unexpected SQLExceptions and force-closing connections under load. Warning at >2 connections and debug tracking remain unchanged.

<sup>Written for commit 4f18d5a9f3c475c91225dbbaaac5a1ba4a9153b1. Summary will update on new commits. <a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2209?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

