### PR TITLE
[Fix] 2316 encode eform image filenames in efmimagemanager.jsp to prevent XSS

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/eform/efmimagemanager.jsp
+++ b/src/main/webapp/WEB-INF/jsp/eform/efmimagemanager.jsp
@@ -32,8 +32,6 @@
 <%@ page import="io.github.carlos_emr.carlos.eform.data.*, io.github.carlos_emr.CarlosProperties, io.github.carlos_emr.carlos.eform.*, java.util.*" %>
 <%@ page import="io.github.carlos_emr.carlos.eform.EFormUtil" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
-<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
-<%@ taglib uri="carlos" prefix="carlos" %>
 <fmt:setBundle basename="oscarResources"/>
 
 
@@ -49,19 +47,14 @@
 
             function deleteImg(image) {
                 if (confirm("<fmt:message key="eform.uploadimages.imgDelete"/>")) {
-                    var form = document.createElement('form');
-                    form.method = 'post';
-                    form.action = '<%=request.getContextPath()%>/eform/deleteImage';
-                    var input = document.createElement('input');
-                    input.type = 'hidden';
-                    input.name = 'filename';
-                    input.value = image;
-                    form.appendChild(input);
-                    document.body.appendChild(form);
-                    form.submit();
+                    document.getElementById('deleteImgFilename').value = image;
+                    document.getElementById('deleteImgForm').submit();
                 }
             }
         </script>
+        <form id="deleteImgForm" method="post" action="<%=request.getContextPath()%>/eform/deleteImage" style="display:none;">
+            <input type="hidden" name="filename" id="deleteImgFilename"/>
+        </form>
     <link rel="stylesheet" href="<%= request.getContextPath() %>/library/bootstrap/5.3.8/css/bootstrap.min.css">
     <script type="text/javascript" src="<%= request.getContextPath() %>/library/bootstrap/5.3.8/js/bootstrap.bundle.min.js"></script>
     </head>
@@ -91,9 +84,9 @@
             ArrayList images = EFormUtil.listImages();
             request.setAttribute("images", images);
             for (int i = 0; i < images.size(); i++) {
-                String fileURL = request.getContextPath() + "/eform/displayImage?imagefile=" + images.get(i);
-                //String fileURL="/OscarDocument/" + project_home + "/eform/images/"+images.get(i);
                 String curimage = (String) images.get(i);
+                String fileURL = request.getContextPath() + "/eform/displayImage?imagefile=" + URLEncoder.encode(curimage, java.nio.charset.StandardCharsets.UTF_8);
+                //String fileURL="/OscarDocument/" + project_home + "/eform/images/"+images.get(i);
         %>
 
         <tr>

--- a/src/main/webapp/WEB-INF/jsp/eform/efmimagemanager.jsp
+++ b/src/main/webapp/WEB-INF/jsp/eform/efmimagemanager.jsp
@@ -52,9 +52,6 @@
                 }
             }
         </script>
-        <form id="deleteImgForm" method="post" action="<%=request.getContextPath()%>/eform/deleteImage" style="display:none;">
-            <input type="hidden" name="filename" id="deleteImgFilename"/>
-        </form>
     <link rel="stylesheet" href="<%= request.getContextPath() %>/library/bootstrap/5.3.8/css/bootstrap.min.css">
     <script type="text/javascript" src="<%= request.getContextPath() %>/library/bootstrap/5.3.8/js/bootstrap.bundle.min.js"></script>
     </head>
@@ -62,6 +59,10 @@
     <body topmargin="0" leftmargin="0" rightmargin="0">
 
     <%@ include file="efmTopNav.jspf" %>
+
+    <form id="deleteImgForm" method="post" action="<%=request.getContextPath()%>/eform/deleteImage" style="display:none;">
+        <input type="hidden" name="filename" id="deleteImgFilename"/>
+    </form>
 
     <h3>Image Library</h3>
 


### PR DESCRIPTION
## Description

  Adds output encoding to the eForm Image Library (`efmimagemanager.jsp`), which
  rendered image filenames into three sinks without encoding — a stored-XSS
  defense-in-depth gap. A malicious filename could break out of the `title`
  attribute, the `onclick` JavaScript string, or the link text and execute script.

  Each filename sink is now encoded with the project's null-safe `SafeEncode`
  helper (scriptlet form `<%= SafeEncode.forXxx(...) %>`), using the method that
  matches where the value lands:

  - line 101 — `title="..."` attribute → `SafeEncode.forHtmlAttribute(curimage)`
  - line 103 — `showImage('...')` onclick string → `SafeEncode.forJavaScriptAttribute(fileURL)`
  - line 103 — link text (HTML body) → `SafeEncode.forHtmlContent(curimage)`
  - line 108 — `deleteImg('...')` onclick string → `SafeEncode.forJavaScriptAttribute(curimage)`
    (already encoded before this change; converted from the `<carlos:encode>` tag
    to the scriptlet form so the whole file uses one consistent style)

  `SafeEncode` is the repository's mandated null-safe wrapper around the OWASP
  Encoder (CLAUDE.md "Use the CARLOS wrappers for all new code"; the CI lint
  `check-encoder-null-safety.sh` forbids raw `Encode.forXxx(...)` because
  `Encode.forXxx(null)` renders the literal string "null"). Scriptlet form was
  chosen over the `<carlos:encode>` tag because this JSP is scriptlet-heavy and it
  avoids nested double quotes inside HTML attributes.

  This is defense-in-depth: `PathValidationUtils.validateFileName()` strips unsafe
  characters at upload, so it isn't exploitable through the normal UI, but the
  view layer should not rely solely on upstream sanitization.

  ## Related Issues

  Fixes #2316

  ## How Was This Tested?

  **Files modified:**
  - `src/main/webapp/WEB-INF/jsp/eform/efmimagemanager.jsp` — wrapped the four filename sinks in `SafeEncode`.
  - `src/test/java/io/github/carlos_emr/carlos/utility/EformImageFilenameEncodingUnitTest.java` — new unit tests (added).

  **Unit tests:** `EformImageFilenameEncodingUnitTest` verifies each encoding
  context neutralizes a malicious filename payload `htmlAttribute` escapes a
  script-tag attribute breakout, `javaScriptAttribute` escapes a cookie-exfil
  single-quote breakout (→ `\x27`), and `html` escapes an SVG `onload` injection
  (`<`/`>` → `&lt;`/`&gt;`).
  ```bash
mvn test -Dtest=EformImageFilenameEncodingUnitTest
  # Tests run: 3, Failures: 0 
```

  Manual testing: Planted malicious-named files directly in the eform image
  dir (bypassing the upload sanitizer) and loaded /carlos/eform/efmimagemanager:
  - Before the fix: filenames fired alert() on hover (title), click (onclick), and page render (<img onerror> link text); View Page Source
  showed the raw payloads.
  - After the fix: no alerts fire, and View Page Source shows the filenames escaped (&#34;, &#39;/\x27, &lt;).

## Videos

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->

Before:

https://github.com/user-attachments/assets/d30239d5-b592-4db5-abcb-bbb0fd638430

After:

https://github.com/user-attachments/assets/7db079c1-d714-4f6d-8bff-2f4d56a534d8

<img width="928" height="276" alt="image" src="https://github.com/user-attachments/assets/09ac0409-1524-4276-8f94-94c1147e5165" />


## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [ ] I have not included any patient data (PHI) in this PR
- [ ] I have added tests for new functionality, or this change doesn't need new tests
- [ ] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Encode eForm image filenames in the image manager JSP to prevent XSS and add regression tests to pin the encoding behavior.

Bug Fixes:
- Encode eForm image filenames rendered into HTML attributes, JavaScript handlers, and link text in efmimagemanager.jsp to close an XSS defense-in-depth gap.

Tests:
- Add unit tests that verify SafeEncode correctly escapes malicious payloads for HTML attribute, JavaScript attribute, and HTML content contexts used by the eForm image manager.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the eForm image library by encoding filenames in `efmimagemanager.jsp` and URL‑encoding image links (UTF‑8) to block stored XSS; also simplified deletion with a hidden body form. Fixes #2316.

- **Bug Fixes**
  - Encode filename in all sinks with `SafeEncode`: `title` → HtmlAttribute, JS handlers → JavaScriptAttribute, link text → HtmlContent.
  - URL‑encode the `imagefile` query param when building `fileURL`; added `EformImageFilenameEncodingUnitTest` (covers null → empty string and renamed display names).

- **Refactors**
  - Removed encoder taglibs; use `SafeEncode` scriptlets for consistency.
  - Replaced dynamic delete‑form creation with a hidden form in the body; `deleteImg(...)` sets the hidden field and submits it (moved out of the head per review).

<sup>Written for commit 5602e4414d9405ed3e4a51db327731e0065b9ced. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2896?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



