### PR TITLE
Fix next appointment lookup for valid demographic numbers

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/eform/actions/RtlPreventions2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/eform/actions/RtlPreventions2Action.java
@@ -89,10 +89,10 @@ public class RtlPreventions2Action extends ActionSupport {
     /**
      * Handles the AJAX request from the RTL eForm's Preventions button.
      *
-     * <p>Writes HTML directly to the response and returns {@code null} to bypass
+     * <p>Writes HTML directly to the response and returns {@code NONE} to bypass
      * Struts result dispatch (no JSP view — the response IS the view).</p>
      *
-     * @return String always {@code null} (response written directly)
+     * @return String always {@code NONE} (response written directly)
      * @throws IOException if the response stream cannot be written to
      */
     @Override
@@ -108,7 +108,7 @@ public class RtlPreventions2Action extends ActionSupport {
         String demoNoParam = request.getParameter("demographic_no");
         if (demoNoParam == null || !demoNoParam.matches("\\d+")) {
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid demographic_no");
-            return null;
+            return NONE;
         }
 
         Integer demographicNo;
@@ -116,7 +116,7 @@ public class RtlPreventions2Action extends ActionSupport {
             demographicNo = Integer.parseInt(demoNoParam);
         } catch (NumberFormatException e) {
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid demographic_no");
-            return null;
+            return NONE;
         }
         try {
             // PreventionManager enforces circle-of-care access via loggedInInfo
@@ -159,6 +159,6 @@ public class RtlPreventions2Action extends ActionSupport {
                 response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Unable to retrieve prevention data");
             }
         }
-        return null;
+        return NONE;
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/prevention/pageUtil/PreventionPrint2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prevention/pageUtil/PreventionPrint2Action.java
@@ -79,7 +79,7 @@ public class PreventionPrint2Action extends ActionSupport {
     /**
      * Validates security privileges and generates the prevention PDF.
      *
-     * @return String {@code null} on success (response written directly), or {@code "error"} if
+     * @return String {@code NONE} on success (response written directly), or {@code "error"} if
      *         PDF generation fails due to a {@link DocumentException} or {@link IOException}
      * @throws SecurityException if the logged-in user lacks {@code _prevention} read privilege
      */
@@ -104,7 +104,7 @@ public class PreventionPrint2Action extends ActionSupport {
             return "error";
         }
 
-        return null;
+        return NONE;
     }
 
 }

--- a/src/main/java/io/github/carlos_emr/carlos/utility/AppointmentUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/AppointmentUtil.java
@@ -37,7 +37,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class AppointmentUtil {
 
-    private static final String NONE = "(none)";
+    static final String NONE = "(none)";
 
     private AppointmentUtil() {
     }
@@ -45,17 +45,18 @@ public class AppointmentUtil {
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
     @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
     public static String getNextAppointment(String demographicNo) {
-        if (demographicNo == null || demographicNo.equalsIgnoreCase("") || demographicNo.equalsIgnoreCase("null")) {
+        String normalizedDemographicNo = demographicNo == null ? "" : demographicNo.trim();
+        if (normalizedDemographicNo.equalsIgnoreCase("") || normalizedDemographicNo.equalsIgnoreCase("null") || !normalizedDemographicNo.matches("\\d+")) {
             return NONE;
         }
 
         OscarAppointmentDao dao = SpringUtils.getBean(OscarAppointmentDao.class);
-        Appointment appt = dao.findNextAppointment(ConversionUtils.fromIntString(demographicNo));
+        Appointment appt = dao.findNextAppointment(ConversionUtils.fromIntString(normalizedDemographicNo));
         if (appt == null) {
             return NONE;
         }
 
-        return ConversionUtils.toDateString(appt.getAppointmentDate());
+        return appt.getAppointmentDate() != null ? ConversionUtils.toDateString(appt.getAppointmentDate()) : NONE;
     }
 
 }

--- a/src/main/java/io/github/carlos_emr/carlos/utility/AppointmentUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/AppointmentUtil.java
@@ -29,8 +29,6 @@
 
 package io.github.carlos_emr.carlos.utility;
 
-import java.util.Date;
-
 import io.github.carlos_emr.carlos.commn.dao.OscarAppointmentDao;
 import io.github.carlos_emr.carlos.commn.model.Appointment;
 
@@ -47,8 +45,7 @@ public class AppointmentUtil {
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
     @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
     public static String getNextAppointment(String demographicNo) {
-        Date nextApptDate = null;
-        if (demographicNo != null && !demographicNo.equalsIgnoreCase("") && !demographicNo.equalsIgnoreCase("null")) {
+        if (demographicNo == null || demographicNo.equalsIgnoreCase("") || demographicNo.equalsIgnoreCase("null")) {
             return NONE;
         }
 
@@ -58,7 +55,7 @@ public class AppointmentUtil {
             return NONE;
         }
 
-        return ConversionUtils.toDateString(nextApptDate);
+        return ConversionUtils.toDateString(appt.getAppointmentDate());
     }
 
 }

--- a/src/test/java/io/github/carlos_emr/carlos/eform/actions/RtlPreventions2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/eform/actions/RtlPreventions2ActionTest.java
@@ -27,6 +27,7 @@ import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 
+import org.apache.struts2.ActionSupport;
 import org.apache.struts2.ServletActionContext;
 import org.junit.jupiter.api.*;
 import org.mockito.*;
@@ -153,7 +154,7 @@ class RtlPreventions2ActionTest extends CarlosUnitTestBase {
 
             String result = action.execute();
 
-            assertThat(result).isNull();
+            assertThat(result).isEqualTo(ActionSupport.NONE);
             assertThat(mockResponse.getStatus()).isEqualTo(400);
         }
 
@@ -164,7 +165,7 @@ class RtlPreventions2ActionTest extends CarlosUnitTestBase {
 
             String result = action.execute();
 
-            assertThat(result).isNull();
+            assertThat(result).isEqualTo(ActionSupport.NONE);
             assertThat(mockResponse.getStatus()).isEqualTo(400);
         }
 
@@ -175,7 +176,7 @@ class RtlPreventions2ActionTest extends CarlosUnitTestBase {
 
             String result = action.execute();
 
-            assertThat(result).isNull();
+            assertThat(result).isEqualTo(ActionSupport.NONE);
             assertThat(mockResponse.getStatus()).isEqualTo(400);
         }
 
@@ -186,7 +187,7 @@ class RtlPreventions2ActionTest extends CarlosUnitTestBase {
 
             String result = action.execute();
 
-            assertThat(result).isNull();
+            assertThat(result).isEqualTo(ActionSupport.NONE);
             assertThat(mockResponse.getStatus()).isEqualTo(400);
         }
 
@@ -197,7 +198,7 @@ class RtlPreventions2ActionTest extends CarlosUnitTestBase {
 
             String result = action.execute();
 
-            assertThat(result).isNull();
+            assertThat(result).isEqualTo(ActionSupport.NONE);
             assertThat(mockResponse.getStatus()).isEqualTo(400);
         }
     }
@@ -379,15 +380,15 @@ class RtlPreventions2ActionTest extends CarlosUnitTestBase {
         }
 
         @Test
-        @DisplayName("Should return null result (writes directly to response)")
-        void shouldReturnNull_asStrutsResult() throws Exception {
+        @DisplayName("Should return NONE result (writes directly to response)")
+        void shouldReturnNone_asStrutsResult() throws Exception {
             mockRequest.setParameter("demographic_no", "123");
             when(mockPreventionManager.getPreventionsByDemographicNo(any(), eq(123)))
                 .thenReturn(new ArrayList<>());
 
             String result = action.execute();
 
-            assertThat(result).isNull();
+            assertThat(result).isEqualTo(ActionSupport.NONE);
         }
     }
 

--- a/src/test/java/io/github/carlos_emr/carlos/utility/AppointmentUtilUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/utility/AppointmentUtilUnitTest.java
@@ -29,9 +29,11 @@ class AppointmentUtilUnitTest extends CarlosUnitTestBase {
         OscarAppointmentDao appointmentDao = mock(OscarAppointmentDao.class);
         registerMock(OscarAppointmentDao.class, appointmentDao);
 
-        assertEquals("(none)", AppointmentUtil.getNextAppointment(null));
-        assertEquals("(none)", AppointmentUtil.getNextAppointment(""));
-        assertEquals("(none)", AppointmentUtil.getNextAppointment("null"));
+        assertEquals(AppointmentUtil.NONE, AppointmentUtil.getNextAppointment(null));
+        assertEquals(AppointmentUtil.NONE, AppointmentUtil.getNextAppointment(""));
+        assertEquals(AppointmentUtil.NONE, AppointmentUtil.getNextAppointment("null"));
+        assertEquals(AppointmentUtil.NONE, AppointmentUtil.getNextAppointment("   "));
+        assertEquals(AppointmentUtil.NONE, AppointmentUtil.getNextAppointment("abc"));
 
         verifyNoInteractions(appointmentDao);
     }
@@ -46,7 +48,7 @@ class AppointmentUtilUnitTest extends CarlosUnitTestBase {
         appointment.setAppointmentDate(date(2026, Calendar.JULY, 15));
         when(appointmentDao.findNextAppointment(123)).thenReturn(appointment);
 
-        assertEquals("2026-07-15", AppointmentUtil.getNextAppointment("123"));
+        assertEquals("2026-07-15", AppointmentUtil.getNextAppointment(" 123 "));
         verify(appointmentDao).findNextAppointment(123);
     }
 
@@ -57,7 +59,20 @@ class AppointmentUtilUnitTest extends CarlosUnitTestBase {
         registerMock(OscarAppointmentDao.class, appointmentDao);
         when(appointmentDao.findNextAppointment(123)).thenReturn(null);
 
-        assertEquals("(none)", AppointmentUtil.getNextAppointment("123"));
+        assertEquals(AppointmentUtil.NONE, AppointmentUtil.getNextAppointment("123"));
+        verify(appointmentDao).findNextAppointment(123);
+    }
+
+    @Test
+    @DisplayName("getNextAppointment returns none when the next appointment date is missing")
+    void getNextAppointmentReturnsNoneWhenAppointmentDateIsMissing() {
+        OscarAppointmentDao appointmentDao = mock(OscarAppointmentDao.class);
+        registerMock(OscarAppointmentDao.class, appointmentDao);
+
+        Appointment appointment = new Appointment();
+        when(appointmentDao.findNextAppointment(123)).thenReturn(appointment);
+
+        assertEquals(AppointmentUtil.NONE, AppointmentUtil.getNextAppointment("123"));
         verify(appointmentDao).findNextAppointment(123);
     }
 

--- a/src/test/java/io/github/carlos_emr/carlos/utility/AppointmentUtilUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/utility/AppointmentUtilUnitTest.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2026 CARLOS EMR Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ */
+package io.github.carlos_emr.carlos.utility;
+
+import io.github.carlos_emr.carlos.commn.dao.OscarAppointmentDao;
+import io.github.carlos_emr.carlos.commn.model.Appointment;
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Calendar;
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@DisplayName("AppointmentUtil Unit Tests")
+class AppointmentUtilUnitTest extends CarlosUnitTestBase {
+
+    @Test
+    @DisplayName("getNextAppointment returns none without DAO lookup for missing demographic numbers")
+    void getNextAppointmentReturnsNoneForMissingDemographicNo() {
+        OscarAppointmentDao appointmentDao = mock(OscarAppointmentDao.class);
+        registerMock(OscarAppointmentDao.class, appointmentDao);
+
+        assertEquals("(none)", AppointmentUtil.getNextAppointment(null));
+        assertEquals("(none)", AppointmentUtil.getNextAppointment(""));
+        assertEquals("(none)", AppointmentUtil.getNextAppointment("null"));
+
+        verifyNoInteractions(appointmentDao);
+    }
+
+    @Test
+    @DisplayName("getNextAppointment looks up and formats the next appointment date for valid demographic numbers")
+    void getNextAppointmentReturnsNextAppointmentDateForValidDemographicNo() {
+        OscarAppointmentDao appointmentDao = mock(OscarAppointmentDao.class);
+        registerMock(OscarAppointmentDao.class, appointmentDao);
+
+        Appointment appointment = new Appointment();
+        appointment.setAppointmentDate(date(2026, Calendar.JULY, 15));
+        when(appointmentDao.findNextAppointment(123)).thenReturn(appointment);
+
+        assertEquals("2026-07-15", AppointmentUtil.getNextAppointment("123"));
+        verify(appointmentDao).findNextAppointment(123);
+    }
+
+    @Test
+    @DisplayName("getNextAppointment returns none when no future appointment exists")
+    void getNextAppointmentReturnsNoneWhenNoAppointmentExists() {
+        OscarAppointmentDao appointmentDao = mock(OscarAppointmentDao.class);
+        registerMock(OscarAppointmentDao.class, appointmentDao);
+        when(appointmentDao.findNextAppointment(123)).thenReturn(null);
+
+        assertEquals("(none)", AppointmentUtil.getNextAppointment("123"));
+        verify(appointmentDao).findNextAppointment(123);
+    }
+
+    private static Date date(int year, int month, int day) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.clear();
+        calendar.set(year, month, day);
+        return calendar.getTime();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes `AppointmentUtil.getNextAppointment()` so invalid or missing `demographicNo` values return early, while valid demographic numbers proceed to the next appointment lookup.

Also returns the fetched appointment date instead of formatting a null placeholder, so callers can receive the actual next appointment date when one exists.

## Changes

- Inverted the invalid `demographicNo` guard condition
- Allowed valid demographic numbers to call `findNextAppointment(...)`
- Returned `appt.getAppointmentDate()` after a successful lookup
- Added unit coverage for invalid input, valid lookup, and no appointment found

## Testing

- Ran the new `AppointmentUtilUnitTest` successfully

Closes #2651 

## Summary by Sourcery

Return Struts NONE for prevention actions that write directly to the response and correct next-appointment lookup behavior for valid demographics while preserving safe handling of invalid values.

Bug Fixes:
- Ensure AppointmentUtil.getNextAppointment skips DAO lookup for missing or invalid demographic numbers and returns the next appointment date when available.
- Return Struts NONE instead of null from RtlPreventions2Action and PreventionPrint2Action to correctly signal that the response is already handled.

Tests:
- Add unit tests for AppointmentUtil covering invalid demographic numbers, valid next-appointment lookups, and the no-appointment case.
- Update RTL preventions action tests to assert a NONE result for both error and successful response-writing paths.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes next-appointment lookup to return the real next date for valid demographics and short-circuit invalid inputs. Also standardizes prevention actions to return `NONE` for direct responses.

- **Bug Fixes**
  - `AppointmentUtil.getNextAppointment(...)`: trims input, enforces numeric-only, and returns `(none)` without DAO for empty/"null"/non-numeric values; valid inputs return the next appointment date or `(none)` if the date is missing.
  - `RtlPreventions2Action` and `PreventionPrint2Action` now return `NONE` (not `null`) to bypass Struts view dispatch.
  - Added unit tests for invalid input, next appointment found, no appointment, and missing appointment date; updated action tests to assert `NONE`.

<sup>Written for commit 4c3934728a377f34c720ce34c2db6808b97584b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



