### PR TITLE
fix: remove encounter request values from invalid logs

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/config/pageUtil/ConsultationLookup2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/config/pageUtil/ConsultationLookup2Action.java
@@ -75,7 +75,7 @@ public class ConsultationLookup2Action extends ActionSupport {
             return getAllSpecialists();
         }
 
-        MiscUtils.getLogger().warn("Invalid method parameter: " + method);
+        MiscUtils.getLogger().warn("Invalid method parameter");
         return NONE;
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EConsult2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EConsult2Action.java
@@ -98,7 +98,7 @@ public class EConsult2Action extends ActionSupport {
         
         // Validate task parameter to prevent URL injection
         if (!isValidTask(task)) {
-            MiscUtils.getLogger().error("Invalid task parameter provided: " + task);
+            MiscUtils.getLogger().error("Invalid task parameter provided");
             return "error";
         }
         
@@ -119,7 +119,7 @@ public class EConsult2Action extends ActionSupport {
         if (demographicNo != null && !demographicNo.isEmpty()) {
             // Validate demographicNo to ensure it's numeric
             if (!demographicNo.matches("^\\d+$")) {
-                MiscUtils.getLogger().error("Invalid demographicNo parameter: " + demographicNo);
+                MiscUtils.getLogger().error("Invalid demographicNo parameter");
                 return "error";
             }
             stringBuilder.append(String.format("?%1$s=%2$s", "patient_id", demographicNo));

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/pageUtil/EctIncomingEncounter2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/pageUtil/EctIncomingEncounter2Action.java
@@ -125,7 +125,7 @@ public class EctIncomingEncounter2Action extends ActionSupport {
 
         // Validate demographicNo is numeric before crossing the trust boundary
         if (!demoNo.matches("\\d+")) {
-            log.error("EctIncomingEncounter2Action called with non-numeric demographicNo: {}", LogSafe.sanitize(demoNo));
+            log.error("EctIncomingEncounter2Action called with non-numeric demographicNo");
             return "failure";
         }
 
@@ -148,7 +148,7 @@ public class EctIncomingEncounter2Action extends ActionSupport {
             bean = (EctSessionBean) request.getSession().getAttribute("EctSessionBean");
             String apptListNo = request.getParameter("appointmentNo");
             if (apptListNo != null && !apptListNo.matches("\\d{1,9}")) {
-                log.warn("Invalid non-numeric appointmentNo in appointmentList branch: {}", LogSafe.sanitize(apptListNo));
+                log.warn("Invalid non-numeric appointmentNo in appointmentList branch");
                 return "failure";
             }
             bean.setUpEncounterPage(loggedInInfo, apptListNo);
@@ -203,7 +203,7 @@ public class EctIncomingEncounter2Action extends ActionSupport {
 
             bean.providerNo = request.getParameter("providerNo");
             if (bean.providerNo != null && !bean.providerNo.isEmpty() && !bean.providerNo.matches("[a-zA-Z0-9]{1,6}")) {
-                log.warn("Invalid providerNo: {}", LogSafe.sanitize(bean.providerNo));
+                log.warn("Invalid providerNo");
                 return "failure";
             }
             if (bean.providerNo == null || bean.providerNo.isEmpty()) {
@@ -215,7 +215,7 @@ public class EctIncomingEncounter2Action extends ActionSupport {
             if (bean.appointmentNo == null || "null".equalsIgnoreCase(bean.appointmentNo) || bean.appointmentNo.isEmpty()) {
                 bean.appointmentNo = null;
             } else if (!bean.appointmentNo.matches("\\d{1,9}")) {
-                log.warn("Invalid appointmentNo: {}", LogSafe.sanitize(bean.appointmentNo));
+                log.warn("Invalid appointmentNo");
                 return "failure";
             }
             // use this one.
@@ -225,7 +225,7 @@ public class EctIncomingEncounter2Action extends ActionSupport {
 
             bean.curProviderNo = request.getParameter("curProviderNo");
             if (bean.curProviderNo != null && !bean.curProviderNo.isEmpty() && !bean.curProviderNo.matches("[a-zA-Z0-9]{1,6}")) {
-                log.warn("Invalid curProviderNo: {}", LogSafe.sanitize(bean.curProviderNo));
+                log.warn("Invalid curProviderNo");
                 return "failure";
             }
             Provider provider = loggedInInfo.getLoggedInProvider();
@@ -271,7 +271,7 @@ public class EctIncomingEncounter2Action extends ActionSupport {
             bean.check = "myCheck";
             bean.oscarMsgID = request.getParameter("msgId");
             if (bean.oscarMsgID != null && !bean.oscarMsgID.matches("\\d+")) {
-                log.warn("Invalid msgId: {}", LogSafe.sanitize(bean.oscarMsgID));
+                log.warn("Invalid msgId");
                 return "failure";
             }
             String sourceParam = request.getParameter("source");


### PR DESCRIPTION
## Summary

- Remove rejected request parameter values from encounter/eConsult invalid-input log messages.
- Address the recent SonarCloud javasecurity:S5145 logging alerts for encounter and eConsult request handling without changing validation behavior.

## Alerts addressed

- #26148, #26149, #26150, #26151, #26152, #26153 in EctIncomingEncounter2Action
- #26154, #26155 in EConsult2Action
- #26156 in ConsultationLookup2Action

## Verification

- mvn -q -DskipTests compile
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitized invalid-input logs in encounter and eConsult flows to remove user-controlled values from messages and resolve SonarCloud javasecurity:S5145 alerts.

- **Bug Fixes**
  - Replaced parameterized invalid-input logs with generic messages (no request values) in `EctIncomingEncounter2Action`, `EConsult2Action`, and `ConsultationLookup2Action`.
  - Validation and behavior are unchanged; only logging is sanitized.

<sup>Written for commit acd2b657748c12bb895cd27834cf2bbe25fb35ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2925?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

