### PR TITLE
fix(security): enforce hasPrivilege on four unprotected JAX-RS REST services (#2798)

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/DemographicMergeService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/DemographicMergeService.java
@@ -73,7 +73,7 @@ public class DemographicMergeService extends AbstractServiceImpl {
     @Path("/{parentId}")
     public OscarSearchResponse<DemographicMergedTo1> getMergedDemographicIds(@PathParam("parentId") Integer parentId) {
         if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_demographic", "r", null)) {
-            throw new RuntimeException("Access Denied");
+            throw new SecurityException("missing required sec object (_demographic)");
         }
         DemographicMergedConverter converter = new DemographicMergedConverter();
         List<DemographicMerged> children = demographicManager.getMergedDemographics(getLoggedInInfo(), parentId);
@@ -95,7 +95,7 @@ public class DemographicMergeService extends AbstractServiceImpl {
     @Path("/")
     public void mergeDemographic(@QueryParam("parentId") Integer parentId, @QueryParam("childId") Integer childId) {
         if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_demographic", "w", null)) {
-            throw new RuntimeException("Access Denied");
+            throw new SecurityException("missing required sec object (_demographic)");
         }
         List<Integer> children = new ArrayList<Integer>();
         children.add(childId);
@@ -113,7 +113,7 @@ public class DemographicMergeService extends AbstractServiceImpl {
     @Path("/")
     public void unmergeDemographic(@QueryParam("parentId") Integer parentId, @QueryParam("childsId") Integer childId) {
         if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_demographic", "w", null)) {
-            throw new RuntimeException("Access Denied");
+            throw new SecurityException("missing required sec object (_demographic)");
         }
         List<Integer> children = new ArrayList<Integer>();
         children.add(childId);

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/DemographicMergeService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/DemographicMergeService.java
@@ -42,6 +42,7 @@ import jakarta.ws.rs.core.MediaType;
 
 import io.github.carlos_emr.carlos.commn.model.DemographicMerged;
 import io.github.carlos_emr.carlos.managers.DemographicManager;
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.webserv.rest.conversion.DemographicMergedConverter;
 import io.github.carlos_emr.carlos.webserv.rest.to.OscarSearchResponse;
 import io.github.carlos_emr.carlos.webserv.rest.to.model.DemographicMergedTo1;
@@ -60,6 +61,9 @@ public class DemographicMergeService extends AbstractServiceImpl {
     @Autowired
     private DemographicManager demographicManager;
 
+    @Autowired
+    private SecurityInfoManager securityInfoManager;
+
     /**
      * Gets child records IDs for the specified parent record
      *
@@ -68,6 +72,9 @@ public class DemographicMergeService extends AbstractServiceImpl {
     @GET
     @Path("/{parentId}")
     public OscarSearchResponse<DemographicMergedTo1> getMergedDemographicIds(@PathParam("parentId") Integer parentId) {
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_demographic", "r", null)) {
+            throw new RuntimeException("Access Denied");
+        }
         DemographicMergedConverter converter = new DemographicMergedConverter();
         List<DemographicMerged> children = demographicManager.getMergedDemographics(getLoggedInInfo(), parentId);
         OscarSearchResponse<DemographicMergedTo1> response = new OscarSearchResponse<DemographicMergedTo1>();
@@ -87,6 +94,9 @@ public class DemographicMergeService extends AbstractServiceImpl {
     @PUT
     @Path("/")
     public void mergeDemographic(@QueryParam("parentId") Integer parentId, @QueryParam("childId") Integer childId) {
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_demographic", "w", null)) {
+            throw new RuntimeException("Access Denied");
+        }
         List<Integer> children = new ArrayList<Integer>();
         children.add(childId);
         demographicManager.mergeDemographics(getLoggedInInfo(), parentId, children);
@@ -102,6 +112,9 @@ public class DemographicMergeService extends AbstractServiceImpl {
     @DELETE
     @Path("/")
     public void unmergeDemographic(@QueryParam("parentId") Integer parentId, @QueryParam("childsId") Integer childId) {
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_demographic", "w", null)) {
+            throw new RuntimeException("Access Denied");
+        }
         List<Integer> children = new ArrayList<Integer>();
         children.add(childId);
         demographicManager.unmergeDemographics(getLoggedInInfo(), parentId, children);

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/DiseaseRegistryService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/DiseaseRegistryService.java
@@ -44,6 +44,7 @@ import io.github.carlos_emr.carlos.commn.dao.DxresearchDAO;
 import io.github.carlos_emr.carlos.commn.dao.QuickListDao;
 import io.github.carlos_emr.carlos.commn.model.Dxresearch;
 import io.github.carlos_emr.carlos.commn.model.QuickList;
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.webserv.rest.to.model.DiagnosisTo1;
 import io.github.carlos_emr.carlos.webserv.rest.to.model.DxQuickList;
 import io.github.carlos_emr.carlos.webserv.rest.to.model.IssueTo1;
@@ -66,10 +67,16 @@ public class DiseaseRegistryService extends AbstractServiceImpl {
     @Qualifier("IssueDAO")
     private IssueDAO issueDao;
 
+    @Autowired
+    private SecurityInfoManager securityInfoManager;
+
     @GET
     @Path("/quickLists")
     @Produces("application/json")
     public List<DxQuickList> getQuickLists() {
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_newCasemgmt.DxRegistry", "r", null)) {
+            throw new RuntimeException("Access Denied");
+        }
 
         Map<String, DxQuickList> quickListMap = new HashMap<String, DxQuickList>();
 
@@ -103,6 +110,9 @@ public class DiseaseRegistryService extends AbstractServiceImpl {
     @Produces("application/json")
     @Consumes("application/json")
     public Response findLikeIssues(DiagnosisTo1 dx) {
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_newCasemgmt.DxRegistry", "r", null)) {
+            return Response.status(Response.Status.FORBIDDEN).build();
+        }
         Issue issue = issueDao.findIssueByTypeAndCode(dx.getCodingSystem(), dx.getCode());
         IssueTo1 returnIssue = new IssueTo1();
         returnIssue.setCode(issue.getCode());
@@ -121,6 +131,9 @@ public class DiseaseRegistryService extends AbstractServiceImpl {
     @Produces("application/json")
     @Consumes("application/json")
     public Response addToDiseaseRegistry(@PathParam("demographicNo") Integer demographicNo, IssueTo1 issue) {
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_newCasemgmt.DxRegistry", "w", null)) {
+            return Response.status(Response.Status.FORBIDDEN).build();
+        }
         boolean activeEntryExists = dxresearchDao.activeEntryExists(demographicNo, issue.getType(), issue.getCode());
 
         if (!activeEntryExists) {
@@ -143,6 +156,9 @@ public class DiseaseRegistryService extends AbstractServiceImpl {
     @Produces("application/json")
     @Consumes("application/json")
     public Response getDiseaseRegistry(@QueryParam("demographicNo") Integer demographicNo) {
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_newCasemgmt.DxRegistry", "r", null)) {
+            return Response.status(Response.Status.FORBIDDEN).build();
+        }
         List<Dxresearch> dxresearchList = dxresearchDao.getByDemographicNo(demographicNo);
         return Response.ok(dxresearchList).build();
     }

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/DiseaseRegistryService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/DiseaseRegistryService.java
@@ -75,7 +75,7 @@ public class DiseaseRegistryService extends AbstractServiceImpl {
     @Produces("application/json")
     public List<DxQuickList> getQuickLists() {
         if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_newCasemgmt.DxRegistry", "r", null)) {
-            throw new RuntimeException("Access Denied");
+            throw new SecurityException("missing required sec object (_newCasemgmt.DxRegistry)");
         }
 
         Map<String, DxQuickList> quickListMap = new HashMap<String, DxQuickList>();
@@ -111,7 +111,7 @@ public class DiseaseRegistryService extends AbstractServiceImpl {
     @Consumes("application/json")
     public Response findLikeIssues(DiagnosisTo1 dx) {
         if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_newCasemgmt.DxRegistry", "r", null)) {
-            return Response.status(Response.Status.FORBIDDEN).build();
+            throw new SecurityException("missing required sec object (_newCasemgmt.DxRegistry)");
         }
         Issue issue = issueDao.findIssueByTypeAndCode(dx.getCodingSystem(), dx.getCode());
         IssueTo1 returnIssue = new IssueTo1();
@@ -132,7 +132,7 @@ public class DiseaseRegistryService extends AbstractServiceImpl {
     @Consumes("application/json")
     public Response addToDiseaseRegistry(@PathParam("demographicNo") Integer demographicNo, IssueTo1 issue) {
         if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_newCasemgmt.DxRegistry", "w", null)) {
-            return Response.status(Response.Status.FORBIDDEN).build();
+            throw new SecurityException("missing required sec object (_newCasemgmt.DxRegistry)");
         }
         boolean activeEntryExists = dxresearchDao.activeEntryExists(demographicNo, issue.getType(), issue.getCode());
 
@@ -157,7 +157,7 @@ public class DiseaseRegistryService extends AbstractServiceImpl {
     @Consumes("application/json")
     public Response getDiseaseRegistry(@QueryParam("demographicNo") Integer demographicNo) {
         if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_newCasemgmt.DxRegistry", "r", null)) {
-            return Response.status(Response.Status.FORBIDDEN).build();
+            throw new SecurityException("missing required sec object (_newCasemgmt.DxRegistry)");
         }
         List<Dxresearch> dxresearchList = dxresearchDao.getByDemographicNo(demographicNo);
         return Response.ok(dxresearchList).build();

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/NotesService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/NotesService.java
@@ -1524,6 +1524,14 @@ public class NotesService extends AbstractServiceImpl {
     @Path("/getGroupNoteExt/{noteId}")
     @Produces("application/json")
     public NoteExtTo1 getGroupNoteExt(@PathParam("noteId") Long noteId) {
+        // Clinical note extension data (treatment, problem description, exposure
+        // details, etc.) is eChart content; require _eChart read before returning
+        // it. Without this an OAuth/REST caller could read any note's PHI by id,
+        // and because OAuthInterceptor skips credential-less requests the call is
+        // otherwise reachable with no authentication at all (see #2798).
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_eChart", "r", null)) {
+            throw new SecurityException("missing required sec object (_eChart)");
+        }
 
         List<CaseManagementNoteExt> lcme = new ArrayList<CaseManagementNoteExt>();
         lcme.addAll(caseManagementMgr.getExtByNote(noteId));

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/PatientDetailStatusService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/PatientDetailStatusService.java
@@ -45,6 +45,7 @@ import io.github.carlos_emr.carlos.integration.mchcv.HCValidationResult;
 import io.github.carlos_emr.carlos.integration.mchcv.HCValidator;
 import io.github.carlos_emr.carlos.integration.mchcv.OnlineHCValidator;
 import io.github.carlos_emr.carlos.managers.DemographicManager;
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.webserv.rest.to.RestResponse;
 import io.github.carlos_emr.carlos.webserv.rest.to.model.PatientDetailStatusTo1;
@@ -61,6 +62,9 @@ public class PatientDetailStatusService extends AbstractServiceImpl {
     @Autowired
     private DemographicManager demographicManager;
 
+    @Autowired
+    private SecurityInfoManager securityInfoManager;
+
     private CarlosProperties oscarProperties = CarlosProperties.getInstance();
     private Logger logger = MiscUtils.getLogger();
 
@@ -68,6 +72,9 @@ public class PatientDetailStatusService extends AbstractServiceImpl {
     @GET
     @Path("/getStatus")
     public PatientDetailStatusTo1 getStatus(@QueryParam("demographicNo") Integer demographicNo) {
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_demographic", "r", null)) {
+            throw new RuntimeException("Access Denied");
+        }
         PatientDetailStatusTo1 status = new PatientDetailStatusTo1();
 
         //from carlos.properties
@@ -85,6 +92,9 @@ public class PatientDetailStatusService extends AbstractServiceImpl {
     @POST
     @Path("/validateHC")
     public HCValidationResult validateHC(ValidateHCRequestTo1 request) {
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_demographic", "r", null)) {
+            throw new RuntimeException("Access Denied");
+        }
         if (request == null || request.getHin() == null || request.getHin().trim().isEmpty()) {
             HCValidationResult error = new HCValidationResult();
             error.setResponseCode(HCValidator.NOT_VALID_RESPONSE_CODE);
@@ -121,6 +131,9 @@ public class PatientDetailStatusService extends AbstractServiceImpl {
     @GET
     @Path("/isUniqueHC")
     public RestResponse<String> isUniqueHC(@QueryParam("hin") String healthCardNo, @QueryParam("demographicNo") Integer demographicNo) {
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_demographic", "r", null)) {
+            return RestResponse.errorResponse("Access Denied");
+        }
         if (healthCardNo != null && !healthCardNo.trim().isEmpty() && demographicNo != null) {
             List<Demographic> demos = demographicManager.searchByHealthCard(getLoggedInInfo(), healthCardNo);
             if (demos != null) {

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/PatientDetailStatusService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/PatientDetailStatusService.java
@@ -73,7 +73,7 @@ public class PatientDetailStatusService extends AbstractServiceImpl {
     @Path("/getStatus")
     public PatientDetailStatusTo1 getStatus(@QueryParam("demographicNo") Integer demographicNo) {
         if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_demographic", "r", null)) {
-            throw new RuntimeException("Access Denied");
+            throw new SecurityException("missing required sec object (_demographic)");
         }
         PatientDetailStatusTo1 status = new PatientDetailStatusTo1();
 
@@ -93,7 +93,7 @@ public class PatientDetailStatusService extends AbstractServiceImpl {
     @Path("/validateHC")
     public HCValidationResult validateHC(ValidateHCRequestTo1 request) {
         if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_demographic", "r", null)) {
-            throw new RuntimeException("Access Denied");
+            throw new SecurityException("missing required sec object (_demographic)");
         }
         if (request == null || request.getHin() == null || request.getHin().trim().isEmpty()) {
             HCValidationResult error = new HCValidationResult();
@@ -132,7 +132,7 @@ public class PatientDetailStatusService extends AbstractServiceImpl {
     @Path("/isUniqueHC")
     public RestResponse<String> isUniqueHC(@QueryParam("hin") String healthCardNo, @QueryParam("demographicNo") Integer demographicNo) {
         if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_demographic", "r", null)) {
-            return RestResponse.errorResponse("Access Denied");
+            throw new SecurityException("missing required sec object (_demographic)");
         }
         if (healthCardNo != null && !healthCardNo.trim().isEmpty() && demographicNo != null) {
             List<Demographic> demos = demographicManager.searchByHealthCard(getLoggedInInfo(), healthCardNo);

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/RxLookupService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/RxLookupService.java
@@ -76,6 +76,9 @@ public class RxLookupService extends AbstractServiceImpl {
     @Path("/search")
     @Produces("application/json")
     public DrugLookupResponse search(@QueryParam("string") String s) {
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_rx", "r", null)) {
+            throw new RuntimeException("Access Denied");
+        }
 
         DrugLookupResponse resp = new DrugLookupResponse();
 
@@ -117,6 +120,9 @@ public class RxLookupService extends AbstractServiceImpl {
     @Path("/details")
     @Produces("application/json")
     public DrugLookupResponse details(@QueryParam("id") String s) {
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_rx", "r", null)) {
+            throw new RuntimeException("Access Denied");
+        }
 
         DrugLookupResponse resp = new DrugLookupResponse();
 
@@ -163,6 +169,9 @@ public class RxLookupService extends AbstractServiceImpl {
     @Path("/parse")
     @Produces
     public DrugResponse parseInstructions(@QueryParam("input") String instructions) {
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_rx", "r", null)) {
+            throw new RuntimeException("Access Denied");
+        }
 
         // the providers no, demographic no, etc... for this drug do not matter.
         // all we care about are the instruction fields.

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/RxLookupService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/RxLookupService.java
@@ -77,7 +77,7 @@ public class RxLookupService extends AbstractServiceImpl {
     @Produces("application/json")
     public DrugLookupResponse search(@QueryParam("string") String s) {
         if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_rx", "r", null)) {
-            throw new RuntimeException("Access Denied");
+            throw new SecurityException("missing required sec object (_rx)");
         }
 
         DrugLookupResponse resp = new DrugLookupResponse();
@@ -121,7 +121,7 @@ public class RxLookupService extends AbstractServiceImpl {
     @Produces("application/json")
     public DrugLookupResponse details(@QueryParam("id") String s) {
         if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_rx", "r", null)) {
-            throw new RuntimeException("Access Denied");
+            throw new SecurityException("missing required sec object (_rx)");
         }
 
         DrugLookupResponse resp = new DrugLookupResponse();
@@ -170,7 +170,7 @@ public class RxLookupService extends AbstractServiceImpl {
     @Produces
     public DrugResponse parseInstructions(@QueryParam("input") String instructions) {
         if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_rx", "r", null)) {
-            throw new RuntimeException("Access Denied");
+            throw new SecurityException("missing required sec object (_rx)");
         }
 
         // the providers no, demographic no, etc... for this drug do not matter.

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/DemographicMergeServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/DemographicMergeServiceUnitTest.java
@@ -127,8 +127,8 @@ class DemographicMergeServiceUnitTest extends CarlosUnitTestBase {
         when(mockSecurityInfoManager.hasPrivilege(any(), anyString(), anyString(), any())).thenReturn(false);
 
         assertThatThrownBy(() -> service.getMergedDemographicIds(5))
-            .isInstanceOf(RuntimeException.class)
-            .hasMessage("Access Denied");
+            .isInstanceOf(SecurityException.class)
+            .hasMessage("missing required sec object (_demographic)");
 
         verify(mockDemographicManager, never()).getMergedDemographics(any(), anyInt());
     }
@@ -151,8 +151,8 @@ class DemographicMergeServiceUnitTest extends CarlosUnitTestBase {
         when(mockSecurityInfoManager.hasPrivilege(any(), anyString(), anyString(), any())).thenReturn(false);
 
         assertThatThrownBy(() -> service.mergeDemographic(1, 2))
-            .isInstanceOf(RuntimeException.class)
-            .hasMessage("Access Denied");
+            .isInstanceOf(SecurityException.class)
+            .hasMessage("missing required sec object (_demographic)");
 
         verify(mockDemographicManager, never()).mergeDemographics(any(), anyInt(), anyList());
     }
@@ -164,8 +164,8 @@ class DemographicMergeServiceUnitTest extends CarlosUnitTestBase {
         when(mockSecurityInfoManager.hasPrivilege(any(), anyString(), anyString(), any())).thenReturn(false);
 
         assertThatThrownBy(() -> service.unmergeDemographic(1, 2))
-            .isInstanceOf(RuntimeException.class)
-            .hasMessage("Access Denied");
+            .isInstanceOf(SecurityException.class)
+            .hasMessage("missing required sec object (_demographic)");
 
         verify(mockDemographicManager, never()).unmergeDemographics(any(), anyInt(), anyList());
     }

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/DemographicMergeServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/DemographicMergeServiceUnitTest.java
@@ -158,6 +158,17 @@ class DemographicMergeServiceUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
+    @DisplayName("should unmerge when caller has _demographic write privilege")
+    @Tag("update")
+    void shouldUnmerge_whenCallerHasWritePrivilege() {
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq("_demographic"), eq("w"), any())).thenReturn(true);
+
+        service.unmergeDemographic(1, 2);
+
+        verify(mockDemographicManager).unmergeDemographics(any(), eq(1), anyList());
+    }
+
+    @Test
     @DisplayName("should deny unmerge when caller lacks _demographic write privilege")
     @Tag("update")
     void shouldDenyUnmerge_whenCallerLacksWritePrivilege() {

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/DemographicMergeServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/DemographicMergeServiceUnitTest.java
@@ -83,9 +83,7 @@ class DemographicMergeServiceUnitTest extends CarlosUnitTestBase {
         Provider provider = mock(Provider.class);
         when(provider.getProviderNo()).thenReturn("101");
         LoggedInInfo loggedInInfo = new LoggedInInfo();
-        Field providerField = LoggedInInfo.class.getDeclaredField("loggedInProvider");
-        providerField.setAccessible(true);
-        providerField.set(loggedInInfo, provider);
+        loggedInInfo.setLoggedInProvider(provider);
         loggedInInfo.setIp("127.0.0.1");
 
         final LoggedInInfo capturedInfo = loggedInInfo;

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/DemographicMergeServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/DemographicMergeServiceUnitTest.java
@@ -1,0 +1,172 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.webserv.rest;
+
+import io.github.carlos_emr.carlos.commn.model.DemographicMerged;
+import io.github.carlos_emr.carlos.managers.DemographicManager;
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import io.github.carlos_emr.carlos.commn.model.Provider;
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
+import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import io.github.carlos_emr.carlos.webserv.rest.to.OscarSearchResponse;
+import io.github.carlos_emr.carlos.webserv.rest.to.model.DemographicMergedTo1;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link DemographicMergeService} privilege enforcement.
+ *
+ * <p>Verifies that every endpoint enforces the {@code _demographic} security object
+ * before delegating to {@link DemographicManager}. Uses a testable subclass that
+ * overrides {@code getLoggedInInfo()} to bypass the CXF HTTP request context.</p>
+ *
+ * @see DemographicMergeService
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("DemographicMergeService Unit Tests")
+@Tag("unit")
+@Tag("fast")
+class DemographicMergeServiceUnitTest extends CarlosUnitTestBase {
+
+    @Mock
+    private DemographicManager mockDemographicManager;
+
+    @Mock
+    private SecurityInfoManager mockSecurityInfoManager;
+
+    private DemographicMergeService service;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        Provider provider = mock(Provider.class);
+        when(provider.getProviderNo()).thenReturn("101");
+        LoggedInInfo loggedInInfo = new LoggedInInfo();
+        Field providerField = LoggedInInfo.class.getDeclaredField("loggedInProvider");
+        providerField.setAccessible(true);
+        providerField.set(loggedInInfo, provider);
+        loggedInInfo.setIp("127.0.0.1");
+
+        final LoggedInInfo capturedInfo = loggedInInfo;
+        service = new DemographicMergeService() {
+            @Override
+            protected LoggedInInfo getLoggedInInfo() {
+                return capturedInfo;
+            }
+        };
+
+        inject("demographicManager", mockDemographicManager);
+        inject("securityInfoManager", mockSecurityInfoManager);
+    }
+
+    private void inject(String fieldName, Object value) throws Exception {
+        Field field = DemographicMergeService.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(service, value);
+    }
+
+    @Test
+    @DisplayName("should return merged ids when caller has _demographic read privilege")
+    @Tag("read")
+    void shouldReturnMergedIds_whenCallerHasReadPrivilege() {
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq("_demographic"), eq("r"), any())).thenReturn(true);
+        when(mockDemographicManager.getMergedDemographics(any(), eq(5)))
+            .thenReturn(Collections.<DemographicMerged>emptyList());
+
+        OscarSearchResponse<DemographicMergedTo1> response = service.getMergedDemographicIds(5);
+
+        assertThat(response).isNotNull();
+        verify(mockDemographicManager).getMergedDemographics(any(), eq(5));
+    }
+
+    @Test
+    @DisplayName("should deny read of merged ids when caller lacks _demographic read privilege")
+    @Tag("read")
+    void shouldDenyReadOfMergedIds_whenCallerLacksReadPrivilege() {
+        when(mockSecurityInfoManager.hasPrivilege(any(), anyString(), anyString(), any())).thenReturn(false);
+
+        assertThatThrownBy(() -> service.getMergedDemographicIds(5))
+            .isInstanceOf(RuntimeException.class)
+            .hasMessage("Access Denied");
+
+        verify(mockDemographicManager, never()).getMergedDemographics(any(), anyInt());
+    }
+
+    @Test
+    @DisplayName("should merge when caller has _demographic write privilege")
+    @Tag("update")
+    void shouldMerge_whenCallerHasWritePrivilege() {
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq("_demographic"), eq("w"), any())).thenReturn(true);
+
+        service.mergeDemographic(1, 2);
+
+        verify(mockDemographicManager).mergeDemographics(any(), eq(1), anyList());
+    }
+
+    @Test
+    @DisplayName("should deny merge when caller lacks _demographic write privilege")
+    @Tag("update")
+    void shouldDenyMerge_whenCallerLacksWritePrivilege() {
+        when(mockSecurityInfoManager.hasPrivilege(any(), anyString(), anyString(), any())).thenReturn(false);
+
+        assertThatThrownBy(() -> service.mergeDemographic(1, 2))
+            .isInstanceOf(RuntimeException.class)
+            .hasMessage("Access Denied");
+
+        verify(mockDemographicManager, never()).mergeDemographics(any(), anyInt(), anyList());
+    }
+
+    @Test
+    @DisplayName("should deny unmerge when caller lacks _demographic write privilege")
+    @Tag("update")
+    void shouldDenyUnmerge_whenCallerLacksWritePrivilege() {
+        when(mockSecurityInfoManager.hasPrivilege(any(), anyString(), anyString(), any())).thenReturn(false);
+
+        assertThatThrownBy(() -> service.unmergeDemographic(1, 2))
+            .isInstanceOf(RuntimeException.class)
+            .hasMessage("Access Denied");
+
+        verify(mockDemographicManager, never()).unmergeDemographics(any(), anyInt(), anyList());
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/DiseaseRegistryServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/DiseaseRegistryServiceUnitTest.java
@@ -1,0 +1,197 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.webserv.rest;
+
+import io.github.carlos_emr.carlos.casemgmt.dao.IssueDAO;
+import io.github.carlos_emr.carlos.commn.dao.DxresearchDAO;
+import io.github.carlos_emr.carlos.commn.dao.QuickListDao;
+import io.github.carlos_emr.carlos.commn.model.Dxresearch;
+import io.github.carlos_emr.carlos.commn.model.QuickList;
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import io.github.carlos_emr.carlos.commn.model.Provider;
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
+import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import io.github.carlos_emr.carlos.webserv.rest.to.model.DiagnosisTo1;
+import io.github.carlos_emr.carlos.webserv.rest.to.model.IssueTo1;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link DiseaseRegistryService} privilege enforcement.
+ *
+ * <p>Verifies that every endpoint enforces the {@code _newCasemgmt.DxRegistry}
+ * security object before reading or writing disease-registry data.</p>
+ *
+ * @see DiseaseRegistryService
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("DiseaseRegistryService Unit Tests")
+@Tag("unit")
+@Tag("fast")
+class DiseaseRegistryServiceUnitTest extends CarlosUnitTestBase {
+
+    private static final String DX_REGISTRY = "_newCasemgmt.DxRegistry";
+
+    @Mock
+    private QuickListDao mockQuickListDao;
+
+    @Mock
+    private DxresearchDAO mockDxresearchDao;
+
+    @Mock
+    private IssueDAO mockIssueDao;
+
+    @Mock
+    private SecurityInfoManager mockSecurityInfoManager;
+
+    private DiseaseRegistryService service;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        Provider provider = mock(Provider.class);
+        when(provider.getProviderNo()).thenReturn("101");
+        LoggedInInfo loggedInInfo = new LoggedInInfo();
+        Field providerField = LoggedInInfo.class.getDeclaredField("loggedInProvider");
+        providerField.setAccessible(true);
+        providerField.set(loggedInInfo, provider);
+        loggedInInfo.setIp("127.0.0.1");
+
+        final LoggedInInfo capturedInfo = loggedInInfo;
+        service = new DiseaseRegistryService() {
+            @Override
+            protected LoggedInInfo getLoggedInInfo() {
+                return capturedInfo;
+            }
+        };
+
+        inject("quickListDao", mockQuickListDao);
+        inject("dxresearchDao", mockDxresearchDao);
+        inject("issueDao", mockIssueDao);
+        inject("securityInfoManager", mockSecurityInfoManager);
+    }
+
+    private void inject(String fieldName, Object value) throws Exception {
+        Field field = DiseaseRegistryService.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(service, value);
+    }
+
+    @Test
+    @DisplayName("should return quick lists when caller has DxRegistry read privilege")
+    @Tag("read")
+    void shouldReturnQuickLists_whenCallerHasReadPrivilege() {
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq(DX_REGISTRY), eq("r"), any())).thenReturn(true);
+        when(mockQuickListDao.findAll()).thenReturn(Collections.<QuickList>emptyList());
+
+        List<?> result = service.getQuickLists();
+
+        assertThat(result).isEmpty();
+        verify(mockQuickListDao).findAll();
+    }
+
+    @Test
+    @DisplayName("should deny quick lists when caller lacks DxRegistry read privilege")
+    @Tag("read")
+    void shouldDenyQuickLists_whenCallerLacksReadPrivilege() {
+        when(mockSecurityInfoManager.hasPrivilege(any(), anyString(), anyString(), any())).thenReturn(false);
+
+        assertThatThrownBy(() -> service.getQuickLists())
+            .isInstanceOf(RuntimeException.class)
+            .hasMessage("Access Denied");
+
+        verify(mockQuickListDao, never()).findAll();
+    }
+
+    @Test
+    @DisplayName("should return forbidden for findLikeIssues when caller lacks DxRegistry read privilege")
+    @Tag("read")
+    void shouldReturnForbiddenForFindLikeIssues_whenCallerLacksReadPrivilege() {
+        when(mockSecurityInfoManager.hasPrivilege(any(), anyString(), anyString(), any())).thenReturn(false);
+
+        Response response = service.findLikeIssues(new DiagnosisTo1());
+
+        assertThat(response.getStatus()).isEqualTo(Response.Status.FORBIDDEN.getStatusCode());
+        verify(mockIssueDao, never()).findIssueByTypeAndCode(anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("should return forbidden for add when caller lacks DxRegistry write privilege")
+    @Tag("create")
+    void shouldReturnForbiddenForAdd_whenCallerLacksWritePrivilege() {
+        when(mockSecurityInfoManager.hasPrivilege(any(), anyString(), anyString(), any())).thenReturn(false);
+
+        Response response = service.addToDiseaseRegistry(123, new IssueTo1());
+
+        assertThat(response.getStatus()).isEqualTo(Response.Status.FORBIDDEN.getStatusCode());
+        verify(mockDxresearchDao, never()).activeEntryExists(anyInt(), anyString(), anyString());
+        verify(mockDxresearchDao, never()).persist(any());
+    }
+
+    @Test
+    @DisplayName("should return disease registry when caller has DxRegistry read privilege")
+    @Tag("read")
+    void shouldReturnDiseaseRegistry_whenCallerHasReadPrivilege() {
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq(DX_REGISTRY), eq("r"), any())).thenReturn(true);
+        when(mockDxresearchDao.getByDemographicNo(123)).thenReturn(Collections.<Dxresearch>emptyList());
+
+        Response response = service.getDiseaseRegistry(123);
+
+        assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+        verify(mockDxresearchDao).getByDemographicNo(123);
+    }
+
+    @Test
+    @DisplayName("should return forbidden for disease registry when caller lacks DxRegistry read privilege")
+    @Tag("read")
+    void shouldReturnForbiddenForDiseaseRegistry_whenCallerLacksReadPrivilege() {
+        when(mockSecurityInfoManager.hasPrivilege(any(), anyString(), anyString(), any())).thenReturn(false);
+
+        Response response = service.getDiseaseRegistry(123);
+
+        assertThat(response.getStatus()).isEqualTo(Response.Status.FORBIDDEN.getStatusCode());
+        verify(mockDxresearchDao, never()).getByDemographicNo(anyInt());
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/DiseaseRegistryServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/DiseaseRegistryServiceUnitTest.java
@@ -22,6 +22,7 @@
 package io.github.carlos_emr.carlos.webserv.rest;
 
 import io.github.carlos_emr.carlos.casemgmt.dao.IssueDAO;
+import io.github.carlos_emr.carlos.casemgmt.model.Issue;
 import io.github.carlos_emr.carlos.commn.dao.DxresearchDAO;
 import io.github.carlos_emr.carlos.commn.dao.QuickListDao;
 import io.github.carlos_emr.carlos.commn.model.Dxresearch;
@@ -144,6 +145,22 @@ class DiseaseRegistryServiceUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
+    @DisplayName("should return matching issue when caller has DxRegistry read privilege")
+    @Tag("read")
+    void shouldReturnMatchingIssue_whenCallerHasReadPrivilege() {
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq(DX_REGISTRY), eq("r"), any())).thenReturn(true);
+        when(mockIssueDao.findIssueByTypeAndCode("icd9", "250")).thenReturn(mock(Issue.class));
+
+        DiagnosisTo1 dx = new DiagnosisTo1();
+        dx.setCodingSystem("icd9");
+        dx.setCode("250");
+        Response response = service.findLikeIssues(dx);
+
+        assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+        verify(mockIssueDao).findIssueByTypeAndCode("icd9", "250");
+    }
+
+    @Test
     @DisplayName("should deny findLikeIssues when caller lacks DxRegistry read privilege")
     @Tag("read")
     void shouldDenyFindLikeIssues_whenCallerLacksReadPrivilege() {
@@ -154,6 +171,38 @@ class DiseaseRegistryServiceUnitTest extends CarlosUnitTestBase {
             .hasMessage("missing required sec object (_newCasemgmt.DxRegistry)");
 
         verify(mockIssueDao, never()).findIssueByTypeAndCode(anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("should persist new entry when caller has DxRegistry write privilege")
+    @Tag("create")
+    void shouldPersistNewEntry_whenCallerHasWritePrivilege() {
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq(DX_REGISTRY), eq("w"), any())).thenReturn(true);
+        when(mockDxresearchDao.activeEntryExists(123, "icd9", "250")).thenReturn(false);
+
+        IssueTo1 issue = new IssueTo1();
+        issue.setType("icd9");
+        issue.setCode("250");
+        Response response = service.addToDiseaseRegistry(123, issue);
+
+        assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+        verify(mockDxresearchDao).persist(any(Dxresearch.class));
+    }
+
+    @Test
+    @DisplayName("should not persist duplicate entry when an active entry already exists")
+    @Tag("create")
+    void shouldNotPersistDuplicate_whenActiveEntryAlreadyExists() {
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq(DX_REGISTRY), eq("w"), any())).thenReturn(true);
+        when(mockDxresearchDao.activeEntryExists(123, "icd9", "250")).thenReturn(true);
+
+        IssueTo1 issue = new IssueTo1();
+        issue.setType("icd9");
+        issue.setCode("250");
+        Response response = service.addToDiseaseRegistry(123, issue);
+
+        assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+        verify(mockDxresearchDao, never()).persist(any());
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/DiseaseRegistryServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/DiseaseRegistryServiceUnitTest.java
@@ -94,9 +94,7 @@ class DiseaseRegistryServiceUnitTest extends CarlosUnitTestBase {
         Provider provider = mock(Provider.class);
         when(provider.getProviderNo()).thenReturn("101");
         LoggedInInfo loggedInInfo = new LoggedInInfo();
-        Field providerField = LoggedInInfo.class.getDeclaredField("loggedInProvider");
-        providerField.setAccessible(true);
-        providerField.set(loggedInInfo, provider);
+        loggedInInfo.setLoggedInProvider(provider);
         loggedInInfo.setIp("127.0.0.1");
 
         final LoggedInInfo capturedInfo = loggedInInfo;

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/DiseaseRegistryServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/DiseaseRegistryServiceUnitTest.java
@@ -139,33 +139,35 @@ class DiseaseRegistryServiceUnitTest extends CarlosUnitTestBase {
         when(mockSecurityInfoManager.hasPrivilege(any(), anyString(), anyString(), any())).thenReturn(false);
 
         assertThatThrownBy(() -> service.getQuickLists())
-            .isInstanceOf(RuntimeException.class)
-            .hasMessage("Access Denied");
+            .isInstanceOf(SecurityException.class)
+            .hasMessage("missing required sec object (_newCasemgmt.DxRegistry)");
 
         verify(mockQuickListDao, never()).findAll();
     }
 
     @Test
-    @DisplayName("should return forbidden for findLikeIssues when caller lacks DxRegistry read privilege")
+    @DisplayName("should deny findLikeIssues when caller lacks DxRegistry read privilege")
     @Tag("read")
-    void shouldReturnForbiddenForFindLikeIssues_whenCallerLacksReadPrivilege() {
+    void shouldDenyFindLikeIssues_whenCallerLacksReadPrivilege() {
         when(mockSecurityInfoManager.hasPrivilege(any(), anyString(), anyString(), any())).thenReturn(false);
 
-        Response response = service.findLikeIssues(new DiagnosisTo1());
+        assertThatThrownBy(() -> service.findLikeIssues(new DiagnosisTo1()))
+            .isInstanceOf(SecurityException.class)
+            .hasMessage("missing required sec object (_newCasemgmt.DxRegistry)");
 
-        assertThat(response.getStatus()).isEqualTo(Response.Status.FORBIDDEN.getStatusCode());
         verify(mockIssueDao, never()).findIssueByTypeAndCode(anyString(), anyString());
     }
 
     @Test
-    @DisplayName("should return forbidden for add when caller lacks DxRegistry write privilege")
+    @DisplayName("should deny add when caller lacks DxRegistry write privilege")
     @Tag("create")
-    void shouldReturnForbiddenForAdd_whenCallerLacksWritePrivilege() {
+    void shouldDenyAdd_whenCallerLacksWritePrivilege() {
         when(mockSecurityInfoManager.hasPrivilege(any(), anyString(), anyString(), any())).thenReturn(false);
 
-        Response response = service.addToDiseaseRegistry(123, new IssueTo1());
+        assertThatThrownBy(() -> service.addToDiseaseRegistry(123, new IssueTo1()))
+            .isInstanceOf(SecurityException.class)
+            .hasMessage("missing required sec object (_newCasemgmt.DxRegistry)");
 
-        assertThat(response.getStatus()).isEqualTo(Response.Status.FORBIDDEN.getStatusCode());
         verify(mockDxresearchDao, never()).activeEntryExists(anyInt(), anyString(), anyString());
         verify(mockDxresearchDao, never()).persist(any());
     }
@@ -184,14 +186,15 @@ class DiseaseRegistryServiceUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
-    @DisplayName("should return forbidden for disease registry when caller lacks DxRegistry read privilege")
+    @DisplayName("should deny disease registry when caller lacks DxRegistry read privilege")
     @Tag("read")
-    void shouldReturnForbiddenForDiseaseRegistry_whenCallerLacksReadPrivilege() {
+    void shouldDenyDiseaseRegistry_whenCallerLacksReadPrivilege() {
         when(mockSecurityInfoManager.hasPrivilege(any(), anyString(), anyString(), any())).thenReturn(false);
 
-        Response response = service.getDiseaseRegistry(123);
+        assertThatThrownBy(() -> service.getDiseaseRegistry(123))
+            .isInstanceOf(SecurityException.class)
+            .hasMessage("missing required sec object (_newCasemgmt.DxRegistry)");
 
-        assertThat(response.getStatus()).isEqualTo(Response.Status.FORBIDDEN.getStatusCode());
         verify(mockDxresearchDao, never()).getByDemographicNo(anyInt());
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/NotesServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/NotesServiceUnitTest.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.webserv.rest;
+
+import io.github.carlos_emr.carlos.casemgmt.model.CaseManagementNoteExt;
+import io.github.carlos_emr.carlos.casemgmt.service.CaseManagementManager;
+import io.github.carlos_emr.carlos.commn.model.Provider;
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
+import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import io.github.carlos_emr.carlos.webserv.rest.to.model.NoteExtTo1;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link NotesService} privilege enforcement.
+ *
+ * <p>Verifies that {@code getGroupNoteExt} enforces the {@code _eChart} security
+ * object before returning clinical note extension data (treatment, problem
+ * description, exposure details, etc.). See #2798.</p>
+ *
+ * @see NotesService
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("NotesService Unit Tests")
+@Tag("unit")
+@Tag("fast")
+class NotesServiceUnitTest extends CarlosUnitTestBase {
+
+    private static final String ECHART = "_eChart";
+
+    @Mock
+    private CaseManagementManager mockCaseManagementMgr;
+
+    @Mock
+    private SecurityInfoManager mockSecurityInfoManager;
+
+    private NotesService service;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        Provider provider = mock(Provider.class);
+        when(provider.getProviderNo()).thenReturn("101");
+        LoggedInInfo loggedInInfo = new LoggedInInfo();
+        loggedInInfo.setLoggedInProvider(provider);
+        loggedInInfo.setIp("127.0.0.1");
+
+        final LoggedInInfo capturedInfo = loggedInInfo;
+        service = new NotesService() {
+            @Override
+            protected LoggedInInfo getLoggedInInfo() {
+                return capturedInfo;
+            }
+        };
+
+        inject("caseManagementMgr", mockCaseManagementMgr);
+        inject("securityInfoManager", mockSecurityInfoManager);
+    }
+
+    private void inject(String fieldName, Object value) throws Exception {
+        Field field = NotesService.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(service, value);
+    }
+
+    @Test
+    @DisplayName("should return note extension data when caller has eChart read privilege")
+    @Tag("read")
+    void shouldReturnGroupNoteExt_whenCallerHasReadPrivilege() {
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq(ECHART), eq("r"), any())).thenReturn(true);
+        CaseManagementNoteExt ext = new CaseManagementNoteExt();
+        ext.setKeyVal(CaseManagementNoteExt.TREATMENT);
+        ext.setValue("Sertraline 50mg daily");
+        when(mockCaseManagementMgr.getExtByNote(94L)).thenReturn(Arrays.asList(ext));
+
+        NoteExtTo1 result = service.getGroupNoteExt(94L);
+
+        assertThat(result.getNoteId()).isEqualTo(94L);
+        assertThat(result.getTreatment()).isEqualTo("Sertraline 50mg daily");
+        verify(mockCaseManagementMgr).getExtByNote(94L);
+    }
+
+    @Test
+    @DisplayName("should deny note extension data when caller lacks eChart read privilege")
+    @Tag("read")
+    void shouldDenyGroupNoteExt_whenCallerLacksReadPrivilege() {
+        when(mockSecurityInfoManager.hasPrivilege(any(), anyString(), anyString(), any())).thenReturn(false);
+
+        assertThatThrownBy(() -> service.getGroupNoteExt(94L))
+            .isInstanceOf(SecurityException.class)
+            .hasMessage("missing required sec object (_eChart)");
+
+        verify(mockCaseManagementMgr, never()).getExtByNote(anyLong());
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/PatientDetailStatusServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/PatientDetailStatusServiceUnitTest.java
@@ -1,0 +1,157 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.webserv.rest;
+
+import io.github.carlos_emr.carlos.managers.DemographicManager;
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import io.github.carlos_emr.carlos.commn.model.Demographic;
+import io.github.carlos_emr.carlos.commn.model.Provider;
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
+import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import io.github.carlos_emr.carlos.webserv.rest.to.GenericRestResponse.ResponseStatus;
+import io.github.carlos_emr.carlos.webserv.rest.to.RestResponse;
+import io.github.carlos_emr.carlos.webserv.rest.to.model.ValidateHCRequestTo1;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link PatientDetailStatusService} privilege enforcement.
+ *
+ * <p>Verifies that the patient-detail-status endpoints enforce the {@code _demographic}
+ * security object before reading demographic data, validating, or searching health cards.</p>
+ *
+ * @see PatientDetailStatusService
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("PatientDetailStatusService Unit Tests")
+@Tag("unit")
+@Tag("fast")
+class PatientDetailStatusServiceUnitTest extends CarlosUnitTestBase {
+
+    @Mock
+    private DemographicManager mockDemographicManager;
+
+    @Mock
+    private SecurityInfoManager mockSecurityInfoManager;
+
+    private PatientDetailStatusService service;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        Provider provider = mock(Provider.class);
+        when(provider.getProviderNo()).thenReturn("101");
+        LoggedInInfo loggedInInfo = new LoggedInInfo();
+        Field providerField = LoggedInInfo.class.getDeclaredField("loggedInProvider");
+        providerField.setAccessible(true);
+        providerField.set(loggedInInfo, provider);
+        loggedInInfo.setIp("127.0.0.1");
+
+        final LoggedInInfo capturedInfo = loggedInInfo;
+        service = new PatientDetailStatusService() {
+            @Override
+            protected LoggedInInfo getLoggedInInfo() {
+                return capturedInfo;
+            }
+        };
+
+        inject("demographicManager", mockDemographicManager);
+        inject("securityInfoManager", mockSecurityInfoManager);
+    }
+
+    private void inject(String fieldName, Object value) throws Exception {
+        Field field = PatientDetailStatusService.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(service, value);
+    }
+
+    @Test
+    @DisplayName("should deny status when caller lacks _demographic read privilege")
+    @Tag("read")
+    void shouldDenyStatus_whenCallerLacksReadPrivilege() {
+        when(mockSecurityInfoManager.hasPrivilege(any(), anyString(), anyString(), any())).thenReturn(false);
+
+        assertThatThrownBy(() -> service.getStatus(1))
+            .isInstanceOf(RuntimeException.class)
+            .hasMessage("Access Denied");
+    }
+
+    @Test
+    @DisplayName("should deny health-card validation when caller lacks _demographic read privilege")
+    @Tag("read")
+    void shouldDenyValidateHC_whenCallerLacksReadPrivilege() {
+        when(mockSecurityInfoManager.hasPrivilege(any(), anyString(), anyString(), any())).thenReturn(false);
+
+        ValidateHCRequestTo1 request = new ValidateHCRequestTo1();
+        request.setHin("1234567890");
+
+        assertThatThrownBy(() -> service.validateHC(request))
+            .isInstanceOf(RuntimeException.class)
+            .hasMessage("Access Denied");
+    }
+
+    @Test
+    @DisplayName("should return uniqueness result when caller has _demographic read privilege")
+    @Tag("read")
+    void shouldReturnUniquenessResult_whenCallerHasReadPrivilege() {
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq("_demographic"), eq("r"), any())).thenReturn(true);
+        when(mockDemographicManager.searchByHealthCard(any(), eq("1234567890")))
+            .thenReturn(Collections.<Demographic>emptyList());
+
+        RestResponse<String> response = service.isUniqueHC("1234567890", 5);
+
+        assertThat(response.getStatus()).isEqualTo(ResponseStatus.SUCCESS);
+        verify(mockDemographicManager).searchByHealthCard(any(), eq("1234567890"));
+    }
+
+    @Test
+    @DisplayName("should deny uniqueness check when caller lacks _demographic read privilege")
+    @Tag("read")
+    void shouldDenyUniquenessCheck_whenCallerLacksReadPrivilege() {
+        when(mockSecurityInfoManager.hasPrivilege(any(), anyString(), anyString(), any())).thenReturn(false);
+
+        RestResponse<String> response = service.isUniqueHC("1234567890", 5);
+
+        assertThat(response.getStatus()).isEqualTo(ResponseStatus.ERROR);
+        verify(mockDemographicManager, never()).searchByHealthCard(any(), anyString());
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/PatientDetailStatusServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/PatientDetailStatusServiceUnitTest.java
@@ -81,9 +81,7 @@ class PatientDetailStatusServiceUnitTest extends CarlosUnitTestBase {
         Provider provider = mock(Provider.class);
         when(provider.getProviderNo()).thenReturn("101");
         LoggedInInfo loggedInInfo = new LoggedInInfo();
-        Field providerField = LoggedInInfo.class.getDeclaredField("loggedInProvider");
-        providerField.setAccessible(true);
-        providerField.set(loggedInInfo, provider);
+        loggedInInfo.setLoggedInProvider(provider);
         loggedInInfo.setIp("127.0.0.1");
 
         final LoggedInInfo capturedInfo = loggedInInfo;

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/PatientDetailStatusServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/PatientDetailStatusServiceUnitTest.java
@@ -21,6 +21,9 @@
  */
 package io.github.carlos_emr.carlos.webserv.rest;
 
+import io.github.carlos_emr.CarlosProperties;
+import io.github.carlos_emr.carlos.integration.mchcv.HCValidationResult;
+import io.github.carlos_emr.carlos.integration.mchcv.HCValidator;
 import io.github.carlos_emr.carlos.managers.DemographicManager;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.commn.model.Demographic;
@@ -29,6 +32,7 @@ import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.webserv.rest.to.GenericRestResponse.ResponseStatus;
 import io.github.carlos_emr.carlos.webserv.rest.to.RestResponse;
+import io.github.carlos_emr.carlos.webserv.rest.to.model.PatientDetailStatusTo1;
 import io.github.carlos_emr.carlos.webserv.rest.to.model.ValidateHCRequestTo1;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -74,6 +78,9 @@ class PatientDetailStatusServiceUnitTest extends CarlosUnitTestBase {
     @Mock
     private SecurityInfoManager mockSecurityInfoManager;
 
+    @Mock
+    private CarlosProperties mockProperties;
+
     private PatientDetailStatusService service;
 
     @BeforeEach
@@ -111,6 +118,35 @@ class PatientDetailStatusServiceUnitTest extends CarlosUnitTestBase {
         assertThatThrownBy(() -> service.getStatus(1))
             .isInstanceOf(SecurityException.class)
             .hasMessage("missing required sec object (_demographic)");
+    }
+
+    @Test
+    @DisplayName("should return status when caller has _demographic read privilege")
+    @Tag("read")
+    void shouldReturnStatus_whenCallerHasReadPrivilege() throws Exception {
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq("_demographic"), eq("r"), any())).thenReturn(true);
+        when(mockProperties.getProperty(anyString(), anyString())).thenReturn("BC");
+        inject("oscarProperties", mockProperties);
+
+        PatientDetailStatusTo1 status = service.getStatus(1);
+
+        assertThat(status).isNotNull();
+        assertThat(status.getBillregion()).isEqualTo("BC");
+        assertThat(status.isConformanceFeaturesEnabled()).isFalse();
+    }
+
+    @Test
+    @DisplayName("should return invalid result for blank health card when caller has _demographic read privilege")
+    @Tag("read")
+    void shouldReturnInvalidResult_whenHealthCardBlankAndCallerHasReadPrivilege() {
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq("_demographic"), eq("r"), any())).thenReturn(true);
+
+        ValidateHCRequestTo1 request = new ValidateHCRequestTo1();
+
+        HCValidationResult result = service.validateHC(request);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getResponseCode()).isEqualTo(HCValidator.NOT_VALID_RESPONSE_CODE);
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/PatientDetailStatusServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/PatientDetailStatusServiceUnitTest.java
@@ -111,8 +111,8 @@ class PatientDetailStatusServiceUnitTest extends CarlosUnitTestBase {
         when(mockSecurityInfoManager.hasPrivilege(any(), anyString(), anyString(), any())).thenReturn(false);
 
         assertThatThrownBy(() -> service.getStatus(1))
-            .isInstanceOf(RuntimeException.class)
-            .hasMessage("Access Denied");
+            .isInstanceOf(SecurityException.class)
+            .hasMessage("missing required sec object (_demographic)");
     }
 
     @Test
@@ -125,8 +125,8 @@ class PatientDetailStatusServiceUnitTest extends CarlosUnitTestBase {
         request.setHin("1234567890");
 
         assertThatThrownBy(() -> service.validateHC(request))
-            .isInstanceOf(RuntimeException.class)
-            .hasMessage("Access Denied");
+            .isInstanceOf(SecurityException.class)
+            .hasMessage("missing required sec object (_demographic)");
     }
 
     @Test
@@ -149,9 +149,10 @@ class PatientDetailStatusServiceUnitTest extends CarlosUnitTestBase {
     void shouldDenyUniquenessCheck_whenCallerLacksReadPrivilege() {
         when(mockSecurityInfoManager.hasPrivilege(any(), anyString(), anyString(), any())).thenReturn(false);
 
-        RestResponse<String> response = service.isUniqueHC("1234567890", 5);
+        assertThatThrownBy(() -> service.isUniqueHC("1234567890", 5))
+            .isInstanceOf(SecurityException.class)
+            .hasMessage("missing required sec object (_demographic)");
 
-        assertThat(response.getStatus()).isEqualTo(ResponseStatus.ERROR);
         verify(mockDemographicManager, never()).searchByHealthCard(any(), anyString());
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/RxLookupServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/RxLookupServiceUnitTest.java
@@ -27,6 +27,7 @@ import io.github.carlos_emr.carlos.commn.model.Provider;
 import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.webserv.rest.to.DrugLookupResponse;
+import io.github.carlos_emr.carlos.webserv.rest.to.DrugResponse;
 import io.github.carlos_emr.carlos.webserv.rest.to.model.DrugSearchTo1;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -161,5 +162,17 @@ class RxLookupServiceUnitTest extends CarlosUnitTestBase {
         assertThatThrownBy(() -> service.parseInstructions("1 tab po daily"))
             .isInstanceOf(SecurityException.class)
             .hasMessage("missing required sec object (_rx)");
+    }
+
+    @Test
+    @DisplayName("should parse instructions when caller has _rx read privilege")
+    @Tag("read")
+    void shouldParseInstructions_whenCallerHasReadPrivilege() {
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq("_rx"), eq("r"), any())).thenReturn(true);
+
+        DrugResponse response = service.parseInstructions("1 tab po daily");
+
+        assertThat(response).isNotNull();
+        assertThat(response.getDrug()).isNotNull();
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/RxLookupServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/RxLookupServiceUnitTest.java
@@ -129,6 +129,19 @@ class RxLookupServiceUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
+    @DisplayName("should return details when caller has _rx read privilege")
+    @Tag("read")
+    void shouldReturnDetails_whenCallerHasReadPrivilege() throws Exception {
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq("_rx"), eq("r"), any())).thenReturn(true);
+        when(mockDrugLookUpManager.details("42")).thenReturn(mock(DrugSearchTo1.class));
+
+        DrugLookupResponse response = service.details("42");
+
+        assertThat(response.isSuccess()).isTrue();
+        verify(mockDrugLookUpManager).details("42");
+    }
+
+    @Test
     @DisplayName("should deny details when caller lacks _rx read privilege")
     @Tag("read")
     void shouldDenyDetails_whenCallerLacksReadPrivilege() throws Exception {

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/RxLookupServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/RxLookupServiceUnitTest.java
@@ -122,8 +122,8 @@ class RxLookupServiceUnitTest extends CarlosUnitTestBase {
         when(mockSecurityInfoManager.hasPrivilege(any(), anyString(), anyString(), any())).thenReturn(false);
 
         assertThatThrownBy(() -> service.search("aspirin"))
-            .isInstanceOf(RuntimeException.class)
-            .hasMessage("Access Denied");
+            .isInstanceOf(SecurityException.class)
+            .hasMessage("missing required sec object (_rx)");
 
         verify(mockDrugLookUpManager, never()).search(anyString());
     }
@@ -135,8 +135,8 @@ class RxLookupServiceUnitTest extends CarlosUnitTestBase {
         when(mockSecurityInfoManager.hasPrivilege(any(), anyString(), anyString(), any())).thenReturn(false);
 
         assertThatThrownBy(() -> service.details("42"))
-            .isInstanceOf(RuntimeException.class)
-            .hasMessage("Access Denied");
+            .isInstanceOf(SecurityException.class)
+            .hasMessage("missing required sec object (_rx)");
 
         verify(mockDrugLookUpManager, never()).details(anyString());
     }
@@ -148,7 +148,7 @@ class RxLookupServiceUnitTest extends CarlosUnitTestBase {
         when(mockSecurityInfoManager.hasPrivilege(any(), anyString(), anyString(), any())).thenReturn(false);
 
         assertThatThrownBy(() -> service.parseInstructions("1 tab po daily"))
-            .isInstanceOf(RuntimeException.class)
-            .hasMessage("Access Denied");
+            .isInstanceOf(SecurityException.class)
+            .hasMessage("missing required sec object (_rx)");
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/RxLookupServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/RxLookupServiceUnitTest.java
@@ -1,0 +1,154 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.webserv.rest;
+
+import io.github.carlos_emr.carlos.managers.DrugLookUp;
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import io.github.carlos_emr.carlos.commn.model.Provider;
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
+import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import io.github.carlos_emr.carlos.webserv.rest.to.DrugLookupResponse;
+import io.github.carlos_emr.carlos.webserv.rest.to.model.DrugSearchTo1;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link RxLookupService} privilege enforcement.
+ *
+ * <p>Verifies that the drug-lookup endpoints enforce the {@code _rx} security object
+ * before performing any drug-product database lookup or instruction parsing.</p>
+ *
+ * @see RxLookupService
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("RxLookupService Unit Tests")
+@Tag("unit")
+@Tag("fast")
+class RxLookupServiceUnitTest extends CarlosUnitTestBase {
+
+    @Mock
+    private DrugLookUp mockDrugLookUpManager;
+
+    @Mock
+    private SecurityInfoManager mockSecurityInfoManager;
+
+    private RxLookupService service;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        Provider provider = mock(Provider.class);
+        when(provider.getProviderNo()).thenReturn("101");
+        LoggedInInfo loggedInInfo = new LoggedInInfo();
+        Field providerField = LoggedInInfo.class.getDeclaredField("loggedInProvider");
+        providerField.setAccessible(true);
+        providerField.set(loggedInInfo, provider);
+        loggedInInfo.setIp("127.0.0.1");
+
+        final LoggedInInfo capturedInfo = loggedInInfo;
+        service = new RxLookupService() {
+            @Override
+            protected LoggedInInfo getLoggedInInfo() {
+                return capturedInfo;
+            }
+        };
+
+        inject("drugLookUpManager", mockDrugLookUpManager);
+        inject("securityInfoManager", mockSecurityInfoManager);
+    }
+
+    private void inject(String fieldName, Object value) throws Exception {
+        Field field = RxLookupService.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(service, value);
+    }
+
+    @Test
+    @DisplayName("should perform search when caller has _rx read privilege")
+    @Tag("read")
+    void shouldPerformSearch_whenCallerHasReadPrivilege() {
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq("_rx"), eq("r"), any())).thenReturn(true);
+        when(mockDrugLookUpManager.search("aspirin")).thenReturn(Collections.<DrugSearchTo1>emptyList());
+
+        DrugLookupResponse response = service.search("aspirin");
+
+        assertThat(response.isSuccess()).isTrue();
+        verify(mockDrugLookUpManager).search("aspirin");
+    }
+
+    @Test
+    @DisplayName("should deny search when caller lacks _rx read privilege")
+    @Tag("read")
+    void shouldDenySearch_whenCallerLacksReadPrivilege() {
+        when(mockSecurityInfoManager.hasPrivilege(any(), anyString(), anyString(), any())).thenReturn(false);
+
+        assertThatThrownBy(() -> service.search("aspirin"))
+            .isInstanceOf(RuntimeException.class)
+            .hasMessage("Access Denied");
+
+        verify(mockDrugLookUpManager, never()).search(anyString());
+    }
+
+    @Test
+    @DisplayName("should deny details when caller lacks _rx read privilege")
+    @Tag("read")
+    void shouldDenyDetails_whenCallerLacksReadPrivilege() throws Exception {
+        when(mockSecurityInfoManager.hasPrivilege(any(), anyString(), anyString(), any())).thenReturn(false);
+
+        assertThatThrownBy(() -> service.details("42"))
+            .isInstanceOf(RuntimeException.class)
+            .hasMessage("Access Denied");
+
+        verify(mockDrugLookUpManager, never()).details(anyString());
+    }
+
+    @Test
+    @DisplayName("should deny instruction parsing when caller lacks _rx read privilege")
+    @Tag("read")
+    void shouldDenyParseInstructions_whenCallerLacksReadPrivilege() {
+        when(mockSecurityInfoManager.hasPrivilege(any(), anyString(), anyString(), any())).thenReturn(false);
+
+        assertThatThrownBy(() -> service.parseInstructions("1 tab po daily"))
+            .isInstanceOf(RuntimeException.class)
+            .hasMessage("Access Denied");
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/RxLookupServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/RxLookupServiceUnitTest.java
@@ -79,9 +79,7 @@ class RxLookupServiceUnitTest extends CarlosUnitTestBase {
         Provider provider = mock(Provider.class);
         when(provider.getProviderNo()).thenReturn("101");
         LoggedInInfo loggedInInfo = new LoggedInInfo();
-        Field providerField = LoggedInInfo.class.getDeclaredField("loggedInProvider");
-        providerField.setAccessible(true);
-        providerField.set(loggedInInfo, provider);
+        loggedInInfo.setLoggedInProvider(provider);
         loggedInInfo.setIp("127.0.0.1");
 
         final LoggedInInfo capturedInfo = loggedInInfo;


### PR DESCRIPTION
Part of #2798 — this PR intentionally covers only the unambiguous subset (5 services); the issue stays **open** for the remaining deferred services (see the "Deferred" section below and the progress checklist on #2798).

## Scope

Issue #2798 reports that most JAX-RS REST services under `webserv/rest/` authenticate the caller but never call `securityInfoManager.hasPrivilege()`, so any logged-in user can invoke them. The full issue spans ~18 services / ~80 endpoints; choosing the correct security object per endpoint is the main risk. This PR is the **focused, high-confidence subset** — only the services whose correct security object/privilege is unambiguous, each verified against existing precedent:

- **DemographicMergeService** → `_demographic` (`r` read, `w` merge/unmerge) — matches the admin merge-record JSP which requires `_demographic` write.
- **DiseaseRegistryService** → `_newCasemgmt.DxRegistry` (`r` reads/lookups, `w` add) — matches the precedent in `RecordUxService`.
- **RxLookupService** → `_rx` (`r`) drug-product lookups — matches `RxWebService`.
- **PatientDetailStatusService** → `_demographic` (`r`) — HC validation, HC-uniqueness search, and patient-detail status are all demographic-context operations.

## Implementation

- Each endpoint now calls `securityInfoManager.hasPrivilege(getLoggedInInfo(), "<secobj>", "<r|w>", null)` at method entry, before any side effect.
- Denials throw the canonical CARLOS `SecurityException("missing required sec object (<secobj>)")` uniformly across all 13 denial sites — the paren form mandated by `CLAUDE.md` and used by ~700 existing call sites (incl. the REST precedent `MeasurementService`).
- `securityInfoManager` injected via `@Autowired` field, matching the surrounding REST services (`RxLookupService` already had the field).
- No PHI in denial messages; CARLOS file headers/GPL notices untouched.

### Denial HTTP status (known, tracked — see #242)

With no JAX-RS `ExceptionMapper` registered for this layer, `SecurityException` currently surfaces as **HTTP 500** rather than 403. This is intentional: it keeps the project-wide `SecurityException` convention rather than introducing a one-off `ForbiddenException`. Mapping `SecurityException` → 403 across the whole REST layer is tracked in **#242** (itself blocked by #243); the 13 denial sites added here are picked up automatically when it lands. Please do not re-flag the 500-vs-403 behavior on this PR.

## Tests

New JUnit 5 unit tests (`@Tag("unit")`/`@Tag("fast")`, `CarlosUnitTestBase`, testable subclass overriding `getLoggedInInfo()`, mocks injected via reflection — mirroring `EFormServiceUnitTest`):

- `DemographicMergeServiceUnitTest` (5)
- `DiseaseRegistryServiceUnitTest` (6)
- `RxLookupServiceUnitTest` (4)
- `PatientDetailStatusServiceUnitTest` (4)

Each covers the allow path (delegation occurs) and the deny path (privilege blocks the action and the underlying manager/DAO is never invoked).

### Local verification

- `mvn test-compile` — success.
- `mvn -Dtest='DemographicMergeServiceUnitTest,DiseaseRegistryServiceUnitTest,RxLookupServiceUnitTest,PatientDetailStatusServiceUnitTest' test` — **19 tests, 0 failures, 0 errors**.

## Deferred (follow-up)

The remaining services from the issue have non-obvious or mixed security-object mappings and were intentionally left out of this PR to avoid breaking legitimate access: `ConsentService` (global consent-type config), `ProgramService` (`_pmm_management`/`_program*` ambiguity), `FormsService` (mixed `_eform`/`_newCasemgmt.forms`), `ReportingService`, `ReportByTemplateService`, `OscarJobService`, `AppService`, `StatusService`, `PharmacyService`, and the partially-covered `PersonaService`/`RecordUxService`/`ResourceService`. These warrant a separate scoped pass (and possibly a follow-up issue) where the correct secobj for each can be established.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds privilege checks to five JAX-RS REST services and standardizes denials to the canonical SecurityException. Expands tests to fully cover allow/deny paths across all guarded endpoints; addresses #2798.

- **Bug Fixes**
  - DemographicMergeService → `_demographic` (r reads, w merge/unmerge)
  - DiseaseRegistryService → `_newCasemgmt.DxRegistry` (r reads/lookups, w add)
  - RxLookupService → `_rx` (r search/details/parse)
  - PatientDetailStatusService → `_demographic` (r status, HC validation/uniqueness)
  - NotesService.getGroupNoteExt → `_eChart` (r note extension data)
  - All denials now throw SecurityException with: missing required sec object (<secobj>).
  - Tests cover allow/deny for unmergeDemographic, Rx details/parseInstructions, disease-registry find/add, patient status/HC validation, and note extension retrieval.

- **Refactors**
  - Unit tests now set the logged-in provider via LoggedInInfo.setLoggedInProvider instead of reflection.

<sup>Written for commit 94a289c14057e24b49e8da54d5fa229af8be45c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3011?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Enforce privilege checks on previously unprotected REST endpoints and add unit tests validating access control for these services.

Bug Fixes:
- Guard DiseaseRegistryService endpoints with _newCasemgmt.DxRegistry read/write privileges before accessing disease registry data.
- Require _demographic read/write privileges on DemographicMergeService endpoints for merged demographic operations.
- Protect PatientDetailStatusService health-card and status endpoints with _demographic read privileges.
- Enforce _rx read privilege on RxLookupService drug search, details, and instruction parsing endpoints.
- Require _eChart read privilege in NotesService.getGroupNoteExt before returning clinical note extension data.

Tests:
- Add unit test suites for DiseaseRegistryService, DemographicMergeService, PatientDetailStatusService, RxLookupService, and NotesService to cover both allowed and denied access paths for the new privilege checks.