### PR TITLE
chore: suppress false-positive log-injection alerts (S5145) in three logging paths

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/BillingONCHeader1.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/BillingONCHeader1.java
@@ -446,7 +446,7 @@ public class BillingONCHeader1 extends AbstractModel<Integer> implements Seriali
         // New typed service flows should call this variant so status drift is
         // rejected at the boundary instead of being re-persisted indefinitely.
         if (value != null && !KNOWN_STATUSES.contains(value)) {
-            logger.warn("Rejecting unknown BillingONCHeader1 status value {} (allowed: {})", // NOSONAR javasecurity:S5145 (SonarCloud alert #26175) — false positive: value is sanitized via LogSafe (OWASP Encode.forJava escapes CR/LF/control chars and caps length), neutralizing log injection; Sonar does not model the LogSafe wrapper as a sanitizer
+            logger.warn("Rejecting unknown BillingONCHeader1 status value {} (allowed: {})", // NOSONAR javasecurity:S5145 (SonarCloud alert #26175) — sanitized with LogSafe
                     LogSafe.sanitize(value), KNOWN_STATUSES);
             throw new IllegalArgumentException(
                     "BillingONCHeader1 status is not in the known set; see logs for the offending value");

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/BillingONCHeader1.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/BillingONCHeader1.java
@@ -446,7 +446,7 @@ public class BillingONCHeader1 extends AbstractModel<Integer> implements Seriali
         // New typed service flows should call this variant so status drift is
         // rejected at the boundary instead of being re-persisted indefinitely.
         if (value != null && !KNOWN_STATUSES.contains(value)) {
-            logger.warn("Rejecting unknown BillingONCHeader1 status value {} (allowed: {})",
+            logger.warn("Rejecting unknown BillingONCHeader1 status value {} (allowed: {})", // NOSONAR javasecurity:S5145 (SonarCloud alert #26175) — false positive: value is sanitized via LogSafe (OWASP Encode.forJava escapes CR/LF/control chars and caps length), neutralizing log injection; Sonar does not model the LogSafe wrapper as a sanitizer
                     LogSafe.sanitize(value), KNOWN_STATUSES);
             throw new IllegalArgumentException(
                     "BillingONCHeader1 status is not in the known set; see logs for the offending value");

--- a/src/main/java/io/github/carlos_emr/carlos/email/action/EmailCompose2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/email/action/EmailCompose2Action.java
@@ -228,7 +228,7 @@ public class EmailCompose2Action extends ActionSupport {
         if (fid != null && !fid.matches("\\d+")) {
             if (logger.isWarnEnabled()) {
                 String sanitizedFid = LogSafe.sanitize(fid);
-                logger.warn("Invalid fid parameter received: {}", sanitizedFid);
+                logger.warn("Invalid fid parameter received: {}", sanitizedFid); // NOSONAR javasecurity:S5145 (SonarCloud alert #26207) — false positive: fid is sanitized via LogSafe (OWASP Encode.forJava escapes CR/LF/control chars and caps length), neutralizing log injection; Sonar does not model the LogSafe wrapper as a sanitizer
             }
             fid = null;
         }

--- a/src/main/java/io/github/carlos_emr/carlos/email/action/EmailCompose2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/email/action/EmailCompose2Action.java
@@ -228,7 +228,7 @@ public class EmailCompose2Action extends ActionSupport {
         if (fid != null && !fid.matches("\\d+")) {
             if (logger.isWarnEnabled()) {
                 String sanitizedFid = LogSafe.sanitize(fid);
-                logger.warn("Invalid fid parameter received: {}", sanitizedFid); // NOSONAR javasecurity:S5145 (SonarCloud alert #26207) — false positive: fid is sanitized via LogSafe (OWASP Encode.forJava escapes CR/LF/control chars and caps length), neutralizing log injection; Sonar does not model the LogSafe wrapper as a sanitizer
+                logger.warn("Invalid fid parameter received: {}", sanitizedFid); // NOSONAR javasecurity:S5145 (SonarCloud alert #26207) — sanitized with LogSafe
             }
             fid = null;
         }

--- a/src/main/java/io/github/carlos_emr/carlos/login/gate/SelectFacility2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/login/gate/SelectFacility2Action.java
@@ -111,7 +111,7 @@ public final class SelectFacility2Action extends BaseLoginPageView2Action {
                 String safeProviderNo = LogSafe.sanitize(providerNo);
                 String safeNextResult = LogSafe.sanitize(nextResult);
                 String safeRemoteAddr = LogSafe.sanitize(request.getRemoteAddr());
-                LOGGER.warn("Rejected /select_facility nextPage before facility mutation: provider={}, nextPage={}, remote={}", // NOSONAR javasecurity:S5145 (SonarCloud alert #26206) — false positive: every user-controlled arg is sanitized via LogSafe (OWASP Encode.forJava escapes CR/LF/control chars and caps length), neutralizing log injection; Sonar does not model the LogSafe wrapper as a sanitizer
+                LOGGER.warn("Rejected /select_facility nextPage before facility mutation: provider={}, nextPage={}, remote={}", // NOSONAR javasecurity:S5145 (SonarCloud alert #26206) — all user-controlled args sanitized with LogSafe
                         safeProviderNo, safeNextResult, safeRemoteAddr);
             }
             return redirectToFacilitySelection(request, response);

--- a/src/main/java/io/github/carlos_emr/carlos/login/gate/SelectFacility2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/login/gate/SelectFacility2Action.java
@@ -111,7 +111,7 @@ public final class SelectFacility2Action extends BaseLoginPageView2Action {
                 String safeProviderNo = LogSafe.sanitize(providerNo);
                 String safeNextResult = LogSafe.sanitize(nextResult);
                 String safeRemoteAddr = LogSafe.sanitize(request.getRemoteAddr());
-                LOGGER.warn("Rejected /select_facility nextPage before facility mutation: provider={}, nextPage={}, remote={}",
+                LOGGER.warn("Rejected /select_facility nextPage before facility mutation: provider={}, nextPage={}, remote={}", // NOSONAR javasecurity:S5145 (SonarCloud alert #26206) — false positive: every user-controlled arg is sanitized via LogSafe (OWASP Encode.forJava escapes CR/LF/control chars and caps length), neutralizing log injection; Sonar does not model the LogSafe wrapper as a sanitizer
                         safeProviderNo, safeNextResult, safeRemoteAddr);
             }
             return redirectToFacilitySelection(request, response);


### PR DESCRIPTION
## Summary

Suppresses three **SonarCloud `javasecurity:S5145`** ("Logging should not be vulnerable to injection attacks") alerts that are **false positives** — the flagged values are already sanitized before logging:

| Alert | File:line | Sink |
|---|---|---|
| #26207 | `EmailCompose2Action.java:231` | `logger.warn(..., sanitizedFid)` where `sanitizedFid = LogSafe.sanitize(fid)` |
| #26206 | `SelectFacility2Action.java:114` | `LOGGER.warn(..., safeProviderNo, safeNextResult, safeRemoteAddr)` — all from `LogSafe.sanitize(...)` |
| #26175 | `BillingONCHeader1.java:449` | `logger.warn(..., LogSafe.sanitize(value), KNOWN_STATUSES)` |

> Note: `#26175/#26206/#26207` are **SonarCloud alert IDs**, not GitHub issues, so this PR has no `fixes #` auto-close link.

## Why these are false positives

Each tainted value is passed through `LogSafe.sanitize()` (`utility/LogSafe.java`), which runs OWASP **`Encode.forJava()`** — escaping CR/LF and other control characters and capping length — fully neutralizing the CRLF log-forgery vector S5145 targets. These exact lines were already remediated by prior merged PRs **#2929** (2026-06-19) and **#2931** (2026-06-23); Sonar re-flags them because its taint engine does not model the project's custom `LogSafe` wrapper as a sanitizer.

## What changed

- Added an inline `// NOSONAR javasecurity:S5145` suppression on each flagged log line, matching the existing codebase convention (e.g. `EctDisplayAction`, `DocumentUploadServlet`, `HttpMethodGuardFilter`), each annotated with the specific alert ID and a justification.
- **No behavioral change** — comment-only edits.

## Testing

- No tests added: the change is comment-only with no runtime behavior to assert; a test over a suppression comment would be meaningless/brittle.
- `mvn -o compile` — passes (exit 0).

## Follow-up (out of scope)

A durable fix is to register `LogSafe.sanitize` as a custom sanitizer in the SonarCloud Java analyzer's security configuration so it stops re-flagging the whole codebase. Worth a separate ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Chores:
- Add NOSONAR javasecurity:S5145 suppressions to three sanitized logger.warn calls to prevent repeated false-positive security alerts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppress three false-positive SonarCloud `javasecurity:S5145` log-injection alerts (#26175, #26206, #26207) by adding inline `// NOSONAR` on already-sanitized logger calls and trimming the comment text to the repo’s convention. All user-controlled values are passed through `LogSafe.sanitize()` (OWASP Encode.forJava), so there is no runtime change.

<sup>Written for commit 5c71addf6ba1b373b754b28b1cd0a6b3053b7ab8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3069?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

