### PR TITLE
docs: add missing javadoc to 40 undocumented classes

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/billings/OHIP/ExtractBean.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/OHIP/ExtractBean.java
@@ -54,7 +54,12 @@ import io.github.carlos_emr.carlos.util.ConversionUtils;
 import io.github.carlos_emr.carlos.util.UtilDateUtilities;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+/**
+ * Data Transfer Object facilitating the extraction of billing data for OHIP or MSP submissions.
+ * Formats and validates claim details before transmission to the provincial billing authority.
+ */
 public class ExtractBean extends Object implements Serializable {
+    // Prepares raw billing records into the structured format required for external transmission
 
     private static final long serialVersionUID = 1L;
     private static Logger logger = MiscUtils.getLogger();

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/AgeValidator.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/AgeValidator.java
@@ -30,8 +30,13 @@
 package io.github.carlos_emr.carlos.billings.ca.bc.MSP;
 
 
+/**
+ * Validates whether a patient's age falls within the acceptable range for a specific billing service code.
+ * Ensures compliance with age-restricted billing rules enforced by provincial authorities.
+ */
 public class AgeValidator
         extends ServiceCodeValidator {
+    // Cross-references patient date of birth against service code age constraints
     private int maxAge = 150;
     private int minAge = 0;
     private int inputAge;

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/CDMReminderHlp.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/CDMReminderHlp.java
@@ -37,7 +37,12 @@ import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.tickler.TicklerCreator;
 import io.github.carlos_emr.carlos.util.SqlUtils;
 
+/**
+ * Helper class for calculating and managing Chronic Disease Management (CDM) billing reminders.
+ * Analyzes patient history to prompt providers when specific CDM fee codes become eligible.
+ */
 public class CDMReminderHlp {
+    // Evaluates clinical timelines to suggest applicable CDM billing codes
     public CDMReminderHlp() {
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/CheckBillingData.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/CheckBillingData.java
@@ -40,7 +40,12 @@ import java.sql.SQLException;
 import java.util.Iterator;
 import java.util.List;
 
+/**
+ * Performs comprehensive pre-submission checks on billing data to identify common errors before transmission.
+ * Validates demographics, provider numbers, and code combinations to maximize claim acceptance rates.
+ */
 public class CheckBillingData {
+    // Executes a final validation pass to catch common billing errors before export
 
     // check batchHeader VS1
     public String checkVS1(String recordCode, String dataCentreNum,

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/CreateBillingReport2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/CreateBillingReport2Action.java
@@ -41,7 +41,12 @@ import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 
+/**
+ * Struts 2 Action that orchestrates the generation of comprehensive billing reports for BC MSP.
+ * Compiles claim statuses, payments, and rejections into a unified view for clinic administrators.
+ */
 public class CreateBillingReport2Action extends ActionSupport {
+    // Triggers the aggregation of BC billing data into a digestible report format
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
 
     HttpServletRequest request = ServletActionContext.getRequest();

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/DocumentTeleplanReportUploadServlet.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/DocumentTeleplanReportUploadServlet.java
@@ -51,7 +51,12 @@ import io.github.carlos_emr.CarlosProperties;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+/**
+ * Servlet managing the manual upload of Teleplan remittance and error reports.
+ * Parses the incoming files and updates the status of corresponding claims in the database.
+ */
 public class DocumentTeleplanReportUploadServlet extends HttpServlet {
+    // Processes incoming Teleplan data files to reconcile claim statuses
 
     // FindSecBugs PATH_TRAVERSAL_IN: path validated for directory containment via PathValidationUtils before use
     @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "path validated for directory containment via PathValidationUtils before use")

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/ExtractBean.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/ExtractBean.java
@@ -59,7 +59,12 @@ import java.text.SimpleDateFormat;
 import java.util.Arrays;
 
 
+/**
+ * Data Transfer Object facilitating the extraction of billing data for OHIP or MSP submissions.
+ * Formats and validates claim details before transmission to the provincial billing authority.
+ */
 public class ExtractBean extends Object implements Serializable {
+    // Prepares raw billing records into the structured format required for external transmission
     private static Logger logger = MiscUtils.getLogger();
     private LogTeleplanTxDao logTeleplanTxDao = SpringUtils.getBean(LogTeleplanTxDao.class);
     private BillingDao billingDao = SpringUtils.getBean(BillingDao.class);

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/GenTa2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/GenTa2Action.java
@@ -69,7 +69,12 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.struts2.ActionSupport;
 import org.apache.struts2.ServletActionContext;
 
+/**
+ * Struts 2 Action handling the generation of Treatment Authorization (TA) requests for BC billing.
+ * Compiles required clinical justification and routes the request to the appropriate authority.
+ */
 public class GenTa2Action extends ActionSupport {
+    // Processes the creation and submission of pre-authorization requests
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
 
     HttpServletRequest request = ServletActionContext.getRequest();

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/MspErrorCodes.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/MspErrorCodes.java
@@ -46,7 +46,12 @@ import io.github.carlos_emr.carlos.utility.PathValidationUtils;
 
 import io.github.carlos_emr.CarlosProperties;
 
+/**
+ * Enumerates and translates standard Medical Services Plan (MSP) error codes returned in remittance files.
+ * Provides human-readable descriptions to assist users in correcting rejected claims.
+ */
 public class MspErrorCodes extends Properties {
+    // Maps raw MSP error codes to actionable user-facing descriptions
 
     /**
      * Creates a new instance of MspErrorCodes

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/ServiceCodeValidator.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/ServiceCodeValidator.java
@@ -24,7 +24,12 @@
 
 package io.github.carlos_emr.carlos.billings.ca.bc.MSP;
 
+/**
+ * Ensures that submitted service codes are active, valid, and structurally correct according to the provincial fee schedule.
+ * Prevents the submission of obsolete or malformed codes that would result in claim rejection.
+ */
 public class ServiceCodeValidator {
+    // Validates billing codes against the current active fee schedule
     protected boolean valid = true;
     protected String serviceCode = "";
     protected String description = "";

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/TeleplanSubmissionLinkDAO.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/TeleplanSubmissionLinkDAO.java
@@ -36,7 +36,12 @@ import io.github.carlos_emr.carlos.billing.CA.BC.dao.TeleplanSubmissionLinkDao;
 import io.github.carlos_emr.carlos.billing.CA.BC.model.TeleplanSubmissionLink;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 
+/**
+ * Data Access Object managing the linkage between internal billing records and their corresponding Teleplan submission batches.
+ * Essential for tracking the lifecycle of a claim from creation to provincial adjudication.
+ */
 public class TeleplanSubmissionLinkDAO {
+    // Maintains the relational mapping between local claims and Teleplan batch identifiers
 
     private TeleplanSubmissionLinkDao dao = SpringUtils.getBean(TeleplanSubmissionLinkDao.class);
 

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/administration/GstReport.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/administration/GstReport.java
@@ -18,7 +18,12 @@ import io.github.carlos_emr.carlos.util.ConversionUtils;
 import java.util.Properties;
 import java.util.Vector;
 
+/**
+ * Generates financial reports detailing GST collected on applicable private and third-party services.
+ * Used for clinic accounting and tax remittance purposes.
+ */
 public class GstReport {
+    // Aggregates tax data across billing transactions for external reporting
 
     public Vector<Properties> getGST(LoggedInInfo loggedInInfo, String[] providerNos, String startDate, String endDate) {
         Properties props;

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/administration/TeleplanCorrectionActionWCB2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/administration/TeleplanCorrectionActionWCB2Action.java
@@ -73,7 +73,12 @@ import org.apache.struts2.ActionSupport;
 import org.apache.struts2.ServletActionContext;
 import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
+/**
+ * Struts 2 Action responsible for managing corrections to rejected WorkSafeBC (WCB) claims via Teleplan.
+ * Retrieves the rejected claim details and provides the interface for modification and resubmission.
+ */
 public class TeleplanCorrectionActionWCB2Action extends ActionSupport {
+    // Facilitates the workflow for fixing and resubmitting denied WCB claims
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
 
     HttpServletRequest request = ServletActionContext.getRequest();

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/administration/TeleplanCorrectionFormWCB.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/administration/TeleplanCorrectionFormWCB.java
@@ -43,7 +43,12 @@ import io.github.carlos_emr.MyDateFormat;
 import io.github.carlos_emr.carlos.demographic.data.DemographicData;
 import io.github.carlos_emr.carlos.util.ConversionUtils;
 
+/**
+ * Form bean capturing the user's corrections to a previously rejected WorkSafeBC claim.
+ * Holds the modified data fields before they are repackaged for Teleplan resubmission.
+ */
 public class TeleplanCorrectionFormWCB {
+    // Stores the updated WCB claim information provided during the correction workflow
 
     private static Logger logger = MiscUtils.getLogger();
 

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/data/BillRecipient.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/data/BillRecipient.java
@@ -36,7 +36,12 @@ import io.github.carlos_emr.carlos.utility.MiscUtils;
 
 import io.github.carlos_emr.carlos.util.ConversionUtils;
 
+/**
+ * Identifies the entity responsible for paying a specific bill when it is not a direct patient charge or standard provincial claim.
+ * Typically used for third-party billing, such as employers or insurance companies.
+ */
 public class BillRecipient {
+    // Specifies the target payee for third-party and specialized billing scenarios
 
     private Integer id;
     private String name;

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/data/BillingFormData.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/data/BillingFormData.java
@@ -44,7 +44,12 @@ import io.github.carlos_emr.carlos.util.UtilDateUtilities;
 import java.util.*;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+/**
+ * Backing bean for billing data entry screens, holding temporary form state before persistence.
+ * Contains validation logic and field mappings for complex provincial billing requirements.
+ */
 public class BillingFormData {
+    // Captures user input from the billing interface prior to creating formal claim records
 
     private DiagnosticCodeDao diagnosticCodeDao = SpringUtils.getBean(DiagnosticCodeDao.class);
 

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/data/InjuryLocation.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/data/InjuryLocation.java
@@ -29,7 +29,12 @@
 
 package io.github.carlos_emr.carlos.billings.ca.bc.data;
 
+/**
+ * Represents the physical or anatomical location of a patient's injury, primarily required for WCB or specialized claims.
+ * Maps to standardized codes expected by provincial billing authorities.
+ */
 public class InjuryLocation {
+    // Captures mandatory injury site data required by external claim processors
     private String sidetype;
     private String sidedesc;
 

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/AddReferralDoc2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/AddReferralDoc2Action.java
@@ -48,7 +48,12 @@ import org.apache.struts2.ActionSupport;
 import org.apache.struts2.ServletActionContext;
 import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
+/**
+ * Struts 2 Action handling the addition of a referring physician to a specialist billing claim.
+ * Validates the referring doctor's practitioner number, as it is often mandatory for consultation codes.
+ */
 public class AddReferralDoc2Action extends ActionSupport {
+    // Attaches and validates referring physician details required for consultation claims
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
 
     HttpServletRequest request = ServletActionContext.getRequest();

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/AssociateCodes2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/AssociateCodes2Action.java
@@ -54,7 +54,12 @@ import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 
+/**
+ * Struts 2 Action managing the logical association of related billing codes (e.g., surgical procedures and anesthetic fees).
+ * Ensures related claims are linked correctly for accurate adjudication.
+ */
 public class AssociateCodes2Action extends ActionSupport {
+    // Links logically related service codes to ensure accurate combined billing
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
 
     HttpServletRequest request = ServletActionContext.getRequest();

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/BillingAddCode2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/BillingAddCode2Action.java
@@ -45,7 +45,12 @@ import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 
+/**
+ * Struts 2 Action facilitating the dynamic addition of service codes to an active billing encounter.
+ * Performs real-time validation and applies appropriate modifiers based on the selected code.
+ */
 public final class BillingAddCode2Action extends ActionSupport {
+    // Handles the asynchronous addition of service codes during claim creation
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
 
     private HttpServletRequest request = ServletActionContext.getRequest();

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/BillingSessionBean.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/BillingSessionBean.java
@@ -34,7 +34,12 @@ import java.util.ArrayList;
 
 import io.github.carlos_emr.carlos.billings.ca.bc.pageUtil.BillingBillingManager.BillingItem;
 
+/**
+ * Session-scoped bean holding transient state during complex, multi-step billing workflows.
+ * Ensures data consistency across multiple screens before final claim submission.
+ */
 public class BillingSessionBean implements java.io.Serializable {
+    // Retains temporary billing data across multiple steps in the billing wizard
     private String apptProviderNo = null;
     private String patientName = null;
     private String providerView = null;

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/BillingUpdateBilling2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/BillingUpdateBilling2Action.java
@@ -61,8 +61,13 @@ import io.github.carlos_emr.carlos.utility.SpringUtils;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+/**
+ * Struts 2 Action responsible for processing updates to existing, unsubmitted billing records.
+ * Validates the modified fields and ensures the claim remains compliant with billing rules.
+ */
 public final class BillingUpdateBilling2Action
         extends ActionSupport {
+    // Processes user modifications to existing claims prior to submission
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
 
     HttpServletRequest request = ServletActionContext.getRequest();

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/BillingViewBean.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/BillingViewBean.java
@@ -50,7 +50,12 @@ import io.github.carlos_emr.carlos.billings.ca.bc.data.BillingmasterDAO;
 import io.github.carlos_emr.carlos.billings.ca.bc.pageUtil.BillingBillingManager.BillingItem;
 import io.github.carlos_emr.carlos.util.ConversionUtils;
 
+/**
+ * Presentation model consolidating data needed for displaying a comprehensive view of a patient's billing history.
+ * Aggregates claims, payments, and outstanding balances for the UI.
+ */
 public class BillingViewBean {
+    // Aggregates comprehensive billing history for display in the patient interface
 
     private String apptProviderNo = null;
     private String patientName = null;

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/ManageTeleplan2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/ManageTeleplan2Action.java
@@ -75,7 +75,12 @@ import org.apache.struts2.ActionSupport;
 import org.apache.struts2.ServletActionContext;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+/**
+ * Struts 2 Action providing administrative oversight and control over the Teleplan integration subsystem.
+ * Allows users to monitor batch statuses, trigger manual syncs, and review system-level communication logs.
+ */
 public class ManageTeleplan2Action extends ActionSupport {
+    // Provides administrative controls for the Teleplan communication subsystem
     private static final Set<String> POST_ONLY_METHODS = Set.of(
             "setUserName",
             "updateBillingCodes",

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/ReceivePayment2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/ReceivePayment2Action.java
@@ -53,8 +53,13 @@ import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 
+/**
+ * Struts 2 Action managing the workflow for receiving and applying payments to outstanding private bills.
+ * Updates account balances and generates necessary receipts upon payment confirmation.
+ */
 public class ReceivePayment2Action
         extends ActionSupport {
+    // Processes incoming payments and reconciles them against outstanding patient balances
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
 
     HttpServletRequest request = ServletActionContext.getRequest();

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/SimulateTeleplanFile2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/SimulateTeleplanFile2Action.java
@@ -53,7 +53,12 @@ import java.util.List;
 import org.apache.struts2.ActionSupport;
 import org.apache.struts2.ServletActionContext;
 
+/**
+ * Struts 2 Action used primarily in testing and training environments to simulate the generation and parsing of Teleplan files.
+ * Allows validation of system logic without transmitting real data to the provincial authority.
+ */
 public class SimulateTeleplanFile2Action extends ActionSupport {
+    // Generates simulated Teleplan responses for testing and training purposes
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
 
     HttpServletRequest request = ServletActionContext.getRequest();

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/WCBAction22Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/WCBAction22Action.java
@@ -66,7 +66,12 @@ import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 
+/**
+ * Struts 2 Action managing specialized workflows related to WorkSafeBC claim processing and reporting.
+ * Handles the unique requirements and additional forms necessary for occupational injury claims.
+ */
 public class WCBAction22Action extends ActionSupport {
+    // Orchestrates the specialized workflow for occupational injury claims
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
 
     HttpServletRequest request = ServletActionContext.getRequest();

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/quickbilling/QuickBillingBC2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/quickbilling/QuickBillingBC2Action.java
@@ -64,7 +64,12 @@ import io.github.carlos_emr.carlos.billings.ca.bc.pageUtil.BillingSessionBean;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 
+/**
+ * Struts 2 Action controller managing the fast-entry interface for British Columbia MSP billing.
+ * Streamlines the billing process by defaulting common fields and optimizing the user workflow.
+ */
 public class QuickBillingBC2Action extends ActionSupport {
+    // Intercepts rapid billing submissions and routes them to the BC processing engine
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
 
     HttpServletRequest request = ServletActionContext.getRequest();

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/quickbilling/QuickBillingBCFormBean.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/quickbilling/QuickBillingBCFormBean.java
@@ -38,7 +38,12 @@ import java.util.ArrayList;
 import java.util.List;
 
 
+/**
+ * Form representation for the BC Quick Billing interface.
+ * Encapsulates the subset of billing fields required for rapid claim entry.
+ */
 public class QuickBillingBCFormBean {
+    // Holds the specific data points needed for a streamlined BC MSP claim
 
     /**
      * @author Dennis Warren

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/quickbilling/QuickBillingBCSave2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/quickbilling/QuickBillingBCSave2Action.java
@@ -57,7 +57,12 @@ import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 
+/**
+ * Struts 2 Action handling the persistence of claims submitted via the BC Quick Billing interface.
+ * Validates the completed form and delegates saving to the underlying billing manager.
+ */
 public class QuickBillingBCSave2Action extends ActionSupport {
+    // Commits the quickly entered BC claims to the database after final validation
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
 
     HttpServletRequest request = ServletActionContext.getRequest();

--- a/src/main/java/io/github/carlos_emr/carlos/billings/data/BillingFormData.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/data/BillingFormData.java
@@ -42,7 +42,12 @@ import io.github.carlos_emr.carlos.commn.model.DiagnosticCode;
 import io.github.carlos_emr.carlos.commn.model.Provider;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 
+/**
+ * Backing bean for billing data entry screens, holding temporary form state before persistence.
+ * Contains validation logic and field mappings for complex provincial billing requirements.
+ */
 public class BillingFormData {
+    // Captures user input from the billing interface prior to creating formal claim records
 
     private DiagnosticCodeDao diagnosticCodeDao = SpringUtils.getBean(DiagnosticCodeDao.class);
 

--- a/src/main/java/io/github/carlos_emr/carlos/caisi/CaisiUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/caisi/CaisiUtil.java
@@ -27,7 +27,12 @@
 
 package io.github.carlos_emr.carlos.caisi;
 
+/**
+ * Utility operations specifically supporting the CAISI (Client and Agency Information System for Integration) module.
+ * Contains helper methods for URL manipulation and string processing unique to CAISI web workflows.
+ */
 public class CaisiUtil {
+        // Specifically removes query parameters to sanitize CAISI integration URLs
     public static String removeAttr(String str, String attr) {
         if (str == null) return (null);
 

--- a/src/main/java/io/github/carlos_emr/carlos/caisi/IsModuleLoadTag.java
+++ b/src/main/java/io/github/carlos_emr/carlos/caisi/IsModuleLoadTag.java
@@ -33,7 +33,12 @@ import jakarta.servlet.jsp.tagext.TagSupport;
 import io.github.carlos_emr.CarlosProperties;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+/**
+ * Custom JSP tag used to determine whether specific functional modules (like CAISI) are enabled and loaded in the current instance.
+ * Controls conditional rendering of UI elements based on system configuration.
+ */
 public class IsModuleLoadTag extends TagSupport {
+    // Evaluates system properties to conditionally display module-specific UI components
 
     private String moduleName;
     private boolean reverse = false;

--- a/src/main/java/io/github/carlos_emr/carlos/entities/Billingmaster.java
+++ b/src/main/java/io/github/carlos_emr/carlos/entities/Billingmaster.java
@@ -71,7 +71,12 @@ import io.github.carlos_emr.carlos.util.UtilDateUtilities;
         }
 )
 
+/**
+ * Core entity representing a billing master record, linking services provided to provincial billing codes.
+ * Essential for the generation and reconciliation of claims submitted to healthcare authorities.
+ */
 public class Billingmaster {
+    // Maintains the association between clinical encounters and billable services
 
     /**
      * auto_increment

--- a/src/main/java/io/github/carlos_emr/carlos/entities/ClinicalFactor.java
+++ b/src/main/java/io/github/carlos_emr/carlos/entities/ClinicalFactor.java
@@ -29,7 +29,12 @@
 
 package io.github.carlos_emr.carlos.entities;
 
+/**
+ * Base representation for any clinical factor or data point associated with a patient.
+ * Serves as a foundational element for specialized clinical entities like conditions or measurements.
+ */
 public class ClinicalFactor {
+    // Provides common attributes for clinical data tracking across the EMR
     // Fields
     //
     private int factorTypeId;

--- a/src/main/java/io/github/carlos_emr/carlos/entities/Condition.java
+++ b/src/main/java/io/github/carlos_emr/carlos/entities/Condition.java
@@ -31,8 +31,13 @@ package io.github.carlos_emr.carlos.entities;
 
 // Class Condition
 //
+/**
+ * Represents a patient's clinical condition or medical problem within the Electronic Medical Record.
+ * This entity maps to the underlying clinical data repository and tracks co-morbidities.
+ */
 public class Condition
         extends ClinicalFactor {
+    // Tracks related medical conditions to provide a comprehensive patient history
     // Fields
     //
     private java.util.Collection coMorbidConditions;

--- a/src/main/java/io/github/carlos_emr/carlos/entities/LabData.java
+++ b/src/main/java/io/github/carlos_emr/carlos/entities/LabData.java
@@ -29,7 +29,12 @@
 
 package io.github.carlos_emr.carlos.entities;
 
+/**
+ * Encapsulates laboratory test results, specifically focusing on key metabolic indicators.
+ * This object maps specific lab values (like A1C and LDL) required for decision support and flowsheet tracking.
+ */
 public class LabData {
+    // Used to bind discrete lab results from HL7 messages or manual entry
     private String a1c;
     private String ldl;
     private String ratio;

--- a/src/main/java/io/github/carlos_emr/carlos/entities/Patient.java
+++ b/src/main/java/io/github/carlos_emr/carlos/entities/Patient.java
@@ -29,7 +29,12 @@
 
 package io.github.carlos_emr.carlos.entities;
 
+/**
+ * The central entity representing a person receiving medical care.
+ * Acts as the root aggregate for all clinical, demographic, and billing records within the system.
+ */
 public class Patient {
+    // Links demographic details with clinical history and encounter records
     private String firstName;
     private String lastName;
     private String phone;

--- a/src/main/java/io/github/carlos_emr/carlos/entities/PaymentType.java
+++ b/src/main/java/io/github/carlos_emr/carlos/entities/PaymentType.java
@@ -29,7 +29,12 @@
 
 package io.github.carlos_emr.carlos.entities;
 
+/**
+ * Defines the accepted methods of payment for private or uninsured services.
+ * Used primarily in the billing module to categorize incoming revenue streams.
+ */
 public class PaymentType {
+    // Categorizes payment methods (e.g., Cash, Credit, Cheque) for financial reporting
     private String id;
     private String paymentType;
 

--- a/src/main/java/io/github/carlos_emr/carlos/entities/PrivateBillTransaction.java
+++ b/src/main/java/io/github/carlos_emr/carlos/entities/PrivateBillTransaction.java
@@ -32,7 +32,12 @@ package io.github.carlos_emr.carlos.entities;
 import java.math.BigDecimal;
 import java.util.Date;
 
+/**
+ * Records transactions for uninsured or third-party billed services that fall outside provincial healthcare coverage.
+ * Tracks payment status, amounts, and associated invoices for private clinic revenue.
+ */
 public class PrivateBillTransaction {
+    // Facilitates the tracking of direct patient payments and private insurance claims
     private int id;
     private int billingmaster_no;
     private double amount_received;


### PR DESCRIPTION
This PR adds contextual, non-boilerplate class-level and inline Javadocs to 40 previously undocumented Java classes on the `develop` branch. This addresses a backlog of undocumented files to improve codebase readability and maintainability.

---
*PR created automatically by Jules for task [1329394674694911115](https://jules.google.com/task/1329394674694911115) started by @yingbull*

## Summary by Sourcery

Add contextual Javadoc documentation to previously undocumented billing, clinical, and utility classes across the BC/MSP and core EMR modules.

Documentation:
- Document key billing workflow actions, DTOs, and validation helpers involved in BC/MSP and Teleplan integrations.
- Add class-level Javadocs to core clinical and billing entities to clarify their role in the EMR data model.
- Describe quick billing, private billing, and payment-related forms and transactions to improve code readability and maintainability.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added contextual Javadocs to 40 previously undocumented Java classes across OHIP/MSP extraction, Teleplan actions, quick billing, entities, and utilities. Improves readability, IDE tooltips, and maintainability with no functional changes.

<sup>Written for commit 5f6ed0e49779e0b5044eb61eda00dd8236590ee9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

