### PR TITLE
fix: encoded provider name in appointmentviewrecordcard.jsp

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/appointment/appointmentviewrecordcard.jsp
+++ b/src/main/webapp/WEB-INF/jsp/appointment/appointmentviewrecordcard.jsp
@@ -215,7 +215,7 @@
                                     }
 
                                 %>
-                                <b style="font-size:14pt"><%=firstLine %>
+                                <b style="font-size:14pt"><carlos:encode value='<%= firstLine %>' context="html"/>
                                 </b><br/>
                                 <carlos:encode value='<%= provider.getSpecialty() %>' context="html"/><br/>
                                 <br/>


### PR DESCRIPTION
<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description

This addresses issue #2679. I encoded the provider name in the HTML so that a provider cannot set their card name to something that could render as a XSS if a user opens that provider's appointment view card.

## How Was This Tested?
To ensure code compiles and tests still pass I ran:
```makefile
make install --run-unit-tests
``` 
with following results:
```shell
[INFO] Results:
[INFO] 
[INFO] Tests run: 5118, Failures: 0, Errors: 0, Skipped: 6
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
``` 

## Checklist

- [X] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [X] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [X] I have not included any patient data (PHI) in this PR
- [X] I have added tests for new functionality, or this change doesn't need new tests
- [X] I have read the [contributing guide](CONTRIBUTING.md)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
HTML-encode the provider name in the appointment record card to prevent XSS when rendering untrusted names. Fixes #2679.

- **Bug Fixes**
  - Replaced `<%= firstLine %>` with `<carlos:encode value='<%= firstLine %>' context="html"/>` in `appointmentviewrecordcard.jsp`.

<sup>Written for commit 8ba1ac228e9c2b0c3dd96dc634d3822da500d082. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2845?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

