### PR TITLE
fix(security): sanitize prevention module log identifiers

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FrmFormRHPrevention2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FrmFormRHPrevention2Action.java
@@ -41,6 +41,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import io.github.carlos_emr.carlos.utility.LogSafe;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
@@ -121,7 +122,10 @@ public class FrmFormRHPrevention2Action extends ActionSupport {
         String workflowId = request.getParameter("workflowId");
         String state = request.getParameter("state");
 
-        MiscUtils.getLogger().debug("FrmFormRHPrevention2Action demographic " + demographicNo);
+        MiscUtils.getLogger().debug(
+        "FrmFormRHPrevention2Action demographic {}",
+        LogSafe.sanitize(demographicNo)
+        );
         String af = SUCCESS;
 
         int workId = -1;
@@ -132,7 +136,11 @@ public class FrmFormRHPrevention2Action extends ActionSupport {
         ArrayList currentWorkFlows = flow.getActiveWorkFlowList(demographicNo);
 
         String dateToParse = request.getParameter("edd");
-        MiscUtils.getLogger().debug("New workflow for " + demographicNo + " EDD " + dateToParse);
+        MiscUtils.getLogger().debug(
+        "New workflow for {} EDD {}",
+        LogSafe.sanitize(demographicNo),
+        dateToParse
+        );
         Date endDate = UtilDateUtilities.StringToDate(dateToParse);
 
         //Currently open work flows ?
@@ -143,7 +151,11 @@ public class FrmFormRHPrevention2Action extends ActionSupport {
             String currentId = (String) h.get("ID");
             if (workflowId != null) {
                 //LOG CHANGE NOW
-                MiscUtils.getLogger().debug("Changing workflow for  " + demographicNo + " to " + state);
+                MiscUtils.getLogger().debug(
+                "Changing workflow for {} to {}",
+                LogSafe.sanitize(demographicNo),
+                state
+                );
 
                 WorkFlowState wfs = new WorkFlowState();
 

--- a/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FrmFormRHPrevention2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FrmFormRHPrevention2Action.java
@@ -139,7 +139,7 @@ public class FrmFormRHPrevention2Action extends ActionSupport {
         MiscUtils.getLogger().debug(
         "New workflow for {} EDD {}",
         LogSafe.sanitize(demographicNo),
-        dateToParse
+        LogSafe.sanitize(dateToParse)
         );
         Date endDate = UtilDateUtilities.StringToDate(dateToParse);
 
@@ -154,7 +154,7 @@ public class FrmFormRHPrevention2Action extends ActionSupport {
                 MiscUtils.getLogger().debug(
                 "Changing workflow for {} to {}",
                 LogSafe.sanitize(demographicNo),
-                state
+                LogSafe.sanitize(state)
                 );
 
                 WorkFlowState wfs = new WorkFlowState();

--- a/src/main/java/io/github/carlos_emr/carlos/prevention/PreventionData.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prevention/PreventionData.java
@@ -43,6 +43,7 @@ import io.github.carlos_emr.carlos.commn.dao.PreventionDao;
 import io.github.carlos_emr.carlos.commn.dao.PreventionExtDao;
 import io.github.carlos_emr.carlos.managers.DHIRSubmissionManager;
 import io.github.carlos_emr.carlos.managers.DemographicManager;
+import io.github.carlos_emr.carlos.utility.LogSafe;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
@@ -345,7 +346,7 @@ public class PreventionData {
     }
 
     public static String getPreventionComment(String id) {
-        log.debug("Calling getPreventionComment " + id);
+        log.debug("Calling getPreventionComment {}", LogSafe.sanitize(id));
         String comment = null;
 
         try {
@@ -512,7 +513,7 @@ public class PreventionData {
                 }
                 addToHashIfNotNull(h, "summary", summary);
                 log.debug("1" + h.get("preventionType") + " " + h.size());
-                log.debug("id" + h.get("id"));
+                log.debug("id {}", LogSafe.sanitizeObject(h.get("id")));
 
             }
         } catch (Exception e) {

--- a/src/main/java/io/github/carlos_emr/carlos/prevention/PreventionDisplayConfig.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prevention/PreventionDisplayConfig.java
@@ -52,6 +52,7 @@ import io.github.carlos_emr.carlos.commn.model.CVCImmunization;
 import io.github.carlos_emr.carlos.commn.model.CVCMapping;
 import io.github.carlos_emr.carlos.managers.CanadianVaccineCatalogueManager;
 import io.github.carlos_emr.carlos.managers.PreventionManager;
+import io.github.carlos_emr.carlos.utility.LogSafe;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.PathValidationUtils;
@@ -258,7 +259,7 @@ public class PreventionDisplayConfig {
     public String getDisplay(LoggedInInfo loggedInInfo, Map<String, Object> setHash, String Demographic_no) {
         String display = "style=\"display:none;\"";
         DemographicData dData = new DemographicData();
-        log.debug("demoage " + Demographic_no);
+        log.debug("demoage {}", LogSafe.sanitize(Demographic_no));
         Demographic demograph = dData.getDemographic(loggedInInfo, Demographic_no);
         try {
             String minAgeStr = (String) setHash.get("minAge");
@@ -267,8 +268,14 @@ public class PreventionDisplayConfig {
             int demoAge = demograph.getAgeInYears();
             String demoSex = demograph.getSex();
             boolean inAgeGroup = true;
-            log.debug("min age " + minAgeStr + " max age " + maxAgeStr + " sex " + sex + " demoAge " + demoAge
-                    + " demoSex " + demoSex);
+            log.debug(
+                "min age {} max age {} sex {} demoAge {} demoSex {}",
+                minAgeStr,
+                maxAgeStr,
+                sex,
+                LogSafe.sanitizeObject(demoAge),
+                LogSafe.sanitize(demoSex)
+            );
             if (minAgeStr != null && maxAgeStr != null) { // between ages
                 log.debug("HERE1");
                 int minAge = Integer.parseInt(minAgeStr);

--- a/src/main/java/io/github/carlos_emr/carlos/prevention/pageUtil/AddPrevention2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prevention/pageUtil/AddPrevention2Action.java
@@ -124,7 +124,11 @@ public class AddPrevention2Action extends ActionSupport {
         if (action != null && "Save & Submit".equals(action)) {
             submitToDhir = true;
         }
-        MiscUtils.getLogger().debug("id {} delete {}", LogSafe.sanitize(id), delete);
+        MiscUtils.getLogger().debug(
+        "id {} delete {}",
+        LogSafe.sanitize(id),
+        LogSafe.sanitize(delete)
+        );
 
         MiscUtils.getLogger().debug("prevention Type " + preventionType);
 

--- a/src/main/java/io/github/carlos_emr/carlos/prevention/pageUtil/AddPrevention2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prevention/pageUtil/AddPrevention2Action.java
@@ -55,6 +55,7 @@ import io.github.carlos_emr.carlos.integration.fhir.api.DHIR;
 import io.github.carlos_emr.carlos.integration.fhir.builder.FhirBundleBuilder;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.provider.model.PreventionManager;
+import io.github.carlos_emr.carlos.utility.LogSafe;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
@@ -123,7 +124,7 @@ public class AddPrevention2Action extends ActionSupport {
         if (action != null && "Save & Submit".equals(action)) {
             submitToDhir = true;
         }
-        MiscUtils.getLogger().debug("id " + id + "  delete " + delete);
+        MiscUtils.getLogger().debug("id {} delete {}", LogSafe.sanitize(id), delete);
 
         MiscUtils.getLogger().debug("prevention Type " + preventionType);
 

--- a/src/main/java/io/github/carlos_emr/carlos/prevention/reports/ChildImmunizationReport.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prevention/reports/ChildImmunizationReport.java
@@ -44,6 +44,8 @@ import java.util.Map;
 
 import io.github.carlos_emr.carlos.commn.model.Demographic;
 import org.apache.logging.log4j.Logger;
+
+import io.github.carlos_emr.carlos.utility.LogSafe;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 
@@ -317,7 +319,7 @@ public class ChildImmunizationReport implements PreventionReport {
             if (prd.state.equals("No Info") || prd.state.equals("due") || prd.state.equals("Overdue")) {
                 // Get LAST contact method
                 EctMeasurementsDataBeanHandler measurementDataHandler = new EctMeasurementsDataBeanHandler(prd.demographicNo, measurementType);
-                log.debug("getting followup data for " + prd.demographicNo);
+                log.debug("getting followup data for {}", LogSafe.sanitizeObject(prd.demographicNo));
 
                 Collection followupData = measurementDataHandler.getMeasurementsDataVector();
                 //NO Contact

--- a/src/main/java/io/github/carlos_emr/carlos/prevention/reports/FollowupManagement.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prevention/reports/FollowupManagement.java
@@ -35,6 +35,8 @@ import java.util.Hashtable;
 import java.util.List;
 
 import org.apache.logging.log4j.Logger;
+
+import io.github.carlos_emr.carlos.utility.LogSafe;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 
 import io.github.carlos_emr.carlos.encounter.oscarMeasurements.util.WriteNewMeasurements;
@@ -93,7 +95,7 @@ public class FollowupManagement {
     }
 
     private void writeProcedure(final String followUpType, final String followUpValue, final String demographicNo, final String providerNo, final Date dateObserved, final String comment) {
-        log.debug("Calling WriteProcedure for " + demographicNo);
+        log.debug("Calling WriteProcedure for {}", LogSafe.sanitize(demographicNo));
         Hashtable measure = new Hashtable();
         measure.put("value", followUpValue);
         measure.put("type", followUpType);

--- a/src/main/java/io/github/carlos_emr/carlos/prevention/reports/PreventionReportUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prevention/reports/PreventionReportUtil.java
@@ -50,7 +50,7 @@ public final class PreventionReportUtil {
     public static DemographicArchiveDao demographicArchiveDao = (DemographicArchiveDao) SpringUtils.getBean(DemographicArchiveDao.class);
 
     public static boolean wasRostered(LoggedInInfo loggedInInfo, Integer demographicId, Date onThisDate) {
-        logger.debug("Checking rosterd: {}", LogSafe.sanitizeObject(demographicId));
+        logger.debug("Checking rostered: {}", LogSafe.sanitizeObject(demographicId));
         Demographic demographic = demographicManager.getDemographic(loggedInInfo, demographicId);
 
         if (rosteredDuringThisTimeDemographic(onThisDate, demographic.getRosterDate(), demographic.getRosterTerminationDate()))
@@ -68,7 +68,7 @@ public final class PreventionReportUtil {
 
     public static boolean wasEnrolledToThisProvider(LoggedInInfo loggedInInfo, Integer demographicId, Date onThisDate, String providerNo) {
         logger.debug(
-            "Checking rosterd: {} for this date {} for this providerNo {}",
+            "Checking rostered: {} for this date {} for this providerNo {}",
          LogSafe.sanitizeObject(demographicId),
          onThisDate,
     LogSafe.sanitize(providerNo)
@@ -94,7 +94,7 @@ public final class PreventionReportUtil {
 
     public static boolean wasRosteredToThisProvider(LoggedInInfo loggedInInfo, Integer demographicId, Date onThisDate, String providerNo) {
             logger.debug(
-            "Checking rosterd: {} for this date {} for this providerNo {}",
+            "Checking rostered: {} for this date {} for this providerNo {}",
             LogSafe.sanitizeObject(demographicId),
             onThisDate,
             LogSafe.sanitize(providerNo)

--- a/src/main/java/io/github/carlos_emr/carlos/prevention/reports/PreventionReportUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prevention/reports/PreventionReportUtil.java
@@ -38,6 +38,7 @@ import io.github.carlos_emr.carlos.commn.dao.DemographicArchiveDao;
 import io.github.carlos_emr.carlos.commn.model.Demographic;
 import io.github.carlos_emr.carlos.commn.model.DemographicArchive;
 import io.github.carlos_emr.carlos.managers.DemographicManager;
+import io.github.carlos_emr.carlos.utility.LogSafe;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
@@ -49,7 +50,7 @@ public final class PreventionReportUtil {
     public static DemographicArchiveDao demographicArchiveDao = (DemographicArchiveDao) SpringUtils.getBean(DemographicArchiveDao.class);
 
     public static boolean wasRostered(LoggedInInfo loggedInInfo, Integer demographicId, Date onThisDate) {
-        logger.debug("Checking rosterd:" + demographicId);
+        logger.debug("Checking rosterd: {}", LogSafe.sanitizeObject(demographicId));
         Demographic demographic = demographicManager.getDemographic(loggedInInfo, demographicId);
 
         if (rosteredDuringThisTimeDemographic(onThisDate, demographic.getRosterDate(), demographic.getRosterTerminationDate()))
@@ -66,7 +67,12 @@ public final class PreventionReportUtil {
 
 
     public static boolean wasEnrolledToThisProvider(LoggedInInfo loggedInInfo, Integer demographicId, Date onThisDate, String providerNo) {
-        logger.debug("Checking rosterd:" + demographicId + " for this date " + onThisDate + " for this providerNo " + providerNo);
+        logger.debug(
+            "Checking rosterd: {} for this date {} for this providerNo {}",
+         LogSafe.sanitizeObject(demographicId),
+         onThisDate,
+    LogSafe.sanitize(providerNo)
+);
         if (providerNo == null) {
             return false;
         }
@@ -87,8 +93,13 @@ public final class PreventionReportUtil {
     }
 
     public static boolean wasRosteredToThisProvider(LoggedInInfo loggedInInfo, Integer demographicId, Date onThisDate, String providerNo) {
-        logger.debug("Checking rosterd:" + demographicId + " for this date " + onThisDate + " for this providerNo " + providerNo);
-        if (providerNo == null) {
+            logger.debug(
+            "Checking rosterd: {} for this date {} for this providerNo {}",
+            LogSafe.sanitizeObject(demographicId),
+            onThisDate,
+            LogSafe.sanitize(providerNo)
+         );
+         if (providerNo == null) {
             return false;
         }
 

--- a/src/main/webapp/WEB-INF/jsp/prevention/PreventionReporting.jsp
+++ b/src/main/webapp/WEB-INF/jsp/prevention/PreventionReporting.jsp
@@ -29,6 +29,7 @@
 
 --%>
 <%@page import="io.github.carlos_emr.carlos.utility.LoggedInInfo" %>
+<%@ page import="io.github.carlos_emr.carlos.utility.LogSafe" %>
 <%@page import="org.apache.commons.lang3.StringUtils" %>
 <%@page import="io.github.carlos_emr.carlos.demographic.data.*,java.util.*, java.text.SimpleDateFormat,io.github.carlos_emr.carlos.prevention.*,io.github.carlos_emr.carlos.providers.data.*,io.github.carlos_emr.carlos.util.*,io.github.carlos_emr.carlos.report.data.*,io.github.carlos_emr.carlos.prevention.pageUtil.*,java.net.*,io.github.carlos_emr.carlos.eform.*" %>
 <%@page import="io.github.carlos_emr.CarlosProperties"%>
@@ -279,7 +280,10 @@
                         Demographic demo = demoData.getDemographic(LoggedInInfo.getLoggedInInfoFromSession(request), dis.demographicNo.toString());
 
                         if (demo == null) {
-                            MiscUtils.getLogger().warn("PreventionReporting: demographic not found for demographicNo=" + dis.demographicNo);
+                            MiscUtils.getLogger().warn(
+                            "PreventionReporting: demographic not found for demographicNo={}",
+                            LogSafe.sanitizeObject(dis.demographicNo)
+                        );
                             continue;
                         }
 


### PR DESCRIPTION
## Description

This PR sanitizes PHI-correlating identifiers before they are written to logs in the prevention module.

Several logging statements were directly logging demographic numbers, prevention record IDs, and provider identifiers. This change updates those log statements to use `LogSafe.sanitize()` or `LogSafe.sanitizeObject()` as appropriate and converts them to parameterized logging, bringing them in line with CARLOS logging policy.

## Related Issues

Fixes #2698

## How Was This Tested?

* Reviewed all locations listed in Issue #2698
* Updated affected logging statements to use `LogSafe.sanitize()` or `LogSafe.sanitizeObject()`
* Added required imports where needed
* Verified changes with `git diff --check`
* Manually reviewed modified files to ensure only issue-related changes were included

## Checklist

* [x] My commits are signed off for the DCO (`git commit -s`)
* [x] My commits follow Conventional Commits format, or I've written clear commit messages and will use the format next time
* [x] I have not included any patient data (PHI) in this PR
* [x] I have added tests for new functionality, or this change doesn't need new tests
* [x] I have read the contributing guide

## Summary by Sourcery

Sanitize prevention-related log messages to remove PHI-correlating identifiers and align logging with security policy by using safe logging utilities and parameterized log statements.

Bug Fixes:
- Prevent logging of raw demographic, prevention record, and provider identifiers in prevention module logs by sanitizing values before logging.

Enhancements:
- Convert multiple prevention and workflow-related log statements to parameterized logging using LogSafe helpers for safer handling of potentially sensitive data.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitizes identifiers and input values in prevention module logs to prevent PHI leakage and align with CARLOS logging policy. Converts string-concatenated logs to parameterized logs using `LogSafe` across actions, reports, and JSP.

- **Bug Fixes**
  - Use `LogSafe.sanitize()` / `LogSafe.sanitizeObject()` for demographic numbers, prevention IDs, provider numbers, dates (EDD), ages, sex, and flags.
  - Convert to parameterized logging in `FrmFormRHPrevention2Action`, `PreventionData`, `PreventionDisplayConfig`, `AddPrevention2Action`, `ChildImmunizationReport`, `FollowupManagement`, `PreventionReportUtil`, and `PreventionReporting.jsp`.
  - No functional changes; only sanitized log output.

<sup>Written for commit 371b8b689b33db47391048593ffafd92bc4d0b20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

