### PR TITLE
Fix legacy SHA-1 password handling alerts

### DIFF
--- a/docs/Password_System.md
+++ b/docs/Password_System.md
@@ -25,7 +25,7 @@ CARLOS maintains backward compatibility with legacy SHA hashes:
 - **Write policy**: New SHA/SHA-1 password hashes must not be created; all new password writes use
   `PasswordHashHelper`/`EncryptionUtils.hash()` and produce `{bcrypt}` hashes.
 - **Static-analysis handling**: The remaining SHA-1 digest call is intentionally limited to the legacy
-  password verifier and carries FindSecBugs/Semgrep suppressions with justification.
+  password verifier and carries FindSecBugs/Semgrep/Sonar suppressions with justification.
 
 ## Database Schema
 

--- a/docs/Password_System.md
+++ b/docs/Password_System.md
@@ -25,7 +25,7 @@ CARLOS maintains backward compatibility with legacy SHA hashes:
 - **Write policy**: New SHA/SHA-1 password hashes must not be created; all new password writes use
   `PasswordHashHelper`/`EncryptionUtils.hash()` and produce `{bcrypt}` hashes.
 - **Static-analysis handling**: The remaining SHA-1 digest call is intentionally limited to the legacy
-  password verifier and carries a `WEAK_MESSAGE_DIGEST_SHA1` suppression with justification.
+  password verifier and carries FindSecBugs/Semgrep suppressions with justification.
 
 ## Database Schema
 

--- a/docs/Password_System.md
+++ b/docs/Password_System.md
@@ -24,8 +24,8 @@ CARLOS maintains backward compatibility with legacy SHA hashes:
 - **Status**: Deprecated, will be upgraded to BCrypt on next login
 - **Write policy**: New SHA/SHA-1 password hashes must not be created; all new password writes use
   `PasswordHashHelper`/`EncryptionUtils.hash()` and produce `{bcrypt}` hashes.
-- **Static-analysis handling**: The remaining SHA-1 digest calls are intentionally limited to legacy
-  verification paths and carry per-site `WEAK_MESSAGE_DIGEST_SHA1` suppressions with justifications.
+- **Static-analysis handling**: The remaining SHA-1 digest call is intentionally limited to the legacy
+  password verifier and carries a `WEAK_MESSAGE_DIGEST_SHA1` suppression with justification.
 
 ## Database Schema
 

--- a/docs/Password_System.md
+++ b/docs/Password_System.md
@@ -22,6 +22,10 @@ CARLOS maintains backward compatibility with legacy SHA hashes:
 - **Format**: Concatenated byte values (e.g., `-51-282443-97-5-9410489-60-1021-45-127-12435464-32`)
 - **Usage**: Existing passwords only, automatically upgraded when user logs in
 - **Status**: Deprecated, will be upgraded to BCrypt on next login
+- **Write policy**: New SHA/SHA-1 password hashes must not be created; all new password writes use
+  `PasswordHashHelper`/`EncryptionUtils.hash()` and produce `{bcrypt}` hashes.
+- **Static-analysis handling**: The remaining SHA-1 digest calls are intentionally limited to legacy
+  verification paths and carry per-site `WEAK_MESSAGE_DIGEST_SHA1` suppressions with justifications.
 
 ## Database Schema
 

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/Security.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/Security.java
@@ -238,12 +238,17 @@ public class Security extends AbstractModel<Integer> {
             return false;
         }
 
-        if (PasswordHashHelper.matches(inputedPassword, password)) {
-            return (true);
-        } else {
+        try {
+            if (PasswordHashHelper.matches(inputedPassword, password)) {
+                return (true);
+            }
+        } catch (IllegalArgumentException e) {
             throttleOnFailedLogin();
-            return (false);
+            return false;
         }
+
+        throttleOnFailedLogin();
+        return (false);
     }
 
     protected void throttleOnFailedLogin() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/Security.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/Security.java
@@ -41,8 +41,8 @@ import jakarta.persistence.Temporal;
 import jakarta.persistence.TemporalType;
 
 import org.apache.logging.log4j.Logger;
-import io.github.carlos_emr.carlos.utility.EncryptionUtils;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
+import io.github.carlos_emr.carlos.utility.password.PasswordHashHelper;
 
 
 @Entity
@@ -233,14 +233,12 @@ public class Security extends AbstractModel<Integer> {
 	@Deprecated
     public boolean checkPassword(String inputedPassword) {
         if (password == null) return (false);
-
-        byte[] sha1Bytes = EncryptionUtils.getSha1(inputedPassword);
-        StringBuilder sb = new StringBuilder();
-        for (byte b : sha1Bytes) {
-            sb.append(b);
+        if (inputedPassword == null) {
+            throttleOnFailedLogin();
+            return false;
         }
 
-        if (password.equals(sb.toString())) {
+        if (PasswordHashHelper.matches(inputedPassword, password)) {
             return (true);
         } else {
             throttleOnFailedLogin();

--- a/src/main/java/io/github/carlos_emr/carlos/utility/EncryptionUtils.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/EncryptionUtils.java
@@ -28,7 +28,6 @@
  */
 package io.github.carlos_emr.carlos.utility;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.github.carlos_emr.CarlosProperties;
 import org.apache.logging.log4j.Logger;
 import io.github.carlos_emr.carlos.utility.password.PasswordHashHelper;
@@ -38,79 +37,19 @@ import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.security.*;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import java.util.Base64;
 import java.util.Objects;
 
 
 public final class EncryptionUtils {
-    private static final QueueCacheValueCloner<byte[]> byteArrayCloner = new QueueCacheValueCloner<byte[]>() {
-        public byte[] cloneBean(byte[] original) {
-            return (byte[]) original.clone();
-        }
-    };
     private static Logger logger = MiscUtils.getLogger();
-    private static final MessageDigest messageDigest = initMessageDigest();
-    private static final QueueCache<String, byte[]> sha1Cache;
-    private static final int MAX_SHA_KEY_CACHE_SIZE = 2048;
     public static final String SECRET_KEY_ENV_VAR = "encryption.util.secret.key";
     private static SecretKeySpec SECRET_KEY_SPEC;
     private static final String ENCRYPTION_PREFIX = "{ENC}";
 
     public EncryptionUtils() {
-    }
-
-    // FindSecBugs WEAK_MESSAGE_DIGEST_SHA1: legacy verification only; BCrypt via PasswordHashHelper
-    // remains the password write path.
-    @SuppressFBWarnings(value = "WEAK_MESSAGE_DIGEST_SHA1",
-            justification = "SHA-1 retained only to verify pre-existing legacy password hashes; "
-                    + "new password hashes use BCrypt via PasswordHashHelper")
-    private static MessageDigest initMessageDigest() {
-        try {
-            return MessageDigest.getInstance("SHA-1");
-        } catch (NoSuchAlgorithmException var1) {
-            logger.error("Error", var1);
-            return null;
-        }
-    }
-
-    /**
-     * @deprecated
-     * Legacy SHA-1 compatibility helper for pre-BCrypt password records only.
-     * Do not use for generating new password hashes; use {@link #hash(CharSequence)}.
-     */
-    @Deprecated
-    public static byte[] getSha1(String s) {
-        byte[] b = (byte[]) sha1Cache.get(s);
-        if (b == null) {
-            b = getSha1NoCache(s);
-            if (s.length() < 2048) {
-                sha1Cache.put(s, b);
-            }
-        }
-
-        return b;
-    }
-
-    /**
-     * @deprecated
-     * Legacy SHA-1 compatibility helper for pre-BCrypt password records only.
-     * Do not use for generating new password hashes; use {@link #hash(CharSequence)}.
-     */
-    @Deprecated
-    private static byte[] getSha1NoCache(String s) {
-        if (s == null) {
-            return null;
-        } else {
-            try {
-                synchronized (Objects.requireNonNull(messageDigest)) {
-                    return messageDigest.digest(s.getBytes("UTF-8"));
-                }
-            } catch (Exception var4) {
-                logger.error("Unexpected error.", var4);
-                return null;
-            }
-        }
     }
 
     /**
@@ -322,7 +261,6 @@ public final class EncryptionUtils {
     }
 
     static {
-        sha1Cache = new QueueCache(4, 2048, byteArrayCloner);
         prepareSecretKeySpec();
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/utility/EncryptionUtils.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/EncryptionUtils.java
@@ -60,8 +60,8 @@ public final class EncryptionUtils {
     public EncryptionUtils() {
     }
 
-    // FindSecBugs WEAK_MESSAGE_DIGEST_SHA1: retained only to verify pre-existing legacy password hashes;
-    // new password hashes are generated through PasswordHashHelper using BCrypt.
+    // FindSecBugs WEAK_MESSAGE_DIGEST_SHA1: legacy verification only; BCrypt via PasswordHashHelper
+    // remains the password write path.
     @SuppressFBWarnings(value = "WEAK_MESSAGE_DIGEST_SHA1",
             justification = "SHA-1 retained only to verify pre-existing legacy password hashes; "
                     + "new password hashes use BCrypt via PasswordHashHelper")

--- a/src/main/java/io/github/carlos_emr/carlos/utility/EncryptionUtils.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/EncryptionUtils.java
@@ -28,6 +28,7 @@
  */
 package io.github.carlos_emr.carlos.utility;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.github.carlos_emr.CarlosProperties;
 import org.apache.logging.log4j.Logger;
 import io.github.carlos_emr.carlos.utility.password.PasswordHashHelper;
@@ -59,6 +60,11 @@ public final class EncryptionUtils {
     public EncryptionUtils() {
     }
 
+    // FindSecBugs WEAK_MESSAGE_DIGEST_SHA1: retained only to verify pre-existing legacy password hashes;
+    // new password hashes are generated through PasswordHashHelper using BCrypt.
+    @SuppressFBWarnings(value = "WEAK_MESSAGE_DIGEST_SHA1",
+            justification = "SHA-1 retained only to verify pre-existing legacy password hashes; "
+                    + "new password hashes use BCrypt via PasswordHashHelper")
     private static MessageDigest initMessageDigest() {
         try {
             return MessageDigest.getInstance("SHA-1");
@@ -70,8 +76,8 @@ public final class EncryptionUtils {
 
     /**
      * @deprecated
-     * weak: do not use for generating password hashes.
-     * use the hash(String password) method below.
+     * Legacy SHA-1 compatibility helper for pre-BCrypt password records only.
+     * Do not use for generating new password hashes; use {@link #hash(CharSequence)}.
      */
     @Deprecated
     public static byte[] getSha1(String s) {
@@ -88,8 +94,8 @@ public final class EncryptionUtils {
 
     /**
      * @deprecated
-     * weak: do not use for generating password hashes.
-     * use the hash(String password) method below.
+     * Legacy SHA-1 compatibility helper for pre-BCrypt password records only.
+     * Do not use for generating new password hashes; use {@link #hash(CharSequence)}.
      */
     @Deprecated
     private static byte[] getSha1NoCache(String s) {
@@ -320,4 +326,3 @@ public final class EncryptionUtils {
         prepareSecretKeySpec();
     }
 }
-

--- a/src/main/java/io/github/carlos_emr/carlos/utility/password/Deprecated_SHA_PasswordEncoder.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/password/Deprecated_SHA_PasswordEncoder.java
@@ -39,8 +39,12 @@ import java.security.MessageDigest;
  * Verifies legacy unprefixed SHA-1 password hashes while accounts migrate to BCrypt.
  * This encoder must not create new SHA-1 hashes; new password creation is handled by
  * {@link PasswordHashHelper} through Spring Security's BCrypt encoder.
+ *
+ * @deprecated Legacy verification adapter retained for pre-BCrypt password rows only.
+ * Do not use for new password hashes; use {@link PasswordHashHelper}.
  */
-@Deprecated
+@Deprecated(since = "2026-06-20", forRemoval = false)
+@SuppressWarnings("java:S1133") // Sonar: removal depends on completion of legacy password migration.
 public class Deprecated_SHA_PasswordEncoder implements PasswordEncoder {
 
     @Override
@@ -68,8 +72,8 @@ public class Deprecated_SHA_PasswordEncoder implements PasswordEncoder {
         return false;
     }
 
-    // FindSecBugs WEAK_MESSAGE_DIGEST_SHA1: compatibility verifier for legacy unprefixed password
-    // rows only; encode() rejects SHA-1 creation and new hashes use BCrypt.
+    // FindSecBugs WEAK_MESSAGE_DIGEST_SHA1: compatibility verifier for legacy unprefixed password rows;
+    // encode() rejects SHA-1 creation and BCrypt remains the password write path.
     @SuppressFBWarnings(value = "WEAK_MESSAGE_DIGEST_SHA1",
             justification = "SHA-1 retained only to verify legacy unprefixed password rows; "
                     + "encode() rejects SHA-1 creation and new hashes use BCrypt")

--- a/src/main/java/io/github/carlos_emr/carlos/utility/password/Deprecated_SHA_PasswordEncoder.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/password/Deprecated_SHA_PasswordEncoder.java
@@ -72,8 +72,8 @@ public class Deprecated_SHA_PasswordEncoder implements PasswordEncoder {
         return false;
     }
 
-    // FindSecBugs WEAK_MESSAGE_DIGEST_SHA1: compatibility verifier for legacy unprefixed password rows;
-    // legacy SHA-1 creation is rejected and BCrypt remains the password write path.
+    // FindSecBugs WEAK_MESSAGE_DIGEST_SHA1: existing unprefixed password rows need SHA-1 verification.
+    // BCrypt remains the password write path because encode() rejects legacy SHA-1 creation.
     @SuppressFBWarnings(value = "WEAK_MESSAGE_DIGEST_SHA1",
             justification = "SHA-1 retained only to verify legacy unprefixed password rows; "
                     + "encode() rejects SHA-1 creation and new hashes use BCrypt")

--- a/src/main/java/io/github/carlos_emr/carlos/utility/password/Deprecated_SHA_PasswordEncoder.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/password/Deprecated_SHA_PasswordEncoder.java
@@ -47,12 +47,27 @@ import java.security.MessageDigest;
 @SuppressWarnings("java:S1133") // Sonar: removal depends on completion of legacy password migration.
 public class Deprecated_SHA_PasswordEncoder implements PasswordEncoder {
 
+    /**
+     * Rejects creation of new legacy SHA-1 password hashes.
+     *
+     * @param rawPassword ignored; SHA-1 password hash creation is disabled.
+     * @return never returns normally.
+     * @throws UnsupportedOperationException always, because legacy SHA-1 is verification-only.
+     */
     @Override
     public String encode(CharSequence rawPassword) {
         throw new UnsupportedOperationException(
                 "Legacy SHA-1 password hashes are verification-only; use PasswordHashHelper for new hashes");
     }
 
+    /**
+     * Verifies a raw password against an existing legacy unprefixed SHA-1 hash.
+     *
+     * @param rawPassword candidate password; must not be {@code null}.
+     * @param encodedPassword existing legacy SHA-1 hash in signed-byte concatenation format.
+     * @return {@code true} when the password matches the legacy hash, otherwise {@code false}.
+     * @throws NullPointerException when {@code rawPassword} is {@code null}.
+     */
     @Override
     public boolean matches(CharSequence rawPassword, String encodedPassword) {
         return this.validateShaPassword(rawPassword.toString(), encodedPassword);

--- a/src/main/java/io/github/carlos_emr/carlos/utility/password/Deprecated_SHA_PasswordEncoder.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/password/Deprecated_SHA_PasswordEncoder.java
@@ -79,7 +79,7 @@ public class Deprecated_SHA_PasswordEncoder implements PasswordEncoder {
                     + "encode() rejects SHA-1 creation and new hashes use BCrypt")
     private String encodeShaPassword(String password) throws Exception {
 
-        MessageDigest md = MessageDigest.getInstance("SHA-1");
+        MessageDigest md = MessageDigest.getInstance("SHA-1"); // nosemgrep: java.lang.security.audit.crypto.use-of-sha1.use-of-sha1 -- legacy prefixless password rows require SHA-1 verification; new hashes use BCrypt
 
         StringBuilder sbTemp = new StringBuilder();
         byte[] btNewPasswd = md.digest(password.getBytes());

--- a/src/main/java/io/github/carlos_emr/carlos/utility/password/Deprecated_SHA_PasswordEncoder.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/password/Deprecated_SHA_PasswordEncoder.java
@@ -28,6 +28,7 @@
 package io.github.carlos_emr.carlos.utility.password;
 
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
@@ -35,18 +36,17 @@ import java.security.MessageDigest;
 
 
 /**
- * This class uses insecure SHA hashing for backwards compatibility while migrating to a newer hashing method.
- * It will be removed in the future.
+ * Verifies legacy unprefixed SHA-1 password hashes while accounts migrate to BCrypt.
+ * This encoder must not create new SHA-1 hashes; new password creation is handled by
+ * {@link PasswordHashHelper} through Spring Security's BCrypt encoder.
  */
+@Deprecated
 public class Deprecated_SHA_PasswordEncoder implements PasswordEncoder {
 
     @Override
     public String encode(CharSequence rawPassword) {
-        try {
-            return this.encodeShaPassword(rawPassword.toString());
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        throw new UnsupportedOperationException(
+                "Legacy SHA-1 password hashes are verification-only; use PasswordHashHelper for new hashes");
     }
 
     @Override
@@ -68,6 +68,11 @@ public class Deprecated_SHA_PasswordEncoder implements PasswordEncoder {
         return false;
     }
 
+    // FindSecBugs WEAK_MESSAGE_DIGEST_SHA1: compatibility verifier for legacy unprefixed password
+    // rows only; encode() rejects SHA-1 creation and new hashes use BCrypt.
+    @SuppressFBWarnings(value = "WEAK_MESSAGE_DIGEST_SHA1",
+            justification = "SHA-1 retained only to verify legacy unprefixed password rows; "
+                    + "encode() rejects SHA-1 creation and new hashes use BCrypt")
     private String encodeShaPassword(String password) throws Exception {
 
         MessageDigest md = MessageDigest.getInstance("SHA");

--- a/src/main/java/io/github/carlos_emr/carlos/utility/password/Deprecated_SHA_PasswordEncoder.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/password/Deprecated_SHA_PasswordEncoder.java
@@ -73,7 +73,7 @@ public class Deprecated_SHA_PasswordEncoder implements PasswordEncoder {
     }
 
     // FindSecBugs WEAK_MESSAGE_DIGEST_SHA1: compatibility verifier for legacy unprefixed password rows;
-    // encode() rejects SHA-1 creation and BCrypt remains the password write path.
+    // legacy SHA-1 creation is rejected and BCrypt remains the password write path.
     @SuppressFBWarnings(value = "WEAK_MESSAGE_DIGEST_SHA1",
             justification = "SHA-1 retained only to verify legacy unprefixed password rows; "
                     + "encode() rejects SHA-1 creation and new hashes use BCrypt")

--- a/src/main/java/io/github/carlos_emr/carlos/utility/password/Deprecated_SHA_PasswordEncoder.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/password/Deprecated_SHA_PasswordEncoder.java
@@ -77,6 +77,7 @@ public class Deprecated_SHA_PasswordEncoder implements PasswordEncoder {
     @SuppressFBWarnings(value = "WEAK_MESSAGE_DIGEST_SHA1",
             justification = "SHA-1 retained only to verify legacy unprefixed password rows; "
                     + "encode() rejects SHA-1 creation and new hashes use BCrypt")
+    @SuppressWarnings("java:S4790") // Sonar: legacy SHA-1 verifier only; new hashes use BCrypt.
     private String encodeShaPassword(String password) throws Exception {
 
         MessageDigest md = MessageDigest.getInstance("SHA-1"); // nosemgrep: java.lang.security.audit.crypto.use-of-sha1.use-of-sha1 -- legacy prefixless password rows require SHA-1 verification; new hashes use BCrypt

--- a/src/main/java/io/github/carlos_emr/carlos/utility/password/Deprecated_SHA_PasswordEncoder.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/password/Deprecated_SHA_PasswordEncoder.java
@@ -79,7 +79,7 @@ public class Deprecated_SHA_PasswordEncoder implements PasswordEncoder {
                     + "encode() rejects SHA-1 creation and new hashes use BCrypt")
     private String encodeShaPassword(String password) throws Exception {
 
-        MessageDigest md = MessageDigest.getInstance("SHA");
+        MessageDigest md = MessageDigest.getInstance("SHA-1");
 
         StringBuilder sbTemp = new StringBuilder();
         byte[] btNewPasswd = md.digest(password.getBytes());

--- a/src/main/webapp/WEB-INF/jsp/provider/providerupdatepassword.jsp
+++ b/src/main/webapp/WEB-INF/jsp/provider/providerupdatepassword.jsp
@@ -33,11 +33,10 @@
     if (session.getAttribute("user") == null)
         response.sendRedirect(request.getContextPath() + "/logoutPage");
     String curUser_no = (String) session.getAttribute("user");
-  MessageDigest md = MessageDigest.getInstance("SHA");
 %>
 
 <%@ page
-        import="java.lang.*, java.util.*, java.text.*,java.security.*, io.github.carlos_emr.*"
+        import="java.lang.*, java.util.*, java.text.*, io.github.carlos_emr.*"
         errorPage="/WEB-INF/jsp/error/errorpage.jsp" %>
 <%@ page import="io.github.carlos_emr.carlos.utility.SpringUtils" %>
 <%@ page import="io.github.carlos_emr.carlos.commn.model.Security" %>

--- a/src/test/java/io/github/carlos_emr/carlos/commn/model/SecurityUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/commn/model/SecurityUnitTest.java
@@ -1,5 +1,6 @@
 /**
- * Copyright (c) 2001-2002. Department of Family Medicine, McMaster University. All Rights Reserved.
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
  * This software is published under the GPL GNU General Public License.
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -14,16 +15,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
- * <p>
- * This software was written for the
- * Department of Family Medicine
- * McMaster University
- * Hamilton
- * Ontario, Canada
- * <p>
- * Now maintained by the CARLOS EMR Project (2026+).
+ *
+ * CARLOS EMR Project
  * https://github.com/carlos-emr/carlos
- * CARLOS has no affiliation with OSCAR or McMaster University.
  */
 
 package io.github.carlos_emr.carlos.commn.model;
@@ -69,6 +63,15 @@ class SecurityUnitTest extends CarlosUnitTestBase {
         TestSecurity security = securityWithPassword(LEGACY_SHA1_HASH);
 
         assertThat(security.checkPassword("wrong-password")).isFalse();
+        assertThat(security.throttleCount).isOne();
+    }
+
+    @Test
+    @DisplayName("should throttle and reject password when stored hash has an unknown prefix")
+    void shouldThrottleAndRejectPassword_whenStoredHashHasUnknownPrefix() {
+        TestSecurity security = securityWithPassword("{unknown}not-a-valid-hash");
+
+        assertThat(security.checkPassword(LEGACY_PASSWORD)).isFalse();
         assertThat(security.throttleCount).isOne();
     }
 

--- a/src/test/java/io/github/carlos_emr/carlos/commn/model/SecurityUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/commn/model/SecurityUnitTest.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2001-2002. Department of Family Medicine, McMaster University. All Rights Reserved.
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ * <p>
+ * This software was written for the
+ * Department of Family Medicine
+ * McMaster University
+ * Hamilton
+ * Ontario, Canada
+ * <p>
+ * Now maintained by the CARLOS EMR Project (2026+).
+ * https://github.com/carlos-emr/carlos
+ * CARLOS has no affiliation with OSCAR or McMaster University.
+ */
+
+package io.github.carlos_emr.carlos.commn.model;
+
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
+import io.github.carlos_emr.carlos.utility.password.PasswordHashHelper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Tag("unit")
+@Tag("model")
+@DisplayName("Security password compatibility")
+@SuppressWarnings("deprecation")
+class SecurityUnitTest extends CarlosUnitTestBase {
+    private static final String LEGACY_PASSWORD = "legacy-password";
+    private static final String LEGACY_SHA1_HASH =
+            "-4331-12498-123-53-58-47-3511810312215-43-120-56-3368-276";
+
+    @Test
+    @DisplayName("should match legacy SHA-1 password when stored password is a legacy hash")
+    void shouldMatchLegacyShaPassword_whenStoredPasswordIsLegacyHash() {
+        TestSecurity security = securityWithPassword(LEGACY_SHA1_HASH);
+
+        assertThat(security.checkPassword(LEGACY_PASSWORD)).isTrue();
+        assertThat(security.throttleCount).isZero();
+    }
+
+    @Test
+    @DisplayName("should match BCrypt password when stored password uses current hash")
+    void shouldMatchBcryptPassword_whenStoredPasswordUsesCurrentHash() {
+        TestSecurity security = securityWithPassword(PasswordHashHelper.encodePassword(LEGACY_PASSWORD));
+
+        assertThat(security.checkPassword(LEGACY_PASSWORD)).isTrue();
+        assertThat(security.throttleCount).isZero();
+    }
+
+    @Test
+    @DisplayName("should throttle and reject password when stored password does not match")
+    void shouldThrottleAndRejectPassword_whenStoredPasswordDoesNotMatch() {
+        TestSecurity security = securityWithPassword(LEGACY_SHA1_HASH);
+
+        assertThat(security.checkPassword("wrong-password")).isFalse();
+        assertThat(security.throttleCount).isOne();
+    }
+
+    @Test
+    @DisplayName("should throttle and reject password when input password is missing")
+    void shouldThrottleAndRejectPassword_whenInputPasswordIsMissing() {
+        TestSecurity security = securityWithPassword(LEGACY_SHA1_HASH);
+
+        assertThat(security.checkPassword(null)).isFalse();
+        assertThat(security.throttleCount).isOne();
+    }
+
+    @Test
+    @DisplayName("should reject password when stored password is missing")
+    void shouldRejectPassword_whenStoredPasswordIsMissing() {
+        TestSecurity security = securityWithPassword(null);
+
+        assertThat(security.checkPassword(LEGACY_PASSWORD)).isFalse();
+        assertThat(security.throttleCount).isZero();
+    }
+
+    private static TestSecurity securityWithPassword(String password) {
+        TestSecurity security = new TestSecurity();
+        security.setPassword(password);
+        return security;
+    }
+
+    private static class TestSecurity extends Security {
+        private int throttleCount;
+
+        @Override
+        protected void throttleOnFailedLogin() {
+            throttleCount++;
+        }
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/utility/password/DeprecatedShaPasswordEncoderUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/utility/password/DeprecatedShaPasswordEncoderUnitTest.java
@@ -38,6 +38,7 @@ class DeprecatedShaPasswordEncoderUnitTest {
             "-4331-12498-123-53-58-47-3511810312215-43-120-56-3368-276";
 
     @Test
+    @DisplayName("should verify legacy SHA-1 password when existing hash is provided")
     void shouldVerifyLegacyShaPassword_whenExistingHashProvided() {
         Deprecated_SHA_PasswordEncoder encoder = new Deprecated_SHA_PasswordEncoder();
 
@@ -46,6 +47,7 @@ class DeprecatedShaPasswordEncoderUnitTest {
     }
 
     @Test
+    @DisplayName("should throw exception when encoding a legacy SHA-1 password")
     void shouldThrowException_whenEncodingLegacyShaPassword() {
         Deprecated_SHA_PasswordEncoder encoder = new Deprecated_SHA_PasswordEncoder();
 
@@ -55,6 +57,7 @@ class DeprecatedShaPasswordEncoderUnitTest {
     }
 
     @Test
+    @DisplayName("should use BCrypt for new password hashes")
     void shouldUseBcrypt_forNewPasswordHashes() {
         String hash = PasswordHashHelper.encodePassword(LEGACY_PASSWORD);
 

--- a/src/test/java/io/github/carlos_emr/carlos/utility/password/DeprecatedShaPasswordEncoderUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/utility/password/DeprecatedShaPasswordEncoderUnitTest.java
@@ -30,6 +30,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayName("Deprecated SHA password encoder")
 @Tag("unit")
+@Tag("utility")
 class DeprecatedShaPasswordEncoderUnitTest {
 
     private static final String LEGACY_PASSWORD = "legacy-password";
@@ -37,7 +38,7 @@ class DeprecatedShaPasswordEncoderUnitTest {
             "-4331-12498-123-53-58-47-3511810312215-43-120-56-3368-276";
 
     @Test
-    void shouldVerifyExistingLegacyShaPasswordHash() {
+    void shouldVerifyLegacyShaPassword_whenExistingHashProvided() {
         Deprecated_SHA_PasswordEncoder encoder = new Deprecated_SHA_PasswordEncoder();
 
         assertThat(encoder.matches(LEGACY_PASSWORD, LEGACY_SHA1_HASH)).isTrue();
@@ -45,7 +46,7 @@ class DeprecatedShaPasswordEncoderUnitTest {
     }
 
     @Test
-    void shouldRejectNewLegacyShaPasswordEncoding() {
+    void shouldThrowException_whenEncodingLegacyShaPassword() {
         Deprecated_SHA_PasswordEncoder encoder = new Deprecated_SHA_PasswordEncoder();
 
         assertThatThrownBy(() -> encoder.encode(LEGACY_PASSWORD))
@@ -54,7 +55,7 @@ class DeprecatedShaPasswordEncoderUnitTest {
     }
 
     @Test
-    void shouldUseBcryptForNewPasswordHashes() {
+    void shouldUseBcrypt_forNewPasswordHashes() {
         String hash = PasswordHashHelper.encodePassword(LEGACY_PASSWORD);
 
         assertThat(hash).startsWith("{bcrypt}");

--- a/src/test/java/io/github/carlos_emr/carlos/utility/password/DeprecatedShaPasswordEncoderUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/utility/password/DeprecatedShaPasswordEncoderUnitTest.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.utility.password;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("Deprecated SHA password encoder")
+@Tag("unit")
+class DeprecatedShaPasswordEncoderUnitTest {
+
+    private static final String LEGACY_PASSWORD = "legacy-password";
+    private static final String LEGACY_SHA1_HASH =
+            "-4331-12498-123-53-58-47-3511810312215-43-120-56-3368-276";
+
+    @Test
+    void shouldVerifyExistingLegacyShaPasswordHash() {
+        Deprecated_SHA_PasswordEncoder encoder = new Deprecated_SHA_PasswordEncoder();
+
+        assertThat(encoder.matches(LEGACY_PASSWORD, LEGACY_SHA1_HASH)).isTrue();
+        assertThat(encoder.matches("wrong-password", LEGACY_SHA1_HASH)).isFalse();
+    }
+
+    @Test
+    void shouldRejectNewLegacyShaPasswordEncoding() {
+        Deprecated_SHA_PasswordEncoder encoder = new Deprecated_SHA_PasswordEncoder();
+
+        assertThatThrownBy(() -> encoder.encode(LEGACY_PASSWORD))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("verification-only");
+    }
+
+    @Test
+    void shouldUseBcryptForNewPasswordHashes() {
+        String hash = PasswordHashHelper.encodePassword(LEGACY_PASSWORD);
+
+        assertThat(hash).startsWith("{bcrypt}");
+        assertThat(PasswordHashHelper.matches(LEGACY_PASSWORD, hash)).isTrue();
+        assertThat(PasswordHashHelper.matches(LEGACY_PASSWORD, LEGACY_SHA1_HASH)).isTrue();
+        assertThat(PasswordHashHelper.upgradeEncoding(LEGACY_SHA1_HASH)).isTrue();
+    }
+}


### PR DESCRIPTION
## Summary
- Documents legacy SHA/SHA-1 password compatibility as verification-only and keeps new password writes on BCrypt.
- Adds justified per-site FindSecBugs suppressions for the two reviewed legacy SHA-1 digest paths: code-scanning alerts #19564 and #19595.
- Makes the deprecated SHA password encoder reject new SHA-1 hash creation, removes an unused JSP SHA digest initialization, and adds unit coverage for legacy verification plus BCrypt creation.

## Alerts
- https://github.com/carlos-emr/carlos/security/code-scanning/19564
- https://github.com/carlos-emr/carlos/security/code-scanning/19595

## Verification
- mvn -q -Dtest=io.github.carlos_emr.carlos.utility.password.DeprecatedShaPasswordEncoderUnitTest test
- mvn -q -DskipTests compile
- Parsed target/spotbugs-result.xml after a SpotBugs profile run: WEAK_MESSAGE_DIGEST_SHA1 bug instances = 0

Note: The SpotBugs Maven invocation completed analysis and generated target/spotbugs-result.xml, but Maven was interrupted after it hung in report rendering. The generated XML was parsed directly for the relevant rule.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Locks legacy SHA‑1 password handling to verification-only and keeps all new password writes on BCrypt. Routes verification through `PasswordHashHelper` and removes legacy SHA‑1 utilities to resolve code scanning alerts #19564 and #19595.

- **Bug Fixes**
  - `Deprecated_SHA_PasswordEncoder.encode(...)` now throws `UnsupportedOperationException`; SHA‑1 is used only in `matches(...)` with FindSecBugs/Semgrep/Sonar suppressions and an explicit "SHA-1" algorithm.
  - `Security.checkPassword(...)` now uses `PasswordHashHelper.matches(...)`; throttles on null input, unknown or malformed hash prefixes, and mismatches, and catches `IllegalArgumentException` for malformed hashes; legacy digest logic removed.
  - Removed public SHA‑1 helpers, cache, and digest init from `EncryptionUtils` and the JSP; updated docs on the write policy, encoder method behavior, and suppression rationale; added unit tests for legacy SHA‑1 verification, BCrypt hashing, and throttling.

<sup>Written for commit 8b3d3e50f70c42c199b2b9c97aba946bf3da3218. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2964?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Enforce BCrypt as the sole algorithm for new password hashes while retaining SHA-1 only for legacy verification, resolving static analysis alerts around weak digests and tightening password checks.

Bug Fixes:
- Prevent creation of new legacy SHA-1 password hashes by making the deprecated SHA encoder verification-only and routing new hashes through BCrypt.
- Harden password verification to handle null inputs, unknown or malformed stored hashes, and to consistently apply login throttling on failures.

Enhancements:
- Remove unused SHA-1 utility and digest initialization code from the encryption utilities and JSP layer to eliminate dead legacy crypto paths.

Documentation:
- Document the legacy SHA-1 verification-only policy, BCrypt as the write path, and the rationale for the remaining SHA-1 static-analysis suppression.

Tests:
- Add unit tests covering legacy SHA-1 verification, BCrypt hashing, and password throttling behavior across success and failure scenarios.