### PR TITLE
chore: suppress informational FindSecBugs taint-source/endpoint markers

### DIFF
--- a/.github/spotbugs/spotbugs-exclude.xml
+++ b/.github/spotbugs/spotbugs-exclude.xml
@@ -136,7 +136,19 @@
          as informational ("count"/"endpoint") detectors, not defects.
          ================================================================ -->
     <Match>
-        <Bug pattern="SERVLET_PARAMETER,STRUTS2_ENDPOINT,SPRING_ENDPOINT,JAXWS_ENDPOINT,JAXRS_ENDPOINT"/>
+        <Bug pattern="SERVLET_PARAMETER"/>
+    </Match>
+    <Match>
+        <Bug pattern="STRUTS2_ENDPOINT"/>
+    </Match>
+    <Match>
+        <Bug pattern="SPRING_ENDPOINT"/>
+    </Match>
+    <Match>
+        <Bug pattern="JAXWS_ENDPOINT"/>
+    </Match>
+    <Match>
+        <Bug pattern="JAXRS_ENDPOINT"/>
     </Match>
 
 </FindBugsFilter>

--- a/.github/spotbugs/spotbugs-exclude.xml
+++ b/.github/spotbugs/spotbugs-exclude.xml
@@ -136,7 +136,7 @@
          as informational ("count"/"endpoint") detectors, not defects.
          ================================================================ -->
     <Match>
-        <Bug patterns="SERVLET_PARAMETER,STRUTS2_ENDPOINT,SPRING_ENDPOINT,JAXWS_ENDPOINT,JAXRS_ENDPOINT"/>
+        <Bug pattern="SERVLET_PARAMETER,STRUTS2_ENDPOINT,SPRING_ENDPOINT,JAXWS_ENDPOINT,JAXRS_ENDPOINT"/>
     </Match>
 
 </FindBugsFilter>

--- a/.github/spotbugs/spotbugs-exclude.xml
+++ b/.github/spotbugs/spotbugs-exclude.xml
@@ -120,4 +120,32 @@
         <Method name="writeBody"/>
     </Match>
 
+    <!-- ================================================================
+         FIND SECURITY BUGS INFORMATIONAL TAINT-SOURCE / ENDPOINT MARKERS
+         These detectors are NOT vulnerabilities. Find Security Bugs emits
+         them to map attack surface: SERVLET_PARAMETER flags every point
+         where request data enters, and *_ENDPOINT flags every reachable
+         action/web-service method. On this codebase they account for the
+         large majority of "security" Code Scanning alerts (~1,300
+         SERVLET_PARAMETER, ~270 STRUTS2_ENDPOINT) while flagging zero
+         concrete sinks. They drown out actionable findings (injection,
+         path traversal, XSS, weak crypto), so we suppress the source/
+         endpoint markers and keep every sink detector active.
+
+         Reference: Find Security Bugs bug patterns — these are documented
+         as informational ("count"/"endpoint") detectors, not defects.
+         ================================================================ -->
+    <Match>
+        <Bug pattern="SERVLET_PARAMETER"/>
+    </Match>
+    <Match>
+        <Bug pattern="STRUTS2_ENDPOINT"/>
+    </Match>
+    <Match>
+        <Bug pattern="JAXWS_ENDPOINT"/>
+    </Match>
+    <Match>
+        <Bug pattern="JAXRS_ENDPOINT"/>
+    </Match>
+
 </FindBugsFilter>

--- a/.github/spotbugs/spotbugs-exclude.xml
+++ b/.github/spotbugs/spotbugs-exclude.xml
@@ -136,16 +136,7 @@
          as informational ("count"/"endpoint") detectors, not defects.
          ================================================================ -->
     <Match>
-        <Bug pattern="SERVLET_PARAMETER"/>
-    </Match>
-    <Match>
-        <Bug pattern="STRUTS2_ENDPOINT"/>
-    </Match>
-    <Match>
-        <Bug pattern="JAXWS_ENDPOINT"/>
-    </Match>
-    <Match>
-        <Bug pattern="JAXRS_ENDPOINT"/>
+        <Bug patterns="SERVLET_PARAMETER,STRUTS2_ENDPOINT,SPRING_ENDPOINT,JAXWS_ENDPOINT,JAXRS_ENDPOINT"/>
     </Match>
 
 </FindBugsFilter>


### PR DESCRIPTION
## Why

After #2236 limited Code Scanning uploads to security findings, **4,998 SpotBugs alerts remained open** (vs PMD which dropped to 1). Investigation of the live Code Scanning alerts shows **all 4,998 are `security`-tagged**, dominated by Find Security Bugs *informational* detectors:

| Rule | Open alerts | Nature |
|------|------:|--------|
| `CRLF_INJECTION_LOGS` | 1,996 | real (log forging) — **kept** |
| `SERVLET_PARAMETER` | 1,296 | **informational taint-source marker** |
| `PATH_TRAVERSAL_IN` | 438 | real — kept |
| `IMPROPER_UNICODE` | 364 | real — kept |
| `STRUTS2_ENDPOINT` | 273 | **informational endpoint marker** |
| `XSS_SERVLET` / `UNVALIDATED_REDIRECT` / `SQL_*` / `XXE_*` | ~400 | real — kept |

`SERVLET_PARAMETER` and the `*_ENDPOINT` detectors carry `category="SECURITY"`, so #2236's category filter (drops only non-SECURITY) cannot remove them. They mark *where untrusted data enters* / *which methods are reachable* — attack-surface info, not defects — and they bury the actionable sink findings.

## What

Exclude `SERVLET_PARAMETER`, `STRUTS2_ENDPOINT`, `SPRING_ENDPOINT`, `JAXWS_ENDPOINT`, and `JAXRS_ENDPOINT` in `.github/spotbugs/spotbugs-exclude.xml` (the `excludeFilterFile` wired at `pom.xml:1832`). This drops them at analysis time, before SARIF conversion — so they're never uploaded and GitHub closes them on the next `develop` SpotBugs run.

`SPRING_ENDPOINT` is retained intentionally as the same class of informational endpoint marker. It is expected to be a no-op for current production code because `spring-webmvc` is test-scope only and there are no production Spring MVC controllers, but keeping it here makes the endpoint-marker policy explicit and consistent.

The filter keeps separate `<Match>` blocks for readability and to avoid ambiguity around filter syntax. Every sink detector stays active (injection, path traversal, XSS, weak crypto, XXE, deserialization, hardcoded password, etc.).

## Effect

~**1,578** informational alerts close (4,998 → ~3,420 open SpotBugs). Real security findings are untouched.

## Not in scope (separate security decision)

`CRLF_INJECTION_LOGS` (~1,996) is the single largest chunk and a real (if high-false-positive) vulnerability class. Suppressing it wholesale would hide a genuine class in a PHI system, so it is intentionally left for a deliberate triage/fix/scoped-suppression decision rather than bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppress informational FindSecBugs taint-source and endpoint markers in SpotBugs to reduce noise and surface real security issues.

Exclude `SERVLET_PARAMETER`, `STRUTS2_ENDPOINT`, `SPRING_ENDPOINT`, `JAXWS_ENDPOINT`, and `JAXRS_ENDPOINT` in `.github/spotbugs/spotbugs-exclude.xml` at analysis time; sink detectors stay active; ~1,578 alerts close on the next run.

<sup>Written for commit f6b105795919d7d738ca1302535405c7d7b649b5. Summary will update on new commits. <a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2246?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

