### PR TITLE
fix(security): gate PersonaService preference save & document authz-primitive endpoints (#2798)

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/PersonaService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/PersonaService.java
@@ -109,6 +109,16 @@ public class PersonaService extends AbstractServiceImpl {
     private DashboardManager dashboardManager;
 
 
+    /*
+     * Authorization-primitive endpoints (/rights, /hasRight, /hasRights,
+     * /isAllowedAccessToPatientRecord) are intentionally NOT gated by hasPrivilege (#2798):
+     * they are the privilege API the UI calls to decide what to render, and every one resolves
+     * its subject from getLoggedInInfo() — they only ever report the *current* caller's own
+     * roles/privileges, never another provider's. Gating them on a security object would be
+     * circular ("need permission to ask whether you have permission") and would break the UI's
+     * permission rendering, with no IDOR to defend against. They fail closed when unauthenticated
+     * because getLoggedInInfo() throws with no LoggedInInfo.
+     */
     @GET
     @Path("/rights")
     @Produces("application/json")
@@ -293,6 +303,12 @@ public class PersonaService extends AbstractServiceImpl {
      * Sets the default program for the logged-in provider.
      */
     public RestResponse<String> setDefaultProgram(@FormParam("programId") Integer programId) {
+        // Self-scoped: switches the caller's OWN current program (own providerNo), and
+        // setCurrentProgramInDomain already rejects a programId outside the provider's domain.
+        // No additional security object applies — the program admin secobjs (_pmm_management /
+        // _program* / _programEdit) govern administering programs, not a provider choosing which
+        // of their own assigned programs is active, so gating with one would wrongly block the
+        // navbar program switcher (#2798).
         programManager2.setCurrentProgramInDomain(getLoggedInInfo().getLoggedInProviderNo(), programId);
         return RestResponse.successResponse(null);
     }
@@ -355,6 +371,13 @@ public class PersonaService extends AbstractServiceImpl {
     @Consumes("application/json")
     public PatientListConfigTo1 saveMyPatientListConfig(PatientListConfigTo1 patientListConfigTo1) {
         Provider provider = getCurrentProvider();
+
+        // Persists the caller's own provider preferences (patientListConfig.*), the same
+        // UserProperty mechanism guarded by updatePreference/updatePreferences below — gate it
+        // with the same _pref/u privilege for parity (#2798).
+        if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_pref", "u", null)) {
+            throw new RuntimeException("Access Denied");
+        }
 
         UserPropertyDAO propDao = (UserPropertyDAO) SpringUtils.getBean(UserPropertyDAO.class);
         Integer numberOfApptsToShow = patientListConfigTo1.getNumberOfApptstoShow();

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/PersonaService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/PersonaService.java
@@ -376,7 +376,7 @@ public class PersonaService extends AbstractServiceImpl {
         // UserProperty mechanism guarded by updatePreference/updatePreferences below — gate it
         // with the same _pref/u privilege for parity (#2798).
         if (!securityInfoManager.hasPrivilege(getLoggedInInfo(), "_pref", "u", null)) {
-            throw new RuntimeException("Access Denied");
+            throw new SecurityException("missing required sec object (_pref)");
         }
 
         UserPropertyDAO propDao = (UserPropertyDAO) SpringUtils.getBean(UserPropertyDAO.class);

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/PersonaServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/PersonaServiceUnitTest.java
@@ -40,9 +40,11 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import java.lang.reflect.Field;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -128,8 +130,16 @@ class PersonaServiceUnitTest extends CarlosUnitTestBase {
         ArgumentCaptor<LoggedInInfo> infoCaptor = ArgumentCaptor.forClass(LoggedInInfo.class);
         verify(mockSecurityInfoManager).hasPrivilege(infoCaptor.capture(), eq("_pref"), eq("u"), isNull());
         assertThat(infoCaptor.getValue()).isSameAs(loggedInInfo);
-        // numberOfApptsToShow (>0) and showReason are each saved.
-        verify(mockUserPropertyDao, times(2)).saveProp(any(UserProperty.class));
+        // Assert the exact properties persisted (provider, name, value), not just the save count,
+        // so the test fails if the wrong preference is written.
+        ArgumentCaptor<UserProperty> propCaptor = ArgumentCaptor.forClass(UserProperty.class);
+        verify(mockUserPropertyDao, times(2)).saveProp(propCaptor.capture());
+        List<UserProperty> saved = propCaptor.getAllValues();
+        assertThat(saved)
+                .extracting(UserProperty::getProviderNo, UserProperty::getName, UserProperty::getValue)
+                .containsExactlyInAnyOrder(
+                        tuple(PROVIDER_NO, "patientListConfig.numberOfApptsToShow", "10"),
+                        tuple(PROVIDER_NO, "patientListConfig.showReason", "true"));
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/PersonaServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/PersonaServiceUnitTest.java
@@ -135,8 +135,8 @@ class PersonaServiceUnitTest extends CarlosUnitTestBase {
         config.setShowReason(true);
 
         assertThatThrownBy(() -> service.saveMyPatientListConfig(config))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessage("Access Denied");
+                .isInstanceOf(SecurityException.class)
+                .hasMessage("missing required sec object (_pref)");
 
         verify(mockUserPropertyDao, never()).saveProp(any(io.github.carlos_emr.carlos.commn.model.UserProperty.class));
     }

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/PersonaServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/PersonaServiceUnitTest.java
@@ -23,6 +23,7 @@ package io.github.carlos_emr.carlos.webserv.rest;
 
 import io.github.carlos_emr.carlos.commn.dao.UserPropertyDAO;
 import io.github.carlos_emr.carlos.commn.model.Provider;
+import io.github.carlos_emr.carlos.commn.model.UserProperty;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
@@ -32,6 +33,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -39,12 +41,14 @@ import org.mockito.quality.Strictness;
 
 import java.lang.reflect.Field;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -119,9 +123,31 @@ class PersonaServiceUnitTest extends CarlosUnitTestBase {
 
         service.saveMyPatientListConfig(config);
 
-        verify(mockSecurityInfoManager).hasPrivilege(any(), eq("_pref"), eq("u"), isNull());
+        // The privilege check must be made against the current caller's own context, not some
+        // other subject — capture and assert the LoggedInInfo rather than matching any().
+        ArgumentCaptor<LoggedInInfo> infoCaptor = ArgumentCaptor.forClass(LoggedInInfo.class);
+        verify(mockSecurityInfoManager).hasPrivilege(infoCaptor.capture(), eq("_pref"), eq("u"), isNull());
+        assertThat(infoCaptor.getValue()).isSameAs(loggedInInfo);
         // numberOfApptsToShow (>0) and showReason are each saved.
-        verify(mockUserPropertyDao, org.mockito.Mockito.times(2)).saveProp(any(io.github.carlos_emr.carlos.commn.model.UserProperty.class));
+        verify(mockUserPropertyDao, times(2)).saveProp(any(UserProperty.class));
+    }
+
+    @Test
+    @Tag("create")
+    @DisplayName("should enforce privilege but skip the appointment count when it is not a positive number")
+    void shouldSkipAppointmentCount_whenNotPositive() {
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq("_pref"), eq("u"), isNull())).thenReturn(true);
+        when(mockUserPropertyDao.getProp(eq(PROVIDER_NO), any())).thenReturn(null);
+
+        PatientListConfigTo1 config = new PatientListConfigTo1();
+        config.setNumberOfApptstoShow(0); // not > 0 → count is not persisted
+        config.setShowReason(true);
+
+        service.saveMyPatientListConfig(config);
+
+        // privilege is still enforced, and only showReason is persisted (count branch skipped).
+        verify(mockSecurityInfoManager).hasPrivilege(any(), eq("_pref"), eq("u"), isNull());
+        verify(mockUserPropertyDao, times(1)).saveProp(any(UserProperty.class));
     }
 
     @Test
@@ -138,6 +164,6 @@ class PersonaServiceUnitTest extends CarlosUnitTestBase {
                 .isInstanceOf(SecurityException.class)
                 .hasMessage("missing required sec object (_pref)");
 
-        verify(mockUserPropertyDao, never()).saveProp(any(io.github.carlos_emr.carlos.commn.model.UserProperty.class));
+        verify(mockUserPropertyDao, never()).saveProp(any(UserProperty.class));
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/PersonaServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/PersonaServiceUnitTest.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.webserv.rest;
+
+import io.github.carlos_emr.carlos.commn.dao.UserPropertyDAO;
+import io.github.carlos_emr.carlos.commn.model.Provider;
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
+import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import io.github.carlos_emr.carlos.webserv.rest.to.model.PatientListConfigTo1;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.lang.reflect.Field;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link PersonaService}.
+ *
+ * <p>Focused on the privilege enforcement added for #2798: {@code saveMyPatientListConfig}
+ * persists the caller's own provider preferences and must require {@code _pref}/{@code u}, matching
+ * the sibling preference mutators {@code updatePreference}/{@code updatePreferences} in the same
+ * class. The four authorization-primitive endpoints ({@code /rights}, {@code /hasRight},
+ * {@code /hasRights}, {@code /isAllowedAccessToPatientRecord}) are deliberately left ungated
+ * (self-scoped privilege API the UI consumes) and are not exercised here.</p>
+ *
+ * <p>Uses a testable subclass that overrides {@code getLoggedInInfo()} to avoid requiring the CXF
+ * HTTP request context at test time; {@code UserPropertyDAO} is supplied via the SpringUtils mock
+ * registry from {@link CarlosUnitTestBase}.</p>
+ *
+ * @since 2026-06-29
+ * @see PersonaService
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("PersonaService Unit Tests")
+@Tag("unit")
+@Tag("fast")
+class PersonaServiceUnitTest extends CarlosUnitTestBase {
+
+    private static final String PROVIDER_NO = "101";
+
+    @Mock
+    private SecurityInfoManager mockSecurityInfoManager;
+
+    @Mock
+    private UserPropertyDAO mockUserPropertyDao;
+
+    private LoggedInInfo loggedInInfo;
+    private PersonaService service;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        Provider provider = mock(Provider.class);
+        when(provider.getProviderNo()).thenReturn(PROVIDER_NO);
+
+        loggedInInfo = new LoggedInInfo();
+        Field providerField = LoggedInInfo.class.getDeclaredField("loggedInProvider");
+        providerField.setAccessible(true);
+        providerField.set(loggedInInfo, provider);
+        loggedInInfo.setIp("127.0.0.1");
+
+        LoggedInInfo capturedInfo = loggedInInfo;
+        service = new PersonaService() {
+            @Override
+            protected LoggedInInfo getLoggedInInfo() {
+                return capturedInfo;
+            }
+        };
+
+        injectDependency(service, "securityInfoManager", mockSecurityInfoManager);
+        registerMock(UserPropertyDAO.class, mockUserPropertyDao);
+    }
+
+    @Test
+    @Tag("create")
+    @DisplayName("should persist provider preferences when caller has _pref update privilege")
+    void shouldPersistProviderPreferences_whenCallerHasPrefUpdatePrivilege() {
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq("_pref"), eq("u"), isNull())).thenReturn(true);
+        when(mockUserPropertyDao.getProp(eq(PROVIDER_NO), any())).thenReturn(null);
+
+        PatientListConfigTo1 config = new PatientListConfigTo1();
+        config.setNumberOfApptstoShow(10);
+        config.setShowReason(true);
+
+        service.saveMyPatientListConfig(config);
+
+        verify(mockSecurityInfoManager).hasPrivilege(any(), eq("_pref"), eq("u"), isNull());
+        // numberOfApptsToShow (>0) and showReason are each saved.
+        verify(mockUserPropertyDao, org.mockito.Mockito.times(2)).saveProp(any(io.github.carlos_emr.carlos.commn.model.UserProperty.class));
+    }
+
+    @Test
+    @Tag("security")
+    @DisplayName("should throw and persist nothing when caller lacks _pref update privilege")
+    void shouldThrowAndPersistNothing_whenCallerLacksPrefUpdatePrivilege() {
+        when(mockSecurityInfoManager.hasPrivilege(any(), eq("_pref"), eq("u"), isNull())).thenReturn(false);
+
+        PatientListConfigTo1 config = new PatientListConfigTo1();
+        config.setNumberOfApptstoShow(10);
+        config.setShowReason(true);
+
+        assertThatThrownBy(() -> service.saveMyPatientListConfig(config))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("Access Denied");
+
+        verify(mockUserPropertyDao, never()).saveProp(any(io.github.carlos_emr.carlos.commn.model.UserProperty.class));
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/PersonaServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/PersonaServiceUnitTest.java
@@ -155,9 +155,15 @@ class PersonaServiceUnitTest extends CarlosUnitTestBase {
 
         service.saveMyPatientListConfig(config);
 
-        // privilege is still enforced, and only showReason is persisted (count branch skipped).
+        // privilege is still enforced, and the single persisted property is showReason — assert
+        // the exact property (not just the count) so the test fails if the count "0" were saved
+        // instead of the count branch being skipped.
         verify(mockSecurityInfoManager).hasPrivilege(any(), eq("_pref"), eq("u"), isNull());
-        verify(mockUserPropertyDao, times(1)).saveProp(any(UserProperty.class));
+        ArgumentCaptor<UserProperty> propCaptor = ArgumentCaptor.forClass(UserProperty.class);
+        verify(mockUserPropertyDao, times(1)).saveProp(propCaptor.capture());
+        assertThat(propCaptor.getValue())
+                .extracting(UserProperty::getProviderNo, UserProperty::getName, UserProperty::getValue)
+                .containsExactly(PROVIDER_NO, "patientListConfig.showReason", "true");
     }
 
     @Test


### PR DESCRIPTION
Part of #2798 (the umbrella issue spans ~8 JAX-RS services and is intentionally kept open — this PR uses **Part of**, not `fixes`, so the umbrella is not auto-closed).

## Why PersonaService is special
PersonaService is the carved-out "authorization primitive" case of #2798. Several of its endpoints **are** the privilege API the UI calls to decide what to render — so the blanket "add `hasPrivilege()` everywhere" remediation is the wrong mental model here. This PR handles it per-endpoint instead of sweeping.

## Scope
- **Gate the one genuine gap:** `saveMyPatientListConfig` (`POST /persona/patientList/config`) persists the caller's own provider preferences (`patientListConfig.*`) via the same `UserProperty` mechanism as its sibling mutators `updatePreference`/`updatePreferences`, but had no privilege check. Add the same `_pref`/`u` check for parity.
- **Document, don't gate, the self-scoped authorization primitives** (`/rights`, `/hasRight`, `/hasRights`, `/isAllowedAccessToPatientRecord`): each resolves its subject from `getLoggedInInfo()` and only ever reports the *current* caller's own rights. Gating them would be circular and break the UI's permission rendering, with no IDOR to defend. They already fail closed when unauthenticated (`getLoggedInInfo()` throws with no `LoggedInInfo`).
- **Document why `setDefaultProgram` needs no secobj:** it is self-scoped (own `providerNo`) and `ProgramManager2.setCurrentProgramInDomain` already rejects a `programId` outside the provider's domain; the program admin secobjs (`_pmm_management`/`_program*`/`_programEdit`) govern administering programs, not a provider switching their own active program.
- The other own-data read endpoints (`/navbar`, `/patientLists`, `/patientList/config` GET, `/preferences`, `/dashboardMenu`) are per-provider self-scoped reads and remain open by design.

## Privilege-object choice
`_pref`/`u` matches the two sibling preference mutators in the same class. (The broader codebase gates provider-preference *writes* with `_pref`/`w`; in-file consistency was preferred — happy to switch to `w` if reviewers prefer the stricter codebase-wide convention.)

## Tests
`PersonaServiceUnitTest` (new) — `@Tag("unit")`:
- allow path: with `_pref`/`u` granted, both provider properties are persisted and the privilege check is invoked.
- deny path: with `_pref`/`u` denied, the method throws `Access Denied` and persists nothing.

## Local verification
- `mvn -o -Dtest=PersonaServiceUnitTest test` → Tests run: 2, Failures: 0, Errors: 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Gate PersonaService provider preference saves with a privilege check while documenting why other self-scoped endpoints remain ungated.

Bug Fixes:
- Require _pref/u privilege before saving patient list configuration for the logged-in provider to close an authorization gap.

Enhancements:
- Clarify in-code rationale for leaving self-scoped authorization-primitive endpoints and default-program switching ungated by security objects.

Tests:
- Add PersonaService unit tests that cover allowed and denied paths for saving patient list configuration, including boundary behavior for appointment count persistence.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Secures provider preference saves in PersonaService by requiring `_pref`/`u`, returning a 403 via `SecurityException` when denied. Documents why self-scoped authz endpoints remain open to avoid breaking UI permission checks. Part of #2798.

- **Bug Fixes**
  - Require `_pref`/`u` for `saveMyPatientListConfig` (`POST /persona/patientList/config`), matching `updatePreference`/`updatePreferences`.
  - On denied privilege, throw `SecurityException("missing required sec object (_pref)")`; tests capture the caller’s `LoggedInInfo`, assert exact saved properties, and in the boundary case assert only `patientListConfig.showReason=true` is persisted when the count is not > 0.
  - Document that `/rights`, `/hasRight`, `/hasRights`, and `/isAllowedAccessToPatientRecord` are self-scoped and intentionally ungated; `setDefaultProgram` is also self-scoped and validated by `ProgramManager2.setCurrentProgramInDomain`.

<sup>Written for commit 3a687f5e1a811a07e527e197e3cae68ebc202b1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3091?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

