### PR TITLE
fix: expose REST DocumentService on session /ws/rs surface

### DIFF
--- a/src/main/resources/spring_ws.xml
+++ b/src/main/resources/spring_ws.xml
@@ -194,6 +194,9 @@
 			<cxf:logging />
 		</jaxrs:features>
 
+		<!-- REST data services are exposed on BOTH the session surface (/ws/rs, here)
+		     and the OAuth surface (/ws/services, applicationContextREST.xml). Keep the two
+		     service-bean lists consistent so every data service is reachable on both. -->
 		<jaxrs:serviceBeans>
 			<bean class="io.github.carlos_emr.carlos.webserv.rest.PharmacyService" autowire="byName"/>
 			<bean class="io.github.carlos_emr.carlos.webserv.rest.DemographicService" autowire="byName"/>
@@ -225,6 +228,7 @@
 <!--			<bean class="org.oscarehr.webservbserv.rest.SystemInfoService" autowire="byName" /> -->
 			<bean class="io.github.carlos_emr.carlos.webserv.rest.LabService" autowire="byName" />
 			<bean class="io.github.carlos_emr.carlos.webserv.rest.MeasurementService" autowire="byName" />
+			<bean class="io.github.carlos_emr.carlos.webserv.rest.DocumentService" autowire="byName" />
 			<bean class="io.github.carlos_emr.carlos.webserv.rest.ConsentService" autowire="byName" />
 			<bean class="io.github.carlos_emr.carlos.webserv.rest.EFormService" autowire="byName"/>
 			<bean class="io.github.carlos_emr.carlos.webserv.rest.EFormsService" autowire="byName"/>

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/RestServiceSurfaceRegistrationUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/RestServiceSurfaceRegistrationUnitTest.java
@@ -23,7 +23,6 @@ package io.github.carlos_emr.carlos.webserv.rest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.FileInputStream;
 import java.io.InputStream;
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -63,8 +62,8 @@ import org.xml.sax.InputSource;
 @Tag("rest")
 class RestServiceSurfaceRegistrationUnitTest {
 
-    private static final String SESSION_CONFIG = "src/main/resources/spring_ws.xml";
-    private static final String OAUTH_CONFIG = "src/main/resources/applicationContextREST.xml";
+    private static final String SESSION_CONFIG = "spring_ws.xml";
+    private static final String OAUTH_CONFIG = "applicationContextREST.xml";
 
     private static final String REST_PACKAGE_PREFIX = "io.github.carlos_emr.carlos.webserv.rest.";
     private static final String DOCUMENT_SERVICE = REST_PACKAGE_PREFIX + "DocumentService";
@@ -153,7 +152,11 @@ class RestServiceSurfaceRegistrationUnitTest {
         db.setEntityResolver((publicId, systemId) ->
                 new InputSource(new java.io.StringReader("")));
 
-        try (InputStream in = new FileInputStream(configPath)) {
+        try (InputStream in = RestServiceSurfaceRegistrationUnitTest.class.getClassLoader()
+                .getResourceAsStream(configPath)) {
+            if (in == null) {
+                throw new java.io.FileNotFoundException("Resource not found on classpath: " + configPath);
+            }
             return db.parse(in);
         }
     }

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/RestServiceSurfaceRegistrationUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/RestServiceSurfaceRegistrationUnitTest.java
@@ -24,7 +24,9 @@ package io.github.carlos_emr.carlos.webserv.rest;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.InputStream;
+import java.util.HashMap;
 import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Set;
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
@@ -34,7 +36,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
-import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 
@@ -65,6 +66,10 @@ class RestServiceSurfaceRegistrationUnitTest {
     private static final String SESSION_CONFIG = "spring_ws.xml";
     private static final String OAUTH_CONFIG = "applicationContextREST.xml";
 
+    /** CXF JAX-RS server addresses that publish the REST data services on each surface. */
+    private static final String SESSION_SERVER_ADDRESS = "/rs";
+    private static final String OAUTH_SERVER_ADDRESS = "/services";
+
     private static final String REST_PACKAGE_PREFIX = "io.github.carlos_emr.carlos.webserv.rest.";
     private static final String DOCUMENT_SERVICE = REST_PACKAGE_PREFIX + "DocumentService";
 
@@ -75,7 +80,7 @@ class RestServiceSurfaceRegistrationUnitTest {
     @Test
     @DisplayName("should register DocumentService on the session surface (/ws/rs)")
     void shouldRegisterDocumentService_onSessionSurface() throws Exception {
-        assertThat(serviceBeanClasses(SESSION_CONFIG))
+        assertThat(serviceBeanClasses(SESSION_CONFIG, SESSION_SERVER_ADDRESS))
                 .as("DocumentService must be reachable on the session /ws/rs surface, "
                         + "consistent with the OAuth /ws/services surface (issue #2961)")
                 .contains(DOCUMENT_SERVICE);
@@ -84,7 +89,7 @@ class RestServiceSurfaceRegistrationUnitTest {
     @Test
     @DisplayName("should register DocumentService on the OAuth surface (/ws/services)")
     void shouldRegisterDocumentService_onOAuthSurface() throws Exception {
-        assertThat(serviceBeanClasses(OAUTH_CONFIG))
+        assertThat(serviceBeanClasses(OAUTH_CONFIG, OAUTH_SERVER_ADDRESS))
                 .as("DocumentService must remain reachable on the OAuth /ws/services surface")
                 .contains(DOCUMENT_SERVICE);
     }
@@ -92,8 +97,10 @@ class RestServiceSurfaceRegistrationUnitTest {
     @Test
     @DisplayName("should expose the same rest-package data services on both surfaces")
     void shouldExposeSameRestServices_onBothSurfaces() throws Exception {
-        Set<String> session = restPackageServices(serviceBeanClasses(SESSION_CONFIG));
-        Set<String> oauth = restPackageServices(serviceBeanClasses(OAUTH_CONFIG));
+        Set<String> session = restPackageServices(
+                serviceBeanClasses(SESSION_CONFIG, SESSION_SERVER_ADDRESS));
+        Set<String> oauth = restPackageServices(
+                serviceBeanClasses(OAUTH_CONFIG, OAUTH_SERVER_ADDRESS));
 
         assertThat(session)
                 .as("every rest-package data service on the OAuth surface must also be "
@@ -113,26 +120,72 @@ class RestServiceSurfaceRegistrationUnitTest {
         return out;
     }
 
-    /** Collects the {@code class} attributes of every bean under a {@code <jaxrs:serviceBeans>}. */
-    private static Set<String> serviceBeanClasses(String configPath) throws Exception {
+    /**
+     * Collects the service classes registered under the {@code <jaxrs:serviceBeans>} of the
+     * single {@code <jaxrs:server>} with the given {@code address} in the config. Both inline
+     * {@code <bean class="...">} registrations and {@code <ref bean="id"/>} references (resolved
+     * to the referenced top-level bean's {@code class}) are counted, so the parity check sees the
+     * real registrations regardless of which form a service uses.
+     */
+    private static Set<String> serviceBeanClasses(String configPath, String serverAddress) throws Exception {
         Document doc = parse(configPath);
-        Set<String> classes = new LinkedHashSet<>();
+        Map<String, String> beanClassById = beanClassesById(doc);
 
-        NodeList serviceBeans = doc.getElementsByTagName("jaxrs:serviceBeans");
-        for (int i = 0; i < serviceBeans.getLength(); i++) {
-            Node node = serviceBeans.item(i);
-            if (node instanceof Element element) {
-                NodeList beans = element.getElementsByTagName("bean");
-                for (int j = 0; j < beans.getLength(); j++) {
-                    Element bean = (Element) beans.item(j);
-                    String clazz = bean.getAttribute("class");
-                    if (clazz != null && !clazz.isBlank()) {
-                        classes.add(clazz.trim());
-                    }
+        Element server = serverByAddress(doc, serverAddress);
+        assertThat(server)
+                .as("config %s must declare a <jaxrs:server> at address %s", configPath, serverAddress)
+                .isNotNull();
+
+        Set<String> classes = new LinkedHashSet<>();
+        NodeList serviceBeansList = server.getElementsByTagName("jaxrs:serviceBeans");
+        for (int i = 0; i < serviceBeansList.getLength(); i++) {
+            Element serviceBeans = (Element) serviceBeansList.item(i);
+
+            NodeList beans = serviceBeans.getElementsByTagName("bean");
+            for (int j = 0; j < beans.getLength(); j++) {
+                String clazz = ((Element) beans.item(j)).getAttribute("class");
+                if (clazz != null && !clazz.isBlank()) {
+                    classes.add(clazz.trim());
+                }
+            }
+
+            NodeList refs = serviceBeans.getElementsByTagName("ref");
+            for (int j = 0; j < refs.getLength(); j++) {
+                String refId = ((Element) refs.item(j)).getAttribute("bean");
+                String clazz = beanClassById.get(refId == null ? "" : refId.trim());
+                if (clazz != null && !clazz.isBlank()) {
+                    classes.add(clazz.trim());
                 }
             }
         }
         return classes;
+    }
+
+    /** Finds the single {@code <jaxrs:server>} element whose {@code address} matches, or null. */
+    private static Element serverByAddress(Document doc, String serverAddress) {
+        NodeList servers = doc.getElementsByTagName("jaxrs:server");
+        for (int i = 0; i < servers.getLength(); i++) {
+            Element server = (Element) servers.item(i);
+            if (serverAddress.equals(server.getAttribute("address"))) {
+                return server;
+            }
+        }
+        return null;
+    }
+
+    /** Maps every top-level {@code <bean id="..." class="...">} id to its class for ref resolution. */
+    private static Map<String, String> beanClassesById(Document doc) {
+        Map<String, String> byId = new HashMap<>();
+        NodeList beans = doc.getElementsByTagName("bean");
+        for (int i = 0; i < beans.getLength(); i++) {
+            Element bean = (Element) beans.item(i);
+            String id = bean.getAttribute("id");
+            String clazz = bean.getAttribute("class");
+            if (id != null && !id.isBlank() && clazz != null && !clazz.isBlank()) {
+                byId.put(id.trim(), clazz.trim());
+            }
+        }
+        return byId;
     }
 
     private static Document parse(String configPath) throws Exception {

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/RestServiceSurfaceRegistrationUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/RestServiceSurfaceRegistrationUnitTest.java
@@ -1,0 +1,160 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.webserv.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+/**
+ * Guards the CARLOS REST API surface registration against drift between the two
+ * CXF JAX-RS servers that publish the {@code io.github.carlos_emr.carlos.webserv.rest}
+ * data services:
+ *
+ * <ul>
+ *   <li>the session surface {@code /ws/rs} (the {@code jaxrServer} server in
+ *       {@code spring_ws.xml}), and</li>
+ *   <li>the OAuth surface {@code /ws/services} (the {@code restServices} server in
+ *       {@code applicationContextREST.xml}).</li>
+ * </ul>
+ *
+ * <p>Issue #2961: {@code DocumentService} was registered only on the OAuth surface,
+ * so the same document operation 404'd on the session surface. These tests assert
+ * the document service is reachable on both surfaces and, more generally, that the
+ * two surfaces stay consistent (aside from the OAuth-only status endpoint).
+ *
+ * @since 2026-06-25
+ */
+@DisplayName("REST service surface registration Tests")
+@Tag("unit")
+@Tag("rest")
+class RestServiceSurfaceRegistrationUnitTest {
+
+    private static final String SESSION_CONFIG = "src/main/resources/spring_ws.xml";
+    private static final String OAUTH_CONFIG = "src/main/resources/applicationContextREST.xml";
+
+    private static final String REST_PACKAGE_PREFIX = "io.github.carlos_emr.carlos.webserv.rest.";
+    private static final String DOCUMENT_SERVICE = REST_PACKAGE_PREFIX + "DocumentService";
+
+    /** OAuth-status endpoint is intentionally OAuth-surface only. */
+    private static final String OAUTH_ONLY_SERVICE =
+            "io.github.carlos_emr.carlos.webserv.oauth.OAuthStatusService";
+
+    @Test
+    @DisplayName("should register DocumentService on the session surface (/ws/rs)")
+    void shouldRegisterDocumentService_onSessionSurface() throws Exception {
+        assertThat(serviceBeanClasses(SESSION_CONFIG))
+                .as("DocumentService must be reachable on the session /ws/rs surface, "
+                        + "consistent with the OAuth /ws/services surface (issue #2961)")
+                .contains(DOCUMENT_SERVICE);
+    }
+
+    @Test
+    @DisplayName("should register DocumentService on the OAuth surface (/ws/services)")
+    void shouldRegisterDocumentService_onOAuthSurface() throws Exception {
+        assertThat(serviceBeanClasses(OAUTH_CONFIG))
+                .as("DocumentService must remain reachable on the OAuth /ws/services surface")
+                .contains(DOCUMENT_SERVICE);
+    }
+
+    @Test
+    @DisplayName("should expose the same rest-package data services on both surfaces")
+    void shouldExposeSameRestServices_onBothSurfaces() throws Exception {
+        Set<String> session = restPackageServices(serviceBeanClasses(SESSION_CONFIG));
+        Set<String> oauth = restPackageServices(serviceBeanClasses(OAUTH_CONFIG));
+
+        assertThat(session)
+                .as("every rest-package data service on the OAuth surface must also be "
+                        + "registered on the session surface")
+                .containsAll(oauth);
+        assertThat(oauth)
+                .as("every rest-package data service on the session surface must also be "
+                        + "registered on the OAuth surface")
+                .containsAll(session);
+    }
+
+    /** Keep only beans in the rest data-service package (drops the OAuth-only status endpoint). */
+    private static Set<String> restPackageServices(Set<String> all) {
+        Set<String> out = new LinkedHashSet<>(all);
+        out.removeIf(c -> !c.startsWith(REST_PACKAGE_PREFIX));
+        out.remove(OAUTH_ONLY_SERVICE);
+        return out;
+    }
+
+    /** Collects the {@code class} attributes of every bean under a {@code <jaxrs:serviceBeans>}. */
+    private static Set<String> serviceBeanClasses(String configPath) throws Exception {
+        Document doc = parse(configPath);
+        Set<String> classes = new LinkedHashSet<>();
+
+        NodeList serviceBeans = doc.getElementsByTagName("jaxrs:serviceBeans");
+        for (int i = 0; i < serviceBeans.getLength(); i++) {
+            Node node = serviceBeans.item(i);
+            if (node instanceof Element element) {
+                NodeList beans = element.getElementsByTagName("bean");
+                for (int j = 0; j < beans.getLength(); j++) {
+                    Element bean = (Element) beans.item(j);
+                    String clazz = bean.getAttribute("class");
+                    if (clazz != null && !clazz.isBlank()) {
+                        classes.add(clazz.trim());
+                    }
+                }
+            }
+        }
+        return classes;
+    }
+
+    private static Document parse(String configPath) throws Exception {
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        dbf.setValidating(false);
+        dbf.setNamespaceAware(false);
+        // Defense-in-depth XML hardening — the inputs are trusted local config
+        // files, but pinning secure-processing + disabling external entities
+        // keeps the test robust across JAXP implementations.
+        dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        dbf.setXIncludeAware(false);
+        dbf.setExpandEntityReferences(false);
+        DocumentBuilder db = dbf.newDocumentBuilder();
+        db.setEntityResolver((publicId, systemId) ->
+                new InputSource(new java.io.StringReader("")));
+
+        try (InputStream in = new FileInputStream(configPath)) {
+            return db.parse(in);
+        }
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/RestServiceSurfaceRegistrationUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/RestServiceSurfaceRegistrationUnitTest.java
@@ -77,6 +77,7 @@ class RestServiceSurfaceRegistrationUnitTest {
     private static final String OAUTH_ONLY_SERVICE =
             "io.github.carlos_emr.carlos.webserv.oauth.OAuthStatusService";
 
+    /** The session {@code /ws/rs} surface must publish DocumentService (the gap fixed by #2961). */
     @Test
     @DisplayName("should register DocumentService on the session surface (/ws/rs)")
     void shouldRegisterDocumentService_onSessionSurface() throws Exception {
@@ -86,6 +87,7 @@ class RestServiceSurfaceRegistrationUnitTest {
                 .contains(DOCUMENT_SERVICE);
     }
 
+    /** The OAuth {@code /ws/services} surface must keep publishing DocumentService. */
     @Test
     @DisplayName("should register DocumentService on the OAuth surface (/ws/services)")
     void shouldRegisterDocumentService_onOAuthSurface() throws Exception {
@@ -94,6 +96,7 @@ class RestServiceSurfaceRegistrationUnitTest {
                 .contains(DOCUMENT_SERVICE);
     }
 
+    /** The session and OAuth surfaces must expose the identical set of rest-package data services. */
     @Test
     @DisplayName("should expose the same rest-package data services on both surfaces")
     void shouldExposeSameRestServices_onBothSurfaces() throws Exception {
@@ -188,6 +191,7 @@ class RestServiceSurfaceRegistrationUnitTest {
         return byId;
     }
 
+    /** Parses a classpath config resource with a hardened, namespace-unaware DOM parser. */
     private static Document parse(String configPath) throws Exception {
         DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
         dbf.setValidating(false);


### PR DESCRIPTION
fixes #2961

## Problem
The REST `DocumentService` (`io.github.carlos_emr.carlos.webserv.rest.DocumentService`) was registered only on the OAuth surface `/ws/services` (`restServices` server in `applicationContextREST.xml`) and **not** on the session surface `/ws/rs` (`jaxrServer` server in `spring_ws.xml`). The same document operation was therefore reachable on one surface and 404'd on the other — an inconsistent, confusing API surface. Every other REST data service is registered on both surfaces.

## Scope
- Register `rest.DocumentService` in the `/ws/rs` (session) `jaxrs:serviceBeans` list in `spring_ws.xml`, mirroring the OAuth `/ws/services` ordering (placed after `MeasurementService`).
- Add a comment documenting that REST data services are intended to be exposed on **both** surfaces and the two lists must stay consistent.
- Add a unit test asserting the registration consistency.

## Why register (not remove)
`DocumentService` extends `AbstractServiceImpl` like the other session services, resolves the caller via `getLoggedInInfo()`, and enforces `securityInfoManager.hasPrivilege(_edoc, WRITE)`. It is already live on the OAuth surface, so adding it to the session surface restores parity rather than dropping in-use functionality. The session surface is the more-authenticated context, so no new privilege boundary is introduced.

## Tests
`RestServiceSurfaceRegistrationUnitTest` (`@Tag("unit")`, `@Tag("rest")`) parses both Spring config files via a hardened DOM parser and asserts:
- `DocumentService` is registered on the session `/ws/rs` surface.
- `DocumentService` is registered on the OAuth `/ws/services` surface.
- The two surfaces expose the same set of rest-package data services (ignoring the OAuth-only status endpoint), guarding against future drift.

Verified locally:
- `mvn -o test -Dtest=RestServiceSurfaceRegistrationUnitTest` → Tests run: 3, Failures: 0, Errors: 0 — BUILD SUCCESS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2961 by exposing the REST `io.github.carlos_emr.carlos.webserv.rest.DocumentService` on the session `/ws/rs` surface to match OAuth `/ws/services`, removing 404s and restoring a consistent API. Adds a parity test to keep both surfaces in sync.

- **Bug Fixes**
  - Registered `DocumentService` on `/ws/rs` in `spring_ws.xml` `jaxrs:serviceBeans`.
  - Added a comment that REST data services must be on both `/ws/rs` and `/ws/services`.
  - Added `RestServiceSurfaceRegistrationUnitTest` to assert `DocumentService` on both surfaces and rest-package parity (excludes the OAuth-only status endpoint); scopes by server address, resolves `<ref bean="...">`, loads configs from the classpath, and includes Javadoc.

<sup>Written for commit 0145892d1493999e30d54210e2e5b6da3ac2a7fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

