### PR TITLE
fix(security): sanitize untrusted values in utility logging (log forging)

### DIFF
--- a/src/main/java/io/github/carlos_emr/CarlosProperties.java
+++ b/src/main/java/io/github/carlos_emr/CarlosProperties.java
@@ -30,6 +30,7 @@
 
 package io.github.carlos_emr;
 
+import io.github.carlos_emr.carlos.utility.LogSafe;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.PathValidationUtils;
 
@@ -129,8 +130,11 @@ public class CarlosProperties extends Properties {
 
         // If no value, return the default if one is configured
         if (value == null) {
+            // key is caller-supplied and may carry CR/LF; sanitize before logging to
+            // prevent log forging (CodeQL log-injection). Default values come from the
+            // internal PROPERTY_DEFAULTS map and are trusted.
             String warning = new StringBuilder()
-                .append("Property '").append(key)
+                .append("Property '").append(LogSafe.sanitize(key))
                 .append("' is missing or not configured. Using default value: '")
                 .append(getDefaultValue(key)).append("'.")
                 .toString();
@@ -140,9 +144,11 @@ public class CarlosProperties extends Properties {
 
         // Check if the value contains a blacklisted namespace
         if (isValueBlacklisted(value)) {
+            // Both key and value are untrusted (key is caller-supplied; value comes from
+            // a properties file/override). Sanitize before logging to prevent log forging.
             String warning = new StringBuilder()
-                .append("Property '").append(key)
-                .append("' has blacklisted value '").append(value)
+                .append("Property '").append(LogSafe.sanitize(key))
+                .append("' has blacklisted value '").append(LogSafe.sanitize(value))
                 .append("' (deprecated namespace). ")
                 .append("This value has been ignored. Using default value instead.")
                 .toString();

--- a/src/main/java/io/github/carlos_emr/SxmlMisc.java
+++ b/src/main/java/io/github/carlos_emr/SxmlMisc.java
@@ -37,6 +37,7 @@ import jakarta.servlet.http.HttpServletRequest;
 
 import org.apache.logging.log4j.Logger;
 
+import io.github.carlos_emr.carlos.utility.LogSafe;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 
 /**
@@ -80,7 +81,10 @@ public class SxmlMisc extends Properties {
 
             // Validate element name - only allow alphanumeric, underscore, hyphen
             if (!temp.matches("^[a-zA-Z0-9_-]+$")) {
-                log.error("Invalid XML element name: " + temp);
+                // temp is an attacker-controlled request parameter name and is logged here
+                // precisely because it failed the alphanumeric guard above, so it may contain
+                // CR/LF or control chars. Sanitize to prevent log forging (CodeQL log-injection).
+                log.error("Invalid XML element name: {}", LogSafe.sanitize(temp));
                 continue; // Skip invalid parameter names
             }
 

--- a/src/main/java/io/github/carlos_emr/SxmlMisc.java
+++ b/src/main/java/io/github/carlos_emr/SxmlMisc.java
@@ -84,7 +84,7 @@ public class SxmlMisc extends Properties {
                 // temp is an attacker-controlled request parameter name and is logged here
                 // precisely because it failed the alphanumeric guard above, so it may contain
                 // CR/LF or control chars. Sanitize to prevent log forging (CodeQL log-injection).
-                log.error("Invalid XML element name: {}", LogSafe.sanitize(temp));
+                log.error("Invalid XML element name: {}", LogSafe.sanitize(temp)); // NOSONAR javasecurity:S5145 — sanitized with LogSafe
                 continue; // Skip invalid parameter names
             }
 

--- a/src/main/java/io/github/carlos_emr/carlos/hospitalReportManager/dao/HRMDocumentDao.java
+++ b/src/main/java/io/github/carlos_emr/carlos/hospitalReportManager/dao/HRMDocumentDao.java
@@ -250,11 +250,11 @@ public class HRMDocumentDao extends AbstractDaoImpl<HRMDocument> {
     @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
     private boolean isValidOrderRequest(String orderColumn, String orderDirection) {
         if (orderColumn != null && !ORDER_COLUMN_HQL.containsKey(orderColumn)) {
-            MiscUtils.getLogger().warn("HRM query: invalid orderColumn '{}' not in allowlist, ignoring ORDER BY", LogSafe.sanitize(orderColumn));
+            MiscUtils.getLogger().warn("HRM query: invalid orderColumn '{}' not in allowlist, ignoring ORDER BY", LogSafe.sanitize(orderColumn)); // NOSONAR javasecurity:S5145 — sanitized with LogSafe
             return false;
         }
         if (orderDirection != null && !orderDirection.equalsIgnoreCase("ASC") && !orderDirection.equalsIgnoreCase("DESC")) {
-            MiscUtils.getLogger().warn("HRM query: invalid orderDirection '{}', ignoring ORDER BY", LogSafe.sanitize(orderDirection));
+            MiscUtils.getLogger().warn("HRM query: invalid orderDirection '{}', ignoring ORDER BY", LogSafe.sanitize(orderDirection)); // NOSONAR javasecurity:S5145 — sanitized with LogSafe
             return false;
         }
         return true;

--- a/src/main/java/io/github/carlos_emr/carlos/hospitalReportManager/dao/HRMDocumentDao.java
+++ b/src/main/java/io/github/carlos_emr/carlos/hospitalReportManager/dao/HRMDocumentDao.java
@@ -23,6 +23,7 @@ import jakarta.persistence.Query;
 import org.apache.commons.lang3.StringUtils;
 import io.github.carlos_emr.carlos.commn.dao.AbstractDaoImpl;
 import io.github.carlos_emr.carlos.hospitalReportManager.model.HRMDocument;
+import io.github.carlos_emr.carlos.utility.LogSafe;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import org.springframework.stereotype.Repository;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -249,11 +250,11 @@ public class HRMDocumentDao extends AbstractDaoImpl<HRMDocument> {
     @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
     private boolean isValidOrderRequest(String orderColumn, String orderDirection) {
         if (orderColumn != null && !ORDER_COLUMN_HQL.containsKey(orderColumn)) {
-            MiscUtils.getLogger().warn("HRM query: invalid orderColumn '{}' not in allowlist, ignoring ORDER BY", orderColumn);
+            MiscUtils.getLogger().warn("HRM query: invalid orderColumn '{}' not in allowlist, ignoring ORDER BY", LogSafe.sanitize(orderColumn));
             return false;
         }
         if (orderDirection != null && !orderDirection.equalsIgnoreCase("ASC") && !orderDirection.equalsIgnoreCase("DESC")) {
-            MiscUtils.getLogger().warn("HRM query: invalid orderDirection '{}', ignoring ORDER BY", orderDirection);
+            MiscUtils.getLogger().warn("HRM query: invalid orderDirection '{}', ignoring ORDER BY", LogSafe.sanitize(orderDirection));
             return false;
         }
         return true;

--- a/src/test/java/io/github/carlos_emr/CarlosPropertiesLogInjectionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/CarlosPropertiesLogInjectionUnitTest.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr;
+
+import io.github.carlos_emr.carlos.test.logging.LogCapture;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Log-injection regression test for {@link CarlosProperties#getProperty(String)}.
+ *
+ * <p>Both warning branches (missing key, blacklisted value) interpolate untrusted
+ * values — the caller-supplied key and a properties-file value — into the log
+ * message. This test drives each branch with CRLF-laden input and asserts the
+ * emitted message carries no raw line breaks (routed through
+ * {@code LogSafe.sanitize}).</p>
+ *
+ * @since 2026-06-18
+ */
+@DisplayName("CarlosProperties log-injection Tests")
+@Tag("unit")
+class CarlosPropertiesLogInjectionUnitTest {
+
+    private static final String FORGED = "INJECTED forged-admin-login-success";
+
+    /** Keys set on the shared singleton; removed after each test to avoid leakage. */
+    private String addedKey;
+
+    @AfterEach
+    void cleanup() {
+        if (addedKey != null) {
+            CarlosProperties.getInstance().remove(addedKey);
+            addedKey = null;
+        }
+    }
+
+    @Test
+    @DisplayName("should sanitize key when property is missing")
+    void shouldSanitizeKey_whenPropertyMissing() {
+        String maliciousKey = "missing.key\r\n" + FORGED;
+
+        try (LogCapture logCapture = LogCapture.forLogger(CarlosProperties.class)) {
+            CarlosProperties.getInstance().getProperty(maliciousKey);
+
+            String logged = lastWarn(logCapture);
+            assertThat(logged).doesNotContain("\r").doesNotContain("\n");
+            assertThat(logged).contains("\\r\\n");
+        }
+    }
+
+    @Test
+    @DisplayName("should sanitize key and value when value is blacklisted")
+    void shouldSanitizeKeyAndValue_whenValueBlacklisted() {
+        addedKey = "blacklisted.key\r\n" + FORGED;
+        // Value begins with the deprecated "oscar." namespace -> blacklist branch fires.
+        String maliciousValue = "oscar.LegacyClass\r\n" + FORGED;
+        CarlosProperties.getInstance().setProperty(addedKey, maliciousValue);
+
+        try (LogCapture logCapture = LogCapture.forLogger(CarlosProperties.class)) {
+            CarlosProperties.getInstance().getProperty(addedKey);
+
+            String logged = lastWarn(logCapture);
+            assertThat(logged).doesNotContain("\r").doesNotContain("\n");
+            // Both the key and the blacklisted value are escaped in the warning.
+            assertThat(logged).contains("blacklisted.key").contains("oscar.LegacyClass");
+            assertThat(logged).contains("\\r\\n");
+        }
+    }
+
+    /** Returns the most recent captured message, asserting at least one was emitted. */
+    private static String lastWarn(LogCapture logCapture) {
+        assertThat(logCapture.messages()).isNotEmpty();
+        return logCapture.messages().get(logCapture.messages().size() - 1);
+    }
+}

--- a/src/test/java/io/github/carlos_emr/SxmlMiscLogInjectionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/SxmlMiscLogInjectionUnitTest.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr;
+
+import io.github.carlos_emr.carlos.test.logging.LogCapture;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Log-injection regression test for {@link SxmlMisc#createXmlDataString}.
+ *
+ * <p>The rejected-element-name warning logs an attacker-controlled HTTP request
+ * parameter name. Because the value is logged precisely on the branch where it
+ * failed the alphanumeric guard, it can carry CR/LF and forge additional log
+ * lines. This test feeds a CRLF-laden parameter name and asserts the emitted log
+ * message contains no raw line breaks (i.e. it was routed through
+ * {@code LogSafe.sanitize}).</p>
+ *
+ * @since 2026-06-18
+ */
+@DisplayName("SxmlMisc log-injection Tests")
+@Tag("unit")
+class SxmlMiscLogInjectionUnitTest {
+
+    /** Forged second log line an attacker would try to smuggle in via the param name. */
+    private static final String FORGED = "INJECTED forged-admin-login-success";
+
+    @Test
+    @DisplayName("should sanitize rejected element name before logging")
+    void shouldSanitizeRejectedElementName_whenParamNameContainsCrlf() {
+        String maliciousName = "field_evil\r\n" + FORGED;
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        when(req.getParameterNames()).thenReturn(Collections.enumeration(List.of(maliciousName)));
+        when(req.getParameter(maliciousName)).thenReturn("someValue");
+
+        try (LogCapture logCapture = LogCapture.forLogger(SxmlMisc.class)) {
+            String result = SxmlMisc.createXmlDataString(req, "field_");
+
+            // Invalid element name is skipped, so it never reaches the XML output.
+            assertThat(result).doesNotContain(FORGED);
+
+            assertThat(logCapture.messages()).hasSize(1);
+            String logged = logCapture.messages().get(0);
+            // No raw CR/LF means no forged log line can be smuggled through.
+            assertThat(logged).doesNotContain("\r").doesNotContain("\n");
+            // The control chars survive as escaped sequences for diagnostics.
+            assertThat(logged).contains("field_evil").contains("\\r\\n");
+        }
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/hospitalReportManager/dao/HRMDocumentDaoLogInjectionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/hospitalReportManager/dao/HRMDocumentDaoLogInjectionUnitTest.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.hospitalReportManager.dao;
+
+import io.github.carlos_emr.carlos.test.logging.LogCapture;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Log-injection regression test for {@link HRMDocumentDao}'s ORDER BY validation.
+ *
+ * <p>{@code isValidOrderRequest} logs the rejected {@code orderColumn} /
+ * {@code orderDirection} sort parameters. These are user-supplied request values
+ * logged on the rejection path, so they can carry CR/LF and forge log lines. The
+ * private method is exercised reflectively (the public callers need an
+ * EntityManager) to assert the rejected values are sanitized before logging.</p>
+ *
+ * @since 2026-06-18
+ */
+@DisplayName("HRMDocumentDao log-injection Tests")
+@Tag("unit")
+class HRMDocumentDaoLogInjectionUnitTest {
+
+    private static final String FORGED = "INJECTED forged-admin-login-success";
+
+    private static boolean invokeIsValidOrderRequest(String orderColumn, String orderDirection) throws Exception {
+        HRMDocumentDao dao = new HRMDocumentDao();
+        Method method = HRMDocumentDao.class.getDeclaredMethod("isValidOrderRequest", String.class, String.class);
+        method.setAccessible(true);
+        return (boolean) method.invoke(dao, orderColumn, orderDirection);
+    }
+
+    @Test
+    @DisplayName("should sanitize rejected orderColumn before logging")
+    void shouldSanitizeOrderColumn_whenNotInAllowlist() throws Exception {
+        String maliciousColumn = "id\r\n" + FORGED;
+
+        try (LogCapture logCapture = LogCapture.forLogger(HRMDocumentDao.class)) {
+            boolean valid = invokeIsValidOrderRequest(maliciousColumn, "ASC");
+
+            assertThat(valid).isFalse();
+            assertThat(logCapture.messages()).hasSize(1);
+            String logged = logCapture.messages().get(0);
+            assertThat(logged).doesNotContain("\r").doesNotContain("\n");
+            assertThat(logged).contains("orderColumn").contains("\\r\\n");
+        }
+    }
+
+    @Test
+    @DisplayName("should sanitize rejected orderDirection before logging")
+    void shouldSanitizeOrderDirection_whenNotAscOrDesc() throws Exception {
+        String maliciousDirection = "ASC\r\n" + FORGED;
+
+        try (LogCapture logCapture = LogCapture.forLogger(HRMDocumentDao.class)) {
+            // A valid allowlisted column lets validation reach the direction check.
+            boolean valid = invokeIsValidOrderRequest("reportDate", maliciousDirection);
+
+            assertThat(valid).isFalse();
+            assertThat(logCapture.messages()).hasSize(1);
+            String logged = logCapture.messages().get(0);
+            assertThat(logged).doesNotContain("\r").doesNotContain("\n");
+            assertThat(logged).contains("orderDirection").contains("\\r\\n");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Hardens four utility logging sites flagged as CodeQL **log-injection** (`java/log-injection`). Three logged attacker-controllable values without neutralizing CR/LF — allowing forged log lines — and are fixed here by routing each tainted value through `LogSafe.sanitize`. The fourth was already sanitized and is documented as a verified no-op.

This is the "Config, XML, Lab/HRM Utility Logging" hardening group.

## Changes

| File | Issue | Tainted value | Notes |
|------|-------|---------------|-------|
| `SxmlMisc.createXmlDataString` | #26145 | HTTP request **parameter name** | Logged on the exact branch where it failed the alphanumeric guard — by construction can contain CR/LF. Was raw string-concat. |
| `HRMDocumentDao.isValidOrderRequest` | #26131 | `orderColumn` / `orderDirection` request sort params | Logged on the allowlist-rejection path. `{}` placeholders do **not** neutralize newlines in log4j2. |
| `CarlosProperties.getProperty` | #26146, #26147 | caller-supplied `key` + properties-file `value` | Missing-key and blacklisted-value warning branches. Trusted `PROPERTY_DEFAULTS` values left as-is. |
| `HandlerClassFactory` | #26132 | — | **No change.** Already sanitized via `LogSafe.sanitize` with `// NOSONAR javasecurity:S5145`. Verified no raw tainted logs remain. |

The duplicate stub `carlos/util/plugin/CarlosProperties.java` has no logging and is untouched.

## Tests

New focused `LogCapture`-based unit tests feed CRLF-laden input to each fixed branch and assert the emitted log message contains **no raw line breaks** (control chars survive only as escaped `\r\n` sequences):

- `SxmlMiscLogInjectionUnitTest`
- `CarlosPropertiesLogInjectionUnitTest` (both missing-key and blacklisted-value branches)
- `HRMDocumentDaoLogInjectionUnitTest` (both orderColumn and orderDirection branches)

```
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

## Issues

Fixes #26145
Fixes #26131
Fixes #26146
Fixes #26147

Verifies #26132 already remediated (no code change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitizes untrusted values in utility logs to block log forging (CR/LF injection) and resolve CodeQL `java/log-injection` findings across XML, HRM, and properties utilities. Also suppresses SonarCloud false positives on the sanitized log lines. Fixes #26145, #26131, #26146, #26147; verifies #26132 is already safe.

- **Bug Fixes**
  - `SxmlMisc.createXmlDataString`: sanitize rejected HTTP parameter names before logging via `LogSafe.sanitize`; added trailing `// NOSONAR javasecurity:S5145 — sanitized with LogSafe`.
  - `HRMDocumentDao.isValidOrderRequest`: sanitize `orderColumn` and `orderDirection` in warn logs; added trailing `// NOSONAR javasecurity:S5145 — sanitized with LogSafe`.
  - `CarlosProperties.getProperty`: sanitize caller-supplied `key` and properties-file `value` in warning branches; trusted defaults unchanged.
  - `HandlerClassFactory`: confirmed already using `LogSafe.sanitize`; no code changes.
  - Added `LogCapture` unit tests for each path to ensure logs contain no raw CR/LF.

<sup>Written for commit 6ea9873b03b6ace3d920d137c5732e9ac59842da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2928?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

