### PR TITLE
chore: suppress CRLF_INJECTION_LOGS noise (~64% of security alerts)

### DIFF
--- a/.github/spotbugs/spotbugs-exclude.xml
+++ b/.github/spotbugs/spotbugs-exclude.xml
@@ -379,4 +379,32 @@
         <Bug pattern="JAXRS_ENDPOINT"/>
     </Match>
 
+    <!-- ================================================================
+         CRLF LOG INJECTION (CWE-117) — ACCEPTED-RISK BLANKET SUPPRESSION
+         CRLF_INJECTION_LOGS is a real but low-severity detector (SpotBugs
+         rank 15) that flags any non-constant value reaching a logging sink.
+         On this codebase it is the single largest alert source (~1,876
+         instances, ~64% of all Code Scanning security alerts).
+
+         Why we suppress the whole pattern rather than model sanitizers:
+         Find Security Bugs taint tracking loses its "safe" tag across String
+         concatenation (Taint.merge intersects tags on '+'), and ~99% of
+         these sinks are either unsanitized or sanitized-then-concatenated
+         (e.g. logger.info("user=" + LogSafe.sanitize(x))). Empirically,
+         marking LogSafe/encoders safe clears only ~4 of the 1,876 — the
+         rest cannot be cleared by configuration in FSB 1.14.0. Per-site
+         @SuppressFBWarnings across 516 files is not maintainable, and the
+         noise drowns out actionable injection/path/XSS/crypto findings.
+
+         Risk accepted: this trades away low-severity log-forging signal.
+         Mitigations remain in place — Log4j2 pattern layouts neutralize raw
+         CR/LF in rendered logs, and LogSafe (io.github.carlos_emr.carlos.
+         utility.LogSafe) is the mandated control for sanitizing user- and
+         PHI-correlating identifiers before logging (see CLAUDE.md). Keep
+         using LogSafe on sensitive log paths regardless of this suppression.
+         ================================================================ -->
+    <Match>
+        <Bug pattern="CRLF_INJECTION_LOGS"/>
+    </Match>
+
 </FindBugsFilter>


### PR DESCRIPTION
## What

Suppresses the `CRLF_INJECTION_LOGS` (CWE-117) detector in `.github/spotbugs/spotbugs-exclude.xml` as documented accepted-risk noise. This removes **~1,876 findings — roughly 64% of all open Code Scanning security alerts** — in one targeted change, while keeping every other detector active.

## Why a blanket suppression instead of teaching the scanner the sanitizers

Investigated whether marking CARLOS's `LogSafe`/`SafeEncode` (and OWASP `Encode`) as safe encoders would clear these. It does not, and I verified why empirically:

- FindSecBugs 1.14.0 **loses the safe tag across String concatenation** — `Taint.merge` intersects taint tags on `+`.
- Isolated probe: `out.println(Encode.forHtml(x))` clears, but `out.println("<br>" + Encode.forHtml(x))` is still flagged — even though `Encode` is already a built-in safe encoder.
- Measured against the real backlog: marking the wrappers safe would clear only **~4 of 1,876** (~99% are unsanitized or sanitized-then-concatenated).

Per-site `@SuppressFBWarnings` across 516 files is unmaintainable, and the volume drowns out actionable injection/path/XSS/crypto findings. The blanket suppression matches the file's existing convention for noisy patterns (`SERVLET_PARAMETER`, `*_ENDPOINT`).

## Risk accepted

CRLF_INJECTION_LOGS is low-severity (SpotBugs rank 15). Mitigations remain:
- Log4j2 pattern layouts neutralize raw CR/LF in rendered logs.
- `LogSafe` remains the **mandated control** for sanitizing user- and PHI-correlating identifiers on sensitive log paths (per CLAUDE.md) — unchanged by this PR.

All other sink detectors stay active.

## Verification

Scoped SpotBugs run on `ManageDocument2Action` + `PhsStarHandler` (which together produced ~28 CRLF findings):
- `CRLF_INJECTION_LOGS`: **0** (suppressed)
- `XSS_SERVLET` (18), `PATH_TRAVERSAL_IN` (9), weak-crypto, correctness detectors: **still firing**

## Follow-up

`XSS_SERVLET` (144 findings, the next-largest actionable cluster) is tracked separately in #2608 for investigation/remediation — it requires per-file code review and is intentionally **not** in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Update SpotBugs exclusion configuration to blanket-suppress the CRLF_INJECTION_LOGS detector as documented accepted risk.