### PR TITLE
fix: restrict eForm template deletion to admin role

### DIFF
--- a/database/mysql/oscardata.sql
+++ b/database/mysql/oscardata.sql
@@ -1712,7 +1712,7 @@ insert into `secObjPrivilege` values('doctor','_newCasemgmt.episode','o',0,'9999
 insert into `secObjPrivilege` values('doctor','_episode','o',0,'999998');
 insert into `secObjPrivilege` values('doctor','_newCasemgmt.photo','x',0,'999998');
 insert into `secObjPrivilege` values('doctor','_hrm','x',0,'999998');
-insert into `secObjPrivilege` values('doctor','_eform','x',0,'999998');
+insert into `secObjPrivilege` values('doctor','_eform','w',0,'999998');
 insert into `secObjPrivilege` values('doctor','_form','x',0,'999998');
 insert into `secObjPrivilege` values('doctor','_measurement','x',0,'999998');
 insert into `secObjPrivilege` values('doctor','_lab','x',0,'999998');

--- a/database/mysql/oscardata.sql
+++ b/database/mysql/oscardata.sql
@@ -1712,6 +1712,7 @@ insert into `secObjPrivilege` values('doctor','_newCasemgmt.episode','o',0,'9999
 insert into `secObjPrivilege` values('doctor','_episode','o',0,'999998');
 insert into `secObjPrivilege` values('doctor','_newCasemgmt.photo','x',0,'999998');
 insert into `secObjPrivilege` values('doctor','_hrm','x',0,'999998');
+insert into `secObjPrivilege` values('admin','_eform','d',0,'999998');
 insert into `secObjPrivilege` values('doctor','_eform','w',0,'999998');
 insert into `secObjPrivilege` values('doctor','_form','x',0,'999998');
 insert into `secObjPrivilege` values('doctor','_measurement','x',0,'999998');

--- a/database/mysql/oscardata.sql
+++ b/database/mysql/oscardata.sql
@@ -1712,7 +1712,6 @@ insert into `secObjPrivilege` values('doctor','_newCasemgmt.episode','o',0,'9999
 insert into `secObjPrivilege` values('doctor','_episode','o',0,'999998');
 insert into `secObjPrivilege` values('doctor','_newCasemgmt.photo','x',0,'999998');
 insert into `secObjPrivilege` values('doctor','_hrm','x',0,'999998');
-insert into `secObjPrivilege` values('admin','_eform','d',0,'999998');
 insert into `secObjPrivilege` values('doctor','_eform','w',0,'999998');
 insert into `secObjPrivilege` values('doctor','_form','x',0,'999998');
 insert into `secObjPrivilege` values('doctor','_measurement','x',0,'999998');

--- a/database/mysql/updates/update-2026-06-15-eform-delete-privilege.sql
+++ b/database/mysql/updates/update-2026-06-15-eform-delete-privilege.sql
@@ -1,0 +1,10 @@
+-- Downgrade the default doctor role's _eform privilege from "x" (full access)
+-- to "w" (write). This makes the independent delete ("d") privilege return false
+-- for doctors, so DelEForm2Action can enforce creator-only deletion for providers
+-- while preserving all existing read, upload, and edit operations.
+-- Admins retain their _eform privilege unchanged.
+UPDATE secObjPrivilege
+   SET privilege = 'w'
+ WHERE roleName = 'doctor'
+   AND objectName = '_eform'
+   AND privilege = 'x';

--- a/database/mysql/updates/update-2026-06-15-eform-delete-privilege.sql
+++ b/database/mysql/updates/update-2026-06-15-eform-delete-privilege.sql
@@ -2,7 +2,17 @@
 -- to "w" (write). This makes the independent delete ("d") privilege return false
 -- for doctors, so DelEForm2Action can enforce creator-only deletion for providers
 -- while preserving all existing read, upload, and edit operations.
--- Admins retain their _eform privilege unchanged.
+-- Grant admins the direct _eform delete privilege checked by DelEForm2Action.
+INSERT INTO secObjPrivilege (roleName, objectName, privilege, orgapplicable, orgcd)
+SELECT 'admin', '_eform', 'd', 0, '999998'
+WHERE NOT EXISTS (
+    SELECT 1
+      FROM secObjPrivilege
+     WHERE roleName = 'admin'
+       AND objectName = '_eform'
+       AND privilege IN ('d', 'x')
+);
+
 UPDATE secObjPrivilege
    SET privilege = 'w'
  WHERE roleName = 'doctor'

--- a/database/mysql/updates/update-2026-06-15-eform-delete-privilege.sql
+++ b/database/mysql/updates/update-2026-06-15-eform-delete-privilege.sql
@@ -1,20 +1,9 @@
 -- Downgrade the default doctor role's _eform privilege from "x" (full access)
--- to "w" (write). This makes the independent delete ("d") privilege return false
--- for doctors, so DelEForm2Action can enforce creator-only deletion for providers
--- while preserving all existing read, upload, and edit operations.
--- Grant admins the direct _eform delete privilege checked by DelEForm2Action.
-INSERT INTO secObjPrivilege (roleName, objectName, privilege, orgapplicable, orgcd)
-SELECT 'admin', '_eform', 'd', 0, '999998'
-WHERE NOT EXISTS (
-    SELECT 1
-      FROM secObjPrivilege
-     WHERE roleName = 'admin'
-       AND objectName = '_eform'
-       AND privilege IN ('d', 'x')
-);
-
+-- to "w" (write). Doctors retain read, upload, and edit operations but lose
+-- the implied delete capability. eForm template deletion is admin-only,
+-- enforced via DelEForm2Action which checks the _admin.eform write privilege.
 UPDATE secObjPrivilege
    SET privilege = 'w'
- WHERE roleName = 'doctor'
+ WHERE roleUserGroup = 'doctor'
    AND objectName = '_eform'
    AND privilege = 'x';

--- a/src/main/java/io/github/carlos_emr/carlos/eform/EFormUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/eform/EFormUtil.java
@@ -196,9 +196,40 @@ public class EFormUtil {
             curht.put("formDateAsDate", eform.getFormDate());
             curht.put("formTime", ConversionUtils.toTimeString(eform.getFormTime()));
             curht.put("roleType", eform.getRoleType());
+            curht.put("formCreator", eform.getCreator());
             results.add(curht);
         }
         return (results);
+    }
+
+    /**
+     * Returns the subset of current eForms visible to a given provider.
+     *
+     * <p>Admins (those with the {@code _eform} delete privilege) see all forms.
+     * Non-admin providers see only forms they personally created plus shared
+     * templates — eForms whose {@code form_creator} is null or blank — which
+     * are org-wide assets available to everyone but deletable only by admins.
+     *
+     * @param sortBy     sort field constant ({@link #NAME}, {@link #SUBJECT}, etc.)
+     * @param deleted    visibility filter ({@link #CURRENT}, {@link #DELETED}, etc.)
+     * @param providerNo the logged-in provider number
+     * @param isAdmin    true when the caller holds the {@code _eform} delete privilege
+     */
+    public static ArrayList<HashMap<String, ? extends Object>> listEFormsForProvider(
+            String sortBy, String deleted, String providerNo, boolean isAdmin) {
+        ArrayList<HashMap<String, ? extends Object>> all = listEForms(sortBy, deleted);
+        if (isAdmin) {
+            return all;
+        }
+        ArrayList<HashMap<String, ? extends Object>> results = new ArrayList<>();
+        for (HashMap<String, ? extends Object> form : all) {
+            String creator = (String) form.get("formCreator");
+            // Include shared templates (no creator) and forms owned by this provider
+            if (org.apache.commons.lang3.StringUtils.isBlank(creator) || providerNo.equals(creator)) {
+                results.add(form);
+            }
+        }
+        return results;
     }
 
     public static ArrayList<HashMap<String, ? extends Object>> listEForms(String sortBy, String deleted, String userRoles) {

--- a/src/main/java/io/github/carlos_emr/carlos/eform/EFormUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/eform/EFormUtil.java
@@ -99,6 +99,8 @@ public class EFormUtil {
 
     private static final Set<String> ALLOWED_SORT_COLUMNS = Set.of(NAME, SUBJECT, DATE, FILE_NAME, PROVIDER);
 
+    static final String FORM_CREATOR_KEY = "formCreator";
+
     // Collaborator beans are resolved lazily (per call) instead of in static-final field
     // initializers. SpringUtils.getBean returns the cached singleton, so the per-call cost is a
     // map lookup, but - critically - the Spring context is no longer touched when the class is
@@ -196,7 +198,7 @@ public class EFormUtil {
             curht.put("formDateAsDate", eform.getFormDate());
             curht.put("formTime", ConversionUtils.toTimeString(eform.getFormTime()));
             curht.put("roleType", eform.getRoleType());
-            curht.put("formCreator", eform.getCreator());
+            curht.put(FORM_CREATOR_KEY, eform.getCreator());
             results.add(curht);
         }
         return (results);
@@ -215,17 +217,17 @@ public class EFormUtil {
      * @param providerNo the logged-in provider number
      * @param isAdmin    true when the caller holds the {@code _eform} delete privilege
      */
-    public static ArrayList<HashMap<String, ? extends Object>> listEFormsForProvider(
+    public static List<HashMap<String, ? extends Object>> listEFormsForProvider(
             String sortBy, String deleted, String providerNo, boolean isAdmin) {
         ArrayList<HashMap<String, ? extends Object>> all = listEForms(sortBy, deleted);
         if (isAdmin) {
             return all;
         }
-        ArrayList<HashMap<String, ? extends Object>> results = new ArrayList<>();
+        List<HashMap<String, ? extends Object>> results = new ArrayList<>();
         for (HashMap<String, ? extends Object> form : all) {
-            String creator = (String) form.get("formCreator");
+            String creator = (String) form.get(FORM_CREATOR_KEY);
             // Include shared templates (no creator) and forms owned by this provider
-            if (org.apache.commons.lang3.StringUtils.isBlank(creator) || providerNo.equals(creator)) {
+            if (StringUtils.isBlank(creator) || providerNo.equals(creator)) {
                 results.add(form);
             }
         }
@@ -506,7 +508,7 @@ public class EFormUtil {
         curht.put("formFileName", eform.getFileName());
         curht.put("formDate", eform.getFormDate().toString());
         curht.put("formTime", eform.getFormTime().toString());
-        curht.put("formCreator", eform.getCreator());
+        curht.put(FORM_CREATOR_KEY, eform.getCreator());
         curht.put("formHtml", eform.getFormHtml());
         curht.put("showLatestFormOnly", eform.isShowLatestFormOnly());
         curht.put("patientIndependent", eform.isPatientIndependent());

--- a/src/main/java/io/github/carlos_emr/carlos/eform/EFormUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/eform/EFormUtil.java
@@ -229,7 +229,7 @@ public class EFormUtil {
         for (HashMap<String, ? extends Object> form : all) {
             String creator = (String) form.get(FORM_CREATOR_KEY);
             // Include shared templates (no creator) and forms owned by this provider
-            if (StringUtils.isBlank(creator) || StringUtils.equals(providerNo, creator)) {
+            if (StringUtils.isBlank(creator) || Objects.equals(providerNo, creator)) {
                 results.add(form);
             }
         }

--- a/src/main/java/io/github/carlos_emr/carlos/eform/EFormUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/eform/EFormUtil.java
@@ -198,42 +198,9 @@ public class EFormUtil {
             curht.put("formDateAsDate", eform.getFormDate());
             curht.put("formTime", ConversionUtils.toTimeString(eform.getFormTime()));
             curht.put("roleType", eform.getRoleType());
-            curht.put(FORM_CREATOR_KEY, eform.getCreator());
             results.add(curht);
         }
         return (results);
-    }
-
-    /**
-     * Returns the subset of current eForms visible to a given provider.
-     *
-     * <p>Admins (those with the {@code _eform} delete privilege) see all forms.
-     * Non-admin providers see only forms they personally created plus shared
-     * templates — eForms whose {@code form_creator} is null or blank — which
-     * are org-wide assets available to everyone but deletable only by admins.
-     *
-     * @param sortBy     sort field constant ({@link #NAME}, {@link #SUBJECT}, etc.)
-     * @param deleted    visibility filter ({@link #CURRENT}, {@link #DELETED}, etc.)
-     * @param providerNo the logged-in provider number
-     * @param isAdmin    true when the caller holds the {@code _eform} delete privilege
-     * @return visible eForm rows for the caller, preserving shared templates and
-     *         creator-owned forms for non-admin providers
-     */
-    public static List<HashMap<String, ? extends Object>> listEFormsForProvider(
-            String sortBy, String deleted, String providerNo, boolean isAdmin) {
-        ArrayList<HashMap<String, ? extends Object>> all = listEForms(sortBy, deleted);
-        if (isAdmin) {
-            return all;
-        }
-        List<HashMap<String, ? extends Object>> results = new ArrayList<>();
-        for (HashMap<String, ? extends Object> form : all) {
-            String creator = (String) form.get(FORM_CREATOR_KEY);
-            // Include shared templates (no creator) and forms owned by this provider
-            if (StringUtils.isBlank(creator) || Objects.equals(providerNo, creator)) {
-                results.add(form);
-            }
-        }
-        return results;
     }
 
     public static ArrayList<HashMap<String, ? extends Object>> listEForms(String sortBy, String deleted, String userRoles) {

--- a/src/main/java/io/github/carlos_emr/carlos/eform/EFormUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/eform/EFormUtil.java
@@ -216,6 +216,8 @@ public class EFormUtil {
      * @param deleted    visibility filter ({@link #CURRENT}, {@link #DELETED}, etc.)
      * @param providerNo the logged-in provider number
      * @param isAdmin    true when the caller holds the {@code _eform} delete privilege
+     * @return visible eForm rows for the caller, preserving shared templates and
+     *         creator-owned forms for non-admin providers
      */
     public static List<HashMap<String, ? extends Object>> listEFormsForProvider(
             String sortBy, String deleted, String providerNo, boolean isAdmin) {
@@ -227,7 +229,7 @@ public class EFormUtil {
         for (HashMap<String, ? extends Object> form : all) {
             String creator = (String) form.get(FORM_CREATOR_KEY);
             // Include shared templates (no creator) and forms owned by this provider
-            if (StringUtils.isBlank(creator) || providerNo.equals(creator)) {
+            if (StringUtils.isBlank(creator) || StringUtils.equals(providerNo, creator)) {
                 results.add(form);
             }
         }

--- a/src/main/java/io/github/carlos_emr/carlos/eform/EFormUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/eform/EFormUtil.java
@@ -99,7 +99,7 @@ public class EFormUtil {
 
     private static final Set<String> ALLOWED_SORT_COLUMNS = Set.of(NAME, SUBJECT, DATE, FILE_NAME, PROVIDER);
 
-    static final String FORM_CREATOR_KEY = "formCreator";
+    public static final String FORM_CREATOR_KEY = "formCreator";
 
     // Collaborator beans are resolved lazily (per call) instead of in static-final field
     // initializers. SpringUtils.getBean returns the cached singleton, so the per-call cost is a

--- a/src/main/java/io/github/carlos_emr/carlos/eform/actions/DelEForm2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/eform/actions/DelEForm2Action.java
@@ -69,6 +69,7 @@ public class DelEForm2Action extends ActionSupport {
 
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an HTTP method constant; not a security or authorization decision.
     @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an HTTP method constant; not a security or authorization decision")
+    @Override
     public String execute() throws java.io.IOException {
         HttpServletRequest request = ServletActionContext.getRequest();
         HttpServletResponse response = ServletActionContext.getResponse();
@@ -78,23 +79,28 @@ public class DelEForm2Action extends ActionSupport {
             return NONE;
         }
 
-        LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
         String fid = request.getParameter("fid");
+        if (StringUtils.isBlank(fid) || !StringUtils.isNumeric(fid)) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Missing or invalid fid");
+            return NONE;
+        }
+        int formId = Integer.parseInt(fid);
 
+        LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
         boolean isAdmin = securityInfoManager.hasPrivilege(loggedInInfo, "_eform", SecurityInfoManager.DELETE, null);
 
         if (!isAdmin) {
             if (!securityInfoManager.hasPrivilege(loggedInInfo, "_eform", SecurityInfoManager.WRITE, null)) {
                 throw new SecurityException("missing required sec object (_eform)");
             }
-            EForm eform = eFormDao.findById(Integer.parseInt(fid));
+            EForm eform = eFormDao.findById(formId);
             if (eform == null) {
                 throw new SecurityException("missing required sec object (_eform)");
             }
             String creator = eform.getCreator();
             String providerNo = loggedInInfo.getLoggedInProviderNo();
             // Shared templates (no creator) and other providers' forms are admin-only
-            if (StringUtils.isBlank(creator) || !providerNo.equals(creator)) {
+            if (StringUtils.isBlank(creator) || !creator.equals(providerNo)) {
                 throw new SecurityException("missing required sec object (_eform)");
             }
         }

--- a/src/main/java/io/github/carlos_emr/carlos/eform/actions/DelEForm2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/eform/actions/DelEForm2Action.java
@@ -72,7 +72,13 @@ public class DelEForm2Action extends ActionSupport {
         }
 
         String fid = request.getParameter("fid");
-        if (StringUtils.isBlank(fid) || !StringUtils.isNumeric(fid)) {
+        if (StringUtils.isBlank(fid)) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Missing or invalid fid");
+            return NONE;
+        }
+        try {
+            Integer.parseInt(fid);
+        } catch (NumberFormatException e) {
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Missing or invalid fid");
             return NONE;
         }

--- a/src/main/java/io/github/carlos_emr/carlos/eform/actions/DelEForm2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/eform/actions/DelEForm2Action.java
@@ -43,8 +43,9 @@ import org.apache.struts2.ServletActionContext;
 /**
  * Deletes an eForm template from the library.
  *
- * <p>Deletion requires the {@code _eform} delete privilege ("d"), which is held by
- * admin-level providers. The doctor role carries only write ("w") and cannot delete.
+ * <p>Deletion requires the {@code _admin.eform} write privilege, which is held by
+ * admin-level providers. The doctor role carries only {@code _eform} write and
+ * cannot delete templates.
  *
  * @since 2026-06-15
  */
@@ -77,8 +78,8 @@ public class DelEForm2Action extends ActionSupport {
         }
 
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
-        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_eform", SecurityInfoManager.DELETE, null)) {
-            throw new SecurityException("missing required sec object (_eform)");
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_admin.eform", SecurityInfoManager.WRITE, null)) {
+            throw new SecurityException("missing required sec object (_admin.eform)");
         }
 
         EFormUtil.delEForm(fid);

--- a/src/main/java/io/github/carlos_emr/carlos/eform/actions/DelEForm2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/eform/actions/DelEForm2Action.java
@@ -59,8 +59,10 @@ import org.apache.struts2.ServletActionContext;
  */
 public class DelEForm2Action extends ActionSupport {
 
-    private final SecurityInfoManager securityInfoManager;
-    private final EFormDao eFormDao;
+    // transient: ActionSupport implements Serializable; Spring-managed beans are not serializable.
+    // Actions are prototype-scoped and never actually serialized, but transient satisfies the contract.
+    private final transient SecurityInfoManager securityInfoManager;
+    private final transient EFormDao eFormDao;
 
     public DelEForm2Action(SecurityInfoManager securityInfoManager, EFormDao eFormDao) {
         this.securityInfoManager = securityInfoManager;

--- a/src/main/java/io/github/carlos_emr/carlos/eform/actions/DelEForm2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/eform/actions/DelEForm2Action.java
@@ -20,42 +20,85 @@
  * McMaster University
  * Hamilton
  * Ontario, Canada
- 
+ *
  * <p>
  * Now maintained by the CARLOS EMR Project (2026+).
  * https://github.com/carlos-emr/carlos
  * CARLOS has no affiliation with OSCAR or McMaster University.
  */
-
-
 package io.github.carlos_emr.carlos.eform.actions;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import io.github.carlos_emr.carlos.commn.dao.EFormDao;
+import io.github.carlos_emr.carlos.commn.model.EForm;
+import io.github.carlos_emr.carlos.eform.EFormUtil;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
-import io.github.carlos_emr.carlos.utility.SpringUtils;
 
-import io.github.carlos_emr.carlos.eform.EFormUtil;
-
+import org.apache.commons.lang3.StringUtils;
 import org.apache.struts2.ActionSupport;
 import org.apache.struts2.ServletActionContext;
 
+/**
+ * Deletes an eForm template from the library.
+ *
+ * <p>Two privilege tiers govern deletion:
+ * <ul>
+ *   <li><b>Admin</b> — providers with the {@code _eform} delete privilege ("d") may delete
+ *       any template, including shared templates with no recorded creator.</li>
+ *   <li><b>Provider</b> — providers with the {@code _eform} write privilege ("w") may delete
+ *       only templates they personally created (matched by {@code form_creator}).</li>
+ * </ul>
+ * Shared templates — those whose {@code form_creator} is null or blank — are org-wide
+ * assets and are intentionally restricted to admin-level deletion.
+ *
+ * @since 2026-06-15
+ */
 public class DelEForm2Action extends ActionSupport {
-    HttpServletRequest request = ServletActionContext.getRequest();
-    HttpServletResponse response = ServletActionContext.getResponse();
 
+    private final SecurityInfoManager securityInfoManager;
+    private final EFormDao eFormDao;
 
-    private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
+    public DelEForm2Action(SecurityInfoManager securityInfoManager, EFormDao eFormDao) {
+        this.securityInfoManager = securityInfoManager;
+        this.eFormDao = eFormDao;
+    }
 
-    public String execute() {
+    // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an HTTP method constant; not a security or authorization decision.
+    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an HTTP method constant; not a security or authorization decision")
+    public String execute() throws java.io.IOException {
+        HttpServletRequest request = ServletActionContext.getRequest();
+        HttpServletResponse response = ServletActionContext.getResponse();
 
-        if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_eform", "w", null)) {
-            throw new SecurityException("missing required sec object (_eform)");
+        if (!"POST".equalsIgnoreCase(request.getMethod())) {
+            response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED, "POST required");
+            return NONE;
         }
 
+        LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
         String fid = request.getParameter("fid");
+
+        boolean isAdmin = securityInfoManager.hasPrivilege(loggedInInfo, "_eform", SecurityInfoManager.DELETE, null);
+
+        if (!isAdmin) {
+            if (!securityInfoManager.hasPrivilege(loggedInInfo, "_eform", SecurityInfoManager.WRITE, null)) {
+                throw new SecurityException("missing required sec object (_eform)");
+            }
+            EForm eform = eFormDao.findById(Integer.parseInt(fid));
+            if (eform == null) {
+                throw new SecurityException("missing required sec object (_eform)");
+            }
+            String creator = eform.getCreator();
+            String providerNo = loggedInInfo.getLoggedInProviderNo();
+            // Shared templates (no creator) and other providers' forms are admin-only
+            if (StringUtils.isBlank(creator) || !providerNo.equals(creator)) {
+                throw new SecurityException("missing required sec object (_eform)");
+            }
+        }
+
         EFormUtil.delEForm(fid);
         return SUCCESS;
     }

--- a/src/main/java/io/github/carlos_emr/carlos/eform/actions/DelEForm2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/eform/actions/DelEForm2Action.java
@@ -86,7 +86,14 @@ public class DelEForm2Action extends ActionSupport {
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Missing or invalid fid");
             return NONE;
         }
-        int formId = Integer.parseInt(fid);
+        int formId;
+        try {
+            formId = Integer.parseInt(fid);
+        } catch (NumberFormatException e) {
+            // Catches overflow values that pass isNumeric (e.g. > Integer.MAX_VALUE)
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Missing or invalid fid");
+            return NONE;
+        }
 
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
         boolean isAdmin = securityInfoManager.hasPrivilege(loggedInInfo, "_eform", SecurityInfoManager.DELETE, null);

--- a/src/main/java/io/github/carlos_emr/carlos/eform/actions/DelEForm2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/eform/actions/DelEForm2Action.java
@@ -32,8 +32,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import io.github.carlos_emr.carlos.commn.dao.EFormDao;
-import io.github.carlos_emr.carlos.commn.model.EForm;
 import io.github.carlos_emr.carlos.eform.EFormUtil;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
@@ -45,15 +43,8 @@ import org.apache.struts2.ServletActionContext;
 /**
  * Deletes an eForm template from the library.
  *
- * <p>Two privilege tiers govern deletion:
- * <ul>
- *   <li><b>Admin</b> — providers with the {@code _eform} delete privilege ("d") may delete
- *       any template, including shared templates with no recorded creator.</li>
- *   <li><b>Provider</b> — providers with the {@code _eform} write privilege ("w") may delete
- *       only templates they personally created (matched by {@code form_creator}).</li>
- * </ul>
- * Shared templates — those whose {@code form_creator} is null or blank — are org-wide
- * assets and are intentionally restricted to admin-level deletion.
+ * <p>Deletion requires the {@code _eform} delete privilege ("d"), which is held by
+ * admin-level providers. The doctor role carries only write ("w") and cannot delete.
  *
  * @since 2026-06-15
  */
@@ -62,11 +53,9 @@ public class DelEForm2Action extends ActionSupport {
     // transient: ActionSupport implements Serializable; Spring-managed beans are not serializable.
     // Actions are prototype-scoped and never actually serialized, but transient satisfies the contract.
     private final transient SecurityInfoManager securityInfoManager;
-    private final transient EFormDao eFormDao;
 
-    public DelEForm2Action(SecurityInfoManager securityInfoManager, EFormDao eFormDao) {
+    public DelEForm2Action(SecurityInfoManager securityInfoManager) {
         this.securityInfoManager = securityInfoManager;
-        this.eFormDao = eFormDao;
     }
 
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an HTTP method constant; not a security or authorization decision.
@@ -86,32 +75,10 @@ public class DelEForm2Action extends ActionSupport {
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Missing or invalid fid");
             return NONE;
         }
-        int formId;
-        try {
-            formId = Integer.parseInt(fid);
-        } catch (NumberFormatException e) {
-            // Catches overflow values that pass isNumeric (e.g. > Integer.MAX_VALUE)
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Missing or invalid fid");
-            return NONE;
-        }
 
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
-        boolean isAdmin = securityInfoManager.hasPrivilege(loggedInInfo, "_eform", SecurityInfoManager.DELETE, null);
-
-        if (!isAdmin) {
-            if (!securityInfoManager.hasPrivilege(loggedInInfo, "_eform", SecurityInfoManager.WRITE, null)) {
-                throw new SecurityException("missing required sec object (_eform)");
-            }
-            EForm eform = eFormDao.findById(formId);
-            if (eform == null) {
-                throw new SecurityException("missing required sec object (_eform)");
-            }
-            String creator = eform.getCreator();
-            String providerNo = loggedInInfo.getLoggedInProviderNo();
-            // Shared templates (no creator) and other providers' forms are admin-only
-            if (StringUtils.isBlank(creator) || !creator.equals(providerNo)) {
-                throw new SecurityException("missing required sec object (_eform)");
-            }
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_eform", SecurityInfoManager.DELETE, null)) {
+            throw new SecurityException("missing required sec object (_eform)");
         }
 
         EFormUtil.delEForm(fid);

--- a/src/main/webapp/WEB-INF/jsp/eform/efmformmanager.jsp
+++ b/src/main/webapp/WEB-INF/jsp/eform/efmformmanager.jsp
@@ -201,14 +201,11 @@
                 LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
                 SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
                 boolean isEFormAdmin = securityInfoManager.hasPrivilege(loggedInInfo, "_eform", SecurityInfoManager.DELETE, null);
-                String currentProviderNo = loggedInInfo.getLoggedInProviderNo();
 
-                List<HashMap<String, ? extends Object>> eForms = EFormUtil.listEFormsForProvider(orderBy, EFormUtil.CURRENT, currentProviderNo, isEFormAdmin);
+                ArrayList<HashMap<String, ? extends Object>> eForms = EFormUtil.listEForms(orderBy, EFormUtil.CURRENT);
                 for (int i = 0; i < eForms.size(); i++) {
                     HashMap<String, ? extends Object> curForm = eForms.get(i);
-                    // Key must stay aligned with EFormUtil.FORM_CREATOR_KEY ("formCreator")
-                    String formCreator = (String) curForm.get("formCreator");
-                    boolean canDelete = isEFormAdmin || (currentProviderNo != null && currentProviderNo.equals(formCreator));
+                    boolean canDelete = isEFormAdmin;
             %>
             <tr>
                 <td><%if (curForm.get("formFileName") != null && curForm.get("formFileName").toString().length() != 0) {%><i

--- a/src/main/webapp/WEB-INF/jsp/eform/efmformmanager.jsp
+++ b/src/main/webapp/WEB-INF/jsp/eform/efmformmanager.jsp
@@ -28,6 +28,9 @@
 <!DOCTYPE html>
 <%@ page import="io.github.carlos_emr.carlos.eform.data.*, io.github.carlos_emr.carlos.eform.*, java.util.*" %>
 <%@ page import="io.github.carlos_emr.carlos.eform.EFormUtil" %>
+<%@ page import="io.github.carlos_emr.carlos.managers.SecurityInfoManager" %>
+<%@ page import="io.github.carlos_emr.carlos.utility.LoggedInInfo" %>
+<%@ page import="io.github.carlos_emr.carlos.utility.SpringUtils" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <fmt:setBundle basename="oscarResources"/>
 
@@ -195,9 +198,16 @@
 
             <tbody>
             <%
-                ArrayList<HashMap<String, ? extends Object>> eForms = EFormUtil.listEForms(orderBy, EFormUtil.CURRENT);
+                LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
+                SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
+                boolean isEFormAdmin = securityInfoManager.hasPrivilege(loggedInInfo, "_eform", SecurityInfoManager.DELETE, null);
+                String currentProviderNo = loggedInInfo.getLoggedInProviderNo();
+
+                ArrayList<HashMap<String, ? extends Object>> eForms = EFormUtil.listEFormsForProvider(orderBy, EFormUtil.CURRENT, currentProviderNo, isEFormAdmin);
                 for (int i = 0; i < eForms.size(); i++) {
                     HashMap<String, ? extends Object> curForm = eForms.get(i);
+                    String formCreator = (String) curForm.get("formCreator");
+                    boolean canDelete = isEFormAdmin || currentProviderNo.equals(formCreator);
             %>
             <tr>
                 <td><%if (curForm.get("formFileName") != null && curForm.get("formFileName").toString().length() != 0) {%><i
@@ -230,10 +240,12 @@
                                 class="fa-solid fa-download" title="<fmt:message key="eform.uploadhtml.btnExport"/>"></i></a>
 
 
+                        <% if (canDelete) { %>
                         <a class="btn btn-link contentLink"
                            href='javascript:void(0);' onclick='confirmNDelete("<%=curForm.get("fid")%>")'
                            title='<fmt:message key="eform.uploadhtml.btnDelete"/> <%=curForm.get("formName")%>'><i
                                 class="fa-solid fa-trash" title="<fmt:message key="eform.uploadhtml.btnDelete"/>"></i></a>
+                        <% } %>
                     </div>
                 </td>
 

--- a/src/main/webapp/WEB-INF/jsp/eform/efmformmanager.jsp
+++ b/src/main/webapp/WEB-INF/jsp/eform/efmformmanager.jsp
@@ -203,7 +203,7 @@
                 boolean isEFormAdmin = securityInfoManager.hasPrivilege(loggedInInfo, "_eform", SecurityInfoManager.DELETE, null);
                 String currentProviderNo = loggedInInfo.getLoggedInProviderNo();
 
-                ArrayList<HashMap<String, ? extends Object>> eForms = EFormUtil.listEFormsForProvider(orderBy, EFormUtil.CURRENT, currentProviderNo, isEFormAdmin);
+                List<HashMap<String, ? extends Object>> eForms = EFormUtil.listEFormsForProvider(orderBy, EFormUtil.CURRENT, currentProviderNo, isEFormAdmin);
                 for (int i = 0; i < eForms.size(); i++) {
                     HashMap<String, ? extends Object> curForm = eForms.get(i);
                     String formCreator = (String) curForm.get("formCreator");

--- a/src/main/webapp/WEB-INF/jsp/eform/efmformmanager.jsp
+++ b/src/main/webapp/WEB-INF/jsp/eform/efmformmanager.jsp
@@ -200,7 +200,7 @@
             <%
                 LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
                 SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
-                boolean isEFormAdmin = securityInfoManager.hasPrivilege(loggedInInfo, "_eform", SecurityInfoManager.DELETE, null);
+                boolean isEFormAdmin = securityInfoManager.hasPrivilege(loggedInInfo, "_admin.eform", SecurityInfoManager.WRITE, null);
 
                 ArrayList<HashMap<String, ? extends Object>> eForms = EFormUtil.listEForms(orderBy, EFormUtil.CURRENT);
                 for (int i = 0; i < eForms.size(); i++) {

--- a/src/main/webapp/WEB-INF/jsp/eform/efmformmanager.jsp
+++ b/src/main/webapp/WEB-INF/jsp/eform/efmformmanager.jsp
@@ -206,8 +206,9 @@
                 List<HashMap<String, ? extends Object>> eForms = EFormUtil.listEFormsForProvider(orderBy, EFormUtil.CURRENT, currentProviderNo, isEFormAdmin);
                 for (int i = 0; i < eForms.size(); i++) {
                     HashMap<String, ? extends Object> curForm = eForms.get(i);
+                    // Key must stay aligned with EFormUtil.FORM_CREATOR_KEY ("formCreator")
                     String formCreator = (String) curForm.get("formCreator");
-                    boolean canDelete = isEFormAdmin || currentProviderNo.equals(formCreator);
+                    boolean canDelete = isEFormAdmin || (currentProviderNo != null && currentProviderNo.equals(formCreator));
             %>
             <tr>
                 <td><%if (curForm.get("formFileName") != null && curForm.get("formFileName").toString().length() != 0) {%><i

--- a/src/test/java/io/github/carlos_emr/carlos/admin/AdminSecuritySeedRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/admin/AdminSecuritySeedRegressionTest.java
@@ -13,6 +13,7 @@
 package io.github.carlos_emr.carlos.admin;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -26,6 +27,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Tag("unit")
 @Tag("admin")
 class AdminSecuritySeedRegressionTest {
+
+    private static final String ADMIN_EFORM_DELETE_GRANT =
+            "insert into `secObjPrivilege` values('admin','_eform','d',0,'999998');";
+    private static final String DOCTOR_EFORM_WRITE_GRANT =
+            "insert into `secObjPrivilege` values('doctor','_eform','w',0,'999998');";
 
     @Test
     @DisplayName("should grant site-access privacy to admin role in fresh and migrated databases")
@@ -41,5 +47,33 @@ class AdminSecuritySeedRegressionTest {
                 .as("existing production databases should receive the same admin privilege")
                 .contains("('_site_access_privacy', 'restrict access to only the assigned sites of a provider', 0)")
                 .contains("('admin', '_site_access_privacy', 'x', 0, '999998')");
+    }
+
+    @Test
+    @DisplayName("should grant admin delete and doctor write for eForms in fresh seed")
+    void shouldGrantAdminDeleteAndDoctorWrite_forEFormsInFreshSeed() throws IOException {
+        String freshSeed = Files.readString(Path.of("database/mysql/oscardata.sql"), StandardCharsets.UTF_8);
+
+        assertThat(freshSeed)
+                .contains(ADMIN_EFORM_DELETE_GRANT, DOCTOR_EFORM_WRITE_GRANT);
+        assertThat(freshSeed.indexOf(DOCTOR_EFORM_WRITE_GRANT))
+                .isGreaterThan(freshSeed.indexOf(ADMIN_EFORM_DELETE_GRANT));
+    }
+
+    @Test
+    @DisplayName("should preserve admin eForm delete privilege while downgrading doctor in migration")
+    void shouldPreserveAdminEFormDeletePrivilege_whileDowngradingDoctorInMigration() throws IOException {
+        String migration = Files.readString(Path.of(
+                "database/mysql/updates/update-2026-06-15-eform-delete-privilege.sql"), StandardCharsets.UTF_8);
+
+        assertThat(migration)
+                .contains("SELECT 'admin', '_eform', 'd', 0, '999998'")
+                .contains("WHERE roleName = 'admin'")
+                .contains("AND objectName = '_eform'")
+                .contains("AND privilege IN ('d', 'x')")
+                .contains("SET privilege = 'w'")
+                .contains("WHERE roleName = 'doctor'")
+                .contains("AND objectName = '_eform'")
+                .contains("AND privilege = 'x'");
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/admin/AdminSecuritySeedRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/admin/AdminSecuritySeedRegressionTest.java
@@ -28,8 +28,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Tag("admin")
 class AdminSecuritySeedRegressionTest {
 
-    private static final String ADMIN_EFORM_DELETE_GRANT =
-            "insert into `secObjPrivilege` values('admin','_eform','d',0,'999998');";
     private static final String DOCTOR_EFORM_WRITE_GRANT =
             "insert into `secObjPrivilege` values('doctor','_eform','w',0,'999998');";
 
@@ -50,30 +48,34 @@ class AdminSecuritySeedRegressionTest {
     }
 
     @Test
-    @DisplayName("should grant admin delete and doctor write for eForms in fresh seed")
-    void shouldGrantAdminDeleteAndDoctorWrite_forEFormsInFreshSeed() throws IOException {
+    @DisplayName("should seed doctor role with eForm write privilege in fresh seed")
+    void shouldSeedDoctorEFormWritePrivilege_inFreshSeed() throws IOException {
         String freshSeed = Files.readString(Path.of("database/mysql/oscardata.sql"), StandardCharsets.UTF_8);
 
         assertThat(freshSeed)
-                .contains(ADMIN_EFORM_DELETE_GRANT, DOCTOR_EFORM_WRITE_GRANT);
-        assertThat(freshSeed.indexOf(DOCTOR_EFORM_WRITE_GRANT))
-                .isGreaterThan(freshSeed.indexOf(ADMIN_EFORM_DELETE_GRANT));
+                .as("fresh dev databases should seed doctor with _eform write (not full-access)")
+                .contains(DOCTOR_EFORM_WRITE_GRANT)
+                .as("admin deletion rights come from the existing _admin.eform grant, not a new _eform:d row")
+                .doesNotContain("'admin','_eform','d'");
     }
 
     @Test
-    @DisplayName("should preserve admin eForm delete privilege while downgrading doctor in migration")
-    void shouldPreserveAdminEFormDeletePrivilege_whileDowngradingDoctorInMigration() throws IOException {
+    @DisplayName("should downgrade doctor _eform privilege using correct column names in migration")
+    void shouldDowngradeDoctorPrivilege_usingCorrectColumnNamesInMigration() throws IOException {
         String migration = Files.readString(Path.of(
                 "database/mysql/updates/update-2026-06-15-eform-delete-privilege.sql"), StandardCharsets.UTF_8);
 
         assertThat(migration)
-                .contains("SELECT 'admin', '_eform', 'd', 0, '999998'")
-                .contains("WHERE roleName = 'admin'")
-                .contains("AND objectName = '_eform'")
-                .contains("AND privilege IN ('d', 'x')")
+                .as("migration must use the real column name 'roleUserGroup', not the non-existent 'roleName'")
+                .contains("roleUserGroup")
+                .doesNotContain("roleName")
+                .as("migration should downgrade doctor from x to w")
                 .contains("SET privilege = 'w'")
-                .contains("WHERE roleName = 'doctor'")
-                .contains("AND objectName = '_eform'")
-                .contains("AND privilege = 'x'");
+                .contains("'doctor'")
+                .contains("'_eform'")
+                .contains("privilege = 'x'")
+                .as("admin deletion rights come from the existing _admin.eform grant; no INSERT needed")
+                .doesNotContain("'admin', '_eform', 'd'")
+                .doesNotContain("'admin','_eform','d'");
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/app/contract/MutatorActionGetRejectionContractTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/app/contract/MutatorActionGetRejectionContractTest.java
@@ -24,7 +24,9 @@ package io.github.carlos_emr.carlos.app.contract;
 import io.github.carlos_emr.carlos.admin.web.SecurityAddSecurity2Action;
 import io.github.carlos_emr.carlos.admin.web.SecurityDelete2Action;
 import io.github.carlos_emr.carlos.admin.web.SecurityUpdate2Action;
+import io.github.carlos_emr.carlos.commn.dao.EFormDao;
 import io.github.carlos_emr.carlos.commn.dao.SecurityDao;
+import io.github.carlos_emr.carlos.eform.actions.DelEForm2Action;
 import io.github.carlos_emr.carlos.log.LogAction;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.security.CarlosMethodSecurity;
@@ -199,7 +201,10 @@ class MutatorActionGetRejectionContractTest {
             Arguments.of("io.github.carlos_emr.carlos.waitinglist.pageUtil.WLAdd2WaitingList2Action",
                     "_demographic", "w"),
             Arguments.of("io.github.carlos_emr.carlos.waitinglist.pageUtil.WLRemoveFromWaitingList2Action",
-                    "_demographic", "w")
+                    "_demographic", "w"),
+            // --- eform ---
+            Arguments.of("io.github.carlos_emr.carlos.eform.actions.DelEForm2Action",
+                    "_eform", "d")
         );
     }
 
@@ -319,7 +324,9 @@ class MutatorActionGetRejectionContractTest {
         "io.github.carlos_emr.carlos.commn.web.FlowSheetCustom2Action",
         "io.github.carlos_emr.carlos.encounter.oscarMeasurements.pageUtil.EctMeasurements2Action",
         "io.github.carlos_emr.carlos.login.gate.SelectFacility2Action",
-        "io.github.carlos_emr.carlos.provider.web.DocumentDescriptionTemplate2Action"
+        "io.github.carlos_emr.carlos.provider.web.DocumentDescriptionTemplate2Action",
+        // eform slice: only DelEForm2Action is registered; broader slice audit tracked in issue #2828.
+        "io.github.carlos_emr.carlos.eform.actions.DelEForm2Action"
     );
 
     @ParameterizedTest(name = "{0} rejects GET and HEAD without side-effects")
@@ -469,6 +476,10 @@ class MutatorActionGetRejectionContractTest {
 
     private static Object instantiateAction(Class<?> actionClass, Map<Class<?>, Object> autoMocks)
             throws Exception {
+        if (actionClass.equals(DelEForm2Action.class)) {
+            EFormDao eFormDao = (EFormDao) autoMocks.computeIfAbsent(EFormDao.class, Mockito::mock);
+            return new DelEForm2Action(mock(SecurityInfoManager.class), eFormDao);
+        }
         if (actionClass.equals(SecurityDelete2Action.class)) {
             CarlosMethodSecurity methodSecurity = mock(CarlosMethodSecurity.class);
             when(methodSecurity.hasAdminWrite()).thenReturn(true);

--- a/src/test/java/io/github/carlos_emr/carlos/app/contract/MutatorActionGetRejectionContractTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/app/contract/MutatorActionGetRejectionContractTest.java
@@ -24,7 +24,6 @@ package io.github.carlos_emr.carlos.app.contract;
 import io.github.carlos_emr.carlos.admin.web.SecurityAddSecurity2Action;
 import io.github.carlos_emr.carlos.admin.web.SecurityDelete2Action;
 import io.github.carlos_emr.carlos.admin.web.SecurityUpdate2Action;
-import io.github.carlos_emr.carlos.commn.dao.EFormDao;
 import io.github.carlos_emr.carlos.commn.dao.SecurityDao;
 import io.github.carlos_emr.carlos.eform.actions.DelEForm2Action;
 import io.github.carlos_emr.carlos.log.LogAction;
@@ -480,8 +479,7 @@ class MutatorActionGetRejectionContractTest {
     private static Object instantiateAction(Class<?> actionClass, Map<Class<?>, Object> autoMocks)
             throws Exception {
         if (actionClass.equals(DelEForm2Action.class)) {
-            EFormDao eFormDao = (EFormDao) autoMocks.computeIfAbsent(EFormDao.class, Mockito::mock);
-            return new DelEForm2Action(mock(SecurityInfoManager.class), eFormDao);
+            return new DelEForm2Action(mock(SecurityInfoManager.class));
         }
         if (actionClass.equals(SecurityDelete2Action.class)) {
             CarlosMethodSecurity methodSecurity = mock(CarlosMethodSecurity.class);

--- a/src/test/java/io/github/carlos_emr/carlos/app/contract/MutatorActionGetRejectionContractTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/app/contract/MutatorActionGetRejectionContractTest.java
@@ -207,7 +207,7 @@ class MutatorActionGetRejectionContractTest {
                     "_demographic", "w"),
             // --- eform ---
             Arguments.of("io.github.carlos_emr.carlos.eform.actions.DelEForm2Action",
-                    "_eform", "d")
+                    "_admin.eform", "w")
         );
     }
 

--- a/src/test/java/io/github/carlos_emr/carlos/eform/EFormUtilIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/eform/EFormUtilIntegrationTest.java
@@ -32,6 +32,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashMap;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -71,5 +72,79 @@ class EFormUtilIntegrationTest extends CarlosTestBase {
         assertThat(loadedForm).doesNotContainKey("fid");
         assertThat(loadedForm).containsEntry("formName", "");
         assertThat(loadedForm).containsEntry("formHtml", "No Such Form in Database");
+    }
+
+    @Test
+    @DisplayName("should list all current eForms for admins")
+    void shouldListAllCurrentEForms_whenProviderIsAdmin() throws Exception {
+        EForm ownForm = persistCurrentForm("ADMIN_VISIBLE_OWN", "doc1");
+        EForm otherForm = persistCurrentForm("ADMIN_VISIBLE_OTHER", "doc2");
+        EForm sharedForm = persistCurrentForm("ADMIN_VISIBLE_SHARED", null);
+
+        List<HashMap<String, ? extends Object>> forms =
+                EFormUtil.listEFormsForProvider(EFormUtil.NAME, EFormUtil.CURRENT, "doc1", true);
+
+        assertThat(formNames(forms))
+                .contains("ADMIN_VISIBLE_OWN", "ADMIN_VISIBLE_OTHER", "ADMIN_VISIBLE_SHARED");
+        assertCreator(forms, ownForm.getId().toString(), "doc1");
+        assertCreator(forms, otherForm.getId().toString(), "doc2");
+        assertCreator(forms, sharedForm.getId().toString(), null);
+    }
+
+    @Test
+    @DisplayName("should list only owned and shared current eForms for non-admin providers")
+    void shouldListOwnedAndSharedCurrentEForms_whenProviderIsNotAdmin() throws Exception {
+        EForm ownForm = persistCurrentForm("PROVIDER_VISIBLE_OWN", "doc1");
+        EForm sharedForm = persistCurrentForm("PROVIDER_VISIBLE_SHARED", null);
+        persistCurrentForm("PROVIDER_HIDDEN_OTHER", "doc2");
+
+        List<HashMap<String, ? extends Object>> forms =
+                EFormUtil.listEFormsForProvider(EFormUtil.NAME, EFormUtil.CURRENT, "doc1", false);
+
+        assertThat(formNames(forms))
+                .contains("PROVIDER_VISIBLE_OWN", "PROVIDER_VISIBLE_SHARED")
+                .doesNotContain("PROVIDER_HIDDEN_OTHER");
+        assertCreator(forms, ownForm.getId().toString(), "doc1");
+        assertCreator(forms, sharedForm.getId().toString(), null);
+    }
+
+    @Test
+    @DisplayName("should list only shared current eForms when provider number is null")
+    void shouldListOnlySharedCurrentEForms_whenProviderNumberIsNull() throws Exception {
+        persistCurrentForm("NULL_PROVIDER_SHARED", null);
+        persistCurrentForm("NULL_PROVIDER_OWNED", "doc1");
+
+        List<HashMap<String, ? extends Object>> forms =
+                EFormUtil.listEFormsForProvider(EFormUtil.NAME, EFormUtil.CURRENT, null, false);
+
+        assertThat(formNames(forms))
+                .contains("NULL_PROVIDER_SHARED")
+                .doesNotContain("NULL_PROVIDER_OWNED");
+        assertThat(forms)
+                .allSatisfy(form -> assertThat(form).containsKey(EFormUtil.FORM_CREATOR_KEY));
+    }
+
+    private EForm persistCurrentForm(String formName, String creator) throws Exception {
+        EForm eForm = new EForm();
+        EntityDataGenerator.generateTestDataForModelClass(eForm);
+        eForm.setFormName(formName);
+        eForm.setCurrent(true);
+        eForm.setCreator(creator);
+        eFormDao.persist(eForm);
+        hibernateTemplate.flush();
+        return eForm;
+    }
+
+    private List<String> formNames(List<HashMap<String, ? extends Object>> forms) {
+        return forms.stream()
+                .map(form -> (String) form.get("formName"))
+                .toList();
+    }
+
+    private void assertCreator(List<HashMap<String, ? extends Object>> forms, String fid, String expectedCreator) {
+        assertThat(forms)
+                .filteredOn(form -> fid.equals(form.get("fid")))
+                .singleElement()
+                .satisfies(form -> assertThat(form.get(EFormUtil.FORM_CREATOR_KEY)).isEqualTo(expectedCreator));
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/eform/EFormUtilIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/eform/EFormUtilIntegrationTest.java
@@ -145,6 +145,6 @@ class EFormUtilIntegrationTest extends CarlosTestBase {
         assertThat(forms)
                 .filteredOn(form -> fid.equals(form.get("fid")))
                 .singleElement()
-                .satisfies(form -> assertThat(form.get(EFormUtil.FORM_CREATOR_KEY)).isEqualTo(expectedCreator));
+                .satisfies(form -> assertThat((java.util.Map<String, Object>) form).containsEntry(EFormUtil.FORM_CREATOR_KEY, expectedCreator));
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/eform/EFormUtilIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/eform/EFormUtilIntegrationTest.java
@@ -32,7 +32,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashMap;
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -72,79 +71,5 @@ class EFormUtilIntegrationTest extends CarlosTestBase {
         assertThat(loadedForm).doesNotContainKey("fid");
         assertThat(loadedForm).containsEntry("formName", "");
         assertThat(loadedForm).containsEntry("formHtml", "No Such Form in Database");
-    }
-
-    @Test
-    @DisplayName("should list all current eForms for admins")
-    void shouldListAllCurrentEForms_whenProviderIsAdmin() throws Exception {
-        EForm ownForm = persistCurrentForm("ADMIN_VISIBLE_OWN", "doc1");
-        EForm otherForm = persistCurrentForm("ADMIN_VISIBLE_OTHER", "doc2");
-        EForm sharedForm = persistCurrentForm("ADMIN_VISIBLE_SHARED", null);
-
-        List<HashMap<String, ? extends Object>> forms =
-                EFormUtil.listEFormsForProvider(EFormUtil.NAME, EFormUtil.CURRENT, "doc1", true);
-
-        assertThat(formNames(forms))
-                .contains("ADMIN_VISIBLE_OWN", "ADMIN_VISIBLE_OTHER", "ADMIN_VISIBLE_SHARED");
-        assertCreator(forms, ownForm.getId().toString(), "doc1");
-        assertCreator(forms, otherForm.getId().toString(), "doc2");
-        assertCreator(forms, sharedForm.getId().toString(), null);
-    }
-
-    @Test
-    @DisplayName("should list only owned and shared current eForms for non-admin providers")
-    void shouldListOwnedAndSharedCurrentEForms_whenProviderIsNotAdmin() throws Exception {
-        EForm ownForm = persistCurrentForm("PROVIDER_VISIBLE_OWN", "doc1");
-        EForm sharedForm = persistCurrentForm("PROVIDER_VISIBLE_SHARED", null);
-        persistCurrentForm("PROVIDER_HIDDEN_OTHER", "doc2");
-
-        List<HashMap<String, ? extends Object>> forms =
-                EFormUtil.listEFormsForProvider(EFormUtil.NAME, EFormUtil.CURRENT, "doc1", false);
-
-        assertThat(formNames(forms))
-                .contains("PROVIDER_VISIBLE_OWN", "PROVIDER_VISIBLE_SHARED")
-                .doesNotContain("PROVIDER_HIDDEN_OTHER");
-        assertCreator(forms, ownForm.getId().toString(), "doc1");
-        assertCreator(forms, sharedForm.getId().toString(), null);
-    }
-
-    @Test
-    @DisplayName("should list only shared current eForms when provider number is null")
-    void shouldListOnlySharedCurrentEForms_whenProviderNumberIsNull() throws Exception {
-        persistCurrentForm("NULL_PROVIDER_SHARED", null);
-        persistCurrentForm("NULL_PROVIDER_OWNED", "doc1");
-
-        List<HashMap<String, ? extends Object>> forms =
-                EFormUtil.listEFormsForProvider(EFormUtil.NAME, EFormUtil.CURRENT, null, false);
-
-        assertThat(formNames(forms))
-                .contains("NULL_PROVIDER_SHARED")
-                .doesNotContain("NULL_PROVIDER_OWNED");
-        assertThat(forms)
-                .allSatisfy(form -> assertThat(form).containsKey(EFormUtil.FORM_CREATOR_KEY));
-    }
-
-    private EForm persistCurrentForm(String formName, String creator) throws Exception {
-        EForm eForm = new EForm();
-        EntityDataGenerator.generateTestDataForModelClass(eForm);
-        eForm.setFormName(formName);
-        eForm.setCurrent(true);
-        eForm.setCreator(creator);
-        eFormDao.persist(eForm);
-        hibernateTemplate.flush();
-        return eForm;
-    }
-
-    private List<String> formNames(List<HashMap<String, ? extends Object>> forms) {
-        return forms.stream()
-                .map(form -> (String) form.get("formName"))
-                .toList();
-    }
-
-    private void assertCreator(List<HashMap<String, ? extends Object>> forms, String fid, String expectedCreator) {
-        assertThat(forms)
-                .filteredOn(form -> fid.equals(form.get("fid")))
-                .singleElement()
-                .satisfies(form -> assertThat((java.util.Map<String, Object>) form).containsEntry(EFormUtil.FORM_CREATOR_KEY, expectedCreator));
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/eform/actions/DelEForm2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/eform/actions/DelEForm2ActionTest.java
@@ -44,8 +44,8 @@ import static org.mockito.Mockito.when;
 /**
  * Unit tests for {@link DelEForm2Action} privilege checks.
  *
- * <p>Deletion requires the {@code _eform} delete ("d") privilege; providers without
- * that privilege are rejected regardless of form ownership.
+ * <p>Deletion requires the {@code _admin.eform} write privilege; providers without
+ * it are rejected regardless of form ownership.
  *
  * @since 2026-06-15
  */
@@ -70,9 +70,9 @@ class DelEForm2ActionTest extends CarlosWebTestBase {
     }
 
     @Test
-    @DisplayName("should delete eForm when provider has _eform delete privilege")
-    void shouldDeleteEForm_whenProviderHasDeletePrivilege() throws Exception {
-        allowPrivilege("_eform", SecurityInfoManager.DELETE);
+    @DisplayName("should delete eForm when provider has _admin.eform write privilege")
+    void shouldDeleteEForm_whenProviderHasAdminEFormWritePrivilege() throws Exception {
+        allowPrivilege("_admin.eform", SecurityInfoManager.WRITE);
 
         try (MockedStatic<EFormUtil> eformUtils = mockStatic(EFormUtil.class)) {
             String result = action.execute();
@@ -82,11 +82,11 @@ class DelEForm2ActionTest extends CarlosWebTestBase {
     }
 
     @Test
-    @DisplayName("should reject delete when provider has no _eform delete privilege")
-    void shouldRejectDelete_whenProviderHasNoDeletePrivilege() {
+    @DisplayName("should reject delete when provider lacks _admin.eform write privilege")
+    void shouldRejectDelete_whenProviderLacksAdminEFormPrivilege() {
         assertThatThrownBy(() -> action.execute())
                 .isInstanceOf(SecurityException.class)
-                .hasMessageContaining("missing required sec object (_eform)");
+                .hasMessageContaining("missing required sec object (_admin.eform)");
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/eform/actions/DelEForm2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/eform/actions/DelEForm2ActionTest.java
@@ -53,7 +53,7 @@ import static org.mockito.Mockito.when;
  * @since 2026-06-15
  */
 @DisplayName("DelEForm2Action — ownership and privilege checks")
-@Tag("unit")
+@Tag("integration")
 @Tag("eform")
 @Tag("security")
 @Tag("delete")

--- a/src/test/java/io/github/carlos_emr/carlos/eform/actions/DelEForm2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/eform/actions/DelEForm2ActionTest.java
@@ -22,8 +22,6 @@
  */
 package io.github.carlos_emr.carlos.eform.actions;
 
-import io.github.carlos_emr.carlos.commn.dao.EFormDao;
-import io.github.carlos_emr.carlos.commn.model.EForm;
 import io.github.carlos_emr.carlos.eform.EFormUtil;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.test.base.CarlosWebTestBase;
@@ -33,7 +31,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 import org.mockito.MockedStatic;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,118 +38,52 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 /**
- * Unit tests for {@link DelEForm2Action} privilege and ownership logic.
+ * Unit tests for {@link DelEForm2Action} privilege checks.
  *
- * <p>Admin-level delete requires the independent {@code _eform} delete ("d") privilege,
- * which is not implied by write ("w"). Providers with only write access may delete
- * eForms they personally created; shared templates (null/blank creator) are admin-only.
+ * <p>Deletion requires the {@code _eform} delete ("d") privilege; providers without
+ * that privilege are rejected regardless of form ownership.
  *
  * @since 2026-06-15
  */
-@DisplayName("DelEForm2Action — ownership and privilege checks")
+@DisplayName("DelEForm2Action — privilege checks")
 @Tag("integration")
 @Tag("eform")
 @Tag("security")
 @Tag("delete")
 class DelEForm2ActionTest extends CarlosWebTestBase {
 
-    private static final String LOGGED_IN_PROVIDER = "999998";
-    private static final String OTHER_PROVIDER = "888888";
     private static final String FID = "42";
-
-    @Mock
-    private EFormDao mockEFormDao;
 
     private DelEForm2Action action;
 
     @BeforeEach
     void setUp() {
-        // Base class allows all by default — override to deny all, then re-grant per test
         when(mockSecurityInfoManager.hasPrivilege(any(LoggedInInfo.class), anyString(), anyString(), any()))
                 .thenReturn(false);
-        when(mockLoggedInInfo.getLoggedInProviderNo()).thenReturn(LOGGED_IN_PROVIDER);
         mockRequest.setMethod("POST");
         mockRequest.setParameter("fid", FID);
-        action = new DelEForm2Action(mockSecurityInfoManager, mockEFormDao);
+        action = new DelEForm2Action(mockSecurityInfoManager);
     }
 
     @Test
-    @DisplayName("should delete any eForm when admin has _eform delete privilege")
-    void shouldDeleteAnyEForm_whenAdminHasDeletePrivilege() throws Exception {
+    @DisplayName("should delete eForm when provider has _eform delete privilege")
+    void shouldDeleteEForm_whenProviderHasDeletePrivilege() throws Exception {
         allowPrivilege("_eform", SecurityInfoManager.DELETE);
 
         try (MockedStatic<EFormUtil> eformUtils = mockStatic(EFormUtil.class)) {
             String result = action.execute();
             assertThat(result).isEqualTo(ActionSupport.SUCCESS);
-            verifyNoInteractions(mockEFormDao);
             eformUtils.verify(() -> EFormUtil.delEForm(FID));
         }
     }
 
     @Test
-    @DisplayName("should delete own eForm when provider has write privilege and is the creator")
-    void shouldDeleteOwnEForm_whenDoctorIsCreator() throws Exception {
-        allowPrivilege("_eform", SecurityInfoManager.WRITE);
-        when(mockEFormDao.findById(42)).thenReturn(eformWithCreator(LOGGED_IN_PROVIDER));
-
-        try (MockedStatic<EFormUtil> eformUtils = mockStatic(EFormUtil.class)) {
-            String result = action.execute();
-            assertThat(result).isEqualTo(ActionSupport.SUCCESS);
-            eformUtils.verify(() -> EFormUtil.delEForm(FID));
-        }
-    }
-
-    @Test
-    @DisplayName("should reject delete when provider tries to delete another provider's eForm")
-    void shouldRejectDelete_whenDoctorDoesNotOwnEForm() {
-        allowPrivilege("_eform", SecurityInfoManager.WRITE);
-        when(mockEFormDao.findById(42)).thenReturn(eformWithCreator(OTHER_PROVIDER));
-
-        assertThatThrownBy(() -> action.execute())
-                .isInstanceOf(SecurityException.class)
-                .hasMessageContaining("missing required sec object (_eform)");
-    }
-
-    @Test
-    @DisplayName("should reject delete when eForm is a shared template with no creator")
-    void shouldRejectDelete_whenFormIsSharedTemplate() {
-        allowPrivilege("_eform", SecurityInfoManager.WRITE);
-        when(mockEFormDao.findById(42)).thenReturn(eformWithCreator(null));
-
-        assertThatThrownBy(() -> action.execute())
-                .isInstanceOf(SecurityException.class)
-                .hasMessageContaining("missing required sec object (_eform)");
-    }
-
-    @Test
-    @DisplayName("should reject delete when eForm creator is blank")
-    void shouldRejectDelete_whenFormCreatorIsBlank() {
-        allowPrivilege("_eform", SecurityInfoManager.WRITE);
-        when(mockEFormDao.findById(42)).thenReturn(eformWithCreator("   "));
-
-        assertThatThrownBy(() -> action.execute())
-                .isInstanceOf(SecurityException.class)
-                .hasMessageContaining("missing required sec object (_eform)");
-    }
-
-    @Test
-    @DisplayName("should reject delete when provider can write but eForm does not exist")
-    void shouldRejectDelete_whenDoctorTargetsMissingEForm() {
-        allowPrivilege("_eform", SecurityInfoManager.WRITE);
-        when(mockEFormDao.findById(42)).thenReturn(null);
-
-        assertThatThrownBy(() -> action.execute())
-                .isInstanceOf(SecurityException.class)
-                .hasMessageContaining("missing required sec object (_eform)");
-    }
-
-    @Test
-    @DisplayName("should reject delete when provider has no eForm privilege at all")
-    void shouldRejectDelete_whenProviderHasNoEFormPrivilege() {
+    @DisplayName("should reject delete when provider has no _eform delete privilege")
+    void shouldRejectDelete_whenProviderHasNoDeletePrivilege() {
         assertThatThrownBy(() -> action.execute())
                 .isInstanceOf(SecurityException.class)
                 .hasMessageContaining("missing required sec object (_eform)");
@@ -167,7 +98,7 @@ class DelEForm2ActionTest extends CarlosWebTestBase {
 
         assertThat(result).isEqualTo(ActionSupport.NONE);
         assertThat(mockResponse.getStatus()).isEqualTo(jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST);
-        verifyNoInteractions(mockEFormDao);
+        verifyNoMoreInteractions(mockSecurityInfoManager);
     }
 
     @Test
@@ -179,19 +110,7 @@ class DelEForm2ActionTest extends CarlosWebTestBase {
 
         assertThat(result).isEqualTo(ActionSupport.NONE);
         assertThat(mockResponse.getStatus()).isEqualTo(jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST);
-        verifyNoInteractions(mockEFormDao);
-    }
-
-    @Test
-    @DisplayName("should return 400 when fid overflows Integer range")
-    void shouldReturn400_whenFidOverflowsInt() throws Exception {
-        mockRequest.setParameter("fid", "99999999999999");
-
-        String result = action.execute();
-
-        assertThat(result).isEqualTo(ActionSupport.NONE);
-        assertThat(mockResponse.getStatus()).isEqualTo(jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST);
-        verifyNoInteractions(mockEFormDao);
+        verifyNoMoreInteractions(mockSecurityInfoManager);
     }
 
     @Test
@@ -203,7 +122,7 @@ class DelEForm2ActionTest extends CarlosWebTestBase {
 
         assertThat(result).isEqualTo(ActionSupport.NONE);
         assertThat(mockResponse.getStatus()).isEqualTo(jakarta.servlet.http.HttpServletResponse.SC_METHOD_NOT_ALLOWED);
-        verifyNoInteractions(mockEFormDao);
+        verifyNoMoreInteractions(mockSecurityInfoManager);
     }
 
     @Test
@@ -215,12 +134,6 @@ class DelEForm2ActionTest extends CarlosWebTestBase {
 
         assertThat(result).isEqualTo(ActionSupport.NONE);
         assertThat(mockResponse.getStatus()).isEqualTo(jakarta.servlet.http.HttpServletResponse.SC_METHOD_NOT_ALLOWED);
-        verifyNoInteractions(mockEFormDao);
-    }
-
-    private EForm eformWithCreator(String creatorProviderNo) {
-        EForm eform = new EForm();
-        eform.setCreator(creatorProviderNo);
-        return eform;
+        verifyNoMoreInteractions(mockSecurityInfoManager);
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/eform/actions/DelEForm2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/eform/actions/DelEForm2ActionTest.java
@@ -137,6 +137,30 @@ class DelEForm2ActionTest extends CarlosWebTestBase {
     }
 
     @Test
+    @DisplayName("should return 400 when fid parameter is missing")
+    void shouldReturn400_whenFidIsMissing() throws Exception {
+        mockRequest.removeParameter("fid");
+
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(mockResponse.getStatus()).isEqualTo(jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST);
+        org.mockito.Mockito.verifyNoInteractions(mockEFormDao);
+    }
+
+    @Test
+    @DisplayName("should return 400 when fid parameter is non-numeric")
+    void shouldReturn400_whenFidIsNonNumeric() throws Exception {
+        mockRequest.setParameter("fid", "not-a-number");
+
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(mockResponse.getStatus()).isEqualTo(jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST);
+        org.mockito.Mockito.verifyNoInteractions(mockEFormDao);
+    }
+
+    @Test
     @DisplayName("should reject GET with 405 and no mutation side-effects")
     void shouldReturn405_whenMethodIsGet() throws Exception {
         mockRequest.setMethod("GET");

--- a/src/test/java/io/github/carlos_emr/carlos/eform/actions/DelEForm2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/eform/actions/DelEForm2ActionTest.java
@@ -41,6 +41,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 /**
@@ -83,12 +84,11 @@ class DelEForm2ActionTest extends CarlosWebTestBase {
     @DisplayName("should delete any eForm when admin has _eform delete privilege")
     void shouldDeleteAnyEForm_whenAdminHasDeletePrivilege() throws Exception {
         allowPrivilege("_eform", SecurityInfoManager.DELETE);
-        // form owned by someone else — admin should still be able to delete it
-        when(mockEFormDao.findById(42)).thenReturn(eformWithCreator(OTHER_PROVIDER));
 
         try (MockedStatic<EFormUtil> eformUtils = mockStatic(EFormUtil.class)) {
             String result = action.execute();
             assertThat(result).isEqualTo(ActionSupport.SUCCESS);
+            verifyNoInteractions(mockEFormDao);
             eformUtils.verify(() -> EFormUtil.delEForm(FID));
         }
     }
@@ -129,6 +129,28 @@ class DelEForm2ActionTest extends CarlosWebTestBase {
     }
 
     @Test
+    @DisplayName("should reject delete when eForm creator is blank")
+    void shouldRejectDelete_whenFormCreatorIsBlank() {
+        allowPrivilege("_eform", SecurityInfoManager.WRITE);
+        when(mockEFormDao.findById(42)).thenReturn(eformWithCreator("   "));
+
+        assertThatThrownBy(() -> action.execute())
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("missing required sec object (_eform)");
+    }
+
+    @Test
+    @DisplayName("should reject delete when provider can write but eForm does not exist")
+    void shouldRejectDelete_whenDoctorTargetsMissingEForm() {
+        allowPrivilege("_eform", SecurityInfoManager.WRITE);
+        when(mockEFormDao.findById(42)).thenReturn(null);
+
+        assertThatThrownBy(() -> action.execute())
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("missing required sec object (_eform)");
+    }
+
+    @Test
     @DisplayName("should reject delete when provider has no eForm privilege at all")
     void shouldRejectDelete_whenProviderHasNoEFormPrivilege() {
         assertThatThrownBy(() -> action.execute())
@@ -145,7 +167,7 @@ class DelEForm2ActionTest extends CarlosWebTestBase {
 
         assertThat(result).isEqualTo(ActionSupport.NONE);
         assertThat(mockResponse.getStatus()).isEqualTo(jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST);
-        org.mockito.Mockito.verifyNoInteractions(mockEFormDao);
+        verifyNoInteractions(mockEFormDao);
     }
 
     @Test
@@ -157,7 +179,7 @@ class DelEForm2ActionTest extends CarlosWebTestBase {
 
         assertThat(result).isEqualTo(ActionSupport.NONE);
         assertThat(mockResponse.getStatus()).isEqualTo(jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST);
-        org.mockito.Mockito.verifyNoInteractions(mockEFormDao);
+        verifyNoInteractions(mockEFormDao);
     }
 
     @Test
@@ -169,7 +191,7 @@ class DelEForm2ActionTest extends CarlosWebTestBase {
 
         assertThat(result).isEqualTo(ActionSupport.NONE);
         assertThat(mockResponse.getStatus()).isEqualTo(jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST);
-        org.mockito.Mockito.verifyNoInteractions(mockEFormDao);
+        verifyNoInteractions(mockEFormDao);
     }
 
     @Test
@@ -181,7 +203,19 @@ class DelEForm2ActionTest extends CarlosWebTestBase {
 
         assertThat(result).isEqualTo(ActionSupport.NONE);
         assertThat(mockResponse.getStatus()).isEqualTo(jakarta.servlet.http.HttpServletResponse.SC_METHOD_NOT_ALLOWED);
-        org.mockito.Mockito.verifyNoInteractions(mockEFormDao);
+        verifyNoInteractions(mockEFormDao);
+    }
+
+    @Test
+    @DisplayName("should reject HEAD with 405 and no mutation side-effects")
+    void shouldReturn405_whenMethodIsHead() throws Exception {
+        mockRequest.setMethod("HEAD");
+
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(mockResponse.getStatus()).isEqualTo(jakarta.servlet.http.HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+        verifyNoInteractions(mockEFormDao);
     }
 
     private EForm eformWithCreator(String creatorProviderNo) {

--- a/src/test/java/io/github/carlos_emr/carlos/eform/actions/DelEForm2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/eform/actions/DelEForm2ActionTest.java
@@ -161,6 +161,18 @@ class DelEForm2ActionTest extends CarlosWebTestBase {
     }
 
     @Test
+    @DisplayName("should return 400 when fid overflows Integer range")
+    void shouldReturn400_whenFidOverflowsInt() throws Exception {
+        mockRequest.setParameter("fid", "99999999999999");
+
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(mockResponse.getStatus()).isEqualTo(jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST);
+        org.mockito.Mockito.verifyNoInteractions(mockEFormDao);
+    }
+
+    @Test
     @DisplayName("should reject GET with 405 and no mutation side-effects")
     void shouldReturn405_whenMethodIsGet() throws Exception {
         mockRequest.setMethod("GET");

--- a/src/test/java/io/github/carlos_emr/carlos/eform/actions/DelEForm2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/eform/actions/DelEForm2ActionTest.java
@@ -114,6 +114,18 @@ class DelEForm2ActionTest extends CarlosWebTestBase {
     }
 
     @Test
+    @DisplayName("should return 400 when fid overflows Integer range")
+    void shouldReturn400_whenFidOverflowsIntegerRange() throws Exception {
+        mockRequest.setParameter("fid", "9999999999999");
+
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(mockResponse.getStatus()).isEqualTo(jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST);
+        verifyNoMoreInteractions(mockSecurityInfoManager);
+    }
+
+    @Test
     @DisplayName("should reject GET with 405 and no mutation side-effects")
     void shouldReturn405_whenMethodIsGet() throws Exception {
         mockRequest.setMethod("GET");

--- a/src/test/java/io/github/carlos_emr/carlos/eform/actions/DelEForm2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/eform/actions/DelEForm2ActionTest.java
@@ -1,0 +1,156 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ * CARLOS has no affiliation with OSCAR or McMaster University.
+ */
+package io.github.carlos_emr.carlos.eform.actions;
+
+import io.github.carlos_emr.carlos.commn.dao.EFormDao;
+import io.github.carlos_emr.carlos.commn.model.EForm;
+import io.github.carlos_emr.carlos.eform.EFormUtil;
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import io.github.carlos_emr.carlos.test.base.CarlosWebTestBase;
+import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import org.apache.struts2.ActionSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link DelEForm2Action} privilege and ownership logic.
+ *
+ * <p>Admin-level delete requires the independent {@code _eform} delete ("d") privilege,
+ * which is not implied by write ("w"). Providers with only write access may delete
+ * eForms they personally created; shared templates (null/blank creator) are admin-only.
+ *
+ * @since 2026-06-15
+ */
+@DisplayName("DelEForm2Action — ownership and privilege checks")
+@Tag("unit")
+@Tag("eform")
+@Tag("security")
+@Tag("delete")
+class DelEForm2ActionTest extends CarlosWebTestBase {
+
+    private static final String LOGGED_IN_PROVIDER = "999998";
+    private static final String OTHER_PROVIDER = "888888";
+    private static final String FID = "42";
+
+    @Mock
+    private EFormDao mockEFormDao;
+
+    private DelEForm2Action action;
+
+    @BeforeEach
+    void setUp() {
+        // Base class allows all by default — override to deny all, then re-grant per test
+        when(mockSecurityInfoManager.hasPrivilege(any(LoggedInInfo.class), anyString(), anyString(), any()))
+                .thenReturn(false);
+        when(mockLoggedInInfo.getLoggedInProviderNo()).thenReturn(LOGGED_IN_PROVIDER);
+        mockRequest.setMethod("POST");
+        mockRequest.setParameter("fid", FID);
+        action = new DelEForm2Action(mockSecurityInfoManager, mockEFormDao);
+    }
+
+    @Test
+    @DisplayName("should delete any eForm when admin has _eform delete privilege")
+    void shouldDeleteAnyEForm_whenAdminHasDeletePrivilege() throws Exception {
+        allowPrivilege("_eform", SecurityInfoManager.DELETE);
+        // form owned by someone else — admin should still be able to delete it
+        when(mockEFormDao.findById(42)).thenReturn(eformWithCreator(OTHER_PROVIDER));
+
+        try (MockedStatic<EFormUtil> eformUtils = mockStatic(EFormUtil.class)) {
+            String result = action.execute();
+            assertThat(result).isEqualTo(ActionSupport.SUCCESS);
+            eformUtils.verify(() -> EFormUtil.delEForm(FID));
+        }
+    }
+
+    @Test
+    @DisplayName("should delete own eForm when provider has write privilege and is the creator")
+    void shouldDeleteOwnEForm_whenDoctorIsCreator() throws Exception {
+        allowPrivilege("_eform", SecurityInfoManager.WRITE);
+        when(mockEFormDao.findById(42)).thenReturn(eformWithCreator(LOGGED_IN_PROVIDER));
+
+        try (MockedStatic<EFormUtil> eformUtils = mockStatic(EFormUtil.class)) {
+            String result = action.execute();
+            assertThat(result).isEqualTo(ActionSupport.SUCCESS);
+            eformUtils.verify(() -> EFormUtil.delEForm(FID));
+        }
+    }
+
+    @Test
+    @DisplayName("should reject delete when provider tries to delete another provider's eForm")
+    void shouldRejectDelete_whenDoctorDoesNotOwnEForm() {
+        allowPrivilege("_eform", SecurityInfoManager.WRITE);
+        when(mockEFormDao.findById(42)).thenReturn(eformWithCreator(OTHER_PROVIDER));
+
+        assertThatThrownBy(() -> action.execute())
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("missing required sec object (_eform)");
+    }
+
+    @Test
+    @DisplayName("should reject delete when eForm is a shared template with no creator")
+    void shouldRejectDelete_whenFormIsSharedTemplate() {
+        allowPrivilege("_eform", SecurityInfoManager.WRITE);
+        when(mockEFormDao.findById(42)).thenReturn(eformWithCreator(null));
+
+        assertThatThrownBy(() -> action.execute())
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("missing required sec object (_eform)");
+    }
+
+    @Test
+    @DisplayName("should reject delete when provider has no eForm privilege at all")
+    void shouldRejectDelete_whenProviderHasNoEFormPrivilege() {
+        assertThatThrownBy(() -> action.execute())
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("missing required sec object (_eform)");
+    }
+
+    @Test
+    @DisplayName("should reject GET with 405 and no mutation side-effects")
+    void shouldReturn405_whenMethodIsGet() throws Exception {
+        mockRequest.setMethod("GET");
+
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(mockResponse.getStatus()).isEqualTo(jakarta.servlet.http.HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+        org.mockito.Mockito.verifyNoInteractions(mockEFormDao);
+    }
+
+    private EForm eformWithCreator(String creatorProviderNo) {
+        EForm eform = new EForm();
+        eform.setCreator(creatorProviderNo);
+        return eform;
+    }
+}


### PR DESCRIPTION
Fixes #2828

## Problem

`DelEForm2Action` existed but was never registered in `struts-eform.xml`, so the delete button in the eForm manager silently 404'd for all providers. This PR wires up the route and enforces admin-only deletion: only providers with the `_admin.eform` write privilege (the admin role) can delete templates. Doctors retain read, upload, and edit access.

## Changes

### Privilege model

- Wired `DelEForm2Action` into `struts-eform.xml` (previously unmapped — deletion was broken for everyone).
- **Template deletion is admin-only**, gated on the `_admin.eform` write privilege, which is already seeded as `x` for the admin role in `oscardata.sql`. No new privilege grant is needed.
- Downgraded the default **doctor** role's `_eform` privilege from `x` (full access) to `w` (write), removing the implied delete capability.
- Doctors retain all read, upload, and edit operations.

### Code

| File | Change |
|------|--------|
| `struts-eform.xml` | Register `eform/delEForm` → `DelEForm2Action` |
| `DelEForm2Action.java` | Constructor injection, POST-only guard (405 on GET/HEAD), `_admin.eform: WRITE` privilege check |
| `efmformmanager.jsp` | Delete button visible only when `_admin.eform: WRITE` is satisfied |
| `oscardata.sql` | Doctor seed row `_eform: x` → `_eform: w`; existing `_admin.eform: x` covers admin deletion |
| `update-2026-06-15-eform-delete-privilege.sql` | Single UPDATE: doctor `_eform: x` → `w` using correct `roleUserGroup` column name |
| `MutatorActionGetRejectionContractTest.java` | `DelEForm2Action` registered as unconditional mutator |
| `DelEForm2ActionTest.java` | 6 unit tests: `_admin.eform: WRITE` allow/deny, 400 for missing/non-numeric fid, 405 for GET/HEAD |
| `AdminSecuritySeedRegressionTest.java` | Verifies doctor `_eform: w` in seed and correct column names in migration |

## Test plan

- [ ] All 6 `DelEForm2ActionTest` unit tests pass
- [ ] `MutatorActionGetRejectionContractTest` (31 tests) pass — `DelEForm2Action` rejects GET/HEAD without side-effects
- [ ] `AdminSecuritySeedRegressionTest` passes — seed has doctor `_eform: w`, migration uses `roleUserGroup`
- [ ] Manual: log in as `carlosdoc` (has `admin` role → `_admin.eform: x`): delete button visible, delete succeeds
- [ ] Manual: log in as a doctor-only provider: delete button not rendered
- [ ] Run migration on dev database: `UPDATE secObjPrivilege SET privilege='w' WHERE roleUserGroup='doctor' AND objectName='_eform' AND privilege='x'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)