### PR TITLE
fix: suppress hardcoded-credential scanner false positives (14 alerts)

### DIFF
--- a/.github/spotbugs/spotbugs-exclude.xml
+++ b/.github/spotbugs/spotbugs-exclude.xml
@@ -898,4 +898,73 @@
         <Bug pattern="CRLF_INJECTION_LOGS"/>
     </Match>
 
+
+    <!-- ================================================================
+         HARD_CODE_PASSWORD FALSE POSITIVES
+         SpotBugs HARD_CODE_PASSWORD fires whenever a String literal is
+         passed to (or compared with) a method whose name contains
+         "password". Three structural patterns recur in this codebase
+         that are never real credentials:
+
+           1. Field-clear pattern: setPassword("") clears an email/form
+              field before sending. The empty literal is not a credential.
+
+           2. WS-Security protocol-type constant: the string "PasswordText"
+              (aliased as WSS4JConstants.PW_TEXT / WSConstants.PW_TEXT) is
+              a WS-Security UsernameToken mechanism URI, not a password value.
+              Any method that configures a WS-Security interceptor property
+              map will trigger this detector.
+
+           3. UI mask sentinel: PASSWORD_MASK_SENTINEL = "**********" is
+              compared against a submitted form field to detect "unchanged"
+              password submissions. It is not a stored or usable credential.
+
+         Each entry below is method-scoped. If you encounter the same
+         pattern in a new method, add a method-scoped entry here rather
+         than annotating the call site.
+         ================================================================ -->
+
+    <!-- setPassword("") calls inside sanitizeEmailFields clear the email
+         DTO's credential fields when encryption is not being used. -->
+    <Match>
+        <Bug pattern="HARD_CODE_PASSWORD"/>
+        <Class name="io.github.carlos_emr.carlos.managers.EmailManager"/>
+        <Method name="sanitizeEmailFields"/>
+    </Match>
+
+    <!-- properties.put(WSHandlerConstants.PASSWORD_TYPE, WSS4JConstants.PW_TEXT)
+         configures the WS-Security UsernameToken mechanism. PW_TEXT is a
+         protocol-type URI string, not a password value. -->
+    <Match>
+        <Bug pattern="HARD_CODE_PASSWORD"/>
+        <Class name="io.github.carlos_emr.carlos.webserv.AuthenticationInWSS4JInterceptor"/>
+        <Method name="initialize"/>
+    </Match>
+
+    <!-- Same WS-Security protocol-type constant set in the outbound interceptor
+         constructor. SpotBugs uses &lt;init&gt; (bytecode name) for constructors. -->
+    <Match>
+        <Bug pattern="HARD_CODE_PASSWORD"/>
+        <Class name="io.github.carlos_emr.carlos.utility.AuthenticationOutWSS4JInterceptor"/>
+        <Method name="&lt;init&gt;"/>
+    </Match>
+
+    <!-- Same WS-Security protocol-type constant in the EDT billing client
+         WS-Security outbound property map builder. -->
+    <Match>
+        <Bug pattern="HARD_CODE_PASSWORD"/>
+        <Class name="io.github.carlos_emr.carlos.integration.ebs.client.ng.EdtClientBuilder"/>
+        <Method name="newWSSOutInterceptorConfiguration"/>
+    </Match>
+
+    <!-- PASSWORD_MASK_SENTINEL = "**********" is the UI placeholder shown
+         in password fields when a credential is already stored. This method
+         checks whether a submitted value equals the sentinel (meaning the
+         admin left the field blank/unchanged). It is not a credential comparison. -->
+    <Match>
+        <Bug pattern="HARD_CODE_PASSWORD"/>
+        <Class name="io.github.carlos_emr.carlos.fax.admin.ConfigureFax2Action"/>
+        <Method name="isPasswordUnchanged"/>
+    </Match>
+
 </FindBugsFilter>

--- a/docs/superpowers/plans/2026-06-10-hardcoded-credential-false-positives.md
+++ b/docs/superpowers/plans/2026-06-10-hardcoded-credential-false-positives.md
@@ -1,0 +1,405 @@
+# Hardcoded-Credential False Positive Suppressions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Suppress 14 hardcoded-credential false-positive scanner alerts across 4 files using the codebase's established suppression conventions, closing the alerts in GitHub Code Scanning without changing any runtime behavior.
+
+**Architecture:** Two suppression layers: `spotbugs-exclude.xml` for structural patterns (empty-string field clears, WS-Security protocol constants, UI mask sentinels) and per-site `@SuppressFBWarnings` / `// NOSONAR` / `// NOPMD` annotations for reviewed intentional code. Both layers require prose justification explaining why the finding is a false positive.
+
+**Tech Stack:** Java 21, SpotBugs + Find Security Bugs, SonarCloud, PMD, `edu.umd.cs.findbugs.annotations.SuppressFBWarnings`
+
+---
+
+## Files
+
+| Action | File |
+|--------|------|
+| Modify | `.github/spotbugs/spotbugs-exclude.xml` |
+| Modify | `src/main/java/io/github/carlos_emr/carlos/login/LoginCheckLoginBean.java` |
+| Modify | `src/main/java/io/github/carlos_emr/carlos/managers/SecurityManager.java` |
+| Modify | `src/main/java/io/github/carlos_emr/carlos/lab/ca/all/pageUtil/LabUpload2Action.java` |
+
+---
+
+## Task 1: Add structural `HARD_CODE_PASSWORD` exclusions to spotbugs-exclude.xml
+
+These five methods always trigger `HARD_CODE_PASSWORD` by structural pattern, not by defect:
+`EmailManager.sanitizeEmailFields` (sets `""` — field clear), the three WS-Security
+interceptor constructors/initializers (contain the string `"PasswordText"` — a protocol-type
+constant), and `ConfigureFax2Action.isPasswordUnchanged` (compares against `"**********"` — a UI mask sentinel).
+
+**Files:**
+- Modify: `.github/spotbugs/spotbugs-exclude.xml`
+
+- [ ] **Step 1: Add the new section to spotbugs-exclude.xml**
+
+Open `.github/spotbugs/spotbugs-exclude.xml`. Find the closing `</FindBugsFilter>` tag at the
+end of the file. Insert the following block immediately before it (after the last `</Match>` block):
+
+```xml
+    <!-- ================================================================
+         HARD_CODE_PASSWORD FALSE POSITIVES
+         SpotBugs HARD_CODE_PASSWORD fires whenever a String literal is
+         passed to (or compared with) a method whose name contains
+         "password". Three structural patterns recur in this codebase
+         that are never real credentials:
+
+           1. Field-clear pattern: setPassword("") clears an email/form
+              field before sending. The empty literal is not a credential.
+
+           2. WS-Security protocol-type constant: the string "PasswordText"
+              (aliased as WSS4JConstants.PW_TEXT / WSConstants.PW_TEXT) is
+              a WS-Security UsernameToken mechanism URI, not a password value.
+              Any method that configures a WS-Security interceptor property
+              map will trigger this detector.
+
+           3. UI mask sentinel: PASSWORD_MASK_SENTINEL = "**********" is
+              compared against a submitted form field to detect "unchanged"
+              password submissions. It is not a stored or usable credential.
+
+         Each entry below is method-scoped. If you encounter the same
+         pattern in a new method, add a method-scoped entry here rather
+         than annotating the call site.
+         ================================================================ -->
+
+    <!-- setPassword("") calls inside sanitizeEmailFields clear the email
+         DTO's credential fields when encryption is not being used. -->
+    <Match>
+        <Bug pattern="HARD_CODE_PASSWORD"/>
+        <Class name="io.github.carlos_emr.carlos.managers.EmailManager"/>
+        <Method name="sanitizeEmailFields"/>
+    </Match>
+
+    <!-- properties.put(WSHandlerConstants.PASSWORD_TYPE, WSS4JConstants.PW_TEXT)
+         configures the WS-Security UsernameToken mechanism. PW_TEXT is a
+         protocol-type URI string, not a password value. -->
+    <Match>
+        <Bug pattern="HARD_CODE_PASSWORD"/>
+        <Class name="io.github.carlos_emr.carlos.webserv.AuthenticationInWSS4JInterceptor"/>
+        <Method name="initialize"/>
+    </Match>
+
+    <!-- Same WS-Security protocol-type constant set in the outbound interceptor
+         constructor. SpotBugs uses <init> (bytecode name) for constructors. -->
+    <Match>
+        <Bug pattern="HARD_CODE_PASSWORD"/>
+        <Class name="io.github.carlos_emr.carlos.utility.AuthenticationOutWSS4JInterceptor"/>
+        <Method name="&lt;init&gt;"/>
+    </Match>
+
+    <!-- Same WS-Security protocol-type constant in the EDT billing client
+         WS-Security outbound property map builder. -->
+    <Match>
+        <Bug pattern="HARD_CODE_PASSWORD"/>
+        <Class name="io.github.carlos_emr.carlos.integration.ebs.client.ng.EdtClientBuilder"/>
+        <Method name="newWSSOutInterceptorConfiguration"/>
+    </Match>
+
+    <!-- PASSWORD_MASK_SENTINEL = "**********" is the UI placeholder shown
+         in password fields when a credential is already stored. This method
+         checks whether a submitted value equals the sentinel (meaning the
+         admin left the field blank/unchanged). It is not a credential comparison. -->
+    <Match>
+        <Bug pattern="HARD_CODE_PASSWORD"/>
+        <Class name="io.github.carlos_emr.carlos.fax.admin.ConfigureFax2Action"/>
+        <Method name="isPasswordUnchanged"/>
+    </Match>
+```
+
+- [ ] **Step 2: Verify the XML is well-formed**
+
+```bash
+xmllint --noout .github/spotbugs/spotbugs-exclude.xml && echo "XML valid"
+```
+
+Expected output: `XML valid`
+
+If `xmllint` is not available: `python3 -c "import xml.etree.ElementTree as ET; ET.parse('.github/spotbugs/spotbugs-exclude.xml'); print('XML valid')"`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/spotbugs/spotbugs-exclude.xml
+git commit -m "fix: suppress HARD_CODE_PASSWORD structural false positives in spotbugs-exclude.xml
+
+Five method-scoped entries cover the three recurring false-positive patterns:
+empty-string field clears (EmailManager), WS-Security protocol-type constants
+(AuthenticationInWSS4JInterceptor, AuthenticationOutWSS4JInterceptor,
+EdtClientBuilder), and the fax admin UI mask sentinel (ConfigureFax2Action).
+Section header documents each pattern so future developers don't re-suppress
+individually."
+```
+
+---
+
+## Task 2: Suppress LoginCheckLoginBean dummy-hash findings (SpotBugs + SonarCloud)
+
+`MISSING_USER_DUMMY_PASSWORD_HASH` is a pre-computed BCrypt hash of a random decoy
+password used solely to equalize timing of the missing-user authentication path
+(prevents user enumeration via response-time differences). It has no usable plaintext.
+SonarCloud `secrets:S8215` and `java:S2068` fire on the field declaration;
+SpotBugs `HARD_CODE_PASSWORD` fires on the `missingUserDummySecurity()` method that
+reads it.
+
+**Files:**
+- Modify: `src/main/java/io/github/carlos_emr/carlos/login/LoginCheckLoginBean.java`
+
+- [ ] **Step 1: Add the SuppressFBWarnings import**
+
+`LoginCheckLoginBean.java` does not currently import `SuppressFBWarnings`. Add it
+after the existing imports (around line 54, after the last `import` statement):
+
+Find this block:
+```java
+import io.github.carlos_emr.carlos.log.LogAction;
+import io.github.carlos_emr.carlos.log.LogConst;
+```
+
+Replace with:
+```java
+import io.github.carlos_emr.carlos.log.LogAction;
+import io.github.carlos_emr.carlos.log.LogConst;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+```
+
+- [ ] **Step 2: Annotate the field and add NOSONAR**
+
+Find the field declaration (around line 121–126):
+```java
+    /**
+     * Pre-computed BCrypt hash of a random decoy password, used only to equalize missing-user
+     * authentication timing with the normal password-validation path.
+     */
+    private static final String MISSING_USER_DUMMY_PASSWORD_HASH =
+            "{bcrypt}$2b$10$YzOXP.2axkRiYS07sVHWkuyvQjcuwR.bGeZd5WHQVJ23py57UES8C";
+```
+
+Replace with:
+```java
+    /**
+     * Pre-computed BCrypt hash of a random decoy password, used only to equalize missing-user
+     * authentication timing with the normal password-validation path.
+     */
+    @SuppressFBWarnings(value = "HARD_CODE_PASSWORD",
+            justification = "BCrypt timing-equalization decoy: a pre-computed hash of a random "
+                    + "throwaway password with no usable plaintext, used only to make "
+                    + "missing-user paths take the same wall-clock time as real password checks")
+    // NOSONAR java:S2068,secrets:S8215 — BCrypt decoy hash for timing equalization; not a usable credential
+    private static final String MISSING_USER_DUMMY_PASSWORD_HASH =
+            "{bcrypt}$2b$10$YzOXP.2axkRiYS07sVHWkuyvQjcuwR.bGeZd5WHQVJ23py57UES8C";
+```
+
+- [ ] **Step 3: Annotate the missingUserDummySecurity() method**
+
+Find the method (around line 342–351):
+```java
+    /**
+     * Builds a throwaway security record for the missing-user password validation path.
+     *
+     * @return Security object containing only the precomputed BCrypt dummy password hash
+     */
+    private static Security missingUserDummySecurity() {
+        Security dummySecurity = new Security();
+        dummySecurity.setPassword(MISSING_USER_DUMMY_PASSWORD_HASH);
+        return dummySecurity;
+    }
+```
+
+Replace with:
+```java
+    /**
+     * Builds a throwaway security record for the missing-user password validation path.
+     *
+     * @return Security object containing only the precomputed BCrypt dummy password hash
+     */
+    @SuppressFBWarnings(value = "HARD_CODE_PASSWORD",
+            justification = "Sets the BCrypt timing-equalization decoy hash; see MISSING_USER_DUMMY_PASSWORD_HASH")
+    // BCrypt timing-equalization decoy — sets dummy hash, not a real credential
+    private static Security missingUserDummySecurity() {
+        Security dummySecurity = new Security();
+        dummySecurity.setPassword(MISSING_USER_DUMMY_PASSWORD_HASH);
+        return dummySecurity;
+    }
+```
+
+- [ ] **Step 4: Compile to confirm no errors**
+
+```bash
+mvn compile -pl . -q 2>&1 | grep -E "ERROR|error:" | head -20
+```
+
+Expected: no output (clean compile). If errors appear, check that the import was added correctly and the annotation syntax matches existing `@SuppressFBWarnings` usages in the file.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/java/io/github/carlos_emr/carlos/login/LoginCheckLoginBean.java
+git commit -m "fix: suppress HARD_CODE_PASSWORD/S2068/secrets:S8215 on BCrypt timing-equalization decoy
+
+MISSING_USER_DUMMY_PASSWORD_HASH is a pre-computed BCrypt hash of a random
+throwaway password used only to equalize missing-user authentication timing
+and prevent user enumeration via response-time differences. It has no usable
+plaintext. Annotated with @SuppressFBWarnings and // NOSONAR with justification."
+```
+
+---
+
+## Task 3: Suppress SecurityManager policy-sentinel false positive
+
+SpotBugs fires `HARD_CODE_PASSWORD` on `checkPasswordAgainstPrevious` because the
+string `"0"` (a policy threshold meaning "zero past passwords to check") appears in a
+method whose name contains "password". It is not a credential.
+
+**Files:**
+- Modify: `src/main/java/io/github/carlos_emr/carlos/managers/SecurityManager.java`
+
+- [ ] **Step 1: Add the SuppressFBWarnings import**
+
+`SecurityManager.java` does not currently import `SuppressFBWarnings`. Find the last
+import line (around line 45, `import java.util.List;`) and add after it:
+
+Find:
+```java
+import java.util.Date;
+import java.util.List;
+```
+
+Replace with:
+```java
+import java.util.Date;
+import java.util.List;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+```
+
+- [ ] **Step 2: Annotate the method**
+
+Find the method signature (around line 88):
+```java
+    public boolean checkPasswordAgainstPrevious(String newPassword, String providerNo) {
+        //check previous passwords policy if the password is being changed
+        String previousPasswordPolicy = CarlosProperties.getInstance().getProperty("password.pastPasswordsToNotUse", "0");
+```
+
+Add the annotation and comment immediately before the method:
+
+Find:
+```java
+    public boolean checkPasswordAgainstPrevious(String newPassword, String providerNo) {
+```
+
+Replace with:
+```java
+    @SuppressFBWarnings(value = "HARD_CODE_PASSWORD",
+            justification = "\"0\" is a policy threshold sentinel (zero past passwords to check), "
+                    + "not a credential; compared against the pastPasswordsToNotUse config property")
+    // "0" = policy threshold, not a password — prevents false positive on method name containing "password"
+    public boolean checkPasswordAgainstPrevious(String newPassword, String providerNo) {
+```
+
+- [ ] **Step 3: Compile to confirm no errors**
+
+```bash
+mvn compile -pl . -q 2>&1 | grep -E "ERROR|error:" | head -20
+```
+
+Expected: no output.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/java/io/github/carlos_emr/carlos/managers/SecurityManager.java
+git commit -m "fix: suppress HARD_CODE_PASSWORD false positive in SecurityManager
+
+\"0\" in checkPasswordAgainstPrevious is a policy threshold sentinel
+(pastPasswordsToNotUse config default), not a credential. SpotBugs fires
+because the string appears in a method whose name contains \"password\"."
+```
+
+---
+
+## Task 4: Suppress LabUpload2Action HardCodedCryptoKey false positive
+
+PMD `HardCodedCryptoKey` fires on `Cipher.getInstance("RSA/ECB/PKCS1Padding")` at line 236
+because the string argument contains cipher algorithm/mode details. No cryptographic key
+material is hardcoded — the algorithm string is a standard JCA transformation name. The
+RSA private key is loaded from the server keystore at runtime.
+
+**Files:**
+- Modify: `src/main/java/io/github/carlos_emr/carlos/lab/ca/all/pageUtil/LabUpload2Action.java`
+
+- [ ] **Step 1: Add the NOPMD suppression comment**
+
+Find line 236 (inside the lab upload decrypt block):
+```java
+            Cipher cipher = Cipher.getInstance("RSA/ECB/PKCS1Padding");
+```
+
+Replace with:
+```java
+            Cipher cipher = Cipher.getInstance("RSA/ECB/PKCS1Padding"); // NOPMD HardCodedCryptoKey — algorithm name string, not a key; RSA private key loaded from server keystore at runtime
+```
+
+- [ ] **Step 2: Compile to confirm no errors**
+
+```bash
+mvn compile -pl . -q 2>&1 | grep -E "ERROR|error:" | head -20
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main/java/io/github/carlos_emr/carlos/lab/ca/all/pageUtil/LabUpload2Action.java
+git commit -m "fix: suppress HardCodedCryptoKey PMD false positive in LabUpload2Action
+
+Cipher.getInstance(\"RSA/ECB/PKCS1Padding\") uses a JCA transformation name
+string, not hardcoded key material. The RSA private key is loaded from the
+server keystore at runtime."
+```
+
+---
+
+## Task 5: Run unit tests and verify overall health
+
+- [ ] **Step 1: Run unit tests**
+
+```bash
+make install --run-unit-tests 2>&1 | tail -20
+```
+
+Expected: `BUILD SUCCESS` with all tests passing. These are compilation + unit tests only (no database required). If tests fail, check that none of the annotation changes accidentally altered method signatures or moved code.
+
+- [ ] **Step 2: Verify alert count in spotbugs-exclude.xml matches expectation**
+
+```bash
+grep -c "HARD_CODE_PASSWORD" .github/spotbugs/spotbugs-exclude.xml
+```
+
+Expected output: `5` (the five new entries added in Task 1).
+
+- [ ] **Step 3: Verify all four Java files compile independently**
+
+```bash
+grep -l "SuppressFBWarnings\|NOPMD HardCodedCryptoKey" \
+  src/main/java/io/github/carlos_emr/carlos/login/LoginCheckLoginBean.java \
+  src/main/java/io/github/carlos_emr/carlos/managers/SecurityManager.java \
+  src/main/java/io/github/carlos_emr/carlos/lab/ca/all/pageUtil/LabUpload2Action.java
+```
+
+Expected: all three paths printed (confirms the suppressions were written to disk).
+
+---
+
+## Alert-to-task mapping (for verification)
+
+| GitHub Alert # | Rule | File | Task |
+|---|---|---|---|
+| 19383–19388 | `HARD_CODE_PASSWORD` | `EmailManager.java` | Task 1 |
+| 19598 | `HARD_CODE_PASSWORD` | `AuthenticationInWSS4JInterceptor.java` | Task 1 |
+| 19556 | `HARD_CODE_PASSWORD` | `AuthenticationOutWSS4JInterceptor.java` | Task 1 |
+| 11059 | `HARD_CODE_PASSWORD` | `EdtClientBuilder.java` | Task 1 |
+| 10510 | `HARD_CODE_PASSWORD` | `ConfigureFax2Action.java` | Task 1 |
+| 19370, 19253, 19254 | `HARD_CODE_PASSWORD`, `secrets:S8215`, `java:S2068` | `LoginCheckLoginBean.java` | Task 2 |
+| 19414 | `HARD_CODE_PASSWORD` | `SecurityManager.java` | Task 3 |
+| 18453 | `HardCodedCryptoKey` | `LabUpload2Action.java` | Task 4 |

--- a/docs/superpowers/plans/2026-06-10-hardcoded-credential-false-positives.md
+++ b/docs/superpowers/plans/2026-06-10-hardcoded-credential-false-positives.md
@@ -373,10 +373,11 @@ Expected: `BUILD SUCCESS` with all tests passing. These are compilation + unit t
 - [ ] **Step 2: Verify alert count in spotbugs-exclude.xml matches expectation**
 
 ```bash
-grep -c "HARD_CODE_PASSWORD" .github/spotbugs/spotbugs-exclude.xml
+grep -c 'pattern="HARD_CODE_PASSWORD"' .github/spotbugs/spotbugs-exclude.xml
 ```
 
-Expected output: `5` (the five new entries added in Task 1).
+Expected output: `5` (the five new `<Bug pattern="HARD_CODE_PASSWORD"/>` entries added in Task 1).
+Note: a plain `grep -c "HARD_CODE_PASSWORD"` would return 7 because the XML section-header comment also mentions the string twice; use the narrower pattern above to count only the suppression entries.
 
 - [ ] **Step 3: Verify all four Java files compile independently**
 

--- a/docs/superpowers/specs/2026-06-10-hardcoded-credential-false-positives-design.md
+++ b/docs/superpowers/specs/2026-06-10-hardcoded-credential-false-positives-design.md
@@ -1,0 +1,98 @@
+# Design: Suppress Hardcoded-Credential False Positives
+
+**Date:** 2026-06-10
+**Status:** Approved
+
+## Problem
+
+GitHub Code Scanning shows 14 open `HARD_CODE_PASSWORD` / `HardCodedCryptoKey` /
+`secrets:S8215` / `java:S2068` alerts. Every one is a false positive — scanners
+misidentifying empty-string field clears, WS-Security protocol-type constants, a
+UI mask sentinel, a BCrypt timing-equalization decoy hash, a policy comparison
+string, and a cipher algorithm name.
+
+Leaving them open creates auditor confusion ("was this reviewed?") and buries
+real future findings in noise.
+
+## Goals
+
+1. Close all 14 alerts in GitHub Code Scanning.
+2. Self-document each suppression so future reviewers understand why it exists.
+3. Add a structural section to `spotbugs-exclude.xml` so recurring structural
+   patterns do not re-accumulate as the codebase grows.
+
+## Non-Goals
+
+- Fix any real credentials (none were found).
+- Change any runtime behavior.
+- Suppress any finding that is not a confirmed false positive.
+
+## Alert Inventory and Disposition
+
+### Structural patterns → `spotbugs-exclude.xml`
+
+These patterns will always fire for a given method because of what the code *is*,
+not because of a bug. They belong in the XML so the pattern is explained once and
+applies to the whole structural class.
+
+| Bug pattern | Class | Method | Why it fires |
+|---|---|---|---|
+| `HARD_CODE_PASSWORD` | `EmailManager` | `sanitizeEmailFields` | `setPassword("")` — clearing a field to empty string |
+| `HARD_CODE_PASSWORD` | `AuthenticationInWSS4JInterceptor` | `initialize` | `"PasswordText"` is a WS-Security protocol-type constant |
+| `HARD_CODE_PASSWORD` | `AuthenticationOutWSS4JInterceptor` | `<init>` | Same WS-Security constant |
+| `HARD_CODE_PASSWORD` | `EdtClientBuilder` | `newWSSOutInterceptorConfiguration` | Same WS-Security constant |
+| `HARD_CODE_PASSWORD` | `ConfigureFax2Action` | `isPasswordUnchanged` | `PASSWORD_MASK_SENTINEL = "**********"` — UI mask sentinel comparison |
+
+All five entries go in a new `HARD_CODE_PASSWORD FALSE POSITIVES` section with an
+explanatory header comment describing the three structural trigger patterns so the
+next developer who encounters the same pattern has context before reaching for a
+new suppression.
+
+### Reviewed per-site findings → `@SuppressFBWarnings` + inline comment
+
+These need call-site review context that is specific to the code's design intent.
+
+| Alert | File | Lines | Mechanism |
+|---|---|---|---|
+| `HARD_CODE_PASSWORD` (SpotBugs) + `java:S2068` + `secrets:S8215` (SonarCloud) | `LoginCheckLoginBean.java` | 125–126, 349 | `@SuppressFBWarnings` on the field constant + `// NOSONAR` on lines 125-126; `@SuppressFBWarnings` on `missingUserDummySecurity()` |
+| `HARD_CODE_PASSWORD` | `SecurityManager.java` | 94 | `@SuppressFBWarnings` on `checkPasswordAgainstPrevious` |
+
+`LoginCheckLoginBean.java` justification: `MISSING_USER_DUMMY_PASSWORD_HASH` is a
+pre-computed BCrypt hash of a random decoy password used solely to equalize
+timing of the missing-user authentication path (prevents user-enumeration via
+timing). It has no meaningful plaintext. This is an intentional security pattern.
+
+`SecurityManager.java` justification: The string `"0"` on line 94 is a policy
+threshold sentinel (zero past passwords to check), not a credential.
+
+### PMD inline suppression
+
+| Alert | File | Line | Mechanism |
+|---|---|---|---|
+| `HardCodedCryptoKey` | `LabUpload2Action.java` | 236 | `// NOPMD HardCodedCryptoKey` inline + adjacent comment |
+
+Justification: `Cipher.getInstance("RSA/ECB/PKCS1Padding")` is an algorithm
+name string, not a key. No cryptographic key material is hardcoded. The padding
+choice is a pre-existing protocol constraint; see adjacent comment in the source.
+
+## Suppression Conventions (matches existing codebase)
+
+- **SpotBugs XML**: method-scoped `<Match>` elements; a prose comment above each
+  entry or section explains the rationale.
+- **`@SuppressFBWarnings`**: annotation on the method (or field for field-level
+  findings); mandatory adjacent `//` comment per CLAUDE.md.
+- **SonarCloud**: `// NOSONAR rule-id — short justification` at end of line.
+- **PMD**: `// NOPMD RuleId — justification` inline.
+
+## Files Changed
+
+- `.github/spotbugs/spotbugs-exclude.xml` — new section with 5 entries
+- `src/main/java/io/github/carlos_emr/carlos/login/LoginCheckLoginBean.java` — field + method annotations + NOSONAR
+- `src/main/java/io/github/carlos_emr/carlos/managers/SecurityManager.java` — method annotation
+- `src/main/java/io/github/carlos_emr/carlos/lab/ca/all/pageUtil/LabUpload2Action.java` — inline NOPMD
+
+## Testing
+
+No behavior change. Verification: run `make install --run-unit-tests` to confirm
+no compilation or test regressions. The SpotBugs and Semgrep runs are CI-only;
+locally confirm the changed files compile clean.

--- a/src/main/java/io/github/carlos_emr/carlos/lab/ca/all/pageUtil/LabUpload2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/lab/ca/all/pageUtil/LabUpload2Action.java
@@ -233,7 +233,7 @@ public class LabUpload2Action extends ActionSupport implements UploadedFilesAwar
             // sender which encrypts with PKCS#1 v1.5. Changing the padding here would break
             // decryption of incoming lab uploads. This is decrypt-only (not encrypt), which
             // limits the attack surface. If the external protocol is ever updated, migrate to OAEP.
-            Cipher cipher = Cipher.getInstance("RSA/ECB/PKCS1Padding");
+            Cipher cipher = Cipher.getInstance("RSA/ECB/PKCS1Padding"); // NOPMD HardCodedCryptoKey — JCA transformation name string, not key material; RSA private key loaded from server keystore at runtime
             cipher.init(Cipher.DECRYPT_MODE, key);
             byte[] newSecretKey = cipher.doFinal(Base64.decodeBase64(skey));
 

--- a/src/main/java/io/github/carlos_emr/carlos/lab/ca/all/pageUtil/LabUpload2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/lab/ca/all/pageUtil/LabUpload2Action.java
@@ -233,7 +233,7 @@ public class LabUpload2Action extends ActionSupport implements UploadedFilesAwar
             // sender which encrypts with PKCS#1 v1.5. Changing the padding here would break
             // decryption of incoming lab uploads. This is decrypt-only (not encrypt), which
             // limits the attack surface. If the external protocol is ever updated, migrate to OAEP.
-            Cipher cipher = Cipher.getInstance("RSA/ECB/PKCS1Padding"); // NOPMD HardCodedCryptoKey — JCA transformation name string, not key material; RSA private key loaded from server keystore at runtime
+            Cipher cipher = Cipher.getInstance("RSA/ECB/PKCS1Padding"); // NOPMD HardCodedCryptoKey — JCA name, not key material // nosemgrep: java.lang.security.audit.crypto.ecb-cipher.ecb-cipher -- "ECB" is JCA convention for RSA single-block, not AES-ECB mode; PKCS#1v1.5 constraint documented above
             cipher.init(Cipher.DECRYPT_MODE, key);
             byte[] newSecretKey = cipher.doFinal(Base64.decodeBase64(skey));
 

--- a/src/main/java/io/github/carlos_emr/carlos/login/LoginCheckLoginBean.java
+++ b/src/main/java/io/github/carlos_emr/carlos/login/LoginCheckLoginBean.java
@@ -51,6 +51,7 @@ import io.github.carlos_emr.carlos.utility.SpringUtils;
 import org.owasp.encoder.Encode;
 import io.github.carlos_emr.carlos.log.LogAction;
 import io.github.carlos_emr.carlos.log.LogConst;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * Bean that validates user credentials and enforces authentication security policies for CARLOS EMR.
@@ -122,6 +123,11 @@ public final class LoginCheckLoginBean {
      * Pre-computed BCrypt hash of a random decoy password, used only to equalize missing-user
      * authentication timing with the normal password-validation path.
      */
+    @SuppressFBWarnings(value = "HARD_CODE_PASSWORD",
+            justification = "BCrypt timing-equalization decoy: a pre-computed hash of a random "
+                    + "throwaway password with no usable plaintext, used only to make "
+                    + "missing-user paths take the same wall-clock time as real password checks")
+    // NOSONAR java:S2068,secrets:S8215 — BCrypt decoy hash for timing equalization; not a usable credential
     private static final String MISSING_USER_DUMMY_PASSWORD_HASH =
             "{bcrypt}$2b$10$YzOXP.2axkRiYS07sVHWkuyvQjcuwR.bGeZd5WHQVJ23py57UES8C";
 
@@ -344,6 +350,9 @@ public final class LoginCheckLoginBean {
      *
      * @return Security object containing only the precomputed BCrypt dummy password hash
      */
+    @SuppressFBWarnings(value = "HARD_CODE_PASSWORD",
+            justification = "Sets the BCrypt timing-equalization decoy hash; see MISSING_USER_DUMMY_PASSWORD_HASH")
+    // BCrypt timing-equalization decoy — sets dummy hash, not a real credential
     private static Security missingUserDummySecurity() {
         Security dummySecurity = new Security();
         dummySecurity.setPassword(MISSING_USER_DUMMY_PASSWORD_HASH);

--- a/src/main/java/io/github/carlos_emr/carlos/login/LoginCheckLoginBean.java
+++ b/src/main/java/io/github/carlos_emr/carlos/login/LoginCheckLoginBean.java
@@ -127,9 +127,8 @@ public final class LoginCheckLoginBean {
             justification = "BCrypt timing-equalization decoy: a pre-computed hash of a random "
                     + "throwaway password with no usable plaintext, used only to make "
                     + "missing-user paths take the same wall-clock time as real password checks")
-    // NOSONAR java:S2068,secrets:S8215 — BCrypt decoy hash for timing equalization; not a usable credential
     private static final String MISSING_USER_DUMMY_PASSWORD_HASH =
-            "{bcrypt}$2b$10$YzOXP.2axkRiYS07sVHWkuyvQjcuwR.bGeZd5WHQVJ23py57UES8C";
+            "{bcrypt}$2b$10$YzOXP.2axkRiYS07sVHWkuyvQjcuwR.bGeZd5WHQVJ23py57UES8C"; // NOSONAR java:S2068,secrets:S8215 — BCrypt decoy hash for timing equalization; not a usable credential
 
     /** Security manager for password encoding, validation, and hash migration */
     private final SecurityManager securityManager = SpringUtils.getBean(SecurityManager.class);

--- a/src/main/java/io/github/carlos_emr/carlos/managers/SecurityManager.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/SecurityManager.java
@@ -43,6 +43,7 @@ import io.github.carlos_emr.carlos.log.LogAction;
 
 import java.util.Date;
 import java.util.List;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 @Service
 public class SecurityManager {
@@ -85,6 +86,10 @@ public class SecurityManager {
         LogAction.addLogSynchronous(loggedInInfo, "SecurityManager.updateSecurityRecord", "id=" + security.getId());
     }
 
+    @SuppressFBWarnings(value = "HARD_CODE_PASSWORD",
+            justification = "\"0\" is a policy threshold sentinel (zero past passwords to check), "
+                    + "not a credential; compared against the pastPasswordsToNotUse config property")
+    // "0" = policy threshold, not a password — prevents false positive on method name containing "password"
     public boolean checkPasswordAgainstPrevious(String newPassword, String providerNo) {
         //check previous passwords policy if the password is being changed
         String previousPasswordPolicy = CarlosProperties.getInstance().getProperty("password.pastPasswordsToNotUse", "0");


### PR DESCRIPTION
## Summary

- Adds a `HARD_CODE_PASSWORD FALSE POSITIVES` section to `.github/spotbugs/spotbugs-exclude.xml` with 5 method-scoped entries covering three structural false-positive patterns: empty-string field clears (`EmailManager`), WS-Security protocol-type constants (`AuthenticationInWSS4JInterceptor`, `AuthenticationOutWSS4JInterceptor`, `EdtClientBuilder`), and the fax admin UI mask sentinel (`ConfigureFax2Action`).
- Annotates `LoginCheckLoginBean.MISSING_USER_DUMMY_PASSWORD_HASH` and `missingUserDummySecurity()` with `@SuppressFBWarnings` + `// NOSONAR java:S2068,secrets:S8215` — the field holds a BCrypt decoy hash used only for timing equalization, not a usable credential.
- Annotates `SecurityManager.checkPasswordAgainstPrevious` with `@SuppressFBWarnings` — the string `"0"` is a policy-threshold default, not a password.
- Adds `// NOPMD HardCodedCryptoKey` to `LabUpload2Action` line 236 — `"RSA/ECB/PKCS1Padding"` is a JCA transformation name string; the actual RSA key is loaded from the server keystore at runtime.

All 14 GitHub Code Scanning alerts (SpotBugs `HARD_CODE_PASSWORD`, SonarCloud `java:S2068` / `secrets:S8215`, PMD `HardCodedCryptoKey`) are confirmed false positives. No runtime behavior changes.

## Alert-to-change mapping

| Alert IDs | Rule | File | Fix |
|---|---|---|---|
| 19383–19388 | `HARD_CODE_PASSWORD` | `EmailManager` | `spotbugs-exclude.xml` |
| 19598 | `HARD_CODE_PASSWORD` | `AuthenticationInWSS4JInterceptor` | `spotbugs-exclude.xml` |
| 19556 | `HARD_CODE_PASSWORD` | `AuthenticationOutWSS4JInterceptor` | `spotbugs-exclude.xml` |
| 11059 | `HARD_CODE_PASSWORD` | `EdtClientBuilder` | `spotbugs-exclude.xml` |
| 10510 | `HARD_CODE_PASSWORD` | `ConfigureFax2Action` | `spotbugs-exclude.xml` |
| 19370, 19253, 19254 | `HARD_CODE_PASSWORD`, `secrets:S8215`, `java:S2068` | `LoginCheckLoginBean` | `@SuppressFBWarnings` + `// NOSONAR` |
| 19414 | `HARD_CODE_PASSWORD` | `SecurityManager` | `@SuppressFBWarnings` |
| 18453 | `HardCodedCryptoKey` | `LabUpload2Action` | `// NOPMD` |

## Test plan

- [ ] CI unit tests pass (`make install --run-unit-tests`)
- [ ] SpotBugs scan shows no new `HARD_CODE_PASSWORD` findings for these methods
- [ ] SonarCloud scan shows alerts 19253, 19254, 19370 closed/resolved
- [ ] PMD scan shows alert 18453 closed/resolved
- [ ] No runtime behavior changed (suppression-only commits)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppresses 14 false-positive hardcoded-credential alerts across SpotBugs, SonarCloud, PMD, and Semgrep; no runtime changes. Adds design/plan docs and documents structural patterns in `.github/spotbugs/spotbugs-exclude.xml`.

- **Bug Fixes**
  - SpotBugs: Added five method-scoped `HARD_CODE_PASSWORD` excludes in `.github/spotbugs/spotbugs-exclude.xml` for empty-string clears, WS-Security protocol-type constants, and the UI mask sentinel.
  - SonarCloud + SpotBugs: In `LoginCheckLoginBean`, annotated the BCrypt decoy hash and `missingUserDummySecurity()` with `@SuppressFBWarnings`, and placed `// NOSONAR` (`java:S2068`, `secrets:S8215`) on the hash declaration line.
  - SpotBugs: In `SecurityManager.checkPasswordAgainstPrevious`, added `@SuppressFBWarnings` for the `"0"` policy-threshold sentinel.
  - PMD + Semgrep: In `LabUpload2Action`, added `// NOPMD HardCodedCryptoKey` and `// nosemgrep` (`java.lang.security.audit.crypto.ecb-cipher.ecb-cipher`) on `Cipher.getInstance("RSA/ECB/PKCS1Padding")`; JCA name, not key material.

<sup>Written for commit cc409d4d6815c48c677c867fcbd0d4185c6f6869. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2774?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

