### PR TITLE
Harden response sanitization stack trace detection

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilter.java
@@ -364,13 +364,21 @@ public class ResponseSanitizationFilter implements Filter {
             if (markerIndex < 0) {
                 return false;
             }
-            // Every marker ends in '.' or ':', so the right boundary is implicit.
-            if (markerIndex == 0 || !isWordCharacter(body.charAt(markerIndex - 1))) {
+            if (hasWordBoundaries(body, markerIndex, marker.length())) {
                 return true;
             }
             searchFrom = markerIndex + 1;
         }
         return false;
+    }
+
+    private static boolean hasWordBoundaries(String body, int markerIndex, int markerLength) {
+        int markerEnd = markerIndex + markerLength;
+        boolean hasLeftBoundary = markerIndex == 0 || !isWordCharacter(body.charAt(markerIndex - 1));
+        boolean hasRightBoundary = !isWordCharacter(body.charAt(markerEnd - 1))
+                || markerEnd == body.length()
+                || !isWordCharacter(body.charAt(markerEnd));
+        return hasLeftBoundary && hasRightBoundary;
     }
 
     private static boolean containsJavaStackFrame(String body) {

--- a/src/main/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilter.java
@@ -44,7 +44,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.Set;
 import java.util.UUID;
-import java.util.regex.Pattern;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
@@ -57,10 +56,10 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * excerpts because error pages can contain PHI even after control-character sanitization.</p>
  *
  * <h3>Detection</h3>
- * <p>Stack trace detection uses a {@link Pattern} that matches common Java stack trace markers:
- * {@code at pkg.Class.method(File.java:nn)}, {@code Caused by:}, {@code java.lang.},
- * {@code jakarta.servlet.}, and class name prefixes for Tomcat, Spring, Hibernate, and
- * the CARLOS application itself.</p>
+ * <p>Stack trace detection uses literal marker checks and deterministic line parsing for common
+ * Java stack trace markers: {@code at pkg.Class.method(File.java:nn)}, {@code Caused by:},
+ * {@code java.lang.}, {@code jakarta.servlet.}, and class name prefixes for Tomcat, Spring,
+ * Hibernate, and the CARLOS application itself.</p>
  *
  * <h3>Scope</h3>
  * <p>Captures responses written via {@link PrintWriter} (text content). Output-stream error
@@ -139,34 +138,18 @@ public class ResponseSanitizationFilter implements Filter {
     static final int MAX_CAPTURE_CHARS = 512 * 1024;
 
     /**
-     * Regex that matches Java stack trace markers commonly found in unhandled error responses.
-     *
-     * <p>Patterns matched:
-     * <ul>
-     *   <li>{@code \n   at pkg.Class.method(File.java:nn)} — standard stack frame line</li>
-     *   <li>{@code Caused by:} — chained exception marker</li>
-     *   <li>{@code java.lang.} — JDK core exception class names (e.g. NullPointerException)</li>
-     *   <li>{@code io.github.carlos_emr.} — CARLOS application class names</li>
-     *   <li>{@code jakarta.servlet.} — Jakarta Servlet API exception class names</li>
-     *   <li>{@code org.apache.} — Apache Tomcat / Struts / Commons class names</li>
-     *   <li>{@code org.springframework.} — Spring Framework class names</li>
-     *   <li>{@code org.hibernate.} — Hibernate ORM class names</li>
-     * </ul>
-     *
-     * <p>The {@code at} frame pattern uses a preceding newline anchor so it does not match
-     * the word "at" in normal English text (e.g. "error at line"). Class name patterns use
-     * a word boundary {@code \b} for the same reason.</p>
+     * Class-name markers commonly found in Java error responses. Callers check these with a
+     * word-boundary equivalent so normal prose containing a marker-like suffix does not match.
      */
-    static final Pattern STACK_TRACE_PATTERN = Pattern.compile(
-            "(?:[\r\n]\\s*at\\s+[\\w.$]+\\.[\\w$<>]+\\([^)]*\\))" // stack frame: \n   at pkg.Class.method(File.java:nn)
-            + "|(?:\\bCaused by:)"                                   // chained exception
-            + "|(?:\\bjava\\.lang\\.)"                               // JDK exception class names
-            + "|(?:\\bio\\.github\\.carlos_emr\\.)"                  // CARLOS class names
-            + "|(?:\\bjakarta\\.servlet\\.)"                         // Servlet API exceptions
-            + "|(?:\\borg\\.apache\\.)"                              // Tomcat / Struts / Commons
-            + "|(?:\\borg\\.springframework\\.)"                     // Spring Framework
-            + "|(?:\\borg\\.hibernate\\.)"                           // Hibernate ORM
-    );
+    private static final String[] STACK_TRACE_MARKERS = {
+            "Caused by:",
+            "java.lang.",
+            "io.github.carlos_emr.",
+            "jakarta.servlet.",
+            "org.apache.",
+            "org.springframework.",
+            "org.hibernate."
+    };
 
     private boolean enabled;
 
@@ -359,13 +342,123 @@ public class ResponseSanitizationFilter implements Filter {
      * Package-private to allow direct unit testing without a servlet container.
      *
      * @param body String the response body to inspect; may be {@code null} or empty
-     * @return {@code true} if the body matches one or more stack trace patterns
+     * @return {@code true} if the body contains one or more stack trace markers
      */
     static boolean containsStackTrace(String body) {
         if (body == null || body.isEmpty()) {
             return false;
         }
-        return STACK_TRACE_PATTERN.matcher(body).find();
+        for (String marker : STACK_TRACE_MARKERS) {
+            if (containsWithWordBoundary(body, marker)) {
+                return true;
+            }
+        }
+        return containsJavaStackFrame(body);
+    }
+
+    private static boolean containsWithWordBoundary(String body, String marker) {
+        int searchFrom = 0;
+        while (searchFrom < body.length()) {
+            int markerIndex = body.indexOf(marker, searchFrom);
+            if (markerIndex < 0) {
+                return false;
+            }
+            if (markerIndex == 0 || !isWordCharacter(body.charAt(markerIndex - 1))) {
+                return true;
+            }
+            searchFrom = markerIndex + 1;
+        }
+        return false;
+    }
+
+    private static boolean containsJavaStackFrame(String body) {
+        int lineStart = 0;
+        while (lineStart < body.length()) {
+            int lineEnd = lineStart;
+            while (lineEnd < body.length()
+                    && body.charAt(lineEnd) != '\r'
+                    && body.charAt(lineEnd) != '\n') {
+                lineEnd++;
+            }
+            if (isJavaStackFrameLine(body, lineStart, lineEnd)) {
+                return true;
+            }
+            if (lineEnd < body.length()
+                    && body.charAt(lineEnd) == '\r'
+                    && lineEnd + 1 < body.length()
+                    && body.charAt(lineEnd + 1) == '\n') {
+                lineEnd++;
+            }
+            lineStart = lineEnd + 1;
+        }
+        return false;
+    }
+
+    private static boolean isJavaStackFrameLine(String body, int lineStart, int lineEnd) {
+        int index = lineStart;
+        while (index < lineEnd && Character.isWhitespace(body.charAt(index))) {
+            index++;
+        }
+        if (index + 3 >= lineEnd || body.charAt(index) != 'a' || body.charAt(index + 1) != 't'
+                || !Character.isWhitespace(body.charAt(index + 2))) {
+            return false;
+        }
+        index += 3;
+        while (index < lineEnd && Character.isWhitespace(body.charAt(index))) {
+            index++;
+        }
+
+        int symbolStart = index;
+        int openParen = indexOf(body, '(', symbolStart, lineEnd);
+        if (openParen < 0) {
+            return false;
+        }
+        int closeParen = indexOf(body, ')', openParen + 1, lineEnd);
+        if (closeParen < 0) {
+            return false;
+        }
+
+        int lastDot = -1;
+        for (int i = symbolStart; i < openParen; i++) {
+            if (body.charAt(i) == '.') {
+                lastDot = i;
+            }
+        }
+        if (lastDot <= symbolStart || lastDot >= openParen - 1) {
+            return false;
+        }
+        for (int i = symbolStart; i < lastDot; i++) {
+            if (!isJavaClassNameCharacter(body.charAt(i))) {
+                return false;
+            }
+        }
+        for (int i = lastDot + 1; i < openParen; i++) {
+            if (!isJavaMethodNameCharacter(body.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static int indexOf(String body, char target, int fromIndex, int toIndexExclusive) {
+        for (int i = fromIndex; i < toIndexExclusive; i++) {
+            if (body.charAt(i) == target) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static boolean isWordCharacter(char c) {
+        return c == '_' || Character.isLetterOrDigit(c);
+    }
+
+    private static boolean isJavaClassNameCharacter(char c) {
+        return c == '.' || c == '$' || isWordCharacter(c);
+    }
+
+    private static boolean isJavaMethodNameCharacter(char c) {
+        return c == '$' || c == '<' || c == '>' || isWordCharacter(c);
     }
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilter.java
@@ -59,7 +59,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * <p>Stack trace detection uses literal marker checks and deterministic line parsing for common
  * Java stack trace markers: {@code at pkg.Class.method(File.java:nn)}, {@code Caused by:},
  * {@code java.lang.}, {@code jakarta.servlet.}, and class name prefixes for Tomcat, Spring,
- * Hibernate, and the CARLOS application itself.</p>
+ * Hibernate, and the CARLOS application itself. Stack-frame lines are detected at the beginning
+ * of the captured body as well as after line breaks so first-line stack traces are sanitized.</p>
  *
  * <h3>Scope</h3>
  * <p>Captures responses written via {@link PrintWriter} (text content). Output-stream error
@@ -363,6 +364,7 @@ public class ResponseSanitizationFilter implements Filter {
             if (markerIndex < 0) {
                 return false;
             }
+            // Every marker ends in '.' or ':', so the right boundary is implicit.
             if (markerIndex == 0 || !isWordCharacter(body.charAt(markerIndex - 1))) {
                 return true;
             }

--- a/src/main/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilter.java
@@ -395,44 +395,65 @@ public class ResponseSanitizationFilter implements Filter {
     }
 
     private static boolean isJavaStackFrameLine(String body, int lineStart, int lineEnd) {
-        int index = lineStart;
-        while (index < lineEnd && Character.isWhitespace(body.charAt(index))) {
-            index++;
-        }
-        if (index + 3 >= lineEnd || body.charAt(index) != 'a' || body.charAt(index + 1) != 't'
-                || !Character.isWhitespace(body.charAt(index + 2))) {
+        int prefixStart = skipWhitespace(body, lineStart, lineEnd);
+        if (!hasStackFramePrefix(body, prefixStart, lineEnd)) {
             return false;
         }
-        index += 3;
-        while (index < lineEnd && Character.isWhitespace(body.charAt(index))) {
-            index++;
-        }
 
-        int symbolStart = index;
+        int symbolStart = skipWhitespace(body, prefixStart + 2, lineEnd);
         int openParen = indexOf(body, '(', symbolStart, lineEnd);
         if (openParen < 0) {
             return false;
         }
         int closeParen = indexOf(body, ')', openParen + 1, lineEnd);
-        if (closeParen < 0) {
-            return false;
-        }
+        return closeParen >= 0 && isJavaStackFrameSymbol(body, symbolStart, openParen);
+    }
 
-        int lastDot = -1;
-        for (int i = symbolStart; i < openParen; i++) {
-            if (body.charAt(i) == '.') {
-                lastDot = i;
+    private static int skipWhitespace(String body, int fromIndex, int toIndexExclusive) {
+        int index = fromIndex;
+        while (index < toIndexExclusive && Character.isWhitespace(body.charAt(index))) {
+            index++;
+        }
+        return index;
+    }
+
+    private static boolean hasStackFramePrefix(String body, int index, int lineEnd) {
+        return index + 2 < lineEnd
+                && body.charAt(index) == 'a'
+                && body.charAt(index + 1) == 't'
+                && Character.isWhitespace(body.charAt(index + 2));
+    }
+
+    private static boolean isJavaStackFrameSymbol(String body, int symbolStart, int openParen) {
+        int lastDot = lastIndexOf(body, '.', symbolStart, openParen);
+        return lastDot > symbolStart
+                && lastDot < openParen - 1
+                && containsOnlyJavaClassNameCharacters(body, symbolStart, lastDot)
+                && containsOnlyJavaMethodNameCharacters(body, lastDot + 1, openParen);
+    }
+
+    private static int lastIndexOf(String body, char target, int fromIndex, int toIndexExclusive) {
+        for (int i = toIndexExclusive - 1; i >= fromIndex; i--) {
+            if (body.charAt(i) == target) {
+                return i;
             }
         }
-        if (lastDot <= symbolStart || lastDot >= openParen - 1) {
-            return false;
-        }
-        for (int i = symbolStart; i < lastDot; i++) {
+        return -1;
+    }
+
+    private static boolean containsOnlyJavaClassNameCharacters(
+            String body, int fromIndex, int toIndexExclusive) {
+        for (int i = fromIndex; i < toIndexExclusive; i++) {
             if (!isJavaClassNameCharacter(body.charAt(i))) {
                 return false;
             }
         }
-        for (int i = lastDot + 1; i < openParen; i++) {
+        return true;
+    }
+
+    private static boolean containsOnlyJavaMethodNameCharacters(
+            String body, int fromIndex, int toIndexExclusive) {
+        for (int i = fromIndex; i < toIndexExclusive; i++) {
             if (!isJavaMethodNameCharacter(body.charAt(i))) {
                 return false;
             }

--- a/src/test/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilterUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilterUnitTest.java
@@ -31,6 +31,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
@@ -241,25 +243,14 @@ class ResponseSanitizationFilterUnitTest {
             assertThat(ResponseSanitizationFilter.containsStackTrace(body)).isTrue();
         }
 
-        @Test
-        @DisplayName("should return false for word 'at' in normal prose text")
-        void shouldReturnFalse_forWordAtInNormalText() {
-            // "at" in plain text (without a preceding newline) should not match the stack frame pattern
-            String body = "An error occurred at line 10 of the configuration file.";
-            assertThat(ResponseSanitizationFilter.containsStackTrace(body)).isFalse();
-        }
-
-        @Test
-        @DisplayName("should return false when marker is embedded in a larger word")
-        void shouldReturnFalse_whenMarkerEmbeddedInWord() {
-            String body = "notjava.lang.Exception is just prose";
-            assertThat(ResponseSanitizationFilter.containsStackTrace(body)).isFalse();
-        }
-
-        @Test
-        @DisplayName("should return false when Caused by marker is embedded in a larger word")
-        void shouldReturnFalse_whenCausedByMarkerEmbeddedInWord() {
-            String body = "notCaused by: this is ordinary text";
+        @ParameterizedTest
+        @DisplayName("should return false for plain text stack trace near misses")
+        @ValueSource(strings = {
+                "An error occurred at line 10 of the configuration file.",
+                "notjava.lang.Exception is just prose",
+                "notCaused by: this is ordinary text"
+        })
+        void shouldReturnFalse_forPlainTextNearMisses(String body) {
             assertThat(ResponseSanitizationFilter.containsStackTrace(body)).isFalse();
         }
 

--- a/src/test/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilterUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilterUnitTest.java
@@ -166,6 +166,13 @@ class ResponseSanitizationFilterUnitTest {
         }
 
         @Test
+        @DisplayName("should return true for body starting with stack frame line")
+        void shouldReturnTrue_forLeadingStackFrameLine() {
+            String body = "at io.github.carlos_emr.carlos.SomeClass.method(SomeClass.java:42)";
+            assertThat(ResponseSanitizationFilter.containsStackTrace(body)).isTrue();
+        }
+
+        @Test
         @DisplayName("should return true for constructor stack frame line")
         void shouldReturnTrue_forConstructorStackFrameLine() {
             String body = "Error\n\tat ca.example.SomeClass.<init>(SomeClass.java:42)";
@@ -250,6 +257,13 @@ class ResponseSanitizationFilterUnitTest {
         }
 
         @Test
+        @DisplayName("should return false when Caused by marker is embedded in a larger word")
+        void shouldReturnFalse_whenCausedByMarkerEmbeddedInWord() {
+            String body = "notCaused by: this is ordinary text";
+            assertThat(ResponseSanitizationFilter.containsStackTrace(body)).isFalse();
+        }
+
+        @Test
         @DisplayName("should complete in time for adversarial stack frame near miss")
         void shouldCompleteInTime_forAdversarialStackFrameNearMiss() {
             String body = "\nat "
@@ -266,6 +280,7 @@ class ResponseSanitizationFilterUnitTest {
         @Test
         @DisplayName("should complete in time for repeated stack frame prefixes")
         void shouldCompleteInTime_forRepeatedStackFramePrefixes() {
+            // Exercises the repeated-line path where each candidate exits before an open paren.
             String body = ("\nat " + "a".repeat(80) + ".method\n")
                     .repeat(ResponseSanitizationFilter.MAX_CAPTURE_CHARS / 90);
 

--- a/src/test/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilterUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilterUnitTest.java
@@ -43,9 +43,11 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
@@ -164,6 +166,13 @@ class ResponseSanitizationFilterUnitTest {
         }
 
         @Test
+        @DisplayName("should return true for constructor stack frame line")
+        void shouldReturnTrue_forConstructorStackFrameLine() {
+            String body = "Error\n\tat ca.example.SomeClass.<init>(SomeClass.java:42)";
+            assertThat(ResponseSanitizationFilter.containsStackTrace(body)).isTrue();
+        }
+
+        @Test
         @DisplayName("should return true for body containing Caused by:")
         void shouldReturnTrue_forCausedByMarker() {
             String body = "java.lang.RuntimeException: Something failed\n"
@@ -231,6 +240,39 @@ class ResponseSanitizationFilterUnitTest {
             // "at" in plain text (without a preceding newline) should not match the stack frame pattern
             String body = "An error occurred at line 10 of the configuration file.";
             assertThat(ResponseSanitizationFilter.containsStackTrace(body)).isFalse();
+        }
+
+        @Test
+        @DisplayName("should return false when marker is embedded in a larger word")
+        void shouldReturnFalse_whenMarkerEmbeddedInWord() {
+            String body = "notjava.lang.Exception is just prose";
+            assertThat(ResponseSanitizationFilter.containsStackTrace(body)).isFalse();
+        }
+
+        @Test
+        @DisplayName("should complete in time for adversarial stack frame near miss")
+        void shouldCompleteInTime_forAdversarialStackFrameNearMiss() {
+            String body = "\nat "
+                    + "a.".repeat(ResponseSanitizationFilter.MAX_CAPTURE_CHARS / 4)
+                    + "method("
+                    + "x".repeat(ResponseSanitizationFilter.MAX_CAPTURE_CHARS / 4);
+
+            boolean result = assertTimeoutPreemptively(Duration.ofSeconds(2),
+                    () -> ResponseSanitizationFilter.containsStackTrace(body));
+
+            assertThat(result).isFalse();
+        }
+
+        @Test
+        @DisplayName("should complete in time for repeated stack frame prefixes")
+        void shouldCompleteInTime_forRepeatedStackFramePrefixes() {
+            String body = ("\nat " + "a".repeat(80) + ".method\n")
+                    .repeat(ResponseSanitizationFilter.MAX_CAPTURE_CHARS / 90);
+
+            boolean result = assertTimeoutPreemptively(Duration.ofSeconds(2),
+                    () -> ResponseSanitizationFilter.containsStackTrace(body));
+
+            assertThat(result).isFalse();
         }
     }
 

--- a/src/test/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilterUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilterUnitTest.java
@@ -167,6 +167,16 @@ class ResponseSanitizationFilterUnitTest {
             assertThat(ResponseSanitizationFilter.containsStackTrace(body)).isTrue();
         }
 
+        @ParameterizedTest
+        @DisplayName("should return true for stack frame line variations")
+        @ValueSource(strings = {
+                "Error\r\nat io.github.carlos_emr.carlos.SomeClass.method(SomeClass.java:42)",
+                "Error\r\n\tat io.github.carlos_emr.carlos.SomeClass.method(SomeClass.java:42)"
+        })
+        void shouldReturnTrue_forStackFrameLineVariations(String body) {
+            assertThat(ResponseSanitizationFilter.containsStackTrace(body)).isTrue();
+        }
+
         @Test
         @DisplayName("should return true for body starting with stack frame line")
         void shouldReturnTrue_forLeadingStackFrameLine() {
@@ -248,7 +258,11 @@ class ResponseSanitizationFilterUnitTest {
         @ValueSource(strings = {
                 "An error occurred at line 10 of the configuration file.",
                 "notjava.lang.Exception is just prose",
-                "notCaused by: this is ordinary text"
+                "notCaused by: this is ordinary text",
+                "foo_java.lang.Exception is part of an identifier",
+                "1java.lang.Exception is part of a token",
+                "foo_Caused by: is embedded in a larger word",
+                "1Caused by: is embedded in a larger token"
         })
         void shouldReturnFalse_forPlainTextNearMisses(String body) {
             assertThat(ResponseSanitizationFilter.containsStackTrace(body)).isFalse();

--- a/src/test/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilterUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilterUnitTest.java
@@ -185,6 +185,13 @@ class ResponseSanitizationFilterUnitTest {
         }
 
         @Test
+        @DisplayName("should return true for body starting with whitespace before stack frame line")
+        void shouldReturnTrue_forLeadingWhitespaceStackFrameLine() {
+            String body = "  \tat io.github.carlos_emr.carlos.SomeClass.method(SomeClass.java:42)";
+            assertThat(ResponseSanitizationFilter.containsStackTrace(body)).isTrue();
+        }
+
+        @Test
         @DisplayName("should return true for constructor stack frame line")
         void shouldReturnTrue_forConstructorStackFrameLine() {
             String body = "Error\n\tat ca.example.SomeClass.<init>(SomeClass.java:42)";


### PR DESCRIPTION
## Summary
- Replace the response sanitization stack-trace regex with deterministic literal marker checks and line-bounded stack-frame parsing.
- Preserve existing stack trace marker coverage, including constructor frames and package/class-name markers.
- Add ReDoS guard coverage for large near-miss stack-frame inputs.

## Security
Addresses code scanning alert #19584 in `ResponseSanitizationFilter.java` by removing the regex surface from central error-response sanitization middleware.

## Tests
- `git diff --check`
- `timeout 180s mvn -q -Dcheckstyle.skip=true -Dtest=io.github.carlos_emr.carlos.utility.ResponseSanitizationFilterUnitTest test`

Note: an initial full focused Maven invocation without `-Dcheckstyle.skip=true` timed out after 5 minutes in this environment while running whole-tree pre-test phases. The checkstyle result generated before timeout reported no violations, and the checkstyle-skipped focused unit test report shows 51 tests, 0 failures/errors.

## Summary by Sourcery

Harden stack trace detection in the response sanitization filter by replacing regex-based matching with deterministic marker checks and line-based parsing to avoid ReDoS risks while preserving coverage of common Java stack traces.

Bug Fixes:
- Prevent potential ReDoS in error-response sanitization by eliminating regex-based stack trace detection in favor of bounded, deterministic parsing.

Enhancements:
- Use literal class-name markers with word-boundary-aware matching and explicit stack-frame line parsing to more accurately detect stack traces, including first-line and constructor frames.
- Extend stack trace detection tests to cover CRLF/tab-indented frames, leading-frame bodies, constructor lines, plain-text near misses, and large adversarial inputs with timeout guards.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened stack trace detection in the response sanitizer by removing regex and using literal markers with bounded, line-based parsing to prevent ReDoS. Adds strict word-boundary checks and detects first-line frames and common tab/CRLF variations.

- **Bug Fixes**
  - Replaced regex in `ResponseSanitizationFilter` with literal marker checks using explicit word-boundary logic and deterministic stack-frame parsing; handles leading-frame lines and tab/CRLF.
  - Tightened marker boundaries to avoid false positives in embedded tokens while preserving constructor frames and package markers: `java.lang.`, `jakarta.servlet.`, `org.apache.`, `org.springframework.`, `org.hibernate.`, `io.github.carlos_emr.`.
  - Expanded tests for CRLF/tab-indented frames, leading-frame and constructor lines, embedded-marker negatives, and timeout-bounded adversarial near-miss and repeated-prefix cases (including parameterized plain-text near misses).

<sup>Written for commit 0d6b3437133f0f07c92964c51907f9ab8b31d9ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

