### PR TITLE
[Fix] Remove unnecessary replacements from doctorName

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/rx/ViewScript2.jsp
+++ b/src/main/webapp/WEB-INF/jsp/rx/ViewScript2.jsp
@@ -164,8 +164,6 @@
                 } else {
                     doctorName = (rxprovider.getFirstName() + ' ' + rxprovider.getSurname());
                 }
-                doctorName = doctorName.replaceAll("\\d{6}", "");
-                doctorName = doctorName.replaceAll("\\-", "");
 
                 vecAddressName = new Vector();
                 vecAddress = new Vector();


### PR DESCRIPTION
the clumsy replacements of {d6} and - for "" were "probably" placed to forcibly prevent redundant CPSO numbers in the signature from being printed eg Dr Joy Smith - 123456 however create difficult to trace bugs for 
Dr Isabelle Smith-Severenson
The signature should allow whatever the end user desires and only be SafeEncode

<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description
Prevents clumsy manipulations of the Signature string
<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues
Fixes #2877 
<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?
OSCAR 19
<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots
not necessary
<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->

## Checklist

- [X] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [X] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [X] I have not included any patient data (PHI) in this PR
- [X] I have added tests for new functionality, or this change doesn't need new tests
- [X] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Bug Fixes:
- Stop stripping six-digit number sequences and hyphens from the doctor name in prescription signatures to avoid corrupting valid names.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop stripping 6‑digit sequences and hyphens from `doctorName` in Rx signatures. Preserves hyphenated names and renders the user-entered signature as-is with SafeEncode, fixing #2877.

<sup>Written for commit cea20b65e4063c8acf59713043f35f5149985b5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

