### PR TITLE
fix: suppress web-service 5xx response bodies to stop PHI leak (#2953)

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilter.java
@@ -317,14 +317,15 @@ public class ResponseSanitizationFilter implements Filter {
             int status = wrapper.getStatus();
             byte[] capturedBytes = wrapper.getCapturedOutput();
             String capturedBody = new String(capturedBytes, StandardCharsets.UTF_8);
-            if (shouldSanitizeErrorBody(status, capturedBody, webServiceRequest)) {
+            String reason = sanitizationReason(status, capturedBody, webServiceRequest);
+            if (reason != null) {
                 String correlationId = generateCorrelationId();
                 LOGGER.error("Sanitizing output-stream error response body "
                                 + "[status={} uri={} correlationId={} reason={}]",
                         status,
                         LogSafe.sanitizeUri(((HttpServletRequest) request).getRequestURI()),
                         correlationId,
-                        sanitizationReason(capturedBody));
+                        reason);
                 sendSanitizedError(httpResponse, status, correlationId);
             } else {
                 writeBytesToResponse(httpResponse, capturedBytes);
@@ -348,7 +349,8 @@ public class ResponseSanitizationFilter implements Filter {
         int status = wrapper.getStatus();
         String capturedBody = wrapper.getCapturedContent();
 
-        if (shouldSanitizeErrorBody(status, capturedBody, webServiceRequest)) {
+        String reason = sanitizationReason(status, capturedBody, webServiceRequest);
+        if (reason != null) {
             // Tainted (stack trace) or web-service 5xx partial body: log correlation details
             // only and send a sanitized replacement.
             String correlationId = generateCorrelationId();
@@ -357,7 +359,7 @@ public class ResponseSanitizationFilter implements Filter {
                     status,
                     LogSafe.sanitizeUri(((HttpServletRequest) request).getRequestURI()),
                     correlationId,
-                    sanitizationReason(capturedBody));
+                    reason);
             sendSanitizedError(httpResponse, status, correlationId);
         } else {
             // Safe response — write captured content through to the real response.
@@ -379,19 +381,29 @@ public class ResponseSanitizationFilter implements Filter {
         return STACK_TRACE_PATTERN.matcher(body).find();
     }
 
+    /** Reason code logged when an error body is replaced because it carries a stack trace. */
+    static final String REASON_STACK_TRACE = "stack-trace-marker";
+
+    /** Reason code logged when a web-service 5xx partial entity body is replaced. */
+    static final String REASON_WEB_SERVICE_5XX = "web-service-5xx-partial-body";
+
     /**
-     * Decides whether a captured error-response body must be replaced with a generic page.
+     * Determines whether a captured error-response body must be replaced with a generic page and,
+     * if so, why. Returns a short, log-safe reason code, or {@code null} when the body may pass
+     * through unchanged. The reason never includes any portion of the response body itself (which
+     * can carry PHI even after the decision).
      *
      * <p>Two independent triggers, both scoped to error status codes ({@code >= 400}):
      * <ul>
-     *   <li>The body contains Java stack trace markers (any error route) — the original
-     *       CWE-209 protection.</li>
-     *   <li>The request targets a web-service route ({@code /ws/*}) and the status is a server
-     *       error ({@code >= 500}). A mid-stream Jackson/JAXB serialization failure commonly
-     *       leaves a clean, well-formed JSON/XML prefix already written — patient demographics,
-     *       names, phone numbers — that the stack-trace heuristic does not match. Web-service
-     *       5xx responses carry no client-meaningful entity body, so suppressing it removes the
-     *       PHI exposure without breaking an API contract. See issue #2953.</li>
+     *   <li>{@link #REASON_STACK_TRACE} — the body contains Java stack trace markers (any error
+     *       route); the original CWE-209 protection.</li>
+     *   <li>{@link #REASON_WEB_SERVICE_5XX} — the request targets a web-service route
+     *       ({@code /ws/*}) and the status is a server error ({@code >= 500}). A mid-stream
+     *       Jackson/JAXB serialization failure commonly leaves a clean, well-formed JSON/XML prefix
+     *       already written — patient demographics, names, phone numbers — that the stack-trace
+     *       heuristic does not match. Web-service 5xx responses carry no client-meaningful entity
+     *       body, so suppressing it removes the PHI exposure without breaking an API contract. See
+     *       issue #2953.</li>
      * </ul>
      *
      * <p>Client errors ({@code 4xx}) on web-service routes are intentionally left to the
@@ -402,28 +414,31 @@ public class ResponseSanitizationFilter implements Filter {
      * @param status             int the response status code
      * @param body               String the captured response body; may be {@code null}/empty
      * @param webServiceRequest  boolean {@code true} if the request targeted a {@code /ws/*} route
-     * @return {@code true} if the body must be replaced with a sanitized error page
+     * @return a log-safe reason code, or {@code null} if the body must not be sanitized
      */
-    static boolean shouldSanitizeErrorBody(int status, String body, boolean webServiceRequest) {
+    static String sanitizationReason(int status, String body, boolean webServiceRequest) {
         if (status < 400) {
-            return false;
+            return null;
         }
         if (body != null && containsStackTrace(body)) {
-            return true;
+            return REASON_STACK_TRACE;
         }
-        return webServiceRequest && status >= 500;
+        if (webServiceRequest && status >= 500) {
+            return REASON_WEB_SERVICE_5XX;
+        }
+        return null;
     }
 
     /**
-     * Returns a short, log-safe reason code describing why a body was sanitized. Never includes
-     * any portion of the response body itself (which can carry PHI even after the decision).
+     * Convenience predicate over {@link #sanitizationReason(int, String, boolean)}.
      *
-     * @param body String the captured body used only to distinguish the trigger
-     * @return {@code "stack-trace-marker"} or {@code "web-service-5xx-partial-body"}
+     * @param status             int the response status code
+     * @param body               String the captured response body; may be {@code null}/empty
+     * @param webServiceRequest  boolean {@code true} if the request targeted a {@code /ws/*} route
+     * @return {@code true} if the body must be replaced with a sanitized error page
      */
-    private static String sanitizationReason(String body) {
-        return (body != null && containsStackTrace(body))
-                ? "stack-trace-marker" : "web-service-5xx-partial-body";
+    static boolean shouldSanitizeErrorBody(int status, String body, boolean webServiceRequest) {
+        return sanitizationReason(status, body, webServiceRequest) != null;
     }
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilter.java
@@ -56,6 +56,13 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * a correlation ID. Logs include status, route, and correlation ID, but never response-body
  * excerpts because error pages can contain PHI even after control-character sanitization.</p>
  *
+ * <p>For web-service routes ({@code /ws/*}, the CXF servlet), the body of any {@code 5xx}
+ * response is replaced regardless of stack-trace content. A mid-stream Jackson/JAXB
+ * serialization failure leaves a clean, well-formed JSON/XML prefix (e.g. patient demographics)
+ * already written; that prefix does not match the stack-trace heuristic but still leaks PHI.
+ * A web-service {@code 5xx} carries no client-meaningful entity body, so suppressing it closes
+ * the exposure without breaking an API contract. See issue #2953.</p>
+ *
  * <h3>Detection</h3>
  * <p>Stack trace detection uses a {@link Pattern} that matches common Java stack trace markers:
  * {@code at pkg.Class.method(File.java:nn)}, {@code Caused by:}, {@code java.lang.},
@@ -249,6 +256,7 @@ public class ResponseSanitizationFilter implements Filter {
         }
 
         HttpServletResponse httpResponse = (HttpServletResponse) response;
+        boolean webServiceRequest = isWebServiceRequest((HttpServletRequest) request);
         CapturingResponseWrapper wrapper = new CapturingResponseWrapper(httpResponse);
 
         try {
@@ -309,13 +317,14 @@ public class ResponseSanitizationFilter implements Filter {
             int status = wrapper.getStatus();
             byte[] capturedBytes = wrapper.getCapturedOutput();
             String capturedBody = new String(capturedBytes, StandardCharsets.UTF_8);
-            if (status >= 400 && containsStackTrace(capturedBody)) {
+            if (shouldSanitizeErrorBody(status, capturedBody, webServiceRequest)) {
                 String correlationId = generateCorrelationId();
-                LOGGER.error("Stack trace detected in output-stream error response "
-                                + "[status={} uri={} correlationId={}]",
+                LOGGER.error("Sanitizing output-stream error response body "
+                                + "[status={} uri={} correlationId={} reason={}]",
                         status,
                         LogSafe.sanitizeUri(((HttpServletRequest) request).getRequestURI()),
-                        correlationId);
+                        correlationId,
+                        sanitizationReason(capturedBody));
                 sendSanitizedError(httpResponse, status, correlationId);
             } else {
                 writeBytesToResponse(httpResponse, capturedBytes);
@@ -339,14 +348,16 @@ public class ResponseSanitizationFilter implements Filter {
         int status = wrapper.getStatus();
         String capturedBody = wrapper.getCapturedContent();
 
-        if (status >= 400 && containsStackTrace(capturedBody)) {
-            // Stack trace detected: log correlation details only and send a sanitized replacement.
+        if (shouldSanitizeErrorBody(status, capturedBody, webServiceRequest)) {
+            // Tainted (stack trace) or web-service 5xx partial body: log correlation details
+            // only and send a sanitized replacement.
             String correlationId = generateCorrelationId();
-            LOGGER.error("Stack trace detected in error response "
-                    + "[status={} uri={} correlationId={}]",
+            LOGGER.error("Sanitizing error response body "
+                    + "[status={} uri={} correlationId={} reason={}]",
                     status,
                     LogSafe.sanitizeUri(((HttpServletRequest) request).getRequestURI()),
-                    correlationId);
+                    correlationId,
+                    sanitizationReason(capturedBody));
             sendSanitizedError(httpResponse, status, correlationId);
         } else {
             // Safe response — write captured content through to the real response.
@@ -366,6 +377,70 @@ public class ResponseSanitizationFilter implements Filter {
             return false;
         }
         return STACK_TRACE_PATTERN.matcher(body).find();
+    }
+
+    /**
+     * Decides whether a captured error-response body must be replaced with a generic page.
+     *
+     * <p>Two independent triggers, both scoped to error status codes ({@code >= 400}):
+     * <ul>
+     *   <li>The body contains Java stack trace markers (any error route) — the original
+     *       CWE-209 protection.</li>
+     *   <li>The request targets a web-service route ({@code /ws/*}) and the status is a server
+     *       error ({@code >= 500}). A mid-stream Jackson/JAXB serialization failure commonly
+     *       leaves a clean, well-formed JSON/XML prefix already written — patient demographics,
+     *       names, phone numbers — that the stack-trace heuristic does not match. Web-service
+     *       5xx responses carry no client-meaningful entity body, so suppressing it removes the
+     *       PHI exposure without breaking an API contract. See issue #2953.</li>
+     * </ul>
+     *
+     * <p>Client errors ({@code 4xx}) on web-service routes are intentionally left to the
+     * stack-trace check alone, because REST endpoints legitimately return structured JSON error
+     * payloads (validation messages, {@code 401}/{@code 403}/{@code 404} envelopes) that callers
+     * depend on.</p>
+     *
+     * @param status             int the response status code
+     * @param body               String the captured response body; may be {@code null}/empty
+     * @param webServiceRequest  boolean {@code true} if the request targeted a {@code /ws/*} route
+     * @return {@code true} if the body must be replaced with a sanitized error page
+     */
+    static boolean shouldSanitizeErrorBody(int status, String body, boolean webServiceRequest) {
+        if (status < 400) {
+            return false;
+        }
+        if (containsStackTrace(body)) {
+            return true;
+        }
+        return webServiceRequest && status >= 500;
+    }
+
+    /**
+     * Returns a short, log-safe reason code describing why a body was sanitized. Never includes
+     * any portion of the response body itself (which can carry PHI even after the decision).
+     *
+     * @param body String the captured body used only to distinguish the trigger
+     * @return {@code "stack-trace-marker"} or {@code "web-service-5xx-partial-body"}
+     */
+    private static String sanitizationReason(String body) {
+        return containsStackTrace(body) ? "stack-trace-marker" : "web-service-5xx-partial-body";
+    }
+
+    /**
+     * Determines whether the request targets a CXF web-service route. The CXF servlet is mapped at
+     * {@code /ws/*} (see {@code web.xml}); {@link HttpServletRequest#getServletPath()} therefore
+     * returns {@code /ws} for these requests. The request URI is checked as a fallback for
+     * forwarded/wrapped requests where the servlet path may not be populated.
+     *
+     * @param request HttpServletRequest the incoming request
+     * @return boolean {@code true} if the request path is under {@code /ws/}
+     */
+    static boolean isWebServiceRequest(HttpServletRequest request) {
+        String servletPath = request.getServletPath();
+        if (servletPath != null && (servletPath.equals("/ws") || servletPath.startsWith("/ws/"))) {
+            return true;
+        }
+        String uri = request.getRequestURI();
+        return uri != null && (uri.contains("/ws/") || uri.endsWith("/ws"));
     }
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilter.java
@@ -408,7 +408,7 @@ public class ResponseSanitizationFilter implements Filter {
         if (status < 400) {
             return false;
         }
-        if (containsStackTrace(body)) {
+        if (body != null && containsStackTrace(body)) {
             return true;
         }
         return webServiceRequest && status >= 500;
@@ -422,14 +422,18 @@ public class ResponseSanitizationFilter implements Filter {
      * @return {@code "stack-trace-marker"} or {@code "web-service-5xx-partial-body"}
      */
     private static String sanitizationReason(String body) {
-        return containsStackTrace(body) ? "stack-trace-marker" : "web-service-5xx-partial-body";
+        return (body != null && containsStackTrace(body))
+                ? "stack-trace-marker" : "web-service-5xx-partial-body";
     }
 
     /**
      * Determines whether the request targets a CXF web-service route. The CXF servlet is mapped at
      * {@code /ws/*} (see {@code web.xml}); {@link HttpServletRequest#getServletPath()} therefore
-     * returns {@code /ws} for these requests. The request URI is checked as a fallback for
-     * forwarded/wrapped requests where the servlet path may not be populated.
+     * returns {@code /ws} for these requests. As a fallback for forwarded/wrapped requests where the
+     * servlet path may not be populated, the <em>context-relative</em> request URI is matched with
+     * an exact/prefix check ({@code /ws} or {@code /ws/...}). A substring match is deliberately
+     * avoided so unrelated paths that merely contain {@code /ws/} (e.g. {@code /proxy/ws/foo}) are
+     * not misclassified as web-service requests.
      *
      * @param request HttpServletRequest the incoming request
      * @return boolean {@code true} if the request path is under {@code /ws/}
@@ -440,7 +444,14 @@ public class ResponseSanitizationFilter implements Filter {
             return true;
         }
         String uri = request.getRequestURI();
-        return uri != null && (uri.contains("/ws/") || uri.endsWith("/ws"));
+        if (uri == null) {
+            return false;
+        }
+        String contextPath = request.getContextPath();
+        String path = (contextPath != null && !contextPath.isEmpty() && uri.startsWith(contextPath))
+                ? uri.substring(contextPath.length())
+                : uri;
+        return path.equals("/ws") || path.startsWith("/ws/");
     }
 
     /**

--- a/src/test/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilterUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilterUnitTest.java
@@ -975,9 +975,12 @@ class ResponseSanitizationFilterUnitTest {
         }
 
         @Test
-        @DisplayName("should return true when request URI contains /ws/")
-        void shouldReturnTrue_whenRequestUriContainsWs() {
+        @DisplayName("should return true when context-relative request URI is under /ws/")
+        void shouldReturnTrue_whenContextRelativeUriIsUnderWs() {
+            // No servlet path populated — exercises the context-relative URI fallback.
             MockHttpServletRequest request = new MockHttpServletRequest();
+            request.setContextPath("/carlos");
+            request.setServletPath("");
             request.setRequestURI("/carlos/ws/rs/demographics/1");
             assertThat(ResponseSanitizationFilter.isWebServiceRequest(request)).isTrue();
         }
@@ -997,6 +1000,18 @@ class ResponseSanitizationFilterUnitTest {
             MockHttpServletRequest request = new MockHttpServletRequest("GET", "/carlos/news/list");
             request.setRequestURI("/carlos/news/list");
             request.setServletPath("/news/list");
+            assertThat(ResponseSanitizationFilter.isWebServiceRequest(request)).isFalse();
+        }
+
+        @Test
+        @DisplayName("should not match a deeper path that merely contains /ws/ as a later segment")
+        void shouldReturnFalse_whenWsAppearsAsLaterPathSegment() {
+            // Fallback path: servlet path empty, URI has /ws/ deep in the path but not at the
+            // context-relative root. A substring match would wrongly classify this as a /ws route.
+            MockHttpServletRequest request = new MockHttpServletRequest("GET", "/carlos/proxy/ws/foo");
+            request.setContextPath("/carlos");
+            request.setServletPath("");
+            request.setRequestURI("/carlos/proxy/ws/foo");
             assertThat(ResponseSanitizationFilter.isWebServiceRequest(request)).isFalse();
         }
     }

--- a/src/test/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilterUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilterUnitTest.java
@@ -920,6 +920,65 @@ class ResponseSanitizationFilterUnitTest {
             assertThat(response.getStatus()).isEqualTo(500);
             assertThat(response.getContentAsString()).isEqualTo(htmlError);
         }
+
+        @Test
+        @DisplayName("should sanitize 500 stack-trace body on /ws route through the full filter")
+        void shouldSanitizeStackTraceBody_whenStatusIs500OnWebServiceRoute() throws Exception {
+            MockHttpServletRequest request = wsRequest("POST");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            // A /ws 500 carrying an actual stack trace must be sanitized via the stack-trace
+            // trigger, exactly as it would on any other route — verified end-to-end here.
+            String stackTraceBody = "java.lang.NullPointerException\n"
+                    + "\tat io.github.carlos_emr.carlos.ws.rs.ScheduleService.getAppointment(ScheduleService.java:88)";
+
+            FilterChain chain = (req, res) -> {
+                HttpServletResponse httpRes = (HttpServletResponse) res;
+                httpRes.setStatus(500);
+                httpRes.setContentType("application/json");
+                res.getWriter().write(stackTraceBody);
+            };
+
+            filter.doFilter(request, response, chain);
+
+            assertThat(response.getStatus()).isEqualTo(500);
+            String sanitized = response.getContentAsString();
+            assertThat(sanitized).doesNotContain("NullPointerException");
+            assertThat(sanitized).doesNotContain("io.github.carlos_emr");
+            assertThat(sanitized).contains("Reference ID:");
+        }
+    }
+
+    @Nested
+    @DisplayName("sanitizationReason()")
+    class SanitizationReason {
+
+        @Test
+        @DisplayName("should report stack-trace reason for any error status with markers")
+        void shouldReportStackTraceReason_forAnyErrorWithMarkers() {
+            String body = "java.lang.NullPointerException\n\tat io.github.carlos_emr.carlos.Foo.bar(Foo.java:1)";
+            assertThat(ResponseSanitizationFilter.sanitizationReason(404, body, false))
+                    .isEqualTo(ResponseSanitizationFilter.REASON_STACK_TRACE);
+            assertThat(ResponseSanitizationFilter.sanitizationReason(500, body, true))
+                    .isEqualTo(ResponseSanitizationFilter.REASON_STACK_TRACE);
+        }
+
+        @Test
+        @DisplayName("should report web-service 5xx reason for clean /ws 5xx body")
+        void shouldReportWebService5xxReason_forCleanWebService5xxBody() {
+            assertThat(ResponseSanitizationFilter.sanitizationReason(500, "{\"phi\":\"x\"}", true))
+                    .isEqualTo(ResponseSanitizationFilter.REASON_WEB_SERVICE_5XX);
+            assertThat(ResponseSanitizationFilter.sanitizationReason(503, null, true))
+                    .isEqualTo(ResponseSanitizationFilter.REASON_WEB_SERVICE_5XX);
+        }
+
+        @Test
+        @DisplayName("should return null when the body must not be sanitized")
+        void shouldReturnNull_whenBodyMustNotBeSanitized() {
+            // Successful status, /ws 4xx without stack trace, and non-/ws 5xx without stack trace.
+            assertThat(ResponseSanitizationFilter.sanitizationReason(200, "{\"phi\":\"x\"}", true)).isNull();
+            assertThat(ResponseSanitizationFilter.sanitizationReason(404, "{\"error\":\"x\"}", true)).isNull();
+            assertThat(ResponseSanitizationFilter.sanitizationReason(500, "plain page", false)).isNull();
+        }
     }
 
     @Nested

--- a/src/test/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilterUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilterUnitTest.java
@@ -826,11 +826,12 @@ class ResponseSanitizationFilterUnitTest {
 
             assertThat(response.getStatus()).isEqualTo(500);
             String sanitized = response.getContentAsString();
-            assertThat(sanitized).doesNotContain("Jane");
-            assertThat(sanitized).doesNotContain("Doe");
-            assertThat(sanitized).doesNotContain("250-555-0143");
-            assertThat(sanitized).doesNotContain("patientStatus");
-            assertThat(sanitized).contains("Reference ID:");
+            assertThat(sanitized)
+                    .doesNotContain("Jane")
+                    .doesNotContain("Doe")
+                    .doesNotContain("250-555-0143")
+                    .doesNotContain("patientStatus")
+                    .contains("Reference ID:");
         }
 
         @Test
@@ -851,9 +852,10 @@ class ResponseSanitizationFilterUnitTest {
 
             assertThat(response.getStatus()).isEqualTo(500);
             String sanitized = response.getContentAsString();
-            assertThat(sanitized).doesNotContain("Jane");
-            assertThat(sanitized).doesNotContain("9999999999");
-            assertThat(sanitized).contains("Reference ID:");
+            assertThat(sanitized)
+                    .doesNotContain("Jane")
+                    .doesNotContain("9999999999")
+                    .contains("Reference ID:");
         }
 
         @Test
@@ -942,9 +944,10 @@ class ResponseSanitizationFilterUnitTest {
 
             assertThat(response.getStatus()).isEqualTo(500);
             String sanitized = response.getContentAsString();
-            assertThat(sanitized).doesNotContain("NullPointerException");
-            assertThat(sanitized).doesNotContain("io.github.carlos_emr");
-            assertThat(sanitized).contains("Reference ID:");
+            assertThat(sanitized)
+                    .doesNotContain("NullPointerException")
+                    .doesNotContain("io.github.carlos_emr")
+                    .contains("Reference ID:");
         }
     }
 

--- a/src/test/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilterUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilterUnitTest.java
@@ -790,6 +790,218 @@ class ResponseSanitizationFilterUnitTest {
     }
 
     // -------------------------------------------------------------------------
+    // doFilter() — web-service (/ws) 5xx partial-body leak (issue #2953)
+    // -------------------------------------------------------------------------
+
+    @Nested
+    @DisplayName("web-service (/ws) error responses")
+    class WebServiceErrors {
+
+        private MockHttpServletRequest wsRequest(String method) {
+            MockHttpServletRequest request = new MockHttpServletRequest(method, "/carlos/ws/rs/schedule/getAppointment");
+            request.setRequestURI("/carlos/ws/rs/schedule/getAppointment");
+            request.setServletPath("/ws");
+            request.setPathInfo("/rs/schedule/getAppointment");
+            return request;
+        }
+
+        @Test
+        @DisplayName("should sanitize 500 partial-JSON body without stack trace on /ws route")
+        void shouldSanitizePartialJsonBody_whenStatusIs500OnWebServiceRoute() throws Exception {
+            MockHttpServletRequest request = wsRequest("POST");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            // Mid-stream Jackson failure: a clean, well-formed JSON prefix with PHI is already
+            // written, then the status flips to 500. No stack-trace markers are present.
+            String partialPhiJson = "{\"appointmentNo\":1234,\"demographic\":{\"firstName\":\"Jane\","
+                    + "\"lastName\":\"Doe\",\"phone\":\"250-555-0143\",\"patientStatus\":\"AC\"}";
+
+            FilterChain chain = (req, res) -> {
+                HttpServletResponse httpRes = (HttpServletResponse) res;
+                httpRes.setStatus(500);
+                httpRes.setContentType("application/json");
+                res.getWriter().write(partialPhiJson);
+            };
+
+            filter.doFilter(request, response, chain);
+
+            assertThat(response.getStatus()).isEqualTo(500);
+            String sanitized = response.getContentAsString();
+            assertThat(sanitized).doesNotContain("Jane");
+            assertThat(sanitized).doesNotContain("Doe");
+            assertThat(sanitized).doesNotContain("250-555-0143");
+            assertThat(sanitized).doesNotContain("patientStatus");
+            assertThat(sanitized).contains("Reference ID:");
+        }
+
+        @Test
+        @DisplayName("should sanitize 500 partial-JSON body written through output stream on /ws route")
+        void shouldSanitizePartialJsonBody_whenWrittenThroughOutputStreamAfterStatus500() throws Exception {
+            MockHttpServletRequest request = wsRequest("POST");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            String partialPhiJson = "{\"demographic\":{\"firstName\":\"Jane\",\"hin\":\"9999999999\"}";
+
+            FilterChain chain = (req, res) -> {
+                HttpServletResponse httpRes = (HttpServletResponse) res;
+                httpRes.setStatus(500);
+                httpRes.setContentType("application/json;charset=UTF-8");
+                res.getOutputStream().write(partialPhiJson.getBytes(StandardCharsets.UTF_8));
+            };
+
+            filter.doFilter(request, response, chain);
+
+            assertThat(response.getStatus()).isEqualTo(500);
+            String sanitized = response.getContentAsString();
+            assertThat(sanitized).doesNotContain("Jane");
+            assertThat(sanitized).doesNotContain("9999999999");
+            assertThat(sanitized).contains("Reference ID:");
+        }
+
+        @Test
+        @DisplayName("should pass through 400 JSON error body on /ws route unchanged")
+        void shouldPassThrough_whenStatusIs400OnWebServiceRoute() throws Exception {
+            MockHttpServletRequest request = wsRequest("POST");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            // Legitimate REST client-error envelope — must NOT be blanked, callers depend on it.
+            String errorEnvelope = "{\"error\":\"validation_failed\",\"field\":\"appointmentNo\"}";
+
+            FilterChain chain = (req, res) -> {
+                HttpServletResponse httpRes = (HttpServletResponse) res;
+                httpRes.setStatus(400);
+                httpRes.setContentType("application/json");
+                res.getWriter().write(errorEnvelope);
+            };
+
+            filter.doFilter(request, response, chain);
+
+            assertThat(response.getStatus()).isEqualTo(400);
+            assertThat(response.getContentAsString()).isEqualTo(errorEnvelope);
+        }
+
+        @Test
+        @DisplayName("should pass through 200 JSON body on /ws route unchanged")
+        void shouldPassThrough_whenStatusIs200OnWebServiceRoute() throws Exception {
+            MockHttpServletRequest request = wsRequest("GET");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            String okJson = "{\"appointmentNo\":1234,\"status\":\"booked\"}";
+
+            FilterChain chain = (req, res) -> {
+                HttpServletResponse httpRes = (HttpServletResponse) res;
+                httpRes.setStatus(200);
+                httpRes.setContentType("application/json");
+                res.getWriter().write(okJson);
+            };
+
+            filter.doFilter(request, response, chain);
+
+            assertThat(response.getStatus()).isEqualTo(200);
+            assertThat(response.getContentAsString()).isEqualTo(okJson);
+        }
+
+        @Test
+        @DisplayName("should pass through 500 body without stack trace on a non-/ws route")
+        void shouldPassThrough_when500WithoutStackTraceOnNonWebServiceRoute() throws Exception {
+            MockHttpServletRequest request = new MockHttpServletRequest("GET", "/carlos/provider/providercontrol");
+            request.setRequestURI("/carlos/provider/providercontrol");
+            request.setServletPath("/provider/providercontrol");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            // A normal (non web-service) 500 HTML page with no stack trace keeps its existing
+            // pass-through behaviour — this change is scoped to /ws routes only.
+            String htmlError = "<html><body><h1>An error occurred</h1></body></html>";
+
+            FilterChain chain = (req, res) -> {
+                HttpServletResponse httpRes = (HttpServletResponse) res;
+                httpRes.setStatus(500);
+                httpRes.setContentType("text/html");
+                res.getWriter().write(htmlError);
+            };
+
+            filter.doFilter(request, response, chain);
+
+            assertThat(response.getStatus()).isEqualTo(500);
+            assertThat(response.getContentAsString()).isEqualTo(htmlError);
+        }
+    }
+
+    @Nested
+    @DisplayName("shouldSanitizeErrorBody()")
+    class ShouldSanitizeErrorBody {
+
+        @Test
+        @DisplayName("should sanitize web-service 5xx regardless of stack-trace content")
+        void shouldSanitize_forWebService5xxWithoutStackTrace() {
+            assertThat(ResponseSanitizationFilter.shouldSanitizeErrorBody(500, "{\"phi\":\"x\"}", true)).isTrue();
+            assertThat(ResponseSanitizationFilter.shouldSanitizeErrorBody(503, "clean body", true)).isTrue();
+        }
+
+        @Test
+        @DisplayName("should not sanitize web-service 4xx without stack trace")
+        void shouldNotSanitize_forWebService4xxWithoutStackTrace() {
+            assertThat(ResponseSanitizationFilter.shouldSanitizeErrorBody(400, "{\"error\":\"x\"}", true)).isFalse();
+            assertThat(ResponseSanitizationFilter.shouldSanitizeErrorBody(404, "not found", true)).isFalse();
+        }
+
+        @Test
+        @DisplayName("should not sanitize non-web-service 5xx without stack trace")
+        void shouldNotSanitize_forNonWebService5xxWithoutStackTrace() {
+            assertThat(ResponseSanitizationFilter.shouldSanitizeErrorBody(500, "plain page", false)).isFalse();
+        }
+
+        @Test
+        @DisplayName("should sanitize any error status with stack-trace markers")
+        void shouldSanitize_forAnyErrorWithStackTrace() {
+            String body = "java.lang.NullPointerException\n\tat io.github.carlos_emr.carlos.Foo.bar(Foo.java:1)";
+            assertThat(ResponseSanitizationFilter.shouldSanitizeErrorBody(404, body, false)).isTrue();
+            assertThat(ResponseSanitizationFilter.shouldSanitizeErrorBody(500, body, false)).isTrue();
+        }
+
+        @Test
+        @DisplayName("should not sanitize successful responses")
+        void shouldNotSanitize_forSuccessfulResponses() {
+            assertThat(ResponseSanitizationFilter.shouldSanitizeErrorBody(200, "{\"phi\":\"x\"}", true)).isFalse();
+            assertThat(ResponseSanitizationFilter.shouldSanitizeErrorBody(302, "", true)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("isWebServiceRequest()")
+    class IsWebServiceRequest {
+
+        @Test
+        @DisplayName("should return true when servlet path is /ws")
+        void shouldReturnTrue_whenServletPathIsWs() {
+            MockHttpServletRequest request = new MockHttpServletRequest("POST", "/carlos/ws/rs/schedule/getAppointment");
+            request.setServletPath("/ws");
+            assertThat(ResponseSanitizationFilter.isWebServiceRequest(request)).isTrue();
+        }
+
+        @Test
+        @DisplayName("should return true when request URI contains /ws/")
+        void shouldReturnTrue_whenRequestUriContainsWs() {
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            request.setRequestURI("/carlos/ws/rs/demographics/1");
+            assertThat(ResponseSanitizationFilter.isWebServiceRequest(request)).isTrue();
+        }
+
+        @Test
+        @DisplayName("should return false for a non-web-service route")
+        void shouldReturnFalse_forNonWebServiceRoute() {
+            MockHttpServletRequest request = new MockHttpServletRequest("GET", "/carlos/provider/providercontrol");
+            request.setRequestURI("/carlos/provider/providercontrol");
+            request.setServletPath("/provider/providercontrol");
+            assertThat(ResponseSanitizationFilter.isWebServiceRequest(request)).isFalse();
+        }
+
+        @Test
+        @DisplayName("should not match an unrelated path that merely contains the letters ws")
+        void shouldReturnFalse_forUnrelatedPathContainingWs() {
+            MockHttpServletRequest request = new MockHttpServletRequest("GET", "/carlos/news/list");
+            request.setRequestURI("/carlos/news/list");
+            request.setServletPath("/news/list");
+            assertThat(ResponseSanitizationFilter.isWebServiceRequest(request)).isFalse();
+        }
+    }
+
+    // -------------------------------------------------------------------------
     // doFilter() — committed response (sendError / sendRedirect)
     // -------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Relates to #2953 — `POST /ws/rs/schedule/getAppointment` returned **HTTP 500** while the response body still contained the partially-serialized appointment and nested demographic JSON (patient name, phone, patient status), leaking PHI.

**Root cause:** a mid-stream Jackson serialization failure leaves a clean, well-formed JSON prefix already written before the failure. `ResponseSanitizationFilter` only replaced bodies that matched its **stack-trace** heuristic, so a clean JSON error body passed through unsanitized (CWE-209).

## Fix

Replace the body of **any 5xx response on a web-service route** (`/ws/*`, the CXF servlet) regardless of stack-trace content, on both the captured writer and output-stream error paths.

- `sanitizationReason(status, body, webServiceRequest)` — central decision: returns a log-safe reason code (`stack-trace-marker` for any route with stack-trace markers; `web-service-5xx-partial-body` for `/ws/*` with status ≥ 500) or `null` to pass through. Computed once per error response.
- `shouldSanitizeErrorBody(...)` — thin predicate over the above (retained for callers/tests).
- `isWebServiceRequest(request)` — matches the CXF servlet path (`/ws/*` per `web.xml`) using the servlet path, with a **context-relative** URI fallback (exact/prefix match, not a substring, to avoid false positives like `/proxy/ws/foo`).

Scoped deliberately, per the response-filter safety guidance in `CLAUDE.md` (targeted by route + status):

- **4xx on `/ws`** keep the stack-trace-only check, so legitimate REST JSON error envelopes (validation messages, `401`/`403`/`404`) are preserved.
- **Non-`/ws` routes** are unaffected — a normal 500 HTML page without a stack trace still passes through.
- The output-stream *passthrough* path already blanked any uncommitted `≥400`; this aligns the captured paths with that behaviour.

> ⚠️ **Behaviour note for reviewers:** on `/ws`, *any* 5xx body is now replaced with the generic HTML error page — a deliberate security-over-contract tradeoff. If a `/ws` endpoint intentionally returns a machine-readable JSON body on 5xx, call it out here. 4xx and non-`/ws` are untouched. (See inline reviewer note comment.)

## Tests

`ResponseSanitizationFilterUnitTest` — **66 tests, all passing**:

- `/ws` 500 partial-JSON PHI leak via **writer** and **output stream** → body replaced with the generic Reference-ID page; PHI absent.
- `/ws` 500 carrying a stack trace → sanitized end-to-end via the stack-trace trigger.
- `/ws` 400 JSON error envelope and `/ws` 200 JSON body → passed through unchanged.
- non-`/ws` 500 without a stack trace → passed through unchanged.
- `sanitizationReason()` / `shouldSanitizeErrorBody()` decision matrix and `isWebServiceRequest()` (incl. a `/proxy/ws/foo` false-positive guard).

Also validated with a live embedded-Jetty A/B (real container, real HTTP): the writer and captured-output-stream `/ws` 5xx paths leak on `develop` and are blanked with this PR.

## Known limitation / follow-up

This fix covers cases where the response is **not yet committed**. If a `/ws` 5xx partial body exceeds the container output buffer, the bytes are flushed before the filter can intervene and PHI still leaks — tracked separately in **#2994** (output-buffering / CXF interceptor). Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
