### PR TITLE
Refactor setTicklerPreferences.jsp for clarity and updates

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/provider/setTicklerPreferences.jsp
+++ b/src/main/webapp/WEB-INF/jsp/provider/setTicklerPreferences.jsp
@@ -29,15 +29,29 @@
 
 --%>
 
-<%@page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
-<%@ include file="/WEB-INF/jsp/casemgmt/taglibs.jsp" %>
-<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
-<%@ taglib uri="carlos" prefix="carlos" %>
-<%@page import="java.util.*" %>
-<%@ page import="java.util.ResourceBundle"%>
+<%--
+    setTicklerPreferences.jsp
 
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-"http://www.w3.org/TR/html4/loose.dtd">
+    POSTs to setTicklerPreferences via method 
+
+    Provides UI for provider Tickler settings
+
+    @param method       
+    @since 2017-07-28
+	
+--%>
+
+<%@page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+
+<%@ page import="java.util.*" %>
+<%@ page import="java.util.ResourceBundle"%>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
+<%@ taglib uri="jakarta.tags.core" prefix="c" %>
+<%@ taglib uri="carlos" prefix="carlos" %>
+<%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<fmt:setBundle basename="oscarResources"/>
+
+<!DOCTYPE html>
 <%
     ResourceBundle bundle = ResourceBundle.getBundle("oscarResources", request.getLocale());
 
@@ -48,89 +62,137 @@
     String providerbtnSubmit = (String) request.getAttribute("providerbtnSubmit");
     String providerbtnClose = (String) request.getAttribute("providerbtnClose");
 %>
-<html>
+<html lang="${pageContext.request.locale.language}">
     <head>
-    <link rel="icon" href="${pageContext.request.contextPath}/images/favicon.ico"/>
+        <link rel="icon" href="${pageContext.request.contextPath}/images/favicon.ico"/>
         <%@ include file="/WEB-INF/jsp/includes/global-head.jspf" %>
+    <%--    The global-head.jspf fragment provides:
+        - Viewport meta tag for responsive design
+        - global.js (legacy focus/refresh helpers)
+        - jQuery 3.7.1
+        - Bootstrap 5.3.3 (JS bundle + CSS)
+        - jQuery UI 1.14.2 CSS (JS must be included page-specifically where dialogs/widgets are needed)
+        - Font Awesome 6.7.2 (icon library)
+        - searchBox.css (shared search/form styles)
+        - global.css (CARLOS design tokens and common classes)
+    --%>
         <base href="<%= request.getScheme() + "://" + request.getServerName() + ":" + request.getServerPort() + request.getContextPath() + "/" %>">
-        <title><%=bundle.getString(providertitle)%></title>
-        <link rel="stylesheet" type="text/css" href="<%= request.getContextPath() %>/encounter/encounterStyles.css">
-
-        <style>
-            input[type="radio"] {
-                margin-left: 20px
-            }
-        </style>
+        <title><fmt:message key="provider.providerpreference.link.ticklerPrefs"/></title>
     </head>
+    <body>
+    <div class="container">
 
-    <body class="BodyStyle" vlink="#0000FF">
-    <table class="MainTable" id="scrollNumber1" name="encounterTable">
-        <tr class="MainTableTopRow">
-            <td class="MainTableTopRowLeftColumn" style="width:135px">
-                <%=bundle.getString(providermsgPrefs)%>
-            </td>
-            <td style="color: white" class="MainTableTopRowRightColumn"></td>
-        </tr>
-        <tr>
-            <td class="MainTableLeftColumn"></td>
-            <td class="MainTableRightColumn">
-                <%if (request.getAttribute("status") == null) {%>
-                <form action="${pageContext.request.contextPath}/setTicklerPreferences" method="post">
-                    <input type="hidden" name="method" value="${carlos:forHtmlAttribute(method)}">
+    <!-- ============================================================
+         PAGE HEADER BAR — short title + long title (icon optional).
+         Mirrors the OSCAR MainTableTopRow / TopStatusBar pattern.
+         Structure:
+           [icon?] [Short Title]   [Long Title .....................]
+         ============================================================ -->
+    <div class="page-header-bar d-flex align-items-center justify-content-between
+                py-2 mb-3 border-bottom" id="header">
+        <div class="d-flex align-items-center gap-2">
+            <i class="fa-solid fa-user-gear" aria-hidden="true"></i>
+            <span class="fw-semibold"><fmt:message key="provider.providerpreference.link.ticklerPrefs"/></span>
+        </div>
+        <div class="text-muted small"><fmt:message key="provider.setTicklerPreferences.header"/></div>
+    </div>
+        <%if (request.getAttribute("status") == null) {%>
+            <form action="${pageContext.request.contextPath}/setTicklerPreferences" method="post">
+                <input type="hidden" name="method" value="${carlos:forHtmlAttribute(method)}">
+    <!-- ============================================================
+         MAIN CONTENT WRAPPER — light background card to separate
+         page content from the body background.
+         ============================================================ -->
+    <div class="bg-light border rounded p-2">
 
-                    <h2><%=bundle.getString("provider.setTicklerPreferences.header")%></h2>
-                    <h3>${carlos:forHtml(providerMsg)}</h3>
+            <!-- ==================================================
+                 CONTENT ROW — two-column layout:
+                   col-12 col-md-2 : left sidebar  (OSCAR left col)
+                   col-12 col-md-10: right content (OSCAR right col)
+                 On small screens both columns stack vertically.
+                 ================================================== -->
+            <div class="row g-2">
 
-                    <input type="radio" id="taskAssigneeDefault" name="taskAssigneeMRP.value" value="default"
-                        <c:if test="${taskAssigneeMRPValue == 'default'}">checked</c:if> onclick="checkAssignee()" /> <%=bundle.getString("provider.setTicklerPreferences.defaultOption")%>
+                <!-- LEFT SIDEBAR COLUMN
+                     Mirrors: MainTableLeftColumn
+                     Contains navigation links / contextual actions. -->
+                <div class="col-12 col-md-2">
 
-                    <input type="radio" id="taskAssigneeMRP" name="taskAssigneeMRP.value" value="mrp"
-                        <c:if test="${taskAssigneeMRPValue == 'mrp'}">checked</c:if> onclick="checkAssignee()" /> <%=bundle.getString("tickler.ticklerMain.MRP")%>
+                </div>
+                <!-- RIGHT CONTENT COLUMN
+                     Mirrors: MainTableRightColumn
+                     Contains the primary form and data entry area. -->
+                <div class="col-12 col-md-10">
 
-                    <input type="radio" id="taskAssigneeProvider" name="taskAssigneeMRP.value" value="provider"
-                        <c:if test="${taskAssigneeMRPValue == 'providers'}">checked</c:if> onclick="checkAssignee()" /> <%=bundle.getString("provider.setTicklerPreferences.setProviderOption")%>
+                    <!-- input group -->
+                    <div class="mb-3">
+                    	<span><fmt:message key="provider.setLabRecallPrefs.delegate"/></span>
+                    	<div class="form-check">
+                        <input type="radio" id="taskAssigneeDefault" name="taskAssigneeMRP.value" 
+                        value="default"
+                        <c:if test="${taskAssigneeMRPValue == 'default'}">checked</c:if> onclick="checkAssignee()" /> <fmt:message key="provider.setTicklerPreferences.defaultOption"/>
+			</div>
+			<div class="form-check">
+                    	<input type="radio" id="taskAssigneeMRP" name="taskAssigneeMRP.value" 
+                    	title="<fmt:message key="provider.setTicklerPreferences.mrpDescription"/>"
+                    	value="mrp"
+                        <c:if test="${taskAssigneeMRPValue == 'mrp'}">checked</c:if> onclick="checkAssignee()" /> <fmt:message key="tickler.ticklerMain.MRP"/>
+			</div>
+			<div class="form-check">
+                    	<input type="radio" id="taskAssigneeProvider" name="taskAssigneeMRP.value" 
+                    	value="provider"
+                        <c:if test="${taskAssigneeMRPValue == 'providers'}">checked</c:if> onclick="checkAssignee()" /> <fmt:message key="provider.setTicklerPreferences.setProviderOption"/>
 
-                    <input type="hidden" id="taskAssignee" name="taskAssigneeSelection.value" />
-
-                    <div style="margin-top:20px;margin-bottom:20px;padding-left:20px;height:50px">
+                    	<input type="hidden" id="taskAssignee" name="taskAssigneeSelection.value" />
+			</div>
+                    </div>
+                    <div class="mb-3">
                         <div style="display:none;" id="taskAssigneeDefaultContainer">
-                            <h3><%=bundle.getString("provider.setTicklerPreferences.noPreference")%></h3>
+                            <span><%=bundle.getString("provider.setTicklerPreferences.noPreference")%></span>
                         </div>
 
                         <div style="display:none;" id="taskAssigneeMRPContainer">
-                            <h3><%=bundle.getString("provider.setTicklerPreferences.mrpDescription")%></h3>
+                            <span><fmt:message key="provider.setTicklerPreferences.mrpDescription"/></span>
                         </div>
 
                         <div style="display:none;" id="taskAssigneeProviderContainer">
-                            <h3><%=bundle.getString("provider.setTicklerPreferences.providerDescription")%></h3>
+                            <span><fmt:message key="provider.setTicklerPreferences.providerDescription"/></span>
                             <br>
-                            <select name="taskAssigneeSelection.value" onchange="updateTaskAssignee(this.value)">
+                            <select name="taskAssigneeSelection.value" onchange="updateTaskAssignee(this.value)" class="form-select form-select-sm" title="<fmt:message key="admin.jobs.choose"/>"
                                 <c:forEach var="provider" items="${providerSelect}">
-                                    <option value="${provider.value}"
+                                    <option value="${carlos:forHtmlAttribute(provider.value)}"
                                         <c:if test="${fn:trim(selectedProvider) == fn:trim(provider.value)}">selected</c:if>>
-                                        ${provider.label}
+                                        ${carlos:forHtmlContent(provider.label)}
                                     </option>
                                 </c:forEach>
                             </select>
                         </div>
                     </div>
+                          
+                    <!-- Primary action -->
+                    <div class="mb-2">
+			<input type="submit" class="btn btn-primary btn-sm" value=" <fmt:message key="global.btnSubmit"/>">
+                        <input type="button" class="btn btn-secondary btn-sm" value="<fmt:message key="global.btnCancel"/>" onclick="window.close();">
+                    </div>
 
-                    <input type="submit" value="<%=bundle.getString(providerbtnSubmit)%>"/>
-                    <input type="button" value="<%=bundle.getString(providerbtnCancel)%>"
-                           onclick="window.close();"/>
-                </form>
-                <%} else {%>
-                <h1><%=bundle.getString(providerMsg)%></h1>
-                <br/><br/>
-                <input type="button" value="<%=bundle.getString(providerbtnClose)%>" onclick="window.close();"/>
-                <%}%>
-            </td>
-        </tr>
-        <tr>
-            <td class="MainTableBottomRowLeftColumn"></td>
-            <td class="MainTableBottomRowRightColumn"></td>
-        </tr>
-    </table>
+                </div><!-- end right column -->
+
+            </div><!-- end .row -->
+
+    </div><!-- end .bg-light -->                           
+        </form> <%} else {%>
+		<div id="AlertBanner"
+			class="alert alert-success alert-dismissible"
+			role="alert">
+			<span id="AlertText"><fmt:message key="<%=providerMsg%>"/></span>
+			<button type="button"
+			class="btn-close"
+			onclick="this.closest('.alert').style.display='none'"
+			aria-label="Close"></button>
+		</div>
+        <br/><br/>
+                <input type="button" class="btn btn-primary btn-sm" value="<fmt:message key="global.btnClose"/>" onclick="window.close();"/>
+<% } %>
 
     <script>
         function checkAssignee() {

--- a/src/main/webapp/WEB-INF/jsp/provider/setTicklerPreferences.jsp
+++ b/src/main/webapp/WEB-INF/jsp/provider/setTicklerPreferences.jsp
@@ -141,14 +141,14 @@
 			<div class="form-check">
                     	<input type="radio" id="taskAssigneeProvider" name="taskAssigneeMRP.value" 
                     	value="provider"
-                        <c:if test="${taskAssigneeMRPValue == 'providers'}">checked</c:if> onclick="checkAssignee()" /> <fmt:message key="provider.setTicklerPreferences.setProviderOption"/>
+                        <c:if test="${taskAssigneeMRPValue == 'provider'}">checked</c:if> onclick="checkAssignee()" /> <fmt:message key="provider.setTicklerPreferences.setProviderOption"/>
 
                     	<input type="hidden" id="taskAssignee" name="taskAssigneeSelection.value" />
 			</div>
                     </div>
                     <div class="mb-3">
                         <div style="display:none;" id="taskAssigneeDefaultContainer">
-                            <span><%=bundle.getString("provider.setTicklerPreferences.noPreference")%></span>
+                            <span><fmt:message key="provider.setTicklerPreferences.noPreference"/></span>
                         </div>
 
                         <div style="display:none;" id="taskAssigneeMRPContainer">
@@ -158,7 +158,7 @@
                         <div style="display:none;" id="taskAssigneeProviderContainer">
                             <span><fmt:message key="provider.setTicklerPreferences.providerDescription"/></span>
                             <br>
-                            <select name="taskAssigneeSelection.value" onchange="updateTaskAssignee(this.value)" class="form-select form-select-sm" title="<fmt:message key="admin.jobs.choose"/>"
+                            <select name="taskAssigneeSelection.value" id="assigneeSelect" onchange="updateTaskAssignee(this.value)" class="form-select form-select-sm" title="<fmt:message key='admin.jobs.choose'/>">
                                 <c:forEach var="provider" items="${providerSelect}">
                                     <option value="${carlos:forHtmlAttribute(provider.value)}"
                                         <c:if test="${fn:trim(selectedProvider) == fn:trim(provider.value)}">selected</c:if>>
@@ -184,11 +184,11 @@
 		<div id="AlertBanner"
 			class="alert alert-success alert-dismissible"
 			role="alert">
-			<span id="AlertText"><fmt:message key="<%=providerMsg%>"/></span>
+			<span id="AlertText"><fmt:message key="${providerMsg}"/></span>
 			<button type="button"
 			class="btn-close"
 			onclick="this.closest('.alert').style.display='none'"
-			aria-label="Close"></button>
+			aria-label="<fmt:message key="global.btnClose"/>"></button>
 		</div>
         <br/><br/>
                 <input type="button" class="btn btn-primary btn-sm" value="<fmt:message key="global.btnClose"/>" onclick="window.close();"/>
@@ -198,6 +198,7 @@
         function checkAssignee() {
             one = document.getElementById("taskAssigneeDefault");
             divDefault = document.getElementById("taskAssigneeDefaultContainer");
+            const mySelect = document.getElementById("assigneeSelect");
 
             if (one.checked) {
                 divDefault.style.display = "block";
@@ -221,8 +222,10 @@
 
             if (provider.checked) {
                 divProvider.style.display = "block";
+                mySelect.disabled = false;
             } else {
                 divProvider.style.display = "none";
+                mySelect.disabled = true;
             }
         }
 

--- a/src/main/webapp/WEB-INF/jsp/provider/setTicklerPreferences.jsp
+++ b/src/main/webapp/WEB-INF/jsp/provider/setTicklerPreferences.jsp
@@ -184,7 +184,7 @@
 		<div id="AlertBanner"
 			class="alert alert-success alert-dismissible"
 			role="alert">
-			<span id="AlertText"><fmt:message key="${providerMsg}"/></span>
+			<span id="AlertText"><%=providerMsg %></span>
 			<button type="button"
 			class="btn-close"
 			onclick="this.closest('.alert').style.display='none'"


### PR DESCRIPTION
Bootstrap, Carlos encode, i18n, HTML5

<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description
Tickler settings ugly, this fix
<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues
Fixes #2992 
<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?
fork off develop
<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots
before
<img width="701" height="216" alt="Screenshot 2026-06-23 at 08-17-30 Lab Recall Settings - Preferences" src="https://github.com/user-attachments/assets/8192c71e-9601-453c-8bfa-393c82eaffb3" />

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->
after
<img width="830" height="528" alt="Screenshot 2026-06-23 at 08-13-23 Tickler Preferences" src="https://github.com/user-attachments/assets/74e10bc4-41cd-418e-837e-d585e456087e" />

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshed Tickler Preferences (`setTicklerPreferences.jsp`) with a responsive Bootstrap layout, improved i18n, and safer output for a cleaner, easier-to-use page. Aligns with #2992 to modernize Tickler settings.

- **Refactors**
  - Moved to HTML5 and Bootstrap 5 layout; added compact header and a dismissible success alert; standardized small primary/secondary buttons.
  - Replaced hardcoded strings with `jakarta.tags.fmt` (`fmt:setBundle("oscarResources")`); success message now renders the server-provided text directly.
  - Hardened output with `carlos:forHtmlAttribute`/`carlos:forHtmlContent`; fixed the “Provider” radio check; disable the assignee select unless “Provider” is chosen.
  - Updated taglibs to `jakarta.tags.core`/`jakarta.tags.functions`; removed legacy table layout and inline styles; set `lang` and used `.form-check` radios for better accessibility and mobile spacing.

<sup>Written for commit fd30ce2182a47ffe6a4fb505aa9e5c1c7ea9a1d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2993?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

