### PR TITLE
Update access URL for CARLOS EMR application

### DIFF
--- a/.devcontainer/PLAYWRIGHT_SETUP.md
+++ b/.devcontainer/PLAYWRIGHT_SETUP.md
@@ -6,9 +6,9 @@ The `.mcp.json` file in the repository root configures the Playwright MCP server
 
 ### Current Configuration
 
-- **Playwright Version**: 1.56.0 (specified in `.devcontainer/development/Dockerfile`)
-- **Chromium Revision**: 1194
-- **Executable Path**: `/root/.cache/ms-playwright/chromium-1194/chrome-linux/chrome`
+- **Playwright Version**: 1.60.0 (specified in `.devcontainer/development/Dockerfile`)
+- **Chromium Revision**: 1223
+- **Executable Path**: `/root/.cache/ms-playwright/chromium-1223/chrome-linux64/chrome`
 
 ### How to Verify the Path
 
@@ -21,8 +21,8 @@ If you need to verify or update the Chromium executable path, follow these steps
 
 2. **Find the Chromium revision** for that Playwright version:
    ```bash
-   # For Playwright 1.56.0
-   curl -s https://raw.githubusercontent.com/microsoft/playwright/v1.56.0/packages/playwright-core/browsers.json | grep -A 3 '"name": "chromium"'
+   # For Playwright 1.60.0
+   curl -s https://raw.githubusercontent.com/microsoft/playwright/v1.60.0/packages/playwright-core/browsers.json | grep -A 3 '"name": "chromium"'
    ```
 
 3. **Verify the installed path** inside the devcontainer:
@@ -41,11 +41,11 @@ Playwright's Chromium installation follows this structure on Linux:
 ```
 /root/.cache/ms-playwright/
 └── chromium-{revision}/
-    └── chrome-linux/
+    └── chrome-linux64/
         └── chrome          # The executable
 ```
 
-**Note**: The directory is `chrome-linux` (not `chrome-linux64`), regardless of whether the system is 32-bit or 64-bit.
+**Note**: Playwright 1.60.0 installs Chromium from Chrome for Testing, which uses the `chrome-linux64` directory on Linux. If the Playwright version changes, verify the directory with `npx playwright install chromium --dry-run` or by inspecting `/root/.cache/ms-playwright/`.
 
 ### Updating the Configuration
 
@@ -60,7 +60,7 @@ If you update the Playwright version in the Dockerfile, you must also update the
          "args": [
            ...
            "--executable-path",
-           "/root/.cache/ms-playwright/chromium-{NEW_REVISION}/chrome-linux/chrome"
+           "/root/.cache/ms-playwright/chromium-{NEW_REVISION}/chrome-linux64/chrome"
          ]
        }
      }
@@ -73,6 +73,7 @@ If you update the Playwright version in the Dockerfile, you must also update the
 |-------------------|-------------------|--------------------------|
 | 1.56.0            | 1194              | 141.0.7390.37            |
 | 1.57.0            | 1200              | 143.0.7499.4             |
+| 1.60.0            | 1223              | 148.0.7778.96            |
 
 To find the mapping for other versions, check the official browsers.json file:
 ```bash

--- a/.devcontainer/PLAYWRIGHT_SETUP.md
+++ b/.devcontainer/PLAYWRIGHT_SETUP.md
@@ -16,7 +16,7 @@ If you need to verify or update the Chromium executable path, follow these steps
 
 1. **Check Playwright version** in the Dockerfile:
    ```bash
-   grep "playwright@" .devcontainer/development/Dockerfile
+   grep "PLAYWRIGHT_VERSION" .devcontainer/development/Dockerfile
    ```
 
 2. **Find the Chromium revision** for that Playwright version:

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -410,7 +410,7 @@ This script checks that:
 
 ### Quick Reference
 
-- **Playwright Version**: Defined in `.devcontainer/development/Dockerfile`
+- **Playwright Version**: `1.60.0`, defined in `.devcontainer/development/Dockerfile`
 - **Configuration File**: `.mcp.json` in repository root
 - **Verification Script**: `.devcontainer/scripts/verify-playwright-path.sh`
 

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -85,7 +85,7 @@ Exploded WAR".
 
 ## Access the application
 
-* Open your web browser and navigate to `http://localhost:8080`.
+* Open your web browser and navigate to `http://localhost:8080/carlos`.
 * You should see the CARLOS EMR application running.
 * Login credentials for local development are: 
     * Username: carlosdoc

--- a/.devcontainer/development/Dockerfile
+++ b/.devcontainer/development/Dockerfile
@@ -100,15 +100,17 @@ RUN npm install -g @github/copilot && \
 RUN npm install -g @openai/codex && \
     echo "✅ OpenAI Codex CLI installed: $(codex --version)"
 
-# Install Playwright globally first to ensure it's available
-# Version 1.56.0 has correct Ubuntu 24.04 t64 package names in its dependency list
-RUN npm install -g playwright@1.56.0 && \
-    echo "✅ Playwright CLI installed: $(npx playwright --version)"
+ARG PLAYWRIGHT_VERSION=1.60.0
+
+# Install Playwright globally first to ensure it's available.
+# Keep this in sync with package.json, .mcp.json, and .devcontainer/PLAYWRIGHT_SETUP.md.
+RUN npm install -g "playwright@${PLAYWRIGHT_VERSION}" && \
+    echo "✅ Playwright CLI installed: $(playwright --version)"
 
 # Install Playwright browsers (Chromium, Firefox) with system dependencies
 # Note: Chrome excluded - no ARM64 Linux builds (breaks Apple Silicon). Chromium is equivalent.
-# Version 1.56.0+ correctly uses t64 package names (e.g., libasound2t64) for Ubuntu 24.04
-RUN npx playwright install --with-deps chromium firefox && \
+# Version 1.60.0 uses the current Playwright browser bundles and Ubuntu 24.04 t64 package names.
+RUN playwright install --with-deps chromium firefox && \
     echo "✅ Playwright browsers installed (Chromium, Firefox)"
 
 # Install pipx and Aider AI coding assistant

--- a/.devcontainer/development/scripts/help-dev
+++ b/.devcontainer/development/scripts/help-dev
@@ -57,7 +57,7 @@ DEBUGGING:
   debug-off               Return to INFO logging level
 
 CONTAINER PORTS:
-  Main app:  http://localhost:8080
+  Main app:  http://localhost:8080/carlos
   Debug:     http://localhost:8000
   Database:  localhost:3306
   Docs:      http://localhost:3000

--- a/.devcontainer/scripts/verify-playwright-path.sh
+++ b/.devcontainer/scripts/verify-playwright-path.sh
@@ -22,7 +22,17 @@ if [ ! -d "/root/.cache/ms-playwright" ]; then
 fi
 
 # Get Playwright version from Dockerfile
-PLAYWRIGHT_VERSION=$(grep -oP 'playwright@\K[0-9.]+' /workspace/.devcontainer/development/Dockerfile || echo "unknown")
+DOCKERFILE="/workspace/.devcontainer/development/Dockerfile"
+PLAYWRIGHT_VERSION="unknown"
+if [ -f "$DOCKERFILE" ]; then
+    PLAYWRIGHT_VERSION=$(awk -F= '/^ARG[[:space:]]+PLAYWRIGHT_VERSION=/ {print $2; exit}' "$DOCKERFILE")
+    if [ -z "$PLAYWRIGHT_VERSION" ]; then
+        PLAYWRIGHT_VERSION=$(grep -oP 'playwright@\K[0-9.]+' "$DOCKERFILE" | head -1 || true)
+    fi
+    if [ -z "$PLAYWRIGHT_VERSION" ]; then
+        PLAYWRIGHT_VERSION="unknown"
+    fi
+fi
 echo "📦 Playwright version in Dockerfile: ${PLAYWRIGHT_VERSION}"
 
 # Check installed Chromium directories

--- a/.devcontainer/scripts/verify-playwright-path.sh
+++ b/.devcontainer/scripts/verify-playwright-path.sh
@@ -41,18 +41,16 @@ fi
 echo
 echo "🌐 Latest installed Chromium revision: ${LATEST_CHROMIUM}"
 
-# Check if the executable exists
-EXPECTED_PATH="/root/.cache/ms-playwright/chromium-${LATEST_CHROMIUM}/chrome-linux/chrome"
-if [ -f "$EXPECTED_PATH" ]; then
+# Check if the executable exists. Playwright browser layouts can change
+# between releases, so discover the path instead of assuming chrome-linux.
+EXPECTED_PATH=$(find "/root/.cache/ms-playwright/chromium-${LATEST_CHROMIUM}" -path "*/chrome" -type f 2>/dev/null | sort | head -1 || true)
+if [ -n "$EXPECTED_PATH" ] && [ -f "$EXPECTED_PATH" ]; then
     echo -e "${GREEN}✅ Chromium executable found at: ${EXPECTED_PATH}${NC}"
 else
-    echo -e "${RED}❌ Chromium executable not found at expected path${NC}"
-    echo "   Expected: ${EXPECTED_PATH}"
-    
-    # Try to find alternative paths
+    echo -e "${RED}❌ Chromium executable not found${NC}"
     echo
     echo "🔎 Searching for chrome executable..."
-    find /root/.cache/ms-playwright/chromium-${LATEST_CHROMIUM} -name "chrome" -type f 2>/dev/null || echo "  Not found"
+    find "/root/.cache/ms-playwright/chromium-${LATEST_CHROMIUM}" -name "chrome" -type f 2>/dev/null || echo "  Not found"
     exit 1
 fi
 

--- a/.mcp.json
+++ b/.mcp.json
@@ -10,7 +10,7 @@
         "--browser",
         "chromium",
         "--executable-path",
-        "/root/.cache/ms-playwright/chromium-1194/chrome-linux/chrome",
+        "/root/.cache/ms-playwright/chromium-1223/chrome-linux64/chrome",
         "--timeout-action",
         "15000",
         "--timeout-navigation",


### PR DESCRIPTION
It was pointed out by @omkarhall that the local devcontainer URL should be `http://localhost:8080/carlos` instead of `http://localhost:8080`. Opening the root URL can route to `/oscar/` and produce a 404.

This PR also refreshes the Playwright devcontainer setup because the Dockerfile was still pinned to Playwright `1.56.0`, which can hang during browser installation in some environments. The devcontainer now uses Playwright `1.60.0`, matching the repo's current npm dependency, and the Playwright MCP Chromium path/docs have been updated for the new browser revision.

## Description

- Update the devcontainer README access URL to `http://localhost:8080/carlos`.
- Update the devcontainer Playwright install pin from `1.56.0` to `1.60.0`.
- Update `.mcp.json` and Playwright setup docs from Chromium revision `1194` to `1223`.
- Make the Playwright path verification script discover the installed Chrome executable instead of assuming the older `chrome-linux` layout.

## Related Issues

N/A

## How Was This Tested?

- `git diff --check`
- `bash -n .devcontainer/scripts/verify-playwright-path.sh`

A full devcontainer rebuild was not run.

## Screenshots

<img width="783" height="264" alt="image" src="https://github.com/user-attachments/assets/1cd77a0d-e90d-4e9c-bd4c-6517dbf3df2b" />

## Checklist

- [X] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [X] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [X] I have not included any patient data (PHI) in this PR
- [X] I have added tests for new functionality, or this change doesn't need new tests
- [X] I have read the [contributing guide](CONTRIBUTING.md)
