### PR TITLE
[codex] Fix duplicate schedule navigation test declarations

### DIFF
--- a/src/test/java/io/github/carlos_emr/carlos/provider/web/ScheduleNavigationAssetRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/provider/web/ScheduleNavigationAssetRegressionTest.java
@@ -63,8 +63,6 @@ class ScheduleNavigationAssetRegressionTest {
             Path.of("src", "main", "webapp", "WEB-INF", "jsp", "tickler", "ticklerMain.jsp");
     private static final Path MAIN_MENU_JSP =
             Path.of("src", "main", "webapp", "WEB-INF", "jsp", "provider", "mainMenu.jsp");
-    private static final Path TICKLER_MAIN_JSP =
-            Path.of("src", "main", "webapp", "WEB-INF", "jsp", "tickler", "ticklerMain.jsp");
     private static final Path REPORT_INDEX_JSP =
             Path.of("src", "main", "webapp", "WEB-INF", "jsp", "report", "reportindex.jsp");
     private static final Path APPOINTMENT_PROVIDER_DAY_JSP =
@@ -121,7 +119,6 @@ class ScheduleNavigationAssetRegressionTest {
         String ticklerMain = Files.readString(TICKLER_MAIN_JSP, StandardCharsets.UTF_8);
         String normalizedTicklerMain = normalizeWhitespace(ticklerMain);
         String mainMenu = Files.readString(MAIN_MENU_JSP, StandardCharsets.UTF_8);
-        String ticklerMain = Files.readString(TICKLER_MAIN_JSP, StandardCharsets.UTF_8);
         String reportIndex = Files.readString(REPORT_INDEX_JSP, StandardCharsets.UTF_8);
         String appointmentProviderDay = Files.readString(APPOINTMENT_PROVIDER_DAY_JSP, StandardCharsets.UTF_8);
         String scheduleScript = Files.readString(SCHEDULE_PAGE_SCRIPT, StandardCharsets.UTF_8);


### PR DESCRIPTION
## What changed
- Removed the duplicate `TICKLER_MAIN_JSP` constant from `ScheduleNavigationAssetRegressionTest`.
- Removed the duplicate `ticklerMain` local variable read in the schedule navigation destination-page regression test.

## Why
`make install` failed during Maven `testCompile` because the test class declared the same field and local variable twice.

## Impact
The test sources compile again, allowing the install/package flow to complete.

## Validation
- `make install` completed successfully with Maven `BUILD SUCCESS` and started Tomcat.

## Summary by Sourcery

Fix a test compilation failure by removing duplicate schedule navigation constants and local variable declarations in ScheduleNavigationAssetRegressionTest.

Bug Fixes:
- Remove duplicate TICKLER_MAIN_JSP constant declaration from ScheduleNavigationAssetRegressionTest.
- Remove duplicate ticklerMain variable read in the schedule navigation destination-page regression test to resolve compilation errors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed a test compile failure by removing a duplicate `TICKLER_MAIN_JSP` constant and a duplicate `ticklerMain` read in `ScheduleNavigationAssetRegressionTest`. Test sources compile again and `make install` completes successfully.

<sup>Written for commit 261dae3e918a00c2478dd53558ac36239ce91b13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2884?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

