### PR TITLE
Fix OAuth web service route handling

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/AbstractServiceImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/AbstractServiceImpl.java
@@ -96,9 +96,13 @@ public abstract class AbstractServiceImpl {
 
         LoggedInInfo info = LoggedInInfo.getLoggedInInfoFromSession(request);
 
-        if (info != null && info.getLoggedInProvider() == null) {
-            // It's possible in the OAuth situation that the session is empty, but we have a valid LoggedInInfo on the request.
-            info = LoggedInInfo.getLoggedInInfoFromRequest(request);
+        if (info == null || info.getLoggedInProvider() == null) {
+            // OAuth-authenticated /ws/services requests are stateless and carry
+            // LoggedInInfo on the request rather than in the browser session.
+            LoggedInInfo requestInfo = LoggedInInfo.getLoggedInInfoFromRequest(request);
+            if (requestInfo != null) {
+                info = requestInfo;
+            }
         }
 
         if (info == null) {

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -228,7 +228,7 @@
         <filter-class>io.github.carlos_emr.carlos.commn.printing.PrivacyStatementAppendingFilter</filter-class>
 		<init-param>
 			<param-name>exclusions</param-name>
-			<param-value>/messenger,/demographic/ViewDemographicEditDemographicJs,/demographic/ViewDemographicPrintDemographic,/demographic/DemographicPdfLabel,/provider/ViewSchedulePageJs</param-value>
+			<param-value>/messenger,/demographic/ViewDemographicEditDemographicJs,/demographic/ViewDemographicPrintDemographic,/demographic/DemographicPdfLabel,/provider/ViewSchedulePageJs,/ws</param-value>
 		</init-param>
 	</filter>
 

--- a/src/test/java/io/github/carlos_emr/carlos/commn/printing/PrivacyStatementAppendingFilterUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/commn/printing/PrivacyStatementAppendingFilterUnitTest.java
@@ -73,6 +73,31 @@ class PrivacyStatementAppendingFilterUnitTest {
     }
 
     @Test
+    @DisplayName("should skip web service routes by excluded prefix")
+    void shouldSkipWebServiceRoutes_byExcludedPrefix() throws Exception {
+        FilterConfig config = mock(FilterConfig.class);
+        when(config.getInitParameter("exclusions")).thenReturn("/ws");
+        PrivacyStatementAppendingFilter localFilter = new PrivacyStatementAppendingFilter();
+        localFilter.init(config);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET",
+                "/carlos/ws/oauth/authorize");
+        request.setContextPath("/carlos");
+        request.setServletPath("/ws/oauth/authorize");
+        TrackingMockHttpServletResponse response = new TrackingMockHttpServletResponse();
+        String body = "<html><body>OAuth consent</body></html>";
+
+        FilterChain chain = (servletRequest, servletResponse) -> {
+            servletResponse.setContentType("text/html;charset=UTF-8");
+            servletResponse.getWriter().write(body);
+        };
+
+        localFilter.doFilter(request, response, chain);
+
+        assertThat(response.getContentAsString()).isEqualTo(body);
+        assertThat(response.getLastRequestedBufferSize()).isZero();
+    }
+
+    @Test
     @DisplayName("should flush non-HTML writer response when statement is skipped")
     void shouldFlushNonHtmlWriterResponse_whenStatementSkipped() throws Exception {
         PrivacyStatementAppendingFilter localFilter = new PrivacyStatementAppendingFilter();

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/AbstractServiceImplUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/AbstractServiceImplUnitTest.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.webserv.rest;
+
+import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.message.MessageImpl;
+import org.apache.cxf.phase.AbstractPhaseInterceptor;
+import org.apache.cxf.phase.Phase;
+import org.apache.cxf.phase.PhaseInterceptorChain;
+import org.apache.cxf.transport.http.AbstractHTTPDestination;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for shared REST service request context handling.
+ */
+@DisplayName("REST AbstractServiceImpl")
+@Tag("unit")
+class AbstractServiceImplUnitTest {
+
+    @Test
+    @DisplayName("should use request scoped login info when session info is missing")
+    void shouldUseRequestScopedLoginInfo_whenSessionInfoMissing() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        LoggedInInfo expected = new LoggedInInfo();
+        LoggedInInfo.setLoggedInInfoIntoRequest(request, expected);
+
+        LoggedInInfo actual = resolveCurrentLoggedInInfo(request);
+
+        assertThat(actual).isSameAs(expected);
+    }
+
+    @Test
+    @DisplayName("should prefer request scoped login info when session provider is missing")
+    void shouldPreferRequestScopedLoginInfo_whenSessionProviderMissing() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        LoggedInInfo sessionInfo = new LoggedInInfo();
+        LoggedInInfo requestInfo = new LoggedInInfo();
+        LoggedInInfo.setLoggedInInfoIntoSession(request.getSession(), sessionInfo);
+        LoggedInInfo.setLoggedInInfoIntoRequest(request, requestInfo);
+
+        LoggedInInfo actual = resolveCurrentLoggedInInfo(request);
+
+        assertThat(actual).isSameAs(requestInfo);
+    }
+
+    private static LoggedInInfo resolveCurrentLoggedInInfo(MockHttpServletRequest request) {
+        Message message = new MessageImpl();
+        message.put(AbstractHTTPDestination.HTTP_REQUEST, request);
+        PhaseInterceptorChain chain = new PhaseInterceptorChain(phases());
+        AtomicReference<LoggedInInfo> resolved = new AtomicReference<>();
+        chain.add(new AbstractPhaseInterceptor<Message>(Phase.RECEIVE) {
+            @Override
+            public void handleMessage(Message message) {
+                resolved.set(new TestService().currentLoggedInInfo());
+            }
+        });
+        chain.doIntercept(message);
+        return resolved.get();
+    }
+
+    private static SortedSet<Phase> phases() {
+        SortedSet<Phase> phases = new TreeSet<>();
+        phases.add(new Phase(Phase.RECEIVE, 1000));
+        return phases;
+    }
+
+    private static final class TestService extends AbstractServiceImpl {
+        private LoggedInInfo currentLoggedInInfo() {
+            return getLoggedInInfo();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- exclude `/ws` routes from the privacy statement appender so OAuth consent and service responses are not rewritten
- let REST services use request-scoped `LoggedInInfo` for stateless OAuth-authenticated calls
- add regression coverage for `/ws/oauth/authorize` filter exclusion and request-scoped REST auth context

## Testing
- `mvn -q -Dtest=PrivacyStatementAppendingFilterUnitTest,AbstractServiceImplUnitTest test`
- local OAuth 1.0a flow with `ModuleNames=Fax,REST`: request token, authorize, access token, and signed resource calls to OAuth info, persona rights, and provider me returned HTTP 200

## Notes
- OAuth routes are published only when the REST module is loaded, so the local test override uses `ModuleNames=Fax,REST`. This PR does not change the default module list for all deployments.

## Summary by Sourcery

Exclude OAuth web service routes from privacy statement rewriting and ensure REST services resolve authentication context from request-scoped LoggedInInfo when needed.

Bug Fixes:
- Prevent the privacy statement appender from modifying HTML responses for /ws OAuth web service routes.
- Correct REST authentication resolution so stateless OAuth-authenticated calls can use request-scoped LoggedInInfo when the session is null or lacks a provider.

Tests:
- Add unit coverage verifying that /ws OAuth routes are excluded by the privacy statement filter prefix configuration.
- Add REST AbstractServiceImpl unit tests ensuring request-scoped LoggedInInfo is preferred when session info is missing or incomplete.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken OAuth web service routes by skipping privacy statement rewrites on `/ws` and using request-scoped `LoggedInInfo` for stateless REST calls. Restores OAuth consent and signed resource responses.

- **Bug Fixes**
  - Added `/ws` to `PrivacyStatementAppendingFilter` exclusions in `web.xml` so `/ws/oauth/authorize` and other OAuth pages aren’t rewritten.
  - Updated `AbstractServiceImpl#getLoggedInInfo` to fall back to request-scoped `LoggedInInfo` when session data is missing or the provider is null, enabling stateless OAuth-signed `/ws/services` calls.
  - Added unit tests for the `/ws/oauth/authorize` filter exclusion and request-scoped auth resolution.

<sup>Written for commit e37a3e022b4ef08db1e646f793772b7b31689b7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

