### PR TITLE
[codex] Suppress bean property injection false positives

### DIFF
--- a/.github/spotbugs/spotbugs-exclude.xml
+++ b/.github/spotbugs/spotbugs-exclude.xml
@@ -348,6 +348,23 @@
         <Method name="withUploadedFiles"/>
     </Match>
 
+
+    <!--
+      Generated JSP classes call Spring BeanUtils.copyProperties between fixed CARLOS model/archive
+      types. No request-controlled property name reaches the sink; request parameters only select
+      the already-loaded provider/demographic context around the copy.
+    -->
+    <Match>
+        <Bug pattern="BEAN_PROPERTY_INJECTION"/>
+        <Class name="jsp.WEB_002dINF.jsp.admin.providerupdate_jsp"/>
+        <Method name="_jspService"/>
+    </Match>
+    <Match>
+        <Bug pattern="BEAN_PROPERTY_INJECTION"/>
+        <Class name="jsp.WEB_002dINF.jsp.demographic.demographicappthistory_jsp"/>
+        <Method name="_jspService"/>
+    </Match>
+
     <!-- ================================================================
          FIND SECURITY BUGS INFORMATIONAL TAINT-SOURCE / ENDPOINT MARKERS
          These detectors are NOT vulnerabilities. Find Security Bugs emits

--- a/docs/static-analysis-workflows.md
+++ b/docs/static-analysis-workflows.md
@@ -307,6 +307,44 @@ These annotations were applied in bulk by `scripts/lint/annotate-improper-unicod
 re-derives the flagged sites from source (tree-sitter) and is idempotent — re-run it after large
 merges to annotate any new drift.
 
+##### `UNVALIDATED_REDIRECT` (open redirect)
+
+Find Security Bugs flags any `response.sendRedirect(...)` whose argument is data-flow reachable
+from request input. The overwhelming majority of CARLOS sites are false positives because the
+redirect target is a **fixed same-origin path** — `request.getContextPath() + "<literal route>"` —
+with request-derived data appended only as URL-encoded **query parameters**, which cannot change
+the host or scheme. The standard justification is:
+
+> *"redirect target is a same-origin application path or validated internal path, not an
+> attacker-controlled external URL."*
+
+**Guard — do not paste this string onto a redirect whose *destination* is request-influenced.**
+It is only accurate when the scheme+host+path are contextPath-anchored or a server-side allowlist
+value. If a request parameter can become the redirect *target* itself (a `nextPage` / `returnURL` /
+`chain` style value), the finding is **real** — gate it through
+`io.github.carlos_emr.carlos.utility.RedirectValidationUtils.isValidRelativeRedirect(...)` (which
+rejects absolute, protocol-relative, backslash/`%5c`, encoded control chars, and `..` traversal)
+**before** suppressing, and write a site-specific justification naming the validator.
+
+##### `BEAN_PROPERTY_INJECTION` (mass assignment)
+
+Fires on `BeanUtils.copyProperties(...)`. The CARLOS sites are false positives because they use the
+Spring **bean-to-bean** form `copyProperties(source, target)` — and its overload
+`copyProperties(source, target, ignoreProperties)`, where the third argument is a *hardcoded* list
+of property names to **skip**, not a source of request input. In both forms the property names come
+from the compiled JavaBean descriptors of the fixed source/target model/DTO types, so no
+request-controlled property name reaches the sink (see e.g. the legitimate 3-arg suppressions in
+`OscarJobService` and `FacilityTransfer`). The standard justification states exactly that.
+
+The distinguishing factor is whether the **property name** is request-derived, not the argument
+count. **Do not** reuse this rationale for Apache Commons `BeanUtils.populate(bean, map)` /
+`BeanUtilsBean.setProperty`, or any sink where the property name itself comes from request data —
+those are genuine mass-assignment sinks.
+For generated-JSP sinks the suppression lives in `.github/spotbugs/spotbugs-exclude.xml` keyed to
+the generated `_jspService` class name — note that such entries silently stop matching if the JSP is
+renamed or migrated to a `2Action`, so prefer an in-source `@SuppressFBWarnings` once the sink moves
+to Java.
+
 ---
 
 ## Relationship to Other Analysis Tools

--- a/src/main/java/io/github/carlos_emr/carlos/admin/web/ManageFlowsheets2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/admin/web/ManageFlowsheets2Action.java
@@ -49,7 +49,8 @@ public class ManageFlowsheets2Action extends ActionSupport {
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
 
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
-    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = {"IMPROPER_UNICODE", "UNVALIDATED_REDIRECT"}, justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     @Override
     public String execute() throws Exception {
         HttpServletRequest request = ServletActionContext.getRequest();

--- a/src/main/java/io/github/carlos_emr/carlos/billing/web/DbManageBillingformAdd2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billing/web/DbManageBillingformAdd2Action.java
@@ -77,7 +77,8 @@ public class DbManageBillingformAdd2Action extends ActionSupport {
      * @throws SecurityException if the user lacks {@code _admin.billing} write privilege
      */
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
-    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = {"IMPROPER_UNICODE", "UNVALIDATED_REDIRECT"}, justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     @Override
     public String execute() throws Exception {
         if (!"POST".equalsIgnoreCase(request.getMethod())) {
@@ -146,6 +147,8 @@ public class DbManageBillingformAdd2Action extends ActionSupport {
      * @param group3     group 3 description
      * @throws Exception if the redirect fails
      */
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     private void redirectWithError(String errMessage, String typeid, String type,
                                    String group1, String group2, String group3) throws Exception {
         String url = request.getContextPath() + "/billing/CA/ON/ManageBillingform"

--- a/src/main/java/io/github/carlos_emr/carlos/billing/web/DbManageBillingformDx2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billing/web/DbManageBillingformDx2Action.java
@@ -69,7 +69,8 @@ public class DbManageBillingformDx2Action extends ActionSupport {
      * @throws SecurityException if the user lacks {@code _admin.billing} write privilege
      */
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
-    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = {"IMPROPER_UNICODE", "UNVALIDATED_REDIRECT"}, justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     @Override
     public String execute() throws Exception {
         if (!"POST".equalsIgnoreCase(request.getMethod())) {

--- a/src/main/java/io/github/carlos_emr/carlos/billing/web/DbManageBillingformPremium2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billing/web/DbManageBillingformPremium2Action.java
@@ -71,7 +71,8 @@ public class DbManageBillingformPremium2Action extends ActionSupport {
      * @throws SecurityException if the user lacks {@code _admin.billing} write privilege
      */
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
-    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = {"IMPROPER_UNICODE", "UNVALIDATED_REDIRECT"}, justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     @Override
     public String execute() throws Exception {
         if (!"POST".equalsIgnoreCase(request.getMethod())) {

--- a/src/main/java/io/github/carlos_emr/carlos/billing/web/DbManageBillingformPremiumDelete2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billing/web/DbManageBillingformPremiumDelete2Action.java
@@ -69,7 +69,8 @@ public class DbManageBillingformPremiumDelete2Action extends ActionSupport {
      * @throws SecurityException if the user lacks {@code _admin.billing} write privilege
      */
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
-    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = {"IMPROPER_UNICODE", "UNVALIDATED_REDIRECT"}, justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     @Override
     public String execute() throws Exception {
         if (!"POST".equalsIgnoreCase(request.getMethod())) {

--- a/src/main/java/io/github/carlos_emr/carlos/billing/web/DbManageBillingformService2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billing/web/DbManageBillingformService2Action.java
@@ -73,7 +73,8 @@ public class DbManageBillingformService2Action extends ActionSupport {
      * @throws SecurityException if the user lacks {@code _admin.billing} write privilege
      */
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
-    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = {"IMPROPER_UNICODE", "UNVALIDATED_REDIRECT"}, justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     @Override
     public String execute() throws Exception {
         if (!"POST".equalsIgnoreCase(request.getMethod())) {

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/administration/TeleplanCorrectionActionWCB2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/administration/TeleplanCorrectionActionWCB2Action.java
@@ -72,6 +72,7 @@ import io.github.carlos_emr.carlos.util.StringUtils;
 import org.apache.struts2.ActionSupport;
 import org.apache.struts2.ServletActionContext;
 import org.apache.struts2.interceptor.parameter.StrutsParameter;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class TeleplanCorrectionActionWCB2Action extends ActionSupport {
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
@@ -85,6 +86,8 @@ public class TeleplanCorrectionActionWCB2Action extends ActionSupport {
     private WcbDao wcbDao = SpringUtils.getBean(WcbDao.class);
     private DemographicManager demographicManager = SpringUtils.getBean(DemographicManager.class);
 
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     public String execute()
             throws IOException, ServletException {
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/AssociateCodes2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/AssociateCodes2Action.java
@@ -53,6 +53,7 @@ import java.io.IOException;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class AssociateCodes2Action extends ActionSupport {
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
@@ -60,6 +61,8 @@ public class AssociateCodes2Action extends ActionSupport {
     HttpServletRequest request = ServletActionContext.getRequest();
     HttpServletResponse response = ServletActionContext.getResponse();
 
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     public String execute() {
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
         if (!securityInfoManager.hasPrivilege(loggedInInfo, "_billing", "w", null)) {

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/BillingCreateBilling2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/BillingCreateBilling2Action.java
@@ -80,6 +80,8 @@ public class BillingCreateBilling2Action extends ActionSupport {
     private ServiceCodeValidationLogic vldt = new ServiceCodeValidationLogic();
     private ArrayList<String> patientDX = new ArrayList<String>(); //List of disease codes for current patient
 
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     public String execute() throws IOException, ServletException {
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
         if (!securityInfoManager.hasPrivilege(loggedInInfo, "_billing", "w", null)) {

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/SupServiceCodeAssoc2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/SupServiceCodeAssoc2Action.java
@@ -40,6 +40,7 @@ import io.github.carlos_emr.carlos.billings.ca.bc.data.SupServiceCodeAssocDAO;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * Struts 2 action for managing British Columbia supplementary service code associations.
@@ -89,6 +90,8 @@ public class SupServiceCodeAssoc2Action extends ActionSupport {
      * @return String "success" to forward to list view, or NONE after redirect
      * @throws RuntimeException if redirect fails
      */
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     public String execute() {
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
         if (!securityInfoManager.hasPrivilege(loggedInInfo, "_billing", "w", null)) {

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/WCBAction22Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/WCBAction22Action.java
@@ -65,6 +65,7 @@ import org.apache.struts2.interceptor.parameter.StrutsParameter;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class WCBAction22Action extends ActionSupport {
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
@@ -75,6 +76,8 @@ public class WCBAction22Action extends ActionSupport {
     public String execute() throws Exception {        return save();
     }
 
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     public String save() throws Exception {
         if (request.getSession().getAttribute("user") == null) {
             return "Logout";

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/BatchBill2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/BatchBill2Action.java
@@ -154,6 +154,8 @@ public class BatchBill2Action extends ActionSupport {
         }
     }
 
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     public String doBatchBill() {
 
         if (rejectNonPostMutation()) {
@@ -239,6 +241,8 @@ public class BatchBill2Action extends ActionSupport {
     }
 
     //Remove demographics from batch billing table
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     public String remove() {
 
 

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/BillingOnPayment2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/BillingOnPayment2Action.java
@@ -59,7 +59,8 @@ public class BillingOnPayment2Action extends ActionSupport {
         this.billingONPaymentAssembler = billingONPaymentAssembler;
     }
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
-    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = {"IMPROPER_UNICODE", "UNVALIDATED_REDIRECT"}, justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     @Override
     public String execute() throws Exception {
         HttpServletRequest request = ServletActionContext.getRequest();

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/FluBillingAdd2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/FluBillingAdd2Action.java
@@ -42,6 +42,7 @@ import io.github.carlos_emr.carlos.utility.LogSafe;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.SafeEncode;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * Struts2 action for adding a flu billing record.
@@ -88,6 +89,8 @@ public class FluBillingAdd2Action extends ActionSupport {
      * @return {@link #SUCCESS}, {@link #ERROR} for validation failures, or {@link #NONE} for a redirect or invalid method
      * @throws Exception if an unexpected error occurs during persistence
      */
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     @Override
     public String execute() throws Exception {
         HttpServletRequest request = ServletActionContext.getRequest();

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/ManageBillingFormAdd2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/ManageBillingFormAdd2Action.java
@@ -42,6 +42,7 @@ import java.util.Objects;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * Struts2 action to add a new Ontario billing form service type.
@@ -73,6 +74,8 @@ public class ManageBillingFormAdd2Action extends ActionSupport {
      * @return {@link #NONE} after redirecting, or if the request method is not POST
      * @throws SecurityException if the user lacks {@code _admin.billing} write privilege
      */
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     @Override
     public String execute() throws Exception {
         if (!BillingRequestGuards.requirePost(request, response)) {
@@ -155,6 +158,8 @@ public class ManageBillingFormAdd2Action extends ActionSupport {
      * @param group3     group 3 description
      * @throws Exception if the redirect fails
      */
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     private void redirectWithError(String errMessage, String typeid, String type,
                                    String group1, String group2, String group3) throws Exception {
         String url = request.getContextPath() + "/billing/CA/ON/ManageBillingform"

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/ManageBillingFormDiag2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/ManageBillingFormDiag2Action.java
@@ -36,6 +36,7 @@ import io.github.carlos_emr.carlos.utility.SpringUtils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * Struts2 action to replace the diagnostic codes for an Ontario billing service type.
@@ -64,6 +65,8 @@ public class ManageBillingFormDiag2Action extends ActionSupport {
      * @return {@link #NONE} after redirecting, or if the request method is not POST
      * @throws SecurityException if the user lacks {@code _admin.billing} write privilege
      */
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     @Override
     public String execute() throws Exception {
         if (!BillingRequestGuards.requirePost(request, response)) {

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/ManageBillingFormPremium2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/ManageBillingFormPremium2Action.java
@@ -36,6 +36,7 @@ import io.github.carlos_emr.carlos.utility.SpringUtils;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * Struts2 action to add premium billing service codes for Ontario billing.
@@ -63,6 +64,8 @@ public class ManageBillingFormPremium2Action extends ActionSupport {
      * @return {@link #NONE} after redirecting, or if the request method is not POST
      * @throws SecurityException if the user lacks {@code _admin.billing} write privilege
      */
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     @Override
     public String execute() throws Exception {
         if (!BillingRequestGuards.requirePost(request, response)) {

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/ManageBillingFormPremiumDelete2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/ManageBillingFormPremiumDelete2Action.java
@@ -35,6 +35,7 @@ import io.github.carlos_emr.carlos.utility.SpringUtils;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * Struts2 action to delete premium billing service codes for Ontario billing.
@@ -63,6 +64,8 @@ public class ManageBillingFormPremiumDelete2Action extends ActionSupport {
      * @return {@link #NONE} after redirecting, or if the request method is not POST
      * @throws SecurityException if the user lacks {@code _admin.billing} write privilege
      */
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     @Override
     public String execute() throws Exception {
         if (!BillingRequestGuards.requirePost(request, response)) {

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/ManageBillingFormService2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/ManageBillingFormService2Action.java
@@ -37,6 +37,7 @@ import io.github.carlos_emr.carlos.utility.SpringUtils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * Struts2 action to replace all service codes for an Ontario billing service type.
@@ -65,6 +66,8 @@ public class ManageBillingFormService2Action extends ActionSupport {
      * @return {@link #NONE} after redirecting, or if the request method is not POST
      * @throws SecurityException if the user lacks {@code _admin.billing} write privilege
      */
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     @Override
     public String execute() throws Exception {
         if (!BillingRequestGuards.requirePost(request, response)) {

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/ManageBillingLocationSave2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/ManageBillingLocationSave2Action.java
@@ -35,6 +35,7 @@ import io.github.carlos_emr.carlos.utility.SpringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * Struts2 action to add clinic billing locations for Ontario billing.
@@ -74,6 +75,8 @@ public class ManageBillingLocationSave2Action extends ActionSupport {
      * @return {@link #NONE} after redirecting, or if the request method is not POST
      * @throws SecurityException if the user lacks {@code _admin.billing} write privilege
      */
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     @Override
     public String execute() throws Exception {
         if (!BillingRequestGuards.requirePost(request, response)) {

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementEntry2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementEntry2Action.java
@@ -2078,8 +2078,9 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
 
         if (chain != null && !chain.equals("")) {
             // FP for open-redirect scanners (CodeQL java/OR): isValidInternalRedirect enforces
-            // relative-only OR same-scheme+host+port match; rejects protocol-relative (//evil),
-            // backslash, userinfo (@evil), and suffix (host.evil) bypasses.
+            // relative-only (via RedirectValidationUtils.isValidRelativeRedirect) OR
+            // same-scheme+host+port match; rejects protocol-relative (//evil), backslash and %5c
+            // (/\evil.com -> //evil.com), userinfo (@evil), and suffix (host.evil) bypasses.
             if (isValidInternalRedirect(chain, request)) {
                 response.sendRedirect(chain); // nosemgrep: java.lang.security.audit.servlets.unvalidated-redirect.unvalidated-redirect-java -- gated by isValidInternalRedirect // lgtm[java/unvalidated-url-redirection]
             } else {
@@ -2091,8 +2092,8 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
         return "windowClose";
     }
 
-    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin billing path built from the current context path and server-side billing values.
-    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin billing path built from the current context path and server-side billing values")
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a fixed same-origin billing path (contextPath + "/billing"); only query parameters (billing/appointment request and session values) vary and cannot alter the host or scheme.
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a fixed same-origin billing path (contextPath + \"/billing\"); only query parameters (billing/appointment request and session values) vary and cannot alter the host or scheme")
     private void sendBillingRedirect(String url) throws IOException {
         response.sendRedirect(url);
     }
@@ -3934,10 +3935,12 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
         // Remove any leading/trailing whitespace
         url = url.trim();
 
-        // Check for relative URLs (safe)
+        // Check for relative URLs (safe). Delegate to the shared validator, which — beyond the
+        // naive "no ://" check this method used to do — also rejects backslash and %5c
+        // (browsers normalise /\evil.com to //evil.com after a redirect), percent-encoded
+        // control characters, and path-traversal escapes.
         if (url.startsWith("/") && !url.startsWith("//")) {
-            // Ensure it doesn't contain protocol-relative URLs
-            return !url.contains("://");
+            return RedirectValidationUtils.isValidRelativeRedirect(url);
         }
 
         // Check if URL starts with the application's context path

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementEntry2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementEntry2Action.java
@@ -2070,7 +2070,8 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
                     + "&appointment_date=" + date
                     + "&start_time=" + start_time
                     + "&bNewForm=1" + dxCodes.toString();
-            logger.debug("BILLING URL " + url);
+            logger.debug("Redirecting to billing form for appointment_no={}, demographic_no={}",
+                    appointmentNo, demoNo);
             sendBillingRedirect(url);
         }
 

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementEntry2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementEntry2Action.java
@@ -2071,7 +2071,7 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
                     + "&start_time=" + start_time
                     + "&bNewForm=1" + dxCodes.toString();
             logger.debug("BILLING URL " + url);
-            response.sendRedirect(url);
+            sendBillingRedirect(url);
         }
 
         String chain = request.getParameter("chain");
@@ -2089,6 +2089,12 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
         }
 
         return "windowClose";
+    }
+
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin billing path built from the current context path and server-side billing values.
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin billing path built from the current context path and server-side billing values")
+    private void sendBillingRedirect(String url) throws IOException {
+        response.sendRedirect(url);
     }
 
     public String cancel() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/Demographic.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/Demographic.java
@@ -240,6 +240,11 @@ public class Demographic extends AbstractModel<Integer> implements Serializable 
         initialize();
     }
 
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
     public Demographic(Demographic d) {
         try {
             BeanUtils.copyProperties(d, this);

--- a/src/main/java/io/github/carlos_emr/carlos/commn/web/Pregnancy2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/web/Pregnancy2Action.java
@@ -605,6 +605,8 @@ public class Pregnancy2Action extends ActionSupport {
         return null;
     }
 
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     public String loadEformByName() {
         EFormDao eformDao = (EFormDao) SpringUtils.getBean(EFormDao.class);
         //Prenatal Screening (IPS) Credit Valley

--- a/src/main/java/io/github/carlos_emr/carlos/dashboard/factory/DashboardBeanFactory.java
+++ b/src/main/java/io/github/carlos_emr/carlos/dashboard/factory/DashboardBeanFactory.java
@@ -31,6 +31,7 @@ package io.github.carlos_emr.carlos.dashboard.factory;
 import java.util.Date;
 import java.util.List;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.springframework.beans.BeanUtils;
 import org.apache.logging.log4j.Logger;
 import io.github.carlos_emr.carlos.commn.model.Dashboard;
@@ -86,6 +87,11 @@ public class DashboardBeanFactory {
         return dashboardBean;
     }
 
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
     private void setDashboardBean(DashboardBean dashboardBean) {
         try {
             // copy matching properties from Bean to Bean

--- a/src/main/java/io/github/carlos_emr/carlos/dashboard/factory/DrilldownBeanFactory.java
+++ b/src/main/java/io/github/carlos_emr/carlos/dashboard/factory/DrilldownBeanFactory.java
@@ -30,6 +30,7 @@ package io.github.carlos_emr.carlos.dashboard.factory;
 
 import java.util.List;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.springframework.beans.BeanUtils;
 import org.apache.logging.log4j.Logger;
 import io.github.carlos_emr.carlos.commn.model.IndicatorTemplate;
@@ -107,6 +108,11 @@ public class DrilldownBeanFactory {
         return drilldownBean;
     }
 
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
     private void setDrilldownBean(DrilldownBean drilldownBean) {
         // copy what is available in the entity bean
         try {

--- a/src/main/java/io/github/carlos_emr/carlos/dashboard/handler/TicklerHandler.java
+++ b/src/main/java/io/github/carlos_emr/carlos/dashboard/handler/TicklerHandler.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 
 import io.github.carlos_emr.carlos.utility.LogSafe;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.springframework.beans.BeanUtils;
 import org.apache.logging.log4j.Logger;
 import io.github.carlos_emr.carlos.commn.model.Tickler;
@@ -100,6 +101,11 @@ public class TicklerHandler {
     /**
      * Adds a copy of the master tickler to each demographic id in the given Collection.
      */
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
     public boolean addTickler(Integer[] demographicArray) {
 
         if (demographicArray == null || demographicArray.length == 0) {

--- a/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/DemographicUpdate2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/DemographicUpdate2Action.java
@@ -93,7 +93,8 @@ public class DemographicUpdate2Action extends ActionSupport {
      *         {@code _demographic} write privilege
      */
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
-    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = {"IMPROPER_UNICODE", "UNVALIDATED_REDIRECT"}, justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     @Override
     public String execute() throws IOException {
         if (!"POST".equals(request.getMethod())) {

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/AddEditDocument2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/AddEditDocument2Action.java
@@ -309,6 +309,8 @@ public class AddEditDocument2Action extends ActionSupport implements UploadedFil
      * @return String the Struts2 result name ("failEdit", "failAdd", "successEdit", or NONE)
      * @throws SecurityException if the user lacks _edoc write privilege
      */
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     public String execute2() {
         if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_edoc", "w", null)) {
             throw new SecurityException("missing required sec object (_edoc)");

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/AddEditHtml2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/AddEditHtml2Action.java
@@ -53,6 +53,7 @@ import io.github.carlos_emr.carlos.util.UtilDateUtilities;
 import org.apache.struts2.ActionSupport;
 import org.apache.struts2.ServletActionContext;
 import org.apache.struts2.interceptor.parameter.StrutsParameter;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class AddEditHtml2Action extends ActionSupport {
     HttpServletRequest request = ServletActionContext.getRequest();
@@ -63,6 +64,8 @@ public class AddEditHtml2Action extends ActionSupport {
     /**
      * Creates a new instance of AddLinkAction
      */
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     public String execute() {
         if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_edoc", "w", null)) {
             throw new SecurityException("missing required sec object (_edoc)");

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/DmsInboxManage2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/DmsInboxManage2Action.java
@@ -192,6 +192,8 @@ public class DmsInboxManage2Action extends ActionSupport {
         return "doclabPreview";
     }
 
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     public String prepareForIndexPage() {
         HttpSession session = request.getSession();
         try {
@@ -283,7 +285,8 @@ public class DmsInboxManage2Action extends ActionSupport {
     }
 
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
-    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = {"IMPROPER_UNICODE", "UNVALIDATED_REDIRECT"}, justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     @SuppressWarnings({"unchecked", "rawtypes"})
     public String prepareForContentPage() {
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
@@ -747,6 +750,8 @@ public class DmsInboxManage2Action extends ActionSupport {
 
     // return a hastable containing queue id to queue name, a hashtable of queue id and a list of document nos.
     // forward to documentInQueus.jsp
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     @SuppressWarnings({"unchecked", "rawtypes"})
     public String getDocumentsInQueues() {
         HttpSession session = request.getSession();

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentDelete2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentDelete2Action.java
@@ -61,7 +61,8 @@ public class DocumentDelete2Action extends ActionSupport {
     private String source;
 
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
-    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = {"IMPROPER_UNICODE", "UNVALIDATED_REDIRECT"}, justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     @Override
     public String execute() throws Exception {
         HttpServletRequest request = ServletActionContext.getRequest();

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentRefile2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentRefile2Action.java
@@ -59,7 +59,8 @@ public class DocumentRefile2Action extends ActionSupport {
     private String viewstatus;
 
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
-    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = {"IMPROPER_UNICODE", "UNVALIDATED_REDIRECT"}, justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     @Override
     public String execute() throws Exception {
         HttpServletRequest request = ServletActionContext.getRequest();

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentUndelete2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentUndelete2Action.java
@@ -64,7 +64,8 @@ public class DocumentUndelete2Action extends ActionSupport {
     private String source;
 
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
-    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = {"IMPROPER_UNICODE", "UNVALIDATED_REDIRECT"}, justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     @Override
     public String execute() throws Exception {
         HttpServletRequest request = ServletActionContext.getRequest();

--- a/src/main/java/io/github/carlos_emr/carlos/dxresearch/pageUtil/dxResearch2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/dxresearch/pageUtil/dxResearch2Action.java
@@ -59,7 +59,8 @@ public class dxResearch2Action extends ActionSupport {
     private static SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
 
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
-    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = {"IMPROPER_UNICODE", "UNVALIDATED_REDIRECT"}, justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     public String execute()
             throws ServletException, IOException {
         if (!"POST".equalsIgnoreCase(request.getMethod())) {

--- a/src/main/java/io/github/carlos_emr/carlos/dxresearch/pageUtil/dxResearchUpdate2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/dxresearch/pageUtil/dxResearchUpdate2Action.java
@@ -61,7 +61,8 @@ public class dxResearchUpdate2Action extends ActionSupport {
     private static SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
 
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
-    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = {"IMPROPER_UNICODE", "UNVALIDATED_REDIRECT"}, justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     public String execute() throws ServletException, IOException {
         if (!"POST".equalsIgnoreCase(request.getMethod())) {
             response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);

--- a/src/main/java/io/github/carlos_emr/carlos/eform/actions/AddEForm2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/eform/actions/AddEForm2Action.java
@@ -49,6 +49,7 @@ import io.github.carlos_emr.carlos.utility.LogSafe;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.PDFGenerationException;
 import io.github.carlos_emr.carlos.utility.PathValidationUtils;
+import io.github.carlos_emr.carlos.utility.SafeEncode;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 import io.github.carlos_emr.carlos.eform.EFormUtil;
 import io.github.carlos_emr.carlos.eform.data.EForm;
@@ -70,7 +71,6 @@ import java.util.regex.Pattern;
 
 import org.apache.struts2.ActionSupport;
 import org.apache.struts2.ServletActionContext;
-import org.owasp.encoder.Encode;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class AddEForm2Action extends ActionSupport {
@@ -364,31 +364,7 @@ public class AddEForm2Action extends ActionSupport {
                  * This form id is sent to the fax action to render it as a faxable PDF.
                  * A preview is returned to the user once the form is rendered.
                  */
-                StringBuilder faxForward = new StringBuilder(request.getContextPath()).append("/fax/faxAction");
-                faxForward.append("?method=").append(URLEncoder.encode("prepareFax", StandardCharsets.UTF_8));
-                faxForward.append("&transactionId=").append(URLEncoder.encode(prev_fdid, StandardCharsets.UTF_8));
-                faxForward.append("&transactionType=").append(URLEncoder.encode(TransactionType.EFORM.name(), StandardCharsets.UTF_8));
-                faxForward.append("&demographicNo=").append(URLEncoder.encode(demographic_no, StandardCharsets.UTF_8));
-
-
-                /*
-                 * Added incase the eForm developer adds these elements to the
-                 * eform.
-                 */
-                if (recipient != null) {
-                    faxForward.append("&recipient=").append(recipient);
-                }
-                if (recipientFaxNumber != null) {
-                    faxForward.append("&recipientFaxNumber=").append(recipientFaxNumber);
-                }
-                if (letterheadFax != null) {
-                    faxForward.append("&letterheadFax=").append(letterheadFax);
-                }
-                try {
-                    response.sendRedirect(faxForward.toString());
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
+                redirectToPreparedFax(prev_fdid, demographic_no, recipient, recipientFaxNumber, letterheadFax);
                 return NONE;
             } else if (print) {
                 return "print";
@@ -506,7 +482,7 @@ public class AddEForm2Action extends ActionSupport {
     // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin email compose path built from the current context path with an encoded eForm id.
     @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin email compose path built from the current context path with an encoded eForm id")
     private void redirectToEmailCompose(String fid) {
-        String path = request.getContextPath() + "/email/emailComposeAction?method=prepareComposeEFormMailer&fid=" + Encode.forUriComponent(fid);
+        String path = request.getContextPath() + "/email/emailComposeAction?method=prepareComposeEFormMailer&fid=" + SafeEncode.forUriComponent(fid);
         try {
             response.sendRedirect(path);
         } catch (IOException e) {

--- a/src/main/java/io/github/carlos_emr/carlos/eform/actions/AddEForm2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/eform/actions/AddEForm2Action.java
@@ -299,30 +299,7 @@ public class AddEForm2Action extends ActionSupport {
             }
 
             if (fax) {
-                StringBuilder faxForward = new StringBuilder(request.getContextPath()).append("/fax/faxAction");
-                faxForward.append("?method=").append("prepareFax");
-                faxForward.append("&transactionId=").append(URLEncoder.encode(fdid, StandardCharsets.UTF_8));
-                faxForward.append("&transactionType=").append(URLEncoder.encode(TransactionType.EFORM.name(), StandardCharsets.UTF_8));
-                faxForward.append("&demographicNo=").append(URLEncoder.encode(demographic_no, StandardCharsets.UTF_8));
-
-                /*
-                 * Added incase the eForm developer adds these elements to the
-                 * eform.
-                 */
-                if (recipient != null && !recipient.isEmpty()) {
-                    faxForward.append("&recipient=").append(URLEncoder.encode(recipient, StandardCharsets.UTF_8));
-                }
-                if (recipientFaxNumber != null && !recipientFaxNumber.isEmpty()) {
-                    faxForward.append("&recipientFaxNumber=").append(URLEncoder.encode(recipientFaxNumber, StandardCharsets.UTF_8));
-                }
-                if (letterheadFax != null && !letterheadFax.isEmpty()) {
-                    faxForward.append("&letterheadFax=").append(URLEncoder.encode(letterheadFax, StandardCharsets.UTF_8));
-                }
-                try {
-                    response.sendRedirect(faxForward.toString());
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
+                redirectToPreparedFax(fdid, demographic_no, recipient, recipientFaxNumber, letterheadFax);
                 return NONE;
             } else if (print) {
                 return "print";
@@ -351,7 +328,6 @@ public class AddEForm2Action extends ActionSupport {
 
                 return "download";
             } else if (isEmailEForm) {
-                String path = request.getContextPath() + "/email/emailComposeAction?method=prepareComposeEFormMailer&fid=" + Encode.forUriComponent(fid);
                 EmailAttachmentSettings settings = EmailAttachmentSettings.of(
                     request,
                     fdid,
@@ -363,11 +339,7 @@ public class AddEForm2Action extends ActionSupport {
                     attachedForms
                 );
                 addEmailAttachmentsToSession(request, settings);
-                try {
-                    response.sendRedirect(path);
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
+                redirectToEmailCompose(fid);
                 return NONE;
             } else {
                 //write template message to echart
@@ -445,7 +417,6 @@ public class AddEForm2Action extends ActionSupport {
 
                 return "download";
             } else if (isEmailEForm) {
-                String path = request.getContextPath() + "/email/emailComposeAction?method=prepareComposeEFormMailer&fid=" + Encode.forUriComponent(fid);
                 EmailAttachmentSettings settings = EmailAttachmentSettings.of(
                     request,
                     prev_fdid,
@@ -457,11 +428,7 @@ public class AddEForm2Action extends ActionSupport {
                     attachedForms
                 );
                 addEmailAttachmentsToSession(request, settings);
-                try {
-                    response.sendRedirect(path);
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
+                redirectToEmailCompose(fid);
                 return NONE;
             }
 
@@ -511,6 +478,42 @@ public class AddEForm2Action extends ActionSupport {
         return "close";
 	}
 	
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin fax action path built from the current context path with encoded query parameters.
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin fax action path built from the current context path with encoded query parameters")
+    private void redirectToPreparedFax(String fdid, String demographicNo, String recipient, String recipientFaxNumber, String letterheadFax) {
+        StringBuilder faxForward = new StringBuilder(request.getContextPath()).append("/fax/faxAction");
+        faxForward.append("?method=").append("prepareFax");
+        faxForward.append("&transactionId=").append(URLEncoder.encode(fdid, StandardCharsets.UTF_8));
+        faxForward.append("&transactionType=").append(URLEncoder.encode(TransactionType.EFORM.name(), StandardCharsets.UTF_8));
+        faxForward.append("&demographicNo=").append(URLEncoder.encode(demographicNo, StandardCharsets.UTF_8));
+
+        if (recipient != null && !recipient.isEmpty()) {
+            faxForward.append("&recipient=").append(URLEncoder.encode(recipient, StandardCharsets.UTF_8));
+        }
+        if (recipientFaxNumber != null && !recipientFaxNumber.isEmpty()) {
+            faxForward.append("&recipientFaxNumber=").append(URLEncoder.encode(recipientFaxNumber, StandardCharsets.UTF_8));
+        }
+        if (letterheadFax != null && !letterheadFax.isEmpty()) {
+            faxForward.append("&letterheadFax=").append(URLEncoder.encode(letterheadFax, StandardCharsets.UTF_8));
+        }
+        try {
+            response.sendRedirect(faxForward.toString());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin email compose path built from the current context path with an encoded eForm id.
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin email compose path built from the current context path with an encoded eForm id")
+    private void redirectToEmailCompose(String fid) {
+        String path = request.getContextPath() + "/email/emailComposeAction?method=prepareComposeEFormMailer&fid=" + Encode.forUriComponent(fid);
+        try {
+            response.sendRedirect(path);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
 	private String generateFileName(LoggedInInfo loggedInInfo, int demographicNo) {
 		DemographicManager demographicManager = SpringUtils.getBean(DemographicManager.class);
 		String demographicLastName = demographicManager.getDemographicFormattedName(loggedInInfo, demographicNo).split(", ")[0];

--- a/src/main/java/io/github/carlos_emr/carlos/eform/actions/OpenEFormByName2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/eform/actions/OpenEFormByName2Action.java
@@ -45,6 +45,7 @@ import io.github.carlos_emr.carlos.utility.SpringUtils;
 import org.apache.struts2.ActionSupport;
 import org.apache.struts2.ServletActionContext;
 import org.owasp.encoder.Encode;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class OpenEFormByName2Action extends ActionSupport {
     HttpServletRequest request = ServletActionContext.getRequest();
@@ -53,6 +54,8 @@ public class OpenEFormByName2Action extends ActionSupport {
 
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
 
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     public String execute() throws IOException {
         String eform_name = request.getParameter("eform_name");
         String demographic_no = request.getParameter("demographic_no");

--- a/src/main/java/io/github/carlos_emr/carlos/eform/actions/PrintPDF2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/eform/actions/PrintPDF2Action.java
@@ -61,6 +61,8 @@ public final class PrintPDF2Action extends ActionSupport {
     private Logger log = MiscUtils.getLogger();
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
 
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     public String execute() throws ServletException, IOException {
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
 

--- a/src/main/java/io/github/carlos_emr/carlos/email/action/EmailSend2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/email/action/EmailSend2Action.java
@@ -165,6 +165,8 @@ public class EmailSend2Action extends ActionSupport {
      * @return String Struts2 result identifier matching the transaction type name
      * @throws RuntimeException if IOException occurs during redirect for EFORM transactions
      */
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     public String cancel() {
         EmailData emailData = prepareEmailFields(request);
         String emailRedirect = emailData.getTransactionType().name();

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2Action.java
@@ -119,7 +119,8 @@ public class EctConsultationFormRequest2Action extends ActionSupport {
      * @throws IOException      when an I/O error occurs during response writing or HL7 sending
      */
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
-    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = {"IMPROPER_UNICODE", "UNVALIDATED_REDIRECT"}, justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     @Override
     public String execute() throws ServletException, IOException {
 

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctDeleteData2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctDeleteData2Action.java
@@ -48,6 +48,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class EctDeleteData2Action extends ActionSupport {
     HttpServletRequest request = ServletActionContext.getRequest();
@@ -56,6 +57,8 @@ public class EctDeleteData2Action extends ActionSupport {
 
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
 
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     public String execute() throws ServletException, IOException {
 
         if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_measurement", "d", null)) {

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctMeasurements2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctMeasurements2Action.java
@@ -83,7 +83,8 @@ public class EctMeasurements2Action extends ActionSupport {
 
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
     // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
-    @SuppressFBWarnings(value = {"XSS_SERVLET", "IMPROPER_UNICODE"}, justification = "XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink. case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = {"XSS_SERVLET", "IMPROPER_UNICODE", "UNVALIDATED_REDIRECT"}, justification = "XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink. case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     public String execute() throws ServletException, IOException {
         if (!"POST".equalsIgnoreCase(request.getMethod())) {
             logger.warn("Rejected measurement submission request with method {} from {}",

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/MeasurementGraphAction22Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/MeasurementGraphAction22Action.java
@@ -107,6 +107,8 @@ public class MeasurementGraphAction22Action extends ActionSupport {
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
     private final String NUMERIC_REGEX = "[^-.\\d]";
 
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     public String execute() throws IOException, ParseException {
         log.debug("In MeasurementGraphAction22Action");
         String userrole = (String) request.getSession().getAttribute("userrole");

--- a/src/main/java/io/github/carlos_emr/carlos/fax/action/Fax2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/fax/action/Fax2Action.java
@@ -94,7 +94,8 @@ public class Fax2Action extends ActionSupport {
     }
 
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
-    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = {"IMPROPER_UNICODE", "UNVALIDATED_REDIRECT"}, justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     @SuppressWarnings("unused")
     public String cancel() {
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);

--- a/src/main/java/io/github/carlos_emr/carlos/form/FrmBCAR20202Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/FrmBCAR20202Action.java
@@ -71,6 +71,7 @@ import java.util.Set;
 
 import org.apache.struts2.ActionSupport;
 import org.apache.struts2.ServletActionContext;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class FrmBCAR20202Action extends ActionSupport {
     HttpServletRequest request = ServletActionContext.getRequest();
@@ -106,6 +107,8 @@ public class FrmBCAR20202Action extends ActionSupport {
         return "exit";
     }
 
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     public String save() throws Exception {
         FrmBCAR2020Record bcar2020Record = (FrmBCAR2020Record) (new FrmRecordFactory()).factory(RECORD_NAME);
 

--- a/src/main/java/io/github/carlos_emr/carlos/form/FrmBCAR20202Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/FrmBCAR20202Action.java
@@ -217,7 +217,7 @@ public class FrmBCAR20202Action extends ActionSupport {
             url = url + forwardTo + ".jsp";
         }
         url = url + "?demographic_no=" + demographicNo + "&formId=" + formId + "&provNo=" + providerNo;
-        response.sendRedirect(url);
+        response.sendRedirect(request.getContextPath() + url);
         return NONE;
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FormForward2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FormForward2Action.java
@@ -64,7 +64,8 @@ public class FormForward2Action extends ActionSupport {
      * forward to the current specified form, e.g. ../form/formar.jsp?demographic_no=
      */
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
-    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = {"IMPROPER_UNICODE", "UNVALIDATED_REDIRECT"}, justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     @Override
     public String execute() throws ServletException, IOException {
 

--- a/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FrmSetupForm2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FrmSetupForm2Action.java
@@ -88,7 +88,8 @@ public final class FrmSetupForm2Action extends ActionSupport {
 
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
     // FindSecBugs PATH_TRAVERSAL_IN: path validated for directory containment via PathValidationUtils before use
-    @SuppressFBWarnings(value = {"IMPROPER_UNICODE", "PATH_TRAVERSAL_IN"}, justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision; and path validated for directory containment via PathValidationUtils before use")
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = {"IMPROPER_UNICODE", "PATH_TRAVERSAL_IN", "UNVALIDATED_REDIRECT"}, justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision; and path validated for directory containment via PathValidationUtils before use. UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     public String execute() throws Exception {
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
 

--- a/src/main/java/io/github/carlos_emr/carlos/form/pharmaForms/formBPMH/business/BpmhForm2Handler.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/pharmaForms/formBPMH/business/BpmhForm2Handler.java
@@ -431,6 +431,11 @@ public class BpmhForm2Handler {
      *
      * @param bpmhDrugBeans
      */
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
     public void setFormBeanDrugList(List<BpmhDrug> bpmhDrugBeans) {
 
         Iterator<Drug> drugListIterator = null;

--- a/src/main/java/io/github/carlos_emr/carlos/integration/mchcv/HCValidationResult.java
+++ b/src/main/java/io/github/carlos_emr/carlos/integration/mchcv/HCValidationResult.java
@@ -263,8 +263,13 @@ public class HCValidationResult {
         return null;
     }
 
-    // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
-    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
+    // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision.
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = {"IMPROPER_UNICODE", "BEAN_PROPERTY_INJECTION"},
+            justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); " +
+                    "not a security or authorization decision. Spring BeanUtils.copyProperties copies " +
+                    "fixed JavaBean descriptors between known CARLOS types; no user-controlled " +
+                    "property name reaches the sink")
     private FeeServiceDetails getFeeServiceDetailsbyFeeServiceCode(String feeServiceCode) {
         FeeServiceDetails selectedFeeServiceDetails = new FeeServiceDetails();
         selectedFeeServiceDetails.setFeeServiceCode(feeServiceCode);

--- a/src/main/java/io/github/carlos_emr/carlos/integration/mchcv/HCValidationResult.java
+++ b/src/main/java/io/github/carlos_emr/carlos/integration/mchcv/HCValidationResult.java
@@ -31,8 +31,6 @@ package io.github.carlos_emr.carlos.integration.mchcv;
 import ca.ontario.health.ebs.EbsFault;
 import ca.ontario.health.hcv.FeeServiceDetails;
 import ca.ontario.health.hcv.ResponseID;
-import org.springframework.beans.BeanUtils;
-import io.github.carlos_emr.carlos.utility.MiscUtils;
 
 import javax.xml.datatype.XMLGregorianCalendar;
 import java.util.Collections;
@@ -264,23 +262,15 @@ public class HCValidationResult {
     }
 
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision.
-    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between known CARLOS types; no user-controlled property name reaches the sink.
-    @SuppressFBWarnings(value = {"IMPROPER_UNICODE", "BEAN_PROPERTY_INJECTION"},
+    @SuppressFBWarnings(value = "IMPROPER_UNICODE",
             justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); " +
-                    "not a security or authorization decision. Spring BeanUtils.copyProperties copies " +
-                    "fixed JavaBean descriptors between known CARLOS types; no user-controlled " +
-                    "property name reaches the sink")
+                    "not a security or authorization decision")
     private FeeServiceDetails getFeeServiceDetailsbyFeeServiceCode(String feeServiceCode) {
         FeeServiceDetails selectedFeeServiceDetails = new FeeServiceDetails();
         selectedFeeServiceDetails.setFeeServiceCode(feeServiceCode);
         for (FeeServiceDetails feeServiceDetail : this.feeServiceDetails) {
             if (feeServiceCode.equalsIgnoreCase(feeServiceDetail.getFeeServiceCode())) {
                 selectedFeeServiceDetails = feeServiceDetail;
-                try {
-                    BeanUtils.copyProperties(feeServiceDetail, selectedFeeServiceDetails);
-                } catch (Exception e) {
-                    MiscUtils.getLogger().warn("Bean Copy error. Fee Service code: " + feeServiceCode, e);
-                }
                 break;
             }
         }

--- a/src/main/java/io/github/carlos_emr/carlos/login/Login2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/login/Login2Action.java
@@ -328,7 +328,8 @@ public final class Login2Action extends ActionSupport {
      */
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
     // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
-    @SuppressFBWarnings(value = {"XSS_SERVLET", "IMPROPER_UNICODE"}, justification = "XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink. case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = {"XSS_SERVLET", "IMPROPER_UNICODE", "UNVALIDATED_REDIRECT"}, justification = "XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink. case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     public String execute() throws ServletException, IOException {
 
         if (!"POST".equals(request.getMethod())) {
@@ -741,6 +742,8 @@ public final class Login2Action extends ActionSupport {
      * @return Struts result name, {@link #NONE}, or null for direct AJAX responses
      * @throws IOException if redirecting or writing the final response fails
      */
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     private String validateMfaAndCompleteLogin(String ip, boolean isMobileOptimized, String submitType,
                                                boolean ajaxResponse) throws IOException {
         HttpSession session = request.getSession(false);
@@ -1089,7 +1092,8 @@ public final class Login2Action extends ActionSupport {
      * @throws IOException if redirecting or writing the response fails
      */
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
-    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = {"IMPROPER_UNICODE", "UNVALIDATED_REDIRECT"}, justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     private String completeAuthenticatedLogin(Security security, String[] strAuth, String ip,
                                               boolean isMobileOptimized, String submitType,
                                               boolean ajaxResponse) throws IOException {
@@ -1359,6 +1363,8 @@ public final class Login2Action extends ActionSupport {
      * @return {@link #NONE} because the response has already been redirected
      * @throws IOException if the servlet container cannot issue the redirect
      */
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     private String redirectForcePasswordResetRetry(String errorMessage) throws IOException {
         HttpSession session = request.getSession(false);
         if (session != null) {

--- a/src/main/java/io/github/carlos_emr/carlos/login/gate/BaseLoginPageView2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/login/gate/BaseLoginPageView2Action.java
@@ -31,7 +31,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 public abstract class BaseLoginPageView2Action extends ActionSupport {
 
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
-    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = {"IMPROPER_UNICODE", "UNVALIDATED_REDIRECT"}, justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     @Override
     public String execute() throws Exception {
         HttpServletRequest request = ServletActionContext.getRequest();

--- a/src/main/java/io/github/carlos_emr/carlos/login/gate/SelectFacility2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/login/gate/SelectFacility2Action.java
@@ -64,7 +64,8 @@ public final class SelectFacility2Action extends BaseLoginPageView2Action {
     }
 
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
-    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = {"IMPROPER_UNICODE", "UNVALIDATED_REDIRECT"}, justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     @Override
     public String execute() throws Exception {
         HttpServletRequest request = ServletActionContext.getRequest();
@@ -145,12 +146,16 @@ public final class SelectFacility2Action extends BaseLoginPageView2Action {
         return "user";
     }
 
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     private String redirectToFacilitySelection(HttpServletRequest request, HttpServletResponse response)
             throws IOException {
         response.sendRedirect(request.getContextPath() + "/select_facility");
         return NONE;
     }
 
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     private String redirectToLogoutAfterInvalidating(HttpSession session, HttpServletRequest request,
                                                      HttpServletResponse response) throws IOException {
         session.invalidate();

--- a/src/main/java/io/github/carlos_emr/carlos/login/gate/ViewForcePasswordReset2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/login/gate/ViewForcePasswordReset2Action.java
@@ -93,6 +93,8 @@ public final class ViewForcePasswordReset2Action extends BaseLoginPageView2Actio
         }
     }
 
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     private String redirectToExpiredSession(HttpServletRequest request) throws IOException {
         HttpServletResponse response = ServletActionContext.getResponse();
         String redirectUrl = Login2Action.loginFailedRedirectUrl(request,

--- a/src/main/java/io/github/carlos_emr/carlos/mds/pageUtil/PatientMatch2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/mds/pageUtil/PatientMatch2Action.java
@@ -47,6 +47,7 @@ import org.owasp.encoder.Encode;
 
 import org.apache.struts2.ActionSupport;
 import org.apache.struts2.ServletActionContext;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * Struts2 action that links a lab result to a demographic record and then
@@ -81,6 +82,8 @@ public class PatientMatch2Action extends ActionSupport {
     public PatientMatch2Action() {
     }
 
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     public String execute()
             throws ServletException, IOException {
 

--- a/src/main/java/io/github/carlos_emr/carlos/mds/pageUtil/ReportReassign2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/mds/pageUtil/ReportReassign2Action.java
@@ -70,7 +70,8 @@ public class ReportReassign2Action extends ActionSupport {
     }
 
     // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
-    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = {"XSS_SERVLET", "UNVALIDATED_REDIRECT"}, justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink. UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     public String execute()
             throws ServletException, IOException {
 

--- a/src/main/java/io/github/carlos_emr/carlos/mds/pageUtil/SearchPatient2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/mds/pageUtil/SearchPatient2Action.java
@@ -48,6 +48,7 @@ import org.owasp.encoder.Encode;
 import org.apache.struts2.ActionSupport;
 import org.apache.struts2.ServletActionContext;
 import io.github.carlos_emr.carlos.utility.LogSafe;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * Struts2 action that handles the E-Chart button functionality in lab display pages.
@@ -102,6 +103,8 @@ public class SearchPatient2Action extends ActionSupport {
      * @throws IOException if an I/O error occurs during redirect
      * @throws SecurityException if the user lacks required "_lab" read privilege
      */
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     public String execute()
             throws ServletException, IOException {
         

--- a/src/main/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgAdjustAttachments2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgAdjustAttachments2Action.java
@@ -72,7 +72,8 @@ public final class MsgAdjustAttachments2Action extends ActionSupport {
      * @since 2026-04-13
      */
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
-    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = {"IMPROPER_UNICODE", "UNVALIDATED_REDIRECT"}, justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     @Override
     public String execute() throws Exception {
         HttpServletRequest request = ServletActionContext.getRequest();

--- a/src/main/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgDisplayMessages2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgDisplayMessages2Action.java
@@ -148,7 +148,8 @@ public class MsgDisplayMessages2Action extends ActionSupport {
      *         record is not found in the database
      */
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
-    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = {"IMPROPER_UNICODE", "UNVALIDATED_REDIRECT"}, justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     public String execute() throws IOException, ServletException {
 
         // Retrieve and validate logged-in provider session

--- a/src/main/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgReDisplayMessages2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgReDisplayMessages2Action.java
@@ -45,6 +45,7 @@ import io.github.carlos_emr.carlos.utility.SpringUtils;
 import org.apache.struts2.ActionSupport;
 import org.apache.struts2.ServletActionContext;
 import org.apache.struts2.interceptor.parameter.StrutsParameter;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * Struts2 action for bulk message operations on the deleted/archived message view.
@@ -106,6 +107,8 @@ public class MsgReDisplayMessages2Action extends ActionSupport {
      * @throws SecurityException if user lacks "_msg" write permissions, or if the session
      *         bean's provider does not match the logged-in user (defensive check)
      */
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     public String execute() throws IOException, ServletException {
 
         // Validate session and permissions

--- a/src/main/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgTransferPostItems2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgTransferPostItems2Action.java
@@ -70,7 +70,8 @@ public final class MsgTransferPostItems2Action extends ActionSupport {
      * @since 2026-04-13
      */
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
-    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = {"IMPROPER_UNICODE", "UNVALIDATED_REDIRECT"}, justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     @Override
     public String execute() throws Exception {
         HttpServletRequest request = ServletActionContext.getRequest();

--- a/src/main/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgViewMessage2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgViewMessage2Action.java
@@ -150,7 +150,8 @@ public class MsgViewMessage2Action extends ActionSupport {
      *         {@code _msg} read privilege
      */
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
-    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = {"IMPROPER_UNICODE", "UNVALIDATED_REDIRECT"}, justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     @Override
     public String execute() throws IOException, ServletException {
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);

--- a/src/main/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgWriteToEncounter2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgWriteToEncounter2Action.java
@@ -44,6 +44,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * Struts2 action for writing message content to a patient encounter.
@@ -119,6 +120,8 @@ public class MsgWriteToEncounter2Action extends ActionSupport {
      * @throws IOException if there's an error with the redirect
      * @throws ServletException if there's a servlet processing error
      */
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     public String execute() throws IOException, ServletException {
         // Validate session and check privilege before any processing
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxShowAllergy2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxShowAllergy2Action.java
@@ -96,13 +96,17 @@ public final class RxShowAllergy2Action extends ActionSupport {
     // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
     @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     public String reorder() {
+        LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_allergy", "r", null)) {
+            throw new RuntimeException("missing required sec object (_allergy)");
+        }
+
         String demoNoParam = request.getParameter("demographicNo");
         if (demoNoParam == null || !demoNoParam.matches("\\d{1,9}")) {
             return "failure";
         }
         reorder(request);
         try {
-            LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
             RxPatientData.Patient patient = RxPatientData.getPatient(loggedInInfo, demoNoParam);
             if (patient != null) {
                 // demoNoParam validated as numeric at method entry

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxShowAllergy2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxShowAllergy2Action.java
@@ -53,6 +53,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import org.owasp.encoder.Encode;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * Struts 2 action for displaying and managing patient allergies.
@@ -92,6 +93,8 @@ public final class RxShowAllergy2Action extends ActionSupport {
      * @return String NONE (redirect handled manually)
      * @throws RuntimeException if redirect fails
      */
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     public String reorder() {
         String demoNoParam = request.getParameter("demographicNo");
         if (demoNoParam == null || !demoNoParam.matches("\\d{1,9}")) {

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/web/CopyFavorites2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/web/CopyFavorites2Action.java
@@ -29,6 +29,7 @@ import java.util.List;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.springframework.beans.BeanUtils;
 import org.apache.logging.log4j.Logger;
 import org.apache.struts2.ServletActionContext;
@@ -95,6 +96,11 @@ public class CopyFavorites2Action extends ActionSupport {
         return SUCCESS;
     }
 
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
     public String copy() {
         logger.debug("copyFavorites-copy");
 

--- a/src/main/java/io/github/carlos_emr/carlos/report/oscarMeasurements/pageUtil/RptInitializeFrequencyOfRelevantTestsCDMReport2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/oscarMeasurements/pageUtil/RptInitializeFrequencyOfRelevantTestsCDMReport2Action.java
@@ -50,6 +50,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class RptInitializeFrequencyOfRelevantTestsCDMReport2Action extends ActionSupport {
     HttpServletRequest request = ServletActionContext.getRequest();
@@ -58,6 +59,8 @@ public class RptInitializeFrequencyOfRelevantTestsCDMReport2Action extends Actio
 
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
 
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     public String execute() throws ServletException, IOException {
 
         if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_report", "r", null)) {

--- a/src/main/java/io/github/carlos_emr/carlos/report/oscarMeasurements/pageUtil/RptInitializePatientsInAbnormalRangeCDMReport2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/oscarMeasurements/pageUtil/RptInitializePatientsInAbnormalRangeCDMReport2Action.java
@@ -48,6 +48,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.*;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class RptInitializePatientsInAbnormalRangeCDMReport2Action extends ActionSupport {
     HttpServletRequest request = ServletActionContext.getRequest();
@@ -56,6 +57,8 @@ public class RptInitializePatientsInAbnormalRangeCDMReport2Action extends Action
 
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
 
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     public String execute() throws ServletException, IOException {
 
         if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_report", "r", null)) {

--- a/src/main/java/io/github/carlos_emr/carlos/report/oscarMeasurements/pageUtil/RptInitializePatientsMetGuidelineCDMReport2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/oscarMeasurements/pageUtil/RptInitializePatientsMetGuidelineCDMReport2Action.java
@@ -49,6 +49,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.*;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class RptInitializePatientsMetGuidelineCDMReport2Action extends ActionSupport {
     HttpServletRequest request = ServletActionContext.getRequest();
@@ -57,6 +58,8 @@ public class RptInitializePatientsMetGuidelineCDMReport2Action extends ActionSup
 
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
 
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     public String execute() throws ServletException, IOException {
 
         if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_report", "r", null)) {

--- a/src/main/java/io/github/carlos_emr/carlos/report/pageUtil/RptByExample2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/pageUtil/RptByExample2Action.java
@@ -56,6 +56,7 @@ import io.github.carlos_emr.carlos.report.bean.RptByExampleQueryBeanHandler;
 import org.apache.struts2.ActionSupport;
 import org.apache.struts2.ServletActionContext;
 import org.apache.struts2.interceptor.parameter.StrutsParameter;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * Struts2 action for the Query-by-Example report tool. Allows admin users to execute
@@ -78,6 +79,8 @@ public class RptByExample2Action extends ActionSupport {
         this.securityInfoManager = securityInfoManager;
     }
 
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     public String execute()
             throws ServletException, IOException {
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);

--- a/src/main/java/io/github/carlos_emr/carlos/sec/LoginFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/sec/LoginFilter.java
@@ -54,6 +54,7 @@ import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.SessionConstants;
 
 import io.github.carlos_emr.CarlosProperties;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * Servlet filter that enforces authentication and session management for CARLOS EMR.
@@ -341,6 +342,8 @@ public class LoginFilter implements Filter {
      * @throws ServletException if servlet-level error occurs during filtering
      * @see SecurityTokenManager for token-based authentication
      */
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     @SuppressWarnings("java:S6541") // Existing authentication/session gate; broad refactor is outside this PR.
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
         logger.debug("Entering LoginFilter.doFilter()");

--- a/src/main/java/io/github/carlos_emr/carlos/sec/UnauthenticatedRejectionResolver.java
+++ b/src/main/java/io/github/carlos_emr/carlos/sec/UnauthenticatedRejectionResolver.java
@@ -72,6 +72,8 @@ public final class UnauthenticatedRejectionResolver {
      * of login HTML. JSON-preferring status routes receive {@code application/json}; other
      * status-code routes receive {@code text/plain}.</p>
      */
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     public static void rejectUnauthenticatedRequest(
             HttpServletRequest request,
             HttpServletResponse response) throws IOException {

--- a/src/main/java/io/github/carlos_emr/carlos/tickler/pageUtil/DbTicklerAdd2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/tickler/pageUtil/DbTicklerAdd2Action.java
@@ -101,7 +101,8 @@ public final class DbTicklerAdd2Action extends ActionSupport {
      * @throws SecurityException if the user lacks {@code _tickler} write privilege
      */
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
-    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = {"IMPROPER_UNICODE", "UNVALIDATED_REDIRECT"}, justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     @Override
     public String execute() throws Exception {
 

--- a/src/main/java/io/github/carlos_emr/carlos/tickler/pageUtil/DbTicklerDemoMain2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/tickler/pageUtil/DbTicklerDemoMain2Action.java
@@ -80,7 +80,8 @@ public final class DbTicklerDemoMain2Action extends ActionSupport {
      * @throws SecurityException if the user lacks {@code _tickler} update privilege
      */
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
-    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = {"IMPROPER_UNICODE", "UNVALIDATED_REDIRECT"}, justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     @Override
     public String execute() throws Exception {
 

--- a/src/main/java/io/github/carlos_emr/carlos/tickler/pageUtil/DbTicklerMain2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/tickler/pageUtil/DbTicklerMain2Action.java
@@ -81,7 +81,8 @@ public final class DbTicklerMain2Action extends ActionSupport {
      * @throws SecurityException if the user lacks {@code _tickler} update privilege
      */
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
-    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = {"IMPROPER_UNICODE", "UNVALIDATED_REDIRECT"}, justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     @Override
     public String execute() throws Exception {
 

--- a/src/main/java/io/github/carlos_emr/carlos/utility/UserActivityFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/UserActivityFilter.java
@@ -45,6 +45,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import java.io.IOException;
 import java.util.Date;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * Filter for determining the inactivity of a user with a session. Pages that automatically refresh should be marked with the parameter autoRefresh=true
@@ -62,6 +63,8 @@ public final class UserActivityFilter implements Filter {
     public void destroy() {
     }
 
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
         boolean redirectToLogout = false;

--- a/src/main/java/io/github/carlos_emr/carlos/waitinglist/pageUtil/WLAdd2WaitingList2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/waitinglist/pageUtil/WLAdd2WaitingList2Action.java
@@ -46,7 +46,8 @@ public final class WLAdd2WaitingList2Action extends ActionSupport {
             SpringUtils.getBean(SecurityInfoManager.class);
 
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
-    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
+    // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL.
+    @SuppressFBWarnings(value = {"IMPROPER_UNICODE", "UNVALIDATED_REDIRECT"}, justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. UNVALIDATED_REDIRECT: redirect target is a same-origin application path or validated internal path, not an attacker-controlled external URL")
     @Override
     public String execute() throws Exception {
         HttpServletRequest request = ServletActionContext.getRequest();

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/OscarJobService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/OscarJobService.java
@@ -53,6 +53,7 @@ import io.github.carlos_emr.carlos.webserv.rest.to.OscarJobResponse;
 import io.github.carlos_emr.carlos.webserv.rest.to.OscarJobTypeResponse;
 import io.github.carlos_emr.carlos.webserv.rest.to.model.OscarJobTo1;
 import io.github.carlos_emr.carlos.webserv.rest.to.model.OscarJobTypeTo1;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.support.CronTrigger;
@@ -73,6 +74,11 @@ public class OscarJobService extends AbstractServiceImpl {
     @GET
     @Path("/types/current")
     @Produces("application/json")
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
     public OscarJobTypeResponse getCurrentlyAvailableJobTypes() {
         List<OscarJobType> results = oscarJobManager.getCurrentlyAvaliableJobTypes();
 
@@ -88,6 +94,11 @@ public class OscarJobService extends AbstractServiceImpl {
     @GET
     @Path("/types/all")
     @Produces("application/json")
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
     public OscarJobTypeResponse getAllJobTypes() {
         List<OscarJobType> results = oscarJobManager.getAllJobTypes();
 
@@ -105,6 +116,11 @@ public class OscarJobService extends AbstractServiceImpl {
     @GET
     @Path("/all")
     @Produces("application/json")
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
     public OscarJobResponse getAllJobs() {
         List<OscarJob> results = oscarJobManager.getAllJobs(getLoggedInInfo());
 
@@ -132,6 +148,11 @@ public class OscarJobService extends AbstractServiceImpl {
     @GET
     @Path("/job/{jobId}")
     @Produces("application/json")
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
     public OscarJobResponse getJob(@PathParam("jobId") Integer jobId) {
         OscarJob result = oscarJobManager.getJob(getLoggedInInfo(), jobId);
 
@@ -290,6 +311,11 @@ public class OscarJobService extends AbstractServiceImpl {
     @GET
     @Path("/jobType/{jobTypeId}")
     @Produces("application/json")
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
     public OscarJobTypeResponse getJobType(@PathParam("jobTypeId") Integer jobTypeId) {
         OscarJobType result = oscarJobManager.getJobType(getLoggedInInfo(), jobTypeId);
 

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/conversion/AdmissionConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/conversion/AdmissionConverter.java
@@ -34,6 +34,7 @@ import io.github.carlos_emr.carlos.managers.DemographicManager;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 import io.github.carlos_emr.carlos.webserv.rest.to.model.AdmissionTo1;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.springframework.beans.BeanUtils;
 import org.springframework.stereotype.Component;
 
@@ -50,6 +51,11 @@ public class AdmissionConverter extends AbstractConverter<Admission, AdmissionTo
     }
 
     @Override
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
     public Admission getAsDomainObject(LoggedInInfo loggedInInfo, AdmissionTo1 t) throws ConversionException {
         Admission d = new Admission();
 
@@ -59,6 +65,11 @@ public class AdmissionConverter extends AbstractConverter<Admission, AdmissionTo
     }
 
     @Override
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
     public AdmissionTo1 getAsTransferObject(LoggedInInfo loggedInInfo, Admission d) throws ConversionException {
         AdmissionTo1 t = new AdmissionTo1();
 

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/conversion/AppointmentConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/conversion/AppointmentConverter.java
@@ -34,6 +34,7 @@ import io.github.carlos_emr.carlos.commn.model.Appointment;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 import io.github.carlos_emr.carlos.webserv.rest.to.model.AppointmentTo1;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.springframework.beans.BeanUtils;
 
 public class AppointmentConverter extends AbstractConverter<Appointment, AppointmentTo1> {
@@ -59,6 +60,11 @@ public class AppointmentConverter extends AbstractConverter<Appointment, Appoint
     }
 
     @Override
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
     public AppointmentTo1 getAsTransferObject(LoggedInInfo loggedInInfo, Appointment d) throws ConversionException {
         AppointmentTo1 t = new AppointmentTo1();
 

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/conversion/AppointmentStatusConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/conversion/AppointmentStatusConverter.java
@@ -31,6 +31,7 @@ package io.github.carlos_emr.carlos.webserv.rest.conversion;
 import io.github.carlos_emr.carlos.commn.model.AppointmentStatus;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.webserv.rest.to.model.AppointmentStatusTo1;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.springframework.beans.BeanUtils;
 import org.springframework.stereotype.Component;
 
@@ -39,6 +40,11 @@ import org.springframework.stereotype.Component;
 public class AppointmentStatusConverter extends AbstractConverter<AppointmentStatus, AppointmentStatusTo1> {
 
     @Override
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
     public AppointmentStatus getAsDomainObject(LoggedInInfo loggedInInfo, AppointmentStatusTo1 t) throws ConversionException {
         AppointmentStatus d = new AppointmentStatus();
         BeanUtils.copyProperties(t, d);
@@ -46,6 +52,11 @@ public class AppointmentStatusConverter extends AbstractConverter<AppointmentSta
     }
 
     @Override
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
     public AppointmentStatusTo1 getAsTransferObject(LoggedInInfo loggedInInfo, AppointmentStatus d) throws ConversionException {
         AppointmentStatusTo1 t = new AppointmentStatusTo1();
         BeanUtils.copyProperties(d, t);

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/conversion/AppointmentTypeConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/conversion/AppointmentTypeConverter.java
@@ -31,11 +31,17 @@ package io.github.carlos_emr.carlos.webserv.rest.conversion;
 import io.github.carlos_emr.carlos.commn.model.AppointmentType;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.webserv.rest.to.model.AppointmentTypeTo1;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.springframework.beans.BeanUtils;
 
 public class AppointmentTypeConverter extends AbstractConverter<AppointmentType, AppointmentTypeTo1> {
 
     @Override
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
     public AppointmentType getAsDomainObject(LoggedInInfo loggedInInfo, AppointmentTypeTo1 t) throws ConversionException {
         AppointmentType d = new AppointmentType();
         BeanUtils.copyProperties(t, d);
@@ -43,6 +49,11 @@ public class AppointmentTypeConverter extends AbstractConverter<AppointmentType,
     }
 
     @Override
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
     public AppointmentTypeTo1 getAsTransferObject(LoggedInInfo loggedInInfo, AppointmentType d) throws ConversionException {
         AppointmentTypeTo1 t = new AppointmentTypeTo1();
         BeanUtils.copyProperties(d, t);

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/conversion/EFormConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/conversion/EFormConverter.java
@@ -31,6 +31,7 @@ package io.github.carlos_emr.carlos.webserv.rest.conversion;
 import io.github.carlos_emr.carlos.commn.model.EForm;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.webserv.rest.to.model.EFormTo1;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.springframework.beans.BeanUtils;
 
 public class EFormConverter extends AbstractConverter<EForm, EFormTo1> {
@@ -54,6 +55,11 @@ public class EFormConverter extends AbstractConverter<EForm, EFormTo1> {
     }
 
     @Override
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
     public EForm getAsDomainObject(LoggedInInfo loggedInInfo, EFormTo1 t) throws ConversionException {
         EForm d = new EForm();
         BeanUtils.copyProperties(t, d);

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/conversion/EFormReportToolConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/conversion/EFormReportToolConverter.java
@@ -39,6 +39,7 @@ import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 import io.github.carlos_emr.carlos.webserv.rest.to.model.EFormReportToolTo1;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.springframework.beans.BeanUtils;
 
 public class EFormReportToolConverter extends AbstractConverter<EFormReportTool, EFormReportToolTo1> {
@@ -61,6 +62,11 @@ public class EFormReportToolConverter extends AbstractConverter<EFormReportTool,
     }
 
     @Override
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
     public EFormReportTool getAsDomainObject(LoggedInInfo loggedInInfo, EFormReportToolTo1 t) throws ConversionException {
         EFormReportTool d = new EFormReportTool();
         BeanUtils.copyProperties(t, d);
@@ -76,6 +82,11 @@ public class EFormReportToolConverter extends AbstractConverter<EFormReportTool,
     }
 
     @Override
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
     public EFormReportToolTo1 getAsTransferObject(LoggedInInfo loggedInInfo, EFormReportTool d) throws ConversionException {
         EFormReportToolTo1 t = new EFormReportToolTo1();
         BeanUtils.copyProperties(d, t);

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/conversion/EncounterFormConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/conversion/EncounterFormConverter.java
@@ -31,12 +31,18 @@ package io.github.carlos_emr.carlos.webserv.rest.conversion;
 import io.github.carlos_emr.carlos.commn.model.EncounterForm;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.webserv.rest.to.model.EncounterFormTo1;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.springframework.beans.BeanUtils;
 
 public class EncounterFormConverter extends AbstractConverter<EncounterForm, EncounterFormTo1> {
 
 
     @Override
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
     public EncounterForm getAsDomainObject(LoggedInInfo loggedInInfo, EncounterFormTo1 t) throws ConversionException {
         EncounterForm d = new EncounterForm();
         BeanUtils.copyProperties(t, d);
@@ -44,6 +50,11 @@ public class EncounterFormConverter extends AbstractConverter<EncounterForm, Enc
     }
 
     @Override
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
     public EncounterFormTo1 getAsTransferObject(LoggedInInfo loggedInInfo, EncounterForm d) throws ConversionException {
         EncounterFormTo1 t = new EncounterFormTo1();
         BeanUtils.copyProperties(d, t);

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/conversion/Hl7TextMessageConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/conversion/Hl7TextMessageConverter.java
@@ -31,11 +31,17 @@ package io.github.carlos_emr.carlos.webserv.rest.conversion;
 import io.github.carlos_emr.carlos.commn.model.Hl7TextMessage;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.webserv.rest.to.model.Hl7TextMessageTo1;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.springframework.beans.BeanUtils;
 
 public class Hl7TextMessageConverter extends AbstractConverter<Hl7TextMessage, Hl7TextMessageTo1> {
 
     @Override
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
     public Hl7TextMessage getAsDomainObject(LoggedInInfo loggedInInfo, Hl7TextMessageTo1 t) throws ConversionException {
         Hl7TextMessage d = new Hl7TextMessage();
         BeanUtils.copyProperties(t, d);
@@ -43,6 +49,11 @@ public class Hl7TextMessageConverter extends AbstractConverter<Hl7TextMessage, H
     }
 
     @Override
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
     public Hl7TextMessageTo1 getAsTransferObject(LoggedInInfo loggedInInfo, Hl7TextMessage d) throws ConversionException {
         Hl7TextMessageTo1 t = new Hl7TextMessageTo1();
         BeanUtils.copyProperties(d, t);

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/conversion/IssueConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/conversion/IssueConverter.java
@@ -31,6 +31,7 @@ package io.github.carlos_emr.carlos.webserv.rest.conversion;
 import io.github.carlos_emr.carlos.casemgmt.model.Issue;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.webserv.rest.to.model.IssueTo1;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.springframework.beans.BeanUtils;
 
 public class IssueConverter extends AbstractConverter<Issue, IssueTo1> {
@@ -43,6 +44,11 @@ public class IssueConverter extends AbstractConverter<Issue, IssueTo1> {
     }
 
     @Override
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
     public IssueTo1 getAsTransferObject(LoggedInInfo loggedInInfo, Issue d) throws ConversionException {
         IssueTo1 t = new IssueTo1();
         BeanUtils.copyProperties(d, t);

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/conversion/LookupListItemConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/conversion/LookupListItemConverter.java
@@ -31,11 +31,17 @@ package io.github.carlos_emr.carlos.webserv.rest.conversion;
 import io.github.carlos_emr.carlos.commn.model.LookupListItem;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.webserv.rest.to.model.LookupListItemTo1;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.springframework.beans.BeanUtils;
 
 public class LookupListItemConverter extends AbstractConverter<LookupListItem, LookupListItemTo1> {
 
     @Override
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
     public LookupListItem getAsDomainObject(LoggedInInfo loggedInInfo, LookupListItemTo1 t) throws ConversionException {
         LookupListItem d = new LookupListItem();
         BeanUtils.copyProperties(t, d);
@@ -43,6 +49,11 @@ public class LookupListItemConverter extends AbstractConverter<LookupListItem, L
     }
 
     @Override
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
     public LookupListItemTo1 getAsTransferObject(LoggedInInfo loggedInInfo, LookupListItem d) throws ConversionException {
         LookupListItemTo1 t = new LookupListItemTo1();
         BeanUtils.copyProperties(d, t);

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/conversion/ScheduleCodesConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/conversion/ScheduleCodesConverter.java
@@ -31,11 +31,17 @@ package io.github.carlos_emr.carlos.webserv.rest.conversion;
 import io.github.carlos_emr.carlos.commn.model.ScheduleTemplateCode;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.webserv.rest.to.model.ScheduleTemplateCodeTo;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.springframework.beans.BeanUtils;
 
 public class ScheduleCodesConverter extends AbstractConverter<ScheduleTemplateCode, ScheduleTemplateCodeTo> {
 
     @Override
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
     public ScheduleTemplateCode getAsDomainObject(LoggedInInfo loggedInInfo, ScheduleTemplateCodeTo t) throws ConversionException {
         ScheduleTemplateCode d = new ScheduleTemplateCode();
         BeanUtils.copyProperties(t, d);
@@ -43,6 +49,11 @@ public class ScheduleCodesConverter extends AbstractConverter<ScheduleTemplateCo
     }
 
     @Override
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
     public ScheduleTemplateCodeTo getAsTransferObject(LoggedInInfo loggedInInfo, ScheduleTemplateCode d) throws ConversionException {
         ScheduleTemplateCodeTo t = new ScheduleTemplateCodeTo();
         BeanUtils.copyProperties(d, t);

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/conversion/ServiceTypeConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/conversion/ServiceTypeConverter.java
@@ -31,11 +31,17 @@ package io.github.carlos_emr.carlos.webserv.rest.conversion;
 import io.github.carlos_emr.carlos.managers.model.ServiceType;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.webserv.rest.to.model.ServiceTypeTo;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.springframework.beans.BeanUtils;
 
 public class ServiceTypeConverter extends AbstractConverter<ServiceType, ServiceTypeTo> {
 
     @Override
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
     public ServiceType getAsDomainObject(LoggedInInfo loggedInInfo, ServiceTypeTo t) throws ConversionException {
         ServiceType d = new ServiceType();
         BeanUtils.copyProperties(t, d);
@@ -43,6 +49,11 @@ public class ServiceTypeConverter extends AbstractConverter<ServiceType, Service
     }
 
     @Override
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
     public ServiceTypeTo getAsTransferObject(LoggedInInfo loggedInInfo, ServiceType d) throws ConversionException {
         ServiceTypeTo t = new ServiceTypeTo();
         BeanUtils.copyProperties(d, t);

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/conversion/TicklerLinkConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/conversion/TicklerLinkConverter.java
@@ -31,6 +31,7 @@ package io.github.carlos_emr.carlos.webserv.rest.conversion;
 import io.github.carlos_emr.carlos.commn.model.TicklerLink;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.webserv.rest.to.model.TicklerLinkTo1;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.springframework.beans.BeanUtils;
 import org.springframework.stereotype.Component;
 
@@ -38,6 +39,11 @@ import org.springframework.stereotype.Component;
 public class TicklerLinkConverter extends AbstractConverter<TicklerLink, TicklerLinkTo1> {
 
     @Override
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
     public TicklerLink getAsDomainObject(LoggedInInfo loggedInInfo, TicklerLinkTo1 t) throws ConversionException {
         TicklerLink d = new TicklerLink();
         BeanUtils.copyProperties(t, d);
@@ -45,6 +51,11 @@ public class TicklerLinkConverter extends AbstractConverter<TicklerLink, Tickler
     }
 
     @Override
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
     public TicklerLinkTo1 getAsTransferObject(LoggedInInfo loggedInInfo, TicklerLink d) throws ConversionException {
         TicklerLinkTo1 t = new TicklerLinkTo1();
         BeanUtils.copyProperties(d, t);

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/conversion/TicklerTextSuggestConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/conversion/TicklerTextSuggestConverter.java
@@ -31,11 +31,17 @@ package io.github.carlos_emr.carlos.webserv.rest.conversion;
 import io.github.carlos_emr.carlos.commn.model.TicklerTextSuggest;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.webserv.rest.to.model.TicklerTextSuggestTo1;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.springframework.beans.BeanUtils;
 
 public class TicklerTextSuggestConverter extends AbstractConverter<TicklerTextSuggest, TicklerTextSuggestTo1> {
 
     @Override
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
     public TicklerTextSuggest getAsDomainObject(LoggedInInfo loggedInInfo, TicklerTextSuggestTo1 t) throws ConversionException {
         TicklerTextSuggest d = new TicklerTextSuggest();
         BeanUtils.copyProperties(t, d);
@@ -43,6 +49,11 @@ public class TicklerTextSuggestConverter extends AbstractConverter<TicklerTextSu
     }
 
     @Override
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
     public TicklerTextSuggestTo1 getAsTransferObject(LoggedInInfo loggedInInfo, TicklerTextSuggest d) throws ConversionException {
         TicklerTextSuggestTo1 t = new TicklerTextSuggestTo1();
         BeanUtils.copyProperties(d, t);

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/transfer_objects/DemographicTransfer.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/transfer_objects/DemographicTransfer.java
@@ -32,6 +32,7 @@ package io.github.carlos_emr.carlos.webserv.transfer_objects;
 
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import io.github.carlos_emr.carlos.commn.model.Demographic;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.springframework.beans.BeanUtils;
 
 import java.util.ArrayList;
@@ -538,6 +539,11 @@ public final class DemographicTransfer {
         this.pronounId = pronounId;
     }
 
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
     public static DemographicTransfer toTransfer(Demographic demographic) {
         if (demographic == null) return (null);
 

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/transfer_objects/DemographicTransfer2.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/transfer_objects/DemographicTransfer2.java
@@ -32,6 +32,7 @@ package io.github.carlos_emr.carlos.webserv.transfer_objects;
 
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import io.github.carlos_emr.carlos.commn.model.Demographic;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.springframework.beans.BeanUtils;
 
 import java.util.ArrayList;
@@ -624,6 +625,11 @@ public final class DemographicTransfer2 {
         this.pronounId = pronounId;
     }
 
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
     public static DemographicTransfer2 toTransfer(Demographic demographic) {
         if (demographic == null) return (null);
 

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/transfer_objects/DocumentTransfer.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/transfer_objects/DocumentTransfer.java
@@ -42,6 +42,7 @@ import io.github.carlos_emr.carlos.managers.DocumentManager;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.springframework.beans.BeanUtils;
 
 public final class DocumentTransfer {
@@ -278,6 +279,11 @@ public final class DocumentTransfer {
     /**
      * ctlDocument can be null
      */
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
     public static DocumentTransfer toTransfer(Document document, CtlDocument ctlDocument) throws IOException {
         if (document == null) return (null);
 

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/transfer_objects/DrugTransfer.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/transfer_objects/DrugTransfer.java
@@ -33,6 +33,7 @@ import java.util.Date;
 import java.util.List;
 
 import io.github.carlos_emr.carlos.commn.model.Drug;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.springframework.beans.BeanUtils;
 
 public class DrugTransfer {
@@ -552,6 +553,11 @@ public class DrugTransfer {
         this.lastUpdateDate = lastUpdateDate;
     }
 
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
     public static DrugTransfer toTransfer(Drug drug) {
         if (drug == null) return (null);
 

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/transfer_objects/MeasurementMapTransfer.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/transfer_objects/MeasurementMapTransfer.java
@@ -34,6 +34,7 @@ import java.util.List;
 
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import io.github.carlos_emr.carlos.commn.model.MeasurementMap;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.springframework.beans.BeanUtils;
 
 public final class MeasurementMapTransfer {
@@ -84,6 +85,11 @@ public final class MeasurementMapTransfer {
         this.labType = labType;
     }
 
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
     public static MeasurementMapTransfer toTransfer(MeasurementMap measurementMap) {
         if (measurementMap == null) return (null);
 

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/transfer_objects/MeasurementTransfer.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/transfer_objects/MeasurementTransfer.java
@@ -35,6 +35,7 @@ import java.util.List;
 
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import io.github.carlos_emr.carlos.commn.model.Measurement;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.springframework.beans.BeanUtils;
 
 public final class MeasurementTransfer {
@@ -50,6 +51,11 @@ public final class MeasurementTransfer {
     private Integer appointmentNo;
     private Date createDate;
 
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
     public static MeasurementTransfer toTransfer(Measurement measurement) {
         if (measurement == null) return (null);
 

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/transfer_objects/PrescriptionTransfer.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/transfer_objects/PrescriptionTransfer.java
@@ -39,6 +39,7 @@ import io.github.carlos_emr.carlos.commn.model.Prescription;
 import io.github.carlos_emr.carlos.managers.PrescriptionManager;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.springframework.beans.BeanUtils;
 
 public final class PrescriptionTransfer {
@@ -139,6 +140,11 @@ public final class PrescriptionTransfer {
      * If prescription is null, then null is returned.
      * If prescription is not null, then drugs must not be null, it should at least be an empty list to signify no drugs.
      */
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
     public static PrescriptionTransfer toTransfer(Prescription prescription, List<Drug> drugs) {
         if (prescription == null) return (null);
 

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/transfer_objects/ProgramTransfer.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/transfer_objects/ProgramTransfer.java
@@ -34,6 +34,7 @@ import java.util.List;
 
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import io.github.carlos_emr.carlos.PMmodule.model.Program;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.springframework.beans.BeanUtils;
 
 public final class ProgramTransfer {
@@ -475,6 +476,11 @@ public final class ProgramTransfer {
         this.lastReferralNotification = lastReferralNotification;
     }
 
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
     public static ProgramTransfer toTransfer(Program program) {
         if (program == null) return (null);
 

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/transfer_objects/ProviderPropertyTransfer.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/transfer_objects/ProviderPropertyTransfer.java
@@ -33,6 +33,7 @@ import java.util.List;
 
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import io.github.carlos_emr.carlos.commn.model.Property;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.springframework.beans.BeanUtils;
 
 public final class ProviderPropertyTransfer {
@@ -65,6 +66,11 @@ public final class ProviderPropertyTransfer {
         this.value = value;
     }
 
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
     public static ProviderPropertyTransfer toTransfer(Property property) {
         if (property == null) return (null);
 

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/transfer_objects/ProviderTransfer.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/transfer_objects/ProviderTransfer.java
@@ -36,6 +36,7 @@ import java.util.List;
 
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import io.github.carlos_emr.carlos.commn.model.Provider;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.springframework.beans.BeanUtils;
 
 public final class ProviderTransfer {
@@ -248,6 +249,11 @@ public final class ProviderTransfer {
         this.title = title;
     }
 
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
     public static ProviderTransfer toTransfer(Provider provider) {
         if (provider == null) return (null);
 

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/transfer_objects/ScheduleTemplateCodeTransfer.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/transfer_objects/ScheduleTemplateCodeTransfer.java
@@ -33,6 +33,7 @@ package io.github.carlos_emr.carlos.webserv.transfer_objects;
 import java.util.List;
 
 import io.github.carlos_emr.carlos.commn.model.ScheduleTemplateCode;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.springframework.beans.BeanUtils;
 
 public final class ScheduleTemplateCodeTransfer {
@@ -101,6 +102,11 @@ public final class ScheduleTemplateCodeTransfer {
         this.bookinglimit = bookinglimit;
     }
 
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
     public static ScheduleTemplateCodeTransfer toTransfer(ScheduleTemplateCode scheduleTemplateCode) {
         if (scheduleTemplateCode == null) return (null);
 

--- a/src/test/java/io/github/carlos_emr/carlos/eform/actions/AddEForm2ActionFaxRedirectTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/eform/actions/AddEForm2ActionFaxRedirectTest.java
@@ -1,5 +1,6 @@
 /**
- * Copyright (c) 2026. CARLOS EMR Project. All Rights Reserved.
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
  * This software is published under the GPL GNU General Public License.
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -15,9 +16,8 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  *
- * Maintained by the CARLOS EMR Project (2026+).
+ * CARLOS EMR Project
  * https://github.com/carlos-emr/carlos
- * CARLOS has no affiliation with OSCAR or McMaster University.
  */
 package io.github.carlos_emr.carlos.eform.actions;
 

--- a/src/test/java/io/github/carlos_emr/carlos/eform/actions/AddEForm2ActionFaxRedirectTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/eform/actions/AddEForm2ActionFaxRedirectTest.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) 2026. CARLOS EMR Project. All Rights Reserved.
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * Maintained by the CARLOS EMR Project (2026+).
+ * https://github.com/carlos-emr/carlos
+ * CARLOS has no affiliation with OSCAR or McMaster University.
+ */
+package io.github.carlos_emr.carlos.eform.actions;
+
+import io.github.carlos_emr.carlos.documentManager.DocumentAttachmentManager;
+import io.github.carlos_emr.carlos.managers.EformDataManager;
+import io.github.carlos_emr.carlos.managers.EmailManager;
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
+
+import org.apache.struts2.ServletActionContext;
+import org.junit.jupiter.api.*;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.lang.reflect.Method;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.mockStatic;
+
+/**
+ * Unit tests for the prepared-fax redirect helper in {@link AddEForm2Action}.
+ *
+ * <p>Both eForm fax branches (current and previous revision) route through the shared
+ * {@code redirectToPreparedFax(...)} helper. These tests pin the security-relevant URL contract:
+ * optional recipient parameters MUST be URL-encoded (a raw {@code &}/{@code #} would otherwise
+ * split or truncate the redirect query string) and empty optional parameters MUST be omitted
+ * rather than emitted as dangling {@code &recipient=} pairs.</p>
+ *
+ * @since 2026-06-06
+ */
+@DisplayName("AddEForm2Action prepared-fax redirect")
+@Tag("unit")
+@Tag("eform")
+@Tag("security")
+class AddEForm2ActionFaxRedirectTest extends CarlosUnitTestBase {
+
+    private MockedStatic<ServletActionContext> servletActionContextMock;
+    private MockHttpServletRequest mockRequest;
+    private MockHttpServletResponse mockResponse;
+    private AddEForm2Action action;
+
+    @BeforeEach
+    void setUp() {
+        // AddEForm2Action resolves these managers from SpringUtils in its field initializers,
+        // so they must be registered before the action is constructed (none are used by the
+        // redirect helper under test — they only need to satisfy construction).
+        registerMock(SecurityInfoManager.class, Mockito.mock(SecurityInfoManager.class));
+        registerMock(EformDataManager.class, Mockito.mock(EformDataManager.class));
+        registerMock(DocumentAttachmentManager.class, Mockito.mock(DocumentAttachmentManager.class));
+        registerMock(EmailManager.class, Mockito.mock(EmailManager.class));
+
+        mockRequest = new MockHttpServletRequest();
+        mockRequest.setContextPath("/carlos");
+        mockResponse = new MockHttpServletResponse();
+
+        // AddEForm2Action reads request/response from ServletActionContext at field-init time,
+        // so the static mock must be active before the action is constructed.
+        servletActionContextMock = mockStatic(ServletActionContext.class);
+        servletActionContextMock.when(ServletActionContext::getRequest).thenReturn(mockRequest);
+        servletActionContextMock.when(ServletActionContext::getResponse).thenReturn(mockResponse);
+
+        action = new AddEForm2Action();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (servletActionContextMock != null) {
+            servletActionContextMock.close();
+        }
+    }
+
+    /** Invokes the private helper via reflection and returns the redirect target it wrote. */
+    private String redirect(String fdid, String demoNo, String recipient, String faxNo, String letterhead)
+            throws Exception {
+        Method m = AddEForm2Action.class.getDeclaredMethod(
+            "redirectToPreparedFax", String.class, String.class, String.class, String.class, String.class);
+        m.setAccessible(true);
+        m.invoke(action, fdid, demoNo, recipient, faxNo, letterhead);
+        return mockResponse.getRedirectedUrl();
+    }
+
+    @Test
+    @DisplayName("should target a same-origin fax path with the mandatory params")
+    void shouldIncludeMandatoryParams_onFaxRedirect() throws Exception {
+        String url = redirect("67", "12345", null, null, null);
+        assertThat(url)
+            .startsWith("/carlos/fax/faxAction?method=prepareFax")
+            .contains("&transactionId=67")
+            .contains("&transactionType=EFORM")
+            .contains("&demographicNo=12345");
+    }
+
+    @Test
+    @DisplayName("should URL-encode a recipient containing query-significant characters")
+    void shouldEncodeRecipient_whenContainsSpecialChars() throws Exception {
+        String url = redirect("67", "12345", "Dr & Smith", null, null);
+        assertThat(url)
+            .contains("&recipient=Dr+%26+Smith")
+            .doesNotContain("Dr & Smith");
+    }
+
+    @Test
+    @DisplayName("should omit optional params when null or empty")
+    void shouldOmitOptionalParams_whenNullOrEmpty() throws Exception {
+        String url = redirect("67", "12345", "", null, "");
+        assertThat(url)
+            .doesNotContain("&recipient=")
+            .doesNotContain("&recipientFaxNumber=")
+            .doesNotContain("&letterheadFax=");
+    }
+
+    @Test
+    @DisplayName("should encode every optional fax param when all are provided")
+    void shouldEncodeAllOptionalParams_whenProvided() throws Exception {
+        String url = redirect("67", "12345", "Smith", "555 1234", "Clinic#1");
+        assertThat(url)
+            .contains("&recipient=Smith")
+            .contains("&recipientFaxNumber=555+1234")
+            .contains("&letterheadFax=Clinic%231");
+    }
+}


### PR DESCRIPTION
## Summary

Suppresses reviewed false-positive security-alert noise for two SpotBugs / Find Security Bugs groups without disabling either rule globally:

- `BEAN_PROPERTY_INJECTION` on safe Spring `BeanUtils.copyProperties(...)` calls between fixed CARLOS types.
- `UNVALIDATED_REDIRECT` on reviewed same-origin/internal redirect flows where the redirect target is fixed, locally constructed, or otherwise constrained by the surrounding code.

## Details

### Bean property injection

- Adds narrow `@SuppressFBWarnings("BEAN_PROPERTY_INJECTION")` annotations with local justification comments at reviewed Java call sites.
- Combines the new suppression with existing suppressions where a method already had another SpotBugs finding annotation.
- Adds two exact generated-JSP class exclusions in `.github/spotbugs/spotbugs-exclude.xml` for JSP-backed Spring `copyProperties` findings.
- Leaves dynamic property-binding patterns unsuppressed.

### Unvalidated redirect

- Adds targeted `@SuppressFBWarnings("UNVALIDATED_REDIRECT")` annotations to reviewed Struts actions, filters, and helper methods where redirect destinations are same-origin or internally constructed.
- Extracts small helper methods where needed so only the reviewed safe redirect branches are suppressed.
- Leaves the reviewed non-straightforward redirect findings unsuppressed for later handling.
- Tracks the remaining 6 redirect alerts in #2716; the AddEForm prepared-fax redirect is now handled in this PR with encoded query parameters.

## Validation

- `git diff --check`
- `mvn -DskipTests -Pskip-dependency-lock compile`
- SpotBugs analyzer generated `target/spotbugs-result.xml`.
- Parsed SpotBugs XML showed `BEAN_PROPERTY_INJECTION` reduced to 0 findings.
- Parsed Java-source `UNVALIDATED_REDIRECT` findings previously showed the intentionally unsuppressed follow-up cases; #2716 now tracks the 6 remaining redirect alerts after the AddEForm prepared-fax redirect was hardened here.

## Notes

The suppressions are intentionally local. This PR does not blanket-disable either rule, and it does not suppress alert patterns where request data can still influence property names or redirect targets in a way that needs code hardening or deeper review.
