### PR TITLE
fix: return forbidden for tickler privilege failures

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/TicklerWebService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/TicklerWebService.java
@@ -33,13 +33,15 @@ import java.util.List;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.Consumes;
-import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -79,6 +81,12 @@ public class TicklerWebService extends AbstractServiceImpl {
     @Autowired
     private ProgramManager2 programManager;
 
+    private void requireTicklerPrivilege(String privilege) {
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_tickler", privilege, null)) {
+            throw new WebApplicationException(Response.status(Response.Status.FORBIDDEN).entity("Access Denied").build());
+        }
+    }
+
 
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
     @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
@@ -88,9 +96,7 @@ public class TicklerWebService extends AbstractServiceImpl {
     @Consumes("application/json")
     public TicklerResponse search(JsonNode json, @QueryParam("startIndex") int startIndex, @QueryParam("limit") int limit) {
 
-        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_tickler", "r", null)) {
-            throw new RuntimeException("Access Denied");
-        }
+        requireTicklerPrivilege("r");
 
         CustomFilter cf = new CustomFilter(true);
 
@@ -149,9 +155,7 @@ public class TicklerWebService extends AbstractServiceImpl {
     @Produces("application/json")
     public TicklerResponse getMyTicklers(@QueryParam("limit") int limit) {
 
-        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_tickler", "r", null)) {
-            throw new RuntimeException("Access Denied");
-        }
+        requireTicklerPrivilege("r");
 
         CustomFilter cf = new CustomFilter(true);
         cf.setAssignee(getLoggedInInfo().getLoggedInProviderNo());
@@ -173,9 +177,7 @@ public class TicklerWebService extends AbstractServiceImpl {
     @Produces("application/json")
     public TicklerResponse getTicklerList() {
 
-        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_tickler", "r", null)) {
-            throw new RuntimeException("Access Denied");
-        }
+        requireTicklerPrivilege("r");
 
         HttpServletRequest req = this.getHttpServletRequest();
 
@@ -267,9 +269,7 @@ public class TicklerWebService extends AbstractServiceImpl {
     @Consumes("application/json")
     public RestResponse<String> completeTicklers(JsonNode json) {
 
-        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_tickler", "u", null)) {
-            throw new RuntimeException("Access Denied");
-        }
+        requireTicklerPrivilege("u");
 
 
         MiscUtils.getLogger().info(json.toString());
@@ -290,9 +290,7 @@ public class TicklerWebService extends AbstractServiceImpl {
     @Consumes("application/json")
     public RestResponse<String> deleteTicklers(JsonNode json) {
 
-        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_tickler", "u", null)) {
-            throw new RuntimeException("Access Denied");
-        }
+        requireTicklerPrivilege("u");
 
         MiscUtils.getLogger().info(json.toString());
 
@@ -312,9 +310,7 @@ public class TicklerWebService extends AbstractServiceImpl {
     @Consumes("application/json")
     public RestResponse<String> updateTickler(JsonNode json) {
 
-        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_tickler", "u", null)) {
-            throw new RuntimeException("Access Denied");
-        }
+        requireTicklerPrivilege("u");
 
         MiscUtils.getLogger().info(json.toString());
 
@@ -365,9 +361,7 @@ public class TicklerWebService extends AbstractServiceImpl {
 
         AbstractSearchResponse<TicklerTextSuggestTo1> response = new AbstractSearchResponse<TicklerTextSuggestTo1>();
 
-        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_tickler", "r", null)) {
-            throw new RuntimeException("Access Denied");
-        }
+        requireTicklerPrivilege("r");
         List<TicklerTextSuggest> suggestions = ticklerManager.getActiveTextSuggestions(getLoggedInInfo());
 
         response.setContent(new TicklerTextSuggestConverter().getAllAsTransferObjects(getLoggedInInfo(), suggestions));
@@ -382,9 +376,7 @@ public class TicklerWebService extends AbstractServiceImpl {
     @Consumes("application/json")
     public RestResponse<String> addTickler(Tickler tickler) {
 
-        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_tickler", "w", null)) {
-            throw new RuntimeException("Access Denied");
-        }
+        requireTicklerPrivilege("w");
 
         tickler.setUpdateDate(new Date());
         tickler.setCreator(getLoggedInInfo().getLoggedInProviderNo());
@@ -405,9 +397,7 @@ public class TicklerWebService extends AbstractServiceImpl {
     @Path("/{demographicNo}/count/overdue")
     @Produces("application/json")
     public int getTicklerOverdueCount(@PathParam("demographicNo") Integer demographicNo) {
-        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_tickler", "r", null)) {
-            throw new RuntimeException("Access Denied");
-        }
+        requireTicklerPrivilege("r");
 
         int count = ticklerManager.getActiveTicklerByDemoCount(getLoggedInInfo(), demographicNo);
         return count;


### PR DESCRIPTION
## Description

Returns a JAX-RS 403 response when TicklerWebService privilege checks fail, instead of throwing a generic RuntimeException that can surface as HTTP 500.

## Related Issues

Fixes #2868

## How Was This Tested?

- `mvn -q -DskipTests compiler:compile`
- `mvn -q -DskipTests compiler:testCompile`
- `mvn -q -Dtest=io.github.carlos_emr.carlos.tickler.manager.TicklerManagerUnitTest test`

Note: full `mvn -DskipTests -Dlicense.skip=true compile` currently fails in `dependency-lock-maven-plugin:check` because the lockfile expects different `ultrabuk-htmltopdf-java` and `jna` artifacts than Maven resolves locally.

## Screenshots

N/A

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Returns HTTP 403 Forbidden when tickler privilege checks fail to prevent 500 errors and provide consistent auth responses. Adds a shared privilege guard across Tickler endpoints.

- **Bug Fixes**
  - Replaced RuntimeException checks with `WebApplicationException` returning 403 ("Access Denied").
  - Added `requireTicklerPrivilege(...)` and applied to `_tickler` privileges (`r`, `w`, `u`) across endpoints.

<sup>Written for commit 44b5edaee6ad0e953404c0766f60ebbed25f9fd5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2874?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Return consistent forbidden responses for unauthorized Tickler operations.

Bug Fixes:
- Return HTTP 403 Forbidden responses when Tickler privilege checks fail instead of allowing authorization failures to surface as generic server errors.

Enhancements:
- Centralize Tickler read, write, and update privilege enforcement across the web service endpoints.