### PR TITLE
test: assert forced-reset staging keeps credential material out of session (fixes #2301)

### DIFF
--- a/src/test/java/io/github/carlos_emr/carlos/login/Login2ActionForcedPasswordResetUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/login/Login2ActionForcedPasswordResetUnitTest.java
@@ -1916,6 +1916,56 @@ class Login2ActionForcedPasswordResetUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
+    @DisplayName("should keep credential material out of session when staging forced reset")
+    void shouldKeepCredentialMaterialOutOfSession_whenStagingForcedReset() {
+        String password = VALID_PASSWORD;
+        String pin = "2026";
+        when(securityManager.encodePassword(password)).thenReturn(ENCODED_OLD_PASSWORD);
+        Login2Action action = newAction(null, null, null);
+
+        ReflectionTestUtils.invokeMethod(action, "setUserInfoToSession", request,
+                USERNAME, password, pin, "/provider/providercontrol.jsp");
+
+        MockHttpSession session = (MockHttpSession) request.getSession(false);
+        String token = (String) session.getAttribute(Login2Action.LOGIN_CREDENTIALS_TOKEN_ATTR);
+
+        // The session carries only the opaque token, which is not itself credential material.
+        assertThat(token).isNotBlank()
+                .doesNotContain(password)
+                .doesNotContain(ENCODED_OLD_PASSWORD);
+
+        // Strong form: enumerate EVERY session attribute and assert none leaks the raw
+        // password, the password hash, or the PIN, so a regression that stashed credential
+        // material under any other key would fail here (not just the known token attribute).
+        Collections.list(session.getAttributeNames()).forEach(name -> {
+            String value = String.valueOf(session.getAttribute(name));
+            assertThat(value)
+                    .as("session attribute '%s' must not contain the password or hash", name)
+                    .doesNotContain(password)
+                    .doesNotContain(ENCODED_OLD_PASSWORD);
+            // The opaque token is a 256-bit Base64URL random reference (verified above), not
+            // credential material; a 4-digit PIN can appear inside it by chance, so the PIN
+            // substring scan is applied to every OTHER attribute only. The PIN cannot leak
+            // into the token itself — tokens come from SecureRandom, independent of the PIN.
+            if (!Login2Action.LOGIN_CREDENTIALS_TOKEN_ATTR.equals(name)) {
+                assertThat(value)
+                        .as("session attribute '%s' must not contain the PIN", name)
+                        .doesNotContain(pin);
+            }
+        });
+
+        // Credentials — including the PIN — live server-side in the cache, referenced only
+        // by the opaque token.
+        LoginCredentialCache.LoginCredentials cached = LoginCredentialCache.getInstance().peek(token);
+        assertThat(cached).isNotNull();
+        assertThat(cached.getEncodedPassword()).isEqualTo(ENCODED_OLD_PASSWORD);
+        assertThat(cached.getPin()).isEqualTo(pin);
+        assertThat(cached.getUserName()).isEqualTo(USERNAME);
+
+        LoginCredentialCache.getInstance().invalidate(token);
+    }
+
+    @Test
     @DisplayName("should return generic fallback when message key is missing everywhere")
     void shouldReturnGenericFallback_whenMessageKeyIsMissingEverywhere() {
         try (LogCapture capture = LogCapture.forLogger(Login2Action.class)) {

--- a/src/test/java/io/github/carlos_emr/carlos/login/Login2ActionForcedPasswordResetUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/login/Login2ActionForcedPasswordResetUnitTest.java
@@ -123,6 +123,22 @@ class Login2ActionForcedPasswordResetUnitTest extends CarlosUnitTestBase {
         return String.join("", "Unit", label, "2026", "!");
     }
 
+    /**
+     * Decodes a session attribute value to text by its real type so credential material stored
+     * as {@code char[]} or {@code byte[]} (not just a {@code String}) is still scanned. Relying on
+     * {@code String.valueOf(Object)} would only exercise {@code toString()} and miss array-typed
+     * secrets, giving a false negative for the "no credential material in session" invariant.
+     */
+    private static String attributeAsText(Object value) {
+        if (value instanceof char[] chars) {
+            return new String(chars);
+        }
+        if (value instanceof byte[] bytes) {
+            return new String(bytes, StandardCharsets.UTF_8);
+        }
+        return String.valueOf(value);
+    }
+
     private MockedStatic<ServletActionContext> servletActionContextMock;
     private AutoCloseable mockitoCloseable;
     private MockHttpServletRequest request;
@@ -1927,42 +1943,47 @@ class Login2ActionForcedPasswordResetUnitTest extends CarlosUnitTestBase {
                 USERNAME, password, pin, "/provider/providercontrol.jsp");
 
         MockHttpSession session = (MockHttpSession) request.getSession(false);
+        assertThat(session).as("forced-reset staging must create a session").isNotNull();
         String token = (String) session.getAttribute(Login2Action.LOGIN_CREDENTIALS_TOKEN_ATTR);
 
-        // The session carries only the opaque token, which is not itself credential material.
-        assertThat(token).isNotBlank()
-                .doesNotContain(password)
-                .doesNotContain(ENCODED_OLD_PASSWORD);
-
-        // Strong form: enumerate EVERY session attribute and assert none leaks the raw
-        // password, the password hash, or the PIN, so a regression that stashed credential
-        // material under any other key would fail here (not just the known token attribute).
-        Collections.list(session.getAttributeNames()).forEach(name -> {
-            String value = String.valueOf(session.getAttribute(name));
-            assertThat(value)
-                    .as("session attribute '%s' must not contain the password or hash", name)
+        try {
+            // The session carries only the opaque token, which is not itself credential material.
+            assertThat(token).isNotBlank()
                     .doesNotContain(password)
                     .doesNotContain(ENCODED_OLD_PASSWORD);
-            // The opaque token is a 256-bit Base64URL random reference (verified above), not
-            // credential material; a 4-digit PIN can appear inside it by chance, so the PIN
-            // substring scan is applied to every OTHER attribute only. The PIN cannot leak
-            // into the token itself — tokens come from SecureRandom, independent of the PIN.
-            if (!Login2Action.LOGIN_CREDENTIALS_TOKEN_ATTR.equals(name)) {
+
+            // Strong form: enumerate EVERY session attribute and assert none leaks the raw
+            // password, the password hash, or the PIN, so a regression that stashed credential
+            // material under any other key would fail here (not just the known token attribute).
+            Collections.list(session.getAttributeNames()).forEach(name -> {
+                String value = attributeAsText(session.getAttribute(name));
                 assertThat(value)
-                        .as("session attribute '%s' must not contain the PIN", name)
-                        .doesNotContain(pin);
-            }
-        });
+                        .as("session attribute '%s' must not contain the password or hash", name)
+                        .doesNotContain(password)
+                        .doesNotContain(ENCODED_OLD_PASSWORD);
+                // The opaque token is a 256-bit Base64URL random reference (verified above), not
+                // credential material; a 4-digit PIN can appear inside it by chance, so the PIN
+                // substring scan is applied to every OTHER attribute only. The PIN cannot leak
+                // into the token itself — tokens come from SecureRandom, independent of the PIN.
+                if (!Login2Action.LOGIN_CREDENTIALS_TOKEN_ATTR.equals(name)) {
+                    assertThat(value)
+                            .as("session attribute '%s' must not contain the PIN", name)
+                            .doesNotContain(pin);
+                }
+            });
 
-        // Credentials — including the PIN — live server-side in the cache, referenced only
-        // by the opaque token.
-        LoginCredentialCache.LoginCredentials cached = LoginCredentialCache.getInstance().peek(token);
-        assertThat(cached).isNotNull();
-        assertThat(cached.getEncodedPassword()).isEqualTo(ENCODED_OLD_PASSWORD);
-        assertThat(cached.getPin()).isEqualTo(pin);
-        assertThat(cached.getUserName()).isEqualTo(USERNAME);
-
-        LoginCredentialCache.getInstance().invalidate(token);
+            // Credentials — including the PIN — live server-side in the cache, referenced only
+            // by the opaque token.
+            LoginCredentialCache.LoginCredentials cached = LoginCredentialCache.getInstance().peek(token);
+            assertThat(cached).isNotNull();
+            assertThat(cached.getEncodedPassword()).isEqualTo(ENCODED_OLD_PASSWORD);
+            assertThat(cached.getPin()).isEqualTo(pin);
+            assertThat(cached.getUserName()).isEqualTo(USERNAME);
+        } finally {
+            // Invalidate even if an assertion above fails, so this entry does not leak into
+            // other tests via the process-wide singleton cache.
+            LoginCredentialCache.getInstance().invalidate(token);
+        }
     }
 
     @Test


### PR DESCRIPTION
## What

Adds a unit test to `Login2ActionForcedPasswordResetUnitTest` that pins the
forced-reset **credential-isolation invariant**: during forced-password-reset
staging, no credential material is written to the HTTP session.

The test invokes `setUserInfoToSession`, then:
- enumerates **every** session attribute and asserts none contains the raw
  password, the password hash, or the PIN;
- excludes only the opaque cache token from the PIN substring scan, since the
  256-bit Base64URL token can coincidentally contain a 4-digit sequence (the
  token is separately asserted to be a non-credential opaque reference, and the
  PIN cannot enter it — tokens come from `SecureRandom`, independent of the PIN);
- confirms the credentials — including the PIN — round-trip through the
  server-side `LoginCredentialCache` via the token.

## Why

This maps directly to the CLAUDE.md login invariant: *"forced-reset credential
material stays out of the HTTP session and is referenced by an opaque,
short-lived cache token."* The existing suite covered the credential-token
lifecycle (mint / invalidate / consume) but never asserted the isolation
invariant itself — so a regression that placed the password, hash, or PIN back
into the session would have gone undetected.

No production code changes; test-only.

## Testing

mvn test -Dtest=Login2ActionForcedPasswordResetUnitTest

## Related

Closes #2301

Enhanced with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Tests:
- Add a unit test that asserts no password, password hash, or PIN is stored in the HTTP session during forced-reset staging and that credentials are only retrievable via the opaque token-backed cache.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a unit test ensuring forced-password-reset staging keeps credentials out of the HTTP session and uses only an opaque token with `LoginCredentialCache`, fixing #2301. It asserts a session is created, scans every session attribute (decoding char[]/byte[]) for leaks, verifies credentials round-trip via the token, and cleans up the cache in a finally block.

<sup>Written for commit e27338cf1c0b4091b779cd4168ac852065c3e182. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

