### PR TITLE
fix: build eConsult SSO return URL from configured base, not request Host

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EConsult2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EConsult2Action.java
@@ -33,6 +33,8 @@ package io.github.carlos_emr.carlos.encounter.oscarConsultationRequest.pageUtil;
 import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
@@ -64,9 +66,15 @@ public class EConsult2Action extends ActionSupport {
     // Maximum length for task parameter to prevent excessive input
     private static final int MAX_TASK_LENGTH = 100;
 
+    // Fixed eConsult SSO return endpoint on this CARLOS instance.
+    private static final String ECONSULT_SSO_LOGIN_PATH = "econsultSSOLogin";
+
     private final CarlosProperties oscarProperties = CarlosProperties.getInstance();
     private final String frontendEconsultUrl = oscarProperties.getProperty("frontendEconsultUrl");
     private final String backendEconsultUrl = oscarProperties.getProperty("backendEconsultUrl");
+    // Trusted, configured public base URL of this CARLOS instance. Used to build the
+    // eConsult SSO return URL so it never reflects a spoofable request Host header.
+    private final String carlosBaseUrl = oscarProperties.getProperty("carlosBaseUrl");
 
     public String execute() {
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
@@ -139,16 +147,16 @@ public class EConsult2Action extends ActionSupport {
      */
     public String login() {
 
-        //Gets the request URL
-        StringBuffer oscarUrl = request.getRequestURL();
-
-        //Determines the initial length by subtracting the length of the servlet path from the full url's length
-        Integer urlLength = oscarUrl.length() - request.getServletPath().length();
-
-        //Sets the length of the URL, found by subtracting the length of the servlet path from the length of the full URL, that way it only gets up to the context path
-        oscarUrl.setLength(urlLength);
-
-        oscarUrl.append(String.format("%1$s%2$s", File.separator, "econsultSSOLogin"));
+        // The SSO return URL must NOT be derived from the client-controlled request Host
+        // (Host / X-Forwarded-Host can be spoofed). Build it from the configured, trusted
+        // public base URL of this CARLOS instance so the post-login return - and any token
+        // material the eConsult side reflects back to it - cannot be steered to an attacker
+        // origin.
+        String oscarReturnUrl = buildSsoReturnUrl(carlosBaseUrl, request.getContextPath());
+        if (oscarReturnUrl == null) {
+            MiscUtils.getLogger().error("Cannot build eConsult SSO return URL: the 'carlosBaseUrl' property is missing or invalid; refusing to fall back to the request Host.");
+            return "error";
+        }
 
         StringBuilder stringBuilder = new StringBuilder(backendEconsultUrl);
 
@@ -159,7 +167,7 @@ public class EConsult2Action extends ActionSupport {
         stringBuilder.append("SAML2/login");
 
         try {
-            stringBuilder.append(String.format("?%1$s=%2$s", "oscarReturnURL", URLEncoder.encode(oscarUrl.toString(), StandardCharsets.UTF_8.toString())));
+            stringBuilder.append(String.format("?%1$s=%2$s", "oscarReturnURL", URLEncoder.encode(oscarReturnUrl, StandardCharsets.UTF_8.toString())));
             stringBuilder.append(String.format("?%1$s=%2$s", "loginStart", new Date().getTime() / 1000));
             response.sendRedirect(stringBuilder.toString());
         } catch (IOException e) {
@@ -167,6 +175,76 @@ public class EConsult2Action extends ActionSupport {
         }
 
         return null;
+    }
+
+    /**
+     * Builds the eConsult SSO return URL from the configured public base URL of this
+     * CARLOS instance plus this deployment's context path and the fixed
+     * {@code /econsultSSOLogin} endpoint.
+     * <p>
+     * Returns {@code null} when no trusted base URL is configured, so the caller can fail
+     * closed instead of emitting a return URL whose host reflects a spoofable request Host
+     * header.
+     *
+     * @param configuredBaseUrl the configured {@code carlosBaseUrl} property value
+     * @param contextPath       this deployment's servlet context path (server-derived, not
+     *                          Host-derived); may be {@code null} or empty for the root context
+     * @return the absolute return URL, or {@code null} when no trusted base URL is configured
+     */
+    static String buildSsoReturnUrl(String configuredBaseUrl, String contextPath) {
+        String trustedOrigin = normalizedConfiguredOrigin(configuredBaseUrl);
+        if (trustedOrigin == null) {
+            return null;
+        }
+
+        String normalizedContextPath = (contextPath == null) ? "" : contextPath;
+
+        return trustedOrigin + normalizedContextPath + "/" + ECONSULT_SSO_LOGIN_PATH;
+    }
+
+    /**
+     * Validates a configured base URL and returns its origin ({@code scheme://host[:port]}),
+     * or {@code null} when it is absent or not a safe absolute http(s) origin. Any path,
+     * query, fragment, or embedded credentials cause the value to be ignored or rejected;
+     * only the scheme, host, and port are trusted.
+     *
+     * @param configuredBaseUrl the configured base URL value to validate
+     * @return the normalized origin, or {@code null} if it is missing or unsafe
+     */
+    private static String normalizedConfiguredOrigin(String configuredBaseUrl) {
+        if (configuredBaseUrl == null || configuredBaseUrl.trim().isEmpty()) {
+            return null;
+        }
+
+        try {
+            URI uri = new URI(configuredBaseUrl.trim());
+            String scheme = uri.getScheme();
+            String host = uri.getHost();
+
+            if (scheme == null || host == null || host.isEmpty()) {
+                return null;
+            }
+
+            scheme = scheme.toLowerCase();
+            if (!"http".equals(scheme) && !"https".equals(scheme)) {
+                return null;
+            }
+
+            // The base must be a bare origin: reject embedded credentials, query, or fragment.
+            if (uri.getUserInfo() != null || uri.getQuery() != null || uri.getFragment() != null) {
+                return null;
+            }
+
+            StringBuilder origin = new StringBuilder(scheme).append("://").append(host);
+            if (uri.getPort() != -1) {
+                origin.append(':').append(uri.getPort());
+            }
+
+            return origin.toString();
+        } catch (URISyntaxException e) {
+            MiscUtils.getLogger().error("Invalid 'carlosBaseUrl' property configured for the eConsult SSO return URL", e);
+            return null;
+        }
     }
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EConsult2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EConsult2Action.java
@@ -38,7 +38,6 @@ import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
-import java.util.Locale;
 import java.util.regex.Pattern;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -220,12 +219,16 @@ public class EConsult2Action extends ActionSupport {
         try {
             URI uri = new URI(configuredBaseUrl.trim());
 
-            String scheme = uri.getScheme();
-            if (scheme == null) {
-                return null;
-            }
-            scheme = scheme.toLowerCase(Locale.ROOT);
-            if (!"http".equals(scheme) && !"https".equals(scheme)) {
+            // URI schemes are ASCII and case-insensitive (RFC 3986). Match with the
+            // locale-independent equalsIgnoreCase and emit a literal lowercase scheme rather
+            // than case-folding the input, which is sensitive to locale/Unicode mappings.
+            String rawScheme = uri.getScheme();
+            String scheme;
+            if ("https".equalsIgnoreCase(rawScheme)) {
+                scheme = "https";
+            } else if ("http".equalsIgnoreCase(rawScheme)) {
+                scheme = "http";
+            } else {
                 return null;
             }
 
@@ -266,7 +269,10 @@ public class EConsult2Action extends ActionSupport {
                 }
             }
 
-            if (host.isEmpty()) {
+            // Reject a malformed authority (e.g. extra ':') that would otherwise yield an
+            // origin with a colon in the host part. Bracketed IPv6 hosts never reach this
+            // fallback because URI#getHost() resolves them.
+            if (host.isEmpty() || host.indexOf(':') >= 0) {
                 return null;
             }
 

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EConsult2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EConsult2Action.java
@@ -169,7 +169,7 @@ public class EConsult2Action extends ActionSupport {
 
         try {
             stringBuilder.append(String.format("?%1$s=%2$s", "oscarReturnURL", URLEncoder.encode(oscarReturnUrl, StandardCharsets.UTF_8.toString())));
-            stringBuilder.append(String.format("?%1$s=%2$s", "loginStart", new Date().getTime() / 1000));
+            stringBuilder.append(String.format("&%1$s=%2$s", "loginStart", new Date().getTime() / 1000));
             response.sendRedirect(stringBuilder.toString());
         } catch (IOException e) {
             MiscUtils.getLogger().error("There was a problem with the redirect of " + stringBuilder.toString(), e);

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EConsult2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EConsult2Action.java
@@ -267,12 +267,16 @@ public class EConsult2Action extends ActionSupport {
                     host = authority;
                     port = -1;
                 }
+                // The fallback host was split out of a non-RFC2396 authority by hand; reject a
+                // leftover ':' from a malformed multi-colon authority (e.g. host:8080:9090).
+                // This check stays inside the fallback so bracketed IPv6 hosts resolved by
+                // URI#getHost() (which legitimately contain ':') are not rejected.
+                if (host.indexOf(':') >= 0) {
+                    return null;
+                }
             }
 
-            // Reject a malformed authority (e.g. extra ':') that would otherwise yield an
-            // origin with a colon in the host part. Bracketed IPv6 hosts never reach this
-            // fallback because URI#getHost() resolves them.
-            if (host.isEmpty() || host.indexOf(':') >= 0) {
+            if (host.isEmpty()) {
                 return null;
             }
 

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EConsult2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EConsult2Action.java
@@ -38,6 +38,7 @@ import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
+import java.util.Locale;
 import java.util.regex.Pattern;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -223,7 +224,7 @@ public class EConsult2Action extends ActionSupport {
             if (scheme == null) {
                 return null;
             }
-            scheme = scheme.toLowerCase();
+            scheme = scheme.toLowerCase(Locale.ROOT);
             if (!"http".equals(scheme) && !"https".equals(scheme)) {
                 return null;
             }
@@ -255,9 +256,8 @@ public class EConsult2Action extends ActionSupport {
                 int portSeparator = authority.lastIndexOf(':');
                 if (portSeparator >= 0) {
                     host = authority.substring(0, portSeparator);
-                    try {
-                        port = Integer.parseInt(authority.substring(portSeparator + 1));
-                    } catch (NumberFormatException e) {
+                    port = parsePort(authority.substring(portSeparator + 1));
+                    if (port == -1) {
                         return null;
                     }
                 } else {
@@ -279,6 +279,34 @@ public class EConsult2Action extends ActionSupport {
         } catch (URISyntaxException e) {
             MiscUtils.getLogger().error("Invalid 'carlosBaseUrl' property configured for the eConsult SSO return URL", e);
             return null;
+        }
+    }
+
+    /**
+     * Parses a URI authority port component, accepting only a non-empty run of ASCII digits
+     * within the valid 0-65535 range. Returns {@code -1} for anything else (empty, signed,
+     * non-numeric, or out of range) so the caller can fail closed. The explicit digit check
+     * is required because {@code Integer.parseInt} alone would tolerate a leading
+     * {@code +}/{@code -} sign and so accept a malformed port.
+     *
+     * @param portValue the raw port text following the authority's {@code ':'} separator
+     * @return the parsed port, or {@code -1} when the value is not a valid port
+     */
+    private static int parsePort(String portValue) {
+        if (portValue.isEmpty()) {
+            return -1;
+        }
+        for (int i = 0; i < portValue.length(); i++) {
+            char c = portValue.charAt(i);
+            if (c < '0' || c > '9') {
+                return -1;
+            }
+        }
+        try {
+            int port = Integer.parseInt(portValue);
+            return (port >= 0 && port <= 65535) ? port : -1;
+        } catch (NumberFormatException e) {
+            return -1;
         }
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EConsult2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EConsult2Action.java
@@ -316,6 +316,13 @@ public class EConsult2Action extends ActionSupport {
                 return null;
             }
 
+            // URI#getHost()'s companion getPort() does not range-check, so reject an
+            // out-of-range port (e.g. :99999) to keep the fail-closed contract consistent
+            // with the underscore-host fallback. -1 means "no port".
+            if (port != -1 && (port < 0 || port > 65535)) {
+                return null;
+            }
+
             StringBuilder origin = new StringBuilder(scheme).append("://").append(host);
             if (port != -1) {
                 origin.append(':').append(port);

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EConsult2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EConsult2Action.java
@@ -38,6 +38,7 @@ import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -69,6 +70,10 @@ public class EConsult2Action extends ActionSupport {
     // Fixed eConsult SSO return endpoint on this CARLOS instance.
     private static final String ECONSULT_SSO_LOGIN_PATH = "econsultSSOLogin";
 
+    // Emit the "eConsult configured but carlosBaseUrl missing" warning at most once per JVM
+    // (this Struts action is instantiated per request, so an instance flag would spam logs).
+    private static final AtomicBoolean ECONSULT_BASE_URL_WARNING_EMITTED = new AtomicBoolean(false);
+
     private final CarlosProperties oscarProperties = CarlosProperties.getInstance();
     private final String frontendEconsultUrl = oscarProperties.getProperty("frontendEconsultUrl");
     private final String backendEconsultUrl = oscarProperties.getProperty("backendEconsultUrl");
@@ -81,6 +86,8 @@ public class EConsult2Action extends ActionSupport {
         if (!securityInfoManager.hasPrivilege(loggedInInfo, "_con", "w", null)) {
             throw new SecurityException("missing required sec object (_con)");
         }
+
+        warnIfEconsultBaseUrlMissing();
 
         if ("login".equals(request.getParameter("method"))) {
             return login();
@@ -175,6 +182,35 @@ public class EConsult2Action extends ActionSupport {
         }
 
         return null;
+    }
+
+    /**
+     * Logs a one-time warning when eConsult is configured (a backend eConsult URL is set) but
+     * the trusted {@code carlosBaseUrl} is missing/blank, so an operator discovers the new
+     * requirement from the logs rather than only when a user's SSO login fails closed.
+     */
+    private void warnIfEconsultBaseUrlMissing() {
+        if (econsultBaseUrlMisconfigured(backendEconsultUrl, carlosBaseUrl)
+                && ECONSULT_BASE_URL_WARNING_EMITTED.compareAndSet(false, true)) {
+            MiscUtils.getLogger().warn("eConsult is configured (backendEconsultUrl set) but 'carlosBaseUrl' is missing or blank; "
+                    + "eConsult SSO login will fail closed until carlosBaseUrl is set to this instance's public base URL (scheme://host[:port]).");
+        }
+    }
+
+    /**
+     * Returns whether eConsult is in use (a backend eConsult URL is configured) while no
+     * trusted public base URL is configured for building the SSO return URL.
+     *
+     * @param backendEconsultUrl the configured {@code backendEconsultUrl} property value
+     * @param carlosBaseUrl      the configured {@code carlosBaseUrl} property value
+     * @return {@code true} when eConsult is configured but {@code carlosBaseUrl} is missing or blank
+     */
+    static boolean econsultBaseUrlMisconfigured(String backendEconsultUrl, String carlosBaseUrl) {
+        return !isBlank(backendEconsultUrl) && isBlank(carlosBaseUrl);
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.trim().isEmpty();
     }
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EConsult2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EConsult2Action.java
@@ -218,26 +218,61 @@ public class EConsult2Action extends ActionSupport {
 
         try {
             URI uri = new URI(configuredBaseUrl.trim());
-            String scheme = uri.getScheme();
-            String host = uri.getHost();
 
-            if (scheme == null || host == null || host.isEmpty()) {
+            String scheme = uri.getScheme();
+            if (scheme == null) {
                 return null;
             }
-
             scheme = scheme.toLowerCase();
             if (!"http".equals(scheme) && !"https".equals(scheme)) {
                 return null;
             }
 
-            // The base must be a bare origin: reject embedded credentials, query, or fragment.
-            if (uri.getUserInfo() != null || uri.getQuery() != null || uri.getFragment() != null) {
+            // The base must be a bare origin: reject query or fragment.
+            if (uri.getQuery() != null || uri.getFragment() != null) {
+                return null;
+            }
+
+            String authority = uri.getAuthority();
+            if (authority == null || authority.isEmpty()) {
+                return null;
+            }
+            // Reject embedded credentials. Checked on the authority directly because
+            // URI#getUserInfo() returns null when the host is not RFC 2396-compliant
+            // (e.g. contains an underscore), which would otherwise slip credentials through.
+            if (authority.indexOf('@') >= 0) {
+                return null;
+            }
+
+            String host = uri.getHost();
+            int port = uri.getPort();
+
+            // URI#getHost() returns null when the host contains characters that are invalid
+            // per RFC 2396 (e.g. an underscore, common in internal/dev hostnames). Fall back
+            // to the authority so such a configured base is still accepted; credentials were
+            // already rejected above.
+            if (host == null) {
+                int portSeparator = authority.lastIndexOf(':');
+                if (portSeparator >= 0) {
+                    host = authority.substring(0, portSeparator);
+                    try {
+                        port = Integer.parseInt(authority.substring(portSeparator + 1));
+                    } catch (NumberFormatException e) {
+                        return null;
+                    }
+                } else {
+                    host = authority;
+                    port = -1;
+                }
+            }
+
+            if (host.isEmpty()) {
                 return null;
             }
 
             StringBuilder origin = new StringBuilder(scheme).append("://").append(host);
-            if (uri.getPort() != -1) {
-                origin.append(':').append(uri.getPort());
+            if (port != -1) {
+                origin.append(':').append(port);
             }
 
             return origin.toString();

--- a/src/main/resources/carlos.properties
+++ b/src/main/resources/carlos.properties
@@ -1292,6 +1292,12 @@ hide_ConReport_link=true
 # To hide/unhide eConsult link in top navigation bar
 hide_eConsult_link=true
 
+# Public-facing base URL (scheme://host[:port]) of this CARLOS instance, e.g.
+# https://emr.example.com . Used to build the eConsult SSO return URL from a trusted
+# value instead of the client-supplied request Host header. Must be set for the
+# eConsult SSO login flow to work; if unset/invalid, eConsult SSO login fails closed.
+#carlosBaseUrl=https://emr.example.com
+
 log.purge.minDays=7
 log.purge.mysqldump=/usr/bin/mysqldump
 

--- a/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EConsult2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EConsult2ActionUnitTest.java
@@ -143,5 +143,12 @@ class EConsult2ActionUnitTest extends CarlosUnitTestBase {
     @DisplayName("Accepts an uppercase scheme regardless of default locale")
     void shouldBuildReturnUrl_withUppercaseScheme() {
         assertThat(EConsult2Action.buildSsoReturnUrl("HTTPS://emr.example.com", "/carlos")).isEqualTo("https://emr.example.com/carlos/econsultSSOLogin");
+        assertThat(EConsult2Action.buildSsoReturnUrl("HtTp://emr.example.com", "/carlos")).isEqualTo("http://emr.example.com/carlos/econsultSSOLogin");
+    }
+
+    @Test
+    @DisplayName("Rejects a malformed multi-colon authority on an underscore hostname")
+    void shouldFailClosed_whenUnderscoreHostnameAuthorityHasExtraColon() {
+        assertThat(EConsult2Action.buildSsoReturnUrl("https://emr_dev.example.com:8080:9090", "/carlos")).isNull();
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EConsult2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EConsult2ActionUnitTest.java
@@ -158,4 +158,20 @@ class EConsult2ActionUnitTest extends CarlosUnitTestBase {
         assertThat(EConsult2Action.buildSsoReturnUrl("https://[::1]", "/carlos")).isEqualTo("https://[::1]/carlos/econsultSSOLogin");
         assertThat(EConsult2Action.buildSsoReturnUrl("https://[2001:db8::1]:9443", "/carlos")).isEqualTo("https://[2001:db8::1]:9443/carlos/econsultSSOLogin");
     }
+
+    @Test
+    @DisplayName("Flags misconfiguration when eConsult is set but the base URL is missing")
+    void shouldReportMisconfigured_whenEconsultConfiguredWithoutBaseUrl() {
+        assertThat(EConsult2Action.econsultBaseUrlMisconfigured("https://econsult.example.com", null)).isTrue();
+        assertThat(EConsult2Action.econsultBaseUrlMisconfigured("https://econsult.example.com", "")).isTrue();
+        assertThat(EConsult2Action.econsultBaseUrlMisconfigured("https://econsult.example.com", "   ")).isTrue();
+    }
+
+    @Test
+    @DisplayName("Does not flag misconfiguration when the base URL is set or eConsult is unused")
+    void shouldNotReportMisconfigured_whenBaseUrlPresentOrEconsultUnused() {
+        assertThat(EConsult2Action.econsultBaseUrlMisconfigured("https://econsult.example.com", "https://emr.example.com")).isFalse();
+        assertThat(EConsult2Action.econsultBaseUrlMisconfigured(null, null)).isFalse();
+        assertThat(EConsult2Action.econsultBaseUrlMisconfigured("", "")).isFalse();
+    }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EConsult2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EConsult2ActionUnitTest.java
@@ -151,4 +151,11 @@ class EConsult2ActionUnitTest extends CarlosUnitTestBase {
     void shouldFailClosed_whenUnderscoreHostnameAuthorityHasExtraColon() {
         assertThat(EConsult2Action.buildSsoReturnUrl("https://emr_dev.example.com:8080:9090", "/carlos")).isNull();
     }
+
+    @Test
+    @DisplayName("Accepts a bracketed IPv6 configured base")
+    void shouldBuildReturnUrl_withIpv6Host() {
+        assertThat(EConsult2Action.buildSsoReturnUrl("https://[::1]", "/carlos")).isEqualTo("https://[::1]/carlos/econsultSSOLogin");
+        assertThat(EConsult2Action.buildSsoReturnUrl("https://[2001:db8::1]:9443", "/carlos")).isEqualTo("https://[2001:db8::1]:9443/carlos/econsultSSOLogin");
+    }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EConsult2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EConsult2ActionUnitTest.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2026 CARLOS EMR Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.encounter.oscarConsultationRequest.pageUtil;
+
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link EConsult2Action}'s eConsult SSO return URL construction.
+ *
+ * <p>Covers the fix for issue #3018: the SSO {@code oscarReturnURL} must be built from
+ * the trusted, configured {@code carlosBaseUrl} rather than from the client-controlled
+ * request Host header.
+ *
+ * @since 2026-06-24
+ */
+@DisplayName("EConsult2Action Unit Tests")
+@Tag("unit")
+@Tag("consultation")
+class EConsult2ActionUnitTest extends CarlosUnitTestBase {
+
+    @Test
+    @DisplayName("Builds the return URL from the configured base, not the request Host")
+    void shouldBuildReturnUrl_withConfiguredBaseAndContextPath() {
+        String returnUrl = EConsult2Action.buildSsoReturnUrl("https://emr.example.com", "/carlos");
+
+        assertThat(returnUrl).isEqualTo("https://emr.example.com/carlos/econsultSSOLogin");
+    }
+
+    @Test
+    @DisplayName("Keeps an explicit port from the configured base")
+    void shouldBuildReturnUrl_withConfiguredPort() {
+        String returnUrl = EConsult2Action.buildSsoReturnUrl("https://emr.example.com:8443", "/carlos");
+
+        assertThat(returnUrl).isEqualTo("https://emr.example.com:8443/carlos/econsultSSOLogin");
+    }
+
+    @Test
+    @DisplayName("Supports the root context (empty context path)")
+    void shouldBuildReturnUrl_withRootContext() {
+        assertThat(EConsult2Action.buildSsoReturnUrl("https://emr.example.com", "")).isEqualTo("https://emr.example.com/econsultSSOLogin");
+        assertThat(EConsult2Action.buildSsoReturnUrl("https://emr.example.com", null)).isEqualTo("https://emr.example.com/econsultSSOLogin");
+    }
+
+    @Test
+    @DisplayName("Ignores any path on the configured base and uses the server context path")
+    void shouldBuildReturnUrl_whenConfiguredBaseHasTrailingPath() {
+        String returnUrl = EConsult2Action.buildSsoReturnUrl("https://emr.example.com/ignored", "/carlos");
+
+        assertThat(returnUrl).isEqualTo("https://emr.example.com/carlos/econsultSSOLogin");
+    }
+
+    @Test
+    @DisplayName("Return URL host never reflects the request context path argument")
+    void shouldBuildReturnUrl_withoutLeakingSpoofedHostFromContextPath() {
+        // Even if a hostile-looking value reaches the context-path argument, the origin is
+        // fixed by the configured base; the value can only ever land in the path component.
+        String returnUrl = EConsult2Action.buildSsoReturnUrl("https://emr.example.com", "/attacker.example.org");
+
+        assertThat(returnUrl).startsWith("https://emr.example.com/");
+        assertThat(returnUrl).isEqualTo("https://emr.example.com/attacker.example.org/econsultSSOLogin");
+    }
+
+    @Test
+    @DisplayName("Fails closed when no base URL is configured")
+    void shouldFailClosed_whenBaseUrlMissing() {
+        assertThat(EConsult2Action.buildSsoReturnUrl(null, "/carlos")).isNull();
+        assertThat(EConsult2Action.buildSsoReturnUrl("", "/carlos")).isNull();
+        assertThat(EConsult2Action.buildSsoReturnUrl("   ", "/carlos")).isNull();
+    }
+
+    @Test
+    @DisplayName("Rejects a configured base with a non-http(s) scheme")
+    void shouldFailClosed_whenBaseUrlSchemeNotHttp() {
+        assertThat(EConsult2Action.buildSsoReturnUrl("ftp://emr.example.com", "/carlos")).isNull();
+        assertThat(EConsult2Action.buildSsoReturnUrl("javascript:alert(1)", "/carlos")).isNull();
+    }
+
+    @Test
+    @DisplayName("Rejects a configured base with no host")
+    void shouldFailClosed_whenBaseUrlHasNoHost() {
+        assertThat(EConsult2Action.buildSsoReturnUrl("https:///econsultSSOLogin", "/carlos")).isNull();
+        assertThat(EConsult2Action.buildSsoReturnUrl("not a url", "/carlos")).isNull();
+    }
+
+    @Test
+    @DisplayName("Rejects a configured base carrying credentials, query, or fragment")
+    void shouldFailClosed_whenBaseUrlIsNotABareOrigin() {
+        assertThat(EConsult2Action.buildSsoReturnUrl("https://user:pass@emr.example.com", "/carlos")).isNull();
+        assertThat(EConsult2Action.buildSsoReturnUrl("https://emr.example.com?x=1", "/carlos")).isNull();
+        assertThat(EConsult2Action.buildSsoReturnUrl("https://emr.example.com#frag", "/carlos")).isNull();
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EConsult2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EConsult2ActionUnitTest.java
@@ -59,6 +59,14 @@ class EConsult2ActionUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
+    @DisplayName("Rejects an out-of-range port on a normal hostname")
+    void shouldFailClosed_whenConfiguredPortOutOfRange() {
+        // java.net.URI#getPort() does not range-check, so the validator must.
+        assertThat(EConsult2Action.buildSsoReturnUrl("https://emr.example.com:99999", "/carlos")).isNull();
+        assertThat(EConsult2Action.buildSsoReturnUrl("https://emr.example.com:70000", "/carlos")).isNull();
+    }
+
+    @Test
     @DisplayName("Supports the root context (empty context path)")
     void shouldBuildReturnUrl_withRootContext() {
         assertThat(EConsult2Action.buildSsoReturnUrl("https://emr.example.com", "")).isEqualTo("https://emr.example.com/econsultSSOLogin");

--- a/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EConsult2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EConsult2ActionUnitTest.java
@@ -113,4 +113,19 @@ class EConsult2ActionUnitTest extends CarlosUnitTestBase {
         assertThat(EConsult2Action.buildSsoReturnUrl("https://emr.example.com?x=1", "/carlos")).isNull();
         assertThat(EConsult2Action.buildSsoReturnUrl("https://emr.example.com#frag", "/carlos")).isNull();
     }
+
+    @Test
+    @DisplayName("Accepts an internal hostname containing an underscore")
+    void shouldBuildReturnUrl_withUnderscoreHostname() {
+        assertThat(EConsult2Action.buildSsoReturnUrl("https://emr_dev.example.com", "/carlos")).isEqualTo("https://emr_dev.example.com/carlos/econsultSSOLogin");
+        assertThat(EConsult2Action.buildSsoReturnUrl("https://emr_dev.example.com:8443", "/carlos")).isEqualTo("https://emr_dev.example.com:8443/carlos/econsultSSOLogin");
+    }
+
+    @Test
+    @DisplayName("Still rejects credentials and bad ports on an underscore hostname")
+    void shouldFailClosed_whenUnderscoreHostnameIsUnsafe() {
+        assertThat(EConsult2Action.buildSsoReturnUrl("https://user:pass@emr_dev.example.com", "/carlos")).isNull();
+        assertThat(EConsult2Action.buildSsoReturnUrl("https://emr_dev.example.com:notaport", "/carlos")).isNull();
+        assertThat(EConsult2Action.buildSsoReturnUrl("https://emr_dev.example.com?x=1", "/carlos")).isNull();
+    }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EConsult2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EConsult2ActionUnitTest.java
@@ -128,4 +128,20 @@ class EConsult2ActionUnitTest extends CarlosUnitTestBase {
         assertThat(EConsult2Action.buildSsoReturnUrl("https://emr_dev.example.com:notaport", "/carlos")).isNull();
         assertThat(EConsult2Action.buildSsoReturnUrl("https://emr_dev.example.com?x=1", "/carlos")).isNull();
     }
+
+    @Test
+    @DisplayName("Rejects signed, empty, or out-of-range fallback ports")
+    void shouldFailClosed_whenUnderscoreHostnamePortIsMalformed() {
+        // Integer.parseInt would tolerate the leading sign; the validator must not.
+        assertThat(EConsult2Action.buildSsoReturnUrl("https://emr_dev.example.com:-443", "/carlos")).isNull();
+        assertThat(EConsult2Action.buildSsoReturnUrl("https://emr_dev.example.com:+443", "/carlos")).isNull();
+        assertThat(EConsult2Action.buildSsoReturnUrl("https://emr_dev.example.com:", "/carlos")).isNull();
+        assertThat(EConsult2Action.buildSsoReturnUrl("https://emr_dev.example.com:99999", "/carlos")).isNull();
+    }
+
+    @Test
+    @DisplayName("Accepts an uppercase scheme regardless of default locale")
+    void shouldBuildReturnUrl_withUppercaseScheme() {
+        assertThat(EConsult2Action.buildSsoReturnUrl("HTTPS://emr.example.com", "/carlos")).isEqualTo("https://emr.example.com/carlos/econsultSSOLogin");
+    }
 }


### PR DESCRIPTION
fixes #3018

## Summary

`EConsult2Action.login()` built the `oscarReturnURL` handed to the eConsult SSO endpoint from `request.getRequestURL()`, whose scheme/host/port reflect the client-supplied `Host` / `X-Forwarded-Host` headers. An attacker who can spoof those headers could make the post-login return URL (and any token material the eConsult side reflects back to it) point at an attacker-controlled origin.

## Scope

- Stop deriving the SSO return URL's origin from the request Host.
- Add a trusted `carlosBaseUrl` property (public base URL of this CARLOS instance) and build the return URL from it + the server-derived context path + the fixed `/econsultSSOLogin` path.
- Validate the configured base as a bare `http(s)` origin (scheme + host + optional port; reject embedded credentials, query, fragment, non-http schemes, missing host).
- Fail closed when no valid base is configured: log and return the `error` result instead of falling back to the spoofable Host.
- Document the new property in `carlos.properties`.

## Changes

- `EConsult2Action.java`: `login()` now calls new package-private static `buildSsoReturnUrl(configuredBaseUrl, contextPath)`, backed by private static `normalizedConfiguredOrigin(...)` for origin validation. Reads new `carlosBaseUrl` property. The `_con` privilege check on the action entry point is unchanged.
- `carlos.properties`: documented, commented-out `carlosBaseUrl` entry near the eConsult settings.

## CARLOS conventions applied

- Privilege check (`_con`) preserved on the action entry point.
- No new forbidden suffixes; pure validation logic kept as private static methods (no new shared class).
- GPL header preserved unchanged; no `@author` tags added.
- This is a navigation/redirect action (not a mutating `*2Action`), so the GET/HEAD mutator contract is unaffected.

## Tests

Added `EConsult2ActionUnitTest` (9 cases, `@Tag("unit")`/`@Tag("consultation")`, extends `CarlosUnitTestBase`):

- Configured base accepted: builds `https://emr.example.com/carlos/econsultSSOLogin`; preserves explicit port; supports root/empty/null context; ignores any path on the configured base.
- Spoofed/unknown host can never reach the origin (only the path component).
- Fails closed when the base is missing/blank, non-http(s) scheme, has no host, or carries credentials/query/fragment.

Verified locally:

```
mvn -q -Dtest=EConsult2ActionUnitTest test
=> Tests run: 9, Failures: 0, Errors: 0, Skipped: 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Build the eConsult SSO return URL from a trusted `carlosBaseUrl` instead of the client Host to prevent spoofed redirects. Validation is tightened (incl. IPv6, underscore hosts, locale-safe scheme, and port range checks) and the `loginStart` delimiter is fixed.

- **Bug Fixes**
  - Build return URL from `carlosBaseUrl` + context path + `/econsultSSOLogin`.
  - Validate base as a bare http(s) origin: locale-safe scheme; strict 0–65535 port range on all hosts; accept underscore and bracketed IPv6; reject credentials, query, fragment, non-http, missing host, and malformed multi-colon authorities.
  - Append `loginStart` with `&` so both params parse correctly.
  - If base is missing/invalid, log and return an error (no fallback to request Host).
  - Emit a one-time WARN when eConsult is configured but `carlosBaseUrl` is unset.

- **Migration**
  - Set `carlosBaseUrl` in `carlos.properties` to the public base URL (scheme://host[:port]), e.g. `https://emr.example.com`, then redeploy/restart.

<sup>Written for commit 4a0bd40303cbf40147d9a550e22f3ce32ccccabd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3023?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

