### PR TITLE
Make path validation clearer to scanners

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/ImportDemographicDataAction42Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/ImportDemographicDataAction42Action.java
@@ -3417,12 +3417,19 @@ public class ImportDemographicDataAction42Action extends ActionSupport implement
             return true;
         }
 
-        if (normalizedPath.startsWith("/") || normalizedPath.startsWith("\\")) {
+        if (normalizedPath.startsWith("/") || normalizedPath.startsWith("\\")
+                || hasWindowsDriveLetterAbsolutePrefix(normalizedPath)) {
             return true;
         }
 
-        // Explicit drive-letter pattern for extra defensive checking
-        return normalizedPath.matches("^[A-Za-z]:[/\\\\].*");
+        return false;
+    }
+
+    private boolean hasWindowsDriveLetterAbsolutePrefix(String normalizedPath) {
+        return normalizedPath.length() >= 3
+                && Character.isLetter(normalizedPath.charAt(0))
+                && normalizedPath.charAt(1) == ':'
+                && isReportPathSeparator(normalizedPath.charAt(2));
     }
 
     private File makeImportLog(ArrayList<String[]> demo, String dir) throws IOException {

--- a/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/ImportDemographicDataAction42Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/ImportDemographicDataAction42Action.java
@@ -3417,12 +3417,8 @@ public class ImportDemographicDataAction42Action extends ActionSupport implement
             return true;
         }
 
-        if (normalizedPath.startsWith("/") || normalizedPath.startsWith("\\")
-                || hasWindowsDriveLetterAbsolutePrefix(normalizedPath)) {
-            return true;
-        }
-
-        return false;
+        return normalizedPath.startsWith("/") || normalizedPath.startsWith("\\")
+                || hasWindowsDriveLetterAbsolutePrefix(normalizedPath);
     }
 
     private boolean hasWindowsDriveLetterAbsolutePrefix(String normalizedPath) {

--- a/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/ImportDemographicDataAction42Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/ImportDemographicDataAction42Action.java
@@ -3295,7 +3295,7 @@ public class ImportDemographicDataAction42Action extends ActionSupport implement
             return null;
         }
 
-        String fileName = new File(normalizedPath).getName();
+        String fileName = extractReportFileName(normalizedPath);
         File currentDir = PathValidationUtils.resolveConfiguredDirectory(currentDirectory, "import current directory");
 
         List<File> candidates = new ArrayList<>();
@@ -3315,6 +3315,24 @@ public class ImportDemographicDataAction42Action extends ActionSupport implement
         }
 
         return null;
+    }
+
+    private String extractReportFileName(String normalizedPath) {
+        int end = normalizedPath.length();
+        while (end > 0 && isReportPathSeparator(normalizedPath.charAt(end - 1))) {
+            end--;
+        }
+        if (end == 0) {
+            return "";
+        }
+
+        int lastForwardSlash = normalizedPath.lastIndexOf('/', end - 1);
+        int lastBackslash = normalizedPath.lastIndexOf('\\', end - 1);
+        return normalizedPath.substring(Math.max(lastForwardSlash, lastBackslash) + 1, end);
+    }
+
+    private boolean isReportPathSeparator(char value) {
+        return value == '/' || value == '\\';
     }
 
     /**
@@ -3394,9 +3412,12 @@ public class ImportDemographicDataAction42Action extends ActionSupport implement
             return false;
         }
 
-        File f = new File(normalizedPath);
-        // Covers Unix and most Windows absolute cases
-        if (f.isAbsolute()) {
+        if (normalizedPath.indexOf('\0') >= 0) {
+            logger.warn("Rejecting invalid report path from XML");
+            return true;
+        }
+
+        if (normalizedPath.startsWith("/") || normalizedPath.startsWith("\\")) {
             return true;
         }
 
@@ -3446,7 +3467,7 @@ public class ImportDemographicDataAction42Action extends ActionSupport implement
         }
 
         File importLog = PathValidationUtils.validateGeneratedChildPath("ImportEvent-" + UtilDateUtilities.getToday("yyyy-MM-dd.HH.mm.ss") + ".log", PathValidationUtils.resolveConfiguredDirectory(dir, "import log directory"));
-        try (BufferedWriter out = new BufferedWriter(new FileWriter(importLog))) {
+        try (BufferedWriter out = Files.newBufferedWriter(importLog.toPath(), StandardCharsets.UTF_8)) {
             int tableWidth = 0;
             for (int i = 0; i < keyword.length; i++) {
                 for (int j = 0; j < keyword[i].length; j++) {

--- a/src/main/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServlet.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServlet.java
@@ -152,36 +152,7 @@ public class FrmCustomedPDFServlet extends HttpServlet {
                     
                     Path filepath;
                     try {
-                        // Use PathValidationUtils for proper path validation
-                        File baseDirFile = PathValidationUtils.resolveConfiguredDirectory(document_dir, "DOCUMENT_DIR");
-                        File validatedPdfFile = PathValidationUtils.validatePath(pdfFile, baseDirFile);
-                        filepath = validatedPdfFile.toPath();
-
-                        if (!Files.exists(filepath)) {
-                            try (java.io.OutputStream fileOut = Files.newOutputStream(filepath)) {
-                                baosPDF.writeTo(fileOut); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- PDF bytes written to file, not HTTP response
-                            }
-                        }
-
-                        // write to temporary file
-                        String tempPath = CarlosProperties.getInstance().getProperty("fax_file_location", System.getProperty("java.io.tmpdir"));
-                        File tempDirFile = PathValidationUtils.resolveConfiguredDirectory(tempPath, "fax_file_location");
-                        File validatedTempPdf = PathValidationUtils.validatePath("prescription_" + pdfid + ".pdf", tempDirFile);
-                        Path tempPdf = validatedTempPdf.toPath();
-
-                        // Copying the fax pdf.
-                        if (Files.exists(filepath) && !Files.exists(tempPdf)) {
-                            FileUtils.copyFile(filepath.toFile(), tempPdf.toFile());
-                        }
-
-                        // tracking file
-                        File validatedTxtFile = PathValidationUtils.validatePath("prescription_" + pdfid + ".txt", tempDirFile);
-                        try (BufferedWriter out = Files.newBufferedWriter(validatedTxtFile.toPath(), StandardCharsets.UTF_8,
-                                StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE)) {
-                            if (faxNo != null) {
-                                out.write(faxNo);
-                            }
-                        }
+                        filepath = prepareValidatedFaxFiles(document_dir, pdfid, pdfFile, faxNo, baosPDF);
                     } catch (SecurityException e) {
                         logger.warn("Prescription fax file path validation failed: {}", e.getClass().getSimpleName());
                         res.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
@@ -287,6 +258,48 @@ public class FrmCustomedPDFServlet extends HttpServlet {
             writer.println("<script>alert('Signature not found. Please sign the prescription.');</script>");
         }
 
+    }
+
+    private Path prepareValidatedFaxFiles(String documentDir, String pdfid, String pdfFile, String faxNo,
+            ByteArrayOutputStream baosPDF) throws IOException {
+        // Use PathValidationUtils for proper path validation
+        File baseDirFile = PathValidationUtils.resolveConfiguredDirectory(documentDir, "DOCUMENT_DIR");
+        File validatedPdfFile = PathValidationUtils.validatePath(pdfFile, baseDirFile);
+        Path filepath = validatedPdfFile.toPath();
+
+        writePdfFileIfMissing(filepath, baosPDF);
+
+        // write to temporary file
+        String tempPath = CarlosProperties.getInstance().getProperty("fax_file_location", System.getProperty("java.io.tmpdir"));
+        File tempDirFile = PathValidationUtils.resolveConfiguredDirectory(tempPath, "fax_file_location");
+        File validatedTempPdf = PathValidationUtils.validatePath("prescription_" + pdfid + ".pdf", tempDirFile);
+        Path tempPdf = validatedTempPdf.toPath();
+
+        // Copying the fax pdf.
+        if (Files.exists(filepath) && !Files.exists(tempPdf)) {
+            FileUtils.copyFile(filepath.toFile(), tempPdf.toFile());
+        }
+
+        File validatedTxtFile = PathValidationUtils.validatePath("prescription_" + pdfid + ".txt", tempDirFile);
+        writeFaxTrackingFile(validatedTxtFile, faxNo);
+        return filepath;
+    }
+
+    private void writePdfFileIfMissing(Path filepath, ByteArrayOutputStream baosPDF) throws IOException {
+        if (!Files.exists(filepath)) {
+            try (java.io.OutputStream fileOut = Files.newOutputStream(filepath)) {
+                baosPDF.writeTo(fileOut); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- PDF bytes written to file, not HTTP response
+            }
+        }
+    }
+
+    private void writeFaxTrackingFile(File trackingFile, String faxNo) throws IOException {
+        try (BufferedWriter out = Files.newBufferedWriter(trackingFile.toPath(), StandardCharsets.UTF_8,
+                StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE)) {
+            if (faxNo != null) {
+                out.write(faxNo);
+            }
+        }
     }
 
 

--- a/src/main/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServlet.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServlet.java
@@ -256,12 +256,11 @@ public class FrmCustomedPDFServlet extends HttpServlet {
     }
 
     private Path prepareValidatedFaxFilesOrReportFailure(String documentDir, String pdfid, String pdfFile,
-            String faxNo, ByteArrayOutputStream baosPDF, HttpServletResponse res, PrintWriter writer)
-            throws IOException {
+            String faxNo, ByteArrayOutputStream baosPDF, HttpServletResponse res, PrintWriter writer) {
         try {
             return prepareValidatedFaxFiles(documentDir, pdfid, pdfFile, faxNo, baosPDF);
-        } catch (SecurityException e) {
-            logger.warn("Prescription fax file path validation failed: {}", e.getClass().getSimpleName());
+        } catch (SecurityException | IOException e) {
+            logger.warn("Prescription fax file preparation failed: {}", e.getClass().getSimpleName());
             res.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
             writer.println("<div id='fax-failure'><h3>Error: Unable to generate fax.</h3><p>Please try again or contact support if the problem persists.</p></div>");
             writer.flush();

--- a/src/main/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServlet.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServlet.java
@@ -33,6 +33,7 @@ package io.github.carlos_emr.carlos.form.pdfservlet;
 import java.io.*;
 
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -295,10 +296,11 @@ public class FrmCustomedPDFServlet extends HttpServlet {
     }
 
     private void writePdfFileIfMissing(Path filepath, ByteArrayOutputStream baosPDF) throws IOException {
-        if (!Files.exists(filepath)) {
-            try (java.io.OutputStream fileOut = Files.newOutputStream(filepath)) {
-                baosPDF.writeTo(fileOut); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- PDF bytes written to file, not HTTP response
-            }
+        try (java.io.OutputStream fileOut = Files.newOutputStream(filepath,
+                StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE)) {
+            baosPDF.writeTo(fileOut); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- PDF bytes written to file, not HTTP response
+        } catch (FileAlreadyExistsException e) {
+            // Preserve the existing PDF if another request created it first.
         }
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServlet.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServlet.java
@@ -150,14 +150,9 @@ public class FrmCustomedPDFServlet extends HttpServlet {
                     String pdfFile = "prescription_" + pdfid + ".pdf";
                     String document_dir = CarlosProperties.getInstance().getProperty("DOCUMENT_DIR");
                     
-                    Path filepath;
-                    try {
-                        filepath = prepareValidatedFaxFiles(document_dir, pdfid, pdfFile, faxNo, baosPDF);
-                    } catch (SecurityException e) {
-                        logger.warn("Prescription fax file path validation failed: {}", e.getClass().getSimpleName());
-                        res.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-                        writer.println("<div id='fax-failure'><h3>Error: Unable to generate fax.</h3><p>Please try again or contact support if the problem persists.</p></div>");
-                        writer.flush();
+                    Path filepath = prepareValidatedFaxFilesOrReportFailure(document_dir, pdfid, pdfFile, faxNo,
+                            baosPDF, res, writer);
+                    if (filepath == null) {
                         return;
                     }
 
@@ -258,6 +253,20 @@ public class FrmCustomedPDFServlet extends HttpServlet {
             writer.println("<script>alert('Signature not found. Please sign the prescription.');</script>");
         }
 
+    }
+
+    private Path prepareValidatedFaxFilesOrReportFailure(String documentDir, String pdfid, String pdfFile,
+            String faxNo, ByteArrayOutputStream baosPDF, HttpServletResponse res, PrintWriter writer)
+            throws IOException {
+        try {
+            return prepareValidatedFaxFiles(documentDir, pdfid, pdfFile, faxNo, baosPDF);
+        } catch (SecurityException e) {
+            logger.warn("Prescription fax file path validation failed: {}", e.getClass().getSimpleName());
+            res.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            writer.println("<div id='fax-failure'><h3>Error: Unable to generate fax.</h3><p>Please try again or contact support if the problem persists.</p></div>");
+            writer.flush();
+            return null;
+        }
     }
 
     private Path prepareValidatedFaxFiles(String documentDir, String pdfid, String pdfFile, String faxNo,

--- a/src/main/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServlet.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServlet.java
@@ -260,7 +260,8 @@ public class FrmCustomedPDFServlet extends HttpServlet {
         try {
             return prepareValidatedFaxFiles(documentDir, pdfid, pdfFile, faxNo, baosPDF);
         } catch (SecurityException | IOException e) {
-            logger.warn("Prescription fax file preparation failed: {}", e.getClass().getSimpleName());
+            logger.warn("Prescription fax file preparation failed: type={}, message={}",
+                    e.getClass().getSimpleName(), LogSafe.sanitize(e.getMessage(), 1024), e);
             res.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
             writer.println("<div id='fax-failure'><h3>Error: Unable to generate fax.</h3><p>Please try again or contact support if the problem persists.</p></div>");
             writer.flush();

--- a/src/main/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServlet.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServlet.java
@@ -32,8 +32,10 @@ package io.github.carlos_emr.carlos.form.pdfservlet;
 
 import java.io.*;
 
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.*;
 import java.util.List;
 
@@ -149,7 +151,7 @@ public class FrmCustomedPDFServlet extends HttpServlet {
                     String document_dir = CarlosProperties.getInstance().getProperty("DOCUMENT_DIR");
                     
                     // Use PathValidationUtils for proper path validation
-                    File baseDirFile = new File(document_dir);
+                    File baseDirFile = PathValidationUtils.resolveConfiguredDirectory(document_dir, "DOCUMENT_DIR");
                     File validatedPdfFile = PathValidationUtils.validatePath(pdfFile, baseDirFile);
                     Path filepath = validatedPdfFile.toPath();
 
@@ -161,7 +163,7 @@ public class FrmCustomedPDFServlet extends HttpServlet {
 
                     // write to temporary file
                     String tempPath = CarlosProperties.getInstance().getProperty("fax_file_location", System.getProperty("java.io.tmpdir"));
-                    File tempDirFile = new File(tempPath);
+                    File tempDirFile = PathValidationUtils.resolveConfiguredDirectory(tempPath, "fax_file_location");
                     File validatedTempPdf = PathValidationUtils.validatePath("prescription_" + pdfid + ".pdf", tempDirFile);
                     Path tempPdf = validatedTempPdf.toPath();
 
@@ -172,9 +174,8 @@ public class FrmCustomedPDFServlet extends HttpServlet {
 
                     // tracking file
                     File validatedTxtFile = PathValidationUtils.validatePath("prescription_" + pdfid + ".txt", tempDirFile);
-                    String txtFile = validatedTxtFile.toString();
-                    try (FileWriter fstream = new FileWriter(txtFile);
-                         BufferedWriter out = new BufferedWriter(fstream)) {
+                    try (BufferedWriter out = Files.newBufferedWriter(validatedTxtFile.toPath(), StandardCharsets.UTF_8,
+                            StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE)) {
                         if (faxNo != null) {
                             out.write(faxNo);
                         }

--- a/src/main/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServlet.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServlet.java
@@ -150,35 +150,44 @@ public class FrmCustomedPDFServlet extends HttpServlet {
                     String pdfFile = "prescription_" + pdfid + ".pdf";
                     String document_dir = CarlosProperties.getInstance().getProperty("DOCUMENT_DIR");
                     
-                    // Use PathValidationUtils for proper path validation
-                    File baseDirFile = PathValidationUtils.resolveConfiguredDirectory(document_dir, "DOCUMENT_DIR");
-                    File validatedPdfFile = PathValidationUtils.validatePath(pdfFile, baseDirFile);
-                    Path filepath = validatedPdfFile.toPath();
+                    Path filepath;
+                    try {
+                        // Use PathValidationUtils for proper path validation
+                        File baseDirFile = PathValidationUtils.resolveConfiguredDirectory(document_dir, "DOCUMENT_DIR");
+                        File validatedPdfFile = PathValidationUtils.validatePath(pdfFile, baseDirFile);
+                        filepath = validatedPdfFile.toPath();
 
-                    if (!Files.exists(filepath)) {
-                        try (java.io.OutputStream fileOut = Files.newOutputStream(filepath)) {
-                            baosPDF.writeTo(fileOut); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- PDF bytes written to file, not HTTP response
+                        if (!Files.exists(filepath)) {
+                            try (java.io.OutputStream fileOut = Files.newOutputStream(filepath)) {
+                                baosPDF.writeTo(fileOut); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- PDF bytes written to file, not HTTP response
+                            }
                         }
-                    }
 
-                    // write to temporary file
-                    String tempPath = CarlosProperties.getInstance().getProperty("fax_file_location", System.getProperty("java.io.tmpdir"));
-                    File tempDirFile = PathValidationUtils.resolveConfiguredDirectory(tempPath, "fax_file_location");
-                    File validatedTempPdf = PathValidationUtils.validatePath("prescription_" + pdfid + ".pdf", tempDirFile);
-                    Path tempPdf = validatedTempPdf.toPath();
+                        // write to temporary file
+                        String tempPath = CarlosProperties.getInstance().getProperty("fax_file_location", System.getProperty("java.io.tmpdir"));
+                        File tempDirFile = PathValidationUtils.resolveConfiguredDirectory(tempPath, "fax_file_location");
+                        File validatedTempPdf = PathValidationUtils.validatePath("prescription_" + pdfid + ".pdf", tempDirFile);
+                        Path tempPdf = validatedTempPdf.toPath();
 
-                    // Copying the fax pdf.
-                    if (Files.exists(filepath) && !Files.exists(tempPdf)) {
-                        FileUtils.copyFile(filepath.toFile(), tempPdf.toFile());
-                    }
-
-                    // tracking file
-                    File validatedTxtFile = PathValidationUtils.validatePath("prescription_" + pdfid + ".txt", tempDirFile);
-                    try (BufferedWriter out = Files.newBufferedWriter(validatedTxtFile.toPath(), StandardCharsets.UTF_8,
-                            StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE)) {
-                        if (faxNo != null) {
-                            out.write(faxNo);
+                        // Copying the fax pdf.
+                        if (Files.exists(filepath) && !Files.exists(tempPdf)) {
+                            FileUtils.copyFile(filepath.toFile(), tempPdf.toFile());
                         }
+
+                        // tracking file
+                        File validatedTxtFile = PathValidationUtils.validatePath("prescription_" + pdfid + ".txt", tempDirFile);
+                        try (BufferedWriter out = Files.newBufferedWriter(validatedTxtFile.toPath(), StandardCharsets.UTF_8,
+                                StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE)) {
+                            if (faxNo != null) {
+                                out.write(faxNo);
+                            }
+                        }
+                    } catch (SecurityException e) {
+                        logger.warn("Prescription fax file path validation failed: {}", e.getClass().getSimpleName());
+                        res.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+                        writer.println("<div id='fax-failure'><h3>Error: Unable to generate fax.</h3><p>Please try again or contact support if the problem persists.</p></div>");
+                        writer.flush();
+                        return;
                     }
 
                     List<FaxConfig> faxConfigs = faxConfigDao.findAll(null, null);

--- a/src/main/java/io/github/carlos_emr/carlos/provider/web/ProviderSignatureImage2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/provider/web/ProviderSignatureImage2Action.java
@@ -155,7 +155,15 @@ public class ProviderSignatureImage2Action extends ActionSupport {
     }
 
     private File getValidatedSignatureFile(String signatureName, HttpServletResponse response) {
-        File imageFolder = new File(CarlosProperties.getInstance().getEformImageDirectory());
+        File imageFolder;
+        try {
+            imageFolder = PathValidationUtils.resolveConfiguredDirectory(
+                    CarlosProperties.getInstance().getEformImageDirectory(), "EFORM_IMAGES_DIR");
+        } catch (SecurityException e) {
+            MiscUtils.getLogger().warn("Invalid eForm image directory for signature image", e);
+            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+            return null;
+        }
         if (!imageFolder.exists()) {
             response.setStatus(HttpServletResponse.SC_NOT_FOUND);
             return null;

--- a/src/test/java/io/github/carlos_emr/carlos/demographic/pageUtil/ImportDemographicDataAction42ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/demographic/pageUtil/ImportDemographicDataAction42ActionUnitTest.java
@@ -209,8 +209,14 @@ class ImportDemographicDataAction42ActionUnitTest extends CarlosWebTestBase {
 
     @Test
     @DisplayName("should allow relative report paths")
-    void shouldAllowRelativeReportPaths() throws Exception {
+    void shouldAllowRelativeReportPaths_whenPathIsRelative() throws Exception {
         assertThat(invokeIsAbsoluteReportPath("reports/result.pdf")).isFalse();
+    }
+
+    @Test
+    @DisplayName("should reject report paths containing null characters")
+    void shouldRejectReportPath_whenPathContainsNullCharacter() throws Exception {
+        assertThat(invokeIsAbsoluteReportPath("reports/result.pdf\0")).isTrue();
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/demographic/pageUtil/ImportDemographicDataAction42ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/demographic/pageUtil/ImportDemographicDataAction42ActionUnitTest.java
@@ -42,6 +42,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 import java.io.File;
 import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -197,5 +198,39 @@ class ImportDemographicDataAction42ActionUnitTest extends CarlosWebTestBase {
         List<String> warnings = (List<String>) getMockRequest().getAttribute("warnings");
         assertThat(warnings).contains(NO_VALID_XML_WARNING);
         assertThat(getMockRequest().getAttribute("importlog")).isNotNull();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/tmp/report.pdf", "C:/reports/report.pdf", "C:\\reports\\report.pdf"})
+    @DisplayName("should identify absolute report paths without constructing File objects")
+    void shouldIdentifyAbsoluteReportPaths_withoutConstructingFileObjects(String path) throws Exception {
+        assertThat(invokeIsAbsoluteReportPath(path)).isTrue();
+    }
+
+    @Test
+    @DisplayName("should allow relative report paths")
+    void shouldAllowRelativeReportPaths() throws Exception {
+        assertThat(invokeIsAbsoluteReportPath("reports/result.pdf")).isFalse();
+    }
+
+    @Test
+    @DisplayName("should extract report file name from platform-neutral separators")
+    void shouldExtractReportFileName_fromPlatformNeutralSeparators() throws Exception {
+        assertThat(invokeExtractReportFileName("nested/result.pdf")).isEqualTo("result.pdf");
+        assertThat(invokeExtractReportFileName("nested\\result.pdf")).isEqualTo("result.pdf");
+        assertThat(invokeExtractReportFileName("nested/result.pdf/")).isEqualTo("result.pdf");
+        assertThat(invokeExtractReportFileName("result.pdf")).isEqualTo("result.pdf");
+    }
+
+    private boolean invokeIsAbsoluteReportPath(String path) throws Exception {
+        Method method = ImportDemographicDataAction42Action.class.getDeclaredMethod("isAbsoluteReportPath", String.class);
+        method.setAccessible(true);
+        return (Boolean) method.invoke(action, path);
+    }
+
+    private String invokeExtractReportFileName(String path) throws Exception {
+        Method method = ImportDemographicDataAction42Action.class.getDeclaredMethod("extractReportFileName", String.class);
+        method.setAccessible(true);
+        return (String) method.invoke(action, path);
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServletUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServletUnitTest.java
@@ -136,6 +136,43 @@ class FrmCustomedPDFServletUnitTest extends CarlosUnitTestBase {
         }
     }
 
+    @Test
+    @DisplayName("should return server error when fax tracking write fails")
+    void shouldReturnServerError_whenFaxTrackingWriteFails(@TempDir Path tempDir) throws Exception {
+        String previousDocumentDir = CarlosProperties.getInstance().getProperty("DOCUMENT_DIR");
+        String previousFaxFileLocation = CarlosProperties.getInstance().getProperty("fax_file_location");
+        Path documentDir = Files.createDirectory(tempDir.resolve("documents"));
+        Path faxDir = Files.createDirectory(tempDir.resolve("fax"));
+        Files.createDirectory(faxDir.resolve("prescription_rx-123.txt"));
+        MockHttpServletRequest request = createFaxRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        LoggedInInfo loggedInInfo = mock(LoggedInInfo.class);
+        when(loggedInInfo.getLoggedInProviderNo()).thenReturn("999998");
+
+        try (MockedStatic<LoggedInInfo> loggedInInfoMock = mockStatic(LoggedInInfo.class);
+             MockedStatic<PrescriptionQrCodeUIBean> qrCodeMock = mockStatic(PrescriptionQrCodeUIBean.class)) {
+            loggedInInfoMock.when(() -> LoggedInInfo.getLoggedInInfoFromSession(any(HttpServletRequest.class)))
+                    .thenReturn(loggedInInfo);
+            qrCodeMock.when(() -> PrescriptionQrCodeUIBean.isPrescriptionQrCodeEnabledForProvider("999998"))
+                    .thenReturn(false);
+            CarlosProperties.getInstance().setProperty("DOCUMENT_DIR", documentDir.toString());
+            CarlosProperties.getInstance().setProperty("fax_file_location", faxDir.toString());
+
+            FrmCustomedPDFServlet servlet = new FrmCustomedPDFServlet();
+            servlet.init(new MockServletConfig(new MockServletContext()));
+
+            servlet.service(request, response);
+
+            assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            assertThat(response.getContentAsString()).contains("Unable to generate fax");
+            assertThat(faxDir.resolve("prescription_rx-123.txt")).isDirectory();
+            verify(faxConfigDao, never()).findAll(any(), any());
+        } finally {
+            restoreProperty("DOCUMENT_DIR", previousDocumentDir);
+            restoreProperty("fax_file_location", previousFaxFileLocation);
+        }
+    }
+
     private MockHttpServletRequest createFaxRequest() {
         MockHttpServletRequest request = new MockHttpServletRequest("POST", "/form/frmcustomedpdf");
         request.addParameter("__method", "oscarRxFax");

--- a/src/test/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServletUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServletUnitTest.java
@@ -32,6 +32,7 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletConfig;
 import org.springframework.mock.web.MockServletContext;
 
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -127,6 +128,47 @@ class FrmCustomedPDFServletUnitTest extends CarlosUnitTestBase {
             assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
             assertThat(documentDir.resolve("prescription_rx-123.pdf")).exists();
             assertThat(faxDir.resolve("prescription_rx-123.pdf")).exists();
+            assertThat(faxDir.resolve("prescription_rx-123.txt")).hasContent("4165551212");
+            verify(faxConfigDao).findAll(any(), any());
+            verify(faxJobDao, never()).persist(any());
+        } finally {
+            restoreProperty("DOCUMENT_DIR", previousDocumentDir);
+            restoreProperty("fax_file_location", previousFaxFileLocation);
+        }
+    }
+
+    @Test
+    @DisplayName("should preserve existing prescription PDF when document file already exists")
+    void shouldPreserveExistingPrescriptionPdf_whenDocumentFileAlreadyExists(@TempDir Path tempDir) throws Exception {
+        String previousDocumentDir = CarlosProperties.getInstance().getProperty("DOCUMENT_DIR");
+        String previousFaxFileLocation = CarlosProperties.getInstance().getProperty("fax_file_location");
+        Path documentDir = Files.createDirectory(tempDir.resolve("documents"));
+        Path faxDir = Files.createDirectory(tempDir.resolve("fax"));
+        Path existingPdf = documentDir.resolve("prescription_rx-123.pdf");
+        Files.writeString(existingPdf, "existing pdf", StandardCharsets.UTF_8);
+        MockHttpServletRequest request = createFaxRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        LoggedInInfo loggedInInfo = mock(LoggedInInfo.class);
+        when(loggedInInfo.getLoggedInProviderNo()).thenReturn("999998");
+        when(faxConfigDao.findAll(any(), any())).thenReturn(Collections.emptyList());
+
+        try (MockedStatic<LoggedInInfo> loggedInInfoMock = mockStatic(LoggedInInfo.class);
+             MockedStatic<PrescriptionQrCodeUIBean> qrCodeMock = mockStatic(PrescriptionQrCodeUIBean.class)) {
+            loggedInInfoMock.when(() -> LoggedInInfo.getLoggedInInfoFromSession(any(HttpServletRequest.class)))
+                    .thenReturn(loggedInInfo);
+            qrCodeMock.when(() -> PrescriptionQrCodeUIBean.isPrescriptionQrCodeEnabledForProvider("999998"))
+                    .thenReturn(false);
+            CarlosProperties.getInstance().setProperty("DOCUMENT_DIR", documentDir.toString());
+            CarlosProperties.getInstance().setProperty("fax_file_location", faxDir.toString());
+
+            FrmCustomedPDFServlet servlet = new FrmCustomedPDFServlet();
+            servlet.init(new MockServletConfig(new MockServletContext()));
+
+            servlet.service(request, response);
+
+            assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
+            assertThat(existingPdf).hasContent("existing pdf");
+            assertThat(faxDir.resolve("prescription_rx-123.pdf")).hasContent("existing pdf");
             assertThat(faxDir.resolve("prescription_rx-123.txt")).hasContent("4165551212");
             verify(faxConfigDao).findAll(any(), any());
             verify(faxJobDao, never()).persist(any());

--- a/src/test/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServletUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServletUnitTest.java
@@ -25,11 +25,16 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.MockedStatic;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletConfig;
 import org.springframework.mock.web.MockServletContext;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -89,6 +94,45 @@ class FrmCustomedPDFServletUnitTest extends CarlosUnitTestBase {
             verify(faxConfigDao, never()).findAll(any(), any());
         } finally {
             restoreProperty("DOCUMENT_DIR", previousDocumentDir);
+        }
+    }
+
+    @Test
+    @DisplayName("should write fax files when configured directories are valid")
+    void shouldWriteValidatedFaxFiles_whenConfiguredDirectoriesAreValid(@TempDir Path tempDir) throws Exception {
+        String previousDocumentDir = CarlosProperties.getInstance().getProperty("DOCUMENT_DIR");
+        String previousFaxFileLocation = CarlosProperties.getInstance().getProperty("fax_file_location");
+        Path documentDir = Files.createDirectory(tempDir.resolve("documents"));
+        Path faxDir = Files.createDirectory(tempDir.resolve("fax"));
+        MockHttpServletRequest request = createFaxRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        LoggedInInfo loggedInInfo = mock(LoggedInInfo.class);
+        when(loggedInInfo.getLoggedInProviderNo()).thenReturn("999998");
+        when(faxConfigDao.findAll(any(), any())).thenReturn(Collections.emptyList());
+
+        try (MockedStatic<LoggedInInfo> loggedInInfoMock = mockStatic(LoggedInInfo.class);
+             MockedStatic<PrescriptionQrCodeUIBean> qrCodeMock = mockStatic(PrescriptionQrCodeUIBean.class)) {
+            loggedInInfoMock.when(() -> LoggedInInfo.getLoggedInInfoFromSession(any(HttpServletRequest.class)))
+                    .thenReturn(loggedInInfo);
+            qrCodeMock.when(() -> PrescriptionQrCodeUIBean.isPrescriptionQrCodeEnabledForProvider("999998"))
+                    .thenReturn(false);
+            CarlosProperties.getInstance().setProperty("DOCUMENT_DIR", documentDir.toString());
+            CarlosProperties.getInstance().setProperty("fax_file_location", faxDir.toString());
+
+            FrmCustomedPDFServlet servlet = new FrmCustomedPDFServlet();
+            servlet.init(new MockServletConfig(new MockServletContext()));
+
+            servlet.service(request, response);
+
+            assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
+            assertThat(documentDir.resolve("prescription_rx-123.pdf")).exists();
+            assertThat(faxDir.resolve("prescription_rx-123.pdf")).exists();
+            assertThat(faxDir.resolve("prescription_rx-123.txt")).hasContent("4165551212");
+            verify(faxConfigDao).findAll(any(), any());
+            verify(faxJobDao, never()).persist(any());
+        } finally {
+            restoreProperty("DOCUMENT_DIR", previousDocumentDir);
+            restoreProperty("fax_file_location", previousFaxFileLocation);
         }
     }
 

--- a/src/test/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServletUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServletUnitTest.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ */
+package io.github.carlos_emr.carlos.form.pdfservlet;
+
+import io.github.carlos_emr.CarlosProperties;
+import io.github.carlos_emr.carlos.PMmodule.dao.ProviderDao;
+import io.github.carlos_emr.carlos.commn.dao.FaxConfigDao;
+import io.github.carlos_emr.carlos.commn.dao.FaxJobDao;
+import io.github.carlos_emr.carlos.commn.dao.ClinicDAO;
+import io.github.carlos_emr.carlos.commn.dao.DemographicDao;
+import io.github.carlos_emr.carlos.commn.dao.DrugDao;
+import io.github.carlos_emr.carlos.commn.dao.PrescriptionDao;
+import io.github.carlos_emr.carlos.managers.FaxManager;
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
+import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import io.github.carlos_emr.carlos.web.PrescriptionQrCodeUIBean;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockServletConfig;
+import org.springframework.mock.web.MockServletContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@DisplayName("FrmCustomedPDFServlet path validation")
+@Tag("unit")
+@Tag("web")
+@Tag("security")
+class FrmCustomedPDFServletUnitTest extends CarlosUnitTestBase {
+
+    private FaxConfigDao faxConfigDao;
+    private FaxJobDao faxJobDao;
+
+    @BeforeEach
+    void setUp() {
+        faxConfigDao = mock(FaxConfigDao.class);
+        faxJobDao = mock(FaxJobDao.class);
+        registerMock(FaxConfigDao.class, faxConfigDao);
+        registerMock(FaxJobDao.class, faxJobDao);
+        registerMock(FaxManager.class, mock(FaxManager.class));
+        registerMock(ClinicDAO.class, mock(ClinicDAO.class));
+        registerMock(ProviderDao.class, mock(ProviderDao.class));
+        registerMock(DemographicDao.class, mock(DemographicDao.class));
+        registerMock(PrescriptionDao.class, mock(PrescriptionDao.class));
+        registerMock(DrugDao.class, mock(DrugDao.class));
+    }
+
+    @Test
+    @DisplayName("should return server error when document directory is invalid")
+    void shouldReturnServerError_whenDocumentDirectoryIsInvalid() throws Exception {
+        String previousDocumentDir = CarlosProperties.getInstance().getProperty("DOCUMENT_DIR");
+        MockHttpServletRequest request = createFaxRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        LoggedInInfo loggedInInfo = mock(LoggedInInfo.class);
+        when(loggedInInfo.getLoggedInProviderNo()).thenReturn("999998");
+
+        try (MockedStatic<LoggedInInfo> loggedInInfoMock = mockStatic(LoggedInInfo.class);
+             MockedStatic<PrescriptionQrCodeUIBean> qrCodeMock = mockStatic(PrescriptionQrCodeUIBean.class)) {
+            loggedInInfoMock.when(() -> LoggedInInfo.getLoggedInInfoFromSession(any(HttpServletRequest.class)))
+                    .thenReturn(loggedInInfo);
+            qrCodeMock.when(() -> PrescriptionQrCodeUIBean.isPrescriptionQrCodeEnabledForProvider("999998"))
+                    .thenReturn(false);
+            CarlosProperties.getInstance().setProperty("DOCUMENT_DIR", " ");
+
+            FrmCustomedPDFServlet servlet = new FrmCustomedPDFServlet();
+            servlet.init(new MockServletConfig(new MockServletContext()));
+
+            servlet.service(request, response);
+
+            assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            assertThat(response.getContentAsString()).contains("Unable to generate fax");
+            verify(faxConfigDao, never()).findAll(any(), any());
+        } finally {
+            restoreProperty("DOCUMENT_DIR", previousDocumentDir);
+        }
+    }
+
+    private MockHttpServletRequest createFaxRequest() {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/form/frmcustomedpdf");
+        request.addParameter("__method", "oscarRxFax");
+        request.addParameter("pdfId", "rx-123");
+        request.addParameter("pharmaFax", "4165551212");
+        request.addParameter("clinicFax", "4165553434");
+        request.addParameter("pharmaName", "Test Pharmacy");
+        request.addParameter("demographic_no", "1");
+        request.addParameter("clinicName", "Test Clinic");
+        request.addParameter("clinicPhone", "4165550000");
+        request.addParameter("patientName", "Test Patient");
+        request.addParameter("patientAddress", "123 Test Street");
+        request.addParameter("patientCityPostal", "Toronto ON");
+        request.addParameter("patientPhone", "4165559999");
+        request.addParameter("sigDoctorName", "Dr Test");
+        request.addParameter("rxDate", "2026-06-19");
+        request.addParameter("rx", "Test prescription");
+        request.addParameter("scriptId", "1");
+        return request;
+    }
+
+    private static void restoreProperty(String key, String previousValue) {
+        if (previousValue == null) {
+            CarlosProperties.getInstance().remove(key);
+        } else {
+            CarlosProperties.getInstance().setProperty(key, previousValue);
+        }
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/provider/web/ProviderSignatureImage2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/provider/web/ProviderSignatureImage2ActionUnitTest.java
@@ -12,6 +12,7 @@ import io.github.carlos_emr.CarlosProperties;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import io.github.carlos_emr.carlos.utility.PathValidationUtils;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.nio.file.Files;
@@ -310,6 +311,28 @@ class ProviderSignatureImage2ActionUnitTest extends CarlosUnitTestBase {
         assertThat(result).isEqualTo(ActionSupport.NONE);
         assertThat(mockResponse.getStatus()).isEqualTo(HttpServletResponse.SC_NOT_FOUND);
         assertThat(mockResponse.getContentAsByteArray()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should return 404 when image directory validation fails")
+    void shouldReturn404_whenImageDirectoryValidationFails() {
+        String configuredDirectory = "/invalid/eform-images";
+        when(mockProperties.getEformImageDirectory()).thenReturn(configuredDirectory);
+
+        try (MockedStatic<PathValidationUtils> pathValidationUtilsMock =
+                     mockStatic(PathValidationUtils.class, org.mockito.Mockito.CALLS_REAL_METHODS)) {
+            pathValidationUtilsMock.when(() -> PathValidationUtils.resolveConfiguredDirectory(
+                            configuredDirectory, "EFORM_IMAGES_DIR"))
+                    .thenThrow(new SecurityException("not allowed"));
+
+            String result = action.execute();
+
+            assertThat(result).isEqualTo(ActionSupport.NONE);
+            assertThat(mockResponse.getStatus()).isEqualTo(HttpServletResponse.SC_NOT_FOUND);
+            assertThat(mockResponse.getContentAsByteArray()).isEmpty();
+            pathValidationUtilsMock.verify(() -> PathValidationUtils.resolveConfiguredDirectory(
+                    configuredDirectory, "EFORM_IMAGES_DIR"));
+        }
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/provider/web/ProviderSignatureImage2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/provider/web/ProviderSignatureImage2ActionUnitTest.java
@@ -300,6 +300,19 @@ class ProviderSignatureImage2ActionUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
+    @DisplayName("should return 404 when the configured image path is not a directory")
+    void shouldReturn404_whenConfiguredImagePathIsNotDirectory() throws Exception {
+        Path configuredFile = Files.createTempFile(tempDir, "eform-images-", ".txt");
+        when(mockProperties.getEformImageDirectory()).thenReturn(configuredFile.toString());
+
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(mockResponse.getStatus()).isEqualTo(HttpServletResponse.SC_NOT_FOUND);
+        assertThat(mockResponse.getContentAsByteArray()).isEmpty();
+    }
+
+    @Test
     @DisplayName("should return bad request when the logged-in provider number is invalid")
     void shouldReturnBadRequest_whenLoggedInProviderNoIsInvalid() {
         when(mockLoggedInInfo.getLoggedInProviderNo()).thenReturn("provider-x");


### PR DESCRIPTION
## Summary

- canonicalize configured base directories before resolving signature and prescription fax files
- write validated fax/import tracking files through `Files.newBufferedWriter` instead of string/FileWriter sinks
- replace report-path `File` construction used for parsing with string-only helpers

## Alerts

- Addresses SpotBugs/Find Security Bugs alerts #19480, #10826, and #9650.

## Verification

- `git diff --check` on the staged scanner-cleanup files passed.
- Attempted `mvn -q -Dtest=ProviderSignatureImage2ActionUnitTest,ImportDemographicDataAction42ActionUnitTest test` in an isolated temp worktree at the commit, but interrupted it after several minutes without output while other unrelated Maven jobs were running on the machine.

## Summary by Sourcery

Clarify and harden path handling for prescription faxing, demographic import reports, and provider signature images while adding coverage for the new validation paths.

Bug Fixes:
- Ensure prescription fax PDFs and tracking files are created only under validated, canonicalized document and fax directories, returning a controlled server error when preparation fails.
- Reject unsafe or malformed report paths and avoid using File objects when checking for absolute report paths or extracting filenames.
- Return 404 responses when configured eForm image directories are invalid or fail validation, instead of silently proceeding.

Enhancements:
- Write import and fax tracking files via UTF-8 NIO writers and extract helper methods to simplify fax file preparation and error reporting.

Tests:
- Add servlet-level tests covering successful fax file generation, invalid document/fax directory handling, and fax tracking write failures.
- Add unit tests for report path helper methods and for eForm image directory validation, including the PathValidationUtils rejection case.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified and hardened path validation for demographic imports, provider signature images, and prescription faxing. Invalid `DOCUMENT_DIR`/`fax_file_location` or I/O now return a controlled 500 with sanitized logging; existing prescription PDFs are preserved (no truncation) and fax/import tracking files use UTF‑8 NIO.

- **Bug Fixes**
  - Canonicalize and validate base dirs before resolving files; return 500 for invalid document/fax dirs or fax I/O, and 404 for invalid/non‑directory eForm image dirs.
  - Reject absolute and null‑byte report paths with string‑only checks, including an explicit Windows drive‑letter prefix; extract report filenames without constructing File.
  - Preserve existing prescription PDFs by creating with CREATE_NEW and copying to the fax temp dir; write tracking files with `Files.newBufferedWriter` (UTF‑8).
  - Log sanitized context and stack trace on fax preparation failures.
  - Tests: servlet‑level coverage for valid/invalid fax dirs, I/O failure, and existing‑file preservation; unit tests for null‑byte/drive‑letter report paths and eForm image directory validation.

- **Refactors**
  - Extract helpers for prescription fax file preparation and controlled failure responses.
  - Simplify absolute report path check to a single boolean return (no behavior change).

<sup>Written for commit 633d9d482930ed25e8b66e5e9077d11d21fc27d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

