### PR TITLE
fix(security): enforce hasPrivilege on ReportingService JAX-RS endpoints (#2798)

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/ReportingService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/ReportingService.java
@@ -54,6 +54,7 @@ import io.github.carlos_emr.carlos.commn.model.EFormReportTool;
 import io.github.carlos_emr.carlos.managers.DemographicManager;
 import io.github.carlos_emr.carlos.managers.DemographicSetsManager;
 import io.github.carlos_emr.carlos.managers.EFormReportToolManager;
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.prev.reports.Report;
 import io.github.carlos_emr.carlos.prev.reports.ReportBuilder;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
@@ -92,10 +93,29 @@ public class ReportingService extends AbstractServiceImpl {
     @Autowired
     PreventionReportDao preventionReportDao;
 
+    @Autowired
+    SecurityInfoManager securityInfoManager;
+
+    /**
+     * Security objects gating this service's three sub-resources. They are deliberately
+     * distinct: demographic-set queries belong to the general reporting module ({@code _report},
+     * matching {@code DemographicSetEdit2Action}); the eForm report tool is an admin utility
+     * ({@code _admin.eformreporttool}, already enforced by {@code EFormReportToolManager} — the
+     * checks here are defense-in-depth at the REST entry point); and prevention reports belong to
+     * the prevention module ({@code _prevention}, matching the page that hosts them,
+     * {@code PreventionReporting.jsp}). See issue #2798.
+     */
+    private static final String SECOBJ_REPORT = "_report";
+    private static final String SECOBJ_EFORM_REPORT_TOOL = "_admin.eformreporttool";
+    private static final String SECOBJ_PREVENTION = "_prevention";
+
     @GET
     @Path("/demographicSets/list")
     @Produces("application/json")
     public AbstractSearchResponse<String> listDemographicSets() {
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), SECOBJ_REPORT, "r", null)) {
+            throw new SecurityException("missing required sec object (" + SECOBJ_REPORT + ")");
+        }
         AbstractSearchResponse<String> response = new AbstractSearchResponse<String>();
 
         response.setContent(demographicSetsManager.getNames(getLoggedInInfo()));
@@ -108,6 +128,9 @@ public class ReportingService extends AbstractServiceImpl {
     @Path("/demographicSets/demographicSet/{name}")
     @Produces("application/json")
     public AbstractSearchResponse<DemographicSets> getDemographicSetByName(@PathParam("name") String name) {
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), SECOBJ_REPORT, "r", null)) {
+            throw new SecurityException("missing required sec object (" + SECOBJ_REPORT + ")");
+        }
         AbstractSearchResponse<DemographicSets> response = new AbstractSearchResponse<DemographicSets>();
 
         response.setContent(demographicSetsManager.getByName(getLoggedInInfo(), name));
@@ -121,6 +144,9 @@ public class ReportingService extends AbstractServiceImpl {
     @Produces("application/json")
     @Consumes("application/json")
     public PatientListApptBean getAsPatientList(JsonNode json) {
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), SECOBJ_REPORT, "r", null)) {
+            throw new SecurityException("missing required sec object (" + SECOBJ_REPORT + ")");
+        }
 
         PatientListApptBean response = new PatientListApptBean();
 
@@ -147,6 +173,9 @@ public class ReportingService extends AbstractServiceImpl {
     @Path("/eformReportTool/list")
     @Produces("application/json")
     public AbstractSearchResponse<EFormReportToolTo1> eformReportToolList() {
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), SECOBJ_EFORM_REPORT_TOOL, "r", null)) {
+            throw new SecurityException("missing required sec object (" + SECOBJ_EFORM_REPORT_TOOL + ")");
+        }
 
         List<EFormReportTool> results = eformReportToolManager.findAll(getLoggedInInfo(), 0, EFormReportToolDao.MAX_LIST_RETURN_SIZE);
 
@@ -166,6 +195,9 @@ public class ReportingService extends AbstractServiceImpl {
     @Produces("application/json")
     @Consumes("application/json")
     public RestResponse<String> addEFormReportTool(EFormReportToolTo1 json) {
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), SECOBJ_EFORM_REPORT_TOOL, "w", null)) {
+            return RestResponse.errorResponse("Access Denied");
+        }
 
         if (StringUtils.isEmpty(json.getName()) || json.getEformId() == 0) {
             return RestResponse.errorResponse("Need required fields");
@@ -187,6 +219,9 @@ public class ReportingService extends AbstractServiceImpl {
     @Produces("application/json")
     @Consumes("application/json")
     public RestResponse<String> populateEFormReportTool(EFormReportToolTo1 json) {
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), SECOBJ_EFORM_REPORT_TOOL, "w", null)) {
+            return RestResponse.errorResponse("Access Denied");
+        }
 
         eformReportToolManager.populateReportTable(getLoggedInInfo(), json.getId());
 
@@ -199,6 +234,9 @@ public class ReportingService extends AbstractServiceImpl {
     @Produces("application/json")
     @Consumes("application/json")
     public RestResponse<String> removeEFormReportTool(EFormReportToolTo1 json) {
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), SECOBJ_EFORM_REPORT_TOOL, "w", null)) {
+            return RestResponse.errorResponse("Access Denied");
+        }
 
         eformReportToolManager.remove(getLoggedInInfo(), json.getId());
 
@@ -210,6 +248,9 @@ public class ReportingService extends AbstractServiceImpl {
     @Produces("application/json")
     @Consumes("application/json")
     public RestResponse<String> markLatestEFormReportTool(EFormReportToolTo1 json) {
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), SECOBJ_EFORM_REPORT_TOOL, "w", null)) {
+            return RestResponse.errorResponse("Access Denied");
+        }
 
         eformReportToolManager.markLatest(getLoggedInInfo(), json.getId());
 
@@ -222,6 +263,9 @@ public class ReportingService extends AbstractServiceImpl {
     @Produces("application/json")
     @Consumes("application/json")
     public RestResponse<String> saveNewPreventionReport(PreventionSearchTo1 preventionSearch) {
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), SECOBJ_PREVENTION, "w", null)) {
+            return RestResponse.errorResponse("Access Denied");
+        }
         //Next thing to do is to save the JSON object to the database
         ObjectMapper mapper = OBJECT_MAPPER;
         try {
@@ -244,6 +288,9 @@ public class ReportingService extends AbstractServiceImpl {
     @Produces("application/json")
     @Consumes("application/json")
     public List<MenuItemTo1> getPreventionReports() {
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), SECOBJ_PREVENTION, "r", null)) {
+            throw new SecurityException("missing required sec object (" + SECOBJ_PREVENTION + ")");
+        }
         List<MenuItemTo1> returnList = new ArrayList<MenuItemTo1>();
         List<PreventionReport> list = preventionReportDao.getPreventionReports();
         for (PreventionReport pr : list) {
@@ -271,6 +318,10 @@ public class ReportingService extends AbstractServiceImpl {
     @Produces("application/json")
     @Consumes("application/json")
     public jakarta.ws.rs.core.Response runPreventionReport(@PathParam("id") Integer id, JsonNode jSONObject) { // will need to change providers to an ojbect
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), SECOBJ_PREVENTION, "r", null)) {
+            return jakarta.ws.rs.core.Response.status(jakarta.ws.rs.core.Response.Status.FORBIDDEN)
+                    .entity("{\"Error\":\"Access Denied\"}").build();
+        }
         Report report = null;
         //Next thing to do is to save the JSON object to the database
         String providerNo = jSONObject.has("providerNo") ? jSONObject.get("providerNo").asText() : "";
@@ -314,6 +365,10 @@ public class ReportingService extends AbstractServiceImpl {
     @Produces("application/json")
     @Consumes("application/json")
     public jakarta.ws.rs.core.Response getPreventionReport(@PathParam("id") Integer id, JsonNode jSONObject) { // will need to change providers to an ojbect
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), SECOBJ_PREVENTION, "r", null)) {
+            return jakarta.ws.rs.core.Response.status(jakarta.ws.rs.core.Response.Status.FORBIDDEN)
+                    .entity("{\"Error\":\"Access Denied\"}").build();
+        }
         PreventionReport pr = preventionReportDao.find(id);
         if (pr == null) {
             logger.warn("Prevention report not found id={}", id);
@@ -351,6 +406,10 @@ public class ReportingService extends AbstractServiceImpl {
     @Produces("application/json")
     @Consumes("application/json")
     public jakarta.ws.rs.core.Response getPreventionReport(@PathParam("id") Integer id) { // will need to change providers to an ojbect
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), SECOBJ_PREVENTION, "w", null)) {
+            return jakarta.ws.rs.core.Response.status(jakarta.ws.rs.core.Response.Status.FORBIDDEN)
+                    .entity("{\"Error\":\"Access Denied\"}").build();
+        }
         PreventionReport pr = preventionReportDao.find(id);
         pr.setActive(false);
         preventionReportDao.merge(pr);

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/ReportingService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/ReportingService.java
@@ -411,6 +411,11 @@ public class ReportingService extends AbstractServiceImpl {
                     .entity("{\"Error\":\"Access Denied\"}").build();
         }
         PreventionReport pr = preventionReportDao.find(id);
+        if (pr == null) {
+            logger.warn("Prevention report not found id={}", id);
+            return jakarta.ws.rs.core.Response.status(404)
+                    .entity("{\"Error\":\"Prevention report not found\"}").build();
+        }
         pr.setActive(false);
         preventionReportDao.merge(pr);
 

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/ReportingServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/ReportingServiceUnitTest.java
@@ -13,9 +13,12 @@
 package io.github.carlos_emr.carlos.webserv.rest;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -45,6 +48,7 @@ import io.github.carlos_emr.carlos.commn.dao.PreventionReportDao;
 import io.github.carlos_emr.carlos.commn.model.PreventionReport;
 import io.github.carlos_emr.carlos.commn.model.Provider;
 import io.github.carlos_emr.carlos.managers.EFormReportToolManager;
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.prev.reports.Report;
 import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
@@ -68,6 +72,9 @@ class ReportingServiceUnitTest extends CarlosUnitTestBase {
 
     @Mock
     private PreventionReportDao mockPreventionReportDao;
+
+    @Mock
+    private SecurityInfoManager mockSecurityInfoManager;
 
     private ReportingService service;
     private LoggedInInfo loggedInInfo;
@@ -114,6 +121,11 @@ class ReportingServiceUnitTest extends CarlosUnitTestBase {
 
         injectDependency(service, "eformReportToolManager", mockEFormReportToolManager);
         injectDependency(service, "preventionReportDao", mockPreventionReportDao);
+        injectDependency(service, "securityInfoManager", mockSecurityInfoManager);
+
+        // Default to granted so the existing behavioural tests exercise the business logic;
+        // the authorization tests below re-stub specific (secobj, privilege) pairs as denied.
+        when(mockSecurityInfoManager.hasPrivilege(any(), any(), any(), any())).thenReturn(true);
     }
 
     @AfterEach
@@ -266,6 +278,84 @@ class ReportingServiceUnitTest extends CarlosUnitTestBase {
             Response response = service.runPreventionReport(11, emptyJson());
 
             assertThat(response.getStatus()).isEqualTo(268);
+        }
+    }
+
+    /**
+     * Authorization guards added for issue #2798. Each of the service's three sub-resources is
+     * gated by a distinct security object: demographic sets by {@code _report}, the eForm report
+     * tool by {@code _admin.eformreporttool}, and prevention reports by {@code _prevention}. These
+     * tests verify the correct object/privilege is requested and that a denial short-circuits the
+     * endpoint before any business logic runs.
+     */
+    @Nested
+    @DisplayName("authorization guards")
+    class AuthorizationGuards {
+
+        private JsonNode emptyJson() {
+            return new ObjectMapper().createObjectNode();
+        }
+
+        @Test
+        @DisplayName("should throw SecurityException when demographicSets list lacks _report read")
+        void shouldThrowSecurityException_whenDemographicSetsListLacksReportRead() {
+            when(mockSecurityInfoManager.hasPrivilege(any(), eq("_report"), eq("r"), any())).thenReturn(false);
+
+            assertThatThrownBy(() -> service.listDemographicSets())
+                    .isInstanceOf(SecurityException.class)
+                    .hasMessageContaining("(_report)");
+        }
+
+        @Test
+        @DisplayName("should deny eformReportTool add when _admin.eformreporttool write is missing")
+        void shouldDenyEformReportToolAdd_whenAdminWriteMissing() {
+            when(mockSecurityInfoManager.hasPrivilege(any(), eq("_admin.eformreporttool"), eq("w"), any()))
+                    .thenReturn(false);
+
+            EFormReportToolTo1 request = new EFormReportToolTo1();
+            request.setName("report_tool_2026");
+            request.setEformId(1);
+
+            RestResponse<String> response = service.addEFormReportTool(request);
+
+            assertThat(response.getStatus()).isEqualTo(ResponseStatus.ERROR);
+            assertThat(response.getError().getMessage()).isEqualTo("Access Denied");
+            verify(mockEFormReportToolManager, never()).addNew(any(), any());
+            verify(mockSecurityInfoManager).hasPrivilege(any(), eq("_admin.eformreporttool"), eq("w"), any());
+        }
+
+        @Test
+        @DisplayName("should deny prevention saveNew when _prevention write is missing")
+        void shouldDenyPreventionSaveNew_whenPreventionWriteMissing() {
+            when(mockSecurityInfoManager.hasPrivilege(any(), eq("_prevention"), eq("w"), any())).thenReturn(false);
+
+            RestResponse<String> response = service.saveNewPreventionReport(new PreventionSearchTo1());
+
+            assertThat(response.getStatus()).isEqualTo(ResponseStatus.ERROR);
+            assertThat(response.getError().getMessage()).isEqualTo("Access Denied");
+            verify(mockPreventionReportDao, never()).persist(any());
+        }
+
+        @Test
+        @DisplayName("should return 403 when runPreventionReport lacks _prevention read")
+        void shouldReturnForbidden_whenRunPreventionReportLacksPreventionRead() {
+            when(mockSecurityInfoManager.hasPrivilege(any(), eq("_prevention"), eq("r"), any())).thenReturn(false);
+
+            Response response = service.runPreventionReport(1, emptyJson());
+
+            assertThat(response.getStatus()).isEqualTo(403);
+            verify(mockPreventionReportDao, never()).find(any());
+        }
+
+        @Test
+        @DisplayName("should return 403 when deactivateReport lacks _prevention write")
+        void shouldReturnForbidden_whenDeactivateReportLacksPreventionWrite() {
+            when(mockSecurityInfoManager.hasPrivilege(any(), eq("_prevention"), eq("w"), any())).thenReturn(false);
+
+            Response response = service.getPreventionReport(1);
+
+            assertThat(response.getStatus()).isEqualTo(403);
+            verify(mockPreventionReportDao, never()).merge(any());
         }
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/ReportingServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/ReportingServiceUnitTest.java
@@ -47,6 +47,7 @@ import io.github.carlos_emr.carlos.commn.dao.EFormDao;
 import io.github.carlos_emr.carlos.commn.dao.PreventionReportDao;
 import io.github.carlos_emr.carlos.commn.model.PreventionReport;
 import io.github.carlos_emr.carlos.commn.model.Provider;
+import io.github.carlos_emr.carlos.managers.DemographicSetsManager;
 import io.github.carlos_emr.carlos.managers.EFormReportToolManager;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.prev.reports.Report;
@@ -75,6 +76,9 @@ class ReportingServiceUnitTest extends CarlosUnitTestBase {
 
     @Mock
     private SecurityInfoManager mockSecurityInfoManager;
+
+    @Mock
+    private DemographicSetsManager mockDemographicSetsManager;
 
     private ReportingService service;
     private LoggedInInfo loggedInInfo;
@@ -122,6 +126,7 @@ class ReportingServiceUnitTest extends CarlosUnitTestBase {
         injectDependency(service, "eformReportToolManager", mockEFormReportToolManager);
         injectDependency(service, "preventionReportDao", mockPreventionReportDao);
         injectDependency(service, "securityInfoManager", mockSecurityInfoManager);
+        injectDependency(service, "demographicSetsManager", mockDemographicSetsManager);
 
         // Default to granted so the existing behavioural tests exercise the business logic;
         // the authorization tests below re-stub specific (secobj, privilege) pairs as denied.
@@ -296,6 +301,8 @@ class ReportingServiceUnitTest extends CarlosUnitTestBase {
             return new ObjectMapper().createObjectNode();
         }
 
+        // --- demographicSets sub-resource: gated by _report read ---
+
         @Test
         @DisplayName("should throw SecurityException when demographicSets list lacks _report read")
         void shouldThrowSecurityException_whenDemographicSetsListLacksReportRead() {
@@ -304,6 +311,43 @@ class ReportingServiceUnitTest extends CarlosUnitTestBase {
             assertThatThrownBy(() -> service.listDemographicSets())
                     .isInstanceOf(SecurityException.class)
                     .hasMessageContaining("(_report)");
+            verify(mockDemographicSetsManager, never()).getNames(any());
+        }
+
+        @Test
+        @DisplayName("should throw SecurityException when demographicSet lookup lacks _report read")
+        void shouldThrowSecurityException_whenDemographicSetByNameLacksReportRead() {
+            when(mockSecurityInfoManager.hasPrivilege(any(), eq("_report"), eq("r"), any())).thenReturn(false);
+
+            assertThatThrownBy(() -> service.getDemographicSetByName("set1"))
+                    .isInstanceOf(SecurityException.class)
+                    .hasMessageContaining("(_report)");
+            verify(mockDemographicSetsManager, never()).getByName(any(), any());
+        }
+
+        @Test
+        @DisplayName("should throw SecurityException when patientList lacks _report read")
+        void shouldThrowSecurityException_whenPatientListLacksReportRead() {
+            when(mockSecurityInfoManager.hasPrivilege(any(), eq("_report"), eq("r"), any())).thenReturn(false);
+
+            assertThatThrownBy(() -> service.getAsPatientList(emptyJson()))
+                    .isInstanceOf(SecurityException.class)
+                    .hasMessageContaining("(_report)");
+            verify(mockDemographicSetsManager, never()).getByName(any(), any());
+        }
+
+        // --- eformReportTool sub-resource: gated by _admin.eformreporttool (read on list, write on mutators) ---
+
+        @Test
+        @DisplayName("should throw SecurityException when eformReportTool list lacks _admin.eformreporttool read")
+        void shouldThrowSecurityException_whenEformReportToolListLacksAdminRead() {
+            when(mockSecurityInfoManager.hasPrivilege(any(), eq("_admin.eformreporttool"), eq("r"), any()))
+                    .thenReturn(false);
+
+            assertThatThrownBy(() -> service.eformReportToolList())
+                    .isInstanceOf(SecurityException.class)
+                    .hasMessageContaining("(_admin.eformreporttool)");
+            verify(mockEFormReportToolManager, never()).findAll(any(), any(), any());
         }
 
         @Test
@@ -321,8 +365,48 @@ class ReportingServiceUnitTest extends CarlosUnitTestBase {
             assertThat(response.getStatus()).isEqualTo(ResponseStatus.ERROR);
             assertThat(response.getError().getMessage()).isEqualTo("Access Denied");
             verify(mockEFormReportToolManager, never()).addNew(any(), any());
-            verify(mockSecurityInfoManager).hasPrivilege(any(), eq("_admin.eformreporttool"), eq("w"), any());
         }
+
+        @Test
+        @DisplayName("should deny eformReportTool populate when _admin.eformreporttool write is missing")
+        void shouldDenyEformReportToolPopulate_whenAdminWriteMissing() {
+            when(mockSecurityInfoManager.hasPrivilege(any(), eq("_admin.eformreporttool"), eq("w"), any()))
+                    .thenReturn(false);
+
+            RestResponse<String> response = service.populateEFormReportTool(new EFormReportToolTo1());
+
+            assertThat(response.getStatus()).isEqualTo(ResponseStatus.ERROR);
+            assertThat(response.getError().getMessage()).isEqualTo("Access Denied");
+            verify(mockEFormReportToolManager, never()).populateReportTable(any(), any());
+        }
+
+        @Test
+        @DisplayName("should deny eformReportTool remove when _admin.eformreporttool write is missing")
+        void shouldDenyEformReportToolRemove_whenAdminWriteMissing() {
+            when(mockSecurityInfoManager.hasPrivilege(any(), eq("_admin.eformreporttool"), eq("w"), any()))
+                    .thenReturn(false);
+
+            RestResponse<String> response = service.removeEFormReportTool(new EFormReportToolTo1());
+
+            assertThat(response.getStatus()).isEqualTo(ResponseStatus.ERROR);
+            assertThat(response.getError().getMessage()).isEqualTo("Access Denied");
+            verify(mockEFormReportToolManager, never()).remove(any(), any());
+        }
+
+        @Test
+        @DisplayName("should deny eformReportTool markLatest when _admin.eformreporttool write is missing")
+        void shouldDenyEformReportToolMarkLatest_whenAdminWriteMissing() {
+            when(mockSecurityInfoManager.hasPrivilege(any(), eq("_admin.eformreporttool"), eq("w"), any()))
+                    .thenReturn(false);
+
+            RestResponse<String> response = service.markLatestEFormReportTool(new EFormReportToolTo1());
+
+            assertThat(response.getStatus()).isEqualTo(ResponseStatus.ERROR);
+            assertThat(response.getError().getMessage()).isEqualTo("Access Denied");
+            verify(mockEFormReportToolManager, never()).markLatest(any(), any());
+        }
+
+        // --- preventionReport sub-resource: gated by _prevention (read on get/run, write on saveNew/deactivate) ---
 
         @Test
         @DisplayName("should deny prevention saveNew when _prevention write is missing")
@@ -337,6 +421,17 @@ class ReportingServiceUnitTest extends CarlosUnitTestBase {
         }
 
         @Test
+        @DisplayName("should throw SecurityException when prevention getList lacks _prevention read")
+        void shouldThrowSecurityException_whenPreventionGetListLacksPreventionRead() {
+            when(mockSecurityInfoManager.hasPrivilege(any(), eq("_prevention"), eq("r"), any())).thenReturn(false);
+
+            assertThatThrownBy(() -> service.getPreventionReports())
+                    .isInstanceOf(SecurityException.class)
+                    .hasMessageContaining("(_prevention)");
+            verify(mockPreventionReportDao, never()).getPreventionReports();
+        }
+
+        @Test
         @DisplayName("should return 403 when runPreventionReport lacks _prevention read")
         void shouldReturnForbidden_whenRunPreventionReportLacksPreventionRead() {
             when(mockSecurityInfoManager.hasPrivilege(any(), eq("_prevention"), eq("r"), any())).thenReturn(false);
@@ -348,14 +443,28 @@ class ReportingServiceUnitTest extends CarlosUnitTestBase {
         }
 
         @Test
+        @DisplayName("should return 403 when getReport (read) lacks _prevention read")
+        void shouldReturnForbidden_whenGetReportLacksPreventionRead() {
+            when(mockSecurityInfoManager.hasPrivilege(any(), eq("_prevention"), eq("r"), any())).thenReturn(false);
+
+            Response response = service.getPreventionReport(1, emptyJson());
+
+            assertThat(response.getStatus()).isEqualTo(403);
+            verify(mockPreventionReportDao, never()).find(any());
+        }
+
+        @Test
         @DisplayName("should return 403 when deactivateReport lacks _prevention write")
         void shouldReturnForbidden_whenDeactivateReportLacksPreventionWrite() {
             when(mockSecurityInfoManager.hasPrivilege(any(), eq("_prevention"), eq("w"), any())).thenReturn(false);
 
+            // The single-arg getPreventionReport overload is the deactivate/merge path
+            // (@Path("/preventionReport/dectivateReport/{id}")); the two-arg overload is the read path.
             Response response = service.getPreventionReport(1);
 
             assertThat(response.getStatus()).isEqualTo(403);
             verify(mockPreventionReportDao, never()).merge(any());
+            verify(mockPreventionReportDao, never()).find(any());
         }
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/ReportingServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/ReportingServiceUnitTest.java
@@ -208,6 +208,30 @@ class ReportingServiceUnitTest extends CarlosUnitTestBase {
         }
 
         @Test
+        @DisplayName("should return 404 when deactivateReport finds no report (no NPE)")
+        void shouldReturnNotFound_whenDeactivateReportMissing() {
+            when(mockPreventionReportDao.find(Integer.valueOf(999))).thenReturn(null);
+
+            Response response = service.getPreventionReport(999);
+
+            assertThat(response.getStatus()).isEqualTo(404);
+            verify(mockPreventionReportDao, never()).merge(any());
+        }
+
+        @Test
+        @DisplayName("should return 200 and merge inactive report when deactivateReport succeeds")
+        void shouldDeactivateReport_whenReportExists() {
+            PreventionReport pr = mock(PreventionReport.class);
+            when(mockPreventionReportDao.find(Integer.valueOf(12))).thenReturn(pr);
+
+            Response response = service.getPreventionReport(12);
+
+            assertThat(response.getStatus()).isEqualTo(200);
+            verify(pr).setActive(false);
+            verify(mockPreventionReportDao).merge(pr);
+        }
+
+        @Test
         @DisplayName("should return 268 when getPreventionReport JSON is malformed")
         void shouldReturn268_whenReportJsonInvalid() {
             PreventionReport pr = mock(PreventionReport.class);


### PR DESCRIPTION
## Summary

`ReportingService` (`/ws/rs/reporting/*`) authenticated its callers but performed **no authorization**, so any logged-in CARLOS user — and, via the `/ws/` LoginFilter exemption noted on #2798, some unauthenticated callers — could invoke all of its endpoints (read demographic sets, run/save/deactivate prevention reports, manage the eForm report tool). This adds `securityInfoManager.hasPrivilege()` to **all 13 endpoints**, one of the remaining services tracked in #2798.

## Scope

- Guard every endpoint of `ReportingService`, mapping each of its **3 sub-resources to its correct, distinct security object** (the issue explicitly warns not to dilute with one blanket guess):
  - `demographicSets/*` → **`_report`** (read) — matches the sibling `DemographicSetEdit2Action`.
  - `eformReportTool/*` → **`_admin.eformreporttool`** (read on `list`, write on `add`/`populate`/`remove`/`markLatest`). This object is already enforced inside `EFormReportToolManager`; the REST-layer checks are defense-in-depth at the entry point.
  - `preventionReport/*` → **`_prevention`** (read on `getList`/`getReport`/`runReport`, write on `saveNew`/`dectivateReport`) — matches the hosting page `PreventionReporting.jsp`.
- Read privilege for reads, write privilege for mutations.
- Confirm `ReportByTemplateService` is an **empty base class** (no annotated endpoints) and leave it untouched — it is a registered JAX-RS Spring bean in `applicationContextREST.xml`/`spring_ws.xml`, so deleting it is out of scope here.

## Changes

- `webserv/rest/ReportingService.java`: inject `SecurityInfoManager`; add a privilege check at the top of all 13 endpoints. Denials follow the existing in-package idiom per return type — `RestResponse.errorResponse("Access Denied")` for `RestResponse` methods, a `403 FORBIDDEN` `jakarta.ws.rs.core.Response` for the `Response` methods, and a paren-form `SecurityException` (`missing required sec object (_objectname)`, per `CLAUDE.md`) for the bean/search-response methods that cannot return an error envelope. Security objects are named constants with a rationale Javadoc.

## Tests

- Extended `ReportingServiceUnitTest` with an `AuthorizationGuards` `@Nested` class covering all three sub-resources and all three denial styles:
  - demographicSets list denied → throws `SecurityException` mentioning `(_report)`.
  - eformReportTool add denied → `RestResponse` ERROR `Access Denied`, manager `addNew` never called, `_admin.eformreporttool`/`w` requested.
  - prevention saveNew denied → `RestResponse` ERROR `Access Denied`, DAO `persist` never called.
  - runPreventionReport denied → `403`, DAO `find` never called.
  - deactivateReport denied → `403`, DAO `merge` never called.
- The existing behavioural tests default the mocked `SecurityInfoManager` to *granted* so they keep exercising business logic.

## Verification (local)

- `mvn test-compile` → BUILD SUCCESS.
- `mvn -o test -Dtest=ReportingServiceUnitTest` → **15 tests, 0 failures/errors** (5 new authorization tests + 10 existing).

## Note

Uses `Part of #2798` (not `fixes`) intentionally — `ReportingService` is one of several services in that umbrella issue, which should remain open until the rest are done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enforce privilege checks across all ReportingService REST endpoints and tighten prevention report deactivation behavior.

Bug Fixes:
- Protect all reporting, eForm report tool, and prevention report endpoints with appropriate read/write privilege checks to prevent unauthorized access.
- Return HTTP 404 instead of a server error when deactivating a non-existent prevention report.

Tests:
- Extend ReportingServiceUnitTest with authorization guard scenarios that verify denial responses and short-circuiting of underlying managers/DAOs for each secured endpoint.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds privilege checks to all 13 `ReportingService` (`/ws/rs/reporting/*`) endpoints and full denial tests to block unauthorized access. Also returns 404 on missing prevention report in `deactivateReport` instead of a 500 (part of #2798).

- **Bug Fixes**
  - Guard every endpoint with `securityInfoManager.hasPrivilege()` using correct security objects: `demographicSets/*` → `_report` (r); `eformReportTool/*` → `_admin.eformreporttool` (r on list, w on add/populate/remove/markLatest); `preventionReport/*` → `_prevention` (r on getList/getReport/runReport, w on saveNew/deactivate).
  - Denials match return type: `RestResponse.errorResponse("Access Denied")`, HTTP 403 `Response`, or `SecurityException` for bean/search responses.
  - Fix `preventionReport/deactivateReport` to return 404 when the report is missing; add tests for the 404 case and the successful deactivate. Tests also cover denial on all 13 endpoints and verify short-circuiting of manager/DAO calls.

<sup>Written for commit fadebf1861d53a1997965e104d6d3ca4f70e504b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3089?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

