### PR TITLE
[codex] Handle security scanner false positives

### DIFF
--- a/.claude/hooks/test-sql-safety-fixtures.json
+++ b/.claude/hooks/test-sql-safety-fixtures.json
@@ -240,6 +240,18 @@
     }
   },
   {
+    "section": "True Positives (should be BLOCKED, exit 2)",
+    "description": "TP-8: StringBuilder raw dynamic entity should be blocked",
+    "expected_exit": 2,
+    "payload": {
+      "tool_name": "Write",
+      "tool_input": {
+        "file_path": "/path/to/UnsafeDao.java",
+        "content": "StringBuilder sb = new StringBuilder();\nsb.append(\"select x from \");\nsb.append(userTable);\nsb.append(\" x where x.id = ?1\");\nQuery q = entityManager.createQuery(sb.toString());\nq.setParameter(1, id);"
+      }
+    }
+  },
+  {
     "section": "Edge Cases",
     "description": "EC-1: Non-Java file (XML) passes",
     "expected_exit": 0,

--- a/.claude/hooks/test-sql-safety-fixtures.json
+++ b/.claude/hooks/test-sql-safety-fixtures.json
@@ -1,0 +1,301 @@
+[
+  {
+    "section": "False Positives (should be ALLOWED, exit 0)",
+    "description": "FP-1: Positional param building (TicklerDaoImpl)",
+    "expected_exit": 0,
+    "payload": {
+      "tool_name": "Edit",
+      "tool_input": {
+        "file_path": "/path/to/TicklerDaoImpl.java",
+        "new_string": "query = query + \" and t.serviceDate >= ?\" + paramIndex++;\nparamList.add(filter.getStartDate());\nquery.setParameter(paramIndex, value);"
+      }
+    }
+  },
+  {
+    "section": "False Positives (should be ALLOWED, exit 0)",
+    "description": "FP-2: IN clause param building (TicklerDaoImpl)",
+    "expected_exit": 0,
+    "payload": {
+      "tool_name": "Edit",
+      "tool_input": {
+        "file_path": "/path/to/TicklerDaoImpl.java",
+        "new_string": "query = query + \" and t.creator IN (\";\nfor (int x = 0; x < providers.length; x++) {\n    if (x > 0) { query += \",\"; }\n    query += \"?\" + paramIndex++;\n    paramList.add(providers[x].getProviderNo());\n}\nquery += \")\";\nquery.setParameter(1, val);"
+      }
+    }
+  },
+  {
+    "section": "False Positives (should be ALLOWED, exit 0)",
+    "description": "FP-3: Status clause with param (TicklerDaoImpl)",
+    "expected_exit": 0,
+    "payload": {
+      "tool_name": "Edit",
+      "tool_input": {
+        "file_path": "/path/to/TicklerDaoImpl.java",
+        "new_string": "query = query + \" and t.status = ?\" + paramIndex++;\nparamList.add(convertStatus(filter.getStatus()));\nquery.setParameter(paramIndex, value);"
+      }
+    }
+  },
+  {
+    "section": "False Positives (should be ALLOWED, exit 0)",
+    "description": "FP-4: Named param building (BillingDaoImpl)",
+    "expected_exit": 0,
+    "payload": {
+      "tool_name": "Edit",
+      "tool_input": {
+        "file_path": "/path/to/BillingDaoImpl.java",
+        "new_string": "serviceCodeValues.append(\"bd.serviceCode = :\").append(param);\nparams.put(param, serviceCodes.get(i));\nquery.setParameter(e.getKey(), e.getValue());"
+      }
+    }
+  },
+  {
+    "section": "False Positives (should be ALLOWED, exit 0)",
+    "description": "FP-5: Query fragment concat (BillingDaoImpl)",
+    "expected_exit": 0,
+    "payload": {
+      "tool_name": "Edit",
+      "tool_input": {
+        "file_path": "/path/to/BillingDaoImpl.java",
+        "new_string": "String queryString = \"FROM Billing b WHERE b.status like :status \" + providerQuery + startDateQuery + endDateQuery + demoQuery;\nparams.put(\"status\", statusType);\nquery.setParameter(param.getKey(), param.getValue());"
+      }
+    }
+  },
+  {
+    "section": "False Positives (should be ALLOWED, exit 0)",
+    "description": "FP-6: Conditional named param clauses (BillingDaoImpl)",
+    "expected_exit": 0,
+    "payload": {
+      "tool_name": "Edit",
+      "tool_input": {
+        "file_path": "/path/to/BillingDaoImpl.java",
+        "new_string": "if (providerNo != null) {\n    providerQuery = \" and b.apptProviderNo = :providerNo\";\n    params.put(\"providerNo\", providerNo);\n}\nif (startDate != null) {\n    startDateQuery = \" and ( b.billingDate >= :startDate ) \";\n    params.put(\"startDate\", startDate);\n}\nquery.setParameter(key, value);"
+      }
+    }
+  },
+  {
+    "section": "False Positives (should be ALLOWED, exit 0)",
+    "description": "FP-7: Entity name from getSimpleName (EFormDaoImpl)",
+    "expected_exit": 0,
+    "payload": {
+      "tool_name": "Edit",
+      "tool_input": {
+        "file_path": "/path/to/EFormDaoImpl.java",
+        "new_string": "StringBuilder buf = new StringBuilder(\"FROM \" + modelClass.getSimpleName() + \" ef WHERE ef.current = ?1\");\nQuery query = entityManager.createQuery(buf.toString());\nquery.setParameter(1, status);"
+      }
+    }
+  },
+  {
+    "section": "False Positives (should be ALLOWED, exit 0)",
+    "description": "FP-8: StringBuilder SELECT with positional params",
+    "expected_exit": 0,
+    "payload": {
+      "tool_name": "Edit",
+      "tool_input": {
+        "file_path": "/path/to/SomeDaoImpl.java",
+        "new_string": "StringBuilder sqlCommand = new StringBuilder(\"select h from \").append(BillingONCHeader1.class.getSimpleName()).append(\" h WHERE \");\nsqlCommand.append(\"h.providerNo = ?\").append(counter++).append(\" AND h.status IN (?\").append(counter++).append(\") \");\nquery.setParameter(counter, val);"
+      }
+    }
+  },
+  {
+    "section": "False Positives (should be ALLOWED, exit 0)",
+    "description": "FP-9: Query var assignment with WHERE",
+    "expected_exit": 0,
+    "payload": {
+      "tool_name": "Edit",
+      "tool_input": {
+        "file_path": "/path/to/SomeDaoImpl.java",
+        "new_string": "query = selectQuery + \" FROM Tickler t, Demographic d where d.DemographicNo = t.demographicNo and d.ProviderNo = ?\" + paramIndex++;\nparamList.add(filter.getMrp());\nquery.setParameter(1, val);"
+      }
+    }
+  },
+  {
+    "section": "False Positives (should be ALLOWED, exit 0)",
+    "description": "FP-10: SQL in comments (should be ignored)",
+    "expected_exit": 0,
+    "payload": {
+      "tool_name": "Edit",
+      "tool_input": {
+        "file_path": "/path/to/SomeDaoImpl.java",
+        "new_string": "// query = \"SELECT * FROM users WHERE id = \" + userId;\n// This old pattern used string concatenation\nquery.setParameter(1, val);"
+      }
+    }
+  },
+  {
+    "section": "False Positives (should be ALLOWED, exit 0)",
+    "description": "FP-11: Keyword LIKE search with params (DxDaoImpl)",
+    "expected_exit": 0,
+    "payload": {
+      "tool_name": "Edit",
+      "tool_input": {
+        "file_path": "/path/to/DxDaoImpl.java",
+        "new_string": "conditions.add(\"(\" + codingSystem + \" like ?\" + paramIndex + \" or description like ?\" + (paramIndex + 1) + \")\");\nquery.setParameter(paramIndex++, likePattern);\nquery.setParameter(paramIndex++, likePattern);"
+      }
+    }
+  },
+  {
+    "section": "False Positives (should be ALLOWED, exit 0)",
+    "description": "FP-12: String literal split across lines",
+    "expected_exit": 0,
+    "payload": {
+      "tool_name": "Edit",
+      "tool_input": {
+        "file_path": "/path/to/SomeDaoImpl.java",
+        "new_string": "String hql = \"SELECT t FROM Tickler t \" + \"WHERE t.status = :status\";\nquery.setParameter(\"status\", status);"
+      }
+    }
+  },
+  {
+    "section": "False Positives (should be ALLOWED, exit 0)",
+    "description": "FP-13: StringBuilder findAll with optional WHERE",
+    "expected_exit": 0,
+    "payload": {
+      "tool_name": "Write",
+      "tool_input": {
+        "file_path": "/path/to/SomeDaoImpl.java",
+        "content": "StringBuilder sb = new StringBuilder();\nsb.append(\"select x from \");\nsb.append(modelClass.getSimpleName());\nsb.append(\" x\");\nif (current != null) {\n    sb.append(\" where x.current=?1\");\n}\nQuery query = entityManager.createQuery(sb.toString());\nif (current != null) {\n    query.setParameter(1, current);\n}"
+      }
+    }
+  },
+  {
+    "section": "True Positives (should be BLOCKED, exit 2)",
+    "description": "TP-1: Direct value injection (userId)",
+    "expected_exit": 2,
+    "payload": {
+      "tool_name": "Edit",
+      "tool_input": {
+        "file_path": "/path/to/UnsafeDao.java",
+        "new_string": "String sql = \"SELECT * FROM users WHERE id = \" + userId;\nstatement.executeQuery(sql);"
+      }
+    }
+  },
+  {
+    "section": "True Positives (should be BLOCKED, exit 2)",
+    "description": "TP-2: String.format SQL injection",
+    "expected_exit": 2,
+    "payload": {
+      "tool_name": "Edit",
+      "tool_input": {
+        "file_path": "/path/to/UnsafeDao.java",
+        "new_string": "String query = String.format(\"SELECT * FROM users WHERE name = %s\", userName);"
+      }
+    }
+  },
+  {
+    "section": "True Positives (should be BLOCKED, exit 2)",
+    "description": "TP-3: Quoted value injection",
+    "expected_exit": 2,
+    "payload": {
+      "tool_name": "Edit",
+      "tool_input": {
+        "file_path": "/path/to/UnsafeDao.java",
+        "new_string": "String sql = \"SELECT * FROM patients WHERE name = '\" + patientName + \"'\";"
+      }
+    }
+  },
+  {
+    "section": "True Positives (should be BLOCKED, exit 2)",
+    "description": "TP-4: executeQuery with direct concat",
+    "expected_exit": 2,
+    "payload": {
+      "tool_name": "Edit",
+      "tool_input": {
+        "file_path": "/path/to/UnsafeDao.java",
+        "new_string": "rs = statement.executeQuery(\"SELECT * FROM users WHERE id = \" + userId);"
+      }
+    }
+  },
+  {
+    "section": "True Positives (should be BLOCKED, exit 2)",
+    "description": "TP-5: createQuery with user value concat",
+    "expected_exit": 2,
+    "payload": {
+      "tool_name": "Edit",
+      "tool_input": {
+        "file_path": "/path/to/UnsafeDao.java",
+        "new_string": "Query q = entityManager.createQuery(\"SELECT u FROM User u WHERE u.name = \" + userName);"
+      }
+    }
+  },
+  {
+    "section": "True Positives (should be BLOCKED, exit 2)",
+    "description": "TP-6: WHERE clause direct value injection",
+    "expected_exit": 2,
+    "payload": {
+      "tool_name": "Edit",
+      "tool_input": {
+        "file_path": "/path/to/UnsafeDao.java",
+        "new_string": "String condition = \"WHERE status = \" + userStatus;\nString sql = \"SELECT * FROM orders \" + condition;"
+      }
+    }
+  },
+  {
+    "section": "True Positives (should be BLOCKED, exit 2)",
+    "description": "TP-7: Mixed safe setParameter and unsafe concat should be blocked",
+    "expected_exit": 2,
+    "payload": {
+      "tool_name": "Edit",
+      "tool_input": {
+        "file_path": "/path/to/MixedDao.java",
+        "new_string": "Query q = entityManager.createQuery(\"SELECT u FROM User u WHERE u.id = :id\");\nq.setParameter(\"id\", userId);\nString sql = \"SELECT * FROM users WHERE name = '\" + userName + \"'\";"
+      }
+    }
+  },
+  {
+    "section": "Edge Cases",
+    "description": "EC-1: Non-Java file (XML) passes",
+    "expected_exit": 0,
+    "payload": {
+      "tool_name": "Write",
+      "tool_input": {
+        "file_path": "/path/to/config.xml",
+        "content": "SELECT * FROM users WHERE id = "
+      }
+    }
+  },
+  {
+    "section": "Edge Cases",
+    "description": "EC-2: Read tool passes regardless",
+    "expected_exit": 0,
+    "payload": {
+      "tool_name": "Read",
+      "tool_input": {
+        "file_path": "/path/to/UnsafeDao.java"
+      }
+    }
+  },
+  {
+    "section": "Edge Cases",
+    "description": "EC-3: Empty content passes",
+    "expected_exit": 0,
+    "payload": {
+      "tool_name": "Edit",
+      "tool_input": {
+        "file_path": "/path/to/SomeDaoImpl.java",
+        "new_string": ""
+      }
+    }
+  },
+  {
+    "section": "Edge Cases",
+    "description": "EC-4: Static parameterized query",
+    "expected_exit": 0,
+    "payload": {
+      "tool_name": "Edit",
+      "tool_input": {
+        "file_path": "/path/to/SafeDao.java",
+        "new_string": "Query q = entityManager.createQuery(\"SELECT u FROM User u WHERE u.id = :id\");\nq.setParameter(\"id\", userId);"
+      }
+    }
+  },
+  {
+    "section": "Edge Cases",
+    "description": "EC-5: Criteria API (always safe)",
+    "expected_exit": 0,
+    "payload": {
+      "tool_name": "Edit",
+      "tool_input": {
+        "file_path": "/path/to/SafeDao.java",
+        "new_string": "CriteriaBuilder cb = entityManager.getCriteriaBuilder();\nCriteriaQuery<User> cq = cb.createQuery(User.class);\nRoot<User> root = cq.from(User.class);\ncq.select(root).where(cb.equal(root.get(\"id\"), userId));"
+      }
+    }
+  }
+]

--- a/.claude/hooks/test-sql-safety-hook.sh
+++ b/.claude/hooks/test-sql-safety-hook.sh
@@ -55,245 +55,30 @@ echo " SQL Safety Hook Test Suite"
 echo "============================================"
 echo ""
 
-# ----------------------------------------------------------------
-# Section 1: FALSE POSITIVES THAT SHOULD NOW PASS (exit 0)
-# ----------------------------------------------------------------
-echo -e "${YELLOW}--- False Positives (should be ALLOWED, exit 0) ---${NC}"
+FIXTURES="$(cd "$(dirname "$0")" && pwd)/test-sql-safety-fixtures.json"
+current_section=""
 
-# Test FP-1: TicklerDaoImpl positional parameter building
-run_test "FP-1: Positional param building (TicklerDaoImpl)" 0 '{
-  "tool_name": "Edit",
-  "tool_input": {
-    "file_path": "/path/to/TicklerDaoImpl.java",
-    "new_string": "query = query + \" and t.serviceDate >= ?\" + paramIndex++;\n            paramList.add(filter.getStartDate());\n            query.setParameter(paramIndex, value);"
-  }
-}'
+while IFS=$'	' read -r section description expected_exit json_payload; do
+    if [ "$section" != "$current_section" ]; then
+        if [ -n "$current_section" ]; then
+            echo ""
+        fi
+        echo -e "${YELLOW}--- $section ---${NC}"
+        current_section="$section"
+    fi
+    run_test "$description" "$expected_exit" "$json_payload"
+done < <(python3 - "$FIXTURES" <<'PYFIXTURES'
+import json
+import sys
 
-# Test FP-2: TicklerDaoImpl IN clause building
-run_test "FP-2: IN clause param building (TicklerDaoImpl)" 0 '{
-  "tool_name": "Edit",
-  "tool_input": {
-    "file_path": "/path/to/TicklerDaoImpl.java",
-    "new_string": "query = query + \" and t.creator IN (\";\nfor (int x = 0; x < providers.length; x++) {\n    if (x > 0) { query += \",\"; }\n    query += \"?\" + paramIndex++;\n    paramList.add(providers[x].getProviderNo());\n}\nquery += \")\";\nquery.setParameter(1, val);"
-  }
-}'
+with open(sys.argv[1], encoding="utf-8") as handle:
+    cases = json.load(handle)
 
-# Test FP-3: TicklerDaoImpl status clause
-run_test "FP-3: Status clause with param (TicklerDaoImpl)" 0 '{
-  "tool_name": "Edit",
-  "tool_input": {
-    "file_path": "/path/to/TicklerDaoImpl.java",
-    "new_string": "query = query + \" and t.status = ?\" + paramIndex++;\nparamList.add(convertStatus(filter.getStatus()));\nquery.setParameter(paramIndex, value);"
-  }
-}'
-
-# Test FP-4: BillingDaoImpl named parameter building
-run_test "FP-4: Named param building (BillingDaoImpl)" 0 '{
-  "tool_name": "Edit",
-  "tool_input": {
-    "file_path": "/path/to/BillingDaoImpl.java",
-    "new_string": "serviceCodeValues.append(\"bd.serviceCode = :\").append(param);\nparams.put(param, serviceCodes.get(i));\nquery.setParameter(e.getKey(), e.getValue());"
-  }
-}'
-
-# Test FP-5: BillingDaoImpl query fragment concatenation
-run_test "FP-5: Query fragment concat (BillingDaoImpl)" 0 '{
-  "tool_name": "Edit",
-  "tool_input": {
-    "file_path": "/path/to/BillingDaoImpl.java",
-    "new_string": "String queryString = \"FROM Billing b WHERE b.status like :status \" + providerQuery + startDateQuery + endDateQuery + demoQuery;\nparams.put(\"status\", statusType);\nquery.setParameter(param.getKey(), param.getValue());"
-  }
-}'
-
-# Test FP-6: BillingDaoImpl conditional clauses with named params
-run_test "FP-6: Conditional named param clauses (BillingDaoImpl)" 0 '{
-  "tool_name": "Edit",
-  "tool_input": {
-    "file_path": "/path/to/BillingDaoImpl.java",
-    "new_string": "if (providerNo != null) {\n    providerQuery = \" and b.apptProviderNo = :providerNo\";\n    params.put(\"providerNo\", providerNo);\n}\nif (startDate != null) {\n    startDateQuery = \" and ( b.billingDate >= :startDate ) \";\n    params.put(\"startDate\", startDate);\n}\nquery.setParameter(key, value);"
-  }
-}'
-
-# Test FP-7: EFormDaoImpl entity name from getSimpleName()
-run_test "FP-7: Entity name from getSimpleName (EFormDaoImpl)" 0 '{
-  "tool_name": "Edit",
-  "tool_input": {
-    "file_path": "/path/to/EFormDaoImpl.java",
-    "new_string": "StringBuilder buf = new StringBuilder(\"FROM \" + modelClass.getSimpleName() + \" ef WHERE ef.current = ?1\");\nQuery query = entityManager.createQuery(buf.toString());\nquery.setParameter(1, status);"
-  }
-}'
-
-# Test FP-8: StringBuilder with SELECT and append with positional params
-run_test "FP-8: StringBuilder SELECT with positional params" 0 '{
-  "tool_name": "Edit",
-  "tool_input": {
-    "file_path": "/path/to/SomeDaoImpl.java",
-    "new_string": "StringBuilder sqlCommand = new StringBuilder(\"select h from \").append(BillingONCHeader1.class.getSimpleName()).append(\" h WHERE \");\nsqlCommand.append(\"h.providerNo = ?\").append(counter++).append(\" AND h.status IN (?\").append(counter++).append(\") \");\nquery.setParameter(counter, val);"
-  }
-}'
-
-# Test FP-9: Query variable assignment with WHERE clause
-run_test "FP-9: Query var assignment with WHERE" 0 '{
-  "tool_name": "Edit",
-  "tool_input": {
-    "file_path": "/path/to/SomeDaoImpl.java",
-    "new_string": "query = selectQuery + \" FROM Tickler t, Demographic d where d.DemographicNo = t.demographicNo and d.ProviderNo = ?\" + paramIndex++;\nparamList.add(filter.getMrp());\nquery.setParameter(1, val);"
-  }
-}'
-
-# Test FP-10: Comment lines with SQL keywords should be ignored
-run_test "FP-10: SQL in comments (should be ignored)" 0 '{
-  "tool_name": "Edit",
-  "tool_input": {
-    "file_path": "/path/to/SomeDaoImpl.java",
-    "new_string": "// query = \"SELECT * FROM users WHERE id = \" + userId;\n// This old pattern used string concatenation\nquery.setParameter(1, val);"
-  }
-}'
-
-# Test FP-11: DxDaoImpl keyword search with positional params
-run_test "FP-11: Keyword LIKE search with params (DxDaoImpl)" 0 '{
-  "tool_name": "Edit",
-  "tool_input": {
-    "file_path": "/path/to/DxDaoImpl.java",
-    "new_string": "conditions.add(\"(\" + codingSystem + \" like ?\" + paramIndex + \" or description like ?\" + (paramIndex + 1) + \")\");\nquery.setParameter(paramIndex++, likePattern);\nquery.setParameter(paramIndex++, likePattern);"
-  }
-}'
-
-# Test FP-12: Pure string literal concatenation (splitting long line)
-run_test "FP-12: String literal split across lines" 0 '{
-  "tool_name": "Edit",
-  "tool_input": {
-    "file_path": "/path/to/SomeDaoImpl.java",
-    "new_string": "String hql = \"SELECT t FROM Tickler t \" + \"WHERE t.status = :status\";\nquery.setParameter(\"status\", status);"
-  }
-}'
-
-# Test FP-13: StringBuilder findAll pattern
-run_test "FP-13: StringBuilder findAll with optional WHERE" 0 '{
-  "tool_name": "Write",
-  "tool_input": {
-    "file_path": "/path/to/SomeDaoImpl.java",
-    "content": "StringBuilder sb = new StringBuilder();\nsb.append(\"select x from \");\nsb.append(modelClass.getSimpleName());\nsb.append(\" x\");\nif (current != null) {\n    sb.append(\" where x.current=?1\");\n}\nQuery query = entityManager.createQuery(sb.toString());\nif (current != null) {\n    query.setParameter(1, current);\n}"
-  }
-}'
-
-echo ""
-
-# ----------------------------------------------------------------
-# Section 2: TRUE POSITIVES THAT MUST STILL BE CAUGHT (exit 2)
-# ----------------------------------------------------------------
-echo -e "${YELLOW}--- True Positives (should be BLOCKED, exit 2) ---${NC}"
-
-# Test TP-1: Direct value injection
-run_test "TP-1: Direct value injection (userId)" 2 '{
-  "tool_name": "Edit",
-  "tool_input": {
-    "file_path": "/path/to/UnsafeDao.java",
-    "new_string": "String sql = \"SELECT * FROM users WHERE id = \" + userId;\nstatement.executeQuery(sql);"
-  }
-}'
-
-# Test TP-2: String.format with SQL
-run_test "TP-2: String.format SQL injection" 2 '{
-  "tool_name": "Edit",
-  "tool_input": {
-    "file_path": "/path/to/UnsafeDao.java",
-    "new_string": "String query = String.format(\"SELECT * FROM users WHERE name = %s\", userName);"
-  }
-}'
-
-# Test TP-3: Quoted value injection (quote-sandwich pattern)
-# Note: Single quotes in JSON content require special bash escaping
-run_test "TP-3: Quoted value injection" 2 '{"tool_name":"Edit","tool_input":{"file_path":"/path/to/UnsafeDao.java","new_string":"String sql = \"SELECT * FROM patients WHERE name = '"'"'\" + patientName + \"'"'"'\";" }}'
-
-# Test TP-4: executeQuery with concatenation (no params)
-run_test "TP-4: executeQuery with direct concat" 2 '{
-  "tool_name": "Edit",
-  "tool_input": {
-    "file_path": "/path/to/UnsafeDao.java",
-    "new_string": "rs = statement.executeQuery(\"SELECT * FROM users WHERE id = \" + userId);"
-  }
-}'
-
-# Test TP-5: createQuery with user input concatenation
-run_test "TP-5: createQuery with user value concat" 2 '{
-  "tool_name": "Edit",
-  "tool_input": {
-    "file_path": "/path/to/UnsafeDao.java",
-    "new_string": "Query q = entityManager.createQuery(\"SELECT u FROM User u WHERE u.name = \" + userName);"
-  }
-}'
-
-# Test TP-6: WHERE clause with direct value
-run_test "TP-6: WHERE clause direct value injection" 2 '{
-  "tool_name": "Edit",
-  "tool_input": {
-    "file_path": "/path/to/UnsafeDao.java",
-    "new_string": "String condition = \"WHERE status = \" + userStatus;\nString sql = \"SELECT * FROM orders \" + condition;"
-  }
-}'
-
-# Test TP-7: Mixed safe setParameter and unsafe concatenation in same file
-# A single setParameter elsewhere in the file must NOT whitelist an unsafe concat.
-# This tests the critical case: file-wide bypass must NOT fire.
-run_test "TP-7: Mixed safe setParameter and unsafe concat should be blocked" 2 '{
-  "tool_name": "Edit",
-  "tool_input": {
-    "file_path": "/path/to/MixedDao.java",
-    "new_string": "Query q = entityManager.createQuery(\"SELECT u FROM User u WHERE u.id = :id\");\nq.setParameter(\"id\", userId);\nString sql = \"SELECT * FROM users WHERE name = '"'"'\" + userName + \"'"'"'\";"
-  }
-}'
-
-echo ""
-
-# ----------------------------------------------------------------
-# Section 3: EDGE CASES (various expected outcomes)
-# ----------------------------------------------------------------
-echo -e "${YELLOW}--- Edge Cases ---${NC}"
-
-# Test EC-1: Non-Java file should always pass
-run_test "EC-1: Non-Java file (XML) passes" 0 '{
-  "tool_name": "Write",
-  "tool_input": {
-    "file_path": "/path/to/config.xml",
-    "content": "SELECT * FROM users WHERE id = "
-  }
-}'
-
-# Test EC-2: Read tool should always pass (hook only checks Edit/Write)
-run_test "EC-2: Read tool passes regardless" 0 '{
-  "tool_name": "Read",
-  "tool_input": {
-    "file_path": "/path/to/UnsafeDao.java"
-  }
-}'
-
-# Test EC-3: Empty content should pass
-run_test "EC-3: Empty content passes" 0 '{
-  "tool_name": "Edit",
-  "tool_input": {
-    "file_path": "/path/to/SomeDaoImpl.java",
-    "new_string": ""
-  }
-}'
-
-# Test EC-4: Safe static query (no concatenation at all)
-run_test "EC-4: Static parameterized query" 0 '{
-  "tool_name": "Edit",
-  "tool_input": {
-    "file_path": "/path/to/SafeDao.java",
-    "new_string": "Query q = entityManager.createQuery(\"SELECT u FROM User u WHERE u.id = :id\");\nq.setParameter(\"id\", userId);"
-  }
-}'
-
-# Test EC-5: Criteria API usage (safe)
-run_test "EC-5: Criteria API (always safe)" 0 '{
-  "tool_name": "Edit",
-  "tool_input": {
-    "file_path": "/path/to/SafeDao.java",
-    "new_string": "CriteriaBuilder cb = entityManager.getCriteriaBuilder();\nCriteriaQuery<User> cq = cb.createQuery(User.class);\nRoot<User> root = cq.from(User.class);\ncq.select(root).where(cb.equal(root.get(\"id\"), userId));"
-  }
-}'
+for case in cases:
+    payload = json.dumps(case["payload"], separators=(",", ":"))
+    print("	".join((case["section"], case["description"], str(case["expected_exit"]), payload)))
+PYFIXTURES
+)
 
 echo ""
 

--- a/.claude/hooks/test-sql-safety-hook.sh
+++ b/.claude/hooks/test-sql-safety-hook.sh
@@ -58,6 +58,8 @@ echo ""
 FIXTURES="$(cd "$(dirname "$0")" && pwd)/test-sql-safety-fixtures.json"
 current_section=""
 
+# The Python fixture emitter below uses tab-delimited fields for Bash.
+# Keep emitted section, description, expected_exit, and JSON payload fields single-line and tab-free.
 while IFS=$'	' read -r section description expected_exit json_payload; do
     if [ "$section" != "$current_section" ]; then
         if [ -n "$current_section" ]; then

--- a/.claude/hooks/validate-sql-safety.py
+++ b/.claude/hooks/validate-sql-safety.py
@@ -343,7 +343,7 @@ def check_sql_injection_patterns(content: str) -> list[str]:
     # Additional check: Look for dangerous patterns in query construction
     raw_query_patterns = [
         # "SELECT ... WHERE id = '" + id + "'"
-        (rf'["\'][^"\']*{sql_keywords}[^"\']*=\s*(["\'])\s*\+\s*\w+\s*\+\s*\1',
+        (rf'["\'][^"\']*{sql_keywords}[^"\']*=\s*(["\'])\s*\+\s*\w+\s*\+\s*\1',  # nosemgrep: skills.code-injection.skill-sql-string-formatting.skill-sql-string-formatting -- detector regex for SQL safety hook, not SQL execution
          "String concatenation with quotes in SQL"),
         # query = "SELECT ... " + variable;
         (rf'\w+\s*=\s*["\'][^"\']*{sql_keywords}[^"\']*["\']\s*\+',

--- a/.claude/hooks/validate-sql-safety.py
+++ b/.claude/hooks/validate-sql-safety.py
@@ -153,11 +153,11 @@ def is_stringbuilder_entity_name_query(line: str, content: str) -> bool:
 
     builder = re.escape(start_match.group(1))
     has_entity_metadata_append = re.search(
-        rf'{builder}\.append\s*\(\s*(?:modelClass\.getSimpleName\(\)|\w+\.class\.getSimpleName\(\))\s*\)',
+        rf'{builder}\.append\s*\(\s*(?:modelClass\.getSimpleName\(\)|\w+\.class\.getSimpleName\(\))\s*\)',  # nosemgrep: skills.code-injection.skill-ldap-injection.skill-ldap-injection -- SQL safety hook regex, not an LDAP filter; builder is escaped with re.escape().
         content,
     )
     has_query_creation = re.search(
-        rf'(?:createQuery|createNativeQuery|createSQLQuery)\s*\(\s*{builder}\.toString\(\)\s*\)',
+        rf'(?:createQuery|createNativeQuery|createSQLQuery)\s*\(\s*{builder}\.toString\(\)\s*\)',  # nosemgrep: skills.code-injection.skill-ldap-injection.skill-ldap-injection -- SQL safety hook regex, not an LDAP filter; builder is escaped with re.escape().
         content,
         re.IGNORECASE,
     )

--- a/.claude/hooks/validate-sql-safety.py
+++ b/.claude/hooks/validate-sql-safety.py
@@ -141,6 +141,29 @@ def has_class_name_insertion(match_text: str, line: str) -> bool:
     return False
 
 
+def is_stringbuilder_entity_name_query(line: str, content: str) -> bool:
+    """Allow StringBuilder queries whose dynamic FROM target is model metadata."""
+    start_match = re.search(
+        r'(\w+)\.append\s*\(\s*["\']\s*select\s+\w+\s+from\s*["\']\s*\)',
+        line,
+        re.IGNORECASE,
+    )
+    if not start_match:
+        return False
+
+    builder = re.escape(start_match.group(1))
+    has_entity_metadata_append = re.search(
+        rf'{builder}\.append\s*\(\s*(?:modelClass\.getSimpleName\(\)|\w+\.class\.getSimpleName\(\))\s*\)',
+        content,
+    )
+    has_query_creation = re.search(
+        rf'(?:createQuery|createNativeQuery|createSQLQuery)\s*\(\s*{builder}\.toString\(\)\s*\)',
+        content,
+        re.IGNORECASE,
+    )
+    return bool(has_entity_metadata_append and has_query_creation and has_parameterized_usage(content))
+
+
 def is_query_builder_variable(match_text: str) -> bool:
     """Check if the concatenated variable is a known query-builder variable name.
     
@@ -206,21 +229,26 @@ def is_safe_pattern(match_text: str, line: str, content: str) -> bool:
     if has_class_name_insertion(match_text, line):
         return True
 
-    # 4. Check if concatenated variable is a query-builder variable AND the line
+    # 4. Check for StringBuilder query construction where the only dynamic FROM
+    # target is model metadata and parameterized usage is present elsewhere.
+    if is_stringbuilder_entity_name_query(line, content):
+        return True
+
+    # 5. Check if concatenated variable is a query-builder variable AND the line
     # also has parameter placeholder evidence (prevents variable-name-only bypasses).
     # A variable named 'sql' or 'providerQuery' is only considered safe when the
     # same line also contains a named or positional parameter placeholder.
     if is_query_builder_variable(match_text) and is_in_string_literal_context(line):
         return True
 
-    # 5. Check if the line has parameter placeholders inside string literals AND
+    # 6. Check if the line has parameter placeholders inside string literals AND
     # the overall content uses parameterized queries.
     # Note: is_in_string_literal_context strips comments first, so a trailing
     # // :id comment cannot bypass this check.
     if is_in_string_literal_context(line) and has_parameterized_usage(content):
         return True
 
-    # 6. Check for string literal + string literal concatenation (no variables)
+    # 7. Check for string literal + string literal concatenation (no variables)
     # "SELECT ..." + " WHERE ..." is just splitting a long string, which is safe.
     if re.search(r'["\']\s*\+\s*["\']', match_text):
         # Pure string-to-string concat with no variable in between

--- a/.github/spotbugs/spotbugs-exclude.xml
+++ b/.github/spotbugs/spotbugs-exclude.xml
@@ -1069,70 +1069,8 @@
         <Method name="toDocument"/>
     </Match>
 
-    <!-- No shell is invoked: commands are fixed or configured executable arrays,
-         with working directories validated before Runtime.exec. -->
-    <Match>
-        <Bug pattern="COMMAND_INJECTION"/>
-        <Class name="io.github.carlos_emr.carlos.demographic.pageUtil.PGPEncrypt"/>
-        <Method name="check"/>
-    </Match>
-    <Match>
-        <Bug pattern="COMMAND_INJECTION"/>
-        <Class name="io.github.carlos_emr.carlos.demographic.pageUtil.PGPEncrypt"/>
-        <Method name="encrypt"/>
-    </Match>
-    <Match>
-        <Bug pattern="COMMAND_INJECTION"/>
-        <Class name="io.github.carlos_emr.carlos.managers.AuditLogManager"/>
-        <Method name="purgeAuditLog"/>
-    </Match>
-
-    <!-- Logout creates empty maxAge(0) deletion cookies; it is not storing
-         sensitive data in insecure cookies. -->
-    <Match>
-        <Bug pattern="INSECURE_COOKIE"/>
-        <Class name="io.github.carlos_emr.carlos.login.Logout2Action"/>
-        <Method name="logout"/>
-    </Match>
-    <Match>
-        <Bug pattern="COOKIE_USAGE"/>
-        <Class name="io.github.carlos_emr.carlos.login.Logout2Action"/>
-        <Method name="logout"/>
-    </Match>
-
-    <!-- ObjectInputFilter is installed before readObject, and file inputs are
-         validated before ObjectInputStream construction. -->
-    <Match>
-        <Bug pattern="OBJECT_DESERIALIZATION"/>
-        <Class name="io.github.carlos_emr.carlos.utility.MiscUtils"/>
-        <Method name="deserialize"/>
-    </Match>
-    <Match>
-        <Bug pattern="OBJECT_DESERIALIZATION"/>
-        <Class name="io.github.carlos_emr.carlos.utility.MiscUtils"/>
-        <Method name="deserializeFromFile"/>
-    </Match>
-
-    <!-- Random values are local filenames/cache busters, not secrets, tokens,
-         credentials, or authorization decisions. -->
-    <Match>
-        <Bug pattern="PREDICTABLE_RANDOM"/>
-        <Class name="io.github.carlos_emr.carlos.lab.ca.all.web.SubmitLabByForm2Action"/>
-        <Method name="saveManage"/>
-    </Match>
-    <Match>
-        <Bug pattern="PREDICTABLE_RANDOM"/>
-        <Class name="io.github.carlos_emr.carlos.billings.ca.bc.Teleplan.TeleplanResponse"/>
-        <Method name="processResponseStream"/>
-    </Match>
-
-    <!-- Redirects are context-relative/validated or fixed-host with URL-encoded
-         query values. Host-header hardening alert #21966 remains out of scope. -->
-    <Match>
-        <Bug pattern="UNVALIDATED_REDIRECT"/>
-        <Class name="io.github.carlos_emr.carlos.casemgmt.web.CaseManagementEntry2Action"/>
-        <Method name="saveAndExit"/>
-    </Match>
+    <!-- Redirect target is a same-origin application path, not an attacker-controlled
+         external URL. -->
     <Match>
         <Bug pattern="UNVALIDATED_REDIRECT"/>
         <Class name="io.github.carlos_emr.carlos.prescript.pageUtil.RxDrugInfo2Action"/>
@@ -1163,11 +1101,6 @@
         <Method name="execute"/>
     </Match>
     <Match>
-        <Bug pattern="SERVLET_SERVER_NAME"/>
-        <Class name="io.github.carlos_emr.carlos.util.FullPathReWrite"/>
-        <Method name="doStartTag"/>
-    </Match>
-    <Match>
         <Bug pattern="SERVLET_CONTENT_TYPE"/>
         <Class name="io.github.carlos_emr.carlos.webserv.oauth.util.OAuth1ParamParser"/>
         <Method name="parseFromRequest"/>
@@ -1185,17 +1118,17 @@
     <Match>
         <Bug pattern="SERVLET_CONTENT_TYPE"/>
         <Class name="io.github.carlos_emr.carlos.webserv.oauth.util.OAuth1SignatureVerifierImplementation"/>
-        <Method name="verify"/>
+        <Method name="verifySignature"/>
     </Match>
     <Match>
         <Bug pattern="SERVLET_QUERY_STRING"/>
         <Class name="io.github.carlos_emr.carlos.webserv.oauth.util.OAuth1SignatureVerifierImplementation"/>
-        <Method name="verify"/>
+        <Method name="verifySignature"/>
     </Match>
     <Match>
         <Bug pattern="SERVLET_SERVER_NAME"/>
         <Class name="io.github.carlos_emr.carlos.webserv.oauth.util.OAuth1SignatureVerifierImplementation"/>
-        <Method name="verify"/>
+        <Method name="verifySignature"/>
     </Match>
     <Match>
         <Bug pattern="SERVLET_HEADER"/>

--- a/.github/spotbugs/spotbugs-exclude.xml
+++ b/.github/spotbugs/spotbugs-exclude.xml
@@ -1069,8 +1069,9 @@
         <Method name="toDocument"/>
     </Match>
 
-    <!-- Redirect target is a same-origin application path, not an attacker-controlled
-         external URL. -->
+    <!-- Redirect host is a hardcoded external constant (resource.oscarmcmaster.org);
+         only a URL-encoded query parameter is appended, so the destination is not
+         attacker-controllable. -->
     <Match>
         <Bug pattern="UNVALIDATED_REDIRECT"/>
         <Class name="io.github.carlos_emr.carlos.prescript.pageUtil.RxDrugInfo2Action"/>

--- a/.github/spotbugs/spotbugs-exclude.xml
+++ b/.github/spotbugs/spotbugs-exclude.xml
@@ -839,6 +839,370 @@
         <Method name="doGet"/>
     </Match>
 
+
+    <!-- ================================================================
+         ISSUE #2833 CONFIRMED SCANNER-ONLY FALSE POSITIVES
+         https://github.com/carlos-emr/carlos/issues/2833
+
+         These are method-scoped filters for alerts revalidated on
+         2026-06-11 as scanner/model gaps. Keep this section focused on
+         the exact safe abstractions documented in the issue: trusted SQL
+         wrappers, secure XmlUtils parser factories, no-shell Runtime.exec
+         arrays, deletion cookies, ObjectInputFilter guarded reads,
+         non-secret randomness, encoded or validated redirects, and
+         servlet metadata used only for routing/canonicalization.
+         ================================================================ -->
+
+    <!-- SQL wrapper methods resolve server-owned query templates, allowlisted fragments,
+         or pass-through JDBC wrapper calls; runtime values are bound separately. -->
+    <Match>
+        <Bug pattern="SQL_INJECTION_SPRING_JDBC"/>
+        <Class name="io.github.carlos_emr.carlos.dao.OscarSuperDao"/>
+        <Method name="executeSelectQuery"/>
+    </Match>
+    <Match>
+        <Bug pattern="SQL_INJECTION_SPRING_JDBC"/>
+        <Class name="io.github.carlos_emr.carlos.dao.OscarSuperDao"/>
+        <Method name="executeRowMappedSelectQuery"/>
+    </Match>
+    <Match>
+        <Bug pattern="SQL_INJECTION_JDBC"/>
+        <Class name="io.github.carlos_emr.carlos.db.LegacyJdbcQuery"/>
+        <Method name="getPreparedResultSetLegacyRaw"/>
+    </Match>
+    <Match>
+        <Bug pattern="SQL_INJECTION_JDBC"/>
+        <Class name="io.github.carlos_emr.carlos.lab.ca.all.upload.MessageUploader"/>
+        <Method name="providerRouteReport"/>
+    </Match>
+    <Match>
+        <Bug pattern="SQL_PREPARED_STATEMENT_GENERATED_FROM_NONCONSTANT_STRING"/>
+        <Class name="io.github.carlos_emr.carlos.lab.ca.all.upload.MessageUploader"/>
+        <Method name="providerRouteReport"/>
+    </Match>
+    <Match>
+        <Bug pattern="SQL_PREPARED_STATEMENT_GENERATED_FROM_NONCONSTANT_STRING"/>
+        <Class name="io.github.carlos_emr.carlos.lab.ca.all.upload.MessageUploader"/>
+        <Method name="patientRouteReport"/>
+    </Match>
+    <Match>
+        <Bug pattern="SQL_INJECTION_JDBC"/>
+        <Class name="io.github.carlos_emr.carlos.lab.ca.on.CML.ABCDParser"/>
+        <Method name="executePatientLookup"/>
+    </Match>
+    <Match>
+        <Bug pattern="SQL_INJECTION_JDBC"/>
+        <Class name="io.github.carlos_emr.carlos.utility.OscarTrackingBasicDataSource$TrackingJdbcConnection"/>
+        <Method name="nativeSQL"/>
+    </Match>
+    <Match>
+        <Bug pattern="SQL_INJECTION_JDBC"/>
+        <Class name="io.github.carlos_emr.carlos.utility.OscarTrackingBasicDataSource$TrackingJdbcConnection"/>
+        <Method name="prepareCall"/>
+    </Match>
+    <Match>
+        <Bug pattern="SQL_INJECTION_JDBC"/>
+        <Class name="io.github.carlos_emr.carlos.utility.OscarTrackingBasicDataSource$TrackingJdbcConnection"/>
+        <Method name="prepareStatement"/>
+    </Match>
+    <Match>
+        <Bug pattern="EXTERNAL_CONFIG_CONTROL"/>
+        <Class name="io.github.carlos_emr.carlos.utility.OscarTrackingBasicDataSource$TrackingJdbcConnection"/>
+        <Method name="setCatalog"/>
+    </Match>
+
+    <!-- XML parsers, schema factories, validators, and JAXB sources all flow through
+         XmlUtils secure helpers that disable DTD/external entity access or fail closed. -->
+    <Match>
+        <Bug pattern="XXE_XMLREADER"/>
+        <Class name="io.github.carlos_emr.OBChecklist_99_12"/>
+        <Method name="doStuff"/>
+    </Match>
+    <Match>
+        <Bug pattern="XXE_XMLREADER"/>
+        <Class name="io.github.carlos_emr.OBRisks_99_12"/>
+        <Method name="doStuff"/>
+    </Match>
+    <Match>
+        <Bug pattern="XXE_XMLREADER"/>
+        <Class name="io.github.carlos_emr.OBRisks_99_12"/>
+        <Method name="getRiskName"/>
+    </Match>
+    <Match>
+        <Bug pattern="XXE_DOCUMENT"/>
+        <Class name="io.github.carlos_emr.carlos.dashboard.handler.IndicatorTemplateHandler"/>
+        <Method name="byteToDocument"/>
+    </Match>
+    <Match>
+        <Bug pattern="XXE_SCHEMA_FACTORY"/>
+        <Class name="io.github.carlos_emr.carlos.dashboard.handler.IndicatorTemplateHandler"/>
+        <Method name="setSchema"/>
+    </Match>
+    <Match>
+        <Bug pattern="XXE_VALIDATOR"/>
+        <Class name="io.github.carlos_emr.carlos.dashboard.handler.IndicatorTemplateHandler"/>
+        <Method name="validateXML"/>
+    </Match>
+    <Match>
+        <Bug pattern="XXE_SAXPARSER"/>
+        <Class name="io.github.carlos_emr.carlos.decision.DesAnnualReviewPlannerChecklist"/>
+        <Method name="doStuff"/>
+    </Match>
+    <Match>
+        <Bug pattern="XXE_SAXPARSER"/>
+        <Class name="io.github.carlos_emr.carlos.decision.DesAnnualReviewPlannerRisk"/>
+        <Method name="doStuff"/>
+    </Match>
+    <Match>
+        <Bug pattern="XXE_SAXPARSER"/>
+        <Class name="io.github.carlos_emr.carlos.decision.DesAnnualReviewPlannerRisk"/>
+        <Method name="getRiskName"/>
+    </Match>
+    <Match>
+        <Bug pattern="XXE_XMLREADER"/>
+        <Class name="io.github.carlos_emr.carlos.decision.DesAntenatalPlannerChecklist_99_12"/>
+        <Method name="doStuff"/>
+    </Match>
+    <Match>
+        <Bug pattern="XXE_XMLREADER"/>
+        <Class name="io.github.carlos_emr.carlos.decision.DesAntenatalPlannerRisks_99_12"/>
+        <Method name="doStuff"/>
+    </Match>
+    <Match>
+        <Bug pattern="XXE_XMLREADER"/>
+        <Class name="io.github.carlos_emr.carlos.decision.DesAntenatalPlannerRisks_99_12"/>
+        <Method name="getRiskName"/>
+    </Match>
+    <Match>
+        <Bug pattern="XXE_DOCUMENT"/>
+        <Class name="io.github.carlos_emr.carlos.demographic.pageUtil.DemographicExportAction42Action"/>
+        <Method name="validateExport"/>
+    </Match>
+    <Match>
+        <Bug pattern="XXE_SCHEMA_FACTORY"/>
+        <Class name="io.github.carlos_emr.carlos.demographic.pageUtil.DemographicExportAction42Action"/>
+        <Method name="validateExport"/>
+    </Match>
+    <Match>
+        <Bug pattern="XXE_VALIDATOR"/>
+        <Class name="io.github.carlos_emr.carlos.demographic.pageUtil.DemographicExportAction42Action"/>
+        <Method name="validateExport"/>
+    </Match>
+    <Match>
+        <Bug pattern="XXE_DOCUMENT"/>
+        <Class name="io.github.carlos_emr.carlos.lab.ca.all.upload.handlers.IHAPOIHandler"/>
+        <Method name="parseXml"/>
+    </Match>
+    <Match>
+        <Bug pattern="XXE_DOCUMENT"/>
+        <Class name="io.github.carlos_emr.carlos.lab.ca.all.upload.handlers.MEDITECHHandler"/>
+        <Method name="parseXml"/>
+    </Match>
+    <Match>
+        <Bug pattern="XXE_DOCUMENT"/>
+        <Class name="io.github.carlos_emr.carlos.lab.ca.all.upload.handlers.PATHL7Handler"/>
+        <Method name="parse"/>
+    </Match>
+    <Match>
+        <Bug pattern="XXE_DOCUMENT"/>
+        <Class name="io.github.carlos_emr.carlos.lab.ca.bc.PathNet.Connection"/>
+        <Method name="CreateDocument"/>
+    </Match>
+    <Match>
+        <Bug pattern="XXE_DOCUMENT"/>
+        <Class name="io.github.carlos_emr.carlos.lab.ca.all.upload.handlers.DefaultHandler"/>
+        <Method name="getXML"/>
+    </Match>
+    <Match>
+        <Bug pattern="XXE_DOCUMENT"/>
+        <Class name="io.github.carlos_emr.carlos.lab.ca.all.upload.handlers.ExcellerisOntarioHandler"/>
+        <Method name="parse"/>
+    </Match>
+    <Match>
+        <Bug pattern="XXE_DOCUMENT"/>
+        <Class name="io.github.carlos_emr.carlos.lab.ca.all.upload.handlers.IHAHandler"/>
+        <Method name="getXML"/>
+    </Match>
+    <Match>
+        <Bug pattern="XXE_SCHEMA_FACTORY"/>
+        <Class name="io.github.carlos_emr.carlos.hospitalReportManager.HRMReportParser"/>
+        <Method name="parseReport" params="io.github.carlos_emr.carlos.utility.LoggedInInfo,java.lang.String,java.util.List"/>
+    </Match>
+    <Match>
+        <Bug pattern="XXE_DOCUMENT"/>
+        <Class name="io.github.carlos_emr.carlos.messenger.docxfer.util.MsgCommxml"/>
+        <Method name="parseXML"/>
+    </Match>
+    <Match>
+        <Bug pattern="XXE_DOCUMENT"/>
+        <Class name="io.github.carlos_emr.carlos.messenger.docxfer.util.MsgCommxml"/>
+        <Method name="parseXMLFile"/>
+    </Match>
+    <Match>
+        <Bug pattern="XXE_DOCUMENT"/>
+        <Class name="io.github.carlos_emr.carlos.messenger.util.Msgxml"/>
+        <Method name="parseXML"/>
+    </Match>
+    <Match>
+        <Bug pattern="XXE_DOCUMENT"/>
+        <Class name="io.github.carlos_emr.carlos.prescript.util.SimpleXmlRpcClient"/>
+        <Method name="parseResponse"/>
+    </Match>
+    <Match>
+        <Bug pattern="XXE_DOCUMENT"/>
+        <Class name="io.github.carlos_emr.carlos.prescript.util.xml"/>
+        <Method name="parseXML"/>
+    </Match>
+    <Match>
+        <Bug pattern="XXE_DOCUMENT"/>
+        <Class name="io.github.carlos_emr.carlos.util.UtilXML"/>
+        <Method name="parseXML"/>
+    </Match>
+    <Match>
+        <Bug pattern="XXE_DOCUMENT"/>
+        <Class name="io.github.carlos_emr.carlos.util.UtilXML"/>
+        <Method name="parseXMLFile"/>
+    </Match>
+    <Match>
+        <Bug pattern="XXE_DOCUMENT"/>
+        <Class name="io.github.carlos_emr.carlos.utility.XmlUtils"/>
+        <Method name="toDocument"/>
+    </Match>
+
+    <!-- No shell is invoked: commands are fixed or configured executable arrays,
+         with working directories validated before Runtime.exec. -->
+    <Match>
+        <Bug pattern="COMMAND_INJECTION"/>
+        <Class name="io.github.carlos_emr.carlos.demographic.pageUtil.PGPEncrypt"/>
+        <Method name="check"/>
+    </Match>
+    <Match>
+        <Bug pattern="COMMAND_INJECTION"/>
+        <Class name="io.github.carlos_emr.carlos.demographic.pageUtil.PGPEncrypt"/>
+        <Method name="encrypt"/>
+    </Match>
+    <Match>
+        <Bug pattern="COMMAND_INJECTION"/>
+        <Class name="io.github.carlos_emr.carlos.managers.AuditLogManager"/>
+        <Method name="purgeAuditLog"/>
+    </Match>
+
+    <!-- Logout creates empty maxAge(0) deletion cookies; it is not storing
+         sensitive data in insecure cookies. -->
+    <Match>
+        <Bug pattern="INSECURE_COOKIE"/>
+        <Class name="io.github.carlos_emr.carlos.login.Logout2Action"/>
+        <Method name="logout"/>
+    </Match>
+    <Match>
+        <Bug pattern="COOKIE_USAGE"/>
+        <Class name="io.github.carlos_emr.carlos.login.Logout2Action"/>
+        <Method name="logout"/>
+    </Match>
+
+    <!-- ObjectInputFilter is installed before readObject, and file inputs are
+         validated before ObjectInputStream construction. -->
+    <Match>
+        <Bug pattern="OBJECT_DESERIALIZATION"/>
+        <Class name="io.github.carlos_emr.carlos.utility.MiscUtils"/>
+        <Method name="deserialize"/>
+    </Match>
+    <Match>
+        <Bug pattern="OBJECT_DESERIALIZATION"/>
+        <Class name="io.github.carlos_emr.carlos.utility.MiscUtils"/>
+        <Method name="deserializeFromFile"/>
+    </Match>
+
+    <!-- Random values are local filenames/cache busters, not secrets, tokens,
+         credentials, or authorization decisions. -->
+    <Match>
+        <Bug pattern="PREDICTABLE_RANDOM"/>
+        <Class name="io.github.carlos_emr.carlos.lab.ca.all.web.SubmitLabByForm2Action"/>
+        <Method name="saveManage"/>
+    </Match>
+    <Match>
+        <Bug pattern="PREDICTABLE_RANDOM"/>
+        <Class name="io.github.carlos_emr.carlos.billings.ca.bc.Teleplan.TeleplanResponse"/>
+        <Method name="processResponseStream"/>
+    </Match>
+
+    <!-- Redirects are context-relative/validated or fixed-host with URL-encoded
+         query values. Host-header hardening alert #21966 remains out of scope. -->
+    <Match>
+        <Bug pattern="UNVALIDATED_REDIRECT"/>
+        <Class name="io.github.carlos_emr.carlos.casemgmt.web.CaseManagementEntry2Action"/>
+        <Method name="saveAndExit"/>
+    </Match>
+    <Match>
+        <Bug pattern="UNVALIDATED_REDIRECT"/>
+        <Class name="io.github.carlos_emr.carlos.prescript.pageUtil.RxDrugInfo2Action"/>
+        <Method name="execute"/>
+    </Match>
+
+    <!-- Servlet metadata is used for multipart parsing, AJAX detection, OAuth
+         canonicalization, or encoded reload URL propagation, not authorization
+         or raw response output. -->
+    <Match>
+        <Bug pattern="SERVLET_CONTENT_TYPE"/>
+        <Class name="io.github.carlos_emr.carlos.billings.MSP.DocumentTeleplanReportUploadServlet"/>
+        <Method name="service"/>
+    </Match>
+    <Match>
+        <Bug pattern="SERVLET_QUERY_STRING"/>
+        <Class name="io.github.carlos_emr.carlos.casemgmt.web.CaseManagementView2Action"/>
+        <Method name="listNotes"/>
+    </Match>
+    <Match>
+        <Bug pattern="SERVLET_HEADER"/>
+        <Class name="io.github.carlos_emr.carlos.commn.printing.PrivacyStatementAppendingFilter"/>
+        <Method name="doFilter"/>
+    </Match>
+    <Match>
+        <Bug pattern="SERVLET_QUERY_STRING"/>
+        <Class name="io.github.carlos_emr.carlos.encounter.pageUtil.EctDisplayAction"/>
+        <Method name="execute"/>
+    </Match>
+    <Match>
+        <Bug pattern="SERVLET_SERVER_NAME"/>
+        <Class name="io.github.carlos_emr.carlos.util.FullPathReWrite"/>
+        <Method name="doStartTag"/>
+    </Match>
+    <Match>
+        <Bug pattern="SERVLET_CONTENT_TYPE"/>
+        <Class name="io.github.carlos_emr.carlos.webserv.oauth.util.OAuth1ParamParser"/>
+        <Method name="parseFromRequest"/>
+    </Match>
+    <Match>
+        <Bug pattern="SERVLET_HEADER"/>
+        <Class name="io.github.carlos_emr.carlos.webserv.oauth.util.OAuth1ParamParser"/>
+        <Method name="parseFromRequest"/>
+    </Match>
+    <Match>
+        <Bug pattern="SERVLET_QUERY_STRING"/>
+        <Class name="io.github.carlos_emr.carlos.webserv.oauth.util.OAuth1ParamParser"/>
+        <Method name="parseFromRequest"/>
+    </Match>
+    <Match>
+        <Bug pattern="SERVLET_CONTENT_TYPE"/>
+        <Class name="io.github.carlos_emr.carlos.webserv.oauth.util.OAuth1SignatureVerifierImplementation"/>
+        <Method name="verify"/>
+    </Match>
+    <Match>
+        <Bug pattern="SERVLET_QUERY_STRING"/>
+        <Class name="io.github.carlos_emr.carlos.webserv.oauth.util.OAuth1SignatureVerifierImplementation"/>
+        <Method name="verify"/>
+    </Match>
+    <Match>
+        <Bug pattern="SERVLET_SERVER_NAME"/>
+        <Class name="io.github.carlos_emr.carlos.webserv.oauth.util.OAuth1SignatureVerifierImplementation"/>
+        <Method name="verify"/>
+    </Match>
+    <Match>
+        <Bug pattern="SERVLET_HEADER"/>
+        <Class name="io.github.carlos_emr.carlos.webserv.oauth.util.OAuthRequestParser"/>
+        <Method name="isOAuth1Request"/>
+    </Match>
+
     <!-- ================================================================
          FIND SECURITY BUGS INFORMATIONAL TAINT-SOURCE / ENDPOINT MARKERS
          These detectors are NOT vulnerabilities. Find Security Bugs emits

--- a/.github/workflows/i18n-validation-workflow.yml
+++ b/.github/workflows/i18n-validation-workflow.yml
@@ -67,9 +67,11 @@ jobs:
 
       - name: Extract keys added to English in this PR
         id: new_keys
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
           # Find keys added to English properties in this PR
-          NEW_EN_KEYS=$(git diff origin/${{ github.base_ref }}...HEAD \
+          NEW_EN_KEYS=$(git diff "origin/${BASE_REF}"...HEAD \
             -- src/main/resources/oscarResources_en.properties \
             | grep '^+' | grep -v '^+++' | grep -Ev '^\+[[:space:]]*[#!]' \
             | sed 's/^+//' | sed -E 's/[[:space:]]*[=:].*//' | sed 's/[[:space:]]*$//' \
@@ -149,6 +151,8 @@ jobs:
           fetch-depth: 0
 
       - name: Check new/modified JSPs for missing fmt:setBundle
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
           has_inherited_bundle() {
             local jsp="$1"
@@ -174,7 +178,7 @@ jobs:
           }
 
           # Only check JSP files changed in this PR
-          CHANGED_JSPS=$(git diff --name-only origin/${{ github.base_ref }}...HEAD \
+          CHANGED_JSPS=$(git diff --name-only "origin/${BASE_REF}"...HEAD \
             | grep -E '\.jspf?$' | grep -v '^test' || true)
 
           if [ -z "$CHANGED_JSPS" ]; then

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -14,6 +14,7 @@ src/main/java/io/github/carlos_emr/carlos/ar2005/
 # Test sources (Semgrep Cloud excludes by default, explicit for CLI)
 src/test/
 src/test-modern/
+.claude/hooks/test-sql-safety-hook.sh
 
 # Non-code assets
 database/

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -14,7 +14,7 @@ src/main/java/io/github/carlos_emr/carlos/ar2005/
 # Test sources (Semgrep Cloud excludes by default, explicit for CLI)
 src/test/
 src/test-modern/
-.claude/hooks/test-sql-safety-hook.sh
+.claude/hooks/test-sql-safety-fixtures.json
 
 # Non-code assets
 database/

--- a/scripts/browser-surface-playwright-checks.js
+++ b/scripts/browser-surface-playwright-checks.js
@@ -106,7 +106,7 @@ function wirePage(page, label) {
 
 async function gotoApp(page, appPath, waitUntil = 'domcontentloaded') {
   // appUrl validates that this remains inside the configured CARLOS base URL.
-  return page.goto(appUrl(appPath), { waitUntil, timeout: 30000 });
+  return page.goto(appUrl(appPath), { waitUntil, timeout: 30000 }); // nosemgrep: javascript.playwright.security.audit.playwright-goto-injection.playwright-goto-injection -- appUrl rejects non-root-relative paths and validateBaseUrl restricts hosts to local/private by default
 }
 
 async function login(context) {
@@ -253,7 +253,7 @@ async function checkAdminPage(context, appPath, label, requiredText) {
   if (requiredText) {
     await page.locator('body').filter({ hasText: requiredText }).waitFor({ state: 'visible', timeout: 15000 });
   }
-  await page.screenshot({ path: path.join(screenshotDir, `surface-${label}.png`), fullPage: true });
+  await page.screenshot({ path: path.join(screenshotDir, `surface-${label}.png`), fullPage: true }); // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal -- local Playwright helper writes screenshots under caller-selected local artifact dir
   await page.close();
 }
 

--- a/scripts/echart-playwright-checks.js
+++ b/scripts/echart-playwright-checks.js
@@ -118,7 +118,7 @@ function wirePage(page, label) {
 async function loginAndOpenSearch(context) {
   const page = await context.newPage();
   wirePage(page, 'schedule');
-  await page.goto(appUrl('/'), { waitUntil: 'domcontentloaded' });
+  await page.goto(appUrl('/'), { waitUntil: 'domcontentloaded' }); // nosemgrep: javascript.playwright.security.audit.playwright-goto-injection.playwright-goto-injection -- appUrl rejects non-root-relative paths and validateBaseUrl restricts hosts to local/private by default
   await page.locator('#username').fill(testUser);
   await page.locator('#password').fill(testPassword);
   await page.locator('#pin').fill(testPin);
@@ -181,7 +181,7 @@ async function assertVisible(page, selector, label) {
 }
 
 async function screenshot(page, name) {
-  await page.screenshot({ path: path.join(screenshotDir, `${name}.png`), fullPage: true });
+  await page.screenshot({ path: path.join(screenshotDir, `${name}.png`), fullPage: true }); // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal -- local Playwright helper writes screenshots under caller-selected local artifact dir
 }
 
 (async () => {

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/Teleplan/TeleplanResponse.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/Teleplan/TeleplanResponse.java
@@ -38,6 +38,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import org.apache.logging.log4j.Logger;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.PathValidationUtils;
@@ -64,6 +66,9 @@ public class TeleplanResponse {
     }
 
 
+    // FindSecBugs PREDICTABLE_RANDOM: Math.random only adds a local Teleplan temp filename suffix.
+    // Do not use this suppression for secrets, tokens, authorization, or request-controlled random values.
+    @SuppressFBWarnings(value = "PREDICTABLE_RANDOM", justification = "Math.random only creates a local Teleplan temporary filename suffix, not a secret, token, or authorization decision")
     void processResponseStream(InputStream in) {
         File tempFile = null;
         try {

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/BillingSaveBilling2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/BillingSaveBilling2Action.java
@@ -545,13 +545,14 @@ public class BillingSaveBilling2Action extends ActionSupport {
         return redirectUrl.toString();
     }
 
-    private void sendReceiptRedirect(HttpServletResponse response, String redirectUrl) throws IOException { // nosemgrep: java.lang.security.audit.unvalidated-redirect.unvalidated-redirect -- redirectUrl is generated server-side by receiptRedirectUrl(...), URL-encodes billing_no values, and is accepted only after RedirectValidationUtils.isValidRelativeRedirect(...)
+    private void sendReceiptRedirect(HttpServletResponse response, String redirectUrl) throws IOException {
         if (!RedirectValidationUtils.isValidRelativeRedirect(redirectUrl)) {
             log.error("Refused unsafe BC billing receipt redirect: redirectUrl={}",
                     LogSafe.sanitize(redirectUrl));
             response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
             return;
         }
+        // nosemgrep: java.lang.security.audit.unvalidated-redirect.unvalidated-redirect -- redirectUrl is generated server-side by receiptRedirectUrl(...), URL-encodes billing_no values, and is accepted only after RedirectValidationUtils.isValidRelativeRedirect(...)
         response.sendRedirect(redirectUrl);
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/BillingSaveBilling2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/BillingSaveBilling2Action.java
@@ -545,14 +545,13 @@ public class BillingSaveBilling2Action extends ActionSupport {
         return redirectUrl.toString();
     }
 
-    private void sendReceiptRedirect(HttpServletResponse response, String redirectUrl) throws IOException {
+    private void sendReceiptRedirect(HttpServletResponse response, String redirectUrl) throws IOException { // nosemgrep: java.lang.security.audit.unvalidated-redirect.unvalidated-redirect -- redirectUrl is generated server-side by receiptRedirectUrl(...), URL-encodes billing_no values, and is accepted only after RedirectValidationUtils.isValidRelativeRedirect(...)
         if (!RedirectValidationUtils.isValidRelativeRedirect(redirectUrl)) {
             log.error("Refused unsafe BC billing receipt redirect: redirectUrl={}",
                     LogSafe.sanitize(redirectUrl));
             response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
             return;
         }
-        // nosemgrep: java.lang.security.audit.unvalidated-redirect.unvalidated-redirect -- redirectUrl is generated server-side by receiptRedirectUrl(...), URL-encodes billing_no values, and is accepted only after RedirectValidationUtils.isValidRelativeRedirect(...)
         response.sendRedirect(redirectUrl);
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/service/BillingClaimSubmissionService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/service/BillingClaimSubmissionService.java
@@ -380,7 +380,7 @@ public class BillingClaimSubmissionService {
         claim1Header = claim1Header.withProviderRmaNo("");
         claim1Header = claim1Header.withAppointmentProviderNo(val.getParameter("apptProvider_no"));
         claim1Header = claim1Header.withAssistantProviderNo("");
-        claim1Header = claim1Header.withCreator((String) val.getSession().getAttribute("user"));
+        claim1Header = claim1Header.withCreator((String) val.getSession().getAttribute("user")); // nosemgrep: java.servlets.security.tainted-session-from-http-request.tainted-session-from-http-request -- reads authenticated user from existing session; does not write request data into session
 
         claim1Header = claim1Header.withClinic(val.getParameter("site"));
 
@@ -483,7 +483,7 @@ public class BillingClaimSubmissionService {
         claim1Header = claim1Header.withProviderRmaNo("");
         claim1Header = claim1Header.withAppointmentProviderNo(val.getParameter("apptProvider_no"));
         claim1Header = claim1Header.withAssistantProviderNo("");
-        claim1Header = claim1Header.withCreator((String) val.getSession().getAttribute("user"));
+        claim1Header = claim1Header.withCreator((String) val.getSession().getAttribute("user")); // nosemgrep: java.servlets.security.tainted-session-from-http-request.tainted-session-from-http-request -- reads authenticated user from existing session; does not write request data into session
         claim1Header = claim1Header.withClinic(val.getParameter("site"));
 
         return claim1Header;

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDaoImpl.java
@@ -2421,17 +2421,17 @@ public class DemographicDaoImpl extends AbstractJpaDao implements ApplicationEve
         }
 
         EntityManager s = entityManager();
-            Query q = s.createQuery(sql); // nosemgrep: java.lang.security.audit.formatted-sql-string.formatted-sql-string, java.lang.security.audit.sqli.jpa-sqli.jpa-sqli -- field/order names are allowlisted above; fieldValue is bound via setParameter below
-            if (!isFieldValueEmpty) {
-                q.setParameter("fieldValue", fieldValue);
-            }
+        Query q = s.createQuery(sql); // nosemgrep: java.lang.security.audit.formatted-sql-string.formatted-sql-string, java.lang.security.audit.sqli.jpa-sqli.jpa-sqli -- field/order names are allowlisted above; fieldValue is bound via setParameter below
+        if (!isFieldValueEmpty) {
+            q.setParameter("fieldValue", fieldValue);
+        }
 
-            q.setMaxResults(10);
+        q.setMaxResults(10);
 
-            if (offset > 0) {
-                q.setFirstResult(offset);
-            }
-            return q.getResultList();
+        if (offset > 0) {
+            q.setFirstResult(offset);
+        }
+        return q.getResultList();
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDaoImpl.java
@@ -2654,7 +2654,7 @@ public class DemographicDaoImpl extends AbstractJpaDao implements ApplicationEve
         MiscUtils.getLogger().debug("demographicQuery: {}", LogSafe.sanitize(demographicQuery, 1000));
 
         EntityManager session = entityManager();
-            Query sqlQuery = session.createNativeQuery(demographicQuery); // nosemgrep: java.lang.security.audit.formatted-sql-string.formatted-sql-string -- generateDemographicSearchQuery allowlists SQL fragments and returns bound params separately
+            Query sqlQuery = session.createNativeQuery(demographicQuery); // nosemgrep: java.lang.security.audit.formatted-sql-string.formatted-sql-string -- generateDemographicSearchQuery builds SQL from enum-selected column/order fragments plus a server-owned inactive_statuses config list; all request values flow through bound params (setParameter below)
             for (String key : params.keySet()) {
                 sqlQuery.setParameter(key, params.get(key));
                 MiscUtils.getLogger().debug("query param: {}={}", LogSafe.sanitize(key),
@@ -2676,7 +2676,7 @@ public class DemographicDaoImpl extends AbstractJpaDao implements ApplicationEve
                 "p.first_name as providerFirstName,d.hin,dm.merged_to");
 
         EntityManager session = entityManager();
-        NativeQuery<?> baseQuery = session.createNativeQuery(demographicQuery).unwrap(NativeQuery.class); // nosemgrep: java.lang.security.audit.formatted-sql-string.formatted-sql-string -- generateDemographicSearchQuery allowlists SQL fragments and returns bound params separately
+        NativeQuery<?> baseQuery = session.createNativeQuery(demographicQuery).unwrap(NativeQuery.class); // nosemgrep: java.lang.security.audit.formatted-sql-string.formatted-sql-string -- generateDemographicSearchQuery builds SQL from enum-selected column/order fragments plus a server-owned inactive_statuses config list; all request values flow through bound params (setParameter below)
 
         for (String key : params.keySet()) {
             baseQuery.setParameter(key, params.get(key));

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDaoImpl.java
@@ -2421,7 +2421,7 @@ public class DemographicDaoImpl extends AbstractJpaDao implements ApplicationEve
         }
 
         EntityManager s = entityManager();
-            Query q = s.createQuery(sql); // nosemgrep: hibernate-sqli — query uses named parameter :fieldValue bound via setParameter below
+            Query q = s.createQuery(sql); // nosemgrep: java.lang.security.audit.formatted-sql-string.formatted-sql-string, java.lang.security.audit.sqli.jpa-sqli.jpa-sqli -- field/order names are allowlisted above; fieldValue is bound via setParameter below
             if (!isFieldValueEmpty) {
                 q.setParameter("fieldValue", fieldValue);
             }
@@ -2654,7 +2654,7 @@ public class DemographicDaoImpl extends AbstractJpaDao implements ApplicationEve
         MiscUtils.getLogger().debug("demographicQuery: {}", LogSafe.sanitize(demographicQuery, 1000));
 
         EntityManager session = entityManager();
-            Query sqlQuery = session.createNativeQuery(demographicQuery);
+            Query sqlQuery = session.createNativeQuery(demographicQuery); // nosemgrep: java.lang.security.audit.formatted-sql-string.formatted-sql-string -- generateDemographicSearchQuery allowlists SQL fragments and returns bound params separately
             for (String key : params.keySet()) {
                 sqlQuery.setParameter(key, params.get(key));
                 MiscUtils.getLogger().debug("query param: {}={}", LogSafe.sanitize(key),
@@ -2676,7 +2676,7 @@ public class DemographicDaoImpl extends AbstractJpaDao implements ApplicationEve
                 "p.first_name as providerFirstName,d.hin,dm.merged_to");
 
         EntityManager session = entityManager();
-        NativeQuery<?> baseQuery = session.createNativeQuery(demographicQuery).unwrap(NativeQuery.class);
+        NativeQuery<?> baseQuery = session.createNativeQuery(demographicQuery).unwrap(NativeQuery.class); // nosemgrep: java.lang.security.audit.formatted-sql-string.formatted-sql-string -- generateDemographicSearchQuery allowlists SQL fragments and returns bound params separately
 
         for (String key : params.keySet()) {
             baseQuery.setParameter(key, params.get(key));

--- a/src/main/java/io/github/carlos_emr/carlos/db/LegacyJdbcQuery.java
+++ b/src/main/java/io/github/carlos_emr/carlos/db/LegacyJdbcQuery.java
@@ -175,7 +175,7 @@ public final class LegacyJdbcQuery {
         PreparedStatement ps = null;
         try {
             // codeql[java/sql-injection] -- TrustedSql is constructed only after legacy SELECT validation; values are bound below.
-            ps = connection.prepareStatement(sql.sql, ResultSet.TYPE_SCROLL_SENSITIVE,
+            ps = connection.prepareStatement(sql.sql, ResultSet.TYPE_SCROLL_SENSITIVE, // nosemgrep: java.lang.security.audit.formatted-sql-string-deepsemgrep.formatted-sql-string-deepsemgrep -- TrustedSql is constructed only after legacy SELECT validation; values are bound below
                     updatable ? ResultSet.CONCUR_UPDATABLE : ResultSet.CONCUR_READ_ONLY);
             bindParams(ps, params);
             ResultSet rs = ps.executeQuery(); // NOSONAR javasecurity:S3649 -- parameterized query boundary
@@ -193,7 +193,7 @@ public final class LegacyJdbcQuery {
         PreparedStatement ps = null;
         try {
             // codeql[java/sql-injection] -- Raw legacy overload is restricted to caller-owned SQL shape; request-driven SQL uses TrustedSql or ParameterizedSql.
-            ps = connection.prepareStatement(sql, ResultSet.TYPE_SCROLL_SENSITIVE,
+            ps = connection.prepareStatement(sql, ResultSet.TYPE_SCROLL_SENSITIVE, // nosemgrep: java.lang.security.audit.formatted-sql-string-deepsemgrep.formatted-sql-string-deepsemgrep -- raw legacy overload is restricted to caller-owned SQL shape; values are bound below
                     updatable ? ResultSet.CONCUR_UPDATABLE : ResultSet.CONCUR_READ_ONLY);
             bindParams(ps, params);
             ResultSet rs = ps.executeQuery(); // NOSONAR javasecurity:S3649 -- parameterized query boundary

--- a/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/PGPEncrypt.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/PGPEncrypt.java
@@ -35,6 +35,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.PathValidationUtils;
 
@@ -65,6 +67,9 @@ public class PGPEncrypt {
             MiscUtils.getLogger().debug("Warning: PGP environment variable (PGP_ENV) not set!");
     }
 
+    // FindSecBugs COMMAND_INJECTION: only static touch and configured PGP argv arrays run in a validated directory.
+    // Do not add request-controlled command fragments under this suppression.
+    @SuppressFBWarnings(value = "COMMAND_INJECTION", justification = "only a static touch command and configured PGP argv arrays run in a PathValidationUtils-validated directory; no request-controlled command fragments")
     public boolean check(String dirName) throws Exception {
         if (!Util.checkDir(dirName)) {
             MiscUtils.getLogger().debug("Error! Cannot write to directory [" + dirName + "]");
@@ -109,6 +114,9 @@ public class PGPEncrypt {
         return rtrn;
     }
 
+    // FindSecBugs COMMAND_INJECTION: PGP invocation uses an argv array from trusted configuration in a validated work directory.
+    // Do not add request-controlled command fragments under this suppression.
+    @SuppressFBWarnings(value = "COMMAND_INJECTION", justification = "PGP invocation uses an argv array from trusted configuration in a PathValidationUtils-validated work directory; no shell expansion")
     boolean encrypt(String srcFile, String workDir) throws Exception {
         if (!Util.checkDir(workDir)) {
             MiscUtils.getLogger().debug("Error! Cannot write to directory [" + workDir + "]");

--- a/src/main/java/io/github/carlos_emr/carlos/lab/ca/all/web/SubmitLabByForm2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/lab/ca/all/web/SubmitLabByForm2Action.java
@@ -90,8 +90,10 @@ public class SubmitLabByForm2Action extends ActionSupport {
      * @throws SecurityException if the current user lacks the required "_lab" write privilege
      * @throws Exception for parse, I/O, or handler invocation errors that are propagated to the caller
      */
-    // FindSecBugs PATH_TRAVERSAL_IN: path validated for directory containment via PathValidationUtils before use
-    @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "path validated for directory containment via PathValidationUtils before use")
+    // FindSecBugs PATH_TRAVERSAL_IN: path validated for directory containment via PathValidationUtils before use.
+    // FindSecBugs PREDICTABLE_RANDOM: Math.random only adds a local HL7 filename suffix.
+    // Do not use this suppression for secrets, tokens, authorization, or request-controlled random values.
+    @SuppressFBWarnings(value = {"PATH_TRAVERSAL_IN", "PREDICTABLE_RANDOM"}, justification = "PATH_TRAVERSAL_IN: path validated for directory containment via PathValidationUtils before use. PREDICTABLE_RANDOM: Math.random only creates a local HL7 filename suffix, not a secret, token, or authorization decision")
     public String saveManage() throws Exception {
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
         String providerNo = loggedInInfo.getLoggedInProviderNo();

--- a/src/main/java/io/github/carlos_emr/carlos/login/LoginCheckLoginBean.java
+++ b/src/main/java/io/github/carlos_emr/carlos/login/LoginCheckLoginBean.java
@@ -127,8 +127,8 @@ public final class LoginCheckLoginBean {
             justification = "BCrypt timing-equalization decoy: a pre-computed hash of a random "
                     + "throwaway password with no usable plaintext, used only to make "
                     + "missing-user paths take the same wall-clock time as real password checks")
-    private static final String MISSING_USER_DUMMY_PASSWORD_HASH = // NOSONAR java:S2068,secrets:S8215 - BCrypt decoy hash for timing equalization; not a usable credential
-            "{bcrypt}$2b$10$YzOXP.2axkRiYS07sVHWkuyvQjcuwR.bGeZd5WHQVJ23py57UES8C"; // nosemgrep: generic.secrets.security.detected-bcrypt-hash.detected-bcrypt-hash -- BCrypt decoy hash for missing-user timing equalization; not a credential
+    private static final String MISSING_USER_DUMMY_PASSWORD_HASH =
+            "{bcrypt}$2b$10$YzOXP.2axkRiYS07sVHWkuyvQjcuwR.bGeZd5WHQVJ23py57UES8C"; // NOSONAR java:S2068,secrets:S8215 -- BCrypt decoy hash for timing equalization; not a usable credential // nosemgrep: generic.secrets.security.detected-bcrypt-hash.detected-bcrypt-hash -- BCrypt decoy hash for missing-user timing equalization; not a credential
 
     /** Security manager for password encoding, validation, and hash migration */
     private final SecurityManager securityManager = SpringUtils.getBean(SecurityManager.class);

--- a/src/main/java/io/github/carlos_emr/carlos/login/LoginCheckLoginBean.java
+++ b/src/main/java/io/github/carlos_emr/carlos/login/LoginCheckLoginBean.java
@@ -127,8 +127,8 @@ public final class LoginCheckLoginBean {
             justification = "BCrypt timing-equalization decoy: a pre-computed hash of a random "
                     + "throwaway password with no usable plaintext, used only to make "
                     + "missing-user paths take the same wall-clock time as real password checks")
-    private static final String MISSING_USER_DUMMY_PASSWORD_HASH =
-            "{bcrypt}$2b$10$YzOXP.2axkRiYS07sVHWkuyvQjcuwR.bGeZd5WHQVJ23py57UES8C"; // NOSONAR java:S2068,secrets:S8215 — BCrypt decoy hash for timing equalization; not a usable credential
+    private static final String MISSING_USER_DUMMY_PASSWORD_HASH = // NOSONAR java:S2068,secrets:S8215 - BCrypt decoy hash for timing equalization; not a usable credential
+            "{bcrypt}$2b$10$YzOXP.2axkRiYS07sVHWkuyvQjcuwR.bGeZd5WHQVJ23py57UES8C"; // nosemgrep: generic.secrets.security.detected-bcrypt-hash.detected-bcrypt-hash -- BCrypt decoy hash for missing-user timing equalization; not a credential
 
     /** Security manager for password encoding, validation, and hash migration */
     private final SecurityManager securityManager = SpringUtils.getBean(SecurityManager.class);

--- a/src/main/java/io/github/carlos_emr/carlos/login/Logout2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/login/Logout2Action.java
@@ -203,7 +203,7 @@ public class Logout2Action extends ActionSupport {
      */
     // FindSecBugs INSECURE_COOKIE/COOKIE_USAGE: logout writes empty maxAge(0) deletion cookies only.
     // Do not add persistent or sensitive cookie writes under this suppression.
-    @SuppressFBWarnings(value = {"INSECURE_COOKIE", "COOKIE_USAGE"}, justification = "logout only creates empty maxAge(0) deletion cookies with Secure, HttpOnly, and SameSite; it does not store sensitive cookie data")
+    @SuppressFBWarnings(value = {"INSECURE_COOKIE", "COOKIE_USAGE"}, justification = "logout only creates empty maxAge(0) deletion cookies with HttpOnly and SameSite=Strict, and Secure when the request is over HTTPS; it does not store sensitive cookie data")
     public String logout() {
 
         // Retrieve existing session without creating new one

--- a/src/main/java/io/github/carlos_emr/carlos/login/Logout2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/login/Logout2Action.java
@@ -29,6 +29,8 @@
 
 package io.github.carlos_emr.carlos.login;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import io.github.carlos_emr.carlos.log.LogAction;
 import io.github.carlos_emr.carlos.log.LogConst;
 
@@ -199,6 +201,9 @@ public class Logout2Action extends ActionSupport {
      * @see Cookie#setMaxAge(int) for cookie expiration
      * @see LogAction#addLog for audit logging
      */
+    // FindSecBugs INSECURE_COOKIE/COOKIE_USAGE: logout writes empty maxAge(0) deletion cookies only.
+    // Do not add persistent or sensitive cookie writes under this suppression.
+    @SuppressFBWarnings(value = {"INSECURE_COOKIE", "COOKIE_USAGE"}, justification = "logout only creates empty maxAge(0) deletion cookies with Secure, HttpOnly, and SameSite; it does not store sensitive cookie data")
     public String logout() {
 
         // Retrieve existing session without creating new one

--- a/src/main/java/io/github/carlos_emr/carlos/managers/AuditLogManager.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/AuditLogManager.java
@@ -38,6 +38,8 @@ import java.time.temporal.ChronoUnit;
 import java.util.Calendar;
 import java.util.Date;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import org.apache.logging.log4j.Logger;
 import io.github.carlos_emr.carlos.commn.dao.OscarLogDao;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
@@ -63,6 +65,9 @@ public class AuditLogManager {
     String dbName = CarlosProperties.getInstance().getProperty("db_name").substring(0, CarlosProperties.getInstance().getProperty("db_name").indexOf("?"));
 
 
+    // FindSecBugs COMMAND_INJECTION: Runtime.exec receives an argv array from trusted config and server-formatted date.
+    // Do not add request-controlled command arguments under this suppression.
+    @SuppressFBWarnings(value = "COMMAND_INJECTION", justification = "Runtime.exec uses an argv array built from trusted deployment config and a server-formatted date; no shell expansion or request-controlled command")
     public int purgeAuditLog(LoggedInInfo loggedInInfo, Date endDateToPurge) throws Exception {
 
         if (outputDirectory == null || outputDirectory.isEmpty()) {

--- a/src/main/java/io/github/carlos_emr/carlos/signature/action/SaveSignatureUpload2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/signature/action/SaveSignatureUpload2Action.java
@@ -181,7 +181,7 @@ public final class SaveSignatureUpload2Action extends ActionSupport {
                 return NONE;
             }
             try (FileOutputStream fos = new FileOutputStream(safeTarget)) {
-                fos.write(imageData);
+                fos.write(imageData); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- writes decoded image bytes to validated file target, not HTTP response HTML
                 MiscUtils.getLogger().debug("Signature uploaded: {}, size={}", LogSafe.sanitize(filename), imageData.length); // NOSONAR javasecurity:S5145 - sanitized with LogSafe
             } catch (IOException e) {
                 MiscUtils.getLogger().error("Error uploading signature from IPAD: {}", LogSafe.sanitize(filename), e); // NOSONAR javasecurity:S5145 - sanitized with LogSafe

--- a/src/main/java/io/github/carlos_emr/carlos/util/zip.java
+++ b/src/main/java/io/github/carlos_emr/carlos/util/zip.java
@@ -160,9 +160,9 @@ public class zip {
 
                     try (BufferedOutputStream dest = new BufferedOutputStream(new FileOutputStream(z), BUFFER)) {
                         while ((count = is.read(data, 0, BUFFER)) != -1) {
-                            dest.write(data, 0, count);
+                            dest.write(data, 0, count); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- writes ZIP entry bytes to a validated file target, not HTTP response HTML
                         }
-                        dest.flush();
+                        dest.flush(); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- flushes file output stream, not HTTP response HTML
                     }
                 }
             }

--- a/src/main/java/io/github/carlos_emr/carlos/utility/CustomInterfaceTag.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/CustomInterfaceTag.java
@@ -110,7 +110,7 @@ public class CustomInterfaceTag extends TagSupport {
                         customTag = "ocean-host=" + Encode.forUriComponent(props.getProperty("ocean_host"));
                     }
 
-                    int randomNo = new Random().nextInt();
+                    int randomNo = new Random().nextInt(); // nosemgrep: java.lang.security.audit.crypto.weak-random.weak-random -- cache-busting query value only; not a token, secret, or authorization decision
                     out.println("<script id=\"mainScript\" src=\"" + contextPath + scriptPath + "?no-cache=" + randomNo + "&autoRefresh=true\" hide_ConReport=\"" + hide_ConReport + "\" cardswipe=\"" + cardswipe + "\" " + customTag + " ></script>");
                 }
             } catch (IOException e) {

--- a/src/main/java/io/github/carlos_emr/carlos/utility/CustomInterfaceTag.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/CustomInterfaceTag.java
@@ -32,7 +32,7 @@ package io.github.carlos_emr.carlos.utility;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Random;
+import java.util.UUID;
 
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpServletRequest;
@@ -110,8 +110,8 @@ public class CustomInterfaceTag extends TagSupport {
                         customTag = "ocean-host=" + Encode.forUriComponent(props.getProperty("ocean_host"));
                     }
 
-                    int randomNo = new Random().nextInt(); // nosemgrep: java.lang.security.audit.crypto.weak-random.weak-random -- cache-busting query value only; not a token, secret, or authorization decision
-                    out.println("<script id=\"mainScript\" src=\"" + contextPath + scriptPath + "?no-cache=" + randomNo + "&autoRefresh=true\" hide_ConReport=\"" + hide_ConReport + "\" cardswipe=\"" + cardswipe + "\" " + customTag + " ></script>");
+                    String cacheBuster = UUID.randomUUID().toString();
+                    out.println("<script id=\"mainScript\" src=\"" + contextPath + scriptPath + "?no-cache=" + cacheBuster + "&autoRefresh=true\" hide_ConReport=\"" + hide_ConReport + "\" cardswipe=\"" + cardswipe + "\" " + customTag + " ></script>");
                 }
             } catch (IOException e) {
                 logger.error("Error", e);

--- a/src/main/java/io/github/carlos_emr/carlos/utility/MiscUtils.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/MiscUtils.java
@@ -257,9 +257,9 @@ public final class MiscUtils {
     }
 
     // FP for deserialization scanners: same DESERIALIZATION_FILTER as deserialize(byte[])
-    // above; callers pass filenames that resolve to internal classpath resources or files
-    // written by the application itself (not user-uploaded bytes).
-    @SuppressFBWarnings(value = "OBJECT_DESERIALIZATION", justification = "ObjectInputFilter is installed before readObject, and file inputs are validated before ObjectInputStream construction")
+    // above; callers pass filenames that resolve to internal classpath resources or
+    // validated configured files written by the application itself (not user-uploaded bytes).
+    @SuppressFBWarnings(value = "OBJECT_DESERIALIZATION", justification = "ObjectInputFilter is installed before readObject; inputs are internal classpath resources or validated configured files")
     public static Serializable deserializeFromFile(String filename) throws IOException, ClassNotFoundException { // lgtm[java/unsafe-deserialization]
         InputStream rawIs = MiscUtils.class.getResourceAsStream(filename);
         if (rawIs == null) {

--- a/src/main/java/io/github/carlos_emr/carlos/utility/MiscUtils.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/MiscUtils.java
@@ -231,6 +231,7 @@ public final class MiscUtils {
     // to java.lang/util/io/math + the project's own namespace. No project class defines
     // a side-effecting readObject/readResolve (verified via grep). Filter set BEFORE
     // readObject is called. Callers pass internally-serialized Integrator payloads.
+    @SuppressFBWarnings(value = "OBJECT_DESERIALIZATION", justification = "ObjectInputFilter is installed before readObject and limits classes/resources; callers pass internally serialized payloads")
     public static Serializable deserialize(byte[] b) throws IOException, ClassNotFoundException { // lgtm[java/unsafe-deserialization]
         try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(b))) {
             ois.setObjectInputFilter(DESERIALIZATION_FILTER);
@@ -258,6 +259,7 @@ public final class MiscUtils {
     // FP for deserialization scanners: same DESERIALIZATION_FILTER as deserialize(byte[])
     // above; callers pass filenames that resolve to internal classpath resources or files
     // written by the application itself (not user-uploaded bytes).
+    @SuppressFBWarnings(value = "OBJECT_DESERIALIZATION", justification = "ObjectInputFilter is installed before readObject, and file inputs are validated before ObjectInputStream construction")
     public static Serializable deserializeFromFile(String filename) throws IOException, ClassNotFoundException { // lgtm[java/unsafe-deserialization]
         InputStream rawIs = MiscUtils.class.getResourceAsStream(filename);
         if (rawIs == null) {

--- a/src/main/webapp/WEB-INF/jsp/waitinglist/DisplayWaitingList.jsp
+++ b/src/main/webapp/WEB-INF/jsp/waitinglist/DisplayWaitingList.jsp
@@ -236,6 +236,7 @@
         function goToPage() {
             document.forms[0].waitingListId.value =
                 document.forms[0].selectedWL.options[document.forms[0].selectedWL.selectedIndex].value;
+            // codeql[js/xss-through-dom] -- assigns a navigation URL; it does not reinterpret text as HTML.
             window.location = "<%=request.getContextPath()%>/waitinglist/SetupDisplayWaitingList?waitingListId=" +
                 document.forms[0].selectedWL.options[document.forms[0].selectedWL.selectedIndex].value;
         }

--- a/src/main/webapp/WEB-INF/jsp/waitinglist/DisplayWaitingList.jsp
+++ b/src/main/webapp/WEB-INF/jsp/waitinglist/DisplayWaitingList.jsp
@@ -234,11 +234,11 @@
     </form>
     <script type="text/javascript">
         function goToPage() {
-            document.forms[0].waitingListId.value =
+            var waitingListId =
                 document.forms[0].selectedWL.options[document.forms[0].selectedWL.selectedIndex].value;
-            // codeql[js/xss-through-dom] -- assigns a navigation URL; it does not reinterpret text as HTML.
+            document.forms[0].waitingListId.value = waitingListId;
             window.location = "<%=request.getContextPath()%>/waitinglist/SetupDisplayWaitingList?waitingListId=" +
-                document.forms[0].selectedWL.options[document.forms[0].selectedWL.selectedIndex].value;
+                encodeURIComponent(waitingListId); // codeql[js/xss-through-dom] -- assigns a navigation URL; it does not reinterpret text as HTML.
         }
 
         function popupEditWlNamePage() {

--- a/src/main/webapp/WEB-INF/jsp/waitinglist/DisplayWaitingList.jsp
+++ b/src/main/webapp/WEB-INF/jsp/waitinglist/DisplayWaitingList.jsp
@@ -238,7 +238,7 @@
                 document.forms[0].selectedWL.options[document.forms[0].selectedWL.selectedIndex].value;
             // codeql[js/xss-through-dom] -- assigns a navigation URL; it does not reinterpret text as HTML.
             window.location = "<%=request.getContextPath()%>/waitinglist/SetupDisplayWaitingList?waitingListId=" +
-                encodeURIComponent(document.forms[0].selectedWL.options[document.forms[0].selectedWL.selectedIndex].value);
+                document.forms[0].selectedWL.options[document.forms[0].selectedWL.selectedIndex].value;
         }
 
         function popupEditWlNamePage() {

--- a/src/main/webapp/WEB-INF/jsp/waitinglist/DisplayWaitingList.jsp
+++ b/src/main/webapp/WEB-INF/jsp/waitinglist/DisplayWaitingList.jsp
@@ -242,11 +242,12 @@
         }
 
         function popupEditWlNamePage() {
-            document.forms[0].waitingListId.value =
+            var waitingListId =
                 document.forms[0].selectedWL.options[document.forms[0].selectedWL.selectedIndex].value;
+            document.forms[0].waitingListId.value = waitingListId;
 
             var redirectPage = "<%=request.getContextPath()%>/waitinglist/WLEditWaitingListNameAction?waitingListId=" +
-                document.forms[0].selectedWL.options[document.forms[0].selectedWL.selectedIndex].value;
+                encodeURIComponent(waitingListId);
             popupDemographicPage(redirectPage);
         }
 

--- a/src/main/webapp/WEB-INF/jsp/waitinglist/DisplayWaitingList.jsp
+++ b/src/main/webapp/WEB-INF/jsp/waitinglist/DisplayWaitingList.jsp
@@ -238,7 +238,7 @@
                 document.forms[0].selectedWL.options[document.forms[0].selectedWL.selectedIndex].value;
             // codeql[js/xss-through-dom] -- assigns a navigation URL; it does not reinterpret text as HTML.
             window.location = "<%=request.getContextPath()%>/waitinglist/SetupDisplayWaitingList?waitingListId=" +
-                document.forms[0].selectedWL.options[document.forms[0].selectedWL.selectedIndex].value;
+                encodeURIComponent(document.forms[0].selectedWL.options[document.forms[0].selectedWL.selectedIndex].value);
         }
 
         function popupEditWlNamePage() {

--- a/src/test/java/io/github/carlos_emr/carlos/utility/XmlUtilsUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/utility/XmlUtilsUnitTest.java
@@ -25,13 +25,16 @@ import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
 import javax.xml.XMLConstants;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
+import java.io.ByteArrayInputStream;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 import java.net.URL;
 import java.util.Collections;
 import java.util.Set;
@@ -71,6 +74,27 @@ class XmlUtilsUnitTest extends CarlosUnitTestBase {
         Schema schema = factory.newSchema(new StreamSource(new StringReader(schemaContent)));
 
         assertThat(XmlUtils.createSecureValidator(schema)).isNotNull();
+    }
+
+    @Test
+    @DisplayName("should parse simple document through secure document builder")
+    void shouldParseSimpleDocument_withToDocument() throws Exception {
+        Document document = XmlUtils.toDocument(new ByteArrayInputStream("""
+                <root><child>ok</child></root>
+                """.getBytes(StandardCharsets.UTF_8)));
+
+        assertThat(document.getDocumentElement().getNodeName()).isEqualTo("root");
+        assertThat(document.getElementsByTagName("child").item(0).getTextContent()).isEqualTo("ok");
+    }
+
+    @Test
+    @DisplayName("should reject DOCTYPE declarations through toDocument")
+    void shouldRejectDoctypeDeclarations_withToDocument() {
+        assertThatThrownBy(() -> XmlUtils.toDocument(new ByteArrayInputStream("""
+                <!DOCTYPE root [<!ENTITY xxe SYSTEM "file:///etc/passwd">]>
+                <root>&xxe;</root>
+                """.getBytes(StandardCharsets.UTF_8))))
+                .isInstanceOf(SAXException.class);
     }
 
     @Test


### PR DESCRIPTION
## Summary

Implements the handling plan from #2833 for the confirmed scanner-only security false positives.

- Adds targeted SpotBugs filters for reviewed helper boundaries: SQL wrappers, secure `XmlUtils` XML parsing/schema/validator flows, no-shell command execution, deletion cookies, deserialization filters, non-secret randomness, redirects, and servlet metadata use.
- Adds exact Semgrep/Sonar/CodeQL suppression comments at reviewed call sites where scanner configuration cannot model the safe behavior.
- Excludes the SQL safety shell fixture from Semgrep while keeping the Python detector scanned and annotating its detector-regex false positive.
- Refactors `github.base_ref` workflow shell interpolation through an environment variable.

GitHub-side false-positive dismissals were already applied for CodeQL/Snyk groups that do not have a practical repo-side scanner mechanism: vendored DataTables, `billReceipt.jsp`, `DisplayWaitingList.jsp`, and `updatedemographicprovider.jsp`.

## Validation

- `semgrep --config .semgrep/ --validate`
- `python3 -m py_compile .claude/hooks/validate-sql-safety.py`
- `bash -n .claude/hooks/test-sql-safety-hook.sh`
- SpotBugs XML parse check
- `git diff --check`
- `mvn -B -DskipTests -Pskip-dependency-lock compile`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppresses confirmed scanner-only security false positives per #2833 with targeted `SpotBugs` excludes and precise `Semgrep`/`CodeQL` suppressions. Expands the SQL safety hook with JSON fixture tests and a rule to allow StringBuilder entity-name queries; no behavior changes.

- **Refactors**
  - Curated `SpotBugs` filters for safe boundaries: SQL wrappers, secure `XmlUtils`, `Runtime.exec` argv arrays, logout deletion cookies, filtered deserialization, non‑secret randomness, validated redirects, servlet metadata reads; added narrow `@SuppressFBWarnings` in methods for predictable random, command argv execution, cookie deletion, and deserialization filter usage; clarified deserialization suppression rationale on `MiscUtils` helpers.
  - Inline `nosemgrep`/`NOSONAR` where models fall short (Playwright `goto`/screenshot path joins, prepared/native SQL, redirect builders, session reads, validated file writes, JSP navigation); tightened JPA/native SQL notes to include server‑owned `inactive_statuses`.
  - SQL safety hook: allow StringBuilder entity‑name queries; annotate detector regex; move tests to `.claude/hooks/test-sql-safety-fixtures.json` and refactor the runner to read them; ignore fixtures in `.semgrepignore`. Added `XmlUtils` tests to confirm secure parsing and DOCTYPE rejection.
  - Replace Random-based cache buster with `UUID` in `CustomInterfaceTag`.

- **Bug Fixes**
  - i18n workflow: use `BASE_REF` env for `git diff` in both steps.
  - Restore `NOSONAR` on bcrypt decoy; move unvalidated‑redirect suppression to the `sendRedirect` sink.
  - `DisplayWaitingList.jsp`: use `encodeURIComponent` for `waitingListId`.

<sup>Written for commit b5b135c5da0eea715c387a42738d3961cefe77a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2838?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

