### PR TITLE
Harden server-side URL fetches

### DIFF
--- a/docs/server-side-url-fetch-policy.md
+++ b/docs/server-side-url-fetch-policy.md
@@ -1,0 +1,43 @@
+# Server-Side URL Fetch Policy
+
+CARLOS server-side code must not fetch arbitrary URLs. Any code path that opens a
+`URL`, `URI`, `URLConnection`, or `InputStream` from a URL must validate the target
+before opening the stream.
+
+## Allowed Patterns
+
+### Same-Application JSP Rendering
+
+`Doc2PDF.parseJSP2PDF` contains a legacy server-side fetch used to render an
+application JSP into PDF. This path is allowed only for same-application URLs:
+
+- scheme must be `http` or `https`
+- host must be loopback or match the servlet request's local connector name/address
+- effective port must match the servlet request's local connector port
+- path must stay inside `HttpServletRequest.getContextPath()`
+- user-info and fragments are rejected
+
+Callers must use the request-aware overload:
+
+```java
+Doc2PDF.GetInputFromURI(request, jsessionid, uri);
+```
+
+The legacy two-argument overload has no request context and fails closed.
+
+### Drools DRL Resources
+
+`DroolsHelper.loadFromUrl` is for local DRL resources only. It accepts:
+
+- `file:` URLs
+- `jar:file:` URLs for classpath resources packaged in local jars or WARs
+
+Network-backed DRL loading is not allowed. The helper rejects `http:`, `https:`,
+`ftp:`, `jar:http:`, and other non-local schemes before opening the stream.
+
+## New URL Fetch Code
+
+New server-side fetch code must define its own allowlist before the sink call. Use
+the narrowest target set possible: a fixed external service host for integrations,
+or same-application validation for internal requests. Do not add generic helpers
+that accept arbitrary URL strings.

--- a/src/main/java/io/github/carlos_emr/carlos/drools/DroolsHelper.java
+++ b/src/main/java/io/github/carlos_emr/carlos/drools/DroolsHelper.java
@@ -145,6 +145,7 @@ public final class DroolsHelper {
         }
     }
 
+    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of parsed ASCII URL schemes in fail-closed local DRL validation")
     private static void validateLocalDrlUrl(URL url) throws DroolsCompilationException {
         if (url == null) {
             throw new DroolsCompilationException("DRL URL must not be null");
@@ -164,6 +165,7 @@ public final class DroolsHelper {
         throw new DroolsCompilationException("Unsupported DRL URL protocol: " + protocol);
     }
 
+    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-folding parsed ASCII jar URL scheme before local file validation")
     private static void validateLocalJarUrl(URL url) throws DroolsCompilationException {
         String spec = url.getFile();
         int separator = spec.indexOf("!/");
@@ -178,6 +180,7 @@ public final class DroolsHelper {
         validateLocalFileUrl(jarFileUrl);
     }
 
+    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of parsed ASCII file URL scheme/localhost in fail-closed local file validation")
     private static void validateLocalFileUrl(String rawUrl) throws DroolsCompilationException {
         try {
             URI uri = new URI(rawUrl);
@@ -186,7 +189,9 @@ public final class DroolsHelper {
             }
 
             String host = uri.getHost();
-            if (host != null && !host.isEmpty() && !"localhost".equalsIgnoreCase(host)) {
+            String path = uri.getPath();
+            if ((host != null && !host.isEmpty() && !"localhost".equalsIgnoreCase(host))
+                    || (host == null && path != null && path.startsWith("//"))) {
                 throw new DroolsCompilationException("DRL file URL must not target a remote host");
             }
         } catch (URISyntaxException e) {

--- a/src/main/java/io/github/carlos_emr/carlos/drools/DroolsHelper.java
+++ b/src/main/java/io/github/carlos_emr/carlos/drools/DroolsHelper.java
@@ -25,9 +25,12 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
 
 import org.apache.commons.io.IOUtils;
@@ -118,7 +121,10 @@ public final class DroolsHelper {
      * Loads DRL rules from a URL and returns a compiled KieBase.
      *
      * <p>Opens a stream to the URL, reads the content as UTF-8 text, and compiles
-     * the DRL. The stream is automatically closed via try-with-resources.</p>
+     * the DRL. The stream is automatically closed via try-with-resources. Only
+     * local classpath/filesystem URLs are accepted: {@code file:} and
+     * {@code jar:file:}. Network-backed URL schemes are rejected before opening
+     * the stream.</p>
      *
      * <p>Typically used to load DRL files from the classpath, e.g.:
      * {@code DroolsHelper.loadFromUrl(getClass().getResource("/oscar/prevention/prevention.drl"))}</p>
@@ -127,12 +133,64 @@ public final class DroolsHelper {
      * @return KieBase compiled rule base ready for creating KieSessions
      * @throws DroolsCompilationException if the URL cannot be read or rule compilation fails
      */
+    // FindSecBugs URLCONNECTION_SSRF_FD: validateLocalDrlUrl rejects network-backed URL schemes before openStream.
+    @SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD", justification = "validateLocalDrlUrl only allows file: and jar:file: DRL resources before opening the stream")
     public static KieBase loadFromUrl(URL url) throws DroolsCompilationException {
+        validateLocalDrlUrl(url);
         try (InputStream is = url.openStream()) {
             String drl = IOUtils.toString(is, StandardCharsets.UTF_8);
             return createKieBaseFromDrl(drl);
         } catch (IOException e) {
             throw new DroolsCompilationException("Failed to read DRL from URL", e);
+        }
+    }
+
+    private static void validateLocalDrlUrl(URL url) throws DroolsCompilationException {
+        if (url == null) {
+            throw new DroolsCompilationException("DRL URL must not be null");
+        }
+
+        String protocol = url.getProtocol();
+        if ("file".equalsIgnoreCase(protocol)) {
+            validateLocalFileUrl(url.toString());
+            return;
+        }
+
+        if ("jar".equalsIgnoreCase(protocol)) {
+            validateLocalJarUrl(url);
+            return;
+        }
+
+        throw new DroolsCompilationException("Unsupported DRL URL protocol: " + protocol);
+    }
+
+    private static void validateLocalJarUrl(URL url) throws DroolsCompilationException {
+        String spec = url.getFile();
+        int separator = spec.indexOf("!/");
+        if (separator < 0) {
+            throw new DroolsCompilationException("Invalid DRL jar URL: missing resource separator");
+        }
+
+        String jarFileUrl = spec.substring(0, separator);
+        if (!jarFileUrl.toLowerCase(Locale.ROOT).startsWith("file:")) {
+            throw new DroolsCompilationException("Unsupported DRL jar URL protocol");
+        }
+        validateLocalFileUrl(jarFileUrl);
+    }
+
+    private static void validateLocalFileUrl(String rawUrl) throws DroolsCompilationException {
+        try {
+            URI uri = new URI(rawUrl);
+            if (!"file".equalsIgnoreCase(uri.getScheme())) {
+                throw new DroolsCompilationException("Unsupported DRL file URL protocol: " + uri.getScheme());
+            }
+
+            String host = uri.getHost();
+            if (host != null && !host.isEmpty() && !"localhost".equalsIgnoreCase(host)) {
+                throw new DroolsCompilationException("DRL file URL must not target a remote host");
+            }
+        } catch (URISyntaxException e) {
+            throw new DroolsCompilationException("Invalid DRL URL", e);
         }
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/util/Doc2PDF.java
+++ b/src/main/java/io/github/carlos_emr/carlos/util/Doc2PDF.java
@@ -169,7 +169,7 @@ public class Doc2PDF {
         try {
 
             // Fetch the rendered JSP page via HTTP and parse it into a clean XHTML document
-            BufferedInputStream in = getInputFromUri(request, jsessionid, uri);
+            BufferedInputStream in = openValidatedInternalFetch(request, jsessionid, uri);
             if (in == null) {
                 throw new IOException("Failed to fetch JSP content from the given URI");
             }
@@ -301,7 +301,7 @@ public class Doc2PDF {
      */
     // FindSecBugs URLCONNECTION_SSRF_FD: validateInternalFetchUri rejects external hosts/schemes before openConnection.
     @SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD", justification = "validateInternalFetchUri enforces same-application http(s) targets before opening a connection")
-    static BufferedInputStream getInputFromUri(HttpServletRequest request, String jsessionid, String uri) {
+    static BufferedInputStream openValidatedInternalFetch(HttpServletRequest request, String jsessionid, String uri) {
 
         HttpURLConnection conn = null;
         try {
@@ -340,9 +340,6 @@ public class Doc2PDF {
             return null;
         } catch (URISyntaxException e) {
             logger.warn("Rejected internal Doc2PDF fetch due to invalid URI syntax");
-            if (conn != null) {
-                conn.disconnect();
-            }
             return null;
         } catch (Exception e) {
             logger.error("Failed to open HTTP connection to fetch URI content", e);

--- a/src/main/java/io/github/carlos_emr/carlos/util/Doc2PDF.java
+++ b/src/main/java/io/github/carlos_emr/carlos/util/Doc2PDF.java
@@ -44,7 +44,6 @@ import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.net.URLEncoder;
 import java.util.Locale;
 import java.util.Vector;
 
@@ -85,6 +84,7 @@ public class Doc2PDF {
     private static Logger logger = MiscUtils.getLogger();
     private static final int INTERNAL_FETCH_CONNECT_TIMEOUT_MS = 5000;
     private static final int INTERNAL_FETCH_READ_TIMEOUT_MS = 30000;
+    private static final char[] HEX_DIGITS = "0123456789ABCDEF".toCharArray();
 
     /**
      * Sends an HTTP 500 error response if the response has not yet been committed.
@@ -169,7 +169,7 @@ public class Doc2PDF {
         try {
 
             // Fetch the rendered JSP page via HTTP and parse it into a clean XHTML document
-            BufferedInputStream in = GetInputFromURI(request, jsessionid, uri);
+            BufferedInputStream in = getInputFromUri(request, jsessionid, uri);
             if (in == null) {
                 throw new IOException("Failed to fetch JSP content from the given URI");
             }
@@ -283,7 +283,11 @@ public class Doc2PDF {
      * @return BufferedInputStream the response body, or null if the connection fails
      */
     public static BufferedInputStream GetInputFromURI(String jsessionid, String uri) {
-        logger.warn("Blocked legacy Doc2PDF server-side fetch without request context");
+        if (jsessionid == null && uri == null) {
+            logger.warn("Blocked legacy Doc2PDF server-side fetch without request context and target data");
+        } else {
+            logger.warn("Blocked legacy Doc2PDF server-side fetch without request context");
+        }
         return null;
     }
 
@@ -297,7 +301,7 @@ public class Doc2PDF {
      */
     // FindSecBugs URLCONNECTION_SSRF_FD: validateInternalFetchUri rejects external hosts/schemes before openConnection.
     @SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD", justification = "validateInternalFetchUri enforces same-application http(s) targets before opening a connection")
-    public static BufferedInputStream GetInputFromURI(HttpServletRequest request, String jsessionid, String uri) {
+    static BufferedInputStream getInputFromUri(HttpServletRequest request, String jsessionid, String uri) {
 
         HttpURLConnection conn = null;
         try {
@@ -307,7 +311,7 @@ public class Doc2PDF {
             URI validatedUri = validateInternalFetchUri(request, uri);
             URL url = appendSessionId(validatedUri, jsessionid).toURL();
 
-            MiscUtils.getLogger().debug("Opening internal Doc2PDF fetch for {}", validatedUri);
+            MiscUtils.getLogger().debug("Opening internal Doc2PDF fetch for validated same-application target");
 
             conn = (HttpURLConnection) url.openConnection();
             conn.setConnectTimeout(INTERNAL_FETCH_CONNECT_TIMEOUT_MS);
@@ -328,8 +332,14 @@ public class Doc2PDF {
             };
             return new BufferedInputStream(wrapped);
 
-        } catch (IllegalArgumentException | URISyntaxException e) {
-            logger.warn("Rejected internal Doc2PDF fetch: {}", e.getMessage());
+        } catch (IllegalArgumentException e) {
+            logger.warn("Rejected internal Doc2PDF fetch due to validation constraints");
+            if (conn != null) {
+                conn.disconnect();
+            }
+            return null;
+        } catch (URISyntaxException e) {
+            logger.warn("Rejected internal Doc2PDF fetch due to invalid URI syntax");
             if (conn != null) {
                 conn.disconnect();
             }
@@ -343,6 +353,7 @@ public class Doc2PDF {
         }
     }
 
+    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of parsed ASCII URL schemes/hosts in fail-closed SSRF validation")
     private static URI validateInternalFetchUri(HttpServletRequest request, String uri)
             throws URISyntaxException {
         if (request == null) {
@@ -411,6 +422,7 @@ public class Doc2PDF {
                 && normalizedTarget.equals(normalizeHost(candidate));
     }
 
+    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-folding parsed hostnames for same-connector comparison; not user identity or authorization")
     private static String normalizeHost(String host) {
         String normalized = host.trim().toLowerCase(Locale.ROOT);
         if (normalized.startsWith("[") && normalized.endsWith("]")) {
@@ -434,6 +446,7 @@ public class Doc2PDF {
         return request.getServerPort();
     }
 
+    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-folding parsed ASCII URL schemes for default port selection")
     private static int effectivePort(String scheme, int port) {
         if (port > 0) {
             return port;
@@ -453,14 +466,45 @@ public class Doc2PDF {
             throw new URISyntaxException(String.valueOf(uri), "JSESSIONID must not be empty");
         }
 
-        String encodedSessionId = URLEncoder.encode(jsessionid, StandardCharsets.UTF_8);
         String rawPath = uri.getRawPath();
         if (rawPath == null || rawPath.isEmpty()) {
             rawPath = "/";
         }
-        String pathWithSession = rawPath + ";jsessionid=" + encodedSessionId;
-        return new URI(uri.getScheme(), uri.getRawAuthority(), pathWithSession,
-                uri.getRawQuery(), null);
+        String pathWithSession = rawPath + ";jsessionid=" + encodePathSegment(jsessionid);
+        StringBuilder rewrittenUri = new StringBuilder()
+                .append(uri.getScheme())
+                .append("://")
+                .append(uri.getRawAuthority())
+                .append(pathWithSession);
+        if (uri.getRawQuery() != null) {
+            rewrittenUri.append('?').append(uri.getRawQuery());
+        }
+        return new URI(rewrittenUri.toString());
+    }
+
+    private static String encodePathSegment(String value) {
+        StringBuilder encoded = new StringBuilder();
+        for (byte b : value.getBytes(StandardCharsets.UTF_8)) {
+            int c = b & 0xff;
+            if (isUnreservedPathByte(c)) {
+                encoded.append((char) c);
+            } else {
+                encoded.append('%');
+                encoded.append(HEX_DIGITS[(c >> 4) & 0x0f]);
+                encoded.append(HEX_DIGITS[c & 0x0f]);
+            }
+        }
+        return encoded.toString();
+    }
+
+    private static boolean isUnreservedPathByte(int c) {
+        return (c >= 'A' && c <= 'Z')
+                || (c >= 'a' && c <= 'z')
+                || (c >= '0' && c <= '9')
+                || c == '-'
+                || c == '.'
+                || c == '_'
+                || c == '~';
     }
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/util/Doc2PDF.java
+++ b/src/main/java/io/github/carlos_emr/carlos/util/Doc2PDF.java
@@ -390,6 +390,9 @@ public class Doc2PDF {
         if (targetPath == null || targetPath.isEmpty()) {
             targetPath = "/";
         }
+        if (containsDotSegment(targetPath)) {
+            throw new IllegalArgumentException("Internal Doc2PDF fetch URI must not contain path traversal");
+        }
         if (!contextPath.isEmpty()
                 && !targetPath.equals(contextPath)
                 && !targetPath.startsWith(contextPath + "/")) {
@@ -417,6 +420,15 @@ public class Doc2PDF {
         return candidate != null
                 && !candidate.trim().isEmpty()
                 && normalizedTarget.equals(normalizeHost(candidate));
+    }
+
+    private static boolean containsDotSegment(String path) {
+        for (String segment : path.split("/", -1)) {
+            if (".".equals(segment) || "..".equals(segment)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-folding parsed hostnames for same-connector comparison; not user identity or authorization")

--- a/src/main/java/io/github/carlos_emr/carlos/util/Doc2PDF.java
+++ b/src/main/java/io/github/carlos_emr/carlos/util/Doc2PDF.java
@@ -42,7 +42,10 @@ import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.URLEncoder;
+import java.util.Locale;
 import java.util.Vector;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -80,6 +83,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 @Deprecated
 public class Doc2PDF {
     private static Logger logger = MiscUtils.getLogger();
+    private static final int INTERNAL_FETCH_CONNECT_TIMEOUT_MS = 5000;
+    private static final int INTERNAL_FETCH_READ_TIMEOUT_MS = 30000;
 
     /**
      * Sends an HTTP 500 error response if the response has not yet been committed.
@@ -164,7 +169,7 @@ public class Doc2PDF {
         try {
 
             // Fetch the rendered JSP page via HTTP and parse it into a clean XHTML document
-            BufferedInputStream in = GetInputFromURI(jsessionid, uri);
+            BufferedInputStream in = GetInputFromURI(request, jsessionid, uri);
             if (in == null) {
                 throw new IOException("Failed to fetch JSP content from the given URI");
             }
@@ -265,24 +270,48 @@ public class Doc2PDF {
     }
 
     /**
-     * Opens an HTTP connection to the given URI with session authentication and returns the input stream.
+     * Opens an internal same-application HTTP(S) connection with session authentication.
+     *
+     * <p>This legacy path is used only for server-side rendering of application JSPs
+     * into PDF. The target URI must use {@code http} or {@code https}, target a
+     * loopback/current local connector host and port, and stay under the current
+     * servlet context path. External hosts, alternate schemes, fragments, user-info,
+     * and cross-context paths are rejected before opening a connection.</p>
      *
      * @param jsessionid String the session ID appended to the URI for authentication
      * @param uri String the target URI to fetch
      * @return BufferedInputStream the response body, or null if the connection fails
      */
     public static BufferedInputStream GetInputFromURI(String jsessionid, String uri) {
+        logger.warn("Blocked legacy Doc2PDF server-side fetch without request context");
+        return null;
+    }
+
+    /**
+     * Opens an internal same-application HTTP(S) connection with session authentication.
+     *
+     * @param request HttpServletRequest providing the allowed server name, port, and context path
+     * @param jsessionid String the session ID appended to the URI for authentication
+     * @param uri String the target URI to fetch
+     * @return BufferedInputStream the response body, or null if the connection fails
+     */
+    // FindSecBugs URLCONNECTION_SSRF_FD: validateInternalFetchUri rejects external hosts/schemes before openConnection.
+    @SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD", justification = "validateInternalFetchUri enforces same-application http(s) targets before opening a connection")
+    public static BufferedInputStream GetInputFromURI(HttpServletRequest request, String jsessionid, String uri) {
 
         HttpURLConnection conn = null;
         try {
             // Append jsessionid to the URL path because this is a server-side HTTP connection
             // that does not share the browser's session cookie; the session ID must be passed
             // via URL rewriting so the target JSP executes within the user's authenticated session.
-            URL url = new URI(uri + ";jsessionid=" + jsessionid).toURL();
+            URI validatedUri = validateInternalFetchUri(request, uri);
+            URL url = appendSessionId(validatedUri, jsessionid).toURL();
 
-            MiscUtils.getLogger().debug(" " + uri + ";jsessionid=" + jsessionid);
+            MiscUtils.getLogger().debug("Opening internal Doc2PDF fetch for {}", validatedUri);
 
             conn = (HttpURLConnection) url.openConnection();
+            conn.setConnectTimeout(INTERNAL_FETCH_CONNECT_TIMEOUT_MS);
+            conn.setReadTimeout(INTERNAL_FETCH_READ_TIMEOUT_MS);
 
             // Wrap the stream so that closing it also disconnects the HTTP connection,
             // preventing connection pool leaks when the caller closes the returned stream.
@@ -299,6 +328,12 @@ public class Doc2PDF {
             };
             return new BufferedInputStream(wrapped);
 
+        } catch (IllegalArgumentException | URISyntaxException e) {
+            logger.warn("Rejected internal Doc2PDF fetch: {}", e.getMessage());
+            if (conn != null) {
+                conn.disconnect();
+            }
+            return null;
         } catch (Exception e) {
             logger.error("Failed to open HTTP connection to fetch URI content", e);
             if (conn != null) {
@@ -306,6 +341,126 @@ public class Doc2PDF {
             }
             return null;
         }
+    }
+
+    private static URI validateInternalFetchUri(HttpServletRequest request, String uri)
+            throws URISyntaxException {
+        if (request == null) {
+            throw new IllegalArgumentException("Request context is required for internal Doc2PDF fetches");
+        }
+        if (uri == null || uri.trim().isEmpty()) {
+            throw new IllegalArgumentException("Internal Doc2PDF fetch URI must not be empty");
+        }
+
+        URI target = new URI(uri).normalize();
+        String scheme = target.getScheme();
+        if (!"http".equalsIgnoreCase(scheme) && !"https".equalsIgnoreCase(scheme)) {
+            throw new IllegalArgumentException("Internal Doc2PDF fetch URI must use http or https");
+        }
+        if (target.getRawUserInfo() != null) {
+            throw new IllegalArgumentException("Internal Doc2PDF fetch URI must not include user info");
+        }
+        if (target.getRawFragment() != null) {
+            throw new IllegalArgumentException("Internal Doc2PDF fetch URI must not include a fragment");
+        }
+
+        if (!isAllowedInternalHost(request, target.getHost())) {
+            throw new IllegalArgumentException("Internal Doc2PDF fetch URI must target the local application connector");
+        }
+
+        int targetPort = effectivePort(target.getScheme(), target.getPort());
+        int requestPort = effectivePort(request.getScheme(), getRequestLocalPort(request));
+        if (targetPort != requestPort) {
+            throw new IllegalArgumentException("Internal Doc2PDF fetch URI must target the local application connector port");
+        }
+
+        String contextPath = request.getContextPath();
+        if (contextPath == null) {
+            contextPath = "";
+        }
+        String targetPath = target.getPath();
+        if (targetPath == null || targetPath.isEmpty()) {
+            targetPath = "/";
+        }
+        if (!contextPath.isEmpty()
+                && !targetPath.equals(contextPath)
+                && !targetPath.startsWith(contextPath + "/")) {
+            throw new IllegalArgumentException("Internal Doc2PDF fetch URI must stay within the current context path");
+        }
+
+        return target;
+    }
+
+    private static boolean isAllowedInternalHost(HttpServletRequest request, String targetHost) {
+        if (targetHost == null || targetHost.trim().isEmpty()) {
+            return false;
+        }
+
+        String normalizedTarget = normalizeHost(targetHost);
+        if (isLoopbackHost(normalizedTarget)) {
+            return true;
+        }
+
+        return matchesHost(normalizedTarget, request.getLocalName())
+                || matchesHost(normalizedTarget, request.getLocalAddr());
+    }
+
+    private static boolean matchesHost(String normalizedTarget, String candidate) {
+        return candidate != null
+                && !candidate.trim().isEmpty()
+                && normalizedTarget.equals(normalizeHost(candidate));
+    }
+
+    private static String normalizeHost(String host) {
+        String normalized = host.trim().toLowerCase(Locale.ROOT);
+        if (normalized.startsWith("[") && normalized.endsWith("]")) {
+            return normalized.substring(1, normalized.length() - 1);
+        }
+        return normalized;
+    }
+
+    private static boolean isLoopbackHost(String normalizedHost) {
+        return "localhost".equals(normalizedHost)
+                || "127.0.0.1".equals(normalizedHost)
+                || "::1".equals(normalizedHost)
+                || "0:0:0:0:0:0:0:1".equals(normalizedHost);
+    }
+
+    private static int getRequestLocalPort(HttpServletRequest request) {
+        int localPort = request.getLocalPort();
+        if (localPort > 0) {
+            return localPort;
+        }
+        return request.getServerPort();
+    }
+
+    private static int effectivePort(String scheme, int port) {
+        if (port > 0) {
+            return port;
+        }
+        String normalizedScheme = scheme == null ? "" : scheme.toLowerCase(Locale.ROOT);
+        if ("https".equals(normalizedScheme)) {
+            return 443;
+        }
+        if ("http".equals(normalizedScheme)) {
+            return 80;
+        }
+        return port;
+    }
+
+    private static URI appendSessionId(URI uri, String jsessionid) throws URISyntaxException {
+        if (jsessionid == null || jsessionid.trim().isEmpty()) {
+            throw new URISyntaxException(String.valueOf(uri), "JSESSIONID must not be empty");
+        }
+
+        String encodedSessionId = URLEncoder.encode(jsessionid, StandardCharsets.UTF_8);
+        String rawPath = uri.getRawPath();
+        if (rawPath == null || rawPath.isEmpty()) {
+            rawPath = "/";
+        }
+        String pathWithSession = rawPath + ";jsessionid=" + encodedSessionId;
+        return new URI(uri.getScheme(), uri.getRawAuthority(), pathWithSession,
+                uri.getRawQuery(), null);
     }
 
     /**

--- a/src/test/java/io/github/carlos_emr/carlos/drools/DroolsHelperUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/drools/DroolsHelperUnitTest.java
@@ -357,6 +357,7 @@ class DroolsHelperUnitTest {
         }
 
         @Test
+        @Tag("security")
         @DisplayName("should reject http URL before opening stream")
         void shouldRejectHttpUrl_beforeOpeningStream() throws Exception {
             URL remoteUrl = new URL("http://169.254.169.254/latest/meta-data/rules.drl");
@@ -378,6 +379,7 @@ class DroolsHelperUnitTest {
         }
 
         @Test
+        @Tag("security")
         @DisplayName("should reject jar URL backed by http before opening stream")
         void shouldRejectJarHttpUrl_beforeOpeningStream() throws Exception {
             URL remoteJarUrl = new URL("jar:http://169.254.169.254/rules.jar!/rules.drl");

--- a/src/test/java/io/github/carlos_emr/carlos/drools/DroolsHelperUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/drools/DroolsHelperUnitTest.java
@@ -367,6 +367,17 @@ class DroolsHelperUnitTest {
         }
 
         @Test
+        @Tag("security")
+        @DisplayName("should reject UNC file URL before opening stream")
+        void shouldRejectUncFileUrl_beforeOpeningStream() throws Exception {
+            URL uncUrl = new URL("file:////server/share/rules.drl");
+
+            assertThatThrownBy(() -> DroolsHelper.loadFromUrl(uncUrl))
+                    .isInstanceOf(DroolsCompilationException.class)
+                    .hasMessageContaining("remote host");
+        }
+
+        @Test
         @DisplayName("should reject jar URL backed by http before opening stream")
         void shouldRejectJarHttpUrl_beforeOpeningStream() throws Exception {
             URL remoteJarUrl = new URL("jar:http://169.254.169.254/rules.jar!/rules.drl");
@@ -374,6 +385,17 @@ class DroolsHelperUnitTest {
             assertThatThrownBy(() -> DroolsHelper.loadFromUrl(remoteJarUrl))
                     .isInstanceOf(DroolsCompilationException.class)
                     .hasMessageContaining("Unsupported DRL jar URL protocol");
+        }
+
+        @Test
+        @Tag("security")
+        @DisplayName("should reject jar URL backed by UNC file before opening stream")
+        void shouldRejectJarUncFileUrl_beforeOpeningStream() throws Exception {
+            URL remoteJarUrl = new URL("jar:file:////server/share/rules.jar!/rules.drl");
+
+            assertThatThrownBy(() -> DroolsHelper.loadFromUrl(remoteJarUrl))
+                    .isInstanceOf(DroolsCompilationException.class)
+                    .hasMessageContaining("remote host");
         }
 
         /**

--- a/src/test/java/io/github/carlos_emr/carlos/drools/DroolsHelperUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/drools/DroolsHelperUnitTest.java
@@ -356,6 +356,26 @@ class DroolsHelperUnitTest {
                     .hasMessageContaining("Failed to read DRL from URL");
         }
 
+        @Test
+        @DisplayName("should reject http URL before opening stream")
+        void shouldRejectHttpUrl_beforeOpeningStream() throws Exception {
+            URL remoteUrl = new URL("http://169.254.169.254/latest/meta-data/rules.drl");
+
+            assertThatThrownBy(() -> DroolsHelper.loadFromUrl(remoteUrl))
+                    .isInstanceOf(DroolsCompilationException.class)
+                    .hasMessageContaining("Unsupported DRL URL protocol");
+        }
+
+        @Test
+        @DisplayName("should reject jar URL backed by http before opening stream")
+        void shouldRejectJarHttpUrl_beforeOpeningStream() throws Exception {
+            URL remoteJarUrl = new URL("jar:http://169.254.169.254/rules.jar!/rules.drl");
+
+            assertThatThrownBy(() -> DroolsHelper.loadFromUrl(remoteJarUrl))
+                    .isInstanceOf(DroolsCompilationException.class)
+                    .hasMessageContaining("Unsupported DRL jar URL protocol");
+        }
+
         /**
          * Integration smoke test: loads the production {@code prevention.drl},
          * compiles it, and verifies a {@link KieSession} can be created from

--- a/src/test/java/io/github/carlos_emr/carlos/util/Doc2PDFIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/util/Doc2PDFIntegrationTest.java
@@ -254,7 +254,7 @@ class Doc2PDFIntegrationTest extends CarlosTestBase {
     @Tag("security")
     @DisplayName("should reject Doc2PDF internal fetch when target host differs")
     void shouldRejectInternalFetch_whenTargetHostDiffers() {
-        assertThat(Doc2PDF.getInputFromUri(request, "ABC123",
+        assertThat(Doc2PDF.openValidatedInternalFetch(request, "ABC123",
                 "http://169.254.169.254/openo/report.jsp")).isNull();
     }
 
@@ -262,14 +262,14 @@ class Doc2PDFIntegrationTest extends CarlosTestBase {
     @Tag("security")
     @DisplayName("should reject Doc2PDF internal fetch when URI uses file scheme")
     void shouldRejectInternalFetch_whenUriUsesFileScheme() {
-        assertThat(Doc2PDF.getInputFromUri(request, "ABC123", "file:///etc/passwd")).isNull();
+        assertThat(Doc2PDF.openValidatedInternalFetch(request, "ABC123", "file:///etc/passwd")).isNull();
     }
 
     @Test
     @Tag("security")
     @DisplayName("should reject Doc2PDF internal fetch outside current context path")
     void shouldRejectInternalFetch_whenOutsideContextPath() {
-        assertThat(Doc2PDF.getInputFromUri(request, "ABC123",
+        assertThat(Doc2PDF.openValidatedInternalFetch(request, "ABC123",
                 "http://localhost:8080/admin/report.jsp")).isNull();
     }
 

--- a/src/test/java/io/github/carlos_emr/carlos/util/Doc2PDFIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/util/Doc2PDFIntegrationTest.java
@@ -275,6 +275,14 @@ class Doc2PDFIntegrationTest extends CarlosTestBase {
 
     @Test
     @Tag("security")
+    @DisplayName("should reject Doc2PDF internal fetch when path contains encoded dot segment")
+    void shouldRejectInternalFetch_whenPathContainsEncodedDotSegment() {
+        assertThat(Doc2PDF.openValidatedInternalFetch(request, "ABC123",
+                "http://localhost:8080/openo/%2e%2e/admin/report.jsp")).isNull();
+    }
+
+    @Test
+    @Tag("security")
     @DisplayName("should reject legacy Doc2PDF fetch without request context")
     void shouldRejectLegacyInternalFetch_withoutRequestContext() {
         assertThat(Doc2PDF.GetInputFromURI("ABC123",

--- a/src/test/java/io/github/carlos_emr/carlos/util/Doc2PDFIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/util/Doc2PDFIntegrationTest.java
@@ -25,6 +25,10 @@
 
 package io.github.carlos_emr.carlos.util;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URI;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
@@ -250,7 +254,7 @@ class Doc2PDFIntegrationTest extends CarlosTestBase {
     @Tag("security")
     @DisplayName("should reject Doc2PDF internal fetch when target host differs")
     void shouldRejectInternalFetch_whenTargetHostDiffers() {
-        assertThat(Doc2PDF.GetInputFromURI(request, "ABC123",
+        assertThat(Doc2PDF.getInputFromUri(request, "ABC123",
                 "http://169.254.169.254/openo/report.jsp")).isNull();
     }
 
@@ -258,14 +262,14 @@ class Doc2PDFIntegrationTest extends CarlosTestBase {
     @Tag("security")
     @DisplayName("should reject Doc2PDF internal fetch when URI uses file scheme")
     void shouldRejectInternalFetch_whenUriUsesFileScheme() {
-        assertThat(Doc2PDF.GetInputFromURI(request, "ABC123", "file:///etc/passwd")).isNull();
+        assertThat(Doc2PDF.getInputFromUri(request, "ABC123", "file:///etc/passwd")).isNull();
     }
 
     @Test
     @Tag("security")
     @DisplayName("should reject Doc2PDF internal fetch outside current context path")
     void shouldRejectInternalFetch_whenOutsideContextPath() {
-        assertThat(Doc2PDF.GetInputFromURI(request, "ABC123",
+        assertThat(Doc2PDF.getInputFromUri(request, "ABC123",
                 "http://localhost:8080/admin/report.jsp")).isNull();
     }
 
@@ -275,6 +279,18 @@ class Doc2PDFIntegrationTest extends CarlosTestBase {
     void shouldRejectLegacyInternalFetch_withoutRequestContext() {
         assertThat(Doc2PDF.GetInputFromURI("ABC123",
                 "http://localhost:8080/openo/report.jsp")).isNull();
+    }
+
+    @Test
+    @Tag("security")
+    @DisplayName("should append session ID without double-encoding encoded URI parts")
+    void shouldAppendSessionId_withoutDoubleEncodingEncodedUriParts() throws Exception {
+        URI rewrittenUri = appendSessionId(
+                "http://localhost:8080/openo/report%20view.jsp?name=Fran%C3%A7ois%20C%C3%B4t%C3%A9",
+                "A B/C+1");
+
+        assertThat(rewrittenUri.toASCIIString())
+                .isEqualTo("http://localhost:8080/openo/report%20view.jsp;jsessionid=A%20B%2FC%2B1?name=Fran%C3%A7ois%20C%C3%B4t%C3%A9");
     }
 
     @Test
@@ -339,6 +355,20 @@ class Doc2PDFIntegrationTest extends CarlosTestBase {
         // Then
         assertThat(response.getContentType()).isEqualTo("application/pdf");
         assertThat(response.getContentAsByteArray()).isNotEmpty();
+    }
+
+    private static URI appendSessionId(String uri, String jsessionid) throws Exception {
+        Method method = Doc2PDF.class.getDeclaredMethod("appendSessionId", URI.class, String.class);
+        method.setAccessible(true);
+        try {
+            return (URI) method.invoke(null, new URI(uri), jsessionid);
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof Exception) {
+                throw (Exception) cause;
+            }
+            throw e;
+        }
     }
 
 }

--- a/src/test/java/io/github/carlos_emr/carlos/util/Doc2PDFIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/util/Doc2PDFIntegrationTest.java
@@ -54,9 +54,14 @@ class Doc2PDFIntegrationTest extends CarlosTestBase {
     @BeforeEach
     void setUp() {
         request = new MockHttpServletRequest();
+        request.setScheme("http");
         request.setProtocol("HTTP/1.1");
         request.setRemoteHost("localhost");
+        request.setServerName("carlos.local");
         request.setServerPort(8080);
+        request.setLocalName("localhost");
+        request.setLocalAddr("127.0.0.1");
+        request.setLocalPort(8080);
         request.setContextPath("/openo");
 
         response = new MockHttpServletResponse();
@@ -242,6 +247,37 @@ class Doc2PDFIntegrationTest extends CarlosTestBase {
     }
 
     @Test
+    @Tag("security")
+    @DisplayName("should reject Doc2PDF internal fetch when target host differs")
+    void shouldRejectInternalFetch_whenTargetHostDiffers() {
+        assertThat(Doc2PDF.GetInputFromURI(request, "ABC123",
+                "http://169.254.169.254/openo/report.jsp")).isNull();
+    }
+
+    @Test
+    @Tag("security")
+    @DisplayName("should reject Doc2PDF internal fetch when URI uses file scheme")
+    void shouldRejectInternalFetch_whenUriUsesFileScheme() {
+        assertThat(Doc2PDF.GetInputFromURI(request, "ABC123", "file:///etc/passwd")).isNull();
+    }
+
+    @Test
+    @Tag("security")
+    @DisplayName("should reject Doc2PDF internal fetch outside current context path")
+    void shouldRejectInternalFetch_whenOutsideContextPath() {
+        assertThat(Doc2PDF.GetInputFromURI(request, "ABC123",
+                "http://localhost:8080/admin/report.jsp")).isNull();
+    }
+
+    @Test
+    @Tag("security")
+    @DisplayName("should reject legacy Doc2PDF fetch without request context")
+    void shouldRejectLegacyInternalFetch_withoutRequestContext() {
+        assertThat(Doc2PDF.GetInputFromURI("ABC123",
+                "http://localhost:8080/openo/report.jsp")).isNull();
+    }
+
+    @Test
     @Tag("parse")
     @DisplayName("should produce PDF when HTML contains input without type attribute")
     void shouldProducePdf_whenHtmlContainsInputWithoutTypeAttribute() {
@@ -304,4 +340,5 @@ class Doc2PDFIntegrationTest extends CarlosTestBase {
         assertThat(response.getContentType()).isEqualTo("application/pdf");
         assertThat(response.getContentAsByteArray()).isNotEmpty();
     }
+
 }


### PR DESCRIPTION
## Summary
- restrict legacy Doc2PDF internal fetches to request-aware local/loopback application URLs
- restrict DroolsHelper URL loading to local file and jar:file DRL resources
- document allowed server-side URL fetch patterns

## Security alerts
- Addresses SpotBugs/Find Security Bugs URLCONNECTION_SSRF_FD alert #19540
- Addresses SpotBugs/Find Security Bugs URLCONNECTION_SSRF_FD alert #9858

## Testing
- git diff --check
- mvn -Dtest=DroolsHelperUnitTest,Doc2PDFIntegrationTest test

Note: full SpotBugs is left to CI for this draft PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened server-side URL fetches to prevent SSRF by enforcing same-app fetches in `Doc2PDF` and limiting `DroolsHelper` DRL loading to local `file:`/`jar:file:` only. Adds strict validation (including encoded path traversal), safe session ID rewriting, timeouts, docs, and tests.

- **Bug Fixes**
  - `Doc2PDF`: new `openValidatedInternalFetch(request, jsessionid, uri)` enforces same-app targets; scheme must be http/https; host must be loopback or match `request.getLocalName()`/`getLocalAddr()`; effective port must match; reject user-info, fragments, and paths outside `request.getContextPath()`; reject dot-segments, including percent-encoded (`%2e`/`%2e%2e`); add connect/read timeouts; legacy `GetInputFromURI(jsessionid, uri)` now fails closed; append `jsessionid` with path-safe encoding (no double-encoding).
  - `DroolsHelper`: accept only `file:` and `jar:file:` DRL URLs; `jar:` must be backed by `file:`; reject network-backed and UNC paths before opening (e.g., `http`, `https`, `jar:http`, `file:////server`, `jar:file:////...`).
  - Docs/tests: add `docs/server-side-url-fetch-policy.md` and security-tagged tests for accept/reject cases (including encoded path traversal). Addresses SpotBugs/FindSecBugs URLCONNECTION_SSRF_FD alerts #19540 and #9858.

- **Migration**
  - Replace calls to `Doc2PDF.GetInputFromURI(jsessionid, uri)` with `Doc2PDF.openValidatedInternalFetch(request, jsessionid, uri)`.
  - Ensure target URIs use the request’s host and port and stay within `request.getContextPath()`.

<sup>Written for commit 51196046a987bb1337392f7b913b66fad92564f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2963?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

