### PR TITLE
Update colorectal screening age to 45yo in prevention.drl

### DIFF
--- a/src/main/resources/oscar/prevention/prevention.drl
+++ b/src/main/resources/oscar/prevention/prevention.drl
@@ -78,7 +78,7 @@
 //   Adult:                    Tdap (10-year booster), Td (10-year repeat), Inf (annual 65+)
 //   Women's health:           HPV-CERVIX (5-year cycle, 25-69), PAP (3-year cycle, 25-69),
 //                              MAM (2-year cycle, 40-74)
-//   Colorectal screening:     FOBT/FIT (2-year cycle, 50-74), Colonoscopy (10-year)
+//   Colorectal screening:     FOBT/FIT (2-year cycle, 45-74), Colonoscopy (10-year)
 //   General wellness:         Smoking assessment (13+), BMD (65+), PHV (annual),
 //                              Annual Physical (annual), Obesity screening (annual)
 //
@@ -1003,7 +1003,7 @@ end
 
 // --------------------------------------------------------------------------
 // FOBT / Colonoscopy: Colorectal cancer screening (4 rules)
-// Canadian guideline: FIT/FOBT every 2 years ages 50-74; colonoscopy every 10 years
+// CCO guideline: FIT/FOBT every 2 years ages 45-74; colonoscopy every 10 years
 // Rule 1: WARNING - FIT overdue (>24mo since FOBT) AND no colonoscopy on record
 // Rule 2: WARNING - No FIT/FOBT or colonoscopy records at all (ages 50-74)
 // Rule 3: WARNING - Colonoscopy >10 years old (120 months) - needs repeat
@@ -1014,7 +1014,7 @@ end
 rule "FOBT 1"
     when
         prev : Prevention()
-        eval( prev.getAgeInYears() >= 50 )
+        eval( prev.getAgeInYears() >= 45 )
         eval( prev.getAgeInYears() <= 74 )
         eval( prev.getHowManyMonthsSinceLast("COLONOSCOPY") == -1 )
         eval( prev.getHowManyMonthsSinceLast("FOBT") >= 24 )
@@ -1026,7 +1026,7 @@ end
 rule "FOBT 2"
     when
         prev : Prevention()
-        eval( prev.getAgeInYears() >= 50 )
+        eval( prev.getAgeInYears() >= 45 )
         eval( prev.getAgeInYears() <= 74 )
         eval( prev.getHowManyMonthsSinceLast("COLONOSCOPY") == -1 )
         eval( prev.getHowManyMonthsSinceLast("FOBT") == -1 )
@@ -1038,7 +1038,7 @@ end
 rule "FOBT 3"
     when
         prev : Prevention()
-        eval( prev.getAgeInYears() >= 50 )
+        eval( prev.getAgeInYears() >= 45 )
         eval( prev.getAgeInYears() <= 74 )
         eval( prev.getHowManyMonthsSinceLast("COLONOSCOPY") >= 120 )
     then

--- a/src/main/resources/oscar/prevention/prevention.drl
+++ b/src/main/resources/oscar/prevention/prevention.drl
@@ -1005,7 +1005,7 @@ end
 // FOBT / Colonoscopy: Colorectal cancer screening (4 rules)
 // CCO guideline: FIT/FOBT every 2 years ages 45-74; colonoscopy every 10 years
 // Rule 1: WARNING - FIT overdue (>24mo since FOBT) AND no colonoscopy on record
-// Rule 2: WARNING - No FIT/FOBT or colonoscopy records at all (ages 50-74)
+// Rule 2: WARNING - No FIT/FOBT or colonoscopy records at all (ages 45-74)
 // Rule 3: WARNING - Colonoscopy >10 years old (120 months) - needs repeat
 // "FOBT Inelligible": REMINDER that colonoscopy makes FIT ineligible (any age)
 // Logic: Colonoscopy supersedes FOBT - if colonoscopy exists, FOBT not needed


### PR DESCRIPTION
as per CCO

<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description
Cancer Care Ontario has moved the start age to 45 to account for increasing risk in younger adults
<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues

<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?

<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->

## Checklist

- [X] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [X] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [X] I have not included any patient data (PHI) in this PR
- [X] I have added tests for new functionality, or this change doesn't need new tests
- [X] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Enhancements:
- Align colorectal cancer prevention rules with updated clinical guidelines by lowering the screening start age to 45.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lowered the start age for FIT/FOBT colorectal screening from 50 to 45 (through 74) per CCO. Updated `prevention.drl` rule checks and related comments so overdue/no-record warnings trigger for ages 45–74; aligns with Linear 2742.

<sup>Written for commit 81e404bd35a771362f7435d0d0ec9e220bfd037a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2743?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

