### PR TITLE
Update CSS for mobile schedule layout for recent changes

### DIFF
--- a/src/main/webapp/mobile/receptionistapptstyle.css
+++ b/src/main/webapp/mobile/receptionistapptstyle.css
@@ -88,7 +88,7 @@ table {
   display: none !important;
 }
 
-table#firstTable td:#userSettings > div {
+table#firstTable td#userSettings > div {
   display: block;
 }
 
@@ -181,7 +181,8 @@ a.encounterBtn, a.masterBtn {
     text-align: center;
     white-space: nowrap;
     z-index: 1;
-    border: 0 solid transparent;
+    border-style: solid;
+    border-color: transparent;
     border-width: 0 5px;
     border-image: url(../mobile/toolButton.png) 0 5 0 5 fill stretch;
 }
@@ -302,8 +303,8 @@ a.encounterBtn, a.masterBtn {
     top: calc(100% + 2px);
     left: 0;
     z-index: 9999;
-    min-width: 360px;
-    max-width: 480px;
+    min-width: 280px;
+    max-width: calc(100vw - 10px);
     max-height: 420px;
     overflow-y: auto;
     background: #fff;
@@ -426,6 +427,6 @@ a.encounterBtn, a.masterBtn {
   display: none;
 }
 
-img {
+.quick-search-wrapper img {
   width: 30px !important;
 }

--- a/src/main/webapp/mobile/receptionistapptstyle.css
+++ b/src/main/webapp/mobile/receptionistapptstyle.css
@@ -139,16 +139,6 @@ a.encounterBtn, a.masterBtn {
     margin: 0px;
     padding: 0px;
 }
-/*
-#navlist {
-    background: #6d84a2 repeat-x;
-    font-size: medium;
-    font-weight: bold;
-    -webkit-box-sizing: border-box;
-    height: 45px;
-    border-bottom: 1px black solid;
-}
-*/
 .rightButton {
     right: 30px;
 }

--- a/src/main/webapp/mobile/receptionistapptstyle.css
+++ b/src/main/webapp/mobile/receptionistapptstyle.css
@@ -69,12 +69,27 @@ span.dateAppointment {
 
 /* Adjustments made to prevent further additions to jsp's from being displayed in the mobile version */
 #navlist > *:not(#today):not(#menu),
-table#firstTable td:not(#firstMenu),
-#navlistcontents > *:not(#search):not(#logoutMobile),
+table#firstTable td:not(#firstMenu):not(#userSettings),
 table#providerSchedule td:not(.scheduleTime00):not(.scheduleTimeNot00):not(.appt):not(.noGrid),
 .appt a:not(.apptLink):not(.encounterBtn):not(.masterBtn):not(.apptStatus),
 .infirmaryView, #calendarLinkBottom, #group, #expandReason {
     display: none;
+}
+table {
+  width: 100%;
+}
+#userSettings {
+  text-align:right;
+  vertical-align: top;
+  padding-right: 6px;
+}
+
+#userSettingsMenu {
+  display: none !important;
+}
+
+table#firstTable td:#userSettings > div {
+  display: block;
 }
 
 a.encounterBtn, a.masterBtn {
@@ -124,7 +139,7 @@ a.encounterBtn, a.masterBtn {
     margin: 0px;
     padding: 0px;
 }
-
+/*
 #navlist {
     background: #6d84a2 repeat-x;
     font-size: medium;
@@ -133,13 +148,13 @@ a.encounterBtn, a.masterBtn {
     height: 45px;
     border-bottom: 1px black solid;
 }
-
+*/
 .rightButton {
-    right: 10px;
+    right: 30px;
 }
 
 .leftButton {
-    left: 10px;
+    left: 30px;
 }
 
 .top {
@@ -149,8 +164,7 @@ a.encounterBtn, a.masterBtn {
 .button, .leftButton, .rightButton {
     position: relative;
     overflow: hidden;
-    /*-webkit-appearance:button;*/
-    margin: 0;
+    margin: 3px;
     border-width: 0 5px;
     padding: 0 3px;
     width: auto;
@@ -159,7 +173,7 @@ a.encounterBtn, a.masterBtn {
     line-height: 30px;
     font-size: 12px;
     font-weight: bold;
-    top: 8px;
+    top: -3px;
     color: #FFFFFF;
     text-shadow: rgba(0, 0, 0, 0.6) 0px -1px 0;
     text-overflow: ellipsis;
@@ -167,8 +181,9 @@ a.encounterBtn, a.masterBtn {
     text-align: center;
     white-space: nowrap;
     z-index: 1;
-    -webkit-border-image: url(../mobile/toolButton.png) 0 5 0 5;
-    -moz-border-image: url(../mobile/toolButton.png) 0 5 0 5;
+    border: 0 solid transparent;
+    border-width: 0 5px;
+    border-image: url(../mobile/toolButton.png) 0 5 0 5 fill stretch;
 }
 
 .blueButton {
@@ -204,7 +219,7 @@ a.encounterBtn, a.masterBtn {
 
 #navlistcontents {
     position: absolute;
-    left: 55px;
+    left: 85px;
     top: 5px;
     border: 1px silver solid;
     background-color: #eeeeff;
@@ -216,7 +231,7 @@ a.encounterBtn, a.masterBtn {
 #dateAndCalendar {
     width: 100%;
     vertical-align: middle;
-    text-align: right;
+    text-align: center;
 }
 
 #providerSchedule {
@@ -227,4 +242,190 @@ a.encounterBtn, a.masterBtn {
 
 #providerSchedule td {
     border-bottom: 1px solid #ccc;
+}
+/* ===== Quick Patient Search Bar ===== */
+.quick-search-wrapper {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    vertical-align: middle;
+    margin-right: 4px;
+}
+
+.quick-search-input-wrapper {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+}
+
+#quickSearch {
+    width: 170px;
+    height: 24px;
+    padding: 2px 26px 2px 6px;
+    font-size: 0.8rem;
+    border: 1px solid #adb5bd;
+    border-radius: 4px;
+    background: #fff;
+    box-sizing: border-box;
+}
+
+#quickSearch:focus {
+    outline: none;
+    border-color: #4a90d9;
+    box-shadow: 0 0 0 2px rgba(74, 144, 217, 0.2);
+}
+
+.quick-search-clear {
+    position: absolute;
+    right: 4px;
+    top: 50%;
+    transform: translateY(-50%);
+    background: none;
+    border: none;
+    padding: 0 2px;
+    cursor: pointer;
+    color: #6c757d;
+    font-size: 0.75rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 1;
+}
+
+.quick-search-clear:hover {
+    color: #343a40;
+}
+
+/* Dropdown container - floats over schedule */
+.quick-search-dropdown {
+    position: absolute;
+    top: calc(100% + 2px);
+    left: 0;
+    z-index: 9999;
+    min-width: 360px;
+    max-width: 480px;
+    max-height: 420px;
+    overflow-y: auto;
+    background: #fff;
+    border: 1px solid rgba(0, 0, 0, 0.15);
+    border-radius: 4px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.18);
+}
+
+/* Result rows */
+.qs-result-row {
+    padding: 6px 10px;
+    cursor: pointer;
+    border-bottom: 1px solid #f0f0f0;
+    background-color: #ffffff;
+}
+
+.qs-result-row.qs-alt {
+    background-color: #f7f9fb;
+}
+
+.qs-result-row:hover,
+.qs-result-row.qs-active {
+    background-color: #dce8f5;
+}
+
+/* Line 1: patient name + badges */
+.qs-line1 {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 4px;
+}
+
+.qs-patient-name {
+    font-size: 0.875rem;
+    color: #212529;
+    font-weight: 700;
+}
+
+.qs-status-label {
+    font-weight: 400;
+    color: #6c757d;
+    font-size: 0.78rem;
+}
+
+/* Badge strip */
+.qs-badges {
+    display: flex;
+    gap: 3px;
+    flex-shrink: 0;
+}
+
+.qs-badge {
+    display: inline-block;
+    padding: 1px 5px;
+    font-size: 0.7rem;
+    font-weight: 600;
+    border-radius: 3px;
+    text-decoration: none;
+    cursor: pointer;
+    white-space: nowrap;
+}
+
+.qs-badge:hover {
+    text-decoration: none;
+    filter: brightness(0.85);
+}
+
+.qs-badge-m  { background: #6c757d; color: #fff; }
+.qs-badge-e  { background: #0d6efd; color: #fff; }
+.qs-badge-rx { background: #198754; color: #fff; }
+.qs-badge-appt { background: #fd7e14; color: #fff; }
+
+/* Lines 2-4: muted detail rows */
+.qs-line2,
+.qs-line3,
+.qs-line4 {
+    font-size: 0.775rem;
+    margin-top: 2px;
+}
+
+.qs-line2 {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.qs-muted {
+    color: #6c757d;
+}
+
+/* No-results and add-link rows */
+.qs-no-results {
+    padding: 8px 12px;
+    font-size: 0.85rem;
+    color: #6c757d;
+    font-style: italic;
+}
+
+.qs-add-link {
+    padding: 6px 10px;
+    border-top: 1px solid #dee2e6;
+    text-align: center;
+}
+
+.qs-add-link a {
+    font-size: 0.8rem;
+    color: #0d6efd;
+    text-decoration: none;
+}
+
+.qs-add-link a:hover {
+    text-decoration: underline;
+}
+
+.quick-btn {
+  display: none;
+}
+.multiplier-input {
+  display: none;
+}
+
+img {
+  width: 30px !important;
 }


### PR DESCRIPTION
<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description
Fixes many issues for mobile
<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues
Fixes #2560 
<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?
Firefox and webkit emulating iphone 17
<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots
broken
<img width="402" height="874" alt="brokeMobileSchedule" src="https://github.com/user-attachments/assets/7b08f499-eff7-463b-a408-4b86ae346667" />
<img width="402" height="874" alt="brokeMobileSchedule1" src="https://github.com/user-attachments/assets/245e2fbe-621a-4d39-8c59-b92d9bab6c9d" />

fixed
<img width="402" height="874" alt="mobile" src="https://github.com/user-attachments/assets/ef001203-832c-4876-b91e-3d61af471866" />
<img width="402" height="874" alt="mobile2" src="https://github.com/user-attachments/assets/b7bb1e1e-1b47-4ff4-909c-81f32e859145" />

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->

## Checklist

- [X] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [X] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [X] I have not included any patient data (PHI) in this PR
- [X] I have added tests for new functionality, or this change doesn't need new tests
- [X] I have read the [contributing guide](CONTRIBUTING.md)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the broken mobile schedule layout in the receptionist app by updating CSS for the header, schedule, controls, and the new Quick Patient Search. Fixes #2560.

- **Bug Fixes**
  - Keep #userSettings visible/rendered; hide #userSettingsMenu.
  - Make tables full width; add row borders on #providerSchedule; center the date header.
  - Adjust header buttons (spacing/position) and #navlistcontents offset for alignment.
  - Replace vendor-specific borders with standard border-image; normalize button margins/offset; remove dead mobile CSS.
  - Add and size Quick Patient Search: input + clear, dropdown widths/heights/z-index, result rows, badges, empty state.
  - Improve touch targets (icons 30px); hide legacy quick controls.

<sup>Written for commit 04ec15d7add314324b2cf46a5b15fdc30aeaad3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



