### PR TITLE
fix: sanitize/suppress log-injection findings in billing + scheduling

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/appt/ApptUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/appt/ApptUtil.java
@@ -102,12 +102,12 @@ public class ApptUtil {
         // Validate numeric ID fields at trust boundary (CWE-501)
         String demoNoParam = request.getParameter("demographic_no");
         if (demoNoParam != null && !demoNoParam.isEmpty() && !demoNoParam.matches("\\d+")) {
-            logger.warn("Invalid non-numeric demographic_no: {}", LogSafe.sanitize(demoNoParam));
+            logger.warn("Invalid non-numeric demographic_no: {}", LogSafe.sanitize(demoNoParam)); // NOSONAR javasecurity:S5145 — sanitized with LogSafe
             return;
         }
         String chartNo = request.getParameter("chart_no");
         if (chartNo != null && !chartNo.isEmpty() && !chartNo.matches("\\d+")) {
-            logger.warn("Invalid non-numeric chart_no: {}", LogSafe.sanitize(chartNo));
+            logger.warn("Invalid non-numeric chart_no: {}", LogSafe.sanitize(chartNo)); // NOSONAR javasecurity:S5145 — sanitized with LogSafe
             return;
         }
 

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/service/BillingOnLookupService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/service/BillingOnLookupService.java
@@ -478,7 +478,7 @@ public class BillingOnLookupService {
             appointmentDao.merge(appt);
             return true;
         }
-        _logger.warn("BillingOnLookupService.updateApptStatus: appointment {} not found; status {} not applied",
+        _logger.warn("BillingOnLookupService.updateApptStatus: appointment {} not found; status {} not applied", // NOSONAR javasecurity:S5145 — sanitized with LogSafe
                 LogSafe.sanitize(apptNo), LogSafe.sanitize(status));
         return false;
     }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/BillingONCHeader1.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/BillingONCHeader1.java
@@ -52,6 +52,7 @@ import jakarta.persistence.TemporalType;
 
 import org.apache.cxf.common.util.StringUtils;
 import org.apache.logging.log4j.Logger;
+import io.github.carlos_emr.carlos.utility.LogSafe;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 /**
  * Legacy Ontario billing claim header entity.
@@ -428,7 +429,7 @@ public class BillingONCHeader1 extends AbstractModel<Integer> implements Seriali
         if (value != null && !KNOWN_STATUSES.contains(value)) {
             BillingStatus.recordUnknownStatusWarning();
             logger.warn("Accepting unknown BillingONCHeader1 status value during deprecation: {} (allowed: {})",
-                    value, KNOWN_STATUSES);
+                    LogSafe.sanitize(value), KNOWN_STATUSES);
         }
         this.status = value;
     }
@@ -446,7 +447,7 @@ public class BillingONCHeader1 extends AbstractModel<Integer> implements Seriali
         // rejected at the boundary instead of being re-persisted indefinitely.
         if (value != null && !KNOWN_STATUSES.contains(value)) {
             logger.warn("Rejecting unknown BillingONCHeader1 status value {} (allowed: {})",
-                    value, KNOWN_STATUSES);
+                    LogSafe.sanitize(value), KNOWN_STATUSES);
             throw new IllegalArgumentException(
                     "BillingONCHeader1 status is not in the known set; see logs for the offending value");
         }

--- a/src/test/java/io/github/carlos_emr/carlos/commn/model/BillingONCHeader1LogInjectionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/commn/model/BillingONCHeader1LogInjectionUnitTest.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.commn.model;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.github.carlos_emr.carlos.test.logging.LogCapture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Log-injection regression tests for {@link BillingONCHeader1}'s status setters.
+ *
+ * <p>Both {@code setStatus} (legacy permissive path) and {@code setStatusStrict}
+ * log the request-derived status token when it is outside the known set. The token
+ * is routed through {@code LogSafe.sanitize()} so CR/LF and other control characters
+ * cannot forge additional log lines (CWE-117 / SonarQube javasecurity:S5145). These
+ * tests pin that neutralization at the exact logger the entity uses.</p>
+ *
+ * @since 2026-06-18
+ */
+@DisplayName("BillingONCHeader1 status logging (log injection)")
+@Tag("unit")
+@Tag("billing")
+class BillingONCHeader1LogInjectionUnitTest {
+
+    private static final String FORGED_STATUS =
+            "Z\r\nWARN forged-line: bypassed-rejection";
+
+    @Test
+    @DisplayName("setStatus neutralizes CR/LF in the logged unknown status value")
+    void shouldSanitizeControlCharacters_whenSetStatusLogsUnknownValue() {
+        try (LogCapture capture = LogCapture.forLogger(BillingONCHeader1.class)) {
+            new BillingONCHeader1().setStatus(FORGED_STATUS);
+
+            String logged = warningMentioningForgedToken(capture.messages());
+            assertThat(logged).doesNotContain("\n").doesNotContain("\r");
+            // The token is still logged for audit, just escaped rather than dropped.
+            assertThat(logged).contains("forged-line");
+        }
+    }
+
+    @Test
+    @DisplayName("setStatusStrict neutralizes CR/LF in the rejected status value before throwing")
+    void shouldSanitizeControlCharacters_whenSetStatusStrictRejectsUnknownValue() {
+        try (LogCapture capture = LogCapture.forLogger(BillingONCHeader1.class)) {
+            assertThatThrownBy(() -> new BillingONCHeader1().setStatusStrict(FORGED_STATUS))
+                    .isInstanceOf(IllegalArgumentException.class);
+
+            String logged = warningMentioningForgedToken(capture.messages());
+            assertThat(logged).doesNotContain("\n").doesNotContain("\r");
+            assertThat(logged).contains("forged-line");
+        }
+    }
+
+    private static String warningMentioningForgedToken(List<String> messages) {
+        return messages.stream()
+                .filter(m -> m.contains("forged-line"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(
+                        "expected a warning that logged the rejected status token, got: " + messages));
+    }
+}


### PR DESCRIPTION
## Summary

Small, coherent operational-workflow PR clearing four SonarQube `javasecurity:S5145` (log injection) findings across the **billing + appointment-scheduling** slice. The findings split into one genuine fix and three verified false positives.

### Genuine fix — `BillingONCHeader1`
The status setters logged the raw, request-derived status token. Both `setStatus()` (the permissive legacy setter) and `setStatusStrict()` now route `value` through `LogSafe.sanitize()`, consistent with the project convention for logging operational identifiers.

- Sonar flagged only `setStatusStrict` (alert #26158), but `setStatus` logs the **same** value via the more reachable legacy request path, so both sites are sanitized to avoid leaving the lenient path bleeding.
- Adds the `LogSafe` import.

### Verified false positives — suppression only
These lines already pass the value through `LogSafe.sanitize()` (truncate + `Encode.forJava()` escaping of CR/LF/control chars). Sonar's taint engine doesn't model `LogSafe` as a sanitizer, so each is annotated with the repo's canonical suppression `// NOSONAR javasecurity:S5145 — sanitized with LogSafe` (matching `ProviderService`, `DocumentUploadServlet`, `zip`, etc.):

- `ApptUtil` — `demographic_no` log (#26143) and `chart_no` log (#26144)
- `BillingOnLookupService.updateApptStatus` — appointment/status log (#26157)

No behavior change for the three suppressions; the only runtime change is the added sanitization in `BillingONCHeader1`.

## Alerts addressed
- #26143, #26144 — `ApptUtil.java`
- #26157 — `BillingOnLookupService.java`
- #26158 — `BillingONCHeader1.java`

## Testing
- Static review of each flagged site; confirmed `LogSafe.sanitize` is the established sanitizer and the NOSONAR form matches existing in-repo usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened logging against injection in billing and appointment scheduling by sanitizing status tokens in `BillingONCHeader1`, suppressing three false-positive SonarQube `javasecurity:S5145` alerts that already use `LogSafe`, and adding a regression test to verify CR/LF neutralization.

- **Bug Fixes**
  - `BillingONCHeader1`: sanitize `status` in both `setStatus` and `setStatusStrict` via `LogSafe.sanitize()`.
  - Suppress already-sanitized logs with `// NOSONAR javasecurity:S5145 — sanitized with LogSafe` in `ApptUtil` (`demographic_no`, `chart_no`) and `BillingOnLookupService.updateApptStatus` (missing appointment/status).
  - Add `BillingONCHeader1LogInjectionUnitTest` to confirm both setters escape CR/LF in logged unknown status values.

<sup>Written for commit 7a7e9be1bd3952731dcb217e02fafd67fee295f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2929?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

