### PR TITLE
chore: support Claude Code OAuth in devcontainer browser interceptor

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -41,14 +41,14 @@
         "13579": {
             "label": "Gemini OAuth Callback",
             "onAutoForward": "silent"
+        },
+        // Claude Code (`claude setup-token`, `claude /login`) binds a random
+        // high port for its OAuth callback. Scope silent auto-forwarding to
+        // that range so unrelated low ports still use VS Code's defaults.
+        "30000-65535": {
+            "label": "Claude Code OAuth Callback",
+            "onAutoForward": "silent"
         }
-    },
-    // Claude Code (`claude setup-token`, `claude /login`) binds a random high
-    // port for its OAuth callback. Without silent auto-forward, VS Code's
-    // default `notify` action delays the tunnel and the host browser hits
-    // `connection failed` on the post-sign-in redirect.
-    "otherPortsAttributes": {
-        "onAutoForward": "silent"
     },
     "containerUser": "root",
     "remoteUser": "root"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -43,6 +43,13 @@
             "onAutoForward": "silent"
         }
     },
+    // Claude Code (`claude setup-token`, `claude /login`) binds a random high
+    // port for its OAuth callback. Without silent auto-forward, VS Code's
+    // default `notify` action delays the tunnel and the host browser hits
+    // `connection failed` on the post-sign-in redirect.
+    "otherPortsAttributes": {
+        "onAutoForward": "silent"
+    },
     "containerUser": "root",
     "remoteUser": "root"
 }

--- a/.devcontainer/development/Dockerfile
+++ b/.devcontainer/development/Dockerfile
@@ -87,8 +87,8 @@ RUN curl -fsSL https://claude.ai/install.sh | bash \
 # Install Gemini CLI.
 # The gemini-browser script intercepts xdg-open so OAuth URLs from any CLI
 # (Gemini, Claude Code, etc.) display cleanly in the terminal for copy-paste
-# (containers can't open desktop browsers). See the script header for the
-# list of recognized OAuth providers and how callback ports are forwarded.
+# (containers can't open desktop browsers). See the script header for
+# details on OAuth handling and callback port forwarding.
 RUN npm install -g @google/gemini-cli \
     && ln -sf /scripts/gemini-browser /usr/local/bin/xdg-open
 

--- a/.devcontainer/development/Dockerfile
+++ b/.devcontainer/development/Dockerfile
@@ -85,8 +85,10 @@ RUN curl -fsSL https://claude.ai/install.sh | bash \
     && which npm && npm install -g @docusaurus/core @docusaurus/preset-classic
 
 # Install Gemini CLI.
-# The gemini-browser script intercepts xdg-open so OAuth URLs display cleanly
-# in the terminal for copy-paste (containers can't open desktop browsers).
+# The gemini-browser script intercepts xdg-open so OAuth URLs from any CLI
+# (Gemini, Claude Code, etc.) display cleanly in the terminal for copy-paste
+# (containers can't open desktop browsers). See the script header for the
+# list of recognized OAuth providers and how callback ports are forwarded.
 RUN npm install -g @google/gemini-cli \
     && ln -sf /scripts/gemini-browser /usr/local/bin/xdg-open
 

--- a/.devcontainer/development/config/bashrc
+++ b/.devcontainer/development/config/bashrc
@@ -91,9 +91,11 @@ export EDITOR=nano
 export JAVA_HOME=/opt/java/openjdk
 export MAVEN_OPTS="-Xmx4G -Xms1G"
 
-# Override VS Code's BROWSER helper for Gemini CLI OAuth
+# Override VS Code's BROWSER helper for CLI OAuth flows (Gemini, Claude Code, ...)
 # VS Code's browser.sh fails to open OAuth URLs correctly from containers.
-# This script captures the URL and prints it for manual copy-paste.
+# This script captures the URL and prints it for manual copy-paste, then
+# relies on VS Code's port auto-forwarding for the localhost:<port>/callback
+# redirect after sign-in.
 export BROWSER=/scripts/gemini-browser
 
 # Add workspace and Go bin to PATH for custom scripts and Go tools

--- a/.devcontainer/development/scripts/gemini-browser
+++ b/.devcontainer/development/scripts/gemini-browser
@@ -9,9 +9,9 @@
 # intercepts those calls.
 #
 # For recognized OAuth providers we print the URL for copy-paste on the host.
-# The host browser then redirects back to http://localhost:PORT/callback after
+# The host browser then redirects back to a localhost callback URL after
 # sign-in; VS Code Remote-Containers auto-forwards that listening port back
-# into the container (see otherPortsAttributes in devcontainer.json).
+# into the container (see portsAttributes in devcontainer.json).
 #
 # For non-OAuth URLs we attempt VS Code's browser helper as a fallback.
 
@@ -24,37 +24,56 @@ fi
 print_oauth_banner() {
     local provider="$1"
     local extra_note="$2"
+    local redirect_note="$3"
+    local provider_file="$4"
 
     echo "" >&2
     echo "==========================================================" >&2
     echo "  ${provider} OAuth - Copy this URL to your desktop browser:" >&2
     echo "==========================================================" >&2
     echo "" >&2
-    echo "$URL" >&2
+    printf "%s\n" "$URL" >&2
     echo "" >&2
     echo "==========================================================" >&2
     if [ -n "$extra_note" ]; then
         echo "  $extra_note" >&2
     fi
-    echo "  After signing in, the browser will redirect to a" >&2
-    echo "  localhost:<port>/callback URL. VS Code Remote-Containers" >&2
+    echo "  After signing in, the browser will redirect to:" >&2
+    echo "  $redirect_note" >&2
     echo "  auto-forwards that port back into the container." >&2
     echo "" >&2
     echo "  URL also saved to: $HOME/oauth_auth_url.txt" >&2
+    if [ -n "$provider_file" ]; then
+        echo "                 and: $provider_file" >&2
+    fi
     echo "==========================================================" >&2
     echo "" >&2
 }
 
-# Persist the URL so it survives terminal scrollback regardless of provider.
-echo "$URL" > "$HOME/oauth_auth_url.txt"
+save_oauth_url() {
+    local provider_file="$1"
+    local old_umask
+
+    old_umask=$(umask)
+    umask 077
+    printf "%s\n" "$URL" > "$HOME/oauth_auth_url.txt"
+    chmod 600 "$HOME/oauth_auth_url.txt"
+    if [ -n "$provider_file" ]; then
+        printf "%s\n" "$URL" > "$provider_file"
+        chmod 600 "$provider_file"
+    fi
+    umask "$old_umask"
+}
 
 case "$URL" in
     *accounts.google.com/o/oauth2*|*accounts.google.com/signin*)
         # Gemini auth uses a fixed callback port via OAUTH_CALLBACK_PORT,
         # which is set in docker-compose.yml and forwarded explicitly.
-        cp "$HOME/oauth_auth_url.txt" "$HOME/gemini_auth_url.txt"
+        save_oauth_url "$HOME/gemini_auth_url.txt"
         print_oauth_banner "GEMINI" \
-            "Callback port pinned to ${OAUTH_CALLBACK_PORT:-13579} (explicit forwardPort)."
+            "Callback port pinned to ${OAUTH_CALLBACK_PORT:-13579} (explicit forwardPort)." \
+            "localhost:${OAUTH_CALLBACK_PORT:-13579} callback URL. VS Code Remote-Containers" \
+            "$HOME/gemini_auth_url.txt"
         exit 0
         ;;
     *console.anthropic.com/*|*claude.ai/oauth*|*claude.ai/login*|*claude.com/oauth*)
@@ -62,9 +81,11 @@ case "$URL" in
         # high port for its OAuth callback. VS Code's port auto-forwarding
         # picks it up once the CLI starts listening; sign-in takes long
         # enough that the forward is established before the redirect.
-        cp "$HOME/oauth_auth_url.txt" "$HOME/claude_auth_url.txt"
+        save_oauth_url "$HOME/claude_auth_url.txt"
         print_oauth_banner "CLAUDE CODE" \
-            "Callback port is chosen dynamically by the CLI."
+            "Callback port is chosen dynamically by the CLI." \
+            "localhost:<port>/callback URL. VS Code Remote-Containers" \
+            "$HOME/claude_auth_url.txt"
         exit 0
         ;;
     *)
@@ -74,7 +95,7 @@ case "$URL" in
             exec "$VSCODE_BROWSER" "$URL"
         fi
         # Fallback: just print it
-        echo "Open in browser: $URL" >&2
+        printf "Open in browser: %s\n" "$URL" >&2
         exit 0
         ;;
 esac

--- a/.devcontainer/development/scripts/gemini-browser
+++ b/.devcontainer/development/scripts/gemini-browser
@@ -1,12 +1,19 @@
 #!/bin/bash
-# gemini-browser - Captures OAuth URLs for Gemini CLI in devcontainer environments
+# gemini-browser - Captures OAuth URLs for CLI tools in devcontainer environments.
 #
-# Gemini CLI uses the 'open' npm package which calls xdg-open on Linux,
-# ignoring the $BROWSER env var. We install this as both /scripts/gemini-browser
-# AND symlinked as /usr/local/bin/xdg-open to intercept those calls.
+# Despite the historical name, this script handles OAuth flows for multiple
+# CLI tools (Gemini, Claude Code, etc.). CLIs running inside a devcontainer
+# typically call the 'open' npm package or xdg-open to launch a browser, which
+# can't reach the host's desktop browser. We install this script as both
+# /scripts/gemini-browser AND symlinked as /usr/local/bin/xdg-open so it
+# intercepts those calls.
 #
-# When the URL is a Google OAuth URL, it prints it cleanly for copy-paste.
-# For non-OAuth URLs, it attempts VS Code's browser helper as fallback.
+# For recognized OAuth providers we print the URL for copy-paste on the host.
+# The host browser then redirects back to http://localhost:PORT/callback after
+# sign-in; VS Code Remote-Containers auto-forwards that listening port back
+# into the container (see otherPortsAttributes in devcontainer.json).
+#
+# For non-OAuth URLs we attempt VS Code's browser helper as a fallback.
 
 URL="$1"
 
@@ -14,27 +21,50 @@ if [ -z "$URL" ]; then
     exit 0
 fi
 
-# Check if this is a Google OAuth URL (Gemini auth flow)
+print_oauth_banner() {
+    local provider="$1"
+    local extra_note="$2"
+
+    echo "" >&2
+    echo "==========================================================" >&2
+    echo "  ${provider} OAuth - Copy this URL to your desktop browser:" >&2
+    echo "==========================================================" >&2
+    echo "" >&2
+    echo "$URL" >&2
+    echo "" >&2
+    echo "==========================================================" >&2
+    if [ -n "$extra_note" ]; then
+        echo "  $extra_note" >&2
+    fi
+    echo "  After signing in, the browser will redirect to a" >&2
+    echo "  localhost:<port>/callback URL. VS Code Remote-Containers" >&2
+    echo "  auto-forwards that port back into the container." >&2
+    echo "" >&2
+    echo "  URL also saved to: $HOME/oauth_auth_url.txt" >&2
+    echo "==========================================================" >&2
+    echo "" >&2
+}
+
+# Persist the URL so it survives terminal scrollback regardless of provider.
+echo "$URL" > "$HOME/oauth_auth_url.txt"
+
 case "$URL" in
     *accounts.google.com/o/oauth2*|*accounts.google.com/signin*)
-        # Log to file for retrieval if terminal scrolls
-        echo "$URL" > "$HOME/gemini_auth_url.txt"
-
-        echo "" >&2
-        echo "==========================================================" >&2
-        echo "  GEMINI OAuth - Copy this URL to your desktop browser:" >&2
-        echo "==========================================================" >&2
-        echo "" >&2
-        echo "$URL" >&2
-        echo "" >&2
-        echo "==========================================================" >&2
-        echo "  After signing in, the browser redirects to" >&2
-        echo "  localhost:${OAUTH_CALLBACK_PORT:-13579} which VS Code" >&2
-        echo "  forwards back to this container automatically." >&2
-        echo "" >&2
-        echo "  URL also saved to: ~/gemini_auth_url.txt" >&2
-        echo "==========================================================" >&2
-        echo "" >&2
+        # Gemini auth uses a fixed callback port via OAUTH_CALLBACK_PORT,
+        # which is set in docker-compose.yml and forwarded explicitly.
+        cp "$HOME/oauth_auth_url.txt" "$HOME/gemini_auth_url.txt"
+        print_oauth_banner "GEMINI" \
+            "Callback port pinned to ${OAUTH_CALLBACK_PORT:-13579} (explicit forwardPort)."
+        exit 0
+        ;;
+    *console.anthropic.com/*|*claude.ai/oauth*|*claude.ai/login*|*claude.com/oauth*)
+        # Claude Code (`claude setup-token`, `claude /login`) binds a random
+        # high port for its OAuth callback. VS Code's port auto-forwarding
+        # picks it up once the CLI starts listening; sign-in takes long
+        # enough that the forward is established before the redirect.
+        cp "$HOME/oauth_auth_url.txt" "$HOME/claude_auth_url.txt"
+        print_oauth_banner "CLAUDE CODE" \
+            "Callback port is chosen dynamically by the CLI."
         exit 0
         ;;
     *)


### PR DESCRIPTION
## Why

The devcontainer's `gemini-browser` script (symlinked as `xdg-open`) only recognized Google/Gemini OAuth URLs. Claude Code's `claude setup-token` / `claude /login` URLs fell through to the VS Code browser fallback, which can't reach the host desktop browser from inside the container — so the login URL never surfaced cleanly for copy-paste, and the post-sign-in `localhost:<port>/callback` redirect wasn't forwarded.

## What

- **`scripts/gemini-browser`**: generalized from Gemini-only to a multi-provider OAuth interceptor. Added a `console.anthropic.com` / `claude.ai/oauth` / `claude.com/oauth` case that prints a copy-paste banner. URL is now persisted provider-agnostically (`oauth_auth_url.txt`) with per-provider copies retained for compatibility.
- **`devcontainer.json`**: `otherPortsAttributes.onAutoForward = silent` so the random high callback port Claude Code binds is auto-forwarded without the `notify` delay that caused `connection failed` on the redirect.
- **`Dockerfile` / `bashrc`**: comments updated to reflect the script is no longer Gemini-specific.

Gemini's existing fixed-port (`OAUTH_CALLBACK_PORT`) flow is unchanged.

## Scope

Devcontainer tooling only — no application/runtime code. Split out of the perf branch (#1832) since it's unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Claude Code OAuth support to the devcontainer `xdg-open` interceptor so login URLs show in the terminal and `localhost:<port>/callback` redirects work. Generalizes the Gemini-only script into a multi-provider OAuth handler, tightens URL file permissions, and scopes silent auto-forwarding to the high port range Claude Code uses.

- **Bug Fixes**
  - `scripts/gemini-browser`: detect `console.anthropic.com`, `claude.ai/oauth`, `claude.ai/login`, and `claude.com/oauth`; print a copy-paste banner; persist URL to `$HOME/oauth_auth_url.txt` (plus provider files) with 0600 permissions; improve messages and fallback output.
  - `devcontainer.json`: set `"otherPortsAttributes"` for `"30000-65535"` to `silent` with a "Claude Code OAuth Callback" label to auto-forward dynamic callback ports only.
  - `Dockerfile` and `bashrc`: update comments to reflect multi-provider OAuth interception and callback forwarding.

<sup>Written for commit 547d457b5c00c5ce42c78d2b692a8161ae3499b3. Summary will update on new commits. <a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2247?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

