### PR TITLE
[Security] [bug] Update pin input autocomplete attribute to 'off'

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/login/index.jsp
+++ b/src/main/webapp/WEB-INF/jsp/login/index.jsp
@@ -633,7 +633,7 @@ body {
                               NIST SP 800-63B (https://pages.nist.gov/800-63-3/sp800-63b.html) and
                               OWASP Authentication Cheat Sheet (https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html)
                               which recommend allowing password managers for stronger credential hygiene
-                            - pin: "one-time-code" \u2014 signal browsers this is a session code, not a saveable credential
+                            - pin: "off" \u2014 shared clinical workstations; prevent autofill of another provider's identity
                         --%>
                         <form action="login" method="POST" name="loginForm">
 
@@ -658,7 +658,7 @@ body {
                             <div class="pin-wrapper">
                                 <div class="input-wrapper mb-3 ${ login_error }">
                                   <!-- The input starts with the secure-text class -->
-                                  <input type="text" id="pin" class="form-control secure-text toggle-input" name="pin" autocomplete="one-time-code"
+                                  <input type="text" id="pin" class="form-control secure-text toggle-input" name="pin" autocomplete="off"
                                                inputmode="numeric"  placeholder="<fmt:message key="admin.securityrecord.formPIN"/>">
                                     <button type="button" tabindex="-1"
                                       id="togglePin"


### PR DESCRIPTION
<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description
Pin autocomplete was set to the token "one-time-code" in theory saved for the browser session
in practice it shows it plain text! as an autofill suggestion, albeit only the last pin, across browser sessions

<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues
Fixes #3075
<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?
develop
<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Bug Fixes:
- Correct PIN input autocomplete configuration from a one-time code hint to fully disabled to prevent unintended PIN autofill and exposure on login.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the login PIN input to autocomplete='off' to block saved or autofill suggestions on shared clinical workstations, fixing #3075. This replaces 'one-time-code', which caused some browsers to show the last PIN in plain text across sessions.

<sup>Written for commit 2df3ab3d451e81dd870f776d795a9f2c53bb922f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3076?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

