### PR TITLE
Security: set JSON Content-Type for Flowsheet2Action responses (resolve XSS_SERVLET alerts)

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/flowsheet/Flowsheet2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/flowsheet/Flowsheet2Action.java
@@ -161,6 +161,12 @@ public class Flowsheet2Action extends ActionSupport {
         return list();
     }
 
+    private void writeJsonResponse(String json) throws IOException {
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(json);
+    }
+
     private FlowSheetUserCreated create(FlowSheetUserCreated fsuc) {
 
         FlowsheetDocument fd = FlowsheetDocument.Factory.newInstance();
@@ -485,7 +491,7 @@ public class Flowsheet2Action extends ActionSupport {
             }
         }
 
-        response.getWriter().write(resp.toString());
+        writeJsonResponse(resp.toString());
         return null;
     }
 
@@ -545,7 +551,7 @@ public class Flowsheet2Action extends ActionSupport {
         }
         resp.put("results", respArr);
 
-        response.getWriter().write(resp.toString());
+        writeJsonResponse(resp.toString());
 
         return null;
 
@@ -574,7 +580,7 @@ public class Flowsheet2Action extends ActionSupport {
         }
         resp.put("results", respArr);
 
-        response.getWriter().write(resp.toString());
+        writeJsonResponse(resp.toString());
 
         return null;
     }
@@ -595,7 +601,7 @@ public class Flowsheet2Action extends ActionSupport {
         }
         resp.put("results", respArr);
 
-        response.getWriter().write(resp.toString());
+        writeJsonResponse(resp.toString());
 
         return null;
     }
@@ -661,7 +667,7 @@ public class Flowsheet2Action extends ActionSupport {
         ObjectNode obj = objectMapper.createObjectNode();
         obj.put("success", true);
         obj.put("id", fsuc.getId());
-        response.getWriter().write(obj.toString());
+        writeJsonResponse(obj.toString());
 
         MeasurementTemplateFlowSheetConfig.getInstance().reloadFlowsheets();
 
@@ -748,7 +754,7 @@ public class Flowsheet2Action extends ActionSupport {
 
         ObjectNode obj = objectMapper.createObjectNode();
         obj.put("success", true);
-        response.getWriter().write(obj.toString());
+        writeJsonResponse(obj.toString());
         return null;
     }
 
@@ -802,7 +808,7 @@ public class Flowsheet2Action extends ActionSupport {
             }
         }
 
-        response.getWriter().write(obj.toString());
+        writeJsonResponse(obj.toString());
         return null;
 
     }
@@ -871,7 +877,7 @@ public class Flowsheet2Action extends ActionSupport {
 
         ObjectNode obj = objectMapper.createObjectNode();
         obj.put("success", true);
-        response.getWriter().write(obj.toString());
+        writeJsonResponse(obj.toString());
         return null;
     }
 
@@ -946,7 +952,7 @@ public class Flowsheet2Action extends ActionSupport {
 
         ObjectNode obj = objectMapper.createObjectNode();
         obj.put("success", true);
-        response.getWriter().write(obj.toString());
+        writeJsonResponse(obj.toString());
         return null;
     }
 
@@ -985,7 +991,7 @@ public class Flowsheet2Action extends ActionSupport {
 
         obj.put("indicators", jIndicators);
 
-        response.getWriter().write(obj.toString());
+        writeJsonResponse(obj.toString());
         return null;
 
     }
@@ -1045,7 +1051,7 @@ public class Flowsheet2Action extends ActionSupport {
             }
         }
 
-        response.getWriter().write(obj.toString());
+        writeJsonResponse(obj.toString());
         return null;
 
     }
@@ -1115,7 +1121,7 @@ public class Flowsheet2Action extends ActionSupport {
 
         ObjectNode obj = objectMapper.createObjectNode();
         obj.put("success", true);
-        response.getWriter().write(obj.toString());
+        writeJsonResponse(obj.toString());
         return null;
     }
 
@@ -1190,7 +1196,7 @@ public class Flowsheet2Action extends ActionSupport {
 
         ObjectNode obj = objectMapper.createObjectNode();
         obj.put("success", true);
-        response.getWriter().write(obj.toString());
+        writeJsonResponse(obj.toString());
         return null;
     }
 
@@ -1265,7 +1271,7 @@ public class Flowsheet2Action extends ActionSupport {
 
         ObjectNode obj = objectMapper.createObjectNode();
         obj.put("success", true);
-        response.getWriter().write(obj.toString());
+        writeJsonResponse(obj.toString());
         return null;
     }
 
@@ -1309,7 +1315,7 @@ public class Flowsheet2Action extends ActionSupport {
             }
         }
 
-        response.getWriter().write(obj.toString());
+        writeJsonResponse(obj.toString());
         return null;
     }
 
@@ -1388,7 +1394,7 @@ public class Flowsheet2Action extends ActionSupport {
             obj.put("items", iArr);
         }
 
-        response.getWriter().write(obj.toString());
+        writeJsonResponse(obj.toString());
         return null;
     }
 
@@ -1433,7 +1439,7 @@ public class Flowsheet2Action extends ActionSupport {
         }
 
         resp.put("results", fsList);
-        response.getWriter().write(resp.toString());
+        writeJsonResponse(resp.toString());
 
         return null;
     }
@@ -1479,7 +1485,7 @@ public class Flowsheet2Action extends ActionSupport {
         }
 
         resp.put("results", fsList);
-        response.getWriter().write(resp.toString());
+        writeJsonResponse(resp.toString());
 
         return null;
     }
@@ -1540,7 +1546,7 @@ public class Flowsheet2Action extends ActionSupport {
         }
         resp.put("results", fsList);
 
-        response.getWriter().write(resp.toString());
+        writeJsonResponse(resp.toString());
         return null;
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/flowsheet/Flowsheet2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/flowsheet/Flowsheet2Action.java
@@ -93,6 +93,7 @@ public class Flowsheet2Action extends ActionSupport {
     HttpServletRequest request = ServletActionContext.getRequest();
     HttpServletResponse response = ServletActionContext.getResponse();
 
+    private static final String JSON_CONTENT_TYPE = "application/json; charset=UTF-8";
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
     private FlowSheetUserCreatedDao flowsheetUserCreatedDao = SpringUtils.getBean(FlowSheetUserCreatedDao.class);
@@ -162,7 +163,7 @@ public class Flowsheet2Action extends ActionSupport {
     }
 
     private void writeJsonResponse(String json) throws IOException {
-        response.setContentType("application/json");
+        response.setContentType(JSON_CONTENT_TYPE);
         response.setCharacterEncoding("UTF-8");
         response.getWriter().write(json);
     }
@@ -683,7 +684,7 @@ public class Flowsheet2Action extends ActionSupport {
         obj.put("success", true);
         obj.put("id", id);
 
-        response.setContentType("application/json");
+        response.setContentType(JSON_CONTENT_TYPE);
         response.setCharacterEncoding("UTF-8");
 
         objectMapper.writeValue(response.getWriter(), obj);

--- a/src/test/java/io/github/carlos_emr/carlos/web/JsonResponseHeaderRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/web/JsonResponseHeaderRegressionTest.java
@@ -68,6 +68,8 @@ class JsonResponseHeaderRegressionTest extends CarlosUnitTestBase {
             "src/main/java/io/github/carlos_emr/carlos/mds/pageUtil/ReportMacro2Action.java");
     private static final Path MEASUREMENT_DATA_ACTION = PROJECT_ROOT.resolve(
             "src/main/java/io/github/carlos_emr/carlos/measurements/web/MeasurementData2Action.java");
+    private static final Path FLOWSHEET2_ACTION = PROJECT_ROOT.resolve(
+            "src/main/java/io/github/carlos_emr/carlos/flowsheet/Flowsheet2Action.java");
 
     private MockedStatic<ServletActionContext> servletActionContextMock;
 
@@ -121,6 +123,27 @@ class JsonResponseHeaderRegressionTest extends CarlosUnitTestBase {
         assertThat(helperJsonContentTypeIndex).isNotNegative();
         assertThat(helperJsonWriteIndex).isNotNegative();
         assertThat(helperJsonContentTypeIndex).isLessThan(helperJsonWriteIndex);
+    }
+
+
+    @Test
+    @DisplayName("should set JSON content type before flowsheet action writes")
+    void shouldSetJsonContentType_beforeFlowsheetActionWrites() throws IOException {
+        String source = Files.readString(FLOWSHEET2_ACTION, StandardCharsets.UTF_8);
+
+        int helperIndex = source.indexOf("private void writeJsonResponse(String json) throws IOException");
+        int helperContentTypeIndex = source.indexOf("response.setContentType(\"application/json\");", helperIndex);
+        int helperEncodingIndex = source.indexOf("response.setCharacterEncoding(\"UTF-8\");", helperIndex);
+        int helperWriteIndex = source.indexOf("response.getWriter().write(json);", helperIndex);
+
+        assertThat(source).doesNotContain("response.getWriter().write(resp.toString())");
+        assertThat(source).doesNotContain("response.getWriter().write(obj.toString())");
+        assertThat(helperIndex).isNotNegative();
+        assertThat(helperContentTypeIndex).isNotNegative();
+        assertThat(helperEncodingIndex).isNotNegative();
+        assertThat(helperWriteIndex).isNotNegative();
+        assertThat(helperContentTypeIndex).isLessThan(helperWriteIndex);
+        assertThat(helperEncodingIndex).isLessThan(helperWriteIndex);
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/web/JsonResponseHeaderRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/web/JsonResponseHeaderRegressionTest.java
@@ -26,6 +26,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
@@ -45,14 +46,23 @@ import org.mockito.MockedStatic;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
+import io.github.carlos_emr.carlos.PMmodule.dao.ProviderDao;
+import io.github.carlos_emr.carlos.commn.dao.DemographicDao;
+import io.github.carlos_emr.carlos.commn.dao.FlowSheetUserCreatedDao;
+import io.github.carlos_emr.carlos.commn.dao.Icd9Dao;
 import io.github.carlos_emr.carlos.commn.dao.MeasurementDao;
+import io.github.carlos_emr.carlos.commn.dao.MeasurementTypeDao;
 import io.github.carlos_emr.carlos.commn.dao.OscarAppointmentDao;
 import io.github.carlos_emr.carlos.commn.dao.TicklerDao;
 import io.github.carlos_emr.carlos.commn.dao.TicklerLinkDao;
 import io.github.carlos_emr.carlos.commn.dao.UserPropertyDAO;
+import io.github.carlos_emr.carlos.commn.dao.ValidationsDao;
 import io.github.carlos_emr.carlos.commn.model.Measurement;
 import io.github.carlos_emr.carlos.commn.model.Provider;
 import io.github.carlos_emr.carlos.commn.model.UserProperty;
+import io.github.carlos_emr.carlos.commn.model.Validations;
+import io.github.carlos_emr.carlos.encounter.oscarMeasurements.MeasurementTemplateFlowSheetConfig;
+import io.github.carlos_emr.carlos.flowsheet.Flowsheet2Action;
 import io.github.carlos_emr.carlos.mds.pageUtil.ReportMacro2Action;
 import io.github.carlos_emr.carlos.measurements.web.MeasurementData2Action;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
@@ -68,8 +78,6 @@ class JsonResponseHeaderRegressionTest extends CarlosUnitTestBase {
             "src/main/java/io/github/carlos_emr/carlos/mds/pageUtil/ReportMacro2Action.java");
     private static final Path MEASUREMENT_DATA_ACTION = PROJECT_ROOT.resolve(
             "src/main/java/io/github/carlos_emr/carlos/measurements/web/MeasurementData2Action.java");
-    private static final Path FLOWSHEET2_ACTION = PROJECT_ROOT.resolve(
-            "src/main/java/io/github/carlos_emr/carlos/flowsheet/Flowsheet2Action.java");
 
     private MockedStatic<ServletActionContext> servletActionContextMock;
 
@@ -127,23 +135,51 @@ class JsonResponseHeaderRegressionTest extends CarlosUnitTestBase {
 
 
     @Test
-    @DisplayName("should set JSON content type before flowsheet action writes")
-    void shouldSetJsonContentType_beforeFlowsheetActionWrites() throws IOException {
-        String source = Files.readString(FLOWSHEET2_ACTION, StandardCharsets.UTF_8);
+    @DisplayName("should emit UTF-8 JSON for flowsheet validations")
+    void shouldEmitUtf8Json_forFlowsheetValidations() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        response.setCharacterEncoding(StandardCharsets.ISO_8859_1.name());
+        configureServletActionContext(request, response);
 
-        int helperIndex = source.indexOf("private void writeJsonResponse(String json) throws IOException");
-        int helperContentTypeIndex = source.indexOf("response.setContentType(\"application/json\");", helperIndex);
-        int helperEncodingIndex = source.indexOf("response.setCharacterEncoding(\"UTF-8\");", helperIndex);
-        int helperWriteIndex = source.indexOf("response.getWriter().write(json);", helperIndex);
+        ValidationsDao validationsDao = mock(ValidationsDao.class);
+        registerFlowsheetActionBeans(mock(FlowSheetUserCreatedDao.class), validationsDao);
+        when(validationsDao.findAll()).thenReturn(List.of(newValidation("José 東京")));
 
-        assertThat(source).doesNotContain("response.getWriter().write(resp.toString())");
-        assertThat(source).doesNotContain("response.getWriter().write(obj.toString())");
-        assertThat(helperIndex).isNotNegative();
-        assertThat(helperContentTypeIndex).isNotNegative();
-        assertThat(helperEncodingIndex).isNotNegative();
-        assertThat(helperWriteIndex).isNotNegative();
-        assertThat(helperContentTypeIndex).isLessThan(helperWriteIndex);
-        assertThat(helperEncodingIndex).isLessThan(helperWriteIndex);
+        new Flowsheet2Action().getValidations();
+
+        String body = new String(response.getContentAsByteArray(), StandardCharsets.UTF_8);
+        assertThat(response.getContentType()).isEqualTo("application/json; charset=UTF-8");
+        assertThat(response.getCharacterEncoding()).isEqualTo(StandardCharsets.UTF_8.name());
+        assertThat(body).contains("José 東京");
+    }
+
+    @Test
+    @DisplayName("should emit UTF-8 JSON for flowsheet deletion")
+    void shouldEmitUtf8Json_forDeleteFlowsheet() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        response.setCharacterEncoding(StandardCharsets.ISO_8859_1.name());
+        request.setParameter("id", "42");
+        configureServletActionContext(request, response);
+
+        FlowSheetUserCreatedDao flowsheetUserCreatedDao = mock(FlowSheetUserCreatedDao.class);
+        registerFlowsheetActionBeans(flowsheetUserCreatedDao, mock(ValidationsDao.class));
+        MeasurementTemplateFlowSheetConfig flowsheetConfig = mock(MeasurementTemplateFlowSheetConfig.class);
+
+        try (MockedStatic<MeasurementTemplateFlowSheetConfig> flowsheetConfigMock =
+                     mockStatic(MeasurementTemplateFlowSheetConfig.class)) {
+            flowsheetConfigMock.when(MeasurementTemplateFlowSheetConfig::getInstance).thenReturn(flowsheetConfig);
+
+            new Flowsheet2Action().deleteFlowsheet();
+        }
+
+        String body = new String(response.getContentAsByteArray(), StandardCharsets.UTF_8);
+        assertThat(response.getContentType()).isEqualTo("application/json; charset=UTF-8");
+        assertThat(response.getCharacterEncoding()).isEqualTo(StandardCharsets.UTF_8.name());
+        assertThat(body).contains("\"success\":true", "\"id\":\"42\"");
+        verify(flowsheetUserCreatedDao).remove(42);
+        verify(flowsheetConfig).reloadFlowsheets();
     }
 
     @Test
@@ -267,6 +303,29 @@ class JsonResponseHeaderRegressionTest extends CarlosUnitTestBase {
         assertThat(response.getContentType()).isEqualTo("application/javascript; charset=UTF-8");
         assertThat(response.getCharacterEncoding()).isEqualTo(StandardCharsets.UTF_8.name());
         assertThat(body).contains("jQuery");
+    }
+
+    private void registerFlowsheetActionBeans(FlowSheetUserCreatedDao flowsheetUserCreatedDao,
+            ValidationsDao validationsDao) {
+        registerMock(SecurityInfoManager.class, mock(SecurityInfoManager.class));
+        registerMock(FlowSheetUserCreatedDao.class, flowsheetUserCreatedDao);
+        registerMock(ProviderDao.class, mock(ProviderDao.class));
+        registerMock(Icd9Dao.class, mock(Icd9Dao.class));
+        registerMock(DemographicDao.class, mock(DemographicDao.class));
+        registerMock(MeasurementTypeDao.class, mock(MeasurementTypeDao.class));
+        registerMock(ValidationsDao.class, validationsDao);
+    }
+
+    private Validations newValidation(String name) {
+        Validations validation = new Validations();
+        validation.setId(7);
+        validation.setName(name);
+        validation.setRegularExp(".*");
+        validation.setMinValue(1.0);
+        validation.setMaxValue(10.0);
+        validation.setMinLength(1);
+        validation.setMaxLength(20);
+        return validation;
     }
 
     private void configureServletActionContext(MockHttpServletRequest request, MockHttpServletResponse response) {


### PR DESCRIPTION
### Motivation
- Static analysis reported multiple `XSS_SERVLET` findings where `Flowsheet2Action` wrote JSON to `response.getWriter()` without an explicit JSON content type, which can allow content-sniffing and reflected XSS risks.
- The repository convention is to emit JSON responses as `application/json; charset=UTF-8` and to verify response headers behaviorally where practical.

### Description
- Add a shared `JSON_CONTENT_TYPE = "application/json; charset=UTF-8"` constant and a `writeJsonResponse(String json)` helper in `Flowsheet2Action`.
- Replace direct `response.getWriter().write(resp.toString())` / `response.getWriter().write(obj.toString())` flowsheet AJAX writes with `writeJsonResponse(...)` so headers are set before the body is written.
- Update `deleteFlowsheet` to use the same `JSON_CONTENT_TYPE` while keeping its existing `objectMapper.writeValue(response.getWriter(), obj)` serialization path.
- Replace the flowsheet source-text-scanning regression with behavioral tests that invoke real `Flowsheet2Action` paths (`getValidations` and `deleteFlowsheet`) and assert `MockHttpServletResponse` content type, character encoding, decoded UTF-8 body, and delete side effects.

### Testing
- `mvn -Dtest=JsonResponseHeaderRegressionTest test`
- `git diff --check`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d81db6850832884175b83a582e7a9)
