### PR TITLE
fix: enforce _admin privilege on OscarJobService scheduled-job REST endpoints

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/OscarJobService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/OscarJobService.java
@@ -43,11 +43,13 @@ import jakarta.ws.rs.FormParam;
 import jakarta.ws.rs.core.MultivaluedMap;
 
 import org.apache.logging.log4j.Logger;
+import io.github.carlos_emr.carlos.commn.exception.AccessDeniedException;
 import io.github.carlos_emr.carlos.commn.jobs.OscarJobExecutingManager;
 import io.github.carlos_emr.carlos.commn.jobs.OscarJobUtils;
 import io.github.carlos_emr.carlos.commn.model.OscarJob;
 import io.github.carlos_emr.carlos.commn.model.OscarJobType;
 import io.github.carlos_emr.carlos.managers.OscarJobManager;
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.webserv.rest.to.OscarJobResponse;
 import io.github.carlos_emr.carlos.webserv.rest.to.OscarJobTypeResponse;
@@ -70,6 +72,31 @@ public class OscarJobService extends AbstractServiceImpl {
     @Autowired
     OscarJobManager oscarJobManager;
 
+    @Autowired
+    SecurityInfoManager securityInfoManager;
+
+    /**
+     * Enforces the Administration security object on every job-scheduler endpoint.
+     *
+     * <p>These endpoints are reachable directly under {@code /ws/rs/jobs/**} and are only
+     * meant to be driven from the {@code _admin}-gated Administration job pages
+     * ({@code admin/ViewJobs}, {@code admin/ViewJobTypes}). The view-layer
+     * {@code <security:oscarSec objectName="_admin">} guard does not protect the REST
+     * endpoint itself, so any authenticated provider could otherwise create, edit, enable,
+     * disable, or schedule jobs — including supplying an arbitrary {@code OscarJobType}
+     * className that the scheduler instantiates and runs. This check restores the intended
+     * {@code _admin} trust boundary at the service layer (read for queries, write for
+     * mutations), mirroring the REST authorization pattern used in {@code RxWebService} (#3010).
+     *
+     * @param action {@code "r"} for read endpoints, {@code "w"} for mutating endpoints
+     * @throws AccessDeniedException if the logged-in provider lacks {@code _admin} at {@code action}
+     */
+    private void requireAdminPrivilege(String action) {
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_admin", action, null)) {
+            throw new AccessDeniedException("_admin", action);
+        }
+    }
+
 
     @GET
     @Path("/types/current")
@@ -80,6 +107,7 @@ public class OscarJobService extends AbstractServiceImpl {
             justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
                     "known CARLOS types; no user-controlled property name reaches the sink")
     public OscarJobTypeResponse getCurrentlyAvailableJobTypes() {
+        requireAdminPrivilege("r");
         List<OscarJobType> results = oscarJobManager.getCurrentlyAvaliableJobTypes();
 
         OscarJobTypeResponse response = new OscarJobTypeResponse();
@@ -100,6 +128,7 @@ public class OscarJobService extends AbstractServiceImpl {
             justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
                     "known CARLOS types; no user-controlled property name reaches the sink")
     public OscarJobTypeResponse getAllJobTypes() {
+        requireAdminPrivilege("r");
         List<OscarJobType> results = oscarJobManager.getAllJobTypes();
 
         OscarJobTypeResponse response = new OscarJobTypeResponse();
@@ -122,6 +151,7 @@ public class OscarJobService extends AbstractServiceImpl {
             justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
                     "known CARLOS types; no user-controlled property name reaches the sink")
     public OscarJobResponse getAllJobs() {
+        requireAdminPrivilege("r");
         List<OscarJob> results = oscarJobManager.getAllJobs(getLoggedInInfo());
 
         OscarJobResponse response = new OscarJobResponse();
@@ -154,6 +184,7 @@ public class OscarJobService extends AbstractServiceImpl {
             justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
                     "known CARLOS types; no user-controlled property name reaches the sink")
     public OscarJobResponse getJob(@PathParam("jobId") Integer jobId) {
+        requireAdminPrivilege("r");
         OscarJob result = oscarJobManager.getJob(getLoggedInInfo(), jobId);
 
         OscarJobResponse response = new OscarJobResponse();
@@ -173,6 +204,7 @@ public class OscarJobService extends AbstractServiceImpl {
     @Produces("application/json")
     @Consumes("application/x-www-form-urlencoded")
     public OscarJobResponse saveJob(MultivaluedMap<String, String> params) {
+        requireAdminPrivilege("w");
         OscarJob job = new OscarJob();
         job.setId(Integer.parseInt(params.getFirst("job.id")));
         job.setDescription(params.getFirst("job.description"));
@@ -217,6 +249,7 @@ public class OscarJobService extends AbstractServiceImpl {
     @Produces("application/json")
     @Consumes("application/x-www-form-urlencoded")
     public OscarJobResponse cancelJob(@FormParam(value = "jobId") Integer jobId) {
+        requireAdminPrivilege("w");
 
         ScheduledFuture<Object> future = OscarJobExecutingManager.getFutures().get(jobId);
         if (future != null) {
@@ -243,6 +276,7 @@ public class OscarJobService extends AbstractServiceImpl {
     @Produces("application/json")
     @Consumes("application/x-www-form-urlencoded")
     public OscarJobResponse saveCrontabExpression(MultivaluedMap<String, String> params) {
+        requireAdminPrivilege("w");
 
         Integer jobId = null;
         try {
@@ -317,6 +351,7 @@ public class OscarJobService extends AbstractServiceImpl {
             justification = "Spring BeanUtils.copyProperties copies fixed JavaBean descriptors between " +
                     "known CARLOS types; no user-controlled property name reaches the sink")
     public OscarJobTypeResponse getJobType(@PathParam("jobTypeId") Integer jobTypeId) {
+        requireAdminPrivilege("r");
         OscarJobType result = oscarJobManager.getJobType(getLoggedInInfo(), jobTypeId);
 
         OscarJobTypeResponse response = new OscarJobTypeResponse();
@@ -333,6 +368,7 @@ public class OscarJobService extends AbstractServiceImpl {
     @Produces("application/json")
     @Consumes("application/x-www-form-urlencoded")
     public OscarJobTypeResponse saveJobType(MultivaluedMap<String, String> params) {
+        requireAdminPrivilege("w");
         OscarJobType job = new OscarJobType();
         job.setId(Integer.parseInt(params.getFirst("jobType.id")));
         job.setName(params.getFirst("jobType.name"));
@@ -367,6 +403,7 @@ public class OscarJobService extends AbstractServiceImpl {
     @Produces("application/json")
     @Consumes("application/x-www-form-urlencoded")
     public OscarJobResponse enableJob(@FormParam(value = "jobId") Integer jobId) {
+        requireAdminPrivilege("w");
         OscarJob job = oscarJobManager.getJob(getLoggedInInfo(), jobId);
         if (job != null) {
             job.setEnabled(true);
@@ -385,6 +422,7 @@ public class OscarJobService extends AbstractServiceImpl {
     @Produces("application/json")
     @Consumes("application/x-www-form-urlencoded")
     public OscarJobResponse disableJob(@FormParam(value = "jobId") Integer jobId) {
+        requireAdminPrivilege("w");
         OscarJob job = oscarJobManager.getJob(getLoggedInInfo(), jobId);
         if (job != null) {
             job.setEnabled(false);

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/OscarJobServiceSecurityTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/OscarJobServiceSecurityTest.java
@@ -1,0 +1,157 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.webserv.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.github.carlos_emr.carlos.commn.exception.AccessDeniedException;
+import io.github.carlos_emr.carlos.commn.model.OscarJob;
+import io.github.carlos_emr.carlos.managers.OscarJobManager;
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import io.github.carlos_emr.carlos.webserv.rest.to.OscarJobResponse;
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Security tests for {@link OscarJobService}, the {@code /ws/rs/jobs/**} scheduled-job
+ * administration endpoints.
+ *
+ * <p>These endpoints are only meant to be driven from the {@code _admin}-gated Administration
+ * job pages. The JSP view guard does not protect the REST endpoint itself, so the service must
+ * enforce the {@code _admin} security object directly (read for queries, write for mutations).
+ * These tests pin that contract — in particular that the job-type mutator, which persists a
+ * caller-supplied className the scheduler later instantiates and runs, refuses callers without
+ * {@code _admin} write before touching any persistence.
+ *
+ * @since 2026-06-29
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("OscarJobService _admin authorization tests")
+@Tag("unit")
+@Tag("rest")
+@Tag("security")
+class OscarJobServiceSecurityTest {
+
+    @Mock
+    private OscarJobManager oscarJobManager;
+
+    @Mock
+    private SecurityInfoManager securityInfoManager;
+
+    @Mock
+    private LoggedInInfo loggedInInfo;
+
+    private OscarJobService service;
+
+    @BeforeEach
+    void setUp() {
+        // Spy so the CXF-backed getLoggedInInfo() can be stubbed without a live message chain.
+        service = spy(new OscarJobService());
+        service.oscarJobManager = oscarJobManager;
+        service.securityInfoManager = securityInfoManager;
+        doReturn(loggedInInfo).when(service).getLoggedInInfo();
+    }
+
+    private void grantAdmin(String action, boolean granted) {
+        when(securityInfoManager.hasPrivilege(any(LoggedInInfo.class), eq("_admin"), eq(action), nullable(String.class)))
+                .thenReturn(granted);
+    }
+
+    @Test
+    @DisplayName("should deny read endpoint when lacking _admin read")
+    void shouldDenyRead_whenLackingAdminRead() {
+        grantAdmin("r", false);
+
+        assertThatThrownBy(() -> service.getAllJobs())
+                .isInstanceOf(AccessDeniedException.class)
+                .satisfies(thrown -> {
+                    AccessDeniedException denied = (AccessDeniedException) thrown;
+                    assertThat(denied.getPermission()).isEqualTo("_admin");
+                    assertThat(denied.getAction()).isEqualTo("r");
+                });
+
+        verifyNoInteractions(oscarJobManager);
+    }
+
+    @Test
+    @DisplayName("should deny saveJob when lacking _admin write")
+    void shouldDenySaveJob_whenLackingAdminWrite() {
+        grantAdmin("w", false);
+
+        // params is never read: the privilege gate is the first statement in saveJob.
+        assertThatThrownBy(() -> service.saveJob(null))
+                .isInstanceOf(AccessDeniedException.class);
+
+        verifyNoInteractions(oscarJobManager);
+    }
+
+    @Test
+    @DisplayName("should deny saveJobType before persisting any caller-supplied className when lacking _admin write")
+    void shouldDenySaveJobType_whenLackingAdminWrite() {
+        grantAdmin("w", false);
+
+        assertThatThrownBy(() -> service.saveJobType(null))
+                .isInstanceOf(AccessDeniedException.class)
+                .satisfies(thrown -> assertThat(((AccessDeniedException) thrown).getAction()).isEqualTo("w"));
+
+        // No job type is persisted for an unauthorized caller (closes the scheduled-execution vector).
+        verifyNoInteractions(oscarJobManager);
+    }
+
+    @Test
+    @DisplayName("should deny enableJob when lacking _admin write")
+    void shouldDenyEnableJob_whenLackingAdminWrite() {
+        grantAdmin("w", false);
+
+        assertThatThrownBy(() -> service.enableJob(7))
+                .isInstanceOf(AccessDeniedException.class);
+
+        verifyNoInteractions(oscarJobManager);
+    }
+
+    @Test
+    @DisplayName("should delegate to manager when _admin read is granted")
+    void shouldDelegateToManager_whenAdminReadGranted() {
+        grantAdmin("r", true);
+        when(oscarJobManager.getAllJobs(loggedInInfo)).thenReturn(Collections.<OscarJob>emptyList());
+
+        OscarJobResponse response = service.getAllJobs();
+
+        assertThat(response).isNotNull();
+        assertThat(response.getJobs()).isEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

Part of the **admin-config (`_admin`-family) REST authorization** review. This part covers **`OscarJobService`** (scheduled-job admin); `AppService` and `ConsentService` are deliberately left for follow-up parts (see below).

The `/ws/rs/jobs/**` endpoints performed **no authorization**. Neither `OscarJobService` nor `OscarJobManager` called `SecurityInfoManager.hasPrivilege`, and the only inbound gate (`AuthenticationInInterceptor`) checks authentication, not privilege. So **any authenticated provider** — including one explicitly denied `_admin` — could list, create, edit, enable, disable, cancel, or re-schedule jobs by calling the REST endpoint directly.

These are Administration-only screens: `jobs.jsp` / `jobTypes.jsp` gate the **view** with `<security:oscarSec objectName="_admin" ...>`, but that guard never protected the endpoint itself. The page then POSTs to `/ws/rs/jobs/saveJob`, `/saveJobType`, etc., which were unguarded — a classic view-layer-only access control gap.

**Highest-impact case:** `saveJobType` persists a caller-supplied `OscarJobType.className`, which `OscarJobUtils.scheduleJob` later instantiates and runs on a cron schedule — i.e. the gap was a scheduled code-execution vector, not just data exposure.

## What changed

- Added `@Autowired SecurityInfoManager securityInfoManager` to `OscarJobService` and a private `requireAdminPrivilege(action)` helper that throws `AccessDeniedException("_admin", action)` when the logged-in provider lacks the right.
- Enforced `_admin` on **all 11 endpoints**: **read** (`r`) on the 5 GET queries; **write** (`w`) on the 6 mutators (`saveJob`, `saveJobType`, `saveCrontabExpression`, `enableJob`, `disableJob`, `cancelJob`).
- This restores the intended `_admin` trust boundary at the service layer, **mirroring the REST authorization pattern just merged in `RxWebService` (#3010)** — including reusing `AccessDeniedException` rather than the generic 2Action `SecurityException` form, for consistency with the surrounding REST layer.

## Why `_admin` r/w is safe

The default `admin` role holds `_admin` with `'x'` rights, which `SecurityInfoManagerImpl.hasPrivilege` treats as satisfying any requested action, so real admins are unaffected. A write grant satisfies read, so the mutators' internal re-reads (`getJob`/`getJobType`) still pass.

## Scope boundary (follow-up parts)

`AppService.getApps` (external OAuth consumer, no internal caller) and `ConsentService` (consent-type **reads are used by ordinary provider demographic workflows** — `add/edit-form-clinical.jsp`, `DemographicAdd/Edit2Action`) have genuinely ambiguous privilege policy and would risk regressions if blanket-gated behind `_admin`. They are intentionally **not** in this PR and need separate, deliberate scoping. This PR therefore does not auto-close the tracking item.

## Tests

`OscarJobServiceSecurityTest` (unit, Mockito) — 5 cases:
- read endpoint denied without `_admin` r (no manager interaction)
- `saveJob` denied without `_admin` w
- `saveJobType` denied **before any persistence** without `_admin` w (pins the scheduled-execution vector closed)
- `enableJob` denied without `_admin` w
- read delegates to the manager when `_admin` r is granted

Verified locally:
- `mvn -o test-compile` → success
- `mvn -o -Dtest=OscarJobServiceSecurityTest test` → **Tests run: 5, Failures: 0, Errors: 0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enforce _admin privileges on all OscarJobService scheduled-job REST endpoints to close an authorization gap where any authenticated provider could manage jobs.

Bug Fixes:
- Require _admin read access on all job and job-type query endpoints under /ws/rs/jobs/**.
- Require _admin write access on all job and job-type mutating endpoints, including job-type creation that controls scheduled execution.

Tests:
- Add OscarJobServiceSecurityTest unit coverage to verify denial of access without _admin and delegation to OscarJobManager when privileges are granted.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lock down scheduled-job REST endpoints by enforcing `_admin` privileges on `OscarJobService`. Fixes an authorization gap where any authenticated user could manage jobs, including creating types that run scheduled code.

- **Bug Fixes**
  - Enforce `_admin` checks on all `OscarJobService` routes using `SecurityInfoManager.hasPrivilege`.
  - Require "r" for GETs and "w" for mutators (`saveJob`, `saveJobType`, `saveCrontabExpression`, `enableJob`, `disableJob`, `cancelJob`).
  - Block `saveJobType` without `_admin` before any persistence to close the scheduled code-execution vector.
  - Add unit tests in `OscarJobServiceSecurityTest` covering deny/allow paths.

<sup>Written for commit e0843b79666a0dd5f1282bd9b08e98bb5e860366. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3087?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

