### PR TITLE
fix: honor X-Forwarded-Proto/Host/Port for request scheme/host/port behind trusted proxy

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/app/XforwardHeaderFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/app/XforwardHeaderFilter.java
@@ -207,6 +207,110 @@ public class XforwardHeaderFilter implements Filter {
             String clientIp = extractClientIp(forwardedFor, trustedProxyIps, trustedProxyCidrs);
             return clientIp != null ? clientIp : remoteAddr;
         }
+
+        @Override
+        public String getScheme() {
+            String proto = forwardedProto();
+            return proto != null ? proto : super.getScheme();
+        }
+
+        @Override
+        public boolean isSecure() {
+            String proto = forwardedProto();
+            return proto != null ? "https".equals(proto) : super.isSecure();
+        }
+
+        @Override
+        public String getServerName() {
+            String host = forwardedHostName();
+            return host != null ? host : super.getServerName();
+        }
+
+        @Override
+        public int getServerPort() {
+            if (!peerIsTrusted()) {
+                return super.getServerPort();
+            }
+            Integer explicitPort = parsePort(firstToken(super.getHeader("X-Forwarded-Port")));
+            if (explicitPort != null) {
+                return explicitPort;
+            }
+            Integer hostPort = parsePort(hostPortPart(firstToken(super.getHeader("X-Forwarded-Host"))));
+            if (hostPort != null) {
+                return hostPort;
+            }
+            String proto = forwardedProto();
+            if (proto != null) {
+                return "https".equals(proto) ? 443 : 80;
+            }
+            return super.getServerPort();
+        }
+
+        private boolean peerIsTrusted() {
+            return isTrustedProxy(super.getRemoteAddr(), trustedProxyIps, trustedProxyCidrs);
+        }
+
+        /**
+         * @return the lowercased {@code X-Forwarded-Proto} value ({@code http} or {@code https})
+         *         when the peer is trusted and the header is present and valid, otherwise {@code null}.
+         */
+        private String forwardedProto() {
+            if (!peerIsTrusted()) {
+                return null;
+            }
+            String proto = firstToken(super.getHeader("X-Forwarded-Proto"));
+            if (proto == null) {
+                return null;
+            }
+            proto = proto.toLowerCase(Locale.ROOT);
+            return ("http".equals(proto) || "https".equals(proto)) ? proto : null;
+        }
+
+        /**
+         * @return the host portion (port stripped) of {@code X-Forwarded-Host} when the peer is
+         *         trusted and the header is present, otherwise {@code null}.
+         */
+        private String forwardedHostName() {
+            if (!peerIsTrusted()) {
+                return null;
+            }
+            String host = firstToken(super.getHeader("X-Forwarded-Host"));
+            if (host == null) {
+                return null;
+            }
+            int colon = host.indexOf(':');
+            String name = (colon >= 0) ? host.substring(0, colon).trim() : host;
+            return name.isEmpty() ? null : name;
+        }
+
+        private static String hostPortPart(String host) {
+            if (host == null) {
+                return null;
+            }
+            int colon = host.indexOf(':');
+            return (colon >= 0 && colon < host.length() - 1) ? host.substring(colon + 1).trim() : null;
+        }
+
+        private static String firstToken(String header) {
+            if (header == null) {
+                return null;
+            }
+            int comma = header.indexOf(',');
+            String token = (comma >= 0 ? header.substring(0, comma) : header).trim();
+            return token.isEmpty() ? null : token;
+        }
+
+        private static Integer parsePort(String value) {
+            if (value == null) {
+                return null;
+            }
+            try {
+                int port = Integer.parseInt(value);
+                return (port >= 1 && port <= 65535) ? port : null;
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        }
     }
 
     static final class CidrRange {

--- a/src/main/java/io/github/carlos_emr/carlos/app/XforwardHeaderFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/app/XforwardHeaderFilter.java
@@ -259,16 +259,19 @@ public class XforwardHeaderFilter implements Filter {
                 return null;
             }
             String proto = firstToken(super.getHeader("X-Forwarded-Proto"));
-            if (proto == null) {
-                return null;
+            if ("https".equalsIgnoreCase(proto)) {
+                return "https";
             }
-            proto = proto.toLowerCase(Locale.ROOT);
-            return ("http".equals(proto) || "https".equals(proto)) ? proto : null;
+            if ("http".equalsIgnoreCase(proto)) {
+                return "http";
+            }
+            return null;
         }
 
         /**
          * @return the host portion (port stripped) of {@code X-Forwarded-Host} when the peer is
-         *         trusted and the header is present, otherwise {@code null}.
+         *         trusted and the header is present, otherwise {@code null}. A bracketed IPv6
+         *         literal keeps its brackets so it remains valid in a reconstructed URL.
          */
         private String forwardedHostName() {
             if (!peerIsTrusted()) {
@@ -278,8 +281,17 @@ public class XforwardHeaderFilter implements Filter {
             if (host == null) {
                 return null;
             }
-            int colon = host.indexOf(':');
-            String name = (colon >= 0) ? host.substring(0, colon).trim() : host;
+            String name;
+            if (host.startsWith("[")) {
+                int close = host.indexOf(']');
+                name = (close >= 0) ? host.substring(0, close + 1).trim() : host;
+            } else {
+                int colon = host.indexOf(':');
+                // Only treat as host:port when there is a single colon (IPv4 / hostname); an
+                // unbracketed value with multiple colons is a bare IPv6 literal, so keep it whole.
+                name = (colon >= 0 && host.indexOf(':', colon + 1) < 0)
+                        ? host.substring(0, colon).trim() : host;
+            }
             return name.isEmpty() ? null : name;
         }
 
@@ -287,8 +299,20 @@ public class XforwardHeaderFilter implements Filter {
             if (host == null) {
                 return null;
             }
+            if (host.startsWith("[")) {
+                int close = host.indexOf(']');
+                if (close >= 0 && close + 1 < host.length() && host.charAt(close + 1) == ':') {
+                    String port = host.substring(close + 2).trim();
+                    return port.isEmpty() ? null : port;
+                }
+                return null;
+            }
             int colon = host.indexOf(':');
-            return (colon >= 0 && colon < host.length() - 1) ? host.substring(colon + 1).trim() : null;
+            // A single colon delimits host:port; multiple colons mean a bare IPv6 literal (no port).
+            if (colon >= 0 && colon < host.length() - 1 && host.indexOf(':', colon + 1) < 0) {
+                return host.substring(colon + 1).trim();
+            }
+            return null;
         }
 
         private static String firstToken(String header) {

--- a/src/main/java/io/github/carlos_emr/carlos/app/XforwardHeaderFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/app/XforwardHeaderFilter.java
@@ -259,10 +259,10 @@ public class XforwardHeaderFilter implements Filter {
                 return null;
             }
             String proto = firstToken(super.getHeader("X-Forwarded-Proto"));
-            if ("https".equalsIgnoreCase(proto)) {
+            if (equalsAsciiIgnoreCase(proto, "https")) {
                 return "https";
             }
-            if ("http".equalsIgnoreCase(proto)) {
+            if (equalsAsciiIgnoreCase(proto, "http")) {
                 return "http";
             }
             return null;
@@ -284,7 +284,9 @@ public class XforwardHeaderFilter implements Filter {
             String name;
             if (host.startsWith("[")) {
                 int close = host.indexOf(']');
-                name = (close >= 0) ? host.substring(0, close + 1).trim() : host;
+                // A bracketed value with no closing bracket is malformed; ignore it so it
+                // cannot override the server name (an empty name falls back to the peer below).
+                name = (close >= 0) ? host.substring(0, close + 1).trim() : "";
             } else {
                 int colon = host.indexOf(':');
                 // Only treat as host:port when there is a single colon (IPv4 / hostname); an
@@ -334,6 +336,32 @@ public class XforwardHeaderFilter implements Filter {
             } catch (NumberFormatException e) {
                 return null;
             }
+        }
+
+        /**
+         * ASCII-only case-insensitive equality against a known lowercase token. This deliberately
+         * avoids {@link String#equalsIgnoreCase} / {@link String#toLowerCase}, whose Unicode case
+         * folding trips the Find Security Bugs IMPROPER_UNICODE rule, while still matching the
+         * small fixed set of expected scheme tokens.
+         *
+         * @param value             the candidate value (may be {@code null})
+         * @param asciiLowerTarget  the target token, expected to be ASCII lowercase
+         * @return {@code true} when {@code value} equals the target ignoring ASCII letter case
+         */
+        private static boolean equalsAsciiIgnoreCase(String value, String asciiLowerTarget) {
+            if (value == null || value.length() != asciiLowerTarget.length()) {
+                return false;
+            }
+            for (int i = 0; i < value.length(); i++) {
+                char c = value.charAt(i);
+                if (c >= 'A' && c <= 'Z') {
+                    c += 32;
+                }
+                if (c != asciiLowerTarget.charAt(i)) {
+                    return false;
+                }
+            }
+            return true;
         }
     }
 

--- a/src/test/java/io/github/carlos_emr/carlos/app/XforwardHeaderFilterUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/app/XforwardHeaderFilterUnitTest.java
@@ -262,6 +262,23 @@ class XforwardHeaderFilterUnitTest {
     }
 
     @Test
+    @DisplayName("should ignore a malformed bracketed forwarded host that has no closing bracket")
+    void shouldIgnoreMalformedBracketedHost_withNoClosingBracket() throws Exception {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getRemoteAddr()).thenReturn("127.0.0.1");
+        when(request.getServerName()).thenReturn("internal-host");
+        when(request.getServerPort()).thenReturn(8080);
+        when(request.getHeader("X-Forwarded-Host")).thenReturn("[2001:db8::1");
+
+        XforwardHeaderFilter.ModifyRemoteAddress wrapper =
+                new XforwardHeaderFilter.ModifyRemoteAddress(
+                        request, Set.of("127.0.0.1"), Set.of());
+
+        assertThat(wrapper.getServerName()).isEqualTo("internal-host");
+        assertThat(wrapper.getServerPort()).isEqualTo(8080);
+    }
+
+    @Test
     @DisplayName("should accept mixed-case forwarded proto without locale-sensitive lowercasing")
     void shouldAcceptMixedCaseForwardedProto_withoutLocaleLowercasing() throws Exception {
         HttpServletRequest request = mock(HttpServletRequest.class);

--- a/src/test/java/io/github/carlos_emr/carlos/app/XforwardHeaderFilterUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/app/XforwardHeaderFilterUnitTest.java
@@ -213,6 +213,70 @@ class XforwardHeaderFilterUnitTest {
     }
 
     @Test
+    @DisplayName("should preserve brackets and extract port for a bracketed IPv6 forwarded host")
+    void shouldPreserveBracketsAndExtractPort_forBracketedIpv6Host() throws Exception {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getRemoteAddr()).thenReturn("127.0.0.1");
+        when(request.getHeader("X-Forwarded-Proto")).thenReturn("https");
+        when(request.getHeader("X-Forwarded-Host")).thenReturn("[2001:db8::1]:8443");
+
+        XforwardHeaderFilter.ModifyRemoteAddress wrapper =
+                new XforwardHeaderFilter.ModifyRemoteAddress(
+                        request, Set.of("127.0.0.1"), Set.of());
+
+        assertThat(wrapper.getServerName()).isEqualTo("[2001:db8::1]");
+        assertThat(wrapper.getServerPort()).isEqualTo(8443);
+    }
+
+    @Test
+    @DisplayName("should keep a bare bracketed IPv6 host intact and infer the scheme default port")
+    void shouldKeepBareBracketedIpv6HostIntact_andInferDefaultPort() throws Exception {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getRemoteAddr()).thenReturn("127.0.0.1");
+        when(request.getHeader("X-Forwarded-Proto")).thenReturn("https");
+        when(request.getHeader("X-Forwarded-Host")).thenReturn("[2001:db8::1]");
+
+        XforwardHeaderFilter.ModifyRemoteAddress wrapper =
+                new XforwardHeaderFilter.ModifyRemoteAddress(
+                        request, Set.of("127.0.0.1"), Set.of());
+
+        assertThat(wrapper.getServerName()).isEqualTo("[2001:db8::1]");
+        assertThat(wrapper.getServerPort()).isEqualTo(443);
+    }
+
+    @Test
+    @DisplayName("should not split an unbracketed IPv6 forwarded host on its colons")
+    void shouldNotSplitUnbracketedIpv6Host_onItsColons() throws Exception {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getRemoteAddr()).thenReturn("127.0.0.1");
+        when(request.getServerPort()).thenReturn(8080);
+        when(request.getHeader("X-Forwarded-Host")).thenReturn("2001:db8::1");
+
+        XforwardHeaderFilter.ModifyRemoteAddress wrapper =
+                new XforwardHeaderFilter.ModifyRemoteAddress(
+                        request, Set.of("127.0.0.1"), Set.of());
+
+        assertThat(wrapper.getServerName()).isEqualTo("2001:db8::1");
+        // No port in the header and no scheme to infer from, so the peer port stands.
+        assertThat(wrapper.getServerPort()).isEqualTo(8080);
+    }
+
+    @Test
+    @DisplayName("should accept mixed-case forwarded proto without locale-sensitive lowercasing")
+    void shouldAcceptMixedCaseForwardedProto_withoutLocaleLowercasing() throws Exception {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getRemoteAddr()).thenReturn("127.0.0.1");
+        when(request.getHeader("X-Forwarded-Proto")).thenReturn("HTTPS");
+
+        XforwardHeaderFilter.ModifyRemoteAddress wrapper =
+                new XforwardHeaderFilter.ModifyRemoteAddress(
+                        request, Set.of("127.0.0.1"), Set.of());
+
+        assertThat(wrapper.getScheme()).isEqualTo("https");
+        assertThat(wrapper.isSecure()).isTrue();
+    }
+
+    @Test
     @DisplayName("filter should wrap HTTP requests before continuing the chain")
     void shouldWrapHttpRequests() throws Exception {
         XforwardHeaderFilter filter = new XforwardHeaderFilter();

--- a/src/test/java/io/github/carlos_emr/carlos/app/XforwardHeaderFilterUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/app/XforwardHeaderFilterUnitTest.java
@@ -107,6 +107,112 @@ class XforwardHeaderFilterUnitTest {
     }
 
     @Test
+    @DisplayName("should reflect forwarded scheme, host and port when peer is trusted")
+    void shouldReflectForwardedSchemeHostAndPort_whenPeerIsTrusted() throws Exception {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getRemoteAddr()).thenReturn("127.0.0.1");
+        when(request.getHeader("X-Forwarded-Proto")).thenReturn("https");
+        when(request.getHeader("X-Forwarded-Host")).thenReturn("clinic.example.ca");
+        when(request.getHeader("X-Forwarded-Port")).thenReturn("443");
+
+        XforwardHeaderFilter.ModifyRemoteAddress wrapper =
+                new XforwardHeaderFilter.ModifyRemoteAddress(
+                        request, Set.of("127.0.0.1"), Set.of());
+
+        assertThat(wrapper.getScheme()).isEqualTo("https");
+        assertThat(wrapper.isSecure()).isTrue();
+        assertThat(wrapper.getServerName()).isEqualTo("clinic.example.ca");
+        assertThat(wrapper.getServerPort()).isEqualTo(443);
+    }
+
+    @Test
+    @DisplayName("should ignore forwarded scheme, host and port when peer is not trusted")
+    void shouldIgnoreForwardedSchemeHostAndPort_whenPeerIsNotTrusted() throws Exception {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getRemoteAddr()).thenReturn("203.0.113.10");
+        when(request.getScheme()).thenReturn("http");
+        when(request.isSecure()).thenReturn(false);
+        when(request.getServerName()).thenReturn("internal-host");
+        when(request.getServerPort()).thenReturn(8080);
+
+        XforwardHeaderFilter.ModifyRemoteAddress wrapper =
+                new XforwardHeaderFilter.ModifyRemoteAddress(
+                        request, Set.of("127.0.0.1"), Set.of());
+
+        assertThat(wrapper.getScheme()).isEqualTo("http");
+        assertThat(wrapper.isSecure()).isFalse();
+        assertThat(wrapper.getServerName()).isEqualTo("internal-host");
+        assertThat(wrapper.getServerPort()).isEqualTo(8080);
+    }
+
+    @Test
+    @DisplayName("should derive host and port from X-Forwarded-Host when port header is absent")
+    void shouldDeriveHostAndPortFromForwardedHost_whenPortHeaderAbsent() throws Exception {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getRemoteAddr()).thenReturn("127.0.0.1");
+        when(request.getHeader("X-Forwarded-Proto")).thenReturn("https");
+        when(request.getHeader("X-Forwarded-Host")).thenReturn("clinic.example.ca:8443");
+
+        XforwardHeaderFilter.ModifyRemoteAddress wrapper =
+                new XforwardHeaderFilter.ModifyRemoteAddress(
+                        request, Set.of("127.0.0.1"), Set.of());
+
+        assertThat(wrapper.getServerName()).isEqualTo("clinic.example.ca");
+        assertThat(wrapper.getServerPort()).isEqualTo(8443);
+    }
+
+    @Test
+    @DisplayName("should infer default port from forwarded scheme when no port is supplied")
+    void shouldInferDefaultPortFromScheme_whenNoPortSupplied() throws Exception {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getRemoteAddr()).thenReturn("127.0.0.1");
+        when(request.getHeader("X-Forwarded-Proto")).thenReturn("https");
+        when(request.getHeader("X-Forwarded-Host")).thenReturn("clinic.example.ca");
+
+        XforwardHeaderFilter.ModifyRemoteAddress wrapper =
+                new XforwardHeaderFilter.ModifyRemoteAddress(
+                        request, Set.of("127.0.0.1"), Set.of());
+
+        assertThat(wrapper.getServerPort()).isEqualTo(443);
+    }
+
+    @Test
+    @DisplayName("should use first hop from comma-separated forwarded headers")
+    void shouldUseFirstHop_whenForwardedHeadersAreCommaSeparated() throws Exception {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getRemoteAddr()).thenReturn("127.0.0.1");
+        when(request.getHeader("X-Forwarded-Proto")).thenReturn("https, http");
+        when(request.getHeader("X-Forwarded-Host")).thenReturn("clinic.example.ca, internal");
+        when(request.getHeader("X-Forwarded-Port")).thenReturn("443, 8080");
+
+        XforwardHeaderFilter.ModifyRemoteAddress wrapper =
+                new XforwardHeaderFilter.ModifyRemoteAddress(
+                        request, Set.of("127.0.0.1"), Set.of());
+
+        assertThat(wrapper.getScheme()).isEqualTo("https");
+        assertThat(wrapper.getServerName()).isEqualTo("clinic.example.ca");
+        assertThat(wrapper.getServerPort()).isEqualTo(443);
+    }
+
+    @Test
+    @DisplayName("should fall back to peer scheme and port when forwarded values are invalid")
+    void shouldFallbackToPeerValues_whenForwardedValuesAreInvalid() throws Exception {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getRemoteAddr()).thenReturn("127.0.0.1");
+        when(request.getScheme()).thenReturn("http");
+        when(request.getServerPort()).thenReturn(8080);
+        when(request.getHeader("X-Forwarded-Proto")).thenReturn("ftp");
+        when(request.getHeader("X-Forwarded-Port")).thenReturn("not-a-port");
+
+        XforwardHeaderFilter.ModifyRemoteAddress wrapper =
+                new XforwardHeaderFilter.ModifyRemoteAddress(
+                        request, Set.of("127.0.0.1"), Set.of());
+
+        assertThat(wrapper.getScheme()).isEqualTo("http");
+        assertThat(wrapper.getServerPort()).isEqualTo(8080);
+    }
+
+    @Test
     @DisplayName("filter should wrap HTTP requests before continuing the chain")
     void shouldWrapHttpRequests() throws Exception {
         XforwardHeaderFilter filter = new XforwardHeaderFilter();


### PR DESCRIPTION
fixes #2941

## Problem
Behind a TLS-terminating reverse proxy, the app sees `http` on an internal port (e.g. 8080). Code that builds absolute URLs from `request.getScheme()`/`getServerName()`/`getServerPort()` — notably the `<reWrite>` `FullPathReWrite` JSP tag, plus OAuth1 signature URL reconstruction (`OAuth1ParamParser`, `OAuth1SignatureVerifierImplementation`) and `CaseManagementEntry2Action` — then emits `http://internal-host:8080/...` instead of the external `https://clinic.example.ca/...`. Result: broken links, internal ports in user-facing URLs, mixed-content blocking, and (most severely) OAuth1 signature verification failures.

## Approach
The repo already has `XforwardHeaderFilter`, mapped to `/*`, which wraps the request and resolves the real client IP from `X-Forwarded-For` **only when the immediate peer is a configured trusted proxy** (`WAF_TRUSTED_PROXY_IPS` / `WAF_TRUSTED_PROXY_CIDRS`).

This change extends that same request wrapper so that, when the peer is trusted, it also reports:
- `getScheme()` / `isSecure()` from `X-Forwarded-Proto`
- `getServerName()` from `X-Forwarded-Host` (port stripped)
- `getServerPort()` from `X-Forwarded-Port`, falling back to the port in `X-Forwarded-Host`, then the scheme default (443/80)

Because the fix lives in a `/*`-mapped request wrapper, every downstream consumer (`FullPathReWrite`, OAuth1, `CaseManagementEntry2Action`, etc.) is corrected at once — no edits to those individual paths.

## Scope
- Extend `XforwardHeaderFilter.ModifyRemoteAddress` to honor `X-Forwarded-Proto`/`Host`/`Port`.
- Reuse the existing trusted-proxy gate; untrusted peers behave exactly as before (headers ignored), preserving the anti-spoofing security boundary.
- Robust parsing: take the first hop of comma-separated values, validate proto (`http`/`https` only) and port range, ignore malformed values.

## Tests
Added 6 unit tests to `XforwardHeaderFilterUnitTest` covering: trusted reflection of scheme/host/port; untrusted peers ignoring the headers; host-with-port parsing; default-port inference from scheme; first-hop selection from comma-separated headers; and fallback on invalid values. Verified locally: `mvn -Dtest=XforwardHeaderFilterUnitTest test` → Tests run: 12, Failures: 0, Errors: 0.

## Notes
This is the in-repo equivalent of the issue's "Option 1" (make `request.getScheme()/getServerPort()` reflect the external request), implemented via the existing trusted-proxy filter rather than requiring a Tomcat `RemoteIpValve`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honor `X-Forwarded-Proto`, `X-Forwarded-Host`, and `X-Forwarded-Port` behind trusted proxies so absolute URLs and OAuth1 signatures use the external scheme/host/port instead of internal values. Fixes #2941.

- **Bug Fixes**
  - Extend `XforwardHeaderFilter.ModifyRemoteAddress` to override `getScheme()`, `isSecure()`, `getServerName()`, and `getServerPort()` when the immediate peer is trusted.
  - Robust, safe parsing: first hop only; ASCII-only case-insensitive match for `http`/`https` (returns canonical lowercase); prefer `X-Forwarded-Port`, then host port, else scheme default; IPv6-safe host handling (keep `[ipv6]`, parse `[ipv6]:port`, don’t split bare IPv6); treat malformed values—including a bracketed host missing `]`—as invalid.
  - Preserve security: ignore forwarding headers from untrusted peers.
  - Add unit tests for trusted/untrusted behavior, host-with-port and defaults, first-hop selection, invalid fallbacks (incl. malformed bracketed host), IPv6 (bracketed and bare), and mixed-case proto.

<sup>Written for commit 5bb8542c24a1e0b14d609e61908a224be8fb8667. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/2999?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

