### PR TITLE
fix: add null check for msgSessionBean in MsgClearMessage2Action

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgClearMessage2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgClearMessage2Action.java
@@ -81,13 +81,13 @@ public final class MsgClearMessage2Action extends ActionSupport {
     HttpServletRequest request = ServletActionContext.getRequest();
     
     /**
-     * HTTP response object, maintained for consistency but not used in this action.
+     * HTTP response object used to redirect when the message session bean is unavailable.
      */
     HttpServletResponse response = ServletActionContext.getResponse();
 
 
 
-/**
+    /**
      * Clears all attachments from the message session bean.
      *
      * <p>This method retrieves the MsgSessionBean from the HTTP session and

--- a/src/main/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgClearMessage2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgClearMessage2Action.java
@@ -87,25 +87,23 @@ public final class MsgClearMessage2Action extends ActionSupport {
 
 
 
-    /**
+/**
      * Clears all attachments from the message session bean.
-     * 
+     *
      * <p>This method retrieves the MsgSessionBean from the HTTP session and
      * invokes its nullAttachment() method to remove all stored attachments.
      * The attachments are permanently cleared from the session, requiring
      * users to re-attach any documents they wish to include in their message.</p>
-     * 
-     * <p>Note: This method does not perform null checking on the session bean.
-     * If the bean is not present in the session, a NullPointerException will
-     * be thrown. This is acceptable as the bean should always exist when this
-     * action is invoked from the message composition interface.</p>
-     * 
-     * @return SUCCESS constant indicating successful attachment clearing
+     *
+     * <p>If the session bean is absent (expired session, direct URL hit, or race
+     * condition), the user is redirected to the message inbox.</p>
+     *
+     * @return SUCCESS if the attachments were cleared successfully, or NONE if the
+     *         session bean was absent and the request was redirected to the inbox
      * @throws IOException if there's an I/O error (declared but not typically thrown)
      * @throws ServletException if there's a servlet processing error (declared but not typically thrown)
      */
-    public String execute()
-            throws IOException, ServletException {
+    public String execute() throws IOException, ServletException {
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
         if (!securityInfoManager.hasPrivilege(loggedInInfo, "_msg", "w", null)) {
             throw new SecurityException("missing required sec object (_msg)");
@@ -114,10 +112,14 @@ public final class MsgClearMessage2Action extends ActionSupport {
         // Retrieve the message session bean from the HTTP session
         MsgSessionBean bean;
         bean = (MsgSessionBean) request.getSession().getAttribute("msgSessionBean");
-        
+        if (bean == null) {
+            response.sendRedirect(response.encodeRedirectURL(
+                    request.getContextPath() + "/messenger/DisplayMessages"));
+            return NONE;
+        }
+
         // Clear all attachments from the bean
         bean.nullAttachment();
-        
         return SUCCESS;
     }
 }


### PR DESCRIPTION
## Description
MsgClearMessage2Action.execute() retrieved msgSessionBean from the HTTP 
session and immediately called bean.nullAttachment() without a null check. 
If the session bean is absent (expired session, direct URL hit, or race 
condition), a NullPointerException was thrown and surfaced as a 500 error.

Added a null guard before invoking the bean. If msgSessionBean is absent, 
the user is redirected to /messenger/DisplayMessages instead.

Also updated the Javadoc which incorrectly stated that no null check was 
performed.
## Related Issues
Fixes #2785
## How Was This Tested?
Manually verified the fix compiles cleanly with make install.
The null guard redirects to /messenger/DisplayMessages when the session 
bean is absent, preventing the NPE.


[x] My commits are signed off for the DCO 
[x] My commits follow Conventional Commits format 
[x]I have not included any patient data
[x] this change doesn't need new tests 
[x] I have read the contributing guide