### PR TITLE
fix: address browser security compatibility issues (#2330)

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/casemgmt/newEncounterHeader.jsp
+++ b/src/main/webapp/WEB-INF/jsp/casemgmt/newEncounterHeader.jsp
@@ -82,24 +82,24 @@ function copyToClip(text, el) {
     if (navigator.clipboard && navigator.clipboard.writeText) {
         navigator.clipboard.writeText(text)
             .then(function() { showFeedback(true); })
-            .catch(function() { showFeedback(fallbackCopy(text)); });
+            .catch(function() { showFeedback(false); });
     } else {
         showFeedback(fallbackCopy(text));
     }
 }
 function fallbackCopy(text) {
+    var ta = document.createElement('textarea');
+    ta.value = text;
+    ta.style.position = 'fixed';
+    ta.style.left = '-9999px';
+    document.body.appendChild(ta);
     try {
-        var ta = document.createElement('textarea');
-        ta.value = text;
-        ta.style.position = 'fixed';
-        ta.style.left = '-9999px';
-        document.body.appendChild(ta);
         ta.select();
-        var ok = document.execCommand('copy');
-        document.body.removeChild(ta);
-        return ok !== false;
+        return !!document.execCommand('copy');
     } catch (e) {
         return false;
+    } finally {
+        document.body.removeChild(ta);
     }
 }
 </script>

--- a/src/main/webapp/WEB-INF/jsp/casemgmt/newEncounterHeader.jsp
+++ b/src/main/webapp/WEB-INF/jsp/casemgmt/newEncounterHeader.jsp
@@ -74,30 +74,33 @@
 <script type="text/javascript">
 function copyToClip(text, el) {
     var orig = el.title;
-    function showFeedback() {
-        el.title = 'Copied!';
+    function showFeedback(success) {
+        el.title = success ? 'Copied!' : 'Copy failed — please copy manually';
         el.style.opacity = '0.5';
-        setTimeout(function() { el.style.opacity = '1'; el.title = orig; }, 600);
+        setTimeout(function() { el.style.opacity = '1'; el.title = orig; }, success ? 600 : 2500);
     }
     if (navigator.clipboard && navigator.clipboard.writeText) {
-        navigator.clipboard.writeText(text).then(showFeedback).catch(function() {
-            fallbackCopy(text);
-            showFeedback();
-        });
+        navigator.clipboard.writeText(text)
+            .then(function() { showFeedback(true); })
+            .catch(function() { showFeedback(fallbackCopy(text)); });
     } else {
-        fallbackCopy(text);
-        showFeedback();
+        showFeedback(fallbackCopy(text));
     }
 }
 function fallbackCopy(text) {
-    var ta = document.createElement('textarea');
-    ta.value = text;
-    ta.style.position = 'fixed';
-    ta.style.left = '-9999px';
-    document.body.appendChild(ta);
-    ta.select();
-    document.execCommand('copy');
-    document.body.removeChild(ta);
+    try {
+        var ta = document.createElement('textarea');
+        ta.value = text;
+        ta.style.position = 'fixed';
+        ta.style.left = '-9999px';
+        document.body.appendChild(ta);
+        ta.select();
+        var ok = document.execCommand('copy');
+        document.body.removeChild(ta);
+        return ok !== false;
+    } catch (e) {
+        return false;
+    }
 }
 </script>
 

--- a/src/main/webapp/WEB-INF/jsp/eform/eformGenerator.jsp
+++ b/src/main/webapp/WEB-INF/jsp/eform/eformGenerator.jsp
@@ -3277,8 +3277,9 @@ and other liscences (MIT, LGPL etc) as indicated
     function save_to_cookie() {
         var exp = new Date();
         exp.setTime(exp.getTime() + (1000 * 60 * 60 * 24 * 30));
-        document.cookie = "drawdata" + "=" + DrawData + "; expires=" + exp.toGMTString() + "; path=/; SameSite=Lax";
-        document.cookie = "inputcounter" + "=" + inputCounter + "; expires=" + exp.toGMTString() + "; path=/; SameSite=Lax";
+        var secureFlag = window.location.protocol === 'https:' ? '; Secure' : '';
+        document.cookie = "drawdata" + "=" + DrawData + "; expires=" + exp.toGMTString() + "; path=/; SameSite=Lax" + secureFlag;
+        document.cookie = "inputcounter" + "=" + inputCounter + "; expires=" + exp.toGMTString() + "; path=/; SameSite=Lax" + secureFlag;
     }
 
     function restoreSaved() {

--- a/src/main/webapp/WEB-INF/jsp/eform/eformGenerator.jsp
+++ b/src/main/webapp/WEB-INF/jsp/eform/eformGenerator.jsp
@@ -3277,8 +3277,8 @@ and other liscences (MIT, LGPL etc) as indicated
     function save_to_cookie() {
         var exp = new Date();
         exp.setTime(exp.getTime() + (1000 * 60 * 60 * 24 * 30));
-        document.cookie = "drawdata" + "=" + DrawData + "; expires=" + exp.toGMTString() + "; path=/";
-        document.cookie = "inputcounter" + "=" + inputCounter + "; expires=" + exp.toGMTString() + "; path=/";
+        document.cookie = "drawdata" + "=" + DrawData + "; expires=" + exp.toGMTString() + "; path=/; SameSite=Lax";
+        document.cookie = "inputcounter" + "=" + inputCounter + "; expires=" + exp.toGMTString() + "; path=/; SameSite=Lax";
     }
 
     function restoreSaved() {

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/addMeasurementMap2.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/addMeasurementMap2.jsp
@@ -155,7 +155,7 @@
                         </tr>
                         <tr>
                             <td colspan="2" class="Cell" align="center">NOTE: <a
-                                    href="javascript:newWindow('http://www.regenstrief.org/medinformatics/loinc/relma','RELMA')">It
+                                    href="javascript:newWindow('https://www.regenstrief.org/medinformatics/loinc/relma','RELMA')">It
                                 is suggested that you use the RELMA application to help determine
                                 correct loinc codes.</a></td>
                         </tr>

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/remapMeasurementMap.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarMeasurements/remapMeasurementMap.jsp
@@ -182,7 +182,7 @@
                         </tr>
                         <tr>
                             <td colspan="2" class="Cell" align="center">NOTE: <a
-                                    href="javascript:newWindow('http://www.regenstrief.org/medinformatics/loinc/relma','RELMA')">It
+                                    href="javascript:newWindow('https://www.regenstrief.org/medinformatics/loinc/relma','RELMA')">It
                                 is suggested that you use the RELMA application to help determine
                                 correct loinc codes.</a></td>
                         </tr>

--- a/src/main/webapp/WEB-INF/jsp/fax/CoverPage.jsp
+++ b/src/main/webapp/WEB-INF/jsp/fax/CoverPage.jsp
@@ -209,7 +209,7 @@
 							<a style="font-size: 10px; font-style: normal;" href="${pageContext.request.contextPath}/encounter/ViewAbout"
                                target="_new">About</a>
 							<a style="font-size: 10px; font-style: normal;" target="_blank"
-                               href="http://www.oscarmanual.org/search?SearchableText=&Title=Chart+Interface&portal_type%3Alist=Document">Help</a>
+                               href="https://www.oscarmanual.org/search?SearchableText=&Title=Chart+Interface&portal_type%3Alist=Document">Help</a>
 						</span>
 					</td>
 				</tr>

--- a/src/main/webapp/WEB-INF/jsp/prevention/index.jsp
+++ b/src/main/webapp/WEB-INF/jsp/prevention/index.jsp
@@ -803,7 +803,7 @@
                     <% } %>
 
 
-                    <a href="#" onclick="popup(600,800,'http://www.phac-aspc.gc.ca/im/is-cv/index-eng.php')">Immunization
+                    <a href="#" onclick="popup(600,800,'https://www.phac-aspc.gc.ca/im/is-cv/index-eng.php')">Immunization
                         Schedules - Public Health Agency of Canada</a>
 
 

--- a/src/main/webapp/js/jquery.fileDownload.js
+++ b/src/main/webapp/js/jquery.fileDownload.js
@@ -101,6 +101,12 @@ $.extend({
             cookieSecure: location.protocol === 'https:',
 
             //
+            //the SameSite attribute for the cookie. Defaults to "Lax" for forward-compatibility.
+            //set to "Strict" or "None" (requires Secure) as needed.
+            //
+            cookieSameSite: "Lax",
+
+            //
             //the title for the popup second window as a download is processing in the case of a mobile browser
             //
             popupWindowTitle: "Initiating file download...",
@@ -314,7 +320,7 @@ $.extend({
 
                 //remove the cookie and iframe
                 var date = new Date(1000);
-                document.cookie = settings.cookieName + "=; expires=" + date.toUTCString() + "; path=" + settings.cookiePath + (settings.cookieSecure ? "; Secure" : "");
+                document.cookie = settings.cookieName + "=; expires=" + date.toUTCString() + "; path=" + settings.cookiePath + (settings.cookieSecure ? "; Secure" : "") + (settings.cookieSameSite ? "; SameSite=" + settings.cookieSameSite : "");
 
                 cleanUp(false);
 


### PR DESCRIPTION
- Upgrade four hardcoded HTTP external links to HTTPS to prevent mixed content blocks on HTTPS deployments (PHAC immunization schedule, Regenstrief RELMA x2, oscarmanual help link)
- Add user-visible failure feedback to clipboard copy: fallbackCopy now returns a boolean via try/catch around execCommand; copyToClip shows 'Copy failed — please copy manually' when both Clipboard API and execCommand are unavailable
- Add SameSite=Lax to eformGenerator draw-data cookies
- Add cookieSameSite setting (default Lax) to jquery.fileDownload.js and wire it into the cookie-clear string

<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description

<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues

<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?

<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [ ] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Improve browser security compatibility and user feedback across the web app.

Bug Fixes:
- Provide clear success or failure feedback when copying to clipboard and handle fallback copy failures more robustly.
- Ensure eForm generator cookies use SameSite=Lax and add Secure when served over HTTPS to align with modern browser cookie policies.
- Set SameSite on jquery.fileDownload tracking cookies when clearing them to avoid browser warnings and future incompatibilities.
- Update several hardcoded HTTP external links to HTTPS to avoid mixed-content issues on secure deployments.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix browser security compatibility by upgrading mixed-content links to HTTPS, tightening cookie attributes (`SameSite`/`Secure`), and improving clipboard copy failure feedback.

- **Bug Fixes**
  - External links: switch 4 HTTP URLs to HTTPS (PHAC, RELMA x2, OSCAR Manual Help).
  - Clipboard: fallbackCopy returns a boolean; no execCommand in async catch; textarea cleanup moved to finally; uses !!document.execCommand; shows “Copy failed — please copy manually” on failure.
  - Cookies: set `SameSite=Lax` on eForm generator cookies and add `Secure` on HTTPS; add `cookieSameSite` (default Lax) to `jquery.fileDownload` and include it when clearing the cookie.

<sup>Written for commit bcb14da2ca604c38bbf380810c934a41a91918bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2358?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

