### PR TITLE
fix(security): enforce hasPrivilege on FormsService JAX-RS endpoints (#2798)

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/FormsService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/FormsService.java
@@ -55,6 +55,7 @@ import io.github.carlos_emr.carlos.commn.model.EForm;
 import io.github.carlos_emr.carlos.commn.model.EFormData;
 import io.github.carlos_emr.carlos.commn.model.EncounterForm;
 import io.github.carlos_emr.carlos.managers.FormsManager;
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 import io.github.carlos_emr.carlos.webserv.rest.conversion.EFormConverter;
@@ -82,17 +83,45 @@ import io.github.carlos_emr.carlos.encounter.data.EctFormData;
 public class FormsService extends AbstractServiceImpl {
     Logger logger = MiscUtils.getLogger();
 
+    /**
+     * Security object guarding eForm (HTML template form) reads. Matches the object used by
+     * {@code EFormService}/{@code EFormsService}, which the #2798 audit already blessed.
+     */
+    private static final String SECOBJ_EFORM = "_eform";
+
+    /**
+     * Security object guarding SQL-table encounter form (BCAR, Rourke, etc.) reads. Matches the
+     * forms-panel gate in {@code RecordUxService}.
+     */
+    private static final String SECOBJ_FORMS = "_newCasemgmt.forms";
+
     @Autowired
     private FormsManager formsManager;
 
     @Autowired
     private AppDefinitionDao appDefinitionDao;
 
+    @Autowired
+    private SecurityInfoManager securityInfoManager;
+
+    /**
+     * Enforces read access on a single security object, failing closed with the CARLOS
+     * paren-form {@link SecurityException} message when the caller lacks the privilege.
+     *
+     * @param secObj the security object name (e.g. {@code _eform} or {@code _newCasemgmt.forms})
+     */
+    private void requireRead(String secObj) {
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), secObj, "r", null)) {
+            throw new SecurityException("missing required sec object (" + secObj + ")");
+        }
+    }
+
 
     @GET
     @Path("/{demographicNo}/all")
     @Produces("application/json")
     public FormListTo1 getFormsForHeading(@PathParam("demographicNo") Integer demographicNo, @QueryParam("heading") String heading) {
+        requireRead(SECOBJ_EFORM);
         FormListTo1 formListTo1 = new FormListTo1();
         if (heading.equals("Completed")) {
             List<EFormData> completedEforms = formsManager.findByDemographicId(getLoggedInInfo(), demographicNo);
@@ -129,6 +158,7 @@ public class FormsService extends AbstractServiceImpl {
     @Path("/allEForms")
     @Produces("application/json")
     public AbstractSearchResponse<EFormTo1> getAllEFormNames() {
+        requireRead(SECOBJ_EFORM);
         AbstractSearchResponse<EFormTo1> response = new AbstractSearchResponse<EFormTo1>();
         response.setContent(new EFormConverter(true).getAllAsTransferObjects(getLoggedInInfo(), formsManager.findByStatus(getLoggedInInfo(), true, EFormSortOrder.NAME)));
         response.setTotal(response.getContent().size());
@@ -140,6 +170,7 @@ public class FormsService extends AbstractServiceImpl {
     @Path("/allEncounterForms")
     @Produces("application/json")
     public AbstractSearchResponse<EncounterFormTo1> getAllFormNames() {
+        requireRead(SECOBJ_FORMS);
         AbstractSearchResponse<EncounterFormTo1> response = new AbstractSearchResponse<EncounterFormTo1>();
         response.setContent(new EncounterFormConverter().getAllAsTransferObjects(getLoggedInInfo(), formsManager.getAllEncounterForms()));
         response.setTotal(response.getContent().size());
@@ -151,6 +182,7 @@ public class FormsService extends AbstractServiceImpl {
     @Path("/selectedEncounterForms")
     @Produces("application/json")
     public AbstractSearchResponse<EncounterFormTo1> getSelectedFormNames() {
+        requireRead(SECOBJ_FORMS);
         AbstractSearchResponse<EncounterFormTo1> response = new AbstractSearchResponse<EncounterFormTo1>();
         response.setContent(new EncounterFormConverter().getAllAsTransferObjects(getLoggedInInfo(), formsManager.getSelectedEncounterForms()));
         response.setTotal(response.getContent().size());
@@ -163,6 +195,7 @@ public class FormsService extends AbstractServiceImpl {
     @Path("/{demographicNo}/completedEncounterForms")
     @Produces("application/json")
     public FormListTo1 getCompletedFormNames(@PathParam("demographicNo") String demographicNo) {
+        requireRead(SECOBJ_FORMS);
         FormListTo1 formListTo1 = new FormListTo1();
 
         List<EncounterForm> encounterForms = formsManager.getAllEncounterForms();
@@ -205,6 +238,7 @@ public class FormsService extends AbstractServiceImpl {
     @Path("/groupNames")
     @Produces("application/json")
     public AbstractSearchResponse<String> getGroupNames() {
+        requireRead(SECOBJ_EFORM);
         AbstractSearchResponse<String> response = new AbstractSearchResponse<String>();
 
         response.setContent(formsManager.getGroupNames());
@@ -217,6 +251,7 @@ public class FormsService extends AbstractServiceImpl {
     @Path("/getFavouriteFormGroup")
     @Produces("application/json")
     public SummaryTo1 getFavouriteFormGroups() {
+        requireRead(SECOBJ_EFORM);
         UserPropertyDAO userPropertyDao = (UserPropertyDAO) SpringUtils.getBean(UserPropertyDAO.class);
         String groupName = userPropertyDao.getStringValue(getLoggedInInfo().getLoggedInProviderNo(), "favourite_eform_group");
         logger.debug("favourite eform group name " + groupName);
@@ -236,6 +271,7 @@ public class FormsService extends AbstractServiceImpl {
     @Path("/getFormGroups")
     @Produces("application/json")
     public List<SummaryTo1> getGroupsWithForms() {
+        requireRead(SECOBJ_EFORM);
         int count = 0;
         List<SummaryTo1> summaryList = new ArrayList<SummaryTo1>();
         List<String> groupNames = formsManager.getGroupNames();
@@ -260,6 +296,12 @@ public class FormsService extends AbstractServiceImpl {
     @Path("/{demographicNo}/formOptions")
     @Produces("application/json")
     public MenuTo1 getFormOptions(@PathParam("demographicNo") String demographicNo) {
+        // Generic forms-panel menu spanning both eForms and encounter forms; allow read on either,
+        // matching the combined forms-panel gate in RecordUxService.
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), SECOBJ_EFORM, "r", null)
+                && !securityInfoManager.hasPrivilege(getLoggedInInfo(), SECOBJ_FORMS, "r", null)) {
+            throw new SecurityException("missing required sec object (" + SECOBJ_EFORM + ")");
+        }
         ResourceBundle bundle = getResourceBundle();
         MenuTo1 formMenu = new MenuTo1();
         int idCounter = 0;

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/FormsService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/FormsService.java
@@ -106,13 +106,27 @@ public class FormsService extends AbstractServiceImpl {
     private SecurityInfoManager securityInfoManager;
 
     /**
-     * Enforces read access on a single security object, failing closed with the CARLOS
-     * paren-form {@link SecurityException} message when the caller lacks the privilege.
+     * Enforces read access on a single security object for a non-patient-scoped read (global form
+     * definitions and group listings), failing closed with the CARLOS paren-form
+     * {@link SecurityException} message when the caller lacks the privilege.
      *
      * @param secObj the security object name (e.g. {@code _eform} or {@code _newCasemgmt.forms})
      */
     private void requireRead(String secObj) {
-        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), secObj, "r", null)) {
+        requireRead(secObj, null);
+    }
+
+    /**
+     * Enforces read access on a single security object for a patient-scoped read. Threading the
+     * demographic into the check lets patient-specific no-rights rules take priority over the
+     * general object privilege (per the {@code SecurityInfoManager} contract); pass {@code null}
+     * via {@link #requireRead(String)} for non-patient-scoped reads.
+     *
+     * @param secObj         the security object name (e.g. {@code _eform} or {@code _newCasemgmt.forms})
+     * @param demographicNo  the patient the read is scoped to, or {@code null} when not patient-scoped
+     */
+    private void requireRead(String secObj, String demographicNo) {
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), secObj, "r", demographicNo)) {
             throw new SecurityException("missing required sec object (" + secObj + ")");
         }
     }
@@ -122,7 +136,7 @@ public class FormsService extends AbstractServiceImpl {
     @Path("/{demographicNo}/all")
     @Produces("application/json")
     public FormListTo1 getFormsForHeading(@PathParam("demographicNo") Integer demographicNo, @QueryParam("heading") String heading) {
-        requireRead(SECOBJ_EFORM);
+        requireRead(SECOBJ_EFORM, demographicNo == null ? null : demographicNo.toString());
         FormListTo1 formListTo1 = new FormListTo1();
         if (heading.equals("Completed")) {
             List<EFormData> completedEforms = formsManager.findByDemographicId(getLoggedInInfo(), demographicNo);
@@ -196,7 +210,7 @@ public class FormsService extends AbstractServiceImpl {
     @Path("/{demographicNo}/completedEncounterForms")
     @Produces("application/json")
     public FormListTo1 getCompletedFormNames(@PathParam("demographicNo") String demographicNo) {
-        requireRead(SECOBJ_FORMS);
+        requireRead(SECOBJ_FORMS, demographicNo);
         FormListTo1 formListTo1 = new FormListTo1();
 
         List<EncounterForm> encounterForms = formsManager.getAllEncounterForms();
@@ -300,8 +314,8 @@ public class FormsService extends AbstractServiceImpl {
         // Generic forms-panel menu spanning both eForms and encounter forms; allow read on either
         // of this service's two security objects, failing closed when the caller holds neither.
         LoggedInInfo loggedInInfo = getLoggedInInfo();
-        if (!securityInfoManager.hasPrivilege(loggedInInfo, SECOBJ_EFORM, "r", null)
-                && !securityInfoManager.hasPrivilege(loggedInInfo, SECOBJ_FORMS, "r", null)) {
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, SECOBJ_EFORM, "r", demographicNo)
+                && !securityInfoManager.hasPrivilege(loggedInInfo, SECOBJ_FORMS, "r", demographicNo)) {
             throw new SecurityException("missing required sec object (" + SECOBJ_EFORM + ")");
         }
         ResourceBundle bundle = getResourceBundle();

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/FormsService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/FormsService.java
@@ -56,6 +56,7 @@ import io.github.carlos_emr.carlos.commn.model.EFormData;
 import io.github.carlos_emr.carlos.commn.model.EncounterForm;
 import io.github.carlos_emr.carlos.managers.FormsManager;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 import io.github.carlos_emr.carlos.webserv.rest.conversion.EFormConverter;
@@ -296,10 +297,11 @@ public class FormsService extends AbstractServiceImpl {
     @Path("/{demographicNo}/formOptions")
     @Produces("application/json")
     public MenuTo1 getFormOptions(@PathParam("demographicNo") String demographicNo) {
-        // Generic forms-panel menu spanning both eForms and encounter forms; allow read on either,
-        // matching the combined forms-panel gate in RecordUxService.
-        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), SECOBJ_EFORM, "r", null)
-                && !securityInfoManager.hasPrivilege(getLoggedInInfo(), SECOBJ_FORMS, "r", null)) {
+        // Generic forms-panel menu spanning both eForms and encounter forms; allow read on either
+        // of this service's two security objects, failing closed when the caller holds neither.
+        LoggedInInfo loggedInInfo = getLoggedInInfo();
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, SECOBJ_EFORM, "r", null)
+                && !securityInfoManager.hasPrivilege(loggedInInfo, SECOBJ_FORMS, "r", null)) {
             throw new SecurityException("missing required sec object (" + SECOBJ_EFORM + ")");
         }
         ResourceBundle bundle = getResourceBundle();

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/FormsService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/FormsService.java
@@ -91,8 +91,9 @@ public class FormsService extends AbstractServiceImpl {
     private static final String SECOBJ_EFORM = "_eform";
 
     /**
-     * Security object guarding SQL-table encounter form (BCAR, Rourke, etc.) reads. Matches the
-     * forms-panel gate in {@code RecordUxService}.
+     * Security object guarding SQL-table encounter form (BCAR, Rourke, etc.) reads. This is the
+     * encounter-form half of the forms-panel gate in {@code RecordUxService}, which permits the
+     * panel on {@code _newCasemgmt.forms} OR {@code _newCasemgmt.eforms}.
      */
     private static final String SECOBJ_FORMS = "_newCasemgmt.forms";
 

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/FormsServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/FormsServiceUnitTest.java
@@ -1,0 +1,236 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.webserv.rest;
+
+import io.github.carlos_emr.carlos.commn.model.Provider;
+import io.github.carlos_emr.carlos.managers.FormsManager;
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
+import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import io.github.carlos_emr.carlos.webserv.rest.to.AbstractSearchResponse;
+import io.github.carlos_emr.carlos.webserv.rest.to.model.MenuTo1;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.List;
+import java.util.ResourceBundle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link FormsService} privilege enforcement (#2798).
+ *
+ * <p>{@code FormsService} is the mixed-security-object case: its endpoints span eForm reads
+ * (guarded by {@code _eform}) and SQL-table encounter form reads (guarded by
+ * {@code _newCasemgmt.forms}). These tests pin the per-endpoint mapping and verify each endpoint
+ * fails closed with the CARLOS paren-form {@link SecurityException} before touching the
+ * {@link FormsManager}.</p>
+ *
+ * @see FormsService
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("FormsService Unit Tests")
+@Tag("unit")
+@Tag("fast")
+class FormsServiceUnitTest extends CarlosUnitTestBase {
+
+    @Mock
+    private FormsManager mockFormsManager;
+
+    @Mock
+    private SecurityInfoManager mockSecurityInfoManager;
+
+    private FormsService service;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        Provider provider = mock(Provider.class);
+        when(provider.getProviderNo()).thenReturn("101");
+        LoggedInInfo loggedInInfo = new LoggedInInfo();
+        loggedInInfo.setLoggedInProvider(provider);
+        loggedInInfo.setIp("127.0.0.1");
+
+        final LoggedInInfo capturedInfo = loggedInInfo;
+        service = new FormsService() {
+            @Override
+            protected LoggedInInfo getLoggedInInfo() {
+                return capturedInfo;
+            }
+
+            // getFormOptions consults the UI bundle, which would otherwise require a live CXF
+            // request context; the bundle value is unused by the method, so a null is sufficient.
+            @Override
+            protected ResourceBundle getResourceBundle() {
+                return null;
+            }
+        };
+
+        inject("formsManager", mockFormsManager);
+        inject("securityInfoManager", mockSecurityInfoManager);
+    }
+
+    private void inject(String fieldName, Object value) throws Exception {
+        Field field = FormsService.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(service, value);
+    }
+
+    // --- eForm endpoints: _eform ---
+
+    @Test
+    @DisplayName("should return eform group names when caller has _eform read privilege")
+    @Tag("read")
+    void shouldReturnGroupNames_whenCallerHasEformReadPrivilege() {
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq("_eform"), eq("r"), any())).thenReturn(true);
+        List<String> groups = Arrays.asList("Cardiology", "Diabetes");
+        when(mockFormsManager.getGroupNames()).thenReturn(groups);
+
+        AbstractSearchResponse<String> response = service.getGroupNames();
+
+        assertThat(response.getContent()).containsExactly("Cardiology", "Diabetes");
+        verify(mockFormsManager).getGroupNames();
+    }
+
+    @Test
+    @DisplayName("should deny eform group names when caller lacks _eform read privilege")
+    @Tag("read")
+    void shouldDenyGroupNames_whenCallerLacksEformReadPrivilege() {
+        when(mockSecurityInfoManager.hasPrivilege(any(), anyString(), anyString(), any())).thenReturn(false);
+
+        assertThatThrownBy(() -> service.getGroupNames())
+            .isInstanceOf(SecurityException.class)
+            .hasMessage("missing required sec object (_eform)");
+
+        verify(mockFormsManager, never()).getGroupNames();
+    }
+
+    @Test
+    @DisplayName("should deny all eform names when caller lacks _eform read privilege")
+    @Tag("read")
+    void shouldDenyAllEFormNames_whenCallerLacksEformReadPrivilege() {
+        when(mockSecurityInfoManager.hasPrivilege(any(), anyString(), anyString(), any())).thenReturn(false);
+
+        assertThatThrownBy(() -> service.getAllEFormNames())
+            .isInstanceOf(SecurityException.class)
+            .hasMessage("missing required sec object (_eform)");
+
+        verify(mockFormsManager, never()).findByStatus(any(), anyBoolean(), any());
+    }
+
+    @Test
+    @DisplayName("should deny forms-for-heading when caller lacks _eform read privilege")
+    @Tag("read")
+    void shouldDenyFormsForHeading_whenCallerLacksEformReadPrivilege() {
+        when(mockSecurityInfoManager.hasPrivilege(any(), anyString(), anyString(), any())).thenReturn(false);
+
+        assertThatThrownBy(() -> service.getFormsForHeading(1, "Completed"))
+            .isInstanceOf(SecurityException.class)
+            .hasMessage("missing required sec object (_eform)");
+
+        verify(mockFormsManager, never()).findByDemographicId(any(), any());
+    }
+
+    // --- Encounter-form endpoints: _newCasemgmt.forms ---
+
+    @Test
+    @DisplayName("should deny all encounter form names when caller lacks _newCasemgmt.forms read privilege")
+    @Tag("read")
+    void shouldDenyAllEncounterFormNames_whenCallerLacksFormsReadPrivilege() {
+        when(mockSecurityInfoManager.hasPrivilege(any(), anyString(), anyString(), any())).thenReturn(false);
+
+        assertThatThrownBy(() -> service.getAllFormNames())
+            .isInstanceOf(SecurityException.class)
+            .hasMessage("missing required sec object (_newCasemgmt.forms)");
+
+        verify(mockFormsManager, never()).getAllEncounterForms();
+    }
+
+    @Test
+    @DisplayName("should deny selected encounter form names when caller lacks _newCasemgmt.forms read privilege")
+    @Tag("read")
+    void shouldDenySelectedEncounterFormNames_whenCallerLacksFormsReadPrivilege() {
+        when(mockSecurityInfoManager.hasPrivilege(any(), anyString(), anyString(), any())).thenReturn(false);
+
+        assertThatThrownBy(() -> service.getSelectedFormNames())
+            .isInstanceOf(SecurityException.class)
+            .hasMessage("missing required sec object (_newCasemgmt.forms)");
+
+        verify(mockFormsManager, never()).getSelectedEncounterForms();
+    }
+
+    @Test
+    @DisplayName("should deny completed encounter forms (patient PHI) when caller lacks _newCasemgmt.forms read privilege")
+    @Tag("read")
+    void shouldDenyCompletedEncounterForms_whenCallerLacksFormsReadPrivilege() {
+        when(mockSecurityInfoManager.hasPrivilege(any(), anyString(), anyString(), any())).thenReturn(false);
+
+        assertThatThrownBy(() -> service.getCompletedFormNames("1"))
+            .isInstanceOf(SecurityException.class)
+            .hasMessage("missing required sec object (_newCasemgmt.forms)");
+
+        verify(mockFormsManager, never()).getAllEncounterForms();
+    }
+
+    // --- Generic forms-panel menu: read on either object ---
+
+    @Test
+    @DisplayName("should deny form options when caller lacks both eform and forms read privilege")
+    @Tag("read")
+    void shouldDenyFormOptions_whenCallerLacksBothReadPrivileges() {
+        when(mockSecurityInfoManager.hasPrivilege(any(), anyString(), anyString(), any())).thenReturn(false);
+
+        assertThatThrownBy(() -> service.getFormOptions("1"))
+            .isInstanceOf(SecurityException.class)
+            .hasMessage("missing required sec object (_eform)");
+    }
+
+    @Test
+    @DisplayName("should return form options when caller has only _newCasemgmt.forms read privilege")
+    @Tag("read")
+    void shouldReturnFormOptions_whenCallerHasOnlyFormsReadPrivilege() {
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq("_eform"), eq("r"), any())).thenReturn(false);
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq("_newCasemgmt.forms"), eq("r"), any())).thenReturn(true);
+
+        MenuTo1 menu = service.getFormOptions("1");
+
+        assertThat(menu).isNotNull();
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/FormsServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/FormsServiceUnitTest.java
@@ -233,4 +233,43 @@ class FormsServiceUnitTest extends CarlosUnitTestBase {
 
         assertThat(menu).isNotNull();
     }
+
+    // --- Patient-scoped reads thread the demographic into the privilege check ---
+
+    @Test
+    @DisplayName("should scope eform privilege check to the patient when reading forms for a heading")
+    @Tag("read")
+    void shouldScopePrivilegeToPatient_whenReadingFormsForHeading() {
+        when(mockSecurityInfoManager.hasPrivilege(any(), anyString(), anyString(), any())).thenReturn(false);
+
+        assertThatThrownBy(() -> service.getFormsForHeading(7, "Completed"))
+            .isInstanceOf(SecurityException.class);
+
+        verify(mockSecurityInfoManager).hasPrivilege(any(), eq("_eform"), eq("r"), eq("7"));
+    }
+
+    @Test
+    @DisplayName("should scope forms privilege check to the patient when reading completed encounter forms")
+    @Tag("read")
+    void shouldScopePrivilegeToPatient_whenReadingCompletedEncounterForms() {
+        when(mockSecurityInfoManager.hasPrivilege(any(), anyString(), anyString(), any())).thenReturn(false);
+
+        assertThatThrownBy(() -> service.getCompletedFormNames("42"))
+            .isInstanceOf(SecurityException.class);
+
+        verify(mockSecurityInfoManager).hasPrivilege(any(), eq("_newCasemgmt.forms"), eq("r"), eq("42"));
+    }
+
+    @Test
+    @DisplayName("should scope form-options privilege check to the patient")
+    @Tag("read")
+    void shouldScopePrivilegeToPatient_whenReadingFormOptions() {
+        when(mockSecurityInfoManager.hasPrivilege(any(), anyString(), anyString(), any())).thenReturn(false);
+
+        assertThatThrownBy(() -> service.getFormOptions("99"))
+            .isInstanceOf(SecurityException.class);
+
+        verify(mockSecurityInfoManager).hasPrivilege(any(), eq("_eform"), eq("r"), eq("99"));
+        verify(mockSecurityInfoManager).hasPrivilege(any(), eq("_newCasemgmt.forms"), eq("r"), eq("99"));
+    }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/FormsServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/FormsServiceUnitTest.java
@@ -37,8 +37,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
 
-import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.List;
 import java.util.ResourceBundle;
@@ -103,14 +103,8 @@ class FormsServiceUnitTest extends CarlosUnitTestBase {
             }
         };
 
-        inject("formsManager", mockFormsManager);
-        inject("securityInfoManager", mockSecurityInfoManager);
-    }
-
-    private void inject(String fieldName, Object value) throws Exception {
-        Field field = FormsService.class.getDeclaredField(fieldName);
-        field.setAccessible(true);
-        field.set(service, value);
+        ReflectionTestUtils.setField(service, "formsManager", mockFormsManager);
+        ReflectionTestUtils.setField(service, "securityInfoManager", mockSecurityInfoManager);
     }
 
     // --- eForm endpoints: _eform ---


### PR DESCRIPTION
## Summary

`FormsService` (`/ws/rs/forms`) is the mixed-security-object case called out in #2798: the caller is authenticated by the REST interceptors, but the service performed **no authorization**, so any valid CARLOS login could read both eForm and SQL-table encounter-form data. This adds a per-endpoint `SecurityInfoManager.hasPrivilege()` read check to all 9 endpoints, mapping each to its correct security object.

Per request, this does **not** auto-close #2798 — that issue tracks ~8 remaining services and stays open. (`Part of #2798`, mirroring how #3011's keyword was downgraded from `fixes`.)

## Security-object mapping (the nuance)

- **eForm reads → `_eform`** (matches the already-blessed `EFormService`/`EFormsService`):
  `getFormsForHeading`, `getAllEFormNames`, `getGroupNames`, `getFavouriteFormGroups`, `getGroupsWithForms`
- **SQL-table encounter form reads → `_newCasemgmt.forms`** (matches `RecordUxService`'s forms-panel gate):
  `getAllFormNames`, `getSelectedFormNames`, `getCompletedFormNames` (patient PHI)
- **Generic forms-panel menu → read on either** object: `getFormOptions`

Failed checks fail closed with the CARLOS paren-form `SecurityException("missing required sec object (_x)")`, consistent with #3011's guards on the unambiguous services.

## Tests

New `FormsServiceUnitTest` (`@Tag("unit")`, mocked `SecurityInfoManager`/`FormsManager`, no DB), mirroring `RxLookupServiceUnitTest` from #3011:
- allow + deny on the `_eform` path (`getGroupNames`)
- deny on `getAllEFormNames` / `getFormsForHeading` (`_eform`)
- deny on `getAllFormNames` / `getSelectedFormNames` / `getCompletedFormNames` (`_newCasemgmt.forms`), each asserting the manager is never invoked (PHI not reached)
- `getFormOptions` deny (neither object) and allow (only `_newCasemgmt.forms`)

Verified locally:
- `mvn test-compile` — BUILD SUCCESS
- `mvn -Dtest=FormsServiceUnitTest test` — Tests run: 9, Failures: 0, Errors: 0

## CARLOS conventions applied

- `SecurityInfoManager.hasPrivilege()` on every endpoint; paren-form `SecurityException` message
- Constructor-style `@Autowired` field matching sibling REST services; no new public API
- Existing copyright header preserved; no `@author`; new test file uses the CARLOS header
- No PHI in logs or messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enforce privilege checks on all FormsService JAX-RS endpoints to restrict eForm and encounter-form reads to authorized users.

Bug Fixes:
- Guard FormsService eForm endpoints with the _eform security object and encounter-form endpoints with _newCasemgmt.forms to prevent unauthorized data access.

Tests:
- Add FormsServiceUnitTest to verify per-endpoint privilege enforcement, patient-scoped checks, and deny-before-execution behavior for FormsService.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces read-privilege checks on all `FormsService` JAX-RS endpoints to block unauthorized reads of eForms and encounter-form data. Part of #2798.

- **Bug Fixes**
  - Added `SecurityInfoManager.hasPrivilege()` across 9 endpoints; eForm reads require `_eform`, encounter-form reads require `_newCasemgmt.forms`; `formOptions` allows read on either and the comment now clarifies its relation to `RecordUxService` (no behavior change; `getLoggedInInfo()` deduped).
  - Patient-scoped endpoints (`getFormsForHeading`, `getCompletedFormNames`, `getFormOptions`) pass `demographicNo` into `hasPrivilege` so patient-specific denies take precedence.
  - Unit tests verify deny-before-execution and patient-scoped checks with consistent error messages; tests now use `ReflectionTestUtils.setField` for field injection.

<sup>Written for commit b0eae6a09e42a699ac18a522c71078cb040bd29b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3088?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

