### PR TITLE
fix: remove PHI debug logging from MSP notes

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/MSPBillingNote.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/MSPBillingNote.java
@@ -40,7 +40,6 @@ import java.util.Date;
 import io.github.carlos_emr.Misc;
 import io.github.carlos_emr.carlos.billing.CA.BC.dao.BillingNoteDao;
 import io.github.carlos_emr.carlos.billing.CA.BC.model.BillingNotes;
-import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 
 import io.github.carlos_emr.carlos.util.ConversionUtils;
@@ -105,7 +104,6 @@ public class MSPBillingNote {
     Seventh - NOTE-DATA-LINE (400)
     */
     public static String getN01(String dataCenterNum, String dataCenterSeqNum, String payeeNum, String practitionerNum, String noteType, String note) {
-        MiscUtils.getLogger().debug("LOOKATME:" + note);
         String s = "N01" + Misc.forwardZero(dataCenterNum, 5) + Misc.forwardZero(dataCenterSeqNum, 7) + Misc.forwardZero(payeeNum, 5) + Misc.forwardZero(practitionerNum, 5) + Misc.forwardSpace(noteType, 1) + Misc.backwardSpace(Misc.stripLineBreaks(note), 400);
         return s;
     }


### PR DESCRIPTION
## Description

Removes the leftover `LOOKATME` debug log from `MSPBillingNote.getN01(...)` so MSP N01 correspondence note text is not written to logs. Also removes the now-unused `MiscUtils` import.

## Related Issues

Fixes #2851

## How Was This Tested?

- `mvn -DskipTests compile`

No focused unit test exists for `MSPBillingNote.getN01(...)`; the change removes logging only and preserves the generated N01 record logic.

## Screenshots

N/A - no visual changes.

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Bug Fixes:
- Stop writing MSP N01 note text to application logs by removing the leftover debug statement that logged the full note content.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed leftover debug logging from `MSPBillingNote.getN01(...)` that wrote MSP N01 note text to logs, preventing PHI from being logged (addresses #2851). Also removed the unused `MiscUtils` import.

<sup>Written for commit aaccef3da72fb551d5199036fc4eec910cfacc0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2872?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

