### PR TITLE
[Fix] 2517 Fixes lab forwarding (missing JS file refs)

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/lab/CA/ALL/labDisplay.jsp
+++ b/src/main/webapp/WEB-INF/jsp/lab/CA/ALL/labDisplay.jsp
@@ -2659,6 +2659,12 @@ input[id^='acklabel_']{
 <%} %>
 
 <script type="text/javascript"
+        src="${pageContext.servletContext.contextPath}/library/jquery/jquery-ui-1.14.2.min.js"></script>
+<script type="text/javascript"
+        src="${pageContext.servletContext.contextPath}/js/demographicProviderAutocomplete.js"></script>
+<script type="text/javascript"
+        src="${pageContext.servletContext.contextPath}/js/carlosAutocomplete.js"></script>
+<script type="text/javascript"
         src="${pageContext.servletContext.contextPath}/library/dompurify/purify.min.js"></script>
 <script type="text/javascript"
         src="${pageContext.servletContext.contextPath}/share/javascript/oscarMDSIndex.js"></script>

--- a/src/main/webapp/WEB-INF/jsp/oscarMDS/Index.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarMDS/Index.jsp
@@ -396,6 +396,8 @@ MDS.index.btnSearch"/>"
             src="${pageContext.servletContext.contextPath}/js/jquery.tablesorter.widgets.js"></script>
     <script type="text/javascript"
             src="${pageContext.servletContext.contextPath}/js/demographicProviderAutocomplete.js"></script>
+    <script type="text/javascript"
+            src="${pageContext.servletContext.contextPath}/js/carlosAutocomplete.js"></script>
 
     <script type="text/javascript" src="${pageContext.servletContext.contextPath}/js/global.js"></script>
     <script type="text/javascript" src="${pageContext.servletContext.contextPath}/share/javascript/Oscar.js"></script>


### PR DESCRIPTION
modified:   src/main/webapp/WEB-INF/jsp/lab/CA/ALL/labDisplay.jsp
	modified:   src/main/webapp/WEB-INF/jsp/oscarMDS/Index.jsp

<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description
Forwarding button in labs did not work
<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

The root cause: SelectProvider.jsp's inline script calls initProviderAutocomplete (from carlosAutocomplete.js), and when it's loaded via the AJAX dialog path in oscarMDSIndex.js, only the inline scripts are re-executed on the parent page — the external <script src> tags in SelectProvider.jsp's <head> are never loaded. So the parent page must supply those dependencies.

[labDisplay.jsp](vscode-webview://0njchuqovskvkqoj3svdbm423mkovcq4kl1qr1m77hjds6moqf7e/src/main/webapp/WEB-INF/jsp/lab/CA/ALL/labDisplay.jsp) — added demographicProviderAutocomplete.js + carlosAutocomplete.js (was missing both)
[Index.jsp](vscode-webview://0njchuqovskvkqoj3svdbm423mkovcq4kl1qr1m77hjds6moqf7e/src/main/webapp/WEB-INF/jsp/oscarMDS/Index.jsp) — added carlosAutocomplete.js (had demographicProviderAutocomplete.js but not the wrapper that defines initProviderAutocomplete)
## Related Issues
Fixes #2517
<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?
production labs

<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Ensure lab forwarding and provider selection dialogs have required autocomplete JavaScript dependencies loaded from the parent pages.

Bug Fixes:
- Restore functionality of the lab forwarding button by including missing autocomplete script dependencies on the lab display page.
- Fix provider autocomplete initialization in the OSCAR MDS index page by adding the wrapper script that defines the initProviderAutocomplete function.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the lab "Forward" action by ensuring provider autocomplete scripts load when the Select Provider dialog opens via AJAX. Adds missing JS includes so `initProviderAutocomplete` is available (Fixes #2517).

- **Bug Fixes**
  - Root cause: inline dialog code called `initProviderAutocomplete`, but external scripts in the dialog weren’t loaded via AJAX; parent pages must include them.
  - Changes: in `labDisplay.jsp` add `jquery-ui-1.14.2.min.js`, `demographicProviderAutocomplete.js`, `carlosAutocomplete.js`; in `oscarMDS/Index.jsp` add `carlosAutocomplete.js`.

<sup>Written for commit 225e23aaf94c60aebbd34ae2091bc094e658fc0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

