### PR TITLE
Suppress doc upload cleanup CodeQL alerts

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentUpload2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentUpload2Action.java
@@ -48,6 +48,7 @@ import io.github.carlos_emr.carlos.commn.model.UserProperty;
 import io.github.carlos_emr.carlos.documentManager.EDoc;
 import io.github.carlos_emr.carlos.documentManager.EDocUtil;
 import io.github.carlos_emr.carlos.documentManager.IncomingDocUtil;
+import io.github.carlos_emr.carlos.managers.NioFileManager;
 import io.github.carlos_emr.carlos.managers.ProgramManager2;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.utility.FileValidationException;
@@ -230,19 +231,10 @@ public class DocumentUpload2Action extends ActionSupport implements UploadedFile
         return null;
     }
 
-    // FindSecBugs PATH_TRAVERSAL_IN: upload temp file is canonicalized and restricted to allowed temp dirs immediately before cleanup delete
-    @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "upload temp file is canonicalized and restricted to allowed temp dirs immediately before cleanup delete")
     private void deleteValidatedUploadTempFile(File uploadFile) {
         try {
             File validatedUpload = PathValidationUtils.validateUpload(uploadFile);
-            if (!PathValidationUtils.isInAllowedTempDirectory(validatedUpload)) {
-                logger.warn("Skipped cleanup for upload outside allowed temp directory");
-                return;
-            }
-
-            // validateUpload canonicalizes and rejects outside-temp paths immediately before cleanup delete.
-            // codeql[java/path-injection]
-            if (!validatedUpload.delete()) {
+            if (!SpringUtils.getBean(NioFileManager.class).deleteTempFile(validatedUpload.getPath())) {
                 logger.debug("Upload temp file cleanup did not delete a file");
             }
         } catch (SecurityException e) {

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentUpload2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentUpload2Action.java
@@ -234,7 +234,7 @@ public class DocumentUpload2Action extends ActionSupport implements UploadedFile
     private void deleteValidatedUploadTempFile(File uploadFile) {
         try {
             File validatedUpload = PathValidationUtils.validateUpload(uploadFile);
-            if (!SpringUtils.getBean(NioFileManager.class).deleteTempFile(validatedUpload.getPath())) {
+            if (!SpringUtils.getBean(NioFileManager.class).deleteTempFile(validatedUpload.getPath())) { // codeql[java/path-injection] validateUpload canonicalizes and restricts uploads to approved temp dirs before delegated cleanup.
                 logger.debug("Upload temp file cleanup did not delete a file");
             }
         } catch (SecurityException e) {

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentUpload2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentUpload2Action.java
@@ -145,7 +145,7 @@ public class DocumentUpload2Action extends ActionSupport implements UploadedFile
                     }
                 }
                 if (docFile != null) {
-                    docFile.delete();
+                    docFile.delete(); // codeql[java/path-injection] -- docFile is reassigned from PathValidationUtils.validateUpload(docFile) above; outside upload paths set it to null before this cleanup delete.
                     docFile = null;
                 }
 
@@ -222,7 +222,7 @@ public class DocumentUpload2Action extends ActionSupport implements UploadedFile
             map.put("size", docFile.length());
 
             if (docFile != null) {
-                docFile.delete();
+                docFile.delete(); // codeql[java/path-injection] -- docFile is reassigned from PathValidationUtils.validateUpload(docFile) above; outside upload paths set it to null before this cleanup delete.
                 docFile = null;
             }
         }

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentUpload2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentUpload2Action.java
@@ -145,7 +145,7 @@ public class DocumentUpload2Action extends ActionSupport implements UploadedFile
                     }
                 }
                 if (docFile != null) {
-                    docFile.delete(); // codeql[java/path-injection] -- docFile is reassigned from PathValidationUtils.validateUpload(docFile) above; outside upload paths set it to null before this cleanup delete.
+                    deleteValidatedUploadTempFile(docFile);
                     docFile = null;
                 }
 
@@ -222,12 +222,32 @@ public class DocumentUpload2Action extends ActionSupport implements UploadedFile
             map.put("size", docFile.length());
 
             if (docFile != null) {
-                docFile.delete(); // codeql[java/path-injection] -- docFile is reassigned from PathValidationUtils.validateUpload(docFile) above; outside upload paths set it to null before this cleanup delete.
+                deleteValidatedUploadTempFile(docFile);
                 docFile = null;
             }
         }
         writeUploadResponse(map);
         return null;
+    }
+
+    // FindSecBugs PATH_TRAVERSAL_IN: upload temp file is canonicalized and restricted to allowed temp dirs immediately before cleanup delete
+    @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "upload temp file is canonicalized and restricted to allowed temp dirs immediately before cleanup delete")
+    private void deleteValidatedUploadTempFile(File uploadFile) {
+        try {
+            File validatedUpload = PathValidationUtils.validateUpload(uploadFile);
+            if (!PathValidationUtils.isInAllowedTempDirectory(validatedUpload)) {
+                logger.warn("Skipped cleanup for upload outside allowed temp directory");
+                return;
+            }
+
+            // validateUpload canonicalizes and rejects outside-temp paths immediately before cleanup delete.
+            // codeql[java/path-injection]
+            if (!validatedUpload.delete()) {
+                logger.debug("Upload temp file cleanup did not delete a file");
+            }
+        } catch (SecurityException e) {
+            logger.warn("Skipped cleanup for invalid upload temp file");
+        }
     }
 
     private void writeUploadResponse(HashMap<String, Object> map) throws IOException {

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentUpload2ActionFilenameValidationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentUpload2ActionFilenameValidationTest.java
@@ -1,5 +1,6 @@
 package io.github.carlos_emr.carlos.documentManager.actions;
 
+import io.github.carlos_emr.carlos.documentManager.IncomingDocUtil;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
@@ -15,6 +16,7 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -38,6 +40,8 @@ class DocumentUpload2ActionFilenameValidationTest extends CarlosUnitTestBase {
     private MockHttpServletResponse response;
     private File tempUploadFile;
     private File tempUploadDirectory;
+    private File tempDestinationFile;
+    private File tempDestinationDirectory;
 
     @BeforeEach
     void setUp() {
@@ -55,14 +59,22 @@ class DocumentUpload2ActionFilenameValidationTest extends CarlosUnitTestBase {
 
     @AfterEach
     void tearDown() throws Exception {
-        if (tempUploadFile != null) {
-            Files.deleteIfExists(tempUploadFile.toPath());
-        }
-        if (tempUploadDirectory != null) {
-            Files.deleteIfExists(tempUploadDirectory.toPath());
-        }
+        Exception cleanupFailure = null;
+
+        cleanupFailure = deleteIfExists(tempDestinationFile, cleanupFailure);
+        cleanupFailure = deleteIfExists(tempUploadFile, cleanupFailure);
+        cleanupFailure = deleteIfExists(tempDestinationDirectory, cleanupFailure);
+        cleanupFailure = deleteIfExists(tempUploadDirectory, cleanupFailure);
         if (servletActionContextMock != null) {
-            servletActionContextMock.close();
+            try {
+                servletActionContextMock.close();
+            } catch (Exception e) {
+                cleanupFailure = appendCleanupFailure(cleanupFailure, e);
+            }
+        }
+
+        if (cleanupFailure != null) {
+            throw cleanupFailure;
         }
     }
 
@@ -101,7 +113,7 @@ class DocumentUpload2ActionFilenameValidationTest extends CarlosUnitTestBase {
 
     @Test
     @DisplayName("incoming docs upload should reject outside temp source before cleanup delete")
-    void incomingDocsUploadShouldRejectOutsideTempSourceBeforeCleanupDelete() throws Exception {
+    void shouldRejectOutsideTempSource_beforeIncomingDocsCleanupDelete() throws Exception {
         request.addParameter("destination", "incomingDocs");
         DocumentUpload2Action action = outsideTempUploadAction("report.pdf");
 
@@ -114,7 +126,7 @@ class DocumentUpload2ActionFilenameValidationTest extends CarlosUnitTestBase {
 
     @Test
     @DisplayName("document upload should reject outside temp source before cleanup delete")
-    void documentUploadShouldRejectOutsideTempSourceBeforeCleanupDelete() throws Exception {
+    void shouldRejectOutsideTempSource_beforeDocumentCleanupDelete() throws Exception {
         DocumentUpload2Action action = outsideTempUploadAction("report.pdf");
 
         String result = action.executeUpload();
@@ -122,6 +134,30 @@ class DocumentUpload2ActionFilenameValidationTest extends CarlosUnitTestBase {
         assertThat(result).isNull();
         assertThat(response.getContentAsString()).contains("Invalid file upload");
         assertThat(tempUploadFile).exists();
+    }
+
+    @Test
+    @DisplayName("incoming docs upload should delete allowed temp source after successful cleanup")
+    void shouldDeleteAllowedTempSource_afterIncomingDocsUploadSucceeds() throws Exception {
+        DocumentUpload2Action action = incomingDocsAction("report.pdf");
+        tempDestinationDirectory = Files.createTempDirectory("incoming-docs-target").toFile();
+
+        assertThat(PathValidationUtils.isInAllowedTempDirectory(tempUploadFile)).isTrue();
+
+        try (MockedStatic<IncomingDocUtil> incomingDocUtilMock = mockStatic(IncomingDocUtil.class)) {
+            incomingDocUtilMock.when(() -> IncomingDocUtil.getAndCreateIncomingDocumentFilePath(null, null))
+                    .thenReturn(tempDestinationDirectory.getPath());
+
+            String result = action.executeUpload();
+            tempDestinationFile = tempDestinationDirectory.toPath().resolve("report.pdf").toFile();
+
+            assertThat(result).isNull();
+            assertThat(response.getContentAsString())
+                    .contains("\"size\":3")
+                    .doesNotContain("error");
+            assertThat(tempDestinationFile).exists();
+            assertThat(tempUploadFile).doesNotExist();
+        }
     }
 
     private DocumentUpload2Action incomingDocsAction(String filename) throws Exception {
@@ -137,8 +173,8 @@ class DocumentUpload2ActionFilenameValidationTest extends CarlosUnitTestBase {
 
     private DocumentUpload2Action outsideTempUploadAction(String filename) throws Exception {
         Path outsideDir = createTempDirectoryOutsideAllowedTemp();
-        Path outsideUpload = Files.writeString(outsideDir.resolve("document-upload.pdf"), "pdf");
         tempUploadDirectory = outsideDir.toFile();
+        Path outsideUpload = Files.writeString(outsideDir.resolve("document-upload.pdf"), "pdf");
         tempUploadFile = outsideUpload.toFile();
 
         assertThat(PathValidationUtils.isInAllowedTempDirectory(tempUploadFile)).isFalse();
@@ -170,5 +206,26 @@ class DocumentUpload2ActionFilenameValidationTest extends CarlosUnitTestBase {
 
         org.junit.jupiter.api.Assumptions.assumeTrue(false, "Unable to create a test upload directory outside allowed temp roots");
         return null;
+    }
+
+    private Exception deleteIfExists(File file, Exception cleanupFailure) {
+        if (file == null) {
+            return cleanupFailure;
+        }
+
+        try {
+            Files.deleteIfExists(file.toPath());
+            return cleanupFailure;
+        } catch (IOException e) {
+            return appendCleanupFailure(cleanupFailure, e);
+        }
+    }
+
+    private Exception appendCleanupFailure(Exception cleanupFailure, Exception exception) {
+        if (cleanupFailure == null) {
+            return exception;
+        }
+        cleanupFailure.addSuppressed(exception);
+        return cleanupFailure;
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentUpload2ActionFilenameValidationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentUpload2ActionFilenameValidationTest.java
@@ -3,6 +3,7 @@ package io.github.carlos_emr.carlos.documentManager.actions;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import io.github.carlos_emr.carlos.utility.PathValidationUtils;
 import org.apache.struts2.ServletActionContext;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -15,6 +16,8 @@ import org.springframework.mock.web.MockHttpServletResponse;
 
 import java.io.File;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -34,6 +37,7 @@ class DocumentUpload2ActionFilenameValidationTest extends CarlosUnitTestBase {
     private MockHttpServletRequest request;
     private MockHttpServletResponse response;
     private File tempUploadFile;
+    private File tempUploadDirectory;
 
     @BeforeEach
     void setUp() {
@@ -53,6 +57,9 @@ class DocumentUpload2ActionFilenameValidationTest extends CarlosUnitTestBase {
     void tearDown() throws Exception {
         if (tempUploadFile != null) {
             Files.deleteIfExists(tempUploadFile.toPath());
+        }
+        if (tempUploadDirectory != null) {
+            Files.deleteIfExists(tempUploadDirectory.toPath());
         }
         if (servletActionContextMock != null) {
             servletActionContextMock.close();
@@ -92,6 +99,31 @@ class DocumentUpload2ActionFilenameValidationTest extends CarlosUnitTestBase {
         assertThat(response.getContentAsString()).contains("Only .pdf file can be uploaded");
     }
 
+    @Test
+    @DisplayName("incoming docs upload should reject outside temp source before cleanup delete")
+    void incomingDocsUploadShouldRejectOutsideTempSourceBeforeCleanupDelete() throws Exception {
+        request.addParameter("destination", "incomingDocs");
+        DocumentUpload2Action action = outsideTempUploadAction("report.pdf");
+
+        String result = action.executeUpload();
+
+        assertThat(result).isNull();
+        assertThat(response.getContentAsString()).contains("Invalid file upload");
+        assertThat(tempUploadFile).exists();
+    }
+
+    @Test
+    @DisplayName("document upload should reject outside temp source before cleanup delete")
+    void documentUploadShouldRejectOutsideTempSourceBeforeCleanupDelete() throws Exception {
+        DocumentUpload2Action action = outsideTempUploadAction("report.pdf");
+
+        String result = action.executeUpload();
+
+        assertThat(result).isNull();
+        assertThat(response.getContentAsString()).contains("Invalid file upload");
+        assertThat(tempUploadFile).exists();
+    }
+
     private DocumentUpload2Action incomingDocsAction(String filename) throws Exception {
         tempUploadFile = File.createTempFile("document-upload", ".pdf");
         Files.writeString(tempUploadFile.toPath(), "pdf");
@@ -101,5 +133,42 @@ class DocumentUpload2ActionFilenameValidationTest extends CarlosUnitTestBase {
         action.setFiledata(tempUploadFile);
         action.setFiledataFileName(filename);
         return action;
+    }
+
+    private DocumentUpload2Action outsideTempUploadAction(String filename) throws Exception {
+        Path outsideDir = createTempDirectoryOutsideAllowedTemp();
+        Path outsideUpload = Files.writeString(outsideDir.resolve("document-upload.pdf"), "pdf");
+        tempUploadDirectory = outsideDir.toFile();
+        tempUploadFile = outsideUpload.toFile();
+
+        assertThat(PathValidationUtils.isInAllowedTempDirectory(tempUploadFile)).isFalse();
+
+        DocumentUpload2Action action = new DocumentUpload2Action();
+        action.setFiledata(tempUploadFile);
+        action.setFiledataFileName(filename);
+        return action;
+    }
+
+    private Path createTempDirectoryOutsideAllowedTemp() throws Exception {
+        List<Path> candidateParents = List.of(
+                Path.of(System.getProperty("user.home", ".")),
+                Path.of("/workspace"),
+                Path.of(".").toAbsolutePath()
+        );
+
+        for (Path candidateParent : candidateParents) {
+            if (!Files.isDirectory(candidateParent) || !Files.isWritable(candidateParent)) {
+                continue;
+            }
+
+            Path candidate = Files.createTempDirectory(candidateParent, "outside-upload-");
+            if (!PathValidationUtils.isInAllowedTempDirectory(candidate.toFile())) {
+                return candidate;
+            }
+            Files.deleteIfExists(candidate);
+        }
+
+        org.junit.jupiter.api.Assumptions.assumeTrue(false, "Unable to create a test upload directory outside allowed temp roots");
+        return null;
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentUpload2ActionFilenameValidationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentUpload2ActionFilenameValidationTest.java
@@ -1,6 +1,7 @@
 package io.github.carlos_emr.carlos.documentManager.actions;
 
 import io.github.carlos_emr.carlos.documentManager.IncomingDocUtil;
+import io.github.carlos_emr.carlos.managers.NioFileManager;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
@@ -36,6 +37,7 @@ class DocumentUpload2ActionFilenameValidationTest extends CarlosUnitTestBase {
 
     private MockedStatic<ServletActionContext> servletActionContextMock;
     private SecurityInfoManager securityInfoManager;
+    private NioFileManager nioFileManager;
     private MockHttpServletRequest request;
     private MockHttpServletResponse response;
     private File tempUploadFile;
@@ -55,6 +57,13 @@ class DocumentUpload2ActionFilenameValidationTest extends CarlosUnitTestBase {
         registerMock(SecurityInfoManager.class, securityInfoManager);
         when(securityInfoManager.hasPrivilege(nullable(LoggedInInfo.class), eq("_edoc"), eq("w"), isNull()))
                 .thenReturn(true);
+
+        nioFileManager = mock(NioFileManager.class);
+        registerMock(NioFileManager.class, nioFileManager);
+        when(nioFileManager.deleteTempFile(nullable(String.class))).thenAnswer(invocation -> {
+            String filePath = invocation.getArgument(0);
+            return filePath != null && Files.deleteIfExists(Path.of(filePath));
+        });
     }
 
     @AfterEach


### PR DESCRIPTION
## Summary
- add inline CodeQL suppressions for alerts #25015/#25016 at both document upload cleanup deletes
- add focused tests proving outside-temp upload paths are rejected before cleanup delete for incoming-docs and normal upload branches

## Tests
- mvn -pl . -Dtest=DocumentUpload2ActionFilenameValidationTest test
- mvn -pl . -Dtest=PathValidationUtilsUnitTest test

## Summary by Sourcery

Add inline CodeQL suppressions for document upload cleanup deletes and tighten test coverage around rejecting uploads from outside the allowed temp directory.

Bug Fixes:
- Ensure document upload flows reject files from outside the allowed temp directory before any cleanup delete is attempted.

Enhancements:
- Add tests covering rejection of outside-temp upload sources for both incoming-docs and standard upload paths.
- Extend test cleanup to remove any temporary upload directories created during tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate and delete temp upload files in `DocumentUpload2Action`, delegate cleanup to `NioFileManager`, and add a documented inline CodeQL suppression for the validated cleanup call. Tests cover rejecting outside-temp uploads and deleting allowed-temp sources after successful incoming-docs uploads.

- **Bug Fixes**
  - Route both cleanup paths through `deleteValidatedUploadTempFile(...)`, which validates via `PathValidationUtils.validateUpload` and delegates to `NioFileManager.deleteTempFile(...)`; skip unsafe deletes with warnings.
  - Add inline `codeql[java/path-injection]` suppression with justification next to the delegated delete (validated and restricted to approved temp dirs).
  - Tests: reject outside-temp uploads for both branches; verify allowed-temp source is removed after a successful incoming-docs upload; improve test teardown.

<sup>Written for commit 998e2ca8472dcf54d3c4af53df72e2a2c5b2bc35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2978?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

