### PR TITLE
fix: prevent SOAP getPrescription fault on null Drug.pastMed

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/webserv/transfer_objects/DrugTransfer.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/transfer_objects/DrugTransfer.java
@@ -563,7 +563,11 @@ public class DrugTransfer {
 
         DrugTransfer transfer = new DrugTransfer();
 
-        BeanUtils.copyProperties(drug, transfer);
+        // Drug.pastMed is a nullable Boolean (default null) while DrugTransfer.pastMed is a
+        // primitive boolean; copying it directly faults when unboxing null. Skip it here and set
+        // it via Drug.isPastMed(), which coalesces null to false.
+        BeanUtils.copyProperties(drug, transfer, "pastMed");
+        transfer.setPastMed(drug.isPastMed());
 
         return (transfer);
     }

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/transfer_objects/DrugTransferUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/transfer_objects/DrugTransferUnitTest.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2001-2002. Department of Family Medicine, McMaster University. All Rights Reserved.
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ * <p>
+ * This software was written for the
+ * Department of Family Medicine
+ * McMaster University
+ * Hamilton
+ * Ontario, Canada
+ *
+ * <p>
+ * Now maintained by the CARLOS EMR Project (2026+).
+ * https://github.com/carlos-emr/carlos
+ * CARLOS has no affiliation with OSCAR or McMaster University.
+ */
+package io.github.carlos_emr.carlos.webserv.transfer_objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.github.carlos_emr.carlos.commn.model.Drug;
+
+/**
+ * Unit tests for {@link DrugTransfer}.
+ *
+ * <p>Tests conversion from Drug domain model to DrugTransfer transfer object, with focus on the
+ * nullable {@code Drug.pastMed} Boolean to primitive {@code DrugTransfer.pastMed} boolean copy
+ * (see issue #2960).
+ */
+@Tag("unit")
+@DisplayName("DrugTransfer unit tests")
+class DrugTransferUnitTest {
+
+    @Test
+    @DisplayName("should not fault and default pastMed to false when Drug.pastMed is null")
+    void shouldConvertDrug_withNullPastMedToFalse() {
+        Drug drug = new Drug();
+        drug.setPastMed(null);
+
+        DrugTransfer transfer = DrugTransfer.toTransfer(drug);
+
+        assertThat(transfer).isNotNull();
+        assertThat(transfer.isPastMed()).isFalse();
+    }
+
+    @Test
+    @DisplayName("should copy pastMed true when Drug.pastMed is TRUE")
+    void shouldConvertDrug_withTruePastMed() {
+        Drug drug = new Drug();
+        drug.setPastMed(Boolean.TRUE);
+
+        DrugTransfer transfer = DrugTransfer.toTransfer(drug);
+
+        assertThat(transfer.isPastMed()).isTrue();
+    }
+
+    @Test
+    @DisplayName("should copy pastMed false when Drug.pastMed is FALSE")
+    void shouldConvertDrug_withFalsePastMed() {
+        Drug drug = new Drug();
+        drug.setPastMed(Boolean.FALSE);
+
+        DrugTransfer transfer = DrugTransfer.toTransfer(drug);
+
+        assertThat(transfer.isPastMed()).isFalse();
+    }
+
+    @Test
+    @DisplayName("should copy remaining scalar fields alongside the pastMed special-case")
+    void shouldConvertDrug_withOtherFieldsCopied() {
+        Drug drug = new Drug();
+        drug.setId(98765);
+        drug.setBrandName("testBrand");
+        drug.setPastMed(null);
+
+        DrugTransfer transfer = DrugTransfer.toTransfer(drug);
+
+        assertThat(transfer.getId()).isEqualTo(98765);
+        assertThat(transfer.getBrandName()).isEqualTo("testBrand");
+        assertThat(transfer.isPastMed()).isFalse();
+    }
+
+    @Test
+    @DisplayName("should return null when the source Drug is null")
+    void shouldConvertDrug_withNullSourceReturnsNull() {
+        assertThat(DrugTransfer.toTransfer(null)).isNull();
+    }
+}


### PR DESCRIPTION
fixes #2960

## Problem
`PrescriptionService.getPrescription` faulted (SOAP fault → HTTP 500) whenever a drug's `pastMed` was null. `DrugTransfer.toTransfer` used `BeanUtils.copyProperties(drug, transfer)`; `Drug.pastMed` is a nullable `Boolean` (default `null`) while `DrugTransfer.pastMed` is a primitive `boolean`, so the reflective primitive setter faulted unboxing null. Since `null` is the default, this was easily hit.

## Scope
- Fix `DrugTransfer.toTransfer` so a null `Drug.pastMed` no longer faults during conversion.
- Preserve the existing primitive-`boolean` WSDL contract (no `boolean` → nillable `Boolean` change).
- Keep existing semantics: null coalesces to `false` (matching `Drug.isPastMed()`).
- Add unit tests; no other behavior changed.

## Change
- `DrugTransfer.toTransfer`: exclude `pastMed` from `BeanUtils.copyProperties(...)` and set it explicitly via the null-safe `drug.isPastMed()` (returns `false` when the underlying `Boolean` is null). Verified `pastMed` is the only primitive `DrugTransfer` field mapped from a nullable `Boolean` in `Drug`; all sibling primitives (`noSubs`, `prn`, `archived`, `customInstructions`, `hideFromCpp`, `startDateUnknown`) are primitive in `Drug` too, so no other field has this latent fault.

## Tests
Added `DrugTransferUnitTest` (`@Tag("unit")`) covering:
- null `Drug.pastMed` → no fault, transfer `pastMed` is `false`
- `Boolean.TRUE` / `Boolean.FALSE` copied through correctly
- other scalar fields (`id`, `brandName`) still copied alongside the special-case
- null source `Drug` → returns null

Verified locally: `mvn -Dtest=DrugTransferUnitTest test` → Tests run: 5, Failures: 0, Errors: 0. Test compilation of the module succeeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Handle nullable pastMed correctly when converting Drug to DrugTransfer to prevent SOAP faults.

Bug Fixes:
- Prevent SOAP getPrescription faults caused by null Drug.pastMed when copying to primitive DrugTransfer.pastMed.

Tests:
- Add DrugTransferUnitTest to verify null-safe pastMed mapping, correct TRUE/FALSE propagation, scalar field copying, and null source handling.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents SOAP 500s in `PrescriptionService.getPrescription` when a drug’s `pastMed` is null (fixes #2960). Keeps the primitive `boolean` WSDL contract and treats null as false.

- **Bug Fixes**
  - In `DrugTransfer.toTransfer`, skip `pastMed` in `BeanUtils.copyProperties(...)` and set it via `drug.isPastMed()` to avoid unboxing null.
  - Add `DrugTransferUnitTest` covering null/true/false `pastMed`, other field copy, and the null-source case.

<sup>Written for commit ec031baddd598ae39c106ac2e067d0d3503b1316. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3036?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

