### PR TITLE
Limit Code Scanning uploads to security findings

### DIFF
--- a/.github/workflows/pmd.yml
+++ b/.github/workflows/pmd.yml
@@ -3,7 +3,8 @@
 # Description:
 # Runs PMD static analysis on CARLOS EMR Java source code to detect
 # common programming flaws, potential bugs, and security issues.
-# Results appear in the GitHub Security tab (SARIF upload).
+# Security-only results appear in the GitHub Security tab (SARIF upload).
+# Full quality results are retained as workflow artifacts and summaries.
 #
 # Runs PMD CLI directly (no third-party action) to avoid org action
 # allow-list restrictions. PMD only needs source code, not compilation.
@@ -94,7 +95,7 @@ jobs:
             echo "PMD ${PMD_VERSION} already cached"
           fi
 
-      - name: Run PMD
+      - name: Run PMD quality scan
         run: |
           set -euo pipefail
           PMD_DIR="pmd-bin-${PMD_VERSION}"
@@ -106,15 +107,35 @@ jobs:
             --report-file pmd-report.sarif \
             --no-fail-on-violation
 
-      - name: Upload SARIF to GitHub Security tab
+      - name: Run PMD security scan
+        run: |
+          set -euo pipefail
+          PMD_DIR="pmd-bin-${PMD_VERSION}"
+          "${PMD_DIR}/bin/pmd" check \
+            --dir src/main/java \
+            --dir src/test/java \
+            --rulesets category/java/security.xml \
+            --format sarif \
+            --report-file pmd-security-report.sarif \
+            --no-fail-on-violation
+
+      - name: Upload security SARIF to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@0daab03d71ff584ef619d027a3fd9146679c5d84
         if: >
           always() &&
-          hashFiles('pmd-report.sarif') != '' &&
+          hashFiles('pmd-security-report.sarif') != '' &&
           (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
         with:
-          sarif_file: pmd-report.sarif
+          sarif_file: pmd-security-report.sarif
           category: pmd
+
+      - name: Upload PMD quality artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: always() && hashFiles('pmd-report.sarif') != ''
+        with:
+          name: pmd-quality-sarif
+          path: pmd-report.sarif
+          retention-days: 14
 
       - name: Report summary
         if: always()
@@ -123,10 +144,19 @@ jobs:
           echo "" >> "$GITHUB_STEP_SUMMARY"
           if [ -f pmd-report.sarif ]; then
             if total=$(jq '[.runs[].results[]?] | length' pmd-report.sarif 2>/dev/null); then
-              echo "PMD produced ${total} SARIF finding(s)." >> "$GITHUB_STEP_SUMMARY"
+              echo "PMD quality scan produced ${total} SARIF finding(s)." >> "$GITHUB_STEP_SUMMARY"
             else
-              echo "PMD SARIF report was generated, but could not be parsed." >> "$GITHUB_STEP_SUMMARY"
+              echo "PMD quality SARIF report was generated, but could not be parsed." >> "$GITHUB_STEP_SUMMARY"
             fi
           else
-            echo "No PMD SARIF report was generated." >> "$GITHUB_STEP_SUMMARY"
+            echo "No PMD quality SARIF report was generated." >> "$GITHUB_STEP_SUMMARY"
+          fi
+          if [ -f pmd-security-report.sarif ]; then
+            if security_total=$(jq '[.runs[].results[]?] | length' pmd-security-report.sarif 2>/dev/null); then
+              echo "PMD security scan uploaded ${security_total} finding(s) to Code Scanning." >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "PMD security SARIF report was generated, but could not be parsed." >> "$GITHUB_STEP_SUMMARY"
+            fi
+          else
+            echo "No PMD security SARIF report was generated." >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/pmd.yml
+++ b/.github/workflows/pmd.yml
@@ -153,7 +153,7 @@ jobs:
           fi
           if [ -f pmd-security-report.sarif ]; then
             if security_total=$(jq '[.runs[].results[]?] | length' pmd-security-report.sarif 2>/dev/null); then
-              echo "PMD security scan uploaded ${security_total} finding(s) to Code Scanning." >> "$GITHUB_STEP_SUMMARY"
+              echo "PMD security scan produced ${security_total} security finding(s)." >> "$GITHUB_STEP_SUMMARY"
             else
               echo "PMD security SARIF report was generated, but could not be parsed." >> "$GITHUB_STEP_SUMMARY"
             fi

--- a/.github/workflows/spotbugs.yml
+++ b/.github/workflows/spotbugs.yml
@@ -263,6 +263,10 @@ jobs:
                           "security-severity": security_severity
                       }
                   }
+              else:
+                  properties = rules_map[bug_type]["properties"]
+                  if float(security_severity) > float(properties["security-severity"]):
+                      properties["security-severity"] = security_severity
 
               result = {
                   "ruleId": bug_type,

--- a/.github/workflows/spotbugs.yml
+++ b/.github/workflows/spotbugs.yml
@@ -163,6 +163,7 @@ jobs:
           "
 
       - name: Build and run SpotBugs
+        id: run_spotbugs
         run: |
           docker exec carlos-tomcat-dev bash -c "
             echo '========================================='
@@ -181,7 +182,10 @@ jobs:
         run: |
           REPORT="target/spotbugs-result.xml"
           if [ ! -f "$REPORT" ]; then
-            echo "No SpotBugs report found at $REPORT"
+            echo "::error::No SpotBugs report found at $REPORT"
+            if [ "${{ steps.run_spotbugs.outcome }}" = "success" ]; then
+              exit 1
+            fi
             exit 0
           fi
 
@@ -191,24 +195,27 @@ jobs:
 
           report_path = "target/spotbugs-result.xml"
           sarif_path = "spotbugs-security-report.sarif"
+          metrics_path = "spotbugs-security-metrics.env"
 
           try:
               tree = ET.parse(report_path)
           except ET.ParseError as e:
               print(f"Failed to parse SpotBugs XML: {e}", file=sys.stderr)
-              sys.exit(0)
+              sys.exit(1)
 
           root = tree.getroot()
           results = []
           rules_map = {}
           total_findings = 0
           skipped_non_security = 0
+          skipped_no_source = 0
 
           for bug in root.findall("BugInstance"):
               total_findings += 1
               bug_type = bug.get("type", "unknown")
               category = bug.get("category", "")
-              if category != "SECURITY":
+              category_normalized = category.strip().upper()
+              if category_normalized != "SECURITY":
                   skipped_non_security += 1
                   continue
 
@@ -251,6 +258,11 @@ jobs:
                       end_line = int(end)
 
               if not uri:
+                  skipped_no_source += 1
+                  print(
+                      f"Skipping SECURITY finding without source location: {bug_type}",
+                      file=sys.stderr
+                  )
                   continue
 
               if bug_type not in rules_map:
@@ -258,7 +270,7 @@ jobs:
                       "id": bug_type,
                       "shortDescription": {"text": bug_type},
                       "properties": {
-                          "category": category,
+                          "category": category_normalized,
                           "tags": ["security"],
                           "security-severity": security_severity
                       }
@@ -299,8 +311,15 @@ jobs:
           with open(sarif_path, "w") as f:
               json.dump(sarif, f, indent=2)
 
+          with open(metrics_path, "w") as f:
+              f.write(f"TOTAL_FINDINGS={total_findings}\n")
+              f.write(f"SECURITY_FINDINGS_UPLOADED={len(results)}\n")
+              f.write(f"SKIPPED_NON_SECURITY={skipped_non_security}\n")
+              f.write(f"SKIPPED_NO_SOURCE={skipped_no_source}\n")
+
           print(f"Converted {len(results)} security findings to SARIF")
           print(f"Skipped {skipped_non_security} non-security findings from {total_findings} total findings")
+          print(f"Skipped {skipped_no_source} security findings without source locations")
           PYEOF
 
       - name: Upload security SARIF to GitHub Code Scanning
@@ -322,21 +341,35 @@ jobs:
         if: always()
         run: |
           REPORT="target/spotbugs-result.xml"
+          METRICS="spotbugs-security-metrics.env"
           echo "### SpotBugs + Find Security Bugs Results" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           if [ -f "$REPORT" ]; then
-            TOTAL=$(grep -c '<BugInstance' "$REPORT" 2>/dev/null || echo "0")
-            HIGH=$(grep -c 'priority="1"' "$REPORT" 2>/dev/null || echo "0")
-            MEDIUM=$(grep -c 'priority="2"' "$REPORT" 2>/dev/null || echo "0")
-            LOW=$(grep -c 'priority="3"' "$REPORT" 2>/dev/null || echo "0")
-            SECURITY=$(grep -c 'category="SECURITY"' "$REPORT" 2>/dev/null || echo "0")
+            TOTAL=$(grep -c '<BugInstance' "$REPORT" 2>/dev/null || true)
+            HIGH=$(grep -c 'priority="1"' "$REPORT" 2>/dev/null || true)
+            MEDIUM=$(grep -c 'priority="2"' "$REPORT" 2>/dev/null || true)
+            LOW=$(grep -c 'priority="3"' "$REPORT" 2>/dev/null || true)
+            SECURITY=$(grep -ci 'category="security"' "$REPORT" 2>/dev/null || true)
             echo "| Severity | Count |" >> "$GITHUB_STEP_SUMMARY"
             echo "|----------|-------|" >> "$GITHUB_STEP_SUMMARY"
-            echo "| High | $HIGH |" >> "$GITHUB_STEP_SUMMARY"
-            echo "| Medium | $MEDIUM |" >> "$GITHUB_STEP_SUMMARY"
-            echo "| Low | $LOW |" >> "$GITHUB_STEP_SUMMARY"
-            echo "| **Security** | **$SECURITY** |" >> "$GITHUB_STEP_SUMMARY"
-            echo "| **Total** | **$TOTAL** |" >> "$GITHUB_STEP_SUMMARY"
+            echo "| High | ${HIGH:-0} |" >> "$GITHUB_STEP_SUMMARY"
+            echo "| Medium | ${MEDIUM:-0} |" >> "$GITHUB_STEP_SUMMARY"
+            echo "| Low | ${LOW:-0} |" >> "$GITHUB_STEP_SUMMARY"
+            echo "| **Security** | **${SECURITY:-0}** |" >> "$GITHUB_STEP_SUMMARY"
+            echo "| **Total** | **${TOTAL:-0}** |" >> "$GITHUB_STEP_SUMMARY"
+            if [ -f "$METRICS" ]; then
+              . "$METRICS"
+              echo "" >> "$GITHUB_STEP_SUMMARY"
+              echo "| Code Scanning upload | Count |" >> "$GITHUB_STEP_SUMMARY"
+              echo "|----------------------|-------|" >> "$GITHUB_STEP_SUMMARY"
+              echo "| Security findings uploaded | ${SECURITY_FINDINGS_UPLOADED:-0} |" >> "$GITHUB_STEP_SUMMARY"
+              echo "| Security findings skipped without source | ${SKIPPED_NO_SOURCE:-0} |" >> "$GITHUB_STEP_SUMMARY"
+              if [ "${SKIPPED_NO_SOURCE:-0}" != "0" ]; then
+                echo "::warning::Skipped ${SKIPPED_NO_SOURCE} SpotBugs SECURITY finding(s) without usable source locations"
+                echo "" >> "$GITHUB_STEP_SUMMARY"
+                echo "**Warning:** ${SKIPPED_NO_SOURCE} security finding(s) lacked usable source locations and were not uploaded to Code Scanning." >> "$GITHUB_STEP_SUMMARY"
+              fi
+            fi
             echo "" >> "$GITHUB_STEP_SUMMARY"
             echo "Only security findings are uploaded to Code Scanning; full SpotBugs results are retained as workflow artifacts." >> "$GITHUB_STEP_SUMMARY"
           else

--- a/.github/workflows/spotbugs.yml
+++ b/.github/workflows/spotbugs.yml
@@ -6,8 +6,8 @@
 # Find Security Bugs adds 150+ security-specific detectors critical for
 # a healthcare application handling PHI.
 #
-# Results appear as PR annotations (GitHub Actions) and in the GitHub
-# Security tab (SARIF upload).
+# Security findings appear in the GitHub Security tab (SARIF upload).
+# Full SpotBugs quality results are retained as workflow artifacts and summaries.
 #
 # Container Images:
 # This workflow uses the same dev container as maven-project.yml to ensure
@@ -176,7 +176,7 @@ jobs:
               -T 1C
           "
 
-      - name: Convert SpotBugs XML to SARIF
+      - name: Convert SpotBugs security XML to SARIF
         if: always()
         run: |
           REPORT="target/spotbugs-result.xml"
@@ -187,10 +187,10 @@ jobs:
 
           python3 << 'PYEOF'
           import xml.etree.ElementTree as ET
-          import json, os, sys
+          import json, sys
 
           report_path = "target/spotbugs-result.xml"
-          sarif_path = "spotbugs-report.sarif"
+          sarif_path = "spotbugs-security-report.sarif"
 
           try:
               tree = ET.parse(report_path)
@@ -199,19 +199,19 @@ jobs:
               sys.exit(0)
 
           root = tree.getroot()
-          src_dirs = []
-          project = root.find("Project")
-          if project is not None:
-              for src in project.findall("SrcDir"):
-                  if src.text:
-                      src_dirs.append(src.text.strip())
-
           results = []
           rules_map = {}
+          total_findings = 0
+          skipped_non_security = 0
 
           for bug in root.findall("BugInstance"):
+              total_findings += 1
               bug_type = bug.get("type", "unknown")
               category = bug.get("category", "")
+              if category != "SECURITY":
+                  skipped_non_security += 1
+                  continue
+
               priority = int(bug.get("priority", "3"))
               message_elem = bug.find("LongMessage")
               short_msg_elem = bug.find("ShortMessage")
@@ -223,14 +223,13 @@ jobs:
               else:
                   message = bug_type
 
-              # Map SpotBugs priority (1=high, 2=medium, 3=low) to SARIF level
               level_map = {1: "error", 2: "warning", 3: "note"}
+              security_severity_map = {1: "8.0", 2: "5.0", 3: "2.0"}
               level = level_map.get(priority, "warning")
+              security_severity = security_severity_map.get(priority, "5.0")
 
-              # Find source location
               source_line = bug.find("SourceLine")
               if source_line is None:
-                  # Try nested in Method or Class
                   for child in bug:
                       sl = child.find("SourceLine")
                       if sl is not None and sl.get("sourcepath"):
@@ -254,12 +253,15 @@ jobs:
               if not uri:
                   continue
 
-              # Register rule
               if bug_type not in rules_map:
                   rules_map[bug_type] = {
                       "id": bug_type,
                       "shortDescription": {"text": bug_type},
-                      "properties": {"category": category}
+                      "properties": {
+                          "category": category,
+                          "tags": ["security"],
+                          "security-severity": security_severity
+                      }
                   }
 
               result = {
@@ -293,15 +295,24 @@ jobs:
           with open(sarif_path, "w") as f:
               json.dump(sarif, f, indent=2)
 
-          print(f"Converted {len(results)} findings to SARIF")
+          print(f"Converted {len(results)} security findings to SARIF")
+          print(f"Skipped {skipped_non_security} non-security findings from {total_findings} total findings")
           PYEOF
 
-      - name: Upload SARIF to GitHub Security tab
+      - name: Upload security SARIF to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@0daab03d71ff584ef619d027a3fd9146679c5d84
-        if: always() && hashFiles('spotbugs-report.sarif') != ''
+        if: always() && hashFiles('spotbugs-security-report.sarif') != ''
         with:
-          sarif_file: spotbugs-report.sarif
+          sarif_file: spotbugs-security-report.sarif
           category: spotbugs
+
+      - name: Upload SpotBugs quality artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: always() && hashFiles('target/spotbugs-result.xml') != ''
+        with:
+          name: spotbugs-quality-xml
+          path: target/spotbugs-result.xml
+          retention-days: 14
 
       - name: Report summary
         if: always()
@@ -323,7 +334,7 @@ jobs:
             echo "| **Security** | **$SECURITY** |" >> "$GITHUB_STEP_SUMMARY"
             echo "| **Total** | **$TOTAL** |" >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "See the **Security** tab for details." >> "$GITHUB_STEP_SUMMARY"
+            echo "Only security findings are uploaded to Code Scanning; full SpotBugs results are retained as workflow artifacts." >> "$GITHUB_STEP_SUMMARY"
           else
             echo "No SpotBugs report generated." >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/spotbugs.yml
+++ b/.github/workflows/spotbugs.yml
@@ -324,7 +324,10 @@ jobs:
 
       - name: Upload security SARIF to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@0daab03d71ff584ef619d027a3fd9146679c5d84
-        if: always() && hashFiles('spotbugs-security-report.sarif') != ''
+        if: >
+          always() &&
+          hashFiles('spotbugs-security-report.sarif') != '' &&
+          (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
         with:
           sarif_file: spotbugs-security-report.sarif
           category: spotbugs
@@ -362,7 +365,7 @@ jobs:
               echo "" >> "$GITHUB_STEP_SUMMARY"
               echo "| Code Scanning upload | Count |" >> "$GITHUB_STEP_SUMMARY"
               echo "|----------------------|-------|" >> "$GITHUB_STEP_SUMMARY"
-              echo "| Security findings uploaded | ${SECURITY_FINDINGS_UPLOADED:-0} |" >> "$GITHUB_STEP_SUMMARY"
+              echo "| Security findings selected for upload | ${SECURITY_FINDINGS_UPLOADED:-0} |" >> "$GITHUB_STEP_SUMMARY"
               echo "| Security findings skipped without source | ${SKIPPED_NO_SOURCE:-0} |" >> "$GITHUB_STEP_SUMMARY"
               if [ "${SKIPPED_NO_SOURCE:-0}" != "0" ]; then
                 echo "::warning::Skipped ${SKIPPED_NO_SOURCE} SpotBugs SECURITY finding(s) without usable source locations"


### PR DESCRIPTION
## Summary
- keep broad PMD and SpotBugs quality scans available as workflow artifacts and summaries
- upload only PMD security SARIF to GitHub Code Scanning
- filter SpotBugs SARIF uploads to SECURITY findings with security metadata

## Testing
- parsed edited workflows with local js-yaml
- compiled embedded SpotBugs converter Python
- ran the converter against a temporary sample report to verify non-security findings are skipped
- ran git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upload only security findings to GitHub Code Scanning; keep full PMD and SpotBugs quality reports as artifacts and in job summaries to reduce Security tab noise. Summaries now clearly separate quality vs security counts.

- **New Features**
  - Split PMD into a full quality scan and a security-only scan; upload only `pmd-security-report.sarif` via `github/codeql-action/upload-sarif`, and store `pmd-report.sarif` with `actions/upload-artifact` (14-day retention).
  - Convert SpotBugs XML to security-only SARIF with `security-severity` metadata and highest severity preserved per rule; upload only `spotbugs-security-report.sarif` and store `target/spotbugs-result.xml` with `actions/upload-artifact` (14-day retention).

- **Bug Fixes**
  - Hardened SpotBugs conversion: case-insensitive SECURITY filtering, skip findings without source locations, fail on malformed XML or when a report is missing after a successful run, and include upload/skip metrics with warnings in the summary.
  - Clarified summaries for PMD and SpotBugs to show quality vs security counts and note that only security findings are uploaded; guard SARIF uploads on forked PRs.

<sup>Written for commit 805f6f5d190f43cc7e7233b786f2a649fa153292. Summary will update on new commits. <a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2236?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

