### PR TITLE
fix: repair broken ScheduleService REST appointment endpoints (#2957)

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/Demographic.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/Demographic.java
@@ -775,8 +775,11 @@ public class Demographic extends AbstractModel<Integer> implements Serializable 
     }
     @jakarta.persistence.Transient
 
+    // The family_physician column is frequently null. Coalesce to "" before matching
+    // (mirroring getFamilyDoctor()'s null handling) so these transient parse getters
+    // never NPE — e.g. when Jackson serializes a Demographic over the REST API.
     public String getFamilyPhysicianLastName() {
-        Matcher m = FD_LAST_NAME.matcher(getFamilyPhysician());
+        Matcher m = FD_LAST_NAME.matcher(StringUtils.trimToEmpty(getFamilyPhysician()));
         if (m.find()) {
             return m.group(2);
         }
@@ -785,7 +788,7 @@ public class Demographic extends AbstractModel<Integer> implements Serializable 
     @jakarta.persistence.Transient
 
     public String getFamilyPhysicianFirstName() {
-        Matcher m = FD_FIRST_NAME.matcher(getFamilyPhysician());
+        Matcher m = FD_FIRST_NAME.matcher(StringUtils.trimToEmpty(getFamilyPhysician()));
         if (m.find()) {
             return m.group(2);
         }
@@ -794,7 +797,7 @@ public class Demographic extends AbstractModel<Integer> implements Serializable 
     @jakarta.persistence.Transient
 
     public String getFamilyPhysicianFullName() {
-        Matcher m = FD_FULL_NAME.matcher(getFamilyPhysician());
+        Matcher m = FD_FULL_NAME.matcher(StringUtils.trimToEmpty(getFamilyPhysician()));
         if (m.find()) {
             return m.group(2);
         }
@@ -803,7 +806,7 @@ public class Demographic extends AbstractModel<Integer> implements Serializable 
     @jakarta.persistence.Transient
 
     public String getFamilyPhysicianNumber() {
-        Matcher m = FD_OHIP.matcher(getFamilyPhysician());
+        Matcher m = FD_OHIP.matcher(StringUtils.trimToEmpty(getFamilyPhysician()));
         if (m.find()) {
             return m.group(2);
         }

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/ScheduleService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/ScheduleService.java
@@ -554,7 +554,7 @@ public class ScheduleService extends AbstractServiceImpl {
         if (value instanceof Character character) {
             return character;
         }
-        String s = value.toString();
+        String s = value.toString().trim();
         return s.isEmpty() ? null : s.charAt(0);
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/ScheduleService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/ScheduleService.java
@@ -560,9 +560,15 @@ public class ScheduleService extends AbstractServiceImpl {
     }
 
     /**
-     * Coerce a single-character JDBC column value to {@link Character}. CHAR columns are
-     * commonly returned as {@code String} by the driver, so a {@code (Character) cast} would
-     * throw; treat empty/blank as {@code null}.
+     * Coerce a JDBC status column value to {@link Character}. CHAR columns are commonly returned
+     * as {@code String} by the driver, so a {@code (Character) cast} would throw; treat
+     * empty/blank as {@code null}.
+     *
+     * <p>The {@code appointment.status} column is {@code char(2)} (a primary status code plus an
+     * optional sub-flag), but {@link AppointmentExtTo} carries status as a single
+     * {@code Character}. The leading character is the primary status code, so taking the first
+     * character is intentional: it preserves the value this list/calendar DTO is shaped to hold
+     * and keeps {@code fetchDays} working for two-character statuses rather than rejecting them.</p>
      */
     private static Character toCharacter(Object value) {
         if (value == null) {

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/ScheduleService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/ScheduleService.java
@@ -251,10 +251,27 @@ public class ScheduleService extends AbstractServiceImpl {
     @Consumes("application/json")
     @Produces("application/json")
     public SchedulingResponse updateAppointment(AppointmentTo1 appointmentTo) {
-        SchedulingResponse response = new SchedulingResponse();
+        if (appointmentTo == null || appointmentTo.getId() == null) {
+            throw new WebApplicationException(Response.status(Status.BAD_REQUEST)
+                    .entity("Appointment id is required").build());
+        }
 
+        // Load the persisted appointment and apply only client-editable fields onto it, so the
+        // server-managed identity/audit fields (createDateTime, creator, creatorSecurityId,
+        // bookingSource) are preserved rather than overwritten by the request payload, and the
+        // updating provider is stamped server-side. A blind DTO->entity merge here would corrupt
+        // the creation audit trail and allow over-posting.
+        Appointment appt = appointmentManager.getAppointment(getLoggedInInfo(), appointmentTo.getId());
+        if (appt == null) {
+            throw new WebApplicationException(Response.status(Status.NOT_FOUND)
+                    .entity("Appointment not found").build());
+        }
+
+        SchedulingResponse response = new SchedulingResponse();
         AppointmentConverter converter = new AppointmentConverter();
-        Appointment appt = converter.getAsDomainObject(getLoggedInInfo(), appointmentTo);
+
+        converter.applyEditableProperties(appointmentTo, appt);
+        appt.setLastUpdateUser(getLoggedInInfo().getLoggedInProviderNo());
 
         scheduleManager.updateAppointment(getLoggedInInfo(), appt);
 

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/ScheduleService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/ScheduleService.java
@@ -366,6 +366,13 @@ public class ScheduleService extends AbstractServiceImpl {
     @Produces("application/json")
     @Consumes("application/json")
     public SchedulingResponse updateAppointmentUrgency(@PathParam("id") Integer id, AppointmentTo1 appt) {
+        // This route was previously unrouted (missing @POST); now that it is reachable, guard a
+        // null/empty request body rather than NPE-ing on appt.getUrgency().
+        if (appt == null) {
+            throw new WebApplicationException(Response.status(Status.BAD_REQUEST)
+                    .entity("Appointment payload is required").build());
+        }
+
         SchedulingResponse response = new SchedulingResponse();
         AppointmentConverter converter = new AppointmentConverter();
         String urgency = appt.getUrgency();
@@ -577,8 +584,11 @@ public class ScheduleService extends AbstractServiceImpl {
         if (value instanceof Character character) {
             return character;
         }
-        String s = value.toString().trim();
-        return s.isEmpty() ? null : s.charAt(0);
+        if (value instanceof String s) {
+            String trimmed = s.trim();
+            return trimmed.isEmpty() ? null : trimmed.charAt(0);
+        }
+        throw new IllegalArgumentException("Unsupported status type: " + value.getClass().getName());
     }
 
 

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/ScheduleService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/ScheduleService.java
@@ -344,6 +344,7 @@ public class ScheduleService extends AbstractServiceImpl {
         return response;
     }
 
+    @POST
     @Path("/appointment/{id}/updateUrgency")
     @Produces("application/json")
     @Consumes("application/json")
@@ -480,13 +481,16 @@ public class ScheduleService extends AbstractServiceImpl {
                 for (Object[] obj : items) {
                     Integer appointmentNo = (Integer) obj[0];
                     String providerNo = (String) obj[1];
-                    Date appointmentDate = (Date) obj[2];
-                    Date startTime = (Date) obj[3];
+                    // This native query returns appointment_date (SQL DATE) and start_time
+                    // (SQL TIME) as java.time.LocalDate / LocalTime under the current JDBC
+                    // driver, and status (CHAR) as a String — convert rather than blind-cast.
+                    Date appointmentDate = toDate(obj[2]);
+                    Date startTime = toDate(obj[3]);
                     Integer demographicNo = (Integer) obj[4];
                     String notes = (String) obj[5];
                     String location = (String) obj[6];
                     String resources = (String) obj[7];
-                    Character status = (Character) obj[8];
+                    Character status = toCharacter(obj[8]);
                     String lastName = (String) obj[9];
                     String firstName = (String) obj[10];
                     String phone = (String) obj[11];
@@ -512,6 +516,46 @@ public class ScheduleService extends AbstractServiceImpl {
             throw new WebApplicationException(Response.status(Status.INTERNAL_SERVER_ERROR).entity("Internal server error").build());
         }
 
+    }
+
+    /**
+     * Coerce a JDBC column value to {@link java.util.Date}. The native appointment query can
+     * hand back {@code java.util.Date} (and subclasses), or — under the current driver —
+     * {@code java.time.LocalDate} / {@code LocalTime} / {@code LocalDateTime} for SQL
+     * DATE/TIME/TIMESTAMP columns. A plain {@code (Date) cast} throws ClassCastException on
+     * the java.time types, which previously surfaced as a 500 from {@code fetchDays}.
+     */
+    private static Date toDate(Object value) {
+        if (value == null || value instanceof Date) {
+            return (Date) value;
+        }
+        if (value instanceof java.time.LocalDate localDate) {
+            return java.sql.Date.valueOf(localDate);
+        }
+        if (value instanceof java.time.LocalTime localTime) {
+            // Keep the epoch date (1970-01-01) so the smart date serializer emits "HH:mm:ss".
+            return java.sql.Time.valueOf(localTime);
+        }
+        if (value instanceof java.time.LocalDateTime localDateTime) {
+            return java.sql.Timestamp.valueOf(localDateTime);
+        }
+        throw new IllegalArgumentException("Unsupported date type: " + value.getClass().getName());
+    }
+
+    /**
+     * Coerce a single-character JDBC column value to {@link Character}. CHAR columns are
+     * commonly returned as {@code String} by the driver, so a {@code (Character) cast} would
+     * throw; treat empty/blank as {@code null}.
+     */
+    private static Character toCharacter(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Character character) {
+            return character;
+        }
+        String s = value.toString();
+        return s.isEmpty() ? null : s.charAt(0);
     }
 
 

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/conversion/AppointmentConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/conversion/AppointmentConverter.java
@@ -55,8 +55,22 @@ public class AppointmentConverter extends AbstractConverter<Appointment, Appoint
     }
 
     @Override
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
     public Appointment getAsDomainObject(LoggedInInfo loggedInInfo, AppointmentTo1 t) throws ConversionException {
-        return null;
+        if (t == null) {
+            return null;
+        }
+        // Inverse of getAsTransferObject(): copy the matching JavaBean properties back onto a
+        // domain Appointment. The DTO-only fields (demographic, provider, billingDetail) have no
+        // counterpart on Appointment and are ignored by copyProperties. Without this, callers such
+        // as updateAppointment received a null Appointment and failed downstream.
+        Appointment d = new Appointment();
+        BeanUtils.copyProperties(t, d);
+        return d;
     }
 
     @Override

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/conversion/AppointmentConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/conversion/AppointmentConverter.java
@@ -39,6 +39,17 @@ import org.springframework.beans.BeanUtils;
 
 public class AppointmentConverter extends AbstractConverter<Appointment, AppointmentTo1> {
 
+    /**
+     * Identity and server-managed audit fields that must never be taken from a client-supplied
+     * transfer object. Copying these from the DTO would allow over-posting (e.g. spoofing
+     * {@code creator}/{@code lastUpdateUser}) and would clobber the original {@code createDateTime}
+     * with the DTO's {@code new Date()} default on every update.
+     */
+    private static final String[] SERVER_MANAGED_PROPERTIES = {
+            "id", "createDateTime", "updateDateTime", "creator", "creatorSecurityId",
+            "lastUpdateUser", "bookingSource"
+    };
+
     private boolean includeDemographic;
     private boolean includeProvider;
 
@@ -64,13 +75,29 @@ public class AppointmentConverter extends AbstractConverter<Appointment, Appoint
         if (t == null) {
             return null;
         }
-        // Inverse of getAsTransferObject(): copy the matching JavaBean properties back onto a
-        // domain Appointment. The DTO-only fields (demographic, provider, billingDetail) have no
-        // counterpart on Appointment and are ignored by copyProperties. Without this, callers such
-        // as updateAppointment received a null Appointment and failed downstream.
+        // Inverse of getAsTransferObject(): copy the client-editable JavaBean properties onto a
+        // domain Appointment. Identity and audit fields are excluded (see applyEditableProperties)
+        // so a caller cannot over-post them. The DTO-only fields (demographic, provider,
+        // billingDetail) have no counterpart on Appointment and are ignored by copyProperties.
+        // Without this, callers such as updateAppointment received a null Appointment and failed.
         Appointment d = new Appointment();
-        BeanUtils.copyProperties(t, d);
+        applyEditableProperties(t, d);
         return d;
+    }
+
+    /**
+     * Copies only the client-editable properties from {@code source} onto {@code target}, leaving
+     * the target's identity and server-managed audit fields ({@link #SERVER_MANAGED_PROPERTIES})
+     * untouched. Used by the update flow to apply changes onto a loaded appointment without
+     * over-posting or corrupting audit data.
+     */
+    // FindSecBugs BEAN_PROPERTY_INJECTION: Spring BeanUtils.copyProperties copies fixed JavaBean
+    // descriptors between known CARLOS types; no user-controlled property name reaches the sink.
+    @SuppressFBWarnings(value = "BEAN_PROPERTY_INJECTION",
+            justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
+                    "known CARLOS types; no user-controlled property name reaches the sink")
+    public void applyEditableProperties(AppointmentTo1 source, Appointment target) {
+        BeanUtils.copyProperties(source, target, SERVER_MANAGED_PROPERTIES);
     }
 
     @Override

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/util/SmartDateDeserializer.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/util/SmartDateDeserializer.java
@@ -31,6 +31,7 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.Month;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -120,7 +121,7 @@ public class SmartDateDeserializer extends JsonDeserializer<Date> {
     private static Date parseTime(String text) throws IOException {
         try {
             LocalTime time = LocalTime.parse(text, TIME_FORMATTER);
-            return Date.from(time.atDate(LocalDate.of(1970, 1, 1)).atZone(ZoneId.systemDefault()).toInstant());
+            return Date.from(time.atDate(LocalDate.of(1970, Month.JANUARY, 1)).atZone(ZoneId.systemDefault()).toInstant());
         } catch (DateTimeParseException e) {
             // Do not echo the raw request value (untrusted / possibly PHI-adjacent); the chained
             // cause retains parser detail for diagnosis.

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/util/SmartDateDeserializer.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/util/SmartDateDeserializer.java
@@ -1,3 +1,24 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
 package io.github.carlos_emr.carlos.webserv.rest.util;
 
 import com.fasterxml.jackson.core.JsonParser;
@@ -54,8 +75,10 @@ public class SmartDateDeserializer extends JsonDeserializer<Date> {
             return null;
         }
 
-        // Epoch-millis timestamp, as written for date+time values.
-        if (token == JsonToken.VALUE_NUMBER_INT || token == JsonToken.VALUE_NUMBER_FLOAT) {
+        // Epoch-millis timestamp, as written for date+time values. Only integer tokens are
+        // accepted; a fractional number is not a valid epoch-millis value and is rejected below
+        // (via handleUnexpectedToken) rather than silently truncated to a long.
+        if (token == JsonToken.VALUE_NUMBER_INT) {
             return new Date(p.getLongValue());
         }
 
@@ -81,7 +104,9 @@ public class SmartDateDeserializer extends JsonDeserializer<Date> {
             try {
                 return new StdDateFormat().parse(text);
             } catch (ParseException e) {
-                throw new IOException("Unparseable date: \"" + text + "\"", e);
+                // Do not echo the raw request value in the message — it is untrusted and may be
+                // PHI-adjacent in a healthcare API. The chained cause carries parser detail.
+                throw new IOException("Unparseable date value", e);
             }
         }
 
@@ -94,7 +119,9 @@ public class SmartDateDeserializer extends JsonDeserializer<Date> {
             LocalTime time = LocalTime.parse(text, TIME_FORMATTER);
             return Date.from(time.atDate(LocalDate.of(1970, 1, 1)).atZone(ZoneId.systemDefault()).toInstant());
         } catch (DateTimeParseException e) {
-            throw new IOException("Unparseable time: \"" + text + "\"", e);
+            // Do not echo the raw request value (untrusted / possibly PHI-adjacent); the chained
+            // cause retains parser detail for diagnosis.
+            throw new IOException("Unparseable time value", e);
         }
     }
 
@@ -103,7 +130,9 @@ public class SmartDateDeserializer extends JsonDeserializer<Date> {
             LocalDate date = LocalDate.parse(text, DATE_FORMATTER);
             return Date.from(date.atStartOfDay(ZoneId.systemDefault()).toInstant());
         } catch (DateTimeParseException e) {
-            throw new IOException("Unparseable date: \"" + text + "\"", e);
+            // Do not echo the raw request value (untrusted / possibly PHI-adjacent); the chained
+            // cause retains parser detail for diagnosis.
+            throw new IOException("Unparseable date value", e);
         }
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/util/SmartDateDeserializer.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/util/SmartDateDeserializer.java
@@ -1,0 +1,82 @@
+package io.github.carlos_emr.carlos.webserv.rest.util;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import java.io.IOException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+/**
+ * Inverse of {@link SmartDateSerializer}: parses the JSON shapes that serializer
+ * emits back into {@link Date} so a value can round-trip through the REST API.
+ *
+ * <p>{@code SmartDateSerializer} writes a {@code Date} as one of:
+ * <ul>
+ *   <li>{@code "HH:mm:ss"} string for time-only values (epoch date 1970-01-01),</li>
+ *   <li>{@code "yyyy-MM-dd"} string for date-only values (midnight), or</li>
+ *   <li>a numeric epoch-millis timestamp otherwise.</li>
+ * </ul>
+ * Jackson's default {@code Date} deserializer only understands the numeric and
+ * ISO-8601 forms, so without this deserializer a client that POSTs back the exact
+ * payload the API just returned (e.g. {@code updateAppointment} echoing a
+ * {@code "HH:mm:ss"} startTime) fails with {@code InvalidFormatException}.</p>
+ */
+public class SmartDateDeserializer extends JsonDeserializer<Date> {
+
+    private static final ThreadLocal<SimpleDateFormat> DATE_FORMAT = ThreadLocal.withInitial(() -> new SimpleDateFormat("yyyy-MM-dd"));
+    private static final ThreadLocal<SimpleDateFormat> TIME_FORMAT = ThreadLocal.withInitial(() -> new SimpleDateFormat("HH:mm:ss"));
+
+    @Override
+    public Date deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        JsonToken token = p.currentToken();
+
+        if (token == JsonToken.VALUE_NULL) {
+            return null;
+        }
+
+        // Epoch-millis timestamp, as written for date+time values.
+        if (token == JsonToken.VALUE_NUMBER_INT || token == JsonToken.VALUE_NUMBER_FLOAT) {
+            return new Date(p.getLongValue());
+        }
+
+        if (token == JsonToken.VALUE_STRING) {
+            String text = p.getText() == null ? "" : p.getText().trim();
+            if (text.isEmpty()) {
+                return null;
+            }
+
+            // Time-only "HH:mm:ss" (8 chars, second char a colon) → epoch-date + time,
+            // matching how SmartDateSerializer round-trips TemporalType.TIME columns.
+            if (text.length() == 8 && text.charAt(2) == ':') {
+                return parse(TIME_FORMAT.get(), text, p);
+            }
+
+            // Date-only "yyyy-MM-dd".
+            if (text.length() == 10 && text.charAt(4) == '-') {
+                return parse(DATE_FORMAT.get(), text, p);
+            }
+
+            // Numeric epoch encoded as a string.
+            try {
+                return new Date(Long.parseLong(text));
+            } catch (NumberFormatException ignored) {
+                // fall through to ctxt's default handling below
+            }
+        }
+
+        // Anything else: defer to the context's standard Date coercion (handles ISO-8601).
+        return (Date) ctxt.handleUnexpectedToken(Date.class, p);
+    }
+
+    private Date parse(SimpleDateFormat format, String text, JsonParser p) throws IOException {
+        try {
+            return format.parse(text);
+        } catch (ParseException e) {
+            throw new IOException("Unparseable date: \"" + text + "\"", e);
+        }
+    }
+}

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/util/SmartDateDeserializer.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/util/SmartDateDeserializer.java
@@ -35,6 +35,7 @@ import java.time.Month;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
 import java.util.Date;
 
 /**
@@ -65,8 +66,15 @@ import java.util.Date;
  */
 public class SmartDateDeserializer extends JsonDeserializer<Date> {
 
-    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm:ss");
-    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+    // STRICT resolution rejects impossible values (e.g. 2026-02-30, 25:00:00) instead of the
+    // default SMART style, which silently clamps them (2026-02-30 -> 2026-02-28). The date pattern
+    // uses proleptic-year "uuuu" because STRICT resolution requires it (year-of-era "yyyy" would
+    // demand an era field); for the positive years this API handles, it matches the serializer's
+    // "yyyy-MM-dd" output exactly.
+    private static final DateTimeFormatter TIME_FORMATTER =
+            DateTimeFormatter.ofPattern("HH:mm:ss").withResolverStyle(ResolverStyle.STRICT);
+    private static final DateTimeFormatter DATE_FORMATTER =
+            DateTimeFormatter.ofPattern("uuuu-MM-dd").withResolverStyle(ResolverStyle.STRICT);
 
     @Override
     public Date deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/util/SmartDateDeserializer.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/util/SmartDateDeserializer.java
@@ -4,10 +4,15 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.util.StdDateFormat;
 
 import java.io.IOException;
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.Date;
 
 /**
@@ -24,11 +29,22 @@ import java.util.Date;
  * ISO-8601 forms, so without this deserializer a client that POSTs back the exact
  * payload the API just returned (e.g. {@code updateAppointment} echoing a
  * {@code "HH:mm:ss"} startTime) fails with {@code InvalidFormatException}.</p>
+ *
+ * <p>Because this is registered on the shared REST {@code ObjectMapper}, it must also
+ * remain backward compatible with what Jackson's default deserializer accepted before
+ * it existed — epoch-millis-as-string and ISO-8601 — which is handled via the
+ * {@link StdDateFormat} fallback.</p>
+ *
+ * <p>The {@code "HH:mm:ss"} and {@code "yyyy-MM-dd"} shapes are parsed in the JVM default
+ * time zone to mirror {@code SmartDateSerializer}, which formats them with a default-zone
+ * {@code SimpleDateFormat}; this keeps those two shapes exactly round-trippable. The
+ * formatters are immutable {@link DateTimeFormatter} instances rather than
+ * {@code ThreadLocal<SimpleDateFormat>} to avoid classloader leaks on servlet redeploy.</p>
  */
 public class SmartDateDeserializer extends JsonDeserializer<Date> {
 
-    private static final ThreadLocal<SimpleDateFormat> DATE_FORMAT = ThreadLocal.withInitial(() -> new SimpleDateFormat("yyyy-MM-dd"));
-    private static final ThreadLocal<SimpleDateFormat> TIME_FORMAT = ThreadLocal.withInitial(() -> new SimpleDateFormat("HH:mm:ss"));
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm:ss");
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
     @Override
     public Date deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
@@ -52,30 +68,41 @@ public class SmartDateDeserializer extends JsonDeserializer<Date> {
             // Time-only "HH:mm:ss" (8 chars, second char a colon) → epoch-date + time,
             // matching how SmartDateSerializer round-trips TemporalType.TIME columns.
             if (text.length() == 8 && text.charAt(2) == ':') {
-                return parse(TIME_FORMAT.get(), text, p);
+                return parseTime(text);
             }
 
-            // Date-only "yyyy-MM-dd".
+            // Date-only "yyyy-MM-dd" → local midnight, matching the serializer's DATE output.
             if (text.length() == 10 && text.charAt(4) == '-') {
-                return parse(DATE_FORMAT.get(), text, p);
+                return parseDate(text);
             }
 
-            // Numeric epoch encoded as a string.
+            // Backward compatibility: epoch-millis-as-string and ISO-8601 — the shapes Jackson's
+            // default Date deserializer (StdDateFormat) accepted before this module existed.
             try {
-                return new Date(Long.parseLong(text));
-            } catch (NumberFormatException ignored) {
-                // fall through to ctxt's default handling below
+                return new StdDateFormat().parse(text);
+            } catch (ParseException e) {
+                throw new IOException("Unparseable date: \"" + text + "\"", e);
             }
         }
 
-        // Anything else: defer to the context's standard Date coercion (handles ISO-8601).
+        // Anything else (object/array/boolean): defer to the context's standard error handling.
         return (Date) ctxt.handleUnexpectedToken(Date.class, p);
     }
 
-    private Date parse(SimpleDateFormat format, String text, JsonParser p) throws IOException {
+    private static Date parseTime(String text) throws IOException {
         try {
-            return format.parse(text);
-        } catch (ParseException e) {
+            LocalTime time = LocalTime.parse(text, TIME_FORMATTER);
+            return Date.from(time.atDate(LocalDate.of(1970, 1, 1)).atZone(ZoneId.systemDefault()).toInstant());
+        } catch (DateTimeParseException e) {
+            throw new IOException("Unparseable time: \"" + text + "\"", e);
+        }
+    }
+
+    private static Date parseDate(String text) throws IOException {
+        try {
+            LocalDate date = LocalDate.parse(text, DATE_FORMATTER);
+            return Date.from(date.atStartOfDay(ZoneId.systemDefault()).toInstant());
+        } catch (DateTimeParseException e) {
             throw new IOException("Unparseable date: \"" + text + "\"", e);
         }
     }

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/util/SmartDateDeserializer.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/util/SmartDateDeserializer.java
@@ -25,9 +25,9 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.util.StdDateFormat;
 
 import java.io.IOException;
+import java.text.DateFormat;
 import java.text.ParseException;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -53,8 +53,8 @@ import java.util.Date;
  *
  * <p>Because this is registered on the shared REST {@code ObjectMapper}, it must also
  * remain backward compatible with what Jackson's default deserializer accepted before
- * it existed — epoch-millis-as-string and ISO-8601 — which is handled via the
- * {@link StdDateFormat} fallback.</p>
+ * it existed — epoch-millis-as-string and ISO-8601 — which is handled by delegating to the
+ * mapper's configured {@code DateFormat} (Jackson's {@code StdDateFormat} by default).</p>
  *
  * <p>The {@code "HH:mm:ss"} and {@code "yyyy-MM-dd"} shapes are parsed in the JVM default
  * time zone to mirror {@code SmartDateSerializer}, which formats them with a default-zone
@@ -100,9 +100,12 @@ public class SmartDateDeserializer extends JsonDeserializer<Date> {
             }
 
             // Backward compatibility: epoch-millis-as-string and ISO-8601 — the shapes Jackson's
-            // default Date deserializer (StdDateFormat) accepted before this module existed.
+            // default Date deserializer accepted before this module existed. Use the mapper's
+            // configured DateFormat (StdDateFormat by default) so any mapper-level date-format or
+            // timezone configuration is honored; clone it because DateFormat is not thread-safe.
+            DateFormat dateFormat = (DateFormat) ctxt.getConfig().getDateFormat().clone();
             try {
-                return new StdDateFormat().parse(text);
+                return dateFormat.parse(text);
             } catch (ParseException e) {
                 // Do not echo the raw request value in the message — it is untrusted and may be
                 // PHI-adjacent in a healthcare API. The chained cause carries parser detail.

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/util/SmartDateModule.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/util/SmartDateModule.java
@@ -5,13 +5,16 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import java.util.Date;
 
 /**
- * Jackson module that registers the SmartDateSerializer for automatic
- * date/datetime format differentiation
+ * Jackson module that registers the SmartDateSerializer (and its inverse
+ * SmartDateDeserializer) for automatic date/datetime format differentiation
  */
 public class SmartDateModule extends SimpleModule {
 
     public SmartDateModule() {
         super("SmartDateModule");
         addSerializer(Date.class, new SmartDateSerializer());
+        // Inverse of the serializer so Date values can round-trip through the REST API
+        // (e.g. a "HH:mm:ss" startTime echoed back to updateAppointment).
+        addDeserializer(Date.class, new SmartDateDeserializer());
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/commn/model/DemographicFamilyPhysicianNameUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/commn/model/DemographicFamilyPhysicianNameUnitTest.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.commn.model;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Guards the null-safety of the transient {@code familyPhysician} parse getters.
+ *
+ * <p>These getters feed the raw {@code family_physician} column into a regex {@code Matcher}.
+ * The column is frequently null, which previously threw an NPE and surfaced as a 500 when
+ * Jackson serialized a Demographic over the REST API (issue #2957).</p>
+ *
+ * @since 2026-06-22
+ */
+@DisplayName("Demographic family physician name parsing")
+@Tag("unit")
+@Tag("demographic")
+class DemographicFamilyPhysicianNameUnitTest {
+
+    @Test
+    @DisplayName("should return empty strings without throwing when familyPhysician is null")
+    void shouldReturnEmpty_whenFamilyPhysicianIsNull() {
+        Demographic demographic = new Demographic();
+        // familyPhysician left null
+
+        assertThatCode(() -> {
+            assertThat(demographic.getFamilyPhysicianLastName()).isEmpty();
+            assertThat(demographic.getFamilyPhysicianFirstName()).isEmpty();
+            assertThat(demographic.getFamilyPhysicianFullName()).isEmpty();
+            assertThat(demographic.getFamilyPhysicianNumber()).isEmpty();
+        }).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("should parse last and first name when familyPhysician is populated")
+    void shouldParseNames_whenFamilyPhysicianPopulated() {
+        Demographic demographic = new Demographic();
+        demographic.setFamilyPhysician("<rdohip>1234</rdohip><rd>Smith, John</rd>");
+
+        assertThat(demographic.getFamilyPhysicianLastName()).isEqualTo("Smith");
+        assertThat(demographic.getFamilyPhysicianFirstName()).isEqualTo("John");
+        assertThat(demographic.getFamilyPhysicianNumber()).isEqualTo("1234");
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/ScheduleServiceAppointmentEndpointsUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/ScheduleServiceAppointmentEndpointsUnitTest.java
@@ -26,6 +26,7 @@ import java.lang.reflect.Method;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.Month;
 import java.util.Date;
 
 import jakarta.ws.rs.POST;
@@ -69,12 +70,12 @@ class ScheduleServiceAppointmentEndpointsUnitTest {
         Method toDate = ScheduleService.class.getDeclaredMethod("toDate", Object.class);
         toDate.setAccessible(true);
 
-        assertThat(toDate.invoke(null, LocalDate.of(2026, 6, 22)))
-                .isEqualTo(java.sql.Date.valueOf(LocalDate.of(2026, 6, 22)));
+        assertThat(toDate.invoke(null, LocalDate.of(2026, Month.JUNE, 22)))
+                .isEqualTo(java.sql.Date.valueOf(LocalDate.of(2026, Month.JUNE, 22)));
         assertThat(toDate.invoke(null, LocalTime.of(9, 30, 0)))
                 .isEqualTo(java.sql.Time.valueOf(LocalTime.of(9, 30, 0)));
-        assertThat(toDate.invoke(null, LocalDateTime.of(2026, 6, 22, 9, 30, 0)))
-                .isEqualTo(java.sql.Timestamp.valueOf(LocalDateTime.of(2026, 6, 22, 9, 30, 0)));
+        assertThat(toDate.invoke(null, LocalDateTime.of(2026, Month.JUNE, 22, 9, 30, 0)))
+                .isEqualTo(java.sql.Timestamp.valueOf(LocalDateTime.of(2026, Month.JUNE, 22, 9, 30, 0)));
 
         Date util = new Date(0);
         assertThat(toDate.invoke(null, util)).isSameAs(util);

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/ScheduleServiceAppointmentEndpointsUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/ScheduleServiceAppointmentEndpointsUnitTest.java
@@ -21,6 +21,7 @@
  */
 package io.github.carlos_emr.carlos.webserv.rest;
 
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -36,6 +37,7 @@ import org.junit.jupiter.api.Test;
 import io.github.carlos_emr.carlos.webserv.rest.to.model.AppointmentTo1;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Regression guards for the appointment endpoints repaired under issue #2957:
@@ -80,6 +82,17 @@ class ScheduleServiceAppointmentEndpointsUnitTest {
     }
 
     @Test
+    @DisplayName("should throw IllegalArgumentException when toDate is given an unsupported type")
+    void shouldThrow_whenToDateGivenUnsupportedType() throws Exception {
+        Method toDate = ScheduleService.class.getDeclaredMethod("toDate", Object.class);
+        toDate.setAccessible(true);
+
+        assertThatThrownBy(() -> toDate.invoke(null, new Object()))
+                .isInstanceOf(InvocationTargetException.class)
+                .hasCauseInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
     @DisplayName("should coerce CHAR column values (String or Character) to Character")
     void shouldCoerceCharColumn_toCharacter() throws Exception {
         Method toCharacter = ScheduleService.class.getDeclaredMethod("toCharacter", Object.class);
@@ -88,6 +101,7 @@ class ScheduleServiceAppointmentEndpointsUnitTest {
         assertThat(toCharacter.invoke(null, "N")).isEqualTo('N');
         assertThat(toCharacter.invoke(null, Character.valueOf('B'))).isEqualTo('B');
         assertThat(toCharacter.invoke(null, "")).isNull();
+        assertThat(toCharacter.invoke(null, "   ")).isNull();
         assertThat(toCharacter.invoke(null, new Object[]{null})).isNull();
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/ScheduleServiceAppointmentEndpointsUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/ScheduleServiceAppointmentEndpointsUnitTest.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.webserv.rest;
+
+import java.lang.reflect.Method;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Date;
+
+import jakarta.ws.rs.POST;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.github.carlos_emr.carlos.webserv.rest.to.model.AppointmentTo1;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression guards for the appointment endpoints repaired under issue #2957:
+ * the missing {@code @POST} on {@code updateAppointmentUrgency} (routed as 404), and the
+ * JDBC value coercion in {@code fetchDays} (java.time / String values that previously threw
+ * ClassCastException).
+ *
+ * @since 2026-06-22
+ */
+@DisplayName("ScheduleService appointment endpoint guards")
+@Tag("unit")
+@Tag("fast")
+class ScheduleServiceAppointmentEndpointsUnitTest {
+
+    @Test
+    @DisplayName("should annotate updateAppointmentUrgency with @POST so JAX-RS can route it")
+    void shouldAnnotateUpdateUrgency_withPost() throws Exception {
+        Method method = ScheduleService.class.getMethod(
+                "updateAppointmentUrgency", Integer.class, AppointmentTo1.class);
+
+        assertThat(method.isAnnotationPresent(POST.class))
+                .as("updateAppointmentUrgency must be a @POST endpoint")
+                .isTrue();
+    }
+
+    @Test
+    @DisplayName("should coerce java.time date/time/datetime values to java.util.Date")
+    void shouldCoerceJavaTimeValues_toDate() throws Exception {
+        Method toDate = ScheduleService.class.getDeclaredMethod("toDate", Object.class);
+        toDate.setAccessible(true);
+
+        assertThat(toDate.invoke(null, LocalDate.of(2026, 6, 22)))
+                .isEqualTo(java.sql.Date.valueOf(LocalDate.of(2026, 6, 22)));
+        assertThat(toDate.invoke(null, LocalTime.of(9, 30, 0)))
+                .isEqualTo(java.sql.Time.valueOf(LocalTime.of(9, 30, 0)));
+        assertThat(toDate.invoke(null, LocalDateTime.of(2026, 6, 22, 9, 30, 0)))
+                .isEqualTo(java.sql.Timestamp.valueOf(LocalDateTime.of(2026, 6, 22, 9, 30, 0)));
+
+        Date util = new Date(0);
+        assertThat(toDate.invoke(null, util)).isSameAs(util);
+        assertThat(toDate.invoke(null, new Object[]{null})).isNull();
+    }
+
+    @Test
+    @DisplayName("should coerce CHAR column values (String or Character) to Character")
+    void shouldCoerceCharColumn_toCharacter() throws Exception {
+        Method toCharacter = ScheduleService.class.getDeclaredMethod("toCharacter", Object.class);
+        toCharacter.setAccessible(true);
+
+        assertThat(toCharacter.invoke(null, "N")).isEqualTo('N');
+        assertThat(toCharacter.invoke(null, Character.valueOf('B'))).isEqualTo('B');
+        assertThat(toCharacter.invoke(null, "")).isNull();
+        assertThat(toCharacter.invoke(null, new Object[]{null})).isNull();
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/ScheduleServiceAppointmentEndpointsUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/ScheduleServiceAppointmentEndpointsUnitTest.java
@@ -104,4 +104,15 @@ class ScheduleServiceAppointmentEndpointsUnitTest {
         assertThat(toCharacter.invoke(null, "   ")).isNull();
         assertThat(toCharacter.invoke(null, new Object[]{null})).isNull();
     }
+
+    @Test
+    @DisplayName("should throw IllegalArgumentException when toCharacter is given an unsupported type")
+    void shouldThrow_whenToCharacterGivenUnsupportedType() throws Exception {
+        Method toCharacter = ScheduleService.class.getDeclaredMethod("toCharacter", Object.class);
+        toCharacter.setAccessible(true);
+
+        assertThatThrownBy(() -> toCharacter.invoke(null, 123))
+                .isInstanceOf(InvocationTargetException.class)
+                .hasCauseInstanceOf(IllegalArgumentException.class);
+    }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/ScheduleServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/ScheduleServiceUnitTest.java
@@ -55,6 +55,7 @@ import io.github.carlos_emr.carlos.webserv.rest.to.model.SearchConfigTo1;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doThrow;
@@ -238,5 +239,16 @@ class ScheduleServiceUnitTest extends CarlosUnitTestBase {
                         .isEqualTo(Response.Status.NOT_FOUND.getStatusCode()));
 
         verify(scheduleManager, never()).updateAppointment(any(), any());
+    }
+
+    @Test
+    @DisplayName("should reject updateUrgency with bad request when the request body is null")
+    void shouldRejectUpdateUrgency_whenBodyIsNull() {
+        assertThatThrownBy(() -> service.updateAppointmentUrgency(99, null))
+                .isInstanceOf(WebApplicationException.class)
+                .satisfies(e -> assertThat(((WebApplicationException) e).getResponse().getStatus())
+                        .isEqualTo(Response.Status.BAD_REQUEST.getStatusCode()));
+
+        verify(appointmentManager, never()).updateAppointmentUrgency(any(), anyInt(), any());
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/ScheduleServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/ScheduleServiceUnitTest.java
@@ -21,8 +21,10 @@
  */
 package io.github.carlos_emr.carlos.webserv.rest;
 
+import java.util.Date;
 import java.util.List;
 
+import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -30,18 +32,28 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import io.github.carlos_emr.carlos.PMmodule.dao.ProviderDao;
 import io.github.carlos_emr.carlos.appointment.search.FilterDefinition;
 import io.github.carlos_emr.carlos.commn.dao.AppointmentSearchDao;
+import io.github.carlos_emr.carlos.commn.dao.DemographicDao;
+import io.github.carlos_emr.carlos.commn.model.Appointment;
 import io.github.carlos_emr.carlos.commn.model.AppointmentSearch;
+import io.github.carlos_emr.carlos.commn.model.Provider;
+import io.github.carlos_emr.carlos.managers.AppointmentManager;
+import io.github.carlos_emr.carlos.managers.ScheduleManager;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import io.github.carlos_emr.carlos.webserv.rest.to.model.AppointmentTo1;
 import io.github.carlos_emr.carlos.webserv.rest.to.model.SearchConfigTo1;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -72,6 +84,12 @@ class ScheduleServiceUnitTest extends CarlosUnitTestBase {
     @Mock
     private AppointmentSearchDao appointmentSearchDao;
 
+    @Mock
+    private AppointmentManager appointmentManager;
+
+    @Mock
+    private ScheduleManager scheduleManager;
+
     private ScheduleService service;
     private LoggedInInfo loggedInInfo;
 
@@ -87,6 +105,8 @@ class ScheduleServiceUnitTest extends CarlosUnitTestBase {
 
         injectDependency(service, "securityInfoManager", securityInfoManager);
         injectDependency(service, "appointmentSearchDao", appointmentSearchDao);
+        injectDependency(service, "appointmentManager", appointmentManager);
+        injectDependency(service, "scheduleManager", scheduleManager);
 
         // Lenient: some tests exercise paths that short-circuit before the privilege check
         // (e.g. findUnknownFilter) or override the stub. Strict-by-default would fail those.
@@ -147,5 +167,76 @@ class ScheduleServiceUnitTest extends CarlosUnitTestBase {
         String unknownFilter = service.findUnknownFilter(List.of(filterDefinition));
 
         assertThat(unknownFilter).isEqualTo("<missing filterClassName>");
+    }
+
+    @Test
+    @DisplayName("should preserve audit fields and stamp the updating provider when updating an appointment")
+    void shouldPreserveAuditFields_whenUpdatingAppointment() {
+        // AppointmentConverter resolves these DAOs via SpringUtils in its field initializers.
+        registerMock(DemographicDao.class, Mockito.mock(DemographicDao.class));
+        registerMock(ProviderDao.class, Mockito.mock(ProviderDao.class));
+
+        Provider loggedInProvider = new Provider();
+        loggedInProvider.setProviderNo("101");
+        loggedInInfo.setLoggedInProvider(loggedInProvider);
+
+        Date originalCreate = new Date(1_000_000_000_000L);
+        Appointment existing = new Appointment();
+        existing.setId(42);
+        existing.setCreateDateTime(originalCreate);
+        existing.setCreator("origCreator");
+        existing.setCreatorSecurityId(7);
+        existing.setReason("old reason");
+        when(appointmentManager.getAppointment(any(), eq(42))).thenReturn(existing);
+
+        AppointmentTo1 hostile = new AppointmentTo1();
+        hostile.setId(42);
+        hostile.setReason("new reason");
+        hostile.setCreator("hacker");
+        hostile.setCreatorSecurityId(999);
+        hostile.setLastUpdateUser("hacker");
+        hostile.setCreateDateTime(new Date(0));
+
+        service.updateAppointment(hostile);
+
+        ArgumentCaptor<Appointment> captor = ArgumentCaptor.forClass(Appointment.class);
+        verify(scheduleManager).updateAppointment(eq(loggedInInfo), captor.capture());
+        Appointment saved = captor.getValue();
+
+        assertThat(saved.getReason()).isEqualTo("new reason");
+        assertThat(saved.getCreateDateTime()).isEqualTo(originalCreate);
+        assertThat(saved.getCreator()).isEqualTo("origCreator");
+        assertThat(saved.getCreatorSecurityId()).isEqualTo(7);
+        assertThat(saved.getLastUpdateUser()).isEqualTo("101");
+    }
+
+    @Test
+    @DisplayName("should reject update with bad request when appointment id is missing")
+    void shouldRejectUpdate_whenIdIsMissing() {
+        AppointmentTo1 to = new AppointmentTo1();
+        to.setId(null);
+
+        assertThatThrownBy(() -> service.updateAppointment(to))
+                .isInstanceOf(WebApplicationException.class)
+                .satisfies(e -> assertThat(((WebApplicationException) e).getResponse().getStatus())
+                        .isEqualTo(Response.Status.BAD_REQUEST.getStatusCode()));
+
+        verify(scheduleManager, never()).updateAppointment(any(), any());
+    }
+
+    @Test
+    @DisplayName("should respond not found when the appointment to update does not exist")
+    void shouldRespondNotFound_whenAppointmentMissing() {
+        when(appointmentManager.getAppointment(any(), eq(404))).thenReturn(null);
+
+        AppointmentTo1 to = new AppointmentTo1();
+        to.setId(404);
+
+        assertThatThrownBy(() -> service.updateAppointment(to))
+                .isInstanceOf(WebApplicationException.class)
+                .satisfies(e -> assertThat(((WebApplicationException) e).getResponse().getStatus())
+                        .isEqualTo(Response.Status.NOT_FOUND.getStatusCode()));
+
+        verify(scheduleManager, never()).updateAppointment(any(), any());
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/conversion/AppointmentConverterUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/conversion/AppointmentConverterUnitTest.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.webserv.rest.conversion;
+
+import java.util.Date;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import io.github.carlos_emr.carlos.PMmodule.dao.ProviderDao;
+import io.github.carlos_emr.carlos.commn.dao.DemographicDao;
+import io.github.carlos_emr.carlos.commn.model.Appointment;
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
+import io.github.carlos_emr.carlos.webserv.rest.to.model.AppointmentTo1;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link AppointmentConverter#getAsDomainObject}, which was a null-returning
+ * stub. updateAppointment relied on it and therefore failed downstream (issue #2957).
+ *
+ * @since 2026-06-22
+ */
+@DisplayName("AppointmentConverter getAsDomainObject")
+class AppointmentConverterUnitTest extends CarlosUnitTestBase {
+
+    @BeforeEach
+    void setUp() {
+        // AppointmentConverter resolves these DAOs via SpringUtils in its field initializers.
+        registerMock(DemographicDao.class, Mockito.mock(DemographicDao.class));
+        registerMock(ProviderDao.class, Mockito.mock(ProviderDao.class));
+    }
+
+    @Test
+    @DisplayName("should copy matching JavaBean properties onto a domain Appointment")
+    void shouldCopyProperties_toDomainAppointment() throws Exception {
+        AppointmentTo1 to = new AppointmentTo1();
+        to.setId(42);
+        to.setProviderNo("999");
+        to.setDemographicNo(123);
+        to.setStatus("t");
+        to.setType("Consult");
+        to.setReason("checkup");
+        to.setNotes("note");
+        Date appointmentDate = new Date();
+        to.setAppointmentDate(appointmentDate);
+
+        Appointment domain = new AppointmentConverter().getAsDomainObject(null, to);
+
+        assertThat(domain).isNotNull();
+        assertThat(domain.getId()).isEqualTo(42);
+        assertThat(domain.getProviderNo()).isEqualTo("999");
+        assertThat(domain.getDemographicNo()).isEqualTo(123);
+        assertThat(domain.getStatus()).isEqualTo("t");
+        assertThat(domain.getType()).isEqualTo("Consult");
+        assertThat(domain.getReason()).isEqualTo("checkup");
+        assertThat(domain.getNotes()).isEqualTo("note");
+        assertThat(domain.getAppointmentDate()).isEqualTo(appointmentDate);
+    }
+
+    @Test
+    @DisplayName("should return null when transfer object is null")
+    void shouldReturnNull_whenTransferObjectIsNull() throws Exception {
+        assertThat(new AppointmentConverter().getAsDomainObject(null, null)).isNull();
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/conversion/AppointmentConverterUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/conversion/AppointmentConverterUnitTest.java
@@ -99,7 +99,7 @@ class AppointmentConverterUnitTest extends CarlosUnitTestBase {
 
     @Test
     @DisplayName("should apply only editable fields onto an existing appointment, preserving audit fields")
-    void shouldApplyEditableFields_ontoExistingAppointment() throws Exception {
+    void shouldApplyEditableFields_ontoExistingAppointment() {
         Date originalCreate = new Date(1_000_000_000_000L);
         Appointment existing = new Appointment();
         existing.setId(42);

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/conversion/AppointmentConverterUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/conversion/AppointmentConverterUnitTest.java
@@ -53,10 +53,9 @@ class AppointmentConverterUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
-    @DisplayName("should copy matching JavaBean properties onto a domain Appointment")
-    void shouldCopyProperties_toDomainAppointment() throws Exception {
+    @DisplayName("should copy editable JavaBean properties onto a domain Appointment")
+    void shouldCopyEditableProperties_toDomainAppointment() throws Exception {
         AppointmentTo1 to = new AppointmentTo1();
-        to.setId(42);
         to.setProviderNo("999");
         to.setDemographicNo(123);
         to.setStatus("t");
@@ -69,7 +68,6 @@ class AppointmentConverterUnitTest extends CarlosUnitTestBase {
         Appointment domain = new AppointmentConverter().getAsDomainObject(null, to);
 
         assertThat(domain).isNotNull();
-        assertThat(domain.getId()).isEqualTo(42);
         assertThat(domain.getProviderNo()).isEqualTo("999");
         assertThat(domain.getDemographicNo()).isEqualTo(123);
         assertThat(domain.getStatus()).isEqualTo("t");
@@ -77,6 +75,53 @@ class AppointmentConverterUnitTest extends CarlosUnitTestBase {
         assertThat(domain.getReason()).isEqualTo("checkup");
         assertThat(domain.getNotes()).isEqualTo("note");
         assertThat(domain.getAppointmentDate()).isEqualTo(appointmentDate);
+    }
+
+    @Test
+    @DisplayName("should not copy identity or server-managed audit fields from the transfer object")
+    void shouldNotCopyServerManagedFields_fromTransferObject() throws Exception {
+        AppointmentTo1 to = new AppointmentTo1();
+        to.setId(42);
+        to.setCreator("hacker");
+        to.setCreatorSecurityId(999);
+        to.setLastUpdateUser("hacker");
+        to.setCreateDateTime(new Date(0));
+
+        Appointment domain = new AppointmentConverter().getAsDomainObject(null, to);
+
+        assertThat(domain.getId()).isNull();
+        assertThat(domain.getCreator()).isNull();
+        assertThat(domain.getCreatorSecurityId()).isNull();
+        assertThat(domain.getLastUpdateUser()).isNull();
+        // createDateTime keeps the entity's own default, not the DTO-supplied epoch value.
+        assertThat(domain.getCreateDateTime()).isNotEqualTo(new Date(0));
+    }
+
+    @Test
+    @DisplayName("should apply only editable fields onto an existing appointment, preserving audit fields")
+    void shouldApplyEditableFields_ontoExistingAppointment() throws Exception {
+        Date originalCreate = new Date(1_000_000_000_000L);
+        Appointment existing = new Appointment();
+        existing.setId(42);
+        existing.setCreateDateTime(originalCreate);
+        existing.setCreator("origCreator");
+        existing.setCreatorSecurityId(7);
+        existing.setReason("old reason");
+
+        AppointmentTo1 to = new AppointmentTo1();
+        to.setId(42);
+        to.setReason("new reason");
+        to.setCreator("hacker");
+        to.setCreatorSecurityId(999);
+        to.setCreateDateTime(new Date(0));
+
+        new AppointmentConverter().applyEditableProperties(to, existing);
+
+        assertThat(existing.getReason()).isEqualTo("new reason");
+        assertThat(existing.getId()).isEqualTo(42);
+        assertThat(existing.getCreateDateTime()).isEqualTo(originalCreate);
+        assertThat(existing.getCreator()).isEqualTo("origCreator");
+        assertThat(existing.getCreatorSecurityId()).isEqualTo(7);
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/util/SmartDateModuleRoundTripUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/util/SmartDateModuleRoundTripUnitTest.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.webserv.rest.util;
+
+import java.util.Calendar;
+import java.util.Date;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.github.carlos_emr.carlos.webserv.rest.to.model.AppointmentTo1;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that {@link SmartDateModule} can round-trip a {@link Date} through the JSON
+ * shapes {@link SmartDateSerializer} emits — the gap that caused {@code updateAppointment}
+ * to fail with {@code InvalidFormatException} when a client POSTed back a {@code "HH:mm:ss"}
+ * startTime the API had just returned (issue #2957).
+ *
+ * @since 2026-06-22
+ */
+@DisplayName("SmartDateModule round-trip")
+@Tag("unit")
+@Tag("fast")
+class SmartDateModuleRoundTripUnitTest {
+
+    private final ObjectMapper mapper = new ObjectMapper().registerModule(new SmartDateModule());
+
+    private static Date dateOf(int y, int mo, int d, int h, int mi, int s) {
+        Calendar cal = Calendar.getInstance();
+        cal.clear();
+        cal.set(y, mo, d, h, mi, s);
+        return cal.getTime();
+    }
+
+    @Test
+    @DisplayName("should serialize a time-only Date as HH:mm:ss and read it back unchanged")
+    void shouldRoundTripTimeOnlyDate_withHmsString() throws Exception {
+        Date time = dateOf(1970, Calendar.JANUARY, 1, 9, 30, 0);
+
+        String json = mapper.writeValueAsString(time);
+        Date back = mapper.readValue(json, Date.class);
+
+        assertThat(json).isEqualTo("\"09:30:00\"");
+        assertThat(back).isEqualTo(time);
+    }
+
+    @Test
+    @DisplayName("should serialize a midnight Date as yyyy-MM-dd and read it back unchanged")
+    void shouldRoundTripDateOnly_withIsoDateString() throws Exception {
+        Date date = dateOf(2026, Calendar.JUNE, 22, 0, 0, 0);
+
+        String json = mapper.writeValueAsString(date);
+        Date back = mapper.readValue(json, Date.class);
+
+        assertThat(json).isEqualTo("\"2026-06-22\"");
+        assertThat(back).isEqualTo(date);
+    }
+
+    @Test
+    @DisplayName("should serialize a date-and-time Date as epoch millis and read it back unchanged")
+    void shouldRoundTripDateTime_withEpochMillis() throws Exception {
+        Date dateTime = dateOf(2026, Calendar.JUNE, 22, 9, 30, 15);
+
+        String json = mapper.writeValueAsString(dateTime);
+        Date back = mapper.readValue(json, Date.class);
+
+        assertThat(json).isEqualTo(String.valueOf(dateTime.getTime()));
+        assertThat(back).isEqualTo(dateTime);
+    }
+
+    @Test
+    @DisplayName("should treat null and empty string as null on deserialize")
+    void shouldReturnNull_forNullAndEmptyString() throws Exception {
+        assertThat(mapper.readValue("null", Date.class)).isNull();
+        assertThat(mapper.readValue("\"\"", Date.class)).isNull();
+    }
+
+    @Test
+    @DisplayName("should round-trip an appointment's startTime/endTime/appointmentDate through the DTO")
+    void shouldRoundTripAppointmentDtoDates_throughSerializer() throws Exception {
+        AppointmentTo1 appt = new AppointmentTo1();
+        appt.setId(42);
+        appt.setProviderNo("999");
+        appt.setStartTime(dateOf(1970, Calendar.JANUARY, 1, 9, 30, 0));
+        appt.setEndTime(dateOf(1970, Calendar.JANUARY, 1, 9, 45, 0));
+        appt.setAppointmentDate(dateOf(2026, Calendar.JUNE, 22, 0, 0, 0));
+
+        String json = mapper.writeValueAsString(appt);
+        AppointmentTo1 back = mapper.readValue(json, AppointmentTo1.class);
+
+        assertThat(back.getId()).isEqualTo(42);
+        assertThat(back.getStartTime()).isEqualTo(appt.getStartTime());
+        assertThat(back.getEndTime()).isEqualTo(appt.getEndTime());
+        assertThat(back.getAppointmentDate()).isEqualTo(appt.getAppointmentDate());
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/util/SmartDateModuleRoundTripUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/util/SmartDateModuleRoundTripUnitTest.java
@@ -138,6 +138,17 @@ class SmartDateModuleRoundTripUnitTest {
     }
 
     @Test
+    @DisplayName("should reject an impossible calendar date rather than clamp it")
+    void shouldRejectImpossibleDate_ratherThanClamp() {
+        // Default SMART resolution would silently clamp these (2026-02-30 -> 2026-02-28); STRICT
+        // resolution rejects them so an invalid request value is not coerced into a wrong date.
+        assertThatThrownBy(() -> mapper.readValue("\"2026-02-30\"", Date.class))
+                .isInstanceOf(IOException.class);
+        assertThatThrownBy(() -> mapper.readValue("\"2025-02-29\"", Date.class))
+                .isInstanceOf(IOException.class);
+    }
+
+    @Test
     @DisplayName("should round-trip an appointment's startTime/endTime/appointmentDate through the DTO")
     void shouldRoundTripAppointmentDtoDates_throughSerializer() throws Exception {
         AppointmentTo1 appt = new AppointmentTo1();

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/util/SmartDateModuleRoundTripUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/util/SmartDateModuleRoundTripUnitTest.java
@@ -21,6 +21,8 @@
  */
 package io.github.carlos_emr.carlos.webserv.rest.util;
 
+import java.io.IOException;
+import java.time.Instant;
 import java.util.Calendar;
 import java.util.Date;
 
@@ -33,6 +35,7 @@ import org.junit.jupiter.api.Test;
 import io.github.carlos_emr.carlos.webserv.rest.to.model.AppointmentTo1;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Verifies that {@link SmartDateModule} can round-trip a {@link Date} through the JSON
@@ -97,6 +100,29 @@ class SmartDateModuleRoundTripUnitTest {
     void shouldReturnNull_forNullAndEmptyString() throws Exception {
         assertThat(mapper.readValue("null", Date.class)).isNull();
         assertThat(mapper.readValue("\"\"", Date.class)).isNull();
+    }
+
+    @Test
+    @DisplayName("should deserialize an epoch-millis value encoded as a string")
+    void shouldDeserializeEpochMillis_fromNumericString() throws Exception {
+        assertThat(mapper.readValue("\"1234567890000\"", Date.class))
+                .isEqualTo(new Date(1234567890000L));
+    }
+
+    @Test
+    @DisplayName("should deserialize an ISO-8601 datetime string for backward compatibility")
+    void shouldDeserializeIso8601_fromDatetimeString() throws Exception {
+        // Not a shape the serializer emits, but the default Jackson deserializer accepted it
+        // before this module registered one; the StdDateFormat fallback must keep parsing it.
+        assertThat(mapper.readValue("\"2026-06-22T09:30:00Z\"", Date.class))
+                .isEqualTo(Date.from(Instant.parse("2026-06-22T09:30:00Z")));
+    }
+
+    @Test
+    @DisplayName("should fail with an IOException for an unparseable date string")
+    void shouldThrowIoException_forUnparseableString() {
+        assertThatThrownBy(() -> mapper.readValue("\"not-a-date\"", Date.class))
+                .isInstanceOf(IOException.class);
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/util/SmartDateModuleRoundTripUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/util/SmartDateModuleRoundTripUnitTest.java
@@ -23,9 +23,11 @@ package io.github.carlos_emr.carlos.webserv.rest.util;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.util.Calendar;
 import java.util.Date;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.junit.jupiter.api.DisplayName;
@@ -142,5 +144,49 @@ class SmartDateModuleRoundTripUnitTest {
         assertThat(back.getStartTime()).isEqualTo(appt.getStartTime());
         assertThat(back.getEndTime()).isEqualTo(appt.getEndTime());
         assertThat(back.getAppointmentDate()).isEqualTo(appt.getAppointmentDate());
+    }
+
+    // --- Backward-compatibility contract -------------------------------------------------------
+    // SmartDateModule is registered on the shared REST ObjectMapper, so its deserializer governs
+    // Date parsing for every REST DTO, not just scheduling. These tests pin the wire shapes the
+    // rest of the API relied on before this module had a deserializer (Jackson's default
+    // StdDateFormat: epoch number/string and ISO-8601), so a future change can't silently break
+    // other endpoints. The only @JsonFormat usage on REST date fields is shape=NUMBER, covered by
+    // the numeric and fixture tests below.
+
+    @Test
+    @DisplayName("should deserialize an epoch-millis value sent as a JSON number")
+    void shouldDeserializeEpochMillis_fromJsonNumber() throws Exception {
+        assertThat(mapper.readValue("1234567890000", Date.class))
+                .isEqualTo(new Date(1234567890000L));
+    }
+
+    @Test
+    @DisplayName("should deserialize ISO-8601 with an explicit offset and with milliseconds")
+    void shouldDeserializeIso8601_withOffsetAndMillis() throws Exception {
+        assertThat(mapper.readValue("\"2026-06-22T09:30:00-04:00\"", Date.class))
+                .isEqualTo(Date.from(OffsetDateTime.parse("2026-06-22T09:30:00-04:00").toInstant()));
+        assertThat(mapper.readValue("\"2026-06-22T09:30:00.123Z\"", Date.class))
+                .isEqualTo(Date.from(Instant.parse("2026-06-22T09:30:00.123Z")));
+    }
+
+    @Test
+    @DisplayName("should round-trip a @JsonFormat(shape=NUMBER) date field as other REST DTOs do")
+    void shouldRoundTripJsonFormatNumberField_likeOtherDtos() throws Exception {
+        JsonFormatNumberFixture fixture = new JsonFormatNumberFixture();
+        fixture.when = dateOf(2026, Calendar.JUNE, 22, 9, 30, 15);
+
+        String json = mapper.writeValueAsString(fixture);
+        JsonFormatNumberFixture back = mapper.readValue(json, JsonFormatNumberFixture.class);
+
+        // shape=NUMBER forces epoch-millis on the wire (matches ProviderTo1/AllergyTo1/etc.).
+        assertThat(json).contains("\"when\":" + fixture.when.getTime());
+        assertThat(back.when).isEqualTo(fixture.when);
+    }
+
+    /** Mirrors the {@code @JsonFormat(shape = NUMBER)} date fields used across REST DTOs. */
+    static class JsonFormatNumberFixture {
+        @JsonFormat(shape = JsonFormat.Shape.NUMBER)
+        public Date when;
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/util/SmartDateModuleRoundTripUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/util/SmartDateModuleRoundTripUnitTest.java
@@ -121,9 +121,19 @@ class SmartDateModuleRoundTripUnitTest {
     }
 
     @Test
-    @DisplayName("should fail with an IOException for an unparseable date string")
-    void shouldThrowIoException_forUnparseableString() {
-        assertThatThrownBy(() -> mapper.readValue("\"not-a-date\"", Date.class))
+    @DisplayName("should fail with an IOException that does not echo the raw value for an unparseable string")
+    void shouldThrowIoException_withoutEchoingRawValue_forUnparseableString() {
+        assertThatThrownBy(() -> mapper.readValue("\"not-a-date-SECRET\"", Date.class))
+                .isInstanceOf(IOException.class)
+                // The untrusted request value must not be echoed into the thrown message (PHI hygiene).
+                .satisfies(ex -> assertThat(ex.getMessage()).doesNotContain("not-a-date-SECRET"));
+    }
+
+    @Test
+    @DisplayName("should reject a fractional number rather than truncate it to an epoch long")
+    void shouldRejectFractionalNumber_ratherThanTruncate() {
+        // A non-integer number is not a valid epoch-millis value; it must not be silently truncated.
+        assertThatThrownBy(() -> mapper.readValue("123.45", Date.class))
                 .isInstanceOf(IOException.class);
     }
 

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/util/SmartDateModuleRoundTripUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/util/SmartDateModuleRoundTripUnitTest.java
@@ -122,7 +122,7 @@ class SmartDateModuleRoundTripUnitTest {
 
     @Test
     @DisplayName("should fail with an IOException that does not echo the raw value for an unparseable string")
-    void shouldThrowIoException_withoutEchoingRawValue_forUnparseableString() {
+    void shouldThrowIoExceptionWithoutEchoingRawValue_forUnparseableString() {
         assertThatThrownBy(() -> mapper.readValue("\"not-a-date-SECRET\"", Date.class))
                 .isInstanceOf(IOException.class)
                 // The untrusted request value must not be echoed into the thrown message (PHI hygiene).


### PR DESCRIPTION
## Summary

Repairs the four broken `/ws/rs/schedule` appointment endpoints reported in #2957. All four live around `ScheduleService` + `AppointmentTo1`/converter, plus the root cause of one 500 in `Demographic`.

| Endpoint | Symptom | Root cause | Fix |
|----------|---------|-----------|-----|
| `updateUrgency` | 404 | `updateAppointmentUrgency` had `@Path`/`@Produces`/`@Consumes` but no `@POST`, so JAX-RS couldn't route it | Added `@POST` (matches `updateStatus`/`updateType`) |
| `getAppointment` | 500 (`NPE: "this.text" is null`) | Serializing a `Demographic` NPE'd in the transient `getFamilyPhysician*` parse getters, which fed a frequently-null `family_physician` column straight into a regex `Matcher` (unlike the null-safe `getFamilyDoctor*` siblings) | Coalesce to `""` with `StringUtils.trimToEmpty(...)` before matching |
| `fetchDays` | 500 (`ClassCastException`) | The native query returns `java.time.LocalDate`/`LocalTime` for SQL DATE/TIME columns (and `String` for the CHAR status) under the current JDBC driver; the blind `(Date)`/`(Character)` casts threw | Added `toDate(...)`/`toCharacter(...)` coercion helpers |
| `updateAppointment` | 500 (`InvalidFormatException`) | `SmartDateSerializer` emits `"HH:mm:ss"`/`"yyyy-MM-dd"` strings but had no matching deserializer, so a client POSTing back the API's own payload failed to deserialize. Additionally `AppointmentConverter.getAsDomainObject` was a `null`-returning stub that `updateAppointment` relied on | Added `SmartDateDeserializer` (registered in `SmartDateModule`) and implemented `getAsDomainObject` symmetrically (`BeanUtils.copyProperties`) |

The `getAppointment` PHI exposure (serializing whole `Demographic`/`Provider` entities) is intentionally **out of scope** here — it remains tracked as a separate Security issue per #2957. This PR only stops the 500.

## Verification

- The exact `getAppointment` NPE (`getFamilyPhysicianLastName` → `Matcher` on null) was reproduced against the configured REST `ObjectMapper`, then confirmed gone after the fix.
- The `updateAppointment` round-trip (`"HH:mm:ss"` startTime serialize → deserialize) was confirmed to return the identical `Date`.

## Tests

New regression tests (all green):
- `SmartDateModuleRoundTripUnitTest` — Date round-trips for time-only / date-only / datetime / null shapes, plus an `AppointmentTo1` round-trip.
- `DemographicFamilyPhysicianNameUnitTest` — `getFamilyPhysician*` null-safety and populated parsing.
- `AppointmentConverterUnitTest` — `getAsDomainObject` copies properties / handles null.
- `ScheduleServiceAppointmentEndpointsUnitTest` — `@POST` presence on `updateUrgency`; `toDate`/`toCharacter` coercion.

```
mvn -o test -Dtest=SmartDateModuleRoundTripUnitTest,DemographicFamilyPhysicianNameUnitTest,AppointmentConverterUnitTest,ScheduleServiceAppointmentEndpointsUnitTest,ScheduleServiceUnitTest
# 16 tests, 0 failures, 0 errors
```

Fixes #2957

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Repair ScheduleService appointment REST endpoints to prevent errors when updating or fetching appointments.

Bug Fixes:
- Enable updateAppointmentUrgency to be routed correctly by annotating it as a POST endpoint.
- Prevent null pointer errors when serializing Demographic family physician fields by making regex parsing null-safe.
- Avoid ClassCastException in appointment fetch queries by coercing JDBC date/time/status values to appropriate Java types.
- Allow appointment updates to deserialize Date fields emitted by SmartDateSerializer by adding a matching SmartDateDeserializer and implementing AppointmentConverter.getAsDomainObject.

Enhancements:
- Add helper coercion methods for JDBC date/time and character fields to make ScheduleService more robust across drivers.

Tests:
- Add unit tests covering SmartDate round-trips, Demographic family physician parsing, AppointmentConverter.getAsDomainObject, and ScheduleService appointment endpoint behaviors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repairs four broken `/ws/rs/schedule` appointment endpoints to stop 404/500s, make REST `Date` fields round‑trip (and reject impossible dates), and block over‑posting that corrupted audit fields. Adds tests that lock backward‑compatible date parsing and endpoint guards. Fixes #2957.

- **Bug Fixes**
  - updateUrgency: add `@POST` so it routes; return 400 when the request body is null.
  - getAppointment: make `Demographic.getFamilyPhysician*` parsing null‑safe to prevent NPEs during serialization.
  - fetchDays: coerce JDBC values via `toDate(...)`/`toCharacter(...)` to handle `LocalDate`/`LocalTime`/`String`; trim blank CHARs to null, take the leading char for `char(2)` status, and reject unsupported types.
  - Date parsing: add `SmartDateDeserializer` in `SmartDateModule` to parse `"HH:mm:ss"`/`"yyyy‑MM‑dd"`/integer epoch‑millis; use STRICT parsing to reject impossible dates; fall back to the mapper’s `DateFormat` for ISO‑8601 and epoch‑millis strings; reject fractional numbers and avoid echoing raw values in errors.
  - updateAppointment: load the existing appointment, apply only editable fields via `AppointmentConverter.applyEditableProperties(...)`, stamp `lastUpdateUser`, and return 400/404 for missing/not‑found IDs.

<sup>Written for commit c3dc2bcb4743ed45dfa6978c2ce751c5ad9017c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2986?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

