### PR TITLE
fix: deny access through inactive security roles (activeyn != 1)

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/SecUserRoleDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/PMmodule/dao/SecUserRoleDaoImpl.java
@@ -108,7 +108,8 @@ public class SecUserRoleDaoImpl extends AbstractJpaDao implements SecUserRoleDao
             throw new IllegalArgumentException();
         }
 
-        String sSQL = "from Secuserrole s where s.providerNo = ?1 and s.roleName = 'admin'";
+        // An inactive admin assignment (activeyn = 0 or legacy NULL) must not grant admin access.
+        String sSQL = "from Secuserrole s where s.providerNo = ?1 and s.roleName = 'admin' and s.activeyn = 1";
         @SuppressWarnings("unchecked")
         List<Secuserrole> entities = (List<Secuserrole>) JpqlQueryHelper.find(entityManager(), sSQL, providerNo);
         boolean result = !entities.isEmpty();

--- a/src/main/java/io/github/carlos_emr/carlos/daos/security/SecuserroleDao.java
+++ b/src/main/java/io/github/carlos_emr/carlos/daos/security/SecuserroleDao.java
@@ -77,6 +77,8 @@ public interface SecuserroleDao {
 
     public List findByProviderNo(Object providerNo);
 
+    public List findActiveByProviderNo(Object providerNo);
+
     public List findByRoleName(Object roleName);
 
     public List findByOrgcd(Object orgcd, boolean activeOnly);

--- a/src/main/java/io/github/carlos_emr/carlos/daos/security/SecuserroleDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/daos/security/SecuserroleDaoImpl.java
@@ -260,6 +260,21 @@ public class SecuserroleDaoImpl extends AbstractJpaDao implements SecuserroleDao
     }
 
     @Override
+    public List findActiveByProviderNo(Object providerNo) {
+        logger.debug("finding active Secuserrole instances by providerNo");
+        try {
+            // Only roles with activeyn = 1 grant access; rows that are inactive (0) or have a
+            // legacy NULL activeyn must not participate in authorization. Mirrors the active-only
+            // filter already used by SecObjPrivilegeDaoImpl.findByFormNamePrivilegeAndProviderNo.
+            String queryString = "from Secuserrole as model where model.providerNo = ?1 and model.activeyn = 1";
+            return JpqlQueryHelper.find(entityManager(), queryString, providerNo);
+        } catch (RuntimeException re) {
+            logger.error("find active by providerNo failed", re);
+            throw re;
+        }
+    }
+
+    @Override
     public List findByRoleName(Object roleName) {
         return findByProperty(ROLE_NAME, roleName);
     }

--- a/src/main/java/io/github/carlos_emr/carlos/login/LoginCheckLoginBean.java
+++ b/src/main/java/io/github/carlos_emr/carlos/login/LoginCheckLoginBean.java
@@ -440,8 +440,8 @@ public final class LoginCheckLoginBean {
         List<SecUserRole> roles = secUserRoleDao.getUserRoles(security.getProviderNo());
         for (SecUserRole role : roles) {
             // Only active (activeyn = 1) role assignments belong in the session role string;
-            // an inactive assignment must not grant access.
-            if (!role.getActive()) {
+            // an inactive assignment must not grant access. Boolean.TRUE.equals is null-tolerant.
+            if (!Boolean.TRUE.equals(role.getActive())) {
                 continue;
             }
             if (rolename == null) {

--- a/src/main/java/io/github/carlos_emr/carlos/login/LoginCheckLoginBean.java
+++ b/src/main/java/io/github/carlos_emr/carlos/login/LoginCheckLoginBean.java
@@ -439,6 +439,11 @@ public final class LoginCheckLoginBean {
         SecUserRoleDao secUserRoleDao = (SecUserRoleDao) SpringUtils.getBean(SecUserRoleDao.class);
         List<SecUserRole> roles = secUserRoleDao.getUserRoles(security.getProviderNo());
         for (SecUserRole role : roles) {
+            // Only active (activeyn = 1) role assignments belong in the session role string;
+            // an inactive assignment must not grant access.
+            if (!role.getActive()) {
+                continue;
+            }
             if (rolename == null) {
                 rolename = role.getRoleName();
             } else {

--- a/src/main/java/io/github/carlos_emr/carlos/managers/SecurityInfoManagerImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/SecurityInfoManagerImpl.java
@@ -66,7 +66,9 @@ public class SecurityInfoManagerImpl implements SecurityInfoManager {
             return Collections.emptyList();
         }
 
-        return secUserRoleDao.findByProviderNo(loggedInInfo.getLoggedInProviderNo());
+        // Only active (activeyn = 1) provider-role assignments grant access; an inactive role
+        // must not feed hasPrivilege / isAllowedAccessToPatientRecord / getSecurityObjects.
+        return secUserRoleDao.findActiveByProviderNo(loggedInInfo.getLoggedInProviderNo());
     }
 
     @Override

--- a/src/test/java/io/github/carlos_emr/carlos/PMmodule/dao/SecUserRoleDaoIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/PMmodule/dao/SecUserRoleDaoIntegrationTest.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.PMmodule.dao;
+
+import io.github.carlos_emr.carlos.model.security.Secuserrole;
+import io.github.carlos_emr.carlos.test.base.CarlosTestBase;
+import io.github.carlos_emr.carlos.test.base.HibernateTemplate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link SecUserRoleDao#hasAdminRole(String)}.
+ *
+ * <p>An admin role assignment grants administrative access only while it is active
+ * ({@code activeyn = 1}). An explicitly deactivated ({@code activeyn = 0}) or legacy
+ * {@code NULL} admin assignment must not be treated as granting admin access.</p>
+ *
+ * @see SecUserRoleDao#hasAdminRole(String)
+ */
+@DisplayName("SecUserRoleDao hasAdminRole Integration Tests")
+@Tag("integration")
+@Tag("dao")
+@Tag("security")
+@Transactional
+public class SecUserRoleDaoIntegrationTest extends CarlosTestBase {
+
+    @Autowired
+    private SecUserRoleDao secUserRoleDao;
+
+    @Autowired
+    private HibernateTemplate hibernateTemplate;
+
+    /**
+     * Persists a {@link Secuserrole} with an explicit activeyn value (which may be
+     * {@code null} to model a legacy row that predates the column being populated).
+     *
+     * @param providerNo String the provider number
+     * @param roleName   String the role name
+     * @param activeyn   Integer the active status (1 = active, 0 = inactive, null = legacy)
+     */
+    private void persistRole(String providerNo, String roleName, Integer activeyn) {
+        Secuserrole role = new Secuserrole();
+        role.setProviderNo(providerNo);
+        role.setRoleName(roleName);
+        role.setOrgcd("ORG1");
+        role.setActiveyn(activeyn);
+        role.setLastUpdateDate(new Date());
+        hibernateTemplate.execute(session -> { session.persist(role); return null; });
+    }
+
+    @Test
+    @Tag("read")
+    @DisplayName("should report admin access when the admin role is active")
+    void shouldReportAdminAccess_whenAdminRoleIsActive() {
+        persistRole("HAR100", "admin", 1);
+        hibernateTemplate.flush();
+
+        assertThat(secUserRoleDao.hasAdminRole("HAR100")).isTrue();
+    }
+
+    @Test
+    @Tag("read")
+    @DisplayName("should deny admin access when the admin role is inactive")
+    void shouldDenyAdminAccess_whenAdminRoleIsInactive() {
+        persistRole("HAR200", "admin", 0);
+        hibernateTemplate.flush();
+
+        assertThat(secUserRoleDao.hasAdminRole("HAR200")).isFalse();
+    }
+
+    @Test
+    @Tag("read")
+    @DisplayName("should deny admin access when the admin role has a legacy NULL activeyn")
+    void shouldDenyAdminAccess_whenAdminRoleHasLegacyNullActiveyn() {
+        persistRole("HAR300", "admin", null);
+        hibernateTemplate.flush();
+
+        assertThat(secUserRoleDao.hasAdminRole("HAR300")).isFalse();
+    }
+
+    @Test
+    @Tag("read")
+    @DisplayName("should deny admin access when the provider only has a non-admin active role")
+    void shouldDenyAdminAccess_whenProviderOnlyHasNonAdminActiveRole() {
+        persistRole("HAR400", "doctor", 1);
+        hibernateTemplate.flush();
+
+        assertThat(secUserRoleDao.hasAdminRole("HAR400")).isFalse();
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/PMmodule/dao/SecUserRoleDaoIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/PMmodule/dao/SecUserRoleDaoIntegrationTest.java
@@ -71,7 +71,10 @@ public class SecUserRoleDaoIntegrationTest extends CarlosTestBase {
         role.setOrgcd("ORG1");
         role.setActiveyn(activeyn);
         role.setLastUpdateDate(new Date());
-        hibernateTemplate.execute(session -> { session.persist(role); return null; });
+        hibernateTemplate.execute(session -> {
+            session.persist(role);
+            return null;
+        });
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/daos/security/SecuserroleDaoIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/daos/security/SecuserroleDaoIntegrationTest.java
@@ -404,6 +404,74 @@ public class SecuserroleDaoIntegrationTest extends CarlosTestBase {
     }
 
     /**
+     * Tests for {@link SecuserroleDao#findActiveByProviderNo(Object)}, the active-only
+     * role lookup used by authorization ({@code SecurityInfoManagerImpl.getRoles}).
+     *
+     * <p>Only assignments with {@code activeyn = 1} may grant access; rows that are
+     * explicitly inactive ({@code activeyn = 0}) or have a legacy {@code NULL}
+     * {@code activeyn} must be excluded.</p>
+     */
+    @Nested
+    @DisplayName("findActiveByProviderNo() operations")
+    class FindActiveByProviderNoOperations {
+
+        @Test
+        @Tag("read")
+        @Tag("security")
+        @DisplayName("should return only active assignments for the provider")
+        void shouldReturnOnlyActiveAssignments_forProvider() {
+            // Given - same provider with one active and one inactive role
+            createSecuserroleWithActive("FA100", "doctor", "ORG1", 1);
+            createSecuserroleWithActive("FA100", "admin", "ORG1", 0);
+            hibernateTemplate.flush();
+
+            // When
+            @SuppressWarnings("unchecked")
+            List<Secuserrole> results = secuserroleDao.findActiveByProviderNo("FA100");
+
+            // Then - only the active "doctor" assignment is returned
+            assertThat(results)
+                .hasSize(1)
+                .allMatch(r -> r.getActiveyn() != null && r.getActiveyn().equals(1));
+            assertThat(results.get(0).getRoleName()).isEqualTo("doctor");
+        }
+
+        @Test
+        @Tag("read")
+        @Tag("security")
+        @DisplayName("should exclude an inactive assignment so it cannot grant access")
+        void shouldExcludeInactiveAssignment_soItCannotGrantAccess() {
+            // Given - provider has only an explicitly deactivated role
+            createSecuserroleWithActive("FA200", "admin", "ORG1", 0);
+            hibernateTemplate.flush();
+
+            // When
+            @SuppressWarnings("unchecked")
+            List<Secuserrole> results = secuserroleDao.findActiveByProviderNo("FA200");
+
+            // Then
+            assertThat(results).isEmpty();
+        }
+
+        @Test
+        @Tag("read")
+        @Tag("security")
+        @DisplayName("should exclude a legacy NULL-activeyn assignment")
+        void shouldExcludeLegacyNullActiveynAssignment_forProvider() {
+            // Given - legacy row with NULL activeyn (createSecuserrole leaves activeyn unset)
+            createSecuserrole("FA300", "doctor", "ORG1");
+            hibernateTemplate.flush();
+
+            // When
+            @SuppressWarnings("unchecked")
+            List<Secuserrole> results = secuserroleDao.findActiveByProviderNo("FA300");
+
+            // Then
+            assertThat(results).isEmpty();
+        }
+    }
+
+    /**
      * Tests for bulk delete operations - covers {@code deleteByOrgcd(String)} and
      * {@code deleteByProviderNo(String)} HQL bulk deletes, plus {@code deleteById(Integer)}.
      * Verifies correct row counts and zero returns for non-existent values.

--- a/src/test/java/io/github/carlos_emr/carlos/login/LoginCheckLoginBeanUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/login/LoginCheckLoginBeanUnitTest.java
@@ -23,6 +23,7 @@ package io.github.carlos_emr.carlos.login;
 
 import io.github.carlos_emr.carlos.PMmodule.dao.ProviderDao;
 import io.github.carlos_emr.carlos.PMmodule.dao.SecUserRoleDao;
+import io.github.carlos_emr.carlos.PMmodule.model.SecUserRole;
 import io.github.carlos_emr.carlos.commn.dao.SecurityDao;
 import io.github.carlos_emr.carlos.commn.model.Security;
 import io.github.carlos_emr.carlos.managers.SecurityManager;
@@ -32,6 +33,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -130,5 +132,37 @@ class LoginCheckLoginBeanUnitTest extends CarlosUnitTestBase {
                 eq("wrongPassword"),
                 argThat(dummySecurity -> dummySecurity != null
                         && EXPECTED_MISSING_USER_DUMMY_PASSWORD_HASH.equals(dummySecurity.getPassword())));
+    }
+
+    @Test
+    @DisplayName("should exclude inactive roles from the session role string on successful login")
+    void shouldExcludeInactiveRoles_fromSessionRoleStringOnSuccessfulLogin() {
+        String username = "activeUser";
+        String providerNo = "999998";
+        // Legacy (< 20 char) password so authentication succeeds via direct comparison.
+        String legacyPassword = "secret";
+        Security security = new Security();
+        security.setProviderNo(providerNo);
+        security.setPassword(legacyPassword);
+        security.setBLocallockset(0);
+        security.setBRemotelockset(0);
+        security.setBExpireset(0);
+        when(securityDao.findByUserName(username)).thenReturn(Collections.singletonList(security));
+
+        SecUserRole activeDoctor = new SecUserRole("doctor", providerNo);
+        activeDoctor.setActive(true);
+        SecUserRole inactiveAdmin = new SecUserRole("admin", providerNo);
+        inactiveAdmin.setActive(false);
+        when(secUserRoleDao.getUserRoles(providerNo))
+                .thenReturn(Arrays.asList(activeDoctor, inactiveAdmin));
+
+        LoginCheckLoginBean bean = new LoginCheckLoginBean();
+        bean.ini(username, legacyPassword, "", "127.0.0.1");
+
+        String[] result = bean.authenticate();
+
+        // strAuth[4] is the comma-separated session role string; the inactive admin role must be absent.
+        assertThat(result).isNotNull();
+        assertThat(result[4]).isEqualTo("doctor");
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/managers/SecurityInfoManagerUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/managers/SecurityInfoManagerUnitTest.java
@@ -124,7 +124,7 @@ public class SecurityInfoManagerUnitTest extends CarlosUnitTestBase {
         when(mockLoggedInInfo.getSession()).thenReturn(mockSession);
 
         // Default: provider has "doctor" role
-        when(mockSecuserroleDao.findByProviderNo(TEST_PROVIDER_NO))
+        when(mockSecuserroleDao.findActiveByProviderNo(TEST_PROVIDER_NO))
             .thenReturn(Collections.singletonList(createRole(TEST_PROVIDER_NO, ROLE_DOCTOR)));
 
         // Default: no privilege data (prevents NPE in OscarRoleObjectPrivilege.getPrivilegeProp)
@@ -245,7 +245,7 @@ public class SecurityInfoManagerUnitTest extends CarlosUnitTestBase {
             List<Secuserrole> roles = securityInfoManager.getRoles(null);
 
             assertThat(roles).isEmpty();
-            verify(mockSecuserroleDao, never()).findByProviderNo(any());
+            verify(mockSecuserroleDao, never()).findActiveByProviderNo(any());
         }
 
         @Test
@@ -256,7 +256,7 @@ public class SecurityInfoManagerUnitTest extends CarlosUnitTestBase {
             List<Secuserrole> roles = securityInfoManager.getRoles(mockLoggedInInfo);
 
             assertThat(roles).isEmpty();
-            verify(mockSecuserroleDao, never()).findByProviderNo(any());
+            verify(mockSecuserroleDao, never()).findActiveByProviderNo(any());
         }
 
         @Test
@@ -264,25 +264,35 @@ public class SecurityInfoManagerUnitTest extends CarlosUnitTestBase {
         void shouldReturnRolesFromDao_whenProviderIsValid() {
             Secuserrole doctorRole = createRole(TEST_PROVIDER_NO, ROLE_DOCTOR);
             Secuserrole adminRole = createRole(TEST_PROVIDER_NO, ROLE_ADMIN);
-            when(mockSecuserroleDao.findByProviderNo(TEST_PROVIDER_NO))
+            when(mockSecuserroleDao.findActiveByProviderNo(TEST_PROVIDER_NO))
                 .thenReturn(Arrays.asList(doctorRole, adminRole));
 
             List<Secuserrole> roles = securityInfoManager.getRoles(mockLoggedInInfo);
 
             assertThat(roles).hasSize(2);
             assertThat(roles).containsExactly(doctorRole, adminRole);
-            verify(mockSecuserroleDao).findByProviderNo(TEST_PROVIDER_NO);
+            verify(mockSecuserroleDao).findActiveByProviderNo(TEST_PROVIDER_NO);
         }
 
         @Test
         @DisplayName("should return empty list when provider has no roles")
         void shouldReturnEmptyList_whenProviderHasNoRoles() {
-            when(mockSecuserroleDao.findByProviderNo(TEST_PROVIDER_NO))
+            when(mockSecuserroleDao.findActiveByProviderNo(TEST_PROVIDER_NO))
                 .thenReturn(Collections.emptyList());
 
             List<Secuserrole> roles = securityInfoManager.getRoles(mockLoggedInInfo);
 
             assertThat(roles).isEmpty();
+        }
+
+        @Test
+        @DisplayName("should resolve roles through the active-only lookup so inactive roles never grant access")
+        void shouldResolveRolesThroughActiveOnlyLookup_soInactiveRolesNeverGrantAccess() {
+            securityInfoManager.getRoles(mockLoggedInInfo);
+
+            // Authorization must read only active assignments; the all-rows lookup must never be used here.
+            verify(mockSecuserroleDao).findActiveByProviderNo(TEST_PROVIDER_NO);
+            verify(mockSecuserroleDao, never()).findByProviderNo(any());
         }
     }
 
@@ -796,7 +806,7 @@ public class SecurityInfoManagerUnitTest extends CarlosUnitTestBase {
             @DisplayName("should grant access through secondary role when primary has no privilege")
             void shouldGrantAccess_throughSecondaryRole() {
                 // Provider has both doctor and admin roles
-                when(mockSecuserroleDao.findByProviderNo(TEST_PROVIDER_NO))
+                when(mockSecuserroleDao.findActiveByProviderNo(TEST_PROVIDER_NO))
                     .thenReturn(Arrays.asList(
                         createRole(TEST_PROVIDER_NO, ROLE_DOCTOR),
                         createRole(TEST_PROVIDER_NO, ROLE_ADMIN)));


### PR DESCRIPTION
fixes #2956

## Scope
Inactive provider-role assignments (`secUserRole.activeyn = 0`, or a legacy `NULL`) still granted access because the role-resolution queries never filtered on `activeyn`. This restricts the three authorization role-resolution paths the issue identified to **active** assignments only (`activeyn = 1`), mirroring the existing active-only filter in `SecObjPrivilegeDaoImpl.findByFormNamePrivilegeAndProviderNo`.

Product intent confirmed in the issue thread; **Option A** (`activeyn = 1`, no migration) was chosen — a query of the `secUserRole` table showed all rows already `activeyn = 1` (0 inactive, 0 legacy `NULL`), so no backfill is needed.

## Changes
- **`SecuserroleDao` / `SecuserroleDaoImpl`**: add `findActiveByProviderNo(providerNo)` (`providerNo AND activeyn = 1`). The generic `findByProviderNo` is left unchanged so non-authorization callers are unaffected.
- **`SecurityInfoManagerImpl.getRoles`**: use `findActiveByProviderNo`, so `hasPrivilege`, `isAllowedAccessToPatientRecord`, and `getSecurityObjects` only ever see active roles.
- **`LoginCheckLoginBean`**: skip inactive roles (`!role.getActive()`) when building the session role string.
- **`PMmodule SecUserRoleDaoImpl.hasAdminRole`**: require `activeyn = 1`, so an inactive `admin` role no longer grants admin access (`PMMFilter` / `OscarSecurityManager`).

## Tests
- `SecuserroleDaoIntegrationTest` → new `findActiveByProviderNo()` cases: returns active-only, excludes `activeyn = 0`, excludes legacy `NULL`.
- New `PMmodule/dao/SecUserRoleDaoIntegrationTest`: `hasAdminRole` true for active admin; false for inactive, legacy `NULL`, and non-admin-only.
- `SecurityInfoManagerUnitTest`: existing stubs updated to the active-only lookup, plus a new test asserting `getRoles` calls `findActiveByProviderNo` and never the all-rows lookup.
- `LoginCheckLoginBeanUnitTest`: new test asserting the session role string omits an inactive role on successful login.

### Local verification
- `mvn test-compile` — success.
- `mvn test -Dtest=SecurityInfoManagerUnitTest,LoginCheckLoginBeanUnitTest` — all pass.
- `mvn test -Dtest=SecuserroleDaoIntegrationTest,SecUserRoleDaoIntegrationTest` — 42 pass, 0 failures.

## Deferred (out of scope)
Other `getUserRoles(...)` consumers (CaseManagementView, DmsInboxManage, InboxManager, NotesService) still receive inactive rows; not part of this ticket's named acceptance criteria (hasPrivilege, session userrole, hasAdminRole). Can be filed as a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Inactive security roles no longer grant access. Authorization, the session role string, and the admin check now read only active role assignments (activeyn = 1).

- **Bug Fixes**
  - Added `SecuserroleDao.findActiveByProviderNo(providerNo)` and used it in `SecurityInfoManagerImpl.getRoles` so `hasPrivilege`, `isAllowedAccessToPatientRecord`, and `getSecurityObjects` resolve active roles only.
  - Updated `LoginCheckLoginBean` to skip inactive roles when building the session role string, using a null-safe `Boolean.TRUE.equals(role.getActive())`.
  - Changed `PMmodule SecUserRoleDaoImpl.hasAdminRole` to require `activeyn = 1` so an inactive `admin` role does not grant admin access.

- **Refactors**
  - Adjusted test style in `SecUserRoleDaoIntegrationTest` to satisfy Checkstyle (one statement per line); no behavior change.

<sup>Written for commit ba63f7497d31acf002d8049719ee1272dfe6cc16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3037?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

