### PR TITLE
fix: tickler bulk complete/delete always 500 (#2958)

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/TicklerWebService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/TicklerWebService.java
@@ -28,6 +28,7 @@
  */
 package io.github.carlos_emr.carlos.webserv.rest;
 
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
@@ -274,10 +275,14 @@ public class TicklerWebService extends AbstractServiceImpl {
 
         MiscUtils.getLogger().info(json.toString());
 
-        ArrayNode ticklerIds = (ArrayNode) json.get("ticklers");
+        List<Integer> ticklerIds;
+        try {
+            ticklerIds = extractTicklerIds(json);
+        } catch (IllegalArgumentException e) {
+            return RestResponse.errorResponse(e.getMessage());
+        }
 
-        for (JsonNode id : ticklerIds) {
-            int ticklerNo = id.asInt();
+        for (Integer ticklerNo : ticklerIds) {
             ticklerManager.completeTickler(getLoggedInInfo(), ticklerNo, getLoggedInInfo().getLoggedInProviderNo());
         }
 
@@ -296,14 +301,45 @@ public class TicklerWebService extends AbstractServiceImpl {
 
         MiscUtils.getLogger().info(json.toString());
 
-        ArrayNode ticklerIds = (ArrayNode) json.get("ticklers");
+        List<Integer> ticklerIds;
+        try {
+            ticklerIds = extractTicklerIds(json);
+        } catch (IllegalArgumentException e) {
+            return RestResponse.errorResponse(e.getMessage());
+        }
 
-        for (JsonNode id : ticklerIds) {
-            int ticklerNo = id.asInt();
+        for (Integer ticklerNo : ticklerIds) {
             ticklerManager.deleteTickler(getLoggedInInfo(), ticklerNo, getLoggedInInfo().getLoggedInProviderNo());
         }
 
         return RestResponse.successResponse(null);
+    }
+
+    /**
+     * Extracts and validates the {@code ticklers} id array from a bulk request body.
+     *
+     * <p>The field must be present, a JSON array, and contain only values that fit a
+     * 32-bit int. Reading ids with {@link JsonNode#asInt()} alone would let a missing
+     * field NPE and silently coerce non-numeric values to {@code 0}, so malformed input
+     * is rejected here with a clear message instead.</p>
+     *
+     * @param json the request body
+     * @return the parsed tickler ids (possibly empty)
+     * @throws IllegalArgumentException if the field is missing, not an array, or holds a non-integer id
+     */
+    private List<Integer> extractTicklerIds(JsonNode json) {
+        JsonNode ticklerIds = json.get("ticklers");
+        if (ticklerIds == null || !ticklerIds.isArray()) {
+            throw new IllegalArgumentException("ticklers must be an array of integer ids");
+        }
+        List<Integer> ids = new ArrayList<>();
+        for (JsonNode id : ticklerIds) {
+            if (!id.canConvertToInt()) {
+                throw new IllegalArgumentException("ticklers must contain only integer ids");
+            }
+            ids.add(id.intValue());
+        }
+        return ids;
     }
 
     @POST

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/TicklerWebService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/TicklerWebService.java
@@ -318,10 +318,14 @@ public class TicklerWebService extends AbstractServiceImpl {
     /**
      * Extracts and validates the {@code ticklers} id array from a bulk request body.
      *
-     * <p>The field must be present, a JSON array, and contain only values that fit a
-     * 32-bit int. Reading ids with {@link JsonNode#asInt()} alone would let a missing
+     * <p>The field must be present, a JSON array, and contain only integral values that
+     * fit a 32-bit int. Reading ids with {@link JsonNode#asInt()} alone would let a missing
      * field NPE and silently coerce non-numeric values to {@code 0}, so malformed input
-     * is rejected here with a clear message instead.</p>
+     * is rejected here with a clear message instead. {@link JsonNode#canConvertToInt()}
+     * alone is not enough: it returns {@code true} for fractional values in int range
+     * (e.g. {@code 1.9}), which {@link JsonNode#intValue()} would silently truncate to
+     * {@code 1}, so {@link JsonNode#isIntegralNumber()} is checked first to reject
+     * non-integral numbers.</p>
      *
      * @param json the request body
      * @return the parsed tickler ids (possibly empty)
@@ -334,7 +338,7 @@ public class TicklerWebService extends AbstractServiceImpl {
         }
         List<Integer> ids = new ArrayList<>();
         for (JsonNode id : ticklerIds) {
-            if (!id.canConvertToInt()) {
+            if (!id.isIntegralNumber() || !id.canConvertToInt()) {
                 throw new IllegalArgumentException("ticklers must contain only integer ids");
             }
             ids.add(id.intValue());

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/TicklerWebService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/TicklerWebService.java
@@ -276,8 +276,8 @@ public class TicklerWebService extends AbstractServiceImpl {
 
         ArrayNode ticklerIds = (ArrayNode) json.get("ticklers");
 
-        for (Object id : ticklerIds) {
-            int ticklerNo = (Integer) id;
+        for (JsonNode id : ticklerIds) {
+            int ticklerNo = id.asInt();
             ticklerManager.completeTickler(getLoggedInInfo(), ticklerNo, getLoggedInInfo().getLoggedInProviderNo());
         }
 
@@ -298,8 +298,8 @@ public class TicklerWebService extends AbstractServiceImpl {
 
         ArrayNode ticklerIds = (ArrayNode) json.get("ticklers");
 
-        for (Object id : ticklerIds) {
-            int ticklerNo = (Integer) id;
+        for (JsonNode id : ticklerIds) {
+            int ticklerNo = id.asInt();
             ticklerManager.deleteTickler(getLoggedInInfo(), ticklerNo, getLoggedInInfo().getLoggedInProviderNo());
         }
 

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/TicklerWebServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/TicklerWebServiceUnitTest.java
@@ -136,7 +136,38 @@ class TicklerWebServiceUnitTest extends CarlosUnitTestBase {
                 .thenReturn(false);
 
         assertThatThrownBy(() -> service.completeTicklers(payload("{\"ticklers\":[1]}")))
-                .isInstanceOf(RuntimeException.class);
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("Access Denied");
+        verify(ticklerManager, never()).completeTickler(any(), any(), any());
+    }
+
+    @Test
+    @Tag("update")
+    @DisplayName("should return an error when the ticklers field is missing")
+    void shouldReturnError_whenTicklersFieldMissing() throws Exception {
+        RestResponse<String> response = service.completeTicklers(payload("{}"));
+
+        assertThat(response.getStatus()).isEqualTo(ResponseStatus.ERROR);
+        verify(ticklerManager, never()).completeTickler(any(), any(), any());
+    }
+
+    @Test
+    @Tag("update")
+    @DisplayName("should return an error when the ticklers field is not an array")
+    void shouldReturnError_whenTicklersIsNotArray() throws Exception {
+        RestResponse<String> response = service.completeTicklers(payload("{\"ticklers\":5}"));
+
+        assertThat(response.getStatus()).isEqualTo(ResponseStatus.ERROR);
+        verify(ticklerManager, never()).completeTickler(any(), any(), any());
+    }
+
+    @Test
+    @Tag("update")
+    @DisplayName("should return an error when a tickler id is not an integer")
+    void shouldReturnError_whenTicklerIdIsNotInteger() throws Exception {
+        RestResponse<String> response = service.completeTicklers(payload("{\"ticklers\":[\"abc\"]}"));
+
+        assertThat(response.getStatus()).isEqualTo(ResponseStatus.ERROR);
         verify(ticklerManager, never()).completeTickler(any(), any(), any());
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/TicklerWebServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/TicklerWebServiceUnitTest.java
@@ -1,0 +1,142 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.webserv.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import io.github.carlos_emr.carlos.managers.TicklerManager;
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
+import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import io.github.carlos_emr.carlos.webserv.rest.to.GenericRestResponse.ResponseStatus;
+import io.github.carlos_emr.carlos.webserv.rest.to.RestResponse;
+
+/**
+ * Unit tests for {@link TicklerWebService} bulk operations.
+ *
+ * <p>Regression coverage for the bulk {@code /complete} and {@code /delete}
+ * endpoints. Iterating a Jackson {@code ArrayNode} yields {@code JsonNode}
+ * elements, so the previous {@code (Integer) id} cast threw
+ * {@link ClassCastException} (HTTP 500) for every non-empty {@code ticklers}
+ * payload; these tests pin that the ids are now read with {@code asInt()} and
+ * the correct tickler numbers reach {@link TicklerManager}.</p>
+ *
+ * @since 2026-06-21
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("TicklerWebService unit tests")
+@Tag("unit")
+@Tag("fast")
+class TicklerWebServiceUnitTest extends CarlosUnitTestBase {
+
+    @Mock
+    private TicklerManager ticklerManager;
+
+    @Mock
+    private SecurityInfoManager securityInfoManager;
+
+    private TicklerWebService service;
+    private LoggedInInfo loggedInInfo;
+
+    @BeforeEach
+    void setUp() {
+        loggedInInfo = new LoggedInInfo();
+        service = new TicklerWebService() {
+            @Override
+            protected LoggedInInfo getLoggedInInfo() {
+                return loggedInInfo;
+            }
+        };
+        injectDependency(service, "ticklerManager", ticklerManager);
+        injectDependency(service, "securityInfoManager", securityInfoManager);
+
+        lenient().when(securityInfoManager.hasPrivilege(any(), eq("_tickler"), eq("u"), any()))
+                .thenReturn(true);
+    }
+
+    private JsonNode payload(String json) throws Exception {
+        return new ObjectMapper().readTree(json);
+    }
+
+    @Test
+    @Tag("update")
+    @DisplayName("should complete each tickler when a valid id array is provided")
+    void shouldCompleteEachTickler_whenValidIdArrayProvided() throws Exception {
+        RestResponse<String> response = service.completeTicklers(payload("{\"ticklers\":[1,2,3]}"));
+
+        assertThat(response.getStatus()).isEqualTo(ResponseStatus.SUCCESS);
+        verify(ticklerManager).completeTickler(eq(loggedInInfo), eq(1), any());
+        verify(ticklerManager).completeTickler(eq(loggedInInfo), eq(2), any());
+        verify(ticklerManager).completeTickler(eq(loggedInInfo), eq(3), any());
+    }
+
+    @Test
+    @Tag("delete")
+    @DisplayName("should delete each tickler when a valid id array is provided")
+    void shouldDeleteEachTickler_whenValidIdArrayProvided() throws Exception {
+        RestResponse<String> response = service.deleteTicklers(payload("{\"ticklers\":[4,5]}"));
+
+        assertThat(response.getStatus()).isEqualTo(ResponseStatus.SUCCESS);
+        verify(ticklerManager).deleteTickler(eq(loggedInInfo), eq(4), any());
+        verify(ticklerManager).deleteTickler(eq(loggedInInfo), eq(5), any());
+    }
+
+    @Test
+    @Tag("update")
+    @DisplayName("should not call the manager when the tickler array is empty")
+    void shouldNotCallManager_whenTicklerArrayIsEmpty() throws Exception {
+        RestResponse<String> response = service.completeTicklers(payload("{\"ticklers\":[]}"));
+
+        assertThat(response.getStatus()).isEqualTo(ResponseStatus.SUCCESS);
+        verify(ticklerManager, never()).completeTickler(any(), any(), any());
+    }
+
+    @Test
+    @Tag("update")
+    @DisplayName("should deny completion when the caller lacks tickler update privilege")
+    void shouldDenyCompletion_whenCallerLacksTicklerUpdatePrivilege() {
+        when(securityInfoManager.hasPrivilege(any(), eq("_tickler"), eq("u"), any()))
+                .thenReturn(false);
+
+        assertThatThrownBy(() -> service.completeTicklers(payload("{\"ticklers\":[1]}")))
+                .isInstanceOf(RuntimeException.class);
+        verify(ticklerManager, never()).completeTickler(any(), any(), any());
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/TicklerWebServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/TicklerWebServiceUnitTest.java
@@ -142,6 +142,19 @@ class TicklerWebServiceUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
+    @Tag("delete")
+    @DisplayName("should deny deletion when the caller lacks tickler update privilege")
+    void shouldDenyDeletion_whenCallerLacksTicklerUpdatePrivilege() {
+        when(securityInfoManager.hasPrivilege(any(), eq("_tickler"), eq("u"), any()))
+                .thenReturn(false);
+
+        assertThatThrownBy(() -> service.deleteTicklers(payload("{\"ticklers\":[1]}")))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("Access Denied");
+        verify(ticklerManager, never()).deleteTickler(any(), any(), any());
+    }
+
+    @Test
     @Tag("update")
     @DisplayName("should return an error when the ticklers field is missing")
     void shouldReturnError_whenTicklersFieldMissing() throws Exception {

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/TicklerWebServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/TicklerWebServiceUnitTest.java
@@ -183,4 +183,16 @@ class TicklerWebServiceUnitTest extends CarlosUnitTestBase {
         assertThat(response.getStatus()).isEqualTo(ResponseStatus.ERROR);
         verify(ticklerManager, never()).completeTickler(any(), any(), any());
     }
+
+    @Test
+    @Tag("update")
+    @DisplayName("should return an error when a tickler id is a fractional number")
+    void shouldReturnError_whenTicklerIdIsFractional() throws Exception {
+        // canConvertToInt() returns true for 1.9 and intValue() would truncate it to 1,
+        // so a fractional id must be rejected rather than silently acting on tickler 1.
+        RestResponse<String> response = service.completeTicklers(payload("{\"ticklers\":[1.9]}"));
+
+        assertThat(response.getStatus()).isEqualTo(ResponseStatus.ERROR);
+        verify(ticklerManager, never()).completeTickler(any(), any(), any());
+    }
 }


### PR DESCRIPTION
## Description

Bulk tickler complete and delete (`POST /tickler/complete`, `POST /tickler/delete`)
returned HTTP 500 for every valid request. Iterating a Jackson `ArrayNode` yields
`JsonNode` elements, so casting each element to `Integer` threw `ClassCastException`.
The ids are now read with `JsonNode.asInt()`, matching the idiom already used in
`updateTickler`.

## Related Issues

Fixes #2958
Related to #2823 (duplicate report of the same defect)

## How Was This Tested?

Added `TicklerWebServiceUnitTest` (complete and delete happy paths, empty array,
privilege-denied). Run: `mvn test -Dtest=TicklerWebServiceUnitTest`
→ Tests run: 4, Failures: 0, Errors: 0 — BUILD SUCCESS.

## Checklist

- [x] My commits are signed off for the DCO (`git commit -s`)
- [x] My commits follow Conventional Commits format
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality
- [x] I have read the contributing guide

## Summary by Sourcery

Fix bulk tickler complete and delete REST endpoints to correctly process tickler IDs from JSON requests and add regression coverage for these operations.

Bug Fixes:
- Resolve ClassCastException in bulk tickler complete and delete endpoints by correctly reading IDs from JSON payloads.

Tests:
- Add TicklerWebService unit tests covering bulk complete/delete success cases, empty payload handling, and privilege-denied behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2958 to stop HTTP 500s in bulk tickler complete/delete. We now validate and parse the `ticklers` array into ints, rejecting missing, non-array, non-integer, fractional, or out‑of‑range IDs; each ID is processed safely and bad input returns a clear error.

- **Bug Fixes**
  - Add a shared extractor that enforces an int array using isIntegralNumber + canConvertToInt, preventing NPEs, silent truncation, and ClassCastException.
  - Expand unit tests to cover complete/delete happy paths, empty arrays, privilege denied for both endpoints, and invalid payloads (missing field, wrong type, non-integer, fractional, out-of-range).

<sup>Written for commit f764322f1ff9b66054fc3e2fb5518722d76355df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2977?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

