### PR TITLE
docs: add missing javadoc to 40 java files

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/administration/GstReport.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/administration/GstReport.java
@@ -18,6 +18,11 @@ import io.github.carlos_emr.carlos.util.ConversionUtils;
 import java.util.Properties;
 import java.util.Vector;
 
+/**
+ * Represents a GstReport in the system.
+ *
+ * @since 2026-06-10
+ */
 public class GstReport {
 
     public Vector<Properties> getGST(LoggedInInfo loggedInInfo, String[] providerNos, String startDate, String endDate) {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/EReferAttachment.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/EReferAttachment.java
@@ -12,6 +12,11 @@ import jakarta.persistence.Table;
 import java.util.Date;
 import java.util.List;
 
+/**
+ * Represents a EReferAttachment in the system.
+ *
+ * @since 2026-06-10
+ */
 @Entity
 @Table(name = "erefer_attachment")
 public class EReferAttachment extends AbstractModel<Integer> {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/EReferAttachmentData.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/EReferAttachmentData.java
@@ -8,6 +8,11 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
+/**
+ * Represents a EReferAttachmentData in the system.
+ *
+ * @since 2026-06-10
+ */
 @Entity
 @IdClass(EReferAttachmentDataCompositeKey.class)
 @Table(name = "erefer_attachment_data")

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/EReferAttachmentDataCompositeKey.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/EReferAttachmentDataCompositeKey.java
@@ -6,6 +6,11 @@ import jakarta.persistence.ManyToOne;
 import java.io.Serializable;
 import java.util.Objects;
 
+/**
+ * Represents a EReferAttachmentDataCompositeKey in the system.
+ *
+ * @since 2026-06-10
+ */
 public class EReferAttachmentDataCompositeKey implements Serializable {
     @ManyToOne
     @JoinColumn(name = "erefer_attachment_id", referencedColumnName = "id")

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/EmailAttachment.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/EmailAttachment.java
@@ -5,6 +5,11 @@ import jakarta.persistence.*;
 
 import io.github.carlos_emr.carlos.commn.model.enumerator.DocumentType;
 
+/**
+ * Represents a EmailAttachment in the system.
+ *
+ * @since 2026-06-10
+ */
 @Entity
 @Table(name = "emailAttachment")
 public class EmailAttachment extends AbstractModel<Integer> {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/EmailConfig.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/EmailConfig.java
@@ -5,6 +5,11 @@ import io.github.carlos_emr.carlos.commn.model.converter.EmailConfigTypeConverte
 import jakarta.persistence.*;
 import java.util.List;
 
+/**
+ * Configuration component defining Email beans and properties.
+ *
+ * @since 2026-06-10
+ */
 @Entity
 @Table(name = "emailConfig")
 public class EmailConfig extends AbstractModel<Integer> {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/JSONAction.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/JSONAction.java
@@ -14,6 +14,11 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
 
+/**
+ * Struts action controller handling JSON HTTP requests.
+ *
+ * @since 2026-06-10
+ */
 public class JSONAction extends ActionSupport {
 
     private final String ENCODING = "UTF-8";

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/AppointmentBookingSourceConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/AppointmentBookingSourceConverter.java
@@ -3,6 +3,11 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.Appointment.BookingSource;
 import jakarta.persistence.Converter;
 
+/**
+ * Handles JPA attribute conversion for AppointmentBookingSource types.
+ *
+ * @since 2026-06-10
+ */
 @Converter
 public class AppointmentBookingSourceConverter extends NullSafeEnumConverter<BookingSource> {
     public AppointmentBookingSourceConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/ClientLinkTypeConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/ClientLinkTypeConverter.java
@@ -3,6 +3,11 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.ClientLink.Type;
 import jakarta.persistence.Converter;
 
+/**
+ * Handles JPA attribute conversion for ClientLinkType types.
+ *
+ * @since 2026-06-10
+ */
 @Converter
 public class ClientLinkTypeConverter extends NullSafeEnumConverter<Type> {
     public ClientLinkTypeConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/DigitalSignatureModuleTypeConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/DigitalSignatureModuleTypeConverter.java
@@ -3,6 +3,11 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.enumerator.ModuleType;
 import jakarta.persistence.Converter;
 
+/**
+ * Handles JPA attribute conversion for DigitalSignatureModuleType types.
+ *
+ * @since 2026-06-10
+ */
 @Converter
 public class DigitalSignatureModuleTypeConverter extends NullSafeEnumConverter<ModuleType> {
     public DigitalSignatureModuleTypeConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailAttachmentDocumentTypeConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailAttachmentDocumentTypeConverter.java
@@ -3,6 +3,11 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.enumerator.DocumentType;
 import jakarta.persistence.Converter;
 
+/**
+ * Handles JPA attribute conversion for EmailAttachmentDocumentType types.
+ *
+ * @since 2026-06-10
+ */
 @Converter
 public class EmailAttachmentDocumentTypeConverter extends NullSafeEnumConverter<DocumentType> {
     public EmailAttachmentDocumentTypeConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailConfigProviderConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailConfigProviderConverter.java
@@ -3,6 +3,11 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.EmailConfig.EmailProvider;
 import jakarta.persistence.Converter;
 
+/**
+ * Handles JPA attribute conversion for EmailConfigProvider types.
+ *
+ * @since 2026-06-10
+ */
 @Converter
 public class EmailConfigProviderConverter extends NullSafeEnumConverter<EmailProvider> {
     public EmailConfigProviderConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailConfigTypeConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailConfigTypeConverter.java
@@ -3,6 +3,11 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.EmailConfig.EmailType;
 import jakarta.persistence.Converter;
 
+/**
+ * Handles JPA attribute conversion for EmailConfigType types.
+ *
+ * @since 2026-06-10
+ */
 @Converter
 public class EmailConfigTypeConverter extends NullSafeEnumConverter<EmailType> {
     public EmailConfigTypeConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailLogChartDisplayOptionConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailLogChartDisplayOptionConverter.java
@@ -3,6 +3,11 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.EmailLog.ChartDisplayOption;
 import jakarta.persistence.Converter;
 
+/**
+ * Handles JPA attribute conversion for EmailLogChartDisplayOption types.
+ *
+ * @since 2026-06-10
+ */
 @Converter
 public class EmailLogChartDisplayOptionConverter extends NullSafeEnumConverter<ChartDisplayOption> {
     public EmailLogChartDisplayOptionConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailLogStatusConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailLogStatusConverter.java
@@ -3,6 +3,11 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.EmailLog.EmailStatus;
 import jakarta.persistence.Converter;
 
+/**
+ * Handles JPA attribute conversion for EmailLogStatus types.
+ *
+ * @since 2026-06-10
+ */
 @Converter
 public class EmailLogStatusConverter extends NullSafeEnumConverter<EmailStatus> {
     public EmailLogStatusConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailLogTransactionTypeConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailLogTransactionTypeConverter.java
@@ -3,6 +3,11 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.EmailLog.TransactionType;
 import jakarta.persistence.Converter;
 
+/**
+ * Handles JPA attribute conversion for EmailLogTransactionType types.
+ *
+ * @since 2026-06-10
+ */
 @Converter
 public class EmailLogTransactionTypeConverter extends NullSafeEnumConverter<TransactionType> {
     public EmailLogTransactionTypeConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/FaxConfigProviderTypeConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/FaxConfigProviderTypeConverter.java
@@ -3,6 +3,11 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.FaxConfig.ProviderType;
 import jakarta.persistence.Converter;
 
+/**
+ * Handles JPA attribute conversion for FaxConfigProviderType types.
+ *
+ * @since 2026-06-10
+ */
 @Converter
 public class FaxConfigProviderTypeConverter extends NullSafeEnumConverter<ProviderType> {
     public FaxConfigProviderTypeConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/FaxJobStatusConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/FaxJobStatusConverter.java
@@ -3,6 +3,11 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.FaxJob.STATUS;
 import jakarta.persistence.Converter;
 
+/**
+ * Handles JPA attribute conversion for FaxJobStatus types.
+ *
+ * @since 2026-06-10
+ */
 @Converter
 public class FaxJobStatusConverter extends NullSafeEnumConverter<STATUS> {
     public FaxJobStatusConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/HnrDataValidationTypeConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/HnrDataValidationTypeConverter.java
@@ -3,6 +3,11 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.HnrDataValidation.Type;
 import jakarta.persistence.Converter;
 
+/**
+ * Handles JPA attribute conversion for HnrDataValidationType types.
+ *
+ * @since 2026-06-10
+ */
 @Converter
 public class HnrDataValidationTypeConverter extends NullSafeEnumConverter<Type> {
     public HnrDataValidationTypeConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/TicklerPriorityConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/TicklerPriorityConverter.java
@@ -3,6 +3,11 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.Tickler.PRIORITY;
 import jakarta.persistence.Converter;
 
+/**
+ * Handles JPA attribute conversion for TicklerPriority types.
+ *
+ * @since 2026-06-10
+ */
 @Converter
 public class TicklerPriorityConverter extends NullSafeEnumConverter<PRIORITY> {
     public TicklerPriorityConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/TicklerStatusConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/TicklerStatusConverter.java
@@ -3,6 +3,11 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.Tickler.STATUS;
 import jakarta.persistence.Converter;
 
+/**
+ * Handles JPA attribute conversion for TicklerStatus types.
+ *
+ * @since 2026-06-10
+ */
 @Converter
 public class TicklerStatusConverter extends NullSafeEnumConverter<STATUS> {
     public TicklerStatusConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/enumerator/DocumentType.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/enumerator/DocumentType.java
@@ -1,5 +1,10 @@
 package io.github.carlos_emr.carlos.commn.model.enumerator;
 
+/**
+ * Represents a DocumentType in the system.
+ *
+ * @since 2026-06-10
+ */
 public enum DocumentType {
     EFORM("E", "eForm"),
     DOC("D", "doc"),

--- a/src/main/java/io/github/carlos_emr/carlos/config/ServletContextConfig.java
+++ b/src/main/java/io/github/carlos_emr/carlos/config/ServletContextConfig.java
@@ -7,6 +7,11 @@ import jakarta.servlet.ServletContext;
 
 import org.springframework.web.context.ServletContextAware;
 
+/**
+ * Configuration component defining ServletContext beans and properties.
+ *
+ * @since 2026-06-10
+ */
 @Configuration
 public class ServletContextConfig implements ServletContextAware {
 

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oceanEReferal/pageUtil/OceanEReferralAttachmentUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oceanEReferal/pageUtil/OceanEReferralAttachmentUtil.java
@@ -10,6 +10,11 @@ import io.github.carlos_emr.carlos.commn.model.EReferAttachment;
 import io.github.carlos_emr.carlos.commn.model.EReferAttachmentData;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 
+/**
+ * Utility class providing static helper methods for OceanEReferralAttachment operations.
+ *
+ * @since 2026-06-10
+ */
 public class OceanEReferralAttachmentUtil {
     private static EReferAttachmentDataDaoImpl eReferAttachmentDataDao = SpringUtils.getBean(EReferAttachmentDataDaoImpl.class);
     private static EReferAttachmentDaoImpl eReferAttachmentDao = SpringUtils.getBean(EReferAttachmentDaoImpl.class);

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/config/data/ConsultationServiceDto.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/config/data/ConsultationServiceDto.java
@@ -1,5 +1,10 @@
 package io.github.carlos_emr.carlos.encounter.oscarConsultationRequest.config.data;
 
+/**
+ * Data Transfer Object carrying ConsultationService data across architectural boundaries.
+ *
+ * @since 2026-06-10
+ */
 public class ConsultationServiceDto {
     private Integer serviceId;
     private String serviceDesc;

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/config/data/SpecialistDto.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/config/data/SpecialistDto.java
@@ -1,5 +1,10 @@
 package io.github.carlos_emr.carlos.encounter.oscarConsultationRequest.config.data;
 
+/**
+ * Data Transfer Object carrying Specialist data across architectural boundaries.
+ *
+ * @since 2026-06-10
+ */
 public class SpecialistDto {
     private Integer specId;
     private String name;

--- a/src/main/java/io/github/carlos_emr/carlos/integration/ebs/App.java
+++ b/src/main/java/io/github/carlos_emr/carlos/integration/ebs/App.java
@@ -1,5 +1,10 @@
 package io.github.carlos_emr.carlos.integration.ebs;
 
+/**
+ * Represents a App in the system.
+ *
+ * @since 2026-06-10
+ */
 public class App
 {
     public static void main(final String[] args) {

--- a/src/main/java/io/github/carlos_emr/carlos/utility/EmailSendingException.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/EmailSendingException.java
@@ -1,5 +1,10 @@
 package io.github.carlos_emr.carlos.utility;
 
+/**
+ * Custom exception indicating an error related to EmailSending.
+ *
+ * @since 2026-06-10
+ */
 public class EmailSendingException extends Exception {
     public EmailSendingException() {
         super();

--- a/src/main/java/io/github/carlos_emr/carlos/utility/JsDateSerializer.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/JsDateSerializer.java
@@ -6,6 +6,11 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import java.io.IOException;
 import java.util.Calendar;
 
+/**
+ * Represents a JsDateSerializer in the system.
+ *
+ * @since 2026-06-10
+ */
 public class JsDateSerializer extends JsonSerializer<java.sql.Date> {
     @Override
     public void serialize(java.sql.Date value, JsonGenerator gen, SerializerProvider serializers) 

--- a/src/main/java/io/github/carlos_emr/carlos/utility/PDFEncryptionUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/PDFEncryptionUtil.java
@@ -9,6 +9,11 @@ import org.apache.pdfbox.pdmodel.encryption.AccessPermission;
 import org.apache.pdfbox.pdmodel.encryption.StandardProtectionPolicy;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+/**
+ * Utility class providing static helper methods for PDFEncryption operations.
+ *
+ * @since 2026-06-10
+ */
 public class PDFEncryptionUtil {
     // FindSecBugs PATH_TRAVERSAL_IN: path derived from trusted configuration/constant/DB value, not user-controllable input
     @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "path derived from trusted configuration/constant/DB value, not user-controllable input")

--- a/src/main/java/io/github/carlos_emr/carlos/ws/DuplicateHinException.java
+++ b/src/main/java/io/github/carlos_emr/carlos/ws/DuplicateHinException.java
@@ -5,6 +5,11 @@ import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import java.io.Serializable;
 
+/**
+ * Custom exception indicating an error related to DuplicateHin.
+ *
+ * @since 2026-06-10
+ */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "DuplicateHinException")
 public class DuplicateHinException implements Serializable

--- a/src/main/java/io/github/carlos_emr/carlos/ws/Gender.java
+++ b/src/main/java/io/github/carlos_emr/carlos/ws/Gender.java
@@ -3,6 +3,11 @@ package io.github.carlos_emr.carlos.ws;
 import jakarta.xml.bind.annotation.XmlEnum;
 import jakarta.xml.bind.annotation.XmlType;
 
+/**
+ * Represents a Gender in the system.
+ *
+ * @since 2026-06-10
+ */
 @XmlType(name = "gender")
 @XmlEnum
 public enum Gender

--- a/src/main/java/io/github/carlos_emr/carlos/ws/HelloWorld.java
+++ b/src/main/java/io/github/carlos_emr/carlos/ws/HelloWorld.java
@@ -5,6 +5,11 @@ import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import java.io.Serializable;
 
+/**
+ * Represents a HelloWorld in the system.
+ *
+ * @since 2026-06-10
+ */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "helloWorld")
 public class HelloWorld implements Serializable

--- a/src/main/java/io/github/carlos_emr/carlos/ws/HelloWorld2.java
+++ b/src/main/java/io/github/carlos_emr/carlos/ws/HelloWorld2.java
@@ -5,6 +5,11 @@ import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import java.io.Serializable;
 
+/**
+ * Represents a HelloWorld2 in the system.
+ *
+ * @since 2026-06-10
+ */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "helloWorld2", propOrder = { "arg0" })
 public class HelloWorld2 implements Serializable

--- a/src/main/java/io/github/carlos_emr/carlos/ws/HelloWorld2Response.java
+++ b/src/main/java/io/github/carlos_emr/carlos/ws/HelloWorld2Response.java
@@ -6,6 +6,11 @@ import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import java.io.Serializable;
 
+/**
+ * Represents a HelloWorld2Response in the system.
+ *
+ * @since 2026-06-10
+ */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "helloWorld2Response", propOrder = { "_return" })
 public class HelloWorld2Response implements Serializable

--- a/src/main/java/io/github/carlos_emr/carlos/ws/HelloWorldResponse.java
+++ b/src/main/java/io/github/carlos_emr/carlos/ws/HelloWorldResponse.java
@@ -6,6 +6,11 @@ import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import java.io.Serializable;
 
+/**
+ * Represents a HelloWorldResponse in the system.
+ *
+ * @since 2026-06-10
+ */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "helloWorldResponse", propOrder = { "_return" })
 public class HelloWorldResponse implements Serializable

--- a/src/main/java/io/github/carlos_emr/carlos/ws/InvalidHinException.java
+++ b/src/main/java/io/github/carlos_emr/carlos/ws/InvalidHinException.java
@@ -5,6 +5,11 @@ import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import java.io.Serializable;
 
+/**
+ * Custom exception indicating an error related to InvalidHin.
+ *
+ * @since 2026-06-10
+ */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "InvalidHinException")
 public class InvalidHinException implements Serializable

--- a/src/main/java/io/github/carlos_emr/carlos/ws/MatchingClientParameters.java
+++ b/src/main/java/io/github/carlos_emr/carlos/ws/MatchingClientParameters.java
@@ -10,6 +10,11 @@ import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import java.io.Serializable;
 
+/**
+ * Represents a MatchingClientParameters in the system.
+ *
+ * @since 2026-06-10
+ */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "matchingClientParameters", propOrder = { "maxEntriesToReturn", "minScore", "firstName", "lastName", "birthDate", "hin" })
 public class MatchingClientParameters implements Serializable

--- a/src/main/java/io/github/carlos_emr/carlos/ws/MatchingClientScore.java
+++ b/src/main/java/io/github/carlos_emr/carlos/ws/MatchingClientScore.java
@@ -5,6 +5,11 @@ import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import java.io.Serializable;
 
+/**
+ * Represents a MatchingClientScore in the system.
+ *
+ * @since 2026-06-10
+ */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "matchingClientScore", propOrder = { "client", "score" })
 public class MatchingClientScore implements Serializable

--- a/src/main/java/io/github/carlos_emr/carlos/ws/ObjectFactory.java
+++ b/src/main/java/io/github/carlos_emr/carlos/ws/ObjectFactory.java
@@ -5,6 +5,11 @@ import jakarta.xml.bind.JAXBElement;
 import javax.xml.namespace.QName;
 import jakarta.xml.bind.annotation.XmlRegistry;
 
+/**
+ * Represents a ObjectFactory in the system.
+ *
+ * @since 2026-06-10
+ */
 @XmlRegistry
 public class ObjectFactory
 {


### PR DESCRIPTION
Added class-level Javadoc to 40 undocumented Java files in the project. The javadocs have been customized according to class type, utilizing the `@since` tag based on git tracking dates and addressing the user requirements for improved inline documentation. Compilation has been verified successfully.

---
*PR created automatically by Jules for task [15417403330732288965](https://jules.google.com/task/15417403330732288965) started by @yingbull*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added class-level Javadoc to 40 Java files to improve readability and IDE hints. No functional changes; build compiles.

- **Refactors**
  - Standardized class summaries for models, converters, DTOs, utilities, and SOAP types.
  - Applied `@since 2026-06-10` tags based on git history.
  - Verified compilation; no code paths changed.

<sup>Written for commit 4678cde4969321c31fc70cdee33fe908f77bfbd8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

