### PR TITLE
fix: keep /ws partial 5xx body uncommitted so it can be sanitized (#2994)

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilter.java
@@ -146,14 +146,24 @@ public class ResponseSanitizationFilter implements Filter {
     static final int MAX_CAPTURE_CHARS = 512 * 1024;
 
     /**
-     * Response buffer size (bytes) applied to web-service ({@code /ws/*}) requests so a partial
-     * entity body written before a late 5xx stays uncommitted — and therefore replaceable — up to
-     * this size. Web-service responses serialize via {@code getOutputStream()} while the status is
-     * still 200 (the filter's pass-through path); the container's small default buffer (~8 KB on
+     * Default response buffer size (bytes) applied to web-service ({@code /ws/*}) requests so a
+     * partial entity body written before a late 5xx stays uncommitted — and therefore replaceable —
+     * up to this size. Web-service responses serialize via {@code getOutputStream()} while the status
+     * is still 200 (the filter's pass-through path); the container's small default buffer (~8 KB on
      * Tomcat) otherwise commits the partial body before a mid-serialization failure flips the status
-     * to 5xx, leaking PHI. Aligned with {@link #MAX_CAPTURE_CHARS}. See issue #2994.
+     * to 5xx, leaking PHI. Aligned with {@link #MAX_CAPTURE_CHARS}. Override with
+     * {@link #WEB_SERVICE_BUFFER_PROPERTY}. See issue #2994.
      */
-    static final int WEB_SERVICE_RESPONSE_BUFFER_BYTES = 512 * 1024;
+    static final int DEFAULT_WEB_SERVICE_RESPONSE_BUFFER_BYTES = 512 * 1024;
+
+    /**
+     * Property name in {@code carlos.properties} that overrides the web-service response buffer size
+     * (in bytes). Lets administrators trade memory (a buffer is held per concurrent {@code /ws}
+     * request) against the size of partial body protected from the #2994 leak. A larger value
+     * protects bigger partial payloads; a smaller value reduces heap pressure under high concurrency.
+     * Absent, blank, or non-positive values fall back to {@link #DEFAULT_WEB_SERVICE_RESPONSE_BUFFER_BYTES}.
+     */
+    static final String WEB_SERVICE_BUFFER_PROPERTY = "response.sanitization.ws.buffer.bytes";
 
     /**
      * Regex that matches Java stack trace markers commonly found in unhandled error responses.
@@ -186,6 +196,7 @@ public class ResponseSanitizationFilter implements Filter {
     );
 
     private boolean enabled;
+    private int webServiceResponseBufferBytes = DEFAULT_WEB_SERVICE_RESPONSE_BUFFER_BYTES;
 
     /**
      * Reads the {@code response.sanitization.enabled} property from {@code carlos.properties}.
@@ -202,6 +213,8 @@ public class ResponseSanitizationFilter implements Filter {
     public void init(FilterConfig filterConfig) throws ServletException {
         String propValue = CarlosProperties.getInstance().getProperty(ENABLED_PROPERTY, "");
         enabled = parseEnabledProperty(propValue);
+        webServiceResponseBufferBytes = parseBufferBytes(
+                CarlosProperties.getInstance().getProperty(WEB_SERVICE_BUFFER_PROPERTY, ""));
         if (!enabled && CarlosProperties.getInstance().isPropertyActive(DISPLAY_ERROR_PROPERTY)) {
             // Sanitization is already disabled via response.sanitization.enabled=false.
             // When DISPLAY_ERROR is also active the developer has opted into full error
@@ -212,7 +225,34 @@ public class ResponseSanitizationFilter implements Filter {
                     + "This is a SECURITY RISK — do not enable in production environments "
                     + "or any system with real patient data.");
         }
-        LOGGER.info("ResponseSanitizationFilter initialized: enabled={}", enabled);
+        LOGGER.info("ResponseSanitizationFilter initialized: enabled={} webServiceResponseBufferBytes={}",
+                enabled, webServiceResponseBufferBytes);
+    }
+
+    /**
+     * Parses the {@link #WEB_SERVICE_BUFFER_PROPERTY} value into a positive byte count, falling back
+     * to {@link #DEFAULT_WEB_SERVICE_RESPONSE_BUFFER_BYTES} when the value is absent, blank,
+     * non-numeric, or non-positive. Package-private for direct unit testing.
+     *
+     * @param propValue String the raw property value; may be {@code null}/blank
+     * @return int the configured buffer size in bytes, or the default on any invalid input
+     */
+    static int parseBufferBytes(String propValue) {
+        if (propValue == null || propValue.isBlank()) {
+            return DEFAULT_WEB_SERVICE_RESPONSE_BUFFER_BYTES;
+        }
+        try {
+            int parsed = Integer.parseInt(propValue.trim());
+            if (parsed > 0) {
+                return parsed;
+            }
+        } catch (NumberFormatException e) {
+            // fall through to the warning + default below
+        }
+        LOGGER.warn("Unrecognized {} value '{}'; using default {} bytes",
+                WEB_SERVICE_BUFFER_PROPERTY, LogSafe.sanitize(propValue),
+                DEFAULT_WEB_SERVICE_RESPONSE_BUFFER_BYTES);
+        return DEFAULT_WEB_SERVICE_RESPONSE_BUFFER_BYTES;
     }
 
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
@@ -485,7 +525,9 @@ public class ResponseSanitizationFilter implements Filter {
     /**
      * Enlarges the response buffer for web-service ({@code /ws/*}) requests so a partial entity body
      * written before a late 5xx stays uncommitted — and therefore replaceable by
-     * {@link #sendSanitizedError} — up to {@link #WEB_SERVICE_RESPONSE_BUFFER_BYTES}.
+     * {@link #sendSanitizedError} — up to the configured buffer size
+     * ({@link #WEB_SERVICE_BUFFER_PROPERTY}, default
+     * {@link #DEFAULT_WEB_SERVICE_RESPONSE_BUFFER_BYTES}).
      *
      * <p>Why this is needed: CXF/JAX-RS serializes responses via {@code getOutputStream()} while the
      * status is still 200, so the wrapper leaves the stream in pass-through mode. With the container's
@@ -500,10 +542,10 @@ public class ResponseSanitizationFilter implements Filter {
      *
      * @param response HttpServletResponse the real (unwrapped) response
      */
-    private static void enlargeWebServiceResponseBuffer(HttpServletResponse response) {
+    private void enlargeWebServiceResponseBuffer(HttpServletResponse response) {
         try {
-            if (response.getBufferSize() < WEB_SERVICE_RESPONSE_BUFFER_BYTES) {
-                response.setBufferSize(WEB_SERVICE_RESPONSE_BUFFER_BYTES);
+            if (response.getBufferSize() < webServiceResponseBufferBytes) {
+                response.setBufferSize(webServiceResponseBufferBytes);
             }
         } catch (IllegalStateException e) {
             // Content already written / response committed — the buffer can no longer be resized.

--- a/src/main/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilter.java
@@ -146,6 +146,16 @@ public class ResponseSanitizationFilter implements Filter {
     static final int MAX_CAPTURE_CHARS = 512 * 1024;
 
     /**
+     * Response buffer size (bytes) applied to web-service ({@code /ws/*}) requests so a partial
+     * entity body written before a late 5xx stays uncommitted — and therefore replaceable — up to
+     * this size. Web-service responses serialize via {@code getOutputStream()} while the status is
+     * still 200 (the filter's pass-through path); the container's small default buffer (~8 KB on
+     * Tomcat) otherwise commits the partial body before a mid-serialization failure flips the status
+     * to 5xx, leaking PHI. Aligned with {@link #MAX_CAPTURE_CHARS}. See issue #2994.
+     */
+    static final int WEB_SERVICE_RESPONSE_BUFFER_BYTES = 512 * 1024;
+
+    /**
      * Regex that matches Java stack trace markers commonly found in unhandled error responses.
      *
      * <p>Patterns matched:
@@ -257,6 +267,9 @@ public class ResponseSanitizationFilter implements Filter {
 
         HttpServletResponse httpResponse = (HttpServletResponse) response;
         boolean webServiceRequest = isWebServiceRequest((HttpServletRequest) request);
+        if (webServiceRequest) {
+            enlargeWebServiceResponseBuffer(httpResponse);
+        }
         CapturingResponseWrapper wrapper = new CapturingResponseWrapper(httpResponse);
 
         try {
@@ -467,6 +480,36 @@ public class ResponseSanitizationFilter implements Filter {
                 ? uri.substring(contextPath.length())
                 : uri;
         return path.equals("/ws") || path.startsWith("/ws/");
+    }
+
+    /**
+     * Enlarges the response buffer for web-service ({@code /ws/*}) requests so a partial entity body
+     * written before a late 5xx stays uncommitted — and therefore replaceable by
+     * {@link #sendSanitizedError} — up to {@link #WEB_SERVICE_RESPONSE_BUFFER_BYTES}.
+     *
+     * <p>Why this is needed: CXF/JAX-RS serializes responses via {@code getOutputStream()} while the
+     * status is still 200, so the wrapper leaves the stream in pass-through mode. With the container's
+     * small default buffer (~8 KB on Tomcat), a partial body larger than that is flushed and committed
+     * before a mid-serialization failure sets a 5xx — at which point the body can no longer be
+     * suppressed and PHI leaks (issue #2994). Keeping the response uncommitted within the buffer lets
+     * the existing pass-through sanitization run.</p>
+     *
+     * <p>Scope/limits: only applied to {@code /ws/*}; the buffer is bounded. Handlers that explicitly
+     * {@code flush()} (e.g. genuine streaming) still commit as before, so streamed responses are
+     * unaffected. Partial bodies larger than the buffer still commit and remain a known residual.</p>
+     *
+     * @param response HttpServletResponse the real (unwrapped) response
+     */
+    private static void enlargeWebServiceResponseBuffer(HttpServletResponse response) {
+        try {
+            if (response.getBufferSize() < WEB_SERVICE_RESPONSE_BUFFER_BYTES) {
+                response.setBufferSize(WEB_SERVICE_RESPONSE_BUFFER_BYTES);
+            }
+        } catch (IllegalStateException e) {
+            // Content already written / response committed — the buffer can no longer be resized.
+            // The existing capture and pass-through logic still applies; nothing more to do here.
+            LOGGER.debug("Cannot enlarge web-service response buffer (already committed or written)", e);
+        }
     }
 
     /**

--- a/src/test/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilterUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilterUnitTest.java
@@ -949,6 +949,74 @@ class ResponseSanitizationFilterUnitTest {
                     .doesNotContain("io.github.carlos_emr")
                     .contains("Reference ID:");
         }
+
+        @Test
+        @DisplayName("should enlarge the response buffer for a /ws request")
+        void shouldEnlargeResponseBuffer_forWebServiceRequest() throws Exception {
+            MockHttpServletRequest request = wsRequest("GET");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            int defaultBuffer = response.getBufferSize();
+
+            FilterChain chain = (req, res) -> ((HttpServletResponse) res).setStatus(200);
+
+            filter.doFilter(request, response, chain);
+
+            assertThat(response.getBufferSize())
+                    .isGreaterThanOrEqualTo(ResponseSanitizationFilter.WEB_SERVICE_RESPONSE_BUFFER_BYTES)
+                    .isGreaterThan(defaultBuffer);
+        }
+
+        @Test
+        @DisplayName("should not enlarge the response buffer for a non-/ws request")
+        void shouldNotEnlargeResponseBuffer_forNonWebServiceRequest() throws Exception {
+            MockHttpServletRequest request = new MockHttpServletRequest("GET", "/carlos/provider/providercontrol");
+            request.setRequestURI("/carlos/provider/providercontrol");
+            request.setServletPath("/provider/providercontrol");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            int defaultBuffer = response.getBufferSize();
+
+            FilterChain chain = (req, res) -> ((HttpServletResponse) res).setStatus(200);
+
+            filter.doFilter(request, response, chain);
+
+            assertThat(response.getBufferSize()).isEqualTo(defaultBuffer);
+        }
+
+        @Test
+        @DisplayName("should sanitize a /ws 500 partial body that would otherwise exceed the default buffer and commit")
+        void shouldSanitizePartialBody_whenLargerThanDefaultBufferOnWebServiceRoute() throws Exception {
+            MockHttpServletRequest request = wsRequest("POST");
+            // MockHttpServletResponse commits once written content exceeds its buffer size (as a
+            // real container does). A partial PHI body larger than the default buffer would commit
+            // and become unrecoverable (the #2994 leak); enlarging the /ws buffer keeps it
+            // uncommitted so the existing pass-through sanitization can replace it.
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            int defaultBuffer = response.getBufferSize();
+            StringBuilder sb = new StringBuilder(
+                    "{\"appointmentNo\":1234,\"demographic\":{\"firstName\":\"Jane\",\"phone\":\"250-555-0143\"");
+            while (sb.length() <= defaultBuffer * 2) {
+                sb.append(",\"note\":\"Jane Doe clinical note padding\"");
+            }
+            String partialPhiJson = sb.toString();
+
+            FilterChain chain = (req, res) -> {
+                HttpServletResponse httpRes = (HttpServletResponse) res;
+                // Stream opened while status is still 200 (pass-through), partial body written,
+                // then a mid-serialization failure flips the status to 500.
+                httpRes.setContentType("application/json");
+                res.getOutputStream().write(partialPhiJson.getBytes(StandardCharsets.UTF_8));
+                httpRes.setStatus(500);
+            };
+
+            filter.doFilter(request, response, chain);
+
+            assertThat(response.getStatus()).isEqualTo(500);
+            String body = response.getContentAsString();
+            assertThat(body)
+                    .doesNotContain("Jane")
+                    .doesNotContain("250-555-0143")
+                    .contains("Reference ID:");
+        }
     }
 
     @Nested

--- a/src/test/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilterUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilterUnitTest.java
@@ -133,6 +133,44 @@ class ResponseSanitizationFilterUnitTest {
     }
 
     @Nested
+    @DisplayName("web-service buffer size parsing")
+    class WebServiceBufferParsing {
+
+        @Test
+        @DisplayName("should use the configured value when a positive integer is provided")
+        void shouldUseConfiguredValue_whenPositiveIntegerProvided() {
+            assertThat(ResponseSanitizationFilter.parseBufferBytes("131072")).isEqualTo(131072);
+            assertThat(ResponseSanitizationFilter.parseBufferBytes("  262144 ")).isEqualTo(262144);
+        }
+
+        @Test
+        @DisplayName("should fall back to the default when value is absent or blank")
+        void shouldFallBackToDefault_whenAbsentOrBlank() {
+            int expected = ResponseSanitizationFilter.DEFAULT_WEB_SERVICE_RESPONSE_BUFFER_BYTES;
+            assertThat(ResponseSanitizationFilter.parseBufferBytes(null)).isEqualTo(expected);
+            assertThat(ResponseSanitizationFilter.parseBufferBytes("")).isEqualTo(expected);
+            assertThat(ResponseSanitizationFilter.parseBufferBytes("   ")).isEqualTo(expected);
+        }
+
+        @Test
+        @DisplayName("should warn and fall back to the default when value is non-positive or non-numeric")
+        void shouldWarnAndFallBackToDefault_whenNonPositiveOrNonNumeric() {
+            int expected = ResponseSanitizationFilter.DEFAULT_WEB_SERVICE_RESPONSE_BUFFER_BYTES;
+            try (LogCapture capture = LogCapture.forLogger(ResponseSanitizationFilter.class)) {
+                assertThat(ResponseSanitizationFilter.parseBufferBytes("0")).isEqualTo(expected);
+                assertThat(ResponseSanitizationFilter.parseBufferBytes("-1")).isEqualTo(expected);
+                assertThat(ResponseSanitizationFilter.parseBufferBytes("abc")).isEqualTo(expected);
+
+                assertThat(capture.events()).anySatisfy(event -> {
+                    assertThat(event.getLevel()).isEqualTo(Level.WARN);
+                    assertThat(event.getMessage().getFormattedMessage())
+                            .contains("Unrecognized response.sanitization.ws.buffer.bytes value");
+                });
+            }
+        }
+    }
+
+    @Nested
     @DisplayName("containsStackTrace()")
     class ContainsStackTrace {
 
@@ -962,7 +1000,7 @@ class ResponseSanitizationFilterUnitTest {
             filter.doFilter(request, response, chain);
 
             assertThat(response.getBufferSize())
-                    .isGreaterThanOrEqualTo(ResponseSanitizationFilter.WEB_SERVICE_RESPONSE_BUFFER_BYTES)
+                    .isGreaterThanOrEqualTo(ResponseSanitizationFilter.DEFAULT_WEB_SERVICE_RESPONSE_BUFFER_BYTES)
                     .isGreaterThan(defaultBuffer);
         }
 
@@ -986,10 +1024,13 @@ class ResponseSanitizationFilterUnitTest {
         @DisplayName("should sanitize a /ws 500 partial body that would otherwise exceed the default buffer and commit")
         void shouldSanitizePartialBody_whenLargerThanDefaultBufferOnWebServiceRoute() throws Exception {
             MockHttpServletRequest request = wsRequest("POST");
-            // MockHttpServletResponse commits once written content exceeds its buffer size (as a
-            // real container does). A partial PHI body larger than the default buffer would commit
-            // and become unrecoverable (the #2994 leak); enlarging the /ws buffer keeps it
-            // uncommitted so the existing pass-through sanitization can replace it.
+            // MockHttpServletResponse commits once written content exceeds its buffer size, like a
+            // real container: its ResponseServletOutputStream.write(int) calls
+            // setCommittedIfBufferSizeExceeded(), and bulk writes route through that per-byte path.
+            // So without the /ws buffer enlargement this partial body (> default buffer) commits and
+            // becomes unrecoverable (the #2994 leak) and this test fails; with it, the body stays
+            // uncommitted and the existing pass-through sanitization replaces it. (Hence this is a
+            // true regression test, not a false positive.)
             MockHttpServletResponse response = new MockHttpServletResponse();
             int defaultBuffer = response.getBufferSize();
             StringBuilder sb = new StringBuilder(


### PR DESCRIPTION
## Summary

Fixes #2994 — closes the committed-response gap left by #2985.

A web-service (`/ws/*`) 5xx whose **partial entity body exceeds the container's small default buffer** (~8 KB on Tomcat) is flushed and committed *before* a mid-serialization failure flips the status to 5xx. Once committed, `ResponseSanitizationFilter` can no longer replace the body, so the partial PHI (patient name, phone, etc.) is already on the wire. This was confirmed live (embedded-Jetty A/B) during #2985 review: the uncommitted paths were fixed there, but the committed/large-payload case still leaked.

## Fix

CXF/JAX-RS serializes via `getOutputStream()` while the status is still 200, so the response stays in the filter's **pass-through** path. The existing pass-through sanitization already suppresses a `/ws` 5xx **while the response is uncommitted** — the only problem is the container commits the partial body too early.

So: **enlarge the response buffer for `/ws` requests** (`WEB_SERVICE_RESPONSE_BUFFER_BYTES` = 512 KB, aligned with `MAX_CAPTURE_CHARS`) at the start of the filter, before the chain runs. The partial body then stays uncommitted up to that size, and the existing sanitization replaces it on the late 5xx.

This is the least-invasive of the ticket's suggested directions (buffer `/ws` responses), deliberately scoped per the response-filter safety guidance in `CLAUDE.md`:

- **Only `/ws/*`** — other routes and content types are untouched.
- **Bounded** — single `setBufferSize` call, no new buffering layer or wrapper change.
- **Streaming-safe** — handlers that explicitly `flush()` (genuine streaming) still commit as before; only handlers that rely on the container's auto-commit-at-buffer-full (i.e. the serialization-failure case) are affected.

### Known residual
Partial bodies **larger than 512 KB** still commit and leak. Fully closing that would require unbounded buffering or a CXF output interceptor (a deeper change). 512 KB covers realistic appointment/list payloads; the residual is documented in code. (This PR therefore does not auto-close #2953; see below.)

## Tests

`ResponseSanitizationFilterUnitTest` — **69 tests, all passing** (+3 new):

- `shouldSanitizePartialBody_whenLargerThanDefaultBufferOnWebServiceRoute` — regression for the committed leak: a `/ws` partial body larger than the default buffer is sanitized (uses `MockHttpServletResponse`'s real buffer-overflow commit simulation; would fail without the buffer enlargement).
- `shouldEnlargeResponseBuffer_forWebServiceRequest` / `shouldNotEnlargeResponseBuffer_forNonWebServiceRequest` — verify the change is `/ws`-scoped.

> Note on the acceptance criterion "commit the embedded-container harness as an integration test": the repo **deliberately excludes embedded Jetty** (`cxf-rt-transports-http-jetty`), so committing the Jetty harness would mean re-adding an intentionally-excluded dependency. Instead the committed regression is the deterministic `MockHttpServletResponse` buffer-overflow test above. The embedded-Jetty harness from #2994 remains available for manual end-to-end validation.

## Related
- Builds on #2985 (uncommitted `/ws` 5xx paths).
- Relates to #2953 — with this merged, the realistic leak range is closed; the >512 KB residual is the only remaining gap, so #2953 is intentionally **not** auto-closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps `/ws` partial 5xx bodies uncommitted so `ResponseSanitizationFilter` can replace them; buffer size is now configurable (default 512 KB). Addresses #2994.

- **Bug Fixes**
  - Enlarge the `/ws/*` response buffer at filter start to prevent early commits and PHI leaks on late 5xx.
  - Scope limited to `/ws`; explicit `flush()` still commits; bodies larger than the buffer may still commit.
  - Added tests for buffer enlargement, non-`/ws` no-op, and the committed-leak regression.
  - Synced with `develop`: stack-trace detection now uses marker array (no behavior change).

- **New Features**
  - Made the `/ws` buffer size configurable via `carlos.properties` (`response.sanitization.ws.buffer.bytes`), default 512 KB.
  - Invalid/absent values fall back to the default with a warning; added parsing tests and log of the chosen size.

<sup>Written for commit 8945aea5aaf23486d1c7fca7516caeb711327ccc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

