### PR TITLE
Suppress Unicode warning in JDBC import guard and fix path traversal in signature image action

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/provider/web/ProviderSignatureImage2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/provider/web/ProviderSignatureImage2Action.java
@@ -96,7 +96,8 @@ public class ProviderSignatureImage2Action extends ActionSupport {
             return NONE;
         }
 
-        String signatureName = UserProperty.CONSULT_SIGNATURE_PREFIX + providerNo + ".png";
+        String signatureName = PathValidationUtils.validatePathComponent(
+                UserProperty.CONSULT_SIGNATURE_PREFIX + providerNo + ".png", "signatureName");
         File sigFile = getValidatedSignatureFile(signatureName, response);
         if (sigFile == null) {
             return NONE;

--- a/src/main/java/io/github/carlos_emr/carlos/util/JDBCUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/util/JDBCUtil.java
@@ -294,8 +294,12 @@ public class JDBCUtil {
         }
     }
 
-    // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
-    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
+    // FindSecBugs IMPROPER_UNICODE: fixed XML wrapper/id element names;
+    // import-managed DB fields are checked separately. See docs/static-analysis-workflows.md
+    @SuppressFBWarnings(
+            value = "IMPROPER_UNICODE",
+            justification = "case-insensitive comparison of fixed XML wrapper/id element names; "
+                    + "import-managed DB fields are checked separately")
     static ResultSet toResultSet(Node node, ResultSet rs) throws SQLException {
         int type = node.getNodeType();
 
@@ -329,6 +333,12 @@ public class JDBCUtil {
 
     }
 
+    // FindSecBugs IMPROPER_UNICODE: fixed ASCII import-managed DB columns;
+    // archive entry name remains the trusted source for patient/timestamp. See docs/static-analysis-workflows.md
+    @SuppressFBWarnings(
+            value = "IMPROPER_UNICODE",
+            justification = "case-insensitive comparison against fixed ASCII import-managed DB column names; "
+                    + "XML body cannot choose patient/timestamp")
     private static boolean isImportTargetManagedField(String name) {
         return IMPORT_TARGET_MANAGED_FIELDS.stream().anyMatch(field -> field.equalsIgnoreCase(name));
     }


### PR DESCRIPTION
## Summary
- add a targeted FindSecBugs IMPROPER_UNICODE suppression for the fixed ASCII import-managed field check in JDBCUtil
- correct the nearby wrapper/id element suppression wording so it matches the actual import trust boundary
- disposition code scanning alert 25630 as a false positive/no practical exploit path
- fix potential path traversal in `ProviderSignatureImage2Action` by adding explicit `PathValidationUtils.validatePathComponent()` on the constructed signature filename before file operations

## Verification
- mvn -q -Dtest=JDBCUtilUnitTest test