### PR TITLE
fix(security): lower REST WebService access logging to DEBUG, method-name-only

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/util/WebServiceLoggingAdvice.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/util/WebServiceLoggingAdvice.java
@@ -60,7 +60,7 @@ public class WebServiceLoggingAdvice {
 
     @Pointcut("execution(public * io.github.carlos_emr.carlos.webserv.rest.*.*(..))")
     public void pointcut() {
-        logger.info("called pointcut");
+        // Pointcut marker only; AspectJ never executes this body.
     }
 
     private String getServiceCallDescription(ProceedingJoinPoint joinpoint) {
@@ -72,14 +72,16 @@ public class WebServiceLoggingAdvice {
 
     @Around("execution(public * io.github.carlos_emr.carlos.webserv.rest.*.*(..))")
     public Object logAccess(ProceedingJoinPoint joinpoint) throws Throwable {
-        if (logger.isInfoEnabled()) {
-            logger.info("Logging access for " + joinpoint);
+        // Log only the service.method name (never the joinpoint argument values, which can
+        // carry PHI or OAuth-derived context) and only at DEBUG so this diagnostic logging is
+        // disabled in production by default. The access record itself is still captured in the
+        // OscarLog audit store below.
+        if (logger.isDebugEnabled()) {
+            logger.debug("REST WS access: {}", getServiceCallDescription(joinpoint));
         }
 
         try {
-            long duration = System.currentTimeMillis();
             Object result = joinpoint.proceed();
-            duration = System.currentTimeMillis() - duration;
 
             logAccess("REST WS: " + getServiceCallDescription(joinpoint));
             return result;

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/util/WebServiceLoggingAdviceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/util/WebServiceLoggingAdviceUnitTest.java
@@ -1,0 +1,166 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.webserv.rest.util;
+
+import java.util.Collections;
+import java.util.List;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.apache.cxf.message.Message;
+import org.apache.cxf.phase.PhaseInterceptorChain;
+import org.apache.logging.log4j.Level;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.Signature;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+import io.github.carlos_emr.carlos.commn.model.OscarLog;
+import io.github.carlos_emr.carlos.log.LogAction;
+import io.github.carlos_emr.carlos.test.logging.LogCapture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link WebServiceLoggingAdvice}.
+ *
+ * <p>Pins the security-hardening contract for issue #2810: REST WebService access logging through
+ * the application logger must stay at DEBUG (off in production by default) and must only carry the
+ * {@code service.method} name — never the joinpoint argument values, which can hold PHI or
+ * OAuth-derived context. The intentional, access-controlled OscarLog audit record is still
+ * written for each invocation.</p>
+ */
+@Tag("unit")
+@Tag("fast")
+class WebServiceLoggingAdviceUnitTest {
+
+    /** Stand-in declaring type so the logged description reads like a real REST service. */
+    private interface PharmacyService {
+    }
+
+    private ProceedingJoinPoint mockJoinPoint(String methodName) {
+        ProceedingJoinPoint joinpoint = mock(ProceedingJoinPoint.class);
+        Signature signature = mock(Signature.class);
+        when(joinpoint.getSignature()).thenReturn(signature);
+        when(signature.getDeclaringType()).thenReturn(PharmacyService.class);
+        when(signature.getName()).thenReturn(methodName);
+        return joinpoint;
+    }
+
+    private MockedStatic<PhaseInterceptorChain> stubCurrentRequest() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getRemoteAddr()).thenReturn("127.0.0.1");
+        when(request.getRequestURL()).thenReturn(new StringBuffer("https://emr.example/ws/rest/PharmacyService"));
+        // Parameter values may carry PHI; they belong only in the access-controlled audit store.
+        when(request.getParameterMap())
+                .thenReturn(Collections.singletonMap("demographicNo", new String[] {"12345SECRET"}));
+
+        Message message = mock(Message.class);
+        when(message.get("HTTP.REQUEST")).thenReturn(request);
+
+        MockedStatic<PhaseInterceptorChain> chain = mockStatic(PhaseInterceptorChain.class);
+        chain.when(PhaseInterceptorChain::getCurrentMessage).thenReturn(message);
+        return chain;
+    }
+
+    @Test
+    @DisplayName("returns the proceed result and logs only the service.method name at DEBUG")
+    void shouldReturnProceedResult_andLogMethodNameOnlyAtDebug() throws Throwable {
+        ProceedingJoinPoint joinpoint = mockJoinPoint("getPharmacies");
+        Object expected = new Object();
+        when(joinpoint.proceed()).thenReturn(expected);
+
+        WebServiceLoggingAdvice advice = new WebServiceLoggingAdvice();
+
+        try (LogCapture capture = LogCapture.forLogger(WebServiceLoggingAdvice.class);
+             MockedStatic<PhaseInterceptorChain> ignoredChain = stubCurrentRequest();
+             MockedStatic<LogAction> ignoredLog = mockStatic(LogAction.class)) {
+
+            Object result = advice.logAccess(joinpoint);
+
+            assertThat(result).isSameAs(expected);
+            verify(joinpoint).proceed();
+
+            assertThat(capture.messages()).contains("REST WS access: PharmacyService.getPharmacies");
+
+            // No INFO-level diagnostic logging, and no leak of parameter/argument values.
+            assertThat(capture.events())
+                    .noneMatch(event -> event.getLevel() == Level.INFO);
+            assertThat(capture.messages())
+                    .noneMatch(message -> message.contains("12345SECRET"))
+                    .noneMatch(message -> message.contains("Logging access for"));
+        }
+    }
+
+    @Test
+    @DisplayName("writes a non-failure OscarLog audit record for a successful call")
+    void shouldWriteAuditRecord_whenCallSucceeds() throws Throwable {
+        ProceedingJoinPoint joinpoint = mockJoinPoint("getPharmacies");
+        when(joinpoint.proceed()).thenReturn("ok");
+
+        WebServiceLoggingAdvice advice = new WebServiceLoggingAdvice();
+
+        try (MockedStatic<PhaseInterceptorChain> ignoredChain = stubCurrentRequest();
+             MockedStatic<LogAction> logAction = mockStatic(LogAction.class)) {
+
+            advice.logAccess(joinpoint);
+
+            ArgumentCaptor<OscarLog> captor = ArgumentCaptor.forClass(OscarLog.class);
+            logAction.verify(() -> LogAction.addLogSynchronous(captor.capture()));
+            assertThat(captor.getValue().getAction()).isEqualTo("REST WS: PharmacyService.getPharmacies");
+        }
+    }
+
+    @Test
+    @DisplayName("rethrows the original throwable and still records a FAILURE audit record")
+    void shouldRethrowAndRecordFailure_whenTargetThrows() throws Throwable {
+        ProceedingJoinPoint joinpoint = mockJoinPoint("getPharmacies");
+        RuntimeException boom = new RuntimeException("boom");
+        when(joinpoint.proceed()).thenThrow(boom);
+
+        WebServiceLoggingAdvice advice = new WebServiceLoggingAdvice();
+
+        try (LogCapture capture = LogCapture.forLogger(WebServiceLoggingAdvice.class);
+             MockedStatic<PhaseInterceptorChain> ignoredChain = stubCurrentRequest();
+             MockedStatic<LogAction> logAction = mockStatic(LogAction.class)) {
+
+            assertThatThrownBy(() -> advice.logAccess(joinpoint)).isSameAs(boom);
+
+            ArgumentCaptor<OscarLog> captor = ArgumentCaptor.forClass(OscarLog.class);
+            logAction.verify(() -> LogAction.addLogSynchronous(captor.capture()));
+            assertThat(captor.getValue().getAction()).isEqualTo("REST WS: FAILURE: PharmacyService.getPharmacies");
+
+            // Failure detail is logged at DEBUG, never INFO, and carries no argument values.
+            List<String> messages = capture.messages();
+            assertThat(capture.events()).noneMatch(event -> event.getLevel() == Level.INFO);
+            assertThat(messages).noneMatch(message -> message.contains("12345SECRET"));
+        }
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/util/WebServiceLoggingAdviceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/util/WebServiceLoggingAdviceUnitTest.java
@@ -92,7 +92,7 @@ class WebServiceLoggingAdviceUnitTest {
 
     @Test
     @DisplayName("returns the proceed result and logs only the service.method name at DEBUG")
-    void shouldReturnProceedResult_andLogMethodNameOnlyAtDebug() throws Throwable {
+    void shouldReturnProceedResultAndLogMethodNameOnly_whenLoggingAtDebug() throws Throwable {
         ProceedingJoinPoint joinpoint = mockJoinPoint("getPharmacies");
         Object expected = new Object();
         when(joinpoint.proceed()).thenReturn(expected);


### PR DESCRIPTION
fixes #2810

## Scope

- `WebServiceLoggingAdvice` is an AOP `@Around` aspect over all REST WebService methods. It logged access at **INFO** via `"Logging access for " + joinpoint` and emitted a stray `INFO` line from the `@Pointcut` marker method. Per the ticket, this puts parameter-bearing diagnostic logging into production application logs — a secondary PHI / OAuth-token store with different access controls than the database.
- Narrow the application-logger output to the **service.method name only** (no joinpoint / argument values) and lower it to **DEBUG**, so this diagnostic logging is disabled in production by default.
- Empty the `@Pointcut` marker method body (AspectJ never executes it) and drop the dead `duration` computation in the advice.
- **Left unchanged:** the `OscarLog` database audit record written for each call. The ticket frames the database as the intended, access-controlled audit store distinct from the log files being hardened.

## Changes

- `src/main/java/io/github/carlos_emr/carlos/webserv/rest/util/WebServiceLoggingAdvice.java`
  - `logAccess(ProceedingJoinPoint)`: INFO → DEBUG, log `getServiceCallDescription(joinpoint)` (`Type.method`) instead of the full joinpoint; removed unused `duration`.
  - `pointcut()`: removed `logger.info("called pointcut")` (empty marker body).

## Tests

- New `WebServiceLoggingAdviceUnitTest` (`@Tag("unit")`, `@Tag("fast")`), using `LogCapture` and Mockito `mockStatic` for `PhaseInterceptorChain` / `LogAction`:
  - returns the `proceed()` result and logs only `REST WS access: PharmacyService.getPharmacies` — asserts **no INFO** events and that no message leaks a parameter value sentinel or the old `"Logging access for"` text.
  - writes a non-failure `OscarLog` audit record on success.
  - rethrows the original throwable and still records a `FAILURE` audit record, with failure detail at DEBUG and no argument values.

## Local verification

- `mvn test-compile -o` — BUILD SUCCESS.
- `mvn test -o -Dtest=WebServiceLoggingAdviceUnitTest` — Tests run: 3, Failures: 0, Errors: 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lower REST WebService access logging to DEBUG and log only the service.method name to avoid PHI/token leakage into application logs. Remove the stray INFO from the pointcut; keep `OscarLog` audit records unchanged.

- **Bug Fixes**
  - Update `WebServiceLoggingAdvice.logAccess`: INFO → DEBUG; log "REST WS access: Type.method"; remove unused duration.
  - Make `pointcut()` a no-op to eliminate the INFO line.
  - Add `WebServiceLoggingAdviceUnitTest` to verify no INFO logs or parameter values and that success/failure still write `OscarLog`.
  - Rename a unit test to follow the BDD preposition rule (no behavior change).

<sup>Written for commit 941cc0e99389e542597fb991697faf33014c7bca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3001?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

