### PR TITLE
Fix issue 2680

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/appointment/addappointment.jsp
+++ b/src/main/webapp/WEB-INF/jsp/appointment/addappointment.jsp
@@ -125,7 +125,6 @@ Ontario, Canada
 <%@ page import="io.github.carlos_emr.carlos.utility.LoggedInInfo" %>
 <%@ page import="io.github.carlos_emr.carlos.utility.SpringUtils" %>
 
-<%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="io.github.carlos_emr.carlos.appt.JdbcApptImpl" %>
 <%@ page import="io.github.carlos_emr.carlos.appt.ApptUtil" %>
 <%@ page import="io.github.carlos_emr.carlos.appt.ApptData" %>

--- a/src/main/webapp/WEB-INF/jsp/appointment/appointmentTypeList.jsp
+++ b/src/main/webapp/WEB-INF/jsp/appointment/appointmentTypeList.jsp
@@ -27,7 +27,6 @@
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <fmt:setBundle basename="oscarResources"/>
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
-<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@ taglib prefix="s" uri="/struts-tags" %>
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
@@ -49,7 +48,6 @@
 <%@ page import="io.github.carlos_emr.carlos.login.*" %>
 <%@ page import="io.github.carlos_emr.carlos.log.*" %>
 <%@ page import="io.github.carlos_emr.carlos.utility.SafeEncode" %>
-<%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="io.github.carlos_emr.carlos.commn.IsPropertiesOn" %>
 <html>
 <head>

--- a/src/main/webapp/WEB-INF/jsp/appointment/appointmentaddarecord.jsp
+++ b/src/main/webapp/WEB-INF/jsp/appointment/appointmentaddarecord.jsp
@@ -46,7 +46,6 @@
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <fmt:setBundle basename="oscarResources"/>
-<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@ taglib uri="carlos" prefix="carlos" %>
 <html>
     <head>

--- a/src/main/webapp/WEB-INF/jsp/appointment/appointmentaddrecordcard.jsp
+++ b/src/main/webapp/WEB-INF/jsp/appointment/appointmentaddrecordcard.jsp
@@ -52,7 +52,6 @@
         import="java.sql.*, java.util.*, io.github.carlos_emr.MyDateFormat, io.github.carlos_emr.carlos.commn.OtherIdManager, io.github.carlos_emr.carlos.util.ConversionUtils" %>
 <%@ page import="io.github.carlos_emr.carlos.event.EventService, io.github.carlos_emr.carlos.utility.SpringUtils" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
-<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@ taglib uri="carlos" prefix="carlos" %>
 <fmt:setBundle basename="oscarResources"/>
 

--- a/src/main/webapp/WEB-INF/jsp/appointment/appointmentaddrecordprint.jsp
+++ b/src/main/webapp/WEB-INF/jsp/appointment/appointmentaddrecordprint.jsp
@@ -53,7 +53,6 @@
         import="java.sql.*, java.util.*, io.github.carlos_emr.MyDateFormat, io.github.carlos_emr.carlos.commn.OtherIdManager,io.github.carlos_emr.carlos.demographic.data.*,java.text.SimpleDateFormat,io.github.carlos_emr.carlos.utility.SpringUtils" %>
 <%@ page import="io.github.carlos_emr.carlos.event.EventService" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
-<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@ taglib uri="carlos" prefix="carlos" %>
 <fmt:setBundle basename="oscarResources"/>
 

--- a/src/main/webapp/WEB-INF/jsp/appointment/appointmenteditrepeatbooking.jsp
+++ b/src/main/webapp/WEB-INF/jsp/appointment/appointmenteditrepeatbooking.jsp
@@ -79,11 +79,9 @@
 <%@ page import="io.github.carlos_emr.carlos.commn.dao.OscarAppointmentDao" %>
 <%@ page import="io.github.carlos_emr.carlos.commn.model.Appointment" %>
 <%@ page import="io.github.carlos_emr.carlos.utility.SpringUtils" %>
-<%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="io.github.carlos_emr.carlos.utility.SafeEncode" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
-<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@ taglib uri="carlos" prefix="carlos" %>
 
 <fmt:setBundle basename="oscarResources"/>

--- a/src/main/webapp/WEB-INF/jsp/appointment/appointmentgrouprecords.jsp
+++ b/src/main/webapp/WEB-INF/jsp/appointment/appointmentgrouprecords.jsp
@@ -78,12 +78,10 @@
 <%@ page import="io.github.carlos_emr.carlos.util.UtilDateUtilities" %>
 <%@ page import="io.github.carlos_emr.carlos.util.ConversionUtils" %>
 <%@ page import="io.github.carlos_emr.MyDateFormat" %>
-<%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="org.owasp.csrfguard.CsrfGuard" %>
 <%@ page import="io.github.carlos_emr.carlos.utility.SafeEncode" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <fmt:setBundle basename="oscarResources"/>
-<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@ taglib uri="carlos" prefix="carlos" %>
 
 

--- a/src/main/webapp/WEB-INF/jsp/appointment/appointmentrepeatbooking.jsp
+++ b/src/main/webapp/WEB-INF/jsp/appointment/appointmentrepeatbooking.jsp
@@ -56,7 +56,6 @@
 <%@ page import="org.owasp.csrfguard.CsrfGuard" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <fmt:setBundle basename="oscarResources"/>
-<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@ taglib uri="carlos" prefix="carlos" %>
 
 <%@page import="io.github.carlos_emr.carlos.commn.dao.AppointmentArchiveDao" %>

--- a/src/main/webapp/WEB-INF/jsp/appointment/appointmentupdatearecord.jsp
+++ b/src/main/webapp/WEB-INF/jsp/appointment/appointmentupdatearecord.jsp
@@ -43,7 +43,6 @@
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <fmt:setBundle basename="oscarResources"/>
-<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@ taglib uri="carlos" prefix="carlos" %>
 <html>
     <head>

--- a/src/main/webapp/WEB-INF/jsp/appointment/appointmentviewrecordcard.jsp
+++ b/src/main/webapp/WEB-INF/jsp/appointment/appointmentviewrecordcard.jsp
@@ -56,7 +56,6 @@
 <%@ page import="io.github.carlos_emr.carlos.commn.model.UserProperty" %>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
-<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@ taglib uri="carlos" prefix="carlos" %>
 <fmt:setBundle basename="oscarResources"/>
 

--- a/src/main/webapp/WEB-INF/jsp/appointment/editappointment.jsp
+++ b/src/main/webapp/WEB-INF/jsp/appointment/editappointment.jsp
@@ -79,7 +79,6 @@
 <%@ page import="io.github.carlos_emr.carlos.encounter.data.EctFormData" %>
 <%@ page import="io.github.carlos_emr.carlos.billings.ca.on.support.BillingOnConstants" %>
 <%@ page import="io.github.carlos_emr.carlos.commn.dao.AppointmentTypeDao" %>
-<%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="io.github.carlos_emr.carlos.appt.ApptUtil" %>
 <%@ page import="io.github.carlos_emr.carlos.appt.ApptData" %>
 <%@ page import="io.github.carlos_emr.carlos.demographic.data.DemographicData" %>

--- a/src/main/webapp/WEB-INF/jsp/appointment/printappointment.jsp
+++ b/src/main/webapp/WEB-INF/jsp/appointment/printappointment.jsp
@@ -29,7 +29,6 @@
 --%>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
-<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@ taglib uri="carlos" prefix="carlos" %>
 <fmt:setBundle basename="oscarResources"/>
 

--- a/src/main/webapp/WEB-INF/jsp/schedule/scheduleDisplayTemplate.jsp
+++ b/src/main/webapp/WEB-INF/jsp/schedule/scheduleDisplayTemplate.jsp
@@ -38,10 +38,8 @@
 <%@page import="io.github.carlos_emr.carlos.commn.model.ScheduleTemplate" %>
 <%@page import="io.github.carlos_emr.carlos.commn.dao.ScheduleTemplateCodeDao" %>
 <%@page import="io.github.carlos_emr.carlos.commn.model.ScheduleTemplateCode" %>
-<%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="io.github.carlos_emr.carlos.util.StringUtils" %>
 <%@ page import="io.github.carlos_emr.carlos.utility.SafeEncode" %>
-<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@ taglib uri="carlos" prefix="carlos" %>
 <%
     ScheduleTemplateDao scheduleTemplateDao = SpringUtils.getBean(ScheduleTemplateDao.class);

--- a/src/main/webapp/WEB-INF/jsp/schedule/schedulecreatedate.jsp
+++ b/src/main/webapp/WEB-INF/jsp/schedule/schedulecreatedate.jsp
@@ -61,7 +61,6 @@
         import="java.util.*, java.sql.*, io.github.carlos_emr.*, java.text.*, java.lang.*,java.net.*"
         errorPage="/WEB-INF/jsp/error/errorpage.jsp" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
-<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@ taglib uri="carlos" prefix="carlos" %>
 <fmt:setBundle basename="oscarResources"/>
 

--- a/src/main/webapp/WEB-INF/jsp/schedule/scheduledatepopup.jsp
+++ b/src/main/webapp/WEB-INF/jsp/schedule/scheduledatepopup.jsp
@@ -41,7 +41,6 @@
 %>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
-<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@ taglib uri="carlos" prefix="carlos" %>
 <fmt:setBundle basename="oscarResources"/>
 
@@ -71,7 +70,6 @@
 <%@page import="io.github.carlos_emr.carlos.commn.dao.SiteDao" %>
 <%@page import="org.springframework.web.context.support.WebApplicationContextUtils" %>
 <%@page import="io.github.carlos_emr.carlos.commn.model.Site" %>
-<%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="io.github.carlos_emr.carlos.util.StringUtils" %>
 <%@ page import="io.github.carlos_emr.carlos.utility.SafeEncode" %>
 <html>

--- a/src/main/webapp/WEB-INF/jsp/schedule/scheduleedittemplate.jsp
+++ b/src/main/webapp/WEB-INF/jsp/schedule/scheduleedittemplate.jsp
@@ -39,7 +39,6 @@
         errorPage="/WEB-INF/jsp/error/errorpage.jsp" %>
 <%@ page import="io.github.carlos_emr.CarlosProperties" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
-<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@ taglib uri="carlos" prefix="carlos" %>
 <fmt:setBundle basename="oscarResources"/>
 

--- a/src/main/webapp/WEB-INF/jsp/schedule/scheduleflipview.jsp
+++ b/src/main/webapp/WEB-INF/jsp/schedule/scheduleflipview.jsp
@@ -108,7 +108,6 @@
              scope="page"/>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
-<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@ taglib uri="carlos" prefix="carlos" %>
 <fmt:setBundle basename="oscarResources"/>
 
@@ -118,7 +117,6 @@
 <%@page import="io.github.carlos_emr.carlos.commn.dao.SiteDao" %>
 <%@page import="org.springframework.web.context.support.WebApplicationContextUtils" %>
 <%@page import="io.github.carlos_emr.carlos.appt.ApptUtil" %>
-<%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="io.github.carlos_emr.carlos.util.StringUtils" %>
 <%@ page import="io.github.carlos_emr.carlos.utility.SafeEncode" %>
 <html>

--- a/src/main/webapp/WEB-INF/jsp/schedule/scheduleholidaysetting.jsp
+++ b/src/main/webapp/WEB-INF/jsp/schedule/scheduleholidaysetting.jsp
@@ -59,7 +59,6 @@
         import="java.util.*, java.sql.*, io.github.carlos_emr.*, java.text.*, java.lang.*"
         errorPage="/WEB-INF/jsp/error/errorpage.jsp" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
-<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@ taglib uri="carlos" prefix="carlos" %>
 <fmt:setBundle basename="oscarResources"/>
 

--- a/src/main/webapp/WEB-INF/jsp/schedule/scheduletemplateapplying.jsp
+++ b/src/main/webapp/WEB-INF/jsp/schedule/scheduletemplateapplying.jsp
@@ -56,7 +56,6 @@
 <%@ page import="java.net.*" %>
 <%@ page import="java.lang.*" %>
 <%@ page import="java.nio.charset.StandardCharsets" %>
-<%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="io.github.carlos_emr.*" %>
 <%@ page import="io.github.carlos_emr.carlos.util.*" %>
 <%@ page import="io.github.carlos_emr.carlos.utility.SpringUtils" %>
@@ -79,7 +78,6 @@
 <fmt:setBundle basename="oscarResources"/>
 <%@ taglib uri="/WEB-INF/rewrite-tag.tld" prefix="rewrite" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
-<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@ taglib uri="carlos" prefix="carlos" %>
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
 <%

--- a/src/main/webapp/WEB-INF/jsp/schedule/scheduletemplatesetting.jsp
+++ b/src/main/webapp/WEB-INF/jsp/schedule/scheduletemplatesetting.jsp
@@ -53,7 +53,6 @@
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <fmt:setBundle basename="oscarResources"/>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
-<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@ taglib uri="carlos" prefix="carlos" %>
 
 


### PR DESCRIPTION
## Description

Removes unused legacy OWASP Encoder taglib declarations and `Encode` imports from 19 JSP files in the `appointment/` and `schedule/` directories.

These files were previously migrated to use the null-safe CARLOS wrappers (`<carlos:encode>`, `SafeEncode.*`), but the legacy declarations were left in place. No `<e:forXxx>` tags or `Encode.forXxx()` calls remain in any of the modified files.
## Related Issues

Fixes #2680

## How Was This Tested?

Dead code removal only, no behavioral changes. Verified manually that no `<e:forXxx>` tags or `Encode.forXxx()` calls remain in any of the modified files after removing the declarations. CI lint check (`check-encoder-null-safety.sh`) will confirm on PR.

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove unused OWASP Encoder taglib and `Encode` imports from 20 appointment/schedule JSPs to complete the migration to null‑safe CARLOS encoders. No behavior changes; cleans up dead code and reduces confusion. Fixes #2680.

- **Refactors**
  - Removed `owasp.encoder.jakarta.advanced` taglib and `org.owasp.encoder.Encode` imports in 20 JSPs across `appointment/` and `schedule/`.
  - All pages now use `<carlos:encode>` and `SafeEncode.*`; CI `check-encoder-null-safety.sh` enforces no `e:forXxx` or `Encode.forXxx()` remain.

<sup>Written for commit 8b67c217fd1c735aa608690e9906437322d6d6a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2910?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

