### PR TITLE
Fix live update for schedule navigation preference

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/provider/mainMenu.jsp
+++ b/src/main/webapp/WEB-INF/jsp/provider/mainMenu.jsp
@@ -393,6 +393,46 @@
     var scheduleNavActive = <%=scheduleNavActive%>;
     var contextPath = document.getElementById("contextPath").value;
 
+    function normalizeScheduleMenuNavigationMode(mode) {
+        if (mode === 'tab' || mode === 'focused') {
+            return mode;
+        }
+        return 'popup';
+    }
+
+    function applyScheduleMenuNavigationPreference(mode) {
+        var normalizedMode = normalizeScheduleMenuNavigationMode(mode);
+        scheduleNavActive = normalizedMode === 'tab' || normalizedMode === 'focused';
+    }
+
+    if (typeof window.applyScheduleNavigationPreference !== 'function') {
+        window.applyScheduleNavigationPreference = applyScheduleMenuNavigationPreference;
+    }
+
+    function handleScheduleMenuNavigationPreferenceMessage(message) {
+        if (message && message.mode) {
+            applyScheduleMenuNavigationPreference(message.mode);
+        }
+    }
+
+    try {
+        var scheduleNavigationPreferenceChannel = new BroadcastChannel('carlos_schedule_navigation_mode');
+        scheduleNavigationPreferenceChannel.onmessage = function(event) {
+            handleScheduleMenuNavigationPreferenceMessage(event.data);
+        };
+    } catch(e) { /* BroadcastChannel not supported */ }
+
+    try {
+        window.addEventListener('storage', function(event) {
+            if (event.key !== 'carlos_schedule_navigation_mode' || !event.newValue) {
+                return;
+            }
+            try {
+                handleScheduleMenuNavigationPreferenceMessage(JSON.parse(event.newValue));
+            } catch(e) {}
+        });
+    } catch(e) {}
+
     function appendScheduleMenuQueryParam(url, key, value) {
         var parts = String(url).split('#');
         var base = parts[0];

--- a/src/main/webapp/WEB-INF/jsp/provider/mainMenu.jsp
+++ b/src/main/webapp/WEB-INF/jsp/provider/mainMenu.jsp
@@ -405,9 +405,14 @@
         scheduleNavActive = normalizedMode === 'tab' || normalizedMode === 'focused';
     }
 
-    if (typeof window.applyScheduleNavigationPreference !== 'function') {
-        window.applyScheduleNavigationPreference = applyScheduleMenuNavigationPreference;
-    }
+    var existingApplyScheduleNavigationPreference = window.applyScheduleNavigationPreference;
+    window.applyScheduleNavigationPreference = function(mode) {
+        applyScheduleMenuNavigationPreference(mode);
+        if (typeof existingApplyScheduleNavigationPreference === 'function'
+                && existingApplyScheduleNavigationPreference !== applyScheduleMenuNavigationPreference) {
+            existingApplyScheduleNavigationPreference(mode);
+        }
+    };
 
     function handleScheduleMenuNavigationPreferenceMessage(message) {
         if (message && message.mode) {

--- a/src/main/webapp/WEB-INF/jsp/provider/providerupdatepreference.jsp
+++ b/src/main/webapp/WEB-INF/jsp/provider/providerupdatepreference.jsp
@@ -145,11 +145,8 @@
 
                     String submittedScheduleNavigationMode = request.getParameter(UserProperty.SCHEDULE_NAVIGATION_MODE);
                     if (submittedScheduleNavigationMode != null) {
-                        savedScheduleNavigationMode = submittedScheduleNavigationMode.trim();
-                        if (!UserProperty.SCHEDULE_NAVIGATION_MODE_TAB.equals(savedScheduleNavigationMode)
-                                && !UserProperty.SCHEDULE_NAVIGATION_MODE_FOCUSED.equals(savedScheduleNavigationMode)) {
-                            savedScheduleNavigationMode = UserProperty.SCHEDULE_NAVIGATION_MODE_POPUP;
-                        }
+                        savedScheduleNavigationMode = UserProperty.resolveScheduleNavigationMode(
+                                submittedScheduleNavigationMode, false);
                     }
 
                     // Save tickler provider number after other preferences succeed

--- a/src/main/webapp/WEB-INF/jsp/provider/providerupdatepreference.jsp
+++ b/src/main/webapp/WEB-INF/jsp/provider/providerupdatepreference.jsp
@@ -116,6 +116,7 @@
             boolean saveSuccess = false;
             String errorDetails = null;
             ProviderPreference providerPreference = null;
+            String savedScheduleNavigationMode = null;
 
             String curUser_providerno = loggedInInfo.getLoggedInProviderNo();
 
@@ -141,6 +142,15 @@
                     // Save all preferences atomically - if any fail, all fail
                     providerPreference = ProviderPreferencesUIBean.updateOrCreateProviderPreferences(request);
                     ProviderPropertyAction.updateOrCreateProviderProperties(request);
+
+                    String submittedScheduleNavigationMode = request.getParameter(UserProperty.SCHEDULE_NAVIGATION_MODE);
+                    if (submittedScheduleNavigationMode != null) {
+                        savedScheduleNavigationMode = submittedScheduleNavigationMode.trim();
+                        if (!UserProperty.SCHEDULE_NAVIGATION_MODE_TAB.equals(savedScheduleNavigationMode)
+                                && !UserProperty.SCHEDULE_NAVIGATION_MODE_FOCUSED.equals(savedScheduleNavigationMode)) {
+                            savedScheduleNavigationMode = UserProperty.SCHEDULE_NAVIGATION_MODE_POPUP;
+                        }
+                    }
 
                     // Save tickler provider number after other preferences succeed
                     if (ticklerforproviderno != null && !ticklerforproviderno.trim().isEmpty()
@@ -181,6 +191,26 @@
         %>
         <% if (saveSuccess) { %>
         <script LANGUAGE="JavaScript">
+            <% if (savedScheduleNavigationMode != null) { %>
+            var scheduleNavigationPreferencePayload = {
+                mode: '<%= org.owasp.encoder.Encode.forJavaScript(savedScheduleNavigationMode) %>',
+                source: 'provider-preference',
+                timestamp: Date.now()
+            };
+            try {
+                if (self.opener && typeof self.opener.applyScheduleNavigationPreference === 'function') {
+                    self.opener.applyScheduleNavigationPreference(scheduleNavigationPreferencePayload.mode);
+                }
+            } catch (e) {}
+            try {
+                var scheduleNavigationPreferenceChannel = new BroadcastChannel('carlos_schedule_navigation_mode');
+                scheduleNavigationPreferenceChannel.postMessage(scheduleNavigationPreferencePayload);
+                scheduleNavigationPreferenceChannel.close();
+            } catch (e) {}
+            try {
+                localStorage.setItem('carlos_schedule_navigation_mode', JSON.stringify(scheduleNavigationPreferencePayload));
+            } catch (e) {}
+            <% } %>
             if (self.opener && typeof self.opener.refresh1 === 'function') {
                 self.opener.refresh1();
             }

--- a/src/main/webapp/WEB-INF/jsp/provider/providerupdatepreference.jsp
+++ b/src/main/webapp/WEB-INF/jsp/provider/providerupdatepreference.jsp
@@ -193,7 +193,7 @@
         <script LANGUAGE="JavaScript">
             <% if (savedScheduleNavigationMode != null) { %>
             var scheduleNavigationPreferencePayload = {
-                mode: '<%= org.owasp.encoder.Encode.forJavaScript(savedScheduleNavigationMode) %>',
+                mode: '<%= SafeEncode.forJavaScript(savedScheduleNavigationMode) %>',
                 source: 'provider-preference',
                 timestamp: Date.now()
             };

--- a/src/main/webapp/WEB-INF/jsp/provider/schedulePage.js.jsp
+++ b/src/main/webapp/WEB-INF/jsp/provider/schedulePage.js.jsp
@@ -416,6 +416,42 @@ var openEncounterInTab = <%=openEncounterInTab%>;
 // Use the JSP encoder wrapper here so null modes render safely and match the rest of this file.
 var scheduleNavigationMode = '${carlos:forJavaScript(scheduleNavigationModeValue)}';
 
+function normalizeScheduleNavigationMode(mode) {
+if (mode === 'tab' || mode === 'focused') {
+return mode;
+}
+return 'popup';
+}
+
+function applyScheduleNavigationPreference(mode) {
+scheduleNavigationMode = normalizeScheduleNavigationMode(mode);
+openEncounterInTab = scheduleNavigationMode === 'tab';
+}
+
+function handleScheduleNavigationPreferenceMessage(message) {
+if (message && message.mode) {
+applyScheduleNavigationPreference(message.mode);
+}
+}
+
+try {
+var scheduleNavigationPreferenceChannel = new BroadcastChannel('carlos_schedule_navigation_mode');
+scheduleNavigationPreferenceChannel.onmessage = function(event) {
+handleScheduleNavigationPreferenceMessage(event.data);
+};
+} catch(e) { /* BroadcastChannel not supported */ }
+
+try {
+window.addEventListener('storage', function(event) {
+if (event.key !== 'carlos_schedule_navigation_mode' || !event.newValue) {
+return;
+}
+try {
+handleScheduleNavigationPreferenceMessage(JSON.parse(event.newValue));
+} catch(e) {}
+});
+} catch(e) {}
+
 function appendQueryParam(url, key, value) {
 var parts = String(url).split('#');
 var base = parts[0];

--- a/src/test/java/io/github/carlos_emr/carlos/provider/web/ScheduleNavigationAssetRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/provider/web/ScheduleNavigationAssetRegressionTest.java
@@ -47,6 +47,8 @@ class ScheduleNavigationAssetRegressionTest {
             Path.of("src", "main", "webapp", "WEB-INF", "jsp", "provider", "schedulePage.js.jsp");
     private static final Path PROVIDER_PREFERENCE_JSP =
             Path.of("src", "main", "webapp", "WEB-INF", "jsp", "provider", "providerpreference.jsp");
+    private static final Path PROVIDER_UPDATE_PREFERENCE_JSP =
+            Path.of("src", "main", "webapp", "WEB-INF", "jsp", "provider", "providerupdatepreference.jsp");
     private static final Path DOCUMENT_REPORT_JSP =
             Path.of("src", "main", "webapp", "WEB-INF", "jsp", "documentManager", "documentReport.jsp");
     private static final Path DISPLAY_MESSAGES_JSP =
@@ -103,6 +105,42 @@ class ScheduleNavigationAssetRegressionTest {
                 .contains("String scheduleNavigationMode = UserProperty.resolveScheduleNavigationMode("
                         + " props.get(UserProperty.SCHEDULE_NAVIGATION_MODE), encOpenInTab);")
                 .doesNotContain("CARLOSDOC_PROVIDER_NO");
+    }
+
+    @Test
+    @DisplayName("should broadcast saved schedule navigation mode with shared resolver")
+    void shouldBroadcastScheduleNavigationMode_whenPreferenceSaved() throws IOException {
+        String providerUpdatePreference = Files.readString(PROVIDER_UPDATE_PREFERENCE_JSP, StandardCharsets.UTF_8);
+        String normalizedProviderUpdatePreference = normalizeWhitespace(providerUpdatePreference);
+
+        assertThat(normalizedProviderUpdatePreference)
+                .contains("savedScheduleNavigationMode = UserProperty.resolveScheduleNavigationMode("
+                        + " submittedScheduleNavigationMode, false);")
+                .contains("mode: '<%= SafeEncode.forJavaScript(savedScheduleNavigationMode) %>'")
+                .contains("self.opener.applyScheduleNavigationPreference(scheduleNavigationPreferencePayload.mode);")
+                .contains("new BroadcastChannel('carlos_schedule_navigation_mode')")
+                .contains("localStorage.setItem('carlos_schedule_navigation_mode',"
+                        + " JSON.stringify(scheduleNavigationPreferencePayload));")
+                .doesNotContain("!UserProperty.SCHEDULE_NAVIGATION_MODE_TAB.equals(savedScheduleNavigationMode)");
+    }
+
+    @Test
+    @DisplayName("should compose menu preference opener hook")
+    void shouldComposePreferenceHook_whenMenuIncluded() throws IOException {
+        String mainMenu = Files.readString(MAIN_MENU_JSP, StandardCharsets.UTF_8);
+        String normalizedMainMenu = normalizeWhitespace(mainMenu);
+
+        assertThat(normalizedMainMenu)
+                .contains("var existingApplyScheduleNavigationPreference ="
+                        + " window.applyScheduleNavigationPreference;")
+                .contains("window.applyScheduleNavigationPreference = function(mode) {"
+                        + " applyScheduleMenuNavigationPreference(mode);"
+                        + " if (typeof existingApplyScheduleNavigationPreference === 'function'"
+                        + " && existingApplyScheduleNavigationPreference !=="
+                        + " applyScheduleMenuNavigationPreference) {"
+                        + " existingApplyScheduleNavigationPreference(mode); } };")
+                .doesNotContain("if (typeof window.applyScheduleNavigationPreference !== 'function') {"
+                        + " window.applyScheduleNavigationPreference = applyScheduleMenuNavigationPreference; }");
     }
 
 


### PR DESCRIPTION
## Issue
Fixes #2900.

## What we are attempting/testing
This PR tries the easy, safer fix for stale schedule navigation preferences: when Provider Preferences saves a new schedule navigation mode, notify already-open CARLOS pages and update their in-memory navigation state for future clicks.

The original report was noticed through Messages, but the stale cached state is shared by the schedule top-menu navigation helpers. This PR is intended to cover future clicks for the shared schedule-navigation items that route through `openScheduleSection` / `openScheduleMenuSection`:

- Inbox / Labs
- Tickler
- Messages
- Consultations
- eDoc
- Report
- Administration

This avoids the more invasive option of pushing users back to the schedule page or trying to transfer the current page state into a new popup. That transfer path is riskier because compose drafts, selected checkboxes, filters, POST-backed pages, and browser popup blockers would all need page-specific handling.

## Approach
- On successful provider preference save, emit the saved `schedule_navigation_mode` through:
  - a direct opener hook when available,
  - `BroadcastChannel('carlos_schedule_navigation_mode')`, and
  - a `localStorage` fallback for browsers/pages where BroadcastChannel is unavailable.
- On the schedule page, listen for that message and update:
  - `scheduleNavigationMode`
  - `openEncounterInTab`
- On schedule-shell menu pages opened with `scheduleNav=1`, listen for the same message and update `scheduleNavActive` so future top-menu clicks stop carrying stale `scheduleNav=1` after switching to `Popup`.

## Why this is the safer first fix
- It does not introduce a new broad reload, page move, or work-transfer path.
- Pages that remain open can update future navigation decisions in place after the preference save.
- The existing provider preference save flow still contains the legacy `refresh1()` opener refresh where that already existed; removing or narrowing that legacy refresh is intentionally out of scope because other saved preferences may depend on it.
- Existing preference-save behavior is otherwise left intact.

## Suggested follow-up
There are older non-schedule pages that cache the legacy `openEncounterInTab` flag directly, especially demographic search/edit JavaScript. Those are not the same schedule top-menu path, but they may have similar stale behavior if a provider changes the preference while those pages are already open. We should audit and decide whether they should listen for the same preference-change event or remain reload-only.

Known places to inspect next:
- `src/main/webapp/WEB-INF/jsp/demographic/demographicsearchresults.jsp`
- `src/main/webapp/WEB-INF/jsp/demographic/demographiceditdemographic.js.jsp`
- shared popup helpers that read `openEncounterInTab` directly outside the schedule page/menu flow

A separate follow-up could also evaluate whether the legacy `providerupdatepreference.jsp` opener `refresh1()` can be safely narrowed without regressing other provider preference saves.

## Verification
Local verification against CARLOS on Tomcat:
1. Set provider `999998` to `schedule_navigation_mode=tab`, `encounter_open_in_tab=yes`.
2. Logged in as `carlosdoc`.
3. Clicked Messages: opened with `_blank` and `scheduleNav=1`.
4. Saved Preferences to `Popup` through the UI.
5. Confirmed DB changed to `schedule_navigation_mode=popup`, `encounter_open_in_tab=no`.
6. Confirmed the already-open schedule page updated in memory to `scheduleNavigationMode="popup"`, `openEncounterInTab=false` without a relogin.
7. Confirmed the already-open Messages page updated `scheduleNavActive=false` without a relogin.
8. Clicked Messages from both pages and confirmed both opened popup-style URLs without `scheduleNav=1`.

Manual verification after deployment also confirmed the original Messages workflow now works without relogging.

Build verification:
- `mvn -DskipTests=true -Dcheckstyle.skip=true -T 1C package war:exploded`
