### PR TITLE
Handle missing upload file in UploadLoginText2Action

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/login/UploadLoginText2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/login/UploadLoginText2Action.java
@@ -20,7 +20,7 @@
  * McMaster University
  * Hamilton
  * Ontario, Canada
- 
+
  * <p>
  * Now maintained by the CARLOS EMR Project (2026+).
  * https://github.com/carlos-emr/carlos
@@ -113,19 +113,24 @@ public class UploadLoginText2Action extends ActionSupport implements UploadedFil
 
 
         try {
-            if (importFile.getName().length() > 0) {
+            if (importFile == null) {
+                MiscUtils.getLogger().warn("No file uploaded — skipping AUA text write");
+            } else if (importFile.getName().length() > 0) {
                 fis = Files.newInputStream(importFile.toPath());
                 String savePath = CarlosProperties.getInstance().getProperty("DOCUMENT_DIR") + "/OSCARloginText.txt";
                 fos = new FileOutputStream(savePath);
+
                 byte[] buf = new byte[128 * 1024];
                 int i = 0;
+
                 while ((i = fis.read(buf)) != -1) {
                     fos.write(buf, 0, i);
                 }
+
                 error = false;
             }
         } catch (Exception e) {
-            MiscUtils.getLogger().error("Error", e);
+            MiscUtils.getLogger().error("Failed to upload AUA text file", e);
             error = true;
         }
 


### PR DESCRIPTION
## Description

This PR prevents a `NullPointerException` in `UploadLoginText2Action` when the form is submitted without selecting a file.

Previously, the action called `importFile.getName()` without checking whether `importFile` was null. This could result in a generic error being logged without indicating that no file had been uploaded. This change adds a null check, logs a warning when no file is provided, and improves the upload failure log message.

## Related Issues

Fixes #2373

## How Was This Tested?

* Reviewed the code path where `importFile` can be null
* Verified that the action now handles missing uploads without throwing a `NullPointerException`
* Verified that existing file upload behavior remains unchanged

## Checklist

* [x] My commits are signed off for the DCO (`git commit -s`)
* [x] My commits follow Conventional Commits format, or I've written clear commit messages and will use the format next time
* [x] I have not included any patient data (PHI) in this PR
* [x] I have added tests for new functionality, or this change doesn't need new tests
* [x] I have read the contributing guide

## Summary by Sourcery

Handle missing upload file in UploadLoginText2Action to prevent errors and improve logging for failed AUA text uploads.

Bug Fixes:
- Prevent a NullPointerException when the upload action is submitted without a selected file by handling a null import file.

Enhancements:
- Improve logging by warning when no file is uploaded and using a more descriptive error message when the AUA text file upload fails.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent a NullPointerException in `UploadLoginText2Action` when the form is submitted without a file. Adds a null check, logs a warning and skips writing when no file is uploaded, and replaces the generic error with "Failed to upload AUA text file"; other upload behavior is unchanged.

<sup>Written for commit 380b861137bbcabfb163c4a493ae2688ff533b1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

