### PR TITLE
[Fix] Update ConsultationFormRequest.jsp for title and address

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConsultationFormRequest.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConsultationFormRequest.jsp
@@ -2160,7 +2160,7 @@ if (userAgent != null) {
         <%-- Page Header --%>
         <div class="page-header-bar d-flex align-items-center justify-content-between">
             <h4 class="page-header-title mb-0">
-                <i class="fa-solid fa-file-medical me-2"></i>Consultation Request
+                <i class="fa-solid fa-file-medical me-2"></i><fmt:message key="encounter.oscarConsultationRequest.ConsultationFormRequest.title"/>
             </h4>
             <div class="d-flex align-items-center gap-2">
                 <span class="badge bg-light text-dark border" style="font-size:0.85rem;">
@@ -2431,8 +2431,8 @@ if (userAgent != null) {
                                         <div class="row g-2" style="font-size:0.85rem;">
                                             <div class="col-md-4">
                                                 <small class="text-muted"><fmt:setBundle basename="oscarResources"/><fmt:message key="encounter.oscarConsultationRequest.ConsultationFormRequest.msgAddress"/></small><br>
-                                                <div style="white-space: pre-line;">
-                                                <carlos:encode value='<%= thisForm.getPatientAddress() %>' context="html"/>
+                                                <div>
+                                                <%= Encode.forHtml(thisForm.getPatientAddress()).replace("&lt;br /&gt;","<br>") %>
                                                 </div>
                                             </div>
                                             <div class="col-md-4">

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConsultationFormRequest.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConsultationFormRequest.jsp
@@ -2433,7 +2433,7 @@ if (userAgent != null) {
                                             <div class="col-md-4">
                                                 <small class="text-muted"><fmt:setBundle basename="oscarResources"/><fmt:message key="encounter.oscarConsultationRequest.ConsultationFormRequest.msgAddress"/></small><br>
                                                 <div>
-                                                <%= Encode.forHtml(thisForm.getPatientAddress()).replace("&lt;br /&gt;","<br>") %>
+                                                <%= SafeEncode.forHtml(thisForm.getPatientAddress()).replace("&lt;br /&gt;","<br>") %>
                                                 </div>
                                             </div>
                                             <div class="col-md-4">


### PR DESCRIPTION
restore JUST any encoded <br />

<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description
Fixes address format
<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues
Fixes #2637 
<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?
FF
<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->
<img width="738" height="137" alt="Screenshot 2026-06-02 at 14-33-19 Demande de consultation CARLOS" src="https://github.com/user-attachments/assets/7dd34445-24be-4683-8ffa-785786212303" />

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2637: Patient address in Consultation Request now renders line breaks instead of showing “&lt;br /&gt;”. Also localizes the page title.

- **Bug Fixes**
  - Escapes the address with `SafeEncode.forHtml`, then converts only encoded “&lt;br /&gt;” tokens into real line breaks to preserve formatting without exposing HTML.

<sup>Written for commit 9bd045fb1bfa717996575d342b172c1cd480a285. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



