### PR TITLE
Fix Consult Request Print by update AJAX data serialization 

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConsultationFormRequest.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConsultationFormRequest.jsp
@@ -2005,7 +2005,7 @@ if (userAgent != null) {
             jQuery.ajax({
                 type: "POST",
                 url: "${ pageContext.request.contextPath }/encounter/RequestConsultation",
-                data: form.serialize(),
+                data: jQuery(form).serialize(),
                 dataType: "json",
                 success: function (data) {
                     HideSpin();
@@ -2393,7 +2393,8 @@ if (userAgent != null) {
                                 <input name="updateAndPrint" type="button" class="btn btn-primary btn-sm"
                                        value="<fmt:message key="encounter.oscarConsultationRequest.ConsultationFormRequest.btnUpdateAndPrint"/>"
                                        onclick="return checkForm('Update Consultation Request And Print Preview','EctConsultationFormRequest2Form');"/>
-                                <input name="printPreview" type="button" class="btn btn-primary btn-sm" value="Print Preview"
+                                <input name="printPreview" type="button" class="btn btn-primary btn-sm" 
+                                       value="<fmt:message key="global.btnPrint"/>"
                                        onclick="return checkForm('And Print Preview','EctConsultationFormRequest2Form');"/>
 
                                 <oscar:oscarPropertiesCheck value="yes" property="consultation_fax_enabled">


### PR DESCRIPTION
... and add missing i18n

<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description
Fixes print spinner that never finishes
<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues
Fixes #2583
<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?
FF
<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots
<img width="960" height="700" alt="Screenshot 2026-06-02 at 12-57-17 Demande de consultation CARLOS" src="https://github.com/user-attachments/assets/eb053f31-d383-4df2-9301-243a0c0e1e37" />

<img width="1022" height="751" alt="Screenshot 2026-06-02 at 12-56-03 Demande de consultation - 2026_06_02_TEST-2 pdf" src="https://github.com/user-attachments/assets/2ea09057-d575-4f4a-a9bb-00c69e47abd8" />

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->

## Checklist

- [X] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [X] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [X] I have not included any patient data (PHI) in this PR
- [X] I have added tests for new functionality, or this change doesn't need new tests
- [X] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Fix consultation request print handling so the AJAX submission completes correctly and the UI uses localized labels for print actions.

Bug Fixes:
- Ensure the consultation request form AJAX call serializes the correct form element so the print spinner completes as expected.

Enhancements:
- Use an existing i18n message key for the print preview button label instead of a hard-coded string.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2583 by correcting AJAX form serialization so Print Preview completes and the spinner stops. Also localizes the Print Preview button label.

- **Bug Fixes**
  - Use jQuery(form).serialize() instead of form.serialize() to submit the consultation request, resolving the endless spinner on Print Preview.
  - Replace the hard-coded "Print Preview" label with i18n using <fmt:message key="global.btnPrint"/>.

<sup>Written for commit 06e6eec530629cbe9008402b796f6ddc47e8db4f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

