### PR TITLE
[codex] suppress validated security false positives

### DIFF
--- a/.github/spotbugs/spotbugs-exclude.xml
+++ b/.github/spotbugs/spotbugs-exclude.xml
@@ -366,6 +366,480 @@
     </Match>
 
     <!-- ================================================================
+         ISSUE #2724 CONFIRMED FALSE POSITIVES
+         These filters cover only the independently validated false-positive
+         set from https://github.com/carlos-emr/carlos/issues/2724#issuecomment-4643722595.
+         Do not add the report's keep-out / needs-action findings here.
+         Keep entries method-scoped so future findings in the same classes remain visible.
+         ================================================================ -->
+
+    <!-- FilenameUtils results are followed by PathValidationUtils containment checks,
+         equality rejection, allowlist lookup, validated child-path construction, or
+         non-filesystem use. -->
+    <Match>
+        <Bug pattern="WEAK_FILENAMEUTILS"/>
+        <Class name="io.github.carlos_emr.DocumentUploadServlet"/>
+        <Method name="service"/>
+    </Match>
+    <Match>
+        <Bug pattern="WEAK_FILENAMEUTILS"/>
+        <Class name="io.github.carlos_emr.carlos.billings.ca.on.web.BillingDocumentErrorReportUpload2Action"/>
+        <Method name="execute"/>
+    </Match>
+    <Match>
+        <Bug pattern="WEAK_FILENAMEUTILS"/>
+        <Class name="io.github.carlos_emr.carlos.billings.ca.on.web.BillingDocumentErrorReportUpload2Action"/>
+        <Method name="requiresPost"/>
+    </Match>
+    <Match>
+        <Bug pattern="WEAK_FILENAMEUTILS"/>
+        <Class name="io.github.carlos_emr.carlos.billings.ca.on.web.BillingLegacyReport2Action"/>
+        <Method name="execute"/>
+    </Match>
+    <Match>
+        <Bug pattern="WEAK_FILENAMEUTILS"/>
+        <Class name="io.github.carlos_emr.carlos.billings.ca.on.web.MoveMohFiles2Action"/>
+        <Method name="buildViewModel"/>
+    </Match>
+    <Match>
+        <Bug pattern="WEAK_FILENAMEUTILS"/>
+        <Class name="io.github.carlos_emr.carlos.billings.ca.on.web.MoveMohFiles2Action"/>
+        <Method name="getFile"/>
+    </Match>
+    <Match>
+        <Bug pattern="WEAK_FILENAMEUTILS"/>
+        <Class name="io.github.carlos_emr.carlos.demographic.pageUtil.ImportLogDownload2Action"/>
+        <Method name="execute"/>
+    </Match>
+    <Match>
+        <Bug pattern="WEAK_FILENAMEUTILS"/>
+        <Class name="io.github.carlos_emr.carlos.demographic.pageUtil.Util"/>
+        <Method name="cleanFile"/>
+    </Match>
+    <Match>
+        <Bug pattern="WEAK_FILENAMEUTILS"/>
+        <Class name="io.github.carlos_emr.carlos.demographic.pageUtil.Util"/>
+        <Method name="downloadFile"/>
+    </Match>
+    <Match>
+        <Bug pattern="WEAK_FILENAMEUTILS"/>
+        <Class name="io.github.carlos_emr.carlos.documentManager.ConvertToEdoc"/>
+        <Method name="filterFileType"/>
+    </Match>
+    <Match>
+        <Bug pattern="WEAK_FILENAMEUTILS"/>
+        <Class name="io.github.carlos_emr.carlos.documentManager.actions.AddEditDocument2Action"/>
+        <Method name="resolveFallbackUploadFileName"/>
+    </Match>
+    <Match>
+        <Bug pattern="WEAK_FILENAMEUTILS"/>
+        <Class name="io.github.carlos_emr.carlos.documentManager.actions.AddEditDocument2Action"/>
+        <Method name="resolveSanitizedUploadedFileName"/>
+    </Match>
+    <Match>
+        <Bug pattern="WEAK_FILENAMEUTILS"/>
+        <Class name="io.github.carlos_emr.carlos.documentManager.actions.AddEditDocument2Action"/>
+        <Method name="safeExtension"/>
+    </Match>
+    <Match>
+        <Bug pattern="WEAK_FILENAMEUTILS"/>
+        <Class name="io.github.carlos_emr.carlos.documentManager.actions.DocumentUpload2Action"/>
+        <Method name="sanitizeFileNameForIncomingDocs"/>
+    </Match>
+    <Match>
+        <Bug pattern="WEAK_FILENAMEUTILS"/>
+        <Class name="io.github.carlos_emr.carlos.documentManager.actions.ManageDocument2Action"/>
+        <Method name="createIncomingCacheVersion"/>
+    </Match>
+    <Match>
+        <Bug pattern="WEAK_FILENAMEUTILS"/>
+        <Class name="io.github.carlos_emr.carlos.documentManager.actions.ManageDocument2Action"/>
+        <Method name="displayIncomingDocs"/>
+    </Match>
+    <Match>
+        <Bug pattern="WEAK_FILENAMEUTILS"/>
+        <Class name="io.github.carlos_emr.carlos.documentManager.actions.ManageDocument2Action"/>
+        <Method name="viewIncomingDocPageAsImage"/>
+    </Match>
+    <Match>
+        <Bug pattern="WEAK_FILENAMEUTILS"/>
+        <Class name="io.github.carlos_emr.carlos.documentManager.actions.ManageDocument2Action"/>
+        <Method name="viewIncomingDocPageAsPdf"/>
+    </Match>
+    <Match>
+        <Bug pattern="WEAK_FILENAMEUTILS"/>
+        <Class name="io.github.carlos_emr.carlos.eform.actions.DelImage2Action"/>
+        <Method name="execute"/>
+    </Match>
+    <Match>
+        <Bug pattern="WEAK_FILENAMEUTILS"/>
+        <Class name="io.github.carlos_emr.carlos.eform.actions.DisplayImage2Action"/>
+        <Method name="validateRequestedFileName"/>
+    </Match>
+    <Match>
+        <Bug pattern="WEAK_FILENAMEUTILS"/>
+        <Class name="io.github.carlos_emr.carlos.eform.util.EFormPDFServlet"/>
+        <Method name="loadGraphicCfg"/>
+    </Match>
+    <Match>
+        <Bug pattern="WEAK_FILENAMEUTILS"/>
+        <Class name="io.github.carlos_emr.carlos.eform.util.EFormPDFServlet"/>
+        <Method name="loadPrintCfg"/>
+    </Match>
+    <Match>
+        <Bug pattern="WEAK_FILENAMEUTILS"/>
+        <Class name="io.github.carlos_emr.carlos.fax.action.Fax2Action"/>
+        <Method name="getPreview"/>
+    </Match>
+    <Match>
+        <Bug pattern="WEAK_FILENAMEUTILS"/>
+        <Class name="io.github.carlos_emr.carlos.form.pdfservlet.FrmPDFServlet"/>
+        <Method name="generatePDFDocumentBytes"/>
+    </Match>
+    <Match>
+        <Bug pattern="WEAK_FILENAMEUTILS"/>
+        <Class name="io.github.carlos_emr.carlos.form.pdfservlet.FrmPDFServlet"/>
+        <Method name="getCfgProp"/>
+    </Match>
+    <Match>
+        <Bug pattern="WEAK_FILENAMEUTILS"/>
+        <Class name="io.github.carlos_emr.carlos.login.LoginResourceAction"/>
+        <Method name="doGet"/>
+    </Match>
+    <Match>
+        <Bug pattern="WEAK_FILENAMEUTILS"/>
+        <Class name="io.github.carlos_emr.carlos.managers.NioFileManagerImpl"/>
+        <Method name="copyFileToOscarDocuments"/>
+    </Match>
+    <Match>
+        <Bug pattern="WEAK_FILENAMEUTILS"/>
+        <Class name="io.github.carlos_emr.carlos.report.pageUtil.printLabDaySheet2Action"/>
+        <Method name="execute"/>
+    </Match>
+    <Match>
+        <Bug pattern="WEAK_FILENAMEUTILS"/>
+        <Class name="io.github.carlos_emr.carlos.utility.PathValidationUtils"/>
+        <Method name="sanitizeFileName"/>
+    </Match>
+    <Match>
+        <Bug pattern="WEAK_FILENAMEUTILS"/>
+        <Class name="io.github.carlos_emr.carlos.utility.PathValidationUtils"/>
+        <Method name="validatePathComponent"/>
+    </Match>
+
+    <!-- String equality does not compare passwords, auth tokens, HMACs, CSRF tokens,
+         session secrets, or other timing-sensitive secret material. -->
+    <Match>
+        <Bug pattern="UNSAFE_HASH_EQUALS"/>
+        <Class name="io.github.carlos_emr.carlos.demographic.pageUtil.Util"/>
+        <Method name="setPreventionTypes"/>
+    </Match>
+    <Match>
+        <Bug pattern="UNSAFE_HASH_EQUALS"/>
+        <Class name="io.github.carlos_emr.carlos.flowsheet.Flowsheet2Action"/>
+        <Method name="removeTarget"/>
+    </Match>
+    <Match>
+        <Bug pattern="UNSAFE_HASH_EQUALS"/>
+        <Class name="io.github.carlos_emr.carlos.flowsheet.Flowsheet2Action"/>
+        <Method name="removeWarning"/>
+    </Match>
+    <Match>
+        <Bug pattern="UNSAFE_HASH_EQUALS"/>
+        <Class name="io.github.carlos_emr.carlos.lab.ca.all.util.LabVersionComparator"/>
+        <Method name="isLabDuplicate"/>
+    </Match>
+    <Match>
+        <Bug pattern="UNSAFE_HASH_EQUALS"/>
+        <Class name="io.github.carlos_emr.carlos.lab.ca.all.util.LabVersionComparator"/>
+        <Method name="lambda$0"/>
+    </Match>
+    <Match>
+        <Bug pattern="UNSAFE_HASH_EQUALS"/>
+        <Class name="io.github.carlos_emr.carlos.prevention.PreventionData"/>
+        <Method name="getPreventionDataFromExt"/>
+    </Match>
+    <Match>
+        <Bug pattern="UNSAFE_HASH_EQUALS"/>
+        <Class name="io.github.carlos_emr.carlos.prevention.PreventionData"/>
+        <Method name="getProviderName"/>
+    </Match>
+    <Match>
+        <Bug pattern="UNSAFE_HASH_EQUALS"/>
+        <Class name="io.github.carlos_emr.carlos.prevention.PreventionDisplayConfig"/>
+        <Method name="display"/>
+    </Match>
+    <Match>
+        <Bug pattern="UNSAFE_HASH_EQUALS"/>
+        <Class name="io.github.carlos_emr.carlos.prevention.PreventionDisplayConfig"/>
+        <Method name="getDisplay"/>
+    </Match>
+    <Match>
+        <Bug pattern="UNSAFE_HASH_EQUALS"/>
+        <Class name="io.github.carlos_emr.carlos.report.ClinicalReports.ClinicalReportManager"/>
+        <Method name="getNumeratorById"/>
+    </Match>
+
+    <!-- Post-match string changes are parser/normalization steps for prescription,
+         dose, or decision-support text, not validation-before-security-sink flows. -->
+    <Match>
+        <Bug pattern="MODIFICATION_AFTER_VALIDATION"/>
+        <Class name="io.github.carlos_emr.carlos.decisionSupport.model.conditionValue.DSValue"/>
+        <Method name="createDSValue"/>
+    </Match>
+    <Match>
+        <Bug pattern="MODIFICATION_AFTER_VALIDATION"/>
+        <Class name="io.github.carlos_emr.carlos.integration.fhir.model.Immunization"/>
+        <Method name="setDose"/>
+    </Match>
+    <Match>
+        <Bug pattern="MODIFICATION_AFTER_VALIDATION"/>
+        <Class name="io.github.carlos_emr.carlos.prescript.util.RxUtil"/>
+        <Method name="findDuration"/>
+    </Match>
+    <Match>
+        <Bug pattern="MODIFICATION_AFTER_VALIDATION"/>
+        <Class name="io.github.carlos_emr.carlos.prescript.util.RxUtil"/>
+        <Method name="getDurationUnitFromQuantityText"/>
+    </Match>
+    <Match>
+        <Bug pattern="MODIFICATION_AFTER_VALIDATION"/>
+        <Class name="io.github.carlos_emr.carlos.prescript.util.RxUtil"/>
+        <Method name="getUnitNameFromQuantityText"/>
+    </Match>
+    <Match>
+        <Bug pattern="MODIFICATION_AFTER_VALIDATION"/>
+        <Class name="io.github.carlos_emr.carlos.prescript.util.RxUtil"/>
+        <Method name="isMitte"/>
+    </Match>
+    <Match>
+        <Bug pattern="MODIFICATION_AFTER_VALIDATION"/>
+        <Class name="io.github.carlos_emr.carlos.prescript.util.RxUtil"/>
+        <Method name="isStringToNumber"/>
+    </Match>
+    <Match>
+        <Bug pattern="MODIFICATION_AFTER_VALIDATION"/>
+        <Class name="io.github.carlos_emr.carlos.prescript.util.RxUtil"/>
+        <Method name="setResultSpecialQuantityRepeat"/>
+    </Match>
+    <Match>
+        <Bug pattern="MODIFICATION_AFTER_VALIDATION"/>
+        <Class name="io.github.carlos_emr.carlos.prescript.util.RxUtil"/>
+        <Method name="trimSpecial"/>
+    </Match>
+    <Match>
+        <Bug pattern="MODIFICATION_AFTER_VALIDATION"/>
+        <Class name="io.github.carlos_emr.carlos.prescription.util.RxUtil"/>
+        <Method name="trimSpecial"/>
+    </Match>
+
+    <!-- Random values are non-secret UI/cache/correlation/provider-number values;
+         temp-file and generic-helper findings remain unsuppressed. -->
+    <Match>
+        <Bug pattern="PREDICTABLE_RANDOM"/>
+        <Class name="io.github.carlos_emr.Misc"/>
+        <Method name="getRandomNumber"/>
+    </Match>
+    <Match>
+        <Bug pattern="PREDICTABLE_RANDOM"/>
+        <Class name="io.github.carlos_emr.carlos.demographic.pageUtil.ImportDemographicDataAction42Action"/>
+        <Method name="generateRandomColor"/>
+    </Match>
+    <Match>
+        <Bug pattern="PREDICTABLE_RANDOM"/>
+        <Class name="io.github.carlos_emr.carlos.encounter.pageUtil.NavBarDisplayDAO"/>
+        <Method name="main"/>
+    </Match>
+    <Match>
+        <Bug pattern="PREDICTABLE_RANDOM"/>
+        <Class name="io.github.carlos_emr.carlos.prescript.pageUtil.RxRePrescribe2Action"/>
+        <Method name="repcbAllLongTerm"/>
+    </Match>
+    <Match>
+        <Bug pattern="PREDICTABLE_RANDOM"/>
+        <Class name="io.github.carlos_emr.carlos.prescript.pageUtil.RxRePrescribe2Action"/>
+        <Method name="represcribe2"/>
+    </Match>
+    <Match>
+        <Bug pattern="PREDICTABLE_RANDOM"/>
+        <Class name="io.github.carlos_emr.carlos.prescript.pageUtil.RxRePrescribe2Action"/>
+        <Method name="represcribeMultiple"/>
+    </Match>
+    <Match>
+        <Bug pattern="PREDICTABLE_RANDOM"/>
+        <Class name="io.github.carlos_emr.carlos.prescript.pageUtil.RxRePrescribe2Action"/>
+        <Method name="saveReRxDrugIdToStash"/>
+    </Match>
+    <Match>
+        <Bug pattern="PREDICTABLE_RANDOM"/>
+        <Class name="io.github.carlos_emr.carlos.prescript.util.RxUtil"/>
+        <Method name="createKeyValPair"/>
+    </Match>
+    <Match>
+        <Bug pattern="PREDICTABLE_RANDOM"/>
+        <Class name="io.github.carlos_emr.carlos.utility.CustomInterfaceTag"/>
+        <Method name="doStartTag"/>
+    </Match>
+
+    <!-- XML/HTML builder values are already escaped by xmlText, SafeEncode, OWASP
+         Encode, or constrained to fixed numeric/date/base64 serialization. -->
+    <Match>
+        <Bug pattern="POTENTIAL_XML_INJECTION"/>
+        <Class name="io.github.carlos_emr.carlos.billings.ca.on.service.BillingShortcutPg2Service"/>
+        <Method name="calculate"/>
+    </Match>
+    <Match>
+        <Bug pattern="POTENTIAL_XML_INJECTION"/>
+        <Class name="io.github.carlos_emr.carlos.billings.ca.on.service.RaDescriptionFileParser"/>
+        <Method name="transactionRowsXml"/>
+    </Match>
+    <Match>
+        <Bug pattern="POTENTIAL_XML_INJECTION"/>
+        <Class name="io.github.carlos_emr.carlos.encounter.oscarConsultationRequest.config.pageUtil.EctConTitlebar"/>
+        <Method name="estBar"/>
+    </Match>
+    <Match>
+        <Bug pattern="POTENTIAL_XML_INJECTION"/>
+        <Class name="io.github.carlos_emr.carlos.prescript.util.SimpleXmlRpcClient"/>
+        <Method name="serializeValue"/>
+    </Match>
+    <Match>
+        <Bug pattern="POTENTIAL_XML_INJECTION"/>
+        <Class name="io.github.carlos_emr.carlos.report.data.RptResultStruct"/>
+        <Method name="getStructure"/>
+    </Match>
+
+    <!-- Case-folded comparisons are fixed-token/domain checks, not authorization
+         or trust-boundary decisions. -->
+    <Match>
+        <Bug pattern="IMPROPER_UNICODE"/>
+        <Class name="io.github.carlos_emr.carlos.documentManager.actions.AddEditDocument2Action"/>
+        <Method name="html5MultiUpload"/>
+    </Match>
+    <Match>
+        <Bug pattern="IMPROPER_UNICODE"/>
+        <Class name="io.github.carlos_emr.carlos.documentManager.actions.AddEditDocument2Action"/>
+        <Method name="resolveFallbackUploadFileName"/>
+    </Match>
+    <Match>
+        <Bug pattern="IMPROPER_UNICODE"/>
+        <Class name="io.github.carlos_emr.carlos.form.FrmRecordHelp"/>
+        <Method name="lastInsertedIdSql"/>
+    </Match>
+    <Match>
+        <Bug pattern="IMPROPER_UNICODE"/>
+        <Class name="io.github.carlos_emr.carlos.util.JDBCUtil"/>
+        <Method name="isImportTargetManagedField"/>
+    </Match>
+    <Match>
+        <Bug pattern="IMPROPER_UNICODE"/>
+        <Class name="io.github.carlos_emr.carlos.util.JDBCUtil"/>
+        <Method name="lambda$0"/>
+    </Match>
+
+    <!-- MD5 is used only as non-cryptographic duplicate-detection/fingerprint
+         metadata, never for passwords, signatures, or integrity trust. -->
+    <Match>
+        <Bug pattern="WEAK_MESSAGE_DIGEST_MD5"/>
+        <Class name="io.github.carlos_emr.carlos.demographic.pageUtil.ImportDemographicDataAction42Action"/>
+        <Method name="importXML"/>
+    </Match>
+    <Match>
+        <Bug pattern="WEAK_MESSAGE_DIGEST_MD5"/>
+        <Class name="io.github.carlos_emr.carlos.lab.FileUploadCheck"/>
+        <Method name="addFile"/>
+    </Match>
+    <Match>
+        <Bug pattern="WEAK_MESSAGE_DIGEST_MD5"/>
+        <Class name="io.github.carlos_emr.carlos.lab.FileUploadCheck"/>
+        <Method name="hasFileBeenUploadedByFileLocation"/>
+    </Match>
+
+    <!-- Request content type values are used for multipart negotiation only,
+         not authorization or raw output. -->
+    <Match>
+        <Bug pattern="SERVLET_CONTENT_TYPE"/>
+        <Class name="io.github.carlos_emr.carlos.app.CarlosCsrfGuardFilter"/>
+        <Method name="isMultipartContent"/>
+    </Match>
+
+    <!-- Session id APIs are used only for presence checks, never to log or trust
+         the session id value. -->
+    <Match>
+        <Bug pattern="SERVLET_SESSION_ID"/>
+        <Class name="io.github.carlos_emr.carlos.app.HttpMethodGuardFilter"/>
+        <Method name="blockRequest"/>
+    </Match>
+
+    <!-- Request headers are used for negotiation, presence checks, or sanitized
+         diagnostics only, not authorization or raw output. -->
+    <Match>
+        <Bug pattern="SERVLET_HEADER"/>
+        <Class name="io.github.carlos_emr.carlos.app.RateLimitFilter"/>
+        <Method name="warnIfForwardedAddressWasNotApplied"/>
+    </Match>
+    <Match>
+        <Bug pattern="SERVLET_HEADER"/>
+        <Class name="io.github.carlos_emr.carlos.casemgmt.web.CaseManagementView2Action"/>
+        <Method name="listNotes"/>
+    </Match>
+    <Match>
+        <Bug pattern="SERVLET_HEADER"/>
+        <Class name="io.github.carlos_emr.carlos.encounter.pageUtil.EctDisplayAction"/>
+        <Method name="execute"/>
+    </Match>
+    <Match>
+        <Bug pattern="SERVLET_HEADER"/>
+        <Class name="io.github.carlos_emr.carlos.login.Login2Action"/>
+        <Method name="execute"/>
+    </Match>
+    <Match>
+        <Bug pattern="SERVLET_HEADER"/>
+        <Class name="io.github.carlos_emr.carlos.sec.UnauthenticatedRejectionResolver"/>
+        <Method name="prefersStructuredResponse"/>
+    </Match>
+    <Match>
+        <Bug pattern="SERVLET_HEADER"/>
+        <Class name="io.github.carlos_emr.carlos.sec.UnauthenticatedRejectionResolver"/>
+        <Method name="rejectUnauthenticatedRequest"/>
+    </Match>
+    <Match>
+        <Bug pattern="SERVLET_HEADER"/>
+        <Class name="io.github.carlos_emr.carlos.utility.RequestNegotiation"/>
+        <Method name="acceptsJson"/>
+    </Match>
+    <Match>
+        <Bug pattern="SERVLET_HEADER"/>
+        <Class name="io.github.carlos_emr.carlos.utility.RequestNegotiation"/>
+        <Method name="isAjax"/>
+    </Match>
+
+    <!-- User-Agent values are reduced to fixed categories or mobile detection,
+         not trusted as authority or emitted raw. -->
+    <Match>
+        <Bug pattern="SERVLET_HEADER_USER_AGENT"/>
+        <Class name="io.github.carlos_emr.carlos.eform.util.EFormViewForPdfGenerationServlet"/>
+        <Method name="doGet"/>
+    </Match>
+    <Match>
+        <Bug pattern="SERVLET_HEADER_USER_AGENT"/>
+        <Class name="io.github.carlos_emr.carlos.login.Login2Action"/>
+        <Method name="execute"/>
+    </Match>
+
+    <!-- Query strings are sanitized before diagnostics and never emitted raw. -->
+    <Match>
+        <Bug pattern="SERVLET_QUERY_STRING"/>
+        <Class name="io.github.carlos_emr.carlos.ui.servlet.ContentRenderingServlet"/>
+        <Method name="doGet"/>
+    </Match>
+    <Match>
+        <Bug pattern="SERVLET_QUERY_STRING"/>
+        <Class name="io.github.carlos_emr.carlos.ui.servlet.ImageRenderingServlet"/>
+        <Method name="doGet"/>
+    </Match>
+
+    <!-- ================================================================
          FIND SECURITY BUGS INFORMATIONAL TAINT-SOURCE / ENDPOINT MARKERS
          These detectors are NOT vulnerabilities. Find Security Bugs emits
          them to map attack surface: SERVLET_PARAMETER flags every point

--- a/.semgrep/jsp-scriptlet-xss-carlos.yml
+++ b/.semgrep/jsp-scriptlet-xss-carlos.yml
@@ -39,7 +39,6 @@ rules:
       # Known-safe scriptlet outputs: context path, boolean/constant control
       # values, and server-side custom tag attributes.
       - pattern-not-regex: '(?m)^.*<%=\s*request\s*\.\s*getContextPath\s*\(\s*\)\s*%>.*$'
-      - pattern-not-regex: '(?m)^.*<%--.*request\s*\.\s*(?:getParameter|getParameterValues|getParameterMap|getParameterNames|getPart|getParts|getQueryString|getHeader|getHeaders|getRequestURI|getRequestURL|getPathInfo|getCookies)\s*\(.*--%>.*$'
       - pattern-not-regex: '(?m)^.*<%=.*request\s*\.\s*getParameter\s*\([^)]*\)\s*==\s*null.*%>.*$'
       - pattern-not-regex: '(?m)^.*<%=.*"true"\s*\.\s*equals\s*\(\s*request\s*\.\s*getParameter\s*\([^)]*\)\s*\).*%>.*$'
       - pattern-not-regex: '(?m)^.*<%=.*\?\s*"[^"]*"\s*:\s*"[^"]*"\s*%>.*$'

--- a/.semgrep/jsp-scriptlet-xss-carlos.yml
+++ b/.semgrep/jsp-scriptlet-xss-carlos.yml
@@ -39,10 +39,11 @@ rules:
       # Known-safe scriptlet outputs: context path, boolean/constant control
       # values, and server-side custom tag attributes.
       - pattern-not-regex: '(?m)^.*<%=\s*request\s*\.\s*getContextPath\s*\(\s*\)\s*%>.*$'
+      - pattern-not-regex: '(?m)^.*<%--.*request\s*\.\s*(?:getParameter|getParameterValues|getParameterMap|getParameterNames|getPart|getParts|getQueryString|getHeader|getHeaders|getRequestURI|getRequestURL|getPathInfo|getCookies)\s*\(.*--%>.*$'
       - pattern-not-regex: '(?m)^.*<%=.*request\s*\.\s*getParameter\s*\([^)]*\)\s*==\s*null.*%>.*$'
       - pattern-not-regex: '(?m)^.*<%=.*"true"\s*\.\s*equals\s*\(\s*request\s*\.\s*getParameter\s*\([^)]*\)\s*\).*%>.*$'
       - pattern-not-regex: '(?m)^.*<%=.*\?\s*"[^"]*"\s*:\s*"[^"]*"\s*%>.*$'
-      - pattern-not-regex: '(?m)^.*<%=.*\?[^%]*"selected"[^%]*:[^%]*""[^%]*%>.*$'
+      - pattern-not-regex: '(?m)^.*<%=.*\?[^%]*"\s*selected"[^%]*:[^%]*""[^%]*%>.*$'
       - pattern-not-regex: '(?m)^.*<%=.*\?[^%]*request\s*\.\s*getContextPath\s*\(\s*\)[^%]*:\s*"[^"]*"\s*%>.*$'
       - pattern-not-regex: '(?m)^.*<%=.*\?\s*bundle\.getString\s*\([^)]*\)\s*:\s*bundle\.getString\s*\([^)]*\)\s*%>.*$'
       - pattern-not-regex: '(?m)^.*<caisirole:SecurityAccess\b.*$'

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/assembler/BillingOnFormViewModelAssembler.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/assembler/BillingOnFormViewModelAssembler.java
@@ -427,7 +427,7 @@ public class BillingOnFormViewModelAssembler {
                     throw sec;
                 } catch (RuntimeException e) {
                     b.siteContextDegraded(true);
-                    MiscUtils.getLogger().warn(
+                    MiscUtils.getLogger().warn( // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                             "Site-suggest lookup failed for provider={}; rendering empty suggestion",
                             LogSafe.sanitize(apptProviderNo), e);
                 }
@@ -442,7 +442,7 @@ public class BillingOnFormViewModelAssembler {
             try {
                 admDate = nullToEmpty(admissionDateLoader.getAdmissionDate(loggedInInfo, demoNo));
             } catch (RuntimeException e) {
-                MiscUtils.getLogger().error(
+                MiscUtils.getLogger().error( // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                         "Admission-date lookup failed for demo={}", LogSafe.sanitize(demoNo), e);
                 b.admissionDateUnavailable(true);
             }
@@ -594,7 +594,7 @@ public class BillingOnFormViewModelAssembler {
                     name = p.getFormattedName();
                 }
             } catch (RuntimeException e) {
-                MiscUtils.getLogger().warn(
+                MiscUtils.getLogger().warn( // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                         "assgProvider display lookup failed for provider={}; rendering blank",
                         LogSafe.sanitize(apptProviderNo), e);
                 return new ResolvedAssgProviderDisplay("", true);
@@ -633,7 +633,7 @@ public class BillingOnFormViewModelAssembler {
             }
         } catch (RuntimeException rtEx) {
             unavailable = true;
-            MiscUtils.getLogger().error(
+            MiscUtils.getLogger().error( // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     "Billing history rows lookup failed for demo={}; rendering with empty history",
                     LogSafe.sanitize(demoNo), rtEx);
         }
@@ -709,7 +709,7 @@ public class BillingOnFormViewModelAssembler {
                 }
             }
         } catch (NumberFormatException nfe) {
-            MiscUtils.getLogger().warn(
+            MiscUtils.getLogger().warn( // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     "Invalid demographic_no for dx lookup: {}",
                     LogSafe.sanitize(demoNo), nfe);
         }
@@ -744,12 +744,12 @@ public class BillingOnFormViewModelAssembler {
             }
         } catch (ClassCastException ccEx) {
             unavailable = true;
-            MiscUtils.getLogger().error(
+            MiscUtils.getLogger().error( // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     "Billing history data-shape regression for demo={} — BillingOnClaimLoader returned unexpected types",
                     LogSafe.sanitize(demoNo), ccEx);
         } catch (RuntimeException rtEx) {
             unavailable = true;
-            MiscUtils.getLogger().error(
+            MiscUtils.getLogger().error( // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     "Billing history lookup failed for demo={}; rendering with empty history",
                     LogSafe.sanitize(demoNo), rtEx);
         }

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/assembler/BillingOnNewReportViewModelAssembler.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/assembler/BillingOnNewReportViewModelAssembler.java
@@ -190,7 +190,7 @@ public class BillingOnNewReportViewModelAssembler {
                     // Unrecognized report action — render empty rows but log
                     // so a typo or future report-type the switch hasn't
                     // caught up with is distinguishable from "no matches".
-                    MiscUtils.getLogger().warn(
+                    MiscUtils.getLogger().warn( // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                             "BillingOnNewReportViewModelAssembler: unknown action [{}]; rendering empty result",
                             LogSafe.sanitize(action));
                     break;

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/assembler/BillingShortcutPg1ViewModelAssembler.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/assembler/BillingShortcutPg1ViewModelAssembler.java
@@ -191,7 +191,7 @@ public class BillingShortcutPg1ViewModelAssembler {
                     // taking the NPE detour through the catch.
                     if (b == null) {
                         historyPartialRowCount++;
-                        MiscUtils.getLogger().warn(
+                        MiscUtils.getLogger().warn( // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                                 "BillingShortcutPg1: null Billing row in history for demo {}; skipping",
                                 LogSafe.sanitize(demoNo));
                         continue;
@@ -570,7 +570,7 @@ public class BillingShortcutPg1ViewModelAssembler {
                     name = p.getFormattedName();
                 }
             } catch (RuntimeException e) {
-                MiscUtils.getLogger().warn(
+                MiscUtils.getLogger().warn( // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                         "Shortcut: assgProvider display lookup failed for provider={}; rendering blank",
                         LogSafe.sanitize(assgProviderNo), e);
                 return new ResolvedAssgProviderDisplay("", true);

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/assembler/GenerateRaDescriptionViewModelAssembler.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/assembler/GenerateRaDescriptionViewModelAssembler.java
@@ -89,7 +89,7 @@ public class GenerateRaDescriptionViewModelAssembler {
         GenerateRaDescriptionViewModel.Builder b = GenerateRaDescriptionViewModel.builder().raNo(nullToEmpty(raNoStr));
         if (raNo == null) {
             if (raNoStr != null && !raNoStr.isBlank()) {
-                MiscUtils.getLogger().warn("GenerateRaDescription: invalid RA number [{}]",
+                MiscUtils.getLogger().warn("GenerateRaDescription: invalid RA number [{}]", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                         LogSafe.sanitize(raNoStr));
                 b.raFileIncomplete(true)
                         .raFileWarning("Invalid RA number; no RA description file was loaded.");

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/assembler/GenerateRaSummaryViewModelAssembler.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/assembler/GenerateRaSummaryViewModelAssembler.java
@@ -96,7 +96,7 @@ public class GenerateRaSummaryViewModelAssembler {
         GenerateRaSummaryViewModel.Builder b = GenerateRaSummaryViewModel.builder().raNo(nullToEmpty(raNoStr));
         if (raNo == null) {
             if (raNoStr != null && !raNoStr.trim().isEmpty()) {
-                MiscUtils.getLogger().warn("GenerateRaSummary: invalid RA number [{}]",
+                MiscUtils.getLogger().warn("GenerateRaSummary: invalid RA number [{}]", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                         LogSafe.sanitize(raNoStr));
                 b.raFileIncomplete(true)
                         .raFileWarning("Invalid RA number; no RA summary file was loaded.");
@@ -277,7 +277,7 @@ public class GenerateRaSummaryViewModelAssembler {
         try {
             return Integer.parseInt(s);
         } catch (NumberFormatException | NullPointerException e) {
-            MiscUtils.getLogger().warn("GenerateRaSummary: invalid integer [{}]; using 0",
+            MiscUtils.getLogger().warn("GenerateRaSummary: invalid integer [{}]; using 0", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     LogSafe.sanitize(s), e);
             return 0;
         }

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/service/BillingCorrectionService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/service/BillingCorrectionService.java
@@ -141,7 +141,7 @@ public class BillingCorrectionService {
         try {
             invoiceId = Integer.valueOf(invoiceNo);
         } catch (NumberFormatException nfe) {
-            MiscUtils.getLogger().error("3rd party payment: invalid billing_no '{}'",
+            MiscUtils.getLogger().error("3rd party payment: invalid billing_no '{}'", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     LogSafe.sanitize(invoiceNo));
             throw new BillingValidationException(
                     "3rd party payment rejected: invalid billing_no ["
@@ -149,7 +149,7 @@ public class BillingCorrectionService {
         }
         BillingONCHeader1 bCh1 = bCh1Dao.findForUpdate(invoiceId);
         if (bCh1 == null) {
-            MiscUtils.getLogger().error("3rd party payment: billing_no '{}' not found",
+            MiscUtils.getLogger().error("3rd party payment: billing_no '{}' not found", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     LogSafe.sanitize(invoiceNo));
             throw new BillingValidationException(
                     "3rd party payment rejected: bill not found ["
@@ -171,7 +171,7 @@ public class BillingCorrectionService {
         try {
             paidAmt = new BigDecimal(amtPaid);
         } catch (NumberFormatException e) {
-            MiscUtils.getLogger().error(
+            MiscUtils.getLogger().error( // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     "3rd party payment: amtPaid '{}' is not a valid number for bill {}",
                     LogSafe.sanitize(amtPaid), invoiceId, e);
             throw new BillingValidationException(
@@ -183,7 +183,7 @@ public class BillingCorrectionService {
         String payMethod = request.getParameter("payMethod");
         BillingPaymentType paymentType = billingPaymentTypeDao.find(payMethod);
         if (paymentType == null) {
-            MiscUtils.getLogger().error(
+            MiscUtils.getLogger().error( // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     "3rd party payment: payMethod '{}' not in billing_payment_type for bill {}",
                     LogSafe.sanitize(payMethod), invoiceId);
             throw new BillingValidationException(
@@ -196,7 +196,7 @@ public class BillingCorrectionService {
         if (payType == null
                 || (!payType.equals("P") /* Payment */
                         && !payType.equals("R") /* Refund */)) {
-            MiscUtils.getLogger().error(
+            MiscUtils.getLogger().error( // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     "3rd party payment: payType '{}' invalid for bill {} (must be P or R)",
                     LogSafe.sanitize(payType), invoiceId);
             throw new BillingValidationException(
@@ -233,7 +233,7 @@ public class BillingCorrectionService {
         try {
             billingNo = Integer.parseInt(rawBillingNo);
         } catch (NumberFormatException e) {
-            MiscUtils.getLogger().error("updateInvoice: invalid xml_billing_no '{}'",
+            MiscUtils.getLogger().error("updateInvoice: invalid xml_billing_no '{}'", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     LogSafe.sanitize(rawBillingNo), e);
             throw new BillingValidationException(
                     "Bill change rejected: invalid bill identifier ("
@@ -245,7 +245,7 @@ public class BillingCorrectionService {
         // eager fetch keeps this read path independent of fetch-mode drift.
         BillingONCHeader1 bCh1 = bCh1Dao.findWithItems(billingNo);
         if (bCh1 == null) {
-            MiscUtils.getLogger().error("updateInvoice: bill {} not found",
+            MiscUtils.getLogger().error("updateInvoice: bill {} not found", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     LogSafe.sanitize(rawBillingNo));
             throw new BillingValidationException(
                     "Bill change rejected: bill ("
@@ -394,7 +394,7 @@ public class BillingCorrectionService {
                 billingDate = DateUtils.parseDate(request.getParameter("xml_appointment_date"), locale);
             } catch (java.text.ParseException e) {
                 String rawAppt = request.getParameter("xml_appointment_date");
-                MiscUtils.getLogger().error("Invalid billing date: {}", LogSafe.sanitize(rawAppt), e);
+                MiscUtils.getLogger().error("Invalid billing date: {}", LogSafe.sanitize(rawAppt), e); // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                 throw new BillingValidationException(
                         "Bill correction rejected: appointment date ["
                         + LogSafe.sanitizeForDisplay(rawAppt)
@@ -406,7 +406,7 @@ public class BillingCorrectionService {
                 visitDate = DateUtils.parseDate(request.getParameter("xml_vdate"), locale);
             } catch (java.text.ParseException e) {
                 String rawVisit = request.getParameter("xml_vdate");
-                MiscUtils.getLogger().error("Invalid visit date: {}", LogSafe.sanitize(rawVisit), e);
+                MiscUtils.getLogger().error("Invalid visit date: {}", LogSafe.sanitize(rawVisit), e); // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                 throw new BillingValidationException(
                         "Bill correction rejected: visit date ["
                         + LogSafe.sanitizeForDisplay(rawVisit)
@@ -542,7 +542,7 @@ public class BillingCorrectionService {
         try {
             serviceDate = DateUtils.parseDate(serviceDateStr, request.getLocale());
         } catch (java.text.ParseException e) {
-            MiscUtils.getLogger().error(
+            MiscUtils.getLogger().error( // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     "Bill item save: unparseable xml_appointment_date={}; aborting",
                     LogSafe.sanitize(serviceDateStr), e);
             throw new BillingValidationException(
@@ -563,7 +563,7 @@ public class BillingCorrectionService {
                 MiscUtils.getLogger().info("({}) Unit Amount:{}",
                         LogSafe.sanitize(serviceCodeId), LogSafe.sanitize(unit)); // NOSONAR javasecurity:S5145 — sanitized with LogSafe
                 if (!unit.matches("\\d+")) {
-                    MiscUtils.getLogger().warn(
+                    MiscUtils.getLogger().warn( // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                             "Bill item {}: non-numeric unit '{}' rewritten to '1'; preserving submission",
                             LogSafe.sanitize(serviceCodeId), LogSafe.sanitize(unit));
                     unit = "1";
@@ -704,7 +704,7 @@ public class BillingCorrectionService {
     private static BillingValidationException newHeaderUpdateRejected(String rawBillingNo) {
         // Log with sanitized id for audit; user message is plain to avoid
         // round-tripping unsanitized data through the rendered error page.
-        MiscUtils.getLogger().error("updateInvoice header rejected for bill {}",
+        MiscUtils.getLogger().error("updateInvoice header rejected for bill {}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                 LogSafe.sanitize(rawBillingNo));
         return new BillingValidationException(
                 "Bill change rejected: header update failed; please refresh and retry.");

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/service/BillingOnReviewDiagPersister.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/service/BillingOnReviewDiagPersister.java
@@ -91,7 +91,7 @@ public class BillingOnReviewDiagPersister {
         String dxCodeMatch = nullToEmpty(request.getParameter("codeMatchToPatientDx"));
         String dxCodeAdd = dxCodeMatch.isEmpty() ? dxCode : dxCodeMatch;
         if (dxCodeAdd.isEmpty()) {
-            MiscUtils.getLogger().error(
+            MiscUtils.getLogger().error( // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     "addToPatientDx requested without a dx code for demographic_no={}",
                     LogSafe.sanitize(demoNo));
             throw new BillingValidationException(
@@ -103,7 +103,7 @@ public class BillingOnReviewDiagPersister {
         try {
             demoNoInt = Integer.valueOf(demoNo);
         } catch (NumberFormatException nfe) {
-            MiscUtils.getLogger().error(
+            MiscUtils.getLogger().error( // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     "addToPatientDx requested with non-numeric demographic_no={}",
                     LogSafe.sanitize(demoNo));
             throw new BillingValidationException(
@@ -128,7 +128,7 @@ public class BillingOnReviewDiagPersister {
             // so the user sees the friendly "submission rejected" page rather
             // than the generic CARLOS Error 500. The save was a clinical
             // write — the operator needs to know it was rejected.
-            MiscUtils.getLogger().error(
+            MiscUtils.getLogger().error( // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     "addToPatientDx: data-integrity violation persisting dx {} for demographic_no={}",
                     LogSafe.sanitize(dxCodeAdd),
                     LogSafe.sanitize(demoNo), dive);
@@ -136,7 +136,7 @@ public class BillingOnReviewDiagPersister {
                     "Could not save dx (" + LogSafe.sanitizeForDisplay(dxCodeAdd)
                     + ") for the patient: it may already be in the registry.", dive);
         } catch (org.hibernate.NonUniqueObjectException nuoe) {
-            MiscUtils.getLogger().error(
+            MiscUtils.getLogger().error( // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     "addToPatientDx: NonUniqueObjectException for dx {}",
                     LogSafe.sanitize(dxCodeAdd), nuoe);
             throw new BillingValidationException(
@@ -150,7 +150,7 @@ public class BillingOnReviewDiagPersister {
             // and has no signal that the dx was *not* added — same audit-trail
             // gap the targeted catches above close. Translate to BVE so the
             // operator gets the friendly "retry" message.
-            MiscUtils.getLogger().error(
+            MiscUtils.getLogger().error( // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     "addToPatientDx: unexpected save failure for dx {}",
                     LogSafe.sanitize(dxCodeAdd), rtEx);
             throw new BillingValidationException(

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/service/BillingThirdPartyService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/service/BillingThirdPartyService.java
@@ -154,7 +154,7 @@ public class BillingThirdPartyService {
             dao.merge(b);
             return true;
         }
-        MiscUtils.getLogger().warn("BillingThirdPartyService.update3rdAddr: address id {} not found",
+        MiscUtils.getLogger().warn("BillingThirdPartyService.update3rdAddr: address id {} not found", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                 LogSafe.sanitize(id));
         return false;
     }

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/service/OnRaSettlementService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/service/OnRaSettlementService.java
@@ -190,7 +190,7 @@ public class OnRaSettlementService {
     private static io.github.carlos_emr.carlos.billings.ca.on.validator.BillingValidationException newInvalidRanoException(String raNoStr) {
         // Log the offending raw value with sanitisation so we keep diagnostic
         // context out of the user-facing exception message.
-        MiscUtils.getLogger().warn("RA settle: rano parse rejected, raw value: {}",
+        MiscUtils.getLogger().warn("RA settle: rano parse rejected, raw value: {}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                 io.github.carlos_emr.carlos.utility.LogSafe.sanitize(raNoStr));
         return new io.github.carlos_emr.carlos.billings.ca.on.validator.BillingValidationException(
                 "RA settle rejected: rano parameter is missing or not a valid integer");

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/validator/BillingOnReviewValidator.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/validator/BillingOnReviewValidator.java
@@ -158,7 +158,7 @@ public class BillingOnReviewValidator {
         Integer demoNoInt = parseDemoNo(demoNo);
         if (demoNoInt == null) {
             if (hasA003AAnnualGuardCandidate(request)) {
-                MiscUtils.getLogger().warn(
+                MiscUtils.getLogger().warn( // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                         "BillingOnReviewValidator: A003A guard failed — non-numeric demographic_no '{}'",
                         LogSafe.sanitize(demoNo));
                 messages.add(new Message(Message.Severity.ERROR,
@@ -182,7 +182,7 @@ public class BillingOnReviewValidator {
             try {
                 serviceDate = DateUtils.parseDate(request.getParameter("service_date"), request.getLocale());
             } catch (java.text.ParseException e) {
-                MiscUtils.getLogger().warn(
+                MiscUtils.getLogger().warn( // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                         "BillingOnReviewValidator: A003A guard failed — unparseable service_date '{}'",
                         LogSafe.sanitize(request.getParameter("service_date")), e);
                 messages.add(new Message(Message.Severity.ERROR,

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/BillingDocumentErrorReportUpload2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/BillingDocumentErrorReportUpload2Action.java
@@ -201,7 +201,7 @@ public class BillingDocumentErrorReportUpload2Action extends ActionSupport imple
             // Get target directory
             String place = props.getProperty("DOCUMENT_DIR");
             if (place == null || place.trim().isEmpty()) {
-                MiscUtils.getLogger().error("DOCUMENT_DIR property is not configured for MOH report upload file {}",
+                MiscUtils.getLogger().error("DOCUMENT_DIR property is not configured for MOH report upload file {}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                         LogSafe.sanitize(fileName));
                 return SaveReportFileResult.failure(CONFIG_ERROR_MESSAGE);
             }
@@ -209,7 +209,7 @@ public class BillingDocumentErrorReportUpload2Action extends ActionSupport imple
             // Use PathValidationUtils to validate and get safe destination path
             File placeDir = new File(place).getCanonicalFile();
             if (!placeDir.exists() || !placeDir.isDirectory()) {
-                MiscUtils.getLogger().error("DOCUMENT_DIR does not exist or is not a directory for MOH report upload file {}: {}",
+                MiscUtils.getLogger().error("DOCUMENT_DIR does not exist or is not a directory for MOH report upload file {}: {}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                         LogSafe.sanitize(fileName), LogSafe.sanitize(place));
                 return SaveReportFileResult.failure(CONFIG_ERROR_MESSAGE);
             }
@@ -218,7 +218,7 @@ public class BillingDocumentErrorReportUpload2Action extends ActionSupport imple
             try {
                 destFile = PathValidationUtils.validatePath(fileName, placeDir);
             } catch (SecurityException e) {
-                MiscUtils.getLogger().error("Invalid MOH report upload filename provided: {}",
+                MiscUtils.getLogger().error("Invalid MOH report upload filename provided: {}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                         LogSafe.sanitize(fileName), e);
                 return SaveReportFileResult.failure(FILE_ACCESS_ERROR_MESSAGE);
             }
@@ -236,7 +236,7 @@ public class BillingDocumentErrorReportUpload2Action extends ActionSupport imple
 
             String inboxDir = props.getProperty("ONEDT_INBOX");
             if (inboxDir == null || inboxDir.trim().isEmpty()) {
-                MiscUtils.getLogger().error("ONEDT_INBOX property is not configured for MOH report upload file {}",
+                MiscUtils.getLogger().error("ONEDT_INBOX property is not configured for MOH report upload file {}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                         LogSafe.sanitize(fileName));
                 return SaveReportFileResult.failure(CONFIG_ERROR_MESSAGE);
             }
@@ -244,7 +244,7 @@ public class BillingDocumentErrorReportUpload2Action extends ActionSupport imple
             // Use PathValidationUtils to validate and get safe inbox path
             File inboxDirFile = new File(inboxDir).getCanonicalFile();
             if (!inboxDirFile.exists() || !inboxDirFile.isDirectory()) {
-                MiscUtils.getLogger().error("ONEDT_INBOX does not exist or is not a directory for MOH report upload file {}: {}",
+                MiscUtils.getLogger().error("ONEDT_INBOX does not exist or is not a directory for MOH report upload file {}: {}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                         LogSafe.sanitize(fileName), LogSafe.sanitize(String.valueOf(inboxDir)));
                 return SaveReportFileResult.failure(CONFIG_ERROR_MESSAGE);
             }
@@ -253,18 +253,18 @@ public class BillingDocumentErrorReportUpload2Action extends ActionSupport imple
             try {
                 inboxFile = PathValidationUtils.validatePath(destFile.getName(), inboxDirFile);
             } catch (SecurityException e) {
-                MiscUtils.getLogger().error("Invalid filename for inbox: {}", LogSafe.sanitize(destFile.getName()));
+                MiscUtils.getLogger().error("Invalid filename for inbox: {}", LogSafe.sanitize(destFile.getName())); // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                 return SaveReportFileResult.failure(FILE_ACCESS_ERROR_MESSAGE);
             }
 
             org.apache.commons.io.FileUtils.copyFile(destFile, inboxFile);
         } catch (FileNotFoundException e) {
-            MiscUtils.getLogger().error("MOH report upload source file not found: {}",
+            MiscUtils.getLogger().error("MOH report upload source file not found: {}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     LogSafe.sanitize(fileName), e);
             return SaveReportFileResult.failure(FILE_ACCESS_ERROR_MESSAGE);
 
         } catch (IOException ioe) {
-            MiscUtils.getLogger().error("MOH report upload IO error for {}",
+            MiscUtils.getLogger().error("MOH report upload IO error for {}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     LogSafe.sanitize(fileName), ioe);
             return SaveReportFileResult.failure(FILE_ACCESS_ERROR_MESSAGE);
         }
@@ -299,7 +299,7 @@ public class BillingDocumentErrorReportUpload2Action extends ActionSupport imple
             boolean bNewBilling = "true".equals(props.getProperty("isNewONbilling", ""));
 
             if (filepath == null || filepath.isBlank()) {
-                MiscUtils.getLogger().error("{} property is not configured for MOH report file {}",
+                MiscUtils.getLogger().error("{} property is not configured for MOH report file {}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                         LogSafe.sanitize(pathDir), LogSafe.sanitize(fileName));
                 return MohReportReadResult.failure(ReadFailureCategory.CONFIGURATION, CONFIG_ERROR_MESSAGE);
             }
@@ -307,7 +307,7 @@ public class BillingDocumentErrorReportUpload2Action extends ActionSupport imple
             // Use PathValidationUtils to validate and get safe file path
             File safeDir = new File(filepath).getCanonicalFile();
             if (!safeDir.exists() || !safeDir.isDirectory()) {
-                MiscUtils.getLogger().error("{} does not exist or is not a directory for MOH report file {}: {}",
+                MiscUtils.getLogger().error("{} does not exist or is not a directory for MOH report file {}: {}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                         LogSafe.sanitize(pathDir), LogSafe.sanitize(fileName),
                         LogSafe.sanitize(filepath));
                 return MohReportReadResult.failure(ReadFailureCategory.CONFIGURATION, CONFIG_ERROR_MESSAGE);
@@ -316,7 +316,7 @@ public class BillingDocumentErrorReportUpload2Action extends ActionSupport imple
             try {
                 inputFile = PathValidationUtils.validatePath(fileName, safeDir);
             } catch (SecurityException e) {
-                MiscUtils.getLogger().error("Invalid MOH report filename provided for {}: {}",
+                MiscUtils.getLogger().error("Invalid MOH report filename provided for {}: {}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                         LogSafe.sanitize(pathDir), LogSafe.sanitize(fileName), e);
                 return MohReportReadResult.failure(ReadFailureCategory.FILE_ACCESS, FILE_ACCESS_ERROR_MESSAGE);
             }
@@ -324,7 +324,7 @@ public class BillingDocumentErrorReportUpload2Action extends ActionSupport imple
             // Get the sanitized filename from the validated path
             String sanitizedFileName = inputFile.getName();
             if (sanitizedFileName.isEmpty()) {
-                MiscUtils.getLogger().warn("MOH report filename empty after sanitization for {}", LogSafe.sanitize(fileName));
+                MiscUtils.getLogger().warn("MOH report filename empty after sanitization for {}", LogSafe.sanitize(fileName)); // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                 return MohReportReadResult.failure(ReadFailureCategory.FILE_ACCESS, FILE_ACCESS_ERROR_MESSAGE);
             }
 
@@ -334,7 +334,7 @@ public class BillingDocumentErrorReportUpload2Action extends ActionSupport imple
 
             // try-with-resources to close the FileInputStream on every exit path.
             try (FileInputStream file = new FileInputStream(inputFile)) {
-                MiscUtils.getLogger().debug("File path: {}",
+                MiscUtils.getLogger().debug("File path: {}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                         LogSafe.sanitize(inputFile.getAbsolutePath()));
 
                 if (prefix.compareTo("E") == 0 || prefix.compareTo("F") == 0) {
@@ -366,7 +366,7 @@ public class BillingDocumentErrorReportUpload2Action extends ActionSupport imple
                     // Unrecognized prefix — supported set is E/F/B/X/R/L. The
                     // caller renders errors.incorrectFileFormat; without this
                     // log the operator can't see what prefix actually arrived.
-                    MiscUtils.getLogger().warn(
+                    MiscUtils.getLogger().warn( // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                             "Unrecognized MOH report prefix [{}] for file {} — supported prefixes are E/F/B/X/R/L",
                             LogSafe.sanitize(prefix),
                             LogSafe.sanitize(sanitizedFileName));
@@ -376,20 +376,20 @@ public class BillingDocumentErrorReportUpload2Action extends ActionSupport imple
 
             request.setAttribute("ReportName", ReportName);
             if (!isGot) {
-                MiscUtils.getLogger().warn("MOH report parser returned unsuccessful verdict for file {} from {}",
+                MiscUtils.getLogger().warn("MOH report parser returned unsuccessful verdict for file {} from {}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                         LogSafe.sanitize(sanitizedFileName), LogSafe.sanitize(pathDir));
                 return MohReportReadResult.failure(ReadFailureCategory.FORMAT, getText("errors.incorrectFileFormat"));
             }
         } catch (FileNotFoundException fnfe) {
-            MiscUtils.getLogger().error("MOH report upload - file not found at validated path for {}: {}",
+            MiscUtils.getLogger().error("MOH report upload - file not found at validated path for {}: {}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     LogSafe.sanitize(pathDir), LogSafe.sanitize(fileName), fnfe);
             return MohReportReadResult.failure(ReadFailureCategory.FILE_ACCESS, FILE_ACCESS_ERROR_MESSAGE);
         } catch (BillingFileImportException importFailure) {
-            MiscUtils.getLogger().error("MOH report import failed for {} from {}",
+            MiscUtils.getLogger().error("MOH report import failed for {} from {}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     LogSafe.sanitize(fileName), LogSafe.sanitize(pathDir), importFailure);
             return MohReportReadResult.failure(ReadFailureCategory.IMPORT, IMPORT_ERROR_MESSAGE);
         } catch (IOException ioe) {
-            MiscUtils.getLogger().error("MOH report upload - IO error reading {} from {}",
+            MiscUtils.getLogger().error("MOH report upload - IO error reading {} from {}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     LogSafe.sanitize(fileName), LogSafe.sanitize(pathDir), ioe);
             return MohReportReadResult.failure(ReadFailureCategory.FILE_ACCESS, FILE_ACCESS_ERROR_MESSAGE);
         }

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/BillingOnPayments2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/BillingOnPayments2Action.java
@@ -401,7 +401,7 @@ public class BillingOnPayments2Action extends ActionSupport {
         try {
             return new ParsedAmount(new BigDecimal(s), false);
         } catch (NumberFormatException e) {
-            MiscUtils.getLogger().warn(
+            MiscUtils.getLogger().warn( // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     "BillingOnPayments view: rendering 0.00 for unparseable amount [{}] (length={}); amountUnreadable=true",
                     LogSafe.sanitize(s), s.length(), e);
             return new ParsedAmount(BigDecimal.ZERO, true);
@@ -604,7 +604,7 @@ public class BillingOnPayments2Action extends ActionSupport {
             int paymentId = Integer.parseInt(request.getParameter("id"));
             billingPaymentDeletionService.deletePayment(paymentId);
         } catch (NumberFormatException nfe) {
-            logger.warn("deletePayment: invalid id parameter: {}",
+            logger.warn("deletePayment: invalid id parameter: {}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     io.github.carlos_emr.carlos.utility.LogSafe.sanitize(request.getParameter("id")), nfe);
             return "failure";
         } catch (io.github.carlos_emr.carlos.billings.ca.on.service.BillingPaymentDeletionService.PaymentNotFoundException notFound) {
@@ -612,11 +612,11 @@ public class BillingOnPayments2Action extends ActionSupport {
             // already gone (concurrent edit, or stale page). Render the
             // current payment list rather than the generic failure page so
             // they see the up-to-date state.
-            logger.warn("deletePayment: paymentId not found: {}",
+            logger.warn("deletePayment: paymentId not found: {}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     io.github.carlos_emr.carlos.utility.LogSafe.sanitize(request.getParameter("id")), notFound);
             return listPayments();
         } catch (Exception ex) {
-            logger.error("Failed to delete payment: {}",
+            logger.error("Failed to delete payment: {}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     io.github.carlos_emr.carlos.utility.LogSafe.sanitize(request.getParameter("id")), ex);
             return "failure";
         }
@@ -637,7 +637,7 @@ public class BillingOnPayments2Action extends ActionSupport {
                 return "failure";
             }
         } catch (NumberFormatException e) {
-            logger.error("Invalid paymentId parameter {}", LogSafe.sanitize(id), e);
+            logger.error("Invalid paymentId parameter {}", LogSafe.sanitize(id), e); // NOSONAR javasecurity:S5145 - sanitized with LogSafe
             return "failure";
         }
         BillingONPayment billPayment = billingONPaymentDao.find(paymentId);
@@ -699,12 +699,12 @@ public class BillingOnPayments2Action extends ActionSupport {
             // Forward to the failure result so the user sees an error
             // instead of a silent empty render. Returning null here would
             // produce a blank page with no operator feedback.
-            logger.error("Invalid billPaymentId parameter {}", LogSafe.sanitize(billPaymentIdRaw), e);
+            logger.error("Invalid billPaymentId parameter {}", LogSafe.sanitize(billPaymentIdRaw), e); // NOSONAR javasecurity:S5145 - sanitized with LogSafe
             return "failure";
         }
         BillingONPayment billPayment = billingONPaymentDao.find(billPaymentId);
         if (billPayment == null) {
-            logger.warn("viewPayment_ext: billPaymentId not found: {}",
+            logger.warn("viewPayment_ext: billPaymentId not found: {}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     LogSafe.sanitize(billPaymentIdRaw));
             return "failure";
         }

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/FluBillingAdd2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/FluBillingAdd2Action.java
@@ -136,7 +136,7 @@ public class FluBillingAdd2Action extends ActionSupport {
         // wrong fee would silently misprice the bill.
         List<BillingService> bsList = billingServiceDao.findByServiceCode(request.getParameter("svcCode"));
         if (bsList != null && bsList.size() > 1) {
-            MiscUtils.getLogger().error(
+            MiscUtils.getLogger().error( // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     "FluBillingAdd2Action: ambiguous fee — {} BillingService rows for svcCode={}",
                     bsList.size(),
                     LogSafe.sanitize(request.getParameter("svcCode")));

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/MoveMohFiles2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/MoveMohFiles2Action.java
@@ -376,7 +376,7 @@ public class MoveMohFiles2Action extends ActionSupport {
                 // and surfaces as a pattern in audit triage; legitimate
                 // calls that hit the right folder break out before more
                 // than one DEBUG fires.
-                logger.debug("EDT folder {} rejected file path during validation: {}",
+                logger.debug("EDT folder {} rejected file path during validation: {}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                         io.github.carlos_emr.carlos.utility.LogSafe.sanitize(folder.name()),
                         io.github.carlos_emr.carlos.utility.LogSafe.sanitize(
                                 file == null ? "null" : file.getPath()));
@@ -407,11 +407,11 @@ public class MoveMohFiles2Action extends ActionSupport {
         try {
             fileName = URLDecoder.decode(fileName, "UTF-8");
         } catch (UnsupportedEncodingException e) {
-            logger.error("Unable to decode {}", LogSafe.sanitize(fileName), e);
+            logger.error("Unable to decode {}", LogSafe.sanitize(fileName), e); // NOSONAR javasecurity:S5145 - sanitized with LogSafe
             return null;
         }
         if (fileName.contains("/") || fileName.contains("\\") || fileName.contains("..")) {
-            logger.warn("Rejected decoded file path: {}", LogSafe.sanitize(fileName));
+            logger.warn("Rejected decoded file path: {}", LogSafe.sanitize(fileName)); // NOSONAR javasecurity:S5145 - sanitized with LogSafe
             return null;
         }
         String safeFileName = FilenameUtils.getName(fileName);
@@ -425,7 +425,7 @@ public class MoveMohFiles2Action extends ActionSupport {
         try {
             return PathValidationUtils.validatePath(safeFileName, new File(folderPath));
         } catch (SecurityException e) {
-            logger.warn("Rejected file path: {} in {}",
+            logger.warn("Rejected file path: {} in {}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     LogSafe.sanitize(fileName), LogSafe.sanitize(folderPath), e);
             return null;
         }
@@ -478,7 +478,7 @@ public class MoveMohFiles2Action extends ActionSupport {
     private String getFolderPath(String folderName) {
     EDTFolder folder = EDTFolder.getFolder(folderName);
     if (folder == null) {
-        logger.warn("moveMOHFiles: invalid folder parameter '{}'", LogSafe.sanitize(folderName));
+        logger.warn("moveMOHFiles: invalid folder parameter '{}'", LogSafe.sanitize(folderName)); // NOSONAR javasecurity:S5145 - sanitized with LogSafe
         return null;
     }
     return folder.getPath();

--- a/src/main/java/io/github/carlos_emr/carlos/commn/web/BillingInvoice2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/web/BillingInvoice2Action.java
@@ -284,9 +284,9 @@ public class BillingInvoice2Action extends ActionSupport {
 
     private String failPdfResponse(String logMessage, Throwable e) throws IOException {
         if (e == null) {
-            MiscUtils.getLogger().error(logMessage);
+            MiscUtils.getLogger().error(logMessage); // NOSONAR javasecurity:S5145 - wrapper message is built from constants and sanitized call-site values
         } else {
-            MiscUtils.getLogger().error(logMessage, e);
+            MiscUtils.getLogger().error(logMessage, e); // NOSONAR javasecurity:S5145 - wrapper message is built from constants and sanitized call-site values
         }
         if (!response.isCommitted()) {
             // Dedicated PDF actions own their error response too. Returning a named result here

--- a/src/main/java/io/github/carlos_emr/carlos/commn/web/BillingInvoice2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/web/BillingInvoice2Action.java
@@ -283,10 +283,11 @@ public class BillingInvoice2Action extends ActionSupport {
     }
 
     private String failPdfResponse(String logMessage, Throwable e) throws IOException {
+        String safeLogMessage = LogSafe.sanitize(logMessage);
         if (e == null) {
-            MiscUtils.getLogger().error(logMessage); // NOSONAR javasecurity:S5145 - wrapper message is built from constants and sanitized call-site values
+            MiscUtils.getLogger().error(safeLogMessage); // NOSONAR javasecurity:S5145 - wrapper message sanitized at helper boundary
         } else {
-            MiscUtils.getLogger().error(logMessage, e); // NOSONAR javasecurity:S5145 - wrapper message is built from constants and sanitized call-site values
+            MiscUtils.getLogger().error(safeLogMessage, e); // NOSONAR javasecurity:S5145 - wrapper message sanitized at helper boundary
         }
         if (!response.isCommitted()) {
             // Dedicated PDF actions own their error response too. Returning a named result here

--- a/src/main/java/io/github/carlos_emr/carlos/commn/web/FlowSheetCustom2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/web/FlowSheetCustom2Action.java
@@ -189,7 +189,7 @@ public class FlowSheetCustom2Action extends ActionSupport {
     @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
     public String execute() throws Exception {
         if (!"POST".equalsIgnoreCase(request.getMethod())) {
-            logger.warn("Rejected flowsheet customization request with method {} from {}",
+            logger.warn("Rejected flowsheet customization request with method {} from {}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     LogSafe.sanitize(String.valueOf(request.getMethod())),
                     LogSafe.sanitize(String.valueOf(request.getRemoteAddr())));
             response.setHeader("Allow", "POST");
@@ -199,7 +199,7 @@ public class FlowSheetCustom2Action extends ActionSupport {
 
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
         if (!securityInfoManager.hasPrivilege(loggedInInfo, "_flowsheet", "w", null)) {
-            logger.warn("Denied flowsheet customization request with method {} from {}",
+            logger.warn("Denied flowsheet customization request with method {} from {}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     LogSafe.sanitize(String.valueOf(request.getMethod())),
                     LogSafe.sanitize(String.valueOf(request.getRemoteAddr())));
             throw new SecurityException("missing required sec object (_flowsheet)");
@@ -221,7 +221,7 @@ public class FlowSheetCustom2Action extends ActionSupport {
         } else if ("revertUpdate".equals(method)) {
             return revertUpdate();
         }
-        logger.warn("Unknown flowsheet customization method {} from {}",
+        logger.warn("Unknown flowsheet customization method {} from {}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                 LogSafe.sanitize(String.valueOf(method)),
                 LogSafe.sanitize(String.valueOf(request.getRemoteAddr())));
         request.setAttribute("errorMessage", "Unknown flowsheet customization method.");
@@ -239,7 +239,7 @@ public class FlowSheetCustom2Action extends ActionSupport {
         LoggedInInfo loggedInInfo = validateCustomizationPermissions(scope, demographicNo);
 
         if (measurement == null || measurement.trim().isEmpty()) {
-            logger.warn("Rejected flowsheet save without measurement for flowsheet {} from {}",
+            logger.warn("Rejected flowsheet save without measurement for flowsheet {} from {}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     LogSafe.sanitize(String.valueOf(flowsheet)),
                     LogSafe.sanitize(String.valueOf(request.getRemoteAddr())));
             request.setAttribute("errorMessage", "Measurement is required to save a flowsheet customization.");
@@ -276,7 +276,7 @@ public class FlowSheetCustom2Action extends ActionSupport {
                 String s = en.nextElement();
                 if (s.startsWith("monthrange")) {
                     String extrachar = s.replaceAll("monthrange", "").trim();
-                    logger.debug("EXTRA CAH {}", LogSafe.sanitize(extrachar));
+                    logger.debug("EXTRA CAH {}", LogSafe.sanitize(extrachar)); // NOSONAR javasecurity:S5145 - sanitized with LogSafe
 
                     if (request.getParameter("monthrange" + extrachar) != null) {
                         String mRange = request.getParameter("monthrange" + extrachar);
@@ -325,7 +325,7 @@ public class FlowSheetCustom2Action extends ActionSupport {
                 cust.setDemographicNo(demographicNo);
                 cust.setCreateDate(new Date());
 
-                logger.debug("SAVE {}", LogSafe.sanitizeObject(cust));
+                logger.debug("SAVE {}", LogSafe.sanitizeObject(cust)); // NOSONAR javasecurity:S5145 - sanitized with LogSafe
 
                 flowSheetCustomizationDao.persist(cust);
 
@@ -372,7 +372,7 @@ public class FlowSheetCustom2Action extends ActionSupport {
                 String s = en.nextElement();
                 if (s.startsWith("strength")) {
                     String extrachar = s.replaceAll("strength", "").trim();
-                    logger.debug("EXTRA CAH {}", LogSafe.sanitize(extrachar));
+                    logger.debug("EXTRA CAH {}", LogSafe.sanitize(extrachar)); // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     boolean go = true;
                     Recommendation rec = new Recommendation();
                     rec.setStrength(request.getParameter(s));
@@ -404,7 +404,7 @@ public class FlowSheetCustom2Action extends ActionSupport {
                     }
                 } else if (s.startsWith("col")) {
                     String extrachar = s.replaceAll("col", "").trim();
-                    logger.debug("EXTRA CHA {}", LogSafe.sanitize(extrachar));
+                    logger.debug("EXTRA CHA {}", LogSafe.sanitize(extrachar)); // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     boolean go = true;
                     int targetCount = 1;
                     TargetColour tcolour = new TargetColour();
@@ -453,7 +453,7 @@ public class FlowSheetCustom2Action extends ActionSupport {
             cust.setMeasurement(item.getItemName()); //THIS THE MEASUREMENT TO SET THIS AFTER!
             cust.setProviderNo(providerNo);
 
-            logger.debug("UPDATE {}", LogSafe.sanitizeObject(cust));
+            logger.debug("UPDATE {}", LogSafe.sanitizeObject(cust)); // NOSONAR javasecurity:S5145 - sanitized with LogSafe
 
             flowSheetCustomizationDao.persist(cust);
 
@@ -485,7 +485,7 @@ public class FlowSheetCustom2Action extends ActionSupport {
         cust.setDemographicNo(ctx.demographicNo);
 
         flowSheetCustomizationDao.persist(cust);
-        logger.debug("HIDE {}", LogSafe.sanitizeObject(cust));
+        logger.debug("HIDE {}", LogSafe.sanitizeObject(cust)); // NOSONAR javasecurity:S5145 - sanitized with LogSafe
 
         setResponseAttributes(ctx);
         return SUCCESS;
@@ -558,7 +558,7 @@ public class FlowSheetCustom2Action extends ActionSupport {
                 cust.setArchived(true);
                 cust.setArchivedDate(new Date());
                 flowSheetCustomizationDao.merge(cust);
-                logger.info("Reverted UPDATE customization {} for measurement {}",
+                logger.info("Reverted UPDATE customization {} for measurement {}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     cust.getId(), LogSafe.sanitize(ctx.measurement));
             }
         }
@@ -598,7 +598,7 @@ public class FlowSheetCustom2Action extends ActionSupport {
             cust.setArchivedDate(new Date());
             flowSheetCustomizationDao.merge(cust);
         }
-        logger.debug("archiveMod {}", LogSafe.sanitizeObject(cust));
+        logger.debug("archiveMod {}", LogSafe.sanitizeObject(cust)); // NOSONAR javasecurity:S5145 - sanitized with LogSafe
 
         request.setAttribute("demographic", demographicNo);
         request.setAttribute("flowsheet", flowsheet);

--- a/src/main/java/io/github/carlos_emr/carlos/event/EventService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/event/EventService.java
@@ -52,7 +52,7 @@ public class EventService implements ApplicationEventPublisherAware {
      */
     public void appointmentStatusChanged(Object source, String appointment_no, String provider_no, String status) {
         if (logger.isDebugEnabled()) {
-            logger.debug("appointmentStatusChanged thrown by {} appt# {} status {}",
+            logger.debug("appointmentStatusChanged thrown by {} appt# {} status {}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     source.getClass().getName(),
                     LogSafe.sanitize(appointment_no),
                     LogSafe.sanitize(status));

--- a/src/main/java/io/github/carlos_emr/carlos/event/EventService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/event/EventService.java
@@ -52,7 +52,7 @@ public class EventService implements ApplicationEventPublisherAware {
      */
     public void appointmentStatusChanged(Object source, String appointment_no, String provider_no, String status) {
         if (logger.isDebugEnabled()) {
-            logger.debug("appointmentStatusChanged thrown by {} appt# {} status {}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
+            logger.debug("appointmentStatusChanged thrown by {} appt# {} status {}", // NOSONAR javasecurity:S5145 - source class is non-request metadata; appointment_no and status sanitized with LogSafe
                     source.getClass().getName(),
                     LogSafe.sanitize(appointment_no),
                     LogSafe.sanitize(status));

--- a/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FormForwardNamed2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FormForwardNamed2Action.java
@@ -52,14 +52,14 @@ public class FormForwardNamed2Action extends ActionSupport {
         String demographicNo = request.getParameter("demographic_no");
         String internalView = FormViewRoutes.resolveInternalViewFromFormLink(formLink);
         if (internalView == null) {
-            MiscUtils.getLogger().warn(
+            MiscUtils.getLogger().warn( // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     "form/forwardname: blocked invalid form_link parameter: {}",
                     LogSafe.sanitize(formLink));
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid form link");
             return NONE;
         }
         if (demographicNo == null || !demographicNo.matches("\\d+")) {
-            MiscUtils.getLogger().warn(
+            MiscUtils.getLogger().warn( // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     "form/forwardname: blocked invalid demographic_no parameter: {}",
                     LogSafe.sanitize(demographicNo));
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid demographic number");

--- a/src/main/java/io/github/carlos_emr/carlos/login/Login2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/login/Login2Action.java
@@ -333,7 +333,7 @@ public final class Login2Action extends ActionSupport {
     public String execute() throws ServletException, IOException {
 
         if (!"POST".equals(request.getMethod())) {
-            MiscUtils.getLogger().info("Rejected non-POST login request: method={}, remote={}, uri={}",
+            MiscUtils.getLogger().info("Rejected non-POST login request: method={}, remote={}, uri={}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     LogSafe.sanitize(request.getMethod()), LogSafe.sanitize(request.getRemoteAddr()),
                     LogSafe.sanitizeUri(request.getRequestURI()));
             String newURL = loginFailedRedirectUrl(message("login.errorApplicationError"));
@@ -373,7 +373,7 @@ public final class Login2Action extends ActionSupport {
                 && request.getParameter("forcedpasswordchange").equalsIgnoreCase("true")
                 && (this.oldPassword != null || this.newPassword != null || this.confirmPassword != null);
         if (forcedPasswordChangeRequest && !isForcedPasswordResetSubmitPath(request)) {
-            logger.warn("Rejected forced password reset payload on non-reset route: uri={}, remote={}",
+            logger.warn("Rejected forced password reset payload on non-reset route: uri={}, remote={}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     LogSafe.sanitizeUri(request.getRequestURI()), LogSafe.sanitize(ip));
             LogAction.addLog("", LogConst.LOGIN, LogConst.CON_LOGIN,
                     "forced_password_reset_wrong_route", ip);
@@ -421,7 +421,7 @@ public final class Login2Action extends ActionSupport {
             // Validate cached nextPage as defense in depth against open redirects.
             if (!RedirectValidationUtils.isValidRelativeRedirect(nextPage)) {
                 if (nextPage != null) {
-                    logger.warn("Rejected invalid nextPage from credential cache: {}", LogSafe.sanitize(nextPage));
+                    logger.warn("Rejected invalid nextPage from credential cache: {}", LogSafe.sanitize(nextPage)); // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                 }
                 nextPage = null;
             }
@@ -471,7 +471,7 @@ public final class Login2Action extends ActionSupport {
                     auditForcedPasswordResetFailure(userName, "persistence_failure");
                     removeAttributesFromSession(request);
                 } catch (RuntimeException secondary) {
-                    logger.error("Unable to cleanly report forced password reset persistence failure: user={}",
+                    logger.error("Unable to cleanly report forced password reset persistence failure: user={}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                             LogSafe.sanitize(userName), secondary);
                 }
                 response.sendRedirect(loginFailedRedirectUrl(message("login.errorResetPersistence")));
@@ -490,7 +490,7 @@ public final class Login2Action extends ActionSupport {
                 try {
                     auditForcedPasswordResetCompletion(userName, "cleanup_failure_relogin");
                 } catch (RuntimeException auditFailure) {
-                    logger.error("Unable to audit forced password reset cleanup failure: user={}",
+                    logger.error("Unable to audit forced password reset cleanup failure: user={}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                             LogSafe.sanitize(userName), auditFailure);
                 }
                 HttpSession session = request.getSession(false);
@@ -523,10 +523,10 @@ public final class Login2Action extends ActionSupport {
             }
             nextPage = request.getParameter("nextPage");
 
-            logger.debug("nextPage: {}", LogSafe.sanitize(nextPage));
+            logger.debug("nextPage: {}", LogSafe.sanitize(nextPage)); // NOSONAR javasecurity:S5145 - sanitized with LogSafe
             // Empty hidden nextPage fields are absent; facility choices post to /select_facility.
             if (nextPage != null && !nextPage.isEmpty()) {
-                logger.warn("Rejected facility selection on CSRF-exempt login route: user={}, nextPage={}",
+                logger.warn("Rejected facility selection on CSRF-exempt login route: user={}, nextPage={}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                         LogSafe.sanitize(userName), LogSafe.sanitize(nextPage));
                 LogAction.addLog(userName, LogConst.LOGIN, LogConst.CON_LOGIN,
                         "facility_selection_on_login_rejected", ip);
@@ -535,7 +535,7 @@ public final class Login2Action extends ActionSupport {
             }
 
             if (cl.isBlock(ip, userName)) {
-                logger.info("{} Blocked: {}", LOG_PRE, LogSafe.sanitize(userName));
+                logger.info("{} Blocked: {}", LOG_PRE, LogSafe.sanitize(userName)); // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                 String lockedMessage = message("login.errorAccountLocked");
                 String newURL = loginFailedRedirectUrl(lockedMessage);
 
@@ -552,7 +552,7 @@ public final class Login2Action extends ActionSupport {
                 return NONE;
             }
 
-            logger.debug("ip was not blocked: {}", LogSafe.sanitize(ip));
+            logger.debug("ip was not blocked: {}", LogSafe.sanitize(ip)); // NOSONAR javasecurity:S5145 - sanitized with LogSafe
         }
 
         // Credential provider authentication boundary.
@@ -560,7 +560,7 @@ public final class Login2Action extends ActionSupport {
         try {
             strAuth = cl.auth(userName, password, pin, ip);
         } catch (Exception e) {
-            logger.error("Authentication provider failed during login: user={}, remote={}, ajax={}",
+            logger.error("Authentication provider failed during login: user={}, remote={}, ajax={}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     LogSafe.sanitize(userName), LogSafe.sanitize(ip), ajaxResponse, e);
             recordAuthenticationExceptionFailure(cl, ip, userName);
             String unableToProcessMessage = message("login.errorUnableToProcess");
@@ -579,7 +579,7 @@ public final class Login2Action extends ActionSupport {
             return NONE;
         }
         
-        logger.debug("strAuth : {}", LogSafe.sanitize(Arrays.toString(strAuth)));
+        logger.debug("strAuth : {}", LogSafe.sanitize(Arrays.toString(strAuth))); // NOSONAR javasecurity:S5145 - sanitized with LogSafe
         
         // Successful login handling.
         if (strAuth != null && strAuth.length != 1) { // login successfully
@@ -587,7 +587,7 @@ public final class Login2Action extends ActionSupport {
             // is the providers record inactive?
             Provider p = providerDao.getProvider(strAuth[0]);
             if (p == null || (p.getStatus() != null && p.getStatus().equals("0"))) {
-                logger.info("{} Inactive: {}", LOG_PRE, LogSafe.sanitize(userName));
+                logger.info("{} Inactive: {}", LOG_PRE, LogSafe.sanitize(userName)); // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                 LogAction.addLog(strAuth[0], "login", "failed", "inactive");
 
                 String newURL = loginFailedRedirectUrl(message("login.errorAccountInactive"));
@@ -601,7 +601,7 @@ public final class Login2Action extends ActionSupport {
              */
             Security security = getSecurity(userName);
             if (security == null) {
-                logger.error("Authenticated user has no security record: {}", LogSafe.sanitize(userName));
+                logger.error("Authenticated user has no security record: {}", LogSafe.sanitize(userName)); // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                 response.sendRedirect(loginFailedRedirectUrl(message("login.errorSecurityRecordMissing")));
                 return NONE;
             }
@@ -637,7 +637,7 @@ public final class Login2Action extends ActionSupport {
         // Authentication failure handling.
         // expired password
         else if (strAuth != null && strAuth.length == 1 && strAuth[0].equals("expired")) {
-            logger.warn("Expired password: user={}, remote={}",
+            logger.warn("Expired password: user={}, remote={}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     LogSafe.sanitize(userName), LogSafe.sanitize(ip));
             cl.updateLoginList(ip, userName);
             String expiredMessage = message("login.errorAccountExpired");
@@ -708,7 +708,7 @@ public final class Login2Action extends ActionSupport {
             }
         } catch (RuntimeException e) {
             session.invalidate();
-            logger.error("Unable to prepare MFA registration: providerNo={}, securityId={}, remote={}",
+            logger.error("Unable to prepare MFA registration: providerNo={}, securityId={}, remote={}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     LogSafe.sanitize(security.getProviderNo()),
                     LogSafe.sanitize(String.valueOf(security.getSecurityNo())),
                     LogSafe.sanitize(ip),
@@ -748,7 +748,7 @@ public final class Login2Action extends ActionSupport {
                                                boolean ajaxResponse) throws IOException {
         HttpSession session = request.getSession(false);
         if (!hasPendingMfaSession(session)) {
-            logger.info("Rejected MFA verification without valid pending challenge: remote={}",
+            logger.info("Rejected MFA verification without valid pending challenge: remote={}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     LogSafe.sanitize(ip));
             if (session != null) {
                 clearPendingMfaSession(session);
@@ -762,7 +762,7 @@ public final class Login2Action extends ActionSupport {
         PendingMfaChallengeCache.PendingMfaChallenge challenge =
                 PendingMfaChallengeCache.getInstance().peek(challengeToken);
         if (challenge == null) {
-            logger.info("Rejected MFA verification because pending challenge token was missing or expired: providerNo={}, remote={}",
+            logger.info("Rejected MFA verification because pending challenge token was missing or expired: providerNo={}, remote={}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     LogSafe.sanitize(pendingProviderNo), LogSafe.sanitize(ip));
             clearPendingMfaSession(session);
             response.sendRedirect(loginFailedRedirectUrl(message("provider.providerchangepassword.errorSessionExpired")));
@@ -774,7 +774,7 @@ public final class Login2Action extends ActionSupport {
         try {
             security = securityDao.find(challenge.securityNo());
         } catch (RuntimeException e) {
-            logger.error("Unable to load security record for pending MFA challenge: providerNo={}, securityId={}, remote={}",
+            logger.error("Unable to load security record for pending MFA challenge: providerNo={}, securityId={}, remote={}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     LogSafe.sanitize(challenge.providerNo()),
                     LogSafe.sanitize(String.valueOf(challenge.securityNo())),
                     LogSafe.sanitize(ip),
@@ -783,7 +783,7 @@ public final class Login2Action extends ActionSupport {
             return loginFailureResult(message("login.errorUnableToProcess"));
         }
         if (security == null) {
-            logger.error("Rejected MFA verification because pending challenge has no security record: providerNo={}, securityId={}, remote={}",
+            logger.error("Rejected MFA verification because pending challenge has no security record: providerNo={}, securityId={}, remote={}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     LogSafe.sanitize(challenge.providerNo()),
                     LogSafe.sanitize(String.valueOf(challenge.securityNo())),
                     LogSafe.sanitize(ip));
@@ -797,7 +797,7 @@ public final class Login2Action extends ActionSupport {
         if (registrationChallenge) {
             mfaSecret = challenge.registrationSecret();
             if (mfaSecret == null || mfaSecret.isEmpty()) {
-                logger.warn("Rejected MFA registration submit without a staged secret: providerNo={}, securityId={}, remote={}",
+                logger.warn("Rejected MFA registration submit without a staged secret: providerNo={}, securityId={}, remote={}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                         LogSafe.sanitize(security.getProviderNo()),
                         LogSafe.sanitize(String.valueOf(security.getSecurityNo())),
                         LogSafe.sanitize(ip));
@@ -809,7 +809,7 @@ public final class Login2Action extends ActionSupport {
             try {
                 mfaSecret = this.mfaManager.getMfaSecret(security);
             } catch (Exception e) {
-                logger.error("Unable to retrieve MFA secret: providerNo={}, securityId={}, remote={}",
+                logger.error("Unable to retrieve MFA secret: providerNo={}, securityId={}, remote={}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                         LogSafe.sanitize(security.getProviderNo()),
                         LogSafe.sanitize(String.valueOf(security.getSecurityNo())),
                         LogSafe.sanitize(ip),
@@ -823,7 +823,7 @@ public final class Login2Action extends ActionSupport {
         try {
             validCode = isValidTotpCode(mfaSecret, this.code);
         } catch (InvalidKeyException e) {
-            logger.error("Unable to validate MFA code: providerNo={}, securityId={}, remote={}",
+            logger.error("Unable to validate MFA code: providerNo={}, securityId={}, remote={}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     LogSafe.sanitize(security.getProviderNo()),
                     LogSafe.sanitize(String.valueOf(security.getSecurityNo())),
                     LogSafe.sanitize(ip),
@@ -837,7 +837,7 @@ public final class Login2Action extends ActionSupport {
             int failedAttempts = incrementPendingMfaAttempts(session);
             if (failedAttempts >= MAX_PENDING_MFA_ATTEMPTS) {
                 LogAction.addLog(security.getProviderNo(), "login", "mfa_locked", "mfa", ip);
-                logger.warn("MFA challenge exhausted retry limit: providerNo={}, securityId={}, remote={}, attempts={}",
+                logger.warn("MFA challenge exhausted retry limit: providerNo={}, securityId={}, remote={}, attempts={}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                         LogSafe.sanitize(security.getProviderNo()),
                         LogSafe.sanitize(String.valueOf(security.getSecurityNo())),
                         LogSafe.sanitize(ip),
@@ -857,7 +857,7 @@ public final class Login2Action extends ActionSupport {
         PendingMfaChallengeCache.PendingMfaChallenge terminalChallenge =
                 PendingMfaChallengeCache.getInstance().consume(challengeToken);
         if (terminalChallenge == null) {
-            logger.info("Rejected MFA verification because pending challenge token was already consumed: providerNo={}, remote={}",
+            logger.info("Rejected MFA verification because pending challenge token was already consumed: providerNo={}, remote={}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     LogSafe.sanitize(pendingProviderNo), LogSafe.sanitize(ip));
             clearPendingMfaSession(session);
             response.sendRedirect(loginFailedRedirectUrl(message("provider.providerchangepassword.errorSessionExpired")));
@@ -873,7 +873,7 @@ public final class Login2Action extends ActionSupport {
             try {
                 this.mfaManager.saveMfaSecret(buildLoggedInInfoForPendingMfa(session, strAuth, security), security, mfaSecret);
             } catch (Exception e) {
-                logger.error("Unable to persist MFA registration secret: providerNo={}, securityId={}, remote={}",
+                logger.error("Unable to persist MFA registration secret: providerNo={}, securityId={}, remote={}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                         LogSafe.sanitize(security.getProviderNo()),
                         LogSafe.sanitize(String.valueOf(security.getSecurityNo())),
                         LogSafe.sanitize(ip),
@@ -1023,12 +1023,12 @@ public final class Login2Action extends ActionSupport {
                 if (providerNo instanceof String) {
                     caseMgmtUsers.add((String) providerNo);
                 } else {
-                    logger.warn("Ignoring non-String CaseMgmtUsers entry during login session setup: type={}",
+                    logger.warn("Ignoring non-String CaseMgmtUsers entry during login session setup: type={}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                             providerNo == null ? "null" : LogSafe.sanitize(providerNo.getClass().getName()));
                 }
             }
         } else if (caseMgmtUsersAttr != null) {
-            logger.warn("CaseMgmtUsers context attribute is not a List: type={}",
+            logger.warn("CaseMgmtUsers context attribute is not a List: type={}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     LogSafe.sanitize(caseMgmtUsersAttr.getClass().getName()));
         }
         return caseMgmtUsers;
@@ -1064,7 +1064,7 @@ public final class Login2Action extends ActionSupport {
             Long longFreq = Long.valueOf(alertFreq);
             AlertTimer.getInstance(configuredAlerts.split(","), longFreq.longValue());
         } catch (NumberFormatException e) {
-            logger.warn("Skipping BC alert timer setup because ALERT_POLL_FREQUENCY is invalid: value={}",
+            logger.warn("Skipping BC alert timer setup because ALERT_POLL_FREQUENCY is invalid: value={}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     LogSafe.sanitize(alertFreq), e);
         } catch (RuntimeException e) {
             // The alert timer is post-login convenience work; startup defects must be visible but
@@ -1111,7 +1111,7 @@ public final class Login2Action extends ActionSupport {
             this.userSessionManager.registerUserSession(security.getSecurityNo(), session);
         }
 
-        logger.debug("Assigned new session for: {} : {} : {}", LogSafe.sanitize(strAuth[0]), LogSafe.sanitize(strAuth[3]), LogSafe.sanitize(strAuth[4]));
+        logger.debug("Assigned new session for: {} : {} : {}", LogSafe.sanitize(strAuth[0]), LogSafe.sanitize(strAuth[3]), LogSafe.sanitize(strAuth[4])); // NOSONAR javasecurity:S5145 - sanitized with LogSafe
         LogAction.addLog(strAuth[0], LogConst.LOGIN, LogConst.CON_LOGIN, "", ip);
 
         Properties pvar = CarlosProperties.getInstance();
@@ -1196,7 +1196,7 @@ public final class Login2Action extends ActionSupport {
 
         Provider provider = providerManager.getProvider(providerNo);
         if (provider == null) {
-            logger.error("Authenticated login could not load provider record: providerNo={}, remote={}",
+            logger.error("Authenticated login could not load provider record: providerNo={}, remote={}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     LogSafe.sanitize(providerNo), LogSafe.sanitize(ip));
             session.invalidate();
             return loginFailureResult(message("login.errorUnableToProcess"));
@@ -1260,7 +1260,7 @@ public final class Login2Action extends ActionSupport {
             return null;
         }
         if (!isValidOauthTokenId(oauthToken)) {
-            logger.warn("Rejected malformed oauth_token during login completion: providerNo={}, remote={}",
+            logger.warn("Rejected malformed oauth_token during login completion: providerNo={}, remote={}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     LogSafe.sanitize(providerNo), LogSafe.sanitize(ip));
             LogAction.addLog(providerNo, LogConst.LOGIN, LogConst.CON_LOGIN, "invalid_oauth_token", ip);
             return buildPostAuthenticationResponse(provider, ajaxResponse, where);
@@ -1347,7 +1347,7 @@ public final class Login2Action extends ActionSupport {
                 || "off".equals(normalized) || "0".equals(normalized)) {
             return false;
         }
-        logger.warn("Unrecognized mandatory_password_reset value {}; defaulting to enabled",
+        logger.warn("Unrecognized mandatory_password_reset value {}; defaulting to enabled", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                 LogSafe.sanitize(value));
         return true;
     }
@@ -1529,7 +1529,7 @@ public final class Login2Action extends ActionSupport {
         String validatedNextPage = nextPage;
         if (!RedirectValidationUtils.isValidRelativeRedirect(validatedNextPage)) {
             if (validatedNextPage != null) {
-                logger.warn("Rejected invalid nextPage before credential cache: {}",
+                logger.warn("Rejected invalid nextPage before credential cache: {}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                         LogSafe.sanitize(validatedNextPage));
             }
             validatedNextPage = null;
@@ -1681,7 +1681,7 @@ public final class Login2Action extends ActionSupport {
      * @param auditReason stable symbolic rejection reason
      */
     private void auditForcedPasswordResetFailure(String userName, String auditReason) {
-        logger.info("Forced password reset rejected: user={}, reason={}",
+        logger.info("Forced password reset rejected: user={}, reason={}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                 LogSafe.sanitize(userName), auditReason);
         LogAction.addLog(userName, "login", "forced_password_reset_failed", auditReason);
     }
@@ -1693,7 +1693,7 @@ public final class Login2Action extends ActionSupport {
      * @param auditReason stable symbolic completion condition
      */
     private void auditForcedPasswordResetCompletion(String userName, String auditReason) {
-        logger.info("Forced password reset completed with follow-up action: user={}, reason={}",
+        logger.info("Forced password reset completed with follow-up action: user={}, reason={}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                 LogSafe.sanitize(userName), auditReason);
         LogAction.addLog(userName, "login", "forced_password_reset_completed", auditReason);
     }
@@ -1706,7 +1706,7 @@ public final class Login2Action extends ActionSupport {
         try {
             cl.updateLoginList(ip, userName);
         } catch (RuntimeException updateFailure) {
-            logger.warn("Unable to update login-failure counter after authentication exception: user={}, remote={}",
+            logger.warn("Unable to update login-failure counter after authentication exception: user={}, remote={}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     LogSafe.sanitize(userName), LogSafe.sanitize(ip), updateFailure);
         }
     }
@@ -1836,7 +1836,7 @@ public final class Login2Action extends ActionSupport {
         try {
             return Integer.parseInt(value.trim());
         } catch (NumberFormatException e) {
-            logger.warn("Invalid integer property {}={}, using default {}", key, LogSafe.sanitize(value),
+            logger.warn("Invalid integer property {}={}, using default {}", key, LogSafe.sanitize(value), // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     defaultValue);
             return defaultValue;
         }

--- a/src/main/java/io/github/carlos_emr/carlos/signature/action/SaveSignatureUpload2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/signature/action/SaveSignatureUpload2Action.java
@@ -121,7 +121,7 @@ public final class SaveSignatureUpload2Action extends ActionSupport {
         // Reject signatureKey values containing anything other than alphanumeric characters
         // to prevent path traversal (e.g. "../" sequences) from escaping the temp directory.
         if (signatureKey != null && !signatureKey.matches("[a-zA-Z0-9]+")) {
-            MiscUtils.getLogger().warn("Invalid signatureKey rejected: {}", LogSafe.sanitize(signatureKey));
+            MiscUtils.getLogger().warn("Invalid signatureKey rejected: {}", LogSafe.sanitize(signatureKey)); // NOSONAR javasecurity:S5145 - sanitized with LogSafe
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid signature key");
             return NONE;
         }
@@ -140,7 +140,7 @@ public final class SaveSignatureUpload2Action extends ActionSupport {
             File tmpDir = new File(System.getProperty("java.io.tmpdir"));
             safeTarget = PathValidationUtils.validateExistingPath(new File(filename), tmpDir);
         } catch (SecurityException e) {
-            MiscUtils.getLogger().warn("Path traversal attempt blocked for signatureKey: {}", LogSafe.sanitize(signatureKey));
+            MiscUtils.getLogger().warn("Path traversal attempt blocked for signatureKey: {}", LogSafe.sanitize(signatureKey)); // NOSONAR javasecurity:S5145 - sanitized with LogSafe
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid signature key");
             return NONE;
         }
@@ -165,7 +165,7 @@ public final class SaveSignatureUpload2Action extends ActionSupport {
             try {
                 imageData = new Base64().decode(encoded.getBytes(StandardCharsets.US_ASCII));
             } catch (IllegalArgumentException e) {
-                MiscUtils.getLogger().warn("Invalid Base64 signatureImage for key {}", LogSafe.sanitize(signatureKey));
+                MiscUtils.getLogger().warn("Invalid Base64 signatureImage for key {}", LogSafe.sanitize(signatureKey)); // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                 response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid image data");
                 return NONE;
             }
@@ -176,15 +176,15 @@ public final class SaveSignatureUpload2Action extends ActionSupport {
             // Belt-and-suspenders: Base64 decoders that strip non-alphabet chars
             // can still produce more than MAX_UPLOAD_BYTES on pathological input.
             if (imageData.length > MAX_UPLOAD_BYTES) {
-                MiscUtils.getLogger().warn("IPAD signature decoded to {} bytes; rejecting", imageData.length);
+                MiscUtils.getLogger().warn("IPAD signature decoded to {} bytes; rejecting", imageData.length); // NOSONAR javasecurity:S5145 - logs numeric/non-request metadata only
                 response.sendError(HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE, "Upload too large");
                 return NONE;
             }
             try (FileOutputStream fos = new FileOutputStream(safeTarget)) {
                 fos.write(imageData);
-                MiscUtils.getLogger().debug("Signature uploaded: {}, size={}", LogSafe.sanitize(filename), imageData.length);
+                MiscUtils.getLogger().debug("Signature uploaded: {}, size={}", LogSafe.sanitize(filename), imageData.length); // NOSONAR javasecurity:S5145 - sanitized with LogSafe
             } catch (IOException e) {
-                MiscUtils.getLogger().error("Error uploading signature from IPAD: {}", LogSafe.sanitize(filename), e);
+                MiscUtils.getLogger().error("Error uploading signature from IPAD: {}", LogSafe.sanitize(filename), e); // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                 deleteQuietly(safeTarget);
                 response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Upload failed");
                 return NONE;
@@ -206,9 +206,9 @@ public final class SaveSignatureUpload2Action extends ActionSupport {
                     fos.write(buffer, 0, bytesRead);
                 }
                 writeOk = true;
-                MiscUtils.getLogger().debug("Signature uploaded: {}, size={}", LogSafe.sanitize(filename), counter);
+                MiscUtils.getLogger().debug("Signature uploaded: {}, size={}", LogSafe.sanitize(filename), counter); // NOSONAR javasecurity:S5145 - sanitized with LogSafe
             } catch (IOException e) {
-                MiscUtils.getLogger().error("Error uploading signature: {}", LogSafe.sanitize(filename), e);
+                MiscUtils.getLogger().error("Error uploading signature: {}", LogSafe.sanitize(filename), e); // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                 response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Upload failed");
                 return NONE;
             } finally {
@@ -217,7 +217,7 @@ public final class SaveSignatureUpload2Action extends ActionSupport {
                 }
             }
         } else {
-            MiscUtils.getLogger().warn("Unknown signature upload source: {}", LogSafe.sanitize(uploadSource));
+            MiscUtils.getLogger().warn("Unknown signature upload source: {}", LogSafe.sanitize(uploadSource)); // NOSONAR javasecurity:S5145 - sanitized with LogSafe
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Unknown source");
             return NONE;
         }
@@ -228,7 +228,7 @@ public final class SaveSignatureUpload2Action extends ActionSupport {
                 try {
                     demographicNo = Integer.parseInt(demographic);
                 } catch (NumberFormatException e) {
-                    MiscUtils.getLogger().warn("Invalid demographicNo: {}", LogSafe.sanitize(demographic));
+                    MiscUtils.getLogger().warn("Invalid demographicNo: {}", LogSafe.sanitize(demographic)); // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                     response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid demographicNo");
                     return NONE;
                 }
@@ -245,7 +245,7 @@ public final class SaveSignatureUpload2Action extends ActionSupport {
                 // Manager documents null-return on expected failures; any propagated
                 // RuntimeException is an unexpected failure mode (e.g. encryption,
                 // DB connectivity). Delete the orphan temp file before surfacing 500.
-                MiscUtils.getLogger().error("Digital signature persist failed for key {}",
+                MiscUtils.getLogger().error("Digital signature persist failed for key {}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                         LogSafe.sanitize(signatureKey), e);
                 deleteQuietly(safeTarget);
                 response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Save failed");
@@ -257,7 +257,7 @@ public final class SaveSignatureUpload2Action extends ActionSupport {
                 // exception. The file upload succeeded but persistence did not —
                 // surface 500 rather than returning an empty signatureId that the
                 // caller has no way to distinguish from a successful save.
-                MiscUtils.getLogger().warn("Digital signature persist returned null for key {}",
+                MiscUtils.getLogger().warn("Digital signature persist returned null for key {}", // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                         LogSafe.sanitize(signatureKey));
                 deleteQuietly(safeTarget);
                 response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Save failed");
@@ -285,7 +285,7 @@ public final class SaveSignatureUpload2Action extends ActionSupport {
         try {
             Files.deleteIfExists(f.toPath());
         } catch (IOException ignored) {
-            MiscUtils.getLogger().warn("Failed to clean up partial upload: {}", LogSafe.sanitize(f.getName()));
+            MiscUtils.getLogger().warn("Failed to clean up partial upload: {}", LogSafe.sanitize(f.getName())); // NOSONAR javasecurity:S5145 - sanitized with LogSafe
         }
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/util/zip.java
+++ b/src/main/java/io/github/carlos_emr/carlos/util/zip.java
@@ -148,7 +148,7 @@ public class zip {
                     try {
                         z = PathValidationUtils.validateZipEntryPath(new ZipEntry(zName), targetDir);
                     } catch (SecurityException e) {
-                        logger.error("Skipping potentially malicious zip entry: {}", LogSafe.sanitize(zName));
+                        logger.error("Skipping potentially malicious zip entry: {}", LogSafe.sanitize(zName)); // NOSONAR javasecurity:S5145 - sanitized with LogSafe
                         continue;
                     }
 
@@ -179,10 +179,10 @@ public class zip {
             if (!dir.exists()) dir.mkdirs();
             boolean success = afile.renameTo(PathValidationUtils.validateGeneratedChildPath(afile.getName(), dir));
             if (!success) {
-                logger.error("io.github.carlos_emr.carlos.util.zip.unzipXML: the zip file {} was not archived", LogSafe.sanitize(fullpath));
+                logger.error("io.github.carlos_emr.carlos.util.zip.unzipXML: the zip file {} was not archived", LogSafe.sanitize(fullpath)); // NOSONAR javasecurity:S5145 - sanitized with LogSafe
             }
         } catch (Exception e) {
-            logger.error("io.github.carlos_emr.carlos.util.zip.unzipXML: failed to archive the zip file {}", LogSafe.sanitize(fullpath), e);
+            logger.error("io.github.carlos_emr.carlos.util.zip.unzipXML: failed to archive the zip file {}", LogSafe.sanitize(fullpath), e); // NOSONAR javasecurity:S5145 - sanitized with LogSafe
         }
         result = true;
         return result;

--- a/src/main/webapp/WEB-INF/jsp/decision/annualreview/checklistedit.jsp
+++ b/src/main/webapp/WEB-INF/jsp/decision/annualreview/checklistedit.jsp
@@ -88,7 +88,7 @@
             <th width="25%" nowrap>
                 <div align="right"><input type='submit' name='submit'
                                           value=' Save '> <input type="button" name="Button"
-                                                                 value="&nbsp;<%=request.getParameter("submit")!=null?" Exit ":"Cancel"%>&nbsp;"
+                                                                 value="&nbsp;<%=request.getParameter("submit")!=null?" Exit ":"Cancel"%>&nbsp;"<%-- nosemgrep: java.jsp.jsp-scriptlet-xss.jsp-scriptlet-xss --%>
                                                                  onClick="onExit();">&nbsp;
                 </div>
             </th>

--- a/src/main/webapp/WEB-INF/jsp/decision/annualreview/riskedit.jsp
+++ b/src/main/webapp/WEB-INF/jsp/decision/annualreview/riskedit.jsp
@@ -86,7 +86,7 @@
             <th width="25%" nowrap>
                 <div align="right"><input type='submit' name='submit'
                                           value=' Save '> <input type="button" name="Button"
-                                                                 value="&nbsp;<%=request.getParameter("submit")!=null?" Exit ":"Cancel"%>&nbsp;"
+                                                                 value="&nbsp;<%=request.getParameter("submit")!=null?" Exit ":"Cancel"%>&nbsp;"<%-- nosemgrep: java.jsp.jsp-scriptlet-xss.jsp-scriptlet-xss --%>
                                                                  onClick="onExit();">&nbsp;
                 </div>
             </th>

--- a/src/main/webapp/WEB-INF/jsp/decision/antenatal/obarchecklistedit_99_12.jsp
+++ b/src/main/webapp/WEB-INF/jsp/decision/antenatal/obarchecklistedit_99_12.jsp
@@ -113,7 +113,7 @@
                                                                            name='submit' value=' Save '> <input
                         type="button"
                         name="Button"
-                        value="&nbsp;<%=request.getParameter("submit")!=null?" Exit ":"Cancel"%>&nbsp;"
+                        value="&nbsp;<%=request.getParameter("submit")!=null?" Exit ":"Cancel"%>&nbsp;"<%-- nosemgrep: java.jsp.jsp-scriptlet-xss.jsp-scriptlet-xss --%>
                         onClick="onExit();">&nbsp;
                 </div>
             </th>

--- a/src/main/webapp/WEB-INF/jsp/decision/antenatal/obarriskedit_99_12.jsp
+++ b/src/main/webapp/WEB-INF/jsp/decision/antenatal/obarriskedit_99_12.jsp
@@ -85,7 +85,7 @@
                                                                            name='submit' value=' Save '> <input
                         type="button"
                         name="Button"
-                        value="&nbsp;<%=request.getParameter("submit")!=null?" Exit ":"Cancel"%>&nbsp;"
+                        value="&nbsp;<%=request.getParameter("submit")!=null?" Exit ":"Cancel"%>&nbsp;"<%-- nosemgrep: java.jsp.jsp-scriptlet-xss.jsp-scriptlet-xss --%>
                         onClick="onExit();">&nbsp;
                 </div>
             </th>

--- a/src/main/webapp/WEB-INF/jsp/demographic/demographicprintdemographic.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/demographicprintdemographic.jsp
@@ -75,7 +75,6 @@
     <div ID="blockDiv1"
          STYLE="position:absolute; visibility:visible; z-index:2; left:<%=left%>px; top:<%=top+i*(height+gap/2)%>px; width:400px; height:100px;">
         <table width="100%" border="0" cellspacing="0" cellpadding="0">
-                <%--    <tr><td><e:forHtmlContent value='<%= StringUtils.noNull(request.getParameter("label1")) %>' /></td></tr>--%>
             <tr>
                 <td><font face="Courier New, Courier, mono" size="2"><b><carlos:encode value='<%= StringUtils.noNull(request.getParameter("last_name")) %>' context="html"/>
                     ,&nbsp;<carlos:encode value='<%= StringUtils.noNull(request.getParameter("first_name")) %>' context="html"/>
@@ -100,7 +99,6 @@
     <div ID="blockDiv1"
          STYLE="position:absolute; visibility:visible; z-index:2; left:<%=left%>px; top:<%=top+b1*(height+gap)+i*(height+gap/2)%>px; width:400px; height:100px;">
         <table width="100%" border="0" cellspacing="0" cellpadding="0">
-                <%--<tr><td><e:forHtmlContent value='<%= StringUtils.noNull(request.getParameter("label2")) %>' /></td></tr>--%>
             <tr>
                 <td><font face="Courier New, Courier, mono" size="2"><b><carlos:encode value='<%= StringUtils.noNull(request.getParameter("last_name")) %>' context="html"/>
                     ,&nbsp;<carlos:encode value='<%= StringUtils.noNull(request.getParameter("first_name")) %>' context="html"/>&nbsp;<carlos:encode value='<%= StringUtils.noNull(request.getParameter("chart_no")) %>' context="html"/>
@@ -123,7 +121,6 @@
     <div ID="blockDiv1"
          STYLE="position:absolute; visibility:visible; z-index:2; left:<%=left%>px; top:<%=top+(b1+b2)*(height+gap)+i*(height+gap/2)%>px; width:400px; height:100px;">
         <table width="100%" border="0" cellspacing="0" cellpadding="0">
-                <%--  <tr><td><e:forHtmlContent value='<%= StringUtils.noNull(request.getParameter("label3")) %>' /></td></tr>--%>
             <tr>
                 <td><font face="Courier New, Courier, mono" size="2"><carlos:encode value='<%= StringUtils.noNull(request.getParameter("last_name")) %>' context="html"/>
                     ,&nbsp;<carlos:encode value='<%= StringUtils.noNull(request.getParameter("first_name")) %>' context="html"/><br><carlos:encode value='<%= StringUtils.noNull(request.getParameter("address")) %>' context="html"/>
@@ -141,7 +138,6 @@
     <div ID="blockDiv1"
          STYLE="position:absolute; visibility:visible; z-index:2; left:<%=left%>px; top:<%=top+(b1+b2+b3)*(height+gap)+i*(height+gap/2)%>px; width:400px; height:100px;">
         <table width="100%" border="0" cellspacing="0" cellpadding="0">
-                <%--  <tr><td><e:forHtmlContent value='<%= StringUtils.noNull(request.getParameter("label4")) %>' /></td></tr>--%>
             <tr>
                 <td><font face="Courier New, Courier, mono"
                           size="2"><carlos:encode value='<%= StringUtils.noNull(request.getParameter("first_name")) %>' context="html"/>&nbsp;<carlos:encode value='<%= StringUtils.noNull(request.getParameter("last_name")) %>' context="html"/>
@@ -158,7 +154,6 @@
     <div ID="blockDiv1"
          STYLE="position:absolute; visibility:visible; z-index:2; left:<%=left%>px; top:<%=top+(b1+b2+b3+b4)*(height+gap)+i*(height+gap/2)%>px; width:400px; height:100px;">
         <table width="100%" border="0" cellspacing="0" cellpadding="0">
-                <%--  <tr><td><e:forHtmlContent value='<%= StringUtils.noNull(request.getParameter("label5")) %>' /></td></tr>--%>
             <tr>
                 <td><font face="Courier New, Courier, mono"
                           size="2"><carlos:encode value='<%= StringUtils.noNull(request.getParameter("chart_no")) %>' context="html"/>&nbsp;&nbsp;<carlos:encode value='<%= StringUtils.noNull(request.getParameter("last_name")) %>' context="html"/>

--- a/src/main/webapp/WEB-INF/jsp/demographic/demographicsearch2apptresults.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/demographicsearch2apptresults.jsp
@@ -229,25 +229,25 @@
             <%--    <ul style="display: flex;">--%>
             <%--        <li>--%>
             <select class="wideInput form-select" name="search_mode">
-                <option value="search_name" <%=request.getParameter("search_mode").equals("search_name") ? "selected" : ""%>>
+                <option value="search_name" <%=request.getParameter("search_mode").equals("search_name") ? "selected" : ""%>><%-- nosemgrep: java.jsp.jsp-scriptlet-xss.jsp-scriptlet-xss --%>
                     <fmt:message key="demographic.demographicsearch2apptresults.optName"/>
                 </option>
-                <option value="search_phone" <%=request.getParameter("search_mode").equals("search_phone") ? "selected" : ""%>>
+                <option value="search_phone" <%=request.getParameter("search_mode").equals("search_phone") ? "selected" : ""%>><%-- nosemgrep: java.jsp.jsp-scriptlet-xss.jsp-scriptlet-xss --%>
                     <fmt:message key="demographic.demographicsearch2apptresults.optPhone"/>
                 </option>
-                <option value="search_dob" <%=request.getParameter("search_mode").equals("search_dob") ? "selected" : ""%>>
+                <option value="search_dob" <%=request.getParameter("search_mode").equals("search_dob") ? "selected" : ""%>><%-- nosemgrep: java.jsp.jsp-scriptlet-xss.jsp-scriptlet-xss --%>
                     <fmt:message key="demographic.demographicsearch2apptresults.optDOB"/>
                 </option>
-                <option value="search_address" <%=request.getParameter("search_mode").equals("search_address") ? "selected" : ""%>>
+                <option value="search_address" <%=request.getParameter("search_mode").equals("search_address") ? "selected" : ""%>><%-- nosemgrep: java.jsp.jsp-scriptlet-xss.jsp-scriptlet-xss --%>
                     <fmt:message key="demographic.demographicsearch2apptresults.optAddress"/>
                 </option>
-                <option value="search_hin" <%=request.getParameter("search_mode").equals("search_hin") ? "selected" : ""%>>
+                <option value="search_hin" <%=request.getParameter("search_mode").equals("search_hin") ? "selected" : ""%>><%-- nosemgrep: java.jsp.jsp-scriptlet-xss.jsp-scriptlet-xss --%>
                     <fmt:message key="demographic.demographicsearch2apptresults.optHIN"/>
                 </option>
-                <option value="search_chart_no" <%=request.getParameter("search_mode").equals("search_chart_no") ? "selected" : ""%>>
+                <option value="search_chart_no" <%=request.getParameter("search_mode").equals("search_chart_no") ? "selected" : ""%>><%-- nosemgrep: java.jsp.jsp-scriptlet-xss.jsp-scriptlet-xss --%>
                     <fmt:message key="demographic.demographicsearch2apptresults.optChart"/>
                 </option>
-                <option value="search_demographic_no" <%=request.getParameter("search_mode").equals("search_demographic_no") ? "selected" : ""%>>
+                <option value="search_demographic_no" <%=request.getParameter("search_mode").equals("search_demographic_no") ? "selected" : ""%>><%-- nosemgrep: java.jsp.jsp-scriptlet-xss.jsp-scriptlet-xss --%>
                     <fmt:message key="demographic.demographicsearch2apptresults.demographicId"/>
                 </option>
             </select>

--- a/src/main/webapp/WEB-INF/jsp/demographic/demographicsearch2apptresults.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/demographicsearch2apptresults.jsp
@@ -229,25 +229,25 @@
             <%--    <ul style="display: flex;">--%>
             <%--        <li>--%>
             <select class="wideInput form-select" name="search_mode">
-                <option value="search_name" <%=request.getParameter("search_mode").equals("search_name") ? "selected" : ""%>><%-- nosemgrep: java.jsp.jsp-scriptlet-xss.jsp-scriptlet-xss --%>
+                <option value="search_name" <%="search_name".equals(request.getParameter("search_mode")) ? "selected" : ""%>><%-- nosemgrep: java.jsp.jsp-scriptlet-xss.jsp-scriptlet-xss --%>
                     <fmt:message key="demographic.demographicsearch2apptresults.optName"/>
                 </option>
-                <option value="search_phone" <%=request.getParameter("search_mode").equals("search_phone") ? "selected" : ""%>><%-- nosemgrep: java.jsp.jsp-scriptlet-xss.jsp-scriptlet-xss --%>
+                <option value="search_phone" <%="search_phone".equals(request.getParameter("search_mode")) ? "selected" : ""%>><%-- nosemgrep: java.jsp.jsp-scriptlet-xss.jsp-scriptlet-xss --%>
                     <fmt:message key="demographic.demographicsearch2apptresults.optPhone"/>
                 </option>
-                <option value="search_dob" <%=request.getParameter("search_mode").equals("search_dob") ? "selected" : ""%>><%-- nosemgrep: java.jsp.jsp-scriptlet-xss.jsp-scriptlet-xss --%>
+                <option value="search_dob" <%="search_dob".equals(request.getParameter("search_mode")) ? "selected" : ""%>><%-- nosemgrep: java.jsp.jsp-scriptlet-xss.jsp-scriptlet-xss --%>
                     <fmt:message key="demographic.demographicsearch2apptresults.optDOB"/>
                 </option>
-                <option value="search_address" <%=request.getParameter("search_mode").equals("search_address") ? "selected" : ""%>><%-- nosemgrep: java.jsp.jsp-scriptlet-xss.jsp-scriptlet-xss --%>
+                <option value="search_address" <%="search_address".equals(request.getParameter("search_mode")) ? "selected" : ""%>><%-- nosemgrep: java.jsp.jsp-scriptlet-xss.jsp-scriptlet-xss --%>
                     <fmt:message key="demographic.demographicsearch2apptresults.optAddress"/>
                 </option>
-                <option value="search_hin" <%=request.getParameter("search_mode").equals("search_hin") ? "selected" : ""%>><%-- nosemgrep: java.jsp.jsp-scriptlet-xss.jsp-scriptlet-xss --%>
+                <option value="search_hin" <%="search_hin".equals(request.getParameter("search_mode")) ? "selected" : ""%>><%-- nosemgrep: java.jsp.jsp-scriptlet-xss.jsp-scriptlet-xss --%>
                     <fmt:message key="demographic.demographicsearch2apptresults.optHIN"/>
                 </option>
-                <option value="search_chart_no" <%=request.getParameter("search_mode").equals("search_chart_no") ? "selected" : ""%>><%-- nosemgrep: java.jsp.jsp-scriptlet-xss.jsp-scriptlet-xss --%>
+                <option value="search_chart_no" <%="search_chart_no".equals(request.getParameter("search_mode")) ? "selected" : ""%>><%-- nosemgrep: java.jsp.jsp-scriptlet-xss.jsp-scriptlet-xss --%>
                     <fmt:message key="demographic.demographicsearch2apptresults.optChart"/>
                 </option>
-                <option value="search_demographic_no" <%=request.getParameter("search_mode").equals("search_demographic_no") ? "selected" : ""%>><%-- nosemgrep: java.jsp.jsp-scriptlet-xss.jsp-scriptlet-xss --%>
+                <option value="search_demographic_no" <%="search_demographic_no".equals(request.getParameter("search_mode")) ? "selected" : ""%>><%-- nosemgrep: java.jsp.jsp-scriptlet-xss.jsp-scriptlet-xss --%>
                     <fmt:message key="demographic.demographicsearch2apptresults.demographicId"/>
                 </option>
             </select>

--- a/src/main/webapp/WEB-INF/jsp/lab/CA/ALL/labDisplay.jsp
+++ b/src/main/webapp/WEB-INF/jsp/lab/CA/ALL/labDisplay.jsp
@@ -880,7 +880,7 @@ input[id^='acklabel_']{
         }
     });
 
-    var _in_window = <%= request.getParameter("inWindow") == null || "true".equals(request.getParameter("inWindow")) %>;
+    var _in_window = <%= request.getParameter("inWindow") == null || "true".equals(request.getParameter("inWindow")) %><%-- nosemgrep: java.jsp.jsp-scriptlet-xss.jsp-scriptlet-xss --%>;
     var contextpath = "<%=request.getContextPath()%>";
 
 </script>

--- a/src/main/webapp/WEB-INF/jsp/provider/obarchecklistedit_99_12.jsp
+++ b/src/main/webapp/WEB-INF/jsp/provider/obarchecklistedit_99_12.jsp
@@ -82,7 +82,7 @@
                                       onClick="popupPage(450,900,'ar1risk_99_12.htm')"><font
                         color="#FFFF66"><%= bundle.getString("provider.obarchecklist.viewRiskNumber") %></font></a> <input type="button"
                                                                            name="Button"
-                                                                           value="&nbsp;<%=request.getParameter("submit")!=null?bundle.getString("provider.obarchecklist.exit"):bundle.getString("provider.obarchecklist.cancel")%>&nbsp;"
+                                                                           value="&nbsp;<%=request.getParameter("submit")!=null?bundle.getString("provider.obarchecklist.exit"):bundle.getString("provider.obarchecklist.cancel")%>&nbsp;"<%-- nosemgrep: java.jsp.jsp-scriptlet-xss.jsp-scriptlet-xss --%>
                                                                            onClick="onExit();">&nbsp;
                 </div>
             </th>

--- a/src/main/webapp/WEB-INF/jsp/provider/obarriskedit_99_12.jsp
+++ b/src/main/webapp/WEB-INF/jsp/provider/obarriskedit_99_12.jsp
@@ -81,7 +81,7 @@
                                       onClick="popupPage(450,900,'ar1risk_99_12.htm')"><font
                         color="#FFFF66"><%= bundle.getString("provider.obarrisk.viewRiskNumber") %></font></a> <input type="button"
                                                                            name="Button"
-                                                                           value="&nbsp;<%=request.getParameter("submit")!=null?bundle.getString("provider.obarrisk.exit"):bundle.getString("provider.obarrisk.cancel")%>&nbsp;"
+                                                                           value="&nbsp;<%=request.getParameter("submit")!=null?bundle.getString("provider.obarrisk.exit"):bundle.getString("provider.obarrisk.cancel")%>&nbsp;"<%-- nosemgrep: java.jsp.jsp-scriptlet-xss.jsp-scriptlet-xss --%>
                                                                            onClick="onExit();">&nbsp;
                 </div>
             </th>

--- a/src/main/webapp/WEB-INF/jsp/provider/obarriskedit_99_12.jsp
+++ b/src/main/webapp/WEB-INF/jsp/provider/obarriskedit_99_12.jsp
@@ -81,7 +81,7 @@
                                       onClick="popupPage(450,900,'ar1risk_99_12.htm')"><font
                         color="#FFFF66"><%= bundle.getString("provider.obarrisk.viewRiskNumber") %></font></a> <input type="button"
                                                                            name="Button"
-                                                                           value="&nbsp;<%=request.getParameter("submit")!=null?bundle.getString("provider.obarrisk.exit"):bundle.getString("provider.obarrisk.cancel")%>&nbsp;"<%-- nosemgrep: java.jsp.jsp-scriptlet-xss.jsp-scriptlet-xss --%>
+                                                                           value="&nbsp;<%=SafeEncode.forHtmlAttribute(request.getParameter("submit")!=null?bundle.getString("provider.obarrisk.exit"):bundle.getString("provider.obarrisk.cancel"))%>&nbsp;"
                                                                            onClick="onExit();">&nbsp;
                 </div>
             </th>

--- a/src/main/webapp/WEB-INF/jsp/schedule/scheduletemplateapplying.jsp
+++ b/src/main/webapp/WEB-INF/jsp/schedule/scheduletemplateapplying.jsp
@@ -682,7 +682,7 @@
                                         for (RSchedule rs : rss) {
                                     %>
                                     <option value="<%=ConversionUtils.toDateString(rs.getsDate())%>"
-                                            <%=request.getParameter("sdate") != null ? (ConversionUtils.toDateString(rs.getsDate()).equals(request.getParameter("sdate")) ? "selected" : "") : (ConversionUtils.toDateString(rs.getsDate()).equals(scheduleRscheduleBean.sdate) ? "selected" : "")%>>
+                                            <%=request.getParameter("sdate") != null ? (ConversionUtils.toDateString(rs.getsDate()).equals(request.getParameter("sdate")) ? "selected" : "") : (ConversionUtils.toDateString(rs.getsDate()).equals(scheduleRscheduleBean.sdate) ? "selected" : "")%><%-- nosemgrep: java.jsp.jsp-scriptlet-xss.jsp-scriptlet-xss --%>>
                                         <%=ConversionUtils.toDateString(rs.getsDate()) + " ~ " + ConversionUtils.toDateString(rs.geteDate())%>
                                     </option>
                                     <%


### PR DESCRIPTION
## Summary

- Suppress or model the issue #2724 confirmed false-positive security alerts with method-scoped SpotBugs filters, line-level Sonar comments, and targeted JSP Semgrep suppressions/rule refinements.
- Reconcile issue #2724's confirmed false-positive count from 156 to 162.
- Leave the report's keep-out/mixed findings visible, including JSON content-type `XSS_SERVLET`, XML builder leftovers, OAuth servlet parsing, and random temp filename cases.

## Why

The independent validation comment on issue #2724 confirmed the tracked false-positive set and identified the 156 count as an arithmetic error. These changes reduce GitHub Security noise without refactoring production code solely to satisfy scanners.

## Validation

- `git diff --check`
- `python3 -m xml.etree.ElementTree .github/spotbugs/spotbugs-exclude.xml`
- `semgrep --config .semgrep/ --validate`
- targeted CARLOS Semgrep scan on the validated JSP files: 0 findings
- bounded `mvn -q -DskipTests -Pspotbugs,skip-dependency-lock spotbugs:spotbugs` wrote `target/spotbugs-result.xml`; Maven hit the 10-minute timeout afterward, but parsed report confirmed the validated groups were cleared while keep-out/mixed groups remained visible

Fixes #2724

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppresses the confirmed false‑positive security alerts from issue #2724 using method‑scoped `SpotBugs` filters, targeted Sonar suppressions, and safer JSP `Semgrep` rules. Adds review follow‑ups: stricter sanitized logging and small JSP rule tweaks without hiding real findings.

- **Bug Fixes**
  - Added method‑scoped `SpotBugs` excludes for the validated false‑positive set.
  - Expanded S5145 handling: marked sanitized logs with `// NOSONAR` and sanitized wrapper messages via `LogSafe` (including `BillingInvoice2Action.failPdfResponse`).
  - JSP scanning hardening: refined the custom `Semgrep` rule to allow whitespace in the "selected" ternary; added targeted `nosemgrep` on known‑safe scriptlets; replaced one attribute with `SafeEncode.forHtmlAttribute(...)`.
  - Reconciled the confirmed false‑positive count to 162; left mixed/needs‑action items visible (JSON content‑type XSS, XML builder leftovers, OAuth parsing, random temp filenames).

<sup>Written for commit 9898347fc501832833ea4ba0785dc9cee958f1ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

