### PR TITLE
2381 bug Preview control is hidden under search in inboxhub

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/web/inboxhub/InboxhubForm.jsp
+++ b/src/main/webapp/WEB-INF/jsp/web/inboxhub/InboxhubForm.jsp
@@ -44,15 +44,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA
 <input type="hidden" class="totalHRMCount" id="totalHRMCount" value="${totalHRMCount}" />
 <input type="hidden" class="totalResultsCount" id="totalResultsCount" value="${totalResultsCount}" />
 
-<!-- Preview button -->
-<div class="card mb-1 shadow-sm rounded-1">
-  <div class="card-body p-2">
-    <div class="d-grid">
-        <input type="checkbox" class="btn-check btn-sm" name="viewMode2" id="btnViewMode2" autocomplete="off" onchange="fetchInboxhubDataByMode(this)" ${query.viewMode ? 'checked' : ''}>
-        <label class="btn btn-secondary btn-sm" id="btnViewModeLabel" for="btnViewMode2"><c:choose><c:when test="${query.viewMode}"><fmt:message key="inboxhub.form.listMode"/></c:when><c:otherwise><fmt:message key="inboxhub.form.previewMode"/></c:otherwise></c:choose></label>
-    </div>
-  </div>
-</div>
 
 <!-- Search form Accordion -->
 <div class="accordion" id="inbox-hub-search">

--- a/src/main/webapp/WEB-INF/jsp/web/inboxhub/InboxhubTopbar.jsp
+++ b/src/main/webapp/WEB-INF/jsp/web/inboxhub/InboxhubTopbar.jsp
@@ -63,6 +63,11 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA
 
 <%-- Ordered by workflow: incoming → pending → uploads → create → config --%>
 <%-- Incoming Docs uses container-fluid, so it intentionally keeps a wider popup. --%>
+
+<!-- Preview button -->
+<input type="checkbox" class="btn-check btn-sm" name="viewMode2" id="btnViewMode2" autocomplete="off" onchange="fetchInboxhubDataByMode(this)" ${query.viewMode ? 'checked' : ''}>
+<label class="btn btn-secondary btn-sm" id="btnViewModeLabel" for="btnViewMode2"><c:choose><c:when test="${query.viewMode}"><fmt:message key="inboxhub.form.listMode"/></c:when><c:otherwise><fmt:message key="inboxhub.form.previewMode"/></c:otherwise></c:choose></label>
+
 <a href="javascript:reportWindow('${carlos:forJavaScript(contextPath)}/documentManager/ViewIncomingDocs',800,1200)" class="nav-link"><fmt:message key="inboxmanager.document.incomingDocs"/></a>
 <a href="javascript:reportWindow('${carlos:forJavaScript(contextPath)}/documentManager/inboxManage?method=getDocumentsInQueues',800,1000)" class="nav-link"><fmt:message key="inboxmanager.document.pendingDocs"/></a>
 <c:choose>


### PR DESCRIPTION
<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description
Improves UX by moving Preview workflow toggle button from being hidden with the search controls to top and left 
<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues
Fixes #2381 
<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?
tested in Firefox and Brave browsers
<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots
Firefox screenshot
Preview button is out of the search and prominent top left

<img width="1215" height="800" alt="Screenshot 2026-05-28 at 12-53-53 Inboxhub" src="https://github.com/user-attachments/assets/bf5288b1-a795-42d2-85bf-e679080f6980" />

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->

## Checklist

- [X] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Bug Fixes:
- Ensure the Inboxhub workflow view toggle is no longer hidden beneath the search controls by moving it into the top bar.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the InboxHub workflow control (preview/list toggle) from the search panel to the topbar so it stays visible and no longer gets hidden under search. Fixes #2381.

<sup>Written for commit b47735c84a38578f863ff18e970f3544a4bc1d4c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2382?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

