### PR TITLE
fix: make labType checks null-safe in plus-meds chart

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/MeasurementGraphAction22Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/MeasurementGraphAction22Action.java
@@ -673,8 +673,9 @@ public class MeasurementGraphAction22Action extends ActionSupport {
 
 
         ArrayList<Map<String, Serializable>> list = null;
-        MiscUtils.getLogger().debug(" lab type >" + labType + "< >" + labType.equals("loinc") + "<" + testName + " " + identifier);
-        if (labType.equals("loinc")) {
+        boolean isLoinc = "loinc".equals(labType);
+        MiscUtils.getLogger().debug("lab type >{}< >{}< {} {}", labType, isLoinc, testName, identifier);
+        if (isLoinc) {
             try {
 
                 Connection conn = DbConnectionFilter.getThreadLocalDbConnection();

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/MeasurementGraphAction22Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/MeasurementGraphAction22Action.java
@@ -674,7 +674,13 @@ public class MeasurementGraphAction22Action extends ActionSupport {
 
         ArrayList<Map<String, Serializable>> list = null;
         boolean isLoinc = "loinc".equals(labType);
-        MiscUtils.getLogger().debug("lab type >{}< >{}< {} {}", labType, isLoinc, testName, identifier);
+        MiscUtils.getLogger().debug(
+                "lab type >{}< >{}< {} {}",
+                LogSafe.sanitize(labType),
+                isLoinc,
+                LogSafe.sanitize(testName),
+                LogSafe.sanitize(identifier)
+        );
         if (isLoinc) {
             try {
 


### PR DESCRIPTION
## Description

This PR resolves a potential `NullPointerException` in `MeasurementGraphAction22Action` that occurs when `labType` is null (e.g., omitted from the request parameters). 

By implementing a null-safe Yoda condition (`"loinc".equals(labType)`), the code safely evaluates the variable, allowing the chart generation to fall back gracefully to the non-LOINC path without crashing the JVM. It also updates the logger to use this safe boolean.

## Related Issues

Fixes #2258

## How Was This Tested?

- Verified the code path to ensure that when `labType` is null, `isLoinc` evaluates to `false`, bypassing the `.equals()` NPE.
- Ensured the existing logic flow for both `"loinc"` and non-LOINC lab types is fully preserved.
- Code compiles cleanly and does not disrupt existing graph generation flows.

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a NullPointerException in the plus-meds lab chart by making the `labType` check null-safe and sanitizing debug logs to avoid PHI leakage. If `labType` is missing, the chart now falls back to the non-LOINC path without crashing.

- **Bug Fixes**
  - Use `"loinc".equals(labType)` and store the result in `isLoinc`.
  - Switch debug log to parameterized format, sanitize `labType`, `testName`, and `identifier`, and include `isLoinc`.

<sup>Written for commit 42f800a310048d0041d6b4308ec26c1eb823d919. Summary will update on new commits. <a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2297?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

