### PR TITLE
fix: Flowsheet2Action direct-response methods now return NONE instead of null

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/flowsheet/Flowsheet2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/flowsheet/Flowsheet2Action.java
@@ -493,7 +493,7 @@ public class Flowsheet2Action extends ActionSupport {
         }
 
         writeJsonResponse(resp.toString());
-        return null;
+        return NONE;
     }
 
     public String addMeasurement() {
@@ -554,7 +554,7 @@ public class Flowsheet2Action extends ActionSupport {
 
         writeJsonResponse(resp.toString());
 
-        return null;
+        return NONE;
 
     }
 
@@ -583,7 +583,7 @@ public class Flowsheet2Action extends ActionSupport {
 
         writeJsonResponse(resp.toString());
 
-        return null;
+        return NONE;
     }
 
     public String getPreventionTypes() throws IOException {
@@ -604,7 +604,7 @@ public class Flowsheet2Action extends ActionSupport {
 
         writeJsonResponse(resp.toString());
 
-        return null;
+        return NONE;
     }
 
     public String addNewFlowsheet() throws IOException {
@@ -672,7 +672,7 @@ public class Flowsheet2Action extends ActionSupport {
 
         MeasurementTemplateFlowSheetConfig.getInstance().reloadFlowsheets();
 
-        return null;
+        return NONE;
     }
 
     public String deleteFlowsheet() throws IOException {
@@ -691,7 +691,7 @@ public class Flowsheet2Action extends ActionSupport {
 
         MeasurementTemplateFlowSheetConfig.getInstance().reloadFlowsheets();
 
-        return null;
+        return NONE;
     }
 
     public String removeItem() throws IOException {
@@ -756,7 +756,7 @@ public class Flowsheet2Action extends ActionSupport {
         ObjectNode obj = objectMapper.createObjectNode();
         obj.put("success", true);
         writeJsonResponse(obj.toString());
-        return null;
+        return NONE;
     }
 
     public String getWarnings() throws IOException {
@@ -810,7 +810,7 @@ public class Flowsheet2Action extends ActionSupport {
         }
 
         writeJsonResponse(obj.toString());
-        return null;
+        return NONE;
 
     }
 
@@ -879,7 +879,7 @@ public class Flowsheet2Action extends ActionSupport {
         ObjectNode obj = objectMapper.createObjectNode();
         obj.put("success", true);
         writeJsonResponse(obj.toString());
-        return null;
+        return NONE;
     }
 
     public String removeTarget() throws IOException {
@@ -954,7 +954,7 @@ public class Flowsheet2Action extends ActionSupport {
         ObjectNode obj = objectMapper.createObjectNode();
         obj.put("success", true);
         writeJsonResponse(obj.toString());
-        return null;
+        return NONE;
     }
 
     public String getIndicators() throws IOException {
@@ -993,7 +993,7 @@ public class Flowsheet2Action extends ActionSupport {
         obj.put("indicators", jIndicators);
 
         writeJsonResponse(obj.toString());
-        return null;
+        return NONE;
 
     }
 
@@ -1053,7 +1053,7 @@ public class Flowsheet2Action extends ActionSupport {
         }
 
         writeJsonResponse(obj.toString());
-        return null;
+        return NONE;
 
     }
 
@@ -1123,7 +1123,7 @@ public class Flowsheet2Action extends ActionSupport {
         ObjectNode obj = objectMapper.createObjectNode();
         obj.put("success", true);
         writeJsonResponse(obj.toString());
-        return null;
+        return NONE;
     }
 
     public String saveFlowsheetItemTarget() throws IOException {
@@ -1198,7 +1198,7 @@ public class Flowsheet2Action extends ActionSupport {
         ObjectNode obj = objectMapper.createObjectNode();
         obj.put("success", true);
         writeJsonResponse(obj.toString());
-        return null;
+        return NONE;
     }
 
     public Rule findRuleInRuleset(Ruleset ruleSet, String indicator) {
@@ -1273,7 +1273,7 @@ public class Flowsheet2Action extends ActionSupport {
         ObjectNode obj = objectMapper.createObjectNode();
         obj.put("success", true);
         writeJsonResponse(obj.toString());
-        return null;
+        return NONE;
     }
 
     public String getFlowsheetItem() throws IOException {
@@ -1317,7 +1317,7 @@ public class Flowsheet2Action extends ActionSupport {
         }
 
         writeJsonResponse(obj.toString());
-        return null;
+        return NONE;
     }
 
     // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
@@ -1396,7 +1396,7 @@ public class Flowsheet2Action extends ActionSupport {
         }
 
         writeJsonResponse(obj.toString());
-        return null;
+        return NONE;
     }
 
     private Measurement findMeasurement(Flowsheet flowsheet, String measurementType) {
@@ -1442,7 +1442,7 @@ public class Flowsheet2Action extends ActionSupport {
         resp.put("results", fsList);
         writeJsonResponse(resp.toString());
 
-        return null;
+        return NONE;
     }
 
     public String listSystem() throws IOException {
@@ -1488,7 +1488,7 @@ public class Flowsheet2Action extends ActionSupport {
         resp.put("results", fsList);
         writeJsonResponse(resp.toString());
 
-        return null;
+        return NONE;
     }
 
     public String list() throws IOException {
@@ -1548,7 +1548,7 @@ public class Flowsheet2Action extends ActionSupport {
         resp.put("results", fsList);
 
         writeJsonResponse(resp.toString());
-        return null;
+        return NONE;
     }
 
     public String reload() {

--- a/src/test/java/io/github/carlos_emr/carlos/flowsheet/Flowsheet2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/flowsheet/Flowsheet2ActionTest.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.flowsheet;
+
+import io.github.carlos_emr.carlos.commn.dao.FlowSheetUserCreatedDao;
+import io.github.carlos_emr.carlos.commn.dao.ValidationsDao;
+import io.github.carlos_emr.carlos.commn.model.Validations;
+import io.github.carlos_emr.carlos.test.base.CarlosWebTestBase;
+
+import java.util.Collections;
+
+import org.apache.struts2.ActionSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+/**
+ * Direct-response contract tests for {@link Flowsheet2Action}.
+ *
+ * <p>Every method that streams JSON to the servlet response must terminate
+ * Struts processing with an explicit {@code return NONE} rather than a bare
+ * {@code null}. The action is mapped with no {@code <result>} elements
+ * (struts-form.xml), so any named/ambiguous result would let Struts attempt
+ * result resolution after the JSON body is already written. These tests pin a
+ * representative read path, a simple list path, and a mutator-style success
+ * path so that contract cannot silently regress.
+ *
+ * @since 2026-06-16
+ */
+@DisplayName("Flowsheet2Action - direct-response NONE contract")
+@Tag("integration")
+@Tag("clinical")
+class Flowsheet2ActionTest extends CarlosWebTestBase {
+
+    private static final String JSON_CONTENT_TYPE = "application/json; charset=UTF-8";
+
+    @Mock
+    private FlowSheetUserCreatedDao mockFlowSheetUserCreatedDao;
+    @Mock
+    private ValidationsDao mockValidationsDao;
+
+    @BeforeEach
+    void setUpAction() {
+        replaceSpringUtilsBean(FlowSheetUserCreatedDao.class, mockFlowSheetUserCreatedDao);
+        replaceSpringUtilsBean(ValidationsDao.class, mockValidationsDao);
+        mockRequest.setMethod("POST");
+    }
+
+    @Test
+    @DisplayName("should return NONE after writing JSON when listing flowsheets")
+    void shouldReturnNone_whenListWritesJsonResponse() throws Exception {
+        when(mockFlowSheetUserCreatedDao.getAllUserCreatedFlowSheets())
+                .thenReturn(Collections.emptyList());
+        addRequestParameter("method", "list");
+
+        String result = executeAction(new Flowsheet2Action());
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(mockResponse.getContentType()).isEqualTo(JSON_CONTENT_TYPE);
+        assertThat(mockResponse.getContentAsString()).contains("results");
+    }
+
+    @Test
+    @DisplayName("should return NONE after writing JSON when fetching validations")
+    void shouldReturnNone_whenGetValidationsWritesJsonResponse() throws Exception {
+        when(mockValidationsDao.findAll()).thenReturn(Collections.emptyList());
+        addRequestParameter("method", "getValidations");
+
+        String result = executeAction(new Flowsheet2Action());
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(mockResponse.getContentType()).isEqualTo(JSON_CONTENT_TYPE);
+        assertThat(mockResponse.getContentAsString()).contains("results");
+    }
+
+    @Test
+    @DisplayName("should return NONE after writing success JSON when removing an item")
+    void shouldReturnNone_whenRemoveItemWritesSuccessJson() throws Exception {
+        // find() returning null skips the XML rewrite branch and writes the
+        // {"success":true} response, exercising the mutator-style direct-response path.
+        when(mockFlowSheetUserCreatedDao.find(1)).thenReturn(null);
+        addRequestParameter("method", "removeItem");
+        addRequestParameter("flowsheetId", "1");
+        addRequestParameter("id", "weight");
+
+        String result = executeAction(new Flowsheet2Action());
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(mockResponse.getContentType()).isEqualTo(JSON_CONTENT_TYPE);
+        assertThat(mockResponse.getContentAsString()).contains("success");
+    }
+}


### PR DESCRIPTION
## Description

Flowsheet2Action had methods that write JSON to the HTTP response and then return null. Per CLAUDE.md, these should end with return NONE so Struts doesn't try to resolve a result after the response is already written.

## Related Issues

Fixes #2885

## How Was This Tested?

Added Flowsheet2ActionTest covering three representative direct-response paths, list(), getValidations(), and removeItem(). They test getting a list, reading simple data, and changing data. Each test confirms the method returns NONE and that the response writes JSON with the correct content type. Ran with mvn test -Dtest=Flowsheet2ActionTest and all 3 passed with 0 failures and BUILD SUCCESS. The clean compile also confirms the main code is fine after the changes.

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure all `Flowsheet2Action` methods that write JSON return NONE instead of null so Struts stops processing after the response is sent, fixing #2885.

- **Bug Fixes**
  - Updated direct-response methods to return NONE after writing JSON (e.g., list, getValidations, removeItem).
  - Added `Flowsheet2ActionTest` to verify NONE is returned and JSON content type is set for representative paths.

<sup>Written for commit 3cefe624cf1cce0ee9b9351c0e974608a910d103. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2914?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

