### PR TITLE
fix(security): make shipped rate-limit tiers honest vs the global cap (#3058)

### DIFF
--- a/.devcontainer/development/config/shared/volumes/carlos.properties
+++ b/.devcontainer/development/config/shared/volumes/carlos.properties
@@ -1106,12 +1106,13 @@ WAF_RATE_LIMIT_ENABLED=false
 # Mode: "enforce" (block with 429) or "detect" (log only, don't block)
 WAF_RATE_LIMIT_MODE=detect
 
-# Global default: applies to all paths not matched by a path-specific rule
-WAF_RATE_LIMIT_DEFAULT_REQUESTS=100
+# Global per-IP cap, incremented on every request (stacks with the path tiers below).
+# Coarse flood backstop sized for a clinic behind one NAT IP; keep each tier below it.
+WAF_RATE_LIMIT_DEFAULT_REQUESTS=2000
 WAF_RATE_LIMIT_DEFAULT_WINDOW_SECONDS=60
 
 # Path-specific rate tiers (comma-separated, format: path=requests/windowSeconds)
-WAF_RATE_LIMIT_PATHS=/login=10/60,/mfa/=10/60,/forcepasswordreset=5/60,/forcepasswordresetSubmit=5/60,/lab/CMLlabUpload=30/60,/lab/newLabUpload=30/60,/ws/=200/60
+WAF_RATE_LIMIT_PATHS=/login=10/60,/mfa/=10/60,/forcepasswordreset=5/60,/forcepasswordresetSubmit=5/60,/lab/CMLlabUpload=30/60,/lab/newLabUpload=30/60,/ws/oauth=15/60,/ws/=120/60
 
 # IPs exempt from rate limiting (comma-separated)
 WAF_RATE_LIMIT_EXEMPT_IPS=127.0.0.1,::1,0:0:0:0:0:0:0:1

--- a/docs/waf-standards-alignment.md
+++ b/docs/waf-standards-alignment.md
@@ -79,7 +79,7 @@ on this control for brute-force or DoS protection must set both `WAF_RATE_LIMIT_
 |----------|---------|-------------|
 | `WAF_RATE_LIMIT_ENABLED` | `false` | Master toggle. Set to `true`, `yes`, or `on` to enable. |
 | `WAF_RATE_LIMIT_MODE` | `detect` | `enforce` = block with HTTP 429; `detect` = log only. |
-| `WAF_RATE_LIMIT_DEFAULT_REQUESTS` | `100` | Global max requests per window for unmatched paths. |
+| `WAF_RATE_LIMIT_DEFAULT_REQUESTS` | `2000` | Global per-IP cap, incremented on every request (stacks with path tiers). Sized as a coarse volumetric flood backstop because the filter covers `/*` (including static assets) and clinics typically share one NAT IP — not a per-user limit. |
 | `WAF_RATE_LIMIT_DEFAULT_WINDOW_SECONDS` | `60` | Global window duration in seconds. |
 | `WAF_RATE_LIMIT_PATHS` | *(see below)* | Comma-separated path tiers: `path=requests/windowSeconds`. |
 | `WAF_RATE_LIMIT_EXEMPT_IPS` | `127.0.0.1,::1,0:0:0:0:0:0:0:1` | IPs exempt from rate limiting. |
@@ -93,8 +93,15 @@ on this control for brute-force or DoS protection must set both `WAF_RATE_LIMIT_
 /forcepasswordreset=5/60   — password reset abuse prevention
 /lab/CMLlabUpload=30/60    — external lab integration
 /lab/newLabUpload=30/60    — external lab integration
-/ws/=200/60                — API traffic patterns
+/ws/oauth=15/60            — OAuth initiate/token (credential-bearing)
+/ws/=120/60                — server-to-server SOAP/REST API traffic
 ```
+
+Each tier stacks with the global cap and is checked after it, so a tier only
+constrains traffic when set **below** `WAF_RATE_LIMIT_DEFAULT_REQUESTS`; a tier
+set above the global cap is inert. Because the global cap is a loose flood
+backstop, these tiers — not the global cap — are what actually protect
+individual endpoints.
 
 ### Deployment Notes
 

--- a/docs/waf-standards-alignment.md
+++ b/docs/waf-standards-alignment.md
@@ -91,6 +91,7 @@ on this control for brute-force or DoS protection must set both `WAF_RATE_LIMIT_
 /login=10/60               — brute force protection
 /mfa/=10/60                — MFA brute force protection
 /forcepasswordreset=5/60   — password reset abuse prevention
+/forcepasswordresetSubmit=5/60 — password reset submit abuse
 /lab/CMLlabUpload=30/60    — external lab integration
 /lab/newLabUpload=30/60    — external lab integration
 /ws/oauth=15/60            — OAuth initiate/token (credential-bearing)

--- a/src/main/resources/carlos.properties
+++ b/src/main/resources/carlos.properties
@@ -1405,6 +1405,12 @@ WAF_RATE_LIMIT_DEFAULT_WINDOW_SECONDS=60
 # Each tier stacks with the global cap above (both counters increment), so a tier
 # only constrains traffic when it is set BELOW WAF_RATE_LIMIT_DEFAULT_REQUESTS;
 # a tier set above the global cap is inert.
+# Because the global cap is a loose flood backstop, these tiers — not the global
+# cap — are what actually protect individual endpoints: the higher the global cap
+# is set, the more the real protection depends on each tier sitting well below it.
+# An endpoint with no tighter tier inherits the full global budget, so e.g.
+# /ws/=120 (not the global 2000) is the effective per-IP cap on API traffic, and
+# /ws/oauth=15 tightens the credential endpoints further.
 #   /login              — 10 req/60s (brute force protection)
 #   /mfa/               — 10 req/60s (MFA brute force protection)
 #   /forcepasswordresetSubmit — 5 req/60s (password reset submit abuse)

--- a/src/main/resources/carlos.properties
+++ b/src/main/resources/carlos.properties
@@ -1388,22 +1388,33 @@ WAF_RATE_LIMIT_ENABLED=false
 # WAF request inspection in detect mode, or vice versa.
 WAF_RATE_LIMIT_MODE=detect
 
-# Global default: applies to all paths not matched by a path-specific rule
-WAF_RATE_LIMIT_DEFAULT_REQUESTS=100
+# Global per-IP cap. This counter is incremented and checked on EVERY request
+# (including requests that also match a path tier below), so it acts as the
+# overall per-IP ceiling, not just a fallback. Because the filter is mapped to
+# /* with no static-asset exclusion and clinics typically share one NAT IP, this
+# must be sized as a coarse volumetric flood backstop large enough to tolerate a
+# whole clinic's browser + static-asset traffic, not as a per-user limit.
+# Consequence: a path tier set HIGHER than this value can never bind (the global
+# cap trips first) — keep every WAF_RATE_LIMIT_PATHS tier at or below this number.
+WAF_RATE_LIMIT_DEFAULT_REQUESTS=2000
 WAF_RATE_LIMIT_DEFAULT_WINDOW_SECONDS=60
 
 # Path-specific rate tiers (comma-separated, format: path=requests/windowSeconds)
 # Paths ending in "/" use prefix matching. Other paths match exactly or on a
 # path boundary ("/", "?", or ";"). More specific paths are checked first.
+# Each tier stacks with the global cap above (both counters increment), so a tier
+# only constrains traffic when it is set BELOW WAF_RATE_LIMIT_DEFAULT_REQUESTS;
+# a tier set above the global cap is inert.
 #   /login              — 10 req/60s (brute force protection)
 #   /mfa/               — 10 req/60s (MFA brute force protection)
 #   /forcepasswordresetSubmit — 5 req/60s (password reset submit abuse)
 #   /lab/CMLlabUpload   — 30 req/60s (external lab integration)
 #   /lab/newLabUpload   — 30 req/60s (external lab integration)
-#   /ws/                — 200 req/60s (API traffic patterns)
+#   /ws/oauth           — 15 req/60s (OAuth initiate/token; credential-bearing)
+#   /ws/                — 120 req/60s (server-to-server SOAP/REST API traffic)
 # Paths are extensionless Struts action names; legacy `.do` / `.jsp` suffixes
 # do not match unless configured explicitly.
-WAF_RATE_LIMIT_PATHS=/login=10/60,/mfa/=10/60,/forcepasswordreset=5/60,/forcepasswordresetSubmit=5/60,/lab/CMLlabUpload=30/60,/lab/newLabUpload=30/60,/ws/=200/60
+WAF_RATE_LIMIT_PATHS=/login=10/60,/mfa/=10/60,/forcepasswordreset=5/60,/forcepasswordresetSubmit=5/60,/lab/CMLlabUpload=30/60,/lab/newLabUpload=30/60,/ws/oauth=15/60,/ws/=120/60
 
 # IPs exempt from rate limiting (comma-separated)
 # Always include loopback for internal PDF generation and health checks

--- a/src/test/java/io/github/carlos_emr/carlos/app/RateLimitConfigInvariantUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/app/RateLimitConfigInvariantUnitTest.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.app;
+
+import io.github.carlos_emr.carlos.app.RateLimitFilter.RateConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Lints the <strong>shipped</strong> rate-limit configuration in
+ * {@code src/main/resources/carlos.properties} so the defaults stay internally consistent.
+ *
+ * <p>{@link RateLimitFilter} increments and checks the global per-IP counter on every request,
+ * stacking it with any matched path tier. A path tier set <em>higher</em> than the global cap can
+ * therefore never bind — the global cap trips first — which silently makes the tier inert and the
+ * documented limit misleading (see issue #3058). These tests pin the invariant against the actual
+ * shipped numbers, reusing the production parser so they cannot drift from filter behavior. They
+ * are intentionally value-agnostic: tuning the numbers later will not break them as long as the
+ * config stays self-consistent.</p>
+ */
+@Tag("unit")
+@Tag("security")
+@DisplayName("Shipped rate-limit config invariants")
+class RateLimitConfigInvariantUnitTest {
+
+    private static final String CONFIG_PATH = "src/main/resources/carlos.properties";
+
+    private Properties loadShippedConfig() throws Exception {
+        File file = new File(CONFIG_PATH);
+        assertThat(file)
+                .as("shipped config %s must exist (test runs from the module root)", CONFIG_PATH)
+                .exists();
+        Properties props = new Properties();
+        try (InputStream in = new FileInputStream(file)) {
+            props.load(in);
+        }
+        return props;
+    }
+
+    @Test
+    @DisplayName("no WAF_RATE_LIMIT_PATHS tier exceeds the global per-IP cap")
+    void shouldKeepEveryPathTierAtOrBelowGlobalCap_forShippedConfig() throws Exception {
+        Properties props = loadShippedConfig();
+
+        String globalRaw = props.getProperty("WAF_RATE_LIMIT_DEFAULT_REQUESTS");
+        assertThat(globalRaw).as("WAF_RATE_LIMIT_DEFAULT_REQUESTS must be set").isNotBlank();
+        int globalCap = Integer.parseInt(globalRaw.trim());
+
+        // Reuse the production parser so the test cannot drift from filter parsing behavior.
+        Map<String, RateConfig> tiers =
+                new RateLimitFilter().parsePathRates(props.getProperty("WAF_RATE_LIMIT_PATHS"));
+        assertThat(tiers).as("shipped config should define path tiers").isNotEmpty();
+
+        tiers.forEach((path, cfg) ->
+                assertThat(cfg.requests)
+                        .as("path tier '%s'=%d/%ds must not exceed the global cap of %d/window "
+                                        + "(a tier above the global cap is inert — see issue #3058)",
+                                path, cfg.requests, cfg.windowSeconds, globalCap)
+                        .isLessThanOrEqualTo(globalCap));
+    }
+
+    @Test
+    @DisplayName("every shipped WAF_RATE_LIMIT_PATHS entry parses with no tier silently dropped")
+    void shouldParseEveryShippedPathEntry_withoutDroppingTiers() throws Exception {
+        Properties props = loadShippedConfig();
+
+        String raw = props.getProperty("WAF_RATE_LIMIT_PATHS");
+        assertThat(raw).as("WAF_RATE_LIMIT_PATHS must be set").isNotBlank();
+
+        long declaredEntries = Arrays.stream(raw.split(","))
+                .map(String::trim)
+                .filter(entry -> !entry.isEmpty())
+                .count();
+
+        Map<String, RateConfig> tiers = new RateLimitFilter().parsePathRates(raw);
+
+        assertThat((long) tiers.size())
+                .as("every comma-separated tier in WAF_RATE_LIMIT_PATHS should parse; a dropped "
+                        + "entry means a malformed or duplicate-path tier in the shipped config")
+                .isEqualTo(declaredEntries);
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/app/RateLimitConfigInvariantUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/app/RateLimitConfigInvariantUnitTest.java
@@ -26,8 +26,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Map;
@@ -52,15 +50,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DisplayName("Shipped rate-limit config invariants")
 class RateLimitConfigInvariantUnitTest {
 
-    private static final String CONFIG_PATH = "src/main/resources/carlos.properties";
+    private static final String CONFIG_RESOURCE = "carlos.properties";
 
     private Properties loadShippedConfig() throws Exception {
-        File file = new File(CONFIG_PATH);
-        assertThat(file)
-                .as("shipped config %s must exist (test runs from the module root)", CONFIG_PATH)
-                .exists();
+        // Load from the test classpath (the processed copy of src/main/resources/carlos.properties)
+        // rather than a relative filesystem path, so the test is not dependent on the launcher's
+        // working directory (parent-module builds, IDE/CI runners).
         Properties props = new Properties();
-        try (InputStream in = new FileInputStream(file)) {
+        try (InputStream in = RateLimitConfigInvariantUnitTest.class
+                .getClassLoader()
+                .getResourceAsStream(CONFIG_RESOURCE)) {
+            assertThat(in)
+                    .as("shipped config %s must exist on the test classpath", CONFIG_RESOURCE)
+                    .isNotNull();
             props.load(in);
         }
         return props;


### PR DESCRIPTION
## Summary

Implements the config-correctness core of #3058. `RateLimitFilter` stacks the global per-IP counter with every matched path tier and checks global **first**, so a tier set **above** the global cap is inert. The shipped defaults had `global=100` with `/ws/=200`, so the documented `/ws/=200` never bound, and the global cap was too low to ever enable in enforce (the `/*` filter counts static assets and clinics share one NAT IP).

This corrects the **shipped numbers** only. `WAF_RATE_LIMIT_ENABLED=false` and `WAF_RATE_LIMIT_MODE=detect` are left unchanged, so there is **no runtime behavior change on deploy** — only the defaults become honest and internally consistent.

## Scope

- Raise global per-IP cap `100 → 2000` (coarse volumetric flood backstop sized for a whole clinic behind one NAT IP, including static-asset traffic on `/*`).
- Lower `/ws/` `200 → 120` so the API tier actually binds below global.
- Split out `/ws/oauth=15/60` for the credential-bearing OAuth initiate/token endpoints (auth-grade, like login/MFA).
- Document the global-vs-path stacking interaction inline in `carlos.properties`.
- Keep `ENABLED=false` / `MODE=detect` (deliberately out of scope to flip).

Numbers are the starting points reasoned out on #3058 (industry anchors + extrapolation to CARLOS's per-IP/NAT/static-asset specifics); they remain tunable.

Deferred (out of scope, noted on #3058): excluding static assets from the filter (a security-sensitive filter change with bypass risk), keying auth-sensitive endpoints by user/session, and enabling enforce.

## Why lowering `/ws` matters even though global went up

The two changes are halves of one fix, not independent knobs. Both counters increment on every request and global is checked first, so for a pure `/ws` client the global cap (2000) never trips — the **`/ws/` tier is the only thing that binds**, capping API traffic at 120/min.

| | global | `/ws/` | effective cap on `/ws` traffic |
|---|---|---|---|
| Before | 100 | 200 (inert) | **100** — the *global* did the limiting |
| After | 2000 | 120 | **120** — the *`/ws/` tier* does the limiting |

Raising global deliberately makes it a loose flood backstop, which means the **per-path tiers now carry the real per-endpoint protection**. If global were raised to 2000 without lowering `/ws/`, API traffic — including scraping `/ws/rs` or credential-stuffing `/ws/oauth` — would inherit the full 2000 budget. So the higher the global backstop, the more protection depends on each tier sitting well below it. This rationale is now documented inline in `carlos.properties`.

## Tests

Added `RateLimitConfigInvariantUnitTest` — a value-agnostic guard that lints the **shipped** `carlos.properties`, reusing the production `RateLimitFilter.parsePathRates` parser:

- no `WAF_RATE_LIMIT_PATHS` tier may exceed the global cap (the issue's acceptance criterion — would have caught the old `/ws/=200` vs `global=100`);
- every declared tier must parse (no malformed/duplicate tier silently dropped).

It is intentionally number-agnostic, so future tuning won't break it as long as the config stays self-consistent.

Verified locally:

```
mvn -Dtest=RateLimitConfigInvariantUnitTest test
```

→ BUILD SUCCESS, Tests run: 2, Failures: 0, Errors: 0.

fixes #3058

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align default WAF rate-limit configuration with the global per-IP cap and guard it with invariants to keep shipped settings internally consistent.

Bug Fixes:
- Raise the global per-IP rate-limit cap and adjust `/ws/` and `/ws/oauth` tiers so path limits bind below the global cap instead of being inert.

Enhancements:
- Document how the global cap stacks with path-specific tiers in both the main configuration and WAF documentation, clarifying that per-path tiers provide the effective endpoint protection.

Tests:
- Add a rate-limit config invariant unit test that loads the shipped `carlos.properties` to ensure all path tiers parse and none exceed the global cap.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align the default WAF rate-limit tiers with the global per‑IP cap so path limits actually bind, and guard the shipped config with an invariant test. Fixes #3058; leaves `WAF_RATE_LIMIT_ENABLED=false` and `WAF_RATE_LIMIT_MODE=detect` unchanged, and syncs docs/devcontainer config to the new numbers.

- **Bug Fixes**
  - Raise global per‑IP cap to 2000; set `/ws/` to 120/60 and add `/ws/oauth` at 15/60 so API tiers bind under global.
  - Add `RateLimitConfigInvariantUnitTest` (loads shipped config from the test classpath) to enforce: tiers ≤ global and all entries parse.
  - Update `docs/waf-standards-alignment.md` to match the new tiers, explain global+path stacking, and include `/forcepasswordresetSubmit=5/60`.
  - Sync `.devcontainer/.../carlos.properties` to the new tiers and clarify that per‑path tiers, not the global cap, protect endpoints.

<sup>Written for commit 28ce472c0308a658749a703de2eaa92808782d7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3066?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

