### PR TITLE
fix: redact PHI from ProviderPeriodAppsTo.toString()

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/to/model/ProviderPeriodAppsTo.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/to/model/ProviderPeriodAppsTo.java
@@ -151,10 +151,7 @@ public class ProviderPeriodAppsTo {
 
     @Override
     public String toString() {
-        return "ProviderPeriodAppsTo [appointmentNo=" + appointmentNo + ", providerNo=" + providerNo
-                + ", appointmentDate=" + appointmentDate + ", demographicNo=" + demographicNo + ", notes=" + notes
-                + ", location=" + location + ", resources=" + resources + ", status=" + status + ", lastUpdateUser="
-                + lastUpdateUser + ", updateDatetime=" + updateDatetime + ", name=" + name + "]";
+        return "ProviderPeriodAppsTo[appointmentNo=" + appointmentNo + ", providerNo=" + providerNo + "]";
     }
 
 }

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/to/model/ProviderPeriodAppsToUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/to/model/ProviderPeriodAppsToUnitTest.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.webserv.rest.to.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("unit")
+@Tag("rest")
+@Tag("regression")
+class ProviderPeriodAppsToUnitTest {
+
+    @Test
+    void shouldIncludeOnlySafeIdentifiers_whenToStringIsCalled() {
+        ProviderPeriodAppsTo appointment = new ProviderPeriodAppsTo();
+        appointment.setAppointmentNo(12345);
+        appointment.setProviderNo("provider-abc");
+        appointment.setNotes("clinical note");
+        appointment.setName("Jane Patient");
+
+        assertThat(appointment.toString())
+                .isEqualTo("ProviderPeriodAppsTo[appointmentNo=12345, providerNo=provider-abc]");
+    }
+}


### PR DESCRIPTION
## Summary
Redact patient and appointment details from `ProviderPeriodAppsTo.toString()`, leaving only the safe identifier format requested in #2808.

Fixes #2808

## Testing
- `mvn -Dtest=ProviderPeriodAppsToUnitTest test` (1 test passed)
- `git diff --check`