### PR TITLE
fix: remove RxUtil ReDoS number regexes

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/prescript/util/RxUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/util/RxUtil.java
@@ -1188,8 +1188,7 @@ public class RxUtil {
 
     private static String findWordAmountAfterMethod(String instructions, String method, String word, String suffix) {
         String safeMethod = Pattern.quote(method);
-        String safeWord = Pattern.quote(word);
-        String regex = safeMethod + "\\s+" + safeWord + suffix;
+        String regex = safeMethod + "\\s+" + word + suffix;
         Pattern pattern = Pattern.compile(regex);
         Matcher matcher = pattern.matcher(instructions);
         p("pattern word =" + regex);

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/util/RxUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/util/RxUtil.java
@@ -593,7 +593,7 @@ public class RxUtil {
                 frequency = changeToStandardFrequencyCode(matchedFrequency);
                 //     p("here11", instructions);
                 //since "\\s+[0-9]+-[0-9]+\\s+" is a case in "\\s+[0-9]+\\s+", check the latter regex first.
-                NumberRange frequencyRange = matchedFrequency.equals(frequency) ? findRangeBeforeFrequency(instructions, matcher.start()) : null;
+                NumberRange frequencyRange = findRangeBeforeFrequency(instructions, matcher.start());
                 if (frequencyRange != null) {
                     takeMinFrequency = frequencyRange.min;
                     takeMaxFrequency = frequencyRange.max;

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/util/RxUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/util/RxUtil.java
@@ -1154,13 +1154,19 @@ public class RxUtil {
     }
 
     private static String convertFractionToAmount(String fraction) {
-        if (fraction.equals("1/2")) {
-            return "0.5";
+        int separator = fraction.indexOf('/');
+        if (separator <= 0 || separator == fraction.length() - 1) {
+            return "0";
         }
-        if (fraction.equals("1/4")) {
-            return "0.25";
+
+        double numerator = Double.parseDouble(fraction.substring(0, separator));
+        double denominator = Double.parseDouble(fraction.substring(separator + 1));
+        if (denominator == 0d || !Double.isFinite(numerator) || !Double.isFinite(denominator)) {
+            return "0";
         }
-        return "0";
+
+        double amount = numerator / denominator;
+        return Double.isFinite(amount) ? Double.toString(amount) : "0";
     }
 
     private static String findWordAmountAfterMethod(String instructions, String method) {

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/util/RxUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/util/RxUtil.java
@@ -589,63 +589,47 @@ public class RxUtil {
             Pattern p = Pattern.compile(s);
             Matcher matcher = p.matcher(instructions);
             if (matcher.find()) {
-                frequency = (instructions.substring(matcher.start(), matcher.end())).trim();
-                frequency = changeToStandardFrequencyCode(frequency);
-                String origFrequency = (instructions.substring(matcher.start(), matcher.end())).trim();
-
-                Pattern p2 = Pattern.compile("\\s*(?:[0-9]+(?:\\.[0-9]+)?|\\.[0-9]+)\\s+" + Pattern.quote(origFrequency)); //allow to detect decimal number.
-                Matcher m2 = p2.matcher(instructions);
-
-                Pattern p4 = Pattern.compile("\\s*(?:[0-9]+(?:\\.[0-9]+)?|\\.[0-9]+)-\\s*(?:[0-9]+(?:\\.[0-9]+)?|\\.[0-9]+)\\s+" + Pattern.quote(frequency)); //use * after the first \s because "1 OD", 1 doesn't have a space in front.
-                Matcher m4 = p4.matcher(instructions);
-                //     p("here11", instructions);
-                //since "\\s+[0-9]+-[0-9]+\\s+" is a case in "\\s+[0-9]+\\s+", check the latter regex first.
-                if (m4.find()) {
-                    String str2 = instructions.substring(m4.start(), m4.end());
-                    Pattern p5 = Pattern.compile("(?:[0-9]+(?:\\.[0-9]+)?|\\.[0-9]+)-\\s*(?:[0-9]+(?:\\.[0-9]+)?|\\.[0-9]+)");
-                    Matcher m5 = p5.matcher(str2);
-                    if (m5.find()) {
-                        String str3 = str2.substring(m5.start(), m5.end());
-                        //       p("here str3", str3);
-                        takeMinFrequency = str3.split("-")[0];
-                        takeMaxFrequency = str3.split("-")[1];
-                    }
-                } else if (m2.find()) {
-                    String str = instructions.substring(m2.start(), m2.end());
-                    Pattern p3 = Pattern.compile("(?:[0-9]+(?:\\.[0-9]+)?|\\.[0-9]+)");
-                    Matcher m3 = p3.matcher(str);
-                    //     p("here22", str);
-                    if (m3.find()) {
-                        amountFrequency = str.substring(m3.start(), m3.end());
-                    }
+	                String matchedFrequency = (instructions.substring(matcher.start(), matcher.end())).trim();
+	                frequency = changeToStandardFrequencyCode(matchedFrequency);
+	                //     p("here11", instructions);
+	                //since "\\s+[0-9]+-[0-9]+\\s+" is a case in "\\s+[0-9]+\\s+", check the latter regex first.
+	                NumberRange frequencyRange = matchedFrequency.equals(frequency) ? findRangeBeforeFrequency(instructions, matcher.start()) : null;
+                if (frequencyRange != null) {
+                    takeMinFrequency = frequencyRange.min;
+                    takeMaxFrequency = frequencyRange.max;
                 } else {
-                    p("word amount");
-                    for (String word : zeroToTen) {
-                        String r1 = "\\s" + word + "\\s*" + Pattern.quote(frequency);
-                        String r2 = "^" + word + "\\s*" + Pattern.quote(frequency); //start at the begin of instructions
-                        Pattern p5 = Pattern.compile(r1);
-                        Matcher m5 = p5.matcher(instructions);
-                        p("pattern word =" + r1);
-                        if (m5.find()) {
-                            amountFrequency = instructions.substring(m5.start(), m5.end());
-                            amountFrequency = amountFrequency.replace(frequency, "").trim();
-                            p("amountFreq=" + amountFrequency);
-                            amountFrequency = convertWordToNumerical(amountFrequency);
-                            p("num amountFreq=" + amountFrequency);
-                            break;
-                        }
-                        p5 = Pattern.compile(r2);
-                        m5 = p5.matcher(instructions);
-                        if (m5.find()) {
-                            amountFrequency = instructions.substring(m5.start(), m5.end());
-                            amountFrequency = amountFrequency.replace(frequency, "").trim();
-                            p("amountFreq=" + amountFrequency);
-                            amountFrequency = convertWordToNumerical(amountFrequency);
-                            p("num amountFreq=" + amountFrequency);
-                            break;
+                    NumberToken frequencyAmount = findDecimalBeforeFrequency(instructions, matcher.start());
+                    if (frequencyAmount != null) {
+                        amountFrequency = frequencyAmount.value;
+                    } else {
+                        p("word amount");
+                        for (String word : zeroToTen) {
+                            String r1 = "\\s" + word + "\\s*" + Pattern.quote(frequency);
+                            String r2 = "^" + word + "\\s*" + Pattern.quote(frequency); //start at the begin of instructions
+                            Pattern p5 = Pattern.compile(r1);
+                            Matcher m5 = p5.matcher(instructions);
+                            p("pattern word =" + r1);
+                            if (m5.find()) {
+                                amountFrequency = instructions.substring(m5.start(), m5.end());
+                                amountFrequency = amountFrequency.replace(frequency, "").trim();
+                                p("amountFreq=" + amountFrequency);
+                                amountFrequency = convertWordToNumerical(amountFrequency);
+                                p("num amountFreq=" + amountFrequency);
+                                break;
+                            }
+                            p5 = Pattern.compile(r2);
+                            m5 = p5.matcher(instructions);
+                            if (m5.find()) {
+                                amountFrequency = instructions.substring(m5.start(), m5.end());
+                                amountFrequency = amountFrequency.replace(frequency, "").trim();
+                                p("amountFreq=" + amountFrequency);
+                                amountFrequency = convertWordToNumerical(amountFrequency);
+                                p("num amountFreq=" + amountFrequency);
+                                break;
+                            }
                         }
                     }
-                }
+	                }
                 //the string before frequency maybe the amount of drug
                 //check if the string is a number, if it is, get the number
                 //if not a number, check if it has "min-max" pattern, if yes, get min and max, if not, ignore
@@ -914,144 +898,302 @@ public class RxUtil {
     }
 
     public static boolean isStringToNumber(String s) {//see if string contains decimal or integer
-        boolean retBool = false;
-        Pattern p1 = Pattern.compile("(?:[0-9]+(?:\\.[0-9]+)?|\\.[0-9]+)");
-        Matcher m1 = p1.matcher(s);
-        if (m1.find()) {
-            String numStr = s.substring(m1.start(), m1.end());
-            String restStr = s.replace(numStr, "").trim();
-            if (restStr != null && restStr.length() > 0) retBool = false;
-            else retBool = true;
-        } else retBool = false;
+        if (s == null) {
+            return false;
+        }
+        String trimmed = s.trim();
+        NumberToken token = findDecimalAt(trimmed, 0);
+        return token != null && token.start == 0 && token.end == trimmed.length();
+    }
 
-        return retBool;
+    private static NumberRange findRangeBeforeFrequency(String text, int frequencyStart) {
+        if (skipWhitespaceBackward(text, frequencyStart) == frequencyStart) {
+            return null;
+        }
+        return findRangeBefore(text, frequencyStart);
+    }
+
+    private static NumberToken findDecimalBeforeFrequency(String text, int frequencyStart) {
+        if (skipWhitespaceBackward(text, frequencyStart) == frequencyStart) {
+            return null;
+        }
+        return findDecimalBefore(text, frequencyStart);
+    }
+
+    private static NumberRange findRangeBefore(String text, int endExclusive) {
+        int end = skipWhitespaceBackward(text, endExclusive);
+        NumberToken max = findDecimalBefore(text, end);
+        if (max == null || max.end != end) {
+            return null;
+        }
+
+        int hyphenIndex = skipWhitespaceBackward(text, max.start) - 1;
+        if (hyphenIndex < 0 || text.charAt(hyphenIndex) != '-') {
+            return null;
+        }
+
+        NumberToken min = findDecimalBefore(text, hyphenIndex);
+        if (min == null || min.end != hyphenIndex) {
+            return null;
+        }
+
+        return new NumberRange(min.value, max.value, max.end);
+    }
+
+    private static NumberRange findRangeAt(String text, int start) {
+        NumberToken min = findDecimalAt(text, start);
+        if (min == null || min.end >= text.length() || text.charAt(min.end) != '-') {
+            return null;
+        }
+
+        int maxStart = skipWhitespaceForward(text, min.end + 1);
+        NumberToken max = findDecimalAt(text, maxStart);
+        if (max == null) {
+            return null;
+        }
+
+        return new NumberRange(min.value, max.value, max.end);
+    }
+
+    private static NumberToken findDecimalBefore(String text, int endExclusive) {
+        int end = skipWhitespaceBackward(text, endExclusive);
+        if (end == 0 || !isDigit(text.charAt(end - 1))) {
+            return null;
+        }
+
+        int start = end;
+        while (start > 0 && isDigit(text.charAt(start - 1))) {
+            start--;
+        }
+
+        if (start > 0 && text.charAt(start - 1) == '.') {
+            int dotIndex = start - 1;
+            int tokenStart = dotIndex;
+            while (tokenStart > 0 && isDigit(text.charAt(tokenStart - 1))) {
+                tokenStart--;
+            }
+            return new NumberToken(text, tokenStart, end);
+        }
+
+        return new NumberToken(text, start, end);
+    }
+
+    private static NumberToken findDecimalAt(String text, int start) {
+        if (start < 0 || start >= text.length()) {
+            return null;
+        }
+
+        int index = start;
+        while (index < text.length() && isDigit(text.charAt(index))) {
+            index++;
+        }
+
+        if (index < text.length() && text.charAt(index) == '.') {
+            int decimalPoint = index;
+            index++;
+            int fractionStart = index;
+            while (index < text.length() && isDigit(text.charAt(index))) {
+                index++;
+            }
+            if (index > fractionStart) {
+                return new NumberToken(text, start, index);
+            }
+            if (decimalPoint > start) {
+                return new NumberToken(text, start, decimalPoint);
+            }
+            return null;
+        }
+
+        if (index > start) {
+            return new NumberToken(text, start, index);
+        }
+
+        return null;
+    }
+
+    private static String findFractionAt(String text, int start) {
+        if (start < 0 || start >= text.length() || !isDigit(text.charAt(start))) {
+            return null;
+        }
+
+        int index = start;
+        while (index < text.length() && isDigit(text.charAt(index))) {
+            index++;
+        }
+
+        if (index < text.length() && text.charAt(index) == '/') {
+            index++;
+            int denominatorStart = index;
+            while (index < text.length() && isDigit(text.charAt(index))) {
+                index++;
+            }
+            if (index == denominatorStart) {
+                return null;
+            }
+        }
+
+        if (!hasWhitespaceAt(text, index)) {
+            return null;
+        }
+
+        return text.substring(start, index);
+    }
+
+    private static int skipWhitespaceBackward(String text, int endExclusive) {
+        int index = Math.min(endExclusive, text.length());
+        while (index > 0 && Character.isWhitespace(text.charAt(index - 1))) {
+            index--;
+        }
+        return index;
+    }
+
+    private static int skipWhitespaceForward(String text, int start) {
+        int index = Math.max(0, start);
+        while (index < text.length() && Character.isWhitespace(text.charAt(index))) {
+            index++;
+        }
+        return index;
+    }
+
+    private static boolean hasWhitespaceAt(String text, int index) {
+        return index < text.length() && Character.isWhitespace(text.charAt(index));
+    }
+
+    private static boolean isDigit(char c) {
+        return c >= '0' && c <= '9';
     }
 
 
-	private static InstructionSegment scanInstruction(String instructions, String[] methods) {
-		InstructionSegment segment = new InstructionSegment();
+    private static InstructionSegment scanInstruction(String instructions, String[] methods) {
+        InstructionSegment segment = new InstructionSegment();
 
-		for (String s : methods) {
-			Pattern p = Pattern.compile(s);
-			Matcher m = p.matcher(instructions);
-			if (m.find()) {
-				p("must be here");
+        for (String s : methods) {
+            Pattern p = Pattern.compile(s);
+            Matcher m = p.matcher(instructions);
+            if (m.find()) {
+                p("must be here");
+                segment.method = instructions.substring(m.start(), m.end());
+                scanForFrequencyAndUpdateInstructionSegment(segment, instructions, segment.method, m.end());
+                break;
+            }
+        }
 
-				segment.method = instructions.substring(m.start(), m.end());
-				scanForFrequencyAndUpdateInstructionSegment(segment, instructions, segment.method);
-				break;
-			}
+        if (segment.method == null) {
+            String placeholderMethod = "<NO_METHOD>";
+            String instructionWithPlaceholderMethod = placeholderMethod + " " + instructions;
+            Pattern p = Pattern.compile("(?i)" + placeholderMethod);
+            Matcher m = p.matcher(instructionWithPlaceholderMethod);
+            if (m.find()) {
+                scanForFrequencyAndUpdateInstructionSegment(segment, instructionWithPlaceholderMethod, placeholderMethod, m.end());
+            }
+        }
+
+        return segment;
+    }
+
+    private static void scanForFrequencyAndUpdateInstructionSegment(InstructionSegment segment, String instructions, String method, int methodEnd) {
+        String takeMinMethod = null;
+        String takeMaxMethod = null;
+        String amountMethod = null;
+        String amountFrequency = null;
+
+        int amountStart = skipWhitespaceForward(instructions, methodEnd);
+        NumberRange methodRange = findRangeAt(instructions, amountStart);
+
+        //since "\\s+[0-9]+-[0-9]+\\s+" is a case in "\\s+[0-9]+\\s+", check the latter regex first.
+        if (methodRange != null && hasWhitespaceAt(instructions, methodRange.end)) {
+            p("else if 1");
+            takeMinMethod = methodRange.min;
+            takeMaxMethod = methodRange.max;
+        } else {
+            NumberToken methodAmount = findDecimalAt(instructions, amountStart);
+            if (methodAmount != null && hasWhitespaceAt(instructions, methodAmount.end)) {
+                p("if 1");
+                p("str1 ", instructions.substring(amountStart, methodAmount.end));
+                p("found1");
+                amountMethod = methodAmount.value;
+                //      p("amountMethod", amountMethod);
+            } else {
+                String fraction = findFractionAt(instructions, amountStart);
+                if (fraction != null) {
+                    amountFrequency = "0";
+                    if (fraction.equals("1/2")) {
+                        amountFrequency = "0.5";
+                    } else if (fraction.equals("1/4")) {
+                        amountFrequency = "0.25";
+                    }
+                } else {
+                    p("word amount");
+                    for (String word : zeroToTen) {
+                        String safeMethod = Pattern.quote(method);
+                        String safeWord = Pattern.quote(word);
+                        String r1 = safeMethod + "\\s+" + safeWord + "\\s";
+                        String r2 = safeMethod + "\\s+" + safeWord + "$";
+                        Pattern p5 = Pattern.compile(r1);
+                        Matcher m5 = p5.matcher(instructions);
+                        p("pattern word =" + r1);
+                        if (m5.find()) {
+                            amountMethod = instructions.substring(m5.start(), m5.end());
+                            amountMethod = amountMethod.replace(method, "").trim();
+                            p("amountMethod=" + amountMethod);
+                            amountMethod = convertWordToNumerical(amountMethod);
+                            p("num amountMethod=" + amountMethod);
+                            break;
+                        } else {
+                            p5 = Pattern.compile(r2);
+                            m5 = p5.matcher(instructions);
+                            p("pattern word =" + r2);
+                            if (m5.find()) {
+                                amountMethod = instructions.substring(m5.start(), m5.end());
+                                amountMethod = amountMethod.replace(method, "").trim();
+                                p("amountMethod=" + amountMethod);
+                                amountMethod = convertWordToNumerical(amountMethod);
+                                p("num amountMethod=" + amountMethod);
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        segment.takeMax = takeMaxMethod;
+        segment.takeMin = takeMinMethod;
+        segment.amountMethod = amountMethod;
+        segment.amountFrequency = amountFrequency;
+    }
+
+		private static class InstructionSegment {
+			String method;
+			String takeMin;
+			String takeMax;
+			String amountMethod;
+			String amountFrequency;
 		}
 
-		if (segment.method == null) {
-			String placeholderMethod = "<NO_METHOD>";
-			String instructionWithPlaceholderMethod = placeholderMethod + " " + instructions;
-			Pattern p = Pattern.compile("(?i)" + placeholderMethod);
-			Matcher m = p.matcher(instructionWithPlaceholderMethod);
-			if (m.find())
-				scanForFrequencyAndUpdateInstructionSegment(segment, instructionWithPlaceholderMethod, placeholderMethod);
-		}
+    private static class NumberToken {
+        final int start;
+        final int end;
+        final String value;
 
-		return segment;
-	}
+        NumberToken(String text, int start, int end) {
+            this.start = start;
+            this.end = end;
+            this.value = text.substring(start, end);
+        }
+    }
 
-	private static void scanForFrequencyAndUpdateInstructionSegment(InstructionSegment segment, String instructions, String method) {
-		String takeMinMethod = null;
-		String takeMaxMethod = null;
-		String amountMethod = null;
-		String amountFrequency = null;
+    private static class NumberRange {
+        final String min;
+        final String max;
+        final int end;
 
-		Pattern p2 = Pattern.compile(Pattern.quote(method) + "\\s*(?:[0-9]+(?:\\.[0-9]+)?|\\.[0-9]+)\\s+");
-		Matcher m2 = p2.matcher(instructions);
-
-		Pattern pF1 = Pattern.compile(Pattern.quote(method) + "\\s*[0-9]+(?:\\/[0-9]+)?\\s+");
-		Matcher mF1 = pF1.matcher(instructions);
-
-		Pattern p4 = Pattern.compile(Pattern.quote(method) + "\\s*(?:[0-9]+(?:\\.[0-9]+)?|\\.[0-9]+)-\\s*(?:[0-9]+(?:\\.[0-9]+)?|\\.[0-9]+)\\s+");
-		Matcher m4 = p4.matcher(instructions);
-
-		//since "\\s+[0-9]+-[0-9]+\\s+" is a case in "\\s+[0-9]+\\s+", check the latter regex first.
-		if (m4.find()) {
-			p("else if 1");
-			String str2 = instructions.substring(m4.start(), m4.end());
-			Pattern p5 = Pattern.compile("(?:[0-9]+(?:\\.[0-9]+)?|\\.[0-9]+)-\\s*(?:[0-9]+(?:\\.[0-9]+)?|\\.[0-9]+)");
-			Matcher m5 = p5.matcher(str2);
-			if (m5.find()) {
-				String str3 = str2.substring(m5.start(), m5.end());
-				//           p("str3", str3);
-				takeMinMethod = str3.split("-")[0];
-				takeMaxMethod = str3.split("-")[1];
-			}
-		} else if (m2.find()) {
-			p("if 1");
-			String str = instructions.substring(m2.start(), m2.end());
-			p("str1 ", str);
-			Pattern p3 = Pattern.compile("(?:[0-9]+(?:\\.[0-9]+)?|\\.[0-9]+)");
-			Matcher m3 = p3.matcher(str);
-			if (m3.find()) {
-				p("found1");
-				amountMethod = str.substring(m3.start(), m3.end());
-				//      p("amountMethod", amountMethod);
-			}
-		} else if (mF1.find()) {
-			String partInstructions = instructions.substring(mF1.start(), mF1.end());
-			Pattern pF2 = Pattern.compile("[0-9]+(?:\\/[0-9]+)?");
-			Matcher mF2 = pF2.matcher(partInstructions);
-
-			if (mF2.find()) {
-				String fraction = partInstructions.substring(mF2.start(), mF2.end());
-				amountFrequency = "0";
-				if (fraction.equals("1/2"))
-					amountFrequency = "0.5";
-				else if (fraction.equals("1/4"))
-					amountFrequency = "0.25";
-			}
-		} else {
-			p("word amount");
-			for (String word : zeroToTen) {
-                String safeMethod = Pattern.quote(method);
-                String safeWord = Pattern.quote(word);
-				String r1 = safeMethod + "\\s+" + safeWord + "\\s";
-				String r2 = safeMethod + "\\s+" + safeWord + "$";
-				Pattern p5 = Pattern.compile(r1);
-				Matcher m5 = p5.matcher(instructions);
-				p("pattern word =" + r1);
-				if (m5.find()) {
-					amountMethod = instructions.substring(m5.start(), m5.end());
-					amountMethod = amountMethod.replace(method, "").trim();
-					p("amountMethod=" + amountMethod);
-					amountMethod = convertWordToNumerical(amountMethod);
-					p("num amountMethod=" + amountMethod);
-					break;
-				} else {
-					p5 = Pattern.compile(r2);
-					m5 = p5.matcher(instructions);
-					p("pattern word =" + r2);
-					if (m5.find()) {
-						amountMethod = instructions.substring(m5.start(), m5.end());
-						amountMethod = amountMethod.replace(method, "").trim();
-						p("amountMethod=" + amountMethod);
-						amountMethod = convertWordToNumerical(amountMethod);
-						p("num amountMethod=" + amountMethod);
-						break;
-					}
-				}
-			}
-		}
-
-		segment.takeMax = takeMaxMethod;
-		segment.takeMin = takeMinMethod;
-		segment.amountMethod = amountMethod;
-		segment.amountFrequency = amountFrequency;
-	}
-
-	private static class InstructionSegment {
-		String method;
-		String takeMin;
-		String takeMax;
-		String amountMethod;
-		String amountFrequency;
-	}
+        NumberRange(String min, String max, int end) {
+            this.min = min;
+            this.max = max;
+            this.end = end;
+        }
+    }
 
 
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/util/RxUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/util/RxUtil.java
@@ -907,22 +907,16 @@ public class RxUtil {
     }
 
     private static NumberRange findRangeBeforeFrequency(String text, int frequencyStart) {
-        if (skipWhitespaceBackward(text, frequencyStart) == frequencyStart) {
-            return null;
-        }
         return findRangeBefore(text, frequencyStart);
     }
 
     private static NumberToken findDecimalBeforeFrequency(String text, int frequencyStart) {
-        if (skipWhitespaceBackward(text, frequencyStart) == frequencyStart) {
-            return null;
-        }
         return findDecimalBefore(text, frequencyStart);
     }
 
     private static NumberRange findRangeBefore(String text, int endExclusive) {
         int end = skipWhitespaceBackward(text, endExclusive);
-        NumberToken max = findDecimalBefore(text, end);
+        NumberToken max = findDecimalBefore(text, end, false);
         if (max == null || max.end != end) {
             return null;
         }
@@ -956,6 +950,10 @@ public class RxUtil {
     }
 
     private static NumberToken findDecimalBefore(String text, int endExclusive) {
+        return findDecimalBefore(text, endExclusive, true);
+    }
+
+    private static NumberToken findDecimalBefore(String text, int endExclusive, boolean requireBoundaryBefore) {
         int end = skipWhitespaceBackward(text, endExclusive);
         if (end == 0 || !isDigit(text.charAt(end - 1))) {
             return null;
@@ -972,13 +970,13 @@ public class RxUtil {
             while (tokenStart > 0 && isDigit(text.charAt(tokenStart - 1))) {
                 tokenStart--;
             }
-            if (!hasTokenBoundaryBefore(text, tokenStart)) {
+            if (requireBoundaryBefore && !hasTokenBoundaryBefore(text, tokenStart)) {
                 return null;
             }
             return new NumberToken(text, tokenStart, end);
         }
 
-        if (!hasTokenBoundaryBefore(text, start)) {
+        if (requireBoundaryBefore && !hasTokenBoundaryBefore(text, start)) {
             return null;
         }
         return new NumberToken(text, start, end);

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/util/RxUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/util/RxUtil.java
@@ -1159,14 +1159,18 @@ public class RxUtil {
             return "0";
         }
 
-        double numerator = Double.parseDouble(fraction.substring(0, separator));
-        double denominator = Double.parseDouble(fraction.substring(separator + 1));
-        if (denominator == 0d || !Double.isFinite(numerator) || !Double.isFinite(denominator)) {
+        try {
+            double numerator = Double.parseDouble(fraction.substring(0, separator));
+            double denominator = Double.parseDouble(fraction.substring(separator + 1));
+            if (denominator == 0d || !Double.isFinite(numerator) || !Double.isFinite(denominator)) {
+                return "0";
+            }
+
+            double amount = numerator / denominator;
+            return Double.isFinite(amount) ? Double.toString(amount) : "0";
+        } catch (NumberFormatException e) {
             return "0";
         }
-
-        double amount = numerator / denominator;
-        return Double.isFinite(amount) ? Double.toString(amount) : "0";
     }
 
     private static String findWordAmountAfterMethod(String instructions, String method) {

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/util/RxUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/util/RxUtil.java
@@ -972,9 +972,15 @@ public class RxUtil {
             while (tokenStart > 0 && isDigit(text.charAt(tokenStart - 1))) {
                 tokenStart--;
             }
+            if (!hasTokenBoundaryBefore(text, tokenStart)) {
+                return null;
+            }
             return new NumberToken(text, tokenStart, end);
         }
 
+        if (!hasTokenBoundaryBefore(text, start)) {
+            return null;
+        }
         return new NumberToken(text, start, end);
     }
 
@@ -1058,6 +1064,10 @@ public class RxUtil {
 
     private static boolean hasTokenBoundaryAt(String text, int index) {
         return index >= text.length() || Character.isWhitespace(text.charAt(index));
+    }
+
+    private static boolean hasTokenBoundaryBefore(String text, int index) {
+        return index <= 0 || Character.isWhitespace(text.charAt(index - 1));
     }
 
     private static boolean isDigit(char c) {

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/util/RxUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/util/RxUtil.java
@@ -589,11 +589,11 @@ public class RxUtil {
             Pattern p = Pattern.compile(s);
             Matcher matcher = p.matcher(instructions);
             if (matcher.find()) {
-	                String matchedFrequency = (instructions.substring(matcher.start(), matcher.end())).trim();
-	                frequency = changeToStandardFrequencyCode(matchedFrequency);
-	                //     p("here11", instructions);
-	                //since "\\s+[0-9]+-[0-9]+\\s+" is a case in "\\s+[0-9]+\\s+", check the latter regex first.
-	                NumberRange frequencyRange = matchedFrequency.equals(frequency) ? findRangeBeforeFrequency(instructions, matcher.start()) : null;
+                String matchedFrequency = (instructions.substring(matcher.start(), matcher.end())).trim();
+                frequency = changeToStandardFrequencyCode(matchedFrequency);
+                //     p("here11", instructions);
+                //since "\\s+[0-9]+-[0-9]+\\s+" is a case in "\\s+[0-9]+\\s+", check the latter regex first.
+                NumberRange frequencyRange = matchedFrequency.equals(frequency) ? findRangeBeforeFrequency(instructions, matcher.start()) : null;
                 if (frequencyRange != null) {
                     takeMinFrequency = frequencyRange.min;
                     takeMaxFrequency = frequencyRange.max;
@@ -629,7 +629,7 @@ public class RxUtil {
                             }
                         }
                     }
-	                }
+                }
                 //the string before frequency maybe the amount of drug
                 //check if the string is a number, if it is, get the number
                 //if not a number, check if it has "min-max" pattern, if yes, get min and max, if not, ignore
@@ -1021,17 +1021,18 @@ public class RxUtil {
             index++;
         }
 
-        if (index < text.length() && text.charAt(index) == '/') {
-            index++;
-            int denominatorStart = index;
-            while (index < text.length() && isDigit(text.charAt(index))) {
-                index++;
-            }
-            if (index == denominatorStart) {
-                return null;
-            }
+        if (index >= text.length() || text.charAt(index) != '/') {
+            return null;
         }
 
+        index++;
+        int denominatorStart = index;
+        while (index < text.length() && isDigit(text.charAt(index))) {
+            index++;
+        }
+        if (index == denominatorStart) {
+            return null;
+        }
         if (!hasWhitespaceAt(text, index)) {
             return null;
         }
@@ -1092,84 +1093,107 @@ public class RxUtil {
     }
 
     private static void scanForFrequencyAndUpdateInstructionSegment(InstructionSegment segment, String instructions, String method, int methodEnd) {
-        String takeMinMethod = null;
-        String takeMaxMethod = null;
-        String amountMethod = null;
-        String amountFrequency = null;
-
         int amountStart = skipWhitespaceForward(instructions, methodEnd);
-        NumberRange methodRange = findRangeAt(instructions, amountStart);
-
-        //since "\\s+[0-9]+-[0-9]+\\s+" is a case in "\\s+[0-9]+\\s+", check the latter regex first.
-        if (methodRange != null && hasWhitespaceAt(instructions, methodRange.end)) {
-            p("else if 1");
-            takeMinMethod = methodRange.min;
-            takeMaxMethod = methodRange.max;
-        } else {
-            NumberToken methodAmount = findDecimalAt(instructions, amountStart);
-            if (methodAmount != null && hasWhitespaceAt(instructions, methodAmount.end)) {
-                p("if 1");
-                p("str1 ", instructions.substring(amountStart, methodAmount.end));
-                p("found1");
-                amountMethod = methodAmount.value;
-                //      p("amountMethod", amountMethod);
-            } else {
-                String fraction = findFractionAt(instructions, amountStart);
-                if (fraction != null) {
-                    amountFrequency = "0";
-                    if (fraction.equals("1/2")) {
-                        amountFrequency = "0.5";
-                    } else if (fraction.equals("1/4")) {
-                        amountFrequency = "0.25";
-                    }
-                } else {
-                    p("word amount");
-                    for (String word : zeroToTen) {
-                        String safeMethod = Pattern.quote(method);
-                        String safeWord = Pattern.quote(word);
-                        String r1 = safeMethod + "\\s+" + safeWord + "\\s";
-                        String r2 = safeMethod + "\\s+" + safeWord + "$";
-                        Pattern p5 = Pattern.compile(r1);
-                        Matcher m5 = p5.matcher(instructions);
-                        p("pattern word =" + r1);
-                        if (m5.find()) {
-                            amountMethod = instructions.substring(m5.start(), m5.end());
-                            amountMethod = amountMethod.replace(method, "").trim();
-                            p("amountMethod=" + amountMethod);
-                            amountMethod = convertWordToNumerical(amountMethod);
-                            p("num amountMethod=" + amountMethod);
-                            break;
-                        } else {
-                            p5 = Pattern.compile(r2);
-                            m5 = p5.matcher(instructions);
-                            p("pattern word =" + r2);
-                            if (m5.find()) {
-                                amountMethod = instructions.substring(m5.start(), m5.end());
-                                amountMethod = amountMethod.replace(method, "").trim();
-                                p("amountMethod=" + amountMethod);
-                                amountMethod = convertWordToNumerical(amountMethod);
-                                p("num amountMethod=" + amountMethod);
-                                break;
-                            }
-                        }
-                    }
-                }
-            }
+        if (setRangeAfterMethod(segment, instructions, amountStart)) {
+            return;
+        }
+        if (setDecimalAfterMethod(segment, instructions, amountStart)) {
+            return;
+        }
+        if (setFractionAfterMethod(segment, instructions, amountStart)) {
+            return;
         }
 
-        segment.takeMax = takeMaxMethod;
-        segment.takeMin = takeMinMethod;
-        segment.amountMethod = amountMethod;
-        segment.amountFrequency = amountFrequency;
+        segment.amountMethod = findWordAmountAfterMethod(instructions, method);
     }
 
-		private static class InstructionSegment {
-			String method;
-			String takeMin;
-			String takeMax;
-			String amountMethod;
-			String amountFrequency;
-		}
+    private static boolean setRangeAfterMethod(InstructionSegment segment, String instructions, int amountStart) {
+        NumberRange methodRange = findRangeAt(instructions, amountStart);
+        if (methodRange == null || !hasWhitespaceAt(instructions, methodRange.end)) {
+            return false;
+        }
+
+        p("else if 1");
+        segment.takeMin = methodRange.min;
+        segment.takeMax = methodRange.max;
+        return true;
+    }
+
+    private static boolean setDecimalAfterMethod(InstructionSegment segment, String instructions, int amountStart) {
+        NumberToken methodAmount = findDecimalAt(instructions, amountStart);
+        if (methodAmount == null || !hasWhitespaceAt(instructions, methodAmount.end)) {
+            return false;
+        }
+
+        p("if 1");
+        p("str1 ", instructions.substring(amountStart, methodAmount.end));
+        p("found1");
+        segment.amountMethod = methodAmount.value;
+        //      p("amountMethod", amountMethod);
+        return true;
+    }
+
+    private static boolean setFractionAfterMethod(InstructionSegment segment, String instructions, int amountStart) {
+        String fraction = findFractionAt(instructions, amountStart);
+        if (fraction == null) {
+            return false;
+        }
+
+        segment.amountFrequency = convertFractionToAmount(fraction);
+        return true;
+    }
+
+    private static String convertFractionToAmount(String fraction) {
+        if (fraction.equals("1/2")) {
+            return "0.5";
+        }
+        if (fraction.equals("1/4")) {
+            return "0.25";
+        }
+        return "0";
+    }
+
+    private static String findWordAmountAfterMethod(String instructions, String method) {
+        p("word amount");
+        for (String word : zeroToTen) {
+            String amountMethod = findWordAmountAfterMethod(instructions, method, word, "\\s");
+            if (amountMethod != null) {
+                return amountMethod;
+            }
+            amountMethod = findWordAmountAfterMethod(instructions, method, word, "$");
+            if (amountMethod != null) {
+                return amountMethod;
+            }
+        }
+        return null;
+    }
+
+    private static String findWordAmountAfterMethod(String instructions, String method, String word, String suffix) {
+        String safeMethod = Pattern.quote(method);
+        String safeWord = Pattern.quote(word);
+        String regex = safeMethod + "\\s+" + safeWord + suffix;
+        Pattern pattern = Pattern.compile(regex);
+        Matcher matcher = pattern.matcher(instructions);
+        p("pattern word =" + regex);
+        if (!matcher.find()) {
+            return null;
+        }
+
+        String amountMethod = instructions.substring(matcher.start(), matcher.end());
+        amountMethod = amountMethod.replace(method, "").trim();
+        p("amountMethod=" + amountMethod);
+        amountMethod = convertWordToNumerical(amountMethod);
+        p("num amountMethod=" + amountMethod);
+        return amountMethod;
+    }
+
+    private static class InstructionSegment {
+        String method;
+        String takeMin;
+        String takeMax;
+        String amountMethod;
+        String amountFrequency;
+    }
 
     private static class NumberToken {
         final int start;

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/util/RxUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/util/RxUtil.java
@@ -1033,7 +1033,7 @@ public class RxUtil {
         if (index == denominatorStart) {
             return null;
         }
-        if (!hasWhitespaceAt(text, index)) {
+        if (!hasTokenBoundaryAt(text, index)) {
             return null;
         }
 
@@ -1056,8 +1056,8 @@ public class RxUtil {
         return index;
     }
 
-    private static boolean hasWhitespaceAt(String text, int index) {
-        return index < text.length() && Character.isWhitespace(text.charAt(index));
+    private static boolean hasTokenBoundaryAt(String text, int index) {
+        return index >= text.length() || Character.isWhitespace(text.charAt(index));
     }
 
     private static boolean isDigit(char c) {
@@ -1109,7 +1109,7 @@ public class RxUtil {
 
     private static boolean setRangeAfterMethod(InstructionSegment segment, String instructions, int amountStart) {
         NumberRange methodRange = findRangeAt(instructions, amountStart);
-        if (methodRange == null || !hasWhitespaceAt(instructions, methodRange.end)) {
+        if (methodRange == null || !hasTokenBoundaryAt(instructions, methodRange.end)) {
             return false;
         }
 
@@ -1121,7 +1121,7 @@ public class RxUtil {
 
     private static boolean setDecimalAfterMethod(InstructionSegment segment, String instructions, int amountStart) {
         NumberToken methodAmount = findDecimalAt(instructions, amountStart);
-        if (methodAmount == null || !hasWhitespaceAt(instructions, methodAmount.end)) {
+        if (methodAmount == null || !hasTokenBoundaryAt(instructions, methodAmount.end)) {
             return false;
         }
 

--- a/src/test/java/io/github/carlos_emr/carlos/prescript/util/RxUtilRegexUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/prescript/util/RxUtilRegexUnitTest.java
@@ -168,6 +168,14 @@ class RxUtilRegexUnitTest {
         }
 
         @Test
+        @DisplayName("should parse word dosage after method")
+        void shouldParseWordDosage_afterMethod() {
+            RxPrescriptionData.Prescription rx = parse("Take one tablet BID ");
+            assertThat(rx.getTakeMax()).isEqualTo(1.0f);
+            assertThat(rx.getFrequencyCode()).isEqualToIgnoringCase("BID");
+        }
+
+        @Test
         @DisplayName("should parse decimal dosage with frequency")
         void shouldParseDecimalDosage_withFrequency() {
             RxPrescriptionData.Prescription rx = parse("Take 1.5 BID ");

--- a/src/test/java/io/github/carlos_emr/carlos/prescript/util/RxUtilRegexUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/prescript/util/RxUtilRegexUnitTest.java
@@ -293,6 +293,14 @@ class RxUtilRegexUnitTest {
         }
 
         @Test
+        @DisplayName("should parse single-space amount before frequency synonym")
+        void shouldParseSingleSpaceAmount_beforeFrequencySynonym() {
+            RxPrescriptionData.Prescription rx = parse("for 1 once daily ");
+            assertThat(rx.getTakeMax()).isEqualTo(1.0f);
+            assertThat(rx.getFrequencyCode()).isEqualToIgnoringCase("OD");
+        }
+
+        @Test
         @DisplayName("should parse single-space range before frequency")
         void shouldParseSingleSpaceRange_beforeFrequency() {
             RxPrescriptionData.Prescription rx = parse("for 1-2 OD ");
@@ -302,9 +310,27 @@ class RxUtilRegexUnitTest {
         }
 
         @Test
+        @DisplayName("should parse single-space range before frequency synonym")
+        void shouldParseSingleSpaceRange_beforeFrequencySynonym() {
+            RxPrescriptionData.Prescription rx = parse("for 1-2 once daily ");
+            assertThat(rx.getTakeMin()).isEqualTo(1.0f);
+            assertThat(rx.getTakeMax()).isEqualTo(2.0f);
+            assertThat(rx.getFrequencyCode()).isEqualToIgnoringCase("OD");
+        }
+
+        @Test
         @DisplayName("should parse single-space decimal range before frequency")
         void shouldParseSingleSpaceDecimalRange_beforeFrequency() {
             RxPrescriptionData.Prescription rx = parse("for 0.5-1.5 OD ");
+            assertThat(rx.getTakeMin()).isEqualTo(0.5f);
+            assertThat(rx.getTakeMax()).isEqualTo(1.5f);
+            assertThat(rx.getFrequencyCode()).isEqualToIgnoringCase("OD");
+        }
+
+        @Test
+        @DisplayName("should parse single-space decimal range before frequency synonym")
+        void shouldParseSingleSpaceDecimalRange_beforeFrequencySynonym() {
+            RxPrescriptionData.Prescription rx = parse("for 0.5-1.5 once daily ");
             assertThat(rx.getTakeMin()).isEqualTo(0.5f);
             assertThat(rx.getTakeMax()).isEqualTo(1.5f);
             assertThat(rx.getFrequencyCode()).isEqualToIgnoringCase("OD");

--- a/src/test/java/io/github/carlos_emr/carlos/prescript/util/RxUtilRegexUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/prescript/util/RxUtilRegexUnitTest.java
@@ -191,6 +191,14 @@ class RxUtilRegexUnitTest {
         }
 
         @Test
+        @DisplayName("should parse leading-dot decimal dosage without method")
+        void shouldParseLeadingDotDecimalDosage_withoutMethod() {
+            RxPrescriptionData.Prescription rx = parse(".5 BID ");
+            assertThat(rx.getTakeMax()).isEqualTo(0.5f);
+            assertThat(rx.getFrequencyCode()).isEqualToIgnoringCase("BID");
+        }
+
+        @Test
         @DisplayName("should parse dosage range with frequency")
         void shouldParseDosageRange_withFrequency() {
             RxPrescriptionData.Prescription rx = parse("Take 1-2 BID ");
@@ -207,6 +215,14 @@ class RxUtilRegexUnitTest {
         }
 
         @Test
+        @DisplayName("should parse leading-dot dosage range with frequency")
+        void shouldParseLeadingDotDosageRange_withFrequency() {
+            RxPrescriptionData.Prescription rx = parse("Take .5-1 BID ");
+            assertThat(rx.getTakeMin()).isEqualTo(0.5f);
+            assertThat(rx.getTakeMax()).isEqualTo(1.0f);
+        }
+
+        @Test
         @DisplayName("should parse dosage range without method")
         void shouldParseDosageRange_withoutMethod() {
             RxPrescriptionData.Prescription rx = parse("0.5-1.5 BID ");
@@ -216,9 +232,25 @@ class RxUtilRegexUnitTest {
         }
 
         @Test
+        @DisplayName("should parse leading-dot dosage range without method")
+        void shouldParseLeadingDotDosageRange_withoutMethod() {
+            RxPrescriptionData.Prescription rx = parse(".5-1 BID ");
+            assertThat(rx.getTakeMin()).isEqualTo(0.5f);
+            assertThat(rx.getTakeMax()).isEqualTo(1.0f);
+            assertThat(rx.getFrequencyCode()).isEqualToIgnoringCase("BID");
+        }
+
+        @Test
         @DisplayName("should parse fraction 1/2 dosage")
         void shouldParseFractionHalf_withFrequency() {
             RxPrescriptionData.Prescription rx = parse("Take 1/2 BID ");
+            assertThat(rx.getTakeMax()).isEqualTo(0.5f);
+        }
+
+        @Test
+        @DisplayName("should parse fraction 1/2 dosage without trailing whitespace")
+        void shouldParseFractionHalf_withoutTrailingWhitespace() {
+            RxPrescriptionData.Prescription rx = parse("Take 1/2");
             assertThat(rx.getTakeMax()).isEqualTo(0.5f);
         }
 

--- a/src/test/java/io/github/carlos_emr/carlos/prescript/util/RxUtilRegexUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/prescript/util/RxUtilRegexUnitTest.java
@@ -302,6 +302,15 @@ class RxUtilRegexUnitTest {
         }
 
         @Test
+        @DisplayName("should parse single-space decimal range before frequency")
+        void shouldParseSingleSpaceDecimalRange_beforeFrequency() {
+            RxPrescriptionData.Prescription rx = parse("for 0.5-1.5 OD ");
+            assertThat(rx.getTakeMin()).isEqualTo(0.5f);
+            assertThat(rx.getTakeMax()).isEqualTo(1.5f);
+            assertThat(rx.getFrequencyCode()).isEqualToIgnoringCase("OD");
+        }
+
+        @Test
         @DisplayName("should ignore compact integer token without whitespace")
         void shouldIgnoreCompactIntegerToken_whenAmountHasNoWhitespace() {
             RxPrescriptionData.Prescription rx = parse("Take 1tablet BID ");

--- a/src/test/java/io/github/carlos_emr/carlos/prescript/util/RxUtilRegexUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/prescript/util/RxUtilRegexUnitTest.java
@@ -278,6 +278,22 @@ class RxUtilRegexUnitTest {
         }
 
         @Test
+        @DisplayName("should ignore compact trailing integer token before frequency")
+        void shouldIgnoreCompactTrailingIntegerToken_whenAmountHasNoWhitespaceBeforeFrequency() {
+            RxPrescriptionData.Prescription rx = parse("Take tablet1 BID ");
+            assertThat(rx.getTakeMax()).isEqualTo(0.0f);
+            assertThat(rx.getFrequencyCode()).isEqualToIgnoringCase("BID");
+        }
+
+        @Test
+        @DisplayName("should ignore compact trailing decimal token before frequency")
+        void shouldIgnoreCompactTrailingDecimalToken_whenAmountHasNoWhitespaceBeforeFrequency() {
+            RxPrescriptionData.Prescription rx = parse("Take tablet.5 BID ");
+            assertThat(rx.getTakeMax()).isEqualTo(0.0f);
+            assertThat(rx.getFrequencyCode()).isEqualToIgnoringCase("BID");
+        }
+
+        @Test
         @DisplayName("should parse OD frequency")
         void shouldParseODFrequency() {
             RxPrescriptionData.Prescription rx = parse("Take 1 OD ");

--- a/src/test/java/io/github/carlos_emr/carlos/prescript/util/RxUtilRegexUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/prescript/util/RxUtilRegexUnitTest.java
@@ -285,11 +285,36 @@ class RxUtilRegexUnitTest {
         }
 
         @Test
+        @DisplayName("should parse single-space amount before frequency")
+        void shouldParseSingleSpaceAmount_beforeFrequency() {
+            RxPrescriptionData.Prescription rx = parse("for 1 OD ");
+            assertThat(rx.getTakeMax()).isEqualTo(1.0f);
+            assertThat(rx.getFrequencyCode()).isEqualToIgnoringCase("OD");
+        }
+
+        @Test
+        @DisplayName("should parse single-space range before frequency")
+        void shouldParseSingleSpaceRange_beforeFrequency() {
+            RxPrescriptionData.Prescription rx = parse("for 1-2 OD ");
+            assertThat(rx.getTakeMin()).isEqualTo(1.0f);
+            assertThat(rx.getTakeMax()).isEqualTo(2.0f);
+            assertThat(rx.getFrequencyCode()).isEqualToIgnoringCase("OD");
+        }
+
+        @Test
         @DisplayName("should ignore compact integer token without whitespace")
         void shouldIgnoreCompactIntegerToken_whenAmountHasNoWhitespace() {
             RxPrescriptionData.Prescription rx = parse("Take 1tablet BID ");
             assertThat(rx.getTakeMax()).isEqualTo(0.0f);
             assertThat(rx.getFrequencyCode()).isEqualToIgnoringCase("BID");
+        }
+
+        @Test
+        @DisplayName("should ignore compact range before frequency")
+        void shouldIgnoreCompactRange_beforeFrequency() {
+            RxPrescriptionData.Prescription rx = parse("for tablet1-2 OD ");
+            assertThat(rx.getTakeMax()).isEqualTo(0.0f);
+            assertThat(rx.getFrequencyCode()).isEqualToIgnoringCase("OD");
         }
 
         @Test

--- a/src/test/java/io/github/carlos_emr/carlos/prescript/util/RxUtilRegexUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/prescript/util/RxUtilRegexUnitTest.java
@@ -262,6 +262,21 @@ class RxUtilRegexUnitTest {
         }
 
         @Test
+        @DisplayName("should parse fraction 3/4 dosage")
+        void shouldParseFractionThreeQuarter_withFrequency() {
+            RxPrescriptionData.Prescription rx = parse("Take 3/4 BID ");
+            assertThat(rx.getTakeMax()).isEqualTo(0.75f);
+        }
+
+        @Test
+        @DisplayName("should ignore fraction with zero denominator")
+        void shouldIgnoreFractionZeroDenominator_withFrequency() {
+            RxPrescriptionData.Prescription rx = parse("Take 1/0 BID ");
+            assertThat(rx.getTakeMax()).isEqualTo(0.0f);
+            assertThat(rx.getFrequencyCode()).isEqualToIgnoringCase("BID");
+        }
+
+        @Test
         @DisplayName("should parse integer dosage with frequency synonym")
         void shouldParseIntegerDosage_withFrequencySynonym() {
             RxPrescriptionData.Prescription rx = parse("Take 1 once daily ");

--- a/src/test/java/io/github/carlos_emr/carlos/prescript/util/RxUtilRegexUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/prescript/util/RxUtilRegexUnitTest.java
@@ -102,6 +102,18 @@ class RxUtilRegexUnitTest {
         }
 
         @Test
+        @DisplayName("should return false for a null string")
+        void shouldReturnFalse_forNullString() {
+            assertThat(RxUtil.isStringToNumber(null)).isFalse();
+        }
+
+        @Test
+        @DisplayName("should return false for a trailing decimal point")
+        void shouldReturnFalse_forTrailingDecimalPoint() {
+            assertThat(RxUtil.isStringToNumber("1.")).isFalse();
+        }
+
+        @Test
         @DisplayName("should return false for a number followed by non-numeric characters")
         void shouldReturnFalse_forNumberFollowedByLetters() {
             assertThat(RxUtil.isStringToNumber("5mg")).isFalse();
@@ -164,6 +176,14 @@ class RxUtilRegexUnitTest {
         }
 
         @Test
+        @DisplayName("should parse decimal dosage without method")
+        void shouldParseDecimalDosage_withoutMethod() {
+            RxPrescriptionData.Prescription rx = parse("1.5 BID ");
+            assertThat(rx.getTakeMax()).isEqualTo(1.5f);
+            assertThat(rx.getFrequencyCode()).isEqualToIgnoringCase("BID");
+        }
+
+        @Test
         @DisplayName("should parse leading-dot decimal dosage with frequency")
         void shouldParseLeadingDotDecimalDosage_withFrequency() {
             RxPrescriptionData.Prescription rx = parse("Take .5 BID ");
@@ -187,10 +207,42 @@ class RxUtilRegexUnitTest {
         }
 
         @Test
+        @DisplayName("should parse dosage range without method")
+        void shouldParseDosageRange_withoutMethod() {
+            RxPrescriptionData.Prescription rx = parse("0.5-1.5 BID ");
+            assertThat(rx.getTakeMin()).isEqualTo(0.5f);
+            assertThat(rx.getTakeMax()).isEqualTo(1.5f);
+            assertThat(rx.getFrequencyCode()).isEqualToIgnoringCase("BID");
+        }
+
+        @Test
         @DisplayName("should parse fraction 1/2 dosage")
         void shouldParseFractionHalf_withFrequency() {
             RxPrescriptionData.Prescription rx = parse("Take 1/2 BID ");
             assertThat(rx.getTakeMax()).isEqualTo(0.5f);
+        }
+
+        @Test
+        @DisplayName("should parse fraction 1/4 dosage")
+        void shouldParseFractionQuarter_withFrequency() {
+            RxPrescriptionData.Prescription rx = parse("Take 1/4 BID ");
+            assertThat(rx.getTakeMax()).isEqualTo(0.25f);
+        }
+
+        @Test
+        @DisplayName("should parse integer dosage with frequency synonym")
+        void shouldParseIntegerDosage_withFrequencySynonym() {
+            RxPrescriptionData.Prescription rx = parse("Take 1 once daily ");
+            assertThat(rx.getTakeMax()).isEqualTo(1.0f);
+            assertThat(rx.getFrequencyCode()).isEqualToIgnoringCase("OD");
+        }
+
+        @Test
+        @DisplayName("should ignore compact integer token without whitespace")
+        void shouldIgnoreCompactIntegerToken_whenAmountHasNoWhitespace() {
+            RxPrescriptionData.Prescription rx = parse("Take 1tablet BID ");
+            assertThat(rx.getTakeMax()).isEqualTo(0.0f);
+            assertThat(rx.getFrequencyCode()).isEqualToIgnoringCase("BID");
         }
 
         @Test


### PR DESCRIPTION
## Summary
- Replace the RxUtil decimal, range, and fraction extraction regexes flagged by CodeQL REDOS alerts 19462 through 19467 with deterministic scanners.
- Preserve the existing frequency parsing flow, including the standardized-frequency range behavior and word-amount fallback paths.

## Testing
- mvn -Dtest=RxUtilRegexUnitTest,RxUtilInstrucParserUnitTest test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced ReDoS-prone number regexes in `RxUtil` with deterministic scanners and strict token boundaries. Restores safe amount/range detection before frequency codes/aliases and after methods, while preserving word-amount parsing.

- **Bug Fixes**
  - Removed decimal/range/fraction regexes; added scanners (before-frequency and after-method) and integrated into method/frequency parsing; preserved word-amount patterns.
  - Parse ranges/decimals right before frequency or aliases (e.g., "once daily") and directly after methods; support methodless amounts; keep standardized-frequency mapping and word-to-number fallbacks.
  - Enforce forward/backward token boundaries; ignore compact tokens like "1tablet", "tablet1", "tablet.5"; `isStringToNumber` is null-safe and rejects trailing dots.
  - Support leading-dot decimals, methodless ranges, and generalized n/d fractions (incl. EOL); guard malformed and zero-denominator cases. Added tests for word amounts and decimal/range-before-frequency (incl. aliases) edge cases. Resolves CodeQL ReDoS alerts 19462–19467.

<sup>Written for commit f9d5b6e700c0f11664c0eb1fda2b58a807de74ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2947?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

