### PR TITLE
Skip SonarCloud for fork PRs and exempt base-update merges from DCO

### DIFF
--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -100,6 +100,7 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/$REPO/pulls/$PR_NUMBER")
           pr_commit_count=$(jq -r '.commits' <<< "$pr_json")
+          base_ref=$(jq -r '.base.ref' <<< "$pr_json")
 
           if [ "$pr_commit_count" -gt 250 ]; then
             echo "::error::CARLOS EMR DCO check cannot automatically verify $pr_commit_count commits because GitHub's pull request commits API is capped at 250 commits."
@@ -115,8 +116,24 @@ jobs:
 
           bot_authors_regex='^(google-labs-jules\[bot\]|copilot-swe-agent\[bot\]|claude\[bot\]|coderabbitai\[bot\]|github-actions\[bot\]|dependabot\[bot\]) <'
 
+          is_github_base_update_merge() {
+            local subject=$1
+            local committer_login=$2
+            local parent_count=$3
+            local base_ref=$4
+            local direct_prefix="Merge branch '$base_ref' into "
+            local remote_prefix="Merge remote-tracking branch 'origin/$base_ref' into "
+
+            if [ "$parent_count" -lt 2 ] || [ "$committer_login" != "web-flow" ]; then
+              return 1
+            fi
+
+            [[ "$subject" == "$direct_prefix"* || "$subject" == "$remote_prefix"* ]]
+          }
+
           missing=()
           bot_exempt=()
+          base_update_merge_exempt=()
           total=0
           passed=0
           page=1
@@ -137,6 +154,8 @@ jobs:
               message=$(jq -r '.message' <<< "$commit")
               author_name=$(jq -r '.author_name // ""' <<< "$commit")
               author_email=$(jq -r '.author_email // ""' <<< "$commit")
+              committer_login=$(jq -r '.committer_login // ""' <<< "$commit")
+              parent_count=$(jq -r '.parent_count // 0' <<< "$commit")
               short="${sha:0:7}"
               subject=$(printf '%s\n' "$message" | sed -n '1p')
               author="$author_name <$author_email>"
@@ -147,6 +166,9 @@ jobs:
               elif printf '%s' "$author" | grep -qE "$bot_authors_regex"; then
                 passed=$((passed + 1))
                 bot_exempt+=("$short - $subject")
+              elif is_github_base_update_merge "$subject" "$committer_login" "$parent_count" "$base_ref"; then
+                passed=$((passed + 1))
+                base_update_merge_exempt+=("$short - $subject")
               else
                 missing+=("$short $subject")
               fi
@@ -154,7 +176,9 @@ jobs:
               sha: .sha,
               message: .commit.message,
               author_name: .commit.author.name,
-              author_email: .commit.author.email
+              author_email: .commit.author.email,
+              committer_login: (.committer.login // ""),
+              parent_count: (.parents | length)
             }' <<< "$commits")
 
             page=$((page + 1))
@@ -163,6 +187,14 @@ jobs:
           if [ ${#bot_exempt[@]} -gt 0 ]; then
             echo "DCO-exempt bot commits (${#bot_exempt[@]}):"
             for entry in "${bot_exempt[@]}"; do
+              printf '  - %s\n' "$entry"
+            done
+            echo ""
+          fi
+
+          if [ ${#base_update_merge_exempt[@]} -gt 0 ]; then
+            echo "DCO-exempt GitHub base-update merge commits (${#base_update_merge_exempt[@]}):"
+            for entry in "${base_update_merge_exempt[@]}"; do
               printf '  - %s\n' "$entry"
             done
             echo ""

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           if [ -z "$SONAR_TOKEN" ]; then
             echo "::error::SONAR_TOKEN is not available in this workflow run."
-            echo "::error::If this is a Dependabot PR, GitHub does not provide repository secrets to the workflow; SonarCloud analysis must be skipped or run via a trusted event."
+            echo "::error::If this is a forked pull request, GitHub does not provide repository secrets to the workflow; SonarCloud analysis must be skipped or run via a trusted event (e.g., push or pull_request_target with appropriate hardening)."
             echo "::error::Otherwise, configure the SONAR_TOKEN repository secret with access to the carlos-emr SonarCloud organization and carlos-emr_carlos project."
             exit 1
           fi

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -48,7 +48,7 @@ jobs:
   build:
     name: Build and analyze
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.actor != 'dependabot[bot]'
     steps:
       - name: Verify SonarCloud configuration
         env:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -56,7 +56,8 @@ jobs:
         run: |
           if [ -z "$SONAR_TOKEN" ]; then
             echo "::error::SONAR_TOKEN is not available in this workflow run."
-            echo "::error::Configure the SONAR_TOKEN repository secret with access to the carlos-emr SonarCloud organization and carlos-emr_carlos project."
+            echo "::error::If this is a Dependabot PR, GitHub does not provide repository secrets to the workflow; SonarCloud analysis must be skipped or run via a trusted event."
+            echo "::error::Otherwise, configure the SONAR_TOKEN repository secret with access to the carlos-emr SonarCloud organization and carlos-emr_carlos project."
             exit 1
           fi
 

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -48,7 +48,7 @@ jobs:
   build:
     name: Build and analyze
     runs-on: ubuntu-latest
-    if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.actor != 'dependabot[bot]'
+    if: (github.event_name != 'pull_request' && github.actor != 'dependabot[bot]') || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]')
     steps:
       - name: Verify SonarCloud configuration
         env:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -48,7 +48,18 @@ jobs:
   build:
     name: Build and analyze
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
+      - name: Verify SonarCloud configuration
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          if [ -z "$SONAR_TOKEN" ]; then
+            echo "::error::SONAR_TOKEN is not available in this workflow run."
+            echo "::error::Configure the SONAR_TOKEN repository secret with access to the carlos-emr SonarCloud organization and carlos-emr_carlos project."
+            exit 1
+          fi
+
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -48,7 +48,15 @@ jobs:
   build:
     name: Build and analyze
     runs-on: ubuntu-latest
-    if: (github.event_name != 'pull_request' && github.actor != 'dependabot[bot]') || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]')
+    if: >
+      github.actor != 'dependabot[bot]' &&
+      (
+        github.event_name != 'pull_request' ||
+        (
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          github.event.pull_request.user.login != 'dependabot[bot]'
+        )
+      )
     steps:
       - name: Verify SonarCloud configuration
         env:
@@ -56,8 +64,8 @@ jobs:
         run: |
           if [ -z "$SONAR_TOKEN" ]; then
             echo "::error::SONAR_TOKEN is not available in this workflow run."
-            echo "::error::If this is a forked pull request, GitHub does not provide repository secrets to the workflow; SonarCloud analysis must be skipped or run via a trusted event (e.g., push or pull_request_target with appropriate hardening)."
-            echo "::error::Otherwise, configure the SONAR_TOKEN repository secret with access to the carlos-emr SonarCloud organization and carlos-emr_carlos project."
+            echo "::error::Configure the SONAR_TOKEN secret with access to the SonarCloud project used by this workflow."
+            echo "::error::For events where GitHub does not expose repository secrets, keep SonarCloud analysis skipped or run it through a trusted manual process."
             exit 1
           fi
 


### PR DESCRIPTION
This pull request updates CI workflow handling for two related PR maintenance cases:

- SonarCloud analysis now skips forked pull requests and Dependabot-authored pull requests where repository secrets are unavailable.
- Trusted SonarCloud runs fail early with clearer `SONAR_TOKEN` guidance before the expensive Maven/Sonar step.
- The DCO workflow now exempts GitHub-created base-branch update merge commits while still requiring sign-off on normal contributor commits.

Validation:

- `git diff --check` passed for the workflow changes.
- The edited DCO shell block passed `bash -n` locally.
- Local predicate checks confirmed the DCO exemption accepts GitHub base-update merge subjects and rejects regular unsigned commits.
- PR checks passed, including DCO, SonarCloud, CodeQL, Semgrep, and the Maven build.

Notes:

- The DCO workflow runs from the base branch under `pull_request_target`, so the DCO exemption will affect future PRs after this workflow change is merged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run SonarCloud only on non-PR events and same-repo PRs, skipping forks and all Dependabot-triggered runs with stricter PR source checks. Add an early `SONAR_TOKEN` pre-check that fails fast with clear guidance, and exempt GitHub base-update merges from DCO.

<sup>Written for commit 582cf3f693295f2db6c856ab1bb02fe1f0c38087. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->