### PR TITLE
fix: derive INR billing creator from session

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/ViewInrBillingGeneration2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/ViewInrBillingGeneration2Action.java
@@ -110,7 +110,7 @@ public class ViewInrBillingGeneration2Action extends ActionSupport {
 
         String clinicNo = request.getParameter("clinic_no");
         String clinicRefCode = request.getParameter("xml_location");
-        String creator = request.getParameter("curUser");
+        String creator = loggedInInfo.getLoggedInProviderNo();
         String curDate = request.getParameter("curDate");
         String appointmentDate = request.getParameter("xml_appointment_date");
 

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/ViewOnInrBillingGeneration2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/ViewOnInrBillingGeneration2Action.java
@@ -107,7 +107,7 @@ public class ViewOnInrBillingGeneration2Action extends ActionSupport {
 
         String clinicNo = request.getParameter("clinic_no");
         String clinicRefCode = request.getParameter("xml_location");
-        String creator = request.getParameter("curUser");
+        String creator = loggedInInfo.getLoggedInProviderNo();
         String appointmentDate = request.getParameter("xml_appointment_date");
 
         Enumeration<String> paramNames = request.getParameterNames();

--- a/src/test/java/io/github/carlos_emr/carlos/billings/ca/on/web/ViewInrBillingGeneration2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/billings/ca/on/web/ViewInrBillingGeneration2ActionUnitTest.java
@@ -114,6 +114,7 @@ class ViewInrBillingGeneration2ActionUnitTest extends CarlosUnitTestBase {
 
         when(mockSecurityInfoManager.hasPrivilege(any(LoggedInInfo.class), eq("_billing"), eq("w"), isNull()))
                 .thenReturn(true);
+        when(mockLoggedInInfo.getLoggedInProviderNo()).thenReturn("999998");
     }
 
     @AfterEach
@@ -170,7 +171,7 @@ class ViewInrBillingGeneration2ActionUnitTest extends CarlosUnitTestBase {
         mockRequest.setParameter("inrbilling7", "on");
         mockRequest.setParameter("clinic_no", "12");
         mockRequest.setParameter("xml_location", "REF1");
-        mockRequest.setParameter("curUser", "carlosdoc");
+        mockRequest.setParameter("curUser", "spoofed");
         mockRequest.setParameter("curDate", "2026-04-26");
         mockRequest.setParameter("xml_appointment_date", "2026-04-26");
 
@@ -186,7 +187,7 @@ class ViewInrBillingGeneration2ActionUnitTest extends CarlosUnitTestBase {
         assertThat(b.getDemographicNo()).isEqualTo(101);
         assertThat(b.getProviderNo()).isEqualTo("999998");
         assertThat(b.getClinicNo()).isEqualTo(12);
-        assertThat(b.getCreator()).isEqualTo("carlosdoc");
+        assertThat(b.getCreator()).isEqualTo("999998");
         assertThat(b.getTotal()).isEqualTo("3370"); // decimal stripped
         assertThat(b.getStatus()).isEqualTo("O");
 

--- a/src/test/java/io/github/carlos_emr/carlos/billings/ca/on/web/ViewOnInrBillingGeneration2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/billings/ca/on/web/ViewOnInrBillingGeneration2ActionUnitTest.java
@@ -116,6 +116,7 @@ class ViewOnInrBillingGeneration2ActionUnitTest extends CarlosUnitTestBase {
 
         when(mockSecurityInfoManager.hasPrivilege(any(LoggedInInfo.class), eq("_billing"), eq("w"), isNull()))
                 .thenReturn(true);
+        when(mockLoggedInInfo.getLoggedInProviderNo()).thenReturn("999998");
     }
 
     @AfterEach
@@ -173,7 +174,7 @@ class ViewOnInrBillingGeneration2ActionUnitTest extends CarlosUnitTestBase {
         mockRequest.setParameter("inrbilling7", "on");
         mockRequest.setParameter("clinic_no", "C1");
         mockRequest.setParameter("xml_location", "REF1");
-        mockRequest.setParameter("curUser", "carlosdoc");
+        mockRequest.setParameter("curUser", "spoofed");
         mockRequest.setParameter("xml_appointment_date", "2026-04-26");
 
         String result = newAction().execute();
@@ -191,7 +192,7 @@ class ViewOnInrBillingGeneration2ActionUnitTest extends CarlosUnitTestBase {
         assertThat(h.getProvince()).isEqualTo("ON");
         assertThat(h.billingDate()).isEqualTo("2026-04-26");
         assertThat(h.getTotal()).isEqualTo("33.70");
-        assertThat(h.getCreator()).isEqualTo("carlosdoc");
+        assertThat(h.getCreator()).isEqualTo("999998");
         assertThat(h.getLocation()).isEqualTo("C1");
         assertThat(h.facilityNumber()).isEqualTo("REF1");
 


### PR DESCRIPTION
## Summary
- Derive the creator from the authenticated session provider in both INR billing generation paths.
- Update the existing tests to verify a caller-supplied `curUser` is ignored.

Partially addresses #2906.

## Testing
- `mvn -Dtest=ViewOnInrBillingGeneration2ActionUnitTest,ViewInrBillingGeneration2ActionUnitTest test` (16 tests passed)
- `git diff --check`