### PR TITLE
fix(security): enforce hasPrivilege on ProgramService and PharmacyService JAX-RS endpoints (#2798)

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/PharmacyService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/PharmacyService.java
@@ -39,7 +39,9 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 
 import io.github.carlos_emr.carlos.commn.dao.PharmacyInfoDao;
+import io.github.carlos_emr.carlos.commn.exception.AccessDeniedException;
 import io.github.carlos_emr.carlos.commn.model.PharmacyInfo;
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.webserv.rest.conversion.PharmacyInfoConverter;
 import io.github.carlos_emr.carlos.webserv.rest.to.OscarSearchResponse;
 import io.github.carlos_emr.carlos.webserv.rest.to.model.PharmacyInfoTo1;
@@ -56,8 +58,14 @@ import org.springframework.stereotype.Component;
 @Consumes(MediaType.APPLICATION_JSON)
 public class PharmacyService extends AbstractServiceImpl {
 
+    /** Security object guarding pharmacy management, matching the Rx pharmacy actions. */
+    private static final String SECURITY_OBJECT = "_rx";
+
     @Autowired
     private PharmacyInfoDao pharmacyInfoDao;
+
+    @Autowired
+    private SecurityInfoManager securityInfoManager;
 
     private PharmacyInfoConverter converter = new PharmacyInfoConverter();
 
@@ -73,6 +81,9 @@ public class PharmacyService extends AbstractServiceImpl {
     @GET
     @Path("/")
     public OscarSearchResponse<PharmacyInfoTo1> getPharmacies(@QueryParam("offset") Integer offset, @QueryParam("limit") Integer limit) {
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), SECURITY_OBJECT, "r", null)) {
+            throw new AccessDeniedException(SECURITY_OBJECT, "r");
+        }
         OscarSearchResponse<PharmacyInfoTo1> result = new OscarSearchResponse<PharmacyInfoTo1>();
         result.getContent().addAll(converter.getAllAsTransferObjects(getLoggedInInfo(), pharmacyInfoDao.findAll(offset, limit)));
         return result;
@@ -87,6 +98,9 @@ public class PharmacyService extends AbstractServiceImpl {
     @GET
     @Path("/{pharmacyId}")
     public PharmacyInfoTo1 getPharmacy(@PathParam("pharmacyId") Integer id) {
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), SECURITY_OBJECT, "r", null)) {
+            throw new AccessDeniedException(SECURITY_OBJECT, "r");
+        }
         return converter.getAsTransferObject(getLoggedInInfo(), pharmacyInfoDao.find(id));
     }
 
@@ -99,6 +113,9 @@ public class PharmacyService extends AbstractServiceImpl {
     @POST
     @Path("/")
     public PharmacyInfoTo1 addPharmacy(PharmacyInfoTo1 pharmacyInfo) {
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), SECURITY_OBJECT, "w", null)) {
+            throw new AccessDeniedException(SECURITY_OBJECT, "w");
+        }
         return converter.getAsTransferObject(getLoggedInInfo(), pharmacyInfoDao.saveEntity(converter.getAsDomainObject(getLoggedInInfo(), pharmacyInfo)));
     }
 
@@ -111,6 +128,9 @@ public class PharmacyService extends AbstractServiceImpl {
     @PUT
     @Path("/")
     public PharmacyInfoTo1 updatePharmacy(PharmacyInfoTo1 pharmacyInfo) {
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), SECURITY_OBJECT, "w", null)) {
+            throw new AccessDeniedException(SECURITY_OBJECT, "w");
+        }
         return converter.getAsTransferObject(getLoggedInInfo(), pharmacyInfoDao.saveEntity(converter.getAsDomainObject(getLoggedInInfo(), pharmacyInfo)));
     }
 
@@ -123,6 +143,9 @@ public class PharmacyService extends AbstractServiceImpl {
     @DELETE
     @Path("/{pharmacyId}")
     public PharmacyInfoTo1 removePharmacy(@PathParam("pharmacyId") Integer id) {
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), SECURITY_OBJECT, "w", null)) {
+            throw new AccessDeniedException(SECURITY_OBJECT, "w");
+        }
         PharmacyInfo pharmacyInfo = pharmacyInfoDao.find(id);
         pharmacyInfo.setStatus(PharmacyInfo.DELETED);
         return converter.getAsTransferObject(getLoggedInInfo(), pharmacyInfoDao.saveEntity(pharmacyInfo));

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/ProgramService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/ProgramService.java
@@ -45,7 +45,9 @@ import org.apache.commons.lang3.time.DateFormatUtils;
 import org.apache.tools.ant.util.DateUtils;
 import io.github.carlos_emr.carlos.PMmodule.model.ProgramProvider;
 import io.github.carlos_emr.carlos.PMmodule.service.AdmissionManager;
+import io.github.carlos_emr.carlos.commn.exception.AccessDeniedException;
 import io.github.carlos_emr.carlos.managers.ProgramManager2;
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.webserv.rest.conversion.AdmissionConverter;
 import io.github.carlos_emr.carlos.webserv.rest.conversion.ProgramConverter;
 import io.github.carlos_emr.carlos.webserv.rest.to.AbstractSearchResponse;
@@ -57,6 +59,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 @Consumes(MediaType.APPLICATION_JSON)
 public class ProgramService extends AbstractServiceImpl {
 
+    /** Security object guarding program-management data, matching the PMmodule actions. */
+    private static final String SECURITY_OBJECT = "_pmm_management";
 
     @Autowired
     ProgramManager2 programManager;
@@ -64,11 +68,18 @@ public class ProgramService extends AbstractServiceImpl {
     @Autowired
     AdmissionManager admissionManager;
 
+    @Autowired
+    private SecurityInfoManager securityInfoManager;
+
 
     @GET
     @Path("/patientList")
     @Produces("application/json")
     public AbstractSearchResponse<AdmissionTo1> getPatientList(@QueryParam("programNo") String programNo, @QueryParam("day") String day, @QueryParam("startIndex") Integer startIndex, @QueryParam("numToReturn") Integer numToReturn) throws Exception {
+
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), SECURITY_OBJECT, "r", null)) {
+            throw new AccessDeniedException(SECURITY_OBJECT, "r");
+        }
 
         AbstractSearchResponse<AdmissionTo1> response = new AbstractSearchResponse<AdmissionTo1>();
 
@@ -113,6 +124,10 @@ public class ProgramService extends AbstractServiceImpl {
     @Path("/programList")
     @Produces("application/json")
     public AbstractSearchResponse<ProgramTo1> getProgramList() throws Exception {
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), SECURITY_OBJECT, "r", null)) {
+            throw new AccessDeniedException(SECURITY_OBJECT, "r");
+        }
+
         AbstractSearchResponse<ProgramTo1> response = new AbstractSearchResponse<ProgramTo1>();
 
         List<ProgramProvider> programProviders = programManager.getProgramDomain(getLoggedInInfo(), getLoggedInInfo().getLoggedInProviderNo());

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/PharmacyServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/PharmacyServiceUnitTest.java
@@ -1,0 +1,200 @@
+/**
+ * Copyright (c) 2001-2002. Department of Family Medicine, McMaster University. All Rights Reserved.
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ * <p>
+ * This software was written for the
+ * Department of Family Medicine
+ * McMaster University
+ * Hamilton
+ * Ontario, Canada
+ *
+ * <p>
+ * Now maintained by the CARLOS EMR Project (2026+).
+ * https://github.com/carlos-emr/carlos
+ * CARLOS has no affiliation with OSCAR or McMaster University.
+ */
+package io.github.carlos_emr.carlos.webserv.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import io.github.carlos_emr.carlos.commn.dao.PharmacyInfoDao;
+import io.github.carlos_emr.carlos.commn.exception.AccessDeniedException;
+import io.github.carlos_emr.carlos.commn.model.PharmacyInfo;
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
+import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import io.github.carlos_emr.carlos.webserv.rest.to.OscarSearchResponse;
+import io.github.carlos_emr.carlos.webserv.rest.to.model.PharmacyInfoTo1;
+
+/**
+ * Unit tests for {@link PharmacyService}.
+ *
+ * <p>Verifies the {@code _rx} privilege checks added to the pharmacy CRUD
+ * JAX-RS endpoints (issue #2798): read endpoints require {@code _rx} "r" and
+ * the create/update/delete mutators require {@code _rx} "w". Uses a testable
+ * subclass that overrides {@code getLoggedInInfo()} to bypass the CXF HTTP
+ * request context, with dependencies injected via reflection.</p>
+ *
+ * @since 2026-06-29
+ * @see PharmacyService
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("PharmacyService Unit Tests")
+@Tag("unit")
+@Tag("fast")
+class PharmacyServiceUnitTest extends CarlosUnitTestBase {
+
+    private static final String SECURITY_OBJECT = "_rx";
+
+    @Mock
+    private PharmacyInfoDao mockPharmacyInfoDao;
+
+    @Mock
+    private SecurityInfoManager mockSecurityInfoManager;
+
+    private PharmacyService service;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        LoggedInInfo loggedInInfo = new LoggedInInfo();
+        loggedInInfo.setIp("127.0.0.1");
+
+        service = new PharmacyService() {
+            @Override
+            protected LoggedInInfo getLoggedInInfo() {
+                return loggedInInfo;
+            }
+        };
+
+        inject("pharmacyInfoDao", mockPharmacyInfoDao);
+        inject("securityInfoManager", mockSecurityInfoManager);
+    }
+
+    private void inject(String fieldName, Object value) throws Exception {
+        Field field = PharmacyService.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(service, value);
+    }
+
+    /** Grants/denies whichever privilege ("r" or "w") the endpoint checks. */
+    private void grant(boolean allowed) {
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq(SECURITY_OBJECT), anyString(), nullable(String.class)))
+                .thenReturn(allowed);
+    }
+
+    @Nested
+    @DisplayName("Read endpoints require _rx read")
+    @Tag("read")
+    class ReadEndpoints {
+
+        @Test
+        @DisplayName("should return pharmacies when caller has _rx read privilege")
+        void shouldReturnPharmacies_whenAuthorized() {
+            grant(true);
+            when(mockPharmacyInfoDao.findAll(0, 10)).thenReturn(new ArrayList<PharmacyInfo>());
+
+            OscarSearchResponse<PharmacyInfoTo1> result = service.getPharmacies(0, 10);
+
+            assertThat(result).isNotNull();
+            assertThat(result.getContent()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("should throw AccessDeniedException for getPharmacies when unauthorized")
+        void shouldThrowAccessDenied_forGetPharmaciesWhenUnauthorized() {
+            grant(false);
+
+            assertThatThrownBy(() -> service.getPharmacies(0, 10))
+                    .isInstanceOf(AccessDeniedException.class);
+
+            verifyNoInteractions(mockPharmacyInfoDao);
+        }
+
+        @Test
+        @DisplayName("should throw AccessDeniedException for getPharmacy when unauthorized")
+        void shouldThrowAccessDenied_forGetPharmacyWhenUnauthorized() {
+            grant(false);
+
+            assertThatThrownBy(() -> service.getPharmacy(1))
+                    .isInstanceOf(AccessDeniedException.class);
+
+            verifyNoInteractions(mockPharmacyInfoDao);
+        }
+    }
+
+    @Nested
+    @DisplayName("Mutator endpoints require _rx write")
+    class MutatorEndpoints {
+
+        @Test
+        @DisplayName("should throw AccessDeniedException for addPharmacy when unauthorized")
+        @Tag("create")
+        void shouldThrowAccessDenied_forAddPharmacyWhenUnauthorized() {
+            grant(false);
+
+            assertThatThrownBy(() -> service.addPharmacy(new PharmacyInfoTo1()))
+                    .isInstanceOf(AccessDeniedException.class);
+
+            verifyNoInteractions(mockPharmacyInfoDao);
+        }
+
+        @Test
+        @DisplayName("should throw AccessDeniedException for updatePharmacy when unauthorized")
+        @Tag("update")
+        void shouldThrowAccessDenied_forUpdatePharmacyWhenUnauthorized() {
+            grant(false);
+
+            assertThatThrownBy(() -> service.updatePharmacy(new PharmacyInfoTo1()))
+                    .isInstanceOf(AccessDeniedException.class);
+
+            verifyNoInteractions(mockPharmacyInfoDao);
+        }
+
+        @Test
+        @DisplayName("should throw AccessDeniedException for removePharmacy when unauthorized")
+        @Tag("delete")
+        void shouldThrowAccessDenied_forRemovePharmacyWhenUnauthorized() {
+            grant(false);
+
+            assertThatThrownBy(() -> service.removePharmacy(1))
+                    .isInstanceOf(AccessDeniedException.class);
+
+            verifyNoInteractions(mockPharmacyInfoDao);
+        }
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/PharmacyServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/PharmacyServiceUnitTest.java
@@ -111,10 +111,17 @@ class PharmacyServiceUnitTest extends CarlosUnitTestBase {
         field.set(service, value);
     }
 
-    /** Grants/denies whichever privilege ("r" or "w") the endpoint checks. */
-    private void grant(boolean allowed) {
+    /**
+     * Grants exactly one privilege action on the pharmacy security object; every other
+     * action is denied. Stubbing the precise action (rather than {@code anyString()}) is
+     * what lets the deny tests prove each endpoint checks the <em>correct</em> action —
+     * e.g. granting only {@code "w"} must still deny a read endpoint.
+     */
+    private void grantOnly(String action) {
         when(mockSecurityInfoManager.hasPrivilege(any(), eq(SECURITY_OBJECT), anyString(), nullable(String.class)))
-                .thenReturn(allowed);
+                .thenReturn(false);
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq(SECURITY_OBJECT), eq(action), nullable(String.class)))
+                .thenReturn(true);
     }
 
     @Nested
@@ -124,8 +131,8 @@ class PharmacyServiceUnitTest extends CarlosUnitTestBase {
 
         @Test
         @DisplayName("should return pharmacies when caller has _rx read privilege")
-        void shouldReturnPharmacies_whenAuthorized() {
-            grant(true);
+        void shouldReturnPharmacies_whenGrantedReadOnly() {
+            grantOnly("r");
             when(mockPharmacyInfoDao.findAll(0, 10)).thenReturn(new ArrayList<PharmacyInfo>());
 
             OscarSearchResponse<PharmacyInfoTo1> result = service.getPharmacies(0, 10);
@@ -135,9 +142,9 @@ class PharmacyServiceUnitTest extends CarlosUnitTestBase {
         }
 
         @Test
-        @DisplayName("should throw AccessDeniedException for getPharmacies when unauthorized")
-        void shouldThrowAccessDenied_forGetPharmaciesWhenUnauthorized() {
-            grant(false);
+        @DisplayName("should throw AccessDeniedException for getPharmacies when only write is granted")
+        void shouldThrowAccessDenied_forGetPharmaciesWhenOnlyWriteGranted() {
+            grantOnly("w");
 
             assertThatThrownBy(() -> service.getPharmacies(0, 10))
                     .isInstanceOf(AccessDeniedException.class);
@@ -146,9 +153,9 @@ class PharmacyServiceUnitTest extends CarlosUnitTestBase {
         }
 
         @Test
-        @DisplayName("should throw AccessDeniedException for getPharmacy when unauthorized")
-        void shouldThrowAccessDenied_forGetPharmacyWhenUnauthorized() {
-            grant(false);
+        @DisplayName("should throw AccessDeniedException for getPharmacy when only write is granted")
+        void shouldThrowAccessDenied_forGetPharmacyWhenOnlyWriteGranted() {
+            grantOnly("w");
 
             assertThatThrownBy(() -> service.getPharmacy(1))
                     .isInstanceOf(AccessDeniedException.class);
@@ -162,34 +169,36 @@ class PharmacyServiceUnitTest extends CarlosUnitTestBase {
     class MutatorEndpoints {
 
         @Test
-        @DisplayName("should throw AccessDeniedException for addPharmacy when unauthorized")
+        @DisplayName("should throw AccessDeniedException for addPharmacy when only read is granted")
         @Tag("create")
-        void shouldThrowAccessDenied_forAddPharmacyWhenUnauthorized() {
-            grant(false);
+        void shouldThrowAccessDenied_forAddPharmacyWhenOnlyReadGranted() {
+            grantOnly("r");
+            PharmacyInfoTo1 pharmacy = new PharmacyInfoTo1();
 
-            assertThatThrownBy(() -> service.addPharmacy(new PharmacyInfoTo1()))
+            assertThatThrownBy(() -> service.addPharmacy(pharmacy))
                     .isInstanceOf(AccessDeniedException.class);
 
             verifyNoInteractions(mockPharmacyInfoDao);
         }
 
         @Test
-        @DisplayName("should throw AccessDeniedException for updatePharmacy when unauthorized")
+        @DisplayName("should throw AccessDeniedException for updatePharmacy when only read is granted")
         @Tag("update")
-        void shouldThrowAccessDenied_forUpdatePharmacyWhenUnauthorized() {
-            grant(false);
+        void shouldThrowAccessDenied_forUpdatePharmacyWhenOnlyReadGranted() {
+            grantOnly("r");
+            PharmacyInfoTo1 pharmacy = new PharmacyInfoTo1();
 
-            assertThatThrownBy(() -> service.updatePharmacy(new PharmacyInfoTo1()))
+            assertThatThrownBy(() -> service.updatePharmacy(pharmacy))
                     .isInstanceOf(AccessDeniedException.class);
 
             verifyNoInteractions(mockPharmacyInfoDao);
         }
 
         @Test
-        @DisplayName("should throw AccessDeniedException for removePharmacy when unauthorized")
+        @DisplayName("should throw AccessDeniedException for removePharmacy when only read is granted")
         @Tag("delete")
-        void shouldThrowAccessDenied_forRemovePharmacyWhenUnauthorized() {
-            grant(false);
+        void shouldThrowAccessDenied_forRemovePharmacyWhenOnlyReadGranted() {
+            grantOnly("r");
 
             assertThatThrownBy(() -> service.removePharmacy(1))
                     .isInstanceOf(AccessDeniedException.class);

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/ProgramServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/ProgramServiceUnitTest.java
@@ -1,0 +1,188 @@
+/**
+ * Copyright (c) 2001-2002. Department of Family Medicine, McMaster University. All Rights Reserved.
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ * <p>
+ * This software was written for the
+ * Department of Family Medicine
+ * McMaster University
+ * Hamilton
+ * Ontario, Canada
+ *
+ * <p>
+ * Now maintained by the CARLOS EMR Project (2026+).
+ * https://github.com/carlos-emr/carlos
+ * CARLOS has no affiliation with OSCAR or McMaster University.
+ */
+package io.github.carlos_emr.carlos.webserv.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Date;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import io.github.carlos_emr.carlos.PMmodule.model.ProgramProvider;
+import io.github.carlos_emr.carlos.commn.model.Admission;
+import io.github.carlos_emr.carlos.PMmodule.service.AdmissionManager;
+import io.github.carlos_emr.carlos.commn.exception.AccessDeniedException;
+import io.github.carlos_emr.carlos.managers.ProgramManager2;
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
+import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import io.github.carlos_emr.carlos.webserv.rest.to.AbstractSearchResponse;
+import io.github.carlos_emr.carlos.webserv.rest.to.model.AdmissionTo1;
+import io.github.carlos_emr.carlos.webserv.rest.to.model.ProgramTo1;
+
+/**
+ * Unit tests for {@link ProgramService}.
+ *
+ * <p>Verifies the {@code _pmm_management} read privilege check added to the
+ * program JAX-RS endpoints (issue #2798). Uses a testable subclass that
+ * overrides {@code getLoggedInInfo()} to bypass the CXF HTTP request context,
+ * with dependencies injected via reflection.</p>
+ *
+ * @since 2026-06-29
+ * @see ProgramService
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("ProgramService Unit Tests")
+@Tag("unit")
+@Tag("fast")
+class ProgramServiceUnitTest extends CarlosUnitTestBase {
+
+    private static final String SECURITY_OBJECT = "_pmm_management";
+
+    @Mock
+    private ProgramManager2 mockProgramManager;
+
+    @Mock
+    private AdmissionManager mockAdmissionManager;
+
+    @Mock
+    private SecurityInfoManager mockSecurityInfoManager;
+
+    private ProgramService service;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        LoggedInInfo loggedInInfo = new LoggedInInfo();
+        loggedInInfo.setIp("127.0.0.1");
+
+        service = new ProgramService() {
+            @Override
+            protected LoggedInInfo getLoggedInInfo() {
+                return loggedInInfo;
+            }
+        };
+
+        inject("programManager", mockProgramManager);
+        inject("admissionManager", mockAdmissionManager);
+        inject("securityInfoManager", mockSecurityInfoManager);
+    }
+
+    private void inject(String fieldName, Object value) throws Exception {
+        Field field = ProgramService.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(service, value);
+    }
+
+    private void grant(boolean allowed) {
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq(SECURITY_OBJECT), anyString(), nullable(String.class)))
+                .thenReturn(allowed);
+    }
+
+    @Nested
+    @DisplayName("getProgramList")
+    @Tag("read")
+    class GetProgramList {
+
+        @Test
+        @DisplayName("should return program response when caller has _pmm_management read privilege")
+        void shouldReturnProgramResponse_whenAuthorized() throws Exception {
+            grant(true);
+            when(mockProgramManager.getProgramDomain(any(), any())).thenReturn(new ArrayList<ProgramProvider>());
+
+            AbstractSearchResponse<ProgramTo1> response = service.getProgramList();
+
+            assertThat(response).isNotNull();
+            assertThat(response.getTotal()).isZero();
+        }
+
+        @Test
+        @DisplayName("should throw AccessDeniedException when caller lacks _pmm_management privilege")
+        void shouldThrowAccessDenied_whenUnauthorized() {
+            grant(false);
+
+            assertThatThrownBy(() -> service.getProgramList())
+                    .isInstanceOf(AccessDeniedException.class);
+
+            verifyNoInteractions(mockProgramManager);
+        }
+    }
+
+    @Nested
+    @DisplayName("getPatientList")
+    @Tag("read")
+    class GetPatientList {
+
+        @Test
+        @DisplayName("should return admission response when caller has _pmm_management read privilege")
+        void shouldReturnAdmissionResponse_whenAuthorized() throws Exception {
+            grant(true);
+            when(mockAdmissionManager.findAdmissionsByProgramAndDate(any(), any(), any(Date.class), anyInt(), anyInt()))
+                    .thenReturn(new ArrayList<Admission>());
+            when(mockAdmissionManager.findAdmissionsByProgramAndDateAsCount(any(), any(), any(Date.class)))
+                    .thenReturn(0);
+
+            AbstractSearchResponse<AdmissionTo1> response = service.getPatientList("1", null, 0, 10);
+
+            assertThat(response).isNotNull();
+            assertThat(response.getContent()).isEmpty();
+            assertThat(response.getTotal()).isZero();
+        }
+
+        @Test
+        @DisplayName("should throw AccessDeniedException when caller lacks _pmm_management privilege")
+        void shouldThrowAccessDenied_whenUnauthorized() {
+            grant(false);
+
+            assertThatThrownBy(() -> service.getPatientList("1", null, 0, 10))
+                    .isInstanceOf(AccessDeniedException.class);
+
+            verifyNoInteractions(mockAdmissionManager);
+        }
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/ProgramServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/ProgramServiceUnitTest.java
@@ -119,9 +119,17 @@ class ProgramServiceUnitTest extends CarlosUnitTestBase {
         field.set(service, value);
     }
 
-    private void grant(boolean allowed) {
+    /**
+     * Grants exactly one privilege action on the program security object; every other
+     * action is denied. Stubbing the precise action (rather than {@code anyString()})
+     * lets the deny tests prove each endpoint checks read ("r") specifically — granting
+     * only "w" must still be rejected.
+     */
+    private void grantOnly(String action) {
         when(mockSecurityInfoManager.hasPrivilege(any(), eq(SECURITY_OBJECT), anyString(), nullable(String.class)))
-                .thenReturn(allowed);
+                .thenReturn(false);
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq(SECURITY_OBJECT), eq(action), nullable(String.class)))
+                .thenReturn(true);
     }
 
     @Nested
@@ -131,8 +139,8 @@ class ProgramServiceUnitTest extends CarlosUnitTestBase {
 
         @Test
         @DisplayName("should return program response when caller has _pmm_management read privilege")
-        void shouldReturnProgramResponse_whenAuthorized() throws Exception {
-            grant(true);
+        void shouldReturnProgramResponse_whenGrantedReadOnly() throws Exception {
+            grantOnly("r");
             when(mockProgramManager.getProgramDomain(any(), any())).thenReturn(new ArrayList<ProgramProvider>());
 
             AbstractSearchResponse<ProgramTo1> response = service.getProgramList();
@@ -142,9 +150,9 @@ class ProgramServiceUnitTest extends CarlosUnitTestBase {
         }
 
         @Test
-        @DisplayName("should throw AccessDeniedException when caller lacks _pmm_management privilege")
-        void shouldThrowAccessDenied_whenUnauthorized() {
-            grant(false);
+        @DisplayName("should throw AccessDeniedException for getProgramList when only write is granted")
+        void shouldThrowAccessDenied_forGetProgramListWhenOnlyWriteGranted() {
+            grantOnly("w");
 
             assertThatThrownBy(() -> service.getProgramList())
                     .isInstanceOf(AccessDeniedException.class);
@@ -160,8 +168,8 @@ class ProgramServiceUnitTest extends CarlosUnitTestBase {
 
         @Test
         @DisplayName("should return admission response when caller has _pmm_management read privilege")
-        void shouldReturnAdmissionResponse_whenAuthorized() throws Exception {
-            grant(true);
+        void shouldReturnAdmissionResponse_whenGrantedReadOnly() throws Exception {
+            grantOnly("r");
             when(mockAdmissionManager.findAdmissionsByProgramAndDate(any(), any(), any(Date.class), anyInt(), anyInt()))
                     .thenReturn(new ArrayList<Admission>());
             when(mockAdmissionManager.findAdmissionsByProgramAndDateAsCount(any(), any(), any(Date.class)))
@@ -175,9 +183,9 @@ class ProgramServiceUnitTest extends CarlosUnitTestBase {
         }
 
         @Test
-        @DisplayName("should throw AccessDeniedException when caller lacks _pmm_management privilege")
-        void shouldThrowAccessDenied_whenUnauthorized() {
-            grant(false);
+        @DisplayName("should throw AccessDeniedException for getPatientList when only write is granted")
+        void shouldThrowAccessDenied_forGetPatientListWhenOnlyWriteGranted() {
+            grantOnly("w");
 
             assertThatThrownBy(() -> service.getPatientList("1", null, 0, 10))
                     .isInstanceOf(AccessDeniedException.class);


### PR DESCRIPTION
## Summary

Part of #2798 (does **not** close it — this covers 2 of the remaining 8 services).

The `ProgramService` (`/ws/rs/program`) and `PharmacyService` (`/ws/rs/pharmacies`) JAX-RS services authenticated the caller but performed **no authorization** — any logged-in user (and, per the unauthenticated `/ws/` gap noted in #2798, potentially anonymous callers) could read program/admission data and perform full pharmacy CRUD.

This PR adds the missing `securityInfoManager.hasPrivilege()` checks to every endpoint in both services, the "Domain CRUD" pairing from the issue's scope-tracking comment.

## Scope

- **ProgramService** — guard `/patientList` and `/programList` with `_pmm_management` `"r"` (the security object every PMmodule action uses).
- **PharmacyService** — guard the two GET reads with `_rx` `"r"`, and the `addPharmacy` (POST) / `updatePharmacy` (PUT) / `removePharmacy` (DELETE) mutators with `_rx` `"w"` (matching the existing Rx pharmacy actions `RxManagePharmacy2Action` / `ViewViewPharmacy2Action`).
- Denied callers throw `AccessDeniedException` **before** any business logic runs, consistent with the just-merged in-package `RxWebService` pattern (#3010). Because the guard fails closed when there is no `LoggedInInfo`, this also covers the unauthenticated case.
- **Boundary:** only these two services; no interceptor/auth-path changes, no behavior change for authorized callers, no other #2798 services touched.

## Tests

- `ProgramServiceUnitTest` — allow + deny for `getPatientList` and `getProgramList`; deny path asserts the managers are never invoked.
- `PharmacyServiceUnitTest` — allow path for the list read, plus deny path for all five endpoints, asserting the DAO is never touched.
- Mocks injected via reflection + a testable subclass overriding `getLoggedInInfo()`, mirroring `EFormServiceUnitTest` / `RxWebServiceUnitTest`.

Verified locally:
- `mvn test-compile` — BUILD SUCCESS
- `mvn surefire:test -Dtest='ProgramServiceUnitTest,PharmacyServiceUnitTest'` — Tests run: 10, Failures: 0, Errors: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add authorization checks to ProgramService and PharmacyService JAX-RS endpoints to ensure only users with appropriate privileges can access program data and perform pharmacy CRUD operations.

Bug Fixes:
- Restrict ProgramService patient and program list endpoints to callers with _pmm_management read privilege.
- Restrict PharmacyService read endpoints to callers with _rx read privilege and mutator endpoints to callers with _rx write privilege.
- Block unauthenticated or unauthorized access to these endpoints by throwing AccessDeniedException before any business logic executes.

Tests:
- Add ProgramServiceUnitTest to cover allowed and denied access paths for patient and program list endpoints, ensuring managers are not invoked on denied requests.
- Add PharmacyServiceUnitTest to cover allowed and denied access paths for all pharmacy endpoints, ensuring the DAO is not invoked on denied requests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds missing authorization to Program and Pharmacy JAX-RS endpoints to block unauthorized reads/writes. Part of #2798; behavior is unchanged for authorized users.

- **Bug Fixes**
  - Program: guard `/patientList` and `/programList` with `_pmm_management` read.
  - Pharmacy: guard GET with `_rx` read; POST/PUT/DELETE with `_rx` write.
  - Unauthorized requests throw `AccessDeniedException` before any business logic, covering unauthenticated callers.
  - Tests: add unit tests for allow/deny paths; assert the correct action is required (`"r"` for reads, `"w"` for writes) and that managers/DAO aren’t called on deny.

<sup>Written for commit dcb0d0a2e7b22a82b9adf684a9fc6dbc4fffd5bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3090?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

