### PR TITLE
3005 bug age hard coded english

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/utility/Utility.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/utility/Utility.java
@@ -512,12 +512,25 @@ public class Utility {
     }
 
     // ################################################################################
+    /**
+     * Retrieves the CARLOS resource bundle for the specified locale with automatic fallback.
+     *
+     * <p>This method implements a three-tier fallback strategy for localized message resources:
+     * <ol>
+     *   <li>Attempts to load "oscarResources" bundle for the requested locale</li>
+     *   <li>Falls back to English (Locale.ENGLISH) if the requested locale is unavailable</li>
+     *   <li>Falls back to the default bundle locale if English is also unavailable</li>
+     * </ol>
+     *
+     * @param locale the desired locale for the resource bundle; if null, uses the system default locale
+     * @return the resource bundle for the requested locale, or the best available fallback bundle
+     */
     public static ResourceBundle getOscarBundle(Locale locale) {
-    
+
         if (locale == null) {
             locale = Locale.getDefault();
         }
-    
+
         try {
             return ResourceBundle.getBundle("oscarResources", locale);
         }
@@ -703,13 +716,22 @@ public class Utility {
     }
 
     /**
-     * This returns the Patients Age string at a point in time. IE. How old the
-     * patient will be right now or how old will they be on march.31 of this
-     * year.
+     * Calculates the patient's age at a specific point in time as a localized string.
      *
-     * @param DOB         Demographics Date of birth
-     * @param pointInTime The date you would like to calculate there age at.
-     * @return age string ( ie 2 months, 4 years .etc )
+     * <p>This method computes the age difference between the patient's date of birth and the
+     * specified reference date, returning a human-readable age string such as "2 months",
+     * "4 years", or "not born yet" based on the provided locale.
+     *
+     * <p>The age is calculated using calendar year/month/day arithmetic and formatted using
+     * localized resource strings retrieved via {@link #getOscarBundle(Locale)}.
+     *
+     * @param DOB the patient's date of birth; if null, returns null
+     * @param pointInTime the reference date for age calculation (e.g., current date or a future appointment date);
+     *                    if before DOB, returns a localized "not born yet" message
+     * @param locale the locale for formatting age strings; if null, falls back to the system default locale,
+     *               then English, then the default bundle locale (see {@link #getOscarBundle(Locale)})
+     * @return formatted age string at the specified date (e.g., "45 years", "3 months", "not born yet"),
+     *         or null if DOB is null
      */
     public static String calcAgeAtDate(Date DOB, Date pointInTime, Locale locale) {
 

--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/utility/Utility.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/utility/Utility.java
@@ -36,7 +36,9 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.ResourceBundle;
 import java.util.StringTokenizer;
-
+import java.util.Date;
+import java.util.Locale;
+import java.util.MissingResourceException;
 import jakarta.servlet.http.HttpServletRequest;
 
 import org.apache.logging.log4j.Logger;
@@ -510,7 +512,25 @@ public class Utility {
     }
 
     // ################################################################################
-
+    public static ResourceBundle getOscarBundle(Locale locale) {
+    
+        if (locale == null) {
+            locale = Locale.getDefault();
+        }
+    
+        try {
+            return ResourceBundle.getBundle("oscarResources", locale);
+        }
+        catch (MissingResourceException e) {
+            try {
+                return ResourceBundle.getBundle("oscarResources", Locale.ENGLISH);
+            }
+            catch (MissingResourceException e2) {
+                return ResourceBundle.getBundle("oscarResources");
+            }
+        }
+    }  
+    
     // ###################################################################################
     public static String toCurrency(double money) {
         double rtn = (Math.round(money * 100)) / 100.00;
@@ -678,8 +698,8 @@ public class Utility {
         return gregoriancalendar.getTime();
     }
 
-    public static String calcAge(Date DOB) {
-        return calcAgeAtDate(DOB, new GregorianCalendar().getTime());
+    public static String calcAgeAtDate(Date DOB, Date pointInTime) {
+        return calcAgeAtDate(DOB, pointInTime, null);
     }
 
     /**
@@ -691,12 +711,16 @@ public class Utility {
      * @param pointInTime The date you would like to calculate there age at.
      * @return age string ( ie 2 months, 4 years .etc )
      */
-    public static String calcAgeAtDate(Date DOB, Date pointInTime) {
-        if (DOB == null) return (null);
+    public static String calcAgeAtDate(Date DOB, Date pointInTime, Locale locale) {
 
-        // If as of date is before birth, return "Not born"
+        if (DOB == null) {
+            return null;
+        }
+    
+        ResourceBundle bundle = getOscarBundle(locale);
+    
         if (pointInTime.before(DOB)) {
-            return ResourceBundle.getBundle("oscarResources").getString("global.notBorn");
+            return bundle.getString("global.notBorn");
         }
 
         GregorianCalendar now = new GregorianCalendar();
@@ -714,22 +738,19 @@ public class Utility {
         int ageInYears = curYear - birthYear;
         String result = ageInYears
                 + " "
-                + ResourceBundle.getBundle("oscarResources").getString(
-                "global.years");
+                + bundle.getString("global.years");
 
         if (curMonth > birthMonth || curMonth == birthMonth
                 && curDay >= birthDay) {
             ageInYears = curYear - birthYear;
             result = ageInYears
                     + " "
-                    + ResourceBundle.getBundle("oscarResources").getString(
-                    "global.years");
+                    + bundle.getString("global.years");
         } else {
             ageInYears = curYear - birthYear - 1;
             result = ageInYears
                     + " "
-                    + ResourceBundle.getBundle("oscarResources").getString(
-                    "global.years");
+                    + bundle.getString("global.years");
         }
         if (ageInYears < 2) {
             int yearDiff = curYear - birthYear;
@@ -750,19 +771,16 @@ public class Utility {
                 result = ageInDays
                         / 30
                         + " "
-                        + ResourceBundle.getBundle("oscarResources").getString(
-                        "global.months");
+                        + bundle.getString("global.months");
             } else if (ageInDays >= 14) {
                 result = ageInDays
                         / 7
                         + " "
-                        + ResourceBundle.getBundle("oscarResources").getString(
-                        "global.weeks");
+                        + bundle.getString("global.weeks");
             } else {
                 result = ageInDays
                         + " "
-                        + ResourceBundle.getBundle("oscarResources").getString(
-                        "global.days");
+                        + bundle.getString("global.days");
             }
         }
         return result;

--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/utility/Utility.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/utility/Utility.java
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.ResourceBundle;
 import java.util.StringTokenizer;
-import java.util.Date;
 import java.util.Locale;
 import java.util.MissingResourceException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -515,34 +514,22 @@ public class Utility {
     /**
      * Retrieves the CARLOS resource bundle for the specified locale with automatic fallback.
      *
-     * <p>This method implements a three-tier fallback strategy for localized message resources:
+     * <p>This method provides the localized message resources:
      * <ol>
      *   <li>Attempts to load "oscarResources" bundle for the requested locale</li>
-     *   <li>Falls back to English (Locale.ENGLISH) if the requested locale is unavailable</li>
-     *   <li>Falls back to the default bundle locale if English is also unavailable</li>
+     *   <li>Falls back to LocaleContextHolder if the requested locale is null</li>
+     *   <li>ResourceBundle handles the usual fallbacks if the resource is not available</li>
      * </ol>
      *
-     * @param locale the desired locale for the resource bundle; if null, uses the system default locale
+     * @param locale the desired locale for the resource bundle; if null, uses the current request's locale
      * @return the resource bundle for the requested locale, or the best available fallback bundle
      */
     public static ResourceBundle getOscarBundle(Locale locale) {
-
         if (locale == null) {
-            locale = Locale.getDefault();
+            locale = org.springframework.context.i18n.LocaleContextHolder.getLocale();
         }
-
-        try {
-            return ResourceBundle.getBundle("oscarResources", locale);
-        }
-        catch (MissingResourceException e) {
-            try {
-                return ResourceBundle.getBundle("oscarResources", Locale.ENGLISH);
-            }
-            catch (MissingResourceException e2) {
-                return ResourceBundle.getBundle("oscarResources");
-            }
-        }
-    }  
+        return ResourceBundle.getBundle("oscarResources", locale);
+    } 
     
     // ###################################################################################
     public static String toCurrency(double money) {
@@ -710,7 +697,11 @@ public class Utility {
         GregorianCalendar gregoriancalendar = new GregorianCalendar(i, j, k);
         return gregoriancalendar.getTime();
     }
-
+    
+    public static String calcAge(Date DOB) {
+        return calcAgeAtDate(DOB, new GregorianCalendar().getTime());
+    }
+    
     public static String calcAgeAtDate(Date DOB, Date pointInTime) {
         return calcAgeAtDate(DOB, pointInTime, null);
     }
@@ -737,6 +728,10 @@ public class Utility {
 
         if (DOB == null) {
             return null;
+        }
+        
+        if (pointInTime == null) {
+            pointInTime = new Date();
         }
     
         ResourceBundle bundle = getOscarBundle(locale);

--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/utility/Utility.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/utility/Utility.java
@@ -517,7 +517,8 @@ public class Utility {
      * <ol>
      *   <li>Uses {@code LocaleContextHolder.getLocale()} when the requested locale is null</li>
      *   <li>Loads the "oscarResources" bundle for the resolved locale</li>
-     *   <li>Delegates any locale fallback to {@link ResourceBundle#getBundle(String, Locale)}</li>
+     *   <li>Delegates to {@link ResourceBundle#getBundle(String, Locale)}, which handles the standard
+     *       locale fallback chain</li>
      * </ol>
      *
      * @param locale the desired locale for the resource bundle; if null, uses the current context locale
@@ -718,8 +719,8 @@ public class Utility {
      * @param DOB the patient's date of birth; if null, returns null
      * @param pointInTime the reference date for age calculation (e.g., current date or a future appointment date);
      *                    if before DOB, returns a localized "not born yet" message
-     * @param locale the locale for formatting age strings; if null, uses the current context locale before
-     *               delegating locale fallback to {@link ResourceBundle#getBundle(String, Locale)}
+     * @param locale the locale for formatting age strings; if null, uses the current context locale;
+     *               {@link ResourceBundle#getBundle(String, Locale)} handles further locale fallback
      * @return formatted age string at the specified date (e.g., "45 years", "3 months", "not born yet"),
      *         or null if DOB is null
      */

--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/utility/Utility.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/utility/Utility.java
@@ -34,10 +34,9 @@ import java.util.Enumeration;
 import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Locale;
 import java.util.ResourceBundle;
 import java.util.StringTokenizer;
-import java.util.Locale;
-import java.util.MissingResourceException;
 import jakarta.servlet.http.HttpServletRequest;
 
 import org.apache.logging.log4j.Logger;
@@ -512,17 +511,17 @@ public class Utility {
 
     // ################################################################################
     /**
-     * Retrieves the CARLOS resource bundle for the specified locale with automatic fallback.
+     * Retrieves the CARLOS resource bundle for the specified locale.
      *
      * <p>This method provides the localized message resources:
      * <ol>
-     *   <li>Attempts to load "oscarResources" bundle for the requested locale</li>
-     *   <li>Falls back to LocaleContextHolder if the requested locale is null</li>
-     *   <li>ResourceBundle handles the usual fallbacks if the resource is not available</li>
+     *   <li>Uses {@code LocaleContextHolder.getLocale()} when the requested locale is null</li>
+     *   <li>Loads the "oscarResources" bundle for the resolved locale</li>
+     *   <li>Delegates any locale fallback to {@link ResourceBundle#getBundle(String, Locale)}</li>
      * </ol>
      *
-     * @param locale the desired locale for the resource bundle; if null, uses the current request's locale
-     * @return the resource bundle for the requested locale, or the best available fallback bundle
+     * @param locale the desired locale for the resource bundle; if null, uses the current context locale
+     * @return the resource bundle selected by {@link ResourceBundle#getBundle(String, Locale)}
      */
     public static ResourceBundle getOscarBundle(Locale locale) {
         if (locale == null) {
@@ -719,8 +718,8 @@ public class Utility {
      * @param DOB the patient's date of birth; if null, returns null
      * @param pointInTime the reference date for age calculation (e.g., current date or a future appointment date);
      *                    if before DOB, returns a localized "not born yet" message
-     * @param locale the locale for formatting age strings; if null, falls back to the system default locale,
-     *               then English, then the default bundle locale (see {@link #getOscarBundle(Locale)})
+     * @param locale the locale for formatting age strings; if null, uses the current context locale before
+     *               delegating locale fallback to {@link ResourceBundle#getBundle(String, Locale)}
      * @return formatted age string at the specified date (e.g., "45 years", "3 months", "not born yet"),
      *         or null if DOB is null
      */

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/Demographic.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/Demographic.java
@@ -42,6 +42,8 @@ import java.io.Serializable;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.*;
+import java.util.Date;
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.springframework.context.i18n.LocaleContextHolder;
@@ -1297,7 +1299,20 @@ public class Demographic extends AbstractModel<Integer> implements Serializable 
     }
 
     public String getAgeAsOf(Date asofDate) {
-        return Utility.calcAgeAtDate(Utility.calcDate(Utility.convertToReplaceStrIfEmptyStr(getYearOfBirth(), DEFAULT_YEAR), Utility.convertToReplaceStrIfEmptyStr(getMonthOfBirth(), DEFAULT_MONTH), Utility.convertToReplaceStrIfEmptyStr(getDateOfBirth(), DEFAULT_DATE)), asofDate);
+        return getAgeAsOf(asofDate, null);
+    }
+    
+    public String getAgeAsOf(Date asofDate, Locale locale) {
+        return Utility.calcAgeAtDate(
+            Utility.calcDate(
+                Utility.convertToReplaceStrIfEmptyStr(
+                    getYearOfBirth(), DEFAULT_YEAR),
+                Utility.convertToReplaceStrIfEmptyStr(
+                    getMonthOfBirth(), DEFAULT_MONTH),
+                Utility.convertToReplaceStrIfEmptyStr(
+                    getDateOfBirth(), DEFAULT_DATE)),
+            asofDate,
+            locale);
     }
     @jakarta.persistence.Transient
 

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/Demographic.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/Demographic.java
@@ -1301,7 +1301,20 @@ public class Demographic extends AbstractModel<Integer> implements Serializable 
     public String getAgeAsOf(Date asofDate) {
         return getAgeAsOf(asofDate, null);
     }
-    
+
+    /**
+     * Calculates the patient's age at a specific point in time using demographic birth date fields.
+     *
+     * <p>This method constructs a birth date from the demographic's year, month, and day of birth fields
+     * (using defaults if any component is missing), then calculates age relative to the given date.
+     *
+     * @param asofDate the reference date for age calculation (must not be null)
+     * @param locale the locale for formatting age strings (e.g., "2 years", "3 months");
+     *               if null, falls back to the system default locale, then English,
+     *               then the default bundle locale
+     * @return formatted age string at the specified date (e.g., "45 years", "3 months", "not born yet"),
+     *         or null if the birth date cannot be calculated
+     */
     public String getAgeAsOf(Date asofDate, Locale locale) {
         return Utility.calcAgeAtDate(
             Utility.calcDate(

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/Demographic.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/Demographic.java
@@ -1308,8 +1308,8 @@ public class Demographic extends AbstractModel<Integer> implements Serializable 
      *
      * @param asofDate the reference date for age calculation; if null, the current date is used
      * @param locale the locale for formatting age strings (e.g., "2 years", "3 months");
-     *               if null, {@link Utility#getOscarBundle(Locale)} uses the current context locale before
-     *               delegating locale fallback to {@link ResourceBundle#getBundle(String, Locale)}
+     *               if null, uses the current context locale; {@link ResourceBundle#getBundle(String, Locale)}
+     *               handles further locale fallback
      * @return formatted age string at the specified date (e.g., "45 years", "3 months", "not born yet"),
      *         or null if the birth date cannot be calculated
      */

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/Demographic.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/Demographic.java
@@ -42,8 +42,6 @@ import java.io.Serializable;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.*;
-import java.util.Date;
-import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.springframework.context.i18n.LocaleContextHolder;
@@ -1308,10 +1306,10 @@ public class Demographic extends AbstractModel<Integer> implements Serializable 
      * <p>This method constructs a birth date from the demographic's year, month, and day of birth fields
      * (using defaults if any component is missing), then calculates age relative to the given date.
      *
-     * @param asofDate the reference date for age calculation (must not be null)
+     * @param asofDate the reference date for age calculation; if null, the current date is used
      * @param locale the locale for formatting age strings (e.g., "2 years", "3 months");
-     *               if null, falls back to the system default locale, then English,
-     *               then the default bundle locale
+     *               if null, {@link Utility#getOscarBundle(Locale)} uses the current context locale before
+     *               delegating locale fallback to {@link ResourceBundle#getBundle(String, Locale)}
      * @return formatted age string at the specified date (e.g., "45 years", "3 months", "not born yet"),
      *         or null if the birth date cannot be calculated
      */

--- a/src/main/webapp/WEB-INF/jsp/demographic/edit-view.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/edit-view.jsp
@@ -285,7 +285,7 @@
                                                                         <span class="info"><carlos:encode value='<%= StringUtils.trimToEmpty(demographic.getGender()) %>' context="html"/></span>
                                                                     </li>
                                                                     <li><span class="label"><fmt:message key="demographic.demographiceditdemographic.msgDemoAge"/>:</span>
-                                                                        <span class="info"><%= demographic.getAgeAsOf(new Date(), request.getLocale()) %>&nbsp;(
+                                                                        <span class="info"><carlos:encode value='<%= demographic.getAgeAsOf(new Date(), request.getLocale()) %>' context="html"/>&nbsp;(
 	                                                        <fmt:message key="demographic.demographiceditdemographic.formDOB"/>: <%=birthYear%>-<%=birthMonth%>-<%=birthDate%>)
                                                         </span>
                                                                     </li>

--- a/src/main/webapp/WEB-INF/jsp/demographic/edit-view.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/edit-view.jsp
@@ -285,7 +285,7 @@
                                                                         <span class="info"><carlos:encode value='<%= StringUtils.trimToEmpty(demographic.getGender()) %>' context="html"/></span>
                                                                     </li>
                                                                     <li><span class="label"><fmt:message key="demographic.demographiceditdemographic.msgDemoAge"/>:</span>
-                                                                        <span class="info"><%=demographic.getAgeAsOf(new Date())%>&nbsp;(
+                                                                        <span class="info"><%= demographic.getAgeAsOf(new Date(), request.getLocale()) %>&nbsp;(
 	                                                        <fmt:message key="demographic.demographiceditdemographic.formDOB"/>: <%=birthYear%>-<%=birthMonth%>-<%=birthDate%>)
                                                         </span>
                                                                     </li>

--- a/src/main/webapp/WEB-INF/jsp/demographic/edit-view.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/edit-view.jsp
@@ -286,7 +286,7 @@
                                                                     </li>
                                                                     <li><span class="label"><fmt:message key="demographic.demographiceditdemographic.msgDemoAge"/>:</span>
                                                                         <span class="info"><carlos:encode value='<%= demographic.getAgeAsOf(new Date(), request.getLocale()) %>' context="html"/>&nbsp;(
-	                                                        <fmt:message key="demographic.demographiceditdemographic.formDOB"/>: <%=birthYear%>-<%=birthMonth%>-<%=birthDate%>)
+	                                                        <fmt:message key="demographic.demographiceditdemographic.formDOB"/>: <carlos:encode value='<%= birthYear %>' context="html"/>-<carlos:encode value='<%= birthMonth %>' context="html"/>-<carlos:encode value='<%= birthDate %>' context="html"/>)
                                                         </span>
                                                                     </li>
                                                                     <li><span class="label"><fmt:message key="demographic.demographiceditdemographic.msgDemoLanguage"/>:</span>

--- a/src/main/webapp/WEB-INF/jsp/demographic/edit.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/edit.jsp
@@ -1099,7 +1099,7 @@
                                 <%
                                     String genderDisplayText = DemographicEditHelper.getGenderDisplayText(request.getLocale(), demographic.getSex());
                                 %>
-                                <span class="patient-header-details"><carlos:encode value='<%= genderDisplayText %>' context="html"/> &middot; <carlos:encode value='<%= demographic.getAgeAsOf(new Date()) %>' context="html"/> &middot; <fmt:message key="demographic.demographiceditdemographic.formDOB"/>: <carlos:encode value='<%= birthYear %>' context="html"/>-<carlos:encode value='<%= birthMonth %>' context="html"/>-<carlos:encode value='<%= birthDate %>' context="html"/></span>
+                                <span class="patient-header-details"><carlos:encode value='<%= genderDisplayText %>' context="html"/> &middot; <carlos:encode value='<%= demographic.getAgeAsOf(new Date(), request.getLocale()) %>' context="html"/> &middot; <fmt:message key="demographic.demographiceditdemographic.formDOB"/>: <carlos:encode value='<%= birthYear %>' context="html"/>-<carlos:encode value='<%= birthMonth %>' context="html"/>-<carlos:encode value='<%= birthDate %>' context="html"/></span>
                                 <% if (demographic.getHin() != null && !demographic.getHin().isEmpty()) { %>
                                 <span class="patient-header-hin"><fmt:message key="demographic.patient.context.hin"/>: <carlos:encode value='<%= demographic.getHin() %>' context="html"/><% if (demographic.getVer() != null && !demographic.getVer().isEmpty()) { %> <carlos:encode value='<%= demographic.getVer() %>' context="html"/><% } %></span>
                                 <% } %>


### PR DESCRIPTION
<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description
Provides age with labels appropriate for the Locale

<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues
Fixes #3005 
<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?

<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->

## Checklist

- [X] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [X] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [X] I have not included any patient data (PHI) in this PR
- [X] I have added tests for new functionality, or this change doesn't need new tests
- [X] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Localize age formatting by using locale-specific resource bundles for age-related labels.

Bug Fixes:
- Ensure age strings use locale-appropriate labels instead of defaulting to English when available.

Enhancements:
- Add a shared helper to resolve the oscarResources bundle with locale and fallbacks.
- Extend age calculation utilities and demographic model methods to accept an optional Locale parameter.
- Update demographic edit view to pass the request locale when rendering patient age.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the age display locale-aware in demographic edit pages and escape the output to prevent XSS. Fixes #3005 using `oscarResources` and `carlos:encode`.

- **Bug Fixes**
  - Localizes age labels for years, months, weeks, days, and “not born yet” using the request locale.
  - Adds locale support across age helpers: `Utility.getOscarBundle(Locale)`, `calcAgeAtDate(..., Locale)`, and `Demographic#getAgeAsOf(Date, Locale)` with sensible fallbacks.
  - Updates `edit-view.jsp` and `edit.jsp` to pass `request.getLocale()` and HTML-escape age and DOB. Clarifies Javadoc for age localization and bundle lookup.

<sup>Written for commit e632c488185387100488d5e0ac825ef1f035e19b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

