### PR TITLE
Fix multiple active sessions per user

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test:browser-surfaces-playwright": "node scripts/browser-surface-playwright-checks.js",
     "test:schedule-links-playwright": "node scripts/schedule-links-playwright-checks.js",
     "test:tickler-crud-playwright": "node scripts/tickler-crud-playwright-checks.js",
-    "test:logout-session-invalidation-playwright": "node scripts/logout-session-invalidation-playwright-checks.js"
+    "test:logout-session-invalidation-playwright": "node scripts/logout-session-invalidation-playwright-checks.js",
+    "test:multiple-session-playwright": "node scripts/multiple-session-playwright-checks.js"
   },
   "dependencies": {
     "@docusaurus/core": "^3.9.2",

--- a/scripts/multiple-session-playwright-checks.js
+++ b/scripts/multiple-session-playwright-checks.js
@@ -1,5 +1,27 @@
 #!/usr/bin/env node
 /*
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+
+/*
  * Browser regression checks for multiple active sessions for the same CARLOS user.
  *
  * The script uses two isolated Playwright browser contexts to model two separate
@@ -104,6 +126,10 @@ async function assertStillAuthenticated(page, label) {
   await assertAuthenticated(page, label);
 }
 
+function isExpectedLogoutDestination(pathname) {
+  return /\/index$|\/logout$|\/login/i.test(pathname) || pathname === `${baseUrl.pathname}/`;
+}
+
 async function assertLogoutPageNoLoop(browser) {
   const context = await browser.newContext({ ignoreHTTPSErrors: true });
   const page = await context.newPage();
@@ -115,13 +141,15 @@ async function assertLogoutPageNoLoop(browser) {
   });
 
   await gotoApp(page, '/logoutPage', { waitUntil: 'domcontentloaded' });
-  await page.waitForTimeout(3000);
+  await page
+    .waitForURL((url) => isExpectedLogoutDestination(new URL(url).pathname), { timeout: 10000 })
+    .catch(() => {});
 
   const current = new URL(page.url()).pathname;
   const logoutPageVisits = paths.filter((path) => path.endsWith('/logoutPage')).length;
   assert(logoutPageVisits <= 1, `unauthenticated /logoutPage looped: ${paths.join(' -> ')}`);
   assert(
-    /\/index$|\/logout$|\/login/i.test(current) || current === `${baseUrl.pathname}/`,
+    isExpectedLogoutDestination(current),
     `unexpected unauthenticated logout destination: ${page.url()}; paths=${paths.join(' -> ')}`
   );
   await assertNotBlank(page, 'unauthenticated logout destination');

--- a/scripts/multiple-session-playwright-checks.js
+++ b/scripts/multiple-session-playwright-checks.js
@@ -60,8 +60,9 @@ function assert(condition, message) {
 }
 
 async function gotoApp(page, appPath, options = {}) {
-  // appUrl rejects non-root-relative paths and validateBaseUrl rejects non-local hosts unless explicitly allowed.
-  return page.goto(appUrl(appPath), options); // nosemgrep
+  const targetUrl = appUrl(appPath);
+  // nosemgrep: javascript.playwright.security.audit.playwright-goto-injection.playwright-goto-injection -- appUrl rejects non-root-relative paths and validateBaseUrl rejects non-local hosts unless explicitly allowed.
+  return page.goto(targetUrl, options);
 }
 
 async function assertNotBlank(page, label, minHtml = 100) {

--- a/scripts/multiple-session-playwright-checks.js
+++ b/scripts/multiple-session-playwright-checks.js
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+/*
+ * Browser regression checks for multiple active sessions for the same CARLOS user.
+ *
+ * The script uses two isolated Playwright browser contexts to model two separate
+ * browsers. A login from browser B must not invalidate browser A. It also verifies
+ * the unauthenticated logoutPage -> logout flow lands on a login page without
+ * redirecting back to logoutPage.
+ *
+ * Defaults are for the local devcontainer:
+ *   node scripts/multiple-session-playwright-checks.js
+ *
+ * Optional environment:
+ *   BASE_URL=http://127.0.0.1:8080/carlos
+ *   CHROME_PATH=/path/to/chrome-or-chromium
+ *   TEST_USER=carlosdoc
+ *   TEST_PASSWORD=carlos2026
+ *   TEST_PIN=2026
+ *   ALLOW_NON_LOCAL_BASE_URL=true only when intentionally targeting a non-local test app
+ */
+
+const { chromium } = require('playwright');
+
+const baseUrl = validateBaseUrl(process.env.BASE_URL || 'http://127.0.0.1:8080/carlos');
+const chromePath = process.env.CHROME_PATH || '';
+const testUser = process.env.TEST_USER || 'carlosdoc';
+const testPassword = process.env.TEST_PASSWORD || 'carlos2026';
+const testPin = process.env.TEST_PIN || '2026';
+
+function validateBaseUrl(rawBaseUrl) {
+  const parsed = new URL(rawBaseUrl);
+  if (!['http:', 'https:'].includes(parsed.protocol)) {
+    throw new Error(`BASE_URL must use http or https, got ${parsed.protocol}`);
+  }
+
+  const host = parsed.hostname.toLowerCase();
+  const localHosts = new Set(['localhost', '127.0.0.1', '::1', '0.0.0.0', 'host.docker.internal', 'carlos']);
+  const privateIpv4 = /^(10\.|192\.168\.|172\.(1[6-9]|2\d|3[0-1])\.)/.test(host);
+  if (!localHosts.has(host) && !privateIpv4 && process.env.ALLOW_NON_LOCAL_BASE_URL !== 'true') {
+    throw new Error(`Refusing non-local BASE_URL host ${host}; set ALLOW_NON_LOCAL_BASE_URL=true for an intentional test target`);
+  }
+  parsed.pathname = parsed.pathname.replace(/\/$/, '');
+  return parsed;
+}
+
+function appUrl(appPath) {
+  if (!appPath.startsWith('/') || appPath.startsWith('//')) {
+    throw new Error(`Application path must be root-relative, got ${appPath}`);
+  }
+  const url = new URL(baseUrl.href);
+  url.pathname = `${baseUrl.pathname}${appPath}`.replace(/\/{2,}/g, '/');
+  url.search = '';
+  return url.toString();
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+async function assertNotBlank(page, label, minHtml = 100) {
+  const text = (await page.locator('body').innerText({ timeout: 10000 })).trim();
+  const html = (await page.locator('body').innerHTML({ timeout: 10000 })).trim();
+  assert(text.length > 0 || html.length >= minHtml, `${label} rendered blank content`);
+  return { text, html };
+}
+
+async function login(context, label) {
+  const page = await context.newPage();
+  await page.goto(appUrl('/'), { waitUntil: 'domcontentloaded' });
+  await page.locator('#username').waitFor({ timeout: 15000 });
+  await assertNotBlank(page, `${label} login page`);
+  await page.locator('#username').fill(testUser);
+  await page.locator('#password').fill(testPassword);
+  await page.locator('#pin').fill(testPin);
+  await Promise.all([
+    page.waitForLoadState('domcontentloaded').catch(() => {}),
+    page.locator('input[type="submit"], button[type="submit"]').first().click(),
+  ]);
+  await page.waitForURL(/provider\/(providercontrol|ViewAppointmentAdminDay)/, { timeout: 30000 });
+  await assertAuthenticated(page, `${label} post-login`);
+  return page;
+}
+
+async function assertAuthenticated(page, label) {
+  await page.waitForLoadState('domcontentloaded').catch(() => {});
+  const url = page.url();
+  const { text, html } = await assertNotBlank(page, label, 1000);
+  assert(!/logoutPage|\/logout\b|\/index\b|login=failed/i.test(url), `${label} was redirected out of the app: ${url}`);
+  assert(/Search|Schedule|Preference|appointment|provider/i.test(text + html), `${label} did not look authenticated`);
+  assert(html.includes('window.__carlosLogoutActive=true;'), `${label} did not include logout broadcast listener`);
+}
+
+async function assertStillAuthenticated(page, label) {
+  await page.goto(appUrl('/provider/providercontrol'), { waitUntil: 'domcontentloaded' });
+  await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
+  await assertAuthenticated(page, label);
+}
+
+async function assertLogoutPageNoLoop(browser) {
+  const context = await browser.newContext({ ignoreHTTPSErrors: true });
+  const page = await context.newPage();
+  const paths = [];
+  page.on('framenavigated', (frame) => {
+    if (frame === page.mainFrame()) {
+      paths.push(new URL(frame.url()).pathname);
+    }
+  });
+
+  await page.goto(appUrl('/logoutPage'), { waitUntil: 'domcontentloaded' });
+  await page.waitForTimeout(3000);
+
+  const current = new URL(page.url()).pathname;
+  const logoutPageVisits = paths.filter((path) => path.endsWith('/logoutPage')).length;
+  assert(logoutPageVisits <= 1, `unauthenticated /logoutPage looped: ${paths.join(' -> ')}`);
+  assert(
+    /\/index$|\/logout$|\/login/i.test(current) || current === `${baseUrl.pathname}/`,
+    `unexpected unauthenticated logout destination: ${page.url()}; paths=${paths.join(' -> ')}`
+  );
+  await assertNotBlank(page, 'unauthenticated logout destination');
+  await context.close();
+  console.log(`PASS unauthenticated logoutPage completed without redirect loop (${paths.join(' -> ') || current})`);
+}
+
+(async () => {
+  const launchOptions = {
+    headless: true,
+    args: ['--no-sandbox', '--disable-dev-shm-usage'],
+  };
+  if (chromePath) {
+    launchOptions.executablePath = chromePath;
+  }
+
+  const browser = await chromium.launch(launchOptions);
+  const contextA = await browser.newContext({ ignoreHTTPSErrors: true });
+  const contextB = await browser.newContext({ ignoreHTTPSErrors: true });
+
+  try {
+    const pageA = await login(contextA, 'browser A');
+    const pageB = await login(contextB, 'browser B');
+
+    await assertStillAuthenticated(pageA, 'browser A after browser B login');
+    await assertStillAuthenticated(pageB, 'browser B after browser A recheck');
+    console.log('PASS same user can keep two independent browser sessions authenticated');
+
+    await assertLogoutPageNoLoop(browser);
+  } finally {
+    await contextA.close().catch(() => {});
+    await contextB.close().catch(() => {});
+    await browser.close().catch(() => {});
+  }
+})().catch((error) => {
+  console.error(error && error.stack ? error.stack : error);
+  process.exit(1);
+});

--- a/scripts/multiple-session-playwright-checks.js
+++ b/scripts/multiple-session-playwright-checks.js
@@ -59,6 +59,11 @@ function assert(condition, message) {
   }
 }
 
+async function gotoApp(page, appPath, options = {}) {
+  // appUrl rejects non-root-relative paths and validateBaseUrl rejects non-local hosts unless explicitly allowed.
+  return page.goto(appUrl(appPath), options); // nosemgrep
+}
+
 async function assertNotBlank(page, label, minHtml = 100) {
   const text = (await page.locator('body').innerText({ timeout: 10000 })).trim();
   const html = (await page.locator('body').innerHTML({ timeout: 10000 })).trim();
@@ -68,7 +73,7 @@ async function assertNotBlank(page, label, minHtml = 100) {
 
 async function login(context, label) {
   const page = await context.newPage();
-  await page.goto(appUrl('/'), { waitUntil: 'domcontentloaded' });
+  await gotoApp(page, '/', { waitUntil: 'domcontentloaded' });
   await page.locator('#username').waitFor({ timeout: 15000 });
   await assertNotBlank(page, `${label} login page`);
   await page.locator('#username').fill(testUser);
@@ -93,7 +98,7 @@ async function assertAuthenticated(page, label) {
 }
 
 async function assertStillAuthenticated(page, label) {
-  await page.goto(appUrl('/provider/providercontrol'), { waitUntil: 'domcontentloaded' });
+  await gotoApp(page, '/provider/providercontrol', { waitUntil: 'domcontentloaded' });
   await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
   await assertAuthenticated(page, label);
 }
@@ -108,7 +113,7 @@ async function assertLogoutPageNoLoop(browser) {
     }
   });
 
-  await page.goto(appUrl('/logoutPage'), { waitUntil: 'domcontentloaded' });
+  await gotoApp(page, '/logoutPage', { waitUntil: 'domcontentloaded' });
   await page.waitForTimeout(3000);
 
   const current = new URL(page.url()).pathname;

--- a/src/main/java/io/github/carlos_emr/carlos/managers/UserSessionManager.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/UserSessionManager.java
@@ -55,6 +55,15 @@ public interface UserSessionManager {
     HttpSession unregisterUserSession(Integer userSecurityCode) throws UserSessionNotFoundException;
 
     /**
+     * Unregisters one user session without affecting other active sessions for the same user.
+     * @param userSecurityCode The user's sec code.
+     * @param session The HTTP session object to unregister.
+     * @return The unregistered HTTP session object.
+     * @throws UserSessionNotFoundException If the user session is not found.
+     */
+    HttpSession unregisterUserSession(Integer userSecurityCode, HttpSession session) throws UserSessionNotFoundException;
+
+    /**
      * Retrieves a registered user session.
      * @param userSecurityCode The user's sec code.
      * @return The registered HTTP session object, or null if not found.

--- a/src/main/java/io/github/carlos_emr/carlos/managers/UserSessionManagerImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/UserSessionManagerImpl.java
@@ -35,6 +35,7 @@ import org.springframework.stereotype.Service;
 import jakarta.servlet.http.HttpSession;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -46,12 +47,10 @@ public class UserSessionManagerImpl implements UserSessionManager {
 
     public static final String KEY_USER_SECURITY_CODE = "UserSecurityCode";
     private static final Logger logger = MiscUtils.getLogger();
-    private static final Map<Integer, HttpSession> userSessionMap = new ConcurrentHashMap<>();
+    private static final Map<Integer, Set<HttpSession>> userSessionMap = new ConcurrentHashMap<>();
 
     /**
      * Registers a user session with the given user sec code and HttpSession.
-     * If a session is already registered for the given user sec code, it is invalidated before registering the
-     * new provided session.
      * @param userSecurityCode The user sec code.
      * @param session The HttpSession.
      */
@@ -59,21 +58,8 @@ public class UserSessionManagerImpl implements UserSessionManager {
     public void registerUserSession(Integer userSecurityCode, HttpSession session) {
         purgeInvalidSessions();
 
-        // Atomically detach any previously registered session to avoid a TOCTOU race
-        // with unregisterUserSession() / session invalidation on other threads.
-        HttpSession previousSession = userSessionMap.remove(userSecurityCode);
-        if (previousSession != null) {
-            try {
-                logger.debug("Existing User Session found, invalidating: {}", previousSession.getId());
-                previousSession.invalidate();
-                logger.debug("Previous user session successfully invalidated");
-            } catch (IllegalStateException e) {
-                MiscUtils.getLogger().debug(e.getMessage());
-            }
-        }
-
-        // Register the new session, overwrite previous registry
-        userSessionMap.put(userSecurityCode, session);
+        userSessionMap.computeIfAbsent(userSecurityCode, key -> ConcurrentHashMap.newKeySet())
+                .add(session);
         // nosemgrep: tainted-session-from-http-request -- userSecurityCode is an internally generated security token, not user input
         session.setAttribute(KEY_USER_SECURITY_CODE, userSecurityCode);
         logger.debug("User Session successfully registered: {}", session.getId());
@@ -88,13 +74,31 @@ public class UserSessionManagerImpl implements UserSessionManager {
     @Override
     public HttpSession unregisterUserSession(Integer userSecurityCode) throws UserSessionNotFoundException {
         if (this.isUserSessionRegistered(userSecurityCode)) {
-            HttpSession session = userSessionMap.remove(userSecurityCode);
-            session.removeAttribute(KEY_USER_SECURITY_CODE);
-            logger.debug("User Session successfully unregistered: {}", session.getId());
+            Set<HttpSession> sessions = userSessionMap.remove(userSecurityCode);
+            HttpSession session = sessions.iterator().next();
+            for (HttpSession registeredSession : sessions) {
+                registeredSession.removeAttribute(KEY_USER_SECURITY_CODE);
+            }
+            logger.debug("User Sessions successfully unregistered for security code: {}", userSecurityCode);
             return session;
         } else {
             throw new UserSessionNotFoundException("User session not registered");
         }
+    }
+
+    @Override
+    public HttpSession unregisterUserSession(Integer userSecurityCode, HttpSession session) throws UserSessionNotFoundException {
+        Set<HttpSession> sessions = userSessionMap.get(userSecurityCode);
+        if (sessions == null || !sessions.remove(session)) {
+            throw new UserSessionNotFoundException("User session not registered");
+        }
+
+        session.removeAttribute(KEY_USER_SECURITY_CODE);
+        if (sessions.isEmpty()) {
+            userSessionMap.remove(userSecurityCode, sessions);
+        }
+        logger.debug("User Session successfully unregistered: {}", session.getId());
+        return session;
     }
 
     /**
@@ -106,7 +110,7 @@ public class UserSessionManagerImpl implements UserSessionManager {
     @Override
     public HttpSession getRegisteredSession(Integer userSecurityCode) {
         if (this.isUserSessionRegistered(userSecurityCode)) {
-            return userSessionMap.get(userSecurityCode);
+            return userSessionMap.get(userSecurityCode).iterator().next();
         } else {
             throw new UserSessionNotFoundException("User session not registered");
         }
@@ -118,13 +122,16 @@ public class UserSessionManagerImpl implements UserSessionManager {
      */
     private void purgeInvalidSessions() {
         userSessionMap.entrySet().removeIf(entry -> {
-            try {
-                entry.getValue().getId(); // throws IllegalStateException if invalidated
-                return false;
-            } catch (IllegalStateException e) {
-                logger.debug("Purging invalidated session for security code: {}", entry.getKey());
-                return true;
-            }
+            entry.getValue().removeIf(session -> {
+                try {
+                    session.getId(); // throws IllegalStateException if invalidated
+                    return false;
+                } catch (IllegalStateException e) {
+                    logger.debug("Purging invalidated session for security code: {}", entry.getKey());
+                    return true;
+                }
+            });
+            return entry.getValue().isEmpty();
         });
     }
 
@@ -135,6 +142,7 @@ public class UserSessionManagerImpl implements UserSessionManager {
      * @return True if the session is registered, false otherwise.
      */
     private boolean isUserSessionRegistered(Integer userSecurityCode) {
-        return Objects.nonNull(userSessionMap.get(userSecurityCode));
+        Set<HttpSession> sessions = userSessionMap.get(userSecurityCode);
+        return Objects.nonNull(sessions) && !sessions.isEmpty();
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/managers/UserSessionManagerImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/UserSessionManagerImpl.java
@@ -67,7 +67,9 @@ public class UserSessionManagerImpl implements UserSessionManager {
         });
         // nosemgrep: tainted-session-from-http-request -- userSecurityCode is an internally generated security token, not user input
         session.setAttribute(KEY_USER_SECURITY_CODE, userSecurityCode);
-        logger.debug("User Session successfully registered: {}", sessionIdForLog(session));
+        if (logger.isDebugEnabled()) {
+            logger.debug("User Session successfully registered: {}", sessionIdForLog(session));
+        }
     }
 
     /**
@@ -104,7 +106,9 @@ public class UserSessionManagerImpl implements UserSessionManager {
         }
 
         removeSecurityCodeAttribute(session);
-        logger.debug("User Session successfully unregistered: {}", sessionIdForLog(session));
+        if (logger.isDebugEnabled()) {
+            logger.debug("User Session successfully unregistered: {}", sessionIdForLog(session));
+        }
         return session;
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/managers/UserSessionManagerImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/UserSessionManagerImpl.java
@@ -34,9 +34,9 @@ import org.springframework.stereotype.Service;
 
 import jakarta.servlet.http.HttpSession;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Implementation of the {@link UserSessionManager} interface.
@@ -58,11 +58,16 @@ public class UserSessionManagerImpl implements UserSessionManager {
     public void registerUserSession(Integer userSecurityCode, HttpSession session) {
         purgeInvalidSessions();
 
-        userSessionMap.computeIfAbsent(userSecurityCode, key -> ConcurrentHashMap.newKeySet())
-                .add(session);
+        userSessionMap.compute(userSecurityCode, (key, sessions) -> {
+            if (sessions == null) {
+                sessions = ConcurrentHashMap.newKeySet();
+            }
+            sessions.add(session);
+            return sessions;
+        });
         // nosemgrep: tainted-session-from-http-request -- userSecurityCode is an internally generated security token, not user input
         session.setAttribute(KEY_USER_SECURITY_CODE, userSecurityCode);
-        logger.debug("User Session successfully registered: {}", session.getId());
+        logger.debug("User Session successfully registered: {}", sessionIdForLog(session));
     }
 
     /**
@@ -73,31 +78,33 @@ public class UserSessionManagerImpl implements UserSessionManager {
      */
     @Override
     public HttpSession unregisterUserSession(Integer userSecurityCode) throws UserSessionNotFoundException {
-        if (this.isUserSessionRegistered(userSecurityCode)) {
-            Set<HttpSession> sessions = userSessionMap.remove(userSecurityCode);
-            HttpSession session = sessions.iterator().next();
-            for (HttpSession registeredSession : sessions) {
-                registeredSession.removeAttribute(KEY_USER_SECURITY_CODE);
-            }
-            logger.debug("User Sessions successfully unregistered for security code: {}", userSecurityCode);
-            return session;
-        } else {
+        Set<HttpSession> sessions = userSessionMap.remove(userSecurityCode);
+        if (sessions == null || sessions.isEmpty()) {
             throw new UserSessionNotFoundException("User session not registered");
         }
+
+        HttpSession session = sessions.iterator().next();
+        for (HttpSession registeredSession : sessions) {
+            removeSecurityCodeAttribute(registeredSession);
+        }
+        logger.debug("User Sessions successfully unregistered for security code: {}", userSecurityCode);
+        return session;
     }
 
     @Override
     public HttpSession unregisterUserSession(Integer userSecurityCode, HttpSession session) throws UserSessionNotFoundException {
-        Set<HttpSession> sessions = userSessionMap.get(userSecurityCode);
-        if (sessions == null || !sessions.remove(session)) {
+        AtomicBoolean removed = new AtomicBoolean(false);
+        userSessionMap.computeIfPresent(userSecurityCode, (key, sessions) -> {
+            removed.set(sessions.remove(session));
+            return sessions.isEmpty() ? null : sessions;
+        });
+
+        if (!removed.get()) {
             throw new UserSessionNotFoundException("User session not registered");
         }
 
-        session.removeAttribute(KEY_USER_SECURITY_CODE);
-        if (sessions.isEmpty()) {
-            userSessionMap.remove(userSecurityCode, sessions);
-        }
-        logger.debug("User Session successfully unregistered: {}", session.getId());
+        removeSecurityCodeAttribute(session);
+        logger.debug("User Session successfully unregistered: {}", sessionIdForLog(session));
         return session;
     }
 
@@ -109,11 +116,11 @@ public class UserSessionManagerImpl implements UserSessionManager {
      */
     @Override
     public HttpSession getRegisteredSession(Integer userSecurityCode) {
-        if (this.isUserSessionRegistered(userSecurityCode)) {
-            return userSessionMap.get(userSecurityCode).iterator().next();
-        } else {
+        Set<HttpSession> sessions = userSessionMap.get(userSecurityCode);
+        if (sessions == null || sessions.isEmpty()) {
             throw new UserSessionNotFoundException("User session not registered");
         }
+        return sessions.iterator().next();
     }
 
     /**
@@ -121,28 +128,35 @@ public class UserSessionManagerImpl implements UserSessionManager {
      * Safety net for sessions that expire without triggering OscarSessionListener.
      */
     private void purgeInvalidSessions() {
-        userSessionMap.entrySet().removeIf(entry -> {
-            entry.getValue().removeIf(session -> {
-                try {
-                    session.getId(); // throws IllegalStateException if invalidated
-                    return false;
-                } catch (IllegalStateException e) {
-                    logger.debug("Purging invalidated session for security code: {}", entry.getKey());
-                    return true;
-                }
+        for (Integer userSecurityCode : userSessionMap.keySet()) {
+            userSessionMap.computeIfPresent(userSecurityCode, (key, sessions) -> {
+                sessions.removeIf(session -> {
+                    try {
+                        session.getId(); // throws IllegalStateException if invalidated
+                        return false;
+                    } catch (IllegalStateException e) {
+                        logger.debug("Purging invalidated session for security code: {}", key);
+                        return true;
+                    }
+                });
+                return sessions.isEmpty() ? null : sessions;
             });
-            return entry.getValue().isEmpty();
-        });
+        }
     }
 
-    /**
-     * Checks if a session is registered for the given user sec code.
-     *
-     * @param userSecurityCode The user sec code.
-     * @return True if the session is registered, false otherwise.
-     */
-    private boolean isUserSessionRegistered(Integer userSecurityCode) {
-        Set<HttpSession> sessions = userSessionMap.get(userSecurityCode);
-        return Objects.nonNull(sessions) && !sessions.isEmpty();
+    private void removeSecurityCodeAttribute(HttpSession session) {
+        try {
+            session.removeAttribute(KEY_USER_SECURITY_CODE);
+        } catch (IllegalStateException e) {
+            logger.debug("Session already invalidated: {}", e.getMessage());
+        }
+    }
+
+    private String sessionIdForLog(HttpSession session) {
+        try {
+            return session.getId();
+        } catch (IllegalStateException e) {
+            return "invalidated";
+        }
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/managers/UserSessionManagerImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/UserSessionManagerImpl.java
@@ -88,6 +88,7 @@ public class UserSessionManagerImpl implements UserSessionManager {
         HttpSession session = sessions.iterator().next();
         for (HttpSession registeredSession : sessions) {
             removeSecurityCodeAttribute(registeredSession);
+            invalidateSession(registeredSession);
         }
         logger.debug("User Sessions successfully unregistered for security code: {}", userSecurityCode);
         return session;
@@ -96,8 +97,10 @@ public class UserSessionManagerImpl implements UserSessionManager {
     @Override
     public HttpSession unregisterUserSession(Integer userSecurityCode, HttpSession session) throws UserSessionNotFoundException {
         AtomicBoolean removed = new AtomicBoolean(false);
+        String sessionId = sessionIdForComparison(session);
         userSessionMap.computeIfPresent(userSecurityCode, (key, sessions) -> {
-            removed.set(sessions.remove(session));
+            removed.set(sessions.removeIf(registeredSession ->
+                    isSameSession(registeredSession, session, sessionId)));
             return sessions.isEmpty() ? null : sessions;
         });
 
@@ -115,14 +118,13 @@ public class UserSessionManagerImpl implements UserSessionManager {
     /**
      * Retrieves the registered HttpSession for the given user sec code.
      * @param userSecurityCode The user sec code.
-     * @return The HttpSession.
-     * @throws UserSessionNotFoundException If no session is found for the given user sec code.
+     * @return The HttpSession, or null if no session is found for the given user sec code.
      */
     @Override
     public HttpSession getRegisteredSession(Integer userSecurityCode) {
         Set<HttpSession> sessions = userSessionMap.get(userSecurityCode);
         if (sessions == null || sessions.isEmpty()) {
-            throw new UserSessionNotFoundException("User session not registered");
+            return null;
         }
         return sessions.iterator().next();
     }
@@ -145,6 +147,29 @@ public class UserSessionManagerImpl implements UserSessionManager {
                 });
                 return sessions.isEmpty() ? null : sessions;
             });
+        }
+    }
+
+    private void invalidateSession(HttpSession session) {
+        try {
+            session.invalidate();
+        } catch (IllegalStateException e) {
+            logger.debug("Session already invalidated: {}", e.getMessage());
+        }
+    }
+
+    private boolean isSameSession(HttpSession registeredSession, HttpSession session, String sessionId) {
+        if (registeredSession == session) {
+            return true;
+        }
+        return sessionId != null && sessionId.equals(sessionIdForComparison(registeredSession));
+    }
+
+    private String sessionIdForComparison(HttpSession session) {
+        try {
+            return session.getId();
+        } catch (IllegalStateException e) {
+            return null;
         }
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/sec/LoginFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/sec/LoginFilter.java
@@ -273,10 +273,11 @@ public class LoginFilter implements Filter {
      * <p>If inactivity timeout is exceeded, users are normally redirected to
      * {@code /logoutPage}. However, if the user is already on one of these pages,
      * the redirect is skipped to avoid infinite redirect loops. Keep this list limited
-     * to unauthenticated public pages; adding authenticated pages would turn timeout
-     * checker failures into a fail-open path for protected content.
+     * to unauthenticated public pages and the logout cleanup action; adding authenticated
+     * pages would turn timeout checker failures into a fail-open path for protected content.
      */
     private static final String[] EXEMPT_URLS_FOR_REQUEST_TIMEOUT_REDIRECT = {
+            LOGOUT_PATH,
             "/logoutPage",
             "/index",
             "/loginfailed"

--- a/src/main/java/io/github/carlos_emr/carlos/sec/LoginFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/sec/LoginFilter.java
@@ -137,7 +137,7 @@ public class LoginFilter implements Filter {
      * <p>Requests to these URLs bypass session validation and are allowed
      * without an authenticated session. This includes:
      * <ul>
-     *   <li>Login/logout pages ({@code /index}, {@code /logoutPage}, {@code /login})</li>
+     *   <li>Login/logout pages ({@code /index}, {@code /logoutPage}, {@code /logout}, {@code /login})</li>
      *   <li>Forced password-reset entrypoints ({@code /forcepasswordreset}, {@code /forcepasswordresetSubmit})</li>
      *   <li>Public static resources (images, CSS, JavaScript, fonts)</li>
      *   <li>Lab upload endpoints (for external lab system integration)</li>
@@ -169,6 +169,7 @@ public class LoginFilter implements Filter {
             "/lab/newLabUpload",
             "/login",
             "/logoutPage",
+            "/logout",
             "/index",
             "/forcepasswordreset",
             "/forcepasswordresetSubmit",
@@ -240,6 +241,7 @@ public class LoginFilter implements Filter {
             "/share/javascript/Oscar.js",
             "/login",
             "/logoutPage",
+            "/logout",
             "/index",
             "/loginfailed",
             "/eformViewForPdfGenerationServlet",

--- a/src/main/java/io/github/carlos_emr/carlos/sec/LoginFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/sec/LoginFilter.java
@@ -131,6 +131,8 @@ public class LoginFilter implements Filter {
     /** Pre-compiled pattern for collapsing consecutive slashes. */
     private static final Pattern REPEATED_SLASH_PATTERN = Pattern.compile("/+");
 
+    private static final String LOGOUT_PATH = "/logout";
+
     /**
      * URLs exempt from authentication requirement.
      *
@@ -169,7 +171,7 @@ public class LoginFilter implements Filter {
             "/lab/newLabUpload",
             "/login",
             "/logoutPage",
-            "/logout",
+            LOGOUT_PATH,
             "/index",
             "/forcepasswordreset",
             "/forcepasswordresetSubmit",
@@ -195,7 +197,7 @@ public class LoginFilter implements Filter {
 
     private static final String[] PENDING_FACILITY_SELECTION_URLS = {
             "/select_facility",
-            "/logout",
+            LOGOUT_PATH,
             "/logoutPage",
             "/images/Oscar.ico",
             "/images/Logo.png",
@@ -241,7 +243,7 @@ public class LoginFilter implements Filter {
             "/share/javascript/Oscar.js",
             "/login",
             "/logoutPage",
-            "/logout",
+            LOGOUT_PATH,
             "/index",
             "/loginfailed",
             "/eformViewForPdfGenerationServlet",
@@ -338,6 +340,7 @@ public class LoginFilter implements Filter {
      * @throws ServletException if servlet-level error occurs during filtering
      * @see SecurityTokenManager for token-based authentication
      */
+    @SuppressWarnings("java:S6541") // Existing authentication/session gate; broad refactor is outside this PR.
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
         logger.debug("Entering LoginFilter.doFilter()");
 

--- a/src/main/java/io/github/carlos_emr/carlos/web/OscarSessionListener.java
+++ b/src/main/java/io/github/carlos_emr/carlos/web/OscarSessionListener.java
@@ -68,7 +68,7 @@ public class OscarSessionListener implements HttpSessionListener {
 		if (userSecurityCode != null) {
 			try {
 				UserSessionManager userSessionManager = SpringUtils.getBean(UserSessionManager.class);
-				userSessionManager.unregisterUserSession(userSecurityCode);
+				userSessionManager.unregisterUserSession(userSecurityCode, session);
 			} catch (UserSessionNotFoundException e) {
 				MiscUtils.getLogger().warn("Failed to unregister session on destroy: {}", e.getMessage());
 			}

--- a/src/test/java/io/github/carlos_emr/carlos/managers/UserSessionManagerImplUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/managers/UserSessionManagerImplUnitTest.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ */
+package io.github.carlos_emr.carlos.managers;
+
+import io.github.carlos_emr.carlos.commn.exception.UserSessionNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpSession;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Tag("unit")
+@Tag("security")
+@DisplayName("UserSessionManagerImpl")
+class UserSessionManagerImplUnitTest {
+
+    @Test
+    @DisplayName("should allow multiple sessions for the same user")
+    void shouldAllowMultipleSessions_forSameUser() {
+        UserSessionManagerImpl manager = new UserSessionManagerImpl();
+        Integer securityCode = 2565;
+        MockHttpSession firstSession = new MockHttpSession();
+        MockHttpSession secondSession = new MockHttpSession();
+
+        manager.registerUserSession(securityCode, firstSession);
+        manager.registerUserSession(securityCode, secondSession);
+
+        assertThatCode(firstSession::getId).doesNotThrowAnyException();
+        assertThatCode(secondSession::getId).doesNotThrowAnyException();
+        assertThat(firstSession.getAttribute(UserSessionManagerImpl.KEY_USER_SECURITY_CODE))
+                .isEqualTo(securityCode);
+        assertThat(secondSession.getAttribute(UserSessionManagerImpl.KEY_USER_SECURITY_CODE))
+                .isEqualTo(securityCode);
+    }
+
+    @Test
+    @DisplayName("should unregister only the destroyed session")
+    void shouldUnregisterOnlyDestroyedSession_forSameUser() {
+        UserSessionManagerImpl manager = new UserSessionManagerImpl();
+        Integer securityCode = 2566;
+        MockHttpSession firstSession = new MockHttpSession();
+        MockHttpSession secondSession = new MockHttpSession();
+
+        manager.registerUserSession(securityCode, firstSession);
+        manager.registerUserSession(securityCode, secondSession);
+
+        assertThat(manager.unregisterUserSession(securityCode, firstSession)).isSameAs(firstSession);
+
+        assertThat(firstSession.getAttribute(UserSessionManagerImpl.KEY_USER_SECURITY_CODE)).isNull();
+        assertThat(secondSession.getAttribute(UserSessionManagerImpl.KEY_USER_SECURITY_CODE))
+                .isEqualTo(securityCode);
+        assertThat(manager.getRegisteredSession(securityCode)).isSameAs(secondSession);
+    }
+
+    @Test
+    @DisplayName("should throw when unregistering an unknown session")
+    void shouldThrow_whenUnregisteringUnknownSession() {
+        UserSessionManagerImpl manager = new UserSessionManagerImpl();
+
+        assertThatThrownBy(() -> manager.unregisterUserSession(2567, new MockHttpSession()))
+                .isInstanceOf(UserSessionNotFoundException.class);
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/managers/UserSessionManagerImplUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/managers/UserSessionManagerImplUnitTest.java
@@ -62,8 +62,9 @@ class UserSessionManagerImplUnitTest {
     @DisplayName("should throw when unregistering an unknown session")
     void shouldThrow_whenUnregisteringUnknownSession() {
         UserSessionManagerImpl manager = new UserSessionManagerImpl();
+        MockHttpSession unknownSession = new MockHttpSession();
 
-        assertThatThrownBy(() -> manager.unregisterUserSession(2567, new MockHttpSession()))
+        assertThatThrownBy(() -> manager.unregisterUserSession(2567, unknownSession))
                 .isInstanceOf(UserSessionNotFoundException.class);
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/managers/UserSessionManagerImplUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/managers/UserSessionManagerImplUnitTest.java
@@ -11,9 +11,14 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpSession;
 
+import jakarta.servlet.http.HttpSession;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @Tag("unit")
 @Tag("security")
@@ -56,6 +61,51 @@ class UserSessionManagerImplUnitTest {
         assertThat(secondSession.getAttribute(UserSessionManagerImpl.KEY_USER_SECURITY_CODE))
                 .isEqualTo(securityCode);
         assertThat(manager.getRegisteredSession(securityCode)).isSameAs(secondSession);
+    }
+
+    @Test
+    @DisplayName("should invalidate all sessions when unregistering a security code")
+    void shouldInvalidateAllSessions_whenUnregisteringSecurityCode() {
+        UserSessionManagerImpl manager = new UserSessionManagerImpl();
+        Integer securityCode = 2569;
+        MockHttpSession firstSession = new MockHttpSession();
+        MockHttpSession secondSession = new MockHttpSession();
+
+        manager.registerUserSession(securityCode, firstSession);
+        manager.registerUserSession(securityCode, secondSession);
+
+        HttpSession unregisteredSession = manager.unregisterUserSession(securityCode);
+
+        assertThat(unregisteredSession).isIn(firstSession, secondSession);
+        assertThat(firstSession.isInvalid()).isTrue();
+        assertThat(secondSession.isInvalid()).isTrue();
+        assertThat(manager.getRegisteredSession(securityCode)).isNull();
+    }
+
+    @Test
+    @DisplayName("should unregister matching session id when session object differs")
+    void shouldUnregisterMatchingSessionId_whenSessionObjectDiffers() {
+        UserSessionManagerImpl manager = new UserSessionManagerImpl();
+        Integer securityCode = 2570;
+        HttpSession registeredSession = mock(HttpSession.class);
+        HttpSession destroyedSession = mock(HttpSession.class);
+        when(registeredSession.getId()).thenReturn("same-session-id");
+        when(destroyedSession.getId()).thenReturn("same-session-id");
+
+        manager.registerUserSession(securityCode, registeredSession);
+
+        assertThat(manager.unregisterUserSession(securityCode, destroyedSession)).isSameAs(destroyedSession);
+
+        assertThat(manager.getRegisteredSession(securityCode)).isNull();
+        verify(destroyedSession).removeAttribute(UserSessionManagerImpl.KEY_USER_SECURITY_CODE);
+    }
+
+    @Test
+    @DisplayName("should return null when no session is registered")
+    void shouldReturnNull_whenNoSessionIsRegistered() {
+        UserSessionManagerImpl manager = new UserSessionManagerImpl();
+
+        assertThat(manager.getRegisteredSession(2568)).isNull();
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/sec/LoginFilterUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/sec/LoginFilterUnitTest.java
@@ -230,6 +230,20 @@ class LoginFilterUnitTest extends CarlosUnitTestBase {
         }
 
         @Test
+        @DisplayName("should pass logout post when unauthenticated")
+        void shouldPassLogoutPost_whenUnauthenticated()
+                throws ServletException, IOException {
+            MockHttpServletRequest request = request("POST", CONTEXT_PATH + "/logout");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            MockFilterChain chain = new MockFilterChain();
+
+            filter.doFilter(request, response, chain);
+
+            assertThat(chain.getRequest()).isSameAs(request);
+            assertThat(response.getRedirectedUrl()).isNull();
+        }
+
+        @Test
         @DisplayName("should audit rejected token authentication")
         void shouldAuditRejectedTokenAuthentication_whenTokenManagerRejects()
                 throws ServletException, IOException {


### PR DESCRIPTION
## Summary
- allow multiple active HTTP sessions for the same user security code instead of invalidating the previous browser session on login
- unregister only the destroyed session from the user-session registry
- allow unauthenticated POSTs to `/logout` so the timeout logout page can complete cleanup without redirecting back to itself

## Tests
- `mvn -q -Dtest=UserSessionManagerImplUnitTest,LoginFilterUnitTest test`
- `mvn -q -Dtest=OscarSessionListenerMfaCleanupUnitTest,Logout2ActionUnitTest test`

Fixes #2565
Fixes #2245

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows multiple concurrent sessions per user without logging out earlier browsers, makes session registry updates atomic, and lets unauthenticated POSTs to `/logout` so timeout cleanup can finish without loops. Fixes #2565 and #2245.

- **Bug Fixes**
  - Support multiple sessions per user with a `Set`; atomic `compute` updates; purge invalidated sessions; safer debug logging; `getRegisteredSession` returns one active session or null.
  - Add `unregisterUserSession(Integer, HttpSession)` and use it in `OscarSessionListener` to remove only the destroyed session (match by object or session id); `unregisterUserSession(Integer)` now invalidates all sessions.
  - Allow unauthenticated access to `/logout` in `LoginFilter`; add `LOGOUT_PATH` constant and include `/logout` in timeout redirect exemptions to prevent loops; suppress a Sonar rule on `doFilter`.
  - Add unit tests and a Playwright regression for multi-session flows and logout exemption; add `test:multiple-session-playwright` with local-only `BASE_URL` guard, a targeted `nosemgrep` suppression for validated `goto`, and safer navigation to avoid redirect loops.

<sup>Written for commit e2515ec563427f73c88cc99ab2c22d03af89ef84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2673?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

