### PR TITLE
Add lab value history to HL7 report DO NOT MERGE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,8 @@ __pycache__/
 /.smarttomcat/
 .claude/settings.local.json
 .claude/*.lock
+# Nested .claude dirs created when Claude runs in a subdirectory are local tooling, not project config
+src/**/.claude/
 
 
 # Docusaurus

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/MeasurementDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/MeasurementDaoImpl.java
@@ -482,16 +482,26 @@ public class MeasurementDaoImpl extends AbstractDaoImpl<Measurement> implements 
 
     @Override
     public List<Object[]> findMeasurementsByDemographicIdAndLocationCode(Integer demoNo, String loincCode) {
-        String sql = "SELECT m.dataField, m.dateObserved, e1.val, e3.val "
-                + "FROM Measurement m, MeasurementsExt e1, MeasurementsExt e2, MeasurementsExt e3, MeasurementMap mm "
-                + "WHERE m.id = e1.measurementId " + "AND e1.keyVal = 'lab_no' " + "AND m.id = e2.measurementId "
-                + "AND e2.keyVal = 'identifier' " + "AND m.id = e3.measurementId " + "AND e3.keyVal = 'abnormal' "
-                + "AND e2.val = mm.identCode " + "AND mm.loincCode = ?1" + "AND m.demographicId = ?2"
-                + "ORDER BY m.dateObserved DESC";
-        Query query = entityManager.createQuery(sql);
-        query.setParameter(1, loincCode);
-        query.setParameter(2, demoNo);
-        return query.getResultList();
+        // Native SQL with conditional aggregation: reads measurementsExt twice (identifier lookup
+        // + lab_no/abnormal pivot) instead of three separate cross-joins, and adds LIMIT 10 so
+        // we never fetch more rows than the caller uses.
+        String sql = "SELECT m.dataField, m.dateObserved,"
+                + " MAX(CASE WHEN me.keyval = 'lab_no' THEN me.val END),"
+                + " MAX(CASE WHEN me.keyval = 'abnormal' THEN me.val END)"
+                + " FROM measurements m"
+                + " INNER JOIN measurementsExt e_id ON e_id.measurement_id = m.id AND e_id.keyval = 'identifier'"
+                + " INNER JOIN measurementMap mm ON mm.ident_code = e_id.val AND mm.loinc_code = :loincCode"
+                + " INNER JOIN measurementsExt me ON me.measurement_id = m.id AND me.keyval IN ('lab_no', 'abnormal')"
+                + " WHERE m.demographicNo = :demoNo"
+                + " GROUP BY m.id, m.dataField, m.dateObserved"
+                + " HAVING MAX(CASE WHEN me.keyval = 'lab_no' THEN me.val END) IS NOT NULL"
+                + "    AND MAX(CASE WHEN me.keyval = 'abnormal' THEN me.val END) IS NOT NULL"
+                + " ORDER BY m.dateObserved DESC"
+                + " LIMIT 10";
+        return entityManager.createNativeQuery(sql)
+                .setParameter("loincCode", loincCode)
+                .setParameter("demoNo", demoNo)
+                .getResultList();
     }
 
     @Override

--- a/src/main/java/io/github/carlos_emr/carlos/lab/gate/LabHistoryByLoinc2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/lab/gate/LabHistoryByLoinc2Action.java
@@ -46,37 +46,58 @@ import java.util.Hashtable;
  */
 public final class LabHistoryByLoinc2Action extends ActionSupport {
 
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
     private final SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
 
+    /**
+     * Reads {@code demographicNo} and {@code loincCode} from the query string, verifies the
+     * caller holds the {@code _lab} read privilege for that patient, then streams the 10
+     * most-recent measurement values for the patient/LOINC pair as a JSON array.
+     *
+     * <p>Request parameters:
+     * <ul>
+     *   <li>{@code demographicNo} – the patient's demographic number (digits only)</li>
+     *   <li>{@code loincCode} – a valid LOINC code (digits hyphen digits, e.g. {@code 33914-3})</li>
+     * </ul>
+     *
+     * <p>Response body on HTTP 200: a JSON array ordered newest-first, e.g.
+     * {@code [{"result":"65","date":"2025-11-20","abn":"N"}, ...]}.
+     * Returns HTTP 400 for missing or malformed parameters; HTTP 403 when the caller lacks
+     * the required lab read privilege for the requested patient.
+     *
+     * @return {@link #NONE} in all paths; this action writes directly to the servlet response
+     * @throws Exception if JSON serialization or response writing fails
+     */
     @Override
     public String execute() throws Exception {
         HttpServletRequest request = ServletActionContext.getRequest();
         HttpServletResponse response = ServletActionContext.getResponse();
 
-        LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
-        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_lab", "r", null)) {
-            response.sendError(HttpServletResponse.SC_FORBIDDEN);
-            return NONE;
-        }
-
+        // Parse and validate inputs before the privilege check so demographicNo
+        // can be passed to hasPrivilege for patient-scoped authorization.
         String demographicNo = StringUtils.trimToEmpty(request.getParameter("demographicNo"));
         String loincCode = StringUtils.trimToEmpty(request.getParameter("loincCode"));
 
-        // demographicNo must be digits; loincCode must follow LOINC format (digits-digit)
-        if (!demographicNo.matches("\\d+") || !loincCode.matches("[0-9]+-[0-9]")) {
+        if (!demographicNo.matches("\\d+") || !loincCode.matches("[0-9]+-[0-9]+")) {
             response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+            return NONE;
+        }
+
+        LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_lab", "r", demographicNo)) {
+            response.sendError(HttpServletResponse.SC_FORBIDDEN);
             return NONE;
         }
 
         ArrayList<Hashtable<String, Serializable>> history =
                 CommonLabTestValues.findValuesByLoinc(demographicNo, loincCode);
 
-        ObjectMapper mapper = new ObjectMapper();
-        ArrayNode arr = mapper.createArrayNode();
+        ArrayNode arr = MAPPER.createArrayNode();
         int limit = Math.min(history.size(), 10);
         for (int i = 0; i < limit; i++) {
             Hashtable<String, Serializable> h = history.get(i);
-            ObjectNode entry = mapper.createObjectNode();
+            ObjectNode entry = MAPPER.createObjectNode();
             entry.put("result", String.valueOf(h.getOrDefault("result", "")));
             // dateObserved from java.sql.Date/Timestamp toString starts with YYYY-MM-DD
             String dateStr = String.valueOf(h.getOrDefault("date", ""));
@@ -90,7 +111,7 @@ public final class LabHistoryByLoinc2Action extends ActionSupport {
 
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
-        mapper.writeValue(response.getWriter(), arr);
+        MAPPER.writeValue(response.getWriter(), arr);
         return NONE;
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/lab/gate/LabHistoryByLoinc2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/lab/gate/LabHistoryByLoinc2Action.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.lab.gate;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.carlos_emr.carlos.lab.ca.on.CommonLabTestValues;
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import io.github.carlos_emr.carlos.utility.SpringUtils;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.struts2.ActionSupport;
+import org.apache.struts2.ServletActionContext;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Hashtable;
+
+/**
+ * JSON endpoint returning up to 10 most-recent measurement values for a given
+ * demographic and LOINC code, ordered newest-first. Used by labDisplay.jsp to
+ * show prior results alongside the current OBX value with a hover tooltip.
+ *
+ * <p>Response is a JSON array:
+ * {@code [{"result":"65","date":"2025-11-20","abn":"N"}, ...]}
+ *
+ * <p>Values come from the measurements table via
+ * {@link CommonLabTestValues#findValuesByLoinc}, which is populated when HL7
+ * lab messages are processed and the OBX identifier has a matching
+ * {@code MeasurementMap} entry with a LOINC code.
+ *
+ * @since 2026-06-07
+ */
+public final class LabHistoryByLoinc2Action extends ActionSupport {
+
+    private final SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
+
+    @Override
+    public String execute() throws Exception {
+        HttpServletRequest request = ServletActionContext.getRequest();
+        HttpServletResponse response = ServletActionContext.getResponse();
+
+        LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_lab", "r", null)) {
+            response.sendError(HttpServletResponse.SC_FORBIDDEN);
+            return NONE;
+        }
+
+        String demographicNo = StringUtils.trimToEmpty(request.getParameter("demographicNo"));
+        String loincCode = StringUtils.trimToEmpty(request.getParameter("loincCode"));
+
+        // demographicNo must be digits; loincCode must follow LOINC format (digits-digit)
+        if (!demographicNo.matches("\\d+") || !loincCode.matches("[0-9]+-[0-9]")) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+            return NONE;
+        }
+
+        ArrayList<Hashtable<String, Serializable>> history =
+                CommonLabTestValues.findValuesByLoinc(demographicNo, loincCode);
+
+        ObjectMapper mapper = new ObjectMapper();
+        ArrayNode arr = mapper.createArrayNode();
+        int limit = Math.min(history.size(), 10);
+        for (int i = 0; i < limit; i++) {
+            Hashtable<String, Serializable> h = history.get(i);
+            ObjectNode entry = mapper.createObjectNode();
+            entry.put("result", String.valueOf(h.getOrDefault("result", "")));
+            // dateObserved from java.sql.Date/Timestamp toString starts with YYYY-MM-DD
+            String dateStr = String.valueOf(h.getOrDefault("date", ""));
+            if (dateStr.length() > 10) {
+                dateStr = dateStr.substring(0, 10);
+            }
+            entry.put("date", dateStr);
+            entry.put("abn", String.valueOf(h.getOrDefault("abn", "")));
+            arr.add(entry);
+        }
+
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        mapper.writeValue(response.getWriter(), arr);
+        return NONE;
+    }
+}

--- a/src/main/resources/oscar/prevention/.claude/settings.json
+++ b/src/main/resources/oscar/prevention/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "additionalDirectories": [
+      "c:\\Users\\17056\\project\\carlos\\src\\main\\webapp\\WEB-INF\\jsp\\lab\\CA\\ALL"
+    ]
+  }
+}

--- a/src/main/resources/oscar/prevention/.claude/settings.json
+++ b/src/main/resources/oscar/prevention/.claude/settings.json
@@ -1,7 +1,1 @@
-{
-  "permissions": {
-    "additionalDirectories": [
-      "c:\\Users\\17056\\project\\carlos\\src\\main\\webapp\\WEB-INF\\jsp\\lab\\CA\\ALL"
-    ]
-  }
-}
+{}

--- a/src/main/resources/oscar/prevention/.claude/settings.json
+++ b/src/main/resources/oscar/prevention/.claude/settings.json
@@ -1,1 +1,8 @@
-{}
+{
+  "permissions": {
+    "additionalDirectories": [
+      "c:\\Users\\17056\\project\\carlos\\src\\main\\java\\io\\github\\carlos_emr\\carlos\\commn\\dao",
+      "c:\\Users\\17056\\project\\carlos\\src\\main\\webapp\\WEB-INF\\jsp\\lab\\CA\\ALL"
+    ]
+  }
+}

--- a/src/main/webapp/WEB-INF/classes/struts-lab.xml
+++ b/src/main/webapp/WEB-INF/classes/struts-lab.xml
@@ -128,5 +128,6 @@
         <action name="lab/CA/ON/ViewLabValuesGraph" class="io.github.carlos_emr.carlos.lab.gate.ViewLabValuesGraph2Action">
             <result name="success">/WEB-INF/jsp/lab/CA/ON/labValuesGraph.jsp</result>
         </action>
+        <action name="lab/CA/ON/LabHistoryByLoinc" class="io.github.carlos_emr.carlos.lab.gate.LabHistoryByLoinc2Action"/>
     </package>
 </struts>

--- a/src/main/webapp/WEB-INF/jsp/lab/CA/ALL/labDisplay.jsp
+++ b/src/main/webapp/WEB-INF/jsp/lab/CA/ALL/labDisplay.jsp
@@ -2524,30 +2524,25 @@ function initLabHistoryDisplay() {
         }
     });
 
-    var loincCodes = Object.keys(loincRows);
-    labHxFetchSequential(loincCodes, loincRows, 0);
+    Object.keys(loincRows).forEach(function(loinc) {
+        labHxFetch(loinc, loincRows[loinc]);
+    });
 }
 
-function labHxFetchSequential(codes, loincRows, index) {
-    if (index >= codes.length) return;
-    var loinc = codes[index];
-    var url = contextpath + '/lab/CA/ON/LabHistoryByLoinc?demographicNo='
-            + encodeURIComponent(labDemographicNo) + '&loincCode=' + encodeURIComponent(loinc);
+function labHxFetch(loinc, cells) {
     var xhr = new XMLHttpRequest();
     xhr.onreadystatechange = function() {
-        if (xhr.readyState !== 4) return;
-        if (xhr.status === 200) {
-            try {
-                var values = JSON.parse(xhr.responseText);
-                // Need at least two entries: values[0]=current, values[1..2]=prior
-                if (values.length > 1) {
-                    loincRows[loinc].forEach(function(cell) { labHxInject(cell, values); });
-                }
-            } catch (e) { /* ignore parse errors */ }
-        }
-        labHxFetchSequential(codes, loincRows, index + 1);
+        if (xhr.readyState !== 4 || xhr.status !== 200) return;
+        try {
+            var values = JSON.parse(xhr.responseText);
+            // Need at least two entries: values[0]=current, values[1..2]=prior
+            if (values.length > 1) {
+                cells.forEach(function(cell) { labHxInject(cell, values); });
+            }
+        } catch (e) { /* ignore parse errors */ }
     };
-    xhr.open('GET', url, true);
+    xhr.open('GET', contextpath + '/lab/CA/ON/LabHistoryByLoinc?demographicNo='
+            + encodeURIComponent(labDemographicNo) + '&loincCode=' + encodeURIComponent(loinc), true);
     xhr.send();
 }
 

--- a/src/main/webapp/WEB-INF/jsp/lab/CA/ALL/labDisplay.jsp
+++ b/src/main/webapp/WEB-INF/jsp/lab/CA/ALL/labDisplay.jsp
@@ -238,6 +238,28 @@
     String formName2 = bShortcutForm ? CarlosProperties.getInstance().getProperty("appt_formview_name2", "") : "";
     String formName2Short = formName2.length() > 3 ? (formName2.substring(0, 2) + ".") : formName2;
     boolean bShortcutForm2 = bShortcutForm && !formName2.equals("");
+
+    // Load LAB_VALUE_HX_JSON from carlos.properties (admin-controlled); default covers common tracked labs.
+    // Re-serialised through Jackson to reject malformed input and normalise the output.
+    String labValueHxDefault = "[{\"name\":\"eGFR\",\"LOINC\":\"33914-3\"}"
+            + ",{\"name\":\"A1C\",\"LOINC\":\"4548-4\"}"
+            + ",{\"name\":\"K\",\"LOINC\":\"2823-3\"}"
+            + ",{\"name\":\"Hb\",\"LOINC\":\"718-7\"}"
+            + ",{\"name\":\"ACR\",\"LOINC\":\"9318-7\"}"
+            + ",{\"name\":\"PSA\",\"LOINC\":\"2857-1\"}"
+            + ",{\"name\":\"CEA\",\"LOINC\":\"2039-6\"}"
+            + ",{\"name\":\"Ferritin\",\"LOINC\":\"2276-4\"}"
+            + ",{\"name\":\"TSH\",\"LOINC\":\"3016-3\"}]";
+    String labValueHxJson;
+    try {
+        ObjectMapper labHxMapper = new ObjectMapper();
+        JsonNode labHxNode = labHxMapper.readTree(props.getProperty("LAB_VALUE_HX_JSON", labValueHxDefault));
+        // Replace "</" so the JSON can be safely embedded inside a <script> block
+        labValueHxJson = labHxMapper.writeValueAsString(labHxNode).replace("</", "<\\/");
+    } catch (Exception e_labHx) {
+        labValueHxJson = labValueHxDefault;
+    }
+
     List<MessageHandler> handlers = new ArrayList<MessageHandler>();
     String[] segmentIDs = null;
     Boolean showAll = showAllstr != null && !"null".equalsIgnoreCase(showAllstr);
@@ -381,6 +403,10 @@ if (securityInfoManager.hasPrivilege(loggedInInfo, "_tickler", "r", demoI) && is
 
     </script>
 
+    <script>
+        var labValueHxConfig = <%=labValueHxJson%>;
+        var labDemographicNo = '<%=SafeEncode.forJavaScript(demographicID != null ? demographicID : "")%>';
+    </script>
 
     <script type="text/javascript">
         // alternately refer to this function in oscarMDSindex.js as labDisplayAjax.jsp does
@@ -2459,6 +2485,117 @@ input[id^='acklabel_']{
         src="${pageContext.servletContext.contextPath}/library/dompurify/purify.min.js"></script>
 <script type="text/javascript"
         src="${pageContext.servletContext.contextPath}/share/javascript/oscarMDSIndex.js"></script>
+
+<script>
+/**
+ * Lab history display: appends the two prior values for configured LOINC codes to each
+ * matching result cell, with a hover tooltip showing all recent values and their dates.
+ * Configured via LAB_VALUE_HX_JSON in carlos.properties (default: eGFR, A1C, K, Hb, ACR,
+ * PSA, CEA, Ferritin, TSH).
+ */
+document.addEventListener('DOMContentLoaded', function() {
+    if (typeof labValueHxConfig === 'undefined' || !labDemographicNo || labDemographicNo === '0') return;
+    initLabHistoryDisplay();
+});
+
+function initLabHistoryDisplay() {
+    // Map each LOINC code to the result cells of matching rows
+    var loincRows = {};
+    document.querySelectorAll('tr.NormalRes, tr.AbnormalRes, tr.HiLoRes').forEach(function(row) {
+        var cells = row.querySelectorAll('td');
+        if (cells.length < 2) return;
+        var links = cells[0].querySelectorAll('a');
+        for (var li = 0; li < links.length; li++) {
+            var href = links[li].getAttribute('href') || '';
+            if (href.indexOf('ViewLabValues') < 0) continue;
+            var m = href.match(/identifier=([^&'")\s]+)/);
+            if (!m) break;
+            var identifier = decodeURIComponent(m[1]);
+            for (var ci = 0; ci < labValueHxConfig.length; ci++) {
+                var loinc = labValueHxConfig[ci].LOINC;
+                // OBX identifiers may be bare LOINC ("33914-3") or prefixed ("33914-3^Name^LN")
+                if (identifier === loinc || identifier.indexOf(loinc + '^') === 0) {
+                    if (!loincRows[loinc]) loincRows[loinc] = [];
+                    loincRows[loinc].push(cells[1]);
+                    break;
+                }
+            }
+            break; // only inspect the first ViewLabValues anchor per row
+        }
+    });
+
+    var loincCodes = Object.keys(loincRows);
+    labHxFetchSequential(loincCodes, loincRows, 0);
+}
+
+function labHxFetchSequential(codes, loincRows, index) {
+    if (index >= codes.length) return;
+    var loinc = codes[index];
+    var url = contextpath + '/lab/CA/ON/LabHistoryByLoinc?demographicNo='
+            + encodeURIComponent(labDemographicNo) + '&loincCode=' + encodeURIComponent(loinc);
+    var xhr = new XMLHttpRequest();
+    xhr.onreadystatechange = function() {
+        if (xhr.readyState !== 4) return;
+        if (xhr.status === 200) {
+            try {
+                var values = JSON.parse(xhr.responseText);
+                // Need at least two entries: values[0]=current, values[1..2]=prior
+                if (values.length > 1) {
+                    loincRows[loinc].forEach(function(cell) { labHxInject(cell, values); });
+                }
+            } catch (e) { /* ignore parse errors */ }
+        }
+        labHxFetchSequential(codes, loincRows, index + 1);
+    };
+    xhr.open('GET', url, true);
+    xhr.send();
+}
+
+function labHxInject(cell, values) {
+    var prior = values.slice(1, 3);
+    if (prior.length === 0) return;
+
+    var prevText = prior.map(function(v) { return labHxEsc(v.result); }).join(' / ');
+    var span = document.createElement('span');
+    span.style.cssText = 'margin-left:8px;color:#000080;font-size:11px;cursor:default;';
+    span.innerHTML = '(' + prevText + ')';
+
+    var tooltip = document.createElement('div');
+    tooltip.style.cssText = 'position:absolute;background:#fefefe;border:1px solid #ccc;'
+            + 'padding:6px 8px;box-shadow:2px 2px 6px rgba(0,0,0,0.2);border-radius:4px;'
+            + 'white-space:nowrap;z-index:9999;display:none;font-size:12px;line-height:1.6;';
+    // Tooltip shows all values; current (index 0) in bold
+    tooltip.innerHTML = values.map(function(v, i) {
+        return '<div>'
+                + (i === 0 ? '<strong>' : '')
+                + labHxEsc(v.result)
+                + (i === 0 ? '</strong>' : '')
+                + ' <span style="color:#36454F;">(' + labHxEsc(v.date) + ')</span></div>';
+    }).join('');
+    document.body.appendChild(tooltip);
+
+    span.addEventListener('mouseover', function(e) {
+        tooltip.style.left = (e.pageX + 12) + 'px';
+        tooltip.style.top = (e.pageY + 12) + 'px';
+        tooltip.style.display = 'block';
+    });
+    span.addEventListener('mousemove', function(e) {
+        tooltip.style.left = (e.pageX + 12) + 'px';
+        tooltip.style.top = (e.pageY + 12) + 'px';
+    });
+    span.addEventListener('mouseout', function() { tooltip.style.display = 'none'; });
+
+    cell.appendChild(span);
+}
+
+function labHxEsc(s) {
+    return String(s)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;');
+}
+</script>
 
 </body>
 </html>


### PR DESCRIPTION
Changes to be committed:
	new file:   src/main/java/io/github/carlos_emr/carlos/lab/gate/LabHistoryByLoinc2Action.java
	new file:   src/main/resources/oscar/prevention/.claude/settings.json
	modified:   src/main/webapp/WEB-INF/classes/struts-lab.xml
	modified:   src/main/webapp/WEB-INF/jsp/lab/CA/ALL/labDisplay.jsp

<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description

<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues
Fixes #1773 
<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?

<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->

## Checklist

- [X] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [X] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [X] I have not included any patient data (PHI) in this PR
- [X] I have added tests for new functionality, or this change doesn't need new tests
- [X] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Expose HL7 lab value history by LOINC and surface prior results inline on the lab display for configured tests.

New Features:
- Add a Struts JSON endpoint that returns recent measurement history for a given demographic and LOINC code with access control and input validation.
- Display recent lab history inline in labDisplay.jsp for selected LOINC-mapped tests, including a tooltip with historical values and dates configurable via LAB_VALUE_HX_JSON.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds automatic past lab values to HL7 report rows. Two prior values show inline next to the current result, with a hover tooltip for recent history. Implements #1773 and speeds up history fetches.

- **New Features**
  - Added `LabHistoryByLoinc2Action`: JSON endpoint returning up to 10 recent values by demographic and LOINC; validates `NNNNN-N` LOINC pattern, returns 400 on bad params and 403 when `_lab` read privilege is missing.
  - Mapped in `struts-lab.xml` as `lab/CA/ON/LabHistoryByLoinc`.
  - Updated `labDisplay.jsp` to detect configured LOINC tests, fetch history, and append two prior values inline; tooltip shows all recent results with dates; configurable via `LAB_VALUE_HX_JSON` (defaults include eGFR, A1C, K, Hb, ACR, PSA, CEA, Ferritin, TSH).

- **Refactors**
  - Optimized measurement lookup in `MeasurementDaoImpl` using native SQL with conditional aggregation and `LIMIT 10` to reduce joins and improve performance.

<sup>Written for commit 0441bc07add4965f96f1b64a451704155dfb6d54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2728?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

