### PR TITLE
chore: refresh docs npm security overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7117,17 +7117,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/esrecurse": {
       "version": "4.3.0",
       "license": "BSD-2-Clause",
@@ -7890,24 +7879,6 @@
       },
       "engines": {
         "node": ">=6.0"
-      }
-    },
-    "node_modules/gray-matter/node_modules/argparse": {
-      "version": "1.0.10",
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/gray-matter/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/gzip-size": {
@@ -8852,7 +8823,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -8938,11 +8921,13 @@
       }
     },
     "node_modules/launch-editor": {
-      "version": "2.13.0",
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.14.1.tgz",
+      "integrity": "sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==",
       "license": "MIT",
       "dependencies": {
         "picocolors": "^1.1.1",
-        "shell-quote": "^1.8.3"
+        "shell-quote": "^1.8.4"
       }
     },
     "node_modules/leven": {
@@ -14515,10 +14500,6 @@
         "wbuf": "^1.7.3"
       }
     },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/srcset": {
       "version": "4.0.0",
       "license": "MIT",
@@ -15546,9 +15527,9 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.4.tgz",
-      "integrity": "sha512-GqDPGZN9bRqKBTkp4aWkobDDHMsrXKoGSdOH56smIri8qR0JG8gfL8/v/f/OZR3/OKXjG8uwJbFVhKm/FNU/UA==",
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.5.tgz",
+      "integrity": "sha512-4wZtCquSuv9CKX8oybo+mqxtxZqWz47uM1Ch94lxowBztOhWCbhqvRbfC/mODOwxgV2brY+JGZpHq58/SuVFYg==",
       "license": "MIT",
       "dependencies": {
         "@types/bonjour": "^3.5.13",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7117,6 +7117,19 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/esrecurse": {
       "version": "4.3.0",
       "license": "BSD-2-Clause",
@@ -7879,6 +7892,28 @@
       },
       "engines": {
         "node": ">=6.0"
+      }
+    },
+    "node_modules/gray-matter/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/gray-matter/node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/gzip-size": {
@@ -14499,6 +14534,12 @@
         "readable-stream": "^3.0.6",
         "wbuf": "^1.7.3"
       }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/srcset": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "@babel/plugin-transform-modules-systemjs": "7.29.4",
     "fast-uri": "3.1.2",
     "joi": "17.13.4",
-    "js-yaml": "4.2.0",
     "launch-editor": "2.14.1",
     "postcss": "8.5.10",
     "shell-quote": "1.8.4",

--- a/package.json
+++ b/package.json
@@ -66,13 +66,13 @@
     "brace-expansion": "5.0.6",
     "@babel/plugin-transform-modules-systemjs": "7.29.4",
     "fast-uri": "3.1.2",
-    "postcss": "8.5.10",
-    "webpack-dev-server": "5.2.5",
-    "ws": "8.20.1",
     "joi": "17.13.4",
+    "js-yaml": "4.2.0",
+    "launch-editor": "2.14.1",
+    "postcss": "8.5.10",
     "shell-quote": "1.8.4",
     "uuid": "11.1.1",
-    "js-yaml": "4.2.0",
-    "launch-editor": "2.14.1"
+    "webpack-dev-server": "5.2.5",
+    "ws": "8.20.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -67,10 +67,12 @@
     "@babel/plugin-transform-modules-systemjs": "7.29.4",
     "fast-uri": "3.1.2",
     "postcss": "8.5.10",
-    "webpack-dev-server": "5.2.4",
+    "webpack-dev-server": "5.2.5",
     "ws": "8.20.1",
     "joi": "17.13.4",
     "shell-quote": "1.8.4",
-    "uuid": "11.1.1"
+    "uuid": "11.1.1",
+    "js-yaml": "4.2.0",
+    "launch-editor": "2.14.1"
   }
 }


### PR DESCRIPTION
## Summary
- Refresh docs npm security overrides for `launch-editor` and `webpack-dev-server`.
- Regenerate `package-lock.json` so `launch-editor` resolves to `2.14.1` and `webpack-dev-server` resolves to `5.2.5`.
- Keep the compatible top-level `js-yaml@4.2.0` lockfile resolution, but do not force `gray-matter` onto `js-yaml` 4.x.
- Restore `gray-matter`'s nested `js-yaml@3.14.2` path because `gray-matter@4.0.3` calls `safeLoad`/`safeDump`, which throw under `js-yaml` 4.x.

## Security alerts
- Addresses https://github.com/carlos-emr/carlos/security/dependabot/104
- Addresses https://github.com/carlos-emr/carlos/security/dependabot/105
- Should address duplicate Semgrep supply-chain alerts after merge/rescan:
  - https://github.com/carlos-emr/carlos/security/code-scanning/26119 for the top-level `js-yaml` copy
  - https://github.com/carlos-emr/carlos/security/code-scanning/26120 for `launch-editor`
  - https://github.com/carlos-emr/carlos/security/code-scanning/26159 for `webpack-dev-server`
- Does not address https://github.com/carlos-emr/carlos/security/dependabot/103 or https://github.com/carlos-emr/carlos/security/code-scanning/26118 because the remaining alert is for `gray-matter`'s nested `js-yaml@3.14.2` copy. Forcing that dependency to `js-yaml` 4.x breaks docs front matter parsing/stringifying.
- Follow-up ticket for the remaining defense-in-depth dependency work: https://github.com/carlos-emr/carlos/issues/2940

## Verification
- `npm install --package-lock-only --ignore-scripts`
- `npm ci --ignore-scripts`
- `npm ls js-yaml gray-matter launch-editor webpack-dev-server`
- `node` smoke test for `gray-matter` front matter parse/stringify
- `git diff --check`
- `npm audit --json` (expected nonzero for the remaining `gray-matter` `js-yaml` copy and separate existing docs-chain findings)
- `mvn test-compile -q`

## Summary by Sourcery

Update documentation tooling dependencies to address security alerts while maintaining compatibility with existing front matter processing.

Bug Fixes:
- Resolve security vulnerabilities by updating launch-editor and webpack-dev-server versions used in docs tooling.

Enhancements:
- Refresh npm dependency resolutions and lockfile for docs-related tooling to align with updated security overrides while preserving compatible js-yaml usage.