### PR TITLE
fix: enforce _eChart read privilege on RecordUxService clinical summaries

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/RecordUxService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/RecordUxService.java
@@ -353,6 +353,9 @@ public class RecordUxService extends AbstractServiceImpl {
     @Produces("application/json")
     public SummaryTo1 getFullSummmary(@PathParam("demographicNo") Integer demographicNo, @PathParam(value = "summaryCode") String summaryCode) {
         LoggedInInfo loggedInInfo = getLoggedInInfo();
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_eChart", "r", demographicNo)) {
+            throw new SecurityException("missing required sec object (_eChart)");
+        }
         SummaryTo1 summary = null;
 
         Summary summaryInterface = (Summary) SpringUtils.getBean(MY_MAP.get(summaryCode));

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/RecordUxServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/RecordUxServiceUnitTest.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.webserv.rest;
+
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
+import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import io.github.carlos_emr.carlos.utility.SpringUtils;
+import io.github.carlos_emr.carlos.webserv.rest.conversion.summary.Summary;
+import io.github.carlos_emr.carlos.webserv.rest.to.model.SummaryTo1;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link RecordUxService} clinical-summary authorization.
+ *
+ * <p>Verifies that {@code getFullSummmary()} — the shared entry point for the
+ * eight clinical-summary REST shortcuts (family history, medical history,
+ * ongoing concerns, other meds, reminders, risk factors, allergies,
+ * preventions) — enforces a patient-specific {@code _eChart} read privilege
+ * before returning any PHI. Uses a testable subclass overriding
+ * {@code getLoggedInInfo()} to avoid requiring the CXF HTTP request context.</p>
+ *
+ * @since 2026-06-24
+ * @see RecordUxService
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@TestMethodOrder(MethodOrderer.MethodName.class)
+@DisplayName("RecordUxService clinical-summary authorization")
+@Tag("unit")
+@Tag("read")
+class RecordUxServiceUnitTest extends CarlosUnitTestBase {
+
+    private static final Integer DEMOGRAPHIC_NO = 12345;
+
+    @Mock
+    private SecurityInfoManager mockSecurityInfoManager;
+
+    private LoggedInInfo loggedInInfo;
+    private RecordUxService service;
+
+    @BeforeEach
+    void setUp() {
+        loggedInInfo = new LoggedInInfo();
+        loggedInInfo.setIp("127.0.0.1");
+
+        LoggedInInfo capturedInfo = loggedInInfo;
+        service = new RecordUxService() {
+            @Override
+            protected LoggedInInfo getLoggedInInfo() {
+                return capturedInfo;
+            }
+        };
+
+        injectDependency(service, "securityInfoManager", mockSecurityInfoManager);
+    }
+
+    @Test
+    @DisplayName("should throw SecurityException without fetching summary when user lacks _eChart read privilege")
+    void shouldThrowSecurityException_whenUserLacksEChartReadPrivilege() {
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq("_eChart"), eq("r"), anyInt())).thenReturn(false);
+
+        assertThatThrownBy(() -> service.getFullSummmary(DEMOGRAPHIC_NO, SummaryTo1.ALLERGIES))
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("(_eChart)");
+
+        // Bean lookup for the summary must never happen once access is denied.
+        springUtilsMock.verify(() -> SpringUtils.getBean(anyString()), never());
+    }
+
+    @Test
+    @DisplayName("should perform a patient-specific privilege check using the demographicNo")
+    void shouldPerformPatientSpecificCheck_withDemographicNo() {
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq("_eChart"), eq("r"), anyInt())).thenReturn(false);
+
+        assertThatThrownBy(() -> service.getFullSummmary(DEMOGRAPHIC_NO, SummaryTo1.MEDICALHISTORY_CODE))
+                .isInstanceOf(SecurityException.class);
+
+        verify(mockSecurityInfoManager).hasPrivilege(loggedInInfo, "_eChart", "r", DEMOGRAPHIC_NO);
+    }
+
+    @Test
+    @DisplayName("should return the summary when user has _eChart read privilege")
+    void shouldReturnSummary_whenUserHasEChartReadPrivilege() {
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq("_eChart"), eq("r"), anyInt())).thenReturn(true);
+
+        SummaryTo1 expected = new SummaryTo1();
+        Summary summaryBean = mock(Summary.class);
+        when(summaryBean.getSummary(eq(loggedInInfo), eq(DEMOGRAPHIC_NO), eq(SummaryTo1.FAMILYHISTORY_CODE)))
+                .thenReturn(expected);
+        springUtilsMock.when(() -> SpringUtils.getBean(anyString())).thenReturn(summaryBean);
+
+        SummaryTo1 result = service.getFullSummmary(DEMOGRAPHIC_NO, SummaryTo1.FAMILYHISTORY_CODE);
+
+        assertThat(result).isSameAs(expected);
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/RecordUxServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/RecordUxServiceUnitTest.java
@@ -32,8 +32,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.TestMethodOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -65,9 +63,7 @@ import static org.mockito.Mockito.when;
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
-@TestMethodOrder(MethodOrderer.MethodName.class)
 @DisplayName("RecordUxService clinical-summary authorization")
-@Tag("unit")
 @Tag("read")
 class RecordUxServiceUnitTest extends CarlosUnitTestBase {
 
@@ -102,7 +98,7 @@ class RecordUxServiceUnitTest extends CarlosUnitTestBase {
 
         assertThatThrownBy(() -> service.getFullSummmary(DEMOGRAPHIC_NO, SummaryTo1.ALLERGIES))
                 .isInstanceOf(SecurityException.class)
-                .hasMessageContaining("(_eChart)");
+                .hasMessage("missing required sec object (_eChart)");
 
         // Bean lookup for the summary must never happen once access is denied.
         springUtilsMock.verify(() -> SpringUtils.getBean(anyString()), never());


### PR DESCRIPTION
fixes #2279

## Problem

The eight clinical-summary REST shortcuts in `RecordUxService` (family history, medical history, ongoing concerns, other meds, reminders, risk factors, allergies, preventions) plus the `fullSummary/{summaryCode}` endpoint all delegate to `getFullSummmary()`, which performed **no `hasPrivilege` check**. Any authenticated user could read another patient's PHI simply by changing the `demographicNo` path parameter, bypassing circle-of-care restrictions.

## Scope

- Add a patient-specific access guard at the start of `getFullSummmary()` — the shared entry point — so all nine endpoints are covered by one fix.
- Use `hasPrivilege(loggedInInfo, "_eChart", "r", demographicNo)` (patient-specific, per the ticket's fix recommendation), throwing `SecurityException` in the CARLOS paren form `missing required sec object (_eChart)` when denied.
- No other behavioural changes.

## Changes

- `webserv/rest/RecordUxService.java`: privilege guard added to `getFullSummmary()` immediately after resolving `LoggedInInfo`, before any summary bean lookup.

## CARLOS conventions applied

- `SecurityInfoManager.hasPrivilege()` enforced at the entry point that all eight shortcuts delegate to.
- Patient-specific (`demographicNo`) check rather than a general role check, matching the stronger pattern used by `RxWebService`.
- `SecurityException` thrown in the paren form (`missing required sec object (_eChart)`), not the colon form.
- No PHI in the error message; no logging changes.

## Tests

Added `RecordUxServiceUnitTest` (`@Tag("unit")`, `@Tag("read")`), using a testable subclass overriding `getLoggedInInfo()`:

- `shouldThrowSecurityException_whenUserLacksEChartReadPrivilege` — denied path throws and never fetches the summary bean.
- `shouldPerformPatientSpecificCheck_withDemographicNo` — verifies the check is patient-specific (passes `demographicNo`).
- `shouldReturnSummary_whenUserHasEChartReadPrivilege` — allowed path returns the summary.

Verified locally: `mvn -Dtest=RecordUxServiceUnitTest test` → Tests run: 3, Failures: 0, Errors: 0. BUILD SUCCESS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces a patient-specific `_eChart` read check on clinical summary endpoints in `RecordUxService` to prevent unauthorized PHI access. A single guard in `getFullSummmary()` now protects all nine routes using the request `demographicNo`.

- **Bug Fixes**
  - Guard `getFullSummmary()` with `hasPrivilege(loggedInInfo, "_eChart", "r", demographicNo)` and throw `SecurityException` ("missing required sec object (_eChart)") when denied.
  - Tests cover deny, patient-specific check, and allow paths; tighten to assert the exact error message and remove redundant annotations.

<sup>Written for commit 1c5c0fc8014ece6afaca07511ca1bdd9bcca1bfe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3021?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

