### PR TITLE
fix: return accurate 400/401/500 for API auth failures instead of HTTP 500 (#2954)

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/webserv/AuthenticationInWSS4JInterceptor.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/AuthenticationInWSS4JInterceptor.java
@@ -43,6 +43,7 @@ import org.apache.cxf.transport.http.AbstractHTTPDestination;
 import org.apache.cxf.ws.security.wss4j.WSS4JInInterceptor;
 import org.apache.logging.log4j.Logger;
 import org.apache.wss4j.common.WSS4JConstants;
+import org.apache.wss4j.common.ext.WSSecurityException;
 import org.apache.wss4j.dom.handler.WSHandlerConstants;
 import org.springframework.beans.factory.annotation.Autowired;
 import jakarta.annotation.PostConstruct;
@@ -106,14 +107,59 @@ public class AuthenticationInWSS4JInterceptor extends WSS4JInInterceptor impleme
             oscarLog.setIp(ip);
             LogAction.addLogSynchronous(oscarLog);
 
-            // WS-Security processing failures here are authentication failures (bad/missing
-            // credentials). Mark the SOAP fault with HTTP 401 so the Soap*FaultOutInterceptor
-            // propagates it as the response code; otherwise CXF defaults the fault to HTTP 500
-            // and bad credentials read to callers as a server error.
-            e.setStatusCode(HttpServletResponse.SC_UNAUTHORIZED);
+            // Map the WS-Security failure to the most appropriate HTTP status so the
+            // Soap*FaultOutInterceptor propagates it as the response code; otherwise CXF
+            // defaults the fault to HTTP 500 and bad credentials read as a server error.
+            // CXF has already replaced the fault body with a safe (obscured) message, so
+            // only the status code is differentiated here -- no extra detail is leaked.
+            e.setStatusCode(resolveFaultStatusCode(e));
 
-            throw (e);
+            throw e;
         }
+    }
+
+    /**
+     * Maps a WS-Security processing failure to an HTTP status without disclosing which
+     * check failed:
+     * <ul>
+     *   <li>401 for authentication failures (bad/absent credentials or token);</li>
+     *   <li>400 for client-side malformed, invalid, unsupported, or expired security headers;</li>
+     *   <li>500 when the failure cannot be positively attributed to the request (callback,
+     *       configuration, or parse errors), so genuine server faults are not mislabelled as
+     *       authentication failures.</li>
+     * </ul>
+     */
+    static int resolveFaultStatusCode(SoapFault fault) {
+        WSSecurityException wss = findWssCause(fault);
+        if (wss == null) {
+            return HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
+        }
+        switch (wss.getErrorCode()) {
+            case FAILED_AUTHENTICATION:
+            case SECURITY_TOKEN_UNAVAILABLE:
+                return HttpServletResponse.SC_UNAUTHORIZED;
+            case MESSAGE_EXPIRED:
+            case INVALID_SECURITY:
+            case INVALID_SECURITY_TOKEN:
+            case UNSUPPORTED_SECURITY_TOKEN:
+            case UNSUPPORTED_ALGORITHM:
+            case FAILED_CHECK:
+            case FAILED_SIGNATURE:
+                return HttpServletResponse.SC_BAD_REQUEST;
+            default:
+                // FAILURE / FAILED_ENCRYPTION / SECURITY_ERROR and anything else are not
+                // reliably client-side -> treat as an unexpected server error.
+                return HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
+        }
+    }
+
+    private static WSSecurityException findWssCause(Throwable t) {
+        for (Throwable cause = t; cause != null; cause = cause.getCause()) {
+            if (cause instanceof WSSecurityException) {
+                return (WSSecurityException) cause;
+            }
+        }
+        return null;
     }
 
     @Override

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/AuthenticationInWSS4JInterceptor.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/AuthenticationInWSS4JInterceptor.java
@@ -88,7 +88,7 @@ public class AuthenticationInWSS4JInterceptor extends WSS4JInInterceptor impleme
         message.put("ws-security.ut.validator", oscarUsernameTokenValidator);
 
         try {
-            super.handleMessage(message);
+            performSecurityCheck(message);
 
             // if it gets here that means it succeeded
             LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromRequest(request);
@@ -116,6 +116,15 @@ public class AuthenticationInWSS4JInterceptor extends WSS4JInInterceptor impleme
 
             throw e;
         }
+    }
+
+    /**
+     * Runs the inbound WS-Security processing (delegates to {@link WSS4JInInterceptor}).
+     * Extracted as a seam so the surrounding authentication logging and HTTP status
+     * mapping can be unit-tested without standing up a full CXF/WSS4J SOAP pipeline.
+     */
+    protected void performSecurityCheck(SoapMessage message) {
+        super.handleMessage(message);
     }
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/AuthenticationInWSS4JInterceptor.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/AuthenticationInWSS4JInterceptor.java
@@ -143,33 +143,27 @@ public class AuthenticationInWSS4JInterceptor extends WSS4JInInterceptor impleme
         if (wss == null) {
             return HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
         }
-        switch (wss.getErrorCode()) {
-            case FAILED_AUTHENTICATION:
-            case SECURITY_TOKEN_UNAVAILABLE:
-                return HttpServletResponse.SC_UNAUTHORIZED;
-            case MESSAGE_EXPIRED:
-            case INVALID_SECURITY:
-            case INVALID_SECURITY_TOKEN:
-            case UNSUPPORTED_SECURITY_TOKEN:
-            case UNSUPPORTED_ALGORITHM:
+        return switch (wss.getErrorCode()) {
+            case FAILED_AUTHENTICATION, SECURITY_TOKEN_UNAVAILABLE ->
+                    HttpServletResponse.SC_UNAUTHORIZED;
             // FAILED_CHECK is "the signature or decryption was invalid" -- i.e. inbound
             // verification of client-supplied data failed. Mapped to 400 (not 401)
             // deliberately: it avoids disclosing whether the credentials were structurally
             // invalid versus recognized-but-wrong.
-            case FAILED_CHECK:
-                return HttpServletResponse.SC_BAD_REQUEST;
-            default:
-                // FAILED_SIGNATURE ("Signature creation failed"), FAILED_ENCRYPTION, FAILURE,
-                // SECURITY_ERROR and anything else are server-side or not reliably attributable
-                // to the request -> treat as an unexpected server error.
-                return HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
-        }
+            case MESSAGE_EXPIRED, INVALID_SECURITY, INVALID_SECURITY_TOKEN,
+                 UNSUPPORTED_SECURITY_TOKEN, UNSUPPORTED_ALGORITHM, FAILED_CHECK ->
+                    HttpServletResponse.SC_BAD_REQUEST;
+            // FAILED_SIGNATURE ("Signature creation failed"), FAILED_ENCRYPTION, FAILURE,
+            // SECURITY_ERROR and anything else are server-side or not reliably attributable
+            // to the request -> treat as an unexpected server error.
+            default -> HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
+        };
     }
 
     private static WSSecurityException findWssCause(Throwable t) {
         for (Throwable cause = t; cause != null; cause = cause.getCause()) {
-            if (cause instanceof WSSecurityException) {
-                return (WSSecurityException) cause;
+            if (cause instanceof WSSecurityException wss) {
+                return wss;
             }
         }
         return null;

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/AuthenticationInWSS4JInterceptor.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/AuthenticationInWSS4JInterceptor.java
@@ -152,15 +152,16 @@ public class AuthenticationInWSS4JInterceptor extends WSS4JInInterceptor impleme
             case INVALID_SECURITY_TOKEN:
             case UNSUPPORTED_SECURITY_TOKEN:
             case UNSUPPORTED_ALGORITHM:
-            // FAILED_CHECK / FAILED_SIGNATURE are signature/digest verification failures.
-            // Mapped to 400 (not 401) deliberately: it avoids disclosing whether the
-            // credentials were structurally invalid versus recognized-but-wrong.
+            // FAILED_CHECK is "the signature or decryption was invalid" -- i.e. inbound
+            // verification of client-supplied data failed. Mapped to 400 (not 401)
+            // deliberately: it avoids disclosing whether the credentials were structurally
+            // invalid versus recognized-but-wrong.
             case FAILED_CHECK:
-            case FAILED_SIGNATURE:
                 return HttpServletResponse.SC_BAD_REQUEST;
             default:
-                // FAILURE / FAILED_ENCRYPTION / SECURITY_ERROR and anything else are not
-                // reliably client-side -> treat as an unexpected server error.
+                // FAILED_SIGNATURE ("Signature creation failed"), FAILED_ENCRYPTION, FAILURE,
+                // SECURITY_ERROR and anything else are server-side or not reliably attributable
+                // to the request -> treat as an unexpected server error.
                 return HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
         }
     }

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/AuthenticationInWSS4JInterceptor.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/AuthenticationInWSS4JInterceptor.java
@@ -35,6 +35,7 @@ import java.util.HashMap;
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.CallbackHandler;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.apache.cxf.binding.soap.SoapFault;
 import org.apache.cxf.binding.soap.SoapMessage;
@@ -104,6 +105,12 @@ public class AuthenticationInWSS4JInterceptor extends WSS4JInInterceptor impleme
             oscarLog.setAction("WS_LOGIN_FAILURE");
             oscarLog.setIp(ip);
             LogAction.addLogSynchronous(oscarLog);
+
+            // WS-Security processing failures here are authentication failures (bad/missing
+            // credentials). Mark the SOAP fault with HTTP 401 so the Soap*FaultOutInterceptor
+            // propagates it as the response code; otherwise CXF defaults the fault to HTTP 500
+            // and bad credentials read to callers as a server error.
+            e.setStatusCode(HttpServletResponse.SC_UNAUTHORIZED);
 
             throw (e);
         }

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/AuthenticationInWSS4JInterceptor.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/AuthenticationInWSS4JInterceptor.java
@@ -143,6 +143,9 @@ public class AuthenticationInWSS4JInterceptor extends WSS4JInInterceptor impleme
             case INVALID_SECURITY_TOKEN:
             case UNSUPPORTED_SECURITY_TOKEN:
             case UNSUPPORTED_ALGORITHM:
+            // FAILED_CHECK / FAILED_SIGNATURE are signature/digest verification failures.
+            // Mapped to 400 (not 401) deliberately: it avoids disclosing whether the
+            // credentials were structurally invalid versus recognized-but-wrong.
             case FAILED_CHECK:
             case FAILED_SIGNATURE:
                 return HttpServletResponse.SC_BAD_REQUEST;

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/oauth/util/OAuthInterceptor.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/oauth/util/OAuthInterceptor.java
@@ -72,8 +72,10 @@ import org.apache.cxf.message.Message;
 import org.apache.cxf.phase.Phase;
 import org.apache.cxf.phase.PhaseInterceptor;
 import org.apache.cxf.transport.http.AbstractHTTPDestination;
+import org.apache.logging.log4j.Logger;
 
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.webserv.oauth.Client;
 import io.github.carlos_emr.carlos.webserv.oauth.OAuth1Exception;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -88,7 +90,9 @@ import io.github.carlos_emr.carlos.webserv.oauth.OAuth1SignatureVerifier;
 @Component
 public class OAuthInterceptor implements PhaseInterceptor<Message> {
 
-    @Autowired 
+    private static final Logger logger = MiscUtils.getLogger();
+
+    @Autowired
     private OscarOAuthDataProvider oauthDataProvider;
 
     @Autowired 
@@ -158,12 +162,20 @@ public class OAuthInterceptor implements PhaseInterceptor<Message> {
             req.setAttribute(info.getLoggedInInfoKey(), info);
 
         } catch (OAuth1Exception e) {
+            // Explicit auth outcome (e.g. 400 missing param, 401 invalid consumer/token):
+            // carries its own intended status code.
             throw toFault(e);
         } catch (IllegalArgumentException badSigOrTime) {
             // from verifier: missing/stale timestamp, bad signature, unknown token, etc.
+            // These are client-side authentication failures -> 401.
             throw toFault(new OAuth1Exception(401, "invalid_signature"));
         } catch (Exception e) {
-            throw toFault(new OAuth1Exception(401, "oauth_authentication_failed"));
+            // Anything else is an unexpected server-side failure (e.g. a data-access error),
+            // NOT an authentication problem. Log the cause for diagnosis but return a generic
+            // 500 so genuine outages are not masked as "bad credentials", and so the client
+            // body reveals nothing about the internal failure.
+            logger.error("Unexpected error during OAuth1 authentication", e);
+            throw toFault(new OAuth1Exception(500, "oauth_processing_error"));
         }
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/oauth/util/OAuthInterceptor.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/oauth/util/OAuthInterceptor.java
@@ -158,13 +158,25 @@ public class OAuthInterceptor implements PhaseInterceptor<Message> {
             req.setAttribute(info.getLoggedInInfoKey(), info);
 
         } catch (OAuth1Exception e) {
-            throw new Fault(e);
+            throw toFault(e);
         } catch (IllegalArgumentException badSigOrTime) {
             // from verifier: missing/stale timestamp, bad signature, unknown token, etc.
-            throw new Fault(new OAuth1Exception(401, "invalid_signature"));
+            throw toFault(new OAuth1Exception(401, "invalid_signature"));
         } catch (Exception e) {
-            throw new Fault(new OAuth1Exception(401, "oauth_authentication_failed"));
+            throw toFault(new OAuth1Exception(401, "oauth_authentication_failed"));
         }
+    }
+
+    /**
+     * Wraps an {@link OAuth1Exception} in a CXF {@link Fault} that carries the intended
+     * HTTP status code. Without {@link Fault#setStatusCode(int)} CXF discards the OAuth
+     * status and defaults an in-interceptor fault to HTTP 500, so a 400/401 authentication
+     * failure would surface to API callers as a server error.
+     */
+    private static Fault toFault(OAuth1Exception e) {
+        Fault fault = new Fault(e);
+        fault.setStatusCode(e.getHttpCode());
+        return fault;
     }
 
     @Override public void handleFault(Message message) { /* no-op */ }

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/AuthenticationInWSS4JInterceptorUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/AuthenticationInWSS4JInterceptorUnitTest.java
@@ -6,16 +6,32 @@
 package io.github.carlos_emr.carlos.webserv;
 
 import javax.xml.namespace.QName;
+import jakarta.servlet.http.HttpServletRequest;
 
 import org.apache.cxf.binding.soap.Soap11;
 import org.apache.cxf.binding.soap.SoapFault;
+import org.apache.cxf.binding.soap.SoapMessage;
+import org.apache.cxf.message.MessageImpl;
+import org.apache.cxf.transport.http.AbstractHTTPDestination;
 import org.apache.wss4j.common.ext.WSSecurityException;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import io.github.carlos_emr.carlos.log.LogAction;
+import io.github.carlos_emr.carlos.commn.model.OscarLog;
+import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
 
 /**
  * Pins the HTTP status mapping for SOAP WS-Security failures (issue #2954). Authentication
@@ -90,5 +106,95 @@ class AuthenticationInWSS4JInterceptorUnitTest {
 
     private static SoapFault soapFaultCausedBy(WSSecurityException.ErrorCode code) {
         return new SoapFault("ws-security failure", new WSSecurityException(code), RECEIVER);
+    }
+
+    // --- handleMessage() wiring -------------------------------------------------
+    // These drive the actual handleMessage flow via a test seam (performSecurityCheck)
+    // so the failure-path status assignment and the success/failure audit logging are
+    // covered without standing up a full CXF/WSS4J SOAP pipeline.
+
+    @Test
+    @DisplayName("should skip processing when there is no HTTP request (outgoing message)")
+    void shouldSkipProcessing_whenNoHttpRequest() {
+        TestInterceptor interceptor = new TestInterceptor(null);
+        SoapMessage message = new SoapMessage(new MessageImpl()); // no HTTP_REQUEST set
+
+        try (MockedStatic<LogAction> logAction = mockStatic(LogAction.class)) {
+            interceptor.handleMessage(message); // must not throw
+
+            assertThat(interceptor.securityCheckCalls).isZero();
+            logAction.verifyNoInteractions();
+        }
+    }
+
+    @Test
+    @DisplayName("should set HTTP 401 on the fault and log a failure when authentication fails")
+    void shouldSetHttp401AndLogFailure_whenAuthenticationFails() {
+        SoapFault authFailure =
+                new SoapFault("auth failed",
+                        new WSSecurityException(WSSecurityException.ErrorCode.FAILED_AUTHENTICATION),
+                        RECEIVER);
+        TestInterceptor interceptor = new TestInterceptor(authFailure);
+        ReflectionTestUtils.setField(interceptor, "oscarUsernameTokenValidator",
+                mock(OscarUsernameTokenValidator.class));
+        SoapMessage message = messageWithRequest(new MockHttpServletRequest());
+
+        try (MockedStatic<LogAction> logAction = mockStatic(LogAction.class)) {
+            SoapFault thrown =
+                    catchThrowableOfType(() -> interceptor.handleMessage(message), SoapFault.class);
+
+            assertThat(thrown).isSameAs(authFailure);
+            assertThat(thrown.getStatusCode()).isEqualTo(401);
+            logAction.verify(() -> LogAction.addLogSynchronous(any(OscarLog.class)), times(1));
+        }
+    }
+
+    @Test
+    @DisplayName("should wire the validator and log success when authentication succeeds")
+    void shouldWireValidatorAndLogSuccess_whenAuthenticationSucceeds() {
+        TestInterceptor interceptor = new TestInterceptor(null); // no fault -> success
+        OscarUsernameTokenValidator validator = mock(OscarUsernameTokenValidator.class);
+        ReflectionTestUtils.setField(interceptor, "oscarUsernameTokenValidator", validator);
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        LoggedInInfo loggedInInfo = new LoggedInInfo();
+        request.setAttribute(loggedInInfo.getLoggedInInfoKey(), loggedInInfo);
+        SoapMessage message = messageWithRequest(request);
+
+        try (MockedStatic<LogAction> logAction = mockStatic(LogAction.class)) {
+            interceptor.handleMessage(message);
+
+            assertThat(interceptor.securityCheckCalls).isEqualTo(1);
+            assertThat(message.get("ws-security.ut.validator")).isSameAs(validator);
+            logAction.verify(() -> LogAction.addLogSynchronous(any(OscarLog.class)), times(1));
+        }
+    }
+
+    private static SoapMessage messageWithRequest(HttpServletRequest request) {
+        SoapMessage message = new SoapMessage(new MessageImpl());
+        message.put(AbstractHTTPDestination.HTTP_REQUEST, request);
+        return message;
+    }
+
+    /**
+     * Replaces the real {@link org.apache.cxf.ws.security.wss4j.WSS4JInInterceptor} processing
+     * with a deterministic outcome: throw {@code faultToThrow} to simulate a WS-Security failure,
+     * or return normally to simulate a successful authentication.
+     */
+    private static final class TestInterceptor extends AuthenticationInWSS4JInterceptor {
+        private final SoapFault faultToThrow;
+        private int securityCheckCalls;
+
+        private TestInterceptor(SoapFault faultToThrow) {
+            this.faultToThrow = faultToThrow;
+        }
+
+        @Override
+        protected void performSecurityCheck(SoapMessage message) {
+            securityCheckCalls++;
+            if (faultToThrow != null) {
+                throw faultToThrow;
+            }
+        }
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/AuthenticationInWSS4JInterceptorUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/AuthenticationInWSS4JInterceptorUnitTest.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ */
+package io.github.carlos_emr.carlos.webserv;
+
+import javax.xml.namespace.QName;
+
+import org.apache.cxf.binding.soap.Soap11;
+import org.apache.cxf.binding.soap.SoapFault;
+import org.apache.wss4j.common.ext.WSSecurityException;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins the HTTP status mapping for SOAP WS-Security failures (issue #2954). Authentication
+ * failures must surface as 401, client-side malformed/invalid security as 400, and anything
+ * not attributable to the request as 500 -- without CXF defaulting every fault to 500 and
+ * without disclosing which check failed.
+ */
+@DisplayName("AuthenticationInWSS4JInterceptor fault status mapping")
+@Tag("unit")
+@Tag("security")
+class AuthenticationInWSS4JInterceptorUnitTest {
+
+    private static final QName RECEIVER = Soap11.getInstance().getReceiver();
+
+    @Test
+    @DisplayName("should map failed authentication to HTTP 401")
+    void shouldMapFault_toHttp401WhenFailedAuthentication() {
+        SoapFault fault = soapFaultCausedBy(WSSecurityException.ErrorCode.FAILED_AUTHENTICATION);
+
+        assertThat(AuthenticationInWSS4JInterceptor.resolveFaultStatusCode(fault)).isEqualTo(401);
+    }
+
+    @Test
+    @DisplayName("should map unavailable security token to HTTP 401")
+    void shouldMapFault_toHttp401WhenSecurityTokenUnavailable() {
+        SoapFault fault = soapFaultCausedBy(WSSecurityException.ErrorCode.SECURITY_TOKEN_UNAVAILABLE);
+
+        assertThat(AuthenticationInWSS4JInterceptor.resolveFaultStatusCode(fault)).isEqualTo(401);
+    }
+
+    @Test
+    @DisplayName("should map an expired message to HTTP 400")
+    void shouldMapFault_toHttp400WhenMessageExpired() {
+        SoapFault fault = soapFaultCausedBy(WSSecurityException.ErrorCode.MESSAGE_EXPIRED);
+
+        assertThat(AuthenticationInWSS4JInterceptor.resolveFaultStatusCode(fault)).isEqualTo(400);
+    }
+
+    @Test
+    @DisplayName("should map invalid security headers to HTTP 400")
+    void shouldMapFault_toHttp400WhenInvalidSecurity() {
+        SoapFault fault = soapFaultCausedBy(WSSecurityException.ErrorCode.INVALID_SECURITY);
+
+        assertThat(AuthenticationInWSS4JInterceptor.resolveFaultStatusCode(fault)).isEqualTo(400);
+    }
+
+    @Test
+    @DisplayName("should map a generic WS-Security failure to HTTP 500")
+    void shouldMapFault_toHttp500WhenGenericFailure() {
+        SoapFault fault = soapFaultCausedBy(WSSecurityException.ErrorCode.FAILURE);
+
+        assertThat(AuthenticationInWSS4JInterceptor.resolveFaultStatusCode(fault)).isEqualTo(500);
+    }
+
+    @Test
+    @DisplayName("should map a fault without a WS-Security cause to HTTP 500")
+    void shouldMapFault_toHttp500WhenNoSecurityCause() {
+        SoapFault fault = new SoapFault("parse error", new RuntimeException("boom"), RECEIVER);
+
+        assertThat(AuthenticationInWSS4JInterceptor.resolveFaultStatusCode(fault)).isEqualTo(500);
+    }
+
+    @Test
+    @DisplayName("should find the WS-Security error code nested deeper in the cause chain")
+    void shouldMapFault_byNestedSecurityCause() {
+        WSSecurityException wss = new WSSecurityException(WSSecurityException.ErrorCode.FAILED_AUTHENTICATION);
+        RuntimeException wrapper = new RuntimeException("wrapped", wss);
+        SoapFault fault = new SoapFault("auth failed", wrapper, RECEIVER);
+
+        assertThat(AuthenticationInWSS4JInterceptor.resolveFaultStatusCode(fault)).isEqualTo(401);
+    }
+
+    private static SoapFault soapFaultCausedBy(WSSecurityException.ErrorCode code) {
+        return new SoapFault("ws-security failure", new WSSecurityException(code), RECEIVER);
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/AuthenticationInWSS4JInterceptorUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/AuthenticationInWSS4JInterceptorUnitTest.java
@@ -79,6 +79,24 @@ class AuthenticationInWSS4JInterceptorUnitTest {
     }
 
     @Test
+    @DisplayName("should map an invalid signature/decryption check to HTTP 400")
+    void shouldMapFault_toHttp400WhenFailedCheck() {
+        SoapFault fault = soapFaultCausedBy(WSSecurityException.ErrorCode.FAILED_CHECK);
+
+        assertThat(AuthenticationInWSS4JInterceptor.resolveFaultStatusCode(fault)).isEqualTo(400);
+    }
+
+    @Test
+    @DisplayName("should map a server-side signature-creation failure to HTTP 500")
+    void shouldMapFault_toHttp500WhenFailedSignature() {
+        // WSS4J FAILED_SIGNATURE is "Signature creation failed" -- a server-side operation,
+        // not a client request error, so it must not be reported as a 4xx.
+        SoapFault fault = soapFaultCausedBy(WSSecurityException.ErrorCode.FAILED_SIGNATURE);
+
+        assertThat(AuthenticationInWSS4JInterceptor.resolveFaultStatusCode(fault)).isEqualTo(500);
+    }
+
+    @Test
     @DisplayName("should map a generic WS-Security failure to HTTP 500")
     void shouldMapFault_toHttp500WhenGenericFailure() {
         SoapFault fault = soapFaultCausedBy(WSSecurityException.ErrorCode.FAILURE);

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/AuthenticationInWSS4JInterceptorUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/AuthenticationInWSS4JInterceptorUnitTest.java
@@ -18,19 +18,18 @@ import org.apache.wss4j.common.ext.WSSecurityException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import io.github.carlos_emr.carlos.log.LogAction;
 import io.github.carlos_emr.carlos.commn.model.OscarLog;
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 
 /**
@@ -42,7 +41,7 @@ import static org.mockito.Mockito.times;
 @DisplayName("AuthenticationInWSS4JInterceptor fault status mapping")
 @Tag("unit")
 @Tag("security")
-class AuthenticationInWSS4JInterceptorUnitTest {
+class AuthenticationInWSS4JInterceptorUnitTest extends CarlosUnitTestBase {
 
     private static final QName RECEIVER = Soap11.getInstance().getReceiver();
 
@@ -137,12 +136,10 @@ class AuthenticationInWSS4JInterceptorUnitTest {
         TestInterceptor interceptor = new TestInterceptor(null);
         SoapMessage message = new SoapMessage(new MessageImpl()); // no HTTP_REQUEST set
 
-        try (MockedStatic<LogAction> logAction = mockStatic(LogAction.class)) {
-            interceptor.handleMessage(message); // must not throw
+        interceptor.handleMessage(message); // must not throw
 
-            assertThat(interceptor.securityCheckCalls).isZero();
-            logAction.verifyNoInteractions();
-        }
+        assertThat(interceptor.securityCheckCalls).isZero();
+        logActionMock.verifyNoInteractions();
     }
 
     @Test
@@ -157,14 +154,12 @@ class AuthenticationInWSS4JInterceptorUnitTest {
                 mock(OscarUsernameTokenValidator.class));
         SoapMessage message = messageWithRequest(new MockHttpServletRequest());
 
-        try (MockedStatic<LogAction> logAction = mockStatic(LogAction.class)) {
-            SoapFault thrown =
-                    catchThrowableOfType(() -> interceptor.handleMessage(message), SoapFault.class);
+        SoapFault thrown =
+                catchThrowableOfType(() -> interceptor.handleMessage(message), SoapFault.class);
 
-            assertThat(thrown).isSameAs(authFailure);
-            assertThat(thrown.getStatusCode()).isEqualTo(401);
-            logAction.verify(() -> LogAction.addLogSynchronous(any(OscarLog.class)), times(1));
-        }
+        assertThat(thrown).isSameAs(authFailure);
+        assertThat(thrown.getStatusCode()).isEqualTo(401);
+        logActionMock.verify(() -> LogAction.addLogSynchronous(any(OscarLog.class)), times(1));
     }
 
     @Test
@@ -179,13 +174,11 @@ class AuthenticationInWSS4JInterceptorUnitTest {
         request.setAttribute(loggedInInfo.getLoggedInInfoKey(), loggedInInfo);
         SoapMessage message = messageWithRequest(request);
 
-        try (MockedStatic<LogAction> logAction = mockStatic(LogAction.class)) {
-            interceptor.handleMessage(message);
+        interceptor.handleMessage(message);
 
-            assertThat(interceptor.securityCheckCalls).isEqualTo(1);
-            assertThat(message.get("ws-security.ut.validator")).isSameAs(validator);
-            logAction.verify(() -> LogAction.addLogSynchronous(any(OscarLog.class)), times(1));
-        }
+        assertThat(interceptor.securityCheckCalls).isEqualTo(1);
+        assertThat(message.get("ws-security.ut.validator")).isSameAs(validator);
+        logActionMock.verify(() -> LogAction.addLogSynchronous(any(OscarLog.class)), times(1));
     }
 
     private static SoapMessage messageWithRequest(HttpServletRequest request) {

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/util/OAuthInterceptorUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/util/OAuthInterceptorUnitTest.java
@@ -7,6 +7,7 @@ package io.github.carlos_emr.carlos.webserv.oauth.util;
 
 import io.github.carlos_emr.carlos.login.OscarOAuthDataProvider;
 import io.github.carlos_emr.carlos.webserv.oauth.Client;
+import io.github.carlos_emr.carlos.webserv.oauth.OAuth1SignatureVerifier;
 
 import org.apache.cxf.interceptor.Fault;
 import org.apache.cxf.message.Message;
@@ -21,6 +22,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -74,6 +76,33 @@ class OAuthInterceptorUnitTest {
     void shouldRaiseFault_withHttp401WhenSignatureVerificationFails() {
         OscarOAuthDataProvider dataProvider = mock(OscarOAuthDataProvider.class);
         when(dataProvider.getClient(TEST_CONSUMER_KEY)).thenReturn(mock(Client.class));
+        // Verifier rejects the signature/timestamp the way it does for a real bad request.
+        OAuth1SignatureVerifier verifier = mock(OAuth1SignatureVerifier.class);
+        when(verifier.verifySignature(any(), any()))
+                .thenThrow(new IllegalArgumentException("bad signature"));
+
+        OAuthInterceptor interceptor = new OAuthInterceptor();
+        ReflectionTestUtils.setField(interceptor, "oauthDataProvider", dataProvider);
+        ReflectionTestUtils.setField(interceptor, "verifier", verifier);
+
+        MockHttpServletRequest request = oauthRequestWithoutCredentials();
+        request.addParameter("oauth_consumer_key", TEST_CONSUMER_KEY);
+        request.addParameter("oauth_token", "some-token");
+        Message message = messageWith(request);
+
+        Fault fault = catchThrowableOfType(() -> interceptor.handleMessage(message), Fault.class);
+
+        assertThat(fault).isNotNull();
+        assertThat(fault.getStatusCode()).isEqualTo(401);
+    }
+
+    @Test
+    @DisplayName("should raise fault with HTTP 500 when an unexpected error occurs")
+    void shouldRaiseFault_withHttp500WhenUnexpectedError() {
+        OscarOAuthDataProvider dataProvider = mock(OscarOAuthDataProvider.class);
+        // A data-access style failure is a server error, not an authentication failure.
+        when(dataProvider.getClient(TEST_CONSUMER_KEY))
+                .thenThrow(new RuntimeException("database unavailable"));
 
         OAuthInterceptor interceptor = new OAuthInterceptor();
         ReflectionTestUtils.setField(interceptor, "oauthDataProvider", dataProvider);
@@ -83,12 +112,10 @@ class OAuthInterceptorUnitTest {
         request.addParameter("oauth_token", "some-token");
         Message message = messageWith(request);
 
-        // No verifier wired -> signature verification fails -> generic auth-failure path.
-        // The intended status (401) must propagate; it must never default to HTTP 500.
         Fault fault = catchThrowableOfType(() -> interceptor.handleMessage(message), Fault.class);
 
         assertThat(fault).isNotNull();
-        assertThat(fault.getStatusCode()).isEqualTo(401);
+        assertThat(fault.getStatusCode()).isEqualTo(500);
     }
 
     /** A request that looks like OAuth1 (has an Authorization header) but carries no usable params. */

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/util/OAuthInterceptorUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/util/OAuthInterceptorUnitTest.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.when;
 /**
  * Pins the CXF status-code propagation for OAuth 1.0a authentication failures
  * (issue #2954). Without {@code Fault.setStatusCode(...)} CXF defaults an
- * in-interceptor fault to HTTP 500, so bad credentials would read to API callers
+ * in-interceptor fault to HTTP 500, so bad credentials would appear to API callers
  * as a server error instead of a clean 400/401.
  */
 @DisplayName("OAuthInterceptor auth-failure status codes")

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/util/OAuthInterceptorUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/util/OAuthInterceptorUnitTest.java
@@ -35,6 +35,8 @@ import static org.mockito.Mockito.when;
 @Tag("security")
 class OAuthInterceptorUnitTest {
 
+    private static final String TEST_CONSUMER_KEY = "consumer-key";
+
     @Test
     @DisplayName("should raise fault with HTTP 400 when consumer key is missing")
     void shouldRaiseFault_withHttp400WhenConsumerKeyMissing() {
@@ -71,13 +73,13 @@ class OAuthInterceptorUnitTest {
     @DisplayName("should raise fault with HTTP 401 when signature verification fails")
     void shouldRaiseFault_withHttp401WhenSignatureVerificationFails() {
         OscarOAuthDataProvider dataProvider = mock(OscarOAuthDataProvider.class);
-        when(dataProvider.getClient(anyConsumer())).thenReturn(mock(Client.class));
+        when(dataProvider.getClient(TEST_CONSUMER_KEY)).thenReturn(mock(Client.class));
 
         OAuthInterceptor interceptor = new OAuthInterceptor();
         ReflectionTestUtils.setField(interceptor, "oauthDataProvider", dataProvider);
 
         MockHttpServletRequest request = oauthRequestWithoutCredentials();
-        request.addParameter("oauth_consumer_key", anyConsumer());
+        request.addParameter("oauth_consumer_key", TEST_CONSUMER_KEY);
         request.addParameter("oauth_token", "some-token");
         Message message = messageWith(request);
 
@@ -87,10 +89,6 @@ class OAuthInterceptorUnitTest {
 
         assertThat(fault).isNotNull();
         assertThat(fault.getStatusCode()).isEqualTo(401);
-    }
-
-    private static String anyConsumer() {
-        return "consumer-key";
     }
 
     /** A request that looks like OAuth1 (has an Authorization header) but carries no usable params. */

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/util/OAuthInterceptorUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/util/OAuthInterceptorUnitTest.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ */
+package io.github.carlos_emr.carlos.webserv.oauth.util;
+
+import io.github.carlos_emr.carlos.login.OscarOAuthDataProvider;
+import io.github.carlos_emr.carlos.webserv.oauth.Client;
+
+import org.apache.cxf.interceptor.Fault;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.message.MessageImpl;
+import org.apache.cxf.transport.http.AbstractHTTPDestination;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Pins the CXF status-code propagation for OAuth 1.0a authentication failures
+ * (issue #2954). Without {@code Fault.setStatusCode(...)} CXF defaults an
+ * in-interceptor fault to HTTP 500, so bad credentials would read to API callers
+ * as a server error instead of a clean 400/401.
+ */
+@DisplayName("OAuthInterceptor auth-failure status codes")
+@Tag("unit")
+@Tag("security")
+class OAuthInterceptorUnitTest {
+
+    @Test
+    @DisplayName("should raise fault with HTTP 400 when consumer key is missing")
+    void shouldRaiseFault_withHttp400WhenConsumerKeyMissing() {
+        OAuthInterceptor interceptor = new OAuthInterceptor();
+        Message message = messageWith(oauthRequestWithoutCredentials());
+
+        Fault fault = catchThrowableOfType(() -> interceptor.handleMessage(message), Fault.class);
+
+        assertThat(fault).isNotNull();
+        assertThat(fault.getStatusCode()).isEqualTo(400);
+    }
+
+    @Test
+    @DisplayName("should raise fault with HTTP 401 when consumer is unknown")
+    void shouldRaiseFault_withHttp401WhenConsumerUnknown() {
+        OscarOAuthDataProvider dataProvider = mock(OscarOAuthDataProvider.class);
+        when(dataProvider.getClient("nope")).thenReturn(null);
+
+        OAuthInterceptor interceptor = new OAuthInterceptor();
+        ReflectionTestUtils.setField(interceptor, "oauthDataProvider", dataProvider);
+
+        MockHttpServletRequest request = oauthRequestWithoutCredentials();
+        request.addParameter("oauth_consumer_key", "nope");
+        request.addParameter("oauth_token", "some-token");
+        Message message = messageWith(request);
+
+        Fault fault = catchThrowableOfType(() -> interceptor.handleMessage(message), Fault.class);
+
+        assertThat(fault).isNotNull();
+        assertThat(fault.getStatusCode()).isEqualTo(401);
+    }
+
+    @Test
+    @DisplayName("should not default to HTTP 500 on authentication failure")
+    void shouldNotDefaultToHttp500_onAuthenticationFailure() {
+        OscarOAuthDataProvider dataProvider = mock(OscarOAuthDataProvider.class);
+        when(dataProvider.getClient(anyConsumer())).thenReturn(mock(Client.class));
+
+        OAuthInterceptor interceptor = new OAuthInterceptor();
+        ReflectionTestUtils.setField(interceptor, "oauthDataProvider", dataProvider);
+
+        MockHttpServletRequest request = oauthRequestWithoutCredentials();
+        request.addParameter("oauth_consumer_key", anyConsumer());
+        request.addParameter("oauth_token", "some-token");
+        Message message = messageWith(request);
+
+        assertThatThrownBy(() -> interceptor.handleMessage(message))
+                .isInstanceOfSatisfying(Fault.class,
+                        fault -> assertThat(fault.getStatusCode()).isNotEqualTo(500));
+    }
+
+    private static String anyConsumer() {
+        return "consumer-key";
+    }
+
+    /** A request that looks like OAuth1 (has an Authorization header) but carries no usable params. */
+    private static MockHttpServletRequest oauthRequestWithoutCredentials() {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/ws/rest/example");
+        request.addHeader("Authorization", "OAuth realm=\"carlos\"");
+        return request;
+    }
+
+    private static Message messageWith(MockHttpServletRequest request) {
+        Message message = new MessageImpl();
+        message.put(AbstractHTTPDestination.HTTP_REQUEST, request);
+        return message;
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/util/OAuthInterceptorUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/util/OAuthInterceptorUnitTest.java
@@ -20,7 +20,6 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -69,8 +68,8 @@ class OAuthInterceptorUnitTest {
     }
 
     @Test
-    @DisplayName("should not default to HTTP 500 on authentication failure")
-    void shouldNotDefaultToHttp500_onAuthenticationFailure() {
+    @DisplayName("should raise fault with HTTP 401 when signature verification fails")
+    void shouldRaiseFault_withHttp401WhenSignatureVerificationFails() {
         OscarOAuthDataProvider dataProvider = mock(OscarOAuthDataProvider.class);
         when(dataProvider.getClient(anyConsumer())).thenReturn(mock(Client.class));
 
@@ -82,9 +81,12 @@ class OAuthInterceptorUnitTest {
         request.addParameter("oauth_token", "some-token");
         Message message = messageWith(request);
 
-        assertThatThrownBy(() -> interceptor.handleMessage(message))
-                .isInstanceOfSatisfying(Fault.class,
-                        fault -> assertThat(fault.getStatusCode()).isNotEqualTo(500));
+        // No verifier wired -> signature verification fails -> generic auth-failure path.
+        // The intended status (401) must propagate; it must never default to HTTP 500.
+        Fault fault = catchThrowableOfType(() -> interceptor.handleMessage(message), Fault.class);
+
+        assertThat(fault).isNotNull();
+        assertThat(fault.getStatusCode()).isEqualTo(401);
     }
 
     private static String anyConsumer() {


### PR DESCRIPTION
## Summary

API authentication failures were surfacing as **HTTP 500** instead of a clean **401/403**, making bad credentials read to API callers as a server error (issue #2954).

### REST (OAuth 1.0a)
`OAuthInterceptor` built `OAuth1Exception(<code>, ...)` with the intended status but threw `new Fault(e)` **without** `setStatusCode(...)`, so CXF discarded the code and defaulted the in-interceptor fault to 500. Added a `toFault(...)` helper that copies `OAuth1Exception.getHttpCode()` onto the `Fault` via `setStatusCode(...)`. Missing params still map to 400; auth failures to 401.

### SOAP (WS-Security UsernameToken)
Failed authentication propagated as a SOAP fault with HTTP 500. `AuthenticationInWSS4JInterceptor` now sets the `SoapFault` status code to **401** before rethrowing. Verified against CXF 4.1.5 sources that `Soap11/12FaultOutInterceptor` copies `Fault.getStatusCode()` into `Message.RESPONSE_CODE`, driving the HTTP status.

## Tests
- New `OAuthInterceptorUnitTest` covering the 400 (missing consumer key), 401 (unknown consumer), and not-500 (generic auth failure) paths. `Tests run: 3, Failures: 0, Errors: 0`.
- Full `test-compile` (main + tests) passes.

fixes #2954

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return accurate HTTP status codes for API auth across REST and SOAP. 401 for bad credentials, 400 for missing/invalid params or security headers, and 500 for unexpected server errors (fixes #2954).

- **Bug Fixes**
  - REST (`OAuth 1.0a`): Wrap `OAuth1Exception` in a CXF `Fault` with `statusCode`; map verifier `IllegalArgumentException` to 401; log unexpected exceptions and return 500 (`oauth_processing_error`) instead of 401.
  - SOAP (WS-Security): Set `SoapFault` status via `resolveFaultStatusCode(...)`—401 for failed auth/token unavailable, 400 for malformed/invalid/unsupported/expired headers (including `FAILED_CHECK`), 500 for non-request causes and `FAILED_SIGNATURE`; extracted `performSecurityCheck(...)` seam to unit-test `handleMessage` wiring.
  - Tests: Added `AuthenticationInWSS4JInterceptorUnitTest` for 401/400/500 mapping and `handleMessage` wiring; expanded `OAuthInterceptorUnitTest` to assert 401 on signature failures and 500 on unexpected errors; renamed helper to `TEST_CONSUMER_KEY`; tests now extend `CarlosUnitTestBase` for static `LogAction` mocking.

- **Refactors**
  - Modernized WS-Security status mapping: arrow `switch` with grouped cases and `instanceof` pattern matching in `findWssCause(...)` (no behavior change).

<sup>Written for commit 312c1678dff3fcdb17bddcf55cb9364cb44052b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2987?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

