### PR TITLE
fix: Rourke export uses per-export filenames and aborts on XML save failure (#3064)

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/RourkeExport2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/RourkeExport2Action.java
@@ -3813,12 +3813,17 @@ public class RourkeExport2Action extends ActionSupport {
             // Always remove the temp XML/zip (PHI) on every exit path — including the save,
             // zip, and DOCUMENT_DIR-validation abort paths — so a failed export never leaves
             // persistent patient-data artifacts in the temp directory. Guarded by existence
-            // so absent files don't emit misleading delete-failure logs.
-            if (xmlFile.exists()) {
-                Util.cleanFiles(files);
-            }
-            if (zipFile.exists()) {
-                Util.cleanFile(zipName, tmpDir);
+            // so absent files don't emit misleading delete-failure logs, and failure-isolated
+            // so a cleanup error can never mask the original save/zip/validation failure.
+            try {
+                if (xmlFile.exists()) {
+                    Util.cleanFiles(files);
+                }
+                if (zipFile.exists()) {
+                    Util.cleanFile(zipName, tmpDir);
+                }
+            } catch (RuntimeException cleanupError) {
+                MiscUtils.getLogger().warn("Failed to clean up Rourke export temp files in " + tmpDir, cleanupError);
             }
         }
     }

--- a/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/RourkeExport2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/RourkeExport2Action.java
@@ -3780,38 +3780,47 @@ public class RourkeExport2Action extends ActionSupport {
         String fileName = "Rourke2009Export-" + exportId + ".xml";
         File tmpDirectory = PathValidationUtils.resolveConfiguredDirectory(tmpDir, "Rourke export temp directory");
         File xmlFile = PathValidationUtils.validateGeneratedChildPath(fileName, tmpDirectory);
-        try {
-            patientDocument.save(xmlFile, options);
-        } catch (IOException e) {
-            // Abort: never zip/persist a missing or partial XML, which could otherwise
-            // ship a stale file (another patient's data) from the temp directory.
-            MiscUtils.getLogger().error("Cannot write .xml file(s) to export directory " + tmpDir + ".\nPlease check directory permissions.", e);
-            throw e;
-        }
-
+        String zipName = "rourke2009_export-" + exportId + ".zip";
         ArrayList<File> files = new ArrayList<File>();
         files.add(xmlFile);
-        //Zip export files
-        String zipName = "rourke2009_export-" + exportId + ".zip";
-        if (!Util.zipFiles(files, zipName, tmpDir)) {
-            // Abort rather than copying a missing/partial zip into DOCUMENT_DIR below.
-            MiscUtils.getLogger().error("Error! Failed zipping export files");
-            throw new Exception("Failed to zip Rourke export files; aborting export");
+        try {
+            try {
+                patientDocument.save(xmlFile, options);
+            } catch (IOException e) {
+                // Abort: never zip/persist a missing or partial XML, which could otherwise
+                // ship a stale file (another patient's data) from the temp directory.
+                MiscUtils.getLogger().error("Cannot write .xml file(s) to export directory " + tmpDir + ".\nPlease check directory permissions.", e);
+                throw e;
+            }
+
+            //Zip export files
+            if (!Util.zipFiles(files, zipName, tmpDir)) {
+                // Abort rather than copying a missing/partial zip into DOCUMENT_DIR below.
+                MiscUtils.getLogger().error("Error! Failed zipping export files");
+                throw new Exception("Failed to zip Rourke export files; aborting export");
+            }
+
+            //copy zip to document directory
+            File zipFile = PathValidationUtils.validateGeneratedChildPath(zipName, tmpDirectory);
+            CarlosProperties properties = CarlosProperties.getInstance();
+            // Require DOCUMENT_DIR to be an existing directory: fail fast on misconfiguration
+            // rather than letting copyFileToDirectory lazily create an unintended location.
+            File destDir = PathValidationUtils.validateConfiguredDirectory(properties.getProperty("DOCUMENT_DIR"), "DOCUMENT_DIR");
+            org.apache.commons.io.FileUtils.copyFileToDirectory(zipFile, destDir);
+
+            return zipName;
+        } finally {
+            // Always remove the temp XML/zip (PHI) on every exit path — including the save,
+            // zip, and DOCUMENT_DIR-validation abort paths — so a failed export never leaves
+            // persistent patient-data artifacts in the temp directory. Guarded by existence
+            // so absent files don't emit misleading delete-failure logs.
+            if (xmlFile.exists()) {
+                Util.cleanFiles(files);
+            }
+            if (new File(tmpDirectory, zipName).exists()) {
+                Util.cleanFile(zipName, tmpDir);
+            }
         }
-
-        //copy zip to document directory
-        File zipFile = PathValidationUtils.validateGeneratedChildPath(zipName, tmpDirectory);
-        CarlosProperties properties = CarlosProperties.getInstance();
-        // Require DOCUMENT_DIR to be an existing directory: fail fast on misconfiguration
-        // rather than letting copyFileToDirectory lazily create an unintended location.
-        File destDir = PathValidationUtils.validateConfiguredDirectory(properties.getProperty("DOCUMENT_DIR"), "DOCUMENT_DIR");
-        org.apache.commons.io.FileUtils.copyFileToDirectory(zipFile, destDir);
-
-        //Remove zip & export files from temp dir
-        Util.cleanFile(zipName, tmpDir);
-        Util.cleanFiles(files);
-
-        return zipName;
     }
 
     private String patientSet;

--- a/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/RourkeExport2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/RourkeExport2Action.java
@@ -3781,6 +3781,7 @@ public class RourkeExport2Action extends ActionSupport {
         File tmpDirectory = PathValidationUtils.resolveConfiguredDirectory(tmpDir, "Rourke export temp directory");
         File xmlFile = PathValidationUtils.validateGeneratedChildPath(fileName, tmpDirectory);
         String zipName = "rourke2009_export-" + exportId + ".zip";
+        File zipFile = PathValidationUtils.validateGeneratedChildPath(zipName, tmpDirectory);
         ArrayList<File> files = new ArrayList<File>();
         files.add(xmlFile);
         try {
@@ -3801,7 +3802,6 @@ public class RourkeExport2Action extends ActionSupport {
             }
 
             //copy zip to document directory
-            File zipFile = PathValidationUtils.validateGeneratedChildPath(zipName, tmpDirectory);
             CarlosProperties properties = CarlosProperties.getInstance();
             // Require DOCUMENT_DIR to be an existing directory: fail fast on misconfiguration
             // rather than letting copyFileToDirectory lazily create an unintended location.
@@ -3817,7 +3817,7 @@ public class RourkeExport2Action extends ActionSupport {
             if (xmlFile.exists()) {
                 Util.cleanFiles(files);
             }
-            if (new File(tmpDirectory, zipName).exists()) {
+            if (zipFile.exists()) {
                 Util.cleanFile(zipName, tmpDir);
             }
         }

--- a/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/RourkeExport2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/RourkeExport2Action.java
@@ -3802,7 +3802,9 @@ public class RourkeExport2Action extends ActionSupport {
         //copy zip to document directory
         File zipFile = PathValidationUtils.validateGeneratedChildPath(zipName, tmpDirectory);
         CarlosProperties properties = CarlosProperties.getInstance();
-        File destDir = PathValidationUtils.resolveConfiguredDirectory(properties.getProperty("DOCUMENT_DIR"), "DOCUMENT_DIR");
+        // Require DOCUMENT_DIR to be an existing directory: fail fast on misconfiguration
+        // rather than letting copyFileToDirectory lazily create an unintended location.
+        File destDir = PathValidationUtils.validateConfiguredDirectory(properties.getProperty("DOCUMENT_DIR"), "DOCUMENT_DIR");
         org.apache.commons.io.FileUtils.copyFileToDirectory(zipFile, destDir);
 
         //Remove zip & export files from temp dir

--- a/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/RourkeExport2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/RourkeExport2Action.java
@@ -3813,17 +3813,22 @@ public class RourkeExport2Action extends ActionSupport {
             // Always remove the temp XML/zip (PHI) on every exit path — including the save,
             // zip, and DOCUMENT_DIR-validation abort paths — so a failed export never leaves
             // persistent patient-data artifacts in the temp directory. Guarded by existence
-            // so absent files don't emit misleading delete-failure logs, and failure-isolated
-            // so a cleanup error can never mask the original save/zip/validation failure.
+            // so absent files don't emit misleading delete-failure logs. Each cleanup is
+            // independently failure-isolated so neither a cleanup error masks the original
+            // save/zip/validation failure nor one failing cleanup skips the other.
             try {
                 if (xmlFile.exists()) {
                     Util.cleanFiles(files);
                 }
+            } catch (RuntimeException cleanupError) {
+                MiscUtils.getLogger().warn("Failed to clean up Rourke export temp XML in " + tmpDir, cleanupError);
+            }
+            try {
                 if (zipFile.exists()) {
                     Util.cleanFile(zipName, tmpDir);
                 }
             } catch (RuntimeException cleanupError) {
-                MiscUtils.getLogger().warn("Failed to clean up Rourke export temp files in " + tmpDir, cleanupError);
+                MiscUtils.getLogger().warn("Failed to clean up Rourke export temp zip in " + tmpDir, cleanupError);
             }
         }
     }

--- a/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/RourkeExport2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/RourkeExport2Action.java
@@ -3774,19 +3774,25 @@ public class RourkeExport2Action extends ActionSupport {
 
         options.setSaveOuter();
 
-        String fileName = "Rourke2009Export.xml";
+        // Per-export unique id shared by the XML and zip names so concurrent or repeated
+        // exports cannot collide on a shared temp filename and package another patient's data.
+        String exportId = UtilDateUtilities.getToday("yyyy-MM-dd.HH.mm.ss") + "-" + UUID.randomUUID();
+        String fileName = "Rourke2009Export-" + exportId + ".xml";
         File tmpDirectory = PathValidationUtils.resolveConfiguredDirectory(tmpDir, "Rourke export temp directory");
         File xmlFile = PathValidationUtils.validateGeneratedChildPath(fileName, tmpDirectory);
         try {
             patientDocument.save(xmlFile, options);
         } catch (IOException e) {
+            // Abort: never zip/persist a missing or partial XML, which could otherwise
+            // ship a stale file (another patient's data) from the temp directory.
             MiscUtils.getLogger().error("Cannot write .xml file(s) to export directory " + tmpDir + ".\nPlease check directory permissions.", e);
+            throw e;
         }
 
         ArrayList<File> files = new ArrayList<File>();
         files.add(xmlFile);
         //Zip export files
-        String zipName = "rourke2009_export-" + UtilDateUtilities.getToday("yyyy-MM-dd.HH.mm.ss") + ".zip";
+        String zipName = "rourke2009_export-" + exportId + ".zip";
         if (!Util.zipFiles(files, zipName, tmpDir)) {
             // Abort rather than copying a missing/partial zip into DOCUMENT_DIR below.
             MiscUtils.getLogger().error("Error! Failed zipping export files");

--- a/src/test/java/io/github/carlos_emr/carlos/demographic/pageUtil/RourkeExport2ActionExportUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/demographic/pageUtil/RourkeExport2ActionExportUnitTest.java
@@ -294,4 +294,38 @@ class RourkeExport2ActionExportUnitTest extends CarlosUnitTestBase {
                     .hasMessage("primary save failure");
         }
     }
+
+    @Test
+    @DisplayName("should still clean the temp zip when temp XML cleanup fails")
+    void shouldStillCleanZip_whenXmlCleanupFails(@TempDir Path tmpDir) throws Throwable {
+        PatientDocument document = mock(PatientDocument.class);
+        // Successful export: materialize XML and zip so both cleanup branches are reached.
+        doAnswer(invocation -> {
+            Files.writeString(invocation.getArgument(0, File.class).toPath(), "<PatientRecord/>");
+            return null;
+        }).when(document).save(any(File.class), any(XmlOptions.class));
+
+        File documentDir = tmpDir.resolve("documents").toFile();
+        assertThat(documentDir.mkdirs()).isTrue();
+        CarlosProperties properties = mock(CarlosProperties.class);
+        when(properties.getProperty("DOCUMENT_DIR")).thenReturn(documentDir.getAbsolutePath());
+
+        try (MockedStatic<Util> util = mockStatic(Util.class);
+             MockedStatic<CarlosProperties> carlosProperties = mockStatic(CarlosProperties.class);
+             MockedStatic<FileUtils> fileUtils = mockStatic(FileUtils.class)) {
+            util.when(() -> Util.zipFiles(any(), anyString(), anyString())).thenAnswer(invocation -> {
+                Files.writeString(new File(invocation.getArgument(2, String.class),
+                        invocation.getArgument(1, String.class)).toPath(), "zip");
+                return true;
+            });
+            carlosProperties.when(CarlosProperties::getInstance).thenReturn(properties);
+            // XML cleanup throws; the zip cleanup must still run (independent isolation).
+            util.when(() -> Util.cleanFiles(any())).thenThrow(new RuntimeException("xml cleanup boom"));
+
+            String zipName = (String) invokeMakeFiles(document, tmpDir.toString());
+
+            assertThat(zipName).startsWith("rourke2009_export-").endsWith(".zip");
+            util.verify(() -> Util.cleanFile(anyString(), anyString()), times(1));
+        }
+    }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/demographic/pageUtil/RourkeExport2ActionExportUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/demographic/pageUtil/RourkeExport2ActionExportUnitTest.java
@@ -260,4 +260,24 @@ class RourkeExport2ActionExportUnitTest extends CarlosUnitTestBase {
                 .as("temp XML containing patient data must be removed on abort")
                 .doesNotExist();
     }
+
+    @Test
+    @DisplayName("should propagate the original failure even when temp cleanup also fails")
+    void shouldPropagateOriginalFailure_whenCleanupAlsoFails(@TempDir Path tmpDir) throws Throwable {
+        PatientDocument document = mock(PatientDocument.class);
+        doAnswer(invocation -> {
+            File target = invocation.getArgument(0, File.class);
+            Files.writeString(target.toPath(), "<PatientRecord/>"); // real temp file so finally attempts cleanup
+            throw new IOException("primary save failure");
+        }).when(document).save(any(File.class), any(XmlOptions.class));
+
+        try (MockedStatic<Util> util = mockStatic(Util.class)) {
+            // Cleanup blows up inside finally; it must not mask the original save failure.
+            util.when(() -> Util.cleanFiles(any())).thenThrow(new RuntimeException("cleanup boom"));
+
+            assertThatThrownBy(() -> invokeMakeFiles(document, tmpDir.toString()))
+                    .isInstanceOf(IOException.class)
+                    .hasMessage("primary save failure");
+        }
+    }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/demographic/pageUtil/RourkeExport2ActionExportUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/demographic/pageUtil/RourkeExport2ActionExportUnitTest.java
@@ -213,4 +213,29 @@ class RourkeExport2ActionExportUnitTest extends CarlosUnitTestBase {
                 .as("each successful export must produce a distinct zip name")
                 .isNotEqualTo(firstZip);
     }
+
+    @Test
+    @DisplayName("should abort the export and not copy when DOCUMENT_DIR does not exist")
+    void shouldAbortWithoutCopying_whenDocumentDirectoryIsMissing(@TempDir Path tmpDir) throws Throwable {
+        PatientDocument document = mock(PatientDocument.class); // save() is a no-op success
+
+        // A configured DOCUMENT_DIR that does not exist must fail fast rather than be lazily created.
+        File missingDir = tmpDir.resolve("missing-document-dir").toFile();
+        assertThat(missingDir).doesNotExist();
+        CarlosProperties properties = mock(CarlosProperties.class);
+        when(properties.getProperty("DOCUMENT_DIR")).thenReturn(missingDir.getAbsolutePath());
+
+        try (MockedStatic<Util> util = mockStatic(Util.class);
+             MockedStatic<CarlosProperties> carlosProperties = mockStatic(CarlosProperties.class);
+             MockedStatic<FileUtils> fileUtils = mockStatic(FileUtils.class)) {
+            util.when(() -> Util.zipFiles(any(), anyString(), anyString())).thenReturn(true);
+            carlosProperties.when(CarlosProperties::getInstance).thenReturn(properties);
+
+            assertThatThrownBy(() -> invokeMakeFiles(document, tmpDir.toString()))
+                    .isInstanceOf(SecurityException.class);
+
+            // The zip is never copied into the misconfigured destination.
+            fileUtils.verify(() -> FileUtils.copyFileToDirectory(any(File.class), any(File.class)), never());
+        }
+    }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/demographic/pageUtil/RourkeExport2ActionExportUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/demographic/pageUtil/RourkeExport2ActionExportUnitTest.java
@@ -1,0 +1,159 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.demographic.pageUtil;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import cdsrourke.PatientDocument;
+
+import io.github.carlos_emr.CarlosProperties;
+import io.github.carlos_emr.carlos.test.base.CarlosWebTestBase;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.xmlbeans.XmlOptions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.MockedStatic;
+
+/**
+ * Unit coverage for {@code RourkeExport2Action} export-file handling (issue #3064): each export
+ * must use a unique temp filename and must abort rather than package a missing/partial XML.
+ *
+ * @since 2026-06-26
+ */
+@DisplayName("RourkeExport2Action export file handling")
+@Tag("unit")
+@Tag("web")
+@Tag("demographic")
+class RourkeExport2ActionExportUnitTest extends CarlosWebTestBase {
+
+    // makeFiles(...) uses only its arguments and static collaborators, not instance fields,
+    // so the action is constructed via its standard no-arg constructor.
+    private RourkeExport2Action newAction() {
+        return new RourkeExport2Action();
+    }
+
+    private static Object invokeMakeFiles(RourkeExport2Action action, PatientDocument doc, String tmpDir)
+            throws Throwable {
+        Method makeFiles = RourkeExport2Action.class.getDeclaredMethod("makeFiles", PatientDocument.class, String.class);
+        makeFiles.setAccessible(true);
+        try {
+            return makeFiles.invoke(action, doc, tmpDir);
+        } catch (InvocationTargetException e) {
+            throw e.getCause();
+        }
+    }
+
+    @Test
+    @DisplayName("should abort the export without zipping when the XML save fails")
+    void shouldAbortWithoutZipping_whenXmlSaveFails(@TempDir Path tmpDir) throws Exception {
+        RourkeExport2Action action = newAction();
+        PatientDocument document = mock(PatientDocument.class);
+        doAnswer(invocation -> {
+            throw new IOException("simulated disk failure");
+        }).when(document).save(any(File.class), any(XmlOptions.class));
+
+        try (MockedStatic<Util> util = mockStatic(Util.class)) {
+            assertThatThrownBy(() -> invokeMakeFiles(action, document, tmpDir.toString()))
+                    .isInstanceOf(IOException.class);
+
+            // The export must never proceed to zip a missing/partial XML.
+            util.verify(() -> Util.zipFiles(any(), anyString(), anyString()), never());
+        }
+    }
+
+    @Test
+    @DisplayName("should use a unique XML filename per export across repeated exports")
+    void shouldUseUniqueXmlFilename_acrossRepeatedExports(@TempDir Path tmpDir) throws Exception {
+        RourkeExport2Action action = newAction();
+        PatientDocument document = mock(PatientDocument.class);
+        List<File> savedTargets = new ArrayList<>();
+        doAnswer(invocation -> {
+            savedTargets.add(invocation.getArgument(0, File.class));
+            throw new IOException("stop before zipping");
+        }).when(document).save(any(File.class), any(XmlOptions.class));
+
+        try (MockedStatic<Util> util = mockStatic(Util.class)) {
+            catchThrowable(() -> invokeMakeFiles(action, document, tmpDir.toString()));
+            catchThrowable(() -> invokeMakeFiles(action, document, tmpDir.toString()));
+        }
+
+        assertThat(savedTargets).hasSize(2);
+        assertThat(savedTargets.get(0).getName())
+                .startsWith("Rourke2009Export-")
+                .endsWith(".xml");
+        assertThat(savedTargets.get(0).getName())
+                .as("each export must target a distinct temp filename")
+                .isNotEqualTo(savedTargets.get(1).getName());
+    }
+
+    @Test
+    @DisplayName("should zip and return a unique export name when the XML save succeeds")
+    void shouldZipAndReturnUniqueExportName_whenSaveSucceeds(@TempDir Path tmpDir) throws Throwable {
+        RourkeExport2Action action = newAction();
+        PatientDocument document = mock(PatientDocument.class); // save() is a no-op success
+
+        File documentDir = tmpDir.resolve("documents").toFile();
+        assertThat(documentDir.mkdirs()).isTrue();
+        CarlosProperties properties = mock(CarlosProperties.class);
+        when(properties.getProperty("DOCUMENT_DIR")).thenReturn(documentDir.getAbsolutePath());
+
+        String firstZip;
+        String secondZip;
+        try (MockedStatic<Util> util = mockStatic(Util.class);
+             MockedStatic<CarlosProperties> carlosProperties = mockStatic(CarlosProperties.class);
+             MockedStatic<FileUtils> fileUtils = mockStatic(FileUtils.class)) {
+            util.when(() -> Util.zipFiles(any(), anyString(), anyString())).thenReturn(true);
+            carlosProperties.when(CarlosProperties::getInstance).thenReturn(properties);
+
+            firstZip = (String) invokeMakeFiles(action, document, tmpDir.toString());
+            secondZip = (String) invokeMakeFiles(action, document, tmpDir.toString());
+
+            util.verify(() -> Util.zipFiles(any(), anyString(), anyString()), times(2));
+        }
+
+        assertThat(firstZip).startsWith("rourke2009_export-").endsWith(".zip");
+        assertThat(secondZip)
+                .as("each successful export must produce a distinct zip name")
+                .isNotEqualTo(firstZip);
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/demographic/pageUtil/RourkeExport2ActionExportUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/demographic/pageUtil/RourkeExport2ActionExportUnitTest.java
@@ -44,15 +44,29 @@ import java.util.List;
 import cdsrourke.PatientDocument;
 
 import io.github.carlos_emr.CarlosProperties;
-import io.github.carlos_emr.carlos.test.base.CarlosWebTestBase;
+import io.github.carlos_emr.carlos.commn.dao.ClinicDAO;
+import io.github.carlos_emr.carlos.commn.dao.DataExportDao;
+import io.github.carlos_emr.carlos.commn.dao.DemographicDao;
+import io.github.carlos_emr.carlos.commn.dao.PartialDateDao;
+import io.github.carlos_emr.carlos.commn.dao.forms.Rourke2009DAO;
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.struts2.ServletActionContext;
 import org.apache.xmlbeans.XmlOptions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
 import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
 
 /**
  * Unit coverage for {@code RourkeExport2Action} export-file handling (issue #3064): each export
@@ -62,18 +76,63 @@ import org.mockito.MockedStatic;
  */
 @DisplayName("RourkeExport2Action export file handling")
 @Tag("unit")
-@Tag("web")
 @Tag("demographic")
-class RourkeExport2ActionExportUnitTest extends CarlosWebTestBase {
+class RourkeExport2ActionExportUnitTest extends CarlosUnitTestBase {
 
-    // makeFiles(...) uses only its arguments and static collaborators, not instance fields,
-    // so the action is constructed via its standard no-arg constructor.
-    private RourkeExport2Action newAction() {
-        return new RourkeExport2Action();
+    @Mock
+    private SecurityInfoManager securityInfoManager;
+    @Mock
+    private ClinicDAO clinicDAO;
+    @Mock
+    private DataExportDao dataExportDAO;
+    @Mock
+    private DemographicDao demographicDao;
+    @Mock
+    private Rourke2009DAO rourke2009DAO;
+    @Mock
+    private PartialDateDao partialDateDao;
+    @Mock
+    private HttpServletRequest request;
+    @Mock
+    private HttpServletResponse response;
+
+    private AutoCloseable mocks;
+    private MockedStatic<ServletActionContext> servletActionContextMock;
+    private RourkeExport2Action action;
+
+    @BeforeEach
+    void setUp() {
+        mocks = MockitoAnnotations.openMocks(this);
+
+        // The no-arg constructor resolves these via SpringUtils.getBean(...).
+        registerMock(SecurityInfoManager.class, securityInfoManager);
+        registerMock(ClinicDAO.class, clinicDAO);
+        registerMock(DataExportDao.class, dataExportDAO);
+        registerMock(DemographicDao.class, demographicDao);
+        registerMock(Rourke2009DAO.class, rourke2009DAO);
+        // Util's static initializer resolves PartialDateDao via SpringUtils when the class loads.
+        registerMock(PartialDateDao.class, partialDateDao);
+
+        // Field initializers read request/response from ServletActionContext at construction.
+        servletActionContextMock = mockStatic(ServletActionContext.class);
+        servletActionContextMock.when(ServletActionContext::getRequest).thenReturn(request);
+        servletActionContextMock.when(ServletActionContext::getResponse).thenReturn(response);
+
+        action = new RourkeExport2Action();
     }
 
-    private static Object invokeMakeFiles(RourkeExport2Action action, PatientDocument doc, String tmpDir)
-            throws Throwable {
+    @AfterEach
+    void tearDown() throws Exception {
+        if (servletActionContextMock != null) {
+            servletActionContextMock.close();
+        }
+        if (mocks != null) {
+            mocks.close();
+        }
+    }
+
+    // makeFiles(...) uses only its arguments and static collaborators, not instance fields.
+    private Object invokeMakeFiles(PatientDocument doc, String tmpDir) throws Throwable {
         Method makeFiles = RourkeExport2Action.class.getDeclaredMethod("makeFiles", PatientDocument.class, String.class);
         makeFiles.setAccessible(true);
         try {
@@ -86,14 +145,13 @@ class RourkeExport2ActionExportUnitTest extends CarlosWebTestBase {
     @Test
     @DisplayName("should abort the export without zipping when the XML save fails")
     void shouldAbortWithoutZipping_whenXmlSaveFails(@TempDir Path tmpDir) throws Exception {
-        RourkeExport2Action action = newAction();
         PatientDocument document = mock(PatientDocument.class);
         doAnswer(invocation -> {
             throw new IOException("simulated disk failure");
         }).when(document).save(any(File.class), any(XmlOptions.class));
 
         try (MockedStatic<Util> util = mockStatic(Util.class)) {
-            assertThatThrownBy(() -> invokeMakeFiles(action, document, tmpDir.toString()))
+            assertThatThrownBy(() -> invokeMakeFiles(document, tmpDir.toString()))
                     .isInstanceOf(IOException.class);
 
             // The export must never proceed to zip a missing/partial XML.
@@ -104,7 +162,6 @@ class RourkeExport2ActionExportUnitTest extends CarlosWebTestBase {
     @Test
     @DisplayName("should use a unique XML filename per export across repeated exports")
     void shouldUseUniqueXmlFilename_acrossRepeatedExports(@TempDir Path tmpDir) throws Exception {
-        RourkeExport2Action action = newAction();
         PatientDocument document = mock(PatientDocument.class);
         List<File> savedTargets = new ArrayList<>();
         doAnswer(invocation -> {
@@ -112,10 +169,8 @@ class RourkeExport2ActionExportUnitTest extends CarlosWebTestBase {
             throw new IOException("stop before zipping");
         }).when(document).save(any(File.class), any(XmlOptions.class));
 
-        try (MockedStatic<Util> util = mockStatic(Util.class)) {
-            catchThrowable(() -> invokeMakeFiles(action, document, tmpDir.toString()));
-            catchThrowable(() -> invokeMakeFiles(action, document, tmpDir.toString()));
-        }
+        catchThrowable(() -> invokeMakeFiles(document, tmpDir.toString()));
+        catchThrowable(() -> invokeMakeFiles(document, tmpDir.toString()));
 
         assertThat(savedTargets).hasSize(2);
         assertThat(savedTargets.get(0).getName())
@@ -129,7 +184,6 @@ class RourkeExport2ActionExportUnitTest extends CarlosWebTestBase {
     @Test
     @DisplayName("should zip and return a unique export name when the XML save succeeds")
     void shouldZipAndReturnUniqueExportName_whenSaveSucceeds(@TempDir Path tmpDir) throws Throwable {
-        RourkeExport2Action action = newAction();
         PatientDocument document = mock(PatientDocument.class); // save() is a no-op success
 
         File documentDir = tmpDir.resolve("documents").toFile();
@@ -139,16 +193,19 @@ class RourkeExport2ActionExportUnitTest extends CarlosWebTestBase {
 
         String firstZip;
         String secondZip;
+        // FileUtils is mocked so the real copyFileToDirectory (which would fail on the
+        // never-actually-written temp zip) is suppressed; CarlosProperties supplies DOCUMENT_DIR.
         try (MockedStatic<Util> util = mockStatic(Util.class);
              MockedStatic<CarlosProperties> carlosProperties = mockStatic(CarlosProperties.class);
              MockedStatic<FileUtils> fileUtils = mockStatic(FileUtils.class)) {
             util.when(() -> Util.zipFiles(any(), anyString(), anyString())).thenReturn(true);
             carlosProperties.when(CarlosProperties::getInstance).thenReturn(properties);
 
-            firstZip = (String) invokeMakeFiles(action, document, tmpDir.toString());
-            secondZip = (String) invokeMakeFiles(action, document, tmpDir.toString());
+            firstZip = (String) invokeMakeFiles(document, tmpDir.toString());
+            secondZip = (String) invokeMakeFiles(document, tmpDir.toString());
 
             util.verify(() -> Util.zipFiles(any(), anyString(), anyString()), times(2));
+            fileUtils.verify(() -> FileUtils.copyFileToDirectory(any(File.class), any(File.class)), times(2));
         }
 
         assertThat(firstZip).startsWith("rourke2009_export-").endsWith(".zip");

--- a/src/test/java/io/github/carlos_emr/carlos/demographic/pageUtil/RourkeExport2ActionExportUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/demographic/pageUtil/RourkeExport2ActionExportUnitTest.java
@@ -37,6 +37,7 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -237,5 +238,26 @@ class RourkeExport2ActionExportUnitTest extends CarlosUnitTestBase {
             // The zip is never copied into the misconfigured destination.
             fileUtils.verify(() -> FileUtils.copyFileToDirectory(any(File.class), any(File.class)), never());
         }
+    }
+
+    @Test
+    @DisplayName("should delete the temp XML when the export aborts after a partial write")
+    void shouldDeleteTempXml_whenExportAbortsAfterPartialWrite(@TempDir Path tmpDir) throws Throwable {
+        PatientDocument document = mock(PatientDocument.class);
+        List<File> written = new ArrayList<>();
+        doAnswer(invocation -> {
+            File target = invocation.getArgument(0, File.class);
+            Files.writeString(target.toPath(), "<PatientRecord/>"); // simulate a partial PHI write
+            written.add(target);
+            throw new IOException("partial write then failure");
+        }).when(document).save(any(File.class), any(XmlOptions.class));
+
+        assertThatThrownBy(() -> invokeMakeFiles(document, tmpDir.toString()))
+                .isInstanceOf(IOException.class);
+
+        assertThat(written).hasSize(1);
+        assertThat(written.get(0))
+                .as("temp XML containing patient data must be removed on abort")
+                .doesNotExist();
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/demographic/pageUtil/RourkeExport2ActionExportUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/demographic/pageUtil/RourkeExport2ActionExportUnitTest.java
@@ -185,7 +185,12 @@ class RourkeExport2ActionExportUnitTest extends CarlosUnitTestBase {
     @Test
     @DisplayName("should zip and return a unique export name when the XML save succeeds")
     void shouldZipAndReturnUniqueExportName_whenSaveSucceeds(@TempDir Path tmpDir) throws Throwable {
-        PatientDocument document = mock(PatientDocument.class); // save() is a no-op success
+        PatientDocument document = mock(PatientDocument.class);
+        // Materialize the XML on save so the success-path cleanup branch (xmlFile.exists()) runs.
+        doAnswer(invocation -> {
+            Files.writeString(invocation.getArgument(0, File.class).toPath(), "<PatientRecord/>");
+            return null;
+        }).when(document).save(any(File.class), any(XmlOptions.class));
 
         File documentDir = tmpDir.resolve("documents").toFile();
         assertThat(documentDir.mkdirs()).isTrue();
@@ -194,12 +199,18 @@ class RourkeExport2ActionExportUnitTest extends CarlosUnitTestBase {
 
         String firstZip;
         String secondZip;
-        // FileUtils is mocked so the real copyFileToDirectory (which would fail on the
-        // never-actually-written temp zip) is suppressed; CarlosProperties supplies DOCUMENT_DIR.
+        // FileUtils is mocked so the real copyFileToDirectory is suppressed; CarlosProperties
+        // supplies DOCUMENT_DIR. zipFiles materializes the temp zip so the success-path cleanup
+        // branch (zipFile.exists()) is exercised.
         try (MockedStatic<Util> util = mockStatic(Util.class);
              MockedStatic<CarlosProperties> carlosProperties = mockStatic(CarlosProperties.class);
              MockedStatic<FileUtils> fileUtils = mockStatic(FileUtils.class)) {
-            util.when(() -> Util.zipFiles(any(), anyString(), anyString())).thenReturn(true);
+            util.when(() -> Util.zipFiles(any(), anyString(), anyString())).thenAnswer(invocation -> {
+                String zip = invocation.getArgument(1, String.class);
+                String dir = invocation.getArgument(2, String.class);
+                Files.writeString(new File(dir, zip).toPath(), "zip");
+                return true;
+            });
             carlosProperties.when(CarlosProperties::getInstance).thenReturn(properties);
 
             firstZip = (String) invokeMakeFiles(document, tmpDir.toString());
@@ -207,6 +218,9 @@ class RourkeExport2ActionExportUnitTest extends CarlosUnitTestBase {
 
             util.verify(() -> Util.zipFiles(any(), anyString(), anyString()), times(2));
             fileUtils.verify(() -> FileUtils.copyFileToDirectory(any(File.class), any(File.class)), times(2));
+            // Success-path cleanup must remove both temp artifacts on each export.
+            util.verify(() -> Util.cleanFiles(any()), times(2));
+            util.verify(() -> Util.cleanFile(anyString(), anyString()), times(2));
         }
 
         assertThat(firstZip).startsWith("rourke2009_export-").endsWith(".zip");


### PR DESCRIPTION
fixes #3064

## Problem
`RourkeExport2Action.makeFiles(...)` wrote patient XML to a **shared fixed filename** (`Rourke2009Export.xml`) in the temp directory and only **logged** XML save failures rather than aborting. Concurrent/repeated exports, or a stale file left by a previously failed save, could cause the **wrong patient's XML** to be zipped and persisted — a PHI exposure risk.

## Scope (full ticket #3064)
- Generate a per-export unique id (`timestamp + UUID`) shared by the XML and zip filenames so exports cannot collide on a shared temp file.
- Rethrow on `patientDocument.save(...)` `IOException` so a missing/partial XML is never zipped or persisted.
- Validate the export destination: use `PathValidationUtils.validateConfiguredDirectory(...)` for `DOCUMENT_DIR` so a missing/misconfigured directory fails fast (`SecurityException`) instead of being lazily created by `copyFileToDirectory` (the ticket's secondary item).

## Changes
- `RourkeExport2Action.java` — unique per-export XML/zip names; abort (rethrow) on XML save failure; `DOCUMENT_DIR` validated as an existing directory. No PHI added to logs (existing message logs only the temp directory path).

## Tests
`RourkeExport2ActionExportUnitTest` (new) covers the acceptance criteria via the `makeFiles` seam:
- **abort-without-zip** when the XML save fails (asserts `IOException` propagates and `Util.zipFiles` is never called),
- **unique XML filename** across repeated exports,
- **happy path** returns a unique zip name and zips once,
- **abort-without-copy** when `DOCUMENT_DIR` does not exist (asserts `SecurityException` and `FileUtils.copyFileToDirectory` is never called).

Verified locally: `mvn test -Dtest=RourkeExport2ActionExportUnitTest -Pskip-dependency-lock` → 4 passed, BUILD SUCCESS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure Rourke export uses unique per-export filenames and aborts cleanly on failures to avoid packaging incorrect or partial patient data.

Bug Fixes:
- Prevent Rourke exports from reusing a shared temp XML filename that could cause another patient's data to be zipped and persisted.
- Stop silently continuing when the patient XML save fails by propagating the IOException and aborting the export.
- Fail fast when DOCUMENT_DIR is misconfigured or missing instead of allowing an unintended directory to be created.

Enhancements:
- Clean up temporary XML and zip files on all export code paths to avoid leaving PHI artifacts in the temp directory.

Tests:
- Add RourkeExport2ActionExportUnitTest to cover abort-on-save-failure, unique filenames per export, happy-path zipping, misconfigured DOCUMENT_DIR handling, and temp-file cleanup behavior.