### PR TITLE
fix(demo-data): vary consultation specialists per demo service

### DIFF
--- a/database/mysql/updates/update-2026-06-01-varied-consult-specialist-demo-data.sql
+++ b/database/mysql/updates/update-2026-06-01-varied-consult-specialist-demo-data.sql
@@ -1,0 +1,72 @@
+-- Vary the local/demo consultation service-specialist mappings so specialist
+-- filtering can be validated against services with distinct result sets.
+--
+-- Guard this update to the small mock dataset used in dev/test environments.
+-- Real provincial specialist imports and production data should not match the
+-- exact service IDs, service names, and mock specialist names below.
+
+SET @has_demo_consult_seed := (
+  SELECT COUNT(*) = 6
+  FROM consultationServices
+  WHERE (serviceId = 3 AND serviceDesc = 'Acarology')
+     OR (serviceId = 2 AND serviceDesc = 'Cardiology')
+     OR (serviceId = 4 AND serviceDesc = 'Cetology')
+     OR (serviceId = 5 AND serviceDesc = 'Embryology')
+     OR (serviceId = 6 AND serviceDesc = 'Geology')
+     OR (serviceId = 1 AND serviceDesc = 'Radiology')
+);
+
+SET @spec_john_c := (
+  SELECT specId
+  FROM professionalSpecialists
+  WHERE fName = 'John' AND lName = 'C'
+  ORDER BY specId
+  LIMIT 1
+);
+
+SET @spec_danny_l := (
+  SELECT specId
+  FROM professionalSpecialists
+  WHERE fName = 'Danny' AND lName = 'L'
+  ORDER BY specId
+  LIMIT 1
+);
+
+SET @spec_test_1 := (
+  SELECT specId
+  FROM professionalSpecialists
+  WHERE fName = '1' AND lName = 'Test'
+  ORDER BY specId
+  LIMIT 1
+);
+
+DELETE FROM serviceSpecialists
+WHERE @has_demo_consult_seed = 1
+  AND @spec_john_c IS NOT NULL
+  AND @spec_danny_l IS NOT NULL
+  AND @spec_test_1 IS NOT NULL
+  AND serviceId IN (1, 2, 3, 4, 5, 6)
+  AND specId IN (@spec_john_c, @spec_danny_l, @spec_test_1);
+
+INSERT INTO serviceSpecialists (serviceId, specId)
+SELECT serviceId, specId
+FROM (
+  SELECT 3 AS serviceId, @spec_john_c AS specId UNION ALL
+  SELECT 2, @spec_danny_l UNION ALL
+  SELECT 4, @spec_john_c UNION ALL
+  SELECT 4, @spec_danny_l UNION ALL
+  SELECT 5, @spec_test_1 UNION ALL
+  SELECT 6, @spec_john_c UNION ALL
+  SELECT 1, @spec_danny_l UNION ALL
+  SELECT 1, @spec_test_1
+) demo_mappings
+WHERE @has_demo_consult_seed = 1
+  AND @spec_john_c IS NOT NULL
+  AND @spec_danny_l IS NOT NULL
+  AND @spec_test_1 IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1
+    FROM serviceSpecialists ss
+    WHERE ss.serviceId = demo_mappings.serviceId
+      AND ss.specId = demo_mappings.specId
+  );

--- a/database/mysql/updates/update-2026-06-01-varied-consult-specialist-demo-data.sql
+++ b/database/mysql/updates/update-2026-06-01-varied-consult-specialist-demo-data.sql
@@ -3,17 +3,75 @@
 --
 -- Guard this update to the small mock dataset used in dev/test environments.
 -- Real provincial specialist imports and production data should not match the
--- exact service IDs, service names, and mock specialist names below.
+-- exact service names and mock specialist names below.
+
+SET @service_acarology := (
+  SELECT serviceId
+  FROM consultationServices
+  WHERE serviceDesc = 'Acarology'
+  ORDER BY serviceId
+  LIMIT 1
+);
+
+SET @service_cardiology := (
+  SELECT serviceId
+  FROM consultationServices
+  WHERE serviceDesc = 'Cardiology'
+  ORDER BY serviceId
+  LIMIT 1
+);
+
+SET @service_cetology := (
+  SELECT serviceId
+  FROM consultationServices
+  WHERE serviceDesc = 'Cetology'
+  ORDER BY serviceId
+  LIMIT 1
+);
+
+SET @service_embryology := (
+  SELECT serviceId
+  FROM consultationServices
+  WHERE serviceDesc = 'Embryology'
+  ORDER BY serviceId
+  LIMIT 1
+);
+
+SET @service_geology := (
+  SELECT serviceId
+  FROM consultationServices
+  WHERE serviceDesc = 'Geology'
+  ORDER BY serviceId
+  LIMIT 1
+);
+
+SET @service_radiology := (
+  SELECT serviceId
+  FROM consultationServices
+  WHERE serviceDesc = 'Radiology'
+  ORDER BY serviceId
+  LIMIT 1
+);
 
 SET @has_demo_consult_seed := (
-  SELECT COUNT(*) = 6
-  FROM consultationServices
-  WHERE (serviceId = 3 AND serviceDesc = 'Acarology')
-     OR (serviceId = 2 AND serviceDesc = 'Cardiology')
-     OR (serviceId = 4 AND serviceDesc = 'Cetology')
-     OR (serviceId = 5 AND serviceDesc = 'Embryology')
-     OR (serviceId = 6 AND serviceDesc = 'Geology')
-     OR (serviceId = 1 AND serviceDesc = 'Radiology')
+  @service_acarology IS NOT NULL
+  AND @service_cardiology IS NOT NULL
+  AND @service_cetology IS NOT NULL
+  AND @service_embryology IS NOT NULL
+  AND @service_geology IS NOT NULL
+  AND @service_radiology IS NOT NULL
+  AND (
+    SELECT COUNT(*) = 6
+    FROM consultationServices
+    WHERE serviceDesc IN (
+      'Acarology',
+      'Cardiology',
+      'Cetology',
+      'Embryology',
+      'Geology',
+      'Radiology'
+    )
+  )
 );
 
 SET @spec_john_c := (
@@ -35,7 +93,7 @@ SET @spec_danny_l := (
 SET @spec_test_1 := (
   SELECT specId
   FROM professionalSpecialists
-  WHERE fName = '1' AND lName = 'Test'
+  WHERE fName = 'Test' AND lName = '1'
   ORDER BY specId
   LIMIT 1
 );
@@ -45,20 +103,27 @@ WHERE @has_demo_consult_seed = 1
   AND @spec_john_c IS NOT NULL
   AND @spec_danny_l IS NOT NULL
   AND @spec_test_1 IS NOT NULL
-  AND serviceId IN (1, 2, 3, 4, 5, 6)
+  AND serviceId IN (
+    @service_acarology,
+    @service_cardiology,
+    @service_cetology,
+    @service_embryology,
+    @service_geology,
+    @service_radiology
+  )
   AND specId IN (@spec_john_c, @spec_danny_l, @spec_test_1);
 
 INSERT INTO serviceSpecialists (serviceId, specId)
 SELECT serviceId, specId
 FROM (
-  SELECT 3 AS serviceId, @spec_john_c AS specId UNION ALL
-  SELECT 2, @spec_danny_l UNION ALL
-  SELECT 4, @spec_john_c UNION ALL
-  SELECT 4, @spec_danny_l UNION ALL
-  SELECT 5, @spec_test_1 UNION ALL
-  SELECT 6, @spec_john_c UNION ALL
-  SELECT 1, @spec_danny_l UNION ALL
-  SELECT 1, @spec_test_1
+  SELECT @service_acarology AS serviceId, @spec_john_c AS specId UNION ALL
+  SELECT @service_cardiology, @spec_danny_l UNION ALL
+  SELECT @service_cetology, @spec_john_c UNION ALL
+  SELECT @service_cetology, @spec_danny_l UNION ALL
+  SELECT @service_embryology, @spec_test_1 UNION ALL
+  SELECT @service_geology, @spec_john_c UNION ALL
+  SELECT @service_radiology, @spec_danny_l UNION ALL
+  SELECT @service_radiology, @spec_test_1
 ) demo_mappings
 WHERE @has_demo_consult_seed = 1
   AND @spec_john_c IS NOT NULL

--- a/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/ConsultationSpecialistDemoSeedRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/ConsultationSpecialistDemoSeedRegressionTest.java
@@ -60,8 +60,8 @@ class ConsultationSpecialistDemoSeedRegressionTest {
                 "SET @service_geology := (",
                 "WHERE serviceDesc = 'Geology'",
                 "SET @service_radiology := (",
-                "WHERE serviceDesc = 'Radiology'");
-        assertThat(migrationSql).doesNotContain(
+                "WHERE serviceDesc = 'Radiology'")
+                .doesNotContain(
                 "serviceId IN (1, 2, 3, 4, 5, 6)",
                 "SELECT 3 AS serviceId");
     }
@@ -79,8 +79,8 @@ class ConsultationSpecialistDemoSeedRegressionTest {
         assertThat(migrationSql).contains(
                 "WHERE fName = 'John' AND lName = 'C'",
                 "WHERE fName = 'Danny' AND lName = 'L'",
-                "WHERE fName = 'Test' AND lName = '1'");
-        assertThat(migrationSql).doesNotContain("WHERE fName = '1' AND lName = 'Test'");
+                "WHERE fName = 'Test' AND lName = '1'")
+                .doesNotContain("WHERE fName = '1' AND lName = 'Test'");
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/ConsultationSpecialistDemoSeedRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/ConsultationSpecialistDemoSeedRegressionTest.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.encounter.oscarConsultationRequest;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Guards the demo consultation service-specialist seed update used by local UI tests.
+ *
+ * @since 2026-06-01
+ */
+@DisplayName("Consultation specialist demo seed regressions")
+@Tag("unit")
+@Tag("database")
+class ConsultationSpecialistDemoSeedRegressionTest {
+
+    private static final Path MIGRATION = Path.of("database", "mysql", "updates",
+            "update-2026-06-01-varied-consult-specialist-demo-data.sql");
+    private static final Path DEVELOPMENT_SEED = Path.of(".devcontainer", "db", "scripts",
+            "development.sql");
+
+    @Test
+    @DisplayName("migration should resolve demo services by description")
+    void shouldResolveServicesByDescription_whenMigrationRuns() throws IOException {
+        String migrationSql = Files.readString(MIGRATION, StandardCharsets.UTF_8);
+
+        assertThat(migrationSql).contains(
+                "SET @service_acarology := (",
+                "WHERE serviceDesc = 'Acarology'",
+                "SET @service_cardiology := (",
+                "WHERE serviceDesc = 'Cardiology'",
+                "SET @service_cetology := (",
+                "WHERE serviceDesc = 'Cetology'",
+                "SET @service_embryology := (",
+                "WHERE serviceDesc = 'Embryology'",
+                "SET @service_geology := (",
+                "WHERE serviceDesc = 'Geology'",
+                "SET @service_radiology := (",
+                "WHERE serviceDesc = 'Radiology'");
+        assertThat(migrationSql).doesNotContain(
+                "serviceId IN (1, 2, 3, 4, 5, 6)",
+                "SELECT 3 AS serviceId");
+    }
+
+    @Test
+    @DisplayName("migration should match mock specialist names in development seed")
+    void shouldMatchMockSpecialistNames_whenGuardingMigration() throws IOException {
+        String migrationSql = Files.readString(MIGRATION, StandardCharsets.UTF_8);
+        String developmentSeedSql = Files.readString(DEVELOPMENT_SEED, StandardCharsets.UTF_8);
+
+        assertThat(developmentSeedSql).contains(
+                "(1,'John','C'",
+                "(2,'Danny','L'",
+                "(3,'Test','1'");
+        assertThat(migrationSql).contains(
+                "WHERE fName = 'John' AND lName = 'C'",
+                "WHERE fName = 'Danny' AND lName = 'L'",
+                "WHERE fName = 'Test' AND lName = '1'");
+        assertThat(migrationSql).doesNotContain("WHERE fName = '1' AND lName = 'Test'");
+    }
+
+    @Test
+    @DisplayName("migration should define distinct demo service specialist mappings")
+    void shouldDefineDistinctMappings_whenMigrationRuns() throws IOException {
+        String migrationSql = Files.readString(MIGRATION, StandardCharsets.UTF_8);
+
+        assertThat(migrationSql).contains(
+                "SELECT @service_acarology AS serviceId, @spec_john_c AS specId",
+                "SELECT @service_cardiology, @spec_danny_l",
+                "SELECT @service_cetology, @spec_john_c",
+                "SELECT @service_cetology, @spec_danny_l",
+                "SELECT @service_embryology, @spec_test_1",
+                "SELECT @service_geology, @spec_john_c",
+                "SELECT @service_radiology, @spec_danny_l",
+                "SELECT @service_radiology, @spec_test_1");
+    }
+}


### PR DESCRIPTION
## Summary

The dev snapshot (`.devcontainer/db/scripts/development.sql`) truncate-reloads `consultationServices` with six fictional labels — Radiology, Cardiology, Acarology, Cetology, Embryology, Geology — and links **every one of them** to the same two legacy specialists (`serviceSpecialists` = `(1..6) → (1,2)`). The consultation request form and **Administration > Faxes… > Edit Specialists Listing** therefore render an identical list whichever service is picked, so a broken service filter is indistinguishable from a working one.

This PR gives each of those services a distinct specialist list, seeded through the demo-data loader.

## What changed since the first revision

The original revision put the fix in `database/mysql/updates/update-2026-06-01-…sql`. **That file could never run**: `database/mysql/updates/` is frozen legacy — `populate_db.sh` applies only a handful of explicitly named files from it, and `carlos-ctl demo-data` applies none. The seed has been moved into the file that already owns the `serviceSpecialists` demo links, `.devcontainer/db/scripts/demo-specialists.sql`, which **both** loaders apply. The `updates/` file is deleted.

## How it works

`demo-specialists.sql` already links the 9001–9060 fake roster to services by joining `professionalSpecialists.specType = consultationServices.serviceDesc`. Of the six snapshot labels, only `Cardiology` also names a real specialty, so it was the only one that join reached. The new trailing block:

- clears the uniform legacy links for the **five** fictional labels, scoped to `specId NOT BETWEEN 9001 AND 9060` so it can only ever remove the snapshot's own rows;
- gives each of the five an explicit slice of the fake roster, deliberately different in membership **and** size, so switching service visibly changes the list.

| Service | Specialists | Count |
|---|---|---|
| Geology | FAKE-Specialist-31 | 1 |
| Cetology | FAKE-Specialist-21…22 | 2 |
| Acarology | FAKE-Specialist-06…08 | 3 |
| Radiology | FAKE-Specialist-36…39 | 4 |
| Embryology | FAKE-Specialist-41…45 | 5 |
| Cardiology | legacy pair + FAKE-Specialist-01…05 (existing `specType` join) | 7 |

## Scope and safety

- **Demo-only by construction.** None of the five fictional labels exists in either province's Flyway `consultationServices` catalog (ON and BC both seed `'Cardiology'` at serviceId 16 and neither seeds the rest), and `consultationServices` is on `scripts/demo-additive-exclude.txt`, so Flyway keeps ownership of that table under `carlos-ctl demo-data`. Every new statement matches zero rows there.
- **`'Cardiology'` is deliberately excluded from the `DELETE`** for the same reason in reverse: it *is* a real provincial label, and Flyway data must win.
- **Idempotent.** `serviceSpecialists` has no primary key, so the insert is deduplicated with `WHERE NOT EXISTS` (`INSERT IGNORE` cannot); the delete is scoped away from the roster, so it cannot remove a row the insert just wrote.

## Verification

Executed against **MariaDB 11.8.8** using the real `V1__baseline_schema.sql` DDL for `consultationServices` / `professionalSpecialists` / `serviceSpecialists` / `billingreferral`:

- **Dev-snapshot shape** (snapshot rows + `demo-specialists.sql`): six services, six distinct lists, counts `1/2/3/4/5/7` — matching the table above.
- **Re-run**: byte-identical result (22 links, 60 `billingreferral` rows) — idempotent.
- **Ontario Flyway shape** (257-service catalog + the additive snapshot's rows): all 12 snapshot links preserved, all 60 `specType` links preserved, 0 fictional labels matched — the new block is a proven no-op on the packaged demo path.

`ConsultationSpecialistDemoSeedRegressionTest` was rewritten to parse the seed instead of string-matching a file that no longer exists. It pins list distinctness, roster membership (every linked `specId` is one this same file inserts), coverage of the snapshot catalog (a snapshot refresh that renames/adds a service now fails the build), the `Cardiology` carve-out, and the retired `updates/` patch staying deleted. Mutation-checked: seeding two services identically, or pointing a link outside the roster, both fail.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gives each fictional consultation service in the dev snapshot its own specialist list so a broken service filter no longer looks identical to a working one.

- Seeds five dev-only services from distinct slices of the 9001–9060 fake roster (1/2/3/4/5 specialists, with `Cardiology`'s 7).
- Moves the fix out of `database/mysql/updates/`, which no demo loader runs, into `demo-specialists.sql`, which both loaders apply.
- Scopes the change to dev-only labels, spares provincial data like `Cardiology`, and is a no-op under `carlos-ctl demo-data`.
- Adds a regression test that parses the seed and pins list distinctness, roster membership, snapshot coverage, the `Cardiology` carve-out, and the retired patch staying deleted.
- Documents the seed's ownership in `CLAUDE.md`.

<sup>Written for commit 0c2bd027c1190ad64bed5e04b81d4b116763f98b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2589?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Seed distinct specialist assignments for the dev snapshot’s fictional consultation services and guard the mappings against future demo-data regressions.

New Features:
- Give each fictional dev-snapshot consultation service a distinct specialist list from the fake demo roster.

Bug Fixes:
- Make demo consultation specialist filtering visibly distinguishable by ensuring services no longer share the same legacy specialist list.

Enhancements:
- Move the seed ownership into the demo-specialists loader used by both demo-data paths while preserving provincial Flyway-owned data and idempotent behavior.

Documentation:
- Document the consultation service specialist links and their regression coverage in the project guidance.

Tests:
- Add regression coverage for service-list distinctness, fake-roster membership, snapshot service coverage, provincial-label protection, and removal of the obsolete updates patch.

Chores:
- Remove the ineffective legacy database update patch.