### PR TITLE
fix: remove tainted base href from loginfailed.jsp (#18895)

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/login/loginfailed.jsp
+++ b/src/main/webapp/WEB-INF/jsp/login/loginfailed.jsp
@@ -43,7 +43,6 @@
     <head>
     <link rel="icon" href="${pageContext.request.contextPath}/images/favicon.ico"/>
         <script type="text/javascript" src="<%= request.getContextPath() %>/js/global.js"></script>
-        <base href="<%= request.getScheme() + "://" + request.getServerName() + ":" + request.getServerPort() + request.getContextPath() + "/" %>">
         <title>Login Failure</title>
     </head>
     <body>


### PR DESCRIPTION
## Summary

Removes the `<base href>` tag from the login failure page, which built its value from `request.getServerName()` — derived from the client-controlled **Host header** — and reflected it **unencoded** into an HTML attribute. This is the sink flagged by **alert #18895** (reflected value in HTML output / `<base>`-tag hijacking).

## Why removal rather than encoding

The tag was dead weight. `loginfailed.jsp` is a small self-contained page and every URL on it is already an absolute, context-rooted path that does **not** resolve against `<base>`:

- favicon — `${pageContext.request.contextPath}/images/favicon.ico`
- script — `<%= request.getContextPath() %>/js/global.js`
- body — only the encoded `errormsg` text plus a static sentence; no relative URLs, forms, or images.

Since nothing depends on `<base>`, deleting it removes the raw `getServerName()` reflection outright instead of encoding a value with no purpose.

## Scope

- Touches only `loginfailed.jsp` (one line removed).
- The same legacy `<base>`/`getServerName()` idiom exists in other older JSPs (e.g. `provider/setTicklerPreferences.jsp`); those are intentionally **out of scope** for this alert and left untouched.

## Risk / testing

- No behavior change.
- No test asserts on the `<base>` tag. `LoginJspMigrationRegressionTest` pins this JSP's `errormsg` precedence and CARLOS encoder usage, both unaffected.

Fixes #18895

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Eliminate reflection of client-controlled host header data into the login failure page's base href attribute by removing the tag.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the <base href> tag from loginfailed.jsp to stop reflecting the client-controlled Host header via request.getServerName(), removing the base-tag hijacking risk (fixes #18895). No behavior change; the page uses absolute, context-rooted URLs.

<sup>Written for commit dec2b178a05ad5b2104322a52ad47b21fcafc834. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2983?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

