### PR TITLE
Fix test regressions and app startup

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/admin/web/ClientManage2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/admin/web/ClientManage2Action.java
@@ -80,12 +80,29 @@ public class ClientManage2Action extends ActionSupport {
     private final transient ServiceAccessTokenDao serviceAccessTokenDao;
     private final transient CarlosMethodSecurity methodSecurity;
 
+    /**
+     * Creates the action for Struts-managed instantiation paths.
+     *
+     * <p>Delegates to the injected constructor after retrieving collaborators
+     * from the Spring context.</p>
+     *
+     * @throws org.springframework.beans.BeansException if a required Spring bean is unavailable
+     * @since 2026-05-19
+     */
     public ClientManage2Action() {
         this(SpringUtils.getBean(ServiceClientDao.class),
                 SpringUtils.getBean(ServiceAccessTokenDao.class),
                 SpringUtils.getBean(CarlosMethodSecurity.class));
     }
 
+    /**
+     * Creates the action with explicit collaborators for Spring injection and tests.
+     *
+     * @param serviceClientDao DAO used to read and mutate service client records
+     * @param serviceAccessTokenDao DAO used to read and delete service access tokens
+     * @param methodSecurity method-level authorization facade for admin privileges
+     * @since 2026-05-19
+     */
     @Autowired
     public ClientManage2Action(ServiceClientDao serviceClientDao,
             ServiceAccessTokenDao serviceAccessTokenDao,

--- a/src/main/java/io/github/carlos_emr/carlos/admin/web/ClientManage2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/admin/web/ClientManage2Action.java
@@ -44,6 +44,7 @@ import io.github.carlos_emr.carlos.utility.SpringUtils;
 import org.apache.logging.log4j.Logger;
 import org.apache.struts2.ActionSupport;
 import org.apache.struts2.ServletActionContext;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
@@ -75,9 +76,24 @@ public class ClientManage2Action extends ActionSupport {
     private static final SecureRandom RANDOM = new SecureRandom();
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
-    private final transient ServiceClientDao serviceClientDao = SpringUtils.getBean(ServiceClientDao.class);
-    private final transient ServiceAccessTokenDao serviceAccessTokenDao = SpringUtils.getBean(ServiceAccessTokenDao.class);
-    private final transient CarlosMethodSecurity methodSecurity = SpringUtils.getBean(CarlosMethodSecurity.class);
+    private final transient ServiceClientDao serviceClientDao;
+    private final transient ServiceAccessTokenDao serviceAccessTokenDao;
+    private final transient CarlosMethodSecurity methodSecurity;
+
+    public ClientManage2Action() {
+        this(SpringUtils.getBean(ServiceClientDao.class),
+                SpringUtils.getBean(ServiceAccessTokenDao.class),
+                SpringUtils.getBean(CarlosMethodSecurity.class));
+    }
+
+    @Autowired
+    public ClientManage2Action(ServiceClientDao serviceClientDao,
+            ServiceAccessTokenDao serviceAccessTokenDao,
+            CarlosMethodSecurity methodSecurity) {
+        this.serviceClientDao = serviceClientDao;
+        this.serviceAccessTokenDao = serviceAccessTokenDao;
+        this.methodSecurity = methodSecurity;
+    }
 
     @Override
     public String execute() throws Exception {

--- a/src/main/java/io/github/carlos_emr/carlos/admin/web/ClinicNbrManage2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/admin/web/ClinicNbrManage2Action.java
@@ -38,6 +38,7 @@ import io.github.carlos_emr.carlos.utility.SpringUtils;
 import org.apache.logging.log4j.Logger;
 import org.apache.struts2.ActionSupport;
 import org.apache.struts2.ServletActionContext;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
@@ -61,8 +62,19 @@ public class ClinicNbrManage2Action extends ActionSupport {
     private static final Logger logger = MiscUtils.getLogger();
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
-    private final transient ClinicNbrDao clinicNbrDao = SpringUtils.getBean(ClinicNbrDao.class);
-    private final transient CarlosMethodSecurity methodSecurity = SpringUtils.getBean(CarlosMethodSecurity.class);
+    private final transient ClinicNbrDao clinicNbrDao;
+    private final transient CarlosMethodSecurity methodSecurity;
+
+    public ClinicNbrManage2Action() {
+        this(SpringUtils.getBean(ClinicNbrDao.class),
+                SpringUtils.getBean(CarlosMethodSecurity.class));
+    }
+
+    @Autowired
+    public ClinicNbrManage2Action(ClinicNbrDao clinicNbrDao, CarlosMethodSecurity methodSecurity) {
+        this.clinicNbrDao = clinicNbrDao;
+        this.methodSecurity = methodSecurity;
+    }
 
     @Override
     public String execute() throws Exception {

--- a/src/main/java/io/github/carlos_emr/carlos/admin/web/ClinicNbrManage2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/admin/web/ClinicNbrManage2Action.java
@@ -65,11 +65,27 @@ public class ClinicNbrManage2Action extends ActionSupport {
     private final transient ClinicNbrDao clinicNbrDao;
     private final transient CarlosMethodSecurity methodSecurity;
 
+    /**
+     * Creates the action for Struts-managed instantiation paths.
+     *
+     * <p>Delegates to the injected constructor after retrieving collaborators
+     * from the Spring context.</p>
+     *
+     * @throws org.springframework.beans.BeansException if a required Spring bean is unavailable
+     * @since 2026-05-19
+     */
     public ClinicNbrManage2Action() {
         this(SpringUtils.getBean(ClinicNbrDao.class),
                 SpringUtils.getBean(CarlosMethodSecurity.class));
     }
 
+    /**
+     * Creates the action with explicit collaborators for Spring injection and tests.
+     *
+     * @param clinicNbrDao DAO used to add and remove clinic number records
+     * @param methodSecurity method-level authorization facade for admin write privileges
+     * @since 2026-05-19
+     */
     @Autowired
     public ClinicNbrManage2Action(ClinicNbrDao clinicNbrDao, CarlosMethodSecurity methodSecurity) {
         this.clinicNbrDao = clinicNbrDao;

--- a/src/main/java/io/github/carlos_emr/carlos/admin/web/GetPublicKey2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/admin/web/GetPublicKey2Action.java
@@ -37,6 +37,7 @@ import io.github.carlos_emr.carlos.utility.SpringUtils;
 
 import org.apache.struts2.ActionSupport;
 import org.apache.struts2.ServletActionContext;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
@@ -59,8 +60,19 @@ public class GetPublicKey2Action extends ActionSupport {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
-    private final transient SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
-    private final transient PublicKeyDao publicKeyDao = SpringUtils.getBean(PublicKeyDao.class);
+    private final transient SecurityInfoManager securityInfoManager;
+    private final transient PublicKeyDao publicKeyDao;
+
+    public GetPublicKey2Action() {
+        this(SpringUtils.getBean(SecurityInfoManager.class),
+                SpringUtils.getBean(PublicKeyDao.class));
+    }
+
+    @Autowired
+    public GetPublicKey2Action(SecurityInfoManager securityInfoManager, PublicKeyDao publicKeyDao) {
+        this.securityInfoManager = securityInfoManager;
+        this.publicKeyDao = publicKeyDao;
+    }
 
     @Override
     public String execute() throws Exception {

--- a/src/main/java/io/github/carlos_emr/carlos/admin/web/GetPublicKey2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/admin/web/GetPublicKey2Action.java
@@ -63,11 +63,27 @@ public class GetPublicKey2Action extends ActionSupport {
     private final transient SecurityInfoManager securityInfoManager;
     private final transient PublicKeyDao publicKeyDao;
 
+    /**
+     * Creates the action for Struts-managed instantiation paths.
+     *
+     * <p>Delegates to the injected constructor after retrieving collaborators
+     * from the Spring context.</p>
+     *
+     * @throws org.springframework.beans.BeansException if a required Spring bean is unavailable
+     * @since 2026-05-19
+     */
     public GetPublicKey2Action() {
         this(SpringUtils.getBean(SecurityInfoManager.class),
                 SpringUtils.getBean(PublicKeyDao.class));
     }
 
+    /**
+     * Creates the action with explicit collaborators for Spring injection and tests.
+     *
+     * @param securityInfoManager authorization service used for admin privilege checks
+     * @param publicKeyDao DAO used to load public key records
+     * @since 2026-05-19
+     */
     @Autowired
     public GetPublicKey2Action(SecurityInfoManager securityInfoManager, PublicKeyDao publicKeyDao) {
         this.securityInfoManager = securityInfoManager;

--- a/src/main/webapp/WEB-INF/jsp/encounter/includes/encounter-rx-allergies.jspf
+++ b/src/main/webapp/WEB-INF/jsp/encounter/includes/encounter-rx-allergies.jspf
@@ -3,6 +3,7 @@
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <%@ taglib uri="jakarta.tags.functions" prefix="fn" %>
+<fmt:setBundle basename="oscarResources"/>
 <%-- Row: Allergies and Prescriptions --%>
 <div class="encounter-card card mb-1" id="presTopTable">
     <div class="card-header d-flex align-items-center">

--- a/src/main/webapp/WEB-INF/jsp/encounter/includes/encounter-rx-allergies.jspf
+++ b/src/main/webapp/WEB-INF/jsp/encounter/includes/encounter-rx-allergies.jspf
@@ -2,6 +2,7 @@
 <%@ taglib uri="carlos" prefix="carlos" %>
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="jakarta.tags.functions" prefix="fn" %>
 <%-- Row: Allergies and Prescriptions --%>
 <div class="encounter-card card mb-1" id="presTopTable">
     <div class="card-header d-flex align-items-center">

--- a/src/main/webapp/web/css/Inboxhub.css
+++ b/src/main/webapp/web/css/Inboxhub.css
@@ -128,6 +128,7 @@ input {
 }
 
 #inbox_table_wrapper > .row {
+
     --bs-gutter-x: 0;
     margin-left: 0;
     margin-right: 0;
@@ -261,6 +262,7 @@ input {
  */
 /* Top navigation bar — utility links (Forwarding Rules, Upload, etc.) */
 .inbox-topbar {
+
     --inbox-nav-color: #00283c;
     --inbox-nav-hover-bg: #486ebd;
     display: flex;
@@ -291,6 +293,7 @@ input {
 
 /* Action toolbar — Forward, File, Acknowledged, Rapid Review, counts */
 .inbox-toolbar {
+
     --inbox-nav-color: #00283c;
     --inbox-nav-hover-bg: #486ebd;
     display: flex;

--- a/src/main/webapp/web/css/Inboxhub.css
+++ b/src/main/webapp/web/css/Inboxhub.css
@@ -120,7 +120,22 @@ input {
     height: calc(100vh - 8em);
     width: 100%;
     overflow-y: auto;
-    overflow-x: hidden;
+    overflow-x: auto;
+}
+
+#inbox_table_wrapper {
+    max-width: 100%;
+}
+
+#inbox_table_wrapper > .row {
+    --bs-gutter-x: 0;
+    margin-left: 0;
+    margin-right: 0;
+}
+
+#inbox_table_wrapper > .row > * {
+    padding-left: 0;
+    padding-right: 0;
 }
 
 .inbox-table td {
@@ -239,12 +254,6 @@ input {
     color: #000;
 }
 
-@media (max-width: 1300px) {
-    .inbox-table-responsive {
-        overflow-x: auto;
-    }
-}
-
 /*
  * Inbox toolbar — styled to match the scheduler top nav bar (topnav.css).
  * Uses a light grey background (#f5f5f5), font (Arial 12px bold), and
@@ -252,10 +261,13 @@ input {
  */
 /* Top navigation bar — utility links (Forwarding Rules, Upload, etc.) */
 .inbox-topbar {
+    --inbox-nav-color: #00283c;
+    --inbox-nav-hover-bg: #486ebd;
     display: flex;
     align-items: center;
     justify-content: center;
     flex-wrap: wrap;
+    gap: 2px;
     padding: 4px 8px;
     background: #f5f5f5;
     border-bottom: 1px solid #ddd;
@@ -264,23 +276,27 @@ input {
 }
 
 .inbox-topbar .nav-link {
-    display: inline;
-    padding: 2px 6px;
+    display: inline-flex;
+    align-items: center;
+    padding: 3px 6px;
     font-weight: bold;
-    color: black;
+    color: var(--inbox-nav-color);
     text-decoration: none;
 }
 
 .inbox-topbar .nav-link:hover {
     color: #fff;
-    background-color: var(--carlos-primary, #337ab7);
+    background-color: var(--inbox-nav-hover-bg);
 }
 
 /* Action toolbar — Forward, File, Acknowledged, Rapid Review, counts */
 .inbox-toolbar {
+    --inbox-nav-color: #00283c;
+    --inbox-nav-hover-bg: #486ebd;
     display: flex;
     align-items: center;
     flex-wrap: wrap;
+    gap: 2px;
     padding: 4px;
     background: #f5f5f5;
     border-bottom: 1px solid #ddd;
@@ -293,7 +309,7 @@ input {
     font-family: Arial, sans-serif;
     font-size: 12px;
     font-weight: bold;
-    color: black;
+    color: var(--inbox-nav-color);
     text-decoration: none;
     cursor: pointer !important;
     border: none;
@@ -309,7 +325,7 @@ input {
 
 .inbox-toolbar-link:hover {
     color: #fff;
-    background-color: var(--carlos-primary, #337ab7);
+    background-color: var(--inbox-nav-hover-bg);
 }
 
 .inbox-toolbar-link input[type="checkbox"] {
@@ -319,7 +335,7 @@ input {
 
 /* Active type filter highlight */
 .inbox-type-filter.active-type-filter {
-    background-color: var(--carlos-primary, #337ab7);
+    background-color: var(--inbox-nav-hover-bg);
     color: #fff;
     border-radius: 3px;
 }

--- a/src/test/java/io/github/carlos_emr/carlos/commn/dao/OntarioMDSpec4DataIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/commn/dao/OntarioMDSpec4DataIntegrationTest.java
@@ -130,23 +130,18 @@ public class OntarioMDSpec4DataIntegrationTest extends CarlosTestBase {
     }
 
     private Provider createProvider(String firstName, String lastName, String providerNo, String specialty) {
-        entityManager.createNativeQuery("""
-                MERGE INTO provider (
-                    provider_no, first_name, last_name, specialty, provider_type,
-                    sex, signed_confidentiality, status
-                ) KEY(provider_no) VALUES (
-                    :providerNo, :firstName, :lastName, :specialty, 'doctor',
-                    'M', CURRENT_TIMESTAMP, '1'
-                )
-                """)
-                .setParameter("providerNo", providerNo)
-                .setParameter("firstName", firstName)
-                .setParameter("lastName", lastName)
-                .setParameter("specialty", specialty)
-                .executeUpdate();
-        entityManager.flush();
-
-        return providerDao.getProvider(providerNo);
+        Provider provider = new Provider();
+        provider.setProviderNo(providerNo);
+        provider.setFirstName(firstName);
+        provider.setLastName(lastName);
+        provider.setSpecialty(specialty);
+        provider.setProviderType("doctor");
+        provider.setSex("M");
+        provider.setSignedConfidentiality(new Date());
+        provider.setStatus("1");
+        hibernateTemplate.saveOrUpdate(provider);
+        hibernateTemplate.flush();
+        return provider;
     }
 
     private Demographic createDemographic(String lastName, String firstName, String providerNo) {

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/PendingDocumentsJspRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/PendingDocumentsJspRegressionTest.java
@@ -134,7 +134,7 @@ public class PendingDocumentsJspRegressionTest {
     void shouldKeepExactPatientNumberValidationRegex_inPendingDocumentsJsp() throws IOException {
         String jsp = Files.readString(PENDING_DOCUMENTS_JSP, StandardCharsets.UTF_8);
 
-        assertThat(jsp).contains("/^-?\\\\d+$/");
+        assertThat(jsp).contains("/^-?\\d+$/");
     }
 
     private static List<String> invalidI18nKeys(Path bundlePath) throws IOException {

--- a/src/test/java/io/github/carlos_emr/carlos/login/LoginJspMigrationRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/login/LoginJspMigrationRegressionTest.java
@@ -211,12 +211,16 @@ class LoginJspMigrationRegressionTest {
                 .doesNotContain("../administration/")
                 .doesNotContain("../administration/index");
         assertThat(mainMenu)
-                .contains("/administration','admin")
+                .contains("String administrationUrl = request.getContextPath() + \"/administration\"")
+                .contains("openScheduleMenuSection")
+                .contains("SafeEncode.forJavaScriptAttribute(administrationUrl)")
                 .doesNotContain("/administration/")
                 .doesNotContain("/administration/index");
         assertThat(appointmentProviderAdminDay)
-                .contains("/administration','admin")
-                .contains("/administration\", \"admin")
+                .contains("String scheduleAdministrationUrl = request.getContextPath() + \"/administration\"")
+                .contains("openScheduleSection")
+                .contains("scheduleAdministrationUrlForJsAttribute")
+                .contains("newWindow(\"<%= request.getContextPath() %>/administration\", \"admin\")")
                 .doesNotContain("/administration/")
                 .doesNotContain("/administration/index");
         assertThat(administrationLeftNav)
@@ -319,9 +323,11 @@ class LoginJspMigrationRegressionTest {
         String csrfGuard = Files.readString(CSRF_GUARD, StandardCharsets.UTF_8);
         String menuConfig = Files.readString(MENU_CONFIG, StandardCharsets.UTF_8);
 
+        assertThat(csrfGuard).contains("CarlosCsrfGuardFilter owns invalid-token responses");
+        assertThat(csrfGuard).doesNotContain("org.owasp.csrfguard.action.Redirect.Page=%servletContext%/errorpage");
+
         assertThat(csrfGuard).contains("%servletContext%/index");
         assertThat(csrfGuard).contains("%servletContext%/logoutPage");
-        assertThat(csrfGuard).contains("%servletContext%/errorpage");
         assertThat(csrfGuard).contains("%servletContext%/login");
         assertThat(csrfGuard).doesNotContain("%servletContext%/forcepasswordresetSubmit");
         assertThat(menuConfig).doesNotContain("location=\"index.jsp\"");


### PR DESCRIPTION
## Summary
- Fix stale regression test expectations for pending documents, login routing, and CSRF invalid-token handling
- Add the missing JSTL functions taglib to encounter-rx-allergies.jspf
- Fix Ontario MD integration test provider fixtures to persist through Hibernate
- Switch admin JSON Spring components to constructor injection so Tomcat startup does not call SpringUtils before the bean factory is initialized

## Verification
- make install --run-tests
- mvn -Dtest=AdminJsonActionsUnitTest,MutatorActionGetRejectionContractTest test
- make install
- Foreground Tomcat startup with catalina.sh run
- All Playwright-backed scripts in scripts/

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Tomcat startup by switching admin JSON actions to constructor injection, stabilizes tests/fixtures, and updates the Inbox hub layout for horizontal scrolling and theme-aligned colors. Also adds missing JSTL functions and sets the i18n bundle in the allergies include.

- **Bug Fixes**
  - Add `jakarta.tags.functions` and set the `fmt` bundle in the encounter allergies include to restore JSTL functions and i18n.
  - Update regression tests for pending documents (regex), login routing, and CSRF invalid-token handling.
  - Persist Ontario MD provider fixtures via `HibernateTemplate.saveOrUpdate` to stabilize integration tests.
  - Inbox hub CSS: enable horizontal scrolling, remove `#inbox_table_wrapper` gutters, and unify toolbar colors/hover with the scheduler; fix spacing for stylelint.

- **Refactors**
  - Convert admin JSON actions to constructor injection (`@Autowired`) to avoid early `SpringUtils` calls during Tomcat startup: `ClientManage2Action`, `ClinicNbrManage2Action`, `GetPublicKey2Action`.
  - Add Javadoc on constructors to clarify Struts vs. Spring instantiation paths.

<sup>Written for commit 781c9381800e3dbe20e074b7a7ffe9c23ce5083d. Summary will update on new commits. <a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2235?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

