### PR TITLE
fix: add auth and redirect parameter validation to provideraddstatus

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/providers/gate/ProviderAddStatusValidator.java
+++ b/src/main/java/io/github/carlos_emr/carlos/providers/gate/ProviderAddStatusValidator.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.providers.gate;
+
+import java.util.regex.Pattern;
+
+/**
+ * Validation helpers for provider appointment status updates.
+ *
+ * @since 2026-06-15
+ */
+public final class ProviderAddStatusValidator {
+
+    private static final Pattern APPOINTMENT_STATUS = Pattern.compile("[a-zA-Z]{1,2}");
+
+    private ProviderAddStatusValidator() {
+    }
+
+    public static String buildValidatedAppointmentStatus(String status, String statusch) {
+        if (status == null || statusch == null || !APPOINTMENT_STATUS.matcher(statusch).matches()) {
+            return null;
+        }
+
+        String appointmentStatus = status + statusch;
+        return APPOINTMENT_STATUS.matcher(appointmentStatus).matches() ? appointmentStatus : null;
+    }
+}

--- a/src/main/java/io/github/carlos_emr/carlos/providers/gate/ProviderAddStatusValidator.java
+++ b/src/main/java/io/github/carlos_emr/carlos/providers/gate/ProviderAddStatusValidator.java
@@ -26,6 +26,13 @@ public final class ProviderAddStatusValidator {
     private ProviderAddStatusValidator() {
     }
 
+    /**
+     * Builds a validated appointment status value from the submitted status fragments.
+     *
+     * @param status existing status prefix, which may be empty but must combine with statusch into one or two letters
+     * @param statusch submitted status change value, which must be one or two letters
+     * @return combined appointment status, or {@code null} when either fragment is null or invalid
+     */
     public static String buildValidatedAppointmentStatus(String status, String statusch) {
         if (status == null || statusch == null || !APPOINTMENT_STATUS.matcher(statusch).matches()) {
             return null;

--- a/src/main/webapp/WEB-INF/jsp/provider/provideraddstatus.jsp
+++ b/src/main/webapp/WEB-INF/jsp/provider/provideraddstatus.jsp
@@ -74,6 +74,18 @@
 
   Appointment appt = appointmentDao.find(appointmentNo);
   int rowsAffected = 0;
+  int view = 0;
+
+  String viewParam = request.getParameter("view");
+
+  if (viewParam != null) {
+    if (!"0".equals(viewParam) && !"1".equals(viewParam)) {
+      response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+      return;
+    }
+
+    view = "1".equals(viewParam) ? 1 : 0;
+  }
 
   if (appt != null) {
     appointmentArchiveDao.archiveAppointment(appt);
@@ -86,18 +98,6 @@
   if (rowsAffected == 1) {//add_record
     EventService eventService = SpringUtils.getBean(EventService.class);//This is when the icon is clicked in the appt screen
     eventService.appointmentStatusChanged(this, String.valueOf(appointmentNo), request.getParameter("provider_no"), request.getParameter("statusch"));
-    int view = 0;
-
-    String viewParam = request.getParameter("view");
-
-    if (viewParam != null) {
-      try {
-        view = Integer.parseInt(viewParam);
-      } catch (NumberFormatException e) {
-        response.sendError(HttpServletResponse.SC_BAD_REQUEST);
-        return;
-      }
-    } //0-multiple views, 1-single view
     String strView = (view == 0) ? "0"
       : ("1&curProvider=" + SafeEncode.forUriComponent(request.getParameter("curProvider"))
       + "&curProviderName=" + SafeEncode.forUriComponent(request.getParameter("curProviderName")));
@@ -117,12 +117,10 @@
       displaypage += "&provider_no="
         + SafeEncode.forUriComponent(request.getParameter("provider_no"));
     }
-    if (true) {
-      out.clear();
-      response.sendRedirect(displaypage);
-      //pageContext.forward(displaypage); //forward request&response to the target page
-      return;
-    }
+    out.clear();
+    response.sendRedirect(displaypage);
+    //pageContext.forward(displaypage); //forward request&response to the target page
+    return;
   } else {
 %>
 <p>

--- a/src/main/webapp/WEB-INF/jsp/provider/provideraddstatus.jsp
+++ b/src/main/webapp/WEB-INF/jsp/provider/provideraddstatus.jsp
@@ -58,10 +58,6 @@
     response.sendError(HttpServletResponse.SC_BAD_REQUEST);
     return;
   }
-  String[] param = new String[3];
-  param[0] = status + statusch;
-  param[1] = curUser_no;
-  param[2] = appointmentNoParam;
 
   int appointmentNo;
 

--- a/src/main/webapp/WEB-INF/jsp/provider/provideraddstatus.jsp
+++ b/src/main/webapp/WEB-INF/jsp/provider/provideraddstatus.jsp
@@ -29,57 +29,100 @@
 
 --%>
 
-<%@ page import="java.sql.*, java.util.*, io.github.carlos_emr.MyDateFormat,io.github.carlos_emr.carlos.event.EventService" %>
+<%@ page
+  import="java.sql.*, java.util.*, io.github.carlos_emr.MyDateFormat,io.github.carlos_emr.carlos.event.EventService" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <fmt:setBundle basename="oscarResources"/>
 <%@page import="io.github.carlos_emr.carlos.commn.dao.AppointmentArchiveDao" %>
 <%@page import="io.github.carlos_emr.carlos.commn.dao.OscarAppointmentDao" %>
 <%@page import="io.github.carlos_emr.carlos.commn.model.Appointment" %>
 <%@page import="io.github.carlos_emr.carlos.utility.SpringUtils" %>
+<%@page import="io.github.carlos_emr.carlos.utility.SafeEncode" %>
 <%
-    AppointmentArchiveDao appointmentArchiveDao = (AppointmentArchiveDao) SpringUtils.getBean(AppointmentArchiveDao.class);
-    OscarAppointmentDao appointmentDao = (OscarAppointmentDao) SpringUtils.getBean(OscarAppointmentDao.class);
+  AppointmentArchiveDao appointmentArchiveDao = (AppointmentArchiveDao) SpringUtils.getBean(AppointmentArchiveDao.class);
+  OscarAppointmentDao appointmentDao = (OscarAppointmentDao) SpringUtils.getBean(OscarAppointmentDao.class);
 %>
 <%
-    //if action is good, then give me the result
-    String[] param = new String[3];
-    param[0] = request.getParameter("status") + request.getParameter("statusch");
-    param[1] = (String) session.getAttribute("user");
-    param[2] = request.getParameter("appointment_no");
-    Appointment appt = appointmentDao.find(Integer.parseInt(request.getParameter("appointment_no")));
-    appointmentArchiveDao.archiveAppointment(appt);
-    int rowsAffected = 0;
-    if (appt != null) {
-        appt.setStatus(request.getParameter("status") + request.getParameter("statusch"));
-        appt.setLastUpdateUser((String) session.getAttribute("user"));
-        appointmentDao.merge(appt);
-        rowsAffected = 1;
-    }
+  //if action is good, then give me the result
+  String curUser_no = (String) session.getAttribute("user");
 
+  if (curUser_no == null) {
+    response.sendRedirect(request.getContextPath() + "/logout.htm");
+    return;
+  }
+  String[] param = new String[3];
+  param[0] = request.getParameter("status") + request.getParameter("statusch");
+  param[1] = curUser_no;
+  param[2] = request.getParameter("appointment_no");
+  String appointmentNoParam = request.getParameter("appointment_no");
+
+  int appointmentNo;
+
+  try {
+    appointmentNo = Integer.parseInt(appointmentNoParam);
+  } catch (NumberFormatException e) {
+    response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+    return;
+  }
+
+  Appointment appt = appointmentDao.find(appointmentNo);
+  int rowsAffected = 0;
+
+  if (appt != null) {
+    appointmentArchiveDao.archiveAppointment(appt);
+    appt.setStatus(request.getParameter("status") + request.getParameter("statusch"));
+    appt.setLastUpdateUser(curUser_no);
+    appointmentDao.merge(appt);
+    rowsAffected = 1;
+  }
+
+
+
+  if (rowsAffected == 1) {//add_record
     EventService eventService = SpringUtils.getBean(EventService.class);//This is when the icon is clicked in the appt screen
     eventService.appointmentStatusChanged(this, request.getParameter("appointment_no"), request.getParameter("provider_no"), request.getParameter("statusch"));
+    int view = 0;
 
-    if (rowsAffected == 1) {//add_record
-        int view = 0;
-        if (request.getParameter("view") != null)
-            view = Integer.parseInt(request.getParameter("view")); //0-multiple views, 1-single view
-        String strView = (view == 0) ? "0" : ("1&curProvider=" + request.getParameter("curProvider") + "&curProviderName=" + request.getParameter("curProviderName"));
-        String strViewAll = request.getParameter("viewall") == null ? "0" : (request.getParameter("viewall"));
-        String displaypage = request.getContextPath() + "/provider/providercontrol?year=" + request.getParameter("year") + "&month=" + request.getParameter("month") + "&day=" + request.getParameter("day") + "&view=" + strView + "&displaymode=day&dboperation=searchappointmentday" + "&viewall=" + strViewAll + "&x=" + request.getParameter("x") + "&y=" + request.getParameter("y");
-        if (request.getParameter("viewWeek") != null) {
-            displaypage += "&provider_no=" + request.getParameter("provider_no");
-        }
-        if (true) {
-            out.clear();
-            response.sendRedirect(displaypage);
-            //pageContext.forward(displaypage); //forward request&response to the target page
-            return;
-        }
-    } else {
+    String viewParam = request.getParameter("view");
+
+    if (viewParam != null) {
+      try {
+        view = Integer.parseInt(viewParam);
+      } catch (NumberFormatException e) {
+        response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+        return;
+      }
+    } //0-multiple views, 1-single view
+    String strView = (view == 0) ? "0"
+      : ("1&curProvider=" + SafeEncode.forUriComponent(request.getParameter("curProvider"))
+      + "&curProviderName=" + SafeEncode.forUriComponent(request.getParameter("curProviderName")));
+    String strViewAll = request.getParameter("viewall") == null
+      ? "0"
+      : SafeEncode.forUriComponent(request.getParameter("viewall"));
+    String displaypage = request.getContextPath()
+      + "/provider/providercontrol?year=" + SafeEncode.forUriComponent(request.getParameter("year"))
+      + "&month=" + SafeEncode.forUriComponent(request.getParameter("month"))
+      + "&day=" + SafeEncode.forUriComponent(request.getParameter("day"))
+      + "&view=" + strView
+      + "&displaymode=day&dboperation=searchappointmentday"
+      + "&viewall=" + strViewAll
+      + "&x=" + SafeEncode.forUriComponent(request.getParameter("x"))
+      + "&y=" + SafeEncode.forUriComponent(request.getParameter("y"));
+    if (request.getParameter("viewWeek") != null) {
+      displaypage += "&provider_no="
+        + SafeEncode.forUriComponent(request.getParameter("provider_no"));
+    }
+    if (true) {
+      out.clear();
+      response.sendRedirect(displaypage);
+      //pageContext.forward(displaypage); //forward request&response to the target page
+      return;
+    }
+  } else {
 %>
 <p>
 <h1><fmt:message key="AddProviderStatus.msgAddFailure"/></h1>
 
 <%
-    }
+  }
 %>

--- a/src/main/webapp/WEB-INF/jsp/provider/provideraddstatus.jsp
+++ b/src/main/webapp/WEB-INF/jsp/provider/provideraddstatus.jsp
@@ -53,16 +53,24 @@
   String appointmentNoParam = request.getParameter("appointment_no");
   String status = request.getParameter("status");
   String statusch = request.getParameter("statusch");
+  String providerNoParam = request.getParameter("provider_no");
 
-  if (status == null || statusch == null) {
+  if (status == null || statusch == null || providerNoParam == null) {
     response.sendError(HttpServletResponse.SC_BAD_REQUEST);
     return;
   }
 
   int appointmentNo;
+  int providerNo;
 
   try {
     appointmentNo = Integer.parseInt(appointmentNoParam);
+  } catch (NumberFormatException e) {
+    response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+    return;
+  }
+  try {
+    providerNo = Integer.parseInt(providerNoParam);
   } catch (NumberFormatException e) {
     response.sendError(HttpServletResponse.SC_BAD_REQUEST);
     return;
@@ -93,7 +101,12 @@
 
   if (rowsAffected == 1) {//add_record
     EventService eventService = SpringUtils.getBean(EventService.class);//This is when the icon is clicked in the appt screen
-    eventService.appointmentStatusChanged(this, String.valueOf(appointmentNo), request.getParameter("provider_no"), request.getParameter("statusch"));
+    eventService.appointmentStatusChanged(
+      this,
+      String.valueOf(appointmentNo),
+      String.valueOf(providerNo),
+      statusch
+    );
     String strView = (view == 0) ? "0"
       : ("1&curProvider=" + SafeEncode.forUriComponent(request.getParameter("curProvider"))
       + "&curProviderName=" + SafeEncode.forUriComponent(request.getParameter("curProviderName")));

--- a/src/main/webapp/WEB-INF/jsp/provider/provideraddstatus.jsp
+++ b/src/main/webapp/WEB-INF/jsp/provider/provideraddstatus.jsp
@@ -50,11 +50,11 @@
     response.sendRedirect(request.getContextPath() + "/logout.htm");
     return;
   }
+  String appointmentNoParam = request.getParameter("appointment_no");
   String[] param = new String[3];
   param[0] = request.getParameter("status") + request.getParameter("statusch");
   param[1] = curUser_no;
-  param[2] = request.getParameter("appointment_no");
-  String appointmentNoParam = request.getParameter("appointment_no");
+  param[2] = appointmentNoParam;
 
   int appointmentNo;
 
@@ -76,11 +76,9 @@
     rowsAffected = 1;
   }
 
-
-
   if (rowsAffected == 1) {//add_record
     EventService eventService = SpringUtils.getBean(EventService.class);//This is when the icon is clicked in the appt screen
-    eventService.appointmentStatusChanged(this, request.getParameter("appointment_no"), request.getParameter("provider_no"), request.getParameter("statusch"));
+    eventService.appointmentStatusChanged(this, String.valueOf(appointmentNo), request.getParameter("provider_no"), request.getParameter("statusch"));
     int view = 0;
 
     String viewParam = request.getParameter("view");

--- a/src/main/webapp/WEB-INF/jsp/provider/provideraddstatus.jsp
+++ b/src/main/webapp/WEB-INF/jsp/provider/provideraddstatus.jsp
@@ -29,6 +29,30 @@
 
 --%>
 
+<%--
+  Purpose: Updates an appointment status from the provider schedule and redirects
+  back to the provider control day view.
+
+  Features:
+  - Requires an authenticated provider session before processing.
+  - Validates appointment and provider identifiers before applying updates.
+  - Archives the appointment before merging the new status.
+  - Publishes the appointment status-change event only after a successful update.
+  - URI-encodes provider-control redirect parameters.
+
+  Expected parameters:
+  - appointment_no: numeric appointment identifier.
+  - provider_no: numeric provider identifier.
+  - status/statusch: status fragments combined for the new appointment status.
+  - view: optional provider view flag, either 0 or 1.
+  - year/month/day/viewall/x/y/viewWeek/curProvider/curProviderName: redirect context.
+
+  Expected session attributes:
+  - user: authenticated provider number.
+
+  @since 2026-06-11
+--%>
+
 <%@ page
   import="java.sql.*, java.util.*, io.github.carlos_emr.MyDateFormat,io.github.carlos_emr.carlos.event.EventService" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
@@ -124,7 +148,7 @@
       + "&y=" + SafeEncode.forUriComponent(request.getParameter("y"));
     if (request.getParameter("viewWeek") != null) {
       displaypage += "&provider_no="
-        + SafeEncode.forUriComponent(request.getParameter("provider_no"));
+        + SafeEncode.forUriComponent(String.valueOf(providerNo));
     }
     out.clear();
     response.sendRedirect(displaypage);

--- a/src/main/webapp/WEB-INF/jsp/provider/provideraddstatus.jsp
+++ b/src/main/webapp/WEB-INF/jsp/provider/provideraddstatus.jsp
@@ -60,6 +60,7 @@
 <%@page import="io.github.carlos_emr.carlos.commn.dao.AppointmentArchiveDao" %>
 <%@page import="io.github.carlos_emr.carlos.commn.dao.OscarAppointmentDao" %>
 <%@page import="io.github.carlos_emr.carlos.commn.model.Appointment" %>
+<%@page import="io.github.carlos_emr.carlos.providers.gate.ProviderAddStatusValidator" %>
 <%@page import="io.github.carlos_emr.carlos.utility.SpringUtils" %>
 <%@page import="io.github.carlos_emr.carlos.utility.SafeEncode" %>
 <%
@@ -78,8 +79,9 @@
   String status = request.getParameter("status");
   String statusch = request.getParameter("statusch");
   String providerNoParam = request.getParameter("provider_no");
+  String appointmentStatus = ProviderAddStatusValidator.buildValidatedAppointmentStatus(status, statusch);
 
-  if (status == null || statusch == null || providerNoParam == null) {
+  if (appointmentStatus == null || providerNoParam == null) {
     response.sendError(HttpServletResponse.SC_BAD_REQUEST);
     return;
   }
@@ -117,7 +119,7 @@
 
   if (appt != null) {
     appointmentArchiveDao.archiveAppointment(appt);
-    appt.setStatus(status + statusch);
+    appt.setStatus(appointmentStatus);
     appt.setLastUpdateUser(curUser_no);
     appointmentDao.merge(appt);
     rowsAffected = 1;

--- a/src/main/webapp/WEB-INF/jsp/provider/provideraddstatus.jsp
+++ b/src/main/webapp/WEB-INF/jsp/provider/provideraddstatus.jsp
@@ -51,8 +51,15 @@
     return;
   }
   String appointmentNoParam = request.getParameter("appointment_no");
+  String status = request.getParameter("status");
+  String statusch = request.getParameter("statusch");
+
+  if (status == null || statusch == null) {
+    response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+    return;
+  }
   String[] param = new String[3];
-  param[0] = request.getParameter("status") + request.getParameter("statusch");
+  param[0] = status + statusch;
   param[1] = curUser_no;
   param[2] = appointmentNoParam;
 
@@ -70,7 +77,7 @@
 
   if (appt != null) {
     appointmentArchiveDao.archiveAppointment(appt);
-    appt.setStatus(request.getParameter("status") + request.getParameter("statusch"));
+    appt.setStatus(status + statusch);
     appt.setLastUpdateUser(curUser_no);
     appointmentDao.merge(appt);
     rowsAffected = 1;

--- a/src/test/java/io/github/carlos_emr/carlos/providers/gate/ProviderAddStatusValidatorUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/providers/gate/ProviderAddStatusValidatorUnitTest.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.providers.gate;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Provider add status validator")
+@Tag("unit")
+@Tag("provider")
+class ProviderAddStatusValidatorUnitTest {
+
+    @Test
+    @DisplayName("should build appointment status with valid fragments")
+    void shouldBuildAppointmentStatus_withValidFragments() {
+        assertThat(ProviderAddStatusValidator.buildValidatedAppointmentStatus("", "C")).isEqualTo("C");
+        assertThat(ProviderAddStatusValidator.buildValidatedAppointmentStatus("C", "S")).isEqualTo("CS");
+        assertThat(ProviderAddStatusValidator.buildValidatedAppointmentStatus("", "t")).isEqualTo("t");
+    }
+
+    @Test
+    @DisplayName("should reject appointment status with missing fragment")
+    void shouldRejectAppointmentStatus_withMissingFragment() {
+        assertThat(ProviderAddStatusValidator.buildValidatedAppointmentStatus(null, "C")).isNull();
+        assertThat(ProviderAddStatusValidator.buildValidatedAppointmentStatus("", null)).isNull();
+        assertThat(ProviderAddStatusValidator.buildValidatedAppointmentStatus("", "")).isNull();
+    }
+
+    @Test
+    @DisplayName("should reject appointment status with invalid characters")
+    void shouldRejectAppointmentStatus_withInvalidCharacters() {
+        assertThat(ProviderAddStatusValidator.buildValidatedAppointmentStatus("", "C&x=1")).isNull();
+        assertThat(ProviderAddStatusValidator.buildValidatedAppointmentStatus("1", "C")).isNull();
+        assertThat(ProviderAddStatusValidator.buildValidatedAppointmentStatus("", " C")).isNull();
+    }
+
+    @Test
+    @DisplayName("should reject appointment status with too many characters")
+    void shouldRejectAppointmentStatus_withTooManyCharacters() {
+        assertThat(ProviderAddStatusValidator.buildValidatedAppointmentStatus("CS", "V")).isNull();
+        assertThat(ProviderAddStatusValidator.buildValidatedAppointmentStatus("", "CSV")).isNull();
+    }
+}


### PR DESCRIPTION
## Description

Fixes security and validation issues in `provideraddstatus.jsp` by:

* adding a defensive session null check for `session.getAttribute("user")`
* encoding `curProvider` and `curProviderName` using `SafeEncode.forUriComponent(...)` before redirect construction
* safely handling invalid `appointment_no` values to avoid `NumberFormatException` and HTTP 500 responses

## Related Issues

Fixes #2772

## How Was This Tested?

* verified JSP compiles after changes
* verified redirect parameters are URI-encoded
* verified invalid `appointment_no` values now return HTTP 400 instead of throwing an exception

## Screenshots

N/A

## Checklist

* [x] My commits are signed off for the [[DCO](https://developercertificate.org/)](https://developercertificate.org/) (`git commit -s`)
* [x] My commits follow [[Conventional Commits](https://www.conventionalcommits.org/)](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
* [x] I have not included any patient data (PHI) in this PR
* [x] I have added tests for new functionality, or this change doesn't need new tests
* [x] I have read the [[contributing guide](https://chatgpt.com/c/CONTRIBUTING.md)](CONTRIBUTING.md)

## Summary by Sourcery

Harden provider appointment status updates with stricter auth, input validation, and safe redirect parameter handling in provideraddstatus.jsp.

Bug Fixes:
- Prevent null session access by checking for an authenticated user and redirecting to logout when missing.
- Validate required status and provider parameters, enforce numeric IDs and constrained view values, and return HTTP 400 on invalid input instead of throwing exceptions.
- Handle missing appointments without updating or dispatching events, avoiding errors when the appointment record is not found.
- URI-encode redirect and query parameters when building the provider control redirect URL to avoid malformed or unsafe redirects.

Enhancements:
- Remove an unused parameter array and simplify JSP variable usage for clarity.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened provider appointment status updates with auth checks, stricter input validation, safe redirect encoding, and documented behavior. Reused the validated `provider_no` for week‑view redirects.

- **Bug Fixes**
  - Added a session check; redirect to logout when `user` is missing.
  - Validated inputs: numeric `appointment_no`/`provider_no`; `view` must be 0 or 1; status built by `ProviderAddStatusValidator` from `status`/`statusch` and must be 1–2 alpha chars; return HTTP 400 on bad input; archive then update only if the appointment exists; dispatch the event only after a successful update.
  - URI-encoded redirect params via `SafeEncode.forUriComponent`; reused the parsed `provider_no` when `viewWeek` is set.

- **Refactors**
  - Removed the unused `param` array; extracted status validation into `ProviderAddStatusValidator` with unit tests and Javadoc; added a JSP header documenting expected parameters and session requirements.

<sup>Written for commit 3d786d648d4b713bfd2c27e09f6631e873c34d75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2791?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

