### PR TITLE
Restrict form XML import to admin eForm writers (defense in depth)

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FrmXmlUpload2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FrmXmlUpload2Action.java
@@ -52,6 +52,10 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
 public class FrmXmlUpload2Action extends ActionSupport implements UploadedFilesAware {
+    private static final String ADMIN_SECURITY_OBJECT = "_admin";
+    private static final String ADMIN_EFORM_SECURITY_OBJECT = "_admin.eform";
+    private static final String WRITE_PRIVILEGE = "w";
+
     HttpServletRequest request = ServletActionContext.getRequest();
     HttpServletResponse response = ServletActionContext.getResponse();
 
@@ -60,8 +64,16 @@ public class FrmXmlUpload2Action extends ActionSupport implements UploadedFilesA
 
     public String execute()
             throws ServletException, IOException {
-        if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_form", "r", null)) {
-            throw new SecurityException("missing required sec object (_form)");
+        if (!"POST".equalsIgnoreCase(request.getMethod())) {
+            response.setHeader("Allow", "POST");
+            response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED, "POST required");
+            return NONE;
+        }
+
+        LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, ADMIN_EFORM_SECURITY_OBJECT, WRITE_PRIVILEGE, null)
+                && !securityInfoManager.hasPrivilege(loggedInInfo, ADMIN_SECURITY_OBJECT, WRITE_PRIVILEGE, null)) {
+            throw new SecurityException("missing required sec object (_admin.eform or _admin)");
         }
         if (uploadValidationError != null) {
             addActionError(uploadValidationError);

--- a/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FrmXmlUpload2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FrmXmlUpload2Action.java
@@ -64,7 +64,7 @@ public class FrmXmlUpload2Action extends ActionSupport implements UploadedFilesA
 
     public String execute()
             throws ServletException, IOException {
-        if (!"POST".equalsIgnoreCase(request.getMethod())) {
+        if (!"POST".equals(request.getMethod())) {
             response.setHeader("Allow", "POST");
             response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED, "POST required");
             return NONE;

--- a/src/main/webapp/WEB-INF/jsp/admin/admin.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/admin.jsp
@@ -426,8 +426,10 @@
             <ul>
                 <li><a href="#"
                        onclick='popupPage(500,1000,"${pageContext.request.contextPath}/form/setupSelect");return false;'><fmt:message key="admin.admin.btnSelectForm"/></a></li>
-                <li><a href="#"
-                       onclick='popupPage(500,1000,"${pageContext.request.contextPath}/form/formXmlUpload");return false;'><fmt:message key="admin.admin.btnImportFormData"/></a></li>
+                <security:oscarSec roleName="<%=roleName$%>" objectName="_admin,_admin.eform" rights="w" reverse="<%=false%>">
+                    <li><a href="#"
+                           onclick='popupPage(500,1000,"${pageContext.request.contextPath}/form/formXmlUpload");return false;'><fmt:message key="admin.admin.btnImportFormData"/></a></li>
+                </security:oscarSec>
                 <li><a href="${pageContext.request.contextPath}/eform/efmformmanager">
                     <fmt:message key="admin.admin.btnUploadForm"/>
                 </a></li>

--- a/src/main/webapp/WEB-INF/jsp/administration/leftNav.jspf
+++ b/src/main/webapp/WEB-INF/jsp/administration/leftNav.jspf
@@ -292,7 +292,9 @@ Properties oscarVariables = CarlosProperties.getInstance();
 			<ul>
 					<li><a href="${ctx}/form/setupSelect" class="contentLink"><fmt:message key="admin.admin.btnSelectForm"/></a></li>
 					
-					<li><a href="${ctx}/form/formXmlUpload" class="contentLink"><fmt:message key="admin.admin.btnImportFormData"/></a></li>
+						<security:oscarSec roleName="<%=roleName$%>" objectName="_admin,_admin.eform" rights="w" reverse="<%=false%>">
+						<li><a href="${ctx}/form/formXmlUpload" class="contentLink"><fmt:message key="admin.admin.btnImportFormData"/></a></li>
+						</security:oscarSec>
 					
 					<li><a href="${ctx}/eform/efmformmanager" class="contentLink defaultForms">
 						<fmt:message key="eform.showmyform.msgManageEFrm"/>

--- a/src/main/webapp/WEB-INF/jsp/form/formXmlUpload.jsp
+++ b/src/main/webapp/WEB-INF/jsp/form/formXmlUpload.jsp
@@ -33,9 +33,9 @@
     String roleName2$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;
 %>
-<security:oscarSec roleName="<%=roleName2$%>" objectName="_form" rights="r" reverse="<%=true%>">
+<security:oscarSec roleName="<%=roleName2$%>" objectName="_admin,_admin.eform" rights="w" reverse="<%=true%>">
     <%authed = false; %>
-    <%response.sendRedirect(request.getContextPath() + "/securityError?type=_form");%>
+    <%response.sendRedirect(request.getContextPath() + "/securityError?type=_admin.eform");%>
 </security:oscarSec>
 <%
     if (!authed) {

--- a/src/test/java/io/github/carlos_emr/carlos/app/contract/MutatorActionGetRejectionContractTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/app/contract/MutatorActionGetRejectionContractTest.java
@@ -165,6 +165,8 @@ class MutatorActionGetRejectionContractTest {
                     "_admin", "w"),
             Arguments.of("io.github.carlos_emr.carlos.admin.web.SecurityUpdate2Action",
                     "_admin", "w"),
+            Arguments.of("io.github.carlos_emr.carlos.form.pageUtil.FrmXmlUpload2Action",
+                    "_admin.eform", "w"),
             // --- clinical measurements / flowsheets ---
             Arguments.of("io.github.carlos_emr.carlos.encounter.oscarMeasurements.pageUtil.EctMeasurements2Action",
                     "_measurement", "w"),

--- a/src/test/java/io/github/carlos_emr/carlos/app/contract/MutatorActionGetRejectionContractTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/app/contract/MutatorActionGetRejectionContractTest.java
@@ -97,7 +97,7 @@ import static org.mockito.Mockito.when;
  * <p><b>Adding a new mutator 2Action.</b> The {@link #discoveryCandidatesMustBeRegistered()}
  * test scans {@code src/main/java} for any {@code *2Action.java} in an audited
  * slice, or explicitly registered legacy class, containing both
- * {@code SC_METHOD_NOT_ALLOWED} and an {@code equalsIgnoreCase("POST")} check
+ * {@code SC_METHOD_NOT_ALLOWED} and a POST method check
  * and fails the build if the class is not listed here. New mutators must be
  * registered in one of:
  *
@@ -320,6 +320,7 @@ class MutatorActionGetRejectionContractTest {
         "io.github.carlos_emr.carlos.billings.ca.on.web.ScheduleOfBenefitsUpload2Action",
         "io.github.carlos_emr.carlos.commn.web.FlowSheetCustom2Action",
         "io.github.carlos_emr.carlos.encounter.oscarMeasurements.pageUtil.EctMeasurements2Action",
+        "io.github.carlos_emr.carlos.form.pageUtil.FrmXmlUpload2Action",
         "io.github.carlos_emr.carlos.login.gate.SelectFacility2Action",
         "io.github.carlos_emr.carlos.provider.web.DocumentDescriptionTemplate2Action"
     );
@@ -517,8 +518,7 @@ class MutatorActionGetRejectionContractTest {
     /**
      * Walks {@code src/main/java} and fails if any {@code *2Action.java}
      * containing both a {@code SC_METHOD_NOT_ALLOWED} reference and a
-     * {@code "POST".equalsIgnoreCase(...)} (or {@code equalsIgnoreCase("POST")})
-     * check is not registered in one of
+     * literal POST method comparison is not registered in one of
      * {@link #unconditionalMutators()}, {@link #CONDITIONAL_MUTATORS}, or
      * {@link #NON_MUTATOR_GATES}.
      *
@@ -585,7 +585,8 @@ class MutatorActionGetRejectionContractTest {
                         + actionSource, e);
             }
             if (source.contains("SC_METHOD_NOT_ALLOWED")
-                    && (source.contains("\"POST\".equalsIgnoreCase(")
+                    && (source.contains("\"POST\".equals(")
+                        || source.contains("\"POST\".equalsIgnoreCase(")
                         || source.contains(".equalsIgnoreCase(\"POST\")"))) {
                 out.add(className);
             }

--- a/src/test/java/io/github/carlos_emr/carlos/form/FormXmlUploadJspMigrationRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/form/FormXmlUploadJspMigrationRegressionTest.java
@@ -86,6 +86,8 @@ class FormXmlUploadJspMigrationRegressionTest {
         assertThat(jsp).contains("/form/xmlUpload");
         assertThat(jsp).contains("enctype=\"multipart/form-data\"");
         assertThat(jsp).containsPattern("(?is)<form\\b[^>]*\\bmethod\\s*=\\s*['\"]post['\"]");
+        assertThat(jsp).contains("objectName=\"_admin,_admin.eform\" rights=\"w\"");
+        assertThat(jsp).doesNotContain("objectName=\"_form\" rights=\"r\"");
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/form/FormXmlUploadJspMigrationRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/form/FormXmlUploadJspMigrationRegressionTest.java
@@ -67,6 +67,7 @@ class FormXmlUploadJspMigrationRegressionTest {
 
         assertThat(jsp).doesNotContain("/form/formXmlUpload.jsp");
         assertThat(jsp).contains("/form/formXmlUpload");
+        assertThat(jsp).contains("objectName=\"_admin,_admin.eform\" rights=\"w\"");
     }
 
     @Test
@@ -76,6 +77,7 @@ class FormXmlUploadJspMigrationRegressionTest {
 
         assertThat(jsp).doesNotContain("/form/formXmlUpload.jsp");
         assertThat(jsp).contains("/form/formXmlUpload");
+        assertThat(jsp).contains("objectName=\"_admin,_admin.eform\" rights=\"w\"");
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/form/pageUtil/FrmXmlUpload2ActionSecurityTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/form/pageUtil/FrmXmlUpload2ActionSecurityTest.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.form.pageUtil;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.apache.struts2.ActionSupport;
+import org.apache.struts2.ServletActionContext;
+import org.apache.struts2.dispatcher.multipart.UploadedFile;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.MockedStatic;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
+import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import io.github.carlos_emr.carlos.utility.PathValidationUtils;
+
+@DisplayName("Form XML upload action security")
+@Tag("unit")
+@Tag("form")
+@Tag("security")
+class FrmXmlUpload2ActionSecurityTest extends CarlosUnitTestBase {
+
+    private MockedStatic<ServletActionContext> servletActionContextMock;
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+    private SecurityInfoManager securityInfoManager;
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void setUp() {
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+        LoggedInInfo.setLoggedInInfoIntoSession(request.getSession(), new LoggedInInfo());
+
+        servletActionContextMock = org.mockito.Mockito.mockStatic(ServletActionContext.class);
+        servletActionContextMock.when(ServletActionContext::getRequest).thenReturn(request);
+        servletActionContextMock.when(ServletActionContext::getResponse).thenReturn(response);
+
+        securityInfoManager = mock(SecurityInfoManager.class);
+        registerMock(SecurityInfoManager.class, securityInfoManager);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (servletActionContextMock != null) {
+            servletActionContextMock.close();
+        }
+    }
+
+    @Test
+    @DisplayName("should reject non-POST requests before privilege or upload processing")
+    void shouldRejectNonPostRequests() throws Exception {
+        request.setMethod("GET");
+
+        String result = new FrmXmlUpload2Action().execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+        assertThat(response.getHeader("Allow")).isEqualTo("POST");
+        verify(securityInfoManager, never()).hasPrivilege(
+                any(LoggedInInfo.class), any(String.class), any(String.class), any(String.class));
+    }
+
+    @Test
+    @DisplayName("should reject direct form XML import for users with only _form read")
+    void shouldRejectFormReadOnlyUsers() {
+        request.setMethod("POST");
+        when(securityInfoManager.hasPrivilege(any(LoggedInInfo.class), eq("_form"), eq("r"), isNull()))
+                .thenReturn(true);
+
+        FrmXmlUpload2Action action = new FrmXmlUpload2Action();
+
+        assertThatThrownBy(action::execute)
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("_admin.eform or _admin");
+
+        verify(securityInfoManager).hasPrivilege(any(LoggedInInfo.class), eq("_admin.eform"), eq("w"), isNull());
+        verify(securityInfoManager).hasPrivilege(any(LoggedInInfo.class), eq("_admin"), eq("w"), isNull());
+        verify(securityInfoManager, never()).hasPrivilege(any(LoggedInInfo.class), eq("_form"), eq("r"), isNull());
+    }
+
+    @Test
+    @DisplayName("should allow admin eForm writers to reach upload validation")
+    void shouldAllowAdminEformWriters() throws Exception {
+        request.setMethod("POST");
+        when(securityInfoManager.hasPrivilege(any(LoggedInInfo.class), eq("_admin.eform"), eq("w"), isNull()))
+                .thenReturn(true);
+        Path upload = Files.createTempFile(tempDir, "forms", ".zip");
+        UploadedFile uploadedFile = uploadedFile(upload, ".hidden.zip", "application/zip");
+
+        FrmXmlUpload2Action action = new FrmXmlUpload2Action();
+        action.withUploadedFiles(List.of(uploadedFile));
+
+        assertThat(action.execute()).isEqualTo(ActionSupport.ERROR);
+        assertThat(action.getActionErrors()).contains(PathValidationUtils.INVALID_FILENAME_MESSAGE);
+        verify(securityInfoManager).hasPrivilege(any(LoggedInInfo.class), eq("_admin.eform"), eq("w"), isNull());
+        verify(securityInfoManager, never()).hasPrivilege(any(LoggedInInfo.class), eq("_admin"), eq("w"), isNull());
+    }
+
+    private static UploadedFile uploadedFile(Path content, String originalName, String contentType) {
+        UploadedFile uploadedFile = mock(UploadedFile.class);
+        when(uploadedFile.getContent()).thenReturn(content.toFile());
+        when(uploadedFile.getOriginalName()).thenReturn(originalName);
+        when(uploadedFile.getContentType()).thenReturn(contentType);
+        return uploadedFile;
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/form/pageUtil/FrmXmlUpload2ActionSecurityUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/form/pageUtil/FrmXmlUpload2ActionSecurityUnitTest.java
@@ -46,6 +46,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.MockedStatic;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -59,7 +61,7 @@ import io.github.carlos_emr.carlos.utility.PathValidationUtils;
 @Tag("unit")
 @Tag("form")
 @Tag("security")
-class FrmXmlUpload2ActionSecurityTest extends CarlosUnitTestBase {
+class FrmXmlUpload2ActionSecurityUnitTest extends CarlosUnitTestBase {
 
     private MockedStatic<ServletActionContext> servletActionContextMock;
     private MockHttpServletRequest request;
@@ -90,10 +92,11 @@ class FrmXmlUpload2ActionSecurityTest extends CarlosUnitTestBase {
         }
     }
 
-    @Test
+    @ParameterizedTest
+    @ValueSource(strings = {"GET", "HEAD", "post"})
     @DisplayName("should reject non-POST requests before privilege or upload processing")
-    void shouldRejectNonPostRequests() throws Exception {
-        request.setMethod("GET");
+    void shouldRejectRequest_whenMethodIsNotPost(String httpMethod) throws Exception {
+        request.setMethod(httpMethod);
 
         String result = new FrmXmlUpload2Action().execute();
 
@@ -106,7 +109,7 @@ class FrmXmlUpload2ActionSecurityTest extends CarlosUnitTestBase {
 
     @Test
     @DisplayName("should reject direct form XML import for users with only _form read")
-    void shouldRejectFormReadOnlyUsers() {
+    void shouldRejectImport_whenUserIsFormReadOnly() {
         request.setMethod("POST");
         when(securityInfoManager.hasPrivilege(any(LoggedInInfo.class), eq("_form"), eq("r"), isNull()))
                 .thenReturn(true);
@@ -124,7 +127,7 @@ class FrmXmlUpload2ActionSecurityTest extends CarlosUnitTestBase {
 
     @Test
     @DisplayName("should allow admin eForm writers to reach upload validation")
-    void shouldAllowAdminEformWriters() throws Exception {
+    void shouldAllowValidation_whenUserIsAdminEformWriter() throws Exception {
         request.setMethod("POST");
         when(securityInfoManager.hasPrivilege(any(LoggedInInfo.class), eq("_admin.eform"), eq("w"), isNull()))
                 .thenReturn(true);
@@ -138,6 +141,26 @@ class FrmXmlUpload2ActionSecurityTest extends CarlosUnitTestBase {
         assertThat(action.getActionErrors()).contains(PathValidationUtils.INVALID_FILENAME_MESSAGE);
         verify(securityInfoManager).hasPrivilege(any(LoggedInInfo.class), eq("_admin.eform"), eq("w"), isNull());
         verify(securityInfoManager, never()).hasPrivilege(any(LoggedInInfo.class), eq("_admin"), eq("w"), isNull());
+    }
+
+    @Test
+    @DisplayName("should allow admin writers to reach upload validation")
+    void shouldAllowValidation_whenUserIsAdminWriter() throws Exception {
+        request.setMethod("POST");
+        when(securityInfoManager.hasPrivilege(any(LoggedInInfo.class), eq("_admin.eform"), eq("w"), isNull()))
+                .thenReturn(false);
+        when(securityInfoManager.hasPrivilege(any(LoggedInInfo.class), eq("_admin"), eq("w"), isNull()))
+                .thenReturn(true);
+        Path upload = Files.createTempFile(tempDir, "forms", ".zip");
+        UploadedFile uploadedFile = uploadedFile(upload, ".hidden.zip", "application/zip");
+
+        FrmXmlUpload2Action action = new FrmXmlUpload2Action();
+        action.withUploadedFiles(List.of(uploadedFile));
+
+        assertThat(action.execute()).isEqualTo(ActionSupport.ERROR);
+        assertThat(action.getActionErrors()).contains(PathValidationUtils.INVALID_FILENAME_MESSAGE);
+        verify(securityInfoManager).hasPrivilege(any(LoggedInInfo.class), eq("_admin.eform"), eq("w"), isNull());
+        verify(securityInfoManager).hasPrivilege(any(LoggedInInfo.class), eq("_admin"), eq("w"), isNull());
     }
 
     private static UploadedFile uploadedFile(Path content, String originalName, String contentType) {

--- a/src/test/java/io/github/carlos_emr/carlos/form/pageUtil/FrmXmlUpload2ActionSecurityUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/form/pageUtil/FrmXmlUpload2ActionSecurityUnitTest.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -104,7 +105,7 @@ class FrmXmlUpload2ActionSecurityUnitTest extends CarlosUnitTestBase {
         assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
         assertThat(response.getHeader("Allow")).isEqualTo("POST");
         verify(securityInfoManager, never()).hasPrivilege(
-                any(LoggedInInfo.class), any(String.class), any(String.class), any(String.class));
+                any(LoggedInInfo.class), any(String.class), any(String.class), nullable(String.class));
     }
 
     @Test
@@ -131,7 +132,7 @@ class FrmXmlUpload2ActionSecurityUnitTest extends CarlosUnitTestBase {
         request.setMethod("POST");
         when(securityInfoManager.hasPrivilege(any(LoggedInInfo.class), eq("_admin.eform"), eq("w"), isNull()))
                 .thenReturn(true);
-        Path upload = Files.createTempFile(tempDir, "forms", ".zip");
+        Path upload = Files.createFile(tempDir.resolve("admin-eform-forms.zip"));
         UploadedFile uploadedFile = uploadedFile(upload, ".hidden.zip", "application/zip");
 
         FrmXmlUpload2Action action = new FrmXmlUpload2Action();
@@ -151,7 +152,7 @@ class FrmXmlUpload2ActionSecurityUnitTest extends CarlosUnitTestBase {
                 .thenReturn(false);
         when(securityInfoManager.hasPrivilege(any(LoggedInInfo.class), eq("_admin"), eq("w"), isNull()))
                 .thenReturn(true);
-        Path upload = Files.createTempFile(tempDir, "forms", ".zip");
+        Path upload = Files.createFile(tempDir.resolve("admin-forms.zip"));
         UploadedFile uploadedFile = uploadedFile(upload, ".hidden.zip", "application/zip");
 
         FrmXmlUpload2Action action = new FrmXmlUpload2Action();


### PR DESCRIPTION
## Summary
- require POST for the form XML import processing action
- require `_admin.eform` or `_admin` write privilege before importing form XML zip entries
- align the import page and admin navigation with the stronger write-level gate
- add regression coverage for direct read-only access, JSP gating, and mutator method rejection

## Verification
- mvn -q -Dtest=FrmXmlUpload2ActionSecurityUnitTest,FormXmlUploadJspMigrationRegressionTest,MutatorActionGetRejectionContractTest test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts form XML import to admin eForm writers. Enforces POST-only and requires write access to `_admin.eform` or `_admin`, with UI links and the upload page gated to match.

- **Bug Fixes**
  - `FrmXmlUpload2Action` rejects non-POST with 405 and `Allow: POST`.
  - Requires `w` on `_admin.eform` or `_admin` before processing uploads.
  - Gates admin page, left nav, and `formXmlUpload.jsp` behind the same write check; redirects to security error on failure.
  - Hardens tests: adds `FrmXmlUpload2ActionSecurityUnitTest`; registers the action in the mutator contract; scanner detects literal POST checks; JSP regression asserts `_admin,_admin.eform` write gating.

<sup>Written for commit a8499df501f22b958a7adca4c6c7ac852d7f43dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

