### PR TITLE
fix: update Teleplan claim totals

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/TeleplanFileWriter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/TeleplanFileWriter.java
@@ -466,7 +466,7 @@ public class TeleplanFileWriter {
         }
 
         public void addToTotal(BigDecimal bd) {
-            bigTotal = bigTotal.add(bd);
+            claimTotal = claimTotal.add(bd);
         }
 
         public void increaseClaims() {


### PR DESCRIPTION
## Description

Fixes the Teleplan per-provider claim total aggregation so `TeleplanFileWriter.Claims.addToTotal()` updates the nested `claimTotal` field instead of mutating the outer `bigTotal` accumulator.

## Related Issues

Fixes #2849

## How Was This Tested?

- `mvn -q org.apache.maven.plugins:maven-compiler-plugin:3.13.0:compile`
- `mvn -q org.apache.maven.plugins:maven-checkstyle-plugin:3.6.0:check -Dcheckstyle.includes=src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/TeleplanFileWriter.java`

## Screenshots

N/A — no visual changes.

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Bug Fixes:
- Fix incorrect Teleplan claim total calculation by updating the nested claim total field rather than the outer big total accumulator.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Teleplan per-provider claim total aggregation by updating `TeleplanFileWriter.Claims.addToTotal()` to add to `claimTotal` instead of `bigTotal`, ensuring correct provider totals. Fixes #2849.

<sup>Written for commit 94bc895cbbdddd36c8698c3094beeb35251c527f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

