### PR TITLE
Disable PMD quality scan in workflow

### DIFF
--- a/.github/workflows/pmd.yml
+++ b/.github/workflows/pmd.yml
@@ -94,18 +94,18 @@ jobs:
           else
             echo "PMD ${PMD_VERSION} already cached"
           fi
-
-      - name: Run PMD quality scan
-        run: |
-          set -euo pipefail
-          PMD_DIR="pmd-bin-${PMD_VERSION}"
-          "${PMD_DIR}/bin/pmd" check \
-            --dir src/main/java \
-            --dir src/test/java \
-            --rulesets .github/pmd/carlos-ruleset.xml \
-            --format sarif \
-            --report-file pmd-report.sarif \
-            --no-fail-on-violation
+#Disabling quality scan temporarily so we get security-focused alerts
+     # - name: Run PMD quality scan
+    #    run: |
+    #      set -euo pipefail
+     #     PMD_DIR="pmd-bin-${PMD_VERSION}"
+      #    "${PMD_DIR}/bin/pmd" check \
+       #     --dir src/main/java \
+        #    --dir src/test/java \
+         #   --rulesets .github/pmd/carlos-ruleset.xml \
+          #  --format sarif \
+           # --report-file pmd-report.sarif \
+            #--no-fail-on-violation
 
       - name: Run PMD security scan
         run: |

--- a/.github/workflows/pmd.yml
+++ b/.github/workflows/pmd.yml
@@ -55,6 +55,7 @@ permissions:
 
 env:
   PMD_VERSION: '7.13.0'
+  PMD_QUALITY_ENABLED: 'false'
 
 jobs:
   pmd:
@@ -94,18 +95,19 @@ jobs:
           else
             echo "PMD ${PMD_VERSION} already cached"
           fi
-#Disabling quality scan temporarily so we get security-focused alerts
-     # - name: Run PMD quality scan
-    #    run: |
-    #      set -euo pipefail
-     #     PMD_DIR="pmd-bin-${PMD_VERSION}"
-      #    "${PMD_DIR}/bin/pmd" check \
-       #     --dir src/main/java \
-        #    --dir src/test/java \
-         #   --rulesets .github/pmd/carlos-ruleset.xml \
-          #  --format sarif \
-           # --report-file pmd-report.sarif \
-            #--no-fail-on-violation
+
+      - name: Run PMD quality scan
+        if: env.PMD_QUALITY_ENABLED == 'true'
+        run: |
+          set -euo pipefail
+          PMD_DIR="pmd-bin-${PMD_VERSION}"
+          "${PMD_DIR}/bin/pmd" check \
+            --dir src/main/java \
+            --dir src/test/java \
+            --rulesets .github/pmd/carlos-ruleset.xml \
+            --format sarif \
+            --report-file pmd-report.sarif \
+            --no-fail-on-violation
 
       - name: Run PMD security scan
         run: |
@@ -131,7 +133,7 @@ jobs:
 
       - name: Upload PMD quality artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if: always() && hashFiles('pmd-report.sarif') != ''
+        if: always() && env.PMD_QUALITY_ENABLED == 'true' && hashFiles('pmd-report.sarif') != ''
         with:
           name: pmd-quality-sarif
           path: pmd-report.sarif
@@ -142,14 +144,16 @@ jobs:
         run: |
           echo "### PMD Results" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          if [ -f pmd-report.sarif ]; then
-            if total=$(jq '[.runs[].results[]?] | length' pmd-report.sarif 2>/dev/null); then
-              echo "PMD quality scan produced ${total} SARIF finding(s)." >> "$GITHUB_STEP_SUMMARY"
+          if [ "${PMD_QUALITY_ENABLED}" = "true" ]; then
+            if [ -f pmd-report.sarif ]; then
+              if total=$(jq '[.runs[].results[]?] | length' pmd-report.sarif 2>/dev/null); then
+                echo "PMD quality scan produced ${total} SARIF finding(s)." >> "$GITHUB_STEP_SUMMARY"
+              else
+                echo "PMD quality SARIF report was generated, but could not be parsed." >> "$GITHUB_STEP_SUMMARY"
+              fi
             else
-              echo "PMD quality SARIF report was generated, but could not be parsed." >> "$GITHUB_STEP_SUMMARY"
+              echo "No PMD quality SARIF report was generated." >> "$GITHUB_STEP_SUMMARY"
             fi
-          else
-            echo "No PMD quality SARIF report was generated." >> "$GITHUB_STEP_SUMMARY"
           fi
           if [ -f pmd-security-report.sarif ]; then
             if security_total=$(jq '[.runs[].results[]?] | length' pmd-security-report.sarif 2>/dev/null); then


### PR DESCRIPTION
## Description

Temporarily disable PMD quality scan to focus on security alerts. We want to target security problems over code quality issues right now, so I've been asked to try and pull out the quality alerts until security is further along. Just comments out the quality scan, will be easy to revert once we're ready

## Summary by Sourcery

Build:
- Introduce PMD_QUALITY_ENABLED environment flag (default false) to control execution of the PMD quality scan, artifact upload, and summary messaging in the PMD GitHub Actions workflow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Temporarily disable the PMD quality scan in CI to reduce noise and focus on security alerts. Introduces `PMD_QUALITY_ENABLED` (default false) to gate the quality run, artifact upload, and summary; the security scan still runs and setting it to true re-enables quality.

<sup>Written for commit b58e66c7eff9c330d105243403d3220af0b99357. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

