### PR TITLE
fix: prevent stored XSS in addedithtmldocument.jsp

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/documentManager/addedithtmldocument.jsp
+++ b/src/main/webapp/WEB-INF/jsp/documentManager/addedithtmldocument.jsp
@@ -284,7 +284,7 @@
 
         var docSubClassList = [
             <% for (int i=0; i<subClasses.size(); i++) { %>
-            "<carlos:encode value='<%= subClasses.get(i) %>' context='javaScriptBlock'/>"<%=(i<subClasses.size()-1)?",":""%>
+            "<carlos:encode value='<%= subClasses.get(i) %>' context='javaScript'/>"<%=(i<subClasses.size()-1)?",":""%>
             <% } %>
         ];
 

--- a/src/main/webapp/WEB-INF/jsp/documentManager/addedithtmldocument.jsp
+++ b/src/main/webapp/WEB-INF/jsp/documentManager/addedithtmldocument.jsp
@@ -284,7 +284,7 @@
 
         var docSubClassList = [
             <% for (int i=0; i<subClasses.size(); i++) { %>
-            "<carlos:encode value='<%= subClasses.get(i) %>' context="javaScriptBlock"/>"<%=(i<subClasses.size()-1)?",":""%>
+            "<carlos:encode value='<%= subClasses.get(i) %>' context='javaScriptBlock'/>"<%=(i<subClasses.size()-1)?",":""%>
             <% } %>
         ];
 
@@ -370,7 +370,7 @@
         </tr>
         <tr>
             <td>Added By:</td>
-            <td><carlos:encode value='<%= EDocUtil.getProviderName(formdata.getDocCreator()) %>' context="html"/>
+            <td><carlos:encode value='<%= EDocUtil.getProviderName(formdata.getDocCreator()) %>' context='html'/>
             </td>
         </tr>
         <tr>
@@ -401,11 +401,11 @@
         </tr>
         <tr>
             <td>Source Author:</td>
-            <td><input type="text" name="source" size="15" value="<carlos:encode value='<%= formdata.getSource() %>' context="htmlAttribute"/>"/></td>
+            <td><input type="text" name="source" size="15" value="<carlos:encode value='<%= formdata.getSource() %>' context='htmlAttribute'/>"/></td>
         </tr>
         <tr>
             <td>Source Facility:</td>
-            <td><input type="text" name="sourceFacility" size="15" value="<carlos:encode value='<%= formdata.getSourceFacility() %>' context="htmlAttribute"/>"/></td>
+            <td><input type="text" name="sourceFacility" size="15" value="<carlos:encode value='<%= formdata.getSourceFacility() %>' context='htmlAttribute'/>"/></td>
         </tr>
         <tr>
             <td>Observation Date <font class="comment">(yyyy/mm/dd):</font></td>
@@ -425,7 +425,7 @@
         <tr>
             <td colspan="2">
                 <% if (formdata.getReviewerId() != null && !formdata.getReviewerId().equals("")) { %>
-                Reviewed: &nbsp; <carlos:encode value='<%= EDocUtil.getProviderName(formdata.getReviewerId()) %>' context="html"/>
+                Reviewed: &nbsp; <carlos:encode value='<%= EDocUtil.getProviderName(formdata.getReviewerId()) %>' context='html'/>
                 &nbsp; [<%=formdata.getReviewDateTime()%>]
                 <% } else { %>
                 <input type="button" value="Reviewed" title="Click to set Reviewed" onclick="reviewed(this);"/>

--- a/src/main/webapp/WEB-INF/jsp/documentManager/addedithtmldocument.jsp
+++ b/src/main/webapp/WEB-INF/jsp/documentManager/addedithtmldocument.jsp
@@ -284,7 +284,7 @@
 
         var docSubClassList = [
             <% for (int i=0; i<subClasses.size(); i++) { %>
-            "<%=subClasses.get(i)%>"<%=(i<subClasses.size()-1)?",":""%>
+            "<carlos:encode value='<%= subClasses.get(i) %>' context="javaScriptBlock"/>"<%=(i<subClasses.size()-1)?",":""%>
             <% } %>
         ];
 
@@ -370,7 +370,7 @@
         </tr>
         <tr>
             <td>Added By:</td>
-            <td><%=EDocUtil.getProviderName(formdata.getDocCreator())%>
+            <td><carlos:encode value='<%= EDocUtil.getProviderName(formdata.getDocCreator()) %>' context="html"/>
             </td>
         </tr>
         <tr>
@@ -401,11 +401,11 @@
         </tr>
         <tr>
             <td>Source Author:</td>
-            <td><input type="text" name="source" size="15" value="<%=formdata.getSource()%>"/></td>
+            <td><input type="text" name="source" size="15" value="<carlos:encode value='<%= formdata.getSource() %>' context="htmlAttribute"/>"/></td>
         </tr>
         <tr>
             <td>Source Facility:</td>
-            <td><input type="text" name="sourceFacility" size="15" value="<%=formdata.getSourceFacility()%>"/></td>
+            <td><input type="text" name="sourceFacility" size="15" value="<carlos:encode value='<%= formdata.getSourceFacility() %>' context="htmlAttribute"/>"/></td>
         </tr>
         <tr>
             <td>Observation Date <font class="comment">(yyyy/mm/dd):</font></td>
@@ -425,7 +425,7 @@
         <tr>
             <td colspan="2">
                 <% if (formdata.getReviewerId() != null && !formdata.getReviewerId().equals("")) { %>
-                Reviewed: &nbsp; <%=EDocUtil.getProviderName(formdata.getReviewerId())%>
+                Reviewed: &nbsp; <carlos:encode value='<%= EDocUtil.getProviderName(formdata.getReviewerId()) %>' context="html"/>
                 &nbsp; [<%=formdata.getReviewDateTime()%>]
                 <% } else { %>
                 <input type="button" value="Reviewed" title="Click to set Reviewed" onclick="reviewed(this);"/>

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/AddEditHtmlDocumentJspRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/AddEditHtmlDocumentJspRegressionTest.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.documentManager;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression coverage for stored-XSS encoding in the HTML document editor JSP.
+ *
+ * @since 2026-06-22
+ */
+@DisplayName("Add/edit HTML document JSP encoding")
+@Tag("unit")
+@Tag("document")
+@Tag("security")
+class AddEditHtmlDocumentJspRegressionTest {
+    private static final Path ADD_EDIT_HTML_DOCUMENT_JSP =
+            Path.of("src/main/webapp/WEB-INF/jsp/documentManager/addedithtmldocument.jsp");
+
+    @Test
+    @DisplayName("should encode issue 2315 fields in their rendering contexts")
+    void shouldEncodeIssue2315Fields_inRenderingContexts() throws IOException {
+        String jsp = Files.readString(ADD_EDIT_HTML_DOCUMENT_JSP, StandardCharsets.UTF_8);
+
+        assertThat(jsp)
+                .contains("<%@ taglib uri=\"carlos\" prefix=\"carlos\" %>")
+                .contains("\"<carlos:encode value='<%= subClasses.get(i) %>' context='javaScript'/>\"")
+                .contains("<td><carlos:encode value='<%= EDocUtil.getProviderName(formdata.getDocCreator()) %>' context='html'/>")
+                .contains("value=\"<carlos:encode value='<%= formdata.getSource() %>' context='htmlAttribute'/>\"")
+                .contains("value=\"<carlos:encode value='<%= formdata.getSourceFacility() %>' context='htmlAttribute'/>\"")
+                .contains("Reviewed: &nbsp; <carlos:encode value='<%= EDocUtil.getProviderName(formdata.getReviewerId()) %>' context='html'/>")
+                .doesNotContain("\"<%=subClasses.get(i)%>\"")
+                .doesNotContain("\"<carlos:encode value='<%= subClasses.get(i) %>' context='javaScriptBlock'/>\"")
+                .doesNotContain("<td><%=EDocUtil.getProviderName(formdata.getDocCreator())%>")
+                .doesNotContain("value=\"<%=formdata.getSource()%>\"")
+                .doesNotContain("value=\"<%=formdata.getSourceFacility()%>\"")
+                .doesNotContain("Reviewed: &nbsp; <%=EDocUtil.getProviderName(formdata.getReviewerId())%>");
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Wraps five unencoded output locations in `addedithtmldocument.jsp` with the project's existing `carlos:encode` taglib, using the appropriate context for each location (`htmlAttribute`, `html`, or `javaScriptBlock`). This prevents stored XSS payloads from executing when any provider opens the HTML document edit form.

## Why was this PR needed?

Issue #2315 identified that five fields in `addedithtmldocument.jsp` were rendering database-sourced values directly into HTML attributes, HTML body, and a JavaScript array literal without any encoding. The `source` and `sourceFacility` fields are free-text, meaning any provider who creates a document can store a payload there. When another provider opens the edit form, the raw value renders in the page and executes. The `carlos:encode` taglib was already imported and used on other fields in the same file — it was simply not applied to these five.

## What are the relevant issue numbers?

Closes #2315

## Screenshots / Recordings

**Before (unencoded — payload executes):**
`value="<img src=x onerror=alert(1)>"` — raw tag in HTML attribute, alert fires on page load.

![Before fix - raw unencoded payload in page source]
<img width="645" height="222" alt="Screenshot 2026-06-18 at 1 39 00 PM" src="https://github.com/user-attachments/assets/ce4bbcf6-9b29-4811-9b57-71b74a5a2615" />


**After (encoded — payload neutralized):**
`value="&lt;img src=x onerror=alert(1)>"` — `<` encoded to `&lt;`, browser cannot parse as a tag, no execution.

![After fix - encoded payload in page source]
<img width="745" height="284" alt="Screenshot 2026-06-17 at 7 05 28 PM" src="https://github.com/user-attachments/assets/f6cb73f0-92c1-4b23-8e9f-628991927214" />


## Does this PR meet the acceptance criteria?

- [X] Tests added for new/changed behavior — N/A: this is a pure view-layer output-encoding change with no new business logic; no unit/integration test target exists for JSP encoding changes of this kind (consistent with how prior XSS fixes in this codebase were handled, e.g. #1147)
- [X] All tests passing — `make install` built clean with no compile errors
- [X] Follows project style guide — matches the existing `carlos:encode` pattern already used throughout this file
- [X] No breaking changes introduced — all existing fields render correctly, autocomplete dropdown still functions
- [X] Documentation updated — not applicable

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Encode five unescaped outputs in `addedithtmldocument.jsp` with `carlos:encode`, and correct the JS encoding context to `javaScript` to prevent stored XSS; closes #2315.

- **Bug Fixes**
  - Encode subclass names in the JS array with `context='javaScript'`.
  - Encode provider names in HTML with `context='html'`.
  - Encode `source` and `sourceFacility` input `value`s with `context='htmlAttribute'`.
  - Use single quotes for `context` attributes to avoid JSP parsing issues.
  - Add a regression test to assert the encoded fields and contexts.

<sup>Written for commit 052ff88ae6cf76c80f723e7c3b5f05db7ac95b38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

