### PR TITLE
fix: validate eform pdf signature urls

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/eform/util/EFormViewForPdfGenerationServlet.java
+++ b/src/main/java/io/github/carlos_emr/carlos/eform/util/EFormViewForPdfGenerationServlet.java
@@ -14,6 +14,8 @@
 package io.github.carlos_emr.carlos.eform.util;
 
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -25,13 +27,14 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import org.apache.logging.log4j.Logger;
-import io.github.carlos_emr.carlos.commn.dao.EFormValueDao;
-import io.github.carlos_emr.carlos.commn.model.EFormValue;
-import io.github.carlos_emr.carlos.utility.MiscUtils;
-import io.github.carlos_emr.carlos.utility.SpringUtils;
+import org.owasp.encoder.Encode;
 
 import io.github.carlos_emr.CarlosProperties;
+import io.github.carlos_emr.carlos.commn.dao.EFormValueDao;
+import io.github.carlos_emr.carlos.commn.model.EFormValue;
 import io.github.carlos_emr.carlos.eform.data.EForm;
+import io.github.carlos_emr.carlos.utility.MiscUtils;
+import io.github.carlos_emr.carlos.utility.SpringUtils;
 
 /**
  * The purpose of this servlet is to allow a local process to convert an eform html page into a pdf file.
@@ -39,6 +42,9 @@ import io.github.carlos_emr.carlos.eform.data.EForm;
 public final class EFormViewForPdfGenerationServlet extends HttpServlet {
 
     private static final Logger logger = MiscUtils.getLogger();
+    private static final String IMAGE_RENDERING_SERVLET_PATH = "/imageRenderingServlet";
+    private static final String PDF_SIGNATURE_SERVLET_PATH = "/EFormSignatureViewForPdfGenerationServlet";
+    private static final String DIGITAL_SIGNATURE_ID_PARAM = "digitalSignatureId";
 
     @Override
     public final void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
@@ -55,17 +61,17 @@ public final class EFormViewForPdfGenerationServlet extends HttpServlet {
             // Add security headers to restrict content capabilities (no scripts, no plugins)
             response.setHeader("X-Content-Type-Options", "nosniff");
             response.setHeader("Content-Security-Policy", "default-src 'self'; script-src 'none'; object-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data:");
-            
+
             boolean prepareForFax = "true".equals(request.getParameter("prepareForFax"));
             String id = request.getParameter("fdid");
             String providerId = request.getParameter("providerId");
-            
+
             // Validate required parameters
             if (id == null || id.trim().isEmpty()) {
                 response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Missing required parameter: fdid");
                 return;
             }
-            
+
             // Validate id is a valid integer
             int formDataId;
             try {
@@ -74,19 +80,18 @@ public final class EFormViewForPdfGenerationServlet extends HttpServlet {
                 response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid parameter: fdid must be a valid number");
                 return;
             }
-            
+
             EForm eForm = new EForm(id);
             eForm.setSignatureCode(request.getContextPath(), request.getHeader("User-Agent"), eForm.getDemographicNo(), providerId);
             eForm.setContextPath(request.getContextPath());
             String projectHome = CarlosProperties.getInstance().getProperty("project_home");
-
 
             EFormValueDao efvDao = (EFormValueDao) SpringUtils.getBean(EFormValueDao.class);
             List<EFormValue> eFormValues = efvDao.findByFormDataId(formDataId);
             for (EFormValue value : eFormValues) {
                 if (value.getVarName().equals("Letter")) {
                     String html = value.getVarValue();
-                    html = html.replace("/imageRenderingServlet", "/EFormSignatureViewForPdfGenerationServlet");
+                    html = html.replace(IMAGE_RENDERING_SERVLET_PATH, PDF_SIGNATURE_SERVLET_PATH);
                     if (prepareForFax) {
                         html = "<div style=\"position:relative\"><div style=\"position:absolute; margin-top:35px;\">" + html + "</div></div>";
                     }
@@ -102,10 +107,14 @@ public final class EFormViewForPdfGenerationServlet extends HttpServlet {
                     Matcher matcher = pattern.matcher(html);
                     boolean matchFound = matcher.find();
                     if (matchFound && matcher.groupCount() == 4) {
-                        String sign = value.getVarValue();
-                        sign = sign.replace("/imageRenderingServlet", "/EFormSignatureViewForPdfGenerationServlet");
+                        String sign = normalizePdfSignatureUrl(value.getVarValue(), request.getContextPath());
+                        if (sign == null) {
+                            logger.warn("Skipping invalid signature URL while preparing eForm PDF");
+                            continue;
+                        }
                         String left = matcher.group(4), top = matcher.group(3), width = matcher.group(2), height = matcher.group(1);
-                        eForm.setFormHtml(html.replace("<div id=\"signatureDisplay\"></div>", String.format("<div id=\"signatureDisplay\"><img src=\"%s\" style=\"position:absolute;left:%s;top:%s;width:%s;height:%s;\" /> </div>", sign, left, top, width, height)));
+                        eForm.setFormHtml(html.replace("<div id=\"signatureDisplay\"></div>",
+                                buildSignatureImageMarkup(sign, left, top, width, height)));
                     }
                 }
             }
@@ -128,5 +137,85 @@ public final class EFormViewForPdfGenerationServlet extends HttpServlet {
                     "An internal error occurred. Please try again or contact your system administrator.");
             }
         }
+    }
+
+    static String normalizePdfSignatureUrl(String rawUrl, String contextPath) {
+        if (rawUrl == null) {
+            return null;
+        }
+
+        String trimmed = rawUrl.trim();
+        if (trimmed.isEmpty() || containsUnsafeHtmlAttributeCharacters(trimmed)) {
+            return null;
+        }
+
+        String rewritten = trimmed.replace(IMAGE_RENDERING_SERVLET_PATH, PDF_SIGNATURE_SERVLET_PATH);
+
+        final URI uri;
+        try {
+            uri = new URI(rewritten);
+        } catch (URISyntaxException e) {
+            return null;
+        }
+
+        if (uri.isOpaque() || uri.getScheme() != null || uri.getHost() != null || uri.getRawAuthority() != null || uri.getFragment() != null) {
+            return null;
+        }
+
+        String normalizedContextPath = normalizeContextPath(contextPath);
+        String uriPath = uri.getPath();
+        String contextScopedPath = normalizedContextPath + PDF_SIGNATURE_SERVLET_PATH;
+
+        if (!PDF_SIGNATURE_SERVLET_PATH.equals(uriPath) && !contextScopedPath.equals(uriPath)) {
+            return null;
+        }
+
+        String digitalSignatureId = extractDigitsQueryParam(uri.getRawQuery(), DIGITAL_SIGNATURE_ID_PARAM);
+        if (digitalSignatureId == null) {
+            return null;
+        }
+
+        if (contextScopedPath.equals(uriPath)) {
+            return contextScopedPath + "?" + DIGITAL_SIGNATURE_ID_PARAM + "=" + digitalSignatureId;
+        }
+        return PDF_SIGNATURE_SERVLET_PATH + "?" + DIGITAL_SIGNATURE_ID_PARAM + "=" + digitalSignatureId;
+    }
+
+    static String buildSignatureImageMarkup(String signatureUrl, String left, String top, String width, String height) {
+        return String.format(
+                "<div id=\"signatureDisplay\"><img src=\"%s\" style=\"position:absolute;left:%s;top:%s;width:%s;height:%s;\" /> </div>",
+                Encode.forHtmlAttribute(signatureUrl), left, top, width, height);
+    }
+
+    private static boolean containsUnsafeHtmlAttributeCharacters(String value) {
+        for (int i = 0; i < value.length(); i++) {
+            char current = value.charAt(i);
+            if (current == '"' || current == '\'' || current == '<' || current == '>' || current == '\r' || current == '\n') {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String normalizeContextPath(String contextPath) {
+        if (contextPath == null || contextPath.isBlank() || "/".equals(contextPath)) {
+            return "";
+        }
+        return contextPath.endsWith("/") ? contextPath.substring(0, contextPath.length() - 1) : contextPath;
+    }
+
+    private static String extractDigitsQueryParam(String rawQuery, String parameterName) {
+        if (rawQuery == null || rawQuery.isBlank()) {
+            return null;
+        }
+
+        for (String pair : rawQuery.split("&")) {
+            String[] parts = pair.split("=", 2);
+            if (parts.length == 2 && parameterName.equals(parts[0]) && parts[1].matches("\\d+")) {
+                return parts[1];
+            }
+        }
+
+        return null;
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/eform/util/EFormViewForPdfGenerationServlet.java
+++ b/src/main/java/io/github/carlos_emr/carlos/eform/util/EFormViewForPdfGenerationServlet.java
@@ -144,12 +144,10 @@ public final class EFormViewForPdfGenerationServlet extends HttpServlet {
             return null;
         }
 
-        String trimmed = rawUrl.trim();
-        if (trimmed.isEmpty() || containsUnsafeHtmlAttributeCharacters(trimmed)) {
+        String rewritten = rawUrl.trim().replace(IMAGE_RENDERING_SERVLET_PATH, PDF_SIGNATURE_SERVLET_PATH);
+        if (rewritten.isEmpty() || containsUnsafeHtmlAttributeCharacters(rewritten)) {
             return null;
         }
-
-        String rewritten = trimmed.replace(IMAGE_RENDERING_SERVLET_PATH, PDF_SIGNATURE_SERVLET_PATH);
 
         final URI uri;
         try {

--- a/src/main/java/io/github/carlos_emr/carlos/eform/util/EFormViewForPdfGenerationServlet.java
+++ b/src/main/java/io/github/carlos_emr/carlos/eform/util/EFormViewForPdfGenerationServlet.java
@@ -27,10 +27,9 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import org.apache.logging.log4j.Logger;
-import org.owasp.encoder.Encode;
-
 import io.github.carlos_emr.CarlosProperties;
 import io.github.carlos_emr.carlos.commn.dao.EFormValueDao;
+import io.github.carlos_emr.carlos.utility.SafeEncode;
 import io.github.carlos_emr.carlos.commn.model.EFormValue;
 import io.github.carlos_emr.carlos.eform.data.EForm;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
@@ -182,7 +181,7 @@ public final class EFormViewForPdfGenerationServlet extends HttpServlet {
     static String buildSignatureImageMarkup(String signatureUrl, String left, String top, String width, String height) {
         return String.format(
                 "<div id=\"signatureDisplay\"><img src=\"%s\" style=\"position:absolute;left:%s;top:%s;width:%s;height:%s;\" /> </div>",
-                Encode.forHtmlAttribute(signatureUrl), left, top, width, height);
+                SafeEncode.forHtmlAttribute(signatureUrl), left, top, width, height);
     }
 
     private static boolean containsUnsafeHtmlAttributeCharacters(String value) {

--- a/src/test/java/io/github/carlos_emr/carlos/eform/util/EFormViewForPdfGenerationServletUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/eform/util/EFormViewForPdfGenerationServletUnitTest.java
@@ -1,3 +1,25 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+
 package io.github.carlos_emr.carlos.eform.util;
 
 import java.util.stream.Stream;

--- a/src/test/java/io/github/carlos_emr/carlos/eform/util/EFormViewForPdfGenerationServletUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/eform/util/EFormViewForPdfGenerationServletUnitTest.java
@@ -1,0 +1,86 @@
+package io.github.carlos_emr.carlos.eform.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("EFormViewForPdfGenerationServlet unit tests")
+@Tag("unit")
+@Tag("fast")
+class EFormViewForPdfGenerationServletUnitTest {
+
+    @Test
+    @DisplayName("should normalize a valid stored signature URL under the current context path")
+    void shouldNormalizeValidStoredSignatureUrl_whenContextScoped() {
+        String normalized = EFormViewForPdfGenerationServlet.normalizePdfSignatureUrl(
+                "/carlos/imageRenderingServlet?source=signature_stored&digitalSignatureId=42&r=99",
+                "/carlos");
+
+        assertThat(normalized).isEqualTo("/carlos/EFormSignatureViewForPdfGenerationServlet?digitalSignatureId=42");
+    }
+
+    @Test
+    @DisplayName("should normalize a valid stored signature URL without a context path prefix")
+    void shouldNormalizeValidStoredSignatureUrl_whenRootRelative() {
+        String normalized = EFormViewForPdfGenerationServlet.normalizePdfSignatureUrl(
+                "/imageRenderingServlet?source=signature_stored&digitalSignatureId=7",
+                "/carlos");
+
+        assertThat(normalized).isEqualTo("/EFormSignatureViewForPdfGenerationServlet?digitalSignatureId=7");
+    }
+
+    @Test
+    @DisplayName("should reject javascript signature URLs")
+    void shouldRejectJavascriptUrl_whenNormalizingSignatureUrl() {
+        String normalized = EFormViewForPdfGenerationServlet.normalizePdfSignatureUrl(
+                "javascript:alert(1)",
+                "/carlos");
+
+        assertThat(normalized).isNull();
+    }
+
+    @Test
+    @DisplayName("should reject external signature URLs")
+    void shouldRejectExternalUrl_whenNormalizingSignatureUrl() {
+        String normalized = EFormViewForPdfGenerationServlet.normalizePdfSignatureUrl(
+                "https://evil.example/EFormSignatureViewForPdfGenerationServlet?digitalSignatureId=5",
+                "/carlos");
+
+        assertThat(normalized).isNull();
+    }
+
+    @Test
+    @DisplayName("should reject quote breaking signature URLs")
+    void shouldRejectQuoteBreakingUrl_whenNormalizingSignatureUrl() {
+        String normalized = EFormViewForPdfGenerationServlet.normalizePdfSignatureUrl(
+                "/carlos/imageRenderingServlet?source=signature_stored&digitalSignatureId=12\" onerror=\"alert(1)",
+                "/carlos");
+
+        assertThat(normalized).isNull();
+    }
+
+    @Test
+    @DisplayName("should reject rewritten URLs that do not carry a numeric digital signature id")
+    void shouldRejectMissingDigitalSignatureId_whenNormalizingSignatureUrl() {
+        String normalized = EFormViewForPdfGenerationServlet.normalizePdfSignatureUrl(
+                "/carlos/imageRenderingServlet?source=signature_preview&signatureRequestId=temp123",
+                "/carlos");
+
+        assertThat(normalized).isNull();
+    }
+
+    @Test
+    @DisplayName("should HTML attribute encode the generated signature image markup")
+    void shouldEncodeSignatureImageMarkup_whenBuildingImageHtml() {
+        String markup = EFormViewForPdfGenerationServlet.buildSignatureImageMarkup(
+                "/carlos/EFormSignatureViewForPdfGenerationServlet?digitalSignatureId=42&foo=bar",
+                "1",
+                "2",
+                "3",
+                "4");
+
+        assertThat(markup).contains("src=\"/carlos/EFormSignatureViewForPdfGenerationServlet?digitalSignatureId=42&amp;foo=bar\"");
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/eform/util/EFormViewForPdfGenerationServletUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/eform/util/EFormViewForPdfGenerationServletUnitTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -36,10 +35,10 @@ class EFormViewForPdfGenerationServletUnitTest {
         assertThat(normalized).isEqualTo("/EFormSignatureViewForPdfGenerationServlet?digitalSignatureId=7");
     }
 
-    @ParameterizedTest(name = "{0}")
+    @ParameterizedTest(name = "invalid signature URL [{index}]")
     @MethodSource("invalidSignatureUrls")
     @DisplayName("should reject invalid signature URLs")
-    void shouldRejectInvalidSignatureUrl_whenNormalizingSignatureUrl(String scenario, String rawUrl) {
+    void shouldRejectInvalidSignatureUrl_whenNormalizingSignatureUrl(String rawUrl) {
         String normalized = EFormViewForPdfGenerationServlet.normalizePdfSignatureUrl(rawUrl, "/carlos");
 
         assertThat(normalized).isNull();
@@ -58,12 +57,12 @@ class EFormViewForPdfGenerationServletUnitTest {
         assertThat(markup).contains("src=\"/carlos/EFormSignatureViewForPdfGenerationServlet?digitalSignatureId=42&amp;foo=bar\"");
     }
 
-    private static Stream<Arguments> invalidSignatureUrls() {
+    private static Stream<String> invalidSignatureUrls() {
         return Stream.of(
-                Arguments.of("javascript scheme", "javascript:alert(1)"),
-                Arguments.of("external url", "https://evil.example/EFormSignatureViewForPdfGenerationServlet?digitalSignatureId=5"),
-                Arguments.of("quote breaking payload", "/carlos/imageRenderingServlet?source=signature_stored&digitalSignatureId=12\" onerror=\"alert(1)"),
-                Arguments.of("missing numeric digital signature id", "/carlos/imageRenderingServlet?source=signature_preview&signatureRequestId=temp123")
+                "javascript:alert(1)",
+                "https://evil.example/EFormSignatureViewForPdfGenerationServlet?digitalSignatureId=5",
+                "/carlos/imageRenderingServlet?source=signature_stored&digitalSignatureId=12\" onerror=\"alert(1)",
+                "/carlos/imageRenderingServlet?source=signature_preview&signatureRequestId=temp123"
         );
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/eform/util/EFormViewForPdfGenerationServletUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/eform/util/EFormViewForPdfGenerationServletUnitTest.java
@@ -1,8 +1,13 @@
 package io.github.carlos_emr.carlos.eform.util;
 
+import java.util.stream.Stream;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -31,42 +36,11 @@ class EFormViewForPdfGenerationServletUnitTest {
         assertThat(normalized).isEqualTo("/EFormSignatureViewForPdfGenerationServlet?digitalSignatureId=7");
     }
 
-    @Test
-    @DisplayName("should reject javascript signature URLs")
-    void shouldRejectJavascriptUrl_whenNormalizingSignatureUrl() {
-        String normalized = EFormViewForPdfGenerationServlet.normalizePdfSignatureUrl(
-                "javascript:alert(1)",
-                "/carlos");
-
-        assertThat(normalized).isNull();
-    }
-
-    @Test
-    @DisplayName("should reject external signature URLs")
-    void shouldRejectExternalUrl_whenNormalizingSignatureUrl() {
-        String normalized = EFormViewForPdfGenerationServlet.normalizePdfSignatureUrl(
-                "https://evil.example/EFormSignatureViewForPdfGenerationServlet?digitalSignatureId=5",
-                "/carlos");
-
-        assertThat(normalized).isNull();
-    }
-
-    @Test
-    @DisplayName("should reject quote breaking signature URLs")
-    void shouldRejectQuoteBreakingUrl_whenNormalizingSignatureUrl() {
-        String normalized = EFormViewForPdfGenerationServlet.normalizePdfSignatureUrl(
-                "/carlos/imageRenderingServlet?source=signature_stored&digitalSignatureId=12\" onerror=\"alert(1)",
-                "/carlos");
-
-        assertThat(normalized).isNull();
-    }
-
-    @Test
-    @DisplayName("should reject rewritten URLs that do not carry a numeric digital signature id")
-    void shouldRejectMissingDigitalSignatureId_whenNormalizingSignatureUrl() {
-        String normalized = EFormViewForPdfGenerationServlet.normalizePdfSignatureUrl(
-                "/carlos/imageRenderingServlet?source=signature_preview&signatureRequestId=temp123",
-                "/carlos");
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("invalidSignatureUrls")
+    @DisplayName("should reject invalid signature URLs")
+    void shouldRejectInvalidSignatureUrl_whenNormalizingSignatureUrl(String scenario, String rawUrl) {
+        String normalized = EFormViewForPdfGenerationServlet.normalizePdfSignatureUrl(rawUrl, "/carlos");
 
         assertThat(normalized).isNull();
     }
@@ -82,5 +56,14 @@ class EFormViewForPdfGenerationServletUnitTest {
                 "4");
 
         assertThat(markup).contains("src=\"/carlos/EFormSignatureViewForPdfGenerationServlet?digitalSignatureId=42&amp;foo=bar\"");
+    }
+
+    private static Stream<Arguments> invalidSignatureUrls() {
+        return Stream.of(
+                Arguments.of("javascript scheme", "javascript:alert(1)"),
+                Arguments.of("external url", "https://evil.example/EFormSignatureViewForPdfGenerationServlet?digitalSignatureId=5"),
+                Arguments.of("quote breaking payload", "/carlos/imageRenderingServlet?source=signature_stored&digitalSignatureId=12\" onerror=\"alert(1)"),
+                Arguments.of("missing numeric digital signature id", "/carlos/imageRenderingServlet?source=signature_preview&signatureRequestId=temp123")
+        );
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/eform/util/EFormViewForPdfGenerationServletUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/eform/util/EFormViewForPdfGenerationServletUnitTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DisplayName("EFormViewForPdfGenerationServlet unit tests")
 @Tag("unit")
 @Tag("fast")
+@Tag("eform")
 class EFormViewForPdfGenerationServletUnitTest {
 
     @Test
@@ -55,6 +56,18 @@ class EFormViewForPdfGenerationServletUnitTest {
                 "4");
 
         assertThat(markup).contains("src=\"/carlos/EFormSignatureViewForPdfGenerationServlet?digitalSignatureId=42&amp;foo=bar\"");
+    }
+
+    @Test
+    @DisplayName("should return null for null input")
+    void shouldReturnNull_forNullUrl() {
+        assertThat(EFormViewForPdfGenerationServlet.normalizePdfSignatureUrl(null, "/carlos")).isNull();
+    }
+
+    @Test
+    @DisplayName("should return null for empty string input")
+    void shouldReturnNull_forEmptyUrl() {
+        assertThat(EFormViewForPdfGenerationServlet.normalizePdfSignatureUrl("", "/carlos")).isNull();
     }
 
     private static Stream<String> invalidSignatureUrls() {


### PR DESCRIPTION
## Summary
Hardens `EFormViewForPdfGenerationServlet` so stored eForm signature URLs are validated after rewriting and HTML-attribute encoded before being inserted into the generated PDF HTML.

Fixes #2924

## What changed
- normalize and validate rewritten signature URLs against the expected local `EFormSignatureViewForPdfGenerationServlet` path
- require a numeric `digitalSignatureId` and strip untrusted extra query parameters from the canonicalized URL
- reject unsafe values such as `javascript:` payloads, external URLs, and quote-breaking attribute content
- HTML-attribute encode the final `img src` before inserting it into the generated signature markup
- add focused unit coverage for valid and malicious URL shapes

## Validation
```bash
mvn -Dtest=io.github.carlos_emr.carlos.eform.util.EFormViewForPdfGenerationServletUnitTest,io.github.carlos_emr.carlos.documentManager.ConvertToEdocUnitTest,io.github.carlos_emr.carlos.managers.EformDataManagerImplCreatePdfUnitTest,io.github.carlos_emr.carlos.documentManager.actions.DocumentPreview2ActionTest test
```

Result: `BUILD SUCCESS`, `32` tests, `0` failures, `0` errors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate and sanitize eForm PDF signature URLs to block unsafe inputs and ensure correct rendering (fixes #2924). Only local `/EFormSignatureViewForPdfGenerationServlet` URLs with a numeric `digitalSignatureId` are accepted, and the final img src is HTML-attribute encoded.

- **Bug Fixes**
  - Rewrite `/imageRenderingServlet` to `/EFormSignatureViewForPdfGenerationServlet` and validate path (root or context-scoped); normalize context path.
  - Canonicalize query: keep only `digitalSignatureId` and require digits.
  - Reject unsafe inputs: external/opaque URLs, any scheme/authority/fragment, and quotes, <, >, CR/LF; skip invalid signatures.
  - Encode img src with `SafeEncode.forHtmlAttribute`; expand tests for root/context paths, malicious cases, encoding, null/empty inputs; add `@Tag("eform")` and GPL header.

<sup>Written for commit 3c37b7b33a24155849ec6d30506d2243de8f336a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2933?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

