### PR TITLE
fix: missing hasPrivilege check on 4 prescription drug REST endpoints in RxWebService

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/RxWebService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/RxWebService.java
@@ -207,6 +207,7 @@ public class RxWebService extends AbstractServiceImpl {
     @Path("/drugs/all/{demographicNo}")
     @Produces(MediaType.APPLICATION_JSON)
     public DrugSearchResponse getAllDrugs(@PathParam("demographicNo") int demographicNo) {
+        requireRxReadPrivilege(demographicNo);
         List<Drug> drugList = rxManager.getDrugs(getLoggedInInfo(), demographicNo, RxStatus.ALL);
         return new DrugSearchResponse(this.drugConverter.getAllAsTransferObjects(getLoggedInInfo(), drugList));
     }
@@ -215,6 +216,7 @@ public class RxWebService extends AbstractServiceImpl {
     @Path("/drugs/current/{demographicNo}")
     @Produces(MediaType.APPLICATION_JSON)
     public DrugSearchResponse getCurrentDrugs(@PathParam("demographicNo") int demographicNo) {
+        requireRxReadPrivilege(demographicNo);
         List<Drug> drugList = rxManager.getDrugs(getLoggedInInfo(), demographicNo, RxStatus.CURRENT);
         return new DrugSearchResponse(this.drugConverter.getAllAsTransferObjects(getLoggedInInfo(), drugList));
     }
@@ -223,6 +225,7 @@ public class RxWebService extends AbstractServiceImpl {
     @Path("/drugs/longterm/{demographicNo}")
     @Produces(MediaType.APPLICATION_JSON)
     public DrugSearchResponse getLongtermDrugs(@PathParam("demographicNo") int demographicNo) {
+        requireRxReadPrivilege(demographicNo);
         List<Drug> drugList = rxManager.getLongTermDrugs(getLoggedInInfo(), demographicNo);
         return new DrugSearchResponse(this.drugConverter.getAllAsTransferObjects(getLoggedInInfo(), drugList));
     }
@@ -231,8 +234,25 @@ public class RxWebService extends AbstractServiceImpl {
     @Path("/drugs/archived/{demographicNo}")
     @Produces(MediaType.APPLICATION_JSON)
     public DrugSearchResponse getArchivedDrugs(@PathParam("demographicNo") int demographicNo) {
+        requireRxReadPrivilege(demographicNo);
         List<Drug> drugList = rxManager.getDrugs(getLoggedInInfo(), demographicNo, RxStatus.ARCHIVED);
         return new DrugSearchResponse(this.drugConverter.getAllAsTransferObjects(getLoggedInInfo(), drugList));
+    }
+
+    /**
+     * Enforces patient-level read access to prescription data for the given demographic.
+     *
+     * <p>Mirrors the guard used by the older {@link #drugs(int, String)} endpoint so the
+     * path-parameter drug listings cannot be used to read another patient's drug history
+     * by altering the {@code demographicNo} in the URL.
+     *
+     * @param demographicNo the demographic whose prescription data is being requested.
+     * @throws AccessDeniedException if the current user lacks {@code _rx} read access to this patient.
+     */
+    private void requireRxReadPrivilege(int demographicNo) {
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_rx", "r", demographicNo)) {
+            throw new AccessDeniedException("_rx", "r", demographicNo);
+        }
     }
 
     /**

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/RxWebServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/RxWebServiceUnitTest.java
@@ -436,6 +436,76 @@ class RxWebServiceUnitTest {
         }
     }
 
+    /**
+     * Tests for the path-parameter drug listing endpoints
+     * ({@code /rx/drugs/{all,current,longterm,archived}/{demographicNo}}).
+     * These verify the patient-level {@code _rx} read privilege check added to
+     * close the IDOR where any authenticated user could read another patient's
+     * drug history by changing {@code demographicNo} in the URL.
+     */
+    @Nested
+    @DisplayName("Path-parameter drug listing privilege checks")
+    class PathParamDrugListing {
+
+        @Test
+        @DisplayName("should return all drugs when caller is authorized for the demographic")
+        void shouldReturnAllDrugs_whenAuthorized() {
+            DrugSearchResponse resp = service.getAllDrugs(1);
+            assertThat(resp.getContent()).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("should return current drugs when caller is authorized for the demographic")
+        void shouldReturnCurrentDrugs_whenAuthorized() {
+            DrugSearchResponse resp = service.getCurrentDrugs(1);
+            assertThat(resp.getContent()).hasSize(1);
+            assertThat(resp.getContent().get(0).getBrandName()).isEqualTo("Tylenol");
+        }
+
+        @Test
+        @DisplayName("should return archived drugs when caller is authorized for the demographic")
+        void shouldReturnArchivedDrugs_whenAuthorized() {
+            DrugSearchResponse resp = service.getArchivedDrugs(1);
+            assertThat(resp.getContent()).hasSize(1);
+            assertThat(resp.getContent().get(0).getBrandName()).isEqualTo("Aspirin");
+        }
+
+        @Test
+        @DisplayName("should deny access to all drugs for unauthorized demographic")
+        void shouldDenyAllDrugs_forUnauthorizedDemographic() {
+            assertThatThrownBy(() -> service.getAllDrugs(6))
+                    .isInstanceOf(AccessDeniedException.class);
+        }
+
+        @Test
+        @DisplayName("should deny access to current drugs for unauthorized demographic")
+        void shouldDenyCurrentDrugs_forUnauthorizedDemographic() {
+            assertThatThrownBy(() -> service.getCurrentDrugs(6))
+                    .isInstanceOf(AccessDeniedException.class);
+        }
+
+        @Test
+        @DisplayName("should deny access to longterm drugs for unauthorized demographic")
+        void shouldDenyLongtermDrugs_forUnauthorizedDemographic() {
+            assertThatThrownBy(() -> service.getLongtermDrugs(6))
+                    .isInstanceOf(AccessDeniedException.class);
+        }
+
+        @Test
+        @DisplayName("should deny access to archived drugs for unauthorized demographic")
+        void shouldDenyArchivedDrugs_forUnauthorizedDemographic() {
+            assertThatThrownBy(() -> service.getArchivedDrugs(6))
+                    .isInstanceOf(AccessDeniedException.class);
+        }
+
+        @Test
+        @DisplayName("should deny access via status dispatcher for unauthorized demographic")
+        void shouldDenyAccess_whenStatusDispatcherUsedForUnauthorizedDemographic() {
+            assertThatThrownBy(() -> service.drugs("all", 6))
+                    .isInstanceOf(AccessDeniedException.class);
+        }
+    }
+
     // ============ MOCK Testing Sub Classes =========
 
     static class MockRxManager extends RxManagerImpl {
@@ -476,6 +546,19 @@ class RxWebServiceUnitTest {
             else if (status.equals(RxManager.CURRENT)) return getCurrentDrugs(info, demographicNo);
             else if (status.equals(RxManager.ARCHIVED)) return getArchivedDrugs(info, demographicNo);
             else return null;
+        }
+
+        @Override
+        public List<Drug> getDrugs(LoggedInInfo info, int demographicNo,
+                io.github.carlos_emr.carlos.webserv.rest.to.model.RxStatus status) {
+            switch (status) {
+                case CURRENT:
+                    return getCurrentDrugs(info, demographicNo);
+                case ARCHIVED:
+                    return getArchivedDrugs(info, demographicNo);
+                default:
+                    return getAllDrugs(info, demographicNo);
+            }
         }
 
         private List<Drug> getAllDrugs(LoggedInInfo info, int id) {

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/RxWebServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/RxWebServiceUnitTest.java
@@ -471,6 +471,13 @@ class RxWebServiceUnitTest {
         }
 
         @Test
+        @DisplayName("should return longterm drugs when caller is authorized for the demographic")
+        void shouldReturnLongtermDrugs_whenAuthorized() {
+            DrugSearchResponse resp = service.getLongtermDrugs(1);
+            assertThat(resp.getContent()).isNotNull();
+        }
+
+        @Test
         @DisplayName("should deny access to all drugs for unauthorized demographic")
         void shouldDenyAllDrugs_forUnauthorizedDemographic() {
             assertThatThrownBy(() -> service.getAllDrugs(6))
@@ -571,6 +578,11 @@ class RxWebServiceUnitTest {
                 if (!d.isArchived()) toReturn.add(d);
             }
             return toReturn;
+        }
+
+        @Override
+        public List<Drug> getLongTermDrugs(LoggedInInfo info, int demographicNo) {
+            return getCurrentDrugs(info, demographicNo);
         }
 
         private List<Drug> getArchivedDrugs(LoggedInInfo info, int id) {

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/RxWebServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/RxWebServiceUnitTest.java
@@ -474,7 +474,8 @@ class RxWebServiceUnitTest {
         @DisplayName("should return longterm drugs when caller is authorized for the demographic")
         void shouldReturnLongtermDrugs_whenAuthorized() {
             DrugSearchResponse resp = service.getLongtermDrugs(1);
-            assertThat(resp.getContent()).isNotNull();
+            assertThat(resp.getContent()).hasSize(1);
+            assertThat(resp.getContent().get(0).getBrandName()).isEqualTo("Tylenol");
         }
 
         @Test


### PR DESCRIPTION
fixes #2278

## Summary

Four newer path-parameter drug listing endpoints in `RxWebService` returned patient prescription data without a `hasPrivilege` check, allowing any authenticated user to read another patient's drug history by altering the `demographicNo` in the URL (IDOR). This adds the same patient-level `_rx` read guard the older `drugs()` endpoint already enforces.

## Scope

- Add a `_rx` `r` privilege check (patient-scoped on `demographicNo`) to:
  - `GET /rx/drugs/all/{demographicNo}` (`getAllDrugs`)
  - `GET /rx/drugs/current/{demographicNo}` (`getCurrentDrugs`)
  - `GET /rx/drugs/longterm/{demographicNo}` (`getLongtermDrugs`)
  - `GET /rx/drugs/archived/{demographicNo}` (`getArchivedDrugs`)
- Mirror the existing secure pattern from the older `drugs(int, String)` method; throw `AccessDeniedException("_rx", "r", demographicNo)` on failure.
- The `GET /rx/drugs/{status}/{demographicNo}` dispatcher is covered transitively because it delegates to these four methods.

## Implementation

- Extracted a small private helper `requireRxReadPrivilege(int demographicNo)` and called it at the start of each of the four endpoints (before any manager/data access). No public API or behavior change for authorized callers.

## Tests

Added a `PathParamDrugListing` nested class to `RxWebServiceUnitTest` (8 new tests):
- Authorized caller (`demographicNo < 5` in the mock) still receives all/current/archived drug lists.
- Unauthorized caller receives `AccessDeniedException` for all four endpoints and via the status dispatcher.
- Also added a mock override of the `RxStatus`-enum `getDrugs` overload so the authorized happy paths exercise the mock manager.

Verified locally:
- `mvn test-compile -q` — clean
- `mvn test -Dtest=RxWebServiceUnitTest` — `Tests run: 35, Failures: 0, Errors: 0, Skipped: 0`, BUILD SUCCESS

## CARLOS conventions applied

- `SecurityInfoManager.hasPrivilege()` at every affected endpoint entry point, patient-scoped on `demographicNo`.
- `AccessDeniedException` used consistently with the existing secure endpoint (these are read GETs, not mutators, so the GET/HEAD rejection contract does not apply).
- No PHI logged; no string-concatenated SQL; private-helper-over-shared-class preference followed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add missing `_rx` read checks to four path-parameter drug listing endpoints in `RxWebService` to block IDOR access to other patients’ prescriptions. Aligns these endpoints with the secure `drugs()` behavior and closes #2278.

- **Bug Fixes**
  - Enforce `_rx` `r` privilege on `GET /rx/drugs/{all,current,longterm,archived}/{demographicNo}`; throw `AccessDeniedException` when unauthorized.
  - Add `requireRxReadPrivilege(int demographicNo)` and call it in each endpoint; the status dispatcher is covered by delegation.
  - Tests: add authorized happy-path for `getLongtermDrugs`, mock `getLongTermDrugs` override, and strengthen longterm assertions; maintain authorized/unauthorized coverage for all four endpoints and the dispatcher.

<sup>Written for commit 4edfa13e0d6b7dbf921b700972c9e83064a02f84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

