### PR TITLE
fix: return NONE after demographic import JSON response

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/ImportDemographicDataAction42Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/ImportDemographicDataAction42Action.java
@@ -374,7 +374,7 @@ public class ImportDemographicDataAction42Action extends ActionSupport implement
         request.setAttribute("importlog", importLog.getPath());
         resetProviderBean(request);
         generateResponse(response, warnings, importLog.getPath());
-        return SUCCESS;
+        return NONE;
     }
 
     private static final ObjectMapper jsonMapper = new ObjectMapper();

--- a/src/test/java/io/github/carlos_emr/carlos/demographic/pageUtil/ImportDemographicDataAction42ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/demographic/pageUtil/ImportDemographicDataAction42ActionUnitTest.java
@@ -192,7 +192,7 @@ class ImportDemographicDataAction42ActionUnitTest extends CarlosWebTestBase {
 
         String result = executeAction(action);
 
-        assertThat(result).isEqualTo(ActionSupport.SUCCESS);
+        assertThat(result).isEqualTo(ActionSupport.NONE);
         @SuppressWarnings("unchecked")
         List<String> warnings = (List<String>) getMockRequest().getAttribute("warnings");
         assertThat(warnings).contains(NO_VALID_XML_WARNING);

--- a/src/test/java/io/github/carlos_emr/carlos/demographic/pageUtil/ImportDemographicDataAction42ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/demographic/pageUtil/ImportDemographicDataAction42ActionUnitTest.java
@@ -197,5 +197,9 @@ class ImportDemographicDataAction42ActionUnitTest extends CarlosWebTestBase {
         List<String> warnings = (List<String>) getMockRequest().getAttribute("warnings");
         assertThat(warnings).contains(NO_VALID_XML_WARNING);
         assertThat(getMockRequest().getAttribute("importlog")).isNotNull();
+        assertThat(getMockResponse().getContentType()).contains("application/json");
+        assertThat(getMockResponse().getContentAsString())
+                .contains(NO_VALID_XML_WARNING)
+                .contains("importLog");
     }
 }


### PR DESCRIPTION
Fixes #3063.

## Summary
- return `NONE` after the demographic import action writes its JSON response directly
- update the existing upload JSON branch unit test to assert `ActionSupport.NONE`

## Tests
- `mvn -Dtest=ImportDemographicDataAction42ActionUnitTest test`

## Summary by Sourcery

Ensure the demographic import action does not return a Struts result after writing its JSON response directly, aligning the action outcome with the response behavior.

Bug Fixes:
- Change the demographic import action to return ActionSupport.NONE instead of SUCCESS after generating a JSON response to avoid unintended navigation or view rendering.

Tests:
- Update the demographic import action unit test to assert the NONE result, validating the corrected action outcome after JSON upload handling.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return `NONE` from `ImportDemographicDataAction42Action` after writing the JSON response to prevent Struts from rendering a view. Updated the unit test to expect `ActionSupport.NONE` and to verify the JSON content type and body include warnings and `importLog`.

<sup>Written for commit 3455fe12a53ca649756102ab877b7fbf1e75adb9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3078?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

