### PR TITLE
Standardize JSON servlet responses

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/web/admin/ProgramManager2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/web/admin/ProgramManager2Action.java
@@ -83,6 +83,7 @@ import io.github.carlos_emr.carlos.match.IMatchManager;
 import io.github.carlos_emr.carlos.match.MatchManager;
 import io.github.carlos_emr.carlos.match.MatchManagerException;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import io.github.carlos_emr.carlos.utility.JsonResponseWriter;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -1541,7 +1542,7 @@ public class ProgramManager2Action extends ActionSupport {
         obj.put("error", error);
 
         try {
-            response.getWriter().print(obj.toString());
+            JsonResponseWriter.write(response, obj);
         } catch (IOException e) {
             MiscUtils.getLogger().warn("error writing json", e);
         }

--- a/src/main/java/io/github/carlos_emr/carlos/dashboard/admin/AssignTickler2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/dashboard/admin/AssignTickler2Action.java
@@ -43,6 +43,7 @@ import io.github.carlos_emr.carlos.managers.ProviderManager2;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.managers.TicklerManager;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import io.github.carlos_emr.carlos.utility.JsonResponseWriter;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 
@@ -111,7 +112,7 @@ public class AssignTickler2Action extends ActionSupport {
         }
 
         try {
-            response.getWriter().write(jsonObject.toString());
+            JsonResponseWriter.write(response, jsonObject);
         } catch (IOException e) {
             MiscUtils.getLogger().error("JSON response failed", e);
             return "error";

--- a/src/main/java/io/github/carlos_emr/carlos/dxresearch/pageUtil/dxCodeSearchJSON2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/dxresearch/pageUtil/dxCodeSearchJSON2Action.java
@@ -28,9 +28,7 @@
  */
 package io.github.carlos_emr.carlos.dxresearch.pageUtil;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
-import java.io.PrintWriter;
 import java.util.List;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -46,6 +44,7 @@ import io.github.carlos_emr.carlos.commn.model.Icd9;
 import io.github.carlos_emr.carlos.managers.CodingSystemManager;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.utility.JsonUtil;
+import io.github.carlos_emr.carlos.utility.JsonResponseWriter;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
@@ -62,7 +61,7 @@ public class dxCodeSearchJSON2Action extends ActionSupport {
     HttpServletRequest request = ServletActionContext.getRequest();
     HttpServletResponse response = ServletActionContext.getResponse();
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private static final ObjectMapper objectMapper = new ObjectMapper();
     private static Logger logger = MiscUtils.getLogger();
 
     public String execute() {
@@ -166,8 +165,6 @@ public class dxCodeSearchJSON2Action extends ActionSupport {
         return null;
     }
 
-    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
-    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     @SuppressWarnings("unused")
     public String validateCode() {
 
@@ -180,10 +177,8 @@ public class dxCodeSearchJSON2Action extends ActionSupport {
         ObjectNode jsonResponse = objectMapper.createObjectNode();
         jsonResponse.put("dxvalid", dxvalid);
 
-        response.setContentType("application/json");
-
-        try (PrintWriter pout = response.getWriter()) {
-            pout.write(jsonResponse.toString());
+        try {
+            JsonResponseWriter.write(response, jsonResponse);
         } catch (IOException e) {
             logger.error("JSON Error", e);
         }
@@ -191,8 +186,6 @@ public class dxCodeSearchJSON2Action extends ActionSupport {
         return null;
     }
 
-    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
-    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     @SuppressWarnings("unused")
     public String getDescription() {
 
@@ -209,10 +202,8 @@ public class dxCodeSearchJSON2Action extends ActionSupport {
         jsonResponse.put("description", description);
         jsonResponse.put("code", code);
 
-        response.setContentType("application/json");
-
-        try (PrintWriter pout = response.getWriter()) {
-            pout.write(jsonResponse.toString());
+        try {
+            JsonResponseWriter.write(response, jsonResponse);
         } catch (IOException e) {
             logger.error("JSON Error", e);
         }
@@ -220,26 +211,16 @@ public class dxCodeSearchJSON2Action extends ActionSupport {
         return null;
     }
 
-    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
-    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     private static void jsonify(final List<?> classList,
                                 final HttpServletResponse response, String[] ignoreMethods) throws IOException {
 
-        response.setContentType("application/json");
-
-        String jsonstring = null;
+        Object jsonBody = objectMapper.createObjectNode();
 
         if (classList != null && !classList.isEmpty()) {
-            jsonstring = JsonUtil.pojoCollectionToJson(classList, ignoreMethods);
+            jsonBody = objectMapper.readTree(JsonUtil.pojoCollectionToJson(classList, ignoreMethods));
         }
 
-        if (jsonstring == null) {
-            jsonstring = "{}";
-        }
-
-        try (PrintWriter pout = response.getWriter()) {
-            pout.write(jsonstring); // nosemgrep: java.servlets.security.servletresponse-writer-xss.servletresponse-writer-xss, java.servlets.security.servletresponse-writer-xss-deepsemgrep.servletresponse-writer-xss-deepsemgrep -- JSON API response with application/json content-type
-        }
+        JsonResponseWriter.write(response, jsonBody);
     }
 
 

--- a/src/main/java/io/github/carlos_emr/carlos/dxresearch/pageUtil/dxCodeSearchJSON2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/dxresearch/pageUtil/dxCodeSearchJSON2Action.java
@@ -214,13 +214,13 @@ public class dxCodeSearchJSON2Action extends ActionSupport {
     private static void jsonify(final List<?> classList,
                                 final HttpServletResponse response, String[] ignoreMethods) throws IOException {
 
-        Object jsonBody = objectMapper.createObjectNode();
+        String jsonString = "{}";
 
         if (classList != null && !classList.isEmpty()) {
-            jsonBody = objectMapper.readTree(JsonUtil.pojoCollectionToJson(classList, ignoreMethods));
+            jsonString = JsonUtil.pojoCollectionToJson(classList, ignoreMethods);
         }
 
-        JsonResponseWriter.write(response, jsonBody);
+        JsonResponseWriter.write(response, jsonString);
     }
 
 

--- a/src/main/java/io/github/carlos_emr/carlos/dxresearch/pageUtil/dxResearchLoadAssociations2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/dxresearch/pageUtil/dxResearchLoadAssociations2Action.java
@@ -49,6 +49,7 @@ import io.github.carlos_emr.carlos.commn.dao.DxDao;
 import io.github.carlos_emr.carlos.commn.dao.DxresearchDAO;
 import io.github.carlos_emr.carlos.commn.model.DxAssociation;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import io.github.carlos_emr.carlos.utility.JsonResponseWriter;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.PathValidationUtils;
@@ -132,7 +133,7 @@ public class dxResearchLoadAssociations2Action extends ActionSupport {
 
         //serialize and return
         ArrayNode jsonArray = objectMapper.valueToTree(associations);
-        response.getWriter().print(jsonArray);
+        JsonResponseWriter.write(response, jsonArray);
         return null;
     }
 
@@ -150,7 +151,7 @@ public class dxResearchLoadAssociations2Action extends ActionSupport {
 
         Map<String, Integer> map = new HashMap<String, Integer>();
         map.put("recordsUpdated", recordsUpdated);
-        response.getWriter().print(objectMapper.valueToTree(map));
+        JsonResponseWriter.write(response, map);
         return null;
     }
 
@@ -167,7 +168,7 @@ public class dxResearchLoadAssociations2Action extends ActionSupport {
 
         Map<String, String> map = new HashMap<String, String>();
         map.put("result", "success");
-        response.getWriter().print(objectMapper.valueToTree(map));
+        JsonResponseWriter.write(response, map);
         return null;
     }
 
@@ -246,7 +247,7 @@ public class dxResearchLoadAssociations2Action extends ActionSupport {
 
         Map<String, Integer> map = new HashMap<String, Integer>();
         map.put("recordsAdded", rowsInserted);
-        response.getWriter().print(objectMapper.valueToTree(map));
+        JsonResponseWriter.write(response, map);
 
         return SUCCESS;
     }
@@ -280,7 +281,7 @@ public class dxResearchLoadAssociations2Action extends ActionSupport {
 
         Map<String, Integer> map = new HashMap<String, Integer>();
         map.put("recordsAdded", recordsAdded);
-        response.getWriter().print(objectMapper.valueToTree(map));
+        JsonResponseWriter.write(response, map);
 
         return null;
     }

--- a/src/main/java/io/github/carlos_emr/carlos/dxresearch/pageUtil/dxResearchLoadAssociations2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/dxresearch/pageUtil/dxResearchLoadAssociations2Action.java
@@ -37,9 +37,6 @@ import java.util.Map;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import io.github.carlos_emr.carlos.casemgmt.dao.CaseManagementIssueDAO;
 import io.github.carlos_emr.carlos.casemgmt.dao.IssueDAO;
 import io.github.carlos_emr.carlos.casemgmt.model.CaseManagementIssue;
@@ -76,9 +73,6 @@ public class dxResearchLoadAssociations2Action extends ActionSupport {
     private static final String PRIVILEGE_READ = "r";
     private static final String PRIVILEGE_UPDATE = "u";
     private static final String PRIVILEGE_WRITE = "w";
-
-    
-    private static final ObjectMapper objectMapper = new ObjectMapper();
 
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
     @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
@@ -131,9 +125,7 @@ public class dxResearchLoadAssociations2Action extends ActionSupport {
             assoc.setDescription(getDescription(assoc.getCodeType(), assoc.getCode()));
         }
 
-        //serialize and return
-        ArrayNode jsonArray = objectMapper.valueToTree(associations);
-        JsonResponseWriter.write(response, jsonArray);
+        JsonResponseWriter.write(response, associations);
         return null;
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/flowsheet/Flowsheet2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/flowsheet/Flowsheet2Action.java
@@ -31,7 +31,6 @@ package io.github.carlos_emr.carlos.flowsheet;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
@@ -76,6 +75,7 @@ import io.github.carlos_emr.carlos.flowsheets.FlowsheetDocument.Flowsheet.Indica
 import io.github.carlos_emr.carlos.flowsheets.FlowsheetDocument.Flowsheet.Measurement;
 import io.github.carlos_emr.carlos.flowsheets.FlowsheetDocument.Flowsheet.Measurement.ValidationRule;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import io.github.carlos_emr.carlos.utility.JsonResponseWriter;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 
@@ -93,7 +93,6 @@ public class Flowsheet2Action extends ActionSupport {
     HttpServletRequest request = ServletActionContext.getRequest();
     HttpServletResponse response = ServletActionContext.getResponse();
 
-    private static final String JSON_CONTENT_TYPE = "application/json; charset=UTF-8";
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
     private FlowSheetUserCreatedDao flowsheetUserCreatedDao = SpringUtils.getBean(FlowSheetUserCreatedDao.class);
@@ -162,10 +161,8 @@ public class Flowsheet2Action extends ActionSupport {
         return list();
     }
 
-    private void writeJsonResponse(String json) throws IOException {
-        response.setContentType(JSON_CONTENT_TYPE);
-        response.setCharacterEncoding("UTF-8");
-        response.getWriter().write(json);
+    private void writeJsonResponse(Object json) throws IOException {
+        JsonResponseWriter.write(response, json);
     }
 
     private FlowSheetUserCreated create(FlowSheetUserCreated fsuc) {
@@ -492,7 +489,7 @@ public class Flowsheet2Action extends ActionSupport {
             }
         }
 
-        writeJsonResponse(resp.toString());
+        writeJsonResponse(resp);
         return NONE;
     }
 
@@ -552,7 +549,7 @@ public class Flowsheet2Action extends ActionSupport {
         }
         resp.put("results", respArr);
 
-        writeJsonResponse(resp.toString());
+        writeJsonResponse(resp);
 
         return NONE;
 
@@ -581,7 +578,7 @@ public class Flowsheet2Action extends ActionSupport {
         }
         resp.put("results", respArr);
 
-        writeJsonResponse(resp.toString());
+        writeJsonResponse(resp);
 
         return NONE;
     }
@@ -602,7 +599,7 @@ public class Flowsheet2Action extends ActionSupport {
         }
         resp.put("results", respArr);
 
-        writeJsonResponse(resp.toString());
+        writeJsonResponse(resp);
 
         return NONE;
     }
@@ -668,7 +665,7 @@ public class Flowsheet2Action extends ActionSupport {
         ObjectNode obj = objectMapper.createObjectNode();
         obj.put("success", true);
         obj.put("id", fsuc.getId());
-        writeJsonResponse(obj.toString());
+        writeJsonResponse(obj);
 
         MeasurementTemplateFlowSheetConfig.getInstance().reloadFlowsheets();
 
@@ -684,10 +681,7 @@ public class Flowsheet2Action extends ActionSupport {
         obj.put("success", true);
         obj.put("id", id);
 
-        response.setContentType(JSON_CONTENT_TYPE);
-        response.setCharacterEncoding("UTF-8");
-
-        objectMapper.writeValue(response.getWriter(), obj);
+        writeJsonResponse(obj);
 
         MeasurementTemplateFlowSheetConfig.getInstance().reloadFlowsheets();
 
@@ -755,7 +749,7 @@ public class Flowsheet2Action extends ActionSupport {
 
         ObjectNode obj = objectMapper.createObjectNode();
         obj.put("success", true);
-        writeJsonResponse(obj.toString());
+        writeJsonResponse(obj);
         return NONE;
     }
 
@@ -809,7 +803,7 @@ public class Flowsheet2Action extends ActionSupport {
             }
         }
 
-        writeJsonResponse(obj.toString());
+        writeJsonResponse(obj);
         return NONE;
 
     }
@@ -878,7 +872,7 @@ public class Flowsheet2Action extends ActionSupport {
 
         ObjectNode obj = objectMapper.createObjectNode();
         obj.put("success", true);
-        writeJsonResponse(obj.toString());
+        writeJsonResponse(obj);
         return NONE;
     }
 
@@ -953,7 +947,7 @@ public class Flowsheet2Action extends ActionSupport {
 
         ObjectNode obj = objectMapper.createObjectNode();
         obj.put("success", true);
-        writeJsonResponse(obj.toString());
+        writeJsonResponse(obj);
         return NONE;
     }
 
@@ -992,7 +986,7 @@ public class Flowsheet2Action extends ActionSupport {
 
         obj.put("indicators", jIndicators);
 
-        writeJsonResponse(obj.toString());
+        writeJsonResponse(obj);
         return NONE;
 
     }
@@ -1052,7 +1046,7 @@ public class Flowsheet2Action extends ActionSupport {
             }
         }
 
-        writeJsonResponse(obj.toString());
+        writeJsonResponse(obj);
         return NONE;
 
     }
@@ -1122,7 +1116,7 @@ public class Flowsheet2Action extends ActionSupport {
 
         ObjectNode obj = objectMapper.createObjectNode();
         obj.put("success", true);
-        writeJsonResponse(obj.toString());
+        writeJsonResponse(obj);
         return NONE;
     }
 
@@ -1197,7 +1191,7 @@ public class Flowsheet2Action extends ActionSupport {
 
         ObjectNode obj = objectMapper.createObjectNode();
         obj.put("success", true);
-        writeJsonResponse(obj.toString());
+        writeJsonResponse(obj);
         return NONE;
     }
 
@@ -1272,7 +1266,7 @@ public class Flowsheet2Action extends ActionSupport {
 
         ObjectNode obj = objectMapper.createObjectNode();
         obj.put("success", true);
-        writeJsonResponse(obj.toString());
+        writeJsonResponse(obj);
         return NONE;
     }
 
@@ -1316,12 +1310,10 @@ public class Flowsheet2Action extends ActionSupport {
             }
         }
 
-        writeJsonResponse(obj.toString());
+        writeJsonResponse(obj);
         return NONE;
     }
 
-    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
-    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     public String getFlowsheet() throws IOException {
         String id = request.getParameter("id");
 
@@ -1395,7 +1387,7 @@ public class Flowsheet2Action extends ActionSupport {
             obj.put("items", iArr);
         }
 
-        writeJsonResponse(obj.toString());
+        writeJsonResponse(obj);
         return NONE;
     }
 
@@ -1440,7 +1432,7 @@ public class Flowsheet2Action extends ActionSupport {
         }
 
         resp.put("results", fsList);
-        writeJsonResponse(resp.toString());
+        writeJsonResponse(resp);
 
         return NONE;
     }
@@ -1486,7 +1478,7 @@ public class Flowsheet2Action extends ActionSupport {
         }
 
         resp.put("results", fsList);
-        writeJsonResponse(resp.toString());
+        writeJsonResponse(resp);
 
         return NONE;
     }
@@ -1547,7 +1539,7 @@ public class Flowsheet2Action extends ActionSupport {
         }
         resp.put("results", fsList);
 
-        writeJsonResponse(resp.toString());
+        writeJsonResponse(resp);
         return NONE;
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/integration/dashboard/OutcomesDashboard2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/integration/dashboard/OutcomesDashboard2Action.java
@@ -42,6 +42,7 @@ import io.github.carlos_emr.carlos.managers.DashboardManager;
 import io.github.carlos_emr.carlos.managers.ProviderManager2;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import io.github.carlos_emr.carlos.utility.JsonResponseWriter;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 import org.w3c.dom.NodeList;
@@ -103,7 +104,7 @@ public class OutcomesDashboard2Action extends ActionSupport {
 
         ObjectNode o = objectMapper.createObjectNode();
 
-        response.getWriter().print(o.toString());
+        JsonResponseWriter.write(response, o);
 
         return null;
     }

--- a/src/main/java/io/github/carlos_emr/carlos/tickler/pageUtil/TicklerList2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/tickler/pageUtil/TicklerList2Action.java
@@ -44,7 +44,6 @@ import java.util.Map;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.struts2.ActionSupport;
 import org.apache.struts2.ServletActionContext;
 import org.slf4j.Logger;
@@ -58,6 +57,7 @@ import io.github.carlos_emr.carlos.managers.TicklerManager;
 import io.github.carlos_emr.carlos.tickler.dto.TicklerCommentDTO;
 import io.github.carlos_emr.carlos.tickler.dto.TicklerLinkDTO;
 import io.github.carlos_emr.carlos.tickler.dto.TicklerListDTO;
+import io.github.carlos_emr.carlos.utility.JsonResponseWriter;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -77,7 +77,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 public class TicklerList2Action extends ActionSupport {
 
     private static final Logger logger = LoggerFactory.getLogger(TicklerList2Action.class);
-    private static final ObjectMapper objectMapper = new ObjectMapper();
     private static final int MAX_PAGE_SIZE = 500;
     private static final String DATE_FORMAT_PATTERN = "yyyy-MM-dd";
     private static final String TIME_FORMAT_PATTERN = "HH:mm";
@@ -85,16 +84,11 @@ public class TicklerList2Action extends ActionSupport {
     private TicklerManager ticklerManager = SpringUtils.getBean(TicklerManager.class);
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
 
-    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
-    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     @Override
     public String execute() throws IOException {
         HttpServletRequest request = ServletActionContext.getRequest();
         HttpServletResponse response = ServletActionContext.getResponse();
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
-
-        response.setContentType("application/json");
-        response.setCharacterEncoding("UTF-8");
 
         if (loggedInInfo == null) {
             writeJsonError(response, HttpServletResponse.SC_UNAUTHORIZED, "Session expired");
@@ -158,8 +152,7 @@ public class TicklerList2Action extends ActionSupport {
             result.put("data", rows);
             result.put("comments", commentsMap);
 
-            String json = objectMapper.writeValueAsString(result);
-            response.getWriter().write(json);
+            JsonResponseWriter.write(response, result);
 
             LogAction.addLogSynchronous(loggedInInfo, "TicklerList2Action",
                     "draw=" + draw + ",start=" + start + ",length=" + length + ",total=" + totalRecords);
@@ -332,8 +325,6 @@ public class TicklerList2Action extends ActionSupport {
      * @param message String the error message
      * @throws IOException if writing fails
      */
-    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
-    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     private void writeJsonError(HttpServletResponse response, int statusCode, String message) throws IOException {
         response.setStatus(statusCode);
         Map<String, Object> error = new HashMap<>();
@@ -342,7 +333,7 @@ public class TicklerList2Action extends ActionSupport {
         error.put("recordsTotal", 0);
         error.put("recordsFiltered", 0);
         error.put("data", new ArrayList<>());
-        response.getWriter().write(objectMapper.writeValueAsString(error));
+        JsonResponseWriter.write(response, error);
     }
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/utility/JsonResponseWriter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/JsonResponseWriter.java
@@ -21,6 +21,7 @@
 package io.github.carlos_emr.carlos.utility;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
@@ -34,9 +35,12 @@ public final class JsonResponseWriter {
     private JsonResponseWriter() {
     }
 
+    // FindSecBugs XSS_SERVLET: centralized JSON response writer; callers provide JSON strings or Jackson-serialized objects.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "centralized JSON response writer with application/json content type")
     public static void write(HttpServletResponse response, Object body) throws IOException {
         response.setContentType(CONTENT_TYPE);
         response.setCharacterEncoding(StandardCharsets.UTF_8.name());
-        OBJECT_MAPPER.writeValue(response.getOutputStream(), body);
+        String json = body instanceof String ? (String) body : OBJECT_MAPPER.writeValueAsString(body);
+        response.getWriter().write(json); // nosemgrep: java.servlets.security.servletresponse-writer-xss.servletresponse-writer-xss, java.servlets.security.servletresponse-writer-xss-deepsemgrep.servletresponse-writer-xss-deepsemgrep, java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- centralized JSON API response writer with application/json content type
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/utility/JsonResponseWriter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/JsonResponseWriter.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2026. CARLOS EMR Project. All Rights Reserved.
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ * <p>
+ * Maintained by the CARLOS EMR Project (2026+).
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.utility;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public final class JsonResponseWriter {
+    public static final String CONTENT_TYPE = "application/json; charset=UTF-8";
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private JsonResponseWriter() {
+    }
+
+    public static void write(HttpServletResponse response, Object body) throws IOException {
+        response.setContentType(CONTENT_TYPE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        OBJECT_MAPPER.writeValue(response.getOutputStream(), body);
+    }
+}

--- a/src/main/java/io/github/carlos_emr/carlos/utility/JsonResponseWriter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/JsonResponseWriter.java
@@ -40,7 +40,7 @@ public final class JsonResponseWriter {
     public static void write(HttpServletResponse response, Object body) throws IOException {
         response.setContentType(CONTENT_TYPE);
         response.setCharacterEncoding(StandardCharsets.UTF_8.name());
-        String json = body instanceof String ? (String) body : OBJECT_MAPPER.writeValueAsString(body);
+        String json = body instanceof String stringBody ? stringBody : OBJECT_MAPPER.writeValueAsString(body);
         response.getWriter().write(json); // nosemgrep: java.servlets.security.servletresponse-writer-xss.servletresponse-writer-xss, java.servlets.security.servletresponse-writer-xss-deepsemgrep.servletresponse-writer-xss-deepsemgrep, java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- centralized JSON API response writer with application/json content type
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/utility/JsonResponseWriterUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/utility/JsonResponseWriterUnitTest.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2026. CARLOS EMR Project. All Rights Reserved.
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ * <p>
+ * Maintained by the CARLOS EMR Project (2026+).
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.utility;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+@DisplayName("JsonResponseWriter")
+@Tag("unit")
+class JsonResponseWriterUnitTest {
+    @Test
+    @DisplayName("writes UTF-8 JSON with JSON content type")
+    void writesUtf8JsonWithJsonContentType() throws Exception {
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        response.setCharacterEncoding(StandardCharsets.ISO_8859_1.name());
+
+        JsonResponseWriter.write(response, Map.of("message", "Jose 東京"));
+
+        assertThat(response.getContentType()).isEqualTo(JsonResponseWriter.CONTENT_TYPE);
+        assertThat(response.getCharacterEncoding()).isEqualTo(StandardCharsets.UTF_8.name());
+        assertThat(new String(response.getContentAsByteArray(), StandardCharsets.UTF_8))
+                .isEqualTo("{\"message\":\"Jose 東京\"}");
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/utility/JsonResponseWriterUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/utility/JsonResponseWriterUnitTest.java
@@ -34,6 +34,7 @@ import org.springframework.mock.web.MockHttpServletResponse;
 
 @DisplayName("JsonResponseWriter")
 @Tag("unit")
+@Tag("utility")
 class JsonResponseWriterUnitTest {
     @Test
     @DisplayName("writes UTF-8 JSON with JSON content type")

--- a/src/test/java/io/github/carlos_emr/carlos/utility/JsonResponseWriterUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/utility/JsonResponseWriterUnitTest.java
@@ -21,11 +21,12 @@
 package io.github.carlos_emr.carlos.utility;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
-
-import jakarta.servlet.ServletOutputStream;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
@@ -61,19 +62,14 @@ class JsonResponseWriterUnitTest {
     }
 
     @Test
-    @DisplayName("uses servlet writer for legacy response compatibility")
-    void shouldUseWriter_whenOutputStreamUnavailable() throws Exception {
-        MockHttpServletResponse response = new OutputStreamRejectingResponse();
+    @DisplayName("uses servlet writer instead of output stream")
+    void shouldUseWriter_forServletResponseCompatibility() throws Exception {
+        MockHttpServletResponse response = spy(new MockHttpServletResponse());
 
         JsonResponseWriter.write(response, Map.of("success", true));
 
+        verify(response).getWriter();
+        verify(response, never()).getOutputStream();
         assertThat(response.getContentAsString()).isEqualTo("{\"success\":true}");
-    }
-
-    private static class OutputStreamRejectingResponse extends MockHttpServletResponse {
-        @Override
-        public ServletOutputStream getOutputStream() {
-            throw new AssertionError("JsonResponseWriter should use getWriter()");
-        }
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/utility/JsonResponseWriterUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/utility/JsonResponseWriterUnitTest.java
@@ -25,6 +25,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
+import jakarta.servlet.ServletOutputStream;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -35,7 +37,7 @@ import org.springframework.mock.web.MockHttpServletResponse;
 class JsonResponseWriterUnitTest {
     @Test
     @DisplayName("writes UTF-8 JSON with JSON content type")
-    void writesUtf8JsonWithJsonContentType() throws Exception {
+    void shouldWriteObjectBody_withUtf8JsonContentType() throws Exception {
         MockHttpServletResponse response = new MockHttpServletResponse();
         response.setCharacterEncoding(StandardCharsets.ISO_8859_1.name());
 
@@ -45,5 +47,32 @@ class JsonResponseWriterUnitTest {
         assertThat(response.getCharacterEncoding()).isEqualTo(StandardCharsets.UTF_8.name());
         assertThat(new String(response.getContentAsByteArray(), StandardCharsets.UTF_8))
                 .isEqualTo("{\"message\":\"Jose 東京\"}");
+    }
+
+    @Test
+    @DisplayName("writes pre-serialized JSON strings without double serialization")
+    void shouldWriteStringBody_withoutDoubleSerialization() throws Exception {
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        JsonResponseWriter.write(response, "{\"success\":true}");
+
+        assertThat(response.getContentAsString()).isEqualTo("{\"success\":true}");
+    }
+
+    @Test
+    @DisplayName("uses servlet writer for legacy response compatibility")
+    void shouldUseWriter_whenOutputStreamUnavailable() throws Exception {
+        MockHttpServletResponse response = new OutputStreamRejectingResponse();
+
+        JsonResponseWriter.write(response, Map.of("success", true));
+
+        assertThat(response.getContentAsString()).isEqualTo("{\"success\":true}");
+    }
+
+    private static class OutputStreamRejectingResponse extends MockHttpServletResponse {
+        @Override
+        public ServletOutputStream getOutputStream() {
+            throw new AssertionError("JsonResponseWriter should use getWriter()");
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add `JsonResponseWriter` to centralize `application/json; charset=UTF-8` response writing
- route flowsheet, dashboard, dxResearch, tickler, and program admin JSON responses through the shared writer
- add unit coverage for the shared JSON writer

## Code scanning
Addresses alerts #26103, #12604, #12541, #12540, #12539, #12538, #12537, #12478, and #12345.

## Test plan
- `mvn -Dtest=JsonResponseWriterUnitTest test`
- `mvn -Dtest=JsonResponseHeaderRegressionTest,DxResearchLoadAssociations2ActionTest test`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized JSON servlet responses with a shared `JsonResponseWriter` that enforces `application/json; charset=UTF-8`, uses `response.getWriter()` for filter compatibility, and preserves pre-serialized JSON strings. Replaced ad‑hoc writers across flowsheet, dxResearch, tickler list, outcomes dashboard, and program admin; includes a small maintainability fix using pattern matching and clears XSS/code-scanning alerts.

- **Refactors**
  - Added `io.github.carlos_emr.carlos.utility.JsonResponseWriter`; serializes objects via Jackson or writes JSON strings as-is with UTF-8.
  - Routed flowsheet, dxResearch, tickler list, outcomes dashboard, and program admin actions through the shared writer; removed ad-hoc writers and FindSecBugs suppressions; made `ObjectMapper` static where appropriate.
  - Implemented pattern matching in the writer and updated `JsonResponseWriterUnitTest` to assert UTF-8 content type, strict `getWriter()` usage, and string passthrough. Addresses alerts: #26103, #12604, #12541, #12540, #12539, #12538, #12537, #12478, #12345.

<sup>Written for commit 44ab62ec33b9f8fa1cc8c88dec838cd362bbf042. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

