### PR TITLE
Remove HTML comments before Flying Saucer fallback to fix eForm PDF preview errors

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/ConvertToEdoc.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/ConvertToEdoc.java
@@ -34,8 +34,10 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Comment;
 import org.jsoup.nodes.Element;
 import org.jsoup.nodes.Entities;
+import org.jsoup.nodes.Node;
 import org.jsoup.select.Elements;
 import io.github.carlos_emr.carlos.commn.model.EFormData;
 import io.github.carlos_emr.carlos.email.core.EmailData;
@@ -428,6 +430,9 @@ public final class ConvertToEdoc {
         
         // Remove scripts (Flying Saucer can't execute them)
         doc.select("script").remove();
+
+        // XML comments cannot contain double hyphens; remove comments before Flying Saucer parses XHTML.
+        removeComments(doc);
         
         // Ensure img tags have alt attributes (XHTML requirement)
         doc.select("img:not([alt])").attr("alt", "");
@@ -436,6 +441,22 @@ public final class ConvertToEdoc {
         doc.select("input:not([type])").attr("type", "text");
         
         return doc;
+    }
+
+    /**
+     * Removes HTML comments before serializing as XHTML. Jsoup preserves comments as-is, but
+     * XML parsers reject comments containing double hyphens, which prevents Flying Saucer from
+     * rendering otherwise valid eForms. Comments are not visible PDF content, so dropping them is
+     * safer than attempting to rewrite author-provided markup.
+     */
+    private static void removeComments(Node node) {
+        for (Node child : new ArrayList<>(node.childNodes())) {
+            if (child instanceof Comment) {
+                child.remove();
+            } else {
+                removeComments(child);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
### Motivation

- Flying Saucer (the fallback PDF renderer) requires well-formed XHTML and fails when XML comments contain `--`, causing eForm PDF preview generation to error. 

### Description
Fixes #2867

- Add imports for `org.jsoup.nodes.Comment` and `org.jsoup.nodes.Node` and a recursive helper `removeComments(Node)` that strips HTML comments from the Jsoup DOM. 
- Call `removeComments(doc)` inside `prepareDocumentForFlyingSaucer` before serializing to XHTML so invalid XML comment text cannot reach the XML parser. 
- Preserve existing fallback preparations (script removal, image `alt` attributes, input `type` defaults) so visible content and other XHTML fixes remain intact. 

### Testing

- Ran `git diff --check` which reported no whitespace or diff errors. 
- Ran `mvn -q -DskipTests compile` which completed successfully. 
- Attempted a focused `mvn -Dtest=ConvertToEdocTest test` during experimentation which errored due to `ConvertToEdoc` static initializers calling `SpringUtils.getBean(...)` without a Spring context (test file was removed before the commit).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d8041a8048328a2f82327ea2c4f28)

## Summary by Sourcery

Bug Fixes:
- Remove HTML comments from the parsed document before Flying Saucer processes it so malformed XML comments with double hyphens no longer break eForm PDF preview rendering.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes HTML comments before the Flying Saucer fallback to stop eForm PDF preview failures caused by invalid XML comments with double hyphens. No visible content changes.

- **Bug Fixes**
  - Added `removeComments(Node)` to recursively strip `org.jsoup.nodes.Comment` nodes.
  - Called in `prepareDocumentForFlyingSaucer` before serializing to XHTML; added `org.jsoup.nodes.Comment` and `org.jsoup.nodes.Node` imports.
  - Keeps existing cleanup (remove scripts, ensure `img` has `alt`, default input `type`).

<sup>Written for commit dfd531e919a5fe4a0cd3dfb0c82d5df9c8ce5159. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2889?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

