### PR TITLE
labDisplay.jsp to load historical HL7 data asynchronously

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/lab/CA/ALL/labDisplay.jsp
+++ b/src/main/webapp/WEB-INF/jsp/lab/CA/ALL/labDisplay.jsp
@@ -240,22 +240,26 @@
     boolean bShortcutForm2 = bShortcutForm && !formName2.equals("");
 
     // Load LAB_VALUE_HX_JSON from carlos.properties (admin-controlled); default covers common tracked labs.
-    // Re-serialised through Jackson to reject malformed input and normalise the output.
+    // normal ranges are necessarily provided here to allow for 
+    // - override (min max of 0) to always show past values eg PSA, CEA, LDL
+    // - when the lab does not offer ranges but a note eg Cholesterol Ferritin or only one bound eg <10
+    // NOTE: the LOINC key is not validated to allow for any coding system Identifier to be used, see OBX.4.1
     String labValueHxDefault = "[{\"name\":\"eGFR\",\"LOINC\":\"33914-3\",\"testName\":\"Glomerular Filtration Rate (eGFR)\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":60,\"max\":999}},"
-  + "{\"name\":\"A1C\",\"LOINC\":\"4548-4\",\"testName\":\"Hemoglobin A1c\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":4,\"max\":5.9}},"
-  + "{\"name\":\"K\",\"LOINC\":\"2823-3\",\"testName\":\"Potassium\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":3.5,\"max\":5}},"
-  + "{\"name\":\"CRP\",\"LOINC\":\"1988-5\",\"testName\":\"C Reactive Protein\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":0,\"max\":7.5}},"
-  + "{\"name\":\"Hb\",\"LOINC\":\"718-7\",\"testName\":\"Hemoglobin\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":135,\"max\":180}},"
-  + "{\"name\":\"AST\",\"LOINC\":\"1920-8\",\"testName\":\"Aspartate Aminotransferase\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":0,\"max\":36}},"
-  + "{\"name\":\"ALT\",\"LOINC\":\"1742-6\",\"testName\":\"Alanine Aminotransferase\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":0,\"max\":50}},"
-  + "{\"name\":\"LDL\",\"LOINC\":\"39469-2\",\"testName\":\"LDL Cholesterol\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":0,\"max\":0}},"
-  + "{\"name\":\"ACR\",\"LOINC\":\"9318-7\",\"testName\":\"Urine ACR (Albumin/Creatinine Ratio)\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":0,\"max\":2}},"
-  + "{\"name\":\"PSA\",\"LOINC\":\"2857-1\",\"testName\":\"Prostate Specific Ag\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":0,\"max\":0}},"
-  + "{\"name\":\"CEA\",\"LOINC\":\"2039-6\",\"testName\":\"Carcinoembryonic Ag\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":0,\"max\":0}},"
-  + "{\"name\":\"Ferritin\",\"LOINC\":\"2276-4\",\"testName\":\"Ferritin\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":45,\"max\":200}},"
-  + "{\"name\":\"TSH\",\"LOINC\":\"3016-3\",\"testName\":\"TSH\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":0.3,\"max\":5.5}},"
-  + "{\"name\":\"TG\",\"LOINC\":\"14927-8\",\"testName\":\"Triglycerides\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":0,\"max\":2.3}}]";
+      + "{\"name\":\"A1C\",\"LOINC\":\"4548-4\",\"testName\":\"Hemoglobin A1c\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":4,\"max\":5.9}},"
+      + "{\"name\":\"K\",\"LOINC\":\"2823-3\",\"testName\":\"Potassium\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":3.5,\"max\":5}},"
+      + "{\"name\":\"CRP\",\"LOINC\":\"1988-5\",\"testName\":\"C Reactive Protein\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":0,\"max\":7.5}},"
+      + "{\"name\":\"Hb\",\"LOINC\":\"718-7\",\"testName\":\"Hemoglobin\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":135,\"max\":180}},"
+      + "{\"name\":\"AST\",\"LOINC\":\"1920-8\",\"testName\":\"Aspartate Aminotransferase\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":0,\"max\":36}},"
+      + "{\"name\":\"ALT\",\"LOINC\":\"1742-6\",\"testName\":\"Alanine Aminotransferase\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":0,\"max\":50}},"
+      + "{\"name\":\"LDL\",\"LOINC\":\"39469-2\",\"testName\":\"LDL Cholesterol\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":0,\"max\":0}},"
+      + "{\"name\":\"ACR\",\"LOINC\":\"9318-7\",\"testName\":\"Urine ACR (Albumin/Creatinine Ratio)\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":0,\"max\":2}},"
+      + "{\"name\":\"PSA\",\"LOINC\":\"2857-1\",\"testName\":\"Total PSA\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":0,\"max\":0}},"
+      + "{\"name\":\"CEA\",\"LOINC\":\"2039-6\",\"testName\":\"Carcinoembryonic Ag\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":0,\"max\":0}},"
+      + "{\"name\":\"Ferritin\",\"LOINC\":\"2276-4\",\"testName\":\"Ferritin\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":50,\"max\":200}},"
+      + "{\"name\":\"TSH\",\"LOINC\":\"3016-3\",\"testName\":\"TSH\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":0.3,\"max\":5.5}},"
+      + "{\"name\":\"TG\",\"LOINC\":\"14927-8\",\"testName\":\"Triglycerides\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":0,\"max\":2.3}}]";
     String labValueHxJson;
+    // Re-serialised through Jackson to reject malformed input and normalise the output.
     try {
         ObjectMapper labHxMapper = new ObjectMapper();
         JsonNode labHxNode = labHxMapper.readTree(props.getProperty("LAB_VALUE_HX_JSON", labValueHxDefault));
@@ -833,9 +837,9 @@ input[id^='acklabel_']{
         function loadHL7hx() {
             const start = Date.now();
              
-            // First pass: check for abnormalities in current values
-            const rows = document.querySelectorAll("tr.AbnormalRes, tr.HiLoRes");
-        
+            // First pass: check for current values out of range
+            // note that tr.NormalRes can occur for abnormal labs without stated normal ranges    
+            const rows = document.querySelectorAll("tr.NormalRes, tr.AbnormalRes, tr.HiLoRes");
             rows.forEach(row => {
                 const cells = row.querySelectorAll("td");
                 cells.forEach((cell, i) => {
@@ -843,8 +847,14 @@ input[id^='acklabel_']{
                     anchors.forEach(a => {
                         const testName = a.textContent.trim();
                         const lab = labConfigs.find(l => testName === l.testName);
-                        if (lab && !abnormalLabs.includes(lab)) {
-                            abnormalLabs.push(lab);
+                        if (lab && i + 1 < cells.length) {
+                            const resultText = cells[i + 1].textContent.trim();
+                            const value = parseFloat(resultText);
+                            if (!isNaN(value) && (value < lab.normalRange.min || value > lab.normalRange.max)) {
+                                if (!abnormalLabs.includes(lab)) {
+                                    abnormalLabs.push(lab);
+                                }
+                            }
                         }
                     });
                 });
@@ -872,11 +882,9 @@ input[id^='acklabel_']{
       }
 
       async function fetchLabValues(lab, demographicNo) {
-          const newURL = `<%=request.getContextPath()%>/lab/CA/ON/ViewLabValues?testName=\${encodeURIComponent(
-              lab.testName
-          )}&demo=\${demographicNo}&labType=HL7&identifier=\${lab.LOINC}`;
-      
-          console.log(`Fetching \${lab.name} values from URL:`, newURL);
+          const newURL = "<%=request.getContextPath()%>/lab/CA/ON/ViewLabValues?testName=" + encodeURIComponent(lab.testName) +
+            "&demo=" + encodeURIComponent(demographicNo) + "&labType=HL7&identifier=" + encodeURIComponent(lab.LOINC);      
+          console.log("Fetching " + lab.name + " values from URL: " + newURL);
       
           try {
               const response = await fetch(newURL);
@@ -947,7 +955,7 @@ input[id^='acklabel_']{
                                       valueEl.textContent = val;
 
                                       const dateEl = document.createElement("strong");
-                                      dateEl.style.color = "`#36454F`";
+                                      dateEl.style.color = "#36454F";
                                       dateEl.textContent = lab.dates[i];
                                       rowEl.append(valueEl, document.createTextNode(" "), dateEl);
                                       tooltip.appendChild(rowEl);

--- a/src/main/webapp/WEB-INF/jsp/lab/CA/ALL/labDisplay.jsp
+++ b/src/main/webapp/WEB-INF/jsp/lab/CA/ALL/labDisplay.jsp
@@ -238,6 +238,35 @@
     String formName2 = bShortcutForm ? CarlosProperties.getInstance().getProperty("appt_formview_name2", "") : "";
     String formName2Short = formName2.length() > 3 ? (formName2.substring(0, 2) + ".") : formName2;
     boolean bShortcutForm2 = bShortcutForm && !formName2.equals("");
+
+    // Load LAB_VALUE_HX_JSON from carlos.properties (admin-controlled); default covers common tracked labs.
+    // Re-serialised through Jackson to reject malformed input and normalise the output.
+    String labValueHxDefault = "[{\"name\":\"eGFR\",\"LOINC\":\"33914-3\",\"testName\":\"Estimated GFR\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":60,\"max\":999}},"
+  + "{\"name\":\"A1C\",\"LOINC\":\"4548-4\",\"testName\":\"Hemoglobin A1c\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":4,\"max\":5.9}},"
+  + "{\"name\":\"K\",\"LOINC\":\"2823-3\",\"testName\":\"Potassium\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":3.5,\"max\":5}},"
+  + "{\"name\":\"CRP\",\"LOINC\":\"1988-5\",\"testName\":\"C Reactive Protein\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":0,\"max\":7.5}},"
+  + "{\"name\":\"Hb\",\"LOINC\":\"718-7\",\"testName\":\"Hemoglobin\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":135,\"max\":180}},"
+  + "{\"name\":\"Hb\",\"LOINC\":\"718-7\",\"testName\":\"Hemoglobin\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":135,\"max\":180}},"
+  + "{\"name\":\"AST\",\"LOINC\":\"1920-8\",\"testName\":\"Aspartate Aminotransferase\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":0,\"max\":36}},"
+  + "{\"name\":\"ALT\",\"LOINC\":\"1742-6\",\"testName\":\"Alanine Aminotransferase\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":0,\"max\":50}},"
+  + "{\"name\":\"LDL\",\"LOINC\":\"39469-2\",\"testName\":\"LDL Cholesterol\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":0,\"max\":0}},"
+  + "{\"name\":\"ACR\",\"LOINC\":\"9318-7\",\"testName\":\"Urine ACR (Albumin/Creatinine Ratio)\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":0,\"max\":2}},"
+  + "{\"name\":\"PSA\",\"LOINC\":\"2857-1\",\"testName\":\"Prostate Specific Ag\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":0,\"max\":0}},"
+  + "{\"name\":\"CEA\",\"LOINC\":\"2039-6\",\"testName\":\"Carcinoembryonic Ag\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":0,\"max\":0}},"
+  + "{\"name\":\"Ferritin\",\"LOINC\":\"2276-4\",\"testName\":\"Ferritin\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":45,\"max\":200}},"
+  + "{\"name\":\"TSH\",\"LOINC\":\"3016-3\",\"testName\":\"TSH\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":0.3,\"max\":5.5}},"
+  + "{\"name\":\"TG\",\"LOINC\":\"14927-8\",\"testName\":\"Triglycerides\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":0,\"max\":2.3}}]";
+    String labValueHxJson;
+    try {
+        ObjectMapper labHxMapper = new ObjectMapper();
+        JsonNode labHxNode = labHxMapper.readTree(props.getProperty("LAB_VALUE_HX_JSON", labValueHxDefault));
+        // Replace "</" so the JSON can be safely embedded inside a <script> block
+        labValueHxJson = labHxMapper.writeValueAsString(labHxNode).replace("</", "<\\/");
+    } catch (Exception e_labHx) {
+        labValueHxJson = labValueHxDefault;
+    }
+
+
     List<MessageHandler> handlers = new ArrayList<MessageHandler>();
     String[] segmentIDs = null;
     Boolean showAll = showAllstr != null && !"null".equalsIgnoreCase(showAllstr);
@@ -568,6 +597,8 @@ input[id^='acklabel_']{
         var providerNo = '<carlos:encode value='<%= providerNo %>' context="javaScriptBlock"/>';
         var demographicNo = '<carlos:encode value='<%= isLinkedToDemographic ? demographicID : "" %>' context="javaScriptBlock"/>';
 
+
+
         function popupStart(vheight, vwidth, varpage, windowname) {
             var page = varpage;
             windowprops = "height=" + vheight + ",width=" + vwidth + ",location=no,scrollbars=yes,menubars=no,toolbars=no,resizable=yes";
@@ -796,11 +827,175 @@ input[id^='acklabel_']{
             }
         }
 
+        const labConfigs = <%=labValueHxJson%>;
+        console.log("config "+labConfigs);
+        const abnormalLabs = [];
+
+        function loadHL7hx() {
+            const start = Date.now();
+             
+            // First pass: check for abnormalities in current values
+            const rows = document.querySelectorAll("tr.NormalRes, tr.AbnormalRes, tr.HiLoRes");
+        
+            rows.forEach(row => {
+                const cells = row.querySelectorAll("td");
+                cells.forEach((cell, i) => {
+                    const anchors = cell.querySelectorAll("a");
+                    anchors.forEach(a => {
+                        const testName = a.textContent.trim();
+                        //const lab = labConfigs.find(l => testName.includes(l.testName));
+                        const lab = labConfigs.find(l => testName === l.testName);
+                        if (lab && i + 1 < cells.length) {
+                            const resultText = cells[i + 1].textContent.trim();
+                            const value = parseFloat(resultText);
+                            if (!isNaN(value) && (value < lab.normalRange.min || value > lab.normalRange.max)) {
+                                if (!abnormalLabs.includes(lab)) {
+                                    abnormalLabs.push(lab);
+                                }
+                            }
+                        }
+                    });
+                });
+            });
+            console.log("abnormal Labs "+abnormalLabs);
+               
+          // Fetch and insert only for abnormal labs
+          fetchLabsSequentially().then(() => {
+              const ms = Date.now() - start;
+              console.log("All labs fetched and inserted at "+Math.floor(ms / 100)/10+"sec");
+          });
+        }
+
+        async function fetchLabsSequentially() {
+          for (let i = 0; i < abnormalLabs.length; i++) {
+              const lab = abnormalLabs[i];
+      
+              // Fetch values for this lab
+              await fetchLabValues(lab, demographicNo);
+      
+              // Insert values immediately after fetching
+              insertLabValues(lab);
+              console.log("Inserted values for "+lab.name);
+          }      
+      }
+
+      async function fetchLabValues(lab, demographicNo) {
+          const newURL = `<%=request.getContextPath()%>/lab/CA/ON/ViewLabValues?t?testName=\${encodeURIComponent(
+              lab.testName
+          )}&demo=\${demographicNo}&labType=HL7&identifier=\${lab.LOINC}`;
+      
+          console.log(`Fetching \${lab.name} values from URL:`, newURL);
+      
+          try {
+              const response = await fetch(newURL);
+      
+              if (!response.ok) {
+                  console.warn(
+                      `Failed to fetch lab: \${lab.name} — status: \${response.status}`
+                  );
+                  return;
+              }
+      
+              const responseText = await response.text();
+      
+              // Convert returned HTML into a DOM document
+              const parser = new DOMParser();
+              const doc = parser.parseFromString(responseText, "text/html");
+      
+              // Select all result rows
+              const rows = doc.querySelectorAll(
+                  "tr.NormalRes, tr.AbnormalRes, tr.LoRes, tr.HiLoRes"
+              );
+      
+              rows.forEach((row) => {
+                  const cells = row.querySelectorAll("td");
+                  if (cells.length < 6) return;
+                  const value = cells[1].textContent.trim();
+                  const dateTime = cells[5].textContent.trim();
+                  // Extract only the YYYY-MM-DD part
+                  const dateMatch = dateTime.match(/^(\d{4}-\d{2}-\d{2})/);
+                  if (!dateMatch) return;
+                  if (lab.values.length < 10) {
+                      lab.values.push(value);
+                      lab.dates.push(dateMatch[1]);
+                  }
+              });
+          } catch (error) {
+              console.error(`Error fetching lab: \${lab.name}`, error);
+          }
+      }
+
+      function insertLabValues(lab) {
+          const rows = document.querySelectorAll("tr.NormalRes, tr.AbnormalRes, tr.HiLoRes");
+      
+          rows.forEach((row) => {
+              const cells = row.querySelectorAll("td");
+      
+              cells.forEach((cell, cellIndex) => {
+                  const anchors = cell.querySelectorAll("a");
+                  anchors.forEach((a) => {
+                      const anchorText = a.textContent.replace(/\s+/g, " ").trim();
+      
+                      //if (anchorText.includes(lab.testName)) {
+                        if (anchorText === lab.testName) {
+                          const resultCell = cells[cellIndex + 1];
+                          if (resultCell) {
+                              const recentResult = parseFloat(resultCell.textContent.trim());
+      
+                              if (!isNaN(recentResult) &&
+                                  (recentResult < lab.normalRange.min || recentResult > lab.normalRange.max)) {
+                                  const span = document.createElement("span");
+                                  span.style.marginLeft = "10px";
+                                  span.style.color = "#000080";
+                                  span.textContent = ` (\${lab.values.slice(1, 3).join(" / ")})`;
+      
+                                  const tooltip = document.createElement("div");
+                                  tooltip.className = "custom-tooltip";
+                                  tooltip.innerHTML = lab.values.map((val, i) =>
+                                     `<div><strong>\${val}</strong> <strong style="color:#36454F;">(\${lab.dates[i]})</strong></div>`
+                                  ).join("");
+                                  tooltip.style.position = "absolute";
+                                  tooltip.style.background = "#fefefe";
+                                  tooltip.style.border = "1px solid #ccc";
+                                  tooltip.style.padding = "6px 8px";
+                                  tooltip.style.boxShadow = "2px 2px 6px rgba(0,0,0,0.2)";
+                                  tooltip.style.borderRadius = "4px";
+                                  tooltip.style.whiteSpace = "nowrap";
+                                  tooltip.style.zIndex = "1000";
+                                  tooltip.style.display = "none";
+                                  tooltip.style.fontSize = "12px";
+      
+                                  document.body.appendChild(tooltip);
+      
+                                  span.addEventListener("mouseover", (e) => {
+                                      tooltip.style.left = (e.pageX + 10) + "px";
+                                      tooltip.style.top = (e.pageY + 10) + "px";
+                                      tooltip.style.display = "block";
+                                  });
+      
+                                  span.addEventListener("mousemove", (e) => {
+                                      tooltip.style.left = (e.pageX + 10) + "px";
+                                      tooltip.style.top = (e.pageY + 10) + "px";
+                                  });
+      
+                                  span.addEventListener("mouseout", () => {
+                                      tooltip.style.display = "none";
+                                  });
+      
+                                  resultCell.appendChild(span);
+                              }
+                          }
+                      }
+                  });
+              });
+          });
+      }
+      
     </script>
 
 </head>
 
-<body onLoad="javascript:matchMe();">
+<body onLoad="javascript:matchMe(); loadHL7hx();">
 
 <!-- form forwarding of the lab -->
 <%

--- a/src/main/webapp/WEB-INF/jsp/lab/CA/ALL/labDisplay.jsp
+++ b/src/main/webapp/WEB-INF/jsp/lab/CA/ALL/labDisplay.jsp
@@ -849,8 +849,8 @@ input[id^='acklabel_']{
                         const lab = labConfigs.find(l => testName === l.testName);
                         if (lab && i + 1 < cells.length) {
                             const resultText = cells[i + 1].textContent.trim();
-                            const valueMatch = resultText.match(/-?\d+(?:\.\d+)?/); // extract the number portion of <10
-                            const value = valueMatch ? parseFloat(valueMatch[0]) : NaN;
+                            const normalizedResult = resultText.replace(/^[<>]=?\s*/, ""); // handle result <10 and 1x10E12
+                            const value = parseFloat(normalizedResult);
                             if (!isNaN(value) && (value < lab.normalRange.min || value > lab.normalRange.max)) {
                                 if (!abnormalLabs.includes(lab)) {
                                     abnormalLabs.push(lab);
@@ -937,7 +937,9 @@ input[id^='acklabel_']{
                         if (anchorText === lab.testName) {
                           const resultCell = cells[cellIndex + 1];
                           if (resultCell) {
-                              const recentResult = parseFloat(resultCell.textContent.trim());
+                              const resultText = resultCell.textContent.trim();
+                              const normalizedResult = resultText.replace(/^[<>]=?\s*/, "");
+                              const recentResult = parseFloat(normalizedResult);      
       
                               if (!isNaN(recentResult) &&
                                   (recentResult < lab.normalRange.min || recentResult > lab.normalRange.max)) {

--- a/src/main/webapp/WEB-INF/jsp/lab/CA/ALL/labDisplay.jsp
+++ b/src/main/webapp/WEB-INF/jsp/lab/CA/ALL/labDisplay.jsp
@@ -849,7 +849,8 @@ input[id^='acklabel_']{
                         const lab = labConfigs.find(l => testName === l.testName);
                         if (lab && i + 1 < cells.length) {
                             const resultText = cells[i + 1].textContent.trim();
-                            const value = parseFloat(resultText);
+                            const valueMatch = resultText.match(/-?\d+(?:\.\d+)?/); // extract the number portion of <10
+                            const value = valueMatch ? parseFloat(valueMatch[0]) : NaN;
                             if (!isNaN(value) && (value < lab.normalRange.min || value > lab.normalRange.max)) {
                                 if (!abnormalLabs.includes(lab)) {
                                     abnormalLabs.push(lab);
@@ -884,8 +885,7 @@ input[id^='acklabel_']{
       async function fetchLabValues(lab, demographicNo) {
           const newURL = "<%=request.getContextPath()%>/lab/CA/ON/ViewLabValues?testName=" + encodeURIComponent(lab.testName) +
             "&demo=" + encodeURIComponent(demographicNo) + "&labType=HL7&identifier=" + encodeURIComponent(lab.LOINC);      
-          console.log("Fetching " + lab.name + " values from URL: " + newURL);
-      
+     
           try {
               const response = await fetch(newURL);
       

--- a/src/main/webapp/WEB-INF/jsp/lab/CA/ALL/labDisplay.jsp
+++ b/src/main/webapp/WEB-INF/jsp/lab/CA/ALL/labDisplay.jsp
@@ -241,11 +241,10 @@
 
     // Load LAB_VALUE_HX_JSON from carlos.properties (admin-controlled); default covers common tracked labs.
     // Re-serialised through Jackson to reject malformed input and normalise the output.
-    String labValueHxDefault = "[{\"name\":\"eGFR\",\"LOINC\":\"33914-3\",\"testName\":\"Estimated GFR\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":60,\"max\":999}},"
+    String labValueHxDefault = "[{\"name\":\"eGFR\",\"LOINC\":\"33914-3\",\"testName\":\"Glomerular Filtration Rate (eGFR)\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":60,\"max\":999}},"
   + "{\"name\":\"A1C\",\"LOINC\":\"4548-4\",\"testName\":\"Hemoglobin A1c\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":4,\"max\":5.9}},"
   + "{\"name\":\"K\",\"LOINC\":\"2823-3\",\"testName\":\"Potassium\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":3.5,\"max\":5}},"
   + "{\"name\":\"CRP\",\"LOINC\":\"1988-5\",\"testName\":\"C Reactive Protein\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":0,\"max\":7.5}},"
-  + "{\"name\":\"Hb\",\"LOINC\":\"718-7\",\"testName\":\"Hemoglobin\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":135,\"max\":180}},"
   + "{\"name\":\"Hb\",\"LOINC\":\"718-7\",\"testName\":\"Hemoglobin\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":135,\"max\":180}},"
   + "{\"name\":\"AST\",\"LOINC\":\"1920-8\",\"testName\":\"Aspartate Aminotransferase\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":0,\"max\":36}},"
   + "{\"name\":\"ALT\",\"LOINC\":\"1742-6\",\"testName\":\"Alanine Aminotransferase\",\"values\":[],\"dates\":[],\"normalRange\":{\"min\":0,\"max\":50}},"
@@ -708,7 +707,7 @@ input[id^='acklabel_']{
                             console.log("Setting lab Tickler. Labid: " + labid + " Demoid: " + demoid);
                             demoid = json.demoId;
                             if (demoid != null && demoid.length > 0) {
-                                window.popup(450, 600, '${pageContext.request.contextPath}/tickler/ForwardDemographicTickler?docType=HL7&docId=' + encodeURIComponent(labid) + '&demographic_no=' + encodeURIComponent(demoid), 'tickler')
+                                window.popup(450, 600, '${pageContext.request.contextPath}/tickler/ForwardDemographicTickler?docType=HL7&docId=' + encodeURIComponent(labid) + '&demographic_no=' + encodeURIComponent(demoid), 'tickler');
                             }
                         } else if (action === 'addComment') {
                             console.log("Adding comment. Formid: " + formid + " labid: " + labid);
@@ -835,7 +834,7 @@ input[id^='acklabel_']{
             const start = Date.now();
              
             // First pass: check for abnormalities in current values
-            const rows = document.querySelectorAll("tr.NormalRes, tr.AbnormalRes, tr.HiLoRes");
+            const rows = document.querySelectorAll("tr.AbnormalRes, tr.HiLoRes");
         
             rows.forEach(row => {
                 const cells = row.querySelectorAll("td");
@@ -843,26 +842,19 @@ input[id^='acklabel_']{
                     const anchors = cell.querySelectorAll("a");
                     anchors.forEach(a => {
                         const testName = a.textContent.trim();
-                        //const lab = labConfigs.find(l => testName.includes(l.testName));
                         const lab = labConfigs.find(l => testName === l.testName);
-                        if (lab && i + 1 < cells.length) {
-                            const resultText = cells[i + 1].textContent.trim();
-                            const value = parseFloat(resultText);
-                            if (!isNaN(value) && (value < lab.normalRange.min || value > lab.normalRange.max)) {
-                                if (!abnormalLabs.includes(lab)) {
-                                    abnormalLabs.push(lab);
-                                }
-                            }
+                        if (lab && !abnormalLabs.includes(lab)) {
+                            abnormalLabs.push(lab);
                         }
                     });
                 });
             });
-            console.log("abnormal Labs "+abnormalLabs);
+            console.log("of "+rows.length +" abnormal Labs "+abnormalLabs.length +" to be checked");
                
           // Fetch and insert only for abnormal labs
           fetchLabsSequentially().then(() => {
               const ms = Date.now() - start;
-              console.log("All labs fetched and inserted at "+Math.floor(ms / 100)/10+"sec");
+              console.log("All labs fetched and inserted in "+Math.floor(ms / 100)/10+" sec");
           });
         }
 
@@ -880,7 +872,7 @@ input[id^='acklabel_']{
       }
 
       async function fetchLabValues(lab, demographicNo) {
-          const newURL = `<%=request.getContextPath()%>/lab/CA/ON/ViewLabValues?t?testName=\${encodeURIComponent(
+          const newURL = `<%=request.getContextPath()%>/lab/CA/ON/ViewLabValues?testName=\${encodeURIComponent(
               lab.testName
           )}&demo=\${demographicNo}&labType=HL7&identifier=\${lab.LOINC}`;
       
@@ -890,9 +882,7 @@ input[id^='acklabel_']{
               const response = await fetch(newURL);
       
               if (!response.ok) {
-                  console.warn(
-                      `Failed to fetch lab: \${lab.name} — status: \${response.status}`
-                  );
+                  console.warn("Failed to fetch lab: " + lab.name + " — status: " + response.status);
                   return;
               }
       
@@ -921,7 +911,7 @@ input[id^='acklabel_']{
                   }
               });
           } catch (error) {
-              console.error(`Error fetching lab: \${lab.name}`, error);
+              console.error("Error fetching lab: "+ lab.name, error);
           }
       }
 
@@ -936,7 +926,6 @@ input[id^='acklabel_']{
                   anchors.forEach((a) => {
                       const anchorText = a.textContent.replace(/\s+/g, " ").trim();
       
-                      //if (anchorText.includes(lab.testName)) {
                         if (anchorText === lab.testName) {
                           const resultCell = cells[cellIndex + 1];
                           if (resultCell) {
@@ -951,9 +940,18 @@ input[id^='acklabel_']{
       
                                   const tooltip = document.createElement("div");
                                   tooltip.className = "custom-tooltip";
-                                  tooltip.innerHTML = lab.values.map((val, i) =>
-                                     `<div><strong>\${val}</strong> <strong style="color:#36454F;">(\${lab.dates[i]})</strong></div>`
-                                  ).join("");
+
+                                  lab.values.forEach((val, i) => {
+                                      const rowEl = document.createElement("div");
+                                      const valueEl = document.createElement("strong");
+                                      valueEl.textContent = val;
+
+                                      const dateEl = document.createElement("strong");
+                                      dateEl.style.color = "`#36454F`";
+                                      dateEl.textContent = lab.dates[i];
+                                      rowEl.append(valueEl, document.createTextNode(" "), dateEl);
+                                      tooltip.appendChild(rowEl);
+                                  });
                                   tooltip.style.position = "absolute";
                                   tooltip.style.background = "#fefefe";
                                   tooltip.style.border = "1px solid #ccc";


### PR DESCRIPTION
... for abnormal labs from a specified list in carlos.properties

<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description
If the lab is abnormal the clinician wants to know the trend
adds automated history to selected labs if abnormal
<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues
Fixes #1773
<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?
production data
<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots
(97/103) are the immediate past values, hover for  up to 10 more

<img width="924" height="251" alt="tootTipLabHx" src="https://github.com/user-attachments/assets/d1f19cfb-c199-4c81-bba3-195fdad1c6ca" />

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Loads historical HL7 lab values asynchronously in `labDisplay.jsp` for abnormal results, showing inline trends with a tooltip for full history so clinicians don’t leave the page (Fixes #1773).

- **New Features**
  - Fetches history only for abnormal labs from a curated config (by `LOINC` and normal ranges); runs after page load and sequentially to reduce `ViewLabValues` load.
  - Shows 2 prior values inline; up to 10 past values with dates on hover via a tooltip.
  - Configurable via `LAB_VALUE_HX_JSON` in `carlos.properties`; JSON is re-serialized and `</`-escaped before embedding.

- **Bug Fixes**
  - Normalizes result parsing for reliable range checks, including limit-of-detection strings (e.g., “<10”) and scientific notation.
  - Removes a console log that exposed the demographic number.

<sup>Written for commit c63c75ab02b69f5404c42de97c6f1fa478ad7f5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



