### PR TITLE
Fix #2344: Remove stale taglib imports and dead-code location dropdow…

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/login/3rdpartyLogin.jsp
+++ b/src/main/webapp/WEB-INF/jsp/login/3rdpartyLogin.jsp
@@ -1,314 +1,324 @@
-<%--
+<%-- Copyright (c) 2001-2002. Department of Family Medicine, McMaster University. All Rights Reserved. This software is
+    published under the GPL GNU General Public License. This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either
+    version 2 of the License, or (at your option) any later version. This program is distributed in the hope that it
+    will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+    PARTICULAR PURPOSE. See the GNU General Public License for more details. You should have received a copy of the GNU
+    General Public License along with this program; if not, write to the Free Software Foundation, Inc., 59 Temple Place
+    - Suite 330, Boston, MA 02111-1307, USA. This software was written for the Department of Family Medicine McMaster
+    University Hamilton Ontario, Canada Migrated from Apache CXF to ScribeJava OAuth1 implementation. Now maintained by
+    the CARLOS EMR Project (2026+). https://github.com/carlos-emr/carlos CARLOS has no affiliation with OSCAR or
+    McMaster University. --%>
 
-    Copyright (c) 2001-2002. Department of Family Medicine, McMaster University. All Rights Reserved.
-    This software is published under the GPL GNU General Public License.
-    This program is free software; you can redistribute it and/or
-    modify it under the terms of the GNU General Public License
-    as published by the Free Software Foundation; either version 2
-    of the License, or (at your option) any later version.
+    <%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
+        <%@ taglib uri="jakarta.tags.core" prefix="c" %>
+            <%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
+                <%@ taglib uri="carlos" prefix="carlos" %>
+                    <%@ page import="io.github.carlos_emr.carlos.utility.LoggedInInfo" %>
+                        <%@ page import="java.util.*" %>
+                            <%@ page import="jakarta.servlet.http.*" %>
+                                <%@ page import="io.github.carlos_emr.carlos.utility.MiscUtils" %>
+                                    <%@ page import="io.github.carlos_emr.carlos.login.OAuthData" %>
+                                        <%@ page import="io.github.carlos_emr.carlos.login.OOBAuthorizationResponse" %>
 
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
-
-    This software was written for the
-    Department of Family Medicine
-    McMaster University
-    Hamilton
-    Ontario, Canada
-
-    Migrated from Apache CXF to ScribeJava OAuth1 implementation.
-
-    Now maintained by the CARLOS EMR Project (2026+).
-    https://github.com/carlos-emr/carlos
-    CARLOS has no affiliation with OSCAR or McMaster University.
-
---%>
-
-<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
-<%@ taglib uri="jakarta.tags.core" prefix="c" %>
-<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
-<%@ taglib uri="carlos" prefix="carlos" %>
-<%@ page import="io.github.carlos_emr.carlos.utility.LoggedInInfo" %>
-<%@ page import="java.util.*" %>
-<%@ page import="jakarta.servlet.http.*" %>
-<%@ page import="io.github.carlos_emr.carlos.utility.MiscUtils" %>
-<%@ page import="io.github.carlos_emr.carlos.login.OAuthData" %>
-<%@ page import="io.github.carlos_emr.carlos.login.OOBAuthorizationResponse" %>
-
-<%
-    // --- Make variables visible to the whole JSP ---
-    OAuthData oauthData = (OAuthData) request.getAttribute("oauthData");
-    if (oauthData == null) {
-        // also check alternate key used elsewhere during the migration
-        oauthData = (OAuthData) request.getAttribute("oauthauthorizationdata");
-    }
-    if (oauthData == null) {
-        oauthData = (OAuthData) session.getAttribute("oauthData");
-        if (oauthData == null) {
-            oauthData = (OAuthData) session.getAttribute("oauthauthorizationdata");
-        }
-    }
-
-    OOBAuthorizationResponse oauthOobResponse =
-        (OOBAuthorizationResponse) request.getAttribute("oobauthorizationresponse");
-    if (oauthOobResponse == null) {
-        oauthOobResponse = (OOBAuthorizationResponse) session.getAttribute("oobauthorizationresponse");
-    }
-
-    LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
-
-    boolean loggedIn = (session.getAttribute("user") != null) && (loggedInInfo != null);
-
-    request.setAttribute("loggedIn", loggedIn);
-
-    String providerName = "";
-    if (loggedInInfo != null && loggedInInfo.getLoggedInProvider() != null) {
-        providerName = loggedInInfo.getLoggedInProvider().getFormattedName();
-    }
-    request.setAttribute("providerName", providerName);
-
-    if (oauthData != null) {
-        request.setAttribute("oauthData", oauthData);
-    }
-    if (oauthOobResponse != null) {
-        request.setAttribute("oauthOobResponse", oauthOobResponse);
-    }
-%>
+                                            <% // --- Make variables visible to the whole JSP --- OAuthData
+                                                oauthData=(OAuthData) request.getAttribute("oauthData"); if
+                                                (oauthData==null) { // also check alternate key used elsewhere during
+                                                the migration oauthData=(OAuthData)
+                                                request.getAttribute("oauthauthorizationdata"); } if (oauthData==null) {
+                                                oauthData=(OAuthData) session.getAttribute("oauthData"); if
+                                                (oauthData==null) { oauthData=(OAuthData)
+                                                session.getAttribute("oauthauthorizationdata"); } }
+                                                OOBAuthorizationResponse oauthOobResponse=(OOBAuthorizationResponse)
+                                                request.getAttribute("oobauthorizationresponse"); if
+                                                (oauthOobResponse==null) { oauthOobResponse=(OOBAuthorizationResponse)
+                                                session.getAttribute("oobauthorizationresponse"); } LoggedInInfo
+                                                loggedInInfo=LoggedInInfo.getLoggedInInfoFromSession(request); boolean
+                                                loggedIn=(session.getAttribute("user") !=null) && (loggedInInfo !=null);
+                                                request.setAttribute("loggedIn", loggedIn); String providerName="" ; if
+                                                (loggedInInfo !=null && loggedInInfo.getLoggedInProvider() !=null) {
+                                                providerName=loggedInInfo.getLoggedInProvider().getFormattedName(); }
+                                                request.setAttribute("providerName", providerName); if (oauthData
+                                                !=null) { request.setAttribute("oauthData", oauthData); } if
+                                                (oauthOobResponse !=null) { request.setAttribute("oauthOobResponse",
+                                                oauthOobResponse); } %>
 
 
-<!DOCTYPE html>
-<html>
-<head>
-    <link rel="icon" href="${pageContext.request.contextPath}/images/favicon.ico"/>
-    <meta charset="UTF-8">
-    <title>Login and Authorize 3rd Party Application</title>
-    <link href="${pageContext.request.contextPath}/library/bootstrap/5.3.8/css/bootstrap.min.css" rel="stylesheet">
-    <style type="text/css">
-        body {
-            padding-top: 40px;
-            padding-bottom: 40px;
-            background-color: #f5f5f5;
-        }
-        .form-signin {
-            max-width: 300px;
-            padding: 19px 29px 29px;
-            margin: 0 auto 20px;
-            background-color: #fff;
-            border: 1px solid #e5e5e5;
-            border-radius: 5px;
-            box-shadow: 0 1px 2px rgba(0, 0, 0, .05);
-        }
-        .form-signin .form-signin-heading,
-        .form-signin .form-check {
-            margin-bottom: 10px;
-        }
-        .form-signin input[type="text"],
-        .form-signin input[type="password"] {
-            font-size: 16px;
-            height: auto;
-            margin-bottom: 15px;
-            padding: 7px 9px;
-        }
-    </style>
-    <script>
-        // tiny DOM helpers
-        const el = (id) => document.getElementById(id);
-        const show = (id) => { const n = el(id); if (n) n.style.display = ""; };
-        const hide = (id) => { const n = el(id); if (n) n.style.display = "none"; };
-        const setText = (id, txt) => { const n = el(id); if (n) n.textContent = txt; };
+                                                <!DOCTYPE html>
+                                                <html>
 
-        // expose to inline onclick handlers
-        window.deny = () => {
-            const decision = el("oauthDecision");
-            const form = el("scopeForm");
-            if (decision) decision.value = "deny";
-            if (form) form.submit();
-        };
+                                                <head>
+                                                    <link rel="icon"
+                                                        href="${pageContext.request.contextPath}/images/favicon.ico" />
+                                                    <meta charset="UTF-8">
+                                                    <title>Login and Authorize 3rd Party Application</title>
+                                                    <link
+                                                        href="${pageContext.request.contextPath}/library/bootstrap/5.3.8/css/bootstrap.min.css"
+                                                        rel="stylesheet">
+                                                    <style type="text/css">
+                                                        body {
+                                                            padding-top: 40px;
+                                                            padding-bottom: 40px;
+                                                            background-color: #f5f5f5;
+                                                        }
 
-        window.submitCredentials = async () => {
-            const username = el("username")?.value || "";
-            const password = el("password")?.value || "";
-            const pin      = el("pin")?.value || "";
-            const oauthToken = el("oauth_token")?.value || "";
+                                                        .form-signin {
+                                                            max-width: 300px;
+                                                            padding: 19px 29px 29px;
+                                                            margin: 0 auto 20px;
+                                                            background-color: #fff;
+                                                            border: 1px solid #e5e5e5;
+                                                            border-radius: 5px;
+                                                            box-shadow: 0 1px 2px rgba(0, 0, 0, .05);
+                                                        }
 
-            // Authentication always rotates the session; rely on the new cookie instead of
-            // URL-rewriting the pre-authentication session id into follow-up OAuth requests.
-            const loginUrl = "${pageContext.request.contextPath}/login";
+                                                        .form-signin .form-signin-heading,
+                                                        .form-signin .form-check {
+                                                            margin-bottom: 10px;
+                                                        }
 
-            const formData = new URLSearchParams();
-            formData.set("username", username);
-            formData.set("password", password);
-            formData.set("pin", pin);
-            formData.set("ajaxResponse", "true");
-            formData.set("oauth_token", oauthToken);
+                                                        .form-signin input[type="text"],
+                                                        .form-signin input[type="password"] {
+                                                            font-size: 16px;
+                                                            height: auto;
+                                                            margin-bottom: 15px;
+                                                            padding: 7px 9px;
+                                                        }
+                                                    </style>
+                                                    <script>
+                                                        // tiny DOM helpers
+                                                        const el = (id) => document.getElementById(id);
+                                                        const show = (id) => { const n = el(id); if (n) n.style.display = ""; };
+                                                        const hide = (id) => { const n = el(id); if (n) n.style.display = "none"; };
+                                                        const setText = (id, txt) => { const n = el(id); if (n) n.textContent = txt; };
 
-            try {
-                const res = await fetch(loginUrl, {
-                    method: "POST",
-                    headers: { "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8" },
-                    body: formData.toString(),
-                    credentials: "same-origin"
-                });
+                                                        // expose to inline onclick handlers
+                                                        window.deny = () => {
+                                                            const decision = el("oauthDecision");
+                                                            const form = el("scopeForm");
+                                                            if (decision) decision.value = "deny";
+                                                            if (form) form.submit();
+                                                        };
 
-                const data = await res.json();
+                                                        window.submitCredentials = async () => {
+                                                            const username = el("username")?.value || "";
+                                                            const password = el("password")?.value || "";
+                                                            const pin = el("pin")?.value || "";
+                                                            const oauthToken = el("oauth_token")?.value || "";
 
-                if (data && data.success) {
-                    hide("login_div");
-                    show("scope_div");
-                    show("loggedin_div");
-                    setText("providerName", data.providerName || "");
-                } else {
-                    const msg = (data && data.error) ? data.error : "Login failed.";
-                    const err = el("login_error");
-                    if (err) {
-                        err.style.display = "";
-                        const span = err.querySelector("span span");
-                        if (span) span.textContent = msg;
-                    }
-                }
-                } catch (e) {
-                    const err = el("login_error");
-                    if (err) {
-                        err.style.display = "";
-                        const span = err.querySelector("span span");
-                        if (span) span.textContent = "Network error. Please try again.";
-                    }
-            }
-        };
+                                                            // Authentication always rotates the session; rely on the new cookie instead of
+                                                            // URL-rewriting the pre-authentication session id into follow-up OAuth requests.
+                                                            const loginUrl = "${pageContext.request.contextPath}/login";
 
-        document.addEventListener("DOMContentLoaded", () => {
-            const loggedIn = ${loggedIn};
-            const hasOauthOobResponse = ${not empty oauthOobResponse};
-            const safeProviderName = '${carlos:forJavaScript(providerName)}';
+                                                            const formData = new URLSearchParams();
+                                                            formData.set("username", username);
+                                                            formData.set("password", password);
+                                                            formData.set("pin", pin);
+                                                            formData.set("ajaxResponse", "true");
+                                                            formData.set("oauth_token", oauthToken);
 
-            if (loggedIn) {
-                hide("login_div");
-                show("scope_div");
-                show("loggedin_div");
-                setText("providerName", safeProviderName);
-            } else {
-                show("login_div");
-                hide("scope_div");
-                hide("loggedin_div");
-            }
+                                                            try {
+                                                                const res = await fetch(loginUrl, {
+                                                                    method: "POST",
+                                                                    headers: { "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8" },
+                                                                    body: formData.toString(),
+                                                                    credentials: "same-origin"
+                                                                });
 
-            if (hasOauthOobResponse) {
-                hide("login_div");
-            }
-        });
-    </script>
-</head>
-<body>
-<div class="container">
-    <div class="row">
-        <div class="col-md-5">
-            <div style="margin-top:25px;">
-                <img src="${pageContext.request.contextPath}/images/OSCAR-LOGO.gif"
-                     width="450" height="274" alt="CARLOS Logo">
-                <p>
-                    <font size="-1" face="Verdana, Arial, Helvetica, sans-serif">
-                        CARLOS EMR<br>
-                        For more info, visit
-                        <a href="http://www.oscarcanada.org">www.oscarcanada.org</a><br>
-                    </font>
-                </p>
-            </div>
-        </div>
-        <div class="col-md-7">
+                                                                const data = await res.json();
 
-            <!-- Username / Password Form -->
-            <div id="login_div" class="form-container">
-                <form class="form-signin">
-                    <h2 class="form-signin-heading">Please sign in</h2>
-                    <input class="form-control mb-2" placeholder="Username"
-                           type="text" id="username">
-                    <input class="form-control mb-2" placeholder="Password"
-                           type="password" id="password">
-                    <input class="form-control mb-2" placeholder="Pin"
-                           type="password" id="pin">
+                                                                if (data && data.success) {
+                                                                    hide("login_div");
+                                                                    show("scope_div");
+                                                                    show("loggedin_div");
+                                                                    setText("providerName", data.providerName || "");
+                                                                } else {
+                                                                    const msg = (data && data.error) ? data.error : "Login failed.";
+                                                                    const err = el("login_error");
+                                                                    if (err) {
+                                                                        err.style.display = "";
+                                                                        const span = err.querySelector("span span");
+                                                                        if (span) span.textContent = msg;
+                                                                    }
+                                                                }
+                                                            } catch (e) {
+                                                                const err = el("login_error");
+                                                                if (err) {
+                                                                    err.style.display = "";
+                                                                    const span = err.querySelector("span span");
+                                                                    if (span) span.textContent = "Network error. Please try again.";
+                                                                }
+                                                            }
+                                                        };
 
-                    <div id="login_error" class="form-text" style="display:none;">
-                        <span class="text-danger">
-                            <strong>Login Failed: </strong><span></span>
-                        </span>
-                    </div>
+                                                        document.addEventListener("DOMContentLoaded", () => {
+                                                            const loggedIn = ${ loggedIn };
+                                                            const hasOauthOobResponse = ${ not empty oauthOobResponse };
+                                                            const safeProviderName = '${carlos:forJavaScript(providerName)}';
 
-                    <button class="btn btn-lg btn-primary"
-                            type="button"
-                            onclick="submitCredentials()">
-                        Sign in
-                    </button>
-                </form>
-            </div>
+                                                            if (loggedIn) {
+                                                                hide("login_div");
+                                                                show("scope_div");
+                                                                show("loggedin_div");
+                                                                setText("providerName", safeProviderName);
+                                                            } else {
+                                                                show("login_div");
+                                                                hide("scope_div");
+                                                                hide("loggedin_div");
+                                                            }
 
-            <!-- Out‐of‐band Verifier Display -->
-            <div id="oob_div">
-            <c:if test="${not empty oauthOobResponse}">
-                <h5>
-                    Request token <carlos:encode value='${oauthOobResponse.requestToken}' context="html"/>
-                    has verifier <carlos:encode value='${oauthOobResponse.verifier}' context="html"/>
-                </h5>
-            </c:if>
-            </div>
+                                                            if (hasOauthOobResponse) {
+                                                                hide("login_div");
+                                                            }
+                                                        });
+                                                    </script>
+                                                </head>
 
-            <!-- OAuth Scope Approval -->
-            <div id="loggedin_div">
-                <c:if test="${not empty oauthData}">
-                    <form class="form-signin">
-                        <h2 class="form-signin-heading">Welcome</h2>
-                        <h4><span id="providerName"></span></h4>
-                    </form>
-                    <h5>
-                        The 3rd party application
-                        &quot;<carlos:encode value='${oauthData.applicationName}' context="html"/>&quot;
-                        is requesting access to your OSCAR account.<br>
-                        URL: <carlos:encode value='${oauthData.applicationURI}' context="html"/>.
-                    </h5>
-                    <h5>Permissions requested:</h5>
-                    <form id="scopeForm" method="post"
-                        action="${carlos:forHtmlAttribute(oauthData.replyTo)}">
-                        <c:forEach var="perm" items="${oauthData.permissions}">
-                            <div class="mb-3">
-                            <div>
-                                <div class="form-check">
-                                <input type="checkbox" class="form-check-input" checked="checked" disabled="disabled">
-                                <label class="form-check-label"><carlos:encode value='${perm}' context="html"/>
-                                <c:if test="${empty fn:trim(perm)}">
-                                    <em>(no description)</em>
-                                </c:if>
-                                </label>
-                                </div>
-                            </div>
-                            </div>
-                        </c:forEach>
+                                                <body>
+                                                    <div class="container">
+                                                        <div class="row">
+                                                            <div class="col-md-5">
+                                                                <div style="margin-top:25px;">
+                                                                    <img src="${pageContext.request.contextPath}/images/OSCAR-LOGO.gif"
+                                                                        width="450" height="274" alt="CARLOS Logo">
+                                                                    <p>
+                                                                        <font size="-1"
+                                                                            face="Verdana, Arial, Helvetica, sans-serif">
+                                                                            CARLOS EMR<br>
+                                                                            For more info, visit
+                                                                            <a
+                                                                                href="http://www.oscarcanada.org">www.oscarcanada.org</a><br>
+                                                                        </font>
+                                                                    </p>
+                                                                </div>
+                                                            </div>
+                                                            <div class="col-md-7">
 
-                        <input type="hidden" name="session_authenticity_token"
-                                value="<carlos:encode value='${oauthData.authenticityToken}' context="htmlAttribute"/>"/>
+                                                                <!-- Username / Password Form -->
+                                                                <div id="login_div" class="form-container">
+                                                                    <form class="form-signin">
+                                                                        <h2 class="form-signin-heading">Please sign in
+                                                                        </h2>
+                                                                        <input class="form-control mb-2"
+                                                                            placeholder="Username" type="text"
+                                                                            id="username">
+                                                                        <input class="form-control mb-2"
+                                                                            placeholder="Password" type="password"
+                                                                            id="password">
+                                                                        <input class="form-control mb-2"
+                                                                            placeholder="Pin" type="password" id="pin">
 
-                        <input type="hidden" name="oauth_token" id="oauth_token"
-                                value="<carlos:encode value='${oauthData.oauthToken}' context="htmlAttribute"/>"/>
+                                                                        <div id="login_error" class="form-text"
+                                                                            style="display:none;">
+                                                                            <span class="text-danger">
+                                                                                <strong>Login Failed:
+                                                                                </strong><span></span>
+                                                                            </span>
+                                                                        </div>
 
-                        <input type="hidden" name="oauthDecision" id="oauthDecision" value="allow"/>
+                                                                        <button class="btn btn-lg btn-primary"
+                                                                            type="button" onclick="submitCredentials()">
+                                                                            Sign in
+                                                                        </button>
+                                                                    </form>
+                                                                </div>
 
-                        <button type="submit" class="btn btn-primary">
-                            Authorize <carlos:encode value='${oauthData.applicationName}' context="html"/>
-                        </button>
+                                                                <!-- Out‐of‐band Verifier Display -->
+                                                                <div id="oob_div">
+                                                                    <c:if test="${not empty oauthOobResponse}">
+                                                                        <h5>
+                                                                            Request token
+                                                                            <carlos:encode
+                                                                                value='${oauthOobResponse.requestToken}'
+                                                                                context="html" />
+                                                                            has verifier
+                                                                            <carlos:encode
+                                                                                value='${oauthOobResponse.verifier}'
+                                                                                context="html" />
+                                                                        </h5>
+                                                                    </c:if>
+                                                                </div>
 
-                        <button type="button" class="btn btn-danger" onclick="deny();">
-                            Cancel
-                        </button>
-                    </form>
-                </c:if>
-            </div>
+                                                                <!-- OAuth Scope Approval -->
+                                                                <div id="loggedin_div">
+                                                                    <c:if test="${not empty oauthData}">
+                                                                        <form class="form-signin">
+                                                                            <h2 class="form-signin-heading">Welcome</h2>
+                                                                            <h4><span id="providerName"></span></h4>
+                                                                        </form>
+                                                                        <h5>
+                                                                            The 3rd party application
+                                                                            &quot;
+                                                                            <carlos:encode
+                                                                                value='${oauthData.applicationName}'
+                                                                                context="html" />&quot;
+                                                                            is requesting access to your OSCAR
+                                                                            account.<br>
+                                                                            URL:
+                                                                            <carlos:encode
+                                                                                value='${oauthData.applicationURI}'
+                                                                                context="html" />.
+                                                                        </h5>
+                                                                        <h5>Permissions requested:</h5>
+                                                                        <form id="scopeForm" method="post"
+                                                                            action="${carlos:forHtmlAttribute(oauthData.replyTo)}">
+                                                                            <c:forEach var="perm"
+                                                                                items="${oauthData.permissions}">
+                                                                                <div class="mb-3">
+                                                                                    <div>
+                                                                                        <div class="form-check">
+                                                                                            <input type="checkbox"
+                                                                                                class="form-check-input"
+                                                                                                checked="checked"
+                                                                                                disabled="disabled">
+                                                                                            <label
+                                                                                                class="form-check-label">
+                                                                                                <carlos:encode
+                                                                                                    value='${perm}'
+                                                                                                    context="html" />
+                                                                                                <c:if
+                                                                                                    test="${empty fn:trim(perm)}">
+                                                                                                    <em>(no
+                                                                                                        description)</em>
+                                                                                                </c:if>
+                                                                                            </label>
+                                                                                        </div>
+                                                                                    </div>
+                                                                                </div>
+                                                                            </c:forEach>
 
-        </div>
-    </div>
-</div>
-</body>
-</html>
+                                                                            <input type="hidden"
+                                                                                name="session_authenticity_token"
+                                                                                value="<carlos:encode value='${oauthData.authenticityToken}' context="
+                                                                                htmlAttribute" />"/>
+
+                                                                            <input type="hidden" name="oauth_token"
+                                                                                id="oauth_token"
+                                                                                value="<carlos:encode value='${oauthData.oauthToken}' context="
+                                                                                htmlAttribute" />"/>
+
+                                                                            <input type="hidden" name="oauthDecision"
+                                                                                id="oauthDecision" value="allow" />
+
+                                                                            <button type="submit"
+                                                                                class="btn btn-primary">
+                                                                                Authorize
+                                                                                <carlos:encode
+                                                                                    value='${oauthData.applicationName}'
+                                                                                    context="html" />
+                                                                            </button>
+
+                                                                            <button type="button" class="btn btn-danger"
+                                                                                onclick="deny();">
+                                                                                Cancel
+                                                                            </button>
+                                                                        </form>
+                                                                    </c:if>
+                                                                </div>
+
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </body>
+
+                                                </html>

--- a/src/main/webapp/WEB-INF/jsp/login/index.jsp
+++ b/src/main/webapp/WEB-INF/jsp/login/index.jsp
@@ -1,764 +1,851 @@
-<%--
-
-    Copyright (c) 2001-2002. Department of Family Medicine, McMaster University. All Rights Reserved.
-    This software is published under the GPL GNU General Public License.
-    This program is free software; you can redistribute it and/or
-    modify it under the terms of the GNU General Public License
-    as published by the Free Software Foundation; either version 2
-    of the License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
-
-    This software was written for the
-    Department of Family Medicine
-    McMaster University
-    Hamilton
-    Ontario, Canada
+<%-- Copyright (c) 2001-2002. Department of Family Medicine, McMaster University. All Rights Reserved. This software is
+    published under the GPL GNU General Public License. This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either
+    version 2 of the License, or (at your option) any later version. This program is distributed in the hope that it
+    will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+    PARTICULAR PURPOSE. See the GNU General Public License for more details. You should have received a copy of the GNU
+    General Public License along with this program; if not, write to the Free Software Foundation, Inc., 59 Temple Place
+    - Suite 330, Boston, MA 02111-1307, USA. This software was written for the Department of Family Medicine McMaster
+    University Hamilton Ontario, Canada Now maintained by the CARLOS EMR Project (2026+).
+    https://github.com/carlos-emr/carlos CARLOS has no affiliation with OSCAR or McMaster University. --%>
 
 
-    Now maintained by the CARLOS EMR Project (2026+).
-    https://github.com/carlos-emr/carlos
-    CARLOS has no affiliation with OSCAR or McMaster University.
+    <%@ page import="io.github.carlos_emr.carlos.login.UAgentInfo" %>
+        <%@ page import="io.github.carlos_emr.carlos.managers.MfaManager" %>
+            <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+                <fmt:setBundle basename="oscarResources" />
+                <%@ taglib uri='jakarta.tags.core' prefix="c" %>
+                        <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
+                            <%@ taglib uri="carlos" prefix="carlos" %>
+                                <%@ page contentType="text/html;charset=UTF-8" pageEncoding="UTF-8" session="false" %>
 
---%>
+                                    <% // detect if mobile device. String userAgent=request.getHeader("User-Agent");
+                                        String accept=request.getHeader("Accept"); UAgentInfo userAgentInfo=new
+                                        UAgentInfo(userAgent, accept); boolean
+                                        isMobileDevice=userAgentInfo.detectMobileQuick();
+                                        pageContext.setAttribute("isMobileDevice", isMobileDevice); %>
 
+                                        <jsp:useBean id="LoginResourceBean"
+                                            beanName="io.github.carlos_emr.carlos.login.LoginResourceBean"
+                                            type="io.github.carlos_emr.carlos.login.LoginResourceBean" />
+                                        <c:set var="login_error" value="" scope="page" />
+                                        <!DOCTYPE html>
+                                        <html>
 
-<%@ page import="io.github.carlos_emr.carlos.login.UAgentInfo" %>
-<%@ page import="io.github.carlos_emr.carlos.managers.MfaManager" %>
-<%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
-<fmt:setBundle basename="oscarResources"/>
-<%@ taglib uri='jakarta.tags.core' prefix="c" %>
-<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
-<%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
-<%@ taglib uri="carlos" prefix="carlos" %>
-<%@ page contentType="text/html;charset=UTF-8" pageEncoding="UTF-8" session="false" %>
+                                        <head>
+                                            <%@ include file="/WEB-INF/jsp/includes/global-head.jspf" %>
+                                                <title>
+                                                    <fmt:message key="loginApplication.title" />
+                                                </title>
 
-<%
-    // detect if mobile device.
-    String userAgent = request.getHeader("User-Agent");
-    String accept = request.getHeader("Accept");
-    UAgentInfo userAgentInfo = new UAgentInfo(userAgent, accept);
-    boolean isMobileDevice = userAgentInfo.detectMobileQuick();
-    pageContext.setAttribute("isMobileDevice", isMobileDevice);
-%>
+                                                <link rel="icon"
+                                                    href="${pageContext.request.contextPath}/images/favicon.ico" />
+                                                <link href="${pageContext.request.contextPath}/css/Roboto.css"
+                                                    rel='stylesheet' type='text/css' />
+                                                <script type="text/javascript">
 
-<jsp:useBean id="LoginResourceBean" beanName="io.github.carlos_emr.carlos.login.LoginResourceBean" type="io.github.carlos_emr.carlos.login.LoginResourceBean"/>
-<c:set var="login_error" value="" scope="page"/>
-<!DOCTYPE html>
-<html>
+                                                    function showHideItem(id) {
+                                                        if (document.getElementById(id).style.display === 'none') {
+                                                            document.getElementById(id).style.display = 'block';
+                                                        } else {
+                                                            document.getElementById(id).style.display = 'none';
+                                                        }
+                                                    }
 
-    <head>
-        <%@ include file="/WEB-INF/jsp/includes/global-head.jspf" %>
-        <title>
-            <fmt:message key="loginApplication.title"/>
-        </title>
+                                                    function togglepwd() {
+                                                        const passwordInput = document.getElementById('password');
+                                                        const toggleBtn = document.getElementById('toggleBtn');
+                                                        // Flip the input type first, then read the post-toggle state for ARIA
+                                                        passwordInput.type = passwordInput.type === 'password' ? 'text' : 'password';
+                                                        const isNowVisible = passwordInput.type === 'text';
+                                                        toggleBtn.setAttribute('aria-pressed', isNowVisible ? 'true' : 'false');
+                                                        toggleBtn.setAttribute('aria-label', isNowVisible ? 'Hide password' : 'Show password');
+                                                    }
 
-        <link rel="icon" href="${pageContext.request.contextPath}/images/favicon.ico"/>
-        <link href="${pageContext.request.contextPath}/css/Roboto.css" rel='stylesheet' type='text/css'/>
-        <script type="text/javascript">
+                                                    function togglepin() {
+                                                        const pinInput = document.getElementById('pin');
+                                                        // Toggle the custom security class
+                                                        pinInput.classList.toggle('secure-text');
+                                                        const toggleBtn = document.getElementById('togglePin');
+                                                        const isNowVisible = !(pinInput.classList.contains("secure-text"));
+                                                        toggleBtn.setAttribute('aria-pressed', isNowVisible ? 'true' : 'false');
+                                                        toggleBtn.setAttribute('aria-label', isNowVisible ? 'Hide PIN' : 'Show PIN');
+                                                    }
 
-            function showHideItem(id) {
-                if (document.getElementById(id).style.display === 'none') {
-                    document.getElementById(id).style.display = 'block';
-                } else {
-                    document.getElementById(id).style.display = 'none';
-                }
-            }
+                                                    function setfocus() {
+                                                        document.loginForm.username.focus();
+                                                        document.loginForm.username.select();
+                                                    }
 
-            function togglepwd(){
-                const passwordInput = document.getElementById('password');
-                const toggleBtn = document.getElementById('toggleBtn');
-                // Flip the input type first, then read the post-toggle state for ARIA
-                passwordInput.type = passwordInput.type === 'password' ? 'text' : 'password';
-                const isNowVisible = passwordInput.type === 'text';
-                toggleBtn.setAttribute('aria-pressed', isNowVisible ? 'true' : 'false');
-                toggleBtn.setAttribute('aria-label', isNowVisible ? 'Hide password' : 'Show password');
-            }
+                                                    // Clear any stale logout signals from a previous session so they do not
+                                                    // cause an immediate logout loop if the user logs in again in this tab.
+                                                    try { localStorage.removeItem('carlos_logout_signal'); } catch (e) { }
+                                                    // Drain and close any pending BroadcastChannel logout messages, then
+                                                    // re-open a channel that ignores messages until the page navigates away.
+                                                    try {
+                                                        var bc = new BroadcastChannel('carlos_logout');
+                                                        bc.onmessage = function () { }; // consume and ignore stale broadcasts
+                                                        // Close on form submit so the authenticated page gets a clean channel
+                                                        var loginForm = document.querySelector('form[name="loginForm"]');
+                                                        if (loginForm) {
+                                                            loginForm.addEventListener('submit', function () { try { bc.close(); } catch (e) { } });
+                                                        }
+                                                    } catch (e) { }
 
-            function togglepin(){
-                const pinInput = document.getElementById('pin');
-                // Toggle the custom security class
-                pinInput.classList.toggle('secure-text');
-                const toggleBtn = document.getElementById('togglePin');
-                const isNowVisible = !(pinInput.classList.contains("secure-text"));
-                toggleBtn.setAttribute('aria-pressed', isNowVisible ? 'true' : 'false');
-                toggleBtn.setAttribute('aria-label', isNowVisible ? 'Hide PIN' : 'Show PIN');
-            }
+                                                    function popupPage(vheight, vwidth, varpage) {
+                                                        var page = "" + varpage;
+                                                        windowprops = "height=" + vheight + ",width=" + vwidth + ",location=no,scrollbars=yes,menubars=no,toolbars=no,resizable=yes";
+                                                        window.open(page, "gpl", windowprops);
+                                                    }
 
-            function setfocus() {
-                document.loginForm.username.focus();
-                document.loginForm.username.select();
-            }
+                                                    function enhancedOrClassic(choice) {
+                                                        document.getElementById("loginType").value = choice;
+                                                    }
+                                                </script>
 
-            // Clear any stale logout signals from a previous session so they do not
-            // cause an immediate logout loop if the user logs in again in this tab.
-            try { localStorage.removeItem('carlos_logout_signal'); } catch(e) {}
-            // Drain and close any pending BroadcastChannel logout messages, then
-            // re-open a channel that ignores messages until the page navigates away.
-            try {
-                var bc = new BroadcastChannel('carlos_logout');
-                bc.onmessage = function() {}; // consume and ignore stale broadcasts
-                // Close on form submit so the authenticated page gets a clean channel
-                var loginForm = document.querySelector('form[name="loginForm"]');
-                if (loginForm) {
-                    loginForm.addEventListener('submit', function() { try { bc.close(); } catch(e) {} });
-                }
-            } catch(e) {}
+                                                <style media="all">
+                                                    body,
+                                                    html {
+                                                        height: 100%;
+                                                    }
 
-            function popupPage(vheight, vwidth, varpage) {
-                var page = "" + varpage;
-                windowprops = "height=" + vheight + ",width=" + vwidth + ",location=no,scrollbars=yes,menubars=no,toolbars=no,resizable=yes";
-                window.open(page, "gpl", windowprops);
-            }
+                                                    body {
+                                                        margin: 0;
+                                                        font-family: 'Roboto', Helvetica, Arial, sans-serif;
+                                                        font-size: 16px;
+                                                        color: #333333;
+                                                        background-color: #ffffff;
+                                                        display: flex;
+                                                        flex-direction: column;
+                                                    }
 
-            function enhancedOrClassic(choice) {
-                document.getElementById("loginType").value = choice;
-            }
-        </script>
+                                                    * {
+                                                        -webkit-box-sizing: border-box;
+                                                        -moz-box-sizing: border-box;
+                                                        box-sizing: border-box;
+                                                    }
 
-        <style media="all">
-            body, html {
-                height: 100%;
-            }
+                                                    .content {
+                                                        flex: 1 0 auto;
+                                                    }
 
-            body {
-                margin: 0;
-                font-family: 'Roboto', Helvetica, Arial, sans-serif;
-                font-size: 16px;
-                color: #333333;
-                background-color: #ffffff;
-                display: flex;
-                flex-direction: column;
-            }
+                                                    .extrasmall a {
+                                                        color: blue;
+                                                    }
 
-            * {
-                -webkit-box-sizing: border-box;
-                -moz-box-sizing: border-box;
-                box-sizing: border-box;
-            }
+                                                    a {
+                                                        text-decoration: none;
+                                                        border: none;
+                                                        padding: 0;
+                                                        margin: 0;
+                                                        color: black;
+                                                    }
 
-            .content {
-                flex: 1 0 auto;
-            }
+                                                    img {
+                                                        max-width: 100%;
+                                                        height: auto;
+                                                        width: auto;
+                                                    }
 
-            .extrasmall a {
-                color: blue;
-            }
+                                                    #clinic_logo {
+                                                        max-width: 400px;
+                                                        margin: 0 auto;
+                                                    }
 
-            a {
-                text-decoration: none;
-                border: none;
-                padding: 0;
-                margin: 0;
-                color: black;
-            }
+                                                    .loginContainer .card-header #oscar_logo {
+                                                        max-width: 300px;
+                                                        margin: 0 auto;
+                                                    }
 
-            img {
-                max-width: 100%;
-                height: auto;
-                width: auto;
-            }
+                                                    .loginContainer .card-header {
+                                                        margin: 0 auto;
+                                                        padding-top: 25px;
+                                                        padding-bottom: 10px;
+                                                    }
 
-            #clinic_logo {
-                max-width: 400px;
-                margin: 0 auto;
-            }
+                                                    h1 {
+                                                        font-size: 38px;
+                                                        font-weight: 300;
+                                                    }
 
-            .loginContainer .card-header #oscar_logo {
-                max-width: 300px;
-                margin: 0 auto;
-            }
+                                                    button,
+                                                    input,
+                                                    optgroup,
+                                                    select,
+                                                    textarea {
+                                                        margin: 0;
+                                                        font: inherit;
+                                                        color: inherit;
+                                                    }
 
-            .loginContainer .card-header {
-                margin: 0 auto;
-                padding-top: 25px;
-                padding-bottom: 10px;
-            }
+                                                    input {
+                                                        line-height: normal;
+                                                    }
 
-            h1 {
-                font-size: 38px;
-                font-weight: 300;
-            }
+                                                    button,
+                                                    input,
+                                                    select,
+                                                    textarea {
+                                                        font-family: inherit;
+                                                        font-size: inherit;
+                                                        line-height: inherit;
+                                                    }
 
-            button, input, optgroup, select, textarea {
-                margin: 0;
-                font: inherit;
-                color: inherit;
-            }
+                                                    .heading,
+                                                    .loginContainer {
+                                                        text-align: center;
+                                                    }
 
-            input {
-                line-height: normal;
-            }
+                                                    .powered {
+                                                        margin-right: auto;
+                                                        margin-left: auto;
+                                                    }
 
-            button, input, select, textarea {
-                font-family: inherit;
-                font-size: inherit;
-                line-height: inherit;
-            }
+                                                    .powered .details {
+                                                        text-align: right;
+                                                        margin: 10px 20px 0 0;
+                                                        display: inline-table;
+                                                        width: 35%;
+                                                    }
 
-            .heading, .loginContainer {
-                text-align: center;
-            }
+                                                    .loginContainer {
+                                                        padding: 30px 15px;
+                                                        margin-right: auto;
+                                                        margin-left: auto;
+                                                    }
 
-            .powered {
-                margin-right: auto;
-                margin-left: auto;
-            }
+                                                    .auaContainer {
+                                                        margin: 0 auto;
+                                                        text-align: left;
+                                                        z-index: 3;
+                                                        margin-bottom: 30px;
+                                                        padding: 15px;
+                                                    }
 
-            .powered .details {
-                text-align: right;
-                margin: 10px 20px 0 0;
-                display: inline-table;
-                width: 35%;
-            }
+                                                    .auaContainer .card {
+                                                        padding: 10px;
+                                                    }
 
-            .loginContainer {
-                padding: 30px 15px;
-                margin-right: auto;
-                margin-left: auto;
-            }
+                                                    .auaContainer .card-header {
+                                                        font-size: small;
+                                                        text-align: center;
+                                                    }
 
-            .auaContainer {
-                margin: 0 auto;
-			text-align: left;
-                z-index: 3;
-                margin-bottom: 30px;
-                padding: 15px;
-            }
+                                                    .auaContainer .card-body {
+                                                        font-size: x-small;
+                                                    }
 
-            .auaContainer .card {
-                padding: 10px;
-            }
+                                                    .card {
+                                                        background-color: #fff;
+                                                        border: 1px solid transparent;
+                                                        border-radius: 4px;
+                                                        -webkit-box-shadow: 0 1px 1px rgba(0, 0, 0, .05);
+                                                        box-shadow: 0 1px 1px rgba(0, 0, 0, .05);
+                                                    }
 
-            .auaContainer .card-header {
-                font-size: small;
-			text-align: center;
-            }
+                                                    .card-body {
+                                                        padding: 10px 40px 40px;
+                                                    }
 
-            .auaContainer .card-body {
-                font-size: x-small;
-            }
+                                                    .card.border-danger>.card-header {
+                                                        color: #a94442;
+                                                        background-color: #f2dede;
+                                                        border-color: #ebccd1;
+                                                    }
 
-            .card {
-                background-color: #fff;
-                border: 1px solid transparent;
-                border-radius: 4px;
-                -webkit-box-shadow: 0 1px 1px rgba(0, 0, 0, .05);
-                box-shadow: 0 1px 1px rgba(0, 0, 0, .05);
-            }
+                                                    .card.border-danger>.card-header+.collapse>.card-body {
+                                                        border-top-color: #ebccd1;
+                                                    }
 
-            .card-body {
-                padding: 10px 40px 40px;
-            }
+                                                    .card.border-danger>.card-header .badge {
+                                                        color: #f2dede;
+                                                        background-color: #a94442;
+                                                    }
 
-            .card.border-danger > .card-header {
-                color: #a94442;
-                background-color: #f2dede;
-                border-color: #ebccd1;
-            }
+                                                    .card.border-danger>.card-footer+.collapse>.card-body {
+                                                        border-bottom-color: #ebccd1;
+                                                    }
 
-            .card.border-danger > .card-header + .collapse > .card-body {
-                border-top-color: #ebccd1;
-            }
+                                                    .card {
+                                                        border-color: #ddd;
+                                                    }
 
-            .card.border-danger > .card-header .badge {
-                color: #f2dede;
-                background-color: #a94442;
-            }
-
-            .card.border-danger > .card-footer + .collapse > .card-body {
-                border-bottom-color: #ebccd1;
-            }
-
-            .card {
-                border-color: #ddd;
-            }
-
-            /* Bootstrap 5 migration: .form-group replaced by .mb-3 utility class.
+                                                    /* Bootstrap 5 migration: .form-group replaced by .mb-3 utility class.
                Custom margin-bottom kept here for login page styling. */
-            .mb-3 {
-                margin-bottom: 15px;
-            }
-
-            .form-control {
-                display: block;
-                width: 100%;
-                height: 34px;
-                padding: 6px 12px;
-                font-size: 14px;
-                line-height: 1.42857143;
-                color: #555;
-                background-color: #fff;
-                background-image: none;
-                border: 1px solid #ccc;
-                border-radius: 4px;
-                -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075);
-                box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075);
-                -webkit-transition: border-color ease-in-out .15s, -webkit-box-shadow ease-in-out .15s;
-                -o-transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
-                transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
-            }
-
-            .is-invalid .form-control {
-                border-color: #a94442;
-                -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075);
-                box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075);
-            }
-
-            .alert {
-                color: #a94442;
-            }
-
-            .btn {
-                display: inline-block;
-                padding: 6px 12px;
-                margin-bottom: 0;
-                font-size: 14px;
-                font-weight: 400;
-                line-height: 1.42857143;
-                text-align: center;
-                white-space: nowrap;
-                vertical-align: middle;
-                -ms-touch-action: manipulation;
-                touch-action: manipulation;
-                cursor: pointer;
-                -webkit-user-select: none;
-                -moz-user-select: none;
-                -ms-user-select: none;
-                user-select: none;
-                background-image: none;
-                border: 1px solid transparent;
-                border-radius: 4px;
-            }
-
-            .btn-primary {
-                color: #fff;
-                background-color: #53b848;
-                border-color: #3f9336;
-            }
-
-            button, html input[type=button], input[type=reset], input[type=submit] {
-                -webkit-appearance: button;
-                cursor: pointer;
-            }
-
-            .btn.active.focus, .btn.active:focus, .btn.focus, .btn:active.focus,
-            .btn:active:focus, .btn:focus {
-                outline: 5px auto -webkit-focus-ring-color;
-                outline-offset: -2px;
-            }
-
-            .btn.focus, .btn:focus, .btn:hover {
-                color: #333;
-                text-decoration: none;
-            }
-
-            .btn.active, .btn:active {
-                background-image: none;
-                outline: 0;
-                -webkit-box-shadow: inset 0 3px 5px rgba(0, 0, 0, .125);
-                box-shadow: inset 0 3px 5px rgba(0, 0, 0, .125);
-            }
-
-            .btn[disabled="disabled"]:hover {
-                cursor: not-allowed;
-            }
-
-            .btn-primary.focus, .btn-primary:focus {
-                color: #fff;
-                background-color: #3f9336;
-                border-color: #3f9336;
-            }
-
-            .btn-primary:hover {
-                color: #fff;
-                background-color: #3f9336;
-                border-color: #3f9336;
-            }
-
-            .btn-primary.active, .btn-primary:active {
-                color: #fff;
-                background-color: #3f9336;
-                border-color: #3f9336;
-            }
-
-            .btn-primary.active, .btn-primary:active {
-                background-image: none;
-            }
-
-
-            .btn.active.focus, .btn.active:focus, .btn.focus, .btn:active.focus,
-            .btn:active:focus, .btn:focus {
-                outline: 5px auto -webkit-focus-ring-color;
-                outline-offset: -2px;
-            }
-
-            .btn-primary.active.focus, .btn-primary.active:focus, .btn-primary.active:hover,
-            .btn-primary:active.focus, .btn-primary:active:focus, .btn-primary:active:hover {
-                color: #fff;
-                background-color: #3f9336;
-                border-color: #3f9336;
-            }
-
-            span#buildInfo {
-                float: right;
-                color: grey;
-                font-size: x-small;
-                text-align: right;
-                position: absolute;
-                right: 0;
-                padding-top: 5px;
-                padding-right: 10px;
-            }
-
-            span.extrasmall {
-                font-size: x-small;
-            }
-
-            .clinic-text {
-                display: inline;
-                font-weight: 400;
-            }
-
-            @media ( min-width: 450px) {
-                .loginContainer, .powered, .auaContainer {
-                    width: 350px;
-                }
-
-                .loginContainer .card-header {
-                    width: 200px;
-                }
-
-                #clinic_logo {
-                    width: 400px;
-                    margin: 0 auto;
-                }
-
-            }
-
-            @media ( min-width: 768px) {
-                .loginContainer, .powered, .auaContainer {
-                    width: 450px;
-                }
-
-                .loginContainer .card-header {
-                    width: 300px;
-                }
-
-                #clinic_logo {
-                    width: 500px;
-                    margin: 0 auto;
-                }
-            }
-
-            @media ( min-width: 992px) {
-            }
-
-            @media ( min-width: 1200px) {
-            }
-
-            footer {
-                padding: 5px 10px;
-                margin-top: 50px;
-                color: grey;
-                position: sticky;
-                flex-shrink: 0;
-            }
-
-            footer a {
-                color: blue;
-            }
-
-            .topbar {
-                height: 25px;
-            }
-
-            #clinic_name {
-                margin-bottom: 0;
-            }
-
-            #clinic_text, #support_text, .topbar #buildInfo {
-                color: grey;
-            }
-
-            .support_details {
-                text-align: left;
-                width: 35%;
-                display: inline-table;
-            }
-
-            .support_details div {
-                font-size: smaller;
-                text-align: center;
-            }
-
-            #supportImageLink img {
-                max-width: 150px;
-                height: auto;
-            }
-
-            /* Hide the default browser eye in Edge */
-            #password::-ms-reveal,
-            #password::-ms-clear {
-              display: none;
-            }
-            .secure-text { -webkit-text-security: disc; }
-
-            .input-wrapper { position: relative; display: inline-block; margin-bottom: 15px; width: 100%; }
-            .toggle-input { width: 100%; padding-right: 35px; box-sizing: border-box; }
-
-            .toggle-btn {
-              position: absolute; right: 10px; top: 17px; transform: translateY(-50%);
-              width: 26px; height: 26px; border: none;
-              cursor: pointer;
-            }
-
-            /* Svg for "Hidden" state (Class-based OR Type-based) */
-            .toggle-input.secure-text + .toggle-btn,
-            .toggle-input[type="password"] + .toggle-btn {
-              display: inline-block;
-              width: 24px; /* 24px+ for click area WCAG SC 2.5.8 AA */
-              height: 24px;
-              background-color: #959595; /* 3:1 contrast ratio as per WCAG, alternately use currentColor; to match text color */
-              -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>');
-              mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>');
-              mask-size: contain;
-              -webkit-mask-repeat: no-repeat;
-              mask-repeat: no-repeat;
-              mask-position: center;
-            }
-
-            /* Svg for "Visible" state */
-            .toggle-input:not(.secure-text):not([type="password"]) + .toggle-btn {
-            display: inline-block;
-              width: 24px; /* NO SMALLER for best practice */
-              height: 24px;
-              background-color: #959595; /* lightest grey that gives 3:1 contrast ratio */
-              -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/><line x1="0" y1="24" x2="24" y2="0" /></svg>');
-              mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/><line x1="0" y1="24" x2="24" y2="0" /></svg>');
-              mask-size: contain;
-              -webkit-mask-repeat: no-repeat;
-              mask-repeat: no-repeat;
-              mask-position: center;
-            }
-        </style>
-<style>
-body {
-  background-image: url("${pageContext.request.contextPath}/images/cloud-bg.svg");
-  background-repeat: no-repeat;
-  background-size: cover;
-  background-position: center;
-  background-attachment: fixed;
-}
-</style>
-    </head>
-
-    <body onLoad="setfocus()">
-
-
-    <div class="content">
-        <div class="topbar">
-            <span id="buildInfo" style="color:black;">
-            	${carlos:forHtml(LoginResourceBean.buildTag)}
-            </span>
-        </div>
-
-        <div class="heading">
-
-            <!-- Clinic logo  -->
-            <div id="clinic_logo">
-                <a target="_blank" href="${ LoginResourceBean.clinicLink }">
-                    <img src="${ pageContext.request.contextPath }/loginResource/clinicLogo.png"
-                         alt="${ LoginResourceBean.clinicLink }"
-                         onerror="this.style.display='none'"/>
-                </a>
-            </div>
-
-<div>
-<br>
-<span style="font-size: 40px; font-weight: bold; color: white; text-shadow: 2px 2px 5px rgba(0,0,0,0.7);">CARLOS</span>
-<br>
-</div>
-            <!-- Clinic info -->
-            <div id="clinic_text">
-                <h2 id="clinic_name">
-                    <a target="_blank" href="${ LoginResourceBean.clinicLink }">
-                        ${carlos:forHtml(LoginResourceBean.clinicName)}
-                    </a>
-                </h2>
-                <div id="clinic_address">
-                    ${ LoginResourceBean.clinicText }
-                </div>
-            </div>
-
-        </div>
-
-        <div class="loginContainer">
-            <div class="card">
-
-                <div class="card-header">
-
-                        <%--			    	<div id="oscar_logo">--%>
-                        <%--				    	<!-- EMR logo -->--%>
-                        <%--			        	<img title="EMR Login" src="${pageContext.request.contextPath}/images/Logo.png"  alt="EMR Login"--%>
-                        <%--			        		onerror="document.getElementById('default_logo').style.display='block'; this.style.display='none'; " />--%>
-                        <%--		        	</div>--%>
-
-                    <!-- default text if logo is missing -->
-                    <h2 id="default_logo" style="display:none;">
-                        <fmt:message key="loginApplication.formLabel"/>
-                    </h2>
-                </div>
-
-                <c:if test='${ param.login eq "failed" }'>
-                    <c:set var="login_error" value="is-invalid" scope="page"/>
-                    <div class="alert">
-                        <fmt:message key="loginApplication.formFailedLabel"/>
-                    </div>
-                </c:if>
-
-                <div class="card-body">
-                    <div class="leftinput">
-                        <%--
-                            Autocomplete attribute strategy (WHATWG HTML spec):
-                            - username: "off" \u2014 shared clinical workstations; prevent autofill of another provider's identity
-                            - password: "current-password" \u2014 enable browser password manager save/fill per
-                              NIST SP 800-63B (https://pages.nist.gov/800-63-3/sp800-63b.html) and
-                              OWASP Authentication Cheat Sheet (https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html)
-                              which recommend allowing password managers for stronger credential hygiene
-                            - pin: "one-time-code" \u2014 signal browsers this is a session code, not a saveable credential
-                        --%>
-                        <form action="login" method="POST" name="loginForm">
-
-                            <div class="mb-3 ${ login_error }">
-                                <input type="text" name="username" id="username" placeholder="<fmt:message key="Logon.userName"/>"
-                                       value="" size="15" maxlength="15" autocomplete="off"
-                                       class="form-control" required>
-                            </div>
-
-                            <div class="input-wrapper mb-3 ${ login_error }">
-                              <input type="password" name="password" id="password" placeholder="<fmt:message key="Logon.passWord"/>" autocomplete="current-password" class="form-control toggle-input" required>
-                              <button type="button" tabindex="-1"
-                                      id="toggleBtn"
-                                      class="toggle-btn"
-                                      aria-label="Show Password"
-                                      aria-pressed="false"
-                                      onclick="togglepwd();">
-                              </button>
-                            </div>
-
-							<% if (MfaManager.isOscarLegacyPinEnabled()) { %>
-                            <div class="pin-wrapper">
-                                <div class="input-wrapper mb-3 ${ login_error }">
-                                  <!-- The input starts with the secure-text class -->
-                                  <input type="text" id="pin" class="form-control secure-text toggle-input" name="pin" autocomplete="one-time-code"
-                                               inputmode="numeric"  placeholder="<fmt:message key="admin.securityrecord.formPIN"/>">
-                                    <button type="button" tabindex="-1"
-                                      id="togglePin"
-                                      class="toggle-btn"
-                                      aria-label="Show PIN"
-                                      aria-pressed="false"
-                                      onclick="togglepin();">
-                                    </button>
-                                    <span class="extrasmall">
-										    <fmt:message key="loginApplication.formCmt"/>
-                                    </span>
-                                </div>
-                            </div>
-							<% } %>
-                            <input type="hidden" id="loginType" name="loginType" value="">
-                            <input type=hidden name='propname'
-                                   value='<fmt:message key="loginApplication.propertyFile"/>'>
-
-                            <div id="buttonContainer">
-                                <c:choose>
-                                    <c:when test="${ isMobileDevice }">
-                                        <input class="btn btn-oscar btn-primary w-100 mb-2" name="submit" id="fullSubmit"
-                                               type="submit" onclick="enhancedOrClassic('C');" value="Full">
-                                        <input class="btn btn-oscar btn-primary w-100 mb-2" name="submit"
-                                               id="mobileSubmit" type="submit" onclick="enhancedOrClassic('C');"
-                                               value="Mobile">
-                                    </c:when>
-                                    <c:otherwise>
-                                        <input class="btn btn-oscar btn-primary w-100 mb-2" name="submit" type="submit"
-                                               onclick="enhancedOrClassic('C');" value="<fmt:message key="index.btnSignIn"/>">
-                                    </c:otherwise>
-                                </c:choose>
-                            </div>
-
-                        </form>
-
-                        <c:if test="${ LoginResourceBean.acceptableUseAgreementManager.auaAvailable }">
-    			            <span class="extrasmall">
-	                        	<fmt:message key="global.aua"/> &nbsp;
-	                        	<a href="javascript:void(0);" onclick="showHideItem('auaText');">
-	                        		<fmt:message key="global.showhide"/>
-	                        	</a>
-	                        </span>
-                        </c:if>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <div id="auaText" class="auaContainer" style="display:none;">
-            <div class="card">
-                <div class="card-header">
-                    Acceptable Use Agreement
-                </div>
-                <div class="card-body">
-                    ${ LoginResourceBean.acceptableUseAgreementManager.text }
-                </div>
-                <div class="card-footer"></div>
-            </div>
-        </div>
-
-
-        <c:if test="${ LoginResourceBean.acceptableUseAgreementManager.auaAvailable and LoginResourceBean.acceptableUseAgreementManager.alwaysShow }">
-            <script type="text/javascript">document.getElementById('auaText').style.display = 'block';</script>
-        </c:if>
-
-        <div class="powered">
-            <c:if test="${ not empty LoginResourceBean.supportLink
+                                                    .mb-3 {
+                                                        margin-bottom: 15px;
+                                                    }
+
+                                                    .form-control {
+                                                        display: block;
+                                                        width: 100%;
+                                                        height: 34px;
+                                                        padding: 6px 12px;
+                                                        font-size: 14px;
+                                                        line-height: 1.42857143;
+                                                        color: #555;
+                                                        background-color: #fff;
+                                                        background-image: none;
+                                                        border: 1px solid #ccc;
+                                                        border-radius: 4px;
+                                                        -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075);
+                                                        box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075);
+                                                        -webkit-transition: border-color ease-in-out .15s, -webkit-box-shadow ease-in-out .15s;
+                                                        -o-transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+                                                        transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+                                                    }
+
+                                                    .is-invalid .form-control {
+                                                        border-color: #a94442;
+                                                        -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075);
+                                                        box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075);
+                                                    }
+
+                                                    .alert {
+                                                        color: #a94442;
+                                                    }
+
+                                                    .btn {
+                                                        display: inline-block;
+                                                        padding: 6px 12px;
+                                                        margin-bottom: 0;
+                                                        font-size: 14px;
+                                                        font-weight: 400;
+                                                        line-height: 1.42857143;
+                                                        text-align: center;
+                                                        white-space: nowrap;
+                                                        vertical-align: middle;
+                                                        -ms-touch-action: manipulation;
+                                                        touch-action: manipulation;
+                                                        cursor: pointer;
+                                                        -webkit-user-select: none;
+                                                        -moz-user-select: none;
+                                                        -ms-user-select: none;
+                                                        user-select: none;
+                                                        background-image: none;
+                                                        border: 1px solid transparent;
+                                                        border-radius: 4px;
+                                                    }
+
+                                                    .btn-primary {
+                                                        color: #fff;
+                                                        background-color: #53b848;
+                                                        border-color: #3f9336;
+                                                    }
+
+                                                    button,
+                                                    html input[type=button],
+                                                    input[type=reset],
+                                                    input[type=submit] {
+                                                        -webkit-appearance: button;
+                                                        cursor: pointer;
+                                                    }
+
+                                                    .btn.active.focus,
+                                                    .btn.active:focus,
+                                                    .btn.focus,
+                                                    .btn:active.focus,
+                                                    .btn:active:focus,
+                                                    .btn:focus {
+                                                        outline: 5px auto -webkit-focus-ring-color;
+                                                        outline-offset: -2px;
+                                                    }
+
+                                                    .btn.focus,
+                                                    .btn:focus,
+                                                    .btn:hover {
+                                                        color: #333;
+                                                        text-decoration: none;
+                                                    }
+
+                                                    .btn.active,
+                                                    .btn:active {
+                                                        background-image: none;
+                                                        outline: 0;
+                                                        -webkit-box-shadow: inset 0 3px 5px rgba(0, 0, 0, .125);
+                                                        box-shadow: inset 0 3px 5px rgba(0, 0, 0, .125);
+                                                    }
+
+                                                    .btn[disabled="disabled"]:hover {
+                                                        cursor: not-allowed;
+                                                    }
+
+                                                    .btn-primary.focus,
+                                                    .btn-primary:focus {
+                                                        color: #fff;
+                                                        background-color: #3f9336;
+                                                        border-color: #3f9336;
+                                                    }
+
+                                                    .btn-primary:hover {
+                                                        color: #fff;
+                                                        background-color: #3f9336;
+                                                        border-color: #3f9336;
+                                                    }
+
+                                                    .btn-primary.active,
+                                                    .btn-primary:active {
+                                                        color: #fff;
+                                                        background-color: #3f9336;
+                                                        border-color: #3f9336;
+                                                    }
+
+                                                    .btn-primary.active,
+                                                    .btn-primary:active {
+                                                        background-image: none;
+                                                    }
+
+
+                                                    .btn.active.focus,
+                                                    .btn.active:focus,
+                                                    .btn.focus,
+                                                    .btn:active.focus,
+                                                    .btn:active:focus,
+                                                    .btn:focus {
+                                                        outline: 5px auto -webkit-focus-ring-color;
+                                                        outline-offset: -2px;
+                                                    }
+
+                                                    .btn-primary.active.focus,
+                                                    .btn-primary.active:focus,
+                                                    .btn-primary.active:hover,
+                                                    .btn-primary:active.focus,
+                                                    .btn-primary:active:focus,
+                                                    .btn-primary:active:hover {
+                                                        color: #fff;
+                                                        background-color: #3f9336;
+                                                        border-color: #3f9336;
+                                                    }
+
+                                                    span#buildInfo {
+                                                        float: right;
+                                                        color: grey;
+                                                        font-size: x-small;
+                                                        text-align: right;
+                                                        position: absolute;
+                                                        right: 0;
+                                                        padding-top: 5px;
+                                                        padding-right: 10px;
+                                                    }
+
+                                                    span.extrasmall {
+                                                        font-size: x-small;
+                                                    }
+
+                                                    .clinic-text {
+                                                        display: inline;
+                                                        font-weight: 400;
+                                                    }
+
+                                                    @media (min-width: 450px) {
+
+                                                        .loginContainer,
+                                                        .powered,
+                                                        .auaContainer {
+                                                            width: 350px;
+                                                        }
+
+                                                        .loginContainer .card-header {
+                                                            width: 200px;
+                                                        }
+
+                                                        #clinic_logo {
+                                                            width: 400px;
+                                                            margin: 0 auto;
+                                                        }
+
+                                                    }
+
+                                                    @media (min-width: 768px) {
+
+                                                        .loginContainer,
+                                                        .powered,
+                                                        .auaContainer {
+                                                            width: 450px;
+                                                        }
+
+                                                        .loginContainer .card-header {
+                                                            width: 300px;
+                                                        }
+
+                                                        #clinic_logo {
+                                                            width: 500px;
+                                                            margin: 0 auto;
+                                                        }
+                                                    }
+
+                                                    @media (min-width: 992px) {}
+
+                                                    @media (min-width: 1200px) {}
+
+                                                    footer {
+                                                        padding: 5px 10px;
+                                                        margin-top: 50px;
+                                                        color: grey;
+                                                        position: sticky;
+                                                        flex-shrink: 0;
+                                                    }
+
+                                                    footer a {
+                                                        color: blue;
+                                                    }
+
+                                                    .topbar {
+                                                        height: 25px;
+                                                    }
+
+                                                    #clinic_name {
+                                                        margin-bottom: 0;
+                                                    }
+
+                                                    #clinic_text,
+                                                    #support_text,
+                                                    .topbar #buildInfo {
+                                                        color: grey;
+                                                    }
+
+                                                    .support_details {
+                                                        text-align: left;
+                                                        width: 35%;
+                                                        display: inline-table;
+                                                    }
+
+                                                    .support_details div {
+                                                        font-size: smaller;
+                                                        text-align: center;
+                                                    }
+
+                                                    #supportImageLink img {
+                                                        max-width: 150px;
+                                                        height: auto;
+                                                    }
+
+                                                    /* Hide the default browser eye in Edge */
+                                                    #password::-ms-reveal,
+                                                    #password::-ms-clear {
+                                                        display: none;
+                                                    }
+
+                                                    .secure-text {
+                                                        -webkit-text-security: disc;
+                                                    }
+
+                                                    .input-wrapper {
+                                                        position: relative;
+                                                        display: inline-block;
+                                                        margin-bottom: 15px;
+                                                        width: 100%;
+                                                    }
+
+                                                    .toggle-input {
+                                                        width: 100%;
+                                                        padding-right: 35px;
+                                                        box-sizing: border-box;
+                                                    }
+
+                                                    .toggle-btn {
+                                                        position: absolute;
+                                                        right: 10px;
+                                                        top: 17px;
+                                                        transform: translateY(-50%);
+                                                        width: 26px;
+                                                        height: 26px;
+                                                        border: none;
+                                                        cursor: pointer;
+                                                    }
+
+                                                    /* Svg for "Hidden" state (Class-based OR Type-based) */
+                                                    .toggle-input.secure-text+.toggle-btn,
+                                                    .toggle-input[type="password"]+.toggle-btn {
+                                                        display: inline-block;
+                                                        width: 24px;
+                                                        /* 24px+ for click area WCAG SC 2.5.8 AA */
+                                                        height: 24px;
+                                                        background-color: #959595;
+                                                        /* 3:1 contrast ratio as per WCAG, alternately use currentColor; to match text color */
+                                                        -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>');
+                                                        mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>');
+                                                        mask-size: contain;
+                                                        -webkit-mask-repeat: no-repeat;
+                                                        mask-repeat: no-repeat;
+                                                        mask-position: center;
+                                                    }
+
+                                                    /* Svg for "Visible" state */
+                                                    .toggle-input:not(.secure-text):not([type="password"])+.toggle-btn {
+                                                        display: inline-block;
+                                                        width: 24px;
+                                                        /* NO SMALLER for best practice */
+                                                        height: 24px;
+                                                        background-color: #959595;
+                                                        /* lightest grey that gives 3:1 contrast ratio */
+                                                        -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/><line x1="0" y1="24" x2="24" y2="0" /></svg>');
+                                                        mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/><line x1="0" y1="24" x2="24" y2="0" /></svg>');
+                                                        mask-size: contain;
+                                                        -webkit-mask-repeat: no-repeat;
+                                                        mask-repeat: no-repeat;
+                                                        mask-position: center;
+                                                    }
+                                                </style>
+                                                <style>
+                                                    body {
+                                                        background-image: url("${pageContext.request.contextPath}/images/cloud-bg.svg");
+                                                        background-repeat: no-repeat;
+                                                        background-size: cover;
+                                                        background-position: center;
+                                                        background-attachment: fixed;
+                                                    }
+                                                </style>
+                                        </head>
+
+                                        <body onLoad="setfocus()">
+
+
+                                            <div class="content">
+                                                <div class="topbar">
+                                                    <span id="buildInfo" style="color:black;">
+                                                        ${carlos:forHtml(LoginResourceBean.buildTag)}
+                                                    </span>
+                                                </div>
+
+                                                <div class="heading">
+
+                                                    <!-- Clinic logo  -->
+                                                    <div id="clinic_logo">
+                                                        <a target="_blank" href="${ LoginResourceBean.clinicLink }">
+                                                            <img src="${ pageContext.request.contextPath }/loginResource/clinicLogo.png"
+                                                                alt="${ LoginResourceBean.clinicLink }"
+                                                                onerror="this.style.display='none'" />
+                                                        </a>
+                                                    </div>
+
+                                                    <div>
+                                                        <br>
+                                                        <span
+                                                            style="font-size: 40px; font-weight: bold; color: white; text-shadow: 2px 2px 5px rgba(0,0,0,0.7);">CARLOS</span>
+                                                        <br>
+                                                    </div>
+                                                    <!-- Clinic info -->
+                                                    <div id="clinic_text">
+                                                        <h2 id="clinic_name">
+                                                            <a target="_blank" href="${ LoginResourceBean.clinicLink }">
+                                                                ${carlos:forHtml(LoginResourceBean.clinicName)}
+                                                            </a>
+                                                        </h2>
+                                                        <div id="clinic_address">
+                                                            ${ LoginResourceBean.clinicText }
+                                                        </div>
+                                                    </div>
+
+                                                </div>
+
+                                                <div class="loginContainer">
+                                                    <div class="card">
+
+                                                        <div class="card-header">
+
+                                                            <%-- <div id="oscar_logo">--%>
+                                                                <%-- <!-- EMR logo -->--%>
+                                                                    <%-- <img title="EMR Login"
+                                                                        src="${pageContext.request.contextPath}/images/Logo.png"
+                                                                        alt="EMR Login" --%>
+                                                                        <%--
+                                                                            onerror="document.getElementById('default_logo').style.display='block'; this.style.display='none'; " />--%>
+                                                                        <%-- </div>--%>
+
+                                                                            <!-- default text if logo is missing -->
+                                                                            <h2 id="default_logo" style="display:none;">
+                                                                                <fmt:message
+                                                                                    key="loginApplication.formLabel" />
+                                                                            </h2>
+                                                        </div>
+
+                                                        <c:if test='${ param.login eq "failed" }'>
+                                                            <c:set var="login_error" value="is-invalid" scope="page" />
+                                                            <div class="alert">
+                                                                <fmt:message key="loginApplication.formFailedLabel" />
+                                                            </div>
+                                                        </c:if>
+
+                                                        <div class="card-body">
+                                                            <div class="leftinput">
+                                                                <%-- Autocomplete attribute strategy (WHATWG HTML spec):
+                                                                    - username: "off" \u2014 shared clinical
+                                                                    workstations; prevent autofill of another provider's
+                                                                    identity - password: "current-password" \u2014
+                                                                    enable browser password manager save/fill per NIST
+                                                                    SP 800-63B
+                                                                    (https://pages.nist.gov/800-63-3/sp800-63b.html) and
+                                                                    OWASP Authentication Cheat Sheet
+                                                                    (https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html)
+                                                                    which recommend allowing password managers for
+                                                                    stronger credential hygiene - pin: "one-time-code"
+                                                                    \u2014 signal browsers this is a session code, not a
+                                                                    saveable credential --%>
+                                                                    <form action="login" method="POST" name="loginForm">
+
+                                                                        <div class="mb-3 ${ login_error }">
+                                                                            <input type="text" name="username"
+                                                                                id="username"
+                                                                                placeholder="<fmt:message key="
+                                                                                Logon.userName" />"
+                                                                            value="" size="15" maxlength="15"
+                                                                            autocomplete="off"
+                                                                            class="form-control" required>
+                                                                        </div>
+
+                                                                        <div
+                                                                            class="input-wrapper mb-3 ${ login_error }">
+                                                                            <input type="password" name="password"
+                                                                                id="password"
+                                                                                placeholder="<fmt:message key="
+                                                                                Logon.passWord" />"
+                                                                            autocomplete="current-password"
+                                                                            class="form-control toggle-input" required>
+                                                                            <button type="button" tabindex="-1"
+                                                                                id="toggleBtn" class="toggle-btn"
+                                                                                aria-label="Show Password"
+                                                                                aria-pressed="false"
+                                                                                onclick="togglepwd();">
+                                                                            </button>
+                                                                        </div>
+
+                                                                        <% if (MfaManager.isOscarLegacyPinEnabled()) {
+                                                                            %>
+                                                                            <div class="pin-wrapper">
+                                                                                <div
+                                                                                    class="input-wrapper mb-3 ${ login_error }">
+                                                                                    <!-- The input starts with the secure-text class -->
+                                                                                    <input type="text" id="pin"
+                                                                                        class="form-control secure-text toggle-input"
+                                                                                        name="pin"
+                                                                                        autocomplete="one-time-code"
+                                                                                        inputmode="numeric"
+                                                                                        placeholder="<fmt:message key="
+                                                                                        admin.securityrecord.formPIN" />">
+                                                                                    <button type="button" tabindex="-1"
+                                                                                        id="togglePin"
+                                                                                        class="toggle-btn"
+                                                                                        aria-label="Show PIN"
+                                                                                        aria-pressed="false"
+                                                                                        onclick="togglepin();">
+                                                                                    </button>
+                                                                                    <span class="extrasmall">
+                                                                                        <fmt:message
+                                                                                            key="loginApplication.formCmt" />
+                                                                                    </span>
+                                                                                </div>
+                                                                            </div>
+                                                                            <% } %>
+                                                                                <input type="hidden" id="loginType"
+                                                                                    name="loginType" value="">
+                                                                                <input type=hidden name='propname'
+                                                                                    value='<fmt:message key="loginApplication.propertyFile"/>'>
+
+                                                                                <div id="buttonContainer">
+                                                                                    <c:choose>
+                                                                                        <c:when
+                                                                                            test="${ isMobileDevice }">
+                                                                                            <input
+                                                                                                class="btn btn-oscar btn-primary w-100 mb-2"
+                                                                                                name="submit"
+                                                                                                id="fullSubmit"
+                                                                                                type="submit"
+                                                                                                onclick="enhancedOrClassic('C');"
+                                                                                                value="Full">
+                                                                                            <input
+                                                                                                class="btn btn-oscar btn-primary w-100 mb-2"
+                                                                                                name="submit"
+                                                                                                id="mobileSubmit"
+                                                                                                type="submit"
+                                                                                                onclick="enhancedOrClassic('C');"
+                                                                                                value="Mobile">
+                                                                                        </c:when>
+                                                                                        <c:otherwise>
+                                                                                            <input
+                                                                                                class="btn btn-oscar btn-primary w-100 mb-2"
+                                                                                                name="submit"
+                                                                                                type="submit"
+                                                                                                onclick="enhancedOrClassic('C');"
+                                                                                                value="<fmt:message key="
+                                                                                                index.btnSignIn" />">
+                                                                                        </c:otherwise>
+                                                                                    </c:choose>
+                                                                                </div>
+
+                                                                    </form>
+
+                                                                    <c:if
+                                                                        test="${ LoginResourceBean.acceptableUseAgreementManager.auaAvailable }">
+                                                                        <span class="extrasmall">
+                                                                            <fmt:message key="global.aua" /> &nbsp;
+                                                                            <a href="javascript:void(0);"
+                                                                                onclick="showHideItem('auaText');">
+                                                                                <fmt:message key="global.showhide" />
+                                                                            </a>
+                                                                        </span>
+                                                                    </c:if>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+
+                                                <div id="auaText" class="auaContainer" style="display:none;">
+                                                    <div class="card">
+                                                        <div class="card-header">
+                                                            Acceptable Use Agreement
+                                                        </div>
+                                                        <div class="card-body">
+                                                            ${ LoginResourceBean.acceptableUseAgreementManager.text }
+                                                        </div>
+                                                        <div class="card-footer"></div>
+                                                    </div>
+                                                </div>
+
+
+                                                <c:if
+                                                    test="${ LoginResourceBean.acceptableUseAgreementManager.auaAvailable and LoginResourceBean.acceptableUseAgreementManager.alwaysShow }">
+                                                    <script
+                                                        type="text/javascript">document.getElementById('auaText').style.display = 'block';</script>
+                                                </c:if>
+
+                                                <div class="powered">
+                                                    <c:if test="${ not empty LoginResourceBean.supportLink
 								or not empty LoginResourceBean.supportName
 								or not empty LoginResourceBean.supportText }">
-                <div class="details">
-                    <div>Powered</div>
-                    <div>by</div>
-                </div>
-            </c:if>
-            <div class="support_details">
-                <a target="_blank" href="${ LoginResourceBean.supportLink }" id="supportImageLink">
-                    <img src="${ pageContext.request.contextPath }/loginResource/supportLogo.png"
-                         alt="Support Image"
-                         onerror="this.style.display='none'; document.getElementById('supportImageLink').style.display='none';">
-                </a>
-                <c:if test="${ not empty LoginResourceBean.supportName }">
-                    <div id="support_name">
-                        <a target="_blank" href="${ LoginResourceBean.supportLink }">
-                            ${carlos:forHtml(LoginResourceBean.supportName)}
-                        </a>
-                    </div>
-                </c:if>
-                <div id="support_text">
-                    ${ LoginResourceBean.supportText }
-                </div>
-            </div>
-        </div>
+                                                        <div class="details">
+                                                            <div>Powered</div>
+                                                            <div>by</div>
+                                                        </div>
+                                                    </c:if>
+                                                    <div class="support_details">
+                                                        <a target="_blank" href="${ LoginResourceBean.supportLink }"
+                                                            id="supportImageLink">
+                                                            <img src="${ pageContext.request.contextPath }/loginResource/supportLogo.png"
+                                                                alt="Support Image"
+                                                                onerror="this.style.display='none'; document.getElementById('supportImageLink').style.display='none';">
+                                                        </a>
+                                                        <c:if test="${ not empty LoginResourceBean.supportName }">
+                                                            <div id="support_name">
+                                                                <a target="_blank"
+                                                                    href="${ LoginResourceBean.supportLink }">
+                                                                    ${carlos:forHtml(LoginResourceBean.supportName)}
+                                                                </a>
+                                                            </div>
+                                                        </c:if>
+                                                        <div id="support_text">
+                                                            ${ LoginResourceBean.supportText }
+                                                        </div>
+                                                    </div>
+                                                </div>
 
-    </div>
-    <footer>
-     	<span id="license" class="extrasmall">
-     		<fmt:message key="loginApplication.leftRmk2"/>
-     	</span>
-    </footer>
+                                            </div>
+                                            <footer>
+                                                <span id="license" class="extrasmall">
+                                                    <fmt:message key="loginApplication.leftRmk2" />
+                                                </span>
+                                            </footer>
 
-    </body>
-</html>
+                                        </body>
+
+                                        </html>

--- a/src/main/webapp/WEB-INF/jsp/login/location.jsp
+++ b/src/main/webapp/WEB-INF/jsp/login/location.jsp
@@ -1,89 +1,35 @@
-<%--
+<%-- Copyright (c) 2001-2002. Department of Family Medicine, McMaster University. All Rights Reserved. This software is
+    published under the GPL GNU General Public License. This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either
+    version 2 of the License, or (at your option) any later version. This program is distributed in the hope that it
+    will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+    PARTICULAR PURPOSE. See the GNU General Public License for more details. You should have received a copy of the GNU
+    General Public License along with this program; if not, write to the Free Software Foundation, Inc., 59 Temple Place
+    - Suite 330, Boston, MA 02111-1307, USA. This software was written for the Department of Family Medicine McMaster
+    University Hamilton Ontario, Canada Now maintained by the CARLOS EMR Project (2026+).
+    https://github.com/carlos-emr/carlos CARLOS has no affiliation with OSCAR or McMaster University. --%>
+                            <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+                                <fmt:setBundle basename="oscarResources" />
+                                            <%@ include file="/WEB-INF/jsp/common/webAppContextAndSuperMgr.jsp" %>
+                                                <!DOCTYPE html
+                                                    PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+                                                <html>
+                                                <p>&nbsp;</p>
+                                                <h3 align="center">
+                                                    <fmt:message key="provider.selectClinicSite" />
+                                                </h3>
 
-    Copyright (c) 2001-2002. Department of Family Medicine, McMaster University. All Rights Reserved.
-    This software is published under the GPL GNU General Public License.
-    This program is free software; you can redistribute it and/or
-    modify it under the terms of the GNU General Public License
-    as published by the Free Software Foundation; either version 2
-    of the License, or (at your option) any later version.
+                                                <head>
+                                                    <link rel="icon"
+                                                        href="${pageContext.request.contextPath}/images/favicon.ico" />
+                                                    <script type="text/javascript"
+                                                        src="<%=request.getContextPath()%>/library/jquery/jquery-3.7.1.min.js"></script>
+                                                    <script
+                                                        src="<%=request.getContextPath()%>/library/jquery/jquery-compat.js"></script>
+                                                </head>
 
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-    GNU General Public License for more details.
+                                                <body>
+                                                            <p>&nbsp;</p>
+                                                </body>
 
-    You should have received a copy of the GNU General Public License
-    along with this program; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
-
-    This software was written for the
-    Department of Family Medicine
-    McMaster University
-    Hamilton
-    Ontario, Canada
-
-
-    Now maintained by the CARLOS EMR Project (2026+).
-    https://github.com/carlos-emr/carlos
-    CARLOS has no affiliation with OSCAR or McMaster University.
-
---%>
-<%@ page import="java.util.*" %>
-<%@ page import="java.util.ArrayList" %>
-<%@ page import="io.github.carlos_emr.carlos.utility.SpringUtils" %>
-<%@ page import="io.github.carlos_emr.carlos.commn.model.Facility" %>
-<%@ page import="io.github.carlos_emr.carlos.utility.LoggedInInfo" %>
-<%@ page import="io.github.carlos_emr.carlos.util.LabelValueBean" %>
-<%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
-<fmt:setBundle basename="oscarResources"/>
-<%@ taglib uri="/WEB-INF/caisi-tag.tld" prefix="caisi" %>
-<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
-<%@ taglib uri="carlos" prefix="carlos" %>
-<%@ include file="/WEB-INF/jsp/common/webAppContextAndSuperMgr.jsp" %>
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
-<html>
-<p>&nbsp;</p>
-<h3 align="center"><fmt:message key="provider.selectClinicSite"/></h3>
-<head>
-    <link rel="icon" href="${pageContext.request.contextPath}/images/favicon.ico"/>
-    <script type="text/javascript" src="<%=request.getContextPath()%>/library/jquery/jquery-3.7.1.min.js"></script>
-    <script src="<%=request.getContextPath()%>/library/jquery/jquery-compat.js"></script>
-</head>
-<body>
-<%
-    LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
-    String providerNo = loggedInInfo.getLoggedInProviderNo();
-    Facility facility = loggedInInfo.getCurrentFacility();
-    List<LabelValueBean> programs = new ArrayList<LabelValueBean>();
-    int defaultprogramId = 0;
-%>
-<p>&nbsp;</p>
-<table align="center">
-    <tr>
-        <td align="right" width="30%"><fmt:message key="provider.clinicSite"/>:</td>
-        <td align="left" width="60%">
-
-            <select id="programIdForLocation" name="programIdForLocation">
-                <%
-                    if (programs != null && !programs.isEmpty()) {
-                        for (LabelValueBean program : programs) {
-                            String selected = (Integer.parseInt(program.getValue()) == defaultprogramId) ? " selected=\"selected\" " : "";
-                %>
-                <option value="<%=program.getValue()%>" <%=selected%>><carlos:encode value='<%= program.getLabel() %>' context="html"/>
-                </option>
-                <% }
-                }
-                %>
-            </select>
-            <input type="button" value="Go -->" onClick="javascript:setLocation();"/>
-        </td>
-    </tr>
-</table>
-</body>
-<script type="text/javascript">
-    function setLocation() {
-        var programIdForLocation = jQuery("#programIdForLocation").val();
-        window.location.href = "<%= request.getContextPath() %>/provider/providercontrol?<%=io.github.carlos_emr.carlos.utility.SessionConstants.CURRENT_PROGRAM_ID%>=" + encodeURIComponent(programIdForLocation);
-    }
-</script>
-</html>
+                                                </html>


### PR DESCRIPTION
…n in location.jsp

<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description

This PR cleans up stale imports and dead code left over from the CARLOS encoder migration in the login JSPs:
1. Removes the unused `owasp.encoder.jakarta.advanced` taglib directive (`<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>`) from `3rdpartyLogin.jsp`, `index.jsp`, and `location.jsp`.
2. Removes permanently dead code in `location.jsp`:
   - The `programs` dropdown list, which was always initialized as an empty `ArrayList` and never populated.
   - The "Go -->" submit button and the `setLocation()` JavaScript function.
   - Unused page imports (e.g. `LabelValueBean`, `SpringUtils`, `Facility`, `LoggedInInfo`, `java.util.*`, `java.util.ArrayList`, etc.) and the unused `carlos` and `caisi` taglib definitions in `location.jsp`.

## Related Issues

Fixes #2344

## How Was This Tested?

1. **JSP Migration Regressions Check**: Ran the maven unit test suite dedicated to the migrated login JSP structures:
   ```bash
   mvn test -Dtest=LoginJspMigrationRegressionTest

## Checklist

- [X] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [X] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [X] I have not included any patient data (PHI) in this PR
- [X] I have added tests for new functionality, or this change doesn't need new tests
- [X] I have read the [contributing guide](CONTRIBUTING.md)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleans up login JSPs by removing the unused `owasp.encoder.jakarta.advanced` taglib and deleting dead code in `location.jsp`. Addresses #2344 by finishing the CARLOS encoder migration cleanup with no user-visible changes.

- **Refactors**
  - Removed `owasp.encoder.jakarta.advanced` taglib from `3rdpartyLogin.jsp`, `index.jsp`, and `location.jsp`.
  - Deleted dead UI and JS in `location.jsp` (empty programs dropdown, “Go -->” button, `setLocation()`).
  - Dropped unused imports and taglibs in `location.jsp` (e.g., `LabelValueBean`, `SpringUtils`, `Facility`, `LoggedInInfo`, `java.util.*`, and `carlos`/`caisi`).

<sup>Written for commit 84b875aa211f857fdd4e7fc2f46a36358b61afef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2752?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

