### PR TITLE
Fix issue 2182 eform image directory

### DIFF
--- a/ISSUE-2182-DOCUMENTATION.md
+++ b/ISSUE-2182-DOCUMENTATION.md
@@ -1,0 +1,177 @@
+# Contribution [#]: [Issue Title]
+
+**Contribution Number:** 2182  
+**Student:** Hana Ahmed 
+**Issue:** https://github.com/carlos-emr/carlos/issues/2182#event-25727024596
+**Status:** Phase I 
+
+---
+
+## Why I Chose This Issue
+
+I chose this issue because it's healthcare-related and seemed like a straightforward first bug to tackle. Honestly, I just wanted to contribute to something that actually matters, and fixing broken images in medical forms felt important
+---
+
+## Understanding the Issue
+
+### Problem Description
+
+When you start up the CARLOS application, the system tries to put eForm image files into a specific folder (/var/lib/OscarDocument/oscar/eform/images/), but that folder doesn't exist by default. Instead of creating the folder automatically, the system just logs a warning and skips deploying the images. This means any eForm that needs those images (like logos or icons) will show broken image placeholders, and most people probably won't even notice the warning buried in all the startup log messages.
+
+
+### Expected Behavior
+
+The system should automatically create the missing /var/lib/OscarDocument/oscar/eform/images/ directory at startup if it doesn't already exist. Then it should deploy the eForm images there without any errors or warnings. If something still goes wrong, the error message should clearly tell someone what to do, not just get lost in a pile of logs.
+
+
+### Current Behavior
+
+The system checks for the directory, doesn't find it, logs a warning that says something like "eForm image directory missing - skipping deployment," and then just moves on with the startup process. The directory never gets created, so the images never get copied over. Users only see broken image icons in their eForms, and unless someone is actively watching the startup logs (which almost no one does), there's no clear indication that anything went wrong
+
+### Affected Components
+
+The bootstrap scripts in .devcontainer/ and likely a Java class in src/ that currently logs the warning when the eForm image directory is missing.
+
+---
+
+## Reproduction Process
+
+### Environment Setup
+
+I cloned the repo using git clone https://github.com/Hanaahmed12/carlos.git and tried to run the devcontainer setup. No major issues yet since I'm still locating the exact file.
+
+### Steps to Reproduce
+
+Start the CARLOS application (foreground Tomcat smoke test)
+
+Watch the startup logs
+
+Notice the warning: "eForm image directory missing - skipping deployment"
+
+Check /var/lib/OscarDocument/oscar/eform/images/ - it doesn't exist
+
+Open an eForm that uses images - they show as broken
+
+### Reproduction Evidence
+
+Commit showing reproduction: Not yet - still searching for the warning location
+
+Screenshots/logs: Not yet
+
+My findings: Haven't pinpointed the exact file yet. Need to search for "OscarDocument" or "eform/images" in the codebase.
+
+---
+
+## Solution Approach
+
+### Analysis
+
+The root cause is that the system expects a directory to exist (/var/lib/OscarDocument/oscar/eform/images/) but never creates it. Instead of creating it automatically, the code just logs a warning and skips deploying the images. This is a defensive programming gap.
+
+### Proposed Solution
+
+Add mkdir -p /var/lib/OscarDocument/oscar/eform/images/ in the bootstrap script before the eForm deployment runs. Also improve the warning message to say "Directory created automatically" instead of just "missing."
+
+### Implementation Plan
+
+Using UMPIRE framework (adapted):
+
+Understand: When CARLOS starts, it tries to deploy eForm images but fails because the target directory doesn't exist.
+
+Match: Other projects handle this by checking for directory existence and creating it if missing (idempotent initialization).
+
+Plan:
+
+Locate the bootstrap script in .devcontainer/ that runs before Tomcat starts
+
+Add mkdir -p /var/lib/OscarDocument/oscar/eform/images/
+
+Also find the Java file that logs the warning and update the message
+
+Test by running the devcontainer and verifying directory exists and images deploy
+
+Implement: Will link branch once created
+
+Review: Check if change follows CARLOS contribution guidelines (need to read CONTRIBUTING.md)
+
+Evaluate: Run the smoke test again - warning should be gone or changed, directory should exist, eForm images should render
+
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+- [ ] Test case 1: [Description]
+- [ ] Test case 2: [Description]
+- [ ] Test case 3: [Description]
+
+### Integration Tests
+
+Run full Tomcat startup, verify no "directory missing" warning
+
+Verify directory exists after startup
+
+Verify eForm images actually appear in a real eForm
+
+### Manual Testing
+
+Run the devcontainer, check the directory path, open an eForm that previously had broken images
+
+---
+
+## Implementation Notes
+
+### Week [1] Progress
+
+Just getting started - cloned the fork, reading through issues, trying to locate the exact files. Need to search the codebase for the warning message.
+
+### Week [Y] Progress
+
+[Continue documenting as you work]
+
+### Code Changes
+
+- **Files modified:** [List]
+- **Key commits:** None yet
+- **Approach decisions:** Will check if maintainers reply to my comment before opening PR
+
+---
+
+## Pull Request
+
+PR Link: Not yet submitted
+
+PR Description: Will adapt this template once PR is ready
+
+Maintainer Feedback:
+
+Pending - no reply to my comment on issue #2182 yet
+
+Status: Researching / Locating files
+
+---
+
+## Learnings & Reflections
+
+### Technical Skills Gained
+
+Not yet - still in planning phase
+
+
+### Challenges Overcome
+
+Finding the exact file location has been harder than expected need to get better at searching large codebases
+
+### What I'd Do Differently Next Time
+
+Maybe ask for file location earlier instead of guessing
+
+---
+
+## Resources Used
+
+Issue 2182 on carlos-emr/carlos
+
+CARLOS README and CONTRIBUTING.md (need to read more thoroughly)

--- a/ISSUE-2182-DOCUMENTATION.md
+++ b/ISSUE-2182-DOCUMENTATION.md
@@ -3,7 +3,7 @@
 **Contribution Number:** 2182  
 **Student:** Hana Ahmed 
 **Issue:** https://github.com/carlos-emr/carlos/issues/2182#event-25727024596
-**Status:** Phase III
+**Status:** Phase IV Complete
 
 ---
 
@@ -111,9 +111,9 @@ Evaluate: Run the smoke test again - warning should be gone or changed, director
 
 ### Unit Tests
 
-- [ ] Test case 1: [Description]
-- [ ] Test case 2: [Description]
-- [ ] Test case 3: [Description]
+- [ ] Test: verify directory is created when it does not exist
+- [ ] Test: verify deployment proceeds after directory is created
+- [ ] Test: verify error is logged when mkdirs() fails
 
 ### Integration Tests
 
@@ -139,6 +139,10 @@ Just getting started - cloned the fork, reading through issues, trying to locate
 
 Located EFormAssetDeployer.java as the source of the bug. Replaced the early return in the if (!targetDir.isDirectory()) block with a mkdirs() call that auto-creates the directory. Committed with DCO sign-off and pushed to working branch.
 
+### Week [4] Progress
+
+I have sent a pr request with the changes I implemented for the issue to be solved and waiting for the maintainer to reply and give me feedback
+
 ### Code Changes
 
 - **Files modified:** src/main/java/io/github/carlos_emr/carlos/eform/EFormAssetDeployer.java
@@ -152,13 +156,15 @@ Located EFormAssetDeployer.java as the source of the bug. Replaced the early ret
 PR Link:https://github.com/carlos-emr/carlos/pull/2971
 Status: Submitted — awaiting maintainer review
 
-PR Description: Will adapt this template once PR is ready
+PR Description:I fixed a startup bug where EFormAssetDeployer.java would log a warning 
+and skip deploying eForm assets if the images directory didn't exist. 
+The fix auto-creates the directory using mkdirs() before proceeding.
 
-Maintainer Feedback:
+Maintainer Feedback: Gemini bot suggested a race condition improvement: changing 
+!targetDir.mkdirs() to !targetDir.mkdirs() && !targetDir.isDirectory()
+Still Awaiting review from th maintainer.
 
-Pending - no reply to my comment on issue #2182 yet
-
-Status: Researching / Locating files
+Status:Awaiting Review
 
 ---
 
@@ -182,5 +188,5 @@ Maybe ask for file location earlier instead of guessing
 ## Resources Used
 
 Issue 2182 on carlos-emr/carlos
-
-CARLOS README and CONTRIBUTING.md (need to read more thoroughly)
+CARLOS README and CONTRIBUTING.md 
+Claude Ai 

--- a/ISSUE-2182-DOCUMENTATION.md
+++ b/ISSUE-2182-DOCUMENTATION.md
@@ -1,9 +1,9 @@
-# Contribution [#]: [Issue Title]
+# Contribution 2182: Smoke test: eForm image directory is missing during startup
 
 **Contribution Number:** 2182  
 **Student:** Hana Ahmed 
 **Issue:** https://github.com/carlos-emr/carlos/issues/2182#event-25727024596
-**Status:** Phase II
+**Status:** Phase III
 
 ---
 
@@ -135,21 +135,22 @@ Run the devcontainer, check the directory path, open an eForm that previously ha
 
 Just getting started - cloned the fork, reading through issues, trying to locate the exact files. Need to search the codebase for the warning message.
 
-### Week [Y] Progress
+### Week [3] Progress
 
-[Continue documenting as you work]
+Located EFormAssetDeployer.java as the source of the bug. Replaced the early return in the if (!targetDir.isDirectory()) block with a mkdirs() call that auto-creates the directory. Committed with DCO sign-off and pushed to working branch.
 
 ### Code Changes
 
 - **Files modified:** src/main/java/io/github/carlos_emr/carlos/eform/EFormAssetDeployer.java
-- **Key commits:** None yet
+- **Key commits:** Replaced early return with mkdirs() to auto-create eForm image directory on startup
 - **Approach decisions:** Will check if maintainers reply to my comment before opening PR
 
 ---
 
 ## Pull Request
 
-PR Link: Not yet submitted
+PR Link:https://github.com/carlos-emr/carlos/pull/2971
+Status: Submitted — awaiting maintainer review
 
 PR Description: Will adapt this template once PR is ready
 
@@ -165,7 +166,7 @@ Status: Researching / Locating files
 
 ### Technical Skills Gained
 
-Not yet - still in planning phase
+Learned how to navigate a large Java codebase using VS Code search. Understood Spring's InitializingBean startup pattern. Learned that git commits to open source projects require DCO sign-off.
 
 
 ### Challenges Overcome

--- a/ISSUE-2182-DOCUMENTATION.md
+++ b/ISSUE-2182-DOCUMENTATION.md
@@ -1,36 +1,38 @@
-# Contribution [#]: [Issue Title]
+# Contribution 2182: Smoke test: eForm image directory is missing during startup
 
 **Contribution Number:** 2182  
-**Student:** Hana Ahmed 
-**Issue:** https://github.com/carlos-emr/carlos/issues/2182#event-25727024596
-**Status:** Phase I 
+**Student:** Hana Ahmed  
+**Issue:** https://github.com/carlos-emr/carlos/issues/2182  
+**Status:** Phase II Complete
 
 ---
 
 ## Why I Chose This Issue
 
-I chose this issue because it's healthcare-related and seemed like a straightforward first bug to tackle. Honestly, I just wanted to contribute to something that actually matters, and fixing broken images in medical forms felt important
+I chose this issue because it's healthcare-related and seemed like a straightforward first bug to tackle. Fixing broken images in medical forms felt important — eForms are used by clinicians daily, and silent failures like this can erode trust in the system.
+
 ---
 
 ## Understanding the Issue
 
 ### Problem Description
 
-When you start up the CARLOS application, the system tries to put eForm image files into a specific folder (/var/lib/OscarDocument/oscar/eform/images/), but that folder doesn't exist by default. Instead of creating the folder automatically, the system just logs a warning and skips deploying the images. This means any eForm that needs those images (like logos or icons) will show broken image placeholders, and most people probably won't even notice the warning buried in all the startup log messages.
-
+When the CARLOS application starts up, it tries to deploy eForm image assets into `/var/lib/OscarDocument/oscar/eform/images/`. That directory doesn't exist by default. Instead of creating it automatically, the Java class `EFormAssetDeployer.java` logs a warning and skips the deployment entirely. Users see broken image placeholders in eForms, and the warning is easy to miss in startup logs.
 
 ### Expected Behavior
 
-The system should automatically create the missing /var/lib/OscarDocument/oscar/eform/images/ directory at startup if it doesn't already exist. Then it should deploy the eForm images there without any errors or warnings. If something still goes wrong, the error message should clearly tell someone what to do, not just get lost in a pile of logs.
-
+The system should automatically create `/var/lib/OscarDocument/oscar/eform/images/` at startup if it doesn't already exist, then deploy the eForm assets there successfully.
 
 ### Current Behavior
 
-The system checks for the directory, doesn't find it, logs a warning that says something like "eForm image directory missing - skipping deployment," and then just moves on with the startup process. The directory never gets created, so the images never get copied over. Users only see broken image icons in their eForms, and unless someone is actively watching the startup logs (which almost no one does), there's no clear indication that anything went wrong
+`EFormAssetDeployer.java` checks if the directory exists, finds it missing, logs:
+`"eForm image directory does not exist: {}; skipping asset deployment"`
+and returns without creating the directory or deploying any assets.
 
 ### Affected Components
 
-The bootstrap scripts in .devcontainer/ and likely a Java class in src/ that currently logs the warning when the eForm image directory is missing.
+- `src/main/java/io/github/carlos_emr/carlos/eform/EFormAssetDeployer.java` — the Java class that logs the warning and skips deployment
+- `.devcontainer/development/Dockerfile` — creates directories under a different path than what the app expects
 
 ---
 
@@ -38,27 +40,31 @@ The bootstrap scripts in .devcontainer/ and likely a Java class in src/ that cur
 
 ### Environment Setup
 
-I cloned the repo using git clone https://github.com/Hanaahmed12/carlos.git and tried to run the devcontainer setup. No major issues yet since I'm still locating the exact file.
+Forked and cloned the repo locally. Opened in VS Code. No devcontainer spin-up issues. Used VS Code's global search (magnifying glass icon) to locate the relevant files by searching `eform/images` and `skipping asset deployment`.
 
 ### Steps to Reproduce
 
-Start the CARLOS application (foreground Tomcat smoke test)
-
-Watch the startup logs
-
-Notice the warning: "eForm image directory missing - skipping deployment"
-
-Check /var/lib/OscarDocument/oscar/eform/images/ - it doesn't exist
-
-Open an eForm that uses images - they show as broken
+1. Start the CARLOS application (foreground Tomcat smoke test)
+2. Watch the startup logs
+3. Observe the warning: `eForm image directory does not exist: /var/lib/OscarDocument/oscar/eform/images/; skipping asset deployment`
+4. Check that `/var/lib/OscarDocument/oscar/eform/images/` does not exist
+5. Open an eForm that uses images — they show as broken
 
 ### Reproduction Evidence
 
-Commit showing reproduction: Not yet - still searching for the warning location
+**Exact file:** `src/main/java/io/github/carlos_emr/carlos/eform/EFormAssetDeployer.java`
 
-Screenshots/logs: Not yet
+**Exact lines causing the bug:**
+```java
+if (!targetDir.isDirectory()) {
+    logger.warn("eForm image directory does not exist: {}; skipping asset deployment", imageDir);
+    return;
+}
+```
 
-My findings: Haven't pinpointed the exact file yet. Need to search for "OscarDocument" or "eform/images" in the codebase.
+The method simply returns instead of creating the directory.
+
+**Branch link:** https://github.com/Hanaahmed12/carlos/tree/fix-issue-2182-eform-image-directory
 
 ---
 
@@ -66,36 +72,35 @@ My findings: Haven't pinpointed the exact file yet. Need to search for "OscarDoc
 
 ### Analysis
 
-The root cause is that the system expects a directory to exist (/var/lib/OscarDocument/oscar/eform/images/) but never creates it. Instead of creating it automatically, the code just logs a warning and skips deploying the images. This is a defensive programming gap.
+The root cause is in `EFormAssetDeployer.java`. The `afterPropertiesSet()` method checks whether the eForm images directory exists. If it doesn't, it logs a warning and exits — never creating the directory or deploying the assets. This is a defensive programming gap: the fix should attempt to create the directory automatically before giving up.
 
 ### Proposed Solution
 
-Add mkdir -p /var/lib/OscarDocument/oscar/eform/images/ in the bootstrap script before the eForm deployment runs. Also improve the warning message to say "Directory created automatically" instead of just "missing."
+In `EFormAssetDeployer.java`, replace the early `return` with a `targetDir.mkdirs()` call to auto-create the directory, then continue with asset deployment. Log an info message confirming the directory was created rather than a warning that it's missing.
 
-### Implementation Plan
+### Implementation Plan (UMPIRE)
 
-Using UMPIRE framework (adapted):
+**Understand:** At startup, `EFormAssetDeployer.java` checks for `/var/lib/OscarDocument/oscar/eform/images/`. If missing, it logs a warning and skips deploying eForm assets, causing broken images in eForms.
 
-Understand: When CARLOS starts, it tries to deploy eForm images but fails because the target directory doesn't exist.
+**Match:** The `populate_db.sh` script in `.devcontainer/db/scripts/` already uses `mkdir -p /var/lib/OscarDocument/oscar/eform/images/` to create this same directory during database bootstrap. The same auto-create pattern should be applied in the Java deployer itself.
 
-Match: Other projects handle this by checking for directory existence and creating it if missing (idempotent initialization).
+**Plan:**
+1. Open `src/main/java/io/github/carlos_emr/carlos/eform/EFormAssetDeployer.java`
+2. Find the `if (!targetDir.isDirectory())` block in `afterPropertiesSet()`
+3. Replace the warning + return with a `targetDir.mkdirs()` call
+4. Log an info message: `"eForm image directory did not exist; created: {}"`
+5. If `mkdirs()` fails, log an error with remediation steps and return
+6. If successful, continue to deploy assets normally
 
-Plan:
+**Implement:** https://github.com/Hanaahmed12/carlos/tree/fix-issue-2182-eform-image-directory *(code coming in Phase III)*
 
-Locate the bootstrap script in .devcontainer/ that runs before Tomcat starts
+**Review:** Read `CONTRIBUTING.md` for commit message format and PR conventions before submitting
 
-Add mkdir -p /var/lib/OscarDocument/oscar/eform/images/
+**Evaluate:** Run Tomcat smoke test — no "skipping asset deployment" warning should appear, directory should exist at `/var/lib/OscarDocument/oscar/eform/images/`, and eForm images should render correctly
 
-Also find the Java file that logs the warning and update the message
+### Files to Modify
 
-Test by running the devcontainer and verifying directory exists and images deploy
-
-Implement: Will link branch once created
-
-Review: Check if change follows CARLOS contribution guidelines (need to read CONTRIBUTING.md)
-
-Evaluate: Run the smoke test again - warning should be gone or changed, directory should exist, eForm images should render
-
+- `src/main/java/io/github/carlos_emr/carlos/eform/EFormAssetDeployer.java`
 
 ---
 
@@ -103,53 +108,39 @@ Evaluate: Run the smoke test again - warning should be gone or changed, director
 
 ### Unit Tests
 
-- [ ] Test case 1: [Description]
-- [ ] Test case 2: [Description]
-- [ ] Test case 3: [Description]
+- [ ] Test that `afterPropertiesSet()` creates the directory if it doesn't exist
+- [ ] Test that `afterPropertiesSet()` skips creation if directory already exists
+- [ ] Test that a proper error is logged if `mkdirs()` fails
 
 ### Integration Tests
 
-Run full Tomcat startup, verify no "directory missing" warning
-
-Verify directory exists after startup
-
-Verify eForm images actually appear in a real eForm
+- Run full Tomcat startup, verify no "skipping asset deployment" warning
+- Verify directory exists at `/var/lib/OscarDocument/oscar/eform/images/` after startup
+- Verify eForm images render correctly in a real eForm
 
 ### Manual Testing
 
-Run the devcontainer, check the directory path, open an eForm that previously had broken images
+Run the devcontainer, check the directory path exists, open an eForm that previously had broken images and confirm they now display correctly
 
 ---
 
 ## Implementation Notes
 
-### Week [1] Progress
+### Week 1 Progress
 
-Just getting started - cloned the fork, reading through issues, trying to locate the exact files. Need to search the codebase for the warning message.
-
-### Week [Y] Progress
-
-[Continue documenting as you work]
+Cloned the fork, set up VS Code, created working branch `fix-issue-2182-eform-image-directory`. Used VS Code global search to locate the exact file (`EFormAssetDeployer.java`) and the exact lines causing the bug. Documented full reproduction steps and UMPIRE solution plan.
 
 ### Code Changes
 
-- **Files modified:** [List]
-- **Key commits:** None yet
-- **Approach decisions:** Will check if maintainers reply to my comment before opening PR
+- **Files to modify:** `src/main/java/io/github/carlos_emr/carlos/eform/EFormAssetDeployer.java`
+- **Key commits:** Branch pushed — code changes coming in Phase III
+- **Approach decisions:** Will use `targetDir.mkdirs()` in Java rather than only relying on shell scripts, so the fix works in all environments not just devcontainer
 
 ---
 
 ## Pull Request
 
-PR Link: Not yet submitted
-
-PR Description: Will adapt this template once PR is ready
-
-Maintainer Feedback:
-
-Pending - no reply to my comment on issue #2182 yet
-
-Status: Researching / Locating files
+PR Link: Not yet submitted — coming in Phase III
 
 ---
 
@@ -157,21 +148,21 @@ Status: Researching / Locating files
 
 ### Technical Skills Gained
 
-Not yet - still in planning phase
-
+Learned how to navigate a large Java/Spring codebase using VS Code global search. Understood how Spring's `InitializingBean` pattern works for startup initialization. Learned the difference between devcontainer bootstrap paths and runtime application paths.
 
 ### Challenges Overcome
 
-Finding the exact file location has been harder than expected need to get better at searching large codebases
+Tracking down the exact Java file took effort — the warning message text was the key search term that led directly to `EFormAssetDeployer.java`.
 
 ### What I'd Do Differently Next Time
 
-Maybe ask for file location earlier instead of guessing
+Search for the exact warning message text earlier instead of browsing folders manually.
 
 ---
 
 ## Resources Used
 
-Issue 2182 on carlos-emr/carlos
-
-CARLOS README and CONTRIBUTING.md (need to read more thoroughly)
+- Issue #2182: https://github.com/carlos-emr/carlos/issues/2182
+- `EFormAssetDeployer.java`: `src/main/java/io/github/carlos_emr/carlos/eform/`
+- `runtime-directories.md`: `docs/`
+- CARLOS `CONTRIBUTING.md`

--- a/ISSUE-2182-DOCUMENTATION.md
+++ b/ISSUE-2182-DOCUMENTATION.md
@@ -1,106 +1,109 @@
-# Contribution 2182: Smoke test: eForm image directory is missing during startup
+# Contribution [#]: [Issue Title]
 
 **Contribution Number:** 2182  
-**Student:** Hana Ahmed  
-**Issue:** https://github.com/carlos-emr/carlos/issues/2182  
-**Status:** Phase II Complete
+**Student:** Hana Ahmed 
+**Issue:** https://github.com/carlos-emr/carlos/issues/2182#event-25727024596
+**Status:** Phase II
 
 ---
 
 ## Why I Chose This Issue
 
-I chose this issue because it's healthcare-related and seemed like a straightforward first bug to tackle. Fixing broken images in medical forms felt important — eForms are used by clinicians daily, and silent failures like this can erode trust in the system.
-
+I chose this issue because it's healthcare-related and seemed like a straightforward first bug to tackle. Honestly, I just wanted to contribute to something that actually matters, and fixing broken images in medical forms felt important
 ---
 
 ## Understanding the Issue
 
 ### Problem Description
 
-When the CARLOS application starts up, it tries to deploy eForm image assets into `/var/lib/OscarDocument/oscar/eform/images/`. That directory doesn't exist by default. Instead of creating it automatically, the Java class `EFormAssetDeployer.java` logs a warning and skips the deployment entirely. Users see broken image placeholders in eForms, and the warning is easy to miss in startup logs.
+When you start up the CARLOS application, the system tries to put eForm image files into a specific folder (/var/lib/OscarDocument/oscar/eform/images/), but that folder doesn't exist by default. Instead of creating the folder automatically, the system just logs a warning and skips deploying the images. This means any eForm that needs those images (like logos or icons) will show broken image placeholders, and most people probably won't even notice the warning buried in all the startup log messages.
+
 
 ### Expected Behavior
 
-The system should automatically create `/var/lib/OscarDocument/oscar/eform/images/` at startup if it doesn't already exist, then deploy the eForm assets there successfully.
+The system should automatically create the missing /var/lib/OscarDocument/oscar/eform/images/ directory at startup if it doesn't already exist. Then it should deploy the eForm images there without any errors or warnings. If something still goes wrong, the error message should clearly tell someone what to do, not just get lost in a pile of logs.
+
 
 ### Current Behavior
 
-`EFormAssetDeployer.java` checks if the directory exists, finds it missing, logs:
-`"eForm image directory does not exist: {}; skipping asset deployment"`
-and returns without creating the directory or deploying any assets.
+The system checks for the directory, doesn't find it, logs a warning that says something like "eForm image directory missing - skipping deployment," and then just moves on with the startup process. The directory never gets created, so the images never get copied over. Users only see broken image icons in their eForms, and unless someone is actively watching the startup logs (which almost no one does), there's no clear indication that anything went wrong
 
 ### Affected Components
 
-- `src/main/java/io/github/carlos_emr/carlos/eform/EFormAssetDeployer.java` — the Java class that logs the warning and skips deployment
-- `.devcontainer/development/Dockerfile` — creates directories under a different path than what the app expects
-
+The Java class EFormAssetDeployer.java in src/main/java/io/github/carlos_emr/carlos/eform/ is where the warning is logged. The .devcontainer/ bootstrap scripts are also involved.
 ---
 
 ## Reproduction Process
 
 ### Environment Setup
 
-Forked and cloned the repo locally. Opened in VS Code. No devcontainer spin-up issues. Used VS Code's global search (magnifying glass icon) to locate the relevant files by searching `eform/images` and `skipping asset deployment`.
+I cloned the repo using git clone https://github.com/Hanaahmed12/carlos.git and opened it in VS Code. Used VS Code global search to locate the relevant files.
 
 ### Steps to Reproduce
 
-1. Start the CARLOS application (foreground Tomcat smoke test)
-2. Watch the startup logs
-3. Observe the warning: `eForm image directory does not exist: /var/lib/OscarDocument/oscar/eform/images/; skipping asset deployment`
-4. Check that `/var/lib/OscarDocument/oscar/eform/images/` does not exist
-5. Open an eForm that uses images — they show as broken
+Start the CARLOS application (foreground Tomcat smoke test)
+
+Watch the startup logs
+
+Notice the warning: "eForm image directory missing - skipping deployment"
+
+Check /var/lib/OscarDocument/oscar/eform/images/ - it doesn't exist
+
+Open an eForm that uses images - they show as broken
 
 ### Reproduction Evidence
 
-**Exact file:** `src/main/java/io/github/carlos_emr/carlos/eform/EFormAssetDeployer.java`
+Commit showing reproduction: Not yet - still searching for the warning location
 
-**Exact lines causing the bug:**
-```java
+Screenshots/logs: Not yet
+
+My findings: Exact file: src/main/java/io/github/carlos_emr/carlos/eform/EFormAssetDeployer.java
+
+Exact lines causing the bug:
 if (!targetDir.isDirectory()) {
     logger.warn("eForm image directory does not exist: {}; skipping asset deployment", imageDir);
     return;
 }
-```
-
-The method simply returns instead of creating the directory.
-
-**Branch link:** https://github.com/Hanaahmed12/carlos/tree/fix-issue-2182-eform-image-directory
-
+Branch link: https://github.com/Hanaahmed12/carlos/tree/fix-issue-2182-eform-image-directory
 ---
 
 ## Solution Approach
 
 ### Analysis
 
-The root cause is in `EFormAssetDeployer.java`. The `afterPropertiesSet()` method checks whether the eForm images directory exists. If it doesn't, it logs a warning and exits — never creating the directory or deploying the assets. This is a defensive programming gap: the fix should attempt to create the directory automatically before giving up.
+The root cause is that the system expects a directory to exist (/var/lib/OscarDocument/oscar/eform/images/) but never creates it. Instead of creating it automatically, the code just logs a warning and skips deploying the images. This is a defensive programming gap.
 
 ### Proposed Solution
 
-In `EFormAssetDeployer.java`, replace the early `return` with a `targetDir.mkdirs()` call to auto-create the directory, then continue with asset deployment. Log an info message confirming the directory was created rather than a warning that it's missing.
+Add mkdir -p /var/lib/OscarDocument/oscar/eform/images/ in the bootstrap script before the eForm deployment runs. Also improve the warning message to say "Directory created automatically" instead of just "missing."
 
-### Implementation Plan (UMPIRE)
+### Implementation Plan
 
-**Understand:** At startup, `EFormAssetDeployer.java` checks for `/var/lib/OscarDocument/oscar/eform/images/`. If missing, it logs a warning and skips deploying eForm assets, causing broken images in eForms.
+Using UMPIRE framework (adapted):
 
-**Match:** The `populate_db.sh` script in `.devcontainer/db/scripts/` already uses `mkdir -p /var/lib/OscarDocument/oscar/eform/images/` to create this same directory during database bootstrap. The same auto-create pattern should be applied in the Java deployer itself.
+Understand: When CARLOS starts, it tries to deploy eForm images but fails because the target directory doesn't exist.
 
-**Plan:**
-1. Open `src/main/java/io/github/carlos_emr/carlos/eform/EFormAssetDeployer.java`
-2. Find the `if (!targetDir.isDirectory())` block in `afterPropertiesSet()`
-3. Replace the warning + return with a `targetDir.mkdirs()` call
-4. Log an info message: `"eForm image directory did not exist; created: {}"`
-5. If `mkdirs()` fails, log an error with remediation steps and return
-6. If successful, continue to deploy assets normally
+Match: Other projects handle this by checking for directory existence and creating it if missing (idempotent initialization).
 
-**Implement:** https://github.com/Hanaahmed12/carlos/tree/fix-issue-2182-eform-image-directory *(code coming in Phase III)*
+Plan:
 
-**Review:** Read `CONTRIBUTING.md` for commit message format and PR conventions before submitting
+Open EFormAssetDeployer.java in src/main/java/io/github/carlos_emr/carlos/eform/
+Find the if (!targetDir.isDirectory()) block in afterPropertiesSet()
 
-**Evaluate:** Run Tomcat smoke test — no "skipping asset deployment" warning should appear, directory should exist at `/var/lib/OscarDocument/oscar/eform/images/`, and eForm images should render correctly
+Add mkdir -p /var/lib/OscarDocument/oscar/eform/images/
 
-### Files to Modify
+Replace the return with targetDir.mkdirs() to auto-create the directory
+Log an info message confirming creation instead of a warning
+Test by running the devcontainer smoke test
 
-- `src/main/java/io/github/carlos_emr/carlos/eform/EFormAssetDeployer.java`
+Test by running the devcontainer and verifying directory exists and images deploy
+
+Implement: Will link branch once created
+
+Review: Check if change follows CARLOS contribution guidelines (need to read CONTRIBUTING.md)
+
+Evaluate: Run the smoke test again - warning should be gone or changed, directory should exist, eForm images should render
+
 
 ---
 
@@ -108,39 +111,53 @@ In `EFormAssetDeployer.java`, replace the early `return` with a `targetDir.mkdir
 
 ### Unit Tests
 
-- [ ] Test that `afterPropertiesSet()` creates the directory if it doesn't exist
-- [ ] Test that `afterPropertiesSet()` skips creation if directory already exists
-- [ ] Test that a proper error is logged if `mkdirs()` fails
+- [ ] Test case 1: [Description]
+- [ ] Test case 2: [Description]
+- [ ] Test case 3: [Description]
 
 ### Integration Tests
 
-- Run full Tomcat startup, verify no "skipping asset deployment" warning
-- Verify directory exists at `/var/lib/OscarDocument/oscar/eform/images/` after startup
-- Verify eForm images render correctly in a real eForm
+Run full Tomcat startup, verify no "directory missing" warning
+
+Verify directory exists after startup
+
+Verify eForm images actually appear in a real eForm
 
 ### Manual Testing
 
-Run the devcontainer, check the directory path exists, open an eForm that previously had broken images and confirm they now display correctly
+Run the devcontainer, check the directory path, open an eForm that previously had broken images
 
 ---
 
 ## Implementation Notes
 
-### Week 1 Progress
+### Week [1] Progress
 
-Cloned the fork, set up VS Code, created working branch `fix-issue-2182-eform-image-directory`. Used VS Code global search to locate the exact file (`EFormAssetDeployer.java`) and the exact lines causing the bug. Documented full reproduction steps and UMPIRE solution plan.
+Just getting started - cloned the fork, reading through issues, trying to locate the exact files. Need to search the codebase for the warning message.
+
+### Week [Y] Progress
+
+[Continue documenting as you work]
 
 ### Code Changes
 
-- **Files to modify:** `src/main/java/io/github/carlos_emr/carlos/eform/EFormAssetDeployer.java`
-- **Key commits:** Branch pushed — code changes coming in Phase III
-- **Approach decisions:** Will use `targetDir.mkdirs()` in Java rather than only relying on shell scripts, so the fix works in all environments not just devcontainer
+- **Files modified:** src/main/java/io/github/carlos_emr/carlos/eform/EFormAssetDeployer.java
+- **Key commits:** None yet
+- **Approach decisions:** Will check if maintainers reply to my comment before opening PR
 
 ---
 
 ## Pull Request
 
-PR Link: Not yet submitted — coming in Phase III
+PR Link: Not yet submitted
+
+PR Description: Will adapt this template once PR is ready
+
+Maintainer Feedback:
+
+Pending - no reply to my comment on issue #2182 yet
+
+Status: Researching / Locating files
 
 ---
 
@@ -148,21 +165,21 @@ PR Link: Not yet submitted — coming in Phase III
 
 ### Technical Skills Gained
 
-Learned how to navigate a large Java/Spring codebase using VS Code global search. Understood how Spring's `InitializingBean` pattern works for startup initialization. Learned the difference between devcontainer bootstrap paths and runtime application paths.
+Not yet - still in planning phase
+
 
 ### Challenges Overcome
 
-Tracking down the exact Java file took effort — the warning message text was the key search term that led directly to `EFormAssetDeployer.java`.
+Finding the exact file location has been harder than expected need to get better at searching large codebases
 
 ### What I'd Do Differently Next Time
 
-Search for the exact warning message text earlier instead of browsing folders manually.
+Maybe ask for file location earlier instead of guessing
 
 ---
 
 ## Resources Used
 
-- Issue #2182: https://github.com/carlos-emr/carlos/issues/2182
-- `EFormAssetDeployer.java`: `src/main/java/io/github/carlos_emr/carlos/eform/`
-- `runtime-directories.md`: `docs/`
-- CARLOS `CONTRIBUTING.md`
+Issue 2182 on carlos-emr/carlos
+
+CARLOS README and CONTRIBUTING.md (need to read more thoroughly)

--- a/src/main/java/io/github/carlos_emr/carlos/eform/EFormAssetDeployer.java
+++ b/src/main/java/io/github/carlos_emr/carlos/eform/EFormAssetDeployer.java
@@ -125,9 +125,12 @@ public class EFormAssetDeployer implements InitializingBean, ServletContextAware
             logger.warn("eForm image directory is invalid: {}; skipping asset deployment", imageDir, e);
             return;
         }
-        if (!targetDir.isDirectory()) {
-            logger.warn("eForm image directory does not exist: {}; skipping asset deployment", imageDir);
-            return;
+         if (!targetDir.isDirectory()) {
+            if (!targetDir.mkdirs()) {
+                logger.error("Failed to create eForm image directory: {}; skipping asset deployment", imageDir);
+                return;
+            }
+            logger.info("Created eForm image directory: {}", imageDir);
         }
 
         for (String asset : ASSETS) {


### PR DESCRIPTION
<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description

During Tomcat startup, EFormAssetDeployer checks whether 
/var/lib/OscarDocument/oscar/eform/images/ exists. If missing, 
it previously logged a warning and skipped asset deployment entirely, 
causing broken images in eForms. This PR replaces the early return 
with a mkdirs() call that automatically creates the directory before 
proceeding with deployment.

## Related Issues

Fixes #2182

## How Was This Tested?

- Code review confirms only the relevant block was changed
- Fix follows the same mkdir -p pattern already used in populate_db.sh
- Full integration testing requires the devcontainer environment


## Checklist

- [ ✅ ] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [ ✅ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [✅  ] I have not included any patient data (PHI) in this PR
- [ ] I have added tests for new functionality, or this change doesn't need new tests
- [ ✅ ] I have read the [contributing guide](CONTRIBUTING.md)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
On startup, `EFormAssetDeployer` now auto-creates `/var/lib/OscarDocument/oscar/eform/images/` if missing and proceeds with asset deployment. This prevents broken eForm images; `ISSUE-2182-DOCUMENTATION.md` updated with Phase IV completion, reproduction steps, analysis, and plan (fixes #2182).

- **Bug Fixes**
  - Replaced early return with `targetDir.mkdirs()`; logs error and skips only if creation fails, logs info on successful creation.

<sup>Written for commit 0353e4e830fa342870c3a465a4f3cb21b235d6d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2971?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

