### PR TITLE
docs: add missing javadoc to 40 java files

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/EReferAttachment.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/EReferAttachment.java
@@ -11,6 +11,10 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.util.Date;
 import java.util.List;
+/**
+ * JPA Entity representing the EReferAttachment record in the database.
+ * Maps the EReferAttachment table columns to object properties for data access.
+ */
 
 @Entity
 @Table(name = "erefer_attachment")
@@ -41,6 +45,7 @@ public class EReferAttachment extends AbstractModel<Integer> {
         this.created = new Date();
     }
 
+    // Retrieves the primary key identifier for this entity
     public Integer getId() {
         return id;
     }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/EReferAttachmentData.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/EReferAttachmentData.java
@@ -7,6 +7,10 @@ import jakarta.persistence.IdClass;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+/**
+ * JPA Entity representing the EReferAttachmentData record in the database.
+ * Maps the EReferAttachmentData table columns to object properties for data access.
+ */
 
 @Entity
 @IdClass(EReferAttachmentDataCompositeKey.class)
@@ -34,6 +38,7 @@ public class EReferAttachmentData extends AbstractModel<EReferAttachmentDataComp
         this.labType = labType;
     }
 
+    // Retrieves the primary key identifier for this entity
     public EReferAttachmentDataCompositeKey getId() {
         return new EReferAttachmentDataCompositeKey(eReferAttachment, labId, labType);
     }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/EReferAttachmentDataCompositeKey.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/EReferAttachmentDataCompositeKey.java
@@ -5,6 +5,10 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import java.io.Serializable;
 import java.util.Objects;
+/**
+ * Composite key representation for the EReferAttachmentData entity.
+ * Used by JPA to uniquely identify records using multiple columns.
+ */
 
 public class EReferAttachmentDataCompositeKey implements Serializable {
     @ManyToOne

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/EmailAttachment.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/EmailAttachment.java
@@ -4,6 +4,10 @@ import io.github.carlos_emr.carlos.commn.model.converter.EmailAttachmentDocument
 import jakarta.persistence.*;
 
 import io.github.carlos_emr.carlos.commn.model.enumerator.DocumentType;
+/**
+ * JPA Entity representing the EmailAttachment record in the database.
+ * Maps the EmailAttachment table columns to object properties for data access.
+ */
 
 @Entity
 @Table(name = "emailAttachment")
@@ -55,6 +59,7 @@ public class EmailAttachment extends AbstractModel<Integer> {
         this.documentId = documentId;
     }
 
+    // Retrieves the primary key identifier for this entity
     public Integer getId() {
         return id;
     }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/EmailConfig.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/EmailConfig.java
@@ -4,6 +4,10 @@ import io.github.carlos_emr.carlos.commn.model.converter.EmailConfigProviderConv
 import io.github.carlos_emr.carlos.commn.model.converter.EmailConfigTypeConverter;
 import jakarta.persistence.*;
 import java.util.List;
+/**
+ * JPA Entity representing the EmailConfig record in the database.
+ * Maps the EmailConfig table columns to object properties for data access.
+ */
 
 @Entity
 @Table(name = "emailConfig")
@@ -55,6 +59,7 @@ public class EmailConfig extends AbstractModel<Integer> {
     }
 
     @Override
+    // Retrieves the primary key identifier for this entity
     public Integer getId() {
         return id;
     }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/JSONAction.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/JSONAction.java
@@ -13,6 +13,10 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
+/**
+ * JPA Entity representing the JSONAction record in the database.
+ * Maps the JSONAction table columns to object properties for data access.
+ */
 
 public class JSONAction extends ActionSupport {
 

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/AppointmentBookingSourceConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/AppointmentBookingSourceConverter.java
@@ -2,10 +2,15 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 
 import io.github.carlos_emr.carlos.commn.model.Appointment.BookingSource;
 import jakarta.persistence.Converter;
+/**
+ * JPA attribute converter specifically for mapping the AppointmentBookingSource enum to its database column.
+ * Ensures that AppointmentBookingSource values are safely persisted and retrieved, defaulting to a fallback if null.
+ */
 
 @Converter
 public class AppointmentBookingSourceConverter extends NullSafeEnumConverter<BookingSource> {
     public AppointmentBookingSourceConverter() {
+        // Initialize the converter mapping to the target enum class
         super(BookingSource.class, null);
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/ClientLinkTypeConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/ClientLinkTypeConverter.java
@@ -2,10 +2,15 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 
 import io.github.carlos_emr.carlos.commn.model.ClientLink.Type;
 import jakarta.persistence.Converter;
+/**
+ * JPA attribute converter specifically for mapping the ClientLinkType enum to its database column.
+ * Ensures that ClientLinkType values are safely persisted and retrieved, defaulting to a fallback if null.
+ */
 
 @Converter
 public class ClientLinkTypeConverter extends NullSafeEnumConverter<Type> {
     public ClientLinkTypeConverter() {
+        // Initialize the converter mapping to the target enum class
         super(Type.class, null);
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/DigitalSignatureModuleTypeConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/DigitalSignatureModuleTypeConverter.java
@@ -2,10 +2,15 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 
 import io.github.carlos_emr.carlos.commn.model.enumerator.ModuleType;
 import jakarta.persistence.Converter;
+/**
+ * JPA attribute converter specifically for mapping the DigitalSignatureModuleType enum to its database column.
+ * Ensures that DigitalSignatureModuleType values are safely persisted and retrieved, defaulting to a fallback if null.
+ */
 
 @Converter
 public class DigitalSignatureModuleTypeConverter extends NullSafeEnumConverter<ModuleType> {
     public DigitalSignatureModuleTypeConverter() {
+        // Initialize the converter mapping to the target enum class
         super(ModuleType.class, null);
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailAttachmentDocumentTypeConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailAttachmentDocumentTypeConverter.java
@@ -2,10 +2,15 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 
 import io.github.carlos_emr.carlos.commn.model.enumerator.DocumentType;
 import jakarta.persistence.Converter;
+/**
+ * JPA attribute converter specifically for mapping the EmailAttachmentDocumentType enum to its database column.
+ * Ensures that EmailAttachmentDocumentType values are safely persisted and retrieved, defaulting to a fallback if null.
+ */
 
 @Converter
 public class EmailAttachmentDocumentTypeConverter extends NullSafeEnumConverter<DocumentType> {
     public EmailAttachmentDocumentTypeConverter() {
+        // Initialize the converter mapping to the target enum class
         super(DocumentType.class, null);
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailConfigProviderConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailConfigProviderConverter.java
@@ -2,10 +2,15 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 
 import io.github.carlos_emr.carlos.commn.model.EmailConfig.EmailProvider;
 import jakarta.persistence.Converter;
+/**
+ * JPA attribute converter specifically for mapping the EmailConfigProvider enum to its database column.
+ * Ensures that EmailConfigProvider values are safely persisted and retrieved, defaulting to a fallback if null.
+ */
 
 @Converter
 public class EmailConfigProviderConverter extends NullSafeEnumConverter<EmailProvider> {
     public EmailConfigProviderConverter() {
+        // Initialize the converter mapping to the target enum class
         super(EmailProvider.class, null);
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailConfigTypeConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailConfigTypeConverter.java
@@ -2,10 +2,15 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 
 import io.github.carlos_emr.carlos.commn.model.EmailConfig.EmailType;
 import jakarta.persistence.Converter;
+/**
+ * JPA attribute converter specifically for mapping the EmailConfigType enum to its database column.
+ * Ensures that EmailConfigType values are safely persisted and retrieved, defaulting to a fallback if null.
+ */
 
 @Converter
 public class EmailConfigTypeConverter extends NullSafeEnumConverter<EmailType> {
     public EmailConfigTypeConverter() {
+        // Initialize the converter mapping to the target enum class
         super(EmailType.class, null);
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailLogChartDisplayOptionConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailLogChartDisplayOptionConverter.java
@@ -2,10 +2,15 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 
 import io.github.carlos_emr.carlos.commn.model.EmailLog.ChartDisplayOption;
 import jakarta.persistence.Converter;
+/**
+ * JPA attribute converter specifically for mapping the EmailLogChartDisplayOption enum to its database column.
+ * Ensures that EmailLogChartDisplayOption values are safely persisted and retrieved, defaulting to a fallback if null.
+ */
 
 @Converter
 public class EmailLogChartDisplayOptionConverter extends NullSafeEnumConverter<ChartDisplayOption> {
     public EmailLogChartDisplayOptionConverter() {
+        // Initialize the converter mapping to the target enum class
         super(ChartDisplayOption.class, null);
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailLogStatusConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailLogStatusConverter.java
@@ -2,10 +2,15 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 
 import io.github.carlos_emr.carlos.commn.model.EmailLog.EmailStatus;
 import jakarta.persistence.Converter;
+/**
+ * JPA attribute converter specifically for mapping the EmailLogStatus enum to its database column.
+ * Ensures that EmailLogStatus values are safely persisted and retrieved, defaulting to a fallback if null.
+ */
 
 @Converter
 public class EmailLogStatusConverter extends NullSafeEnumConverter<EmailStatus> {
     public EmailLogStatusConverter() {
+        // Initialize the converter mapping to the target enum class
         super(EmailStatus.class, null);
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailLogTransactionTypeConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailLogTransactionTypeConverter.java
@@ -2,10 +2,15 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 
 import io.github.carlos_emr.carlos.commn.model.EmailLog.TransactionType;
 import jakarta.persistence.Converter;
+/**
+ * JPA attribute converter specifically for mapping the EmailLogTransactionType enum to its database column.
+ * Ensures that EmailLogTransactionType values are safely persisted and retrieved, defaulting to a fallback if null.
+ */
 
 @Converter
 public class EmailLogTransactionTypeConverter extends NullSafeEnumConverter<TransactionType> {
     public EmailLogTransactionTypeConverter() {
+        // Initialize the converter mapping to the target enum class
         super(TransactionType.class, null);
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/FaxConfigProviderTypeConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/FaxConfigProviderTypeConverter.java
@@ -2,10 +2,15 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 
 import io.github.carlos_emr.carlos.commn.model.FaxConfig.ProviderType;
 import jakarta.persistence.Converter;
+/**
+ * JPA attribute converter specifically for mapping the FaxConfigProviderType enum to its database column.
+ * Ensures that FaxConfigProviderType values are safely persisted and retrieved, defaulting to a fallback if null.
+ */
 
 @Converter
 public class FaxConfigProviderTypeConverter extends NullSafeEnumConverter<ProviderType> {
     public FaxConfigProviderTypeConverter() {
+        // Initialize the converter mapping to the target enum class
         super(ProviderType.class, ProviderType.MIDDLEWARE);
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/FaxJobStatusConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/FaxJobStatusConverter.java
@@ -2,10 +2,15 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 
 import io.github.carlos_emr.carlos.commn.model.FaxJob.STATUS;
 import jakarta.persistence.Converter;
+/**
+ * JPA attribute converter specifically for mapping the FaxJobStatus enum to its database column.
+ * Ensures that FaxJobStatus values are safely persisted and retrieved, defaulting to a fallback if null.
+ */
 
 @Converter
 public class FaxJobStatusConverter extends NullSafeEnumConverter<STATUS> {
     public FaxJobStatusConverter() {
+        // Initialize the converter mapping to the target enum class
         super(STATUS.class, null);
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/HnrDataValidationTypeConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/HnrDataValidationTypeConverter.java
@@ -2,10 +2,15 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 
 import io.github.carlos_emr.carlos.commn.model.HnrDataValidation.Type;
 import jakarta.persistence.Converter;
+/**
+ * JPA attribute converter specifically for mapping the HnrDataValidationType enum to its database column.
+ * Ensures that HnrDataValidationType values are safely persisted and retrieved, defaulting to a fallback if null.
+ */
 
 @Converter
 public class HnrDataValidationTypeConverter extends NullSafeEnumConverter<Type> {
     public HnrDataValidationTypeConverter() {
+        // Initialize the converter mapping to the target enum class
         super(Type.class, null);
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/TicklerPriorityConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/TicklerPriorityConverter.java
@@ -2,10 +2,15 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 
 import io.github.carlos_emr.carlos.commn.model.Tickler.PRIORITY;
 import jakarta.persistence.Converter;
+/**
+ * JPA attribute converter specifically for mapping the TicklerPriority enum to its database column.
+ * Ensures that TicklerPriority values are safely persisted and retrieved, defaulting to a fallback if null.
+ */
 
 @Converter
 public class TicklerPriorityConverter extends NullSafeEnumConverter<PRIORITY> {
     public TicklerPriorityConverter() {
+        // Initialize the converter mapping to the target enum class
         super(PRIORITY.class, PRIORITY.Normal);
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/TicklerStatusConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/TicklerStatusConverter.java
@@ -2,10 +2,15 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 
 import io.github.carlos_emr.carlos.commn.model.Tickler.STATUS;
 import jakarta.persistence.Converter;
+/**
+ * JPA attribute converter specifically for mapping the TicklerStatus enum to its database column.
+ * Ensures that TicklerStatus values are safely persisted and retrieved, defaulting to a fallback if null.
+ */
 
 @Converter
 public class TicklerStatusConverter extends NullSafeEnumConverter<STATUS> {
     public TicklerStatusConverter() {
+        // Initialize the converter mapping to the target enum class
         super(STATUS.class, STATUS.A);
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/enumerator/ConsultationRequestExtKey.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/enumerator/ConsultationRequestExtKey.java
@@ -1,4 +1,8 @@
 package io.github.carlos_emr.carlos.commn.model.enumerator;
+/**
+ * Enumeration defining the specific constants for ConsultationRequestExtKey within the CARLOS system.
+ * These values represent strictly allowed options for ConsultationRequestExtKey in the domain model.
+ */
 
 public enum ConsultationRequestExtKey {
     EREFERRAL_REF("ereferral_ref"),

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/enumerator/CppCode.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/enumerator/CppCode.java
@@ -2,6 +2,10 @@ package io.github.carlos_emr.carlos.commn.model.enumerator;
 
 import java.util.ArrayList;
 import java.util.List;
+/**
+ * Enumeration defining the specific constants for CppCode within the CARLOS system.
+ * These values represent strictly allowed options for CppCode in the domain model.
+ */
 
 public enum CppCode {
     OMEDS("OMeds"),

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/enumerator/DemographicExtKey.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/enumerator/DemographicExtKey.java
@@ -19,6 +19,11 @@ import java.util.Map;
 /**
  * <code>DemographicExtKey</code> contains key name constants for demographicExt table
  */
+/**
+ * Enumeration defining the specific constants for DemographicExtKey within the CARLOS system.
+ * These values represent strictly allowed options for DemographicExtKey in the domain model.
+ */
+
 public enum DemographicExtKey {
     ABORIGINAL("aboriginal"),
     ALERT_ALLERGY("alertForAllergy", "allergyalert"),

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/enumerator/DocumentType.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/enumerator/DocumentType.java
@@ -1,4 +1,8 @@
 package io.github.carlos_emr.carlos.commn.model.enumerator;
+/**
+ * Enumeration defining the specific constants for DocumentType within the CARLOS system.
+ * These values represent strictly allowed options for DocumentType in the domain model.
+ */
 
 public enum DocumentType {
     EFORM("E", "eForm"),

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/enumerator/Gender.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/enumerator/Gender.java
@@ -38,10 +38,16 @@ import io.github.carlos_emr.carlos.commn.model.AbstractModel;
  * Model class for the lst_gender database table.
  * Contains an enumerated class for Gender code.
  */
+/**
+ * Enumeration defining the specific constants for Gender within the CARLOS system.
+ * These values represent strictly allowed options for Gender in the domain model.
+ */
+
 @Entity
 @Table(name = "lst_gender")
 @NamedQuery(name = "Gender.findAll", query = "SELECT g FROM Gender g")
 public class Gender extends AbstractModel<String> implements Serializable {
+    // Unique identifier for reliable serialization across different JVMs
     private static final long serialVersionUID = 1L;
 
 

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/enumerator/LabType.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/enumerator/LabType.java
@@ -4,6 +4,11 @@ package io.github.carlos_emr.carlos.commn.model.enumerator;
  * Lab type values used for initialization of a matching handler/parser for
  * processing incoming lab reports.
  */
+/**
+ * Enumeration defining the specific constants for LabType within the CARLOS system.
+ * These values represent strictly allowed options for LabType in the domain model.
+ */
+
 public enum LabType {
     ALPHA,
     CML,

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/enumerator/ModuleType.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/enumerator/ModuleType.java
@@ -26,6 +26,10 @@
  */
 
 package io.github.carlos_emr.carlos.commn.model.enumerator;
+/**
+ * Enumeration defining the specific constants for ModuleType within the CARLOS system.
+ * These values represent strictly allowed options for ModuleType in the domain model.
+ */
 
 public enum ModuleType {
     CONSULTATION,

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/enumerator/Pronoun.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/enumerator/Pronoun.java
@@ -32,12 +32,17 @@ import io.github.carlos_emr.carlos.commn.model.AbstractModel;
 
 import jakarta.persistence.*;
 import java.io.Serializable;
+/**
+ * Enumeration defining the specific constants for Pronoun within the CARLOS system.
+ * These values represent strictly allowed options for Pronoun in the domain model.
+ */
 
 @Entity
 @Table(name = "lst_pronoun")
 @NamedQuery(name = "Pronoun.findAll", query = "SELECT p FROM Pronoun p")
 public class Pronoun extends AbstractModel<String> implements Serializable {
 
+    // Unique identifier for reliable serialization across different JVMs
     private static final long serialVersionUID = 1L;
 
 

--- a/src/main/java/io/github/carlos_emr/carlos/config/ServletContextConfig.java
+++ b/src/main/java/io/github/carlos_emr/carlos/config/ServletContextConfig.java
@@ -6,6 +6,10 @@ import org.springframework.context.annotation.Configuration;
 import jakarta.servlet.ServletContext;
 
 import org.springframework.web.context.ServletContextAware;
+/**
+ * Configuration or utility class for ServletContextConfig.
+ * Handles initialization and setup of ServletContextConfig related beans or helper methods.
+ */
 
 @Configuration
 public class ServletContextConfig implements ServletContextAware {

--- a/src/main/java/io/github/carlos_emr/carlos/utility/EmailSendingException.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/EmailSendingException.java
@@ -1,4 +1,8 @@
 package io.github.carlos_emr.carlos.utility;
+/**
+ * Custom exception thrown when a specific EmailSending error occurs.
+ * This allows upstream handlers to catch and format the EmailSendingException appropriately for the client.
+ */
 
 public class EmailSendingException extends Exception {
     public EmailSendingException() {

--- a/src/main/java/io/github/carlos_emr/carlos/ws/DuplicateHinException.java
+++ b/src/main/java/io/github/carlos_emr/carlos/ws/DuplicateHinException.java
@@ -4,10 +4,15 @@ import jakarta.xml.bind.annotation.XmlType;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import java.io.Serializable;
+/**
+ * Custom exception thrown when a specific DuplicateHin error occurs.
+ * This allows upstream handlers to catch and format the DuplicateHinException appropriately for the client.
+ */
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "DuplicateHinException")
 public class DuplicateHinException implements Serializable
 {
+    // Unique identifier for reliable serialization across different JVMs
     private static final long serialVersionUID = 1L;
 }

--- a/src/main/java/io/github/carlos_emr/carlos/ws/Gender.java
+++ b/src/main/java/io/github/carlos_emr/carlos/ws/Gender.java
@@ -2,6 +2,10 @@ package io.github.carlos_emr.carlos.ws;
 
 import jakarta.xml.bind.annotation.XmlEnum;
 import jakarta.xml.bind.annotation.XmlType;
+/**
+ * Enum representing the Gender of a patient or user in the web service context.
+ * Used to map external gender codes to internal CARLOS representations.
+ */
 
 @XmlType(name = "gender")
 @XmlEnum

--- a/src/main/java/io/github/carlos_emr/carlos/ws/HelloWorld.java
+++ b/src/main/java/io/github/carlos_emr/carlos/ws/HelloWorld.java
@@ -4,10 +4,15 @@ import jakarta.xml.bind.annotation.XmlType;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import java.io.Serializable;
+/**
+ * Data Transfer Object representing the payload for the HelloWorld web service request.
+ * Encapsulates the parameters provided by the SOAP/REST client.
+ */
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "helloWorld")
 public class HelloWorld implements Serializable
 {
+    // Unique identifier for reliable serialization across different JVMs
     private static final long serialVersionUID = 1L;
 }

--- a/src/main/java/io/github/carlos_emr/carlos/ws/HelloWorld2.java
+++ b/src/main/java/io/github/carlos_emr/carlos/ws/HelloWorld2.java
@@ -4,11 +4,16 @@ import jakarta.xml.bind.annotation.XmlType;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import java.io.Serializable;
+/**
+ * Data Transfer Object representing the payload for the HelloWorld2 web service request.
+ * Encapsulates the parameters provided by the SOAP/REST client.
+ */
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "helloWorld2", propOrder = { "arg0" })
 public class HelloWorld2 implements Serializable
 {
+    // Unique identifier for reliable serialization across different JVMs
     private static final long serialVersionUID = 1L;
     protected String arg0;
     

--- a/src/main/java/io/github/carlos_emr/carlos/ws/HelloWorld2Response.java
+++ b/src/main/java/io/github/carlos_emr/carlos/ws/HelloWorld2Response.java
@@ -5,11 +5,16 @@ import jakarta.xml.bind.annotation.XmlType;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import java.io.Serializable;
+/**
+ * Data Transfer Object representing the payload for the HelloWorld2Response web service response.
+ * Encapsulates the result data sent back to the SOAP/REST client.
+ */
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "helloWorld2Response", propOrder = { "_return" })
 public class HelloWorld2Response implements Serializable
 {
+    // Unique identifier for reliable serialization across different JVMs
     private static final long serialVersionUID = 1L;
     @XmlElement(name = "return")
     protected String _return;

--- a/src/main/java/io/github/carlos_emr/carlos/ws/HelloWorldResponse.java
+++ b/src/main/java/io/github/carlos_emr/carlos/ws/HelloWorldResponse.java
@@ -5,11 +5,16 @@ import jakarta.xml.bind.annotation.XmlType;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import java.io.Serializable;
+/**
+ * Data Transfer Object representing the payload for the HelloWorldResponse web service response.
+ * Encapsulates the result data sent back to the SOAP/REST client.
+ */
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "helloWorldResponse", propOrder = { "_return" })
 public class HelloWorldResponse implements Serializable
 {
+    // Unique identifier for reliable serialization across different JVMs
     private static final long serialVersionUID = 1L;
     @XmlElement(name = "return")
     protected String _return;

--- a/src/main/java/io/github/carlos_emr/carlos/ws/InvalidHinException.java
+++ b/src/main/java/io/github/carlos_emr/carlos/ws/InvalidHinException.java
@@ -4,10 +4,15 @@ import jakarta.xml.bind.annotation.XmlType;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import java.io.Serializable;
+/**
+ * Custom exception thrown when a specific InvalidHin error occurs.
+ * This allows upstream handlers to catch and format the InvalidHinException appropriately for the client.
+ */
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "InvalidHinException")
 public class InvalidHinException implements Serializable
 {
+    // Unique identifier for reliable serialization across different JVMs
     private static final long serialVersionUID = 1L;
 }

--- a/src/main/java/io/github/carlos_emr/carlos/ws/MatchingClientParameters.java
+++ b/src/main/java/io/github/carlos_emr/carlos/ws/MatchingClientParameters.java
@@ -9,11 +9,16 @@ import jakarta.xml.bind.annotation.XmlType;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import java.io.Serializable;
+/**
+ * Data Transfer Object representing the payload for the MatchingClientParameters web service request.
+ * Encapsulates the parameters provided by the SOAP/REST client.
+ */
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "matchingClientParameters", propOrder = { "maxEntriesToReturn", "minScore", "firstName", "lastName", "birthDate", "hin" })
 public class MatchingClientParameters implements Serializable
 {
+    // Unique identifier for reliable serialization across different JVMs
     private static final long serialVersionUID = 1L;
     protected int maxEntriesToReturn;
     protected int minScore;

--- a/src/main/java/io/github/carlos_emr/carlos/ws/MatchingClientScore.java
+++ b/src/main/java/io/github/carlos_emr/carlos/ws/MatchingClientScore.java
@@ -4,11 +4,16 @@ import jakarta.xml.bind.annotation.XmlType;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import java.io.Serializable;
+/**
+ * Data Transfer Object representing the payload for the MatchingClientScore web service request.
+ * Encapsulates the parameters provided by the SOAP/REST client.
+ */
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "matchingClientScore", propOrder = { "client", "score" })
 public class MatchingClientScore implements Serializable
 {
+    // Unique identifier for reliable serialization across different JVMs
     private static final long serialVersionUID = 1L;
     protected Client client;
     protected int score;

--- a/src/main/java/io/github/carlos_emr/carlos/ws/ObjectFactory.java
+++ b/src/main/java/io/github/carlos_emr/carlos/ws/ObjectFactory.java
@@ -4,6 +4,10 @@ import jakarta.xml.bind.annotation.XmlElementDecl;
 import jakarta.xml.bind.JAXBElement;
 import javax.xml.namespace.QName;
 import jakarta.xml.bind.annotation.XmlRegistry;
+/**
+ * JAXB ObjectFactory used to create instances of web service payload classes.
+ * Required by the JAXB context to instantiate XML elements like HelloWorld and Gender.
+ */
 
 @XmlRegistry
 public class ObjectFactory


### PR DESCRIPTION
This PR adds meaningful class-level javadocs and inline documentation to 40 java files to improve documentation coverage across the project.

---
*PR created automatically by Jules for task [2169264902729561581](https://jules.google.com/task/2169264902729561581) started by @yingbull*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added missing Javadoc to 40 Java files across `commn` models, converters, enums, web-service DTOs/exceptions, and `ServletContextConfig` to improve documentation coverage and readability. No functional changes.

<sup>Written for commit 364f5ed7e23ce4899a4a08d14f8cdb9bcecbf38e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

