### PR TITLE
feat: add Cortico/Juno integration config placeholders

### DIFF
--- a/docs/api/cortico-integration-config-placeholders.md
+++ b/docs/api/cortico-integration-config-placeholders.md
@@ -42,10 +42,14 @@ and separately tested. All keys default to empty.
 
 ## Related documentation
 
-For the full label-to-contract mapping these placeholders support, see the
-Cortico CARLOS API compatibility matrix:
-[`docs/api/cortico-carlos-compatibility.md`](./cortico-carlos-compatibility.md)
-(added by PR #2916). When that matrix references clinic-specific status codes,
-reminder note markers, default provider/location/appointment type, demographic
-search field, or default document type, the configurable values are the
-`integration.cortico.*` keys documented above.
+The placeholder-to-contract mapping is inlined in the table above, so this
+document is self-contained. For the full Cortico/Juno label-to-contract
+compatibility matrix, see `docs/api/cortico-carlos-compatibility.md`.
+
+> **Note:** `docs/api/cortico-carlos-compatibility.md` is added by PR #2916 and
+> is **not yet present on `develop`**. The path is intentionally not a link
+> until that PR merges, to avoid a broken (404) cross-reference. When the matrix
+> references clinic-specific status codes, reminder note markers, default
+> provider/location/appointment type, demographic search field, or default
+> document type, the configurable values are the `integration.cortico.*` keys
+> documented above.

--- a/docs/api/cortico-integration-config-placeholders.md
+++ b/docs/api/cortico-integration-config-placeholders.md
@@ -1,0 +1,51 @@
+---
+id: cortico-integration-config-placeholders
+title: Cortico/Juno Integration Config Placeholders
+---
+
+# Cortico/Juno Integration Config Placeholders
+
+This document describes the clinic-specific configuration placeholders reserved
+for future Cortico/Juno-style integration adapter workflows. The placeholder
+keys live in `src/main/resources/carlos.properties` under the
+`integration.cortico.*` namespace.
+
+These keys are **placeholders only**. No CARLOS code reads them yet, so
+populating them or leaving them blank does not change any existing appointment,
+demographic, provider, or document API behavior. Their purpose is to make future
+adapter work explicit and configurable instead of relying on hardcoded
+assumptions.
+
+Each value is clinic-specific and must be supplied **per environment** — in the
+per-environment override config, never in the committed default
+`carlos.properties` — before a future adapter that consumes the value is wired
+and separately tested. All keys default to empty.
+
+> **Do not commit** clinic-specific identifiers, status codes, provider/location
+> numbers, OAuth/SOAP credentials, or any PHI into `carlos.properties`. Supply
+> real values only in the per-environment override config.
+
+## Placeholder keys
+
+| Config key | Meaning | Required for future adapter? | Safe default |
+| --- | --- | --- | --- |
+| `integration.cortico.appointment.status.confirmed` | Status code written for a confirmed appointment via `ScheduleService.updateAppointment`. | Yes, for `confirm_appointment`. | Empty (no default assumed). |
+| `integration.cortico.appointment.status.cancelled` | Status code written for a cancelled appointment. Commonly `C`. | Yes, for `cancel_appointment`. | Empty (no default assumed). |
+| `integration.cortico.appointment.status.arrived` | Status code written for an arrived/here appointment. Commonly `H`. | Yes, for `here_appointment`. | Empty (no default assumed). |
+| `integration.cortico.appointment.reminder.email_note_marker` | Marker text appended to `AppointmentTransfer.notes` when a reminder email is sent. Appended, not replaced. | Yes, for `reminder_email_sent_appointment`. | Empty (no marker appended). |
+| `integration.cortico.appointment.reminder.sms_note_marker` | Marker text appended to `AppointmentTransfer.notes` when a reminder SMS is sent. Appended, not replaced. | Yes, for `reminder_sms_sent_appointment`. | Empty (no marker appended). |
+| `integration.cortico.default_location` | Default location/clinic identifier when the inbound request omits one. | Optional. | Empty (no default assumed). |
+| `integration.cortico.default_provider` | Default provider number when the inbound request omits one. | Optional. | Empty (no default assumed). |
+| `integration.cortico.default_appointment_type` | Default appointment type when the inbound request omits one. | Optional. | Empty (no default assumed). |
+| `integration.cortico.demographic.search.phn_field` | Demographic search field carrying the PHN/HIN for `searchDemographicsByAttributes` (the native field is `hin`). | Optional. | Empty (adapter decides explicitly). |
+| `integration.cortico.document.default_type` | Default document type for adapter document-upload workflows. | Optional. | Empty (no default assumed). |
+
+## Related documentation
+
+For the full label-to-contract mapping these placeholders support, see the
+Cortico CARLOS API compatibility matrix:
+[`docs/api/cortico-carlos-compatibility.md`](./cortico-carlos-compatibility.md)
+(added by PR #2916). When that matrix references clinic-specific status codes,
+reminder note markers, default provider/location/appointment type, demographic
+search field, or default document type, the configurable values are the
+`integration.cortico.*` keys documented above.

--- a/src/main/resources/carlos.properties
+++ b/src/main/resources/carlos.properties
@@ -1454,3 +1454,63 @@ response.sanitization.enabled=true
 # Default: false (property absent — isPropertyActive returns false)
 #
 # DISPLAY_ERROR=false
+
+# ==============================================================================
+# CORTICO/JUNO INTEGRATION PLACEHOLDERS
+# ==============================================================================
+#
+# These keys reserve clinic-specific configuration for future Cortico/Juno-style
+# integration adapter workflows. They are PLACEHOLDERS ONLY: no CARLOS code reads
+# them yet, so populating or leaving them blank changes no existing behavior.
+# Each value is clinic-specific and MUST be supplied per environment before a
+# future adapter that consumes it is wired and separately tested.
+#
+# All keys default to EMPTY. Do not commit clinic-specific identifiers, status
+# codes, provider/location numbers, or any PHI into this file — supply real
+# values only in the per-environment override config.
+#
+# See docs/api/cortico-integration-config-placeholders.md for per-key meaning,
+# required-ness, and safe defaults. That doc links to the compatibility matrix
+# (docs/api/cortico-carlos-compatibility.md, added by PR #2916) describing the
+# native CARLOS/OSCAR contracts these placeholders map onto.
+
+# Appointment status code written for a confirmed appointment
+# (ScheduleService.updateAppointment). Clinic-specific; commonly empty until set.
+integration.cortico.appointment.status.confirmed=
+
+# Appointment status code written for a cancelled appointment
+# (ScheduleService.updateAppointment). Commonly "C" in OSCAR deployments.
+integration.cortico.appointment.status.cancelled=
+
+# Appointment status code written for an arrived/here appointment
+# (ScheduleService.updateAppointment). Commonly "H" in OSCAR deployments.
+integration.cortico.appointment.status.arrived=
+
+# Marker text appended to AppointmentTransfer.notes when a reminder email has
+# been sent. Existing notes must be preserved; the marker is appended, not replaced.
+integration.cortico.appointment.reminder.email_note_marker=
+
+# Marker text appended to AppointmentTransfer.notes when a reminder SMS has
+# been sent. Existing notes must be preserved; the marker is appended, not replaced.
+integration.cortico.appointment.reminder.sms_note_marker=
+
+# Default location/clinic identifier for adapter workflows that must supply one
+# when the inbound request omits it. Empty means no default is assumed.
+integration.cortico.default_location=
+
+# Default provider number for adapter workflows that must supply one when the
+# inbound request omits it. Empty means no default is assumed.
+integration.cortico.default_provider=
+
+# Default appointment type for adapter workflows that must supply one when the
+# inbound request omits it. Empty means no default is assumed.
+integration.cortico.default_appointment_type=
+
+# Demographic search field that carries the PHN/HIN for attribute searches
+# (DemographicService.searchDemographicsByAttributes uses the "hin" field).
+# Empty means the adapter must decide the search field explicitly.
+integration.cortico.demographic.search.phn_field=
+
+# Default document type for adapter document-upload workflows
+# (DocumentService.saveDocumentToDemographic). Empty means no default is assumed.
+integration.cortico.document.default_type=

--- a/src/test/java/io/github/carlos_emr/carlos/config/CorticoIntegrationConfigPlaceholdersTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/config/CorticoIntegrationConfigPlaceholdersTest.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Properties;
+
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guards the Cortico/Juno integration configuration placeholders in
+ * {@code carlos.properties}.
+ *
+ * <p>The keys are placeholders for future adapter workflows: no CARLOS code
+ * reads them yet. This test pins two invariants the placeholders depend on:
+ * the keys are declared (so future adapter work has a documented home), and
+ * every key defaults to empty (so no clinic-specific value or PHI is committed
+ * into the default config and existing behavior stays unchanged).</p>
+ *
+ * @since 2026-06-25
+ */
+@DisplayName("Cortico integration config placeholders")
+@Tag("unit")
+@Tag("read")
+class CorticoIntegrationConfigPlaceholdersTest extends CarlosUnitTestBase {
+
+    /**
+     * Classpath resource name for the runtime defaults properties.
+     * Loaded via the test's ClassLoader rather than a filesystem path to
+     * keep this test independent of the working directory and build layout.
+     */
+    private static final String CARLOS_PROPERTIES_RESOURCE = "carlos.properties";
+
+    private static final List<String> CORTICO_PLACEHOLDER_KEYS = List.of(
+            "integration.cortico.appointment.status.confirmed",
+            "integration.cortico.appointment.status.cancelled",
+            "integration.cortico.appointment.status.arrived",
+            "integration.cortico.appointment.reminder.email_note_marker",
+            "integration.cortico.appointment.reminder.sms_note_marker",
+            "integration.cortico.default_location",
+            "integration.cortico.default_provider",
+            "integration.cortico.default_appointment_type",
+            "integration.cortico.demographic.search.phn_field",
+            "integration.cortico.document.default_type");
+
+    @Test
+    @DisplayName("should declare Cortico integration placeholder keys in carlos properties")
+    void shouldDeclareCorticoPlaceholderKeys_inCarlosProperties() throws IOException {
+        String content = readCarlosPropertiesContent();
+        Properties properties = loadCarlosProperties();
+
+        assertThat(content).contains("# CORTICO/JUNO INTEGRATION PLACEHOLDERS");
+        assertThat(properties.stringPropertyNames()).containsAll(CORTICO_PLACEHOLDER_KEYS);
+    }
+
+    @Test
+    @DisplayName("should default every Cortico placeholder to empty so no clinic value or PHI ships")
+    void shouldDefaultEveryCorticoPlaceholderToEmpty_forSafeDefaults() throws IOException {
+        Properties properties = loadCarlosProperties();
+
+        assertThat(CORTICO_PLACEHOLDER_KEYS)
+                .allSatisfy(key -> assertThat(properties.getProperty(key))
+                        .as("placeholder %s must default to empty", key)
+                        .isEmpty());
+    }
+
+    private String readCarlosPropertiesContent() throws IOException {
+        try (InputStream inputStream = openCarlosProperties()) {
+            return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    private Properties loadCarlosProperties() throws IOException {
+        Properties properties = new Properties();
+        try (Reader reader = new InputStreamReader(openCarlosProperties(), StandardCharsets.UTF_8)) {
+            properties.load(reader);
+        }
+        return properties;
+    }
+
+    private InputStream openCarlosProperties() {
+        InputStream inputStream = Thread.currentThread()
+                .getContextClassLoader()
+                .getResourceAsStream(CARLOS_PROPERTIES_RESOURCE);
+        if (inputStream == null) {
+            throw new IllegalStateException("Missing classpath resource: " + CARLOS_PROPERTIES_RESOURCE);
+        }
+        return inputStream;
+    }
+}


### PR DESCRIPTION
fixes #3033

## Scope

- Add documented placeholder config keys under the `integration.cortico.*` namespace in `src/main/resources/carlos.properties` for future Cortico/Juno-style integration adapter workflows.
- Cover appointment confirmed/cancelled/arrived statuses, email/SMS reminder note markers, and default provider/location/appointment type/document type/demographic search field.
- Keep all defaults **empty** — no CARLOS code reads them yet, so existing appointment, demographic, provider, and document API behavior is unchanged.
- Document each key (meaning, required-ness, safe default) and link back to the Cortico compatibility matrix from PR #2916.

## Changes

- **`src/main/resources/carlos.properties`** — new, fully-commented `CORTICO/JUNO INTEGRATION PLACEHOLDERS` section with the 10 placeholder keys, all empty by default, each with an inline note of meaning and safe-default behavior plus a warning not to commit clinic-specific values or PHI.
- **`docs/api/cortico-integration-config-placeholders.md`** — new doc describing each key (meaning, required-ness, safe default) and linking to `docs/api/cortico-carlos-compatibility.md` (added by PR #2916). A dedicated doc was used because the compatibility matrix file does not yet exist on `develop`.
- **`CorticoIntegrationConfigPlaceholdersTest`** — unit test guarding that the keys are declared and that every key defaults to empty (so no clinic value or PHI ships in the default config).

### Out of scope (per ticket)

- No `.ws` alias routes, no Cortico adapter/proxy implementation, no behavior changes.

## Tests

- Added `src/test/java/io/github/carlos_emr/carlos/config/CorticoIntegrationConfigPlaceholdersTest.java` (`@Tag("unit")`, `@Tag("read")`), mirroring the existing `CarlosPropertiesRuntimeDefaultsTest` precedent:
  - `shouldDeclareCorticoPlaceholderKeys_inCarlosProperties` — all 10 keys present and section comment exists.
  - `shouldDefaultEveryCorticoPlaceholderToEmpty_forSafeDefaults` — every placeholder defaults to empty.
- Verified locally: `mvn test -Dtest=CorticoIntegrationConfigPlaceholdersTest` → `Tests run: 2, Failures: 0, Errors: 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add placeholder config keys under `integration.cortico.*` in `carlos.properties` for future Cortico/Juno adapter workflows. All keys default to empty, so behavior is unchanged; adds docs and a unit test to lock this in (maps to #3033).

- **New Features**
  - Add 10 placeholder keys in `src/main/resources/carlos.properties` (confirmed/cancelled/arrived statuses, reminder email/SMS note markers, defaults for provider, location, appointment type, document type, demographic PHN field).
  - Add `docs/api/cortico-integration-config-placeholders.md` explaining each key and referencing the Cortico compatibility matrix; de-links the path until PR #2916 merges to avoid a 404.
  - Add `CorticoIntegrationConfigPlaceholdersTest` to ensure all keys exist and default to empty (no clinic data or PHI in defaults).

<sup>Written for commit 9e0c533ff9653d205a612b4e04e99c69f5cc186d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3034?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

