### PR TITLE
fix(maintenance): remove stale Encode imports and migrate to SafeEncode

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/eform/actions/RtlPreventions2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/eform/actions/RtlPreventions2Action.java
@@ -35,8 +35,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.struts2.ActionSupport;
 import org.apache.struts2.ServletActionContext;
-import org.owasp.encoder.Encode;
 
+import io.github.carlos_emr.carlos.utility.SafeEncode;
 import io.github.carlos_emr.carlos.commn.model.Prevention;
 import io.github.carlos_emr.carlos.managers.PreventionManager;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
@@ -100,7 +100,7 @@ public class RtlPreventions2Action extends ActionSupport {
         // Mandatory security check — same _eform privilege used by all eForm endpoints
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
         if (!securityInfoManager.hasPrivilege(loggedInInfo, "_eform", "r", null)) {
-            throw new SecurityException("missing required security object _eform");
+            throw new SecurityException("missing required sec object (_eform)");
         }
 
         // Validate demographic_no: must be digits only. The regex check prevents
@@ -139,8 +139,8 @@ public class RtlPreventions2Action extends ActionSupport {
                         ? DATE_FORMAT.format(p.getPreventionDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate())
                         : "";
                     // OWASP-encode both values before inserting into HTML
-                    html.append("<tr><td>").append(Encode.forHtml(type))
-                        .append("</td><td>").append(Encode.forHtml(date))
+                    html.append("<tr><td>").append(SafeEncode.forHtml(type))
+                        .append("</td><td>").append(SafeEncode.forHtml(date))
                         .append("</td></tr>");
                 }
                 html.append("</table>");

--- a/src/main/java/io/github/carlos_emr/carlos/eform/actions/RtlPreventions2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/eform/actions/RtlPreventions2Action.java
@@ -100,7 +100,7 @@ public class RtlPreventions2Action extends ActionSupport {
         // Mandatory security check — same _eform privilege used by all eForm endpoints
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
         if (!securityInfoManager.hasPrivilege(loggedInInfo, "_eform", "r", null)) {
-            throw new SecurityException("missing required sec object (_eform)");
+            throw new SecurityException("missing required sec object");
         }
 
         // Validate demographic_no: must be digits only. The regex check prevents

--- a/src/main/webapp/WEB-INF/jsp/prevention/AddPreventionData.jsp
+++ b/src/main/webapp/WEB-INF/jsp/prevention/AddPreventionData.jsp
@@ -87,7 +87,6 @@
 <%@ page import="io.github.carlos_emr.carlos.prevention.PreventionDisplayConfig" %>
 <%@ page import="io.github.carlos_emr.carlos.util.UtilDateUtilities" %>
 <%@ page import="io.github.carlos_emr.carlos.commn.model.*" %>
-<%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="io.github.carlos_emr.carlos.utility.SafeEncode" %>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>

--- a/src/main/webapp/WEB-INF/jsp/prevention/PreventionReporting.jsp
+++ b/src/main/webapp/WEB-INF/jsp/prevention/PreventionReporting.jsp
@@ -33,7 +33,7 @@
 <%@page import="io.github.carlos_emr.carlos.demographic.data.*,java.util.*, java.text.SimpleDateFormat,io.github.carlos_emr.carlos.prevention.*,io.github.carlos_emr.carlos.providers.data.*,io.github.carlos_emr.carlos.util.*,io.github.carlos_emr.carlos.report.data.*,io.github.carlos_emr.carlos.prevention.pageUtil.*,java.net.*,io.github.carlos_emr.carlos.eform.*" %>
 <%@page import="io.github.carlos_emr.CarlosProperties"%>
 <%@page import="io.github.carlos_emr.carlos.utility.SpringUtils"%>
-<%@ page import="org.owasp.encoder.Encode" %>
+
 <%@ page import="io.github.carlos_emr.carlos.demographic.data.DemographicNameAgeString" %>
 <%@ page import="io.github.carlos_emr.carlos.demographic.data.DemographicData" %>
 <%@ page import="io.github.carlos_emr.carlos.prevention.pageUtil.PreventionReportDisplay" %>

--- a/src/main/webapp/WEB-INF/jsp/prevention/index.jsp
+++ b/src/main/webapp/WEB-INF/jsp/prevention/index.jsp
@@ -69,7 +69,7 @@
 <%@ page import="io.github.carlos_emr.carlos.utility.MiscUtils" %>
 <%@ page import="io.github.carlos_emr.carlos.utility.SpringUtils" %>
 <%@ page import="io.github.carlos_emr.carlos.utility.WebUtils" %>
-<%@page import="org.owasp.encoder.Encode" %>
+
 <%@page import="io.github.carlos_emr.carlos.commn.model.UserProperty" %>
 <%@page import="io.github.carlos_emr.carlos.commn.dao.UserPropertyDAO" %>
 <%@page import="io.github.carlos_emr.carlos.commn.model.CVCMapping" %>


### PR DESCRIPTION
- Remove legacy org.owasp.encoder.Encoder imports from 3 prevention JSPs
- Replace Encode.forHtml() with SafeEncode.forHtml() in RtlPreventions2Action
- Fix SecurityException message format per CLAUDE.md

<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description

<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues

<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?

<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->

## Checklist

- [ ] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [ ] I have not included any patient data (PHI) in this PR
- [ ] I have added tests for new functionality, or this change doesn't need new tests
- [ ] I have read the [contributing guide](CONTRIBUTING.md)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated HTML encoding to `SafeEncode` and removed stale `org.owasp.encoder.Encode` imports from three prevention JSPs. In `RtlPreventions2Action`, replaced `Encode.forHtml()` with `SafeEncode.forHtml()` and standardized the SecurityException message to "missing required sec object".

<sup>Written for commit cf68b548458b511b161a0d4d73ed2d1390d3e399. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

