### PR TITLE
fix: Addressed raw types (Hashtable, ArrayList without generics) in AddPrevention2Action, FrmFormRHPrevention2Action, PreventionReport2Action

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FrmFormRHPrevention2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FrmFormRHPrevention2Action.java
@@ -31,10 +31,10 @@
 package io.github.carlos_emr.carlos.form.pageUtil;
 
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.Enumeration;
-import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -129,7 +129,7 @@ public class FrmFormRHPrevention2Action extends ActionSupport {
         String workflowType = "RH";
         WorkFlowFactory flowFactory = new WorkFlowFactory();
         WorkFlow flow = flowFactory.getWorkFlow(workflowType);
-        ArrayList<Hashtable<String, Object>> currentWorkFlows = flow.getActiveWorkFlowList(demographicNo);
+        List<Map<String, Object>> currentWorkFlows = flow.getActiveWorkFlowList(demographicNo);
 
         String dateToParse = request.getParameter("edd");
         MiscUtils.getLogger().debug("New workflow for " + demographicNo + " EDD " + dateToParse);
@@ -139,7 +139,7 @@ public class FrmFormRHPrevention2Action extends ActionSupport {
         if (currentWorkFlows != null && currentWorkFlows.size() > 0) {
             MiscUtils.getLogger().debug("size of current workflows " + currentWorkFlows.size());
             request.setAttribute("currentWorkFlow", currentWorkFlows.get(0));
-            Hashtable<String, Object> h = currentWorkFlows.get(0);
+            Map<String, Object> h = currentWorkFlows.get(0);
             String currentId = (String) h.get("ID");
             if (workflowId != null) {
                 //LOG CHANGE NOW

--- a/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FrmFormRHPrevention2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FrmFormRHPrevention2Action.java
@@ -139,7 +139,7 @@ public class FrmFormRHPrevention2Action extends ActionSupport {
         if (currentWorkFlows != null && currentWorkFlows.size() > 0) {
             MiscUtils.getLogger().debug("size of current workflows " + currentWorkFlows.size());
             request.setAttribute("currentWorkFlow", currentWorkFlows.get(0));
-            Hashtable<String, Object> h = (Hashtable<String, Object>) currentWorkFlows.get(0);
+            Hashtable<String, Object> h = currentWorkFlows.get(0);
             String currentId = (String) h.get("ID");
             if (workflowId != null) {
                 //LOG CHANGE NOW
@@ -170,7 +170,7 @@ public class FrmFormRHPrevention2Action extends ActionSupport {
             rec = recorder.factory(request.getParameter("form_class"));
             Properties props = new Properties();
             for (Enumeration<String> varEnum = request.getParameterNames(); varEnum.hasMoreElements(); ) {
-                String name = (String) varEnum.nextElement();
+                String name = varEnum.nextElement();
                 props.setProperty(name, request.getParameter(name));
             }
             if (!props.containsKey("workflowId")) {

--- a/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FrmFormRHPrevention2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FrmFormRHPrevention2Action.java
@@ -129,7 +129,7 @@ public class FrmFormRHPrevention2Action extends ActionSupport {
         String workflowType = "RH";
         WorkFlowFactory flowFactory = new WorkFlowFactory();
         WorkFlow flow = flowFactory.getWorkFlow(workflowType);
-        ArrayList currentWorkFlows = flow.getActiveWorkFlowList(demographicNo);
+        ArrayList<Hashtable<String, Object>> currentWorkFlows = flow.getActiveWorkFlowList(demographicNo);
 
         String dateToParse = request.getParameter("edd");
         MiscUtils.getLogger().debug("New workflow for " + demographicNo + " EDD " + dateToParse);
@@ -139,7 +139,7 @@ public class FrmFormRHPrevention2Action extends ActionSupport {
         if (currentWorkFlows != null && currentWorkFlows.size() > 0) {
             MiscUtils.getLogger().debug("size of current workflows " + currentWorkFlows.size());
             request.setAttribute("currentWorkFlow", currentWorkFlows.get(0));
-            Hashtable h = (Hashtable) currentWorkFlows.get(0);
+            Hashtable<String, Object> h = (Hashtable<String, Object>) currentWorkFlows.get(0);
             String currentId = (String) h.get("ID");
             if (workflowId != null) {
                 //LOG CHANGE NOW
@@ -169,7 +169,7 @@ public class FrmFormRHPrevention2Action extends ActionSupport {
         try {
             rec = recorder.factory(request.getParameter("form_class"));
             Properties props = new Properties();
-            for (Enumeration varEnum = request.getParameterNames(); varEnum.hasMoreElements(); ) {
+            for (Enumeration<String> varEnum = request.getParameterNames(); varEnum.hasMoreElements(); ) {
                 String name = (String) varEnum.nextElement();
                 props.setProperty(name, request.getParameter(name));
             }

--- a/src/main/java/io/github/carlos_emr/carlos/prevention/pageUtil/PreventionReport2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prevention/pageUtil/PreventionReport2Action.java
@@ -118,7 +118,7 @@ public class PreventionReport2Action extends ActionSupport {
             request.setAttribute("ReportType", prevention);
         }
 
-        Hashtable h = report.runReport(loggedInInfo, list, asDate);
+        Hashtable<String, Object> h = report.runReport(loggedInInfo, list, asDate);
         request.setAttribute("up2date", h.get("up2date"));
         request.setAttribute("percent", h.get("percent"));
         request.setAttribute("percentWithGrace", h.get("percentWithGrace"));

--- a/src/main/java/io/github/carlos_emr/carlos/prevention/reports/MammogramReport.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prevention/reports/MammogramReport.java
@@ -66,7 +66,7 @@ public class MammogramReport implements PreventionReport {
 
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
     @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
-    public Hashtable runReport(LoggedInInfo loggedInInfo, ArrayList<ArrayList<String>> list, Date asofDate) {
+    public Hashtable<String, Object> runReport(LoggedInInfo loggedInInfo, ArrayList<ArrayList<String>> list, Date asofDate) {
         int inList = 0;
         double done = 0, doneWithGrace = 0;
         ArrayList<PreventionReportDisplay> returnReport = new ArrayList<PreventionReportDisplay>();

--- a/src/main/java/io/github/carlos_emr/carlos/prevention/reports/PapReport.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prevention/reports/PapReport.java
@@ -71,7 +71,7 @@ public class PapReport implements PreventionReport {
 
         /////
         for (int i = 0; i < list.size(); i++) {//for each  element in arraylist
-            ArrayList<String> fieldList = (ArrayList<String>) list.get(i);
+            ArrayList<String> fieldList = list.get(i);
             Integer demo = Integer.valueOf(fieldList.get(0));
             //search   prevention_date prevention_type  deleted   refused
             ArrayList<Map<String, Object>> prevs = PreventionData.getPreventionData(loggedInInfo, "PAP", demo);

--- a/src/main/java/io/github/carlos_emr/carlos/prevention/reports/PapReport.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prevention/reports/PapReport.java
@@ -64,7 +64,7 @@ public class PapReport implements PreventionReport {
     public PapReport() {
     }
 
-    public Hashtable runReport(LoggedInInfo loggedInInfo, ArrayList list, Date asofDate) {
+    public Hashtable<String, Object> runReport(LoggedInInfo loggedInInfo, ArrayList<ArrayList<String>> list, Date asofDate) {
         int inList = 0;
         double done = 0, doneWithGrace = 0;
         ArrayList<PreventionReportDisplay> returnReport = new ArrayList<PreventionReportDisplay>();

--- a/src/main/java/io/github/carlos_emr/carlos/prevention/reports/PreventionReport.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prevention/reports/PreventionReport.java
@@ -40,5 +40,5 @@ import io.github.carlos_emr.carlos.utility.LoggedInInfo;
  * @author jay
  */
 public interface PreventionReport {
-    public Hashtable runReport(LoggedInInfo loggedInInfo, ArrayList<ArrayList<String>> list, Date asofDate);
+    public Hashtable<String, Object> runReport(LoggedInInfo loggedInInfo, ArrayList<ArrayList<String>> list, Date asofDate);
 }

--- a/src/main/java/io/github/carlos_emr/carlos/workflow/RHWorkFlow.java
+++ b/src/main/java/io/github/carlos_emr/carlos/workflow/RHWorkFlow.java
@@ -80,12 +80,12 @@ public class RHWorkFlow implements WorkFlow {
     }
 
 
-    public ArrayList getActiveWorkFlowList(String demographicNo) {
+    public ArrayList<Hashtable<String, Object>> getActiveWorkFlowList(String demographicNo) {
         WorkFlowState wfs = new WorkFlowState();
         return wfs.getActiveWorkFlowList(RHWorkFlow.WORKFLOWTYPE, demographicNo);
     }
 
-    public ArrayList getActiveWorkFlowList() {
+    public ArrayList<Hashtable<String, Object>> getActiveWorkFlowList() {
         WorkFlowState wfs = new WorkFlowState();
         return wfs.getActiveWorkFlowList(RHWorkFlow.WORKFLOWTYPE);
     }
@@ -111,7 +111,7 @@ public class RHWorkFlow implements WorkFlow {
         return wfs.addToWorkFlow(WorkFlowState.RHWORKFLOW, providerNo, demographicNo, endDate, WorkFlowState.INIT_STATE);
     }
 
-    public WorkFlowInfo executeRules(Hashtable hashtable) {
+    public WorkFlowInfo executeRules(Hashtable<String, Object> hashtable) {
         WorkFlowInfo wfi = new WorkFlowInfo(hashtable);
         WorkFlowDS wfDS = WorkFlowDSFactory.getWorkFlowDS("Rh_workflow.drl");
         try {
@@ -122,7 +122,7 @@ public class RHWorkFlow implements WorkFlow {
         return wfi;
     }
 
-    public WorkFlowInfo executeRules(WorkFlowDS wfDS, Hashtable hashtable) {
+    public WorkFlowInfo executeRules(WorkFlowDS wfDS, Hashtable<String, Object> hashtable) {
         WorkFlowInfo wfi = new WorkFlowInfo(hashtable);
         try {
             wfi = wfDS.getMessages(wfi);

--- a/src/main/java/io/github/carlos_emr/carlos/workflow/RHWorkFlow.java
+++ b/src/main/java/io/github/carlos_emr/carlos/workflow/RHWorkFlow.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.Hashtable;
 import java.util.List;
+import java.util.Map;
 
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 
@@ -48,8 +49,8 @@ public class RHWorkFlow implements WorkFlow {
      * Creates a new instance of RHWorkFlow
      */
     static final String WORKFLOWTYPE = "RH";
-    static Hashtable<String, WFState> states = null;
-    static ArrayList<WFState> stateList = null;
+    static Map<String, WFState> states = null;
+    static List<WFState> stateList = null;
 
     public RHWorkFlow() {
         states = new Hashtable<String, WFState>();
@@ -80,12 +81,12 @@ public class RHWorkFlow implements WorkFlow {
     }
 
 
-    public ArrayList<Hashtable<String, Object>> getActiveWorkFlowList(String demographicNo) {
+    public List<Map<String, Object>> getActiveWorkFlowList(String demographicNo) {
         WorkFlowState wfs = new WorkFlowState();
         return wfs.getActiveWorkFlowList(RHWorkFlow.WORKFLOWTYPE, demographicNo);
     }
 
-    public ArrayList<Hashtable<String, Object>> getActiveWorkFlowList() {
+    public List<Map<String, Object>> getActiveWorkFlowList() {
         WorkFlowState wfs = new WorkFlowState();
         return wfs.getActiveWorkFlowList(RHWorkFlow.WORKFLOWTYPE);
     }
@@ -111,8 +112,8 @@ public class RHWorkFlow implements WorkFlow {
         return wfs.addToWorkFlow(WorkFlowState.RHWORKFLOW, providerNo, demographicNo, endDate, WorkFlowState.INIT_STATE);
     }
 
-    public WorkFlowInfo executeRules(Hashtable<String, Object> hashtable) {
-        WorkFlowInfo wfi = new WorkFlowInfo(hashtable);
+    public WorkFlowInfo executeRules(Map<String, Object> data) {
+        WorkFlowInfo wfi = new WorkFlowInfo(data);
         WorkFlowDS wfDS = WorkFlowDSFactory.getWorkFlowDS("Rh_workflow.drl");
         try {
             wfi = wfDS.getMessages(wfi);
@@ -122,8 +123,8 @@ public class RHWorkFlow implements WorkFlow {
         return wfi;
     }
 
-    public WorkFlowInfo executeRules(WorkFlowDS wfDS, Hashtable<String, Object> hashtable) {
-        WorkFlowInfo wfi = new WorkFlowInfo(hashtable);
+    public WorkFlowInfo executeRules(WorkFlowDS wfDS, Map<String, Object> data) {
+        WorkFlowInfo wfi = new WorkFlowInfo(data);
         try {
             wfi = wfDS.getMessages(wfi);
         } catch (Exception e) {

--- a/src/main/java/io/github/carlos_emr/carlos/workflow/WorkFlow.java
+++ b/src/main/java/io/github/carlos_emr/carlos/workflow/WorkFlow.java
@@ -50,17 +50,17 @@ import java.util.List;
  * @author jay
  */
 public interface WorkFlow {
-    public ArrayList getActiveWorkFlowList(String demographicNo);
+    public ArrayList<Hashtable<String, Object>> getActiveWorkFlowList(String demographicNo);
 
-    public ArrayList getActiveWorkFlowList();
+    public ArrayList<Hashtable<String, Object>> getActiveWorkFlowList();
 
     public String getState(String state);
 
-    public List getStates();
+    public List<WFState> getStates();
 
-    public WorkFlowInfo executeRules(Hashtable hashtable);
+    public WorkFlowInfo executeRules(Hashtable<String, Object> hashtable);
 
-    public WorkFlowInfo executeRules(WorkFlowDS wfDS, Hashtable hashtable);
+    public WorkFlowInfo executeRules(WorkFlowDS wfDS, Hashtable<String, Object> hashtable);
 
     public String getLink(String demographic, String workFlowId);
 

--- a/src/main/java/io/github/carlos_emr/carlos/workflow/WorkFlow.java
+++ b/src/main/java/io/github/carlos_emr/carlos/workflow/WorkFlow.java
@@ -39,10 +39,9 @@
 
 package io.github.carlos_emr.carlos.workflow;
 
-import java.util.ArrayList;
 import java.util.Date;
-import java.util.Hashtable;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Generic WorkFlow Description.
@@ -50,17 +49,17 @@ import java.util.List;
  * @author jay
  */
 public interface WorkFlow {
-    public ArrayList<Hashtable<String, Object>> getActiveWorkFlowList(String demographicNo);
+    public List<Map<String, Object>> getActiveWorkFlowList(String demographicNo);
 
-    public ArrayList<Hashtable<String, Object>> getActiveWorkFlowList();
+    public List<Map<String, Object>> getActiveWorkFlowList();
 
     public String getState(String state);
 
     public List<WFState> getStates();
 
-    public WorkFlowInfo executeRules(Hashtable<String, Object> hashtable);
+    public WorkFlowInfo executeRules(Map<String, Object> data);
 
-    public WorkFlowInfo executeRules(WorkFlowDS wfDS, Hashtable<String, Object> hashtable);
+    public WorkFlowInfo executeRules(WorkFlowDS wfDS, Map<String, Object> data);
 
     public String getLink(String demographic, String workFlowId);
 

--- a/src/main/java/io/github/carlos_emr/carlos/workflow/WorkFlowInfo.java
+++ b/src/main/java/io/github/carlos_emr/carlos/workflow/WorkFlowInfo.java
@@ -31,7 +31,7 @@
 package io.github.carlos_emr.carlos.workflow;
 
 import java.util.Date;
-import java.util.Hashtable;
+import java.util.Map;
 
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 
@@ -56,7 +56,7 @@ public class WorkFlowInfo {
     public WorkFlowInfo() {
     }
 
-    public WorkFlowInfo(Hashtable<String, Object> h) {
+    public WorkFlowInfo(Map<String, Object> h) {
         MiscUtils.getLogger().debug("loading data...");
         this.setID((String) h.get("ID"));
         this.setWorkflowType((String) h.get("workflow_type"));

--- a/src/main/java/io/github/carlos_emr/carlos/workflow/WorkFlowInfo.java
+++ b/src/main/java/io/github/carlos_emr/carlos/workflow/WorkFlowInfo.java
@@ -56,7 +56,7 @@ public class WorkFlowInfo {
     public WorkFlowInfo() {
     }
 
-    public WorkFlowInfo(Hashtable h) {
+    public WorkFlowInfo(Hashtable<String, Object> h) {
         MiscUtils.getLogger().debug("loading data...");
         this.setID((String) h.get("ID"));
         this.setWorkflowType((String) h.get("workflow_type"));

--- a/src/main/java/io/github/carlos_emr/carlos/workflow/WorkFlowState.java
+++ b/src/main/java/io/github/carlos_emr/carlos/workflow/WorkFlowState.java
@@ -84,12 +84,12 @@ public class WorkFlowState {
     }
 
 
-    public ArrayList getWorkFlowList(String workflowType) {
-        ArrayList list = new ArrayList();
+    public ArrayList<Hashtable<String, Object>> getWorkFlowList(String workflowType) {
+        ArrayList<Hashtable<String, Object>> list = new ArrayList<Hashtable<String, Object>>();
 
         List<WorkFlow> ws = dao.findByWorkflowType(workflowType);
         for (WorkFlow w : ws) {
-            Hashtable h = new Hashtable();
+            Hashtable<String, Object> h = new Hashtable<String, Object>();
             h.put("ID", w.getId().toString());
             h.put("workflow_type", w.getWorkflowType());
             h.put("create_date_time", w.getCreateDateTime());
@@ -104,12 +104,12 @@ public class WorkFlowState {
         return list;
     }
 
-    public ArrayList getActiveWorkFlowList(String workflowType) {
-        ArrayList list = new ArrayList();
+    public ArrayList<Hashtable<String, Object>> getActiveWorkFlowList(String workflowType) {
+        ArrayList<Hashtable<String, Object>> list = new ArrayList<Hashtable<String, Object>>();
 
         List<WorkFlow> ws = dao.findActiveByWorkflowType(workflowType);
         for (WorkFlow w : ws) {
-            Hashtable h = new Hashtable();
+            Hashtable<String, Object> h = new Hashtable<String, Object>();
             h.put("ID", w.getId().toString());
             h.put("workflow_type", w.getWorkflowType());
             h.put("create_date_time", w.getCreateDateTime());
@@ -124,11 +124,11 @@ public class WorkFlowState {
         return list;
     }
 
-    public ArrayList getActiveWorkFlowList(String workflowType, String demographicNo) {
-        ArrayList list = new ArrayList();
+    public ArrayList<Hashtable<String, Object>> getActiveWorkFlowList(String workflowType, String demographicNo) {
+        ArrayList<Hashtable<String, Object>> list = new ArrayList<Hashtable<String, Object>>();
         List<WorkFlow> ws = dao.findActiveByWorkflowTypeAndDemographicNo(workflowType, demographicNo);
         for (WorkFlow w : ws) {
-            Hashtable h = new Hashtable();
+            Hashtable<String, Object> h = new Hashtable<String, Object>();
             h.put("ID", w.getId().toString());
             h.put("workflow_type", w.getWorkflowType());
             h.put("create_date_time", w.getCreateDateTime());
@@ -144,7 +144,7 @@ public class WorkFlowState {
 
 
     public static String rhState(Object s) {
-        Hashtable h = new Hashtable();
+        Hashtable<String, String> h = new Hashtable<String, String>();
         h.put("1", "No Appt made");
         h.put("2", "Appt Booked");
         h.put("3", "Injection 28");

--- a/src/main/java/io/github/carlos_emr/carlos/workflow/WorkFlowState.java
+++ b/src/main/java/io/github/carlos_emr/carlos/workflow/WorkFlowState.java
@@ -118,7 +118,8 @@ public class WorkFlowState {
             "1", "No Appt made",
             "2", "Appt Booked",
             "3", "Injection 28",
-            "4", "Missed Appt",
+            "4", "Requires Another Injection",
+            "5", "Missed Appt",
             "C", "Closed"
     );
 

--- a/src/main/java/io/github/carlos_emr/carlos/workflow/WorkFlowState.java
+++ b/src/main/java/io/github/carlos_emr/carlos/workflow/WorkFlowState.java
@@ -151,6 +151,6 @@ public class WorkFlowState {
         h.put("4", "Missed Appt");
         h.put("C", "Closed");
         String ss = (String) s;
-        return (String) h.get(ss);
+        return h.get(ss);
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/workflow/WorkFlowState.java
+++ b/src/main/java/io/github/carlos_emr/carlos/workflow/WorkFlowState.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.Hashtable;
 import java.util.List;
+import java.util.Map;
 
 import io.github.carlos_emr.carlos.commn.model.WorkFlow;
 import io.github.carlos_emr.carlos.commn.dao.WorkFlowDao;
@@ -84,51 +85,10 @@ public class WorkFlowState {
     }
 
 
-    public ArrayList<Hashtable<String, Object>> getWorkFlowList(String workflowType) {
-        ArrayList<Hashtable<String, Object>> list = new ArrayList<Hashtable<String, Object>>();
-
-        List<WorkFlow> ws = dao.findByWorkflowType(workflowType);
+    private static List<Map<String, Object>> toMapList(List<WorkFlow> ws) {
+        List<Map<String, Object>> list = new ArrayList<Map<String, Object>>();
         for (WorkFlow w : ws) {
-            Hashtable<String, Object> h = new Hashtable<String, Object>();
-            h.put("ID", w.getId().toString());
-            h.put("workflow_type", w.getWorkflowType());
-            h.put("create_date_time", w.getCreateDateTime());
-            h.put("demographic_no", w.getDemographicNo());
-            if (w.getCompletionDate() != null) {
-                h.put("completion_date", w.getCompletionDate());
-            }
-            h.put("current_state", w.getCurrentState());
-            list.add(h);
-        }
-
-        return list;
-    }
-
-    public ArrayList<Hashtable<String, Object>> getActiveWorkFlowList(String workflowType) {
-        ArrayList<Hashtable<String, Object>> list = new ArrayList<Hashtable<String, Object>>();
-
-        List<WorkFlow> ws = dao.findActiveByWorkflowType(workflowType);
-        for (WorkFlow w : ws) {
-            Hashtable<String, Object> h = new Hashtable<String, Object>();
-            h.put("ID", w.getId().toString());
-            h.put("workflow_type", w.getWorkflowType());
-            h.put("create_date_time", w.getCreateDateTime());
-            h.put("demographic_no", w.getDemographicNo());
-            if (w.getCompletionDate() != null) {
-                h.put("completion_date", w.getCompletionDate());
-            }
-            h.put("current_state", w.getCurrentState());
-            list.add(h);
-        }
-
-        return list;
-    }
-
-    public ArrayList<Hashtable<String, Object>> getActiveWorkFlowList(String workflowType, String demographicNo) {
-        ArrayList<Hashtable<String, Object>> list = new ArrayList<Hashtable<String, Object>>();
-        List<WorkFlow> ws = dao.findActiveByWorkflowTypeAndDemographicNo(workflowType, demographicNo);
-        for (WorkFlow w : ws) {
-            Hashtable<String, Object> h = new Hashtable<String, Object>();
+            Map<String, Object> h = new Hashtable<String, Object>();
             h.put("ID", w.getId().toString());
             h.put("workflow_type", w.getWorkflowType());
             h.put("create_date_time", w.getCreateDateTime());
@@ -142,15 +102,27 @@ public class WorkFlowState {
         return list;
     }
 
+    public List<Map<String, Object>> getWorkFlowList(String workflowType) {
+        return toMapList(dao.findByWorkflowType(workflowType));
+    }
+
+    public List<Map<String, Object>> getActiveWorkFlowList(String workflowType) {
+        return toMapList(dao.findActiveByWorkflowType(workflowType));
+    }
+
+    public List<Map<String, Object>> getActiveWorkFlowList(String workflowType, String demographicNo) {
+        return toMapList(dao.findActiveByWorkflowTypeAndDemographicNo(workflowType, demographicNo));
+    }
+
+    private static final Map<String, String> RH_STATES = Map.of(
+            "1", "No Appt made",
+            "2", "Appt Booked",
+            "3", "Injection 28",
+            "4", "Missed Appt",
+            "C", "Closed"
+    );
 
     public static String rhState(Object s) {
-        Hashtable<String, String> h = new Hashtable<String, String>();
-        h.put("1", "No Appt made");
-        h.put("2", "Appt Booked");
-        h.put("3", "Injection 28");
-        h.put("4", "Missed Appt");
-        h.put("C", "Closed");
-        String ss = (String) s;
-        return h.get(ss);
+        return RH_STATES.get((String) s);
     }
 }

--- a/src/main/webapp/WEB-INF/jsp/form/formRhImmuneGlobulin.jsp
+++ b/src/main/webapp/WEB-INF/jsp/form/formRhImmuneGlobulin.jsp
@@ -244,7 +244,7 @@
                 WorkFlowFactory flowFactory = new WorkFlowFactory();
                 WorkFlow flow = flowFactory.getWorkFlow(workflowType);
 
-                ArrayList currentWorkFlows = flow.getActiveWorkFlowList(demographicNo);
+                List<Map<String, Object>> currentWorkFlows = flow.getActiveWorkFlowList(demographicNo);
 
                 if (currentWorkFlows != null && currentWorkFlows.size() > 0) {
                     request.setAttribute("currentWorkFlow", currentWorkFlows.get(0));

--- a/src/main/webapp/WEB-INF/jsp/form/formRhImmuneGlobulin.jsp
+++ b/src/main/webapp/WEB-INF/jsp/form/formRhImmuneGlobulin.jsp
@@ -232,7 +232,7 @@
 
 
     <%
-        Hashtable h = null;
+        Map<String, Object> h = null;
         String newFlowNeeded = (String) request.getAttribute("newWorkFlowNeeded");
     %>
     <div>
@@ -248,7 +248,7 @@
 
                 if (currentWorkFlows != null && currentWorkFlows.size() > 0) {
                     request.setAttribute("currentWorkFlow", currentWorkFlows.get(0));
-                    h = (Hashtable) currentWorkFlows.get(0);
+                    h = currentWorkFlows.get(0);
                 }
 
                 if (h != null) {
@@ -280,9 +280,9 @@
             <label>Change State:</label>
             <select name="state">
                 <%
-                    ArrayList states = new ArrayList(flow.getStates());
+                    List<WFState> states = new ArrayList<WFState>(flow.getStates());
                     for (int i = 0; i < states.size(); i++) {
-                        WFState state = (WFState) states.get(i);
+                        WFState state = states.get(i);
                 %>
                 <option value="<carlos:encode value='<%= state.getKey() %>' context="htmlAttribute"/>"
                         <%= (state.getKey().equals(h.get("current_state")) ? " selected" : "")%>><carlos:encode value='<%= state.getName() %>' context="html"/>
@@ -608,7 +608,7 @@
             //Hack to display injections after a workflow has been closed.
             if (h == null && !props.getProperty("workflowId","").equals("") && !props.getProperty("workflowId","").equals("-1")){
                try{
-                   h = new  Hashtable();
+                   h = new  Hashtable<String, Object>();
                    h.put("ID", props.getProperty("workflowId",""));
                    String ddate = props.getProperty("edd","");
                    ddate = ddate.substring(0,10);

--- a/src/main/webapp/WEB-INF/jsp/oscarWorkflow/WorkFlowList.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarWorkflow/WorkFlowList.jsp
@@ -138,7 +138,7 @@
                     //WorkFlowState workFlow = new WorkFlowState();
                     WorkFlowFactory flowFactory = new WorkFlowFactory();
                     WorkFlow flow = flowFactory.getWorkFlow(workflowType);
-                    ArrayList workList = flow.getActiveWorkFlowList();
+                    List<Map<String, Object>> workList = flow.getActiveWorkFlowList();
 
                     if (workList != null && workList.size() > 0) {
                         DemographicNameAgeString deName = DemographicNameAgeString.getInstance();
@@ -160,7 +160,7 @@
                         WorkFlowDS wfDS = flow.getWorkFlowDS();
 
                         for (int j = 0; j < workList.size(); j++) {
-                            Hashtable h = (Hashtable) workList.get(j);
+                            Map<String, Object> h = workList.get(j);
                           Map<String, String> demoHash = deName.getNameAgeSexHashtable(LoggedInInfo.getLoggedInInfoFromSession(request), ""+h.get("demographic_no"));
                             String colour = "";
 


### PR DESCRIPTION
<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description

Fixed raw collection type usage in the Prevention module by adding generic bounds to the affected Hashtable and ArrayList usages.
This PR keeps the scope narrow and focuses on the raw type issues called out in #2703. I updated the affected prevention action/report flow to use typed collections where possible, including the PreventionReport.runReport() interface and related implementations needed for compilation.
In the files I touched I also noticed a few other instances of using raw types and addressed those also.

## How Was This Tested?
To ensure code compiles and tests still pass I ran:
```makefile
make install --run-unit-tests
``` 
with following results:
```shell
[INFO] Results:
[INFO] 
[INFO] Tests run: 5118, Failures: 0, Errors: 0, Skipped: 6
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
``` 

## Checklist

- [X] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [X] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [X] I have not included any patient data (PHI) in this PR
- [X] I have added tests for new functionality, or this change doesn't need new tests
- [X] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Add generic type parameters to workflow and prevention report collection APIs to eliminate raw types and improve type safety across the prevention/RH workflow flows.

Enhancements:
- Type the WorkFlow and WorkFlowState APIs to use ArrayList<Hashtable<String, Object>> and List<WFState> instead of raw collections for workflow lists and states.
- Update prevention report interfaces and implementations to return Hashtable<String, Object> and accept ArrayList<ArrayList<String>> for report data, aligning callers with typed collections.
- Tighten typing in RH prevention form handling by using parameterized Hashtables and Enumerations and by updating WorkFlowInfo to accept a typed Hashtable<String, Object>.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced raw collections with generics across prevention and workflow code, switched public APIs to interface types, and updated JSP callers for type safety. Also corrected RH workflow state labels. Addresses #2703.

- **Refactors**
  - Workflow APIs now use interfaces: `getActiveWorkFlowList` returns `List<Map<String, Object>>`, `getStates` returns `List<WFState>`, and `executeRules` accepts `Map<String, Object>`; updated `WorkFlow`, `RHWorkFlow`, `WorkFlowState`, and JSP callers.
  - Prevention reports: `PreventionReport.runReport` returns `Hashtable<String, Object>` and accepts `ArrayList<ArrayList<String>>`; updated `MammogramReport`, `PapReport`, and `PreventionReport2Action`.
  - Cleanups: `WorkFlowInfo` constructor takes `Map<String, Object>`; `WorkFlowState` builds typed map lists via a helper and uses a static map for `rhState`; `FrmFormRHPrevention2Action` uses `List`/`Map` generics and `Enumeration<String>` with redundant casts removed.

- **Bug Fixes**
  - Corrected RH state mapping: code `4` is "Requires Another Injection" and code `5` is "Missed Appt".

<sup>Written for commit 3f4c05049ccd36eab1f1a9f377f8e1292b66cf56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

