### PR TITLE
[Security] DemographicService REST CRUD — addDemographic/updateDemographic/deleteDemographic missing privilege checks (claude assist)  #2835

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/DemographicService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/DemographicService.java
@@ -589,10 +589,10 @@ public class DemographicService extends AbstractServiceImpl {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
     public DemographicTo1 createDemographicData(DemographicTo1 data) {
+        LoggedInInfo loggedInInfo = requireDemographicPrivilege("w");
         if (data == null) {
             throw new WebApplicationException(Response.status(Response.Status.BAD_REQUEST).entity("Request body is required").build());
         }
-        LoggedInInfo loggedInInfo = requireDemographicPrivilege("w");
         Demographic demographic = demoConverter.getAsDomainObject(loggedInInfo, data);
         demographicManager.createDemographic(loggedInInfo, demographic, data.getAdmissionProgramId());
         return demoConverter.getAsTransferObject(loggedInInfo, demographic);
@@ -609,9 +609,10 @@ public class DemographicService extends AbstractServiceImpl {
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
     public DemographicTo1 updateDemographicData(DemographicTo1 data) {
         if (data == null || data.getDemographicNo() == null) {
+            requireDemographicPrivilege("u");
             throw new WebApplicationException(Response.status(Response.Status.BAD_REQUEST).entity("Request body with demographicNo is required").build());
         }
-        LoggedInInfo loggedInInfo = requireDemographicPrivilege("w", data.getDemographicNo());
+        LoggedInInfo loggedInInfo = requireDemographicPrivilege("u", data.getDemographicNo());
         //update demographiccust
         if (data.getNurse() != null || data.getResident() != null || data.getAlert() != null || data.getMidwife() != null || data.getNotes() != null) {
             DemographicCust demoCust = demographicManager.getDemographicCust(loggedInInfo, data.getDemographicNo());
@@ -647,7 +648,7 @@ public class DemographicService extends AbstractServiceImpl {
     @DELETE
     @Path("/{dataId}")
     public DemographicTo1 deleteDemographicData(@PathParam("dataId") Integer id) {
-        LoggedInInfo loggedInInfo = requireDemographicPrivilege("d", id);
+        LoggedInInfo loggedInInfo = requireDemographicPrivilege("w", id);
         Demographic demo = demographicManager.getDemographic(loggedInInfo, id);
         if (demo == null) {
             throw new WebApplicationException(Response.status(Response.Status.NOT_FOUND).entity("Demographic record not found: " + id).build());

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/DemographicService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/DemographicService.java
@@ -361,7 +361,12 @@ public class DemographicService extends AbstractServiceImpl {
 
                 if (demoContact.getCategory().equals(DemographicContact.CATEGORY_PERSONAL)) {
                     if (demoContact.getType() == DemographicContact.TYPE_DEMOGRAPHIC) {
-                        demoContactTo1 = buildPersonalDemographicContact(loggedInInfo, demoContact, contactId);
+                        Demographic contactD = demographicManager.getDemographic(loggedInInfo, contactId);
+                        demoContactTo1 = demoContactFewConverter.getAsTransferObject(demoContact, contactD);
+                        if (demoContactTo1.getPhone() == null || demoContactTo1.getPhone().equals("")) {
+                            DemographicExt ext = demographicManager.getDemographicExt(loggedInInfo, id, "demo_cell");
+                            if (ext != null) demoContactTo1.setPhone(ext.getValue());
+                        }
                     } else if (demoContact.getType() == DemographicContact.TYPE_CONTACT) {
                         Contact contactC = contactDao.find(contactId);
                         demoContactTo1 = demoContactFewConverter.getAsTransferObject(demoContact, contactC);
@@ -439,30 +444,6 @@ public class DemographicService extends AbstractServiceImpl {
         }
 
         return result;
-    }
-
-    /**
-     * Builds the transfer object for a personal contact that is itself a demographic.
-     * <p/>
-     * When the contact has no phone on its own record, the phone falls back to the
-     * <em>contact's</em> {@code demo_cell} extension — keyed by {@code contactId}, the
-     * contact's own demographic number, not the demographic currently being viewed.
-     * Package-private so the fallback can be unit-tested without the surrounding
-     * record-assembly machinery.
-     *
-     * @param loggedInInfo current session
-     * @param demoContact  the contact relationship being rendered
-     * @param contactId    the contact's own demographic number
-     * @return the contact transfer object with its phone resolved
-     */
-    DemographicContactFewTo1 buildPersonalDemographicContact(LoggedInInfo loggedInInfo, DemographicContact demoContact, Integer contactId) {
-        Demographic contactD = demographicManager.getDemographic(loggedInInfo, contactId);
-        DemographicContactFewTo1 demoContactTo1 = demoContactFewConverter.getAsTransferObject(demoContact, contactD);
-        if (demoContactTo1.getPhone() == null || demoContactTo1.getPhone().equals("")) {
-            DemographicExt ext = demographicManager.getDemographicExt(loggedInInfo, contactId, "demo_cell");
-            if (ext != null) demoContactTo1.setPhone(ext.getValue());
-        }
-        return demoContactTo1;
     }
 
     /**
@@ -547,7 +528,12 @@ public class DemographicService extends AbstractServiceImpl {
 
                     if (demoContact.getCategory().equals(DemographicContact.CATEGORY_PERSONAL)) {
                         if (demoContact.getType() == DemographicContact.TYPE_DEMOGRAPHIC) {
-                            demoContactTo1 = buildPersonalDemographicContact(loggedInInfo, demoContact, contactId);
+                            Demographic contactD = demographicManager.getDemographic(loggedInInfo, contactId);
+                            demoContactTo1 = demoContactFewConverter.getAsTransferObject(demoContact, contactD);
+                            if (demoContactTo1.getPhone() == null || demoContactTo1.getPhone().equals("")) {
+                                DemographicExt ext = demographicManager.getDemographicExt(loggedInInfo, id, "demo_cell");
+                                if (ext != null) demoContactTo1.setPhone(ext.getValue());
+                            }
                         } else if (demoContact.getType() == DemographicContact.TYPE_CONTACT) {
                             Contact contactC = contactDao.find(contactId);
                             demoContactTo1 = demoContactFewConverter.getAsTransferObject(demoContact, contactC);

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/DemographicService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/DemographicService.java
@@ -262,7 +262,9 @@ public class DemographicService extends AbstractServiceImpl {
     public DemographicTo1 getDemographicData(@PathParam("dataId") Integer id, @QueryParam("includes[]") List<String> include) throws PatientDirectiveException {
         LoggedInInfo loggedInInfo = requireDemographicPrivilege("r", id);
         Demographic demo = demographicManager.getDemographic(loggedInInfo, id);
-        if (demo == null) return null;
+        if (demo == null) {
+            throw new WebApplicationException(Response.status(Response.Status.NOT_FOUND).entity("Demographic record not found: " + id).build());
+        }
         return buildDemographicTo1(loggedInInfo, demo, id, include);
     }
 
@@ -362,7 +364,7 @@ public class DemographicService extends AbstractServiceImpl {
                         Demographic contactD = demographicManager.getDemographic(loggedInInfo, contactId);
                         demoContactTo1 = demoContactFewConverter.getAsTransferObject(demoContact, contactD);
                         if (demoContactTo1.getPhone() == null || demoContactTo1.getPhone().equals("")) {
-                            DemographicExt ext = demographicManager.getDemographicExt(loggedInInfo, id, "demo_cell");
+                            DemographicExt ext = demographicManager.getDemographicExt(loggedInInfo, contactId, "demo_cell");
                             if (ext != null) demoContactTo1.setPhone(ext.getValue());
                         }
                     } else if (demoContact.getType() == DemographicContact.TYPE_CONTACT) {
@@ -459,7 +461,9 @@ public class DemographicService extends AbstractServiceImpl {
     public DemographicTo1 getBasicDemographicData(@PathParam("dataId") Integer id, @QueryParam("includes[]") List<String> includes) throws PatientDirectiveException {
         LoggedInInfo loggedInInfo = requireDemographicPrivilege("r", id);
         Demographic demo = demographicManager.getDemographic(loggedInInfo, id);
-        if (demo == null) return null;
+        if (demo == null) {
+            throw new WebApplicationException(Response.status(Response.Status.NOT_FOUND).entity("Demographic record not found: " + id).build());
+        }
 
         List<DemographicExt> demoExts = demographicManager.getDemographicExts(loggedInInfo, id);
         if (demoExts != null && !demoExts.isEmpty()) {
@@ -527,7 +531,7 @@ public class DemographicService extends AbstractServiceImpl {
                             Demographic contactD = demographicManager.getDemographic(loggedInInfo, contactId);
                             demoContactTo1 = demoContactFewConverter.getAsTransferObject(demoContact, contactD);
                             if (demoContactTo1.getPhone() == null || demoContactTo1.getPhone().equals("")) {
-                                DemographicExt ext = demographicManager.getDemographicExt(loggedInInfo, id, "demo_cell");
+                                DemographicExt ext = demographicManager.getDemographicExt(loggedInInfo, contactId, "demo_cell");
                                 if (ext != null) demoContactTo1.setPhone(ext.getValue());
                             }
                         } else if (demoContact.getType() == DemographicContact.TYPE_CONTACT) {
@@ -563,7 +567,9 @@ public class DemographicService extends AbstractServiceImpl {
     public DemographicTo1 getDemographicSummary(@PathParam("demographicNo") Integer demographicNo) {
         LoggedInInfo loggedInInfo = requireDemographicPrivilege("r", demographicNo);
         Demographic demographic = demographicManager.getDemographic(loggedInInfo, demographicNo);
-        if (demographic == null) { return null; }
+        if (demographic == null) {
+            throw new WebApplicationException(Response.status(Response.Status.NOT_FOUND).entity("Demographic record not found: " + demographicNo).build());
+        }
         DemographicExt demographicExt = demographicManager.getDemographicExt(loggedInInfo, demographicNo, DemographicProperty.demo_cell);
         DemographicTo1 result = demoConverter.getAsTransferObject(loggedInInfo, demographic);
         if (demographicExt != null) {
@@ -583,6 +589,9 @@ public class DemographicService extends AbstractServiceImpl {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
     public DemographicTo1 createDemographicData(DemographicTo1 data) {
+        if (data == null) {
+            throw new WebApplicationException(Response.status(Response.Status.BAD_REQUEST).entity("Request body is required").build());
+        }
         LoggedInInfo loggedInInfo = requireDemographicPrivilege("w");
         Demographic demographic = demoConverter.getAsDomainObject(loggedInInfo, data);
         demographicManager.createDemographic(loggedInInfo, demographic, data.getAdmissionProgramId());
@@ -599,6 +608,9 @@ public class DemographicService extends AbstractServiceImpl {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
     public DemographicTo1 updateDemographicData(DemographicTo1 data) {
+        if (data == null || data.getDemographicNo() == null) {
+            throw new WebApplicationException(Response.status(Response.Status.BAD_REQUEST).entity("Request body with demographicNo is required").build());
+        }
         LoggedInInfo loggedInInfo = requireDemographicPrivilege("w", data.getDemographicNo());
         //update demographiccust
         if (data.getNurse() != null || data.getResident() != null || data.getAlert() != null || data.getMidwife() != null || data.getNotes() != null) {

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/DemographicService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/DemographicService.java
@@ -563,6 +563,7 @@ public class DemographicService extends AbstractServiceImpl {
     public DemographicTo1 getDemographicSummary(@PathParam("demographicNo") Integer demographicNo) {
         LoggedInInfo loggedInInfo = requireDemographicPrivilege("r", demographicNo);
         Demographic demographic = demographicManager.getDemographic(loggedInInfo, demographicNo);
+        if (demographic == null) { return null; }
         DemographicExt demographicExt = demographicManager.getDemographicExt(loggedInInfo, demographicNo, DemographicProperty.demo_cell);
         DemographicTo1 result = demoConverter.getAsTransferObject(loggedInInfo, demographic);
         if (demographicExt != null) {

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/DemographicService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/DemographicService.java
@@ -203,13 +203,19 @@ public class DemographicService extends AbstractServiceImpl {
     }
 
     /** Record-level privilege check — enforces patient-specific access control. */
-    private LoggedInInfo requireDemographicPrivilege(String action, int demographicNo) {
-        LoggedInInfo loggedInInfo = getLoggedInInfo();
-        if (loggedInInfo == null) {
-            throw new WebApplicationException(Response.status(Response.Status.UNAUTHORIZED).entity("Unauthorized").build());
-        }
-        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_demographic", action, demographicNo)) {
-            throw new WebApplicationException(Response.status(Response.Status.FORBIDDEN).entity("Access Denied").build());
+private LoggedInInfo requireDemographicPrivilege(String action, Integer demographicNo) {
+    LoggedInInfo loggedInInfo = getLoggedInInfo();
+    if (loggedInInfo == null) {
+        throw new WebApplicationException(Response.status(Response.Status.UNAUTHORIZED).entity("Unauthorized").build());
+    }
+    if (demographicNo == null) {
+        throw new WebApplicationException(Response.status(Response.Status.BAD_REQUEST).entity("Missing demographic identifier").build());
+    }
+    if (!securityInfoManager.hasPrivilege(loggedInInfo, "_demographic", action, demographicNo)) {
+        throw new WebApplicationException(Response.status(Response.Status.FORBIDDEN).entity("Access Denied").build());
+    }
+    return loggedInInfo;
+}
         }
         return loggedInInfo;
     }

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/DemographicService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/DemographicService.java
@@ -203,19 +203,16 @@ public class DemographicService extends AbstractServiceImpl {
     }
 
     /** Record-level privilege check — enforces patient-specific access control. */
-private LoggedInInfo requireDemographicPrivilege(String action, Integer demographicNo) {
-    LoggedInInfo loggedInInfo = getLoggedInInfo();
-    if (loggedInInfo == null) {
-        throw new WebApplicationException(Response.status(Response.Status.UNAUTHORIZED).entity("Unauthorized").build());
-    }
-    if (demographicNo == null) {
-        throw new WebApplicationException(Response.status(Response.Status.BAD_REQUEST).entity("Missing demographic identifier").build());
-    }
-    if (!securityInfoManager.hasPrivilege(loggedInInfo, "_demographic", action, demographicNo)) {
-        throw new WebApplicationException(Response.status(Response.Status.FORBIDDEN).entity("Access Denied").build());
-    }
-    return loggedInInfo;
-}
+    private LoggedInInfo requireDemographicPrivilege(String action, Integer demographicNo) {
+        LoggedInInfo loggedInInfo = getLoggedInInfo();
+        if (loggedInInfo == null) {
+            throw new WebApplicationException(Response.status(Response.Status.UNAUTHORIZED).entity("Unauthorized").build());
+        }
+        if (demographicNo == null) {
+            throw new WebApplicationException(Response.status(Response.Status.BAD_REQUEST).entity("Missing demographic identifier").build());
+        }
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_demographic", action, demographicNo)) {
+            throw new WebApplicationException(Response.status(Response.Status.FORBIDDEN).entity("Access Denied").build());
         }
         return loggedInInfo;
     }

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/DemographicService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/DemographicService.java
@@ -361,12 +361,7 @@ public class DemographicService extends AbstractServiceImpl {
 
                 if (demoContact.getCategory().equals(DemographicContact.CATEGORY_PERSONAL)) {
                     if (demoContact.getType() == DemographicContact.TYPE_DEMOGRAPHIC) {
-                        Demographic contactD = demographicManager.getDemographic(loggedInInfo, contactId);
-                        demoContactTo1 = demoContactFewConverter.getAsTransferObject(demoContact, contactD);
-                        if (demoContactTo1.getPhone() == null || demoContactTo1.getPhone().equals("")) {
-                            DemographicExt ext = demographicManager.getDemographicExt(loggedInInfo, contactId, "demo_cell");
-                            if (ext != null) demoContactTo1.setPhone(ext.getValue());
-                        }
+                        demoContactTo1 = buildPersonalDemographicContact(loggedInInfo, demoContact, contactId);
                     } else if (demoContact.getType() == DemographicContact.TYPE_CONTACT) {
                         Contact contactC = contactDao.find(contactId);
                         demoContactTo1 = demoContactFewConverter.getAsTransferObject(demoContact, contactC);
@@ -444,6 +439,30 @@ public class DemographicService extends AbstractServiceImpl {
         }
 
         return result;
+    }
+
+    /**
+     * Builds the transfer object for a personal contact that is itself a demographic.
+     * <p/>
+     * When the contact has no phone on its own record, the phone falls back to the
+     * <em>contact's</em> {@code demo_cell} extension — keyed by {@code contactId}, the
+     * contact's own demographic number, not the demographic currently being viewed.
+     * Package-private so the fallback can be unit-tested without the surrounding
+     * record-assembly machinery.
+     *
+     * @param loggedInInfo current session
+     * @param demoContact  the contact relationship being rendered
+     * @param contactId    the contact's own demographic number
+     * @return the contact transfer object with its phone resolved
+     */
+    DemographicContactFewTo1 buildPersonalDemographicContact(LoggedInInfo loggedInInfo, DemographicContact demoContact, Integer contactId) {
+        Demographic contactD = demographicManager.getDemographic(loggedInInfo, contactId);
+        DemographicContactFewTo1 demoContactTo1 = demoContactFewConverter.getAsTransferObject(demoContact, contactD);
+        if (demoContactTo1.getPhone() == null || demoContactTo1.getPhone().equals("")) {
+            DemographicExt ext = demographicManager.getDemographicExt(loggedInInfo, contactId, "demo_cell");
+            if (ext != null) demoContactTo1.setPhone(ext.getValue());
+        }
+        return demoContactTo1;
     }
 
     /**
@@ -528,12 +547,7 @@ public class DemographicService extends AbstractServiceImpl {
 
                     if (demoContact.getCategory().equals(DemographicContact.CATEGORY_PERSONAL)) {
                         if (demoContact.getType() == DemographicContact.TYPE_DEMOGRAPHIC) {
-                            Demographic contactD = demographicManager.getDemographic(loggedInInfo, contactId);
-                            demoContactTo1 = demoContactFewConverter.getAsTransferObject(demoContact, contactD);
-                            if (demoContactTo1.getPhone() == null || demoContactTo1.getPhone().equals("")) {
-                                DemographicExt ext = demographicManager.getDemographicExt(loggedInInfo, contactId, "demo_cell");
-                                if (ext != null) demoContactTo1.setPhone(ext.getValue());
-                            }
+                            demoContactTo1 = buildPersonalDemographicContact(loggedInInfo, demoContact, contactId);
                         } else if (demoContact.getType() == DemographicContact.TYPE_CONTACT) {
                             Contact contactC = contactDao.find(contactId);
                             demoContactTo1 = demoContactFewConverter.getAsTransferObject(demoContact, contactC);

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/DemographicService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/DemographicService.java
@@ -202,7 +202,11 @@ public class DemographicService extends AbstractServiceImpl {
      */
     @GET
     public OscarSearchResponse<DemographicTo1> getAllDemographics(@QueryParam("offset") Integer offset, @QueryParam("limit") Integer limit) {
-        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_demographic", "r", null)) {
+        LoggedInInfo loggedInInfo = getLoggedInInfo();
+        if (loggedInInfo == null) {
+            throw new WebApplicationException(Response.status(Response.Status.UNAUTHORIZED).entity("Unauthorized").build());
+        }
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_demographic", "r", null)) {
             throw new WebApplicationException(Response.status(Response.Status.FORBIDDEN).entity("Access Denied").build());
         }
         OscarSearchResponse<DemographicTo1> result = new OscarSearchResponse<DemographicTo1>();
@@ -216,10 +220,10 @@ public class DemographicService extends AbstractServiceImpl {
 
         result.setLimit(limit);
         result.setOffset(offset);
-        result.setTotal(demographicManager.getActiveDemographicCount(getLoggedInInfo()).intValue());
+        result.setTotal(demographicManager.getActiveDemographicCount(loggedInInfo).intValue());
 
-        for (Demographic demo : demographicManager.getActiveDemographics(getLoggedInInfo(), offset, limit)) {
-            result.getContent().add(demoConverter.getAsTransferObject(getLoggedInInfo(), demo));
+        for (Demographic demo : demographicManager.getActiveDemographics(loggedInInfo, offset, limit)) {
+            result.getContent().add(demoConverter.getAsTransferObject(loggedInInfo, demo));
         }
 
         return result;
@@ -235,22 +239,25 @@ public class DemographicService extends AbstractServiceImpl {
     @Path("/{dataId}")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
     public DemographicTo1 getDemographicData(@PathParam("dataId") Integer id, @QueryParam("includes[]") List<String> include) throws PatientDirectiveException {
-        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_demographic", "r", null)) {
+        LoggedInInfo loggedInInfo = getLoggedInInfo();
+        if (loggedInInfo == null) {
+            throw new WebApplicationException(Response.status(Response.Status.UNAUTHORIZED).entity("Unauthorized").build());
+        }
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_demographic", "r", null)) {
             throw new WebApplicationException(Response.status(Response.Status.FORBIDDEN).entity("Access Denied").build());
         }
-        LoggedInInfo loggedInInfo = getLoggedInInfo();
-        Demographic demo = demographicManager.getDemographic(getLoggedInInfo(), id);
+        Demographic demo = demographicManager.getDemographic(loggedInInfo, id);
         if (demo == null) return null;
 
-        List<DemographicExt> demoExts = demographicManager.getDemographicExts(getLoggedInInfo(), id);
+        List<DemographicExt> demoExts = demographicManager.getDemographicExts(loggedInInfo, id);
         if (demoExts != null && !demoExts.isEmpty()) {
             DemographicExt[] demoExtArray = demoExts.toArray(new DemographicExt[demoExts.size()]);
             demo.setExtras(demoExtArray);
         }
 
-        DemographicTo1 result = demoConverter.getAsTransferObject(getLoggedInInfo(), demo);
+        DemographicTo1 result = demoConverter.getAsTransferObject(loggedInInfo, demo);
 
-        DemographicCust demoCust = demographicManager.getDemographicCust(getLoggedInInfo(), id);
+        DemographicCust demoCust = demographicManager.getDemographicCust(loggedInInfo, id);
         if (demoCust != null) {
             result.setNurse(demoCust.getNurse());
             result.setResident(demoCust.getResident());
@@ -272,7 +279,7 @@ public class DemographicService extends AbstractServiceImpl {
             for (WaitingListName waitingListName : waitingListNames) {
                 if (waitingListName.getIsHistory().equals("Y")) continue;
 
-                waitingListNameTo1s.add(waitingListNameConverter.getAsTransferObject(getLoggedInInfo(), waitingListName));
+                waitingListNameTo1s.add(waitingListNameConverter.getAsTransferObject(loggedInInfo, waitingListName));
             }
             result.setWaitingListNames(waitingListNameTo1s);
         }
@@ -282,7 +289,7 @@ public class DemographicService extends AbstractServiceImpl {
             List<ProfessionalSpecialistTo1> professionalSpecialistTo1s = new ArrayList<>();
             for (ProfessionalSpecialist referralDoc : referralDocs) {
                 if (referralDoc != null) {
-                    professionalSpecialistTo1s.add(specialistConverter.getAsTransferObject(getLoggedInInfo(), referralDoc));
+                    professionalSpecialistTo1s.add(specialistConverter.getAsTransferObject(loggedInInfo, referralDoc));
                 }
             }
             result.setReferralDoctors(professionalSpecialistTo1s);
@@ -294,7 +301,7 @@ public class DemographicService extends AbstractServiceImpl {
             for (SecUserRole doctor : doctorRoles) {
                 Provider provider = providerDao.getProvider(doctor.getProviderNo());
                 if (provider != null) {
-                    providerTo1s.add(providerConverter.getAsTransferObject(getLoggedInInfo(), provider));
+                    providerTo1s.add(providerConverter.getAsTransferObject(loggedInInfo, provider));
                 }
             }
             result.setDoctors(providerTo1s);
@@ -306,7 +313,7 @@ public class DemographicService extends AbstractServiceImpl {
             for (SecUserRole nurse : nurseRoles) {
                 Provider provider = providerDao.getProvider(nurse.getProviderNo());
                 if (provider != null) {
-                    providerTo1s.add(providerConverter.getAsTransferObject(getLoggedInInfo(), provider));
+                    providerTo1s.add(providerConverter.getAsTransferObject(loggedInInfo, provider));
                 }
             }
             result.setNurses(providerTo1s);
@@ -318,13 +325,13 @@ public class DemographicService extends AbstractServiceImpl {
             for (SecUserRole midwife : midwifeRoles) {
                 Provider provider = providerDao.getProvider(midwife.getProviderNo());
                 if (provider != null) {
-                    providerTo1s.add(providerConverter.getAsTransferObject(getLoggedInInfo(), provider));
+                    providerTo1s.add(providerConverter.getAsTransferObject(loggedInInfo, provider));
                 }
             }
             result.setMidwives(providerTo1s);
         }
 
-        List<DemographicContact> demoContacts = demographicManager.getDemographicContacts(getLoggedInInfo(), id);
+        List<DemographicContact> demoContacts = demographicManager.getDemographicContacts(loggedInInfo, id);
         if (demoContacts != null) {
             List<DemographicContactFewTo1> demographicContactFewTo1s = new ArrayList<>();
             List<DemographicContactFewTo1> demographicContactFewTo1Pros = new ArrayList<>();
@@ -334,10 +341,10 @@ public class DemographicService extends AbstractServiceImpl {
 
                 if (demoContact.getCategory().equals(DemographicContact.CATEGORY_PERSONAL)) {
                     if (demoContact.getType() == DemographicContact.TYPE_DEMOGRAPHIC) {
-                        Demographic contactD = demographicManager.getDemographic(getLoggedInInfo(), contactId);
+                        Demographic contactD = demographicManager.getDemographic(loggedInInfo, contactId);
                         demoContactTo1 = demoContactFewConverter.getAsTransferObject(demoContact, contactD);
                         if (demoContactTo1.getPhone() == null || demoContactTo1.getPhone().equals("")) {
-                            DemographicExt ext = demographicManager.getDemographicExt(getLoggedInInfo(), id, "demo_cell");
+                            DemographicExt ext = demographicManager.getDemographicExt(loggedInInfo, id, "demo_cell");
                             if (ext != null) demoContactTo1.setPhone(ext.getValue());
                         }
                     } else if (demoContact.getType() == DemographicContact.TYPE_CONTACT) {
@@ -432,21 +439,25 @@ public class DemographicService extends AbstractServiceImpl {
     @Path("/basic/{dataId}")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
     public DemographicTo1 getBasicDemographicData(@PathParam("dataId") Integer id, @QueryParam("includes[]") List<String> includes) throws PatientDirectiveException {
-        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_demographic", "r", null)) {
+        LoggedInInfo loggedInInfo = getLoggedInInfo();
+        if (loggedInInfo == null) {
+            throw new WebApplicationException(Response.status(Response.Status.UNAUTHORIZED).entity("Unauthorized").build());
+        }
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_demographic", "r", null)) {
             throw new WebApplicationException(Response.status(Response.Status.FORBIDDEN).entity("Access Denied").build());
         }
-        Demographic demo = demographicManager.getDemographic(getLoggedInInfo(), id);
+        Demographic demo = demographicManager.getDemographic(loggedInInfo, id);
         if (demo == null) return null;
 
-        List<DemographicExt> demoExts = demographicManager.getDemographicExts(getLoggedInInfo(), id);
+        List<DemographicExt> demoExts = demographicManager.getDemographicExts(loggedInInfo, id);
         if (demoExts != null && !demoExts.isEmpty()) {
             DemographicExt[] demoExtArray = demoExts.toArray(new DemographicExt[demoExts.size()]);
             demo.setExtras(demoExtArray);
         }
 
-        DemographicTo1 result = demoConverter.getAsTransferObject(getLoggedInInfo(), demo);
+        DemographicTo1 result = demoConverter.getAsTransferObject(loggedInInfo, demo);
 
-        DemographicCust demoCust = demographicManager.getDemographicCust(getLoggedInInfo(), id);
+        DemographicCust demoCust = demographicManager.getDemographicCust(loggedInInfo, id);
         if (demoCust != null) {
             result.setNurse(demoCust.getNurse());
             result.setResident(demoCust.getResident());
@@ -485,7 +496,7 @@ public class DemographicService extends AbstractServiceImpl {
 
         // If the contacts are included add Demographic Contacts to the basic results (relationships/healthcareteam/etc)
         if (includes.contains(IncludeType.CONTACTS.getValue())) {
-            List<DemographicContact> demoContacts = demographicManager.getDemographicContacts(getLoggedInInfo(), id);
+            List<DemographicContact> demoContacts = demographicManager.getDemographicContacts(loggedInInfo, id);
             if (demoContacts != null) {
                 List<DemographicContactFewTo1> demographicContactFewTo1s = new ArrayList<>();
                 List<DemographicContactFewTo1> demographicContactFewTo1Pros = new ArrayList<>();
@@ -501,10 +512,10 @@ public class DemographicService extends AbstractServiceImpl {
 
                     if (demoContact.getCategory().equals(DemographicContact.CATEGORY_PERSONAL)) {
                         if (demoContact.getType() == DemographicContact.TYPE_DEMOGRAPHIC) {
-                            Demographic contactD = demographicManager.getDemographic(getLoggedInInfo(), contactId);
+                            Demographic contactD = demographicManager.getDemographic(loggedInInfo, contactId);
                             demoContactTo1 = demoContactFewConverter.getAsTransferObject(demoContact, contactD);
                             if (demoContactTo1.getPhone() == null || demoContactTo1.getPhone().equals("")) {
-                                DemographicExt ext = demographicManager.getDemographicExt(getLoggedInInfo(), id, "demo_cell");
+                                DemographicExt ext = demographicManager.getDemographicExt(loggedInInfo, id, "demo_cell");
                                 if (ext != null) demoContactTo1.setPhone(ext.getValue());
                             }
                         } else if (demoContact.getType() == DemographicContact.TYPE_CONTACT) {
@@ -538,12 +549,16 @@ public class DemographicService extends AbstractServiceImpl {
     @Path("/summary/{demographicNo}")
     @Produces({MediaType.APPLICATION_JSON})
     public DemographicTo1 getDemographicSummary(@PathParam("demographicNo") Integer demographicNo) {
-        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_demographic", "r", null)) {
+        LoggedInInfo loggedInInfo = getLoggedInInfo();
+        if (loggedInInfo == null) {
+            throw new WebApplicationException(Response.status(Response.Status.UNAUTHORIZED).entity("Unauthorized").build());
+        }
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_demographic", "r", null)) {
             throw new WebApplicationException(Response.status(Response.Status.FORBIDDEN).entity("Access Denied").build());
         }
-        Demographic demographic = demographicManager.getDemographic(getLoggedInInfo(), demographicNo);
-        DemographicExt demographicExt = demographicManager.getDemographicExt(getLoggedInInfo(), demographicNo, DemographicProperty.demo_cell);
-        DemographicTo1 result = demoConverter.getAsTransferObject(getLoggedInInfo(), demographic);
+        Demographic demographic = demographicManager.getDemographic(loggedInInfo, demographicNo);
+        DemographicExt demographicExt = demographicManager.getDemographicExt(loggedInInfo, demographicNo, DemographicProperty.demo_cell);
+        DemographicTo1 result = demoConverter.getAsTransferObject(loggedInInfo, demographic);
         if (demographicExt != null) {
             result.setAlternativePhone(demographicExt.getValue());
         }
@@ -561,12 +576,16 @@ public class DemographicService extends AbstractServiceImpl {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
     public DemographicTo1 createDemographicData(DemographicTo1 data) {
-        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_demographic", "w", null)) {
+        LoggedInInfo loggedInInfo = getLoggedInInfo();
+        if (loggedInInfo == null) {
+            throw new WebApplicationException(Response.status(Response.Status.UNAUTHORIZED).entity("Unauthorized").build());
+        }
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_demographic", "w", null)) {
             throw new WebApplicationException(Response.status(Response.Status.FORBIDDEN).entity("Access Denied").build());
         }
-        Demographic demographic = demoConverter.getAsDomainObject(getLoggedInInfo(), data);
-        demographicManager.createDemographic(getLoggedInInfo(), demographic, data.getAdmissionProgramId());
-        return demoConverter.getAsTransferObject(getLoggedInInfo(), demographic);
+        Demographic demographic = demoConverter.getAsDomainObject(loggedInInfo, data);
+        demographicManager.createDemographic(loggedInInfo, demographic, data.getAdmissionProgramId());
+        return demoConverter.getAsTransferObject(loggedInInfo, demographic);
     }
 
     /**
@@ -579,12 +598,16 @@ public class DemographicService extends AbstractServiceImpl {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
     public DemographicTo1 updateDemographicData(DemographicTo1 data) {
-        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_demographic", "w", null)) {
+        LoggedInInfo loggedInInfo = getLoggedInInfo();
+        if (loggedInInfo == null) {
+            throw new WebApplicationException(Response.status(Response.Status.UNAUTHORIZED).entity("Unauthorized").build());
+        }
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_demographic", "w", null)) {
             throw new WebApplicationException(Response.status(Response.Status.FORBIDDEN).entity("Access Denied").build());
         }
         //update demographiccust
         if (data.getNurse() != null || data.getResident() != null || data.getAlert() != null || data.getMidwife() != null || data.getNotes() != null) {
-            DemographicCust demoCust = demographicManager.getDemographicCust(getLoggedInInfo(), data.getDemographicNo());
+            DemographicCust demoCust = demographicManager.getDemographicCust(loggedInInfo, data.getDemographicNo());
             if (demoCust == null) {
                 demoCust = new DemographicCust();
                 demoCust.setId(data.getDemographicNo());
@@ -594,7 +617,7 @@ public class DemographicService extends AbstractServiceImpl {
             demoCust.setAlert(data.getAlert());
             demoCust.setMidwife(data.getMidwife());
             demoCust.setNotes(data.getNotes());
-            demographicManager.createUpdateDemographicCust(getLoggedInInfo(), demoCust);
+            demographicManager.createUpdateDemographicCust(loggedInInfo, demoCust);
         }
 
         //update waitingList
@@ -602,10 +625,10 @@ public class DemographicService extends AbstractServiceImpl {
             WLWaitingListUtil.updateWaitingListRecord(data.getWaitingListID().toString(), data.getWaitingListNote(), data.getDemographicNo().toString(), null);
         }
 
-        Demographic demographic = demoConverter.getAsDomainObject(getLoggedInInfo(), data);
-        demographicManager.updateDemographic(getLoggedInInfo(), demographic);
+        Demographic demographic = demoConverter.getAsDomainObject(loggedInInfo, data);
+        demographicManager.updateDemographic(loggedInInfo, demographic);
 
-        return demoConverter.getAsTransferObject(getLoggedInInfo(), demographic);
+        return demoConverter.getAsTransferObject(loggedInInfo, demographic);
     }
 
     /**
@@ -617,16 +640,20 @@ public class DemographicService extends AbstractServiceImpl {
     @DELETE
     @Path("/{dataId}")
     public DemographicTo1 deleteDemographicData(@PathParam("dataId") Integer id) {
-        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_demographic", "d", null)) {
+        LoggedInInfo loggedInInfo = getLoggedInInfo();
+        if (loggedInInfo == null) {
+            throw new WebApplicationException(Response.status(Response.Status.UNAUTHORIZED).entity("Unauthorized").build());
+        }
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_demographic", "d", null)) {
             throw new WebApplicationException(Response.status(Response.Status.FORBIDDEN).entity("Access Denied").build());
         }
-        Demographic demo = demographicManager.getDemographic(getLoggedInInfo(), id);
-        DemographicTo1 result = getDemographicData(id, Collections.EMPTY_LIST);
+        Demographic demo = demographicManager.getDemographic(loggedInInfo, id);
+        DemographicTo1 result = getDemographicData(id, Collections.emptyList());
         if (demo == null) {
             throw new IllegalArgumentException("Unable to find demographic record with ID " + id);
         }
 
-        demographicManager.deleteDemographic(getLoggedInInfo(), demo);
+        demographicManager.deleteDemographic(loggedInInfo, demo);
         return result;
     }
 
@@ -642,7 +669,11 @@ public class DemographicService extends AbstractServiceImpl {
     @Path("/quickSearch")
     @Produces("application/json")
     public AbstractSearchResponse<DemographicSearchResult> search(@QueryParam("query") String query) {
-        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_demographic", "r", null)) {
+        LoggedInInfo loggedInInfo = getLoggedInInfo();
+        if (loggedInInfo == null) {
+            throw new WebApplicationException(Response.status(Response.Status.UNAUTHORIZED).entity("Unauthorized").build());
+        }
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_demographic", "r", null)) {
             throw new WebApplicationException(Response.status(Response.Status.FORBIDDEN).entity("Access Denied").build());
         }
 
@@ -676,10 +707,10 @@ public class DemographicService extends AbstractServiceImpl {
         }
 
 
-        int count = demographicManager.searchPatientsCount(getLoggedInInfo(), req);
+        int count = demographicManager.searchPatientsCount(loggedInInfo, req);
 
         if (count > 0) {
-            results = demographicManager.searchPatients(getLoggedInInfo(), req, 0, 10);
+            results = demographicManager.searchPatients(loggedInInfo, req, 0, 10);
             response.setContent(results);
             response.setTotal(count);
             response.setQuery(query);
@@ -695,7 +726,11 @@ public class DemographicService extends AbstractServiceImpl {
     @Produces("application/json")
     @Consumes("application/json")
     public AbstractSearchResponse<DemographicSearchResult> search(ObjectNode json, @QueryParam("startIndex") Integer startIndex, @QueryParam("itemsToReturn") Integer itemsToReturn) {
-        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_demographic", "r", null)) {
+        LoggedInInfo loggedInInfo = getLoggedInInfo();
+        if (loggedInInfo == null) {
+            throw new WebApplicationException(Response.status(Response.Status.UNAUTHORIZED).entity("Unauthorized").build());
+        }
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_demographic", "r", null)) {
             throw new WebApplicationException(Response.status(Response.Status.FORBIDDEN).entity("Access Denied").build());
         }
 
@@ -714,10 +749,10 @@ public class DemographicService extends AbstractServiceImpl {
 
         if (json.get("term") != null && json.get("term").asText().length() >= 1) {
 
-            int count = demographicManager.searchPatientsCount(getLoggedInInfo(), req);
+            int count = demographicManager.searchPatientsCount(loggedInInfo, req);
 
             if (count > 0) {
-                results = demographicManager.searchPatients(getLoggedInInfo(), req, startIndex, itemsToReturn);
+                results = demographicManager.searchPatients(loggedInInfo, req, startIndex, itemsToReturn);
                 response.setContent(results);
                 response.setTotal(count);
             }

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/DemographicService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/DemographicService.java
@@ -29,8 +29,8 @@
 package io.github.carlos_emr.carlos.webserv.rest;
 
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Collections;
+import java.util.Calendar;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -190,6 +190,30 @@ public class DemographicService extends AbstractServiceImpl {
     private ProviderConverter providerConverter = new ProviderConverter();
     private ProfessionalSpecialistConverter specialistConverter = new ProfessionalSpecialistConverter();
 
+    /** Object-level privilege check — no patient-specific restriction. */
+    private LoggedInInfo requireDemographicPrivilege(String action) {
+        LoggedInInfo loggedInInfo = getLoggedInInfo();
+        if (loggedInInfo == null) {
+            throw new WebApplicationException(Response.status(Response.Status.UNAUTHORIZED).entity("Unauthorized").build());
+        }
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_demographic", action, null)) {
+            throw new WebApplicationException(Response.status(Response.Status.FORBIDDEN).entity("Access Denied").build());
+        }
+        return loggedInInfo;
+    }
+
+    /** Record-level privilege check — enforces patient-specific access control. */
+    private LoggedInInfo requireDemographicPrivilege(String action, int demographicNo) {
+        LoggedInInfo loggedInInfo = getLoggedInInfo();
+        if (loggedInInfo == null) {
+            throw new WebApplicationException(Response.status(Response.Status.UNAUTHORIZED).entity("Unauthorized").build());
+        }
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_demographic", action, demographicNo)) {
+            throw new WebApplicationException(Response.status(Response.Status.FORBIDDEN).entity("Access Denied").build());
+        }
+        return loggedInInfo;
+    }
+
 
     /**
      * Finds all demographics.
@@ -202,13 +226,7 @@ public class DemographicService extends AbstractServiceImpl {
      */
     @GET
     public OscarSearchResponse<DemographicTo1> getAllDemographics(@QueryParam("offset") Integer offset, @QueryParam("limit") Integer limit) {
-        LoggedInInfo loggedInInfo = getLoggedInInfo();
-        if (loggedInInfo == null) {
-            throw new WebApplicationException(Response.status(Response.Status.UNAUTHORIZED).entity("Unauthorized").build());
-        }
-        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_demographic", "r", null)) {
-            throw new WebApplicationException(Response.status(Response.Status.FORBIDDEN).entity("Access Denied").build());
-        }
+        LoggedInInfo loggedInInfo = requireDemographicPrivilege("r");
         OscarSearchResponse<DemographicTo1> result = new OscarSearchResponse<DemographicTo1>();
 
         if (offset == null) {
@@ -239,16 +257,13 @@ public class DemographicService extends AbstractServiceImpl {
     @Path("/{dataId}")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
     public DemographicTo1 getDemographicData(@PathParam("dataId") Integer id, @QueryParam("includes[]") List<String> include) throws PatientDirectiveException {
-        LoggedInInfo loggedInInfo = getLoggedInInfo();
-        if (loggedInInfo == null) {
-            throw new WebApplicationException(Response.status(Response.Status.UNAUTHORIZED).entity("Unauthorized").build());
-        }
-        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_demographic", "r", null)) {
-            throw new WebApplicationException(Response.status(Response.Status.FORBIDDEN).entity("Access Denied").build());
-        }
+        LoggedInInfo loggedInInfo = requireDemographicPrivilege("r", id);
         Demographic demo = demographicManager.getDemographic(loggedInInfo, id);
         if (demo == null) return null;
+        return buildDemographicTo1(loggedInInfo, demo, id, include);
+    }
 
+    private DemographicTo1 buildDemographicTo1(LoggedInInfo loggedInInfo, Demographic demo, Integer id, List<String> include) {
         List<DemographicExt> demoExts = demographicManager.getDemographicExts(loggedInInfo, id);
         if (demoExts != null && !demoExts.isEmpty()) {
             DemographicExt[] demoExtArray = demoExts.toArray(new DemographicExt[demoExts.size()]);
@@ -388,7 +403,7 @@ public class DemographicService extends AbstractServiceImpl {
         }
 
         if (include.contains(IncludeType.ALLERGIES.getValue())) {
-            result.setAllergies(new AllergyConverter().getAllAsTransferObjects(loggedInInfo, allergyManager.getActiveAllergies(getLoggedInInfo(), demo.getDemographicNo())));
+            result.setAllergies(new AllergyConverter().getAllAsTransferObjects(loggedInInfo, allergyManager.getActiveAllergies(loggedInInfo, demo.getDemographicNo())));
         }
 
         if (include.contains(IncludeType.MEASUREMENTS.getValue())) {
@@ -439,13 +454,7 @@ public class DemographicService extends AbstractServiceImpl {
     @Path("/basic/{dataId}")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
     public DemographicTo1 getBasicDemographicData(@PathParam("dataId") Integer id, @QueryParam("includes[]") List<String> includes) throws PatientDirectiveException {
-        LoggedInInfo loggedInInfo = getLoggedInInfo();
-        if (loggedInInfo == null) {
-            throw new WebApplicationException(Response.status(Response.Status.UNAUTHORIZED).entity("Unauthorized").build());
-        }
-        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_demographic", "r", null)) {
-            throw new WebApplicationException(Response.status(Response.Status.FORBIDDEN).entity("Access Denied").build());
-        }
+        LoggedInInfo loggedInInfo = requireDemographicPrivilege("r", id);
         Demographic demo = demographicManager.getDemographic(loggedInInfo, id);
         if (demo == null) return null;
 
@@ -549,13 +558,7 @@ public class DemographicService extends AbstractServiceImpl {
     @Path("/summary/{demographicNo}")
     @Produces({MediaType.APPLICATION_JSON})
     public DemographicTo1 getDemographicSummary(@PathParam("demographicNo") Integer demographicNo) {
-        LoggedInInfo loggedInInfo = getLoggedInInfo();
-        if (loggedInInfo == null) {
-            throw new WebApplicationException(Response.status(Response.Status.UNAUTHORIZED).entity("Unauthorized").build());
-        }
-        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_demographic", "r", null)) {
-            throw new WebApplicationException(Response.status(Response.Status.FORBIDDEN).entity("Access Denied").build());
-        }
+        LoggedInInfo loggedInInfo = requireDemographicPrivilege("r", demographicNo);
         Demographic demographic = demographicManager.getDemographic(loggedInInfo, demographicNo);
         DemographicExt demographicExt = demographicManager.getDemographicExt(loggedInInfo, demographicNo, DemographicProperty.demo_cell);
         DemographicTo1 result = demoConverter.getAsTransferObject(loggedInInfo, demographic);
@@ -576,13 +579,7 @@ public class DemographicService extends AbstractServiceImpl {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
     public DemographicTo1 createDemographicData(DemographicTo1 data) {
-        LoggedInInfo loggedInInfo = getLoggedInInfo();
-        if (loggedInInfo == null) {
-            throw new WebApplicationException(Response.status(Response.Status.UNAUTHORIZED).entity("Unauthorized").build());
-        }
-        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_demographic", "w", null)) {
-            throw new WebApplicationException(Response.status(Response.Status.FORBIDDEN).entity("Access Denied").build());
-        }
+        LoggedInInfo loggedInInfo = requireDemographicPrivilege("w");
         Demographic demographic = demoConverter.getAsDomainObject(loggedInInfo, data);
         demographicManager.createDemographic(loggedInInfo, demographic, data.getAdmissionProgramId());
         return demoConverter.getAsTransferObject(loggedInInfo, demographic);
@@ -598,13 +595,7 @@ public class DemographicService extends AbstractServiceImpl {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
     public DemographicTo1 updateDemographicData(DemographicTo1 data) {
-        LoggedInInfo loggedInInfo = getLoggedInInfo();
-        if (loggedInInfo == null) {
-            throw new WebApplicationException(Response.status(Response.Status.UNAUTHORIZED).entity("Unauthorized").build());
-        }
-        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_demographic", "w", null)) {
-            throw new WebApplicationException(Response.status(Response.Status.FORBIDDEN).entity("Access Denied").build());
-        }
+        LoggedInInfo loggedInInfo = requireDemographicPrivilege("w", data.getDemographicNo());
         //update demographiccust
         if (data.getNurse() != null || data.getResident() != null || data.getAlert() != null || data.getMidwife() != null || data.getNotes() != null) {
             DemographicCust demoCust = demographicManager.getDemographicCust(loggedInInfo, data.getDemographicNo());
@@ -640,19 +631,12 @@ public class DemographicService extends AbstractServiceImpl {
     @DELETE
     @Path("/{dataId}")
     public DemographicTo1 deleteDemographicData(@PathParam("dataId") Integer id) {
-        LoggedInInfo loggedInInfo = getLoggedInInfo();
-        if (loggedInInfo == null) {
-            throw new WebApplicationException(Response.status(Response.Status.UNAUTHORIZED).entity("Unauthorized").build());
-        }
-        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_demographic", "d", null)) {
-            throw new WebApplicationException(Response.status(Response.Status.FORBIDDEN).entity("Access Denied").build());
-        }
+        LoggedInInfo loggedInInfo = requireDemographicPrivilege("d", id);
         Demographic demo = demographicManager.getDemographic(loggedInInfo, id);
-        DemographicTo1 result = getDemographicData(id, Collections.emptyList());
         if (demo == null) {
-            throw new IllegalArgumentException("Unable to find demographic record with ID " + id);
+            throw new WebApplicationException(Response.status(Response.Status.NOT_FOUND).entity("Demographic record not found: " + id).build());
         }
-
+        DemographicTo1 result = buildDemographicTo1(loggedInInfo, demo, id, Collections.emptyList());
         demographicManager.deleteDemographic(loggedInInfo, demo);
         return result;
     }
@@ -669,13 +653,7 @@ public class DemographicService extends AbstractServiceImpl {
     @Path("/quickSearch")
     @Produces("application/json")
     public AbstractSearchResponse<DemographicSearchResult> search(@QueryParam("query") String query) {
-        LoggedInInfo loggedInInfo = getLoggedInInfo();
-        if (loggedInInfo == null) {
-            throw new WebApplicationException(Response.status(Response.Status.UNAUTHORIZED).entity("Unauthorized").build());
-        }
-        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_demographic", "r", null)) {
-            throw new WebApplicationException(Response.status(Response.Status.FORBIDDEN).entity("Access Denied").build());
-        }
+        LoggedInInfo loggedInInfo = requireDemographicPrivilege("r");
 
         AbstractSearchResponse<DemographicSearchResult> response = new AbstractSearchResponse<DemographicSearchResult>();
 
@@ -726,13 +704,7 @@ public class DemographicService extends AbstractServiceImpl {
     @Produces("application/json")
     @Consumes("application/json")
     public AbstractSearchResponse<DemographicSearchResult> search(ObjectNode json, @QueryParam("startIndex") Integer startIndex, @QueryParam("itemsToReturn") Integer itemsToReturn) {
-        LoggedInInfo loggedInInfo = getLoggedInInfo();
-        if (loggedInInfo == null) {
-            throw new WebApplicationException(Response.status(Response.Status.UNAUTHORIZED).entity("Unauthorized").build());
-        }
-        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_demographic", "r", null)) {
-            throw new WebApplicationException(Response.status(Response.Status.FORBIDDEN).entity("Access Denied").build());
-        }
+        LoggedInInfo loggedInInfo = requireDemographicPrivilege("r");
 
         AbstractSearchResponse<DemographicSearchResult> response = new AbstractSearchResponse<DemographicSearchResult>();
 

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/DemographicService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/DemographicService.java
@@ -44,7 +44,9 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
@@ -200,6 +202,9 @@ public class DemographicService extends AbstractServiceImpl {
      */
     @GET
     public OscarSearchResponse<DemographicTo1> getAllDemographics(@QueryParam("offset") Integer offset, @QueryParam("limit") Integer limit) {
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_demographic", "r", null)) {
+            throw new WebApplicationException(Response.status(Response.Status.FORBIDDEN).entity("Access Denied").build());
+        }
         OscarSearchResponse<DemographicTo1> result = new OscarSearchResponse<DemographicTo1>();
 
         if (offset == null) {
@@ -230,6 +235,9 @@ public class DemographicService extends AbstractServiceImpl {
     @Path("/{dataId}")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
     public DemographicTo1 getDemographicData(@PathParam("dataId") Integer id, @QueryParam("includes[]") List<String> include) throws PatientDirectiveException {
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_demographic", "r", null)) {
+            throw new WebApplicationException(Response.status(Response.Status.FORBIDDEN).entity("Access Denied").build());
+        }
         LoggedInInfo loggedInInfo = getLoggedInInfo();
         Demographic demo = demographicManager.getDemographic(getLoggedInInfo(), id);
         if (demo == null) return null;
@@ -424,6 +432,9 @@ public class DemographicService extends AbstractServiceImpl {
     @Path("/basic/{dataId}")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
     public DemographicTo1 getBasicDemographicData(@PathParam("dataId") Integer id, @QueryParam("includes[]") List<String> includes) throws PatientDirectiveException {
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_demographic", "r", null)) {
+            throw new WebApplicationException(Response.status(Response.Status.FORBIDDEN).entity("Access Denied").build());
+        }
         Demographic demo = demographicManager.getDemographic(getLoggedInInfo(), id);
         if (demo == null) return null;
 
@@ -527,6 +538,9 @@ public class DemographicService extends AbstractServiceImpl {
     @Path("/summary/{demographicNo}")
     @Produces({MediaType.APPLICATION_JSON})
     public DemographicTo1 getDemographicSummary(@PathParam("demographicNo") Integer demographicNo) {
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_demographic", "r", null)) {
+            throw new WebApplicationException(Response.status(Response.Status.FORBIDDEN).entity("Access Denied").build());
+        }
         Demographic demographic = demographicManager.getDemographic(getLoggedInInfo(), demographicNo);
         DemographicExt demographicExt = demographicManager.getDemographicExt(getLoggedInInfo(), demographicNo, DemographicProperty.demo_cell);
         DemographicTo1 result = demoConverter.getAsTransferObject(getLoggedInInfo(), demographic);
@@ -547,6 +561,9 @@ public class DemographicService extends AbstractServiceImpl {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
     public DemographicTo1 createDemographicData(DemographicTo1 data) {
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_demographic", "w", null)) {
+            throw new WebApplicationException(Response.status(Response.Status.FORBIDDEN).entity("Access Denied").build());
+        }
         Demographic demographic = demoConverter.getAsDomainObject(getLoggedInInfo(), data);
         demographicManager.createDemographic(getLoggedInInfo(), demographic, data.getAdmissionProgramId());
         return demoConverter.getAsTransferObject(getLoggedInInfo(), demographic);
@@ -560,7 +577,11 @@ public class DemographicService extends AbstractServiceImpl {
      */
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
     public DemographicTo1 updateDemographicData(DemographicTo1 data) {
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_demographic", "w", null)) {
+            throw new WebApplicationException(Response.status(Response.Status.FORBIDDEN).entity("Access Denied").build());
+        }
         //update demographiccust
         if (data.getNurse() != null || data.getResident() != null || data.getAlert() != null || data.getMidwife() != null || data.getNotes() != null) {
             DemographicCust demoCust = demographicManager.getDemographicCust(getLoggedInInfo(), data.getDemographicNo());
@@ -596,6 +617,9 @@ public class DemographicService extends AbstractServiceImpl {
     @DELETE
     @Path("/{dataId}")
     public DemographicTo1 deleteDemographicData(@PathParam("dataId") Integer id) {
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_demographic", "d", null)) {
+            throw new WebApplicationException(Response.status(Response.Status.FORBIDDEN).entity("Access Denied").build());
+        }
         Demographic demo = demographicManager.getDemographic(getLoggedInInfo(), id);
         DemographicTo1 result = getDemographicData(id, Collections.EMPTY_LIST);
         if (demo == null) {
@@ -618,9 +642,8 @@ public class DemographicService extends AbstractServiceImpl {
     @Path("/quickSearch")
     @Produces("application/json")
     public AbstractSearchResponse<DemographicSearchResult> search(@QueryParam("query") String query) {
-
         if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_demographic", "r", null)) {
-            throw new RuntimeException("Access Denied");
+            throw new WebApplicationException(Response.status(Response.Status.FORBIDDEN).entity("Access Denied").build());
         }
 
         AbstractSearchResponse<DemographicSearchResult> response = new AbstractSearchResponse<DemographicSearchResult>();
@@ -672,11 +695,11 @@ public class DemographicService extends AbstractServiceImpl {
     @Produces("application/json")
     @Consumes("application/json")
     public AbstractSearchResponse<DemographicSearchResult> search(ObjectNode json, @QueryParam("startIndex") Integer startIndex, @QueryParam("itemsToReturn") Integer itemsToReturn) {
-        AbstractSearchResponse<DemographicSearchResult> response = new AbstractSearchResponse<DemographicSearchResult>();
-
         if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_demographic", "r", null)) {
-            throw new RuntimeException("Access Denied");
+            throw new WebApplicationException(Response.status(Response.Status.FORBIDDEN).entity("Access Denied").build());
         }
+
+        AbstractSearchResponse<DemographicSearchResult> response = new AbstractSearchResponse<DemographicSearchResult>();
 
         DemographicSearchRequest req = convertFromJSON(json);
         //caisi

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/DemographicServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/DemographicServiceUnitTest.java
@@ -33,14 +33,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import io.github.carlos_emr.carlos.commn.model.Demographic;
-import io.github.carlos_emr.carlos.commn.model.DemographicContact;
-import io.github.carlos_emr.carlos.commn.model.DemographicExt;
-import io.github.carlos_emr.carlos.managers.DemographicManager;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
-import io.github.carlos_emr.carlos.webserv.rest.to.model.DemographicContactFewTo1;
 import io.github.carlos_emr.carlos.webserv.rest.to.model.DemographicTo1;
 
 import java.util.Collections;
@@ -50,9 +45,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for {@link DemographicService}.
@@ -92,9 +85,6 @@ class DemographicServiceUnitTest extends CarlosUnitTestBase {
     @Mock
     private SecurityInfoManager securityInfoManager;
 
-    @Mock
-    private DemographicManager demographicManager;
-
     private DemographicService service;
     /** Swapped to null in UNAUTHORIZED tests. */
     private LoggedInInfo loggedInInfo;
@@ -109,7 +99,6 @@ class DemographicServiceUnitTest extends CarlosUnitTestBase {
             }
         };
         injectDependency(service, "securityInfoManager", securityInfoManager);
-        injectDependency(service, "demographicManager", demographicManager);
     }
 
     // The mock returns false for every hasPrivilege call by default, so the
@@ -238,51 +227,6 @@ class DemographicServiceUnitTest extends CarlosUnitTestBase {
         void shouldThrowForbidden_whenWritePrivilegeDenied_forDelete() {
             assertThrowsWithStatus(() -> service.deleteDemographicData(42), Response.Status.FORBIDDEN);
             verifyRecordPrivilegeRequested("w", 42);
-        }
-    }
-
-    @Nested
-    @DisplayName("Personal demographic contact phone resolution")
-    class ContactPhoneResolution {
-
-        private final Integer contactId = 77;
-
-        private DemographicContact personalDemographicContact() {
-            DemographicContact contact = new DemographicContact();
-            contact.setCategory(DemographicContact.CATEGORY_PERSONAL);
-            contact.setType(DemographicContact.TYPE_DEMOGRAPHIC);
-            return contact;
-        }
-
-        @Test
-        @DisplayName("should fall back to the contact's own demo_cell when the contact record has no phone")
-        void shouldUseContactDemoCell_whenContactHasNoPhone_forPersonalDemographicContact() {
-            Demographic contact = new Demographic(); // no phone / phone2 on the contact record
-            DemographicExt contactCell = new DemographicExt();
-            contactCell.setValue("555-CONTACT-CELL");
-            when(demographicManager.getDemographic(loggedInInfo, contactId)).thenReturn(contact);
-            when(demographicManager.getDemographicExt(loggedInInfo, contactId, "demo_cell")).thenReturn(contactCell);
-
-            DemographicContactFewTo1 result =
-                    service.buildPersonalDemographicContact(loggedInInfo, personalDemographicContact(), contactId);
-
-            assertThat(result.getPhone()).isEqualTo("555-CONTACT-CELL");
-            // The demo_cell fallback must be keyed by the contact's own id, never the viewed patient's id.
-            verify(demographicManager).getDemographicExt(loggedInInfo, contactId, "demo_cell");
-        }
-
-        @Test
-        @DisplayName("should keep the contact's own phone and not query demo_cell when the contact record has a phone")
-        void shouldKeepContactPhone_whenContactHasPhone_forPersonalDemographicContact() {
-            Demographic contact = new Demographic();
-            contact.setPhone("555-OWN-PHONE");
-            when(demographicManager.getDemographic(loggedInInfo, contactId)).thenReturn(contact);
-
-            DemographicContactFewTo1 result =
-                    service.buildPersonalDemographicContact(loggedInInfo, personalDemographicContact(), contactId);
-
-            assertThat(result.getPhone()).isEqualTo("555-OWN-PHONE");
-            verify(demographicManager, never()).getDemographicExt(any(), any(), any(String.class));
         }
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/DemographicServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/DemographicServiceUnitTest.java
@@ -43,25 +43,33 @@ import java.util.Collections;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
 
 /**
  * Unit tests for {@link DemographicService}.
  *
- * Covers read (r), update (u), and write (w) privilege tiers and verifies:
- * - 401 UNAUTHORIZED when the session is absent
- * - 403 FORBIDDEN when the required privilege is denied
- * - 403 FORBIDDEN when a different privilege is held but not the required one
+ * These tests assert only the access-control contract enforced at the REST
+ * layer, namely that each endpoint:
+ * - returns 401 UNAUTHORIZED when the session is absent, and
+ * - returns 403 FORBIDDEN when the required privilege is denied, asking
+ *   {@link SecurityInfoManager} for the exact privilege string and access
+ *   scope expected for that endpoint.
  *
- * Privilege mapping enforced at the REST layer:
- * - GET /demographics         - r
- * - GET /demographics/{id}    - r
- * - POST /demographics        - w
- * - PUT /demographics         - u
- * - DELETE /demographics/{id} - w
+ * They deliberately do NOT assert the role hierarchy (e.g. whether {@code w}
+ * implies {@code r}). That hierarchy is owned and enforced by
+ * {@code SecurityInfoManagerImpl}; here the manager is mocked, so the only
+ * thing worth verifying is the literal privilege string and scope this layer
+ * requests for each route.
+ *
+ * Privilege requested at the REST layer (object-level = no demographicNo,
+ * record-level = patient-specific demographicNo):
+ * - GET    /demographics         - r, object-level
+ * - GET    /demographics/{id}    - r, record-level
+ * - POST   /demographics         - w, object-level
+ * - PUT    /demographics         - u, record-level
+ * - DELETE /demographics/{id}    - w, record-level
  *
  * @since 2026-06-29
  * @see DemographicService
@@ -93,22 +101,34 @@ class DemographicServiceUnitTest extends CarlosUnitTestBase {
         injectDependency(service, "securityInfoManager", securityInfoManager);
     }
 
-    private void grantPrivilege(String privilege) {
-        lenient().when(securityInfoManager.hasPrivilege(any(), eq("_demographic"), eq(privilege), isNull()))
-                .thenReturn(true);
-        lenient().when(securityInfoManager.hasPrivilege(any(), eq("_demographic"), eq(privilege), anyInt()))
-                .thenReturn(true);
-    }
-
-    private void denyPrivilege(String privilege) {
-        lenient().when(securityInfoManager.hasPrivilege(any(), eq("_demographic"), eq(privilege), isNull()))
-                .thenReturn(false);
-        lenient().when(securityInfoManager.hasPrivilege(any(), eq("_demographic"), eq(privilege), anyInt()))
-                .thenReturn(false);
-    }
+    // The mock returns false for every hasPrivilege call by default, so the
+    // required privilege is implicitly denied; no per-privilege stubbing is
+    // needed for the FORBIDDEN paths. Tests instead assert which privilege
+    // string and scope the REST layer asked for, via Mockito verify(...).
 
     private static int statusOf(Throwable ex) {
         return ((WebApplicationException) ex).getResponse().getStatus();
+    }
+
+    private void assertThrowsWithStatus(ThrowingRunnable call, Response.Status expected) {
+        assertThatThrownBy(call::run)
+                .isInstanceOf(WebApplicationException.class)
+                .satisfies(ex -> assertThat(statusOf(ex)).isEqualTo(expected.getStatusCode()));
+    }
+
+    /** Asserts the object-level privilege string requested (no demographicNo). */
+    private void verifyObjectPrivilegeRequested(String privilege) {
+        verify(securityInfoManager).hasPrivilege(any(), eq("_demographic"), eq(privilege), isNull());
+    }
+
+    /** Asserts the record-level privilege string and demographicNo requested. */
+    private void verifyRecordPrivilegeRequested(String privilege, Integer demographicNo) {
+        verify(securityInfoManager).hasPrivilege(any(), eq("_demographic"), eq(privilege), eq(demographicNo));
+    }
+
+    @FunctionalInterface
+    private interface ThrowingRunnable {
+        void run() throws Exception;
     }
 
     @Nested
@@ -119,62 +139,28 @@ class DemographicServiceUnitTest extends CarlosUnitTestBase {
         @DisplayName("should throw 401 when not authenticated for GET /demographics")
         void shouldThrowUnauthorized_whenNotAuthenticated_forGetAllDemographics() {
             loggedInInfo = null;
-            assertThatThrownBy(() -> service.getAllDemographics(null, null))
-                    .isInstanceOf(WebApplicationException.class)
-                    .satisfies(ex -> assertThat(statusOf(ex))
-                            .isEqualTo(Response.Status.UNAUTHORIZED.getStatusCode()));
+            assertThrowsWithStatus(() -> service.getAllDemographics(null, null), Response.Status.UNAUTHORIZED);
         }
 
         @Test
-        @DisplayName("should throw 403 when read privilege denied for GET /demographics")
+        @DisplayName("should request object-level 'r' and throw 403 when denied for GET /demographics")
         void shouldThrowForbidden_whenReadPrivilegeDenied_forGetAllDemographics() {
-            denyPrivilege("r");
-            assertThatThrownBy(() -> service.getAllDemographics(null, null))
-                    .isInstanceOf(WebApplicationException.class)
-                    .satisfies(ex -> assertThat(statusOf(ex))
-                            .isEqualTo(Response.Status.FORBIDDEN.getStatusCode()));
+            assertThrowsWithStatus(() -> service.getAllDemographics(null, null), Response.Status.FORBIDDEN);
+            verifyObjectPrivilegeRequested("r");
         }
 
         @Test
         @DisplayName("should throw 401 when not authenticated for GET /demographics/{id}")
         void shouldThrowUnauthorized_whenNotAuthenticated_forGetDemographicData() {
             loggedInInfo = null;
-            assertThatThrownBy(() -> service.getDemographicData(42, Collections.emptyList()))
-                    .isInstanceOf(WebApplicationException.class)
-                    .satisfies(ex -> assertThat(statusOf(ex))
-                            .isEqualTo(Response.Status.UNAUTHORIZED.getStatusCode()));
+            assertThrowsWithStatus(() -> service.getDemographicData(42, Collections.emptyList()), Response.Status.UNAUTHORIZED);
         }
 
         @Test
-        @DisplayName("should throw 403 when read privilege denied for GET /demographics/{id}")
+        @DisplayName("should request record-level 'r' for the demographicNo and throw 403 when denied for GET /demographics/{id}")
         void shouldThrowForbidden_whenReadPrivilegeDenied_forGetDemographicData() {
-            denyPrivilege("r");
-            assertThatThrownBy(() -> service.getDemographicData(42, Collections.emptyList()))
-                    .isInstanceOf(WebApplicationException.class)
-                    .satisfies(ex -> assertThat(statusOf(ex))
-                            .isEqualTo(Response.Status.FORBIDDEN.getStatusCode()));
-        }
-
-        @Test
-        @DisplayName("should throw 403 when only update privilege held for GET /demographics")
-        void shouldThrowForbidden_whenOnlyUpdatePrivilege_forGetAllDemographics() {
-            grantPrivilege("u");
-            denyPrivilege("r");
-            assertThatThrownBy(() -> service.getAllDemographics(null, null))
-                    .isInstanceOf(WebApplicationException.class)
-                    .satisfies(ex -> assertThat(statusOf(ex))
-                            .isEqualTo(Response.Status.FORBIDDEN.getStatusCode()));
-        }
-
-        @Test
-        @DisplayName("should throw 403 when only write privilege held for GET /demographics")
-        void shouldThrowForbidden_whenOnlyWritePrivilege_forGetAllDemographics() {
-            grantPrivilege("w");
-            denyPrivilege("r");
-            assertThatThrownBy(() -> service.getAllDemographics(null, null))
-                    .isInstanceOf(WebApplicationException.class)
-                    .satisfies(ex -> assertThat(statusOf(ex))
-                            .isEqualTo(Response.Status.FORBIDDEN.getStatusCode()));
+            assertThrowsWithStatus(() -> service.getDemographicData(42, Collections.emptyList()), Response.Status.FORBIDDEN);
+            verifyRecordPrivilegeRequested("r", 42);
         }
     }
 
@@ -192,43 +178,14 @@ class DemographicServiceUnitTest extends CarlosUnitTestBase {
         @DisplayName("should throw 401 when not authenticated for PUT /demographics")
         void shouldThrowUnauthorized_whenNotAuthenticated_forUpdate() {
             loggedInInfo = null;
-            assertThatThrownBy(() -> service.updateDemographicData(validPayload()))
-                    .isInstanceOf(WebApplicationException.class)
-                    .satisfies(ex -> assertThat(statusOf(ex))
-                            .isEqualTo(Response.Status.UNAUTHORIZED.getStatusCode()));
+            assertThrowsWithStatus(() -> service.updateDemographicData(validPayload()), Response.Status.UNAUTHORIZED);
         }
 
         @Test
-        @DisplayName("should throw 403 when update privilege denied for PUT /demographics")
+        @DisplayName("should request record-level 'u' for the demographicNo and throw 403 when denied for PUT /demographics")
         void shouldThrowForbidden_whenUpdatePrivilegeDenied_forUpdate() {
-            denyPrivilege("u");
-            assertThatThrownBy(() -> service.updateDemographicData(validPayload()))
-                    .isInstanceOf(WebApplicationException.class)
-                    .satisfies(ex -> assertThat(statusOf(ex))
-                            .isEqualTo(Response.Status.FORBIDDEN.getStatusCode()));
-        }
-
-        @Test
-        @DisplayName("should throw 403 when only read privilege held for PUT /demographics")
-        void shouldThrowForbidden_whenOnlyReadPrivilege_forUpdate() {
-            grantPrivilege("r");
-            denyPrivilege("u");
-            assertThatThrownBy(() -> service.updateDemographicData(validPayload()))
-                    .isInstanceOf(WebApplicationException.class)
-                    .satisfies(ex -> assertThat(statusOf(ex))
-                            .isEqualTo(Response.Status.FORBIDDEN.getStatusCode()));
-        }
-
-        @Test
-        @DisplayName("should throw 403 when only write privilege held for PUT /demographics")
-        void shouldThrowForbidden_whenOnlyWritePrivilege_forUpdate() {
-            // w does not imply u -- PUT /demographics requires u, not w
-            grantPrivilege("w");
-            denyPrivilege("u");
-            assertThatThrownBy(() -> service.updateDemographicData(validPayload()))
-                    .isInstanceOf(WebApplicationException.class)
-                    .satisfies(ex -> assertThat(statusOf(ex))
-                            .isEqualTo(Response.Status.FORBIDDEN.getStatusCode()));
+            assertThrowsWithStatus(() -> service.updateDemographicData(validPayload()), Response.Status.FORBIDDEN);
+            verifyRecordPrivilegeRequested("u", 42);
         }
 
         @Test
@@ -236,10 +193,7 @@ class DemographicServiceUnitTest extends CarlosUnitTestBase {
         void shouldThrowUnauthorized_whenNotAuthenticated_andBodyIsNull_forUpdate() {
             // auth must fire before the null-body check, even in the missing-demographicNo branch
             loggedInInfo = null;
-            assertThatThrownBy(() -> service.updateDemographicData(null))
-                    .isInstanceOf(WebApplicationException.class)
-                    .satisfies(ex -> assertThat(statusOf(ex))
-                            .isEqualTo(Response.Status.UNAUTHORIZED.getStatusCode()));
+            assertThrowsWithStatus(() -> service.updateDemographicData(null), Response.Status.UNAUTHORIZED);
         }
     }
 
@@ -251,75 +205,28 @@ class DemographicServiceUnitTest extends CarlosUnitTestBase {
         @DisplayName("should throw 401 when not authenticated for POST /demographics")
         void shouldThrowUnauthorized_whenNotAuthenticated_forCreate() {
             loggedInInfo = null;
-            assertThatThrownBy(() -> service.createDemographicData(new DemographicTo1()))
-                    .isInstanceOf(WebApplicationException.class)
-                    .satisfies(ex -> assertThat(statusOf(ex))
-                            .isEqualTo(Response.Status.UNAUTHORIZED.getStatusCode()));
+            assertThrowsWithStatus(() -> service.createDemographicData(new DemographicTo1()), Response.Status.UNAUTHORIZED);
         }
 
         @Test
-        @DisplayName("should throw 403 when write privilege denied for POST /demographics")
+        @DisplayName("should request object-level 'w' and throw 403 when denied for POST /demographics")
         void shouldThrowForbidden_whenWritePrivilegeDenied_forCreate() {
-            denyPrivilege("w");
-            assertThatThrownBy(() -> service.createDemographicData(new DemographicTo1()))
-                    .isInstanceOf(WebApplicationException.class)
-                    .satisfies(ex -> assertThat(statusOf(ex))
-                            .isEqualTo(Response.Status.FORBIDDEN.getStatusCode()));
-        }
-
-        @Test
-        @DisplayName("should throw 403 when only read privilege held for POST /demographics")
-        void shouldThrowForbidden_whenOnlyReadPrivilege_forCreate() {
-            grantPrivilege("r");
-            denyPrivilege("w");
-            assertThatThrownBy(() -> service.createDemographicData(new DemographicTo1()))
-                    .isInstanceOf(WebApplicationException.class)
-                    .satisfies(ex -> assertThat(statusOf(ex))
-                            .isEqualTo(Response.Status.FORBIDDEN.getStatusCode()));
+            assertThrowsWithStatus(() -> service.createDemographicData(new DemographicTo1()), Response.Status.FORBIDDEN);
+            verifyObjectPrivilegeRequested("w");
         }
 
         @Test
         @DisplayName("should throw 401 when not authenticated for DELETE /demographics/{id}")
         void shouldThrowUnauthorized_whenNotAuthenticated_forDelete() {
             loggedInInfo = null;
-            assertThatThrownBy(() -> service.deleteDemographicData(42))
-                    .isInstanceOf(WebApplicationException.class)
-                    .satisfies(ex -> assertThat(statusOf(ex))
-                            .isEqualTo(Response.Status.UNAUTHORIZED.getStatusCode()));
+            assertThrowsWithStatus(() -> service.deleteDemographicData(42), Response.Status.UNAUTHORIZED);
         }
 
         @Test
-        @DisplayName("should throw 403 when write privilege denied for DELETE /demographics/{id}")
+        @DisplayName("should request record-level 'w' for the demographicNo and throw 403 when denied for DELETE /demographics/{id}")
         void shouldThrowForbidden_whenWritePrivilegeDenied_forDelete() {
-            denyPrivilege("w");
-            assertThatThrownBy(() -> service.deleteDemographicData(42))
-                    .isInstanceOf(WebApplicationException.class)
-                    .satisfies(ex -> assertThat(statusOf(ex))
-                            .isEqualTo(Response.Status.FORBIDDEN.getStatusCode()));
-        }
-
-        @Test
-        @DisplayName("should throw 403 when only delete privilege held for DELETE /demographics/{id}")
-        void shouldThrowForbidden_whenOnlyDeletePrivilege_forDelete() {
-            // DELETE /demographics/{id} requires w to align with DemographicManagerImpl.deleteDemographic;
-            // holding d alone is not sufficient.
-            grantPrivilege("d");
-            denyPrivilege("w");
-            assertThatThrownBy(() -> service.deleteDemographicData(42))
-                    .isInstanceOf(WebApplicationException.class)
-                    .satisfies(ex -> assertThat(statusOf(ex))
-                            .isEqualTo(Response.Status.FORBIDDEN.getStatusCode()));
-        }
-
-        @Test
-        @DisplayName("should throw 403 when only read privilege held for DELETE /demographics/{id}")
-        void shouldThrowForbidden_whenOnlyReadPrivilege_forDelete() {
-            grantPrivilege("r");
-            denyPrivilege("w");
-            assertThatThrownBy(() -> service.deleteDemographicData(42))
-                    .isInstanceOf(WebApplicationException.class)
-                    .satisfies(ex -> assertThat(statusOf(ex))
-                            .isEqualTo(Response.Status.FORBIDDEN.getStatusCode()));
+            assertThrowsWithStatus(() -> service.deleteDemographicData(42), Response.Status.FORBIDDEN);
+            verifyRecordPrivilegeRequested("w", 42);
         }
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/DemographicServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/DemographicServiceUnitTest.java
@@ -1,0 +1,325 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.webserv.rest;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
+import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import io.github.carlos_emr.carlos.webserv.rest.to.model.DemographicTo1;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.lenient;
+
+/**
+ * Unit tests for {@link DemographicService}.
+ *
+ * Covers read (r), update (u), and write (w) privilege tiers and verifies:
+ * - 401 UNAUTHORIZED when the session is absent
+ * - 403 FORBIDDEN when the required privilege is denied
+ * - 403 FORBIDDEN when a different privilege is held but not the required one
+ *
+ * Privilege mapping enforced at the REST layer:
+ * - GET /demographics         - r
+ * - GET /demographics/{id}    - r
+ * - POST /demographics        - w
+ * - PUT /demographics         - u
+ * - DELETE /demographics/{id} - w
+ *
+ * @since 2026-06-29
+ * @see DemographicService
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DemographicService unit tests")
+@Tag("unit")
+@Tag("fast")
+@Tag("security")
+@Tag("demographic")
+class DemographicServiceUnitTest extends CarlosUnitTestBase {
+
+    @Mock
+    private SecurityInfoManager securityInfoManager;
+
+    private DemographicService service;
+    /** Swapped to null in UNAUTHORIZED tests. */
+    private LoggedInInfo loggedInInfo;
+
+    @BeforeEach
+    void setUp() {
+        loggedInInfo = new LoggedInInfo();
+        service = new DemographicService() {
+            @Override
+            protected LoggedInInfo getLoggedInInfo() {
+                return loggedInInfo;
+            }
+        };
+        injectDependency(service, "securityInfoManager", securityInfoManager);
+    }
+
+    private void grantPrivilege(String privilege) {
+        lenient().when(securityInfoManager.hasPrivilege(any(), eq("_demographic"), eq(privilege), isNull()))
+                .thenReturn(true);
+        lenient().when(securityInfoManager.hasPrivilege(any(), eq("_demographic"), eq(privilege), anyInt()))
+                .thenReturn(true);
+    }
+
+    private void denyPrivilege(String privilege) {
+        lenient().when(securityInfoManager.hasPrivilege(any(), eq("_demographic"), eq(privilege), isNull()))
+                .thenReturn(false);
+        lenient().when(securityInfoManager.hasPrivilege(any(), eq("_demographic"), eq(privilege), anyInt()))
+                .thenReturn(false);
+    }
+
+    private static int statusOf(Throwable ex) {
+        return ((WebApplicationException) ex).getResponse().getStatus();
+    }
+
+    @Nested
+    @DisplayName("Read privilege (r)")
+    class ReadPrivilege {
+
+        @Test
+        @DisplayName("should throw 401 when not authenticated for GET /demographics")
+        void shouldThrowUnauthorized_whenNotAuthenticated_forGetAllDemographics() {
+            loggedInInfo = null;
+            assertThatThrownBy(() -> service.getAllDemographics(null, null))
+                    .isInstanceOf(WebApplicationException.class)
+                    .satisfies(ex -> assertThat(statusOf(ex))
+                            .isEqualTo(Response.Status.UNAUTHORIZED.getStatusCode()));
+        }
+
+        @Test
+        @DisplayName("should throw 403 when read privilege denied for GET /demographics")
+        void shouldThrowForbidden_whenReadPrivilegeDenied_forGetAllDemographics() {
+            denyPrivilege("r");
+            assertThatThrownBy(() -> service.getAllDemographics(null, null))
+                    .isInstanceOf(WebApplicationException.class)
+                    .satisfies(ex -> assertThat(statusOf(ex))
+                            .isEqualTo(Response.Status.FORBIDDEN.getStatusCode()));
+        }
+
+        @Test
+        @DisplayName("should throw 401 when not authenticated for GET /demographics/{id}")
+        void shouldThrowUnauthorized_whenNotAuthenticated_forGetDemographicData() {
+            loggedInInfo = null;
+            assertThatThrownBy(() -> service.getDemographicData(42, Collections.emptyList()))
+                    .isInstanceOf(WebApplicationException.class)
+                    .satisfies(ex -> assertThat(statusOf(ex))
+                            .isEqualTo(Response.Status.UNAUTHORIZED.getStatusCode()));
+        }
+
+        @Test
+        @DisplayName("should throw 403 when read privilege denied for GET /demographics/{id}")
+        void shouldThrowForbidden_whenReadPrivilegeDenied_forGetDemographicData() {
+            denyPrivilege("r");
+            assertThatThrownBy(() -> service.getDemographicData(42, Collections.emptyList()))
+                    .isInstanceOf(WebApplicationException.class)
+                    .satisfies(ex -> assertThat(statusOf(ex))
+                            .isEqualTo(Response.Status.FORBIDDEN.getStatusCode()));
+        }
+
+        @Test
+        @DisplayName("should throw 403 when only update privilege held for GET /demographics")
+        void shouldThrowForbidden_whenOnlyUpdatePrivilege_forGetAllDemographics() {
+            grantPrivilege("u");
+            denyPrivilege("r");
+            assertThatThrownBy(() -> service.getAllDemographics(null, null))
+                    .isInstanceOf(WebApplicationException.class)
+                    .satisfies(ex -> assertThat(statusOf(ex))
+                            .isEqualTo(Response.Status.FORBIDDEN.getStatusCode()));
+        }
+
+        @Test
+        @DisplayName("should throw 403 when only write privilege held for GET /demographics")
+        void shouldThrowForbidden_whenOnlyWritePrivilege_forGetAllDemographics() {
+            grantPrivilege("w");
+            denyPrivilege("r");
+            assertThatThrownBy(() -> service.getAllDemographics(null, null))
+                    .isInstanceOf(WebApplicationException.class)
+                    .satisfies(ex -> assertThat(statusOf(ex))
+                            .isEqualTo(Response.Status.FORBIDDEN.getStatusCode()));
+        }
+    }
+
+    @Nested
+    @DisplayName("Update privilege (u) -- PUT /demographics")
+    class UpdatePrivilege {
+
+        private DemographicTo1 validPayload() {
+            DemographicTo1 data = new DemographicTo1();
+            data.setDemographicNo(42);
+            return data;
+        }
+
+        @Test
+        @DisplayName("should throw 401 when not authenticated for PUT /demographics")
+        void shouldThrowUnauthorized_whenNotAuthenticated_forUpdate() {
+            loggedInInfo = null;
+            assertThatThrownBy(() -> service.updateDemographicData(validPayload()))
+                    .isInstanceOf(WebApplicationException.class)
+                    .satisfies(ex -> assertThat(statusOf(ex))
+                            .isEqualTo(Response.Status.UNAUTHORIZED.getStatusCode()));
+        }
+
+        @Test
+        @DisplayName("should throw 403 when update privilege denied for PUT /demographics")
+        void shouldThrowForbidden_whenUpdatePrivilegeDenied_forUpdate() {
+            denyPrivilege("u");
+            assertThatThrownBy(() -> service.updateDemographicData(validPayload()))
+                    .isInstanceOf(WebApplicationException.class)
+                    .satisfies(ex -> assertThat(statusOf(ex))
+                            .isEqualTo(Response.Status.FORBIDDEN.getStatusCode()));
+        }
+
+        @Test
+        @DisplayName("should throw 403 when only read privilege held for PUT /demographics")
+        void shouldThrowForbidden_whenOnlyReadPrivilege_forUpdate() {
+            grantPrivilege("r");
+            denyPrivilege("u");
+            assertThatThrownBy(() -> service.updateDemographicData(validPayload()))
+                    .isInstanceOf(WebApplicationException.class)
+                    .satisfies(ex -> assertThat(statusOf(ex))
+                            .isEqualTo(Response.Status.FORBIDDEN.getStatusCode()));
+        }
+
+        @Test
+        @DisplayName("should throw 403 when only write privilege held for PUT /demographics")
+        void shouldThrowForbidden_whenOnlyWritePrivilege_forUpdate() {
+            // w does not imply u -- PUT /demographics requires u, not w
+            grantPrivilege("w");
+            denyPrivilege("u");
+            assertThatThrownBy(() -> service.updateDemographicData(validPayload()))
+                    .isInstanceOf(WebApplicationException.class)
+                    .satisfies(ex -> assertThat(statusOf(ex))
+                            .isEqualTo(Response.Status.FORBIDDEN.getStatusCode()));
+        }
+
+        @Test
+        @DisplayName("should throw 401 before 400 when not authenticated and body is null for PUT /demographics")
+        void shouldThrowUnauthorized_whenNotAuthenticated_andBodyIsNull_forUpdate() {
+            // auth must fire before the null-body check, even in the missing-demographicNo branch
+            loggedInInfo = null;
+            assertThatThrownBy(() -> service.updateDemographicData(null))
+                    .isInstanceOf(WebApplicationException.class)
+                    .satisfies(ex -> assertThat(statusOf(ex))
+                            .isEqualTo(Response.Status.UNAUTHORIZED.getStatusCode()));
+        }
+    }
+
+    @Nested
+    @DisplayName("Write privilege (w) -- POST /demographics and DELETE /demographics/{id}")
+    class WritePrivilege {
+
+        @Test
+        @DisplayName("should throw 401 when not authenticated for POST /demographics")
+        void shouldThrowUnauthorized_whenNotAuthenticated_forCreate() {
+            loggedInInfo = null;
+            assertThatThrownBy(() -> service.createDemographicData(new DemographicTo1()))
+                    .isInstanceOf(WebApplicationException.class)
+                    .satisfies(ex -> assertThat(statusOf(ex))
+                            .isEqualTo(Response.Status.UNAUTHORIZED.getStatusCode()));
+        }
+
+        @Test
+        @DisplayName("should throw 403 when write privilege denied for POST /demographics")
+        void shouldThrowForbidden_whenWritePrivilegeDenied_forCreate() {
+            denyPrivilege("w");
+            assertThatThrownBy(() -> service.createDemographicData(new DemographicTo1()))
+                    .isInstanceOf(WebApplicationException.class)
+                    .satisfies(ex -> assertThat(statusOf(ex))
+                            .isEqualTo(Response.Status.FORBIDDEN.getStatusCode()));
+        }
+
+        @Test
+        @DisplayName("should throw 403 when only read privilege held for POST /demographics")
+        void shouldThrowForbidden_whenOnlyReadPrivilege_forCreate() {
+            grantPrivilege("r");
+            denyPrivilege("w");
+            assertThatThrownBy(() -> service.createDemographicData(new DemographicTo1()))
+                    .isInstanceOf(WebApplicationException.class)
+                    .satisfies(ex -> assertThat(statusOf(ex))
+                            .isEqualTo(Response.Status.FORBIDDEN.getStatusCode()));
+        }
+
+        @Test
+        @DisplayName("should throw 401 when not authenticated for DELETE /demographics/{id}")
+        void shouldThrowUnauthorized_whenNotAuthenticated_forDelete() {
+            loggedInInfo = null;
+            assertThatThrownBy(() -> service.deleteDemographicData(42))
+                    .isInstanceOf(WebApplicationException.class)
+                    .satisfies(ex -> assertThat(statusOf(ex))
+                            .isEqualTo(Response.Status.UNAUTHORIZED.getStatusCode()));
+        }
+
+        @Test
+        @DisplayName("should throw 403 when write privilege denied for DELETE /demographics/{id}")
+        void shouldThrowForbidden_whenWritePrivilegeDenied_forDelete() {
+            denyPrivilege("w");
+            assertThatThrownBy(() -> service.deleteDemographicData(42))
+                    .isInstanceOf(WebApplicationException.class)
+                    .satisfies(ex -> assertThat(statusOf(ex))
+                            .isEqualTo(Response.Status.FORBIDDEN.getStatusCode()));
+        }
+
+        @Test
+        @DisplayName("should throw 403 when only delete privilege held for DELETE /demographics/{id}")
+        void shouldThrowForbidden_whenOnlyDeletePrivilege_forDelete() {
+            // DELETE /demographics/{id} requires w to align with DemographicManagerImpl.deleteDemographic;
+            // holding d alone is not sufficient.
+            grantPrivilege("d");
+            denyPrivilege("w");
+            assertThatThrownBy(() -> service.deleteDemographicData(42))
+                    .isInstanceOf(WebApplicationException.class)
+                    .satisfies(ex -> assertThat(statusOf(ex))
+                            .isEqualTo(Response.Status.FORBIDDEN.getStatusCode()));
+        }
+
+        @Test
+        @DisplayName("should throw 403 when only read privilege held for DELETE /demographics/{id}")
+        void shouldThrowForbidden_whenOnlyReadPrivilege_forDelete() {
+            grantPrivilege("r");
+            denyPrivilege("w");
+            assertThatThrownBy(() -> service.deleteDemographicData(42))
+                    .isInstanceOf(WebApplicationException.class)
+                    .satisfies(ex -> assertThat(statusOf(ex))
+                            .isEqualTo(Response.Status.FORBIDDEN.getStatusCode()));
+        }
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/DemographicServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/DemographicServiceUnitTest.java
@@ -33,9 +33,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import io.github.carlos_emr.carlos.commn.model.Demographic;
+import io.github.carlos_emr.carlos.commn.model.DemographicContact;
+import io.github.carlos_emr.carlos.commn.model.DemographicExt;
+import io.github.carlos_emr.carlos.managers.DemographicManager;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import io.github.carlos_emr.carlos.webserv.rest.to.model.DemographicContactFewTo1;
 import io.github.carlos_emr.carlos.webserv.rest.to.model.DemographicTo1;
 
 import java.util.Collections;
@@ -45,7 +50,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for {@link DemographicService}.
@@ -85,6 +92,9 @@ class DemographicServiceUnitTest extends CarlosUnitTestBase {
     @Mock
     private SecurityInfoManager securityInfoManager;
 
+    @Mock
+    private DemographicManager demographicManager;
+
     private DemographicService service;
     /** Swapped to null in UNAUTHORIZED tests. */
     private LoggedInInfo loggedInInfo;
@@ -99,6 +109,7 @@ class DemographicServiceUnitTest extends CarlosUnitTestBase {
             }
         };
         injectDependency(service, "securityInfoManager", securityInfoManager);
+        injectDependency(service, "demographicManager", demographicManager);
     }
 
     // The mock returns false for every hasPrivilege call by default, so the
@@ -227,6 +238,51 @@ class DemographicServiceUnitTest extends CarlosUnitTestBase {
         void shouldThrowForbidden_whenWritePrivilegeDenied_forDelete() {
             assertThrowsWithStatus(() -> service.deleteDemographicData(42), Response.Status.FORBIDDEN);
             verifyRecordPrivilegeRequested("w", 42);
+        }
+    }
+
+    @Nested
+    @DisplayName("Personal demographic contact phone resolution")
+    class ContactPhoneResolution {
+
+        private final Integer contactId = 77;
+
+        private DemographicContact personalDemographicContact() {
+            DemographicContact contact = new DemographicContact();
+            contact.setCategory(DemographicContact.CATEGORY_PERSONAL);
+            contact.setType(DemographicContact.TYPE_DEMOGRAPHIC);
+            return contact;
+        }
+
+        @Test
+        @DisplayName("should fall back to the contact's own demo_cell when the contact record has no phone")
+        void shouldUseContactDemoCell_whenContactHasNoPhone_forPersonalDemographicContact() {
+            Demographic contact = new Demographic(); // no phone / phone2 on the contact record
+            DemographicExt contactCell = new DemographicExt();
+            contactCell.setValue("555-CONTACT-CELL");
+            when(demographicManager.getDemographic(loggedInInfo, contactId)).thenReturn(contact);
+            when(demographicManager.getDemographicExt(loggedInInfo, contactId, "demo_cell")).thenReturn(contactCell);
+
+            DemographicContactFewTo1 result =
+                    service.buildPersonalDemographicContact(loggedInInfo, personalDemographicContact(), contactId);
+
+            assertThat(result.getPhone()).isEqualTo("555-CONTACT-CELL");
+            // The demo_cell fallback must be keyed by the contact's own id, never the viewed patient's id.
+            verify(demographicManager).getDemographicExt(loggedInInfo, contactId, "demo_cell");
+        }
+
+        @Test
+        @DisplayName("should keep the contact's own phone and not query demo_cell when the contact record has a phone")
+        void shouldKeepContactPhone_whenContactHasPhone_forPersonalDemographicContact() {
+            Demographic contact = new Demographic();
+            contact.setPhone("555-OWN-PHONE");
+            when(demographicManager.getDemographic(loggedInInfo, contactId)).thenReturn(contact);
+
+            DemographicContactFewTo1 result =
+                    service.buildPersonalDemographicContact(loggedInInfo, personalDemographicContact(), contactId);
+
+            assertThat(result.getPhone()).isEqualTo("555-OWN-PHONE");
+            verify(demographicManager, never()).getDemographicExt(any(), any(), any(String.class));
         }
     }
 }


### PR DESCRIPTION
<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description

Resolves issue #2835. DemographicService exposes full CRUD operations on patient demographic records without any securityInfoManager.hasPrivilege() check. Any authenticated CARLOS user can create, read, update, or delete patient records regardless of their assigned role. I added securityInfoManager.hasPrivilege() calls at the top of each method with the appropriate security object (_demographic r/w/d), returning HTTP 403 on failure.

## How Was This Tested?

make install --run-unit-tests
```
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 5146, Failures: 0, Errors: 0, Skipped: 6
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
```
## Checklist

- [X] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [X] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [X] I have not included any patient data (PHI) in this PR
- [X] I have added tests for new functionality, or this change doesn't need new tests
- [X] I have read the [contributing guide](CONTRIBUTING.md)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Secured DemographicService by enforcing `_demographic` privilege checks across CRUD, basic/summary, and search, and standardized HTTP errors. Reverted the contact phone fallback change to keep existing `demo_cell` behavior.

- **Bug Fixes**
  - Enforce privileges via `requireDemographicPrivilege()`: `r` for GET/search, `w` for POST/DELETE, `u` for PUT; record-level checks when an ID is present; DELETE uses `w`.
  - Return 404 for missing records in GET/basic/summary/DELETE; 401 for unauthenticated; 403 for denied; 400 for bad/missing IDs or bodies. Auth is checked before validation.
  - Validate requests: POST requires a body; PUT requires a body with `demographicNo`; added `@Produces` on PUT (JSON/XML).
  - Search endpoints now return 401/403 instead of runtime errors.

- **Refactors**
  - Reuse a single `LoggedInInfo` and extracted `buildDemographicTo1(...)` to reduce duplication.
  - Added unit tests that assert the exact privilege string and scope requested from the REST layer.

<sup>Written for commit eed48240293b3787fe0df41ab73ad92693cd843b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2873?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



## Summary by Sourcery

Enforce privilege checks and standardize responses for DemographicService REST CRUD and search endpoints.

Bug Fixes:
- Guard all demographic CRUD, summary, and search endpoints with `_demographic` read/write/delete privilege checks including record-level access control.
- Return proper HTTP status codes (401, 403, 404) instead of runtime/illegal argument exceptions for unauthorized or missing demographic operations.

Enhancements:
- Introduce shared helper methods to centralize demographic privilege checking and reuse LoggedInInfo across operations.
- Refactor demographic retrieval and conversion into a reusable builder method to avoid duplication and ensure consistent response content.
- Add explicit JSON/XML response production for demographic update operations.