### PR TITLE
fix: missing hasPrivilege on allergy, lab, and disease registry REST endpoints

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/AllergyService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/AllergyService.java
@@ -37,8 +37,10 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 
+import io.github.carlos_emr.carlos.commn.exception.AccessDeniedException;
 import io.github.carlos_emr.carlos.commn.model.Allergy;
 import io.github.carlos_emr.carlos.managers.AllergyManager;
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.webserv.rest.conversion.AllergyConverter;
 import io.github.carlos_emr.carlos.webserv.rest.to.AllergyResponse;
 import io.github.carlos_emr.carlos.webserv.rest.to.model.AllergyTo1;
@@ -52,12 +54,19 @@ import org.springframework.stereotype.Component;
 public class AllergyService extends AbstractServiceImpl {
 
     @Autowired
-    private AllergyManager allergyManager;
+    protected AllergyManager allergyManager;
+
+    @Autowired
+    protected SecurityInfoManager securityInfoManager;
 
     @GET
     @Path("/active")
     @Produces("application/json")
     public AllergyResponse getCurrentAllergies(@QueryParam("demographicNo") Integer demographicNo) {
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_allergy", SecurityInfoManager.READ, demographicNo)) {
+            throw new AccessDeniedException("_allergy", SecurityInfoManager.READ, demographicNo);
+        }
+
         List<Allergy> allergies = allergyManager.getActiveAllergies(getLoggedInInfo(), demographicNo);
 
         List<AllergyTo1> allergiesT = new AllergyConverter().getAllAsTransferObjects(getLoggedInInfo(), allergies);

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/AllergyService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/AllergyService.java
@@ -30,6 +30,7 @@ package io.github.carlos_emr.carlos.webserv.rest;
 
 import java.util.List;
 
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
@@ -63,6 +64,9 @@ public class AllergyService extends AbstractServiceImpl {
     @Path("/active")
     @Produces("application/json")
     public AllergyResponse getCurrentAllergies(@QueryParam("demographicNo") Integer demographicNo) {
+        if (demographicNo == null) {
+            throw new BadRequestException("demographicNo is required");
+        }
         if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_allergy", SecurityInfoManager.READ, demographicNo)) {
             throw new AccessDeniedException("_allergy", SecurityInfoManager.READ, demographicNo);
         }

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/DiseaseRegistryService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/DiseaseRegistryService.java
@@ -126,6 +126,9 @@ public class DiseaseRegistryService extends AbstractServiceImpl {
     @Produces("application/json")
     @Consumes("application/json")
     public Response addToDiseaseRegistry(@PathParam("demographicNo") Integer demographicNo, IssueTo1 issue) {
+        if (demographicNo == null) {
+            throw new BadRequestException("demographicNo is required");
+        }
         if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_dxresearch", SecurityInfoManager.WRITE, demographicNo)) {
             throw new AccessDeniedException("_dxresearch", SecurityInfoManager.WRITE, demographicNo);
         }
@@ -152,6 +155,9 @@ public class DiseaseRegistryService extends AbstractServiceImpl {
     @Produces("application/json")
     @Consumes("application/json")
     public Response getDiseaseRegistry(@QueryParam("demographicNo") Integer demographicNo) {
+        if (demographicNo == null) {
+            throw new BadRequestException("demographicNo is required");
+        }
         if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_dxresearch", SecurityInfoManager.READ, demographicNo)) {
             throw new AccessDeniedException("_dxresearch", SecurityInfoManager.READ, demographicNo);
         }

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/DiseaseRegistryService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/DiseaseRegistryService.java
@@ -40,6 +40,7 @@ import jakarta.ws.rs.core.Response;
 
 import io.github.carlos_emr.carlos.casemgmt.dao.IssueDAO;
 import io.github.carlos_emr.carlos.casemgmt.model.Issue;
+import io.github.carlos_emr.carlos.commn.exception.AccessDeniedException;
 import io.github.carlos_emr.carlos.commn.dao.DxresearchDAO;
 import io.github.carlos_emr.carlos.commn.dao.QuickListDao;
 import io.github.carlos_emr.carlos.commn.model.Dxresearch;
@@ -50,6 +51,7 @@ import io.github.carlos_emr.carlos.webserv.rest.to.model.IssueTo1;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import io.github.carlos_emr.carlos.log.LogAction;
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 
 @Path("/dxRegisty")
 @Consumes(MediaType.APPLICATION_JSON)
@@ -65,6 +67,9 @@ public class DiseaseRegistryService extends AbstractServiceImpl {
     @Autowired
     @Qualifier("IssueDAO")
     private IssueDAO issueDao;
+
+    @Autowired
+    protected SecurityInfoManager securityInfoManager;
 
     @GET
     @Path("/quickLists")
@@ -121,6 +126,10 @@ public class DiseaseRegistryService extends AbstractServiceImpl {
     @Produces("application/json")
     @Consumes("application/json")
     public Response addToDiseaseRegistry(@PathParam("demographicNo") Integer demographicNo, IssueTo1 issue) {
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_dxresearch", SecurityInfoManager.WRITE, demographicNo)) {
+            throw new AccessDeniedException("_dxresearch", SecurityInfoManager.WRITE, demographicNo);
+        }
+
         boolean activeEntryExists = dxresearchDao.activeEntryExists(demographicNo, issue.getType(), issue.getCode());
 
         if (!activeEntryExists) {
@@ -143,6 +152,10 @@ public class DiseaseRegistryService extends AbstractServiceImpl {
     @Produces("application/json")
     @Consumes("application/json")
     public Response getDiseaseRegistry(@QueryParam("demographicNo") Integer demographicNo) {
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_dxresearch", SecurityInfoManager.READ, demographicNo)) {
+            throw new AccessDeniedException("_dxresearch", SecurityInfoManager.READ, demographicNo);
+        }
+
         List<Dxresearch> dxresearchList = dxresearchDao.getByDemographicNo(demographicNo);
         return Response.ok(dxresearchList).build();
     }

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/LabService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/LabService.java
@@ -56,6 +56,7 @@ import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.PathValidationUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
+import io.github.carlos_emr.carlos.commn.exception.AccessDeniedException;
 import io.github.carlos_emr.carlos.commn.model.Hl7TextMessage;
 import io.github.carlos_emr.carlos.managers.LabManager;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
@@ -79,15 +80,19 @@ public class LabService extends AbstractServiceImpl {
 	private static Logger logger = MiscUtils.getLogger();
 
     @Autowired
-	private LabManager labManager;
+	protected LabManager labManager;
 	@Autowired
-	private SecurityInfoManager securityInfoManager;
+	protected SecurityInfoManager securityInfoManager;
 
     @GET
     @Path("/hl7LabsByDemographicNo")
     @Produces("application/json")
     public LabResponse getHl7LabsByDemographicNo(@QueryParam("demographicNo") int demographicNo, @QueryParam("offset") int offset, @QueryParam("limit") int limit) {
 //	public LabResponse getHl7LabsByDemographicNo() {
+
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_lab", SecurityInfoManager.READ, demographicNo)) {
+            throw new AccessDeniedException("_lab", SecurityInfoManager.READ, demographicNo);
+        }
 
         LabResponse response = new LabResponse();
 

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/AllergyServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/AllergyServiceUnitTest.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2001-2002. Department of Family Medicine, McMaster University. All Rights Reserved.
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ * <p>
+ * This software was written for the
+ * Department of Family Medicine
+ * McMaster University
+ * Hamilton
+ * Ontario, Canada
+ * <p>
+ * Now maintained by the CARLOS EMR Project (2026+).
+ * https://github.com/carlos-emr/carlos
+ * CARLOS has no affiliation with OSCAR or McMaster University.
+ */
+package io.github.carlos_emr.carlos.webserv.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.github.carlos_emr.carlos.commn.exception.AccessDeniedException;
+import io.github.carlos_emr.carlos.managers.AllergyManager;
+import io.github.carlos_emr.carlos.managers.SecurityInfoManagerImpl;
+import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import io.github.carlos_emr.carlos.webserv.rest.to.AllergyResponse;
+
+/**
+ * Unit tests for {@link AllergyService}.
+ *
+ * <p>Verifies the patient-level {@code _allergy} read privilege check added to
+ * the {@code /allergies/active} endpoint so an authenticated user without access
+ * to a patient cannot read that patient's active allergies by supplying an
+ * arbitrary {@code demographicNo} (issue #2280).
+ */
+@Tag("unit")
+@Tag("rest")
+@DisplayName("AllergyService unit tests")
+class AllergyServiceUnitTest {
+
+    private AllergyManager allergyManager;
+    private AllergyService service;
+
+    @BeforeEach
+    void setUp() {
+        allergyManager = mock(AllergyManager.class);
+        when(allergyManager.getActiveAllergies(null, 1)).thenReturn(Collections.emptyList());
+        service = new TestableAllergyService(allergyManager);
+    }
+
+    @Test
+    @DisplayName("should return active allergies when caller is authorized for the demographic")
+    void shouldReturnActiveAllergies_whenAuthorized() {
+        AllergyResponse response = service.getCurrentAllergies(1);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getAllergies()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should deny access to active allergies for an unauthorized demographic")
+    void shouldDenyActiveAllergies_forUnauthorizedDemographic() {
+        assertThatThrownBy(() -> service.getCurrentAllergies(6))
+                .isInstanceOf(AccessDeniedException.class);
+    }
+
+    /** Mock SecurityInfoManager that grants access only for demographicNo &lt; 5. */
+    static class TestMockSecurityInfoManager extends SecurityInfoManagerImpl {
+        @Override
+        public boolean hasPrivilege(LoggedInInfo loggedInInfo, String objectName, String privilege, int demographicNo) {
+            return demographicNo < 5;
+        }
+    }
+
+    static class TestableAllergyService extends AllergyService {
+        TestableAllergyService(AllergyManager allergyManager) {
+            super();
+            this.allergyManager = allergyManager;
+            this.securityInfoManager = new TestMockSecurityInfoManager();
+        }
+
+        @Override
+        protected LoggedInInfo getLoggedInInfo() {
+            return null;
+        }
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/AllergyServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/AllergyServiceUnitTest.java
@@ -34,6 +34,8 @@ import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 
+import jakarta.ws.rs.BadRequestException;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
@@ -82,6 +84,13 @@ class AllergyServiceUnitTest {
     void shouldDenyActiveAllergies_forUnauthorizedDemographic() {
         assertThatThrownBy(() -> service.getCurrentAllergies(6))
                 .isInstanceOf(AccessDeniedException.class);
+    }
+
+    @Test
+    @DisplayName("should reject the request when demographicNo is missing")
+    void shouldRejectActiveAllergies_whenDemographicNoMissing() {
+        assertThatThrownBy(() -> service.getCurrentAllergies(null))
+                .isInstanceOf(BadRequestException.class);
     }
 
     /** Mock SecurityInfoManager that grants access only for demographicNo &lt; 5. */

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/DiseaseRegistryServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/DiseaseRegistryServiceUnitTest.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2001-2002. Department of Family Medicine, McMaster University. All Rights Reserved.
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ * <p>
+ * This software was written for the
+ * Department of Family Medicine
+ * McMaster University
+ * Hamilton
+ * Ontario, Canada
+ * <p>
+ * Now maintained by the CARLOS EMR Project (2026+).
+ * https://github.com/carlos-emr/carlos
+ * CARLOS has no affiliation with OSCAR or McMaster University.
+ */
+package io.github.carlos_emr.carlos.webserv.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import jakarta.ws.rs.core.Response;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.github.carlos_emr.carlos.commn.dao.DxresearchDAO;
+import io.github.carlos_emr.carlos.commn.exception.AccessDeniedException;
+import io.github.carlos_emr.carlos.managers.SecurityInfoManagerImpl;
+import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import io.github.carlos_emr.carlos.webserv.rest.to.model.IssueTo1;
+
+/**
+ * Unit tests for {@link DiseaseRegistryService}.
+ *
+ * <p>Verifies the patient-level {@code _dxresearch} privilege checks added to the
+ * disease-registry endpoints (issue #2280): a {@code w} (write) check on the
+ * mutating {@code /{demographicNo}/add} endpoint and an {@code r} (read) check on
+ * {@code /getDiseaseRegistry}. Without these, any authenticated user could read or
+ * write a patient's diagnosis codes by supplying an arbitrary {@code demographicNo}.
+ */
+@Tag("unit")
+@Tag("rest")
+@DisplayName("DiseaseRegistryService unit tests")
+class DiseaseRegistryServiceUnitTest {
+
+    private DxresearchDAO dxresearchDao;
+    private DiseaseRegistryService service;
+
+    @BeforeEach
+    void setUp() {
+        dxresearchDao = mock(DxresearchDAO.class);
+        when(dxresearchDao.getByDemographicNo(1)).thenReturn(Collections.emptyList());
+        service = new TestableDiseaseRegistryService(dxresearchDao);
+    }
+
+    @Test
+    @DisplayName("should return the disease registry when caller is authorized for the demographic")
+    void shouldReturnDiseaseRegistry_whenAuthorized() {
+        Response response = service.getDiseaseRegistry(1);
+
+        assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+    }
+
+    @Test
+    @DisplayName("should deny reading the disease registry for an unauthorized demographic")
+    void shouldDenyDiseaseRegistry_forUnauthorizedDemographic() {
+        assertThatThrownBy(() -> service.getDiseaseRegistry(6))
+                .isInstanceOf(AccessDeniedException.class);
+    }
+
+    @Test
+    @DisplayName("should deny adding to the disease registry for an unauthorized demographic without persisting")
+    void shouldDenyAddToDiseaseRegistry_forUnauthorizedDemographic() {
+        IssueTo1 issue = new IssueTo1();
+        issue.setType("icd9");
+        issue.setCode("250");
+
+        assertThatThrownBy(() -> service.addToDiseaseRegistry(6, issue))
+                .isInstanceOf(AccessDeniedException.class);
+
+        verify(dxresearchDao, never()).activeEntryExists(6, "icd9", "250");
+        verify(dxresearchDao, never()).persist(org.mockito.ArgumentMatchers.any());
+    }
+
+    /** Mock SecurityInfoManager that grants access only for demographicNo &lt; 5. */
+    static class TestMockSecurityInfoManager extends SecurityInfoManagerImpl {
+        @Override
+        public boolean hasPrivilege(LoggedInInfo loggedInInfo, String objectName, String privilege, int demographicNo) {
+            return demographicNo < 5;
+        }
+    }
+
+    static class TestableDiseaseRegistryService extends DiseaseRegistryService {
+        TestableDiseaseRegistryService(DxresearchDAO dxresearchDao) {
+            super();
+            this.dxresearchDao = dxresearchDao;
+            this.securityInfoManager = new TestMockSecurityInfoManager();
+        }
+
+        @Override
+        protected LoggedInInfo getLoggedInInfo() {
+            return null;
+        }
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/DiseaseRegistryServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/DiseaseRegistryServiceUnitTest.java
@@ -36,6 +36,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.core.Response;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -100,6 +101,26 @@ class DiseaseRegistryServiceUnitTest {
 
         verify(dxresearchDao, never()).activeEntryExists(6, "icd9", "250");
         verify(dxresearchDao, never()).persist(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("should reject adding to the disease registry when demographicNo is missing without persisting")
+    void shouldRejectAddToDiseaseRegistry_whenDemographicNoMissing() {
+        IssueTo1 issue = new IssueTo1();
+        issue.setType("icd9");
+        issue.setCode("250");
+
+        assertThatThrownBy(() -> service.addToDiseaseRegistry(null, issue))
+                .isInstanceOf(BadRequestException.class);
+
+        verify(dxresearchDao, never()).persist(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("should reject reading the disease registry when demographicNo is missing")
+    void shouldRejectDiseaseRegistry_whenDemographicNoMissing() {
+        assertThatThrownBy(() -> service.getDiseaseRegistry(null))
+                .isInstanceOf(BadRequestException.class);
     }
 
     /** Mock SecurityInfoManager that grants access only for demographicNo &lt; 5. */

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/LabServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/LabServiceUnitTest.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2001-2002. Department of Family Medicine, McMaster University. All Rights Reserved.
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ * <p>
+ * This software was written for the
+ * Department of Family Medicine
+ * McMaster University
+ * Hamilton
+ * Ontario, Canada
+ * <p>
+ * Now maintained by the CARLOS EMR Project (2026+).
+ * https://github.com/carlos-emr/carlos
+ * CARLOS has no affiliation with OSCAR or McMaster University.
+ */
+package io.github.carlos_emr.carlos.webserv.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.github.carlos_emr.carlos.commn.exception.AccessDeniedException;
+import io.github.carlos_emr.carlos.managers.LabManager;
+import io.github.carlos_emr.carlos.managers.SecurityInfoManagerImpl;
+import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import io.github.carlos_emr.carlos.webserv.rest.to.LabResponse;
+
+/**
+ * Unit tests for {@link LabService}.
+ *
+ * <p>Verifies the patient-level {@code _lab} read privilege check added to the
+ * {@code /labs/hl7LabsByDemographicNo} endpoint so an authenticated user without
+ * access to a patient cannot read that patient's HL7 lab messages by supplying
+ * an arbitrary {@code demographicNo} (issue #2280).
+ */
+@Tag("unit")
+@Tag("rest")
+@DisplayName("LabService unit tests")
+class LabServiceUnitTest {
+
+    private LabManager labManager;
+    private LabService service;
+
+    @BeforeEach
+    void setUp() {
+        labManager = mock(LabManager.class);
+        when(labManager.getHl7Messages(null, 1, 0, 10)).thenReturn(Collections.emptyList());
+        service = new TestableLabService(labManager);
+    }
+
+    @Test
+    @DisplayName("should return HL7 lab messages when caller is authorized for the demographic")
+    void shouldReturnHl7Labs_whenAuthorized() {
+        LabResponse response = service.getHl7LabsByDemographicNo(1, 0, 10);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getMessages()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should deny access to HL7 lab messages for an unauthorized demographic")
+    void shouldDenyHl7Labs_forUnauthorizedDemographic() {
+        assertThatThrownBy(() -> service.getHl7LabsByDemographicNo(6, 0, 10))
+                .isInstanceOf(AccessDeniedException.class);
+    }
+
+    /** Mock SecurityInfoManager that grants access only for demographicNo &lt; 5. */
+    static class TestMockSecurityInfoManager extends SecurityInfoManagerImpl {
+        @Override
+        public boolean hasPrivilege(LoggedInInfo loggedInInfo, String objectName, String privilege, int demographicNo) {
+            return demographicNo < 5;
+        }
+    }
+
+    static class TestableLabService extends LabService {
+        TestableLabService(LabManager labManager) {
+            super();
+            this.labManager = labManager;
+            this.securityInfoManager = new TestMockSecurityInfoManager();
+        }
+
+        @Override
+        protected LoggedInInfo getLoggedInInfo() {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2280

## Summary

Three REST resources exposed patient PHI without patient-level authorization, letting any authenticated user read or write another patient's data by supplying an arbitrary `demographicNo`. This adds a `securityInfoManager.hasPrivilege(...)` guard at each affected entry point, before any DAO/manager call, following the established pattern in `RxWebService` and the sibling fix in #3010.

> **Updated after merging `develop`.** While this PR was open, develop added its own guards to all four `DiseaseRegistryService` endpoints using `_newCasemgmt.DxRegistry` (the object `RecordUxService` and the disease-registry UI already use) with a paren-form `SecurityException`. The merge keeps develop's security object and exception type there — switching to `_dxresearch` would deny any deployment that grants `_newCasemgmt.DxRegistry` but not `_dxresearch`, and would leave the class internally inconsistent. What this PR now contributes on top of develop is the part develop's guards do not cover: **patient scoping**.

## Changes

- **AllergyService** — `GET /allergies/active` now requires `_allergy` `r` access for the requested patient (was unguarded).
- **LabService** — `GET /labs/hl7LabsByDemographicNo` now requires `_lab` `r` access for the requested patient (was unguarded; matches the existing `_lab` `w` check on `hl7LabUpload` in the same class).
- **DiseaseRegistryService** — `POST /{demographicNo}/add` and `GET /getDiseaseRegistry` now pass the requested `demographicNo` to `hasPrivilege` instead of `null`, so a patient-specific `_newCasemgmt.DxRegistry` restriction takes priority over the caller's general module privilege. The module-wide guards develop added are otherwise unchanged, as are the two endpoints (`/quickLists`, `/findLikeIssue`) that take no `demographicNo`.

A missing `demographicNo` is rejected with a `400 BadRequestException` before the (unboxing) privilege check on the three `Integer`-typed parameters, so an omitted query/path parameter is a client error rather than a 500. `LabService` takes a primitive `int` and is unaffected.

## CARLOS conventions applied

- `hasPrivilege` on every affected entry point, with the correct security object and action (read vs. write), evaluated before any side effect.
- `SecurityException` messages use paren form; no PHI in logs or error messages.
- Field injection consistent with the surrounding REST services; all injected fields stay `private`.

## Tests

`@Tag("unit")` / `@Tag("rest")`, JUnit 5 + AssertJ + Mockito — 18 tests across the three classes, all passing locally (`mvn test -Dtest=AllergyServiceUnitTest,LabServiceUnitTest,DiseaseRegistryServiceUnitTest`, and again together with `RxWebServiceUnitTest`, `RecordUxServiceUnitTest` and `RestServiceSurfaceRegistrationUnitTest` — 56 tests, 0 failures).

- `AllergyServiceUnitTest` (3) — authorized read; denial for an unauthorized demographic without reaching the manager; 400 when `demographicNo` is missing.
- `LabServiceUnitTest` (2) — authorized read; denial without reaching the manager.
- `DiseaseRegistryServiceUnitTest` (13) — develop's nine endpoint-coverage tests, plus four added here: both patient-scoped checks refuse a denied demographic *and* never fall back to a module-wide (`demographicNo == null`) check, and both endpoints reject a missing `demographicNo` without touching the DAO. The authorized cases now assert `hasPrivilege` was called with the exact `demographicNo`, so a guard that stopped being patient-scoped fails the test instead of silently passing.

Review follow-ups addressed: the null-`Integer` unboxing finding (gemini-code-assist, cubic) is fixed by the 400 above; the duplicated `TestMockSecurityInfoManager` (CodeRabbit) is gone — all three tests now use a Mockito `@Mock SecurityInfoManager` injected reflectively, which also let the four production fields that had been widened to `protected` go back to `private`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U1vPGNjjzWdkED2vmUYAe8

## Summary by Sourcery

Protect allergy, laboratory, and disease registry REST resources with patient-scoped privilege enforcement before accessing patient data.

Bug Fixes:
- Enforce patient-level authorization before reading allergies, HL7 labs, or disease registry data and before writing disease registry entries.
- Reject missing disease registry and allergy patient identifiers as bad requests instead of allowing invalid privilege checks.

Enhancements:
- Make disease registry authorization patient-scoped so patient-specific restrictions take precedence over module-wide privileges.

Tests:
- Add REST unit coverage for authorized access, authorization denial, patient scoping, missing identifiers, and prevention of DAO or manager calls after denied requests.