### PR TITLE
Model path validation for scanners

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -9,21 +9,6 @@
 
 name: "CARLOS EMR CodeQL Configuration"
 
-# Custom CodeQL model packs for CARLOS-specific sanitizers.
-#
-# carlos-java-models registers PathValidationUtils, LogSanitizer callers, and
-# OWASP Encoder methods as explicit summaryModel / neutralModel entries so
-# CodeQL recognises them as sanitizers and does not raise false positives on
-# code paths that pass through them.
-#
-# Pack location: .github/codeql/extensions/carlos-java-models/
-#
-# Note: local pack references may require CodeQL advanced setup. If GitHub's
-# default setup silently ignores this entry, convert to advanced setup with a
-# workflow that passes this config via github/codeql-action/init's config-file.
-packs:
-  - carlos-emr/carlos-java-models
-
 # Exclude bundled third-party JavaScript libraries from JavaScript/TypeScript analysis.
 #
 # These directories contain unmodified copies of external libraries (Bootstrap,

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -9,6 +9,21 @@
 
 name: "CARLOS EMR CodeQL Configuration"
 
+# Custom CodeQL model packs for CARLOS-specific sanitizers.
+#
+# carlos-java-models registers PathValidationUtils, LogSanitizer callers, and
+# OWASP Encoder methods as explicit summaryModel / neutralModel entries so
+# CodeQL recognises them as sanitizers and does not raise false positives on
+# code paths that pass through them.
+#
+# Pack location: .github/codeql/extensions/carlos-java-models/
+#
+# Note: local pack references may require CodeQL advanced setup. If GitHub's
+# default setup silently ignores this entry, convert to advanced setup with a
+# workflow that passes this config via github/codeql-action/init's config-file.
+packs:
+  - carlos-emr/carlos-java-models
+
 # Exclude bundled third-party JavaScript libraries from JavaScript/TypeScript analysis.
 #
 # These directories contain unmodified copies of external libraries (Bootstrap,

--- a/.github/codeql/extensions/carlos-java-models/models/path-validation-sanitizers.yml
+++ b/.github/codeql/extensions/carlos-java-models/models/path-validation-sanitizers.yml
@@ -105,9 +105,9 @@ extensions:
       # Guard predicate only; returns boolean with no relevant taint-flow to callers.
       - ["io.github.carlos_emr.carlos.utility", "PathValidationUtils", "isInAllowedTempDirectory", "(java.io.File)", "summary", "manual"]
 
-      # Filename-only validators return safe path components and throw on null,
-      # hidden, or path-like inputs. They do not preserve user-controlled path
-      # taint for path traversal analysis.
+      # Filename-only validators return safe path components and reject or strip
+      # unsafe path input. They do not preserve user-controlled path taint for
+      # path traversal analysis.
       - ["io.github.carlos_emr.carlos.utility", "PathValidationUtils", "validateFileName", "(java.lang.String)", "summary", "manual"]
       - ["io.github.carlos_emr.carlos.utility", "PathValidationUtils", "validateStrictFileName", "(java.lang.String)", "summary", "manual"]
       - ["io.github.carlos_emr.carlos.utility", "PathValidationUtils", "validateGeneratedFileName", "(java.lang.String)", "summary", "manual"]

--- a/.github/codeql/extensions/carlos-java-models/models/path-validation-sanitizers.yml
+++ b/.github/codeql/extensions/carlos-java-models/models/path-validation-sanitizers.yml
@@ -35,6 +35,12 @@ extensions:
       # flow source so that taint from it is cut off at the sanitizer boundary.
       - ["io.github.carlos_emr.carlos.utility", "PathValidationUtils", false, "validatePath", "(java.lang.String,java.io.File)", "", "Argument[1]", "ReturnValue", "taint", "manual"]
 
+      # validateUserFilePath(String userFilename, File allowedDir) -> File
+      # Applies legacy filename normalization and validates the resulting path is
+      # within allowedDir. Like validatePath, the return value is bounded by
+      # allowedDir (Argument[1]); the user-provided filename is sanitized.
+      - ["io.github.carlos_emr.carlos.utility", "PathValidationUtils", false, "validateUserFilePath", "(java.lang.String,java.io.File)", "", "Argument[1]", "ReturnValue", "taint", "manual"]
+
       # validateExistingPath(File file, File allowedDir) -> File
       # Validates that file is within allowedDir and returns it. The return value
       # is guaranteed to be within allowedDir (Argument[1]); modelling only that
@@ -98,6 +104,13 @@ extensions:
       # isInAllowedTempDirectory(File file) -> boolean
       # Guard predicate only; returns boolean with no relevant taint-flow to callers.
       - ["io.github.carlos_emr.carlos.utility", "PathValidationUtils", "isInAllowedTempDirectory", "(java.io.File)", "summary", "manual"]
+
+      # Filename-only validators return safe path components and throw on null,
+      # hidden, or path-like inputs. They do not preserve user-controlled path
+      # taint for path traversal analysis.
+      - ["io.github.carlos_emr.carlos.utility", "PathValidationUtils", "validateFileName", "(java.lang.String)", "summary", "manual"]
+      - ["io.github.carlos_emr.carlos.utility", "PathValidationUtils", "validateStrictFileName", "(java.lang.String)", "summary", "manual"]
+      - ["io.github.carlos_emr.carlos.utility", "PathValidationUtils", "validateGeneratedFileName", "(java.lang.String)", "summary", "manual"]
 
       # FaxManagerImpl.validateFilePath(String) -> void
       # Guard method that validates and throws on failure. No taint flows through.

--- a/.github/codeql/extensions/carlos-java-models/models/path-validation-sanitizers.yml
+++ b/.github/codeql/extensions/carlos-java-models/models/path-validation-sanitizers.yml
@@ -105,13 +105,6 @@ extensions:
       # Guard predicate only; returns boolean with no relevant taint-flow to callers.
       - ["io.github.carlos_emr.carlos.utility", "PathValidationUtils", "isInAllowedTempDirectory", "(java.io.File)", "summary", "manual"]
 
-      # Filename-only validators return safe path components and reject or strip
-      # unsafe path input. They do not preserve user-controlled path taint for
-      # path traversal analysis.
-      - ["io.github.carlos_emr.carlos.utility", "PathValidationUtils", "validateFileName", "(java.lang.String)", "summary", "manual"]
-      - ["io.github.carlos_emr.carlos.utility", "PathValidationUtils", "validateStrictFileName", "(java.lang.String)", "summary", "manual"]
-      - ["io.github.carlos_emr.carlos.utility", "PathValidationUtils", "validateGeneratedFileName", "(java.lang.String)", "summary", "manual"]
-
       # FaxManagerImpl.validateFilePath(String) -> void
       # Guard method that validates and throws on failure. No taint flows through.
       - ["io.github.carlos_emr.carlos.managers", "FaxManagerImpl", "validateFilePath", "(java.lang.String)", "summary", "manual"]

--- a/.github/codeql/extensions/carlos-java-models/qlpack.yml
+++ b/.github/codeql/extensions/carlos-java-models/qlpack.yml
@@ -3,3 +3,5 @@ version: 1.0.0
 library: true
 extensionTargets:
   codeql/java-all: "*"
+dataExtensions:
+  - models/**/*.yml

--- a/.github/spotbugs/spotbugs-exclude.xml
+++ b/.github/spotbugs/spotbugs-exclude.xml
@@ -155,7 +155,7 @@
     <!-- Teleplan send files are resolved under HOME_DIR with PathValidationUtils.validatePath(). -->
     <Match>
         <Bug pattern="PATH_TRAVERSAL_IN"/>
-        <Class name="io.github.carlos_emr.carlos.billings.ca.bc.pageUtil.ManageTeleplan2Action"/>
+        <Class name="io.github.carlos_emr.carlos.billing.CA.BC.pageUtil.ManageTeleplan2Action"/>
         <Method name="sendFile"/>
     </Match>
 

--- a/.github/spotbugs/spotbugs-exclude.xml
+++ b/.github/spotbugs/spotbugs-exclude.xml
@@ -131,7 +131,7 @@
     <!-- Teleplan response files are bounded by DOCUMENT_DIR or an allowed temp directory before reading. -->
     <Match>
         <Bug pattern="PATH_TRAVERSAL_IN"/>
-        <Class name="io.github.carlos_emr.carlos.billing.CA.BC.Teleplan.TeleplanCodesManager"/>
+        <Class name="io.github.carlos_emr.carlos.billings.ca.bc.Teleplan.TeleplanCodesManager"/>
         <Method name="parse"/>
     </Match>
 

--- a/.github/spotbugs/spotbugs-exclude.xml
+++ b/.github/spotbugs/spotbugs-exclude.xml
@@ -162,7 +162,7 @@
     <!-- Ontario RA imports validate the selected file under DOCUMENT_DIR before parsing. -->
     <Match>
         <Bug pattern="PATH_TRAVERSAL_IN"/>
-        <Class name="io.github.carlos_emr.carlos.billings.ca.on.service.BillingOnRaService"/>
+        <Class name="io.github.carlos_emr.carlos.billing.CA.ON.service.BillingOnRaService"/>
         <Method name="importRAFile"/>
     </Match>
 

--- a/.github/spotbugs/spotbugs-exclude.xml
+++ b/.github/spotbugs/spotbugs-exclude.xml
@@ -138,31 +138,31 @@
     <!-- Teleplan explanatory/ICD response files are validated before FileReader opens them. -->
     <Match>
         <Bug pattern="PATH_TRAVERSAL_IN"/>
-        <Class name="io.github.carlos_emr.carlos.billing.CA.BC.pageUtil.ManageTeleplan2Action"/>
+        <Class name="io.github.carlos_emr.carlos.billings.ca.bc.pageUtil.ManageTeleplan2Action"/>
         <Method name="updateteleplanICDCodesList"/>
     </Match>
     <Match>
         <Bug pattern="PATH_TRAVERSAL_IN"/>
-        <Class name="io.github.carlos_emr.carlos.billing.CA.BC.pageUtil.ManageTeleplan2Action"/>
+        <Class name="io.github.carlos_emr.carlos.billings.ca.bc.pageUtil.ManageTeleplan2Action"/>
         <Method name="updateExplanatoryCodesList"/>
     </Match>
     <Match>
         <Bug pattern="PATH_TRAVERSAL_IN"/>
-        <Class name="io.github.carlos_emr.carlos.billing.CA.BC.pageUtil.ManageTeleplan2Action"/>
+        <Class name="io.github.carlos_emr.carlos.billings.ca.bc.pageUtil.ManageTeleplan2Action"/>
         <Method name="checkElig"/>
     </Match>
 
     <!-- Teleplan send files are resolved under HOME_DIR with PathValidationUtils.validatePath(). -->
     <Match>
         <Bug pattern="PATH_TRAVERSAL_IN"/>
-        <Class name="io.github.carlos_emr.carlos.billing.CA.BC.pageUtil.ManageTeleplan2Action"/>
+        <Class name="io.github.carlos_emr.carlos.billings.ca.bc.pageUtil.ManageTeleplan2Action"/>
         <Method name="sendFile"/>
     </Match>
 
     <!-- Ontario RA imports validate the selected file under DOCUMENT_DIR before parsing. -->
     <Match>
         <Bug pattern="PATH_TRAVERSAL_IN"/>
-        <Class name="io.github.carlos_emr.carlos.billing.CA.ON.service.BillingOnRaService"/>
+        <Class name="io.github.carlos_emr.carlos.billings.ca.on.service.BillingOnRaService"/>
         <Method name="importRAFile"/>
     </Match>
 
@@ -170,7 +170,9 @@
     <Match>
         <Bug pattern="PATH_TRAVERSAL_IN"/>
         <Class name="io.github.carlos_emr.carlos.util.GenericDownload"/>
-        <Method name="transferFile"/>
+        <Method name="transferFile"
+                params="jakarta.servlet.http.HttpServletResponse,jakarta.servlet.ServletOutputStream,java.lang.String,java.lang.String,java.lang.String"
+                returns="void"/>
     </Match>
 
     <!-- Document manager file creation/lookup is bounded by DOCUMENT_DIR via PathValidationUtils. -->

--- a/.github/spotbugs/spotbugs-exclude.xml
+++ b/.github/spotbugs/spotbugs-exclude.xml
@@ -143,7 +143,7 @@
     </Match>
     <Match>
         <Bug pattern="PATH_TRAVERSAL_IN"/>
-        <Class name="io.github.carlos_emr.carlos.billings.ca.bc.pageUtil.ManageTeleplan2Action"/>
+        <Class name="io.github.carlos_emr.carlos.billing.CA.BC.pageUtil.ManageTeleplan2Action"/>
         <Method name="updateExplanatoryCodesList"/>
     </Match>
     <Match>

--- a/.github/spotbugs/spotbugs-exclude.xml
+++ b/.github/spotbugs/spotbugs-exclude.xml
@@ -121,6 +121,78 @@
     </Match>
 
     <!-- ================================================================
+         FIND SECURITY BUGS PATH TRAVERSAL FALSE POSITIVES
+         These are exact method-level suppressions for reviewed file paths
+         where the flagged sink receives a File that has already passed
+         PathValidationUtils or equivalent canonical containment checks.
+         Do not broaden these to package/class-level PATH_TRAVERSAL rules.
+         ================================================================ -->
+
+    <!-- Teleplan response files are bounded by DOCUMENT_DIR or an allowed temp directory before reading. -->
+    <Match>
+        <Bug pattern="PATH_TRAVERSAL_IN"/>
+        <Class name="io.github.carlos_emr.carlos.billings.ca.bc.Teleplan.TeleplanCodesManager"/>
+        <Method name="parse"/>
+    </Match>
+
+    <!-- Teleplan explanatory/ICD response files are validated before FileReader opens them. -->
+    <Match>
+        <Bug pattern="PATH_TRAVERSAL_IN"/>
+        <Class name="io.github.carlos_emr.carlos.billings.ca.bc.pageUtil.ManageTeleplan2Action"/>
+        <Method name="updateteleplanICDCodesList"/>
+    </Match>
+    <Match>
+        <Bug pattern="PATH_TRAVERSAL_IN"/>
+        <Class name="io.github.carlos_emr.carlos.billings.ca.bc.pageUtil.ManageTeleplan2Action"/>
+        <Method name="updateExplanatoryCodesList"/>
+    </Match>
+    <Match>
+        <Bug pattern="PATH_TRAVERSAL_IN"/>
+        <Class name="io.github.carlos_emr.carlos.billings.ca.bc.pageUtil.ManageTeleplan2Action"/>
+        <Method name="checkElig"/>
+    </Match>
+
+    <!-- Teleplan send files are resolved under HOME_DIR with PathValidationUtils.validatePath(). -->
+    <Match>
+        <Bug pattern="PATH_TRAVERSAL_IN"/>
+        <Class name="io.github.carlos_emr.carlos.billings.ca.bc.pageUtil.ManageTeleplan2Action"/>
+        <Method name="sendFile"/>
+    </Match>
+
+    <!-- Ontario RA imports validate the selected file under DOCUMENT_DIR before parsing. -->
+    <Match>
+        <Bug pattern="PATH_TRAVERSAL_IN"/>
+        <Class name="io.github.carlos_emr.carlos.billings.ca.on.service.BillingOnRaService"/>
+        <Method name="importRAFile"/>
+    </Match>
+
+    <!-- Generic downloads canonicalize the directory and validate the filename before FileInputStream. -->
+    <Match>
+        <Bug pattern="PATH_TRAVERSAL_IN"/>
+        <Class name="io.github.carlos_emr.carlos.util.GenericDownload"/>
+        <Method name="transferFile"/>
+    </Match>
+
+    <!-- Document manager file creation/lookup is bounded by DOCUMENT_DIR via PathValidationUtils. -->
+    <Match>
+        <Bug pattern="PATH_TRAVERSAL_IN"/>
+        <Class name="io.github.carlos_emr.carlos.managers.DocumentManagerImpl"/>
+        <Method name="createDocument"/>
+    </Match>
+    <Match>
+        <Bug pattern="PATH_TRAVERSAL_IN"/>
+        <Class name="io.github.carlos_emr.carlos.managers.DocumentManagerImpl"/>
+        <Method name="getFullPathToDocument"/>
+    </Match>
+
+    <!-- Uploaded image temp files are accepted only after PathValidationUtils.validateUpload(). -->
+    <Match>
+        <Bug pattern="PATH_TRAVERSAL_IN"/>
+        <Class name="io.github.carlos_emr.carlos.eform.upload.ImageUpload2Action"/>
+        <Method name="withUploadedFiles"/>
+    </Match>
+
+    <!-- ================================================================
          FIND SECURITY BUGS INFORMATIONAL TAINT-SOURCE / ENDPOINT MARKERS
          These detectors are NOT vulnerabilities. Find Security Bugs emits
          them to map attack surface: SERVLET_PARAMETER flags every point

--- a/.github/spotbugs/spotbugs-exclude.xml
+++ b/.github/spotbugs/spotbugs-exclude.xml
@@ -138,7 +138,7 @@
     <!-- Teleplan explanatory/ICD response files are validated before FileReader opens them. -->
     <Match>
         <Bug pattern="PATH_TRAVERSAL_IN"/>
-        <Class name="io.github.carlos_emr.carlos.billings.ca.bc.pageUtil.ManageTeleplan2Action"/>
+        <Class name="io.github.carlos_emr.carlos.billing.CA.BC.pageUtil.ManageTeleplan2Action"/>
         <Method name="updateteleplanICDCodesList"/>
     </Match>
     <Match>

--- a/.github/spotbugs/spotbugs-exclude.xml
+++ b/.github/spotbugs/spotbugs-exclude.xml
@@ -148,7 +148,7 @@
     </Match>
     <Match>
         <Bug pattern="PATH_TRAVERSAL_IN"/>
-        <Class name="io.github.carlos_emr.carlos.billings.ca.bc.pageUtil.ManageTeleplan2Action"/>
+        <Class name="io.github.carlos_emr.carlos.billing.CA.BC.pageUtil.ManageTeleplan2Action"/>
         <Method name="checkElig"/>
     </Match>
 

--- a/.github/spotbugs/spotbugs-exclude.xml
+++ b/.github/spotbugs/spotbugs-exclude.xml
@@ -131,7 +131,7 @@
     <!-- Teleplan response files are bounded by DOCUMENT_DIR or an allowed temp directory before reading. -->
     <Match>
         <Bug pattern="PATH_TRAVERSAL_IN"/>
-        <Class name="io.github.carlos_emr.carlos.billings.ca.bc.Teleplan.TeleplanCodesManager"/>
+        <Class name="io.github.carlos_emr.carlos.billing.CA.BC.Teleplan.TeleplanCodesManager"/>
         <Method name="parse"/>
     </Match>
 

--- a/src/test/java/io/github/carlos_emr/carlos/PMmodule/dao/ProviderDaoCacheIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/PMmodule/dao/ProviderDaoCacheIntegrationTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.CacheManager;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -41,7 +42,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -61,6 +62,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Tag("dao")
 @Tag("cache")
 @Transactional(propagation = Propagation.NOT_SUPPORTED)
+@Isolated
 class ProviderDaoCacheIntegrationTest extends CarlosTestBase {
 
     @Autowired
@@ -76,12 +78,16 @@ class ProviderDaoCacheIntegrationTest extends CarlosTestBase {
     private PlatformTransactionManager transactionManager;
 
     private final List<String> providerNosToCleanUp = new ArrayList<>();
+    private final AtomicInteger providerNoSequence = new AtomicInteger();
     private TransactionTemplate transactionTemplate;
+    private String uniquePrefix;
 
     @BeforeEach
     void setUpTransactionsAndCaches() {
         transactionTemplate = new TransactionTemplate(transactionManager);
         transactionTemplate.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        uniquePrefix = "C" + Long.toString(System.nanoTime(), 36);
+        uniquePrefix = uniquePrefix.substring(Math.max(0, uniquePrefix.length() - 4));
         clearProviderCaches();
     }
 
@@ -220,6 +226,6 @@ class ProviderDaoCacheIntegrationTest extends CarlosTestBase {
     }
 
     private String newProviderNo() {
-        return String.format("C%05d", ThreadLocalRandom.current().nextInt(10000, 100000));
+        return String.format("%s%02d", uniquePrefix, providerNoSequence.incrementAndGet());
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/PMmodule/dao/VacancyDaoIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/PMmodule/dao/VacancyDaoIntegrationTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Comparator;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -199,10 +200,13 @@ public class VacancyDaoIntegrationTest extends CarlosTestBase {
         vacancy5.setStatus(status1);
         dao.persist(vacancy5);
 
-        List<Vacancy> result = dao.getVacanciesByWlProgramId(wlProgramId1);
+        List<Vacancy> result = dao.getVacanciesByWlProgramIdAndStatus(wlProgramId1, status1);
 
         assertThat(result).hasSize(3);
-        assertThat(result).containsExactly(vacancy1, vacancy3, vacancy5);
+        assertThat(result).containsExactlyElementsOf(
+                List.of(vacancy1, vacancy3, vacancy5).stream()
+                        .sorted(Comparator.comparing(Vacancy::getName))
+                        .toList());
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/PMmodule/dao/VacancyDaoIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/PMmodule/dao/VacancyDaoIntegrationTest.java
@@ -174,30 +174,35 @@ public class VacancyDaoIntegrationTest extends CarlosTestBase {
         EntityDataGenerator.generateTestDataForModelClass(vacancy1);
         vacancy1.setWlProgramId(wlProgramId1);
         vacancy1.setStatus(status1);
+        vacancy1.setName("alpha");
         dao.persist(vacancy1);
 
         Vacancy vacancy2 = new Vacancy();
         EntityDataGenerator.generateTestDataForModelClass(vacancy2);
         vacancy2.setWlProgramId(wlProgramId2);
         vacancy2.setStatus(status2);
+        vacancy2.setName("bravo");
         dao.persist(vacancy2);
 
         Vacancy vacancy3 = new Vacancy();
         EntityDataGenerator.generateTestDataForModelClass(vacancy3);
         vacancy3.setWlProgramId(wlProgramId1);
         vacancy3.setStatus(status1);
+        vacancy3.setName("charlie");
         dao.persist(vacancy3);
 
         Vacancy vacancy4 = new Vacancy();
         EntityDataGenerator.generateTestDataForModelClass(vacancy4);
         vacancy4.setWlProgramId(wlProgramId2);
         vacancy4.setStatus(status1);
+        vacancy4.setName("delta");
         dao.persist(vacancy4);
 
         Vacancy vacancy5 = new Vacancy();
         EntityDataGenerator.generateTestDataForModelClass(vacancy5);
         vacancy5.setWlProgramId(wlProgramId1);
         vacancy5.setStatus(status1);
+        vacancy5.setName("echo");
         dao.persist(vacancy5);
 
         List<Vacancy> result = dao.getVacanciesByWlProgramIdAndStatus(wlProgramId1, status1);

--- a/src/test/java/io/github/carlos_emr/carlos/commn/dao/UserPropertyDAOIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/commn/dao/UserPropertyDAOIntegrationTest.java
@@ -33,6 +33,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -52,6 +53,8 @@ import static org.assertj.core.api.Assertions.*;
 @Transactional
 public class UserPropertyDAOIntegrationTest extends CarlosTestBase {
 
+    private static final AtomicInteger UNIQUE_SEQUENCE = new AtomicInteger();
+
     @Autowired
     private UserPropertyDAO userPropertyDAO;
 
@@ -65,6 +68,14 @@ public class UserPropertyDAOIntegrationTest extends CarlosTestBase {
         return prop;
     }
 
+    private String uniqueProviderNo() {
+        return String.format("U%05d", UNIQUE_SEQUENCE.incrementAndGet());
+    }
+
+    private String uniqueName(String prefix) {
+        return prefix + "-" + UNIQUE_SEQUENCE.incrementAndGet();
+    }
+
     @Nested
     @DisplayName("getProp(providerNo, name)")
     class GetPropByProviderAndName {
@@ -73,11 +84,14 @@ public class UserPropertyDAOIntegrationTest extends CarlosTestBase {
         @Tag("read")
         @DisplayName("should return property matching provider number and name")
         void shouldReturnProperty_whenProviderNoAndNameMatch() throws Exception {
-            UserProperty prop1 = createProperty("100", "alpha", "val1");
-            createProperty("200", "bravo", "val2");
-            hibernateTemplate.flush();
+            String matchingProviderNo = uniqueProviderNo();
+            String otherProviderNo = uniqueProviderNo();
+            String matchingName = uniqueName("alpha");
+            UserProperty prop1 = createProperty(matchingProviderNo, matchingName, "val1");
+            createProperty(otherProviderNo, uniqueName("bravo"), "val2");
+            userPropertyDAO.flush();
 
-            UserProperty result = userPropertyDAO.getProp("100", "alpha");
+            UserProperty result = userPropertyDAO.getProp(matchingProviderNo, matchingName);
 
             assertThat(result).isNotNull();
             assertThat(result.getId()).isEqualTo(prop1.getId());
@@ -87,10 +101,10 @@ public class UserPropertyDAOIntegrationTest extends CarlosTestBase {
         @Tag("read")
         @DisplayName("should return null when no property matches provider and name")
         void shouldReturnNull_whenNoPropertyMatchesProviderAndName() throws Exception {
-            createProperty("100", "alpha", "val1");
-            hibernateTemplate.flush();
+            createProperty(uniqueProviderNo(), uniqueName("alpha"), "val1");
+            userPropertyDAO.flush();
 
-            UserProperty result = userPropertyDAO.getProp("999", "nonexistent");
+            UserProperty result = userPropertyDAO.getProp(uniqueProviderNo(), uniqueName("missing"));
             assertThat(result).isNull();
         }
     }
@@ -103,11 +117,12 @@ public class UserPropertyDAOIntegrationTest extends CarlosTestBase {
         @Tag("read")
         @DisplayName("should return property matching name")
         void shouldReturnProperty_whenNameMatches() throws Exception {
-            UserProperty prop1 = createProperty("100", "alpha", "val1");
-            createProperty("200", "bravo", "val2");
-            hibernateTemplate.flush();
+            String matchingName = uniqueName("alpha");
+            UserProperty prop1 = createProperty(uniqueProviderNo(), matchingName, "val1");
+            createProperty(uniqueProviderNo(), uniqueName("bravo"), "val2");
+            userPropertyDAO.flush();
 
-            UserProperty result = userPropertyDAO.getProp("alpha");
+            UserProperty result = userPropertyDAO.getProp(matchingName);
 
             assertThat(result).isNotNull();
             assertThat(result.getId()).isEqualTo(prop1.getId());
@@ -122,12 +137,14 @@ public class UserPropertyDAOIntegrationTest extends CarlosTestBase {
         @Tag("query")
         @DisplayName("should return all properties for a given provider number")
         void shouldReturnAllProperties_forGivenProviderNo() throws Exception {
-            UserProperty prop1 = createProperty("100", "name1", "val1");
-            createProperty("200", "name2", "val2");
-            UserProperty prop3 = createProperty("100", "name3", "val3");
-            hibernateTemplate.flush();
+            String matchingProviderNo = uniqueProviderNo();
+            String otherProviderNo = uniqueProviderNo();
+            UserProperty prop1 = createProperty(matchingProviderNo, uniqueName("name1"), "val1");
+            createProperty(otherProviderNo, uniqueName("name2"), "val2");
+            UserProperty prop3 = createProperty(matchingProviderNo, uniqueName("name3"), "val3");
+            userPropertyDAO.flush();
 
-            List<UserProperty> result = userPropertyDAO.getDemographicProperties("100");
+            List<UserProperty> result = userPropertyDAO.getDemographicProperties(matchingProviderNo);
 
             assertThat(result).hasSize(2);
             assertThat(result).extracting(UserProperty::getId)
@@ -138,10 +155,10 @@ public class UserPropertyDAOIntegrationTest extends CarlosTestBase {
         @Tag("query")
         @DisplayName("should return empty list when no properties exist for provider")
         void shouldReturnEmptyList_whenNoPropertiesExistForProvider() throws Exception {
-            createProperty("100", "name1", "val1");
-            hibernateTemplate.flush();
+            createProperty(uniqueProviderNo(), uniqueName("name1"), "val1");
+            userPropertyDAO.flush();
 
-            List<UserProperty> result = userPropertyDAO.getDemographicProperties("999");
+            List<UserProperty> result = userPropertyDAO.getDemographicProperties(uniqueProviderNo());
             assertThat(result).isEmpty();
         }
     }
@@ -154,26 +171,30 @@ public class UserPropertyDAOIntegrationTest extends CarlosTestBase {
         @Tag("query")
         @DisplayName("should return properties as name-value map for provider")
         void shouldReturnPropertiesAsMap_forGivenProviderNo() throws Exception {
-            createProperty("100", "alpha", "Value1");
-            createProperty("100", "bravo", "Value2");
-            createProperty("200", "charlie", "Value3");
-            hibernateTemplate.flush();
+            String matchingProviderNo = uniqueProviderNo();
+            String otherProviderNo = uniqueProviderNo();
+            String firstName = uniqueName("alpha");
+            String secondName = uniqueName("bravo");
+            createProperty(matchingProviderNo, firstName, "Value1");
+            createProperty(matchingProviderNo, secondName, "Value2");
+            createProperty(otherProviderNo, uniqueName("charlie"), "Value3");
+            userPropertyDAO.flush();
 
-            Map<String, String> result = userPropertyDAO.getProviderPropertiesAsMap("100");
+            Map<String, String> result = userPropertyDAO.getProviderPropertiesAsMap(matchingProviderNo);
 
             assertThat(result).hasSize(2);
-            assertThat(result).containsEntry("alpha", "Value1");
-            assertThat(result).containsEntry("bravo", "Value2");
+            assertThat(result).containsEntry(firstName, "Value1");
+            assertThat(result).containsEntry(secondName, "Value2");
         }
 
         @Test
         @Tag("query")
         @DisplayName("should return empty map when no properties exist for provider")
         void shouldReturnEmptyMap_whenNoPropertiesExistForProvider() throws Exception {
-            createProperty("100", "alpha", "Value1");
-            hibernateTemplate.flush();
+            createProperty(uniqueProviderNo(), uniqueName("alpha"), "Value1");
+            userPropertyDAO.flush();
 
-            Map<String, String> result = userPropertyDAO.getProviderPropertiesAsMap("999");
+            Map<String, String> result = userPropertyDAO.getProviderPropertiesAsMap(uniqueProviderNo());
             assertThat(result).isEmpty();
         }
     }

--- a/src/test/java/io/github/carlos_emr/carlos/test/base/CarlosWebTestBase.java
+++ b/src/test/java/io/github/carlos_emr/carlos/test/base/CarlosWebTestBase.java
@@ -22,9 +22,11 @@
  */
 package io.github.carlos_emr.carlos.test.base;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockHttpSession;
@@ -50,6 +52,7 @@ import static org.mockito.Mockito.when;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -76,6 +79,7 @@ public abstract class CarlosWebTestBase extends CarlosTestBase {
 
     // Map to store request parameters
     protected Map<String, String[]> requestParameters;
+    private final Map<String, ReplacedSpringBean> replacedSpringBeans = new LinkedHashMap<>();
 
     @BeforeEach
     public void setUpWeb() {
@@ -165,14 +169,52 @@ public abstract class CarlosWebTestBase extends CarlosTestBase {
             String beanName = beanClass.getSimpleName();
             beanName = Character.toLowerCase(beanName.charAt(0)) + beanName.substring(1);
 
-            if (beanFactory instanceof org.springframework.beans.factory.support.DefaultListableBeanFactory) {
-                var factory = (org.springframework.beans.factory.support.DefaultListableBeanFactory) beanFactory;
+            if (beanFactory instanceof DefaultListableBeanFactory) {
+                var factory = (DefaultListableBeanFactory) beanFactory;
+                rememberReplacedBean(factory, beanName);
                 factory.destroySingleton(beanName);
                 factory.registerSingleton(beanName, mockBean);
             }
         } catch (Exception e) {
             logger.warn("Could not replace SpringUtils bean: {}", beanClass.getName(), e);
         }
+    }
+
+    @AfterEach
+    void restoreSpringUtilsBeans() {
+        try {
+            var beanFactory = applicationContext.getAutowireCapableBeanFactory();
+            if (beanFactory instanceof DefaultListableBeanFactory) {
+                var factory = (DefaultListableBeanFactory) beanFactory;
+                for (Map.Entry<String, ReplacedSpringBean> entry : replacedSpringBeans.entrySet()) {
+                    String beanName = entry.getKey();
+                    ReplacedSpringBean replacedBean = entry.getValue();
+                    factory.destroySingleton(beanName);
+                    if (!replacedBean.hadBeanDefinition() && replacedBean.originalSingleton() != null) {
+                        factory.registerSingleton(beanName, replacedBean.originalSingleton());
+                    }
+                }
+            }
+        } finally {
+            replacedSpringBeans.clear();
+            ActionContext.clear();
+        }
+    }
+
+    private void rememberReplacedBean(DefaultListableBeanFactory factory, String beanName) {
+        if (replacedSpringBeans.containsKey(beanName)) {
+            return;
+        }
+
+        boolean hadBeanDefinition = factory.containsBeanDefinition(beanName);
+        Object originalSingleton = null;
+        if (!hadBeanDefinition && factory.containsSingleton(beanName)) {
+            originalSingleton = factory.getSingleton(beanName);
+        }
+        replacedSpringBeans.put(beanName, new ReplacedSpringBean(hadBeanDefinition, originalSingleton));
+    }
+
+    private record ReplacedSpringBean(boolean hadBeanDefinition, Object originalSingleton) {
     }
 
     /**


### PR DESCRIPTION
## Summary
- add missing CodeQL data-extension metadata and PathValidationUtils models for File-returning path validators and guard methods
- keep the local CARLOS CodeQL model pack under .github/codeql/extensions so default setup can discover the data extensions
- add exact method-level FindSecBugs path traversal excludes for reviewed paths already protected by PathValidationUtils or canonical containment checks
- correct a flaky VacancyDao integration test expectation so CI asserts the status-filtered query and its name ordering explicitly

## Verification
- parsed .github/spotbugs/spotbugs-exclude.xml with Python ElementTree
- parsed CodeQL YAML files with node/js-yaml
- ran git diff --check
- ran `mvn -q -Dtest=io.github.carlos_emr.carlos.PMmodule.dao.VacancyDaoIntegrationTest#shouldReturnVacancies_byWlProgramIdAndStatus test`

## Notes
- PMD does not need a matching path traversal suppression because the configured PMD Java security rules do not include a path traversal detector.