### PR TITLE
fix: avoid NPE when labType is null

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/MeasurementGraphAction22Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/MeasurementGraphAction22Action.java
@@ -673,8 +673,9 @@ public class MeasurementGraphAction22Action extends ActionSupport {
 
 
         ArrayList<Map<String, Serializable>> list = null;
-        MiscUtils.getLogger().debug(" lab type >" + labType + "< >" + labType.equals("loinc") + "<" + testName + " " + identifier);
-        if (labType.equals("loinc")) {
+        boolean isLoinc = "loinc".equals(labType);
+        MiscUtils.getLogger().debug(" lab type >{}< >{}< {} {}", labType, isLoinc, testName, identifier);
+        if (isLoinc) {
             try {
 
                 Connection conn = DbConnectionFilter.getThreadLocalDbConnection();


### PR DESCRIPTION
## Description

  `MeasurementGraphAction22Action.actualLabChartRefPlusMeds(...)` can throw
  `NullPointerException` when the `labType` request parameter is omitted —
  `labType.equals("loinc")` is called directly on a null reference.

  - Extract `boolean isLoinc = "loinc".equals(labType)` once and reuse it
  - Switch debug log from string concatenation to SLF4J `{}` placeholders
  - No behavior change: LOINC and non-LOINC paths work as before

  ## Related Issues

  Fixes #2234

  ## How Was This Tested?

  - [x] `make install` builds and deploys successfully
  - [x] Called without `labType` — no NPE, execution falls through to the non-LOINC path
  - [x] `labType=loinc` — chart generation unchanged
  - [x] Non-LOINC `labType` — chart generation unchanged

  ## Screenshots

  Not applicable — no visual changes.

  ## Checklist

  - [ ] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
  - [x] My commits follow Conventional Commits format
  - [x] I have not included any patient data (PHI) in this PR
  - [x] I have added tests for new functionality, or this change doesn't need new tests
  - [x] I have read the contributing guide

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a NullPointerException in lab chart generation when the labType request parameter is missing (Fixes #2234). Adds a null-safe "loinc" check and switches debug logging to SLF4J placeholders; behavior for LOINC and non-LOINC paths is unchanged.

<sup>Written for commit 2a57d43800a479b9a372e6e4c0a9cb71dfa7a5ed. Summary will update on new commits. <a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2298?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

