### PR TITLE
 fix: replace Integer.parseInt with safe default fallback layout size in 

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/encounter/pageUtil/EctSaveEncounter2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/pageUtil/EctSaveEncounter2Action.java
@@ -65,6 +65,13 @@ import org.apache.struts2.ServletActionContext;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class EctSaveEncounter2Action extends ActionSupport {
+
+    static final int DEFAULT_ROW_ONE_SIZE = 60;
+    static final int DEFAULT_ROW_TWO_SIZE = 60;
+    static final int DEFAULT_ROW_THREE_SIZE = 378;
+    static final int DEFAULT_PRES_BOX_SIZE = 30;
+    private static final int MIN_LAYOUT_SIZE = 10;
+
     HttpServletRequest httpservletrequest = ServletActionContext.getRequest();
     HttpServletResponse httpservletresponse = ServletActionContext.getResponse();
 
@@ -73,6 +80,11 @@ public class EctSaveEncounter2Action extends ActionSupport {
     OscarAppointmentDao appointmentDao = (OscarAppointmentDao) SpringUtils.getBean(OscarAppointmentDao.class);
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
 
+
+    static int parseLayoutSize(String param, int defaultValue) {
+        int value = ConversionUtils.fromIntString(param);
+        return value >= MIN_LAYOUT_SIZE ? value : defaultValue;
+    }
 
     private String getLatestID(String demoNo) {
         EChartDao dao = SpringUtils.getBean(EChartDao.class);
@@ -277,10 +289,10 @@ public class EctSaveEncounter2Action extends ActionSupport {
 
         EncounterWindow ew = new EncounterWindow();
         ew.setProviderNo(sessionbean.providerNo);
-        ew.setRowOneSize(Integer.parseInt(httpservletrequest.getParameter("rowOneSize")));
-        ew.setRowTwoSize(Integer.parseInt(httpservletrequest.getParameter("rowTwoSize")));
-        ew.setRowThreeSize(Integer.parseInt(httpservletrequest.getParameter("rowThreeSize")));
-        ew.setPresBoxSize(Integer.parseInt(httpservletrequest.getParameter("presBoxSize")));
+        ew.setRowOneSize(parseLayoutSize(httpservletrequest.getParameter("rowOneSize"), DEFAULT_ROW_ONE_SIZE));
+        ew.setRowTwoSize(parseLayoutSize(httpservletrequest.getParameter("rowTwoSize"), DEFAULT_ROW_TWO_SIZE));
+        ew.setRowThreeSize(parseLayoutSize(httpservletrequest.getParameter("rowThreeSize"), DEFAULT_ROW_THREE_SIZE));
+        ew.setPresBoxSize(parseLayoutSize(httpservletrequest.getParameter("presBoxSize"), DEFAULT_PRES_BOX_SIZE));
         encounterWindowDao.persist(ew);
 
         String forward = null;

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/pageUtil/EctSaveEncounter2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/pageUtil/EctSaveEncounter2Action.java
@@ -81,9 +81,22 @@ public class EctSaveEncounter2Action extends ActionSupport {
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
 
 
+    /**
+     * Parses a layout size from the given request parameter string.
+     * Returns {@code defaultValue} if the parameter is null, non-numeric,
+     * or below the minimum layout size threshold ({@value MIN_LAYOUT_SIZE} px).
+     *
+     * @param param        the raw request parameter string
+     * @param defaultValue the field-specific default to apply on invalid input
+     * @return the parsed size, or {@code defaultValue} if the input is invalid or too small
+     */
     static int parseLayoutSize(String param, int defaultValue) {
         int value = ConversionUtils.fromIntString(param);
-        return value >= MIN_LAYOUT_SIZE ? value : defaultValue;
+        if (value >= MIN_LAYOUT_SIZE) {
+            return value;
+        }
+        log.debug("parseLayoutSize: invalid or missing layout param, using default {}", defaultValue);
+        return defaultValue;
     }
 
     private String getLatestID(String demoNo) {

--- a/src/test/java/io/github/carlos_emr/carlos/encounter/pageUtil/EctSaveEncounter2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/encounter/pageUtil/EctSaveEncounter2ActionTest.java
@@ -1,0 +1,39 @@
+package io.github.carlos_emr.carlos.encounter.pageUtil;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static io.github.carlos_emr.carlos.encounter.pageUtil.EctSaveEncounter2Action.DEFAULT_ROW_ONE_SIZE;
+import static io.github.carlos_emr.carlos.encounter.pageUtil.EctSaveEncounter2Action.parseLayoutSize;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Tag("unit")
+@Tag("fast")
+@Tag("encounter")
+class EctSaveEncounter2ActionTest {
+
+    @Test
+    void shouldReturnDefault_whenParamIsNull() {
+        assertThat(parseLayoutSize(null, DEFAULT_ROW_ONE_SIZE)).isEqualTo(DEFAULT_ROW_ONE_SIZE);
+    }
+
+    @Test
+    void shouldReturnDefault_whenParamIsNonNumeric() {
+        assertThat(parseLayoutSize("abc", DEFAULT_ROW_ONE_SIZE)).isEqualTo(DEFAULT_ROW_ONE_SIZE);
+    }
+
+    @Test
+    void shouldReturnDefault_whenParamIsNegative() {
+        assertThat(parseLayoutSize("-5", DEFAULT_ROW_ONE_SIZE)).isEqualTo(DEFAULT_ROW_ONE_SIZE);
+    }
+
+    @Test
+    void shouldReturnDefault_whenValueIsBelowMinimum() {
+        assertThat(parseLayoutSize("9", DEFAULT_ROW_ONE_SIZE)).isEqualTo(DEFAULT_ROW_ONE_SIZE);
+    }
+
+    @Test
+    void shouldReturnValue_whenParamIsValid() {
+        assertThat(parseLayoutSize("50", DEFAULT_ROW_ONE_SIZE)).isEqualTo(50);
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/encounter/pageUtil/EctSaveEncounter2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/encounter/pageUtil/EctSaveEncounter2ActionUnitTest.java
@@ -10,7 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Tag("unit")
 @Tag("fast")
 @Tag("encounter")
-class EctSaveEncounter2ActionTest {
+class EctSaveEncounter2ActionUnitTest {
 
     @Test
     void shouldReturnDefault_whenParamIsNull() {
@@ -30,6 +30,11 @@ class EctSaveEncounter2ActionTest {
     @Test
     void shouldReturnDefault_whenValueIsBelowMinimum() {
         assertThat(parseLayoutSize("9", DEFAULT_ROW_ONE_SIZE)).isEqualTo(DEFAULT_ROW_ONE_SIZE);
+    }
+
+    @Test
+    void shouldReturnValue_whenParamEqualsMinimum() {
+        assertThat(parseLayoutSize("10", DEFAULT_ROW_ONE_SIZE)).isEqualTo(10);
     }
 
     @Test


### PR DESCRIPTION
…parsing

<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description

<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->
`EctSaveEncounter2Action.execute()` called `Integer.parseInt()` on four request parameters (`rowOneSize`, `rowTwoSize`, `rowThreeSize`, `presBoxSize`) with no null check or validation. Any missing or non-numeric value threw an unhandled `NumberFormatException`, resulting in a 500 error.

Replaced the four `parseInt` calls with a `parseLayoutSize()` helper that uses `ConversionUtils.fromIntString()` for null/non-numeric safety, then clamps any value below the minimum UI height (10px) to the field's known default (60 / 60 / 378 / 30).

## Related Issues

<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->
Related to #2595

## How Was This Tested?
Added unit tests in `EctSaveEncounter2ActionTest` covering:
- `null` parameter → returns default
- Non-numeric string → returns default
- Negative value → returns default
- Value below minimum (9) → returns default
- Valid value (50) → passes through unchanged

## Screenshots

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Handle encounter layout size parameters safely to avoid failures from invalid request values.

Bug Fixes:
- Prevent unhandled errors when encounter layout size request parameters are null, non-numeric, or below the minimum size by falling back to sane defaults.

Tests:
- Add unit tests covering the layout size parsing helper for null, non-numeric, negative, below-minimum, and valid values.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent 500s when saving encounter layout by safely parsing layout size params and falling back to defaults. Enforces a 10px minimum; invalid or too-small values no longer crash.

- **Bug Fixes**
  - Replaced `Integer.parseInt` for `rowOneSize`, `rowTwoSize`, `rowThreeSize`, `presBoxSize` with `parseLayoutSize()` using `ConversionUtils.fromIntString`; values <10 or non-numeric/null use defaults (60, 60, 378, 30), 10+ pass; logs a debug message on fallback.
  - Added unit tests in `EctSaveEncounter2ActionUnitTest` for null, non-numeric, negative, below-min, equals-min, and valid inputs.

<sup>Written for commit 76f0cafddb8b3c949ef64e15f1783549c394ed06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2886?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

