### PR TITLE
fix: avoid host-derived URLs in FullPathReWrite (security and quality fix)

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/util/FullPathReWrite.java
+++ b/src/main/java/io/github/carlos_emr/carlos/util/FullPathReWrite.java
@@ -31,7 +31,6 @@
 package io.github.carlos_emr.carlos.util;
 
 import java.io.IOException;
-import java.util.Locale;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.jsp.JspException;
@@ -127,15 +126,15 @@ public class FullPathReWrite extends TagSupport {
     static String encodeForContext(String value, String context) throws JspException {
         String normalizedContext = (context == null || context.isBlank())
                 ? DEFAULT_CONTEXT
-                : context.toLowerCase(Locale.ROOT);
+                : context;
         switch (normalizedContext) {
             case "html":
                 return SafeEncode.forHtml(value);
-            case "htmlattribute":
+            case "htmlAttribute":
                 return SafeEncode.forHtmlAttribute(value);
-            case "javascriptattribute":
+            case "javaScriptAttribute":
                 return SafeEncode.forJavaScriptAttribute(value);
-            case "javascriptblock":
+            case "javaScriptBlock":
                 return SafeEncode.forJavaScriptBlock(value);
             default:
                 throw new JspException("Unsupported FullPathReWrite encoding context: " + context);

--- a/src/main/java/io/github/carlos_emr/carlos/util/FullPathReWrite.java
+++ b/src/main/java/io/github/carlos_emr/carlos/util/FullPathReWrite.java
@@ -83,11 +83,18 @@ public class FullPathReWrite extends TagSupport {
     }
 
     static String buildRelativeUrl(HttpServletRequest request, String jspPage) {
+        String safeJspPage = jspPage == null ? "" : jspPage;
+        if (request == null) {
+            return safeJspPage;
+        }
         String temp = request.getRequestURI();
+        if (temp == null) {
+            return safeJspPage;
+        }
         int last = temp.lastIndexOf('/');
-        String path = temp.substring(0, last);
+        String path = last >= 0 ? temp.substring(0, last) : "";
 
-        return path + "/" + jspPage;
+        return path + "/" + safeJspPage;
     }
 
 

--- a/src/main/java/io/github/carlos_emr/carlos/util/FullPathReWrite.java
+++ b/src/main/java/io/github/carlos_emr/carlos/util/FullPathReWrite.java
@@ -73,7 +73,8 @@ public class FullPathReWrite extends TagSupport {
 
         JspWriter out = pageContext.getOut();
         try {
-            out.write(SafeEncode.forHtmlContent(returnTag));
+            // This tag is embedded in JavaScript strings and HTML attributes; keep quote encoding.
+            out.write(SafeEncode.forHtml(returnTag));
             out.flush();
         } catch (IOException e) {
             throw new JspException(e.toString());

--- a/src/main/java/io/github/carlos_emr/carlos/util/FullPathReWrite.java
+++ b/src/main/java/io/github/carlos_emr/carlos/util/FullPathReWrite.java
@@ -44,7 +44,7 @@ public class FullPathReWrite extends TagSupport {
 
 
     /**
-     * The server name to use instead of request.getServerName().
+     * Legacy server attribute retained for tag compatibility.
      */
     protected String server = null;
 
@@ -69,12 +69,7 @@ public class FullPathReWrite extends TagSupport {
     public int doStartTag() throws JspException {
         HttpServletRequest request = (HttpServletRequest) pageContext.getRequest();
 
-        String temp = request.getRequestURI();
-        int last = temp.lastIndexOf('/');
-        String path = temp.substring(0, last);
-
-
-        String returnTag = request.getScheme() + "://" + request.getServerName() + ":" + request.getServerPort() + path + "/" + getJspPage();
+        String returnTag = buildRelativeUrl(request, getJspPage());
 
         JspWriter out = pageContext.getOut();
         try {
@@ -85,6 +80,14 @@ public class FullPathReWrite extends TagSupport {
         }
 
         return EVAL_BODY_INCLUDE;
+    }
+
+    static String buildRelativeUrl(HttpServletRequest request, String jspPage) {
+        String temp = request.getRequestURI();
+        int last = temp.lastIndexOf('/');
+        String path = temp.substring(0, last);
+
+        return path + "/" + jspPage;
     }
 
 

--- a/src/main/java/io/github/carlos_emr/carlos/util/FullPathReWrite.java
+++ b/src/main/java/io/github/carlos_emr/carlos/util/FullPathReWrite.java
@@ -37,7 +37,7 @@ import jakarta.servlet.jsp.JspException;
 import jakarta.servlet.jsp.JspWriter;
 import jakarta.servlet.jsp.tagext.TagSupport;
 
-import org.owasp.encoder.Encode;
+import io.github.carlos_emr.carlos.utility.SafeEncode;
 
 
 public class FullPathReWrite extends TagSupport {
@@ -73,7 +73,7 @@ public class FullPathReWrite extends TagSupport {
 
         JspWriter out = pageContext.getOut();
         try {
-            out.write(Encode.forHtml(returnTag));
+            out.write(SafeEncode.forHtml(returnTag));
             out.flush();
         } catch (IOException e) {
             throw new JspException(e.toString());

--- a/src/main/java/io/github/carlos_emr/carlos/util/FullPathReWrite.java
+++ b/src/main/java/io/github/carlos_emr/carlos/util/FullPathReWrite.java
@@ -73,7 +73,7 @@ public class FullPathReWrite extends TagSupport {
 
         JspWriter out = pageContext.getOut();
         try {
-            out.write(SafeEncode.forHtml(returnTag));
+            out.write(SafeEncode.forHtmlContent(returnTag));
             out.flush();
         } catch (IOException e) {
             throw new JspException(e.toString());

--- a/src/main/java/io/github/carlos_emr/carlos/util/FullPathReWrite.java
+++ b/src/main/java/io/github/carlos_emr/carlos/util/FullPathReWrite.java
@@ -40,6 +40,17 @@ import jakarta.servlet.jsp.tagext.TagSupport;
 import io.github.carlos_emr.carlos.utility.SafeEncode;
 
 
+/**
+ * JSP tag handler that rewrites a target JSP page into a request-path-relative URL.
+ * <p>
+ * The tag deliberately avoids request scheme, server name, and server port values so
+ * untrusted Host header data cannot affect generated links. Use the optional
+ * {@code context} attribute to choose output encoding for the place where the URL is
+ * rendered: {@code html}, {@code htmlAttribute}, {@code javaScriptAttribute}, or
+ * {@code javaScriptBlock}.
+ *
+ * @since 2026-06-17
+ */
 public class FullPathReWrite extends TagSupport {
 
     private static final String DEFAULT_CONTEXT = "html";
@@ -108,6 +119,17 @@ public class FullPathReWrite extends TagSupport {
         super.release();
     }
 
+    /**
+     * Builds a relative URL from the request URI directory and the configured JSP page.
+     * <p>
+     * Null request or URI values return the JSP page unchanged. A null JSP page is
+     * treated as an empty string. The method intentionally preserves the historical
+     * path-joining shape used by legacy JSP call sites.
+     *
+     * @param request the current request, or {@code null}
+     * @param jspPage the JSP page value to append, or {@code null}
+     * @return a request-path-relative URL, never {@code null}
+     */
     static String buildRelativeUrl(HttpServletRequest request, String jspPage) {
         String safeJspPage = jspPage == null ? "" : jspPage;
         if (request == null) {
@@ -123,6 +145,18 @@ public class FullPathReWrite extends TagSupport {
         return path + "/" + safeJspPage;
     }
 
+    /**
+     * Encodes a generated URL for the requested JSP rendering context.
+     * <p>
+     * Supported contexts are {@code html}, {@code htmlAttribute},
+     * {@code javaScriptAttribute}, and {@code javaScriptBlock}. A null or blank context
+     * uses the default {@code html} encoding.
+     *
+     * @param value the URL value to encode
+     * @param context the encoding context, or {@code null} for the default
+     * @return the encoded URL string
+     * @throws JspException if the context value is unsupported
+     */
     static String encodeForContext(String value, String context) throws JspException {
         String normalizedContext = (context == null || context.isBlank())
                 ? DEFAULT_CONTEXT

--- a/src/main/java/io/github/carlos_emr/carlos/util/FullPathReWrite.java
+++ b/src/main/java/io/github/carlos_emr/carlos/util/FullPathReWrite.java
@@ -31,6 +31,7 @@
 package io.github.carlos_emr.carlos.util;
 
 import java.io.IOException;
+import java.util.Locale;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.jsp.JspException;
@@ -42,6 +43,7 @@ import io.github.carlos_emr.carlos.utility.SafeEncode;
 
 public class FullPathReWrite extends TagSupport {
 
+    private static final String DEFAULT_CONTEXT = "html";
 
     /**
      * Legacy server attribute retained for tag compatibility.
@@ -53,12 +55,25 @@ public class FullPathReWrite extends TagSupport {
      */
     protected String jspPage = null;
 
+    /**
+     * Output encoding context. Defaults to legacy HTML encoding.
+     */
+    protected String context = DEFAULT_CONTEXT;
+
     public String getJspPage() {
         return (this.jspPage == null) ? "" : this.jspPage;
     }
 
     public void setJspPage(String jspPage) {
         this.jspPage = jspPage;
+    }
+
+    public String getContext() {
+        return this.context;
+    }
+
+    public void setContext(String context) {
+        this.context = context;
     }
 
     /**
@@ -73,14 +88,25 @@ public class FullPathReWrite extends TagSupport {
 
         JspWriter out = pageContext.getOut();
         try {
-            // This tag is embedded in JavaScript strings and HTML attributes; keep quote encoding.
-            out.write(SafeEncode.forHtml(returnTag));
+            out.write(encodeForContext(returnTag, context));
             out.flush();
         } catch (IOException e) {
             throw new JspException(e.toString());
         }
 
         return EVAL_BODY_INCLUDE;
+    }
+
+    @Override
+    public int doEndTag() throws JspException {
+        resetAttributes();
+        return EVAL_PAGE;
+    }
+
+    @Override
+    public void release() {
+        resetAttributes();
+        super.release();
     }
 
     static String buildRelativeUrl(HttpServletRequest request, String jspPage) {
@@ -96,6 +122,30 @@ public class FullPathReWrite extends TagSupport {
         String path = last >= 0 ? temp.substring(0, last) : "";
 
         return path + "/" + safeJspPage;
+    }
+
+    static String encodeForContext(String value, String context) throws JspException {
+        String normalizedContext = (context == null || context.isBlank())
+                ? DEFAULT_CONTEXT
+                : context.toLowerCase(Locale.ROOT);
+        switch (normalizedContext) {
+            case "html":
+                return SafeEncode.forHtml(value);
+            case "htmlattribute":
+                return SafeEncode.forHtmlAttribute(value);
+            case "javascriptattribute":
+                return SafeEncode.forJavaScriptAttribute(value);
+            case "javascriptblock":
+                return SafeEncode.forJavaScriptBlock(value);
+            default:
+                throw new JspException("Unsupported FullPathReWrite encoding context: " + context);
+        }
+    }
+
+    private void resetAttributes() {
+        server = null;
+        jspPage = null;
+        context = DEFAULT_CONTEXT;
     }
 
 

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/adjustBill.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/adjustBill.jsp
@@ -228,10 +228,10 @@
 
         function ScriptAttach(elementName) {
             var d = elementName;
-            t0 = escape(document.forms['reprocessBilling'].elements[d].value);
-            t1 = escape("");
-            t2 = escape("");
-            awnd = rs('att', '<rewrite:reWrite jspPage="/billing/CA/BC/ViewBillingDigNewSearch" context="javaScriptBlock"/>?name=' + t0 + '&name1=' + t1 + '&name2=' + t2 + '&search=&formElement=' + d + '&formName=reprocessBilling', 820, 660, 1);
+            t0 = encodeURIComponent(document.forms['reprocessBilling'].elements[d].value);
+            t1 = encodeURIComponent("");
+            t2 = encodeURIComponent("");
+            awnd = rs('att', '<rewrite:reWrite jspPage="/billing/CA/BC/ViewBillingDigNewSearch" context="javaScriptBlock"/>?name=' + t0 + '&name1=' + t1 + '&name2=' + t2 + '&search=&formElement=' + encodeURIComponent(d) + '&formName=reprocessBilling', 820, 660, 1);
             awnd.focus();
         }
 
@@ -239,26 +239,26 @@
             var code = codeElementName;
             var form = formName;
             var price = priceElementName;
-            t0 = escape(document.forms[form].elements[code].value);
-            t1 = escape("");
-            t2 = escape("");
-            awnd = rs('att', '<rewrite:reWrite jspPage="/billing/CA/BC/ViewBillingGetPriceCode" context="javaScriptBlock"/>?name=' + t0 + '&name1=' + t1 + '&name2=' + t2 + '&search=&formElementCode=' + t0 + '&formName=' + form + '&formElementPrice=' + price + '&formNothing=blank', 820, 660, 1);
+            t0 = encodeURIComponent(document.forms[form].elements[code].value);
+            t1 = encodeURIComponent("");
+            t2 = encodeURIComponent("");
+            awnd = rs('att', '<rewrite:reWrite jspPage="/billing/CA/BC/ViewBillingGetPriceCode" context="javaScriptBlock"/>?name=' + t0 + '&name1=' + t1 + '&name2=' + t2 + '&search=&formElementCode=' + t0 + '&formName=' + encodeURIComponent(form) + '&formElementPrice=' + encodeURIComponent(price) + '&formNothing=blank', 820, 660, 1);
             awnd.focus();
         }
 
         function OtherScriptAttach() {
-            t0 = escape(document.forms['reprocessBilling'].service_code.value);
-            t1 = escape("");
-            t2 = escape("");
+            t0 = encodeURIComponent(document.forms['reprocessBilling'].service_code.value);
+            t1 = encodeURIComponent("");
+            t2 = encodeURIComponent("");
             awnd = rs('att', '<rewrite:reWrite jspPage="/billing/CA/BC/ViewBillingCodeNewSearch" context="javaScriptBlock"/>?name=' + t0 + '&name1=' + t1 + '&name2=' + t2 + '&search=&formName=reprocessBilling&formElement=service_code', 820, 660, 1);
             awnd.focus();
         }
 
         function ReferralScriptAttach(elementName) {
             var d = elementName;
-            t0 = escape(document.forms['reprocessBilling'].elements[d].value);
-            t1 = escape("");
-            awnd = rs('att', '<rewrite:reWrite jspPage="/billing/CA/BC/ViewBillingReferCodeSearch" context="javaScriptBlock"/>?name=' + t0 + '&name1=' + t1 + '&name2=&search=&formElement=' + d + '&formName=reprocessBilling', 600, 600, 1);
+            t0 = encodeURIComponent(document.forms['reprocessBilling'].elements[d].value);
+            t1 = encodeURIComponent("");
+            awnd = rs('att', '<rewrite:reWrite jspPage="/billing/CA/BC/ViewBillingReferCodeSearch" context="javaScriptBlock"/>?name=' + t0 + '&name1=' + t1 + '&name2=&search=&formElement=' + encodeURIComponent(d) + '&formName=reprocessBilling', 600, 600, 1);
             awnd.focus();
         }
 
@@ -356,7 +356,13 @@
             var serviceDate = document.getElementById('serviceDate').value;
             var str = document.forms[form].elements[field].value;
             var providerNo = document.getElementById('providerNo').value;
-            var url = '<rewrite:reWrite jspPage="/billing/CA/BC/support/BillingFeeItem" context="javaScriptBlock"/>' + '?form=' + form + '&field=' + field + '&feeField=billingAmount&corrections=1&searchStr=' + str + '&serviceDate=' + serviceDate + '&providerNo=' + providerNo;
+            var url = '<rewrite:reWrite jspPage="/billing/CA/BC/support/BillingFeeItem" context="javaScriptBlock"/>'
+                + '?form=' + encodeURIComponent(form)
+                + '&field=' + encodeURIComponent(field)
+                + '&feeField=billingAmount&corrections=1'
+                + '&searchStr=' + encodeURIComponent(str)
+                + '&serviceDate=' + encodeURIComponent(serviceDate)
+                + '&providerNo=' + encodeURIComponent(providerNo);
             var windowName = field;
             popup(height, width, url, windowName);
         }

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/adjustBill.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/adjustBill.jsp
@@ -228,9 +228,9 @@
 
         function ScriptAttach(elementName) {
             var d = elementName;
-            t0 = encodeURIComponent(document.forms['reprocessBilling'].elements[d].value);
-            t1 = encodeURIComponent("");
-            t2 = encodeURIComponent("");
+            var t0 = encodeURIComponent(document.forms['reprocessBilling'].elements[d].value);
+            var t1 = encodeURIComponent("");
+            var t2 = encodeURIComponent("");
             awnd = rs('att', '<rewrite:reWrite jspPage="/billing/CA/BC/ViewBillingDigNewSearch" context="javaScriptBlock"/>?name=' + t0 + '&name1=' + t1 + '&name2=' + t2 + '&search=&formElement=' + encodeURIComponent(d) + '&formName=reprocessBilling', 820, 660, 1);
             awnd.focus();
         }
@@ -239,25 +239,25 @@
             var code = codeElementName;
             var form = formName;
             var price = priceElementName;
-            t0 = encodeURIComponent(document.forms[form].elements[code].value);
-            t1 = encodeURIComponent("");
-            t2 = encodeURIComponent("");
+            var t0 = encodeURIComponent(document.forms[form].elements[code].value);
+            var t1 = encodeURIComponent("");
+            var t2 = encodeURIComponent("");
             awnd = rs('att', '<rewrite:reWrite jspPage="/billing/CA/BC/ViewBillingGetPriceCode" context="javaScriptBlock"/>?name=' + t0 + '&name1=' + t1 + '&name2=' + t2 + '&search=&formElementCode=' + t0 + '&formName=' + encodeURIComponent(form) + '&formElementPrice=' + encodeURIComponent(price) + '&formNothing=blank', 820, 660, 1);
             awnd.focus();
         }
 
         function OtherScriptAttach() {
-            t0 = encodeURIComponent(document.forms['reprocessBilling'].service_code.value);
-            t1 = encodeURIComponent("");
-            t2 = encodeURIComponent("");
+            var t0 = encodeURIComponent(document.forms['reprocessBilling'].service_code.value);
+            var t1 = encodeURIComponent("");
+            var t2 = encodeURIComponent("");
             awnd = rs('att', '<rewrite:reWrite jspPage="/billing/CA/BC/ViewBillingCodeNewSearch" context="javaScriptBlock"/>?name=' + t0 + '&name1=' + t1 + '&name2=' + t2 + '&search=&formName=reprocessBilling&formElement=service_code', 820, 660, 1);
             awnd.focus();
         }
 
         function ReferralScriptAttach(elementName) {
             var d = elementName;
-            t0 = encodeURIComponent(document.forms['reprocessBilling'].elements[d].value);
-            t1 = encodeURIComponent("");
+            var t0 = encodeURIComponent(document.forms['reprocessBilling'].elements[d].value);
+            var t1 = encodeURIComponent("");
             awnd = rs('att', '<rewrite:reWrite jspPage="/billing/CA/BC/ViewBillingReferCodeSearch" context="javaScriptBlock"/>?name=' + t0 + '&name1=' + t1 + '&name2=&search=&formElement=' + encodeURIComponent(d) + '&formName=reprocessBilling', 600, 600, 1);
             awnd.focus();
         }

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/adjustBill.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/adjustBill.jsp
@@ -231,7 +231,7 @@
             t0 = escape(document.forms['reprocessBilling'].elements[d].value);
             t1 = escape("");
             t2 = escape("");
-            awnd = rs('att', '<rewrite:reWrite jspPage="/billing/CA/BC/ViewBillingDigNewSearch"/>?name=' + t0 + '&name1=' + t1 + '&name2=' + t2 + '&search=&formElement=' + d + '&formName=reprocessBilling', 820, 660, 1);
+            awnd = rs('att', '<rewrite:reWrite jspPage="/billing/CA/BC/ViewBillingDigNewSearch" context="javaScriptBlock"/>?name=' + t0 + '&name1=' + t1 + '&name2=' + t2 + '&search=&formElement=' + d + '&formName=reprocessBilling', 820, 660, 1);
             awnd.focus();
         }
 
@@ -242,7 +242,7 @@
             t0 = escape(document.forms[form].elements[code].value);
             t1 = escape("");
             t2 = escape("");
-            awnd = rs('att', '<rewrite:reWrite jspPage="/billing/CA/BC/ViewBillingGetPriceCode"/>?name=' + t0 + '&name1=' + t1 + '&name2=' + t2 + '&search=&formElementCode=' + t0 + '&formName=' + form + '&formElementPrice=' + price + '&formNothing=blank', 820, 660, 1);
+            awnd = rs('att', '<rewrite:reWrite jspPage="/billing/CA/BC/ViewBillingGetPriceCode" context="javaScriptBlock"/>?name=' + t0 + '&name1=' + t1 + '&name2=' + t2 + '&search=&formElementCode=' + t0 + '&formName=' + form + '&formElementPrice=' + price + '&formNothing=blank', 820, 660, 1);
             awnd.focus();
         }
 
@@ -250,7 +250,7 @@
             t0 = escape(document.forms['reprocessBilling'].service_code.value);
             t1 = escape("");
             t2 = escape("");
-            awnd = rs('att', '<rewrite:reWrite jspPage="/billing/CA/BC/ViewBillingCodeNewSearch"/>?name=' + t0 + '&name1=' + t1 + '&name2=' + t2 + '&search=&formName=reprocessBilling&formElement=service_code', 820, 660, 1);
+            awnd = rs('att', '<rewrite:reWrite jspPage="/billing/CA/BC/ViewBillingCodeNewSearch" context="javaScriptBlock"/>?name=' + t0 + '&name1=' + t1 + '&name2=' + t2 + '&search=&formName=reprocessBilling&formElement=service_code', 820, 660, 1);
             awnd.focus();
         }
 
@@ -258,7 +258,7 @@
             var d = elementName;
             t0 = escape(document.forms['reprocessBilling'].elements[d].value);
             t1 = escape("");
-            awnd = rs('att', '<rewrite:reWrite jspPage="/billing/CA/BC/ViewBillingReferCodeSearch"/>?name=' + t0 + '&name1=' + t1 + '&name2=&search=&formElement=' + d + '&formName=reprocessBilling', 600, 600, 1);
+            awnd = rs('att', '<rewrite:reWrite jspPage="/billing/CA/BC/ViewBillingReferCodeSearch" context="javaScriptBlock"/>?name=' + t0 + '&name1=' + t1 + '&name2=&search=&formElement=' + d + '&formName=reprocessBilling', 600, 600, 1);
             awnd.focus();
         }
 
@@ -356,7 +356,7 @@
             var serviceDate = document.getElementById('serviceDate').value;
             var str = document.forms[form].elements[field].value;
             var providerNo = document.getElementById('providerNo').value;
-            var url = '<rewrite:reWrite jspPage="/billing/CA/BC/support/BillingFeeItem"/>' + '?form=' + form + '&field=' + field + '&feeField=billingAmount&corrections=1&searchStr=' + str + '&serviceDate=' + serviceDate + '&providerNo=' + providerNo;
+            var url = '<rewrite:reWrite jspPage="/billing/CA/BC/support/BillingFeeItem" context="javaScriptBlock"/>' + '?form=' + form + '&field=' + field + '&feeField=billingAmount&corrections=1&searchStr=' + str + '&serviceDate=' + serviceDate + '&providerNo=' + providerNo;
             var windowName = field;
             popup(height, width, url, windowName);
         }

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingBC.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingBC.jsp
@@ -823,9 +823,9 @@
         var awnd = null;
 
         function OtherScriptAttach() {
-            t0 = escape(document.BillingCreateBillingForm.xml_other1.value);
-            t1 = escape(document.BillingCreateBillingForm.xml_other2.value);
-            t2 = escape(document.BillingCreateBillingForm.xml_other3.value);
+            t0 = encodeURIComponent(document.BillingCreateBillingForm.xml_other1.value);
+            t1 = encodeURIComponent(document.BillingCreateBillingForm.xml_other2.value);
+            t2 = encodeURIComponent(document.BillingCreateBillingForm.xml_other3.value);
             awnd = rs('att', '<rewrite:reWrite jspPage="/billing/CA/BC/ViewBillingCodeNewSearch" context="javaScriptBlock"/>?name=' + t0 + '&name1=' + t1 + '&name2=' + t2 + '&search=', 820, 740, 1);
             awnd.focus();
         }
@@ -841,16 +841,16 @@
 
         function ReferralScriptAttach(elementName) {
             var d = elementName;
-            t0 = escape(document.BillingCreateBillingForm.elements[d].value);
-            t1 = escape("");
-            awnd = rs('att', '<rewrite:reWrite jspPage="/billing/CA/BC/ViewBillingReferCodeSearch" context="javaScriptBlock"/>?name=' + t0 + '&name1=' + t1 + '&name2=&search=&formElement=' + d + '&formName=BillingCreateBillingForm', 600, 600, 1);
+            t0 = encodeURIComponent(document.BillingCreateBillingForm.elements[d].value);
+            t1 = encodeURIComponent("");
+            awnd = rs('att', '<rewrite:reWrite jspPage="/billing/CA/BC/ViewBillingReferCodeSearch" context="javaScriptBlock"/>?name=' + t0 + '&name1=' + t1 + '&name2=&search=&formElement=' + encodeURIComponent(d) + '&formName=BillingCreateBillingForm', 600, 600, 1);
             awnd.focus();
         }
 
 
         function ResearchScriptAttach() {
-            t0 = escape(document.serviceform.xml_referral1.value);
-            t1 = escape(document.serviceform.xml_referral2.value);
+            t0 = encodeURIComponent(document.serviceform.xml_referral1.value);
+            t1 = encodeURIComponent(document.serviceform.xml_referral2.value);
 
             awnd = rs('att', '<rewrite:reWrite jspPage="billingReferralCodeSearch.jsp" context="javaScriptBlock"/>?name=' + t0 + '&name1=' + t1 + '&search=', 600, 600, 1);
             awnd.focus();

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingBC.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingBC.jsp
@@ -852,7 +852,7 @@
             t0 = escape(document.serviceform.xml_referral1.value);
             t1 = escape(document.serviceform.xml_referral2.value);
 
-            awnd = rs('att', '<%= request.getContextPath() %>/billing/CA/<rewrite:reWrite jspPage="billingReferralCodeSearch.jsp" context="javaScriptBlock"/>?name=' + t0 + '&name1=' + t1 + '&search=', 600, 600, 1);
+            awnd = rs('att', '<rewrite:reWrite jspPage="billingReferralCodeSearch.jsp" context="javaScriptBlock"/>?name=' + t0 + '&name1=' + t1 + '&search=', 600, 600, 1);
             awnd.focus();
         }
 

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingBC.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingBC.jsp
@@ -826,7 +826,7 @@
             t0 = escape(document.BillingCreateBillingForm.xml_other1.value);
             t1 = escape(document.BillingCreateBillingForm.xml_other2.value);
             t2 = escape(document.BillingCreateBillingForm.xml_other3.value);
-            awnd = rs('att', '<rewrite:reWrite jspPage="/billing/CA/BC/ViewBillingCodeNewSearch"/>?name=' + t0 + '&name1=' + t1 + '&name2=' + t2 + '&search=', 820, 740, 1);
+            awnd = rs('att', '<rewrite:reWrite jspPage="/billing/CA/BC/ViewBillingCodeNewSearch" context="javaScriptBlock"/>?name=' + t0 + '&name1=' + t1 + '&name2=' + t2 + '&search=', 820, 740, 1);
             awnd.focus();
         }
 
@@ -843,7 +843,7 @@
             var d = elementName;
             t0 = escape(document.BillingCreateBillingForm.elements[d].value);
             t1 = escape("");
-            awnd = rs('att', '<rewrite:reWrite jspPage="/billing/CA/BC/ViewBillingReferCodeSearch"/>?name=' + t0 + '&name1=' + t1 + '&name2=&search=&formElement=' + d + '&formName=BillingCreateBillingForm', 600, 600, 1);
+            awnd = rs('att', '<rewrite:reWrite jspPage="/billing/CA/BC/ViewBillingReferCodeSearch" context="javaScriptBlock"/>?name=' + t0 + '&name1=' + t1 + '&name2=&search=&formElement=' + d + '&formName=BillingCreateBillingForm', 600, 600, 1);
             awnd.focus();
         }
 
@@ -852,7 +852,7 @@
             t0 = escape(document.serviceform.xml_referral1.value);
             t1 = escape(document.serviceform.xml_referral2.value);
 
-            awnd = rs('att', '<%= request.getContextPath() %>/billing/CA/<rewrite:reWrite jspPage="billingReferralCodeSearch.jsp"/>?name=' + t0 + '&name1=' + t1 + '&search=', 600, 600, 1);
+            awnd = rs('att', '<%= request.getContextPath() %>/billing/CA/<rewrite:reWrite jspPage="billingReferralCodeSearch.jsp" context="javaScriptBlock"/>?name=' + t0 + '&name1=' + t1 + '&search=', 600, 600, 1);
             awnd.focus();
         }
 

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingBC.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingBC.jsp
@@ -823,9 +823,9 @@
         var awnd = null;
 
         function OtherScriptAttach() {
-            t0 = encodeURIComponent(document.BillingCreateBillingForm.xml_other1.value);
-            t1 = encodeURIComponent(document.BillingCreateBillingForm.xml_other2.value);
-            t2 = encodeURIComponent(document.BillingCreateBillingForm.xml_other3.value);
+            var t0 = encodeURIComponent(document.BillingCreateBillingForm.xml_other1.value);
+            var t1 = encodeURIComponent(document.BillingCreateBillingForm.xml_other2.value);
+            var t2 = encodeURIComponent(document.BillingCreateBillingForm.xml_other3.value);
             awnd = rs('att', '<rewrite:reWrite jspPage="/billing/CA/BC/ViewBillingCodeNewSearch" context="javaScriptBlock"/>?name=' + t0 + '&name1=' + t1 + '&name2=' + t2 + '&search=', 820, 740, 1);
             awnd.focus();
         }
@@ -841,16 +841,16 @@
 
         function ReferralScriptAttach(elementName) {
             var d = elementName;
-            t0 = encodeURIComponent(document.BillingCreateBillingForm.elements[d].value);
-            t1 = encodeURIComponent("");
+            var t0 = encodeURIComponent(document.BillingCreateBillingForm.elements[d].value);
+            var t1 = encodeURIComponent("");
             awnd = rs('att', '<rewrite:reWrite jspPage="/billing/CA/BC/ViewBillingReferCodeSearch" context="javaScriptBlock"/>?name=' + t0 + '&name1=' + t1 + '&name2=&search=&formElement=' + encodeURIComponent(d) + '&formName=BillingCreateBillingForm', 600, 600, 1);
             awnd.focus();
         }
 
 
         function ResearchScriptAttach() {
-            t0 = encodeURIComponent(document.serviceform.xml_referral1.value);
-            t1 = encodeURIComponent(document.serviceform.xml_referral2.value);
+            var t0 = encodeURIComponent(document.serviceform.xml_referral1.value);
+            var t1 = encodeURIComponent(document.serviceform.xml_referral2.value);
 
             awnd = rs('att', '<rewrite:reWrite jspPage="billingReferralCodeSearch.jsp" context="javaScriptBlock"/>?name=' + t0 + '&name1=' + t1 + '&search=', 600, 600, 1);
             awnd.focus();

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingSVCTrayAssoc.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingSVCTrayAssoc.jsp
@@ -45,7 +45,7 @@
                 var width = 575;
                 var height = 400;
                 var str = document.forms[form].elements[field].value;
-                var url = '<rewrite:reWrite jspPage="/billing/CA/BC/support/BillingFeeItem"/>' + '?form=' + form + '&field=' + field + '&searchStr=' + str;
+                var url = '<rewrite:reWrite jspPage="/billing/CA/BC/support/BillingFeeItem" context="javaScriptBlock"/>' + '?form=' + form + '&field=' + field + '&searchStr=' + str;
                 var windowName = field;
                 popup(height, width, url, windowName);
             }

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingSVCTrayAssoc.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingSVCTrayAssoc.jsp
@@ -45,7 +45,10 @@
                 var width = 575;
                 var height = 400;
                 var str = document.forms[form].elements[field].value;
-                var url = '<rewrite:reWrite jspPage="/billing/CA/BC/support/BillingFeeItem" context="javaScriptBlock"/>' + '?form=' + form + '&field=' + field + '&searchStr=' + str;
+                var url = '<rewrite:reWrite jspPage="/billing/CA/BC/support/BillingFeeItem" context="javaScriptBlock"/>'
+                    + '?form=' + encodeURIComponent(form)
+                    + '&field=' + encodeURIComponent(field)
+                    + '&searchStr=' + encodeURIComponent(str);
                 var windowName = field;
                 popup(height, width, url, windowName);
             }

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/dxcode_svccode_assoc.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/dxcode_svccode_assoc.jsp
@@ -43,7 +43,7 @@
 
 
             function OtherScriptAttach() {
-                t0 = encodeURIComponent(document.forms[0].xml_other1.value);
+                var t0 = encodeURIComponent(document.forms[0].xml_other1.value);
                 awnd = rs('att', '<rewrite:reWrite jspPage="/billing/CA/BC/ViewBillingCodeNewSearch" context="javaScriptBlock"/>?name=' + t0 + '&name1=&name2=&search=', 820, 660, 1);
                 awnd.focus();
             }

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/dxcode_svccode_assoc.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/dxcode_svccode_assoc.jsp
@@ -43,7 +43,7 @@
 
 
             function OtherScriptAttach() {
-                t0 = escape(document.forms[0].xml_other1.value);
+                t0 = encodeURIComponent(document.forms[0].xml_other1.value);
                 awnd = rs('att', '<rewrite:reWrite jspPage="/billing/CA/BC/ViewBillingCodeNewSearch" context="javaScriptBlock"/>?name=' + t0 + '&name1=&name2=&search=', 820, 660, 1);
                 awnd.focus();
             }

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/dxcode_svccode_assoc.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/dxcode_svccode_assoc.jsp
@@ -44,7 +44,7 @@
 
             function OtherScriptAttach() {
                 t0 = escape(document.forms[0].xml_other1.value);
-                awnd = rs('att', '<rewrite:reWrite jspPage="/billing/CA/BC/ViewBillingCodeNewSearch"/>?name=' + t0 + '&name1=&name2=&search=', 820, 660, 1);
+                awnd = rs('att', '<rewrite:reWrite jspPage="/billing/CA/BC/ViewBillingCodeNewSearch" context="javaScriptBlock"/>?name=' + t0 + '&name1=&name2=&search=', 820, 660, 1);
                 awnd.focus();
             }
 

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/formwcb.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/formwcb.jsp
@@ -322,7 +322,10 @@
                 var width = 650;
                 var height = 400;
                 var str = document.forms[form].elements[field].value;
-                var url = '<rewrite:reWrite jspPage="/billing/CA/BC/support/BodyPart" context="javaScriptBlock"/>' + '?form=' + form + '&field=' + field + '&searchStr=' + str;
+                var url = '<rewrite:reWrite jspPage="/billing/CA/BC/support/BodyPart" context="javaScriptBlock"/>'
+                    + '?form=' + encodeURIComponent(form)
+                    + '&field=' + encodeURIComponent(field)
+                    + '&searchStr=' + encodeURIComponent(str);
                 var windowName = field;
                 popup(height, width, url, windowName);
             }
@@ -331,7 +334,10 @@
                 var width = 800;
                 var height = 400;
                 var str = document.forms[form].elements[field].value;
-                var url = '<rewrite:reWrite jspPage="/billing/CA/BC/support/NatureInjury" context="javaScriptBlock"/>' + '?form=' + form + '&field=' + field + '&searchStr=' + str;
+                var url = '<rewrite:reWrite jspPage="/billing/CA/BC/support/NatureInjury" context="javaScriptBlock"/>'
+                    + '?form=' + encodeURIComponent(form)
+                    + '&field=' + encodeURIComponent(field)
+                    + '&searchStr=' + encodeURIComponent(str);
                 var windowName = field;
                 popup(height, width, url, windowName);
             }

--- a/src/main/webapp/WEB-INF/jsp/billing/CA/BC/formwcb.jsp
+++ b/src/main/webapp/WEB-INF/jsp/billing/CA/BC/formwcb.jsp
@@ -298,7 +298,7 @@
                 var width = 575;
                 var height = 400;
                 var str = document.forms[form].elements[field].value;
-                var url = '<rewrite:reWrite jspPage="/billing/CA/BC/support/BillingFeeItem"/>'
+                var url = '<rewrite:reWrite jspPage="/billing/CA/BC/support/BillingFeeItem" context="javaScriptBlock"/>'
                     + '?form=' + encodeURIComponent(form)
                     + '&field=' + encodeURIComponent(field)
                     + '&searchStr=' + encodeURIComponent(str);
@@ -310,7 +310,7 @@
                 var width = 575;
                 var height = 400;
                 var str = document.forms[form].elements[field].value;
-                var url = '<rewrite:reWrite jspPage="/billing/CA/BC/support/Icd9"/>'
+                var url = '<rewrite:reWrite jspPage="/billing/CA/BC/support/Icd9" context="javaScriptBlock"/>'
                     + '?form=' + encodeURIComponent(form)
                     + '&field=' + encodeURIComponent(field)
                     + '&searchStr=' + encodeURIComponent(str);
@@ -322,7 +322,7 @@
                 var width = 650;
                 var height = 400;
                 var str = document.forms[form].elements[field].value;
-                var url = '<rewrite:reWrite jspPage="/billing/CA/BC/support/BodyPart"/>' + '?form=' + form + '&field=' + field + '&searchStr=' + str;
+                var url = '<rewrite:reWrite jspPage="/billing/CA/BC/support/BodyPart" context="javaScriptBlock"/>' + '?form=' + form + '&field=' + field + '&searchStr=' + str;
                 var windowName = field;
                 popup(height, width, url, windowName);
             }
@@ -331,7 +331,7 @@
                 var width = 800;
                 var height = 400;
                 var str = document.forms[form].elements[field].value;
-                var url = '<rewrite:reWrite jspPage="/billing/CA/BC/support/NatureInjury"/>' + '?form=' + form + '&field=' + field + '&searchStr=' + str;
+                var url = '<rewrite:reWrite jspPage="/billing/CA/BC/support/NatureInjury" context="javaScriptBlock"/>' + '?form=' + form + '&field=' + field + '&searchStr=' + str;
                 var windowName = field;
                 popup(height, width, url, windowName);
             }

--- a/src/main/webapp/WEB-INF/jsp/documentManager/documentReport.jsp
+++ b/src/main/webapp/WEB-INF/jsp/documentManager/documentReport.jsp
@@ -741,7 +741,7 @@
                         value="<fmt:message key='dms.documentReport.btnDoneClose'/>"
                         onclick="window.closeWindow()"/>
                 <input type="button" value="<fmt:message key='dms.documentReport.btnCombinePDF'/>" class="btn btn-secondary"
-                       onclick="return submitForm('<rewrite:reWrite jspPage="combinePDFs"/>');"/>
+                       onclick="return submitForm('<rewrite:reWrite jspPage="combinePDFs" context="javaScriptAttribute"/>');"/>
             </div>
 
         </form>

--- a/src/main/webapp/WEB-INF/jsp/prevention/index.jsp
+++ b/src/main/webapp/WEB-INF/jsp/prevention/index.jsp
@@ -777,7 +777,7 @@
                 </oscar:oscarPropertiesCheck></td>
 
             <form name="printFrm" method="post" onsubmit="return onPrint();"
-                  action="<rewrite:reWrite jspPage="printPrevention"/>">
+                  action="<rewrite:reWrite jspPage="printPrevention" context="htmlAttribute"/>">
                 <input type="hidden" name="immunizationOnly" value="false"/>
                 <td valign="top" class="MainTableRightColumn">
 

--- a/src/main/webapp/WEB-INF/rewrite-tag.tld
+++ b/src/main/webapp/WEB-INF/rewrite-tag.tld
@@ -40,6 +40,12 @@
             </tldx>
             -->
   </attribute>
+  <attribute>
+    <name>context</name>
+    <required>false</required>
+    <rtexprvalue>true</rtexprvalue>
+            <type>String</type>
+  </attribute>
 </tag>
 
 </taglib>

--- a/src/test/java/io/github/carlos_emr/carlos/util/FullPathReWriteJspRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/util/FullPathReWriteJspRegressionTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026 CARLOS EMR Project. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.util;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Tag("unit")
+@Tag("security")
+@DisplayName("FullPathReWrite JSP regressions")
+class FullPathReWriteJspRegressionTest {
+
+    private static final Path ADJUST_BILL_JSP = Path.of(
+            "src/main/webapp/WEB-INF/jsp/billing/CA/BC/adjustBill.jsp");
+    private static final Path BILLING_BC_JSP = Path.of(
+            "src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingBC.jsp");
+    private static final Path BILLING_SVC_TRAY_ASSOC_JSP = Path.of(
+            "src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingSVCTrayAssoc.jsp");
+    private static final Path DXCODE_SVCCODE_ASSOC_JSP = Path.of(
+            "src/main/webapp/WEB-INF/jsp/billing/CA/BC/dxcode_svccode_assoc.jsp");
+
+    @Test
+    @DisplayName("should encode runtime query values in rewrite popup URLs")
+    void shouldEncodeRuntimeQueryValues_inRewritePopupUrls() throws IOException {
+        String adjustBill = read(ADJUST_BILL_JSP);
+        String billingBC = read(BILLING_BC_JSP);
+        String billingSvcTrayAssoc = read(BILLING_SVC_TRAY_ASSOC_JSP);
+        String dxcodeSvcCodeAssoc = read(DXCODE_SVCCODE_ASSOC_JSP);
+
+        assertThat(adjustBill)
+                .contains("encodeURIComponent(document.forms['reprocessBilling'].elements[d].value)")
+                .contains("encodeURIComponent(document.forms[form].elements[code].value)")
+                .contains("encodeURIComponent(document.forms['reprocessBilling'].service_code.value)")
+                .contains("encodeURIComponent(form)")
+                .contains("encodeURIComponent(field)")
+                .contains("encodeURIComponent(str)")
+                .contains("encodeURIComponent(serviceDate)")
+                .contains("encodeURIComponent(providerNo)")
+                .doesNotContain("&formElement=' + d")
+                .doesNotContain("&formName=' + form")
+                .doesNotContain("&formElementPrice=' + price")
+                .doesNotContain("&searchStr=' + str")
+                .doesNotContain("&serviceDate=' + serviceDate")
+                .doesNotContain("&providerNo=' + providerNo");
+
+        assertThat(billingBC)
+                .contains("encodeURIComponent(document.BillingCreateBillingForm.xml_other1.value)")
+                .contains("encodeURIComponent(document.BillingCreateBillingForm.elements[d].value)")
+                .contains("encodeURIComponent(document.serviceform.xml_referral1.value)")
+                .contains("encodeURIComponent(d)")
+                .doesNotContain("escape(document.BillingCreateBillingForm")
+                .doesNotContain("escape(document.serviceform")
+                .doesNotContain("&formElement=' + d");
+
+        assertThat(billingSvcTrayAssoc)
+                .contains("encodeURIComponent(form)")
+                .contains("encodeURIComponent(field)")
+                .contains("encodeURIComponent(str)")
+                .doesNotContain("+ '?form=' + form + '&field=' + field + '&searchStr=' + str");
+
+        assertThat(dxcodeSvcCodeAssoc)
+                .contains("encodeURIComponent(document.forms[0].xml_other1.value)")
+                .doesNotContain("escape(document.forms[0].xml_other1.value)");
+    }
+
+    private static String read(Path path) throws IOException {
+        return Files.readString(path, StandardCharsets.UTF_8);
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/util/FullPathReWriteJspRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/util/FullPathReWriteJspRegressionTest.java
@@ -32,6 +32,8 @@ class FullPathReWriteJspRegressionTest {
             "src/main/webapp/WEB-INF/jsp/billing/CA/BC/billingSVCTrayAssoc.jsp");
     private static final Path DXCODE_SVCCODE_ASSOC_JSP = Path.of(
             "src/main/webapp/WEB-INF/jsp/billing/CA/BC/dxcode_svccode_assoc.jsp");
+    private static final Path FORMWCB_JSP = Path.of(
+            "src/main/webapp/WEB-INF/jsp/billing/CA/BC/formwcb.jsp");
 
     @Test
     @DisplayName("should encode runtime query values in rewrite popup URLs")
@@ -40,11 +42,12 @@ class FullPathReWriteJspRegressionTest {
         String billingBC = read(BILLING_BC_JSP);
         String billingSvcTrayAssoc = read(BILLING_SVC_TRAY_ASSOC_JSP);
         String dxcodeSvcCodeAssoc = read(DXCODE_SVCCODE_ASSOC_JSP);
+        String formwcb = read(FORMWCB_JSP);
 
         assertThat(adjustBill)
-                .contains("encodeURIComponent(document.forms['reprocessBilling'].elements[d].value)")
-                .contains("encodeURIComponent(document.forms[form].elements[code].value)")
-                .contains("encodeURIComponent(document.forms['reprocessBilling'].service_code.value)")
+                .contains("var t0 = encodeURIComponent(document.forms['reprocessBilling'].elements[d].value)")
+                .contains("var t0 = encodeURIComponent(document.forms[form].elements[code].value)")
+                .contains("var t0 = encodeURIComponent(document.forms['reprocessBilling'].service_code.value)")
                 .contains("encodeURIComponent(form)")
                 .contains("encodeURIComponent(field)")
                 .contains("encodeURIComponent(str)")
@@ -58,9 +61,9 @@ class FullPathReWriteJspRegressionTest {
                 .doesNotContain("&providerNo=' + providerNo");
 
         assertThat(billingBC)
-                .contains("encodeURIComponent(document.BillingCreateBillingForm.xml_other1.value)")
-                .contains("encodeURIComponent(document.BillingCreateBillingForm.elements[d].value)")
-                .contains("encodeURIComponent(document.serviceform.xml_referral1.value)")
+                .contains("var t0 = encodeURIComponent(document.BillingCreateBillingForm.xml_other1.value)")
+                .contains("var t0 = encodeURIComponent(document.BillingCreateBillingForm.elements[d].value)")
+                .contains("var t0 = encodeURIComponent(document.serviceform.xml_referral1.value)")
                 .contains("encodeURIComponent(d)")
                 .doesNotContain("escape(document.BillingCreateBillingForm")
                 .doesNotContain("escape(document.serviceform")
@@ -75,6 +78,13 @@ class FullPathReWriteJspRegressionTest {
         assertThat(dxcodeSvcCodeAssoc)
                 .contains("var t0 = encodeURIComponent(document.forms[0].xml_other1.value)")
                 .doesNotContain("escape(document.forms[0].xml_other1.value)");
+
+        assertThat(formwcb)
+                .contains("context=\"javaScriptBlock\"")
+                .contains("encodeURIComponent(form)")
+                .contains("encodeURIComponent(field)")
+                .contains("encodeURIComponent(str)")
+                .doesNotContain("&searchStr=' + str");
     }
 
     private static String read(Path path) throws IOException {

--- a/src/test/java/io/github/carlos_emr/carlos/util/FullPathReWriteJspRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/util/FullPathReWriteJspRegressionTest.java
@@ -73,7 +73,7 @@ class FullPathReWriteJspRegressionTest {
                 .doesNotContain("+ '?form=' + form + '&field=' + field + '&searchStr=' + str");
 
         assertThat(dxcodeSvcCodeAssoc)
-                .contains("encodeURIComponent(document.forms[0].xml_other1.value)")
+                .contains("var t0 = encodeURIComponent(document.forms[0].xml_other1.value)")
                 .doesNotContain("escape(document.forms[0].xml_other1.value)");
     }
 

--- a/src/test/java/io/github/carlos_emr/carlos/util/FullPathReWriteUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/util/FullPathReWriteUnitTest.java
@@ -105,12 +105,12 @@ class FullPathReWriteUnitTest {
         when(pageContext.getOut()).thenReturn(writer);
         FullPathReWrite tag = new FullPathReWrite();
         tag.setPageContext(pageContext);
-        tag.setJspPage("combinePDFs?name=<script>");
+        tag.setJspPage("combinePDFs?name=O'Brien&x=<script>");
 
         int result = tag.doStartTag();
 
         assertThat(result).isEqualTo(jakarta.servlet.jsp.tagext.Tag.EVAL_BODY_INCLUDE);
-        verify(writer).write("/carlos/documentManager/combinePDFs?name=&lt;script&gt;");
+        verify(writer).write("/carlos/documentManager/combinePDFs?name=O'Brien&amp;x=&lt;script&gt;");
         verify(writer).flush();
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/util/FullPathReWriteUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/util/FullPathReWriteUnitTest.java
@@ -105,12 +105,12 @@ class FullPathReWriteUnitTest {
         when(pageContext.getOut()).thenReturn(writer);
         FullPathReWrite tag = new FullPathReWrite();
         tag.setPageContext(pageContext);
-        tag.setJspPage("combinePDFs?name=O'Brien&x=<script>");
+        tag.setJspPage("combinePDFs?name=\"O'Brien\"&x=<script>");
 
         int result = tag.doStartTag();
 
         assertThat(result).isEqualTo(jakarta.servlet.jsp.tagext.Tag.EVAL_BODY_INCLUDE);
-        verify(writer).write("/carlos/documentManager/combinePDFs?name=O'Brien&amp;x=&lt;script&gt;");
+        verify(writer).write("/carlos/documentManager/combinePDFs?name=&#34;O&#39;Brien&#34;&amp;x=&lt;script&gt;");
         verify(writer).flush();
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/util/FullPathReWriteUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/util/FullPathReWriteUnitTest.java
@@ -9,6 +9,7 @@
 package io.github.carlos_emr.carlos.util;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.jsp.JspException;
 import jakarta.servlet.jsp.JspWriter;
 import jakarta.servlet.jsp.PageContext;
 
@@ -18,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -95,8 +97,8 @@ class FullPathReWriteUnitTest {
     }
 
     @Test
-    @DisplayName("should encode relative URL when rendering tag")
-    void shouldEncodeUrl_whenRenderingTag() throws Exception {
+    @DisplayName("should use legacy HTML encoding by default when rendering tag")
+    void shouldUseLegacyHtmlEncodingByDefault_whenRenderingTag() throws Exception {
         MockHttpServletRequest request = new MockHttpServletRequest("GET",
                 "/carlos/documentManager/documentReport.jsp");
         PageContext pageContext = mock(PageContext.class);
@@ -112,5 +114,88 @@ class FullPathReWriteUnitTest {
         assertThat(result).isEqualTo(jakarta.servlet.jsp.tagext.Tag.EVAL_BODY_INCLUDE);
         verify(writer).write("/carlos/documentManager/combinePDFs?name=&#34;O&#39;Brien&#34;&amp;x=&lt;script&gt;");
         verify(writer).flush();
+    }
+
+    @Test
+    @DisplayName("should encode URL for HTML attributes when requested")
+    void shouldEncodeUrlForHtmlAttributes_whenRenderingTag() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET",
+                "/carlos/prevention/index.jsp");
+        PageContext pageContext = mock(PageContext.class);
+        JspWriter writer = mock(JspWriter.class);
+        when(pageContext.getRequest()).thenReturn(request);
+        when(pageContext.getOut()).thenReturn(writer);
+        FullPathReWrite tag = new FullPathReWrite();
+        tag.setPageContext(pageContext);
+        tag.setJspPage("printPrevention?name=\"O'Brien\"&x=<script>");
+        tag.setContext("htmlAttribute");
+
+        int result = tag.doStartTag();
+
+        assertThat(result).isEqualTo(jakarta.servlet.jsp.tagext.Tag.EVAL_BODY_INCLUDE);
+        verify(writer).write("/carlos/prevention/printPrevention?name=&#34;O&#39;Brien&#34;&amp;x=&lt;script>");
+        verify(writer).flush();
+    }
+
+    @Test
+    @DisplayName("should encode URL for JavaScript attributes when requested")
+    void shouldEncodeUrlForJavaScriptAttributes_whenRenderingTag() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET",
+                "/carlos/documentManager/documentReport.jsp");
+        PageContext pageContext = mock(PageContext.class);
+        JspWriter writer = mock(JspWriter.class);
+        when(pageContext.getRequest()).thenReturn(request);
+        when(pageContext.getOut()).thenReturn(writer);
+        FullPathReWrite tag = new FullPathReWrite();
+        tag.setPageContext(pageContext);
+        tag.setJspPage("combinePDFs', window.__pwned = 1, '");
+        tag.setContext("javaScriptAttribute");
+
+        int result = tag.doStartTag();
+
+        assertThat(result).isEqualTo(jakarta.servlet.jsp.tagext.Tag.EVAL_BODY_INCLUDE);
+        verify(writer).write("/carlos/documentManager/combinePDFs\\x27, window.__pwned = 1, \\x27");
+        verify(writer).flush();
+    }
+
+    @Test
+    @DisplayName("should encode URL for JavaScript blocks when requested")
+    void shouldEncodeUrlForJavaScriptBlocks_whenRenderingTag() throws Exception {
+        assertThat(FullPathReWrite.encodeForContext(
+                "/carlos/x?name=\"O'Brien\"&x=</script>", "javaScriptBlock"))
+                .isEqualTo("\\/carlos\\/x?name=\\\"O\\'Brien\\\"\\x26x=<\\/script>");
+    }
+
+    @Test
+    @DisplayName("should use default HTML encoding when context is blank")
+    void shouldUseDefaultHtmlEncoding_whenContextIsBlank() throws Exception {
+        assertThat(FullPathReWrite.encodeForContext("<script>", null))
+                .isEqualTo("&lt;script&gt;");
+        assertThat(FullPathReWrite.encodeForContext("<script>", " "))
+                .isEqualTo("&lt;script&gt;");
+    }
+
+    @Test
+    @DisplayName("should reset tag attributes when tag ends")
+    void shouldResetTagAttributes_whenTagEnds() throws Exception {
+        FullPathReWrite tag = new FullPathReWrite();
+        tag.setServer("legacy.example");
+        tag.setJspPage("combinePDFs");
+        tag.setContext("javaScriptAttribute");
+
+        int result = tag.doEndTag();
+
+        assertThat(result).isEqualTo(jakarta.servlet.jsp.tagext.Tag.EVAL_PAGE);
+        assertThat(tag.getServer()).isNull();
+        assertThat(tag.getJspPage()).isEmpty();
+        assertThat(tag.getContext()).isEqualTo("html");
+    }
+
+    @Test
+    @DisplayName("should reject unsupported encoding context")
+    void shouldRejectUnsupportedEncodingContext_whenRenderingTag() {
+        assertThatThrownBy(() -> FullPathReWrite.encodeForContext("/carlos/x", "cssUrl"))
+                .isInstanceOf(JspException.class)
+                .hasMessageContaining("Unsupported FullPathReWrite encoding context");
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/util/FullPathReWriteUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/util/FullPathReWriteUnitTest.java
@@ -8,12 +8,16 @@
  */
 package io.github.carlos_emr.carlos.util;
 
+import jakarta.servlet.http.HttpServletRequest;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @Tag("unit")
 @Tag("security")
@@ -31,8 +35,8 @@ class FullPathReWriteUnitTest {
 
         String url = FullPathReWrite.buildRelativeUrl(request, "combinePDFs");
 
-        assertThat(url).isEqualTo("/carlos/documentManager/combinePDFs");
         assertThat(url)
+                .isEqualTo("/carlos/documentManager/combinePDFs")
                 .doesNotContain("attacker.example")
                 .doesNotContain("https://")
                 .doesNotContain(":4443");
@@ -48,5 +52,42 @@ class FullPathReWriteUnitTest {
                 "/billing/CA/BC/ViewBillingCodeNewSearch");
 
         assertThat(url).isEqualTo("/carlos/billing/CA/BC//billing/CA/BC/ViewBillingCodeNewSearch");
+    }
+
+    @Test
+    @DisplayName("should return jspPage when request is unavailable")
+    void shouldReturnJspPage_whenRequestIsUnavailable() {
+        assertThat(FullPathReWrite.buildRelativeUrl(null, "combinePDFs"))
+                .isEqualTo("combinePDFs");
+    }
+
+    @Test
+    @DisplayName("should return jspPage when request URI is unavailable")
+    void shouldReturnJspPage_whenRequestUriIsUnavailable() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getRequestURI()).thenReturn(null);
+
+        assertThat(FullPathReWrite.buildRelativeUrl(request, "combinePDFs"))
+                .isEqualTo("combinePDFs");
+    }
+
+    @Test
+    @DisplayName("should use root path when request URI has no slash")
+    void shouldUseRootPath_whenRequestUriHasNoSlash() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getRequestURI()).thenReturn("documentReport.jsp");
+
+        assertThat(FullPathReWrite.buildRelativeUrl(request, "combinePDFs"))
+                .isEqualTo("/combinePDFs");
+    }
+
+    @Test
+    @DisplayName("should treat null jspPage as empty")
+    void shouldTreatJspPage_whenValueIsNull() {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET",
+                "/carlos/documentManager/documentReport.jsp");
+
+        assertThat(FullPathReWrite.buildRelativeUrl(request, null))
+                .isEqualTo("/carlos/documentManager/");
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/util/FullPathReWriteUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/util/FullPathReWriteUnitTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 CARLOS EMR Project. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Tag("unit")
+@Tag("security")
+@DisplayName("FullPathReWrite")
+class FullPathReWriteUnitTest {
+
+    @Test
+    @DisplayName("should not include request host data when building rewrite URL")
+    void shouldNotIncludeRequestHostData_whenBuildingRewriteUrl() {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET",
+                "/carlos/documentManager/documentReport.jsp");
+        request.setScheme("https");
+        request.setServerName("attacker.example");
+        request.setServerPort(4443);
+
+        String url = FullPathReWrite.buildRelativeUrl(request, "combinePDFs");
+
+        assertThat(url).isEqualTo("/carlos/documentManager/combinePDFs");
+        assertThat(url)
+                .doesNotContain("attacker.example")
+                .doesNotContain("https://")
+                .doesNotContain(":4443");
+    }
+
+    @Test
+    @DisplayName("should preserve existing path shape for absolute jspPage values")
+    void shouldPreserveExistingPathShape_forAbsoluteJspPageValues() {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET",
+                "/carlos/billing/CA/BC/adjustBill.jsp");
+
+        String url = FullPathReWrite.buildRelativeUrl(request,
+                "/billing/CA/BC/ViewBillingCodeNewSearch");
+
+        assertThat(url).isEqualTo("/carlos/billing/CA/BC//billing/CA/BC/ViewBillingCodeNewSearch");
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/util/FullPathReWriteUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/util/FullPathReWriteUnitTest.java
@@ -9,6 +9,8 @@
 package io.github.carlos_emr.carlos.util;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.jsp.JspWriter;
+import jakarta.servlet.jsp.PageContext;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
@@ -17,6 +19,7 @@ import org.springframework.mock.web.MockHttpServletRequest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @Tag("unit")
@@ -89,5 +92,25 @@ class FullPathReWriteUnitTest {
 
         assertThat(FullPathReWrite.buildRelativeUrl(request, null))
                 .isEqualTo("/carlos/documentManager/");
+    }
+
+    @Test
+    @DisplayName("should encode relative URL when rendering tag")
+    void shouldEncodeUrl_whenRenderingTag() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET",
+                "/carlos/documentManager/documentReport.jsp");
+        PageContext pageContext = mock(PageContext.class);
+        JspWriter writer = mock(JspWriter.class);
+        when(pageContext.getRequest()).thenReturn(request);
+        when(pageContext.getOut()).thenReturn(writer);
+        FullPathReWrite tag = new FullPathReWrite();
+        tag.setPageContext(pageContext);
+        tag.setJspPage("combinePDFs?name=<script>");
+
+        int result = tag.doStartTag();
+
+        assertThat(result).isEqualTo(jakarta.servlet.jsp.tagext.Tag.EVAL_BODY_INCLUDE);
+        verify(writer).write("/carlos/documentManager/combinePDFs?name=&lt;script&gt;");
+        verify(writer).flush();
     }
 }


### PR DESCRIPTION
## Description

Addresses code scanning alert https://github.com/carlos-emr/carlos/security/code-scanning/25544.

`FullPathReWrite` no longer builds rewrite URLs from `HttpServletRequest` scheme, server name, or server port. The tag now emits the same request-path-relative URL shape without trusting Host-header-derived request metadata.

Added a regression test that sets a hostile request host and asserts the generated URL does not include the host, scheme, or port.

## Related Issues

Related to code scanning alert #25544 (`SERVLET_SERVER_NAME`).

## How Was This Tested?

- `mvn -q -Dtest=FullPathReWriteUnitTest test`
- `timeout 180s mvn -q -DskipTests compile spotbugs:spotbugs -Pspotbugs -Dspotbugs.onlyAnalyze=io.github.carlos_emr.carlos.util.FullPathReWrite`
  - Class-scoped SpotBugs report contains no `SERVLET_SERVER_NAME` for `FullPathReWrite`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops using Host-derived data and adds output-encoding contexts to `FullPathReWrite` to safely render URLs in HTML and JavaScript. Also encodes and localizes popup query variables to prevent injection and globals; addresses code scanning alert #25544 (`SERVLET_SERVER_NAME`).

- **Bug Fixes**
  - Build relative URLs with `buildRelativeUrl()` using only `request.getRequestURI()`; handles null request/URI, no-slash paths, null `jspPage`, and preserves legacy path-join shape.
  - Default HTML encoding now uses `SafeEncode.forHtml`; tag resets attributes on `doEndTag()`/`release()` to avoid stale state.
  - Encoding context dispatch uses exact values (no case mapping) to avoid Unicode case-conversion issues.
  - Declare and localize popup query variables (e.g., `var t0`) to avoid leaking into the global scope in JS popups.

- **New Features**
  - Added `context` tag attribute with supported values: `html` (default), `htmlAttribute`, `javaScriptAttribute`, `javaScriptBlock`. Updated `rewrite-tag.tld` and JSPs to pass the correct context and use `encodeURIComponent` for dynamic query values (e.g., billing popups, document combine PDFs, prevention print); tests cover encoding, URL shape, encoded query usage, and unsupported contexts.

<sup>Written for commit f4823d0bb906a9a4971186c9fc05191928fa8cc0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

