### PR TITLE
Add active CARLOS menu tab indicator

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/utility/NavPath.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/NavPath.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026 CARLOS EMR Project. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.utility;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Path-matching helpers for server-side active navigation tab detection.
+ *
+ * <p>Checks both the live request path and any Jakarta forward attributes so
+ * that forwarded requests activate the same nav tab as direct requests.
+ *
+ * @since 2026-05-27
+ */
+public final class NavPath {
+
+    private NavPath() {
+        // static utility
+    }
+
+    /**
+     * Safely coerces a Jakarta forward attribute value to a path string.
+     * Returns an empty string when the attribute is absent or not a String,
+     * preventing ClassCastException from non-String forward attribute types.
+     */
+    static String forwardAttribute(Object value) {
+        return value instanceof String string ? string : "";
+    }
+
+    /**
+     * Returns {@code true} when {@code path} contains {@code pattern} at a
+     * path-segment boundary.
+     *
+     * <p>A match is accepted when the pattern appears at the end of the string
+     * or is immediately followed by {@code /}, {@code ?}, {@code ;}, or
+     * {@code #}, preventing partial-segment false positives (e.g.
+     * {@code /administration-panel} does not match {@code /administration}).
+     * Patterns that end with {@code /} are accepted anywhere they appear as a
+     * substring.
+     */
+    static boolean pathMatches(String path, String pattern) {
+        if (StringUtils.isBlank(path) || StringUtils.isBlank(pattern)) {
+            return false;
+        }
+
+        int fromIndex = 0;
+        while (true) {
+            int index = path.indexOf(pattern, fromIndex);
+            if (index < 0) {
+                return false;
+            }
+
+            int boundaryIndex = index + pattern.length();
+            if (boundaryIndex >= path.length() || pattern.endsWith("/")) {
+                return true;
+            }
+
+            char boundary = path.charAt(boundaryIndex);
+            if (boundary == '/' || boundary == '?' || boundary == ';' || boundary == '#') {
+                return true;
+            }
+
+            fromIndex = index + 1;
+        }
+    }
+
+    /**
+     * Returns {@code true} when the current request or any Jakarta forward
+     * attribute matches one of the given path patterns.
+     *
+     * <p>Checks {@code getRequestURI()}, {@code getServletPath()},
+     * {@code jakarta.servlet.forward.request_uri}, and
+     * {@code jakarta.servlet.forward.servlet_path} so both direct and forwarded
+     * requests activate the correct tab.
+     *
+     * @param request  the current servlet request
+     * @param patterns one or more path prefixes or segments to test
+     * @return {@code true} if any path source matches any pattern
+     */
+    public static boolean requestPathMatches(HttpServletRequest request, String... patterns) {
+        String requestUri = StringUtils.defaultString(request.getRequestURI());
+        String servletPath = StringUtils.defaultString(request.getServletPath());
+        String forwardRequestUri = forwardAttribute(request.getAttribute("jakarta.servlet.forward.request_uri"));
+        String forwardServletPath = forwardAttribute(request.getAttribute("jakarta.servlet.forward.servlet_path"));
+
+        for (String pattern : patterns) {
+            if (pathMatches(requestUri, pattern)
+                    || pathMatches(servletPath, pattern)
+                    || pathMatches(forwardRequestUri, pattern)
+                    || pathMatches(forwardServletPath, pattern)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/webapp/WEB-INF/jsp/provider/appointmentprovideradminday.jsp
+++ b/src/main/webapp/WEB-INF/jsp/provider/appointmentprovideradminday.jsp
@@ -55,6 +55,7 @@
 <%@ page import="io.github.carlos_emr.carlos.util.ConversionUtils" %>
 <%@ page import="io.github.carlos_emr.carlos.commn.model.*" %>
 <%@ page import="io.github.carlos_emr.carlos.utility.SafeEncode" %>
+<%@ page import="io.github.carlos_emr.carlos.utility.NavPath" %>
 
 <%@ taglib uri="/WEB-INF/caisi-tag.tld" prefix="caisi" %>
 <%@ taglib uri="/WEB-INF/special_tag.tld" prefix="special" %>
@@ -902,15 +903,18 @@
                 </div>
                 <ul id="navlist">
                     <c:if test="${infirmaryView_isOscar != 'false'}">
+                        <% String scheduleNavActiveClass = NavPath.requestPathMatches(request,
+                                "/provider/providercontrol", "/provider/appointmentprovideradmin",
+                                "/provider/appointmentprovideradminday") ? "nav-active" : ""; %>
                         <% if (request.getParameter("viewall") != null && request.getParameter("viewall").equals("1")) { %>
-                        <li>
+                        <li class="<%= scheduleNavActiveClass %>">
                             <a href=# onClick="review('0')"
                                title="<fmt:message key="provider.appointmentProviderAdminDay.viewProvAval"/>">
                                 <fmt:message key="provider.appointmentProviderAdminDay.schedView"/>
                             </a>
                         </li>
                         <% } else { %>
-                        <li>
+                        <li class="<%= scheduleNavActiveClass %>">
                             <a href='<%= request.getContextPath() %>/provider/providercontrol?year=<%=curYear%>&month=<%=curMonth%>&day=<%=curDay%>&view=0&displaymode=day&dboperation=searchappointmentday&viewall=1'>
                                 <fmt:message key="provider.appointmentProviderAdminDay.schedView"/>
                             </a>
@@ -955,11 +959,11 @@
                                 <oscar:oscarPropertiesCheck property="NOT_FOR_CAISI" value="no" defaultVal="true">
                                     <c:if test="${doctorLinkRights}">
                                         <li>
-                                       <a HREF="#" id="inboxLink">
+                                       <a HREF="<%= "1".equals(request.getParameter("scheduleNav")) ? request.getContextPath() + "/web/inboxhub/Inboxhub?method=displayInboxForm&scheduleNav=1" : "#" %>" id="inboxLink">
                                                 <span id="oscar_new_lab" title="<fmt:message key="provider.appointmentProviderAdminDay.viewLabReports"/>"><fmt:message key="global.lab"/></span>
                                             </a>
                                             <oscar:newUnclaimedLab>
-                                                <a id="unclaimedLabLink" class="tabalert" HREF="javascript:void(0)"
+                                                <a id="unclaimedLabLink" class="tabalert" HREF="<%= "1".equals(request.getParameter("scheduleNav")) ? request.getContextPath() + "/web/inboxhub/Inboxhub?method=displayInboxForm&unclaimed=1&scheduleNav=1" : "javascript:void(0)" %>"
                                                    title='<fmt:message key="inbox.inboxmanager.msgUnmatched"/>'>U</a>
                                             </oscar:newUnclaimedLab>
                                         </li>
@@ -1118,15 +1122,6 @@
                                 </li>
 
                             </security:oscarSec>
-
-                            <caisi:isModuleLoad moduleName="TORONTO_RFQ" reverse="true">
-                                <security:oscarSec roleName="<%=roleName$%>" objectName="_resource" rights="r">
-                                    <li>
-                                        <a href="https://www.oscargalaxy.org" target="_blank" rel="noopener noreferrer"
-                                           title="<fmt:message key="provider.appointmentProviderAdminDay.viewResources"/>"><fmt:message key="encounter.Index.clinicalResources"/></a>
-                                    </li>
-                                </security:oscarSec>
-                            </caisi:isModuleLoad>
 
                             <% if (isMobileOptimized) { %>
                         </ul>
@@ -3058,8 +3053,10 @@
 
 <script>
     const contextPath = document.getElementById("contextPath").value;
-    const inboxLinkClickEvent = "popupInboxManager('" + contextPath + "/web/inboxhub/Inboxhub?method=displayInboxForm', 800);return false;";
-    const unclaimedLabLinkClickEvent = "popupInboxManager('" + contextPath + "/web/inboxhub/Inboxhub?method=displayInboxForm&unclaimed=1', 800);return false;";
+    const inboxUrl = contextPath + "/web/inboxhub/Inboxhub?method=displayInboxForm";
+    const unclaimedLabUrl = contextPath + "/web/inboxhub/Inboxhub?method=displayInboxForm&unclaimed=1";
+    const inboxLinkClickEvent = "return openScheduleSection('" + inboxUrl + "', function(u){ popupInboxManager(u, 800); }, event);";
+    const unclaimedLabLinkClickEvent = "return openScheduleSection('" + unclaimedLabUrl + "', function(u){ popupInboxManager(u, 800); }, event);";
 
     const inboxLink = document.getElementById("inboxLink");
     if (inboxLink) {

--- a/src/main/webapp/WEB-INF/jsp/provider/mainMenu.jsp
+++ b/src/main/webapp/WEB-INF/jsp/provider/mainMenu.jsp
@@ -54,6 +54,7 @@
 <%@ page import="io.github.carlos_emr.carlos.commn.model.UserProperty" %>
 <%@ page import="io.github.carlos_emr.carlos.commn.model.Provider" %>
 <%@ page import="io.github.carlos_emr.carlos.utility.SafeEncode" %>
+<%@ page import="io.github.carlos_emr.carlos.utility.NavPath" %>
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
 <%@ taglib uri="carlos" prefix="carlos" %>
 
@@ -84,6 +85,20 @@
     String userlastname = loggedInProvider != null ? loggedInProvider.getLastName() : "";
     String encodedUserName = URLEncoder.encode(StringUtils.trim(userfirstname + " " + userlastname), StandardCharsets.UTF_8);
     boolean scheduleNavActive = "1".equals(request.getParameter("scheduleNav"));
+    boolean scheduleTabActive = NavPath.requestPathMatches(request, "/provider/providercontrol",
+            "/provider/appointmentprovideradmin", "/provider/appointmentprovideradminday");
+    boolean searchTabActive = NavPath.requestPathMatches(request, "/demographic/ViewSearch",
+            "/PMmodule/ClientSearch", "/PMmodule/ClientSearch2");
+    boolean inboxTabActive = NavPath.requestPathMatches(request, "/web/inboxhub",
+            "/documentManager/ViewInbox");
+    boolean ticklerTabActive = NavPath.requestPathMatches(request, "/tickler/");
+    boolean messengerTabActive = NavPath.requestPathMatches(request, "/messenger/");
+    boolean consultationTabActive = NavPath.requestPathMatches(request, "/encounter/IncomingConsultation",
+            "/encounter/oscarConsultationRequest");
+    boolean documentTabActive = NavPath.requestPathMatches(request, "/documentManager/") && !inboxTabActive;
+    boolean reportTabActive = NavPath.requestPathMatches(request, "/report/", "/oscarReport/");
+    boolean adminTabActive = NavPath.requestPathMatches(request, "/administration", "/admin/");
+    boolean econsultTabActive = NavPath.requestPathMatches(request, "/encounter/econsult");
 
     // Build menu destinations once so same-tab navigation and popup fallbacks cannot drift apart.
     String messengerUrl = request.getContextPath() + "/messenger/DisplayMessages?providerNo=" + curUser_no + "&userName=" + encodedUserName;
@@ -99,21 +114,21 @@
 <input type="hidden" value="${pageContext.servletContext.contextPath}" id="contextPath" />
 <table id="firstTable" class="noprint">
     <tr>
-        <td class="icon-container">
-            <img alt="CARLOS EMR" src="<%=request.getContextPath()%>/images/oscar_logo_small.png" width="19">
-        </td>
         <td id="firstMenu">
+            <div class="icon-container">
+                <img alt="CARLOS EMR" src="<%=request.getContextPath()%>/images/oscar_logo_small.png" width="19">
+            </div>
             <ul id="navlist">
                 <c:if test="${infirmaryView_isOscar ne 'false'}">
                     <% if (request.getParameter("viewall") != null && request.getParameter("viewall").equals("1")) { %>
-                    <li>
+                    <li class="<%= scheduleTabActive ? "nav-active" : "" %>">
                         <a href=# onClick="review('0')"
                            title="<fmt:message key="provider.appointmentProviderAdminDay.viewProvAval"/>">
                             <fmt:message key="provider.appointmentProviderAdminDay.schedView"/>
                         </a>
                     </li>
                     <% } else { %>
-                    <li>
+                    <li class="<%= scheduleTabActive ? "nav-active" : "" %>">
                         <a href='<%= request.getContextPath() %>/provider/providercontrol?year=<%=curYear%>&month=<%=curMonth%>&day=<%=curDay%>&view=0&displaymode=day&dboperation=searchappointmentday&viewall=1'>
                             <fmt:message key="provider.appointmentProviderAdminDay.schedView"/>
                         </a>
@@ -132,7 +147,7 @@
                         <% } %>
 
                         <security:oscarSec roleName="<%=roleName$%>" objectName="_search" rights="r">
-                            <li id="search">
+                            <li id="search" class="<%= searchTabActive ? "nav-active" : "" %>">
                                 <caisi:isModuleLoad moduleName="caisi">
                                     <%
                                         String caisiSearch = oscarVariables.getProperty("caisi.search.workflow", "true");
@@ -162,13 +177,13 @@
                             <oscar:oscarPropertiesCheck property="NOT_FOR_CAISI" value="no" defaultVal="true">
                                 <security:oscarSec roleName="<%=roleName$%>" objectName="_appointment.doctorLink"
                                                    rights="r">
-                                    <li>
-                                        <a HREF="#" id="inboxLink"
+                                    <li class="<%= inboxTabActive ? "nav-active" : "" %>">
+                                        <a HREF="<%= scheduleNavActive ? request.getContextPath() + "/web/inboxhub/Inboxhub?method=displayInboxForm&scheduleNav=1" : "#" %>" id="inboxLink"
                                            TITLE='<fmt:message key="provider.appointmentProviderAdminDay.viewLabReports"/>'>
                                             <span id="oscar_new_lab"><fmt:message key="global.lab"/></span>
                                         </a>
                                         <oscar:newUnclaimedLab>
-                                            <a id="unclaimedLabLink" class="tabalert" HREF="javascript:void(0)"
+                                            <a id="unclaimedLabLink" class="tabalert" HREF="<%= scheduleNavActive ? request.getContextPath() + "/web/inboxhub/Inboxhub?method=displayInboxForm&unclaimed=1&scheduleNav=1" : "javascript:void(0)" %>"
                                                title='<fmt:message key="provider.appointmentProviderAdminDay.viewLabReports"/>'>U</a>
                                         </oscar:newUnclaimedLab>
                                     </li>
@@ -177,7 +192,7 @@
                         </caisi:isModuleLoad>
 
                         <security:oscarSec roleName="<%=roleName$%>" objectName="_tickler" rights="r">
-                            <li>
+                            <li class="<%= ticklerTabActive ? "nav-active" : "" %>">
                                 <a HREF="#"
                                    ONCLICK="return openScheduleMenuSection('<%=SafeEncode.forJavaScriptAttribute(ticklerUrl)%>', function(u){ popupPage2(u,'ticklerPage'); }, event);"
                                    TITLE='<fmt:message key="global.tickler"/>'>
@@ -187,7 +202,7 @@
 
                         <caisi:isModuleLoad moduleName="TORONTO_RFQ" reverse="true">
                             <security:oscarSec roleName="<%=roleName$%>" objectName="_msg" rights="r">
-                                <li>
+                                <li class="<%= messengerTabActive ? "nav-active" : "" %>">
                                     <a HREF="#"
                                        ONCLICK="return openScheduleMenuSection('<%=SafeEncode.forJavaScriptAttribute(messengerUrl)%>', function(u){ popupOscarRx(600,1024,u); }, event);"
                                        title="<fmt:message key="global.messenger"/>">
@@ -197,7 +212,7 @@
                         </caisi:isModuleLoad>
                         <caisi:isModuleLoad moduleName="TORONTO_RFQ" reverse="true">
                             <security:oscarSec roleName="<%=roleName$%>" objectName="_con" rights="r">
-                                <li id="con">
+                                <li id="con" class="<%= consultationTabActive ? "nav-active" : "" %>">
                                     <a HREF="#"
                                        ONCLICK="return openScheduleMenuSection('<%=SafeEncode.forJavaScriptAttribute(consultationUrl)%>', function(u){ popupOscarRx(625,1024,u); }, event);"
                                        title="<fmt:message key="provider.appointmentProviderAdminDay.viewConReq"/>">
@@ -205,9 +220,20 @@
                                 </li>
                             </security:oscarSec>
                         </caisi:isModuleLoad>
+                        <%
+                            boolean hide_eConsult = CarlosProperties.getInstance().isPropertyActive("hide_eConsult_link");
+                            if ("on".equalsIgnoreCase(prov) && !hide_eConsult) {
+                        %>
+                        <li id="econ" class="<%= econsultTabActive ? "nav-active" : "" %>">
+                            <a href="#" onclick="popupOscarRx(625, 1024, '<%=SafeEncode.forJavaScriptAttribute(econsultUrl)%>')"
+                               title="eConsult">
+                                <span><fmt:message key="provider.mainMenu.eConsult"/></span></a>
+                        </li>
+                        <% } %>
+
                         <caisi:isModuleLoad moduleName="TORONTO_RFQ" reverse="true">
                             <security:oscarSec roleName="<%=roleName$%>" objectName="_edoc" rights="r">
-                                <li>
+                                <li class="<%= documentTabActive ? "nav-active" : "" %>">
                                     <a HREF="#"
                                        onclick="return openScheduleMenuSection('<%=SafeEncode.forJavaScriptAttribute(documentReportUrl)%>', function(u){ popup('700', '1024', u, 'edocView'); }, event);"
                                        TITLE='<fmt:message key="provider.appointmentProviderAdminDay.viewEdoc"/>'><fmt:message key="global.edoc"/></a>
@@ -217,34 +243,11 @@
 
                         <caisi:isModuleLoad moduleName="TORONTO_RFQ" reverse="true">
                             <security:oscarSec roleName="<%=roleName$%>" objectName="_report" rights="r">
-                                <li>
+                                <li class="<%= reportTabActive ? "nav-active" : "" %>">
                                     <a HREF="#"
                                        ONCLICK="return openScheduleMenuSection('<%=SafeEncode.forJavaScriptAttribute(reportIndexUrl)%>', function(u){ popupPage2(u,'reportPage'); }, event);"
                                        TITLE='<fmt:message key="global.genReport"/>'
                                        OnMouseOver="window.status='<fmt:message key="global.genReport"/>' ; return true"><fmt:message key="global.report"/></a>
-                                </li>
-                            </security:oscarSec>
-                        </caisi:isModuleLoad>
-
-                        <caisi:isModuleLoad moduleName="TORONTO_RFQ" reverse="true">
-                            <security:oscarSec roleName="<%=roleName$%>"
-                                               objectName="_admin,_admin.userAdmin,_admin.schedule,_admin.billing,_admin.resource,_admin.reporting,_admin.backup,_admin.messenger,_admin.eform,_admin.encounter,_admin.misc,_admin.fax,_admin.flowsheet"
-                                               rights="r">
-
-                                <li id="admin2">
-                                    <a href="javascript:void(0)" id="admin-panel" TITLE='<fmt:message key="admin.admin.page.title"/>'
-                                       onclick="return openScheduleMenuSection('<%=SafeEncode.forJavaScriptAttribute(administrationUrl)%>', function(u){ newWindow(u,'admin'); }, event);"><fmt:message key="provider.mainMenu.administration"/></a>
-                                </li>
-
-                            </security:oscarSec>
-                        </caisi:isModuleLoad>
-
-                        <caisi:isModuleLoad moduleName="TORONTO_RFQ" reverse="true">
-                            <security:oscarSec roleName="<%=roleName$%>" objectName="_resource" rights="r">
-                                <li>
-                                    <a href="#" ONCLICK="popupPage2('<%=SafeEncode.forJavaScriptAttribute(StringUtils.defaultString(resourcebaseurl))%>');return false;"
-                                       title="<fmt:message key="provider.appointmentProviderAdminDay.viewResources"/>"
-                                       onmouseover="window.status='<fmt:message key="provider.appointmentProviderAdminDay.viewResources"/>';return true"><fmt:message key="encounter.Index.clinicalResources"/></a>
                                 </li>
                             </security:oscarSec>
                         </caisi:isModuleLoad>
@@ -264,16 +267,18 @@
                             </a></li>
                         </oscar:oscarPropertiesCheck>
 
-                        <%
-                            boolean hide_eConsult = CarlosProperties.getInstance().isPropertyActive("hide_eConsult_link");
-                            if ("on".equalsIgnoreCase(prov) && !hide_eConsult) {
-                        %>
-                        <li id="econ">
-                            <a href="#" onclick="popupOscarRx(625, 1024, '<%=SafeEncode.forJavaScriptAttribute(econsultUrl)%>')"
-                               title="eConsult">
-                                <span><fmt:message key="provider.mainMenu.eConsult"/></span></a>
-                        </li>
-                        <% } %>
+                        <caisi:isModuleLoad moduleName="TORONTO_RFQ" reverse="true">
+                            <security:oscarSec roleName="<%=roleName$%>"
+                                               objectName="_admin,_admin.userAdmin,_admin.schedule,_admin.billing,_admin.resource,_admin.reporting,_admin.backup,_admin.messenger,_admin.eform,_admin.encounter,_admin.misc,_admin.fax,_admin.flowsheet"
+                                               rights="r">
+
+                                <li id="admin2" class="<%= adminTabActive ? "nav-active" : "" %>">
+                                    <a href="javascript:void(0)" id="admin-panel" TITLE='<fmt:message key="admin.admin.page.title"/>'
+                                       onclick="return openScheduleMenuSection('<%=SafeEncode.forJavaScriptAttribute(administrationUrl)%>', function(u){ newWindow(u,'admin'); }, event);"><fmt:message key="provider.mainMenu.administration"/></a>
+                                </li>
+
+                            </security:oscarSec>
+                        </caisi:isModuleLoad>
 
                         <security:oscarSec roleName="<%=roleName$%>" objectName="_dashboardDisplay" rights="r">
                             <%
@@ -368,11 +373,11 @@
                     </security:oscarSec>
                 </li>
             </ul>
-        </td>
-        <td>
-            <a id="logoutButton" title="<fmt:message key="global.btnLogout"/>" href="<%= request.getContextPath() %>/logoutPage">
-                <span class="fa-solid fa-power-off"></span>
-            </a>
+            <div>
+                <a id="logoutButton" title="<fmt:message key="global.btnLogout"/>" href="<%= request.getContextPath() %>/logoutPage">
+                    <span class="fa-solid fa-power-off"></span>
+                </a>
+            </div>
         </td>
 
     </tr>
@@ -466,8 +471,10 @@
         };
     }
 
-    var inboxLinkClickEvent = "popupInboxManager('" + contextPath + "/web/inboxhub/Inboxhub?method=displayInboxForm', 800);return false;";
-    var unclaimedLabLinkClickEvent = "popupInboxManager('" + contextPath + "/web/inboxhub/Inboxhub?method=displayInboxForm&unclaimed=1', 800);return false;";
+    var inboxUrl = contextPath + "/web/inboxhub/Inboxhub?method=displayInboxForm";
+    var unclaimedLabUrl = contextPath + "/web/inboxhub/Inboxhub?method=displayInboxForm&unclaimed=1";
+    var inboxLinkClickEvent = "return openScheduleMenuSection('" + inboxUrl + "', function(u){ popupInboxManager(u, 800); }, event);";
+    var unclaimedLabLinkClickEvent = "return openScheduleMenuSection('" + unclaimedLabUrl + "', function(u){ popupInboxManager(u, 800); }, event);";
 
     const inboxLink = document.getElementById("inboxLink");
     if (inboxLink) {

--- a/src/main/webapp/WEB-INF/jsp/web/inboxhub/Inboxhub.jsp
+++ b/src/main/webapp/WEB-INF/jsp/web/inboxhub/Inboxhub.jsp
@@ -51,6 +51,9 @@
     <link rel="stylesheet" type="text/css" media="all" href="${pageContext.request.contextPath}/library/jquery/jquery-ui.structure-1.14.2.min.css" />
     <link href="${pageContext.request.contextPath}/css/fontawesome-all.min.css" rel="stylesheet">
     <link rel="stylesheet" type="text/css" href="${pageContext.request.contextPath}/share/css/global.css"/>
+    <c:if test="${param.scheduleNav eq '1'}">
+        <link rel="stylesheet" type="text/css" href="${pageContext.request.contextPath}/css/topnav.css"/>
+    </c:if>
     <link rel="stylesheet" type="text/css" href="${pageContext.request.contextPath}/web/css/Inboxhub.css?v=1.0"/>
 
     <script type="text/javascript" src="${pageContext.request.contextPath}/library/flatpickr/flatpickr.min.js"></script>
@@ -66,8 +69,11 @@
 </head>
 <body>
 <jsp:include page="/WEB-INF/jsp/includes/spinner.jspf" flush="true"/>
+<c:if test="${param.scheduleNav eq '1'}">
+    <jsp:include page="/WEB-INF/jsp/provider/mainMenu.jsp"/>
+</c:if>
 <script>
-    const contextPath = "<carlos:encode value='${pageContext.request.contextPath}' context="javaScript"/>";
+    const inboxContextPath = "<carlos:encode value='${pageContext.request.contextPath}' context="javaScript"/>";
     const inboxSearchLabel = "<fmt:message key='inboxhub.form.search'/>";
 
     /**

--- a/src/main/webapp/css/receptionistapptstyle.css
+++ b/src/main/webapp/css/receptionistapptstyle.css
@@ -325,6 +325,14 @@ table#firstTable a:focus-visible {
     background-color: #486ebd;
 }
 
+table#firstTable td#firstMenu ul#navlist li.nav-active,
+table#firstTable td#firstMenu ul#navlist li.nav-active > a,
+table#firstTable td#firstMenu ul#navlist li.nav-active > a:visited,
+table#firstTable td#firstMenu ul#navlist li.nav-active > a:active {
+    color: #00283c;
+    background-color: #d9d9d9;
+}
+
 input, select, textarea {
     background-color: #F4EaD7;
     border: 1px solid #0097cf;
@@ -427,12 +435,12 @@ a:hover .tabalert {
     color: white !important;
 }
 
-table#firstTable td#firstMenu ul#navlist li:not(.dashboardDropdown) {
+table#firstTable td#firstMenu ul#navlist > li:not(.dashboardDropdown) {
     line-height: 1;
     display: inline-block;
 }
 
-table#firstTable td#firstMenu ul#navlist li a:not(.dashboardDropdown) {
+table#firstTable td#firstMenu ul#navlist > li:not(.dashboardDropdown) > a {
     display: inline-block;
     padding: 5px;
 }
@@ -445,6 +453,35 @@ table#firstTable td#firstMenu #navlist li:hover {
 table#firstTable td#firstMenu #navlist li a:hover {
     color: #fff;
     background-color: #486ebd;
+}
+
+table#firstTable td#firstMenu ul#navlist li.nav-active > a.tabalert,
+table#firstTable td#firstMenu ul#navlist li.nav-active > a .tabalert,
+table#firstTable td#firstMenu ul#navlist li.nav-active > a span {
+    color: #00283c !important;
+}
+
+table#firstTable td#firstMenu ul#navlist li.nav-active:hover,
+table#firstTable td#firstMenu ul#navlist li.nav-active > a:hover,
+table#firstTable td#firstMenu ul#navlist li.nav-active > a:focus,
+table#firstTable td#firstMenu ul#navlist li.nav-active > a:focus-visible {
+    color: #fff;
+    background-color: #486ebd;
+}
+
+table#firstTable td#firstMenu ul#navlist li.nav-active:hover > a.tabalert,
+table#firstTable td#firstMenu ul#navlist li.nav-active:hover > a .tabalert,
+table#firstTable td#firstMenu ul#navlist li.nav-active:hover > a span,
+table#firstTable td#firstMenu ul#navlist li.nav-active > a:hover.tabalert,
+table#firstTable td#firstMenu ul#navlist li.nav-active > a:hover .tabalert,
+table#firstTable td#firstMenu ul#navlist li.nav-active > a:hover span,
+table#firstTable td#firstMenu ul#navlist li.nav-active > a:focus.tabalert,
+table#firstTable td#firstMenu ul#navlist li.nav-active > a:focus .tabalert,
+table#firstTable td#firstMenu ul#navlist li.nav-active > a:focus span,
+table#firstTable td#firstMenu ul#navlist li.nav-active > a:focus-visible.tabalert,
+table#firstTable td#firstMenu ul#navlist li.nav-active > a:focus-visible .tabalert,
+table#firstTable td#firstMenu ul#navlist li.nav-active > a:focus-visible span {
+    color: #fff !important;
 }
 
 table#firstTable td#firstMenu #navlist #logoutMobile {

--- a/src/main/webapp/css/topnav.css
+++ b/src/main/webapp/css/topnav.css
@@ -28,10 +28,6 @@ table#firstTable td {
     font-size: 12px;
 }
 
-table#firstTable tr td.icon-container {
-    padding-left: 10px;
-}
-
 table#firstTable td#firstMenu {
     flex: 1 1 auto;
     margin-left: 10px;
@@ -40,6 +36,11 @@ table#firstTable td#firstMenu {
 table#firstTable td#userSettings {
     flex: 0 0 auto;
     margin-right: 15px;
+}
+
+table#firstTable td#firstMenu .icon-container {
+    display: inline-flex;
+    align-items: center;
 }
 
 table#firstTable td#firstMenu ul#navlist:not(.dashboardDropdown),
@@ -51,16 +52,20 @@ table#firstTable td#userSettings ul#userSettingsMenu:not(.dashboardDropdown) {
 }
 
 table#firstTable td#userSettings ul#userSettingsMenu li,
-/* Keep top-level menu layout from leaking into dashboard dropdown rows; the
-   dropdown marker is on a nested div, so scope these rules to direct children. */
-table#firstTable td#firstMenu ul#navlist > li {
+table#firstTable td#firstMenu ul#navlist > li:not(.dashboardDropdown) {
     line-height: 1;
     display: inline-block;
+    padding: 0;
 }
 
-table#firstTable td#firstMenu ul#navlist > li > a {
+table#firstTable td#firstMenu ul#navlist > li:not(.dashboardDropdown) > a {
     display: inline-block;
     padding: 5px;
+}
+
+table#firstTable td#userSettings ul#userSettingsMenu {
+    display: flex;
+    gap: 5px;
 }
 
 table#firstTable a,
@@ -78,6 +83,43 @@ table#firstTable td#firstMenu #navlist li:hover,
 table#firstTable td#firstMenu #navlist li a:hover {
     color: #fff;
     background-color: #486ebd;
+}
+
+table#firstTable td#firstMenu ul#navlist li.nav-active,
+table#firstTable td#firstMenu ul#navlist li.nav-active > a,
+table#firstTable td#firstMenu ul#navlist li.nav-active > a:visited,
+table#firstTable td#firstMenu ul#navlist li.nav-active > a:active {
+    color: #00283c;
+    background-color: #d9d9d9;
+}
+
+table#firstTable td#firstMenu ul#navlist li.nav-active > a.tabalert,
+table#firstTable td#firstMenu ul#navlist li.nav-active > a .tabalert,
+table#firstTable td#firstMenu ul#navlist li.nav-active > a span {
+    color: #00283c !important;
+}
+
+table#firstTable td#firstMenu ul#navlist li.nav-active:hover,
+table#firstTable td#firstMenu ul#navlist li.nav-active > a:hover,
+table#firstTable td#firstMenu ul#navlist li.nav-active > a:focus,
+table#firstTable td#firstMenu ul#navlist li.nav-active > a:focus-visible {
+    color: #fff;
+    background-color: #486ebd;
+}
+
+table#firstTable td#firstMenu ul#navlist li.nav-active:hover > a.tabalert,
+table#firstTable td#firstMenu ul#navlist li.nav-active:hover > a .tabalert,
+table#firstTable td#firstMenu ul#navlist li.nav-active:hover > a span,
+table#firstTable td#firstMenu ul#navlist li.nav-active > a:hover.tabalert,
+table#firstTable td#firstMenu ul#navlist li.nav-active > a:hover .tabalert,
+table#firstTable td#firstMenu ul#navlist li.nav-active > a:hover span,
+table#firstTable td#firstMenu ul#navlist li.nav-active > a:focus.tabalert,
+table#firstTable td#firstMenu ul#navlist li.nav-active > a:focus .tabalert,
+table#firstTable td#firstMenu ul#navlist li.nav-active > a:focus span,
+table#firstTable td#firstMenu ul#navlist li.nav-active > a:focus-visible.tabalert,
+table#firstTable td#firstMenu ul#navlist li.nav-active > a:focus-visible .tabalert,
+table#firstTable td#firstMenu ul#navlist li.nav-active > a:focus-visible span {
+    color: #fff !important;
 }
 
 table#firstTable #logoutButton span {
@@ -144,30 +186,6 @@ table.topnav td {
     font-size: 12px;
 }
 
-
-#navlist {
-    margin: 0;
-    padding: 0;
-    white-space: nowrap;
-}
-
-#navlist > li {
-    padding-top: 0.5px;
-    padding-bottom: 0.5px;
-    padding-left: 2.5px;
-    padding-right: 2.5px;
-    display: inline;
-}
-
-#navlist > li:hover {
-    color: #fff;
-    background-color: #486ebd;
-}
-
-#navlist > li > a:hover {
-    color: #fff;
-    background-color: #486ebd;
-}
 
 /* Match the schedule bar alert affordance; these links need higher specificity
    than the general topnav anchor color rules above. */

--- a/src/test/java/io/github/carlos_emr/carlos/provider/web/ScheduleNavigationAssetRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/provider/web/ScheduleNavigationAssetRegressionTest.java
@@ -55,10 +55,16 @@ class ScheduleNavigationAssetRegressionTest {
             Path.of("src", "main", "webapp", "WEB-INF", "jsp", "messenger", "ViewMessage.jsp");
     private static final Path CREATE_MESSAGE_JSP =
             Path.of("src", "main", "webapp", "WEB-INF", "jsp", "messenger", "CreateMessage.jsp");
+    private static final Path INBOXHUB_JSP =
+            Path.of("src", "main", "webapp", "WEB-INF", "jsp", "web", "inboxhub", "Inboxhub.jsp");
     private static final Path MAIN_MENU_JSP =
             Path.of("src", "main", "webapp", "WEB-INF", "jsp", "provider", "mainMenu.jsp");
+    private static final Path APPOINTMENT_PROVIDER_DAY_JSP =
+            Path.of("src", "main", "webapp", "WEB-INF", "jsp", "provider", "appointmentprovideradminday.jsp");
     private static final Path TOPNAV_CSS =
             Path.of("src", "main", "webapp", "css", "topnav.css");
+    private static final Path RECEPTIONIST_APPT_CSS =
+            Path.of("src", "main", "webapp", "css", "receptionistapptstyle.css");
     /**
      * Verifies sortable mailbox-header URLs keep their existing query state and
      * append the schedule navigation flag after box/demographic parameters.
@@ -101,16 +107,36 @@ class ScheduleNavigationAssetRegressionTest {
         String displayMessages = Files.readString(DISPLAY_MESSAGES_JSP, StandardCharsets.UTF_8);
         String viewMessage = Files.readString(VIEW_MESSAGE_JSP, StandardCharsets.UTF_8);
         String createMessage = Files.readString(CREATE_MESSAGE_JSP, StandardCharsets.UTF_8);
+        String inboxhub = Files.readString(INBOXHUB_JSP, StandardCharsets.UTF_8);
         String mainMenu = Files.readString(MAIN_MENU_JSP, StandardCharsets.UTF_8);
+        String appointmentProviderDay = Files.readString(APPOINTMENT_PROVIDER_DAY_JSP, StandardCharsets.UTF_8);
         String scheduleScript = Files.readString(SCHEDULE_PAGE_SCRIPT, StandardCharsets.UTF_8);
         String topnavCss = Files.readString(TOPNAV_CSS, StandardCharsets.UTF_8);
+        String receptionistApptCss = Files.readString(RECEPTIONIST_APPT_CSS, StandardCharsets.UTF_8);
 
         assertThat(documentReport)
                 .contains("<link rel=\"stylesheet\" href=\"<%=request.getContextPath()%>/css/topnav.css\">")
                 .contains("<jsp:include page=\"/WEB-INF/jsp/provider/mainMenu.jsp\"/>");
         assertThat(topnavCss)
                 .contains("table#firstTable .dashboardDropdown")
-                .contains("table#firstTable .dropdown:hover .dashboardDropdown");
+                .contains("table#firstTable .dropdown:hover .dashboardDropdown")
+                .contains("ul#navlist > li:not(.dashboardDropdown)")
+                .contains("ul#navlist > li:not(.dashboardDropdown) > a")
+                .doesNotContain("ul#navlist li:not(.dashboardDropdown)")
+                .doesNotContain("ul#navlist li a:not(.dashboardDropdown)")
+                .contains("li.nav-active > a")
+                .contains("li.nav-active:hover")
+                .contains("li.nav-active > a:hover")
+                .contains("li.nav-active > a:focus")
+                .contains("li.nav-active > a.tabalert")
+                .contains("li.nav-active > a span");
+        assertThat(receptionistApptCss)
+                .contains("li.nav-active > a")
+                .contains("li.nav-active:hover")
+                .contains("li.nav-active > a:hover")
+                .contains("li.nav-active > a:focus")
+                .contains("li.nav-active > a.tabalert")
+                .contains("li.nav-active > a span");
         assertThat(displayMessages)
                 .contains("String boxTypeQuerySuffix = pageType > 0 ? \"&boxType=\" + pageType : \"\";")
                 .contains("String demographicQuerySuffix = pageType == 3 && demographic_no != null")
@@ -127,10 +153,49 @@ class ScheduleNavigationAssetRegressionTest {
                 .contains("<jsp:include page=\"/WEB-INF/jsp/provider/mainMenu.jsp\"/>")
                 .contains("ClearMessage<%=scheduleNavFirstQuerySuffix%>")
                 .contains("DisplayMessages<%=scheduleNavFirstQuerySuffix%>");
+        assertThat(inboxhub)
+                .contains("<c:if test=\"${param.scheduleNav eq '1'}\">")
+                .contains("<link rel=\"stylesheet\" type=\"text/css\" href=\"${pageContext.request.contextPath}/css/topnav.css\"/>")
+                .contains("<jsp:include page=\"/WEB-INF/jsp/provider/mainMenu.jsp\"/>")
+                .contains("const inboxContextPath =")
+                .doesNotContain("const contextPath =");
         assertThat(mainMenu)
+                .contains("NavPath.requestPathMatches")
+                .doesNotContain("private boolean requestPathMatches")
+                .doesNotContain("private boolean pathMatches")
+                .contains("<td id=\"firstMenu\">")
+                .contains("<div class=\"icon-container\">")
+                .contains("<td id=\"userSettings\">")
+                .contains("<a id=\"logoutButton\"")
+                .contains("scheduleTabActive")
+                .contains("messengerTabActive")
+                .contains("requestPathMatches(request, \"/provider/providercontrol\",")
+                .contains("\"/provider/appointmentprovideradmin\", \"/provider/appointmentprovideradminday\")")
+                .contains("class=\"<%= scheduleTabActive ? \"nav-active\" : \"\" %>\"")
+                .contains("class=\"<%= inboxTabActive ? \"nav-active\" : \"\" %>\"")
+                .contains("HREF=\"<%= scheduleNavActive ? request.getContextPath() + \"/web/inboxhub/Inboxhub?method=displayInboxForm&scheduleNav=1\" : \"#\" %>\" id=\"inboxLink\"")
+                .contains("HREF=\"<%= scheduleNavActive ? request.getContextPath() + \"/web/inboxhub/Inboxhub?method=displayInboxForm&unclaimed=1&scheduleNav=1\" : \"javascript:void(0)\" %>\"")
+                .contains("class=\"<%= messengerTabActive ? \"nav-active\" : \"\" %>\"")
+                .contains("var inboxUrl = contextPath + \"/web/inboxhub/Inboxhub?method=displayInboxForm\";")
+                .contains("return openScheduleMenuSection('\" + inboxUrl + \"', function(u){ popupInboxManager(u, 800); }, event);")
                 .contains("!window.popup.scheduleMenuFallback")
                 .contains("fallbackMenuPopup.scheduleMenuFallback = true;")
-                .contains("window.popup = fallbackMenuPopup;");
+                .contains("window.popup = fallbackMenuPopup;")
+                .doesNotContain("navRequestPath")
+                .doesNotContain("(String) request.getAttribute")
+                .doesNotContain("resourceTabActive")
+                .doesNotContain("encounter.Index.clinicalResources");
+        assertThat(appointmentProviderDay)
+                .contains("scheduleNavActiveClass = NavPath.requestPathMatches(request,")
+                .contains("/provider/appointmentprovideradminday")
+                .contains("<li class=\"<%= scheduleNavActiveClass %>\">")
+                .contains("HREF=\"<%= \"1\".equals(request.getParameter(\"scheduleNav\")) ? request.getContextPath() + \"/web/inboxhub/Inboxhub?method=displayInboxForm&scheduleNav=1\" : \"#\" %>\" id=\"inboxLink\"")
+                .contains("HREF=\"<%= \"1\".equals(request.getParameter(\"scheduleNav\")) ? request.getContextPath() + \"/web/inboxhub/Inboxhub?method=displayInboxForm&unclaimed=1&scheduleNav=1\" : \"javascript:void(0)\" %>\"")
+                .contains("const inboxUrl = contextPath + \"/web/inboxhub/Inboxhub?method=displayInboxForm\";")
+                .contains("return openScheduleSection('\" + inboxUrl + \"', function(u){ popupInboxManager(u, 800); }, event);")
+                .doesNotContain("openScheduleMenuSection")
+                .doesNotContain("popupInboxManager('\" + contextPath + \"/web/inboxhub/Inboxhub?method=displayInboxForm', 800);return false;")
+                .doesNotContain("encounter.Index.clinicalResources");
         assertThat(scheduleScript)
                 .contains("var usesScheduleShell = scheduleNavigationMode === 'focused'"
                         + " || scheduleNavigationMode === 'tab';")

--- a/src/test/java/io/github/carlos_emr/carlos/utility/NavPathUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/utility/NavPathUnitTest.java
@@ -132,6 +132,17 @@ class NavPathUnitTest {
         }
 
         @Test
+        void shouldReturnTrue_whenForwardRequestUriMatchesPattern() {
+            when(request.getRequestURI()).thenReturn("/carlos/some/dispatcher");
+            when(request.getServletPath()).thenReturn("/some/dispatcher");
+            when(request.getAttribute("jakarta.servlet.forward.request_uri"))
+                    .thenReturn("/carlos/report/ViewReportindex");
+            when(request.getAttribute("jakarta.servlet.forward.servlet_path")).thenReturn(null);
+
+            assertThat(NavPath.requestPathMatches(request, "/report/")).isTrue();
+        }
+
+        @Test
         void shouldReturnTrue_whenAnyOfMultiplePatternsMatches() {
             when(request.getRequestURI()).thenReturn("/carlos/provider/providercontrol");
             when(request.getServletPath()).thenReturn("/provider/providercontrol");

--- a/src/test/java/io/github/carlos_emr/carlos/utility/NavPathUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/utility/NavPathUnitTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2026 CARLOS EMR Project. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.utility;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link NavPath}.
+ *
+ * @since 2026-05-27
+ */
+@DisplayName("NavPath")
+@Tag("unit")
+@ExtendWith(MockitoExtension.class)
+class NavPathUnitTest {
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Nested
+    @DisplayName("forwardAttribute")
+    class ForwardAttributeTests {
+
+        @Test
+        void shouldReturnValue_whenAttributeIsString() {
+            assertThat(NavPath.forwardAttribute("/tickler/ViewTicklerMain"))
+                    .isEqualTo("/tickler/ViewTicklerMain");
+        }
+
+        @Test
+        void shouldReturnEmpty_whenAttributeIsNull() {
+            assertThat(NavPath.forwardAttribute(null)).isEmpty();
+        }
+
+        @Test
+        void shouldReturnEmpty_whenAttributeIsNonStringType() {
+            assertThat(NavPath.forwardAttribute(Integer.valueOf(42))).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("pathMatches")
+    class PathMatchesTests {
+
+        @Test
+        void shouldReturnTrue_whenTrailingSlashPatternMatchesSegment() {
+            assertThat(NavPath.pathMatches("/tickler/ViewTicklerMain", "/tickler/")).isTrue();
+        }
+
+        @Test
+        void shouldReturnTrue_whenPatternMatchesWithQueryBoundary() {
+            assertThat(NavPath.pathMatches("/report/ViewReportindex?param=1", "/report/")).isTrue();
+        }
+
+        @Test
+        void shouldReturnTrue_whenPatternMatchesExactPath() {
+            assertThat(NavPath.pathMatches("/provider/providercontrol", "/provider/providercontrol")).isTrue();
+        }
+
+        @Test
+        void shouldReturnTrue_whenPatternMatchesWithSlashBoundary() {
+            assertThat(NavPath.pathMatches("/provider/appointmentprovideradmin/day", "/provider/appointmentprovideradmin")).isTrue();
+        }
+
+        @Test
+        void shouldReturnFalse_whenBoundaryCharIsHyphen() {
+            assertThat(NavPath.pathMatches("/administration-panel/", "/administration")).isFalse();
+        }
+
+        @Test
+        void shouldReturnTrue_whenLaterOccurrenceHasValidBoundary() {
+            assertThat(NavPath.pathMatches(
+                    "/prefix/administration-panel/redirect/administration?tab=users",
+                    "/administration")).isTrue();
+        }
+
+        @Test
+        void shouldReturnFalse_whenPathIsBlank() {
+            assertThat(NavPath.pathMatches("", "/tickler/")).isFalse();
+        }
+
+        @Test
+        void shouldReturnFalse_whenPatternIsBlank() {
+            assertThat(NavPath.pathMatches("/tickler/ViewTicklerMain", "")).isFalse();
+        }
+
+        @Test
+        void shouldReturnFalse_whenPatternNotInPath() {
+            assertThat(NavPath.pathMatches("/report/ViewReportindex", "/tickler/")).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("requestPathMatches")
+    class RequestPathMatchesTests {
+
+        @Test
+        void shouldReturnTrue_whenRequestUriMatchesPattern() {
+            when(request.getRequestURI()).thenReturn("/carlos/tickler/ViewTicklerMain");
+            when(request.getServletPath()).thenReturn("/tickler/ViewTicklerMain");
+            when(request.getAttribute("jakarta.servlet.forward.request_uri")).thenReturn(null);
+            when(request.getAttribute("jakarta.servlet.forward.servlet_path")).thenReturn(null);
+
+            assertThat(NavPath.requestPathMatches(request, "/tickler/")).isTrue();
+        }
+
+        @Test
+        void shouldReturnTrue_whenForwardServletPathMatchesPattern() {
+            when(request.getRequestURI()).thenReturn("/carlos/some/dispatcher");
+            when(request.getServletPath()).thenReturn("/some/dispatcher");
+            when(request.getAttribute("jakarta.servlet.forward.request_uri")).thenReturn(null);
+            when(request.getAttribute("jakarta.servlet.forward.servlet_path"))
+                    .thenReturn("/tickler/ViewTicklerMain");
+
+            assertThat(NavPath.requestPathMatches(request, "/tickler/")).isTrue();
+        }
+
+        @Test
+        void shouldReturnTrue_whenAnyOfMultiplePatternsMatches() {
+            when(request.getRequestURI()).thenReturn("/carlos/provider/providercontrol");
+            when(request.getServletPath()).thenReturn("/provider/providercontrol");
+            when(request.getAttribute("jakarta.servlet.forward.request_uri")).thenReturn(null);
+            when(request.getAttribute("jakarta.servlet.forward.servlet_path")).thenReturn(null);
+
+            assertThat(NavPath.requestPathMatches(request, "/tickler/", "/provider/providercontrol")).isTrue();
+        }
+
+        @Test
+        void shouldReturnFalse_whenNoPathMatchesAnyPattern() {
+            when(request.getRequestURI()).thenReturn("/carlos/report/ViewReportindex");
+            when(request.getServletPath()).thenReturn("/report/ViewReportindex");
+            when(request.getAttribute("jakarta.servlet.forward.request_uri")).thenReturn(null);
+            when(request.getAttribute("jakarta.servlet.forward.servlet_path")).thenReturn(null);
+
+            assertThat(NavPath.requestPathMatches(request, "/tickler/", "/messenger/")).isFalse();
+        }
+
+        @Test
+        void shouldHandleNullForwardAttributes_withoutException() {
+            when(request.getRequestURI()).thenReturn("/carlos/administration");
+            when(request.getServletPath()).thenReturn("/administration");
+            when(request.getAttribute("jakarta.servlet.forward.request_uri")).thenReturn(null);
+            when(request.getAttribute("jakarta.servlet.forward.servlet_path")).thenReturn(null);
+
+            assertThat(NavPath.requestPathMatches(request, "/administration")).isTrue();
+        }
+
+        @Test
+        void shouldHandleNonStringForwardAttribute_withoutException() {
+            when(request.getRequestURI()).thenReturn("/carlos/messenger/DisplayMessages");
+            when(request.getServletPath()).thenReturn("/messenger/DisplayMessages");
+            when(request.getAttribute("jakarta.servlet.forward.request_uri")).thenReturn(Integer.valueOf(1));
+            when(request.getAttribute("jakarta.servlet.forward.servlet_path")).thenReturn(null);
+
+            assertThat(NavPath.requestPathMatches(request, "/messenger/")).isTrue();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- mark the current CARLOS menu tab with a nav-active class based on the current request path
- style the active tab with the same blue background used by nav hover states
- keep alert/count text white while its tab is active so the active state is readable
- add regression coverage for active-tab markup and CSS

refs #2254

## Tests
- mvn -q -Dtest=ScheduleNavigationAssetRegressionTest test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Highlights the active CARLOS top-nav tab based on the current or forwarded path. Keeps Inbox highlighted when opened from Schedule and aligns styling/layout across the top nav, schedule header, and Inbox.

- New Features
  - Server-side active-tab detection for Schedule, Search, Inbox, Tickler, Messenger, Consultation, Documents, Reports, Admin, and eConsult; suppress Documents when Inbox is active.
  - Apply nav-active in `mainMenu.jsp` and the schedule header; route Inbox/Unclaimed to real URLs with `scheduleNav=1`; include the shared top nav and load `topnav.css` in Inbox when opened from Schedule.

- Refactors
  - Extract path matching to `io.github.carlos_emr.carlos.utility.NavPath`; update JSPs to `NavPath.requestPathMatches()` and add `NavPathUnitTest`, including coverage for forward request URI.
  - Normalize top-nav layout/styles: move logo/logout into the first menu cell; scope spacing/hover to direct children (`ul#navlist > li` and `> a`); unify active/hover/focus and `.nav-active` styles in `topnav.css` and receptionist schedule CSS; remove the legacy Resources menu.
  - Use `openScheduleSection`/`openScheduleMenuSection` for Inbox/menu actions with popup fallbacks; expand regression tests to lock in selector structure, nav-active behavior, Inbox/schedule integration, path-boundary cases, and forward-path handling.

<sup>Written for commit 421ec9a03b8ea2d7d6b25d579f2d66b0fc174e4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Highlight the active CARLOS top navigation tab based on the current or forwarded request path and align schedule, inbox, and receptionist views with consistent layout and styles.

New Features:
- Add server-side detection of active nav tabs for schedule, search, inbox, tickler, messenger, consultation, documents, reports, admin, and eConsult based on request and forward paths.
- Render the shared top navigation bar and styling within Inboxhub when opened in schedule navigation mode so the Inbox respects active-tab state.

Enhancements:
- Unify nav item layout and active/hover styling for the top navigation and receptionist schedule header, including updated logo/logout placement and scoped list item rules.
- Route Inbox and unclaimed lab links through real URLs in schedule views so active state and scheduleNav integration are preserved while still supporting popup behavior.
- Remove the legacy clinical resources menu entries from provider navigation to simplify the top nav.

Tests:
- Extend schedule navigation regression tests to cover active-tab markup and CSS contracts, Inboxhub scheduleNav integration, NavPath usage in JSPs, and receptionist/topnav styling.
- Introduce NavPath unit tests to validate boundary-aware path matching and handling of Jakarta forward attributes.