### PR TITLE
fix: harden eform pdf render pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test:tickler-crud-playwright": "node scripts/tickler-crud-playwright-checks.js",
     "test:logout-session-invalidation-playwright": "node scripts/logout-session-invalidation-playwright-checks.js",
     "test:multiple-session-playwright": "node scripts/multiple-session-playwright-checks.js",
-    "test:logout-redirect-playwright": "node scripts/logout-redirect-playwright-checks.js"
+    "test:logout-redirect-playwright": "node scripts/logout-redirect-playwright-checks.js",
+    "test:eform-render-playwright": "node scripts/eform-render-playwright-checks.js"
   },
   "dependencies": {
     "@docusaurus/core": "^3.9.2",

--- a/scripts/eform-render-playwright-checks.js
+++ b/scripts/eform-render-playwright-checks.js
@@ -1,4 +1,25 @@
 #!/usr/bin/env node
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
 /*
  * App-backed browser regression checks for the eForm PDF/render pipeline.
  *
@@ -127,7 +148,7 @@ function formPrint() {
 </form>
 </body>
 </html>`;
-  fs.writeFileSync(htmlPath, html, 'utf8');
+  fs.writeFileSync(htmlPath, html, 'utf8'); // nosemgrep: javascript.lang.security.audit.unknown-value-with-script-tag.unknown-value-with-script-tag -- html is a fixed local test fixture, not external input
 
   return { tempDir, imagePath, htmlPath };
 }
@@ -181,7 +202,7 @@ function wirePage(page, label) {
 }
 
 async function gotoApp(page, appPath, waitUntil = 'domcontentloaded') {
-  return page.goto(appUrl(appPath), { waitUntil, timeout: 30000 });
+  return page.goto(appUrl(appPath), { waitUntil, timeout: 30000 }); // nosemgrep: javascript.playwright.security.audit.playwright-goto-injection.playwright-goto-injection -- appUrl rejects non-root-relative paths and validateBaseUrl restricts hosts to local/private by default
 }
 
 async function login(context) {
@@ -303,7 +324,7 @@ function assertDisplayImageFetchesSucceeded(imageName) {
   if (!fid) {
     return;
   }
-  await page.evaluate((submittedFid) => {
+  await page.evaluate((submittedFid) => { // nosemgrep: javascript.playwright.security.audit.playwright-evaluate-arg-injection.playwright-evaluate-arg-injection -- submittedFid is passed as a Playwright argument, not interpolated into code
     const form = document.createElement('form');
     form.method = 'post';
     form.action = `${window.location.origin}${window.location.pathname.replace(/\/efmformmanager.*$/, '')}/delEForm`;

--- a/scripts/eform-render-playwright-checks.js
+++ b/scripts/eform-render-playwright-checks.js
@@ -1,0 +1,438 @@
+#!/usr/bin/env node
+/*
+ * App-backed browser regression checks for the eForm PDF/render pipeline.
+ *
+ * This script logs into a running CARLOS app, uploads a tiny background image,
+ * imports a temporary eForm whose HTML intentionally contains malformed comment
+ * syntax plus a ${oscar_image_path} background image reference, opens the eForm
+ * from the admin library, and verifies that:
+ *   1. the eForm still renders in the popup without an error page
+ *   2. the background image resolves through displayImage
+ *   3. /previewDocs?method=renderEFormPDF returns a real PDF for the imported form
+ *
+ * Defaults are for the local devcontainer:
+ *   node scripts/eform-render-playwright-checks.js
+ *
+ * Optional environment:
+ *   BASE_URL=http://127.0.0.1:8080/carlos
+ *   CHROME_PATH=/path/to/chrome-or-chromium
+ *   TEST_USER=carlosdoc
+ *   TEST_PASSWORD=carlos2026
+ *   TEST_PIN=2026
+ *   EFORM_SCREENSHOT_DIR=/tmp
+ *   ALLOW_NON_LOCAL_BASE_URL=true only when intentionally targeting a non-local test app
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { chromium } = require('playwright');
+
+const baseUrl = validateBaseUrl(process.env.BASE_URL || 'http://127.0.0.1:8080/carlos');
+const chromePath = process.env.CHROME_PATH || '';
+const testUser = process.env.TEST_USER || 'carlosdoc';
+const testPassword = process.env.TEST_PASSWORD || 'carlos2026';
+const testPin = process.env.TEST_PIN || '2026';
+const screenshotDir = process.env.EFORM_SCREENSHOT_DIR || '/tmp';
+
+const bgImageName = 'playwright_pdf_render_bg.png';
+const transparentPngBase64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Wl5n2QAAAAASUVORK5CYII=';
+
+const badResponses = [];
+const consoleIssues = [];
+const displayImageResponses = [];
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function validateBaseUrl(rawBaseUrl) {
+  const parsed = new URL(rawBaseUrl);
+  if (!['http:', 'https:'].includes(parsed.protocol)) {
+    throw new Error(`BASE_URL must use http or https, got ${parsed.protocol}`);
+  }
+
+  const host = parsed.hostname.toLowerCase();
+  const localHosts = new Set(['localhost', '127.0.0.1', '::1', '0.0.0.0', 'host.docker.internal', 'carlos']);
+  const privateIpv4 = /^(10\.|192\.168\.|172\.(1[6-9]|2\d|3[0-1])\.)/.test(host);
+  if (!localHosts.has(host) && !privateIpv4 && process.env.ALLOW_NON_LOCAL_BASE_URL !== 'true') {
+    throw new Error(`Refusing non-local BASE_URL host ${host}; set ALLOW_NON_LOCAL_BASE_URL=true for an intentional test target`);
+  }
+  parsed.pathname = parsed.pathname.replace(/\/$/, '');
+  return parsed;
+}
+
+function appUrl(appPath) {
+  if (!appPath.startsWith('/') || appPath.startsWith('//')) {
+    throw new Error(`Application path must be root-relative, got ${appPath}`);
+  }
+  const relative = new URL(appPath, 'http://localhost');
+  const url = new URL(baseUrl.href);
+  url.pathname = `${baseUrl.pathname}${relative.pathname}`.replace(/\/{2,}/g, '/');
+  url.search = relative.search;
+  return url.toString();
+}
+
+function createFixtureFiles() {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'carlos-eform-render-'));
+  const imagePath = path.join(tempDir, bgImageName);
+  fs.writeFileSync(imagePath, Buffer.from(transparentPngBase64, 'base64'));
+
+  const htmlPath = path.join(tempDir, 'playwright-render-pipeline.html');
+  const html = `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Playwright Render Pipeline</title>
+<style type="text/css" media="print">
+ .DoNotPrint { display: none; }
+ .noborder {
+   border: 0;
+   background: transparent;
+   overflow: hidden;
+ }
+</style>
+<script language="javascript">
+var needToConfirm = false;
+document.onkeyup = function setDirtyFlag() {
+  needToConfirm = true;
+};
+function releaseDirtyFlag() {
+  needToConfirm = false;
+}
+window.onbeforeunload = function confirmExit() {
+  if (needToConfirm) {
+    return "Unsaved changes";
+  }
+};
+function formPrint() {
+  window.print();
+}
+</script>
+</head>
+<body onload="">
+<form method="post" action="" name="FormName" id="FormName">
+<!-- malformed -- comment-->
+<div id="page1" style="page-break-after:always;position:relative;">
+<img id="BGImage1" src="\${oscar_image_path}${bgImageName}" style="position:relative;left:0;top:0;width:750px;height:140px;">
+<input name="patient_nameL" id="patient_nameL" type="text" value="TemplateSeed" class="noborder" style="position:absolute;left:40px;top:32px;width:220px;height:22px;" oscarDB="patient_nameL">
+<input name="subject" id="subject" type="text" class="noborder" style="position:absolute;left:40px;top:72px;width:220px;height:22px;">
+</div>
+<div class="DoNotPrint" id="BottomButtons" style="position:absolute;top:180px;left:0;">
+  <input value="Submit" name="SubmitButton" id="SubmitButton" type="submit" onclick="releaseDirtyFlag();">
+  <input value="Print" name="PrintButton" id="PrintButton" type="button" onclick="formPrint();">
+</div>
+</form>
+</body>
+</html>`;
+  fs.writeFileSync(htmlPath, html, 'utf8');
+
+  return { tempDir, imagePath, htmlPath };
+}
+
+function isExpectedMissingAsset(status, responseUrl) {
+  return status === 404 && (/\/favicon\.ico$/.test(responseUrl) || /\/imageRenderingServlet\?/.test(responseUrl));
+}
+
+function isIgnorableConsoleMessage(message) {
+  const text = message.text();
+  return /Content Security Policy.*report-only/i.test(text)
+    || /Master token \[CSRF-TOKEN\]/.test(text)
+    || /Hidden token fields .* were updated with new token value/.test(text)
+    || /window\.print/i.test(text);
+}
+
+function isSevereConsoleMessage(message) {
+  if (isIgnorableConsoleMessage(message)) {
+    return false;
+  }
+  const text = message.text();
+  if (message.type() === 'error') {
+    return true;
+  }
+  return /(ReferenceError|TypeError|SyntaxError|\$ is not defined|jQuery is not defined|Cannot read|Cannot set|is not defined)/i.test(text);
+}
+
+function wirePage(page, label) {
+  page.on('dialog', async (dialog) => {
+    consoleIssues.push({ label, type: 'dialog', text: dialog.message() });
+    await dialog.dismiss().catch(() => {});
+  });
+  page.on('response', (response) => {
+    const responseUrl = response.url();
+    const status = response.status();
+    if (/\/eform\/displayImage(?:\.do)?\?imagefile=/.test(responseUrl)) {
+      displayImageResponses.push({ label, status, url: responseUrl, contentType: response.headers()['content-type'] || '' });
+    }
+    if (status >= 400 && !isExpectedMissingAsset(status, responseUrl)) {
+      badResponses.push({ label, status, method: response.request().method(), url: responseUrl, contentType: response.headers()['content-type'] || '' });
+    }
+  });
+  page.on('console', (message) => {
+    if (isSevereConsoleMessage(message)) {
+      consoleIssues.push({ label, type: message.type(), text: message.text(), location: message.location() });
+    }
+  });
+  page.on('pageerror', (error) => {
+    consoleIssues.push({ label, type: 'pageerror', text: error.stack || error.message });
+  });
+}
+
+async function gotoApp(page, appPath, waitUntil = 'domcontentloaded') {
+  return page.goto(appUrl(appPath), { waitUntil, timeout: 30000 });
+}
+
+async function login(context) {
+  const page = await context.newPage();
+  wirePage(page, 'login');
+  await gotoApp(page, '/');
+  await page.locator('#username').fill(testUser);
+  await page.locator('#password').fill(testPassword);
+  if (await page.locator('#pin').count()) {
+    await page.locator('#pin').fill(testPin);
+  }
+  await Promise.all([
+    page.waitForURL(/providercontrol|appointment/i, { timeout: 30000 }),
+    page.locator('input[type="submit"], button[type="submit"]').first().click(),
+  ]);
+  await page.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+  return page;
+}
+
+async function ensureImageUploaded(context, imagePath, imageName) {
+  const page = await context.newPage();
+  wirePage(page, `image:${imageName}`);
+  try {
+    await gotoApp(page, '/eform/efmimagemanager');
+    await page.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+    const imageLink = page.locator('#tblImage a.viewImage', { hasText: imageName }).first();
+    if (await imageLink.count()) {
+      return;
+    }
+
+    const frame = page.frameLocator('#uploadFrame');
+    await frame.locator('#image').setInputFiles(imagePath);
+    await frame.locator('input.upload[type="submit"]').click();
+    await page.waitForURL(/administration\?show=ImageUpload/, { timeout: 10000 }).catch(() => {});
+    await gotoApp(page, '/eform/efmimagemanager');
+    await page.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+    await page.locator('#tblImage a.viewImage', { hasText: imageName }).first().waitFor({ state: 'visible', timeout: 15000 });
+  } finally {
+    await page.close();
+  }
+}
+
+async function uploadEform(context, formName, formSubject, htmlPath) {
+  const page = await context.newPage();
+  wirePage(page, 'eform-upload');
+  try {
+    await gotoApp(page, '/eform/efmformmanager');
+    await page.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+
+    const frame = page.frameLocator('#uploadFrame');
+    await frame.locator('input[name="formName"]').fill(formName);
+    await frame.locator('input[name="formSubject"]').fill(formSubject);
+    await frame.locator('#patientIndependent').check();
+    await frame.locator('#formHtml').setInputFiles(htmlPath);
+    await frame.locator('input.upload[type="submit"]').click();
+
+    await page.waitForURL(/administration\?show=Forms/, { timeout: 10000 }).catch(() => {});
+    await gotoApp(page, '/eform/efmformmanager');
+    await page.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+
+    const row = page.locator('#eformTbl tbody tr', { hasText: formName }).first();
+    await row.waitFor({ state: 'visible', timeout: 15000 });
+
+    const editHref = await row.locator('a[href*="efmformmanageredit?fid="]').first().getAttribute('href');
+    assert(editHref, `Could not find edit link for imported eForm ${formName}`);
+    const parsed = new URL(editHref, baseUrl.href);
+    const fid = parsed.searchParams.get('fid');
+    assert(fid, `Could not extract fid from edit link ${editHref}`);
+    return { page, row, fid };
+  } catch (error) {
+    await page.close().catch(() => {});
+    throw error;
+  }
+}
+
+async function openManagerPreview(context, row) {
+  const popupPromise = context.waitForEvent('page');
+  await row.locator('td a').first().click();
+  const popup = await popupPromise;
+  wirePage(popup, 'manager-preview');
+  await popup.waitForLoadState('domcontentloaded', { timeout: 30000 });
+  await popup.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+  return popup;
+}
+
+async function openImportedEform(context, fid, demographicNo) {
+  const popup = await context.newPage();
+  wirePage(popup, 'eform-popup');
+  await gotoApp(popup, `/eform/efmformadd_data?fid=${encodeURIComponent(fid)}&demographic_no=${encodeURIComponent(demographicNo)}`);
+  await popup.waitForLoadState('domcontentloaded', { timeout: 30000 });
+  await popup.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+  return popup;
+}
+
+async function assertNotErrorPage(page, label) {
+  const text = await page.locator('body').innerText({ timeout: 10000 }).catch(() => '');
+  assert(!/CARLOS has encountered an unexpected error|HTTP Status 500|Exception Report/i.test(text), `${label} rendered an error page`);
+  assert(text.trim().length > 0, `${label} rendered a blank page`);
+}
+
+async function assertImageLoaded(page, selector, label) {
+  const loaded = await page.locator(selector).evaluate((img) => ({
+    complete: img.complete,
+    width: img.naturalWidth,
+    height: img.naturalHeight,
+    src: img.currentSrc || img.src,
+  }));
+  assert(loaded.complete, `${label} did not finish loading`);
+  assert(loaded.width > 0 && loaded.height > 0, `${label} failed to decode: ${loaded.src}`);
+}
+
+function assertDisplayImageFetchesSucceeded(imageName) {
+  const matches = displayImageResponses.filter((response) => response.url.includes(`imagefile=${encodeURIComponent(imageName)}`) || response.url.includes(`imagefile=${imageName}`));
+  assert(matches.length > 0, `No displayImage response captured for ${imageName}`);
+  assert(matches.some((response) => response.status === 200), `displayImage never returned 200 for ${imageName}: ${JSON.stringify(matches, null, 2)}`);
+}
+
+ async function cleanupImportedEform(page, fid) {
+  if (!fid) {
+    return;
+  }
+  await page.evaluate((submittedFid) => {
+    const form = document.createElement('form');
+    form.method = 'post';
+    form.action = `${window.location.origin}${window.location.pathname.replace(/\/efmformmanager.*$/, '')}/delEForm`;
+    const input = document.createElement('input');
+    input.type = 'hidden';
+    input.name = 'fid';
+    input.value = submittedFid;
+    form.appendChild(input);
+    document.body.appendChild(form);
+    form.submit();
+  }, fid);
+  await page.waitForLoadState('domcontentloaded', { timeout: 15000 }).catch(() => {});
+  await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {});
+}
+
+(async () => {
+  const fixture = createFixtureFiles();
+  const timestamp = Date.now();
+  const importedFormName = `Playwright Render Pipeline ${timestamp}`;
+  const importedFormSubject = `Render pipeline ${timestamp}`;
+  const renderedPdfPath = path.join(screenshotDir, `eform-render-pipeline-${timestamp}.pdf`);
+  const screenshotPath = path.join(screenshotDir, `eform-render-pipeline-${timestamp}.png`);
+  let importedFid = null;
+  let managerPage = null;
+
+  const launchOptions = {
+    headless: true,
+    args: ['--no-sandbox', '--disable-dev-shm-usage'],
+  };
+  if (chromePath) {
+    launchOptions.executablePath = chromePath;
+  }
+
+  const browser = await chromium.launch(launchOptions);
+  try {
+    const context = await browser.newContext({ acceptDownloads: true, ignoreHTTPSErrors: true, viewport: { width: 1100, height: 1600 } });
+    const landingPage = await login(context);
+    await landingPage.close();
+
+    await ensureImageUploaded(context, fixture.imagePath, bgImageName);
+    const uploadResult = await uploadEform(context, importedFormName, importedFormSubject, fixture.htmlPath);
+    managerPage = uploadResult.page;
+    importedFid = uploadResult.fid;
+
+    const managerPreview = await openManagerPreview(context, uploadResult.row);
+    await assertNotErrorPage(managerPreview, 'manager preview popup');
+    await assertImageLoaded(managerPreview, '#BGImage1', 'manager preview background image');
+    const managerPreviewState = await managerPreview.evaluate(() => ({
+      patientLast: document.getElementById('patient_nameL') ? document.getElementById('patient_nameL').value : '',
+      bgSrc: document.getElementById('BGImage1') ? document.getElementById('BGImage1').src : '',
+    }));
+    assert(managerPreviewState.patientLast === 'TemplateSeed', `Manager preview did not render template-stored field data: ${managerPreviewState.patientLast}`);
+    await managerPreview.close();
+
+    const popup = await openImportedEform(context, importedFid, '1');
+    await assertNotErrorPage(popup, 'render-pipeline eForm popup');
+
+    await popup.fill('#patient_nameL', 'Playwright');
+    const popupState = await popup.evaluate(() => ({
+      patientLast: document.getElementById('patient_nameL').value,
+      title: document.title,
+      warningMessage: document.getElementById('warningMessage') ? document.getElementById('warningMessage').value : '',
+      bgSrc: document.getElementById('BGImage1') ? document.getElementById('BGImage1').src : '',
+    }));
+    assert(popupState.patientLast === 'Playwright', 'Imported render-pipeline eForm field was not editable');
+    assert(!popupState.warningMessage, `Unexpected warning message on initial popup render: ${popupState.warningMessage}`);
+    await assertImageLoaded(popup, '#BGImage1', 'render-pipeline background image');
+    assertDisplayImageFetchesSucceeded(bgImageName);
+
+    const downloadPromise = popup.waitForEvent('download', { timeout: 60000 });
+    await popup.locator('#remoteDownloadButton').click();
+    const download = await downloadPromise;
+
+    fs.mkdirSync(screenshotDir, { recursive: true });
+    await download.saveAs(renderedPdfPath);
+    const pdfBytes = fs.readFileSync(renderedPdfPath);
+    assert(pdfBytes.subarray(0, 5).toString('utf8') === '%PDF-', 'Downloaded payload was not a PDF');
+    assert(pdfBytes.length > 500, `Downloaded PDF payload was unexpectedly small (${pdfBytes.length} bytes)`);
+
+    await popup.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+    const postDownloadState = await popup.evaluate(() => ({
+      warningMessage: document.getElementById('warningMessage') ? document.getElementById('warningMessage').value : '',
+      errorMessage: document.getElementById('errorMessage') ? document.getElementById('errorMessage').value : '',
+      isDownloadEForm: document.getElementById('isDownloadEForm') ? document.getElementById('isDownloadEForm').value : '',
+    }));
+    assert(!postDownloadState.warningMessage, `Unexpected warning after remote download: ${postDownloadState.warningMessage}`);
+    assert(!postDownloadState.errorMessage, `Unexpected error after remote download: ${postDownloadState.errorMessage}`);
+
+    await popup.screenshot({ path: screenshotPath, fullPage: true });
+
+    const fatalBadResponses = badResponses.filter((response) => !(response.label === 'eform-popup' && response.url.includes('/oscar/eform/displayImage?imagefile=')));
+    const fatalConsoleIssues = consoleIssues.filter((issue) => issue.type !== 'dialog' &&
+      !(issue.label && issue.label.startsWith('image:') && /\$ is not defined/.test(issue.text)) &&
+      !(issue.label === 'eform-upload' && /checkFormAndDisable is not defined/.test(issue.text)) &&
+      !(issue.label === 'eform-popup' && /Failed to load resource/.test(issue.text) && /\/oscar\/eform\/displayImage\?imagefile=/.test(issue.location && issue.location.url ? issue.location.url : '')));
+    assert(fatalBadResponses.length === 0, `unexpected HTTP errors: ${JSON.stringify(fatalBadResponses, null, 2)}`);
+    assert(fatalConsoleIssues.length === 0, `unexpected browser console failures: ${JSON.stringify(fatalConsoleIssues, null, 2)}`);
+
+    console.log(JSON.stringify({
+      importedFormName,
+      importedFormSubject,
+      importedFid,
+      screenshotPath,
+      renderedPdfPath,
+      pdfBytes: pdfBytes.length,
+      managerPreviewBgSrc: managerPreviewState.bgSrc,
+      popupBgSrc: popupState.bgSrc,
+      isDownloadEFormAfterSave: postDownloadState.isDownloadEForm,
+      ignoredPopupDisplayImage404s: badResponses.filter((response) => response.label === 'eform-popup' && response.url.includes('/oscar/eform/displayImage?imagefile=')).length,
+    }, null, 2));
+    console.log('PASS app-backed eForm render pipeline Playwright check');
+
+    await popup.close();
+  } finally {
+    if (managerPage && !managerPage.isClosed()) {
+      await cleanupImportedEform(managerPage, importedFid).catch(() => {});
+      await managerPage.close().catch(() => {});
+    }
+    fs.rmSync(fixture.tempDir, { recursive: true, force: true });
+    await browser.close();
+  }
+})().catch((error) => {
+  console.error('FAIL app-backed eForm render pipeline Playwright check');
+  console.error(error.stack || error.message);
+  if (badResponses.length) {
+    console.error(`HTTP errors: ${JSON.stringify(badResponses, null, 2)}`);
+  }
+  if (consoleIssues.length) {
+    console.error(`Console issues: ${JSON.stringify(consoleIssues, null, 2)}`);
+  }
+  process.exit(1);
+});

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/ConvertToEdoc.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/ConvertToEdoc.java
@@ -625,7 +625,7 @@ public final class ConvertToEdoc {
             String translatedPath = translateSingleResourcePath(originalPath);
             if (translatedPath != null) {
                 element.attr("background", translatedPath);
-            } else if (isDisallowedResourcePath(originalPath)) {
+            } else {
                 element.removeAttr("background");
             }
         }
@@ -656,10 +656,8 @@ public final class ConvertToEdoc {
             String replacement;
             if (translatedPath != null) {
                 replacement = Matcher.quoteReplacement("url('" + translatedPath + "')");
-            } else if (isDisallowedResourcePath(originalPath)) {
-                replacement = "url('')";
             } else {
-                replacement = matcher.group(0);
+                replacement = "url('')";
             }
             matcher.appendReplacement(rewrittenCss, replacement);
         }
@@ -739,6 +737,8 @@ public final class ConvertToEdoc {
                     List<String> potentialFilePaths = collectPotentialFilePaths(path);
                     if (!potentialFilePaths.isEmpty()) {
                         pathTranslationMap.put(potentialFilePaths, element);
+                    } else {
+                        element.remove();
                     }
                 }
             }

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/ConvertToEdoc.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/ConvertToEdoc.java
@@ -33,9 +33,11 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.jsoup.Jsoup;
+import org.jsoup.nodes.Comment;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.nodes.Entities;
+import org.jsoup.nodes.Node;
 import org.jsoup.select.Elements;
 import io.github.carlos_emr.carlos.commn.model.EFormData;
 import io.github.carlos_emr.carlos.email.core.EmailData;
@@ -58,6 +60,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -103,6 +107,7 @@ public final class ConvertToEdoc {
     private static final String SYSTEM_ID = "-1";
     private static final String DEFAULT_WKHTMLTOPDF_COMMAND = "/usr/bin/wkhtmltopdf";
     private static final String DEFAULT_WKHTMLTOPDF_ARGS = "--enable-local-file-access --minimum-font-size 10 --print-media-type --encoding utf-8 -T 10mm -L 8mm -R 8mm --disable-javascript";
+    private static final Pattern CSS_URL_PATTERN = Pattern.compile("url\\((['\"]?)([^\\\"\")]+)\\1\\)", Pattern.CASE_INSENSITIVE);
     
     private static String realPath;
     private static final NioFileManager nioFileManager = SpringUtils.getBean(NioFileManager.class);
@@ -416,8 +421,9 @@ public final class ConvertToEdoc {
     /**
      * Prepare document for Flying Saucer which requires strict XHTML
      */
-    private static Document prepareDocumentForFlyingSaucer(String document) {
+    static Document prepareDocumentForFlyingSaucer(String document) {
         Document doc = Jsoup.parse(document);
+        normalizeHtmlCommentsForXml(doc);
         
         // Flying Saucer requires XML/XHTML syntax
         doc.outputSettings()
@@ -436,6 +442,19 @@ public final class ConvertToEdoc {
         doc.select("input:not([type])").attr("type", "text");
         
         return doc;
+    }
+
+    private static void normalizeHtmlCommentsForXml(Node root) {
+        for (Node child : root.childNodes()) {
+            if (child instanceof Comment comment) {
+                String normalized = comment.getData().replace("--", "- -");
+                if (normalized.endsWith("-")) {
+                    normalized += " ";
+                }
+                comment.setData(normalized);
+            }
+            normalizeHtmlCommentsForXml(child);
+        }
     }
 
     /**
@@ -551,6 +570,9 @@ public final class ConvertToEdoc {
         Map<List<String>, Element> pathTranslationMap = new HashMap<>();
         translateLinkPaths(document, pathTranslationMap);
         translateImagePaths(document, pathTranslationMap);
+        translateBackgroundAttributes(document);
+        translateInlineStylePaths(document);
+        translateEmbeddedStylesheetPaths(document);
 
         for (Map.Entry<List<String>, Element> pathSet : pathTranslationMap.entrySet()) {
             if (!pathSet.getKey().isEmpty()) {
@@ -592,6 +614,88 @@ public final class ConvertToEdoc {
         translatePaths(imageNodeList, ElementAttribute.src, pathTranslationMap);
     }
 
+    private static void translateBackgroundAttributes(Document document) {
+        for (Element element : document.select("[background]")) {
+            String translatedPath = translateSingleResourcePath(element.attr("background"));
+            if (translatedPath != null) {
+                element.attr("background", translatedPath);
+            }
+        }
+    }
+
+    private static void translateInlineStylePaths(Document document) {
+        for (Element element : document.select("[style]")) {
+            element.attr("style", rewriteCssResourceUrls(element.attr("style")));
+        }
+    }
+
+    private static void translateEmbeddedStylesheetPaths(Document document) {
+        for (Element styleElement : document.getElementsByTag("style")) {
+            styleElement.text(rewriteCssResourceUrls(styleElement.data()));
+        }
+    }
+
+    private static String rewriteCssResourceUrls(String cssText) {
+        if (StringUtils.isBlank(cssText)) {
+            return cssText;
+        }
+
+        Matcher matcher = CSS_URL_PATTERN.matcher(cssText);
+        StringBuffer rewrittenCss = new StringBuffer();
+        while (matcher.find()) {
+            String translatedPath = translateSingleResourcePath(matcher.group(2).trim());
+            String replacement = translatedPath == null
+                    ? matcher.group(0)
+                    : Matcher.quoteReplacement("url('" + translatedPath + "')");
+            matcher.appendReplacement(rewrittenCss, replacement);
+        }
+        matcher.appendTail(rewrittenCss);
+        return rewrittenCss.toString();
+    }
+
+    private static String translateSingleResourcePath(String path) {
+        return validateLink(collectPotentialFilePaths(path));
+    }
+
+    private static List<String> collectPotentialFilePaths(String path) {
+        String parameters = null;
+        String[] parameterList = null;
+        List<String> potentialFilePaths = new ArrayList<>();
+
+        if (StringUtils.isBlank(path)) {
+            return potentialFilePaths;
+        }
+
+        if (path.startsWith("http") || path.startsWith("HTTP")) {
+            return potentialFilePaths;
+        }
+
+        if (path.contains("?")) {
+            parameters = path.split("\\?", 2)[1];
+        } else {
+            String realPath = getRealPath(path);
+            if (!realPath.isEmpty()) {
+                potentialFilePaths.add(realPath);
+            }
+        }
+
+        if (parameters != null && parameters.contains("&")) {
+            parameterList = parameters.split("&");
+        }
+
+        if (parameterList != null) {
+            for (String parameter : parameterList) {
+                if (parameter.contains("=")) {
+                    potentialFilePaths.add(buildImageDirectoryPath(parameter.split("=", 2)[1]));
+                }
+            }
+        } else if (parameters != null && parameters.contains("=")) {
+            potentialFilePaths.add(buildImageDirectoryPath(parameters.split("=", 2)[1]));
+        }
+
+        return potentialFilePaths;
+    }
+
     /**
      * Translate any given Link or Image element resource path from
      * a Struts HTTP request parameter or HTTP relative context path.
@@ -611,9 +715,6 @@ public final class ConvertToEdoc {
             }
 
             String path = element.attributes().get(pathAttribute.name());
-            String parameters = null;
-            String[] parameterList = null;
-            List<String> potentialFilePaths = new ArrayList<>();
 
             /*
              * NO EXTERNAL LINKS. These are removed.
@@ -623,39 +724,10 @@ public final class ConvertToEdoc {
              */
             if (path.startsWith("http") || path.startsWith("HTTP")) {
                 element.remove();
+                continue;
             }
 
-            // internal GET links are validated.
-            else if (path.contains("?")) {
-                // image or link paths with parameters
-                parameters = path.split("\\?")[1];
-            } else if (!path.isEmpty()) {
-                // these are most likely relative context paths
-                path = getRealPath(path);
-                if (!path.isEmpty()) {
-                    potentialFilePaths.add(path);
-                }
-            }
-
-            /* parse the parameters and test if any are links to the eForm
-             * images library. Otherwise, these resources are no good.
-             */
-            if (parameters != null && parameters.contains("&")) {
-                parameterList = parameters.split("&");
-            }
-
-            if (parameterList != null) {
-                for (String parameter : parameterList) {
-                    if (parameter.contains("=")) {
-                        // these are file names that need a path.
-                        path = buildImageDirectoryPath(parameter.split("=")[1]);
-                        potentialFilePaths.add(path);
-                    }
-                }
-            } else if (parameters != null && parameters.contains("=")) {
-                path = buildImageDirectoryPath(parameters.split("=")[1]);
-                potentialFilePaths.add(path);
-            }
+            List<String> potentialFilePaths = collectPotentialFilePaths(path);
 
             if (!potentialFilePaths.isEmpty()) {
                 pathTranslationMap.put(potentialFilePaths, element);
@@ -839,7 +911,7 @@ public final class ConvertToEdoc {
      * Clean up any artifacts or poorly formed XHTML
      * and fetch the HTML template resources.
      */
-    private static String tidyDocument(final String documentString) {
+    static String tidyDocument(final String documentString) {
         Document document = getDocument(documentString);
 
         /*
@@ -856,6 +928,11 @@ public final class ConvertToEdoc {
          * for some strange reason.
          */
         return documentToString(document);
+    }
+
+    static String tidyDocument(final String documentString, String realPath) {
+        ConvertToEdoc.realPath = realPath;
+        return tidyDocument(documentString);
     }
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/ConvertToEdoc.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/ConvertToEdoc.java
@@ -56,6 +56,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
@@ -626,7 +627,7 @@ public final class ConvertToEdoc {
             String translatedPath = translateSingleResourcePath(originalPath);
             if (translatedPath != null) {
                 element.attr(BACKGROUND_ATTRIBUTE, translatedPath);
-            } else {
+            } else if (!isEmbeddedDataResourcePath(originalPath)) {
                 element.removeAttr(BACKGROUND_ATTRIBUTE);
             }
         }
@@ -657,6 +658,8 @@ public final class ConvertToEdoc {
             String replacement;
             if (translatedPath != null) {
                 replacement = Matcher.quoteReplacement("url('" + translatedPath + "')");
+            } else if (isEmbeddedDataResourcePath(originalPath)) {
+                replacement = Matcher.quoteReplacement(matcher.group(0));
             } else {
                 replacement = "url('')";
             }
@@ -667,6 +670,9 @@ public final class ConvertToEdoc {
     }
 
     private static String translateSingleResourcePath(String path) {
+        if (isEmbeddedDataResourcePath(path)) {
+            return path;
+        }
         return validateLink(collectPotentialFilePaths(path));
     }
 
@@ -734,7 +740,7 @@ public final class ConvertToEdoc {
                 String path = element.attributes().get(pathAttribute.name());
                 if (isExternalResourcePath(path)) {
                     element.remove();
-                } else {
+                } else if (!isEmbeddedDataResourcePath(path)) {
                     List<String> potentialFilePaths = collectPotentialFilePaths(path);
                     if (!potentialFilePaths.isEmpty()) {
                         pathTranslationMap.put(potentialFilePaths, element);
@@ -755,13 +761,30 @@ public final class ConvertToEdoc {
                 || normalized.startsWith("file:");
     }
 
+    private static boolean isEmbeddedDataResourcePath(String path) {
+        return StringUtils.trimToEmpty(path).toLowerCase(Locale.ROOT).startsWith("data:");
+    }
+
     private static boolean isDisallowedResourcePath(String path) {
         if (isExternalResourcePath(path)) {
             return true;
         }
 
+        if (isEmbeddedDataResourcePath(path)) {
+            return false;
+        }
+
         String normalized = StringUtils.trimToEmpty(path);
-        return !normalized.isEmpty() && Path.of(normalized).isAbsolute();
+        if (normalized.isEmpty()) {
+            return false;
+        }
+
+        try {
+            return Path.of(normalized).isAbsolute();
+        } catch (InvalidPathException e) {
+            logger.debug("Skipping malformed resource path", e);
+            return true;
+        }
     }
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/ConvertToEdoc.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/ConvertToEdoc.java
@@ -452,12 +452,7 @@ public final class ConvertToEdoc {
 
         for (Node child : root.childNodes()) {
             if (child instanceof Comment comment) {
-                String commentData = comment.getData();
-                if (commentData == null) {
-                    continue;
-                }
-
-                String normalized = commentData.replace("--", "- -");
+                String normalized = comment.getData().replace("--", "- -");
                 if (normalized.endsWith("-")) {
                     normalized += " ";
                 }
@@ -640,7 +635,7 @@ public final class ConvertToEdoc {
     }
 
     private static void translateEmbeddedStylesheetPaths(Document document) {
-        for (Element styleElement : document.getElementsByTag("style")) {
+        for (Element styleElement : document.getElementsByTag(STYLE_ATTRIBUTE)) {
             styleElement.text(rewriteCssResourceUrls(styleElement.data()));
         }
     }

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/ConvertToEdoc.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/ConvertToEdoc.java
@@ -108,6 +108,7 @@ public final class ConvertToEdoc {
     private static final String DEFAULT_WKHTMLTOPDF_COMMAND = "/usr/bin/wkhtmltopdf";
     private static final String DEFAULT_WKHTMLTOPDF_ARGS = "--enable-local-file-access --minimum-font-size 10 --print-media-type --encoding utf-8 -T 10mm -L 8mm -R 8mm --disable-javascript";
     private static final String STYLE_ATTRIBUTE = "style";
+    private static final String BACKGROUND_ATTRIBUTE = "background";
     private static final Pattern CSS_URL_PATTERN = Pattern.compile("url\\((['\"]?)([^\"')]+)\\1\\)", Pattern.CASE_INSENSITIVE);
     
     private static String realPath;
@@ -620,13 +621,13 @@ public final class ConvertToEdoc {
     }
 
     private static void translateBackgroundAttributes(Document document) {
-        for (Element element : document.select("[background]")) {
-            String originalPath = element.attr("background");
+        for (Element element : document.select("[" + BACKGROUND_ATTRIBUTE + "]")) {
+            String originalPath = element.attr(BACKGROUND_ATTRIBUTE);
             String translatedPath = translateSingleResourcePath(originalPath);
             if (translatedPath != null) {
-                element.attr("background", translatedPath);
+                element.attr(BACKGROUND_ATTRIBUTE, translatedPath);
             } else {
-                element.removeAttr("background");
+                element.removeAttr(BACKGROUND_ATTRIBUTE);
             }
         }
     }

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/ConvertToEdoc.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/ConvertToEdoc.java
@@ -107,7 +107,8 @@ public final class ConvertToEdoc {
     private static final String SYSTEM_ID = "-1";
     private static final String DEFAULT_WKHTMLTOPDF_COMMAND = "/usr/bin/wkhtmltopdf";
     private static final String DEFAULT_WKHTMLTOPDF_ARGS = "--enable-local-file-access --minimum-font-size 10 --print-media-type --encoding utf-8 -T 10mm -L 8mm -R 8mm --disable-javascript";
-    private static final Pattern CSS_URL_PATTERN = Pattern.compile("url\\((['\"]?)([^\\\"\")]+)\\1\\)", Pattern.CASE_INSENSITIVE);
+    private static final String STYLE_ATTRIBUTE = "style";
+    private static final Pattern CSS_URL_PATTERN = Pattern.compile("url\\((['\"]?)([^\"')]+)\\1\\)", Pattern.CASE_INSENSITIVE);
     
     private static String realPath;
     private static final NioFileManager nioFileManager = SpringUtils.getBean(NioFileManager.class);
@@ -445,9 +446,18 @@ public final class ConvertToEdoc {
     }
 
     private static void normalizeHtmlCommentsForXml(Node root) {
+        if (root == null) {
+            return;
+        }
+
         for (Node child : root.childNodes()) {
             if (child instanceof Comment comment) {
-                String normalized = comment.getData().replace("--", "- -");
+                String commentData = comment.getData();
+                if (commentData == null) {
+                    continue;
+                }
+
+                String normalized = commentData.replace("--", "- -");
                 if (normalized.endsWith("-")) {
                     normalized += " ";
                 }
@@ -624,8 +634,8 @@ public final class ConvertToEdoc {
     }
 
     private static void translateInlineStylePaths(Document document) {
-        for (Element element : document.select("[style]")) {
-            element.attr("style", rewriteCssResourceUrls(element.attr("style")));
+        for (Element element : document.select("[" + STYLE_ATTRIBUTE + "]")) {
+            element.attr(STYLE_ATTRIBUTE, rewriteCssResourceUrls(element.attr(STYLE_ATTRIBUTE)));
         }
     }
 
@@ -641,7 +651,7 @@ public final class ConvertToEdoc {
         }
 
         Matcher matcher = CSS_URL_PATTERN.matcher(cssText);
-        StringBuffer rewrittenCss = new StringBuffer();
+        StringBuilder rewrittenCss = new StringBuilder();
         while (matcher.find()) {
             String translatedPath = translateSingleResourcePath(matcher.group(2).trim());
             String replacement = translatedPath == null
@@ -658,42 +668,50 @@ public final class ConvertToEdoc {
     }
 
     private static List<String> collectPotentialFilePaths(String path) {
-        String parameters = null;
-        String[] parameterList = null;
         List<String> potentialFilePaths = new ArrayList<>();
 
-        if (StringUtils.isBlank(path)) {
-            return potentialFilePaths;
-        }
-
-        if (path.startsWith("http") || path.startsWith("HTTP")) {
+        if (!isTranslatableResourcePath(path)) {
             return potentialFilePaths;
         }
 
         if (path.contains("?")) {
-            parameters = path.split("\\?", 2)[1];
+            collectImageDirectoryCandidates(path, potentialFilePaths);
         } else {
-            String realPath = getRealPath(path);
-            if (!realPath.isEmpty()) {
-                potentialFilePaths.add(realPath);
-            }
-        }
-
-        if (parameters != null && parameters.contains("&")) {
-            parameterList = parameters.split("&");
-        }
-
-        if (parameterList != null) {
-            for (String parameter : parameterList) {
-                if (parameter.contains("=")) {
-                    potentialFilePaths.add(buildImageDirectoryPath(parameter.split("=", 2)[1]));
-                }
-            }
-        } else if (parameters != null && parameters.contains("=")) {
-            potentialFilePaths.add(buildImageDirectoryPath(parameters.split("=", 2)[1]));
+            collectRealPathCandidates(path, potentialFilePaths);
         }
 
         return potentialFilePaths;
+    }
+
+    private static boolean isTranslatableResourcePath(String path) {
+        return StringUtils.isNotBlank(path)
+                && !path.startsWith("http")
+                && !path.startsWith("HTTP");
+    }
+
+    private static void collectRealPathCandidates(String path, List<String> potentialFilePaths) {
+        String resolvedPath = getRealPath(path);
+        if (!resolvedPath.isEmpty()) {
+            potentialFilePaths.add(resolvedPath);
+        }
+    }
+
+    private static void collectImageDirectoryCandidates(String path, List<String> potentialFilePaths) {
+        String parameters = path.split("\\?", 2)[1];
+        for (String parameter : parameters.split("&")) {
+            String candidate = buildImageDirectoryCandidate(parameter);
+            if (!candidate.isEmpty()) {
+                potentialFilePaths.add(candidate);
+            }
+        }
+    }
+
+    private static String buildImageDirectoryCandidate(String parameter) {
+        if (!parameter.contains("=")) {
+            return "";
+        }
+
+        return buildImageDirectoryPath(parameter.split("=", 2)[1]);
     }
 
     /**
@@ -709,30 +727,22 @@ public final class ConvertToEdoc {
      */
     private static void translatePaths(Elements nodeList, ElementAttribute pathAttribute, Map<List<String>, Element> pathTranslationMap) {
         for (Element element : nodeList) {
-            // go no further if there is no link attribute.
-            if (!element.hasAttr(pathAttribute.name())) {
-                continue;
-            }
-
-            String path = element.attributes().get(pathAttribute.name());
-
-            /*
-             * NO EXTERNAL LINKS. These are removed.
-             * eForms are often imported from unknown sources.
-             * Developers tend to use insecure CDN's, links to images, tracking tokens,
-             * and advertisements.
-             */
-            if (path.startsWith("http") || path.startsWith("HTTP")) {
-                element.remove();
-                continue;
-            }
-
-            List<String> potentialFilePaths = collectPotentialFilePaths(path);
-
-            if (!potentialFilePaths.isEmpty()) {
-                pathTranslationMap.put(potentialFilePaths, element);
+            if (element.hasAttr(pathAttribute.name())) {
+                String path = element.attributes().get(pathAttribute.name());
+                if (isExternalResourcePath(path)) {
+                    element.remove();
+                } else {
+                    List<String> potentialFilePaths = collectPotentialFilePaths(path);
+                    if (!potentialFilePaths.isEmpty()) {
+                        pathTranslationMap.put(potentialFilePaths, element);
+                    }
+                }
             }
         }
+    }
+
+    private static boolean isExternalResourcePath(String path) {
+        return path.startsWith("http") || path.startsWith("HTTP");
     }
 
     /**
@@ -759,33 +769,33 @@ public final class ConvertToEdoc {
     // FindSecBugs PATH_TRAVERSAL_IN: path validated for directory containment via PathValidationUtils before use
     @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "path validated for directory containment via PathValidationUtils before use")
     private static String getRealPath(String uri) {
-        String contextRealPath = "";
-
-        // Try to resolve relative paths
-        if (ConvertToEdoc.realPath != null) {
-            try {
-				Path basePath = PathValidationUtils.resolveConfiguredDirectory(ConvertToEdoc.realPath, "real path").toPath();
-				String fileNameToFind = PathValidationUtils.validatePathComponent(Paths.get(uri).getFileName().toString(), "resource file name");
-
-				try (Stream<Path> paths = Files.walk(basePath)) {
-					Path found = paths
-						.filter(Files::isRegularFile)
-						.filter(path -> path.getFileName().toString().equals(fileNameToFind))
-						.findFirst()
-						.orElse(null);
-
-					if (found != null) { 
-						contextRealPath = found.toAbsolutePath().toString(); 
-					} else {
-						contextRealPath = uri;
-					}
-				}
-			} catch (Exception e) {
-				logger.error("Error while searching file in directory: " + ConvertToEdoc.realPath, e);
-			}
+        if (ConvertToEdoc.realPath == null) {
+            return "";
         }
 
-        return contextRealPath;
+        try {
+            File realPathDirectory = PathValidationUtils.resolveConfiguredDirectory(ConvertToEdoc.realPath, "real path");
+            Path basePath = realPathDirectory.toPath();
+            String fileNameToFind = PathValidationUtils.validatePathComponent(Paths.get(uri).getFileName().toString(), "resource file name");
+
+            try (Stream<Path> paths = Files.walk(basePath)) {
+                Path found = paths
+                        .filter(Files::isRegularFile)
+                        .filter(path -> path.getFileName().toString().equals(fileNameToFind))
+                        .findFirst()
+                        .orElse(null);
+
+                if (found == null) {
+                    return "";
+                }
+
+                File validatedFile = PathValidationUtils.validateExistingPath(found.toFile(), realPathDirectory);
+                return validatedFile.getAbsolutePath();
+            }
+        } catch (Exception e) {
+            logger.error("Error while searching file in directory: " + ConvertToEdoc.realPath, e);
+            return "";
+        }
     }
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/ConvertToEdoc.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/ConvertToEdoc.java
@@ -621,9 +621,12 @@ public final class ConvertToEdoc {
 
     private static void translateBackgroundAttributes(Document document) {
         for (Element element : document.select("[background]")) {
-            String translatedPath = translateSingleResourcePath(element.attr("background"));
+            String originalPath = element.attr("background");
+            String translatedPath = translateSingleResourcePath(originalPath);
             if (translatedPath != null) {
                 element.attr("background", translatedPath);
+            } else if (isDisallowedResourcePath(originalPath)) {
+                element.removeAttr("background");
             }
         }
     }
@@ -648,10 +651,16 @@ public final class ConvertToEdoc {
         Matcher matcher = CSS_URL_PATTERN.matcher(cssText);
         StringBuilder rewrittenCss = new StringBuilder();
         while (matcher.find()) {
-            String translatedPath = translateSingleResourcePath(matcher.group(2).trim());
-            String replacement = translatedPath == null
-                    ? matcher.group(0)
-                    : Matcher.quoteReplacement("url('" + translatedPath + "')");
+            String originalPath = matcher.group(2).trim();
+            String translatedPath = translateSingleResourcePath(originalPath);
+            String replacement;
+            if (translatedPath != null) {
+                replacement = Matcher.quoteReplacement("url('" + translatedPath + "')");
+            } else if (isDisallowedResourcePath(originalPath)) {
+                replacement = "url('')";
+            } else {
+                replacement = matcher.group(0);
+            }
             matcher.appendReplacement(rewrittenCss, replacement);
         }
         matcher.appendTail(rewrittenCss);
@@ -670,6 +679,8 @@ public final class ConvertToEdoc {
         }
 
         if (path.contains("?")) {
+            String basePath = path.split("\\?", 2)[0];
+            collectRealPathCandidates(basePath, potentialFilePaths);
             collectImageDirectoryCandidates(path, potentialFilePaths);
         } else {
             collectRealPathCandidates(path, potentialFilePaths);
@@ -679,9 +690,7 @@ public final class ConvertToEdoc {
     }
 
     private static boolean isTranslatableResourcePath(String path) {
-        return StringUtils.isNotBlank(path)
-                && !path.startsWith("http")
-                && !path.startsWith("HTTP");
+        return StringUtils.isNotBlank(path) && !isDisallowedResourcePath(path);
     }
 
     private static void collectRealPathCandidates(String path, List<String> potentialFilePaths) {
@@ -737,7 +746,21 @@ public final class ConvertToEdoc {
     }
 
     private static boolean isExternalResourcePath(String path) {
-        return path.startsWith("http") || path.startsWith("HTTP");
+        String normalized = StringUtils.trimToEmpty(path).toLowerCase(Locale.ROOT);
+        return normalized.startsWith("http://")
+                || normalized.startsWith("https://")
+                || normalized.startsWith("//")
+                || normalized.startsWith("ftp://")
+                || normalized.startsWith("file:");
+    }
+
+    private static boolean isDisallowedResourcePath(String path) {
+        if (isExternalResourcePath(path)) {
+            return true;
+        }
+
+        String normalized = StringUtils.trimToEmpty(path);
+        return !normalized.isEmpty() && Path.of(normalized).isAbsolute();
     }
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentPreview2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentPreview2Action.java
@@ -136,7 +136,7 @@ public class DocumentPreview2Action extends ActionSupport {
                 requirePrivilege(loggedInInfo, "_con", SecurityInfoManager.WRITE);
                 return fetchConsultDocuments();
             default:
-                logger.warn("Unsupported previewDocs method requested: {}", LogSafe.sanitize(method));
+                logger.warn("Unsupported previewDocs method requested.");
                 response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
                 return NONE;
         }

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentPreview2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentPreview2Action.java
@@ -63,6 +63,11 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  */
 public class DocumentPreview2Action extends ActionSupport {
     private static final String FETCH_CONSULT_DOCUMENTS = "fetchConsultDocuments";
+    private static final String EDOC_PDF_RENDER_FAILURE_MESSAGE = "Failed to render document PDF.";
+    private static final String EFORM_PDF_RENDER_FAILURE_MESSAGE = "Failed to render eForm PDF.";
+    private static final String HRM_PDF_RENDER_FAILURE_MESSAGE = "Failed to render HRM PDF.";
+    private static final String LAB_PDF_RENDER_FAILURE_MESSAGE = "Failed to render lab PDF.";
+    private static final String FORM_PDF_RENDER_FAILURE_MESSAGE = "Failed to render form PDF.";
 
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
 
@@ -168,7 +173,7 @@ public class DocumentPreview2Action extends ActionSupport {
             generateResponse(response, docPDFPath);
         } catch (PDFGenerationException e) {
             logger.error("Error occurred while rendering eDoc. " + e.getMessage(), e);
-            generateResponse(response, e.getMessage());
+            generateResponse(response, EDOC_PDF_RENDER_FAILURE_MESSAGE);
         }
     }
 
@@ -197,7 +202,7 @@ public class DocumentPreview2Action extends ActionSupport {
             generateResponse(response, eFormPDFPath);
         } catch (PDFGenerationException e) {
             logger.error("Error occurred while rendering eForm. " + e.getMessage(), e);
-            generateResponse(response, "Failed to render eForm PDF.");
+            generateResponse(response, EFORM_PDF_RENDER_FAILURE_MESSAGE);
         }
     }
 
@@ -226,7 +231,7 @@ public class DocumentPreview2Action extends ActionSupport {
             generateResponse(response, hrmPDFPath);
         } catch (PDFGenerationException e) {
             logger.error("Error occurred while rendering HRM. " + e.getMessage(), e);
-            generateResponse(response, e.getMessage());
+            generateResponse(response, HRM_PDF_RENDER_FAILURE_MESSAGE);
         }
     }
 
@@ -254,7 +259,7 @@ public class DocumentPreview2Action extends ActionSupport {
             generateResponse(response, labPDFPath);
         } catch (PDFGenerationException e) {
             logger.error("Error occurred while rendering Lab. " + e.getMessage(), e);
-            generateResponse(response, e.getMessage());
+            generateResponse(response, LAB_PDF_RENDER_FAILURE_MESSAGE);
         }
     }
 
@@ -276,7 +281,7 @@ public class DocumentPreview2Action extends ActionSupport {
             generateResponse(response, formPDFPath);
         } catch (PDFGenerationException e) {
             logger.error("Error occurred while rendering Form. " + e.getMessage(), e);
-            generateResponse(response, e.getMessage());
+            generateResponse(response, FORM_PDF_RENDER_FAILURE_MESSAGE);
         }
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentPreview2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentPreview2Action.java
@@ -197,7 +197,7 @@ public class DocumentPreview2Action extends ActionSupport {
             generateResponse(response, eFormPDFPath);
         } catch (PDFGenerationException e) {
             logger.error("Error occurred while rendering eForm. " + e.getMessage(), e);
-            generateResponse(response, e.getMessage());
+            generateResponse(response, "Failed to render eForm PDF.");
         }
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/eform/actions/AddEForm2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/eform/actions/AddEForm2Action.java
@@ -79,6 +79,7 @@ public class AddEForm2Action extends ActionSupport {
 
     private static final Logger logger = MiscUtils.getLogger();
     private static final String INVALID_FILENAME_MESSAGE_KEY = "dms.error.invalidFilename";
+    private static final String ERROR_ATTRIBUTE = "error";
     private static final String PDF_DOWNLOAD_FAILURE_MESSAGE = "This eForm (and attachments, if applicable) could not be downloaded.";
     private static final String PDF_PREVIEW_WARNING_MESSAGE = "This eForm was saved, but its PDF preview could not be generated.";
 
@@ -210,7 +211,7 @@ public class AddEForm2Action extends ActionSupport {
         try {
             validatedTemplateFileName = validateTemplateFileName(curForm.getFormFileName());
         } catch (FileValidationException e) {
-            request.setAttribute("error", "true");
+            request.setAttribute(ERROR_ATTRIBUTE, "true");
             request.setAttribute("errorMessage", getInvalidFilenameMessage());
             logger.warn("Rejected invalid eForm template filename");
             return ERROR;
@@ -520,7 +521,7 @@ public class AddEForm2Action extends ActionSupport {
 
     private void setPdfError(String message, Exception e) {
         logger.error(message, e);
-        request.setAttribute("error", "true");
+        request.setAttribute(ERROR_ATTRIBUTE, "true");
         request.setAttribute("errorMessage", message);
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/eform/actions/AddEForm2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/eform/actions/AddEForm2Action.java
@@ -126,6 +126,12 @@ public class AddEForm2Action extends ActionSupport {
     @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
     public String execute() {
 
+        String method = request.getMethod();
+        if ("GET".equalsIgnoreCase(method) || "HEAD".equalsIgnoreCase(method)) {
+            response.setStatus(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+            return NONE;
+        }
+
         if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_eform", "w", null)) {
             throw new SecurityException("missing required sec object (_eform)");
         }
@@ -204,6 +210,7 @@ public class AddEForm2Action extends ActionSupport {
         try {
             validatedTemplateFileName = validateTemplateFileName(curForm.getFormFileName());
         } catch (FileValidationException e) {
+            request.setAttribute("error", "true");
             request.setAttribute("errorMessage", getInvalidFilenameMessage());
             logger.warn("Rejected invalid eForm template filename");
             return ERROR;
@@ -289,13 +296,10 @@ public class AddEForm2Action extends ActionSupport {
             request.setAttribute("fdid", fdid);
             request.setAttribute("demographicId", demographic_no);
 
-            if (saveAsEdoc) {
-                try {
+            if (saveAsEdoc) {                try {
                     documentAttachmentManager.saveEFormAsEDoc(request, response);
                 } catch (PDFGenerationException e) {
-                    logger.error(e.getMessage(), e);
-                    String errorMessage = "This eForm (and attachments, if applicable) could not be added to this patient’s documents. \\n\\n" + e.getMessage();
-                    request.setAttribute("errorMessage", errorMessage);
+                    setPdfError("This eForm (and attachments, if applicable) could not be added to this patient’s documents.", e);
                     return "error";
                 }
             }
@@ -406,13 +410,10 @@ public class AddEForm2Action extends ActionSupport {
                 return NONE;
             }
 
-            if (saveAsEdoc) {
-                try {
+            if (saveAsEdoc) {                try {
                     documentAttachmentManager.saveEFormAsEDoc(request, response);
                 } catch (PDFGenerationException e) {
-                    logger.error(e.getMessage(), e);
-                    String errorMessage = "This eForm (and attachments, if applicable) could not be added to this patient’s documents. \\n\\n" + e.getMessage();
-                    request.setAttribute("errorMessage", errorMessage);
+                    setPdfError("This eForm (and attachments, if applicable) could not be added to this patient’s documents.", e);
                     return "error";
                 }
             }
@@ -524,7 +525,7 @@ public class AddEForm2Action extends ActionSupport {
     }
 
     private void setPdfWarning(String message, Exception e) {
-        logger.error(message, e);
+        logger.warn(message, e);
         request.setAttribute("warningMessage", message);
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/eform/actions/AddEForm2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/eform/actions/AddEForm2Action.java
@@ -79,6 +79,8 @@ public class AddEForm2Action extends ActionSupport {
 
     private static final Logger logger = MiscUtils.getLogger();
     private static final String INVALID_FILENAME_MESSAGE_KEY = "dms.error.invalidFilename";
+    private static final String PDF_DOWNLOAD_FAILURE_MESSAGE = "This eForm (and attachments, if applicable) could not be downloaded.";
+    private static final String PDF_PREVIEW_WARNING_MESSAGE = "This eForm was saved, but its PDF preview could not be generated.";
 
     /**
      * Validates the eform_link parameter format to prevent session attribute injection (CWE-501).
@@ -313,9 +315,7 @@ public class AddEForm2Action extends ActionSupport {
                     Path eFormPdfPath = documentAttachmentManager.renderEFormWithAttachments(request, response);
                     pdfBase64 = documentAttachmentManager.convertPDFToBase64(eFormPdfPath);
                 } catch (PDFGenerationException e) {
-                    logger.error(e.getMessage(), e);
-                    String errorMessage = "This eForm (and attachments, if applicable) could not be downloaded. \\n\\n" + e.getMessage();
-                    request.setAttribute("errorMessage", errorMessage);
+                    setPdfError(PDF_DOWNLOAD_FAILURE_MESSAGE, e);
                     return "error";
                 }
 
@@ -378,9 +378,7 @@ public class AddEForm2Action extends ActionSupport {
                     Path eFormPdfPath = documentAttachmentManager.renderEFormWithAttachments(request, response);
                     pdfBase64 = documentAttachmentManager.convertPDFToBase64(eFormPdfPath);
                 } catch (PDFGenerationException e) {
-                    logger.error(e.getMessage(), e);
-                    String errorMessage = "This eForm (and attachments, if applicable) could not be downloaded. \\n\\n" + e.getMessage();
-                    request.setAttribute("errorMessage", errorMessage);
+                    setPdfError(PDF_DOWNLOAD_FAILURE_MESSAGE, e);
                     return "error";
                 }
 
@@ -432,26 +430,7 @@ public class AddEForm2Action extends ActionSupport {
 		}
 
         String fdid = (String) request.getAttribute("fdid");
-
-		String pdfBase64;
-		try {
-			Path eFormPdfPath = documentAttachmentManager.renderEFormWithAttachments(request, response);
-			pdfBase64 = documentAttachmentManager.convertPDFToBase64(eFormPdfPath);
-		} catch (PDFGenerationException e) {
-			logger.error(e.getMessage(), e);
-			String errorMessage = "This eForm (and attachments, if applicable) could not be downloaded. \\n\\n" + e.getMessage();
-			request.setAttribute("errorMessage", errorMessage);
-			return "error";
-		}
-
-		request.setAttribute("eFormPDF", pdfBase64);
-		request.setAttribute("eFormPDFName", generateFileName(loggedInInfo, Integer.parseInt(demographic_no)));
-		request.setAttribute("isSuccess_Autoclose", "true");
-
-        request.setAttribute("fdid", fdid);
-        request.setAttribute("parentAjaxId", "eforms");
-
-        return "close";
+        return closeWithPdfPreview(loggedInInfo, demographic_no, fdid);
 	}
 	
     // FindSecBugs UNVALIDATED_REDIRECT: redirect target is a same-origin fax action path built from the current context path with encoded query parameters.
@@ -499,6 +478,34 @@ public class AddEForm2Action extends ActionSupport {
         String formattedDate = dateFormat.format(currentDate);
 
         return formattedDate + "_" + demographicLastName + ".pdf";
+    }
+
+    String closeWithPdfPreview(LoggedInInfo loggedInInfo, String demographicNo, String fdid) {
+        String pdfBase64;
+        try {
+            Path eFormPdfPath = documentAttachmentManager.renderEFormWithAttachments(request, response);
+            pdfBase64 = documentAttachmentManager.convertPDFToBase64(eFormPdfPath);
+        } catch (PDFGenerationException e) {
+            setPdfWarning(PDF_PREVIEW_WARNING_MESSAGE, e);
+            pdfBase64 = "";
+        }
+
+        request.setAttribute("eFormPDF", pdfBase64);
+        request.setAttribute("eFormPDFName", generateFileName(loggedInInfo, Integer.parseInt(demographicNo)));
+        request.setAttribute("isSuccess_Autoclose", "true");
+        request.setAttribute("fdid", fdid);
+        request.setAttribute("parentAjaxId", "eforms");
+        return "close";
+    }
+
+    private void setPdfError(String message, PDFGenerationException e) {
+        logger.error(e.getMessage(), e);
+        request.setAttribute("errorMessage", message + " \n\n" + e.getMessage());
+    }
+
+    private void setPdfWarning(String message, PDFGenerationException e) {
+        logger.error(e.getMessage(), e);
+        request.setAttribute("warningMessage", message + " \n\n" + e.getMessage());
     }
 
     private String getInvalidFilenameMessage() {

--- a/src/main/java/io/github/carlos_emr/carlos/eform/actions/AddEForm2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/eform/actions/AddEForm2Action.java
@@ -473,6 +473,10 @@ public class AddEForm2Action extends ActionSupport {
 		DemographicManager demographicManager = SpringUtils.getBean(DemographicManager.class);
 		String demographicLastName = demographicManager.getDemographicFormattedName(loggedInInfo, demographicNo).split(", ")[0];
 
+        return buildPdfFileName(demographicLastName);
+    }
+
+    private String buildPdfFileName(String demographicLastName) {
         Date currentDate = new Date();
         SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy_MM_dd");
         String formattedDate = dateFormat.format(currentDate);
@@ -480,32 +484,47 @@ public class AddEForm2Action extends ActionSupport {
         return formattedDate + "_" + demographicLastName + ".pdf";
     }
 
+    private String getFallbackPdfFileName() {
+        return buildPdfFileName("eform");
+    }
+
+    private String generatePreviewFileName(LoggedInInfo loggedInInfo, String demographicNo) {
+        try {
+            return generateFileName(loggedInInfo, Integer.parseInt(demographicNo));
+        } catch (RuntimeException e) {
+            logger.warn("Falling back to generic PDF filename for demographic {}", LogSafe.sanitize(demographicNo), e);
+            return getFallbackPdfFileName();
+        }
+    }
+
     String closeWithPdfPreview(LoggedInInfo loggedInInfo, String demographicNo, String fdid) {
-        String pdfBase64;
+        String pdfBase64 = "";
         try {
             Path eFormPdfPath = documentAttachmentManager.renderEFormWithAttachments(request, response);
+            if (eFormPdfPath == null) {
+                throw new PDFGenerationException("eForm PDF preview path was not generated");
+            }
             pdfBase64 = documentAttachmentManager.convertPDFToBase64(eFormPdfPath);
-        } catch (PDFGenerationException e) {
+        } catch (Exception e) {
             setPdfWarning(PDF_PREVIEW_WARNING_MESSAGE, e);
-            pdfBase64 = "";
         }
 
         request.setAttribute("eFormPDF", pdfBase64);
-        request.setAttribute("eFormPDFName", generateFileName(loggedInInfo, Integer.parseInt(demographicNo)));
+        request.setAttribute("eFormPDFName", generatePreviewFileName(loggedInInfo, demographicNo));
         request.setAttribute("isSuccess_Autoclose", "true");
         request.setAttribute("fdid", fdid);
         request.setAttribute("parentAjaxId", "eforms");
         return "close";
     }
 
-    private void setPdfError(String message, PDFGenerationException e) {
-        logger.error(e.getMessage(), e);
-        request.setAttribute("errorMessage", message + " \n\n" + e.getMessage());
+    private void setPdfError(String message, Exception e) {
+        logger.error(message, e);
+        request.setAttribute("errorMessage", message);
     }
 
-    private void setPdfWarning(String message, PDFGenerationException e) {
-        logger.error(e.getMessage(), e);
-        request.setAttribute("warningMessage", message + " \n\n" + e.getMessage());
+    private void setPdfWarning(String message, Exception e) {
+        logger.error(message, e);
+        request.setAttribute("warningMessage", message);
     }
 
     private String getInvalidFilenameMessage() {

--- a/src/main/java/io/github/carlos_emr/carlos/eform/actions/AddEForm2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/eform/actions/AddEForm2Action.java
@@ -519,6 +519,7 @@ public class AddEForm2Action extends ActionSupport {
 
     private void setPdfError(String message, Exception e) {
         logger.error(message, e);
+        request.setAttribute("error", "true");
         request.setAttribute("errorMessage", message);
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/managers/EformDataManagerImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/EformDataManagerImpl.java
@@ -190,13 +190,18 @@ public class EformDataManagerImpl implements EformDataManager {
         try {
             path = ConvertToEdoc.saveAsTempPDF(eformData);
         } catch (Exception e) {
-            throw new PDFGenerationException("Error Details: EForm [" + eformData.getFormName() + "] could not be converted into a PDF", e);
+            throw new PDFGenerationException("EForm PDF generation failed during HTML-to-PDF conversion.", e);
+        }
+
+        if (path == null) {
+            throw new PDFGenerationException("EForm PDF generation failed during HTML-to-PDF conversion.");
         }
 
         if (Files.isReadable(path)) {
             LogAction.addLogSynchronous(loggedInInfo, "EformDataManager.saveEformDataAsPDF", "Document saved at " + path.toString());
         } else {
             LogAction.addLogSynchronous(loggedInInfo, "EformDataManager.saveEformDataAsPDF", "Document failed to save for eform id " + fdid);
+            throw new PDFGenerationException("EForm PDF generation produced an unreadable temporary file.");
         }
 
         return path;

--- a/src/main/webapp/WEB-INF/classes/struts-eform.xml
+++ b/src/main/webapp/WEB-INF/classes/struts-eform.xml
@@ -79,10 +79,10 @@
             <result name="success">/WEB-INF/jsp/eform/partials/import.jsp</result>
         </action>
         <action name="eform/addEForm" class="io.github.carlos_emr.carlos.eform.actions.AddEForm2Action">
-            <result name="close">/eform/efmshowform_data</result>
+            <result name="close">/WEB-INF/jsp/eform/efmshowform_data.jsp</result>
             <result name="fax">/fax/faxAction</result>
-            <result name="download">/eform/efmshowform_data</result>
-            <result name="error">/eform/efmshowform_data?error=true</result>
+            <result name="download">/WEB-INF/jsp/eform/efmshowform_data.jsp</result>
+            <result name="error">/WEB-INF/jsp/eform/efmshowform_data.jsp</result>
             <result name="emailCompose">/email/emailComposeAction</result>
         </action>
         <action name="eform/efmPrintPDF" class="io.github.carlos_emr.carlos.eform.actions.PrintPDF2Action">

--- a/src/main/webapp/WEB-INF/jsp/eform/efmshowform_data.jsp
+++ b/src/main/webapp/WEB-INF/jsp/eform/efmshowform_data.jsp
@@ -111,7 +111,7 @@
         eForm = new EForm(fid, "-1"); //form cannot be submitted, demographic_no "-1" indicate this specialty
         eForm.setContextPath(request.getContextPath());
         eForm.setOscarOPEN(request.getRequestURI());
-        eForm.setImagePath();
+        eForm.setImagePath(request.getContextPath());
         eForm.setFdid("");
     }
 
@@ -141,7 +141,7 @@
     eForm.addHiddenInputElement("fid", eForm.getFid());
 
     // Add EForm error message
-    eForm.addHiddenInputElement("error", request.getParameter("error"));
+    eForm.addHiddenInputElement("error", request.getParameter("error") != null ? request.getParameter("error") : (String) request.getAttribute("error"));
     eForm.addHiddenInputElement("errorMessage", (String) request.getAttribute("errorMessage"));
     eForm.addHiddenInputElement("warningMessage", (String) request.getAttribute("warningMessage"));
 

--- a/src/main/webapp/WEB-INF/jsp/eform/efmshowform_data.jsp
+++ b/src/main/webapp/WEB-INF/jsp/eform/efmshowform_data.jsp
@@ -143,6 +143,7 @@
     // Add EForm error message
     eForm.addHiddenInputElement("error", request.getParameter("error"));
     eForm.addHiddenInputElement("errorMessage", (String) request.getAttribute("errorMessage"));
+    eForm.addHiddenInputElement("warningMessage", (String) request.getAttribute("warningMessage"));
 
     // Add EForm properties for handling download operation
     eForm.addHiddenInputElement("eFormPDFName", (String) request.getAttribute("eFormPDFName"));

--- a/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
+++ b/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
@@ -40,7 +40,7 @@ document.addEventListener("DOMContentLoaded", function(){
 		document.getElementById("isSuccess_Autoclose").value === 'true';
     const warningMessage = document.getElementById("warningMessage") ? document.getElementById("warningMessage").value : "";
     if (warningMessage) {
-        showWarningAlert(warningMessage.replace(/\\n/g, "\n"), isSuccessAndAutoclose ? remoteClose : undefined);
+        showWarningAlert(warningMessage.replaceAll("\\n", "\n"), isSuccessAndAutoclose ? remoteClose : undefined);
     } else if (isSuccessAndAutoclose) {
 		showSuccessAlert(remoteClose);
 	}

--- a/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
+++ b/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
@@ -38,7 +38,10 @@ document.addEventListener("DOMContentLoaded", function(){
 
 	const isSuccessAndAutoclose = document.getElementById("isSuccess_Autoclose") &&
 		document.getElementById("isSuccess_Autoclose").value === 'true';
-	if (isSuccessAndAutoclose) {
+    const warningMessage = document.getElementById("warningMessage") ? document.getElementById("warningMessage").value : "";
+    if (warningMessage) {
+        showWarningAlert(warningMessage.replace(/\\n/g, "\n"), isSuccessAndAutoclose ? remoteClose : undefined);
+    } else if (isSuccessAndAutoclose) {
 		showSuccessAlert(remoteClose);
 	}
 	});

--- a/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
+++ b/src/main/webapp/eform/eformFloatingToolbar/eform_floating_toolbar.js
@@ -40,7 +40,7 @@ document.addEventListener("DOMContentLoaded", function(){
 		document.getElementById("isSuccess_Autoclose").value === 'true';
     const warningMessage = document.getElementById("warningMessage") ? document.getElementById("warningMessage").value : "";
     if (warningMessage) {
-        showWarningAlert(warningMessage.replaceAll("\\n", "\n"), isSuccessAndAutoclose ? remoteClose : undefined);
+        showWarningAlert(warningMessage.replaceAll(String.raw`\n`, "\n"), isSuccessAndAutoclose ? remoteClose : undefined);
     } else if (isSuccessAndAutoclose) {
 		showSuccessAlert(remoteClose);
 	}

--- a/src/main/webapp/js/oscar-alert.js
+++ b/src/main/webapp/js/oscar-alert.js
@@ -84,6 +84,13 @@ function showSuccessAlert(onDismissEvent) {
     this.createAndShowAlert('submit-success-alert', 'The form has been saved successfully.', 'success', 5, onDismissEvent);
 }
 
+/**
+ * Show a warning alert
+ */
+function showWarningAlert(message, onDismissEvent) {
+    this.createAndShowAlert('submit-warning-alert', message, 'warning', 7, onDismissEvent);
+}
+
 function sleep(ms) {
     return new Promise(resolve => setTimeout(resolve, ms));
 }

--- a/src/test/java/io/github/carlos_emr/carlos/app/contract/MutatorActionGetRejectionContractTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/app/contract/MutatorActionGetRejectionContractTest.java
@@ -167,6 +167,8 @@ class MutatorActionGetRejectionContractTest {
                     "_admin", "w"),
             Arguments.of("io.github.carlos_emr.carlos.form.pageUtil.FrmXmlUpload2Action",
                     "_admin.eform", "w"),
+            Arguments.of("io.github.carlos_emr.carlos.eform.actions.AddEForm2Action",
+                    "_eform", "w"),
             // --- clinical measurements / flowsheets ---
             Arguments.of("io.github.carlos_emr.carlos.encounter.oscarMeasurements.pageUtil.EctMeasurements2Action",
                     "_measurement", "w"),

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/ConvertToEdocUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/ConvertToEdocUnitTest.java
@@ -26,7 +26,7 @@ class ConvertToEdocUnitTest extends CarlosUnitTestBase {
 
     @Test
     @DisplayName("should normalize invalid HTML comments for Flying Saucer")
-    void shouldNormalizeInvalidHtmlCommentsForFlyingSaucer() {
+    void shouldNormalizeInvalidHtmlComments_whenPreparingForFlyingSaucer() {
         Document document = ConvertToEdoc.prepareDocumentForFlyingSaucer("<html><body><!-- bad -- comment--><div>ok</div></body></html>");
 
         assertThat(document.outerHtml()).contains("bad - - comment--");
@@ -35,7 +35,7 @@ class ConvertToEdocUnitTest extends CarlosUnitTestBase {
 
     @Test
     @DisplayName("should translate inline background asset paths during tidy")
-    void shouldTranslateInlineBackgroundAssetPathsDuringTidy() throws Exception {
+    void shouldTranslateInlineBackgroundAssetPaths_whenTidyingDocument() throws Exception {
         Path tempDir = Files.createTempDirectory("convert-edoc");
         Path image = Files.createFile(tempDir.resolve("stamp.png"));
 
@@ -47,7 +47,7 @@ class ConvertToEdocUnitTest extends CarlosUnitTestBase {
     }
     @Test
     @DisplayName("should not translate inline background asset paths outside the allowed real path root")
-    void shouldNotTranslateInlineBackgroundAssetPathsOutsideAllowedRealPathRoot() throws Exception {
+    void shouldNotTranslateInlineBackgroundAssetPaths_whenOutsideAllowedRealPathRoot() throws Exception {
         Path tempDir = Files.createTempDirectory("convert-edoc-root");
         Path externalDir = Files.createTempDirectory("convert-edoc-external");
         Path externalImage = Files.createFile(externalDir.resolve("outside-stamp.png"));
@@ -56,7 +56,20 @@ class ConvertToEdocUnitTest extends CarlosUnitTestBase {
 
         String tidied = ConvertToEdoc.tidyDocument(html, tempDir.toString());
 
-        assertThat(tidied).contains(externalImage.toAbsolutePath().toString());
+        assertThat(tidied).doesNotContain(externalImage.toAbsolutePath().toString());
+    }
+
+    @Test
+    @DisplayName("should translate cache-busted local asset paths during tidy")
+    void shouldTranslateCacheBustedLocalAssetPaths_whenTidyingDocument() throws Exception {
+        Path tempDir = Files.createTempDirectory("convert-edoc-cache");
+        Path image = Files.createFile(tempDir.resolve("stamp.png"));
+
+        String html = "<html><body style=\"background-image:url('stamp.png?v=1')\"><div>x</div></body></html>";
+
+        String tidied = ConvertToEdoc.tidyDocument(html, tempDir.toString());
+
+        assertThat(tidied).contains(image.toAbsolutePath().toString());
     }
 
 }

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/ConvertToEdocUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/ConvertToEdocUnitTest.java
@@ -45,4 +45,18 @@ class ConvertToEdocUnitTest extends CarlosUnitTestBase {
 
         assertThat(tidied).contains(image.toAbsolutePath().toString());
     }
+    @Test
+    @DisplayName("should not translate inline background asset paths outside the allowed real path root")
+    void shouldNotTranslateInlineBackgroundAssetPathsOutsideAllowedRealPathRoot() throws Exception {
+        Path tempDir = Files.createTempDirectory("convert-edoc-root");
+        Path externalDir = Files.createTempDirectory("convert-edoc-external");
+        Path externalImage = Files.createFile(externalDir.resolve("outside-stamp.png"));
+
+        String html = "<html><body style=\"background-image:url('" + externalImage.toAbsolutePath() + "')\"><div>x</div></body></html>";
+
+        String tidied = ConvertToEdoc.tidyDocument(html, tempDir.toString());
+
+        assertThat(tidied).contains(externalImage.toAbsolutePath().toString());
+    }
+
 }

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/ConvertToEdocUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/ConvertToEdocUnitTest.java
@@ -1,0 +1,48 @@
+package io.github.carlos_emr.carlos.documentManager;
+
+import io.github.carlos_emr.carlos.managers.NioFileManager;
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
+import org.jsoup.nodes.Document;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ConvertToEdoc unit tests")
+@Tag("unit")
+@Tag("fast")
+class ConvertToEdocUnitTest extends CarlosUnitTestBase {
+
+    @BeforeEach
+    void setUp() {
+        registerMock(NioFileManager.class, Mockito.mock(NioFileManager.class));
+    }
+
+    @Test
+    @DisplayName("should normalize invalid HTML comments for Flying Saucer")
+    void shouldNormalizeInvalidHtmlCommentsForFlyingSaucer() {
+        Document document = ConvertToEdoc.prepareDocumentForFlyingSaucer("<html><body><!-- bad -- comment--><div>ok</div></body></html>");
+
+        assertThat(document.outerHtml()).contains("bad - - comment--");
+        assertThat(document.outerHtml()).doesNotContain("bad -- comment--");
+    }
+
+    @Test
+    @DisplayName("should translate inline background asset paths during tidy")
+    void shouldTranslateInlineBackgroundAssetPathsDuringTidy() throws Exception {
+        Path tempDir = Files.createTempDirectory("convert-edoc");
+        Path image = Files.createFile(tempDir.resolve("stamp.png"));
+
+        String html = "<html><body style=\"background-image:url('stamp.png')\"><div background=\"stamp.png\">x</div></body></html>";
+
+        String tidied = ConvertToEdoc.tidyDocument(html, tempDir.toString());
+
+        assertThat(tidied).contains(image.toAbsolutePath().toString());
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/ConvertToEdocUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/ConvertToEdocUnitTest.java
@@ -45,6 +45,7 @@ class ConvertToEdocUnitTest extends CarlosUnitTestBase {
 
         assertThat(tidied).contains(image.toAbsolutePath().toString());
     }
+
     @Test
     @DisplayName("should not translate inline background asset paths outside the allowed real path root")
     void shouldNotTranslateInlineBackgroundAssetPaths_whenOutsideAllowedRealPathRoot() throws Exception {
@@ -72,4 +73,29 @@ class ConvertToEdocUnitTest extends CarlosUnitTestBase {
         assertThat(tidied).contains(image.toAbsolutePath().toString());
     }
 
+    @Test
+    @DisplayName("should strip unresolved traversal shaped background asset paths during tidy")
+    void shouldStripUnresolvedTraversalShapedBackgroundAssetPaths_whenTidyingDocument() throws Exception {
+        Path tempDir = Files.createTempDirectory("convert-edoc-traversal");
+        String traversalPath = "../../../../etc/passwd.png";
+
+        String html = "<html><body style=\"background-image:url('" + traversalPath + "')\"><div background=\"" + traversalPath + "\">x</div></body></html>";
+
+        String tidied = ConvertToEdoc.tidyDocument(html, tempDir.toString());
+
+        assertThat(tidied).doesNotContain(traversalPath);
+        assertThat(tidied).contains("background-image:url('')");
+        assertThat(tidied).doesNotContain("background=\"");
+    }
+
+    @Test
+    @DisplayName("should remove unresolved traversal shaped resource elements when parsing document")
+    void shouldRemoveUnresolvedTraversalShapedResourceElements_whenParsingDocument() throws Exception {
+        String html = "<html><head><link rel=\"stylesheet\" href=\"../../../../etc/passwd.css\"></head>"
+                + "<body><img src=\"../../../../etc/passwd.png\"><script src=\"../../../../etc/passwd.js\"></script></body></html>";
+
+        Document document = ConvertToEdoc.getDocument(html, Files.createTempDirectory("convert-edoc-validate").toString());
+
+        assertThat(document.select("link[href], img[src], script[src]")).isEmpty();
+    }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/ConvertToEdocUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/ConvertToEdocUnitTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
 import java.nio.file.Files;
@@ -35,8 +36,7 @@ class ConvertToEdocUnitTest extends CarlosUnitTestBase {
 
     @Test
     @DisplayName("should translate inline background asset paths during tidy")
-    void shouldTranslateInlineBackgroundAssetPaths_whenTidyingDocument() throws Exception {
-        Path tempDir = Files.createTempDirectory("convert-edoc");
+    void shouldTranslateInlineBackgroundAssetPaths_whenTidyingDocument(@TempDir Path tempDir) throws Exception {
         Path image = Files.createFile(tempDir.resolve("stamp.png"));
 
         String html = "<html><body style=\"background-image:url('stamp.png')\"><div background=\"stamp.png\">x</div></body></html>";
@@ -48,9 +48,8 @@ class ConvertToEdocUnitTest extends CarlosUnitTestBase {
 
     @Test
     @DisplayName("should not translate inline background asset paths outside the allowed real path root")
-    void shouldNotTranslateInlineBackgroundAssetPaths_whenOutsideAllowedRealPathRoot() throws Exception {
-        Path tempDir = Files.createTempDirectory("convert-edoc-root");
-        Path externalDir = Files.createTempDirectory("convert-edoc-external");
+    void shouldNotTranslateInlineBackgroundAssetPaths_whenOutsideAllowedRealPathRoot(@TempDir Path tempDir) throws Exception {
+        Path externalDir = Files.createDirectory(tempDir.resolve("external"));
         Path externalImage = Files.createFile(externalDir.resolve("outside-stamp.png"));
 
         String html = "<html><body style=\"background-image:url('" + externalImage.toAbsolutePath() + "')\"><div>x</div></body></html>";
@@ -62,8 +61,7 @@ class ConvertToEdocUnitTest extends CarlosUnitTestBase {
 
     @Test
     @DisplayName("should translate cache-busted local asset paths during tidy")
-    void shouldTranslateCacheBustedLocalAssetPaths_whenTidyingDocument() throws Exception {
-        Path tempDir = Files.createTempDirectory("convert-edoc-cache");
+    void shouldTranslateCacheBustedLocalAssetPaths_whenTidyingDocument(@TempDir Path tempDir) throws Exception {
         Path image = Files.createFile(tempDir.resolve("stamp.png"));
 
         String html = "<html><body style=\"background-image:url('stamp.png?v=1')\"><div>x</div></body></html>";
@@ -74,27 +72,51 @@ class ConvertToEdocUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
-    @DisplayName("should strip unresolved traversal shaped background asset paths during tidy")
-    void shouldStripUnresolvedTraversalShapedBackgroundAssetPaths_whenTidyingDocument() throws Exception {
-        Path tempDir = Files.createTempDirectory("convert-edoc-traversal");
-        String traversalPath = "../../../../etc/passwd.png";
+    @DisplayName("should preserve data uri backgrounds during tidy")
+    void shouldPreserveDataUriBackgrounds_whenTidyingDocument(@TempDir Path tempDir) throws Exception {
+        String dataUri = "data:image/png;base64,ZmFrZQ==";
+        String html = "<html><body style=\"background-image:url('" + dataUri + "')\"><div background=\"" + dataUri + "\">x</div></body></html>";
 
+        String tidied = ConvertToEdoc.tidyDocument(html, tempDir.toString());
+
+        assertThat(tidied)
+                .contains("background-image:url('" + dataUri + "')")
+                .contains("background=\"" + dataUri + "\"");
+    }
+
+    @Test
+    @DisplayName("should strip unresolved traversal shaped background asset paths during tidy")
+    void shouldStripUnresolvedTraversalShapedBackgroundAssetPaths_whenTidyingDocument(@TempDir Path tempDir) {
+        String traversalPath = "../../../../etc/passwd.png";
         String html = "<html><body style=\"background-image:url('" + traversalPath + "')\"><div background=\"" + traversalPath + "\">x</div></body></html>";
 
         String tidied = ConvertToEdoc.tidyDocument(html, tempDir.toString());
 
-        assertThat(tidied).doesNotContain(traversalPath);
-        assertThat(tidied).contains("background-image:url('')");
-        assertThat(tidied).doesNotContain("background=\"");
+        assertThat(tidied)
+                .doesNotContain(traversalPath)
+                .contains("background-image:url('')")
+                .doesNotContain("background=\"");
+    }
+
+    @Test
+    @DisplayName("should preserve data uri resource elements when parsing document")
+    void shouldPreserveDataUriResourceElements_whenParsingDocument(@TempDir Path tempDir) {
+        String dataUri = "data:image/png;base64,ZmFrZQ==";
+        String html = "<html><head><link rel=\"icon\" href=\"" + dataUri + "\"></head>"
+                + "<body><img alt=\"inline\" src=\"" + dataUri + "\"><script src=\"data:text/javascript,console.log(1)\"></script></body></html>";
+
+        Document document = ConvertToEdoc.getDocument(html, tempDir.toString());
+
+        assertThat(document.select("link[href], img[src], script[src]")).hasSize(3);
     }
 
     @Test
     @DisplayName("should remove unresolved traversal shaped resource elements when parsing document")
-    void shouldRemoveUnresolvedTraversalShapedResourceElements_whenParsingDocument() throws Exception {
+    void shouldRemoveUnresolvedTraversalShapedResourceElements_whenParsingDocument(@TempDir Path tempDir) {
         String html = "<html><head><link rel=\"stylesheet\" href=\"../../../../etc/passwd.css\"></head>"
                 + "<body><img src=\"../../../../etc/passwd.png\"><script src=\"../../../../etc/passwd.js\"></script></body></html>";
 
-        Document document = ConvertToEdoc.getDocument(html, Files.createTempDirectory("convert-edoc-validate").toString());
+        Document document = ConvertToEdoc.getDocument(html, tempDir.toString());
 
         assertThat(document.select("link[href], img[src], script[src]")).isEmpty();
     }

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/ConvertToEdocUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/ConvertToEdocUnitTest.java
@@ -73,7 +73,7 @@ class ConvertToEdocUnitTest extends CarlosUnitTestBase {
 
     @Test
     @DisplayName("should preserve data uri backgrounds during tidy")
-    void shouldPreserveDataUriBackgrounds_whenTidyingDocument(@TempDir Path tempDir) throws Exception {
+    void shouldPreserveDataUriBackgrounds_whenTidyingDocument(@TempDir Path tempDir) {
         String dataUri = "data:image/png;base64,ZmFrZQ==";
         String html = "<html><body style=\"background-image:url('" + dataUri + "')\"><div background=\"" + dataUri + "\">x</div></body></html>";
 

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentPreview2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentPreview2ActionTest.java
@@ -336,4 +336,19 @@ class DocumentPreview2ActionTest extends CarlosUnitTestBase {
         assertThat(response.getContentAsString()).contains("Invalid eDocId");
         verify(mockDocumentAttachmentManager, never()).renderDocument(eq(mockLoggedInInfo), eq(DocumentType.DOC), any());
     }
+    @Test
+    @DisplayName("should return error json when render eform pdf generation fails")
+    void shouldReturnErrorJson_whenRenderEformPdfGenerationFails() throws Exception {
+        request.setParameter("method", "renderEFormPDF");
+        request.setParameter("eFormId", "42");
+
+        when(mockDocumentAttachmentManager.renderDocument(mockLoggedInInfo, DocumentType.EFORM, 42))
+                .thenThrow(new io.github.carlos_emr.carlos.utility.PDFGenerationException("render failed"));
+
+        String result = action.execute();
+
+        assertThat(result).isNull();
+        assertThat(response.getContentAsString()).contains("errorMessage").contains("render failed");
+    }
+
 }

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentPreview2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentPreview2ActionTest.java
@@ -348,7 +348,7 @@ class DocumentPreview2ActionTest extends CarlosUnitTestBase {
         String result = action.execute();
 
         assertThat(result).isNull();
-        assertThat(response.getContentAsString()).contains("errorMessage").contains("render failed");
+        assertThat(response.getContentAsString()).contains("errorMessage").doesNotContain("render failed");
     }
 
 }

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentPreview2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentPreview2ActionTest.java
@@ -351,4 +351,59 @@ class DocumentPreview2ActionTest extends CarlosUnitTestBase {
         assertThat(response.getContentAsString()).contains("errorMessage").doesNotContain("render failed");
     }
 
+    @Test
+    @DisplayName("should return error json when render non eform pdf generation fails")
+    void shouldReturnErrorJson_whenRenderNonEformPdfGenerationFails() throws Exception {
+        request.setParameter("method", "renderEDocPDF");
+        request.setParameter("eDocId", "42");
+        when(mockDocumentAttachmentManager.renderDocument(mockLoggedInInfo, DocumentType.DOC, 42))
+                .thenThrow(new io.github.carlos_emr.carlos.utility.PDFGenerationException("edoc failed"));
+
+        String result = action.execute();
+
+        assertThat(result).isNull();
+        assertThat(response.getContentAsString()).contains("errorMessage").doesNotContain("edoc failed");
+
+        response = new MockHttpServletResponse();
+        servletActionContextMock.when(ServletActionContext::getResponse).thenReturn(response);
+        action.response = response;
+        request.setParameter("method", "renderHrmPDF");
+        request.removeParameter("eDocId");
+        request.setParameter("hrmId", "43");
+        when(mockDocumentAttachmentManager.renderDocument(mockLoggedInInfo, DocumentType.HRM, 43))
+                .thenThrow(new io.github.carlos_emr.carlos.utility.PDFGenerationException("hrm failed"));
+
+        result = action.execute();
+
+        assertThat(result).isNull();
+        assertThat(response.getContentAsString()).contains("errorMessage").doesNotContain("hrm failed");
+
+        response = new MockHttpServletResponse();
+        servletActionContextMock.when(ServletActionContext::getResponse).thenReturn(response);
+        action.response = response;
+        request.setParameter("method", "renderLabPDF");
+        request.removeParameter("hrmId");
+        request.setParameter("segmentId", "44");
+        when(mockDocumentAttachmentManager.renderDocument(mockLoggedInInfo, DocumentType.LAB, 44))
+                .thenThrow(new io.github.carlos_emr.carlos.utility.PDFGenerationException("lab failed"));
+
+        result = action.execute();
+
+        assertThat(result).isNull();
+        assertThat(response.getContentAsString()).contains("errorMessage").doesNotContain("lab failed");
+    }
+
+    @Test
+    @DisplayName("should return error json when render form pdf generation fails")
+    void shouldReturnErrorJson_whenRenderFormPdfGenerationFails() throws Exception {
+        request.setParameter("method", "renderFormPDF");
+        when(mockDocumentAttachmentManager.renderDocument(request, response, DocumentType.FORM))
+                .thenThrow(new io.github.carlos_emr.carlos.utility.PDFGenerationException("form failed"));
+
+        String result = action.execute();
+
+        assertThat(result).isNull();
+        assertThat(response.getContentAsString()).contains("errorMessage").doesNotContain("form failed");
+    }
+
 }

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentPreview2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentPreview2ActionTest.java
@@ -352,8 +352,8 @@ class DocumentPreview2ActionTest extends CarlosUnitTestBase {
     }
 
     @Test
-    @DisplayName("should return error json when render non eform pdf generation fails")
-    void shouldReturnErrorJson_whenRenderNonEformPdfGenerationFails() throws Exception {
+    @DisplayName("should return error json when render edoc pdf generation fails")
+    void shouldReturnErrorJson_whenRenderEdocPdfGenerationFails() throws Exception {
         request.setParameter("method", "renderEDocPDF");
         request.setParameter("eDocId", "42");
         when(mockDocumentAttachmentManager.renderDocument(mockLoggedInInfo, DocumentType.DOC, 42))
@@ -363,31 +363,31 @@ class DocumentPreview2ActionTest extends CarlosUnitTestBase {
 
         assertThat(result).isNull();
         assertThat(response.getContentAsString()).contains("errorMessage").doesNotContain("edoc failed");
+    }
 
-        response = new MockHttpServletResponse();
-        servletActionContextMock.when(ServletActionContext::getResponse).thenReturn(response);
-        action.response = response;
+    @Test
+    @DisplayName("should return error json when render hrm pdf generation fails")
+    void shouldReturnErrorJson_whenRenderHrmPdfGenerationFails() throws Exception {
         request.setParameter("method", "renderHrmPDF");
-        request.removeParameter("eDocId");
         request.setParameter("hrmId", "43");
         when(mockDocumentAttachmentManager.renderDocument(mockLoggedInInfo, DocumentType.HRM, 43))
                 .thenThrow(new io.github.carlos_emr.carlos.utility.PDFGenerationException("hrm failed"));
 
-        result = action.execute();
+        String result = action.execute();
 
         assertThat(result).isNull();
         assertThat(response.getContentAsString()).contains("errorMessage").doesNotContain("hrm failed");
+    }
 
-        response = new MockHttpServletResponse();
-        servletActionContextMock.when(ServletActionContext::getResponse).thenReturn(response);
-        action.response = response;
+    @Test
+    @DisplayName("should return error json when render lab pdf generation fails")
+    void shouldReturnErrorJson_whenRenderLabPdfGenerationFails() throws Exception {
         request.setParameter("method", "renderLabPDF");
-        request.removeParameter("hrmId");
         request.setParameter("segmentId", "44");
         when(mockDocumentAttachmentManager.renderDocument(mockLoggedInInfo, DocumentType.LAB, 44))
                 .thenThrow(new io.github.carlos_emr.carlos.utility.PDFGenerationException("lab failed"));
 
-        result = action.execute();
+        String result = action.execute();
 
         assertThat(result).isNull();
         assertThat(response.getContentAsString()).contains("errorMessage").doesNotContain("lab failed");

--- a/src/test/java/io/github/carlos_emr/carlos/eform/EFormJspMigrationRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/eform/EFormJspMigrationRegressionTest.java
@@ -82,7 +82,7 @@ class EFormJspMigrationRegressionTest {
 
     @Test
     @DisplayName("addEForm results should render the internal eForm JSP directly so POST save flows do not hit the GET-only gate")
-    void addEFormResultsShouldRenderInternalShowFormJsp() throws IOException {
+    void shouldRenderInternalShowFormJsp_whenAddEFormReturnsResults() throws IOException {
         String struts = Files.readString(STRUTS_EFORM_XML, StandardCharsets.UTF_8);
         String jsp = Files.readString(Path.of("src/main/webapp/WEB-INF/jsp/eform/efmshowform_data.jsp"), StandardCharsets.UTF_8);
 
@@ -96,11 +96,11 @@ class EFormJspMigrationRegressionTest {
 
     @Test
     @DisplayName("admin eForm preview should resolve image placeholders through the active request context")
-    void adminEFormPreviewShouldUseRequestContextForImagePath() throws IOException {
+    void shouldUseRequestContextForImagePath_whenAdminEFormPreviewRenders() throws IOException {
         String jsp = Files.readString(Path.of("src/main/webapp/WEB-INF/jsp/eform/efmshowform_data.jsp"), StandardCharsets.UTF_8);
 
-        assertThat(jsp).contains("eForm.setImagePath(request.getContextPath());");
-        assertThat(jsp).doesNotContain("eForm.setImagePath();");
+        assertThat(jsp).contains("eForm.setImagePath(request.getContextPath());")
+                .doesNotContain("eForm.setImagePath();");
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/eform/EFormJspMigrationRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/eform/EFormJspMigrationRegressionTest.java
@@ -86,10 +86,11 @@ class EFormJspMigrationRegressionTest {
         String struts = Files.readString(STRUTS_EFORM_XML, StandardCharsets.UTF_8);
         String jsp = Files.readString(Path.of("src/main/webapp/WEB-INF/jsp/eform/efmshowform_data.jsp"), StandardCharsets.UTF_8);
 
-        assertThat(struts).contains("<action name=\"eform/addEForm\" class=\"io.github.carlos_emr.carlos.eform.actions.AddEForm2Action\">");
-        assertThat(struts).contains("<result name=\"close\">/WEB-INF/jsp/eform/efmshowform_data.jsp</result>");
-        assertThat(struts).contains("<result name=\"download\">/WEB-INF/jsp/eform/efmshowform_data.jsp</result>");
-        assertThat(struts).contains("<result name=\"error\">/WEB-INF/jsp/eform/efmshowform_data.jsp</result>");
+        assertThat(struts)
+                .contains("<action name=\"eform/addEForm\" class=\"io.github.carlos_emr.carlos.eform.actions.AddEForm2Action\">")
+                .contains("<result name=\"close\">/WEB-INF/jsp/eform/efmshowform_data.jsp</result>")
+                .contains("<result name=\"download\">/WEB-INF/jsp/eform/efmshowform_data.jsp</result>")
+                .contains("<result name=\"error\">/WEB-INF/jsp/eform/efmshowform_data.jsp</result>");
         assertThat(jsp).contains("request.getParameter(\"error\") != null ? request.getParameter(\"error\") : (String) request.getAttribute(\"error\")");
     }
 

--- a/src/test/java/io/github/carlos_emr/carlos/eform/EFormJspMigrationRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/eform/EFormJspMigrationRegressionTest.java
@@ -81,6 +81,29 @@ class EFormJspMigrationRegressionTest {
     }
 
     @Test
+    @DisplayName("addEForm results should render the internal eForm JSP directly so POST save flows do not hit the GET-only gate")
+    void addEFormResultsShouldRenderInternalShowFormJsp() throws IOException {
+        String struts = Files.readString(STRUTS_EFORM_XML, StandardCharsets.UTF_8);
+        String jsp = Files.readString(Path.of("src/main/webapp/WEB-INF/jsp/eform/efmshowform_data.jsp"), StandardCharsets.UTF_8);
+
+        assertThat(struts).contains("<action name=\"eform/addEForm\" class=\"io.github.carlos_emr.carlos.eform.actions.AddEForm2Action\">");
+        assertThat(struts).contains("<result name=\"close\">/WEB-INF/jsp/eform/efmshowform_data.jsp</result>");
+        assertThat(struts).contains("<result name=\"download\">/WEB-INF/jsp/eform/efmshowform_data.jsp</result>");
+        assertThat(struts).contains("<result name=\"error\">/WEB-INF/jsp/eform/efmshowform_data.jsp</result>");
+        assertThat(jsp).contains("request.getParameter(\"error\") != null ? request.getParameter(\"error\") : (String) request.getAttribute(\"error\")");
+    }
+
+
+    @Test
+    @DisplayName("admin eForm preview should resolve image placeholders through the active request context")
+    void adminEFormPreviewShouldUseRequestContextForImagePath() throws IOException {
+        String jsp = Files.readString(Path.of("src/main/webapp/WEB-INF/jsp/eform/efmshowform_data.jsp"), StandardCharsets.UTF_8);
+
+        assertThat(jsp).contains("eForm.setImagePath(request.getContextPath());");
+        assertThat(jsp).doesNotContain("eForm.setImagePath();");
+    }
+
+    @Test
     @DisplayName("struts eForm config should keep both extensionless and legacy displayImage routes")
     void shouldKeepDisplayImageCompatibilityRoutes_whenReadingStrutsEFormConfig() throws IOException {
         String struts = Files.readString(STRUTS_EFORM_XML, StandardCharsets.UTF_8);

--- a/src/test/java/io/github/carlos_emr/carlos/eform/actions/AddEForm2ActionPdfWarningTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/eform/actions/AddEForm2ActionPdfWarningTest.java
@@ -47,7 +47,7 @@ class AddEForm2ActionPdfWarningTest extends CarlosUnitTestBase {
     private MockHttpServletResponse response;
 
     @BeforeEach
-    void setUp() throws Exception {
+    void setUp() {
         mocks = MockitoAnnotations.openMocks(this);
         registerMock(SecurityInfoManager.class, securityInfoManager);
         registerMock(EformDataManager.class, eformDataManager);

--- a/src/test/java/io/github/carlos_emr/carlos/eform/actions/AddEForm2ActionPdfWarningTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/eform/actions/AddEForm2ActionPdfWarningTest.java
@@ -1,0 +1,95 @@
+package io.github.carlos_emr.carlos.eform.actions;
+
+import io.github.carlos_emr.carlos.documentManager.DocumentAttachmentManager;
+import io.github.carlos_emr.carlos.managers.DemographicManager;
+import io.github.carlos_emr.carlos.managers.EformDataManager;
+import io.github.carlos_emr.carlos.managers.EmailManager;
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
+import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import io.github.carlos_emr.carlos.utility.PDFGenerationException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.apache.struts2.ServletActionContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+@DisplayName("AddEForm2Action PDF warning")
+@Tag("unit")
+@Tag("fast")
+class AddEForm2ActionPdfWarningTest extends CarlosUnitTestBase {
+
+    @Mock private SecurityInfoManager securityInfoManager;
+    @Mock private EformDataManager eformDataManager;
+    @Mock private DocumentAttachmentManager documentAttachmentManager;
+    @Mock private EmailManager emailManager;
+    @Mock private DemographicManager demographicManager;
+    @Mock private LoggedInInfo loggedInInfo;
+
+    private AutoCloseable mocks;
+    private MockedStatic<ServletActionContext> servletActionContextMock;
+    private MockedStatic<LoggedInInfo> loggedInInfoMock;
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        mocks = MockitoAnnotations.openMocks(this);
+        registerMock(SecurityInfoManager.class, securityInfoManager);
+        registerMock(EformDataManager.class, eformDataManager);
+        registerMock(DocumentAttachmentManager.class, documentAttachmentManager);
+        registerMock(EmailManager.class, emailManager);
+        registerMock(DemographicManager.class, demographicManager);
+
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+
+        servletActionContextMock = mockStatic(ServletActionContext.class);
+        servletActionContextMock.when(ServletActionContext::getRequest).thenReturn(request);
+        servletActionContextMock.when(ServletActionContext::getResponse).thenReturn(response);
+
+        loggedInInfoMock = mockStatic(LoggedInInfo.class);
+        loggedInInfoMock.when(() -> LoggedInInfo.getLoggedInInfoFromSession(any(HttpServletRequest.class))).thenReturn(loggedInInfo);
+        when(demographicManager.getDemographicFormattedName(loggedInInfo, 123)).thenReturn("Doe, Jane");
+        when(documentAttachmentManager.renderEFormWithAttachments(request, response))
+                .thenThrow(new PDFGenerationException("render failed"));
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (loggedInInfoMock != null) loggedInInfoMock.close();
+        if (servletActionContextMock != null) servletActionContextMock.close();
+        if (mocks != null) mocks.close();
+    }
+
+    @Test
+    @DisplayName("should close with warning when preview pdf generation fails")
+    void shouldCloseWithWarningWhenPreviewPdfGenerationFails() {
+        AddEForm2Action action = new AddEForm2Action();
+
+        String result = action.closeWithPdfPreview(loggedInInfo, "123", "42");
+
+        assertThat(result).isEqualTo("close");
+        assertThat(request.getAttribute("warningMessage").toString()).contains("saved").contains("render failed");
+        assertThat(request.getAttribute("isSuccess_Autoclose")).isEqualTo("true");
+        assertThat(request.getAttribute("fdid")).isEqualTo("42");
+        assertThat(request.getAttribute("parentAjaxId")).isEqualTo("eforms");
+        assertThat(request.getAttribute("errorMessage")).isNull();
+        assertThat(request.getAttribute("eFormPDF")).isEqualTo("");
+        assertThat(request.getAttribute("eFormPDFName")).isEqualTo("" + new java.text.SimpleDateFormat("yyyy_MM_dd").format(new java.util.Date()) + "_Doe.pdf");
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/eform/actions/AddEForm2ActionPdfWarningTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/eform/actions/AddEForm2ActionPdfWarningTest.java
@@ -76,7 +76,7 @@ class AddEForm2ActionPdfWarningTest extends CarlosUnitTestBase {
 
     @Test
     @DisplayName("should close with warning when preview pdf generation fails")
-    void shouldCloseWithWarningWhenPreviewPdfGenerationFails() throws Exception {
+    void shouldCloseWithWarning_whenPreviewPdfGenerationFails() throws Exception {
         AddEForm2Action action = new AddEForm2Action();
         when(documentAttachmentManager.renderEFormWithAttachments(request, response))
                 .thenThrow(new PDFGenerationException("render failed"));
@@ -96,7 +96,7 @@ class AddEForm2ActionPdfWarningTest extends CarlosUnitTestBase {
 
     @Test
     @DisplayName("should close with warning when preview conversion throws runtime exception")
-    void shouldCloseWithWarningWhenPreviewConversionThrowsRuntimeException() throws Exception {
+    void shouldCloseWithWarning_whenPreviewConversionThrowsRuntimeException() throws Exception {
         AddEForm2Action action = new AddEForm2Action();
         Path pdfPath = Path.of("/tmp/eform-preview.pdf");
 
@@ -112,7 +112,7 @@ class AddEForm2ActionPdfWarningTest extends CarlosUnitTestBase {
 
     @Test
     @DisplayName("should fall back to generic filename when demographic number is invalid")
-    void shouldFallBackToGenericFilenameWhenDemographicNumberIsInvalid() throws Exception {
+    void shouldFallBackToGenericFilename_whenDemographicNumberIsInvalid() throws Exception {
         AddEForm2Action action = new AddEForm2Action();
         when(documentAttachmentManager.renderEFormWithAttachments(request, response))
                 .thenThrow(new PDFGenerationException("render failed"));

--- a/src/test/java/io/github/carlos_emr/carlos/eform/actions/AddEForm2ActionPdfWarningTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/eform/actions/AddEForm2ActionPdfWarningTest.java
@@ -65,8 +65,6 @@ class AddEForm2ActionPdfWarningTest extends CarlosUnitTestBase {
         loggedInInfoMock = mockStatic(LoggedInInfo.class);
         loggedInInfoMock.when(() -> LoggedInInfo.getLoggedInInfoFromSession(any(HttpServletRequest.class))).thenReturn(loggedInInfo);
         when(demographicManager.getDemographicFormattedName(loggedInInfo, 123)).thenReturn("Doe, Jane");
-        when(documentAttachmentManager.renderEFormWithAttachments(request, response))
-                .thenThrow(new PDFGenerationException("render failed"));
     }
 
     @AfterEach
@@ -78,18 +76,51 @@ class AddEForm2ActionPdfWarningTest extends CarlosUnitTestBase {
 
     @Test
     @DisplayName("should close with warning when preview pdf generation fails")
-    void shouldCloseWithWarningWhenPreviewPdfGenerationFails() {
+    void shouldCloseWithWarningWhenPreviewPdfGenerationFails() throws Exception {
         AddEForm2Action action = new AddEForm2Action();
+        when(documentAttachmentManager.renderEFormWithAttachments(request, response))
+                .thenThrow(new PDFGenerationException("render failed"));
 
         String result = action.closeWithPdfPreview(loggedInInfo, "123", "42");
 
         assertThat(result).isEqualTo("close");
-        assertThat(request.getAttribute("warningMessage").toString()).contains("saved").contains("render failed");
+        assertThat(request.getAttribute("warningMessage")).isEqualTo("This eForm was saved, but its PDF preview could not be generated.");
+        assertThat(request.getAttribute("warningMessage").toString()).doesNotContain("render failed");
         assertThat(request.getAttribute("isSuccess_Autoclose")).isEqualTo("true");
         assertThat(request.getAttribute("fdid")).isEqualTo("42");
         assertThat(request.getAttribute("parentAjaxId")).isEqualTo("eforms");
         assertThat(request.getAttribute("errorMessage")).isNull();
         assertThat(request.getAttribute("eFormPDF")).isEqualTo("");
-        assertThat(request.getAttribute("eFormPDFName")).isEqualTo("" + new java.text.SimpleDateFormat("yyyy_MM_dd").format(new java.util.Date()) + "_Doe.pdf");
+        assertThat(request.getAttribute("eFormPDFName").toString()).matches("\\d{4}_\\d{2}_\\d{2}_Doe\\.pdf");
+    }
+
+    @Test
+    @DisplayName("should close with warning when preview conversion throws runtime exception")
+    void shouldCloseWithWarningWhenPreviewConversionThrowsRuntimeException() throws Exception {
+        AddEForm2Action action = new AddEForm2Action();
+        Path pdfPath = Path.of("/tmp/eform-preview.pdf");
+
+        when(documentAttachmentManager.renderEFormWithAttachments(request, response)).thenReturn(pdfPath);
+        when(documentAttachmentManager.convertPDFToBase64(pdfPath)).thenThrow(new IllegalStateException("bad preview"));
+
+        String result = action.closeWithPdfPreview(loggedInInfo, "123", "42");
+
+        assertThat(result).isEqualTo("close");
+        assertThat(request.getAttribute("warningMessage")).isEqualTo("This eForm was saved, but its PDF preview could not be generated.");
+        assertThat(request.getAttribute("eFormPDF")).isEqualTo("");
+    }
+
+    @Test
+    @DisplayName("should fall back to generic filename when demographic number is invalid")
+    void shouldFallBackToGenericFilenameWhenDemographicNumberIsInvalid() throws Exception {
+        AddEForm2Action action = new AddEForm2Action();
+        when(documentAttachmentManager.renderEFormWithAttachments(request, response))
+                .thenThrow(new PDFGenerationException("render failed"));
+
+        String result = action.closeWithPdfPreview(loggedInInfo, "not-a-number", "42");
+
+        assertThat(result).isEqualTo("close");
+        assertThat(request.getAttribute("warningMessage")).isEqualTo("This eForm was saved, but its PDF preview could not be generated.");
+        assertThat(request.getAttribute("eFormPDFName").toString()).matches("\\d{4}_\\d{2}_\\d{2}_eform\\.pdf");
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/managers/EformDataManagerImplCreatePdfUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/managers/EformDataManagerImplCreatePdfUnitTest.java
@@ -4,7 +4,6 @@ import io.github.carlos_emr.carlos.commn.dao.EFormDataDao;
 import io.github.carlos_emr.carlos.commn.model.EFormData;
 import io.github.carlos_emr.carlos.documentManager.ConvertToEdoc;
 import io.github.carlos_emr.carlos.documentManager.DocumentAttachmentManager;
-import io.github.carlos_emr.carlos.managers.NioFileManager;
 import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.PDFGenerationException;

--- a/src/test/java/io/github/carlos_emr/carlos/managers/EformDataManagerImplCreatePdfUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/managers/EformDataManagerImplCreatePdfUnitTest.java
@@ -73,7 +73,7 @@ class EformDataManagerImplCreatePdfUnitTest extends CarlosUnitTestBase {
 
     @Test
     @DisplayName("should throw PDFGenerationException when conversion returns null path")
-    void shouldThrowPdfGenerationExceptionWhenConversionReturnsNullPath() {
+    void shouldThrowPdfGenerationException_whenConversionReturnsNullPath() {
         convertToEdocMock.when(() -> ConvertToEdoc.saveAsTempPDF(any(EFormData.class))).thenReturn(null);
 
         assertThatThrownBy(() -> manager.createEformPDF(loggedInInfo, 77))

--- a/src/test/java/io/github/carlos_emr/carlos/managers/EformDataManagerImplCreatePdfUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/managers/EformDataManagerImplCreatePdfUnitTest.java
@@ -1,0 +1,84 @@
+package io.github.carlos_emr.carlos.managers;
+
+import io.github.carlos_emr.carlos.commn.dao.EFormDataDao;
+import io.github.carlos_emr.carlos.commn.model.EFormData;
+import io.github.carlos_emr.carlos.documentManager.ConvertToEdoc;
+import io.github.carlos_emr.carlos.documentManager.DocumentAttachmentManager;
+import io.github.carlos_emr.carlos.managers.NioFileManager;
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
+import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import io.github.carlos_emr.carlos.utility.PDFGenerationException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+@DisplayName("EformDataManagerImpl createEformPDF")
+@Tag("unit")
+@Tag("fast")
+class EformDataManagerImplCreatePdfUnitTest extends CarlosUnitTestBase {
+
+    @Mock private SecurityInfoManager securityInfoManager;
+    @Mock private EFormDataDao eFormDataDao;
+    @Mock private DocumentManager documentManager;
+    @Mock private DocumentAttachmentManager documentAttachmentManager;
+    @Mock private FormsManager formsManager;
+    @Mock private LoggedInInfo loggedInInfo;
+
+    private AutoCloseable mocks;
+    private MockedStatic<ConvertToEdoc> convertToEdocMock;
+    private EformDataManagerImpl manager;
+
+    @BeforeEach
+    void setUp() {
+        mocks = MockitoAnnotations.openMocks(this);
+        registerMock(SecurityInfoManager.class, securityInfoManager);
+        registerMock(NioFileManager.class, org.mockito.Mockito.mock(NioFileManager.class));
+        registerMock(DocumentAttachmentManager.class, documentAttachmentManager);
+        registerMock(FormsManager.class, formsManager);
+
+        manager = new EformDataManagerImpl();
+        injectDependency(manager, "securityInfoManager", securityInfoManager);
+        injectDependency(manager, "eFormDataDao", eFormDataDao);
+        injectDependency(manager, "documentManager", documentManager);
+        injectDependency(manager, "documentAttachmentManager", documentAttachmentManager);
+        injectDependency(manager, "formsManager", formsManager);
+
+        when(securityInfoManager.hasPrivilege(eq(loggedInInfo), eq("_eform"), eq(SecurityInfoManager.UPDATE), isNull())).thenReturn(true);
+
+        EFormData eformData = new EFormData();
+        eformData.setId(77);
+        eformData.setFormName("Consult Form");
+        eformData.setFormData("<html></html>");
+        when(eFormDataDao.find(77)).thenReturn(eformData);
+
+        convertToEdocMock = mockStatic(ConvertToEdoc.class);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (convertToEdocMock != null) convertToEdocMock.close();
+        if (mocks != null) mocks.close();
+    }
+
+    @Test
+    @DisplayName("should throw PDFGenerationException when conversion returns null path")
+    void shouldThrowPdfGenerationExceptionWhenConversionReturnsNullPath() {
+        convertToEdocMock.when(() -> ConvertToEdoc.saveAsTempPDF(any(EFormData.class))).thenReturn(null);
+
+        assertThatThrownBy(() -> manager.createEformPDF(loggedInInfo, 77))
+                .isInstanceOf(PDFGenerationException.class)
+                .hasMessageContaining("HTML-to-PDF conversion");
+    }
+}


### PR DESCRIPTION
## What changed
This PR hardens the shared eForm PDF/render pipeline that sits behind consultation attachment preview, eForm save-close preview generation, and generated eForm PDFs.

It makes three targeted fixes:
- normalizes malformed legacy HTML comments before the Flying Saucer fallback runs
- treats failed eForm PDF generation as a real `PDFGenerationException` instead of letting a `null` temp path fall through
- keeps the normal save/close flow successful when only the follow-on PDF preview generation fails, surfacing a warning instead of an error page

It also expands local asset translation for PDF generation so background resources referenced through inline CSS, embedded styles, and legacy `background=` attributes survive PDF rendering more reliably.

## Why it changed
This is aimed at the eForm issues clustered around the PDF/render pipeline:
- `#2867` consultation/eForm preview failures on malformed legacy HTML
- `#2869` successful eForm saves that still end on an error when preview/PDF generation fails afterward
- `#2618` malformed eForm PDFs with missing background assets and degraded layout

The root problems were:
- fallback XHTML rendering was stricter than the legacy eForm HTML it received
- `ConvertToEdoc.saveAsTempPDF(...)` could fail and return `null`, and the manager layer treated that like a usable path
- `AddEForm2Action` treated post-save preview generation as fatal even after persistence had already completed

## Impact
- consultation/eChart preview has a better chance of rendering legacy eForms instead of failing on malformed comments
- eForm save/close no longer turns a successful save into a blocking error just because preview generation failed afterward
- generated PDFs retain more local background/style resources than before

## Validation
Focused regression coverage added and run:
- `ConvertToEdocUnitTest`
- `EformDataManagerImplCreatePdfUnitTest`
- `AddEForm2ActionPdfWarningTest`
- `DocumentPreview2ActionTest`

Command used:
```bash
mvn -Dtest=io.github.carlos_emr.carlos.documentManager.ConvertToEdocUnitTest,io.github.carlos_emr.carlos.managers.EformDataManagerImplCreatePdfUnitTest,io.github.carlos_emr.carlos.eform.actions.AddEForm2ActionPdfWarningTest,io.github.carlos_emr.carlos.documentManager.actions.DocumentPreview2ActionTest test
```

Result: `BUILD SUCCESS`, `16` tests run, `0` failures, `0` errors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the eForm preview/PDF pipeline to handle legacy HTML, safely resolve local assets, preserve embedded resources, and return generic errors from all render endpoints. Added an app-backed Playwright check and a toolbar warning when preview generation fails so saves still succeed.

- **Bug Fixes**
  - Normalize malformed HTML comments before the Flying Saucer fallback.
  - Expand and validate local asset translation: rewrite CSS `url()` in inline/embedded styles and legacy `background=`, resolve only under the configured real path, drop external/absolute paths, strip unresolved/traversal-shaped resources, and preserve `data:` resources.
  - Throw `PDFGenerationException` on conversion errors, null temp paths, or unreadable temp files.
  - Keep save/close successful when only preview generation fails; set `warningMessage` and show a toolbar warning.
  - Forward results to the internal JSP and reject GET/HEAD to `eform/addEForm` to avoid GET-only gating and method misuse.
  - Return generic failure messages for eDoc, eForm, HRM, Lab, and Form PDF renders.

- **New Features**
  - Added `scripts/eform-render-playwright-checks.js` and `npm run test:eform-render-playwright` to exercise end‑to‑end eForm preview and PDF generation (admin preview loads, background image resolves via `displayImage`, and `/previewDocs?method=renderEFormPDF` returns a PDF).

<sup>Written for commit 8c921ea2e18e5b5b12f6a3ec51506aa608b59ab4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

