### PR TITLE
Fix eForm PDF null path handling

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/managers/EformDataManagerImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/EformDataManagerImpl.java
@@ -193,12 +193,12 @@ public class EformDataManagerImpl implements EformDataManager {
             throw new PDFGenerationException("Error Details: EForm [" + eformData.getFormName() + "] could not be converted into a PDF", e);
         }
 
-        if (Files.isReadable(path)) {
-            LogAction.addLogSynchronous(loggedInInfo, "EformDataManager.saveEformDataAsPDF", "Document saved at " + path.toString());
-        } else {
+        if (path == null || !Files.isReadable(path)) {
             LogAction.addLogSynchronous(loggedInInfo, "EformDataManager.saveEformDataAsPDF", "Document failed to save for eform id " + fdid);
+            throw new PDFGenerationException("Error Details: EForm [" + eformData.getFormName() + "] could not be converted into a readable PDF");
         }
 
+        LogAction.addLogSynchronous(loggedInInfo, "EformDataManager.saveEformDataAsPDF", "Document saved at " + path);
         return path;
     }
 


### PR DESCRIPTION
### Motivation
- Prevent a `NullPointerException` when `createEformPDF` returns a null `Path` (previously `Files.isReadable(path)` could be called with `path == null`) and provide a clear `PDFGenerationException` and logging instead.

Fixes #2869
### Description
- Add a guard `if (path == null || !Files.isReadable(path))` in `EformDataManagerImpl.createEformPDF` to log the failure and throw a `PDFGenerationException` when the temporary PDF is missing or unreadable.
- Move the success log to after the guard and return the verified `Path` so downstream code does not encounter `Files.isReadable(null)`.

### Testing
- Ran `mvn -q -DskipTests compile`, which completed successfully.
- No unit tests were modified; this change is a runtime guard to avoid the reported NPE in save/attachment rendering.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d7fefb9fc8328827cc1065d16fe63)

## Summary by Sourcery

Bug Fixes:
- Ensure eForm PDF generation throws a PDFGenerationException with logging when the generated Path is null or unreadable instead of triggering a NullPointerException.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes eForm PDF generation by validating the file path and failing fast with a PDFGenerationException instead of a NullPointerException. Success is logged only after the file is confirmed readable.

- Bug Fixes
  - Guard added: if path is null or unreadable, log failure and throw PDFGenerationException.
  - Move success log after validation and return the verified Path.

<sup>Written for commit 03985e958ebd577ef4f36711e0ffa7b3dada5792. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2888?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

