### PR TITLE
Consultation Start/End date search returns no results even when matching referral dates exist (codex assist)  #2588

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/ConsultationRequestDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/ConsultationRequestDaoImpl.java
@@ -36,7 +36,6 @@ import java.util.List;
 
 import jakarta.persistence.Query;
 
-import org.apache.commons.lang3.time.DateFormatUtils;
 import io.github.carlos_emr.carlos.commn.NativeSql;
 import io.github.carlos_emr.carlos.commn.model.ConsultationRequest;
 import io.github.carlos_emr.carlos.consultation.dto.ConsultationRequestListItemDTO;
@@ -88,23 +87,21 @@ public class ConsultationRequestDaoImpl extends AbstractDaoImpl<ConsultationRequ
         }
 
         if (!team.isEmpty()) {
-            sql.append("and cr.sendTo = '" + team + "' ");
+            sql.append("and cr.sendTo = :team ");
         }
 
+        boolean searchByAppt = searchDate != null && searchDate.equals("1");
+
         if (startDate != null) {
-            if (searchDate != null && searchDate.equals("1")) {
-                sql.append("and cr.appointmentDate >= '" + DateFormatUtils.ISO_DATETIME_FORMAT.format(startDate) + "' ");
-            } else {
-                sql.append("and cr.referralDate >= '" + DateFormatUtils.ISO_DATETIME_FORMAT.format(startDate) + "' ");
-            }
+            sql.append(searchByAppt
+                    ? "and cr.appointmentDate >= :startDate "
+                    : "and cr.referralDate >= :startDate ");
         }
 
         if (endDate != null) {
-            if (searchDate != null && searchDate.equals("1")) {
-                sql.append("and cr.appointmentDate <= '" + DateFormatUtils.ISO_DATETIME_FORMAT.format(endDate) + "' ");
-            } else {
-                sql.append("and cr.referralDate <= '" + DateFormatUtils.ISO_DATETIME_FORMAT.format(endDate) + "' ");
-            }
+            sql.append(searchByAppt
+                    ? "and cr.appointmentDate <= :endDate "
+                    : "and cr.referralDate <= :endDate ");
         }
 
         String orderDesc = desc != null && desc.equals("1") ? "DESC" : "";
@@ -135,6 +132,15 @@ public class ConsultationRequestDaoImpl extends AbstractDaoImpl<ConsultationRequ
 
 
         Query query = entityManager.createQuery(sql.toString());
+        if (!team.isEmpty()) {
+            query.setParameter("team", team);
+        }
+        if (startDate != null) {
+            query.setParameter("startDate", startDate);
+        }
+        if (endDate != null) {
+            query.setParameter("endDate", endDate);
+        }
         query.setFirstResult(offset != null ? offset : 0);
 
         //need to never send more than MAX_LIST_RETURN_SIZE


### PR DESCRIPTION
<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description

The issue here was that DateFormatUtils.ISO_DATETIME_FORMAT.format(startDate) produces a string like 2024-05-21T00:00:00. The T separator is not valid in JPQL date literals for MariaDB, so the query would execute but match nothing and return 0 rows. I got rid of the date formatting and used named parameters for startDate and endDate instead.

## Related Issues

Fixes #2588 

## How Was This Tested?

1. Log in as carlosdoc.
2. Open consultations: ```/encounter/IncomingConsultation```
3. Confirm the unfiltered table shows rows with referral dates including 2024-05-21 and 2024-05-17.
4. Set:
   - Start: 2024-05-17
   - End: 2024-05-21
   - Search on: Referral Date
5. Click Search.
6. Rows with Referral Date between 2024-05-17 and 2024-05-21 should be shown.

## Screenshots

<img width="1755" height="891" alt="Screenshot 2026-06-14 at 9 46 21 PM" src="https://github.com/user-attachments/assets/ae9716a5-6277-4e3a-b9eb-7843b74cabd6" />


## Checklist

- [X] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [X] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [X] I have not included any patient data (PHI) in this PR
- [X] I have added tests for new functionality, or this change doesn't need new tests
- [X] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Fix consultation search queries to correctly filter by referral or appointment dates and use bind parameters instead of interpolated literals.

Bug Fixes:
- Resolve consultation start/end date searches returning no results when matching referral or appointment dates exist.

Enhancements:
- Switch consultation search query to use named parameters for team and date filters instead of string-concatenated literals for safer and more robust querying.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes date-range search for consultations so Referral Date or Appointment Date filters return the correct rows. Replaces string-formatted JPQL date literals with named parameters (including team) to work with MariaDB and avoid mismatches; fixes #2588.

- **Bug Fixes**
  - Use `:startDate`, `:endDate`, and `:team` parameters in `io.github.carlos_emr.carlos.commn.dao.ConsultationRequestDaoImpl`.
  - Select the correct column based on the "Search on" value (appointment vs referral date).

<sup>Written for commit 7bf6a0e306423e97e2fddbd56c8c3a2a8502f535. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

