### PR TITLE
fix(security): fail closed when OAuth REST request has no credentials (#2798)

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/webserv/oauth/util/OAuthInterceptor.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/oauth/util/OAuthInterceptor.java
@@ -117,9 +117,17 @@ public class OAuthInterceptor implements PhaseInterceptor<Message> {
         HttpServletRequest req =
             (HttpServletRequest) message.get(AbstractHTTPDestination.HTTP_REQUEST);
 
-        // 1) Skip non-OAuth1 requests
+        // 1) Fail closed: this interceptor guards the OAuth-only REST surface
+        // (/ws/services). A request that carries no OAuth credentials cannot be
+        // authenticated here, so reject it (401) instead of silently passing it
+        // through. Passing it through left every handler that omits its own
+        // privilege check reachable by an anonymous caller (unauthenticated PHI
+        // reads / IDOR / mutations) — see #2798. Session/browser clients use the
+        // separate session REST surface at /ws/rs (AuthenticationInInterceptor),
+        // so this does not affect them.
         if (!OAuthRequestParser.isOAuth1Request(req)) {
-            return;
+            auditAuthFailure(req.getRemoteAddr(), null);
+            throw toFault(new OAuth1Exception(401, "authentication_required"));
         }
 
         // Hoisted so the audit on both success and the auth-failure paths can record them.

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/oauth/util/OAuthInterceptor.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/oauth/util/OAuthInterceptor.java
@@ -124,9 +124,11 @@ public class OAuthInterceptor implements PhaseInterceptor<Message> {
         // privilege check reachable by an anonymous caller (unauthenticated PHI
         // reads / IDOR / mutations) — see #2798. Session/browser clients use the
         // separate session REST surface at /ws/rs (AuthenticationInInterceptor),
-        // so this does not affect them.
-        if (!OAuthRequestParser.isOAuth1Request(req)) {
-            auditAuthFailure(req.getRemoteAddr(), null);
+        // so this does not affect them. A null request (non-HTTP transport) also
+        // cannot be authenticated, so it fails closed the same way.
+        if (req == null || !OAuthRequestParser.isOAuth1Request(req)) {
+            String remoteAddr = (req != null) ? req.getRemoteAddr() : null;
+            auditAuthFailure(remoteAddr, null);
             throw toFault(new OAuth1Exception(401, "authentication_required"));
         }
 

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/util/OAuthInterceptorAuditLoggingUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/util/OAuthInterceptorAuditLoggingUnitTest.java
@@ -219,12 +219,18 @@ class OAuthInterceptorAuditLoggingUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
-    @DisplayName("does not audit requests that are not OAuth1 requests")
-    void shouldNotLog_whenRequestIsNotOAuth1() {
+    @DisplayName("audits a login failure and rejects a request that is not an OAuth1 request")
+    void shouldLogFailure_whenRequestIsNotOAuth1() {
+        // No Authorization header (setUp) and no oauth_consumer_key: the OAuth-only surface must
+        // fail closed (#2798), auditing the rejection and throwing a 401 rather than passing through.
         when(request.getParameter("oauth_consumer_key")).thenReturn(null);
 
-        interceptor.handleMessage(message);
+        assertThatThrownBy(() -> interceptor.handleMessage(message)).isInstanceOf(Fault.class);
 
-        logActionMock.verifyNoInteractions();
+        OscarLog log = captureSingleLog();
+        assertThat(log.getAction()).isEqualTo("OAUTH_LOGIN_FAILURE");
+        assertThat(log.getIp()).isEqualTo(REMOTE_IP);
+        assertThat(log.getProviderNo()).isNull();
+        assertThat(log.getContent()).isNull();
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/util/OAuthInterceptorAuditLoggingUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/util/OAuthInterceptorAuditLoggingUnitTest.java
@@ -233,4 +233,20 @@ class OAuthInterceptorAuditLoggingUnitTest extends CarlosUnitTestBase {
         assertThat(log.getProviderNo()).isNull();
         assertThat(log.getContent()).isNull();
     }
+
+    @Test
+    @DisplayName("audits a login failure and rejects when no HTTP request is present")
+    void shouldLogFailure_whenRequestIsNull() {
+        // A non-HTTP transport leaves no HttpServletRequest on the message: the OAuth-only surface
+        // must still fail closed (#2798), auditing the rejection (no IP available) and throwing 401.
+        when(message.get(AbstractHTTPDestination.HTTP_REQUEST)).thenReturn(null);
+
+        assertThatThrownBy(() -> interceptor.handleMessage(message)).isInstanceOf(Fault.class);
+
+        OscarLog log = captureSingleLog();
+        assertThat(log.getAction()).isEqualTo("OAUTH_LOGIN_FAILURE");
+        assertThat(log.getIp()).isNull();
+        assertThat(log.getProviderNo()).isNull();
+        assertThat(log.getContent()).isNull();
+    }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/util/OAuthInterceptorUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/util/OAuthInterceptorUnitTest.java
@@ -119,6 +119,23 @@ class OAuthInterceptorUnitTest {
     }
 
     /** A request that looks like OAuth1 (has an Authorization header) but carries no usable params. */
+    @Test
+    @DisplayName("should raise fault with HTTP 401 when request carries no OAuth credentials")
+    void shouldRaiseFault_withHttp401WhenNoOAuthCredentials() {
+        OAuthInterceptor interceptor = new OAuthInterceptor();
+        // No Authorization header and no oauth_consumer_key param: the request is
+        // not OAuth-authenticated. The OAuth-only /ws/services surface must fail
+        // closed rather than let an anonymous caller reach the handler (#2798).
+        MockHttpServletRequest request =
+                new MockHttpServletRequest("POST", "/ws/services/notes/getGroupNoteExt/94");
+        Message message = messageWith(request);
+
+        Fault fault = catchThrowableOfType(() -> interceptor.handleMessage(message), Fault.class);
+
+        assertThat(fault).isNotNull();
+        assertThat(fault.getStatusCode()).isEqualTo(401);
+    }
+
     private static MockHttpServletRequest oauthRequestWithoutCredentials() {
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/ws/rest/example");
         request.addHeader("Authorization", "OAuth realm=\"carlos\"");

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/util/OAuthInterceptorUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/util/OAuthInterceptorUnitTest.java
@@ -118,7 +118,6 @@ class OAuthInterceptorUnitTest {
         assertThat(fault.getStatusCode()).isEqualTo(500);
     }
 
-    /** A request that looks like OAuth1 (has an Authorization header) but carries no usable params. */
     @Test
     @DisplayName("should raise fault with HTTP 401 when request carries no OAuth credentials")
     void shouldRaiseFault_withHttp401WhenNoOAuthCredentials() {
@@ -136,6 +135,21 @@ class OAuthInterceptorUnitTest {
         assertThat(fault.getStatusCode()).isEqualTo(401);
     }
 
+    @Test
+    @DisplayName("should raise fault with HTTP 401 when no HTTP request is present")
+    void shouldRaiseFault_withHttp401WhenRequestIsNull() {
+        OAuthInterceptor interceptor = new OAuthInterceptor();
+        // No HttpServletRequest on the message (e.g. a non-HTTP transport): the
+        // request cannot be authenticated, so it must fail closed rather than NPE.
+        Message message = new MessageImpl();
+
+        Fault fault = catchThrowableOfType(() -> interceptor.handleMessage(message), Fault.class);
+
+        assertThat(fault).isNotNull();
+        assertThat(fault.getStatusCode()).isEqualTo(401);
+    }
+
+    /** A request that looks like OAuth1 (has an Authorization header) but carries no usable params. */
     private static MockHttpServletRequest oauthRequestWithoutCredentials() {
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/ws/rest/example");
         request.addHeader("Authorization", "OAuth realm=\"carlos\"");


### PR DESCRIPTION
## Summary

Makes the OAuth REST interceptor **fail closed**. `OAuthInterceptor` guards the OAuth-only REST surface (`/ws/services`) but silently `return`ed for any request that carried no OAuth parameters, so every handler that omits its own `hasPrivilege()` check was reachable by an **anonymous caller** — unauthenticated PHI reads, IDOR, and mutations. This is the root cause behind the per-endpoint gaps in #2798: those endpoints are exposed not just to "any authenticated user" but to callers with no credentials at all.

## Root cause

- `LoginFilter` exempts `/ws/` (`sec/LoginFilter.java`), correctly, since API clients are stateless.
- `OAuthInterceptor.handleMessage` did `if (!OAuthRequestParser.isOAuth1Request(req)) return;` — passing credential-less requests straight through with no `LoggedInInfo` attached.
- Handlers without their own privilege check then executed for anonymous callers.

Demonstrated (local build, seeded test PHI on a disposable DB):
```
curl -X POST http://localhost:8080/carlos/ws/services/notes/getGroupNoteExt/94   # no auth at all
→ 200  {clinical note ext: treatment, problemDesc, ...}
```

## Change

In `OAuthInterceptor`, reject a credential-less request to the protected surface with **401** (audited as an auth failure) instead of passing it through.

## Why this is safe for session/browser clients

The REST data services are exposed on **two** surfaces:
- `/ws/services` — OAuth only, guarded by `OAuthInterceptor` (this PR).
- `/ws/rs` — session, guarded by `AuthenticationInInterceptor` (`spring_ws.xml`), used by the browser frontend.

So failing closed on `/ws/services` does not affect session/browser access. I also checked that nothing on `/ws/services` is intentionally public — even `StatusService.checkIfAuthed` calls `getLoggedInInfo()` and requires a logged-in provider — so no allowlist is needed.

## Scope / relationship to #2798 and #3011

- #3011 adds per-endpoint `hasPrivilege()` (the right per-resource RBAC fix). This PR is the **complementary default-deny** so that any endpoint missed by that sweep — or added later — is not anonymously reachable.
- Out of scope here: the per-endpoint security objects (#3011) and the separate reliability bug where AOP-advised services (`DemographicService`, etc.) currently 500 with "Authentication info is not available" even for a valid token (CXF current-message context lost in `WebServiceLoggingAdvice`).

## Tests

`OAuthInterceptorUnitTest` — added `shouldRaiseFault_withHttp401WhenNoOAuthCredentials` (credential-less request → 401). Full class: **5 tests, 0 failures**. Existing 400/401/500 auth-failure cases unchanged.

## Verification done

- Built and deployed `develop` locally; confirmed the unauthenticated `getGroupNoteExt` PoC returns data before this change.
- Unit tests pass: `mvn -Dtest=OAuthInterceptorUnitTest test` → 5/5.

> Draft pending a manual end-to-end check that a valid OAuth client still authenticates and that no internal `/ws/services` consumer relied on the previous pass-through behavior.

Refs #2798.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enforce fail-closed behavior on the OAuth REST surface so credential-less or non-HTTP requests to /ws/services are rejected with 401 instead of being processed anonymously.

Bug Fixes:
- Reject OAuth REST requests that lack OAuth credentials or an HTTP request with HTTP 401 to prevent anonymous access to protected handlers.
- Audit OAuth login failures for non-OAuth1 and null-request paths, avoiding silent pass-through and potential NPEs.

Tests:
- Extend OAuth interceptor unit and audit-logging tests to cover credential-less and null-request scenarios, including verification of 401 responses and audit records.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject credential-less and non-HTTP requests on the OAuth REST surface by returning 401, blocking anonymous access to `/ws/services`. This enforces default-deny for OAuth and addresses #2798.

- **Bug Fixes**
  - Return 401 and audit an `OAUTH_LOGIN_FAILURE` when OAuth credentials are missing or the `HttpServletRequest` is null, preventing NPEs and anonymous access.
  - Updated tests: added unit tests for credential-less and null-request paths, including audit assertions (no IP when the request is null); `/ws/rs` session traffic is unaffected.

<sup>Written for commit fdfe79ef682f54455bd08a7b5003b1205164b212. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3085?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

