### PR TITLE
fix: unguarded Integer.parseInt(demographic_no)

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/prevention/pageUtil/AddPrevention2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prevention/pageUtil/AddPrevention2Action.java
@@ -20,7 +20,7 @@
  * McMaster University
  * Hamilton
  * Ontario, Canada
- 
+
  * <p>
  * Now maintained by the CARLOS EMR Project (2026+).
  * https://github.com/carlos-emr/carlos
@@ -311,7 +311,9 @@ public class AddPrevention2Action extends ActionSupport {
         }
 
         DemographicDao demographicDao = SpringUtils.getBean(DemographicDao.class);
-        if (!demographicDao.clientExists(Integer.parseInt(demographic_no))) {
+        if (demographic_no == null || !demographic_no.matches("\\d+")) {
+            result.add("Invalid or missing demographic_no");
+        } else if (!demographicDao.clientExists(Integer.parseInt(demographic_no))) {
             result.add("Patient not found");
         }
 


### PR DESCRIPTION
Closes #2757 

<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description

<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->
Applied the suggested fix to the unguarded Integer.parseInt(demographic_no) bug.

## Related Issues

<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?

<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Bug Fixes:
- Prevent NumberFormatException by validating demographic_no is present and numeric before parsing and checking if the patient exists.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate demographic_no before parsing to prevent crashes and give a clear error message. Null or non-numeric values now add "Invalid or missing demographic_no"; otherwise we check if the patient exists.

<sup>Written for commit f206a531b0c38e27b633763bdee662d4b04aed83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

