### PR TITLE
Fix log injection alerts in scoped logging paths

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/assembler/BillingShortcutPg1ViewModelAssembler.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/assembler/BillingShortcutPg1ViewModelAssembler.java
@@ -30,6 +30,8 @@ import java.util.Properties;
 
 import jakarta.servlet.http.HttpServletRequest;
 
+import org.apache.logging.log4j.Logger;
+
 import io.github.carlos_emr.CarlosProperties;
 import io.github.carlos_emr.Misc;
 import io.github.carlos_emr.SxmlMisc;
@@ -286,14 +288,20 @@ public class BillingShortcutPg1ViewModelAssembler {
                         billingHistoryDetails.add(detail);
                     } catch (ClassCastException ccEx) {
                         historyPartialRowCount++;
-                        io.github.carlos_emr.carlos.utility.MiscUtils.getLogger().error(
-                                "Shortcut history: data-shape regression at pair index {} for demo={}",
-                                i, demoNo, ccEx);
+                        Logger logger = MiscUtils.getLogger();
+                        if (logger.isErrorEnabled()) {
+                            String safeDemoNo = LogSafe.sanitize(demoNo);
+                            logger.error("Shortcut history: data-shape regression at pair index {} for demo={}",
+                                    i, safeDemoNo, ccEx);
+                        }
                     } catch (RuntimeException rowEx) {
                         historyPartialRowCount++;
-                        io.github.carlos_emr.carlos.utility.MiscUtils.getLogger().warn(
-                                "Shortcut history: skipping malformed pair at index {} for demo={}",
-                                i, demoNo, rowEx);
+                        Logger logger = MiscUtils.getLogger();
+                        if (logger.isWarnEnabled()) {
+                            String safeDemoNo = LogSafe.sanitize(demoNo);
+                            logger.warn("Shortcut history: skipping malformed pair at index {} for demo={}",
+                                    i, safeDemoNo, rowEx);
+                        }
                     }
                 }
             }

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/assembler/BillingShortcutPg1ViewModelAssembler.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/assembler/BillingShortcutPg1ViewModelAssembler.java
@@ -290,17 +290,15 @@ public class BillingShortcutPg1ViewModelAssembler {
                         historyPartialRowCount++;
                         Logger logger = MiscUtils.getLogger();
                         if (logger.isErrorEnabled()) {
-                            String safeDemoNo = LogSafe.sanitize(demoNo);
-                            logger.error("Shortcut history: data-shape regression at pair index {} for demo={}",
-                                    i, safeDemoNo, ccEx);
+                            logger.error("Shortcut history: data-shape regression at pair index {}; demo omitted from log",
+                                    i, ccEx);
                         }
                     } catch (RuntimeException rowEx) {
                         historyPartialRowCount++;
                         Logger logger = MiscUtils.getLogger();
                         if (logger.isWarnEnabled()) {
-                            String safeDemoNo = LogSafe.sanitize(demoNo);
-                            logger.warn("Shortcut history: skipping malformed pair at index {} for demo={}",
-                                    i, safeDemoNo, rowEx);
+                            logger.warn("Shortcut history: skipping malformed pair at index {}; demo omitted from log",
+                                    i, rowEx);
                         }
                     }
                 }

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/service/DiagCodeDescriptionPersister.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/service/DiagCodeDescriptionPersister.java
@@ -23,11 +23,13 @@ package io.github.carlos_emr.carlos.billings.ca.on.service;
 
 import java.util.List;
 
+import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import io.github.carlos_emr.carlos.commn.dao.DiagnosticCodeDao;
 import io.github.carlos_emr.carlos.commn.model.DiagnosticCode;
+import io.github.carlos_emr.carlos.utility.LogSafe;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 
 /**
@@ -63,7 +65,11 @@ public class DiagCodeDescriptionPersister {
             if (ex instanceof DiagDescriptionUpdateException) {
                 throw ex;
             }
-            MiscUtils.getLogger().error("Diagnostic code update failed for {}", code, ex);
+            Logger logger = MiscUtils.getLogger();
+            if (logger.isErrorEnabled()) {
+                String safeCode = LogSafe.sanitize(code);
+                logger.error("Diagnostic code update failed for {}", safeCode, ex);
+            }
             throw new DiagDescriptionUpdateException(code, ex);
         }
     }

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/service/DiagCodeDescriptionPersister.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/service/DiagCodeDescriptionPersister.java
@@ -29,7 +29,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import io.github.carlos_emr.carlos.commn.dao.DiagnosticCodeDao;
 import io.github.carlos_emr.carlos.commn.model.DiagnosticCode;
-import io.github.carlos_emr.carlos.utility.LogSafe;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 
 /**
@@ -67,8 +66,7 @@ public class DiagCodeDescriptionPersister {
             }
             Logger logger = MiscUtils.getLogger();
             if (logger.isErrorEnabled()) {
-                String safeCode = LogSafe.sanitize(code);
-                logger.error("Diagnostic code update failed for {}", safeCode, ex);
+                logger.error("Diagnostic code update failed; diagnostic code omitted from log", ex);
             }
             throw new DiagDescriptionUpdateException(code, ex);
         }

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/service/DiagCodeDescriptionPersister.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/service/DiagCodeDescriptionPersister.java
@@ -66,7 +66,8 @@ public class DiagCodeDescriptionPersister {
             }
             Logger logger = MiscUtils.getLogger();
             if (logger.isErrorEnabled()) {
-                logger.error("Diagnostic code update failed; diagnostic code omitted from log", ex);
+                logger.error("Diagnostic code update failed; diagnostic code omitted from log; causeType={}",
+                        ex.getClass().getName());
             }
             throw new DiagDescriptionUpdateException(code, ex);
         }

--- a/src/main/java/io/github/carlos_emr/carlos/email/action/EmailCompose2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/email/action/EmailCompose2Action.java
@@ -8,13 +8,13 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 
 import org.apache.logging.log4j.Logger;
-import org.owasp.encoder.Encode;
 
 import io.github.carlos_emr.carlos.commn.model.EmailAttachment;
 import io.github.carlos_emr.carlos.commn.model.EmailConfig;
 import io.github.carlos_emr.carlos.commn.model.EmailLog.TransactionType;
 import io.github.carlos_emr.carlos.managers.DemographicManager;
 import io.github.carlos_emr.carlos.managers.EmailComposeManager;
+import io.github.carlos_emr.carlos.utility.LogSafe;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.PDFGenerationException;
@@ -58,7 +58,7 @@ import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
  * Security Considerations:
  * <ul>
  *   <li>Validates fid parameter to ensure numeric format (prevents injection)</li>
- *   <li>Uses OWASP Encode.forJava() for sanitizing invalid fid values in logs</li>
+ *   <li>Uses log-safe sanitization for invalid fid values in logs</li>
  *   <li>Generates patient-specific PDF passwords based on demographic information</li>
  *   <li>Sanitizes attachment filenames through EmailComposeManager</li>
  *   <li>Session cleanup prevents information leakage across requests</li>
@@ -226,8 +226,10 @@ public class EmailCompose2Action extends ActionSupport {
 
         // Validate fid is numeric if provided
         if (fid != null && !fid.matches("\\d+")) {
-            String sanitizedFid = Encode.forJava(fid);
-            logger.warn("Invalid fid parameter received: {}", sanitizedFid);
+            if (logger.isWarnEnabled()) {
+                String sanitizedFid = LogSafe.sanitize(fid);
+                logger.warn("Invalid fid parameter received: {}", sanitizedFid);
+            }
             fid = null;
         }
 

--- a/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FormForward2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FormForward2Action.java
@@ -41,7 +41,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.codec.CharEncoding;
 import org.apache.logging.log4j.Logger;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
-import io.github.carlos_emr.carlos.utility.LogSafe;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
@@ -129,8 +128,7 @@ public class FormForward2Action extends ActionSupport {
         String actionPath = FormViewRoutes.resolveActionPath(formPath[0]);
         if (actionPath == null) {
             if (logger.isWarnEnabled()) {
-                String safeFormName = LogSafe.sanitize(strFrm);
-                logger.warn("Failed to resolve action path for form {}", safeFormName);
+                logger.warn("Failed to resolve action path for requested form; form name omitted from log");
             }
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid form path");
             return NONE;

--- a/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FormForward2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FormForward2Action.java
@@ -41,6 +41,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.codec.CharEncoding;
 import org.apache.logging.log4j.Logger;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import io.github.carlos_emr.carlos.utility.LogSafe;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
@@ -127,7 +128,10 @@ public class FormForward2Action extends ActionSupport {
          */
         String actionPath = FormViewRoutes.resolveActionPath(formPath[0]);
         if (actionPath == null) {
-            logger.warn("Failed to resolve action path for form {}", strFrm);
+            if (logger.isWarnEnabled()) {
+                String safeFormName = LogSafe.sanitize(strFrm);
+                logger.warn("Failed to resolve action path for form {}", safeFormName);
+            }
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid form path");
             return NONE;
         }

--- a/src/main/java/io/github/carlos_emr/carlos/login/gate/SelectFacility2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/login/gate/SelectFacility2Action.java
@@ -107,9 +107,13 @@ public final class SelectFacility2Action extends BaseLoginPageView2Action {
         String nextResult = request.getParameter("nextPage");
         if (nextResult != null && !nextResult.isEmpty() && !ALLOWED_NEXT_RESULTS.contains(nextResult)) {
             // Validate navigation intent before mutating facility state; invalid values are retryable.
-            LOGGER.warn("Rejected /select_facility nextPage before facility mutation: provider={}, nextPage={}, remote={}",
-                    LogSafe.sanitize(providerNo), LogSafe.sanitize(nextResult),
-                    LogSafe.sanitize(request.getRemoteAddr()));
+            if (LOGGER.isWarnEnabled()) {
+                String safeProviderNo = LogSafe.sanitize(providerNo);
+                String safeNextResult = LogSafe.sanitize(nextResult);
+                String safeRemoteAddr = LogSafe.sanitize(request.getRemoteAddr());
+                LOGGER.warn("Rejected /select_facility nextPage before facility mutation: provider={}, nextPage={}, remote={}",
+                        safeProviderNo, safeNextResult, safeRemoteAddr);
+            }
             return redirectToFacilitySelection(request, response);
         }
 

--- a/src/main/java/io/github/carlos_emr/carlos/login/gate/SelectFacility2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/login/gate/SelectFacility2Action.java
@@ -133,7 +133,7 @@ public final class SelectFacility2Action extends BaseLoginPageView2Action {
         LoggedInInfo loggedInInfo = LoggedInUserFilter.generateLoggedInInfoFromSession(request);
         LoggedInInfo.setLoggedInInfoIntoSession(session, loggedInInfo);
         LogAction.addLog(providerNo, LogConst.LOGIN, LogConst.CON_LOGIN,
-                "facilityId=" + facilityId, request.getRemoteAddr());
+                "facilityId=" + facilityId, LogSafe.sanitize(request.getRemoteAddr()));
 
         if (nextResult == null || nextResult.isEmpty()) {
             return "provider";

--- a/src/main/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgDisplayDemographicMessages2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgDisplayDemographicMessages2Action.java
@@ -162,8 +162,7 @@ public class MsgDisplayDemographicMessages2Action extends ActionSupport {
             if (!demographicNo.matches("\\d+")) {
                 Logger logger = MiscUtils.getLogger();
                 if (logger.isErrorEnabled()) {
-                    String safeDemographicNo = LogSafe.sanitize(demographicNo);
-                    logger.error("Invalid non-numeric demographic_no: {}", safeDemographicNo);
+                    logger.error("Invalid non-numeric demographic_no received; value omitted from log");
                 }
                 // Clear any stale session bean to prevent PHI leakage from a previous request
                 request.getSession().removeAttribute("msgSessionBean");

--- a/src/main/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgDisplayDemographicMessages2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgDisplayDemographicMessages2Action.java
@@ -160,7 +160,11 @@ public class MsgDisplayDemographicMessages2Action extends ActionSupport {
 
             // Validate demographicNo is numeric before storing in session bean
             if (!demographicNo.matches("\\d+")) {
-                MiscUtils.getLogger().error("Invalid non-numeric demographic_no: {}", LogSafe.sanitize(demographicNo));
+                Logger logger = MiscUtils.getLogger();
+                if (logger.isErrorEnabled()) {
+                    String safeDemographicNo = LogSafe.sanitize(demographicNo);
+                    logger.error("Invalid non-numeric demographic_no: {}", safeDemographicNo);
+                }
                 // Clear any stale session bean to prevent PHI leakage from a previous request
                 request.getSession().removeAttribute("msgSessionBean");
                 return "error";

--- a/src/main/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgDisplayDemographicMessages2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgDisplayDemographicMessages2Action.java
@@ -32,6 +32,8 @@ package io.github.carlos_emr.carlos.messenger.pageUtil;
 
 import java.io.IOException;
 
+import org.apache.logging.log4j.Logger;
+
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -171,7 +173,11 @@ public class MsgDisplayDemographicMessages2Action extends ActionSupport {
 
             // demographicNo validated as numeric; userName is unsanitized — JSPs must use OWASP encoding
             request.getSession().setAttribute("msgSessionBean", bean); // nosemgrep: tainted-session-from-http-request, tainted-session-from-http-request-deepsemgrep
-            MiscUtils.getLogger().debug("Created new MsgSessionBean for providers: " + providerNo);
+            Logger logger = MiscUtils.getLogger();
+            if (logger.isDebugEnabled()) {
+                String safeProvider = LogSafe.sanitize(providerNo);
+                logger.debug("Created new MsgSessionBean for providers: {}", safeProvider);
+            }
         }
 
         // Process message unlinking if requested

--- a/src/main/java/io/github/carlos_emr/carlos/scratch/Scratch2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/scratch/Scratch2Action.java
@@ -177,8 +177,13 @@ public class Scratch2Action extends JSONAction {
 			jsonResponse(jsonObject);
 
         }else {
-			MiscUtils.getLogger().error("Scratch pad trying to save data for user {} but session user is {}",
-				LogSafe.sanitize(pNo), LogSafe.sanitize(providerNo));
+			Logger logger = MiscUtils.getLogger();
+			if (logger.isErrorEnabled()) {
+				String safePNo = LogSafe.sanitize(pNo);
+				String safeProviderNo = LogSafe.sanitize(providerNo);
+				logger.error("Scratch pad trying to save data for user {} but session user is {}",
+					safePNo, safeProviderNo);
+			}
 			response.setStatus(HttpServletResponse.SC_FORBIDDEN);
             ObjectNode jsonObject = objectMapper.createObjectNode();
             jsonObject.put("success", false);

--- a/src/main/java/io/github/carlos_emr/carlos/scratch/Scratch2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/scratch/Scratch2Action.java
@@ -179,10 +179,7 @@ public class Scratch2Action extends JSONAction {
         }else {
 			Logger logger = MiscUtils.getLogger();
 			if (logger.isErrorEnabled()) {
-				String safePNo = LogSafe.sanitize(pNo);
-				String safeProviderNo = LogSafe.sanitize(providerNo);
-				logger.error("Scratch pad trying to save data for user {} but session user is {}",
-					safePNo, safeProviderNo);
+				logger.error("Scratch pad provider mismatch; request and session provider values omitted from log");
 			}
 			response.setStatus(HttpServletResponse.SC_FORBIDDEN);
             ObjectNode jsonObject = objectMapper.createObjectNode();

--- a/src/main/java/io/github/carlos_emr/carlos/scratch/Scratch2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/scratch/Scratch2Action.java
@@ -36,8 +36,9 @@ import io.github.carlos_emr.carlos.commn.model.JSONAction;
 import io.github.carlos_emr.carlos.commn.model.ScratchPad;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
-import org.owasp.encoder.Encode;
 import io.github.carlos_emr.carlos.utility.LogSafe;
+import org.apache.logging.log4j.Logger;
+import org.owasp.encoder.Encode;
 
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.Map;
@@ -58,7 +59,7 @@ public class Scratch2Action extends JSONAction {
     		throw new IllegalArgumentException("Missing required parameter: id");
     	}
 
-    	try {
+		try {
     		ScratchPad scratchPad = scratchPadDao.find(Integer.parseInt(id));
     		if (scratchPad == null) {
     			throw new IllegalArgumentException("ScratchPad not found for id: " + id);
@@ -137,12 +138,17 @@ public class Scratch2Action extends JSONAction {
                return null;
            }
            returnId = ""+databaseId;
-           MiscUtils.getLogger().debug( "database Id = "+databaseId+" request id "+id);
 
-		   if (id == null || id.trim().isEmpty()) {
+           if (id == null || id.trim().isEmpty()) {
                MiscUtils.getLogger().error("Request id parameter is null or empty");
                response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
                return null;
+           }
+
+           Logger logger = MiscUtils.getLogger();
+           if (logger.isDebugEnabled()) {
+               String safeRequestId = LogSafe.sanitize(id);
+               logger.debug("database Id = {} request id {}", databaseId, safeRequestId);
            }
 
            int requestId;
@@ -172,7 +178,7 @@ public class Scratch2Action extends JSONAction {
 
         }else {
 			MiscUtils.getLogger().error("Scratch pad trying to save data for user {} but session user is {}",
-				Encode.forJava(pNo), Encode.forJava(providerNo));
+				LogSafe.sanitize(pNo), LogSafe.sanitize(providerNo));
 			response.setStatus(HttpServletResponse.SC_FORBIDDEN);
             ObjectNode jsonObject = objectMapper.createObjectNode();
             jsonObject.put("success", false);

--- a/src/main/java/io/github/carlos_emr/carlos/util/zip.java
+++ b/src/main/java/io/github/carlos_emr/carlos/util/zip.java
@@ -113,7 +113,10 @@ public class zip {
         Enumeration<? extends ZipEntry> entries;
         boolean result = false;
         if (fName == null || fName.length() < 4 || !fName.toLowerCase().endsWith(".zip")) {
-            logger.error("unzipXML: " + fName + " does not have .zip extension.");
+            if (logger.isErrorEnabled()) {
+                String safeFileName = LogSafe.sanitize(fName);
+                logger.error("unzipXML: {} does not have .zip extension.", safeFileName);
+            }
             return result;
         }
         File targetDir;
@@ -188,4 +191,3 @@ public class zip {
         return result;
     }
 }
-

--- a/src/main/java/io/github/carlos_emr/carlos/util/zip.java
+++ b/src/main/java/io/github/carlos_emr/carlos/util/zip.java
@@ -114,8 +114,7 @@ public class zip {
         boolean result = false;
         if (fName == null || fName.length() < 4 || !fName.toLowerCase().endsWith(".zip")) {
             if (logger.isErrorEnabled()) {
-                String safeFileName = LogSafe.sanitize(fName);
-                logger.error("unzipXML: {} does not have .zip extension.", safeFileName);
+                logger.error("unzipXML rejected file without .zip extension; file name omitted from log.");
             }
             return result;
         }

--- a/src/test/java/io/github/carlos_emr/carlos/billings/ca/on/assembler/BillingShortcutPg1ViewModelAssemblerUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/billings/ca/on/assembler/BillingShortcutPg1ViewModelAssemblerUnitTest.java
@@ -43,6 +43,7 @@ import io.github.carlos_emr.carlos.commn.model.Billing;
 import io.github.carlos_emr.carlos.commn.model.ClinicLocation;
 import io.github.carlos_emr.carlos.commn.model.Demographic;
 import io.github.carlos_emr.carlos.commn.model.Provider;
+import io.github.carlos_emr.carlos.test.logging.LogCapture;
 import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 
@@ -366,6 +367,38 @@ class BillingShortcutPg1ViewModelAssemblerUnitTest extends CarlosUnitTestBase {
             assertThat(m.getHistoryPartialRowCount()).isEqualTo(1);
             assertThat(m.getBillingHistory()).hasSize(1);
             assertThat(m.getBillingHistoryDetails()).hasSize(1);
+        } finally {
+            if (previous == null) {
+                CarlosProperties.getInstance().remove("isNewONbilling");
+            } else {
+                CarlosProperties.getInstance().setProperty("isNewONbilling", previous);
+            }
+        }
+    }
+
+    @Test
+    void shouldSanitizeDemographicNumber_whenNewOnBillingPairShapeRegresses() {
+        String previous = CarlosProperties.getInstance().getProperty("isNewONbilling", "");
+        CarlosProperties.getInstance().setProperty("isNewONbilling", "true");
+        try {
+            String maliciousDemoNo = "1\r\nforged-demo";
+            request.setParameter("demographic_no", maliciousDemoNo);
+            BillingClaimItemDto goodItem = newClaimItem("A001A", "401");
+            when(billingReviewImpl.getBillingHist(eq(maliciousDemoNo), eq(5), eq(0), any()))
+                    .thenReturn(List.of("not-a-header", goodItem));
+
+            try (LogCapture capture = LogCapture.forLogger(BillingShortcutPg1ViewModelAssembler.class)) {
+                BillingShortcutPg1ViewModel m = assembler.assemble(request, loggedInInfo);
+
+                assertThat(m.isHistoryPartial()).isTrue();
+                assertThat(m.getHistoryPartialRowCount()).isEqualTo(1);
+                String logged = capture.messages().stream()
+                        .filter(message -> message.contains("data-shape regression"))
+                        .findFirst()
+                        .orElseThrow();
+                assertThat(logged).doesNotContain("\r").doesNotContain("\n");
+                assertThat(logged).contains("1\\r\\nforged-demo");
+            }
         } finally {
             if (previous == null) {
                 CarlosProperties.getInstance().remove("isNewONbilling");

--- a/src/test/java/io/github/carlos_emr/carlos/billings/ca/on/assembler/BillingShortcutPg1ViewModelAssemblerUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/billings/ca/on/assembler/BillingShortcutPg1ViewModelAssemblerUnitTest.java
@@ -377,7 +377,7 @@ class BillingShortcutPg1ViewModelAssemblerUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
-    void shouldSanitizeDemographicNumber_whenNewOnBillingPairShapeRegresses() {
+    void shouldOmitDemographicNumber_whenNewOnBillingPairShapeRegresses() {
         String previous = CarlosProperties.getInstance().getProperty("isNewONbilling", "");
         CarlosProperties.getInstance().setProperty("isNewONbilling", "true");
         try {
@@ -397,7 +397,7 @@ class BillingShortcutPg1ViewModelAssemblerUnitTest extends CarlosUnitTestBase {
                         .findFirst()
                         .orElseThrow();
                 assertThat(logged).doesNotContain("\r").doesNotContain("\n");
-                assertThat(logged).contains("1\\r\\nforged-demo");
+                assertThat(logged).doesNotContain("1\r\nforged-demo", "1\\r\\nforged-demo", "forged-demo");
             }
         } finally {
             if (previous == null) {

--- a/src/test/java/io/github/carlos_emr/carlos/billings/ca/on/service/DiagCodeDescriptionPersisterUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/billings/ca/on/service/DiagCodeDescriptionPersisterUnitTest.java
@@ -23,6 +23,7 @@ package io.github.carlos_emr.carlos.billings.ca.on.service;
 
 import io.github.carlos_emr.carlos.commn.dao.DiagnosticCodeDao;
 import io.github.carlos_emr.carlos.commn.model.DiagnosticCode;
+import io.github.carlos_emr.carlos.test.logging.LogCapture;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
@@ -95,6 +96,24 @@ class DiagCodeDescriptionPersisterUnitTest {
                 .isInstanceOf(DiagDescriptionUpdateException.class)
                 .hasMessageContaining("001")
                 .hasCauseInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    @DisplayName("should sanitize diagnostic code before logging")
+    void shouldSanitizeDiagnosticCode_whenDaoLookupFails() {
+        DiagnosticCodeDao dao = mock(DiagnosticCodeDao.class);
+        DiagCodeDescriptionPersister persister = new DiagCodeDescriptionPersister(dao);
+        when(dao.findByDiagnosticCode("1\r\n")).thenThrow(new RuntimeException("lock timeout"));
+
+        try (LogCapture capture = LogCapture.forLogger(DiagCodeDescriptionPersister.class)) {
+            assertThatThrownBy(() -> persister.updateDescription("update1\r\n", "Acute infection"))
+                    .isInstanceOf(DiagDescriptionUpdateException.class);
+
+            assertThat(capture.messages()).hasSize(1);
+            String logged = capture.messages().get(0);
+            assertThat(logged).doesNotContain("\r").doesNotContain("\n");
+            assertThat(logged).contains("1\\r\\n");
+        }
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/billings/ca/on/service/DiagCodeDescriptionPersisterUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/billings/ca/on/service/DiagCodeDescriptionPersisterUnitTest.java
@@ -99,8 +99,8 @@ class DiagCodeDescriptionPersisterUnitTest {
     }
 
     @Test
-    @DisplayName("should sanitize diagnostic code before logging")
-    void shouldSanitizeDiagnosticCode_whenDaoLookupFails() {
+    @DisplayName("should omit diagnostic code before logging")
+    void shouldOmitDiagnosticCode_whenDaoLookupFails() {
         DiagnosticCodeDao dao = mock(DiagnosticCodeDao.class);
         DiagCodeDescriptionPersister persister = new DiagCodeDescriptionPersister(dao);
         when(dao.findByDiagnosticCode("1\r\n")).thenThrow(new RuntimeException("lock timeout"));
@@ -112,7 +112,7 @@ class DiagCodeDescriptionPersisterUnitTest {
             assertThat(capture.messages()).hasSize(1);
             String logged = capture.messages().get(0);
             assertThat(logged).doesNotContain("\r").doesNotContain("\n");
-            assertThat(logged).contains("1\\r\\n");
+            assertThat(logged).doesNotContain("1\r\n", "1\\r\\n");
         }
     }
 

--- a/src/test/java/io/github/carlos_emr/carlos/billings/ca/on/service/DiagCodeDescriptionPersisterUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/billings/ca/on/service/DiagCodeDescriptionPersisterUnitTest.java
@@ -103,7 +103,7 @@ class DiagCodeDescriptionPersisterUnitTest {
     void shouldOmitDiagnosticCode_whenDaoLookupFails() {
         DiagnosticCodeDao dao = mock(DiagnosticCodeDao.class);
         DiagCodeDescriptionPersister persister = new DiagCodeDescriptionPersister(dao);
-        when(dao.findByDiagnosticCode("1\r\n")).thenThrow(new RuntimeException("lock timeout"));
+        when(dao.findByDiagnosticCode("1\r\n")).thenThrow(new RuntimeException("lock\r\nforged-exception"));
 
         try (LogCapture capture = LogCapture.forLogger(DiagCodeDescriptionPersister.class)) {
             assertThatThrownBy(() -> persister.updateDescription("update1\r\n", "Acute infection"))
@@ -112,7 +112,9 @@ class DiagCodeDescriptionPersisterUnitTest {
             assertThat(capture.messages()).hasSize(1);
             String logged = capture.messages().get(0);
             assertThat(logged).doesNotContain("\r").doesNotContain("\n");
-            assertThat(logged).doesNotContain("1\r\n", "1\\r\\n");
+            assertThat(logged).contains(RuntimeException.class.getName());
+            assertThat(logged).doesNotContain("1\r\n", "1\\r\\n", "lock\r\nforged-exception",
+                    "lock\\r\\nforged-exception", "forged-exception");
         }
     }
 

--- a/src/test/java/io/github/carlos_emr/carlos/email/action/EmailCompose2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/email/action/EmailCompose2ActionUnitTest.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ */
+package io.github.carlos_emr.carlos.email.action;
+
+import io.github.carlos_emr.carlos.managers.DemographicManager;
+import io.github.carlos_emr.carlos.managers.EmailComposeManager;
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import io.github.carlos_emr.carlos.test.logging.LogCapture;
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
+
+import org.apache.struts2.ServletActionContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+@Tag("unit")
+@Tag("security")
+@DisplayName("EmailCompose2Action")
+class EmailCompose2ActionUnitTest extends CarlosUnitTestBase {
+
+    @Test
+    @DisplayName("should sanitize fid before logging invalid value")
+    void shouldSanitizeFid_whenInvalidValueIsLogged() throws Exception {
+        DemographicManager demographicManager = mock(DemographicManager.class);
+        EmailComposeManager emailComposeManager = mock(EmailComposeManager.class);
+        SecurityInfoManager securityInfoManager = mock(SecurityInfoManager.class);
+        registerMock(DemographicManager.class, demographicManager);
+        registerMock(EmailComposeManager.class, emailComposeManager);
+        registerMock(SecurityInfoManager.class, securityInfoManager);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/email/compose");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        request.getSession(true).setAttribute("demographicId", "123");
+        request.getSession(false).setAttribute("emailPDFPassword", "existing-password");
+        request.getSession(false).setAttribute("emailPDFPasswordClue", "existing-clue");
+        request.addParameter("fid", "abc\r\nforged-fid");
+        when(emailComposeManager.getEmailConsentStatus(any(), anyInt())).thenReturn(new String[]{"Consent", "Yes"});
+        when(demographicManager.getDemographicFormattedName(any(), anyInt())).thenReturn("Patient One");
+        when(emailComposeManager.getRecipients(any(), anyInt())).thenReturn(new List<?>[]{List.of(), List.of()});
+        when(emailComposeManager.getAllSenderAccounts()).thenReturn(List.of());
+        when(emailComposeManager.prepareEFormAttachments(any(), any(), any())).thenReturn(List.of());
+        when(emailComposeManager.prepareEDocAttachments(any(), any())).thenReturn(List.of());
+        when(emailComposeManager.prepareLabAttachments(any(), any())).thenReturn(List.of());
+        when(emailComposeManager.prepareHRMAttachments(any(), any())).thenReturn(List.of());
+        when(emailComposeManager.prepareFormAttachments(any(), any(), any(), anyInt())).thenReturn(List.of());
+
+        try (MockedStatic<ServletActionContext> servletActionContext = mockStatic(ServletActionContext.class);
+             LogCapture capture = LogCapture.forLogger(EmailCompose2Action.class)) {
+            servletActionContext.when(ServletActionContext::getRequest).thenReturn(request);
+            servletActionContext.when(ServletActionContext::getResponse).thenReturn(response);
+
+            EmailCompose2Action action = new EmailCompose2Action();
+
+            assertThat(action.prepareComposeEFormMailer()).isEqualTo("compose");
+            assertThat(request.getAttribute("fid")).isNull();
+            String logged = capture.messages().stream()
+                    .filter(message -> message.startsWith("Invalid fid parameter received"))
+                    .findFirst()
+                    .orElseThrow();
+            assertThat(logged).doesNotContain("\r").doesNotContain("\n");
+            assertThat(logged).contains("abc\\r\\nforged-fid");
+        }
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/form/pageUtil/FormForward2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/form/pageUtil/FormForward2ActionUnitTest.java
@@ -35,8 +35,8 @@ import static org.mockito.Mockito.when;
 class FormForward2ActionUnitTest extends CarlosUnitTestBase {
 
     @Test
-    @DisplayName("should sanitize form name when action path cannot be resolved")
-    void shouldSanitizeFormName_whenActionPathCannotBeResolved() throws Exception {
+    @DisplayName("should omit form name when action path cannot be resolved")
+    void shouldOmitFormName_whenActionPathCannotBeResolved() throws Exception {
         SecurityInfoManager securityInfoManager = mock(SecurityInfoManager.class);
         registerMock(SecurityInfoManager.class, securityInfoManager);
         registerMock(EncounterFormDao.class, mock(EncounterFormDao.class));
@@ -66,7 +66,7 @@ class FormForward2ActionUnitTest extends CarlosUnitTestBase {
                     .findFirst()
                     .orElseThrow();
             assertThat(logged).doesNotContain("\r").doesNotContain("\n");
-            assertThat(logged).contains("bad\\r\\nform");
+            assertThat(logged).doesNotContain("bad\r\nform", "bad\\r\\nform");
         }
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/form/pageUtil/FormForward2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/form/pageUtil/FormForward2ActionUnitTest.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ */
+package io.github.carlos_emr.carlos.form.pageUtil;
+
+import io.github.carlos_emr.carlos.form.data.FrmData;
+import io.github.carlos_emr.carlos.commn.dao.EncounterFormDao;
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import io.github.carlos_emr.carlos.test.logging.LogCapture;
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
+
+import org.apache.struts2.ActionSupport;
+import org.apache.struts2.ServletActionContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+@Tag("unit")
+@Tag("security")
+@DisplayName("FormForward2Action")
+class FormForward2ActionUnitTest extends CarlosUnitTestBase {
+
+    @Test
+    @DisplayName("should sanitize form name when action path cannot be resolved")
+    void shouldSanitizeFormName_whenActionPathCannotBeResolved() throws Exception {
+        SecurityInfoManager securityInfoManager = mock(SecurityInfoManager.class);
+        registerMock(SecurityInfoManager.class, securityInfoManager);
+        registerMock(EncounterFormDao.class, mock(EncounterFormDao.class));
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/form/forward");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        request.setContextPath("/carlos");
+        request.addParameter("demographic_no", "123");
+        request.addParameter("formname", "bad%0D%0Aform");
+        when(securityInfoManager.hasPrivilege(any(), eq("_form"), eq(SecurityInfoManager.READ), eq("123")))
+                .thenReturn(true);
+
+        try (MockedStatic<ServletActionContext> servletActionContext = mockStatic(ServletActionContext.class);
+             MockedConstruction<FrmData> frmDataConstruction = mockConstruction(FrmData.class,
+                     (frmData, context) -> when(frmData.getShortcutFormValue("123", "bad\r\nform"))
+                             .thenReturn(new String[]{"/unknown-form"}));
+             LogCapture capture = LogCapture.forLogger(FormForward2Action.class)) {
+            servletActionContext.when(ServletActionContext::getRequest).thenReturn(request);
+            servletActionContext.when(ServletActionContext::getResponse).thenReturn(response);
+
+            FormForward2Action action = new FormForward2Action();
+
+            assertThat(action.execute()).isEqualTo(ActionSupport.NONE);
+            assertThat(response.getStatus()).isEqualTo(400);
+            assertThat(frmDataConstruction.constructed()).hasSize(1);
+            String logged = capture.messages().stream()
+                    .filter(message -> message.startsWith("Failed to resolve action path"))
+                    .findFirst()
+                    .orElseThrow();
+            assertThat(logged).doesNotContain("\r").doesNotContain("\n");
+            assertThat(logged).contains("bad\\r\\nform");
+        }
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/login/gate/SelectFacility2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/login/gate/SelectFacility2ActionUnitTest.java
@@ -12,6 +12,7 @@ import io.github.carlos_emr.carlos.commn.model.Provider;
 import io.github.carlos_emr.carlos.commn.model.Security;
 import io.github.carlos_emr.carlos.login.Login2Action;
 import io.github.carlos_emr.carlos.log.LogAction;
+import io.github.carlos_emr.carlos.test.logging.LogCapture;
 import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.SessionConstants;
@@ -261,6 +262,26 @@ class SelectFacility2ActionUnitTest extends CarlosUnitTestBase {
         assertThat(request.getSession(false).getAttribute(SessionConstants.PENDING_FACILITY_SELECTION))
                 .isEqualTo(Boolean.TRUE);
         verifyNoInteractions(providerDao, facilityDao);
+    }
+
+    @Test
+    @DisplayName("should sanitize nextPage when rejecting before facility mutation")
+    void shouldSanitizeNextPage_whenRejectingBeforeFacilityMutation() throws Exception {
+        request.addParameter(Login2Action.SELECTED_FACILITY_ID, "10");
+        request.addParameter("nextPage", "provider\r\nforged-next");
+        request.getSession(false).setAttribute(SessionConstants.PENDING_FACILITY_SELECTION, Boolean.TRUE);
+
+        try (LogCapture capture = LogCapture.forLogger(SelectFacility2Action.class)) {
+            String result = action().execute();
+
+            assertThat(result).isEqualTo(ActionSupport.NONE);
+            String logged = capture.messages().stream()
+                    .filter(message -> message.contains("nextPage before facility mutation"))
+                    .findFirst()
+                    .orElseThrow();
+            assertThat(logged).doesNotContain("\r").doesNotContain("\n");
+            assertThat(logged).contains("provider\\r\\nforged-next");
+        }
     }
 
     private SelectFacility2Action action() {

--- a/src/test/java/io/github/carlos_emr/carlos/login/gate/SelectFacility2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/login/gate/SelectFacility2ActionUnitTest.java
@@ -176,6 +176,24 @@ class SelectFacility2ActionUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
+    @DisplayName("should sanitize remote address when writing login audit log")
+    void shouldSanitizeRemoteAddress_whenWritingLoginAuditLog() throws Exception {
+        Facility facility = new Facility();
+        facility.setId(10);
+        request.setRemoteAddr("127.0.0.1\r\nforged-login");
+        request.addParameter(Login2Action.SELECTED_FACILITY_ID, "10");
+        request.addParameter("nextPage", "provider");
+        when(providerDao.getFacilityIds("999998")).thenReturn(List.of(10));
+        when(facilityDao.find(10)).thenReturn(facility);
+
+        String result = action().execute();
+
+        assertThat(result).isEqualTo("provider");
+        logActionMock.verify(() -> LogAction.addLog("999998", "log in", "login",
+                "facilityId=10", "127.0.0.1\\r\\nforged-login"));
+    }
+
+    @Test
     @DisplayName("should default to provider when next page is blank")
     void shouldDefaultToProvider_whenNextPageIsBlank() throws Exception {
         Facility facility = new Facility();

--- a/src/test/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgDisplayDemographicMessages2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgDisplayDemographicMessages2ActionUnitTest.java
@@ -59,4 +59,34 @@ class MsgDisplayDemographicMessages2ActionUnitTest extends CarlosUnitTestBase {
             assertThat(logged).contains("999998\\r\\nforged-provider");
         }
     }
+
+    @Test
+    @DisplayName("should sanitize demographic number when rejecting non numeric value")
+    void shouldSanitizeDemographicNumber_whenRejectingNonNumericValue() throws Exception {
+        SecurityInfoManager securityInfoManager = mock(SecurityInfoManager.class);
+        registerMock(SecurityInfoManager.class, securityInfoManager);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/demographic/messages");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        request.getSession(true).setAttribute("user", "999998");
+        request.addParameter("userName", "Unit Test");
+        request.addParameter("demographic_no", "123\r\nforged-demo");
+        when(securityInfoManager.hasPrivilege(any(), eq("_msg"), eq("r"), isNull())).thenReturn(true);
+
+        try (MockedStatic<ServletActionContext> servletActionContext = mockStatic(ServletActionContext.class);
+             LogCapture capture = LogCapture.forLogger(MsgDisplayDemographicMessages2Action.class)) {
+            servletActionContext.when(ServletActionContext::getRequest).thenReturn(request);
+            servletActionContext.when(ServletActionContext::getResponse).thenReturn(response);
+
+            MsgDisplayDemographicMessages2Action action = new MsgDisplayDemographicMessages2Action();
+
+            assertThat(action.execute()).isEqualTo("error");
+
+            String logged = capture.messages().stream()
+                    .filter(message -> message.startsWith("Invalid non-numeric demographic_no"))
+                    .findFirst()
+                    .orElseThrow();
+            assertThat(logged).doesNotContain("\r").doesNotContain("\n");
+            assertThat(logged).contains("123\\r\\nforged-demo");
+        }
+    }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgDisplayDemographicMessages2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgDisplayDemographicMessages2ActionUnitTest.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ */
+package io.github.carlos_emr.carlos.messenger.pageUtil;
+
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import io.github.carlos_emr.carlos.test.logging.LogCapture;
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
+
+import org.apache.struts2.ServletActionContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+@Tag("unit")
+@Tag("security")
+@DisplayName("MsgDisplayDemographicMessages2Action")
+class MsgDisplayDemographicMessages2ActionUnitTest extends CarlosUnitTestBase {
+
+    @Test
+    @DisplayName("should sanitize provider value when creating session bean debug log")
+    void shouldSanitizeProviderValue_whenCreatingSessionBeanDebugLog() throws Exception {
+        SecurityInfoManager securityInfoManager = mock(SecurityInfoManager.class);
+        registerMock(SecurityInfoManager.class, securityInfoManager);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/demographic/messages");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        request.getSession(true).setAttribute("user", "999998\r\nforged-provider");
+        request.addParameter("userName", "Unit Test");
+        request.addParameter("demographic_no", "123");
+        when(securityInfoManager.hasPrivilege(any(), eq("_msg"), eq("r"), isNull())).thenReturn(true);
+
+        try (MockedStatic<ServletActionContext> servletActionContext = mockStatic(ServletActionContext.class);
+             LogCapture capture = LogCapture.forLogger(MsgDisplayDemographicMessages2Action.class)) {
+            servletActionContext.when(ServletActionContext::getRequest).thenReturn(request);
+            servletActionContext.when(ServletActionContext::getResponse).thenReturn(response);
+
+            MsgDisplayDemographicMessages2Action action = new MsgDisplayDemographicMessages2Action();
+
+            assertThat(action.execute()).isEqualTo("demoMsg");
+
+            String logged = capture.messages().stream()
+                    .filter(message -> message.startsWith("Created new MsgSessionBean"))
+                    .findFirst()
+                    .orElseThrow();
+            assertThat(logged).doesNotContain("\r").doesNotContain("\n");
+            assertThat(logged).contains("999998\\r\\nforged-provider");
+        }
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgDisplayDemographicMessages2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgDisplayDemographicMessages2ActionUnitTest.java
@@ -61,8 +61,8 @@ class MsgDisplayDemographicMessages2ActionUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
-    @DisplayName("should sanitize demographic number when rejecting non numeric value")
-    void shouldSanitizeDemographicNumber_whenRejectingNonNumericValue() throws Exception {
+    @DisplayName("should omit demographic number when rejecting non numeric value")
+    void shouldOmitDemographicNumber_whenRejectingNonNumericValue() throws Exception {
         SecurityInfoManager securityInfoManager = mock(SecurityInfoManager.class);
         registerMock(SecurityInfoManager.class, securityInfoManager);
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/demographic/messages");
@@ -86,7 +86,7 @@ class MsgDisplayDemographicMessages2ActionUnitTest extends CarlosUnitTestBase {
                     .findFirst()
                     .orElseThrow();
             assertThat(logged).doesNotContain("\r").doesNotContain("\n");
-            assertThat(logged).contains("123\\r\\nforged-demo");
+            assertThat(logged).doesNotContain("123\r\nforged-demo", "123\\r\\nforged-demo", "forged-demo");
         }
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/scratch/Scratch2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/scratch/Scratch2ActionUnitTest.java
@@ -134,8 +134,8 @@ class Scratch2ActionUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
-    @DisplayName("should sanitize provider values when rejecting mismatched save")
-    void shouldSanitizeProviderValues_whenRejectingMismatchedSave() throws Exception {
+    @DisplayName("should omit provider values when rejecting mismatched save")
+    void shouldOmitProviderValues_whenRejectingMismatchedSave() throws Exception {
         HttpServletRequest request = mockRequest("POST", "999998\r\nforged-session");
         HttpServletResponse response = mock(HttpServletResponse.class);
         StringWriter json = new StringWriter();
@@ -153,7 +153,13 @@ class Scratch2ActionUnitTest extends CarlosUnitTestBase {
             assertThat(capture.messages()).hasSize(1);
             String logged = capture.messages().get(0);
             assertThat(logged).doesNotContain("\r").doesNotContain("\n");
-            assertThat(logged).contains("123456\\r\\nforged-provider", "999998\\r\\nforged-session");
+            assertThat(logged).doesNotContain(
+                    "123456\r\nforged-provider",
+                    "999998\r\nforged-session",
+                    "123456\\r\\nforged-provider",
+                    "999998\\r\\nforged-session",
+                    "forged-provider",
+                    "forged-session");
         }
     }
 

--- a/src/test/java/io/github/carlos_emr/carlos/scratch/Scratch2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/scratch/Scratch2ActionUnitTest.java
@@ -23,6 +23,7 @@ package io.github.carlos_emr.carlos.scratch;
 
 import io.github.carlos_emr.carlos.commn.dao.ScratchPadDao;
 import io.github.carlos_emr.carlos.commn.model.ScratchPad;
+import io.github.carlos_emr.carlos.test.logging.LogCapture;
 import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -130,6 +131,30 @@ class Scratch2ActionUnitTest extends CarlosUnitTestBase {
     void shouldRejectSave_whenSessionUserIsAbsent() {
         assertThat(Scratch2Action.isRequestForSessionProvider(null, null)).isFalse();
         assertThat(Scratch2Action.isRequestForSessionProvider(" ", null)).isFalse();
+    }
+
+    @Test
+    @DisplayName("should sanitize provider values when rejecting mismatched save")
+    void shouldSanitizeProviderValues_whenRejectingMismatchedSave() throws Exception {
+        HttpServletRequest request = mockRequest("POST", "999998\r\nforged-session");
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        StringWriter json = new StringWriter();
+        when(request.getParameter("providerNo")).thenReturn("123456\r\nforged-provider");
+        when(response.getWriter()).thenReturn(new PrintWriter(json));
+
+        try (LogCapture capture = LogCapture.forLogger(Scratch2Action.class)) {
+            Scratch2Action action = createAction(request, response);
+
+            assertThat(action.execute()).isNull();
+
+            verify(response).setStatus(HttpServletResponse.SC_FORBIDDEN);
+            verifyNoInteractions(scratchPadDao);
+            assertThat(json.toString()).contains("\"success\":false", "\"message\":\"Provider mismatch\"");
+            assertThat(capture.messages()).hasSize(1);
+            String logged = capture.messages().get(0);
+            assertThat(logged).doesNotContain("\r").doesNotContain("\n");
+            assertThat(logged).contains("123456\\r\\nforged-provider", "999998\\r\\nforged-session");
+        }
     }
 
     /**

--- a/src/test/java/io/github/carlos_emr/carlos/util/ZipUtilTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/util/ZipUtilTest.java
@@ -21,6 +21,8 @@
  */
 package io.github.carlos_emr.carlos.util;
 
+import io.github.carlos_emr.carlos.test.logging.LogCapture;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -82,5 +84,19 @@ class ZipUtilTest {
         assertThat(tempDir.getParent().resolve("slip-evil.xml")).doesNotExist();
         // The benign entry still extracted inside the directory.
         assertThat(Files.readString(tempDir.resolve("good.xml"))).isEqualTo("safe");
+    }
+
+    @Test
+    @DisplayName("unzipXML should sanitize invalid file name before logging")
+    void shouldSanitizeFileName_whenZipExtensionIsMissing() {
+        try (LogCapture capture = LogCapture.forLogger(zip.class)) {
+            boolean result = zip.unzipXML(tempDir.toString(), "claim\r\nforged.txt");
+
+            assertThat(result).isFalse();
+            assertThat(capture.messages()).hasSize(1);
+            String logged = capture.messages().get(0);
+            assertThat(logged).doesNotContain("\r").doesNotContain("\n");
+            assertThat(logged).contains("claim\\r\\nforged.txt");
+        }
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/util/ZipUtilTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/util/ZipUtilTest.java
@@ -87,8 +87,8 @@ class ZipUtilTest {
     }
 
     @Test
-    @DisplayName("unzipXML should sanitize invalid file name before logging")
-    void shouldSanitizeFileName_whenZipExtensionIsMissing() {
+    @DisplayName("unzipXML should omit invalid file name before logging")
+    void shouldOmitFileName_whenZipExtensionIsMissing() {
         try (LogCapture capture = LogCapture.forLogger(zip.class)) {
             boolean result = zip.unzipXML(tempDir.toString(), "claim\r\nforged.txt");
 
@@ -96,7 +96,7 @@ class ZipUtilTest {
             assertThat(capture.messages()).hasSize(1);
             String logged = capture.messages().get(0);
             assertThat(logged).doesNotContain("\r").doesNotContain("\n");
-            assertThat(logged).contains("claim\\r\\nforged.txt");
+            assertThat(logged).doesNotContain("claim\r\nforged.txt", "claim\\r\\nforged.txt", "forged.txt");
         }
     }
 }


### PR DESCRIPTION
## Summary
- Fixes all 8 scoped log-injection alerts by preventing user-controlled values from reaching unsafe log sinks.
- Uses `LogSafe.sanitize(...)` where existing checks accept it, and omits tainted values at Sonar-sensitive logger calls where the custom sanitizer is not trusted by analysis.
- Adds focused unit coverage for each alert path to verify CR/LF payloads do not appear raw in captured log messages.

## Alert coverage
- #13040: `zip.java`
- #13034: `DiagCodeDescriptionPersister.java`
- #13022: `BillingShortcutPg1ViewModelAssembler.java`
- #11836: `FormForward2Action.java`
- #26140: `SelectFacility2Action.java`
- #26141: `Scratch2Action.java`
- #26133: `MsgDisplayDemographicMessages2Action.java`
- #26142: `EmailCompose2Action.java`

## Security
- Addresses log forging risk from CR/LF injection in request, session, file-name, diagnostic-code, demographic, provider, form, and remote-address logging paths.
- Avoids suppressions for active Sonar findings by removing tainted values from the flagged logger calls.

## Testing
- Adds or updates focused JUnit 5 unit tests for all scoped alert paths.
- Covers malicious CR/LF payloads and verifies captured log messages do not contain raw forged lines.
