### PR TITLE
Return NONE instead of null in DisplayPersonalInfoAppointment2Action.toggle()

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/provider/web/DisplayPersonalInfoAppointment2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/provider/web/DisplayPersonalInfoAppointment2Action.java
@@ -78,7 +78,7 @@ public class DisplayPersonalInfoAppointment2Action extends ActionSupport {
         // nosemgrep: tainted-session-from-http-request -- showPersonal is a Boolean toggled from existing session state, not user input
         request.getSession().setAttribute("showPersonal", showPersonal);
 
-        return null;
+        return NONE;
     }
 
 }

--- a/src/main/webapp/WEB-INF/classes/struts-provider.xml
+++ b/src/main/webapp/WEB-INF/classes/struts-provider.xml
@@ -113,6 +113,9 @@
         <action name="DocumentDescriptionTemplate" class="io.github.carlos_emr.carlos.provider.web.DocumentDescriptionTemplate2Action"/>
         <action name="PrinterList" class="io.github.carlos_emr.carlos.printer.PrinterList2Action"/>
         <action name="saveWorkView" class="io.github.carlos_emr.carlos.provider.web.ProviderView2Action" method="execute"/>
+        <!-- Toggles the showPersonal session flag and returns the reserved "none" result
+             (ActionSupport.NONE), so Struts renders no result body. No <result> mapping is
+             intentional: any mapping here would emit unwanted markup after the no-op response. -->
         <action name="Provider/showPersonal" class="io.github.carlos_emr.carlos.provider.web.DisplayPersonalInfoAppointment2Action"/>
 
 

--- a/src/test/java/io/github/carlos_emr/carlos/provider/web/DisplayPersonalInfoAppointment2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/provider/web/DisplayPersonalInfoAppointment2ActionUnitTest.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ */
+package io.github.carlos_emr.carlos.provider.web;
+
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import io.github.carlos_emr.carlos.utility.SpringUtils;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.apache.struts2.ActionSupport;
+import org.apache.struts2.ServletActionContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the session-toggle action behind {@code Provider/showPersonal}.
+ *
+ * <p>The action has no Struts result mappings: it flips the {@code showPersonal} session attribute
+ * and must terminate processing with {@link ActionSupport#NONE}. Returning a bare {@code null}
+ * (the regression fixed on this branch) lets Struts try to resolve a named result and render HTML
+ * into what callers treat as a no-body toggle response. These tests pin the {@code NONE} contract
+ * and the toggle semantics.</p>
+ */
+@Tag("unit")
+@Tag("security")
+@DisplayName("DisplayPersonalInfoAppointment2Action")
+class DisplayPersonalInfoAppointment2ActionUnitTest {
+
+    @Test
+    @DisplayName("should return NONE and set showPersonal true when attribute is absent")
+    void shouldReturnNoneAndSetTrue_whenAttributeAbsent() {
+        withMockedContext(true, request -> {
+            DisplayPersonalInfoAppointment2Action action = new DisplayPersonalInfoAppointment2Action();
+
+            String result = action.execute();
+
+            assertThat(result).isEqualTo(ActionSupport.NONE);
+            assertThat(request.getSession().getAttribute("showPersonal")).isEqualTo(Boolean.TRUE);
+        });
+    }
+
+    @Test
+    @DisplayName("should return NONE and flip showPersonal to false when previously true")
+    void shouldReturnNoneAndSetFalse_whenPreviouslyTrue() {
+        withMockedContext(true, request -> {
+            request.getSession().setAttribute("showPersonal", Boolean.TRUE);
+            DisplayPersonalInfoAppointment2Action action = new DisplayPersonalInfoAppointment2Action();
+
+            String result = action.execute();
+
+            assertThat(result).isEqualTo(ActionSupport.NONE);
+            assertThat(request.getSession().getAttribute("showPersonal")).isEqualTo(Boolean.FALSE);
+        });
+    }
+
+    @Test
+    @DisplayName("should return NONE and flip showPersonal to true when previously false")
+    void shouldReturnNoneAndSetTrue_whenPreviouslyFalse() {
+        withMockedContext(true, request -> {
+            request.getSession().setAttribute("showPersonal", Boolean.FALSE);
+            DisplayPersonalInfoAppointment2Action action = new DisplayPersonalInfoAppointment2Action();
+
+            String result = action.execute();
+
+            assertThat(result).isEqualTo(ActionSupport.NONE);
+            assertThat(request.getSession().getAttribute("showPersonal")).isEqualTo(Boolean.TRUE);
+        });
+    }
+
+    @Test
+    @DisplayName("should throw SecurityException when _demographic read privilege is missing")
+    void shouldThrowSecurityException_whenPrivilegeMissing() {
+        withMockedContext(false, request -> {
+            DisplayPersonalInfoAppointment2Action action = new DisplayPersonalInfoAppointment2Action();
+
+            assertThatThrownBy(action::execute)
+                    .isInstanceOf(SecurityException.class)
+                    .hasMessageContaining("(_demographic)");
+            assertThat(request.getSession().getAttribute("showPersonal")).isNull();
+        });
+    }
+
+    /**
+     * Drives {@code body} with {@link ServletActionContext}, {@link SpringUtils}, and
+     * {@link LoggedInInfo} statically mocked so the action's field initializers resolve against the
+     * test doubles. The action is constructed inside {@code body} so it picks up these statics.
+     *
+     * @param hasPrivilege whether {@code _demographic}/{@code r} privilege is granted
+     * @param body         test logic receiving the backing request
+     */
+    private void withMockedContext(boolean hasPrivilege, RequestConsumer body) {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/carlos/Provider/showPersonal");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        SecurityInfoManager securityInfoManager = mock(SecurityInfoManager.class);
+        LoggedInInfo loggedInInfo = mock(LoggedInInfo.class);
+
+        try (MockedStatic<ServletActionContext> servletContext = mockStatic(ServletActionContext.class);
+             MockedStatic<SpringUtils> springUtils = mockStatic(SpringUtils.class);
+             MockedStatic<LoggedInInfo> loggedInInfoStatic = mockStatic(LoggedInInfo.class)) {
+
+            servletContext.when(ServletActionContext::getRequest).thenReturn(request);
+            servletContext.when(ServletActionContext::getResponse).thenReturn(response);
+            springUtils.when(() -> SpringUtils.getBean(SecurityInfoManager.class))
+                    .thenReturn(securityInfoManager);
+            loggedInInfoStatic.when(() -> LoggedInInfo.getLoggedInInfoFromSession(any(HttpServletRequest.class)))
+                    .thenReturn(loggedInInfo);
+            when(securityInfoManager.hasPrivilege(eq(loggedInInfo), eq("_demographic"), eq("r"), isNull()))
+                    .thenReturn(hasPrivilege);
+
+            body.accept(request);
+        }
+    }
+
+    @FunctionalInterface
+    private interface RequestConsumer {
+        void accept(MockHttpServletRequest request);
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/provider/web/DisplayPersonalInfoAppointment2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/provider/web/DisplayPersonalInfoAppointment2ActionUnitTest.java
@@ -43,19 +43,28 @@ import static org.mockito.Mockito.when;
 @DisplayName("DisplayPersonalInfoAppointment2Action")
 class DisplayPersonalInfoAppointment2ActionUnitTest {
 
+    /**
+     * Pins the regression directly on {@code toggle()}: a first-time toggle (no prior session
+     * attribute) must default {@code showPersonal} to {@code true} and return {@link
+     * ActionSupport#NONE} so Struts renders no result body.
+     */
     @Test
     @DisplayName("should return NONE and set showPersonal true when attribute is absent")
     void shouldReturnNoneAndSetTrue_whenAttributeAbsent() {
         withMockedContext(true, request -> {
             DisplayPersonalInfoAppointment2Action action = new DisplayPersonalInfoAppointment2Action();
 
-            String result = action.execute();
+            String result = action.toggle();
 
             assertThat(result).isEqualTo(ActionSupport.NONE);
             assertThat(request.getSession().getAttribute("showPersonal")).isEqualTo(Boolean.TRUE);
         });
     }
 
+    /**
+     * Verifies {@code toggle()} flips an existing {@code true} flag to {@code false} and still
+     * returns {@link ActionSupport#NONE}.
+     */
     @Test
     @DisplayName("should return NONE and flip showPersonal to false when previously true")
     void shouldReturnNoneAndSetFalse_whenPreviouslyTrue() {
@@ -63,13 +72,17 @@ class DisplayPersonalInfoAppointment2ActionUnitTest {
             request.getSession().setAttribute("showPersonal", Boolean.TRUE);
             DisplayPersonalInfoAppointment2Action action = new DisplayPersonalInfoAppointment2Action();
 
-            String result = action.execute();
+            String result = action.toggle();
 
             assertThat(result).isEqualTo(ActionSupport.NONE);
             assertThat(request.getSession().getAttribute("showPersonal")).isEqualTo(Boolean.FALSE);
         });
     }
 
+    /**
+     * Verifies {@code toggle()} flips an existing {@code false} flag back to {@code true} and still
+     * returns {@link ActionSupport#NONE}.
+     */
     @Test
     @DisplayName("should return NONE and flip showPersonal to true when previously false")
     void shouldReturnNoneAndSetTrue_whenPreviouslyFalse() {
@@ -77,13 +90,18 @@ class DisplayPersonalInfoAppointment2ActionUnitTest {
             request.getSession().setAttribute("showPersonal", Boolean.FALSE);
             DisplayPersonalInfoAppointment2Action action = new DisplayPersonalInfoAppointment2Action();
 
-            String result = action.execute();
+            String result = action.toggle();
 
             assertThat(result).isEqualTo(ActionSupport.NONE);
             assertThat(request.getSession().getAttribute("showPersonal")).isEqualTo(Boolean.TRUE);
         });
     }
 
+    /**
+     * Confirms the privilege gate in {@code execute()} rejects callers lacking {@code _demographic}
+     * read rights before any toggle side-effect runs. This case must drive {@code execute()} (not
+     * {@code toggle()}) because the security check lives in {@code execute()}.
+     */
     @Test
     @DisplayName("should throw SecurityException when _demographic read privilege is missing")
     void shouldThrowSecurityException_whenPrivilegeMissing() {


### PR DESCRIPTION
## Description

Fixes the return null to return NONE in DisplayPersonalInfoAppointment2Action.toggle(). 

## Related Issues

Fixes #2650

## How Was This Tested?

4 tests in DisplayPersonalInfoAppointment2ActionUnitTest.java to test for bolean flipping, returning NONE, and SecurityException.

## Checklist

- [ ] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [ ] I have not included any patient data (PHI) in this PR
- [ ] I have added tests for new functionality, or this change doesn't need new tests
- [ ] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Align DisplayPersonalInfoAppointment2Action with the Struts NONE result contract and add regression coverage for its session toggle and security behavior.

Bug Fixes:
- Ensure DisplayPersonalInfoAppointment2Action returns NONE instead of null to prevent unintended Struts result resolution when toggling the showPersonal session flag.

Tests:
- Add unit tests verifying showPersonal session toggling semantics, NONE result return value, and SecurityException behavior when _demographic read privilege is missing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return `NONE` from `DisplayPersonalInfoAppointment2Action.toggle()` to stop Struts result resolution and avoid stray markup. Document that `Provider/showPersonal` has no `<result>` mapping, and add unit tests that call `toggle()` directly to pin the `showPersonal` flip, the `NONE` contract, and the `_demographic` read-privilege gate; fixes #2650.

<sup>Written for commit cee1a2179658a03d22e58cce4ba467c5e773dd92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2979?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

