### PR TITLE
feat(security): enforce OAuth 1.0a scopes behind a feature flag (#3083)

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/login/OscarOAuthDataProvider.java
+++ b/src/main/java/io/github/carlos_emr/carlos/login/OscarOAuthDataProvider.java
@@ -199,34 +199,6 @@ public class OscarOAuthDataProvider {
         return at;
     }
 
-    public AccessToken getAccessToken(String tokenId) {
-        ServiceAccessToken sat = findUnexpiredAccessToken(tokenId);
-        if (sat == null) return null;
-
-        ServiceClient sc = serviceClientDao.find(sat.getClientId());
-        Client client = getClient(sc.getKey());
-
-        AccessToken at = new AccessToken(client, sat.getTokenId(), sat.getTokenSecret(),
-            sat.getLifetime(), sat.getIssued());
-        at.setSubject(new UserSubject(sat.getProviderNo(), new ArrayList<>()));
-
-        List<OAuth1Permission> perms = new ArrayList<>();
-        // Persisted scopes may be null/blank (e.g. tokens minted before scopes carried meaning); treat
-        // that as no granted scopes rather than NPE-ing, so scope enforcement fails closed (403) instead
-        // of surfacing a 500 for an otherwise-valid token.
-        String scopes = sat.getScopes();
-        if (scopes != null && !scopes.isBlank()) {
-            for (String scope : scopes.split(" ")) {
-                if (!scope.isEmpty()) {
-                    perms.add(new OAuth1Permission(scope, scope));
-                }
-            }
-        }
-        at.setScopes(perms);
-
-        return at;
-    }
-
     public void removeToken(String tokenId) {
         ServiceRequestToken srt = serviceRequestTokenDao.findByTokenId(tokenId);
         if (srt != null) serviceRequestTokenDao.remove(srt);
@@ -367,7 +339,13 @@ public class OscarOAuthDataProvider {
         }
     }
 
-    private ServiceAccessToken findUnexpiredAccessToken(String accessTokenId) {
+    /**
+     * The persisted access token for {@code accessTokenId} if it exists and is unexpired, otherwise
+     * {@code null} (an expired token is removed as a side effect). Callers can read both the provider
+     * ({@link ServiceAccessToken#getProviderNo()}) and the granted scopes ({@link ServiceAccessToken#getScopes()})
+     * off the returned entity in a single lookup, rather than loading the token twice.
+     */
+    public ServiceAccessToken findUnexpiredAccessToken(String accessTokenId) {
         ServiceAccessToken sat = serviceAccessTokenDao.findByTokenId(accessTokenId);
         if (sat == null) {
             return null;

--- a/src/main/java/io/github/carlos_emr/carlos/login/OscarOAuthDataProvider.java
+++ b/src/main/java/io/github/carlos_emr/carlos/login/OscarOAuthDataProvider.java
@@ -211,8 +211,16 @@ public class OscarOAuthDataProvider {
         at.setSubject(new UserSubject(sat.getProviderNo(), new ArrayList<>()));
 
         List<OAuth1Permission> perms = new ArrayList<>();
-        for (String scope : sat.getScopes().split(" ")) {
-            perms.add(new OAuth1Permission(scope, scope));
+        // Persisted scopes may be null/blank (e.g. tokens minted before scopes carried meaning); treat
+        // that as no granted scopes rather than NPE-ing, so scope enforcement fails closed (403) instead
+        // of surfacing a 500 for an otherwise-valid token.
+        String scopes = sat.getScopes();
+        if (scopes != null && !scopes.isBlank()) {
+            for (String scope : scopes.split(" ")) {
+                if (!scope.isEmpty()) {
+                    perms.add(new OAuth1Permission(scope, scope));
+                }
+            }
         }
         at.setScopes(perms);
 

--- a/src/main/java/io/github/carlos_emr/carlos/login/OscarRequestTokenService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/login/OscarRequestTokenService.java
@@ -58,9 +58,11 @@
 
 package io.github.carlos_emr.carlos.login;
 
+import io.github.carlos_emr.CarlosProperties;
 import io.github.carlos_emr.carlos.webserv.oauth.OAuth1Request;
 import io.github.carlos_emr.carlos.webserv.oauth.OAuth1SignatureVerifier;
 import io.github.carlos_emr.carlos.webserv.oauth.OAuth1Exception;
+import io.github.carlos_emr.carlos.webserv.oauth.OAuthScopes;
 import io.github.carlos_emr.carlos.webserv.oauth.Client;
 import io.github.carlos_emr.carlos.webserv.oauth.RequestTokenRegistration;
 import io.github.carlos_emr.carlos.webserv.oauth.RequestToken;
@@ -77,6 +79,13 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 
 public class OscarRequestTokenService {
+
+    /**
+     * Config flag gating OAuth 1.0a scope enforcement (issue #3083). Absent/false (the default) keeps the
+     * historical lenient behaviour where any scope string is accepted and persisted; a truthy value makes
+     * {@code /initiate} reject empty or unknown scopes.
+     */
+    private static final String SCOPE_ENFORCEMENT_PROPERTY = "oauth.scope.enforcement.enabled";
 
     private final OscarOAuthDataProvider dataProvider;
     private final OAuth1ParamParser parser;
@@ -132,8 +141,12 @@ public class OscarRequestTokenService {
 
         reg.setCallback(cbToStore);   // <-- store plain URL now (not encoded)
 
-        if (oreq.scopesCsv != null && !oreq.scopesCsv.isBlank()) {
-            reg.setScopes(oreq.scopesCsv.split("\\s+"));
+        String[] requestedScopes = (oreq.scopesCsv != null && !oreq.scopesCsv.isBlank())
+                ? oreq.scopesCsv.split("\\s+")
+                : new String[0];
+        validateRequestedScopes(requestedScopes);
+        if (requestedScopes.length > 0) {
+            reg.setScopes(requestedScopes);
         }
         RequestToken rt = dataProvider.createRequestToken(reg);
 
@@ -144,6 +157,32 @@ public class OscarRequestTokenService {
         return Response.ok(body).type(MediaType.APPLICATION_FORM_URLENCODED).build();
     }
     
+    /**
+     * Validates the scopes requested at {@code /initiate} against the recognised vocabulary (issue #3083).
+     *
+     * <p>When scope enforcement is enabled, a request token may only be issued for known
+     * {@code <domain>.read}/{@code <domain>.write} scopes, and at least one scope must be requested; this
+     * stops arbitrary/meaningless scope strings (and empty grants that later read as "full access") from
+     * being persisted onto a token. When enforcement is disabled (the default) this is a no-op so existing
+     * integrations are unaffected.
+     *
+     * @throws OAuth1Exception 400 {@code invalid_scope} if no scopes are requested or any requested scope
+     *                         is outside the vocabulary
+     */
+    private static void validateRequestedScopes(String[] scopes) {
+        if (!CarlosProperties.getInstance().isPropertyActive(SCOPE_ENFORCEMENT_PROPERTY)) {
+            return;
+        }
+        if (scopes == null || scopes.length == 0) {
+            throw new OAuth1Exception(400, "invalid_scope");
+        }
+        for (String scope : scopes) {
+            if (!OAuthScopes.isKnownScope(scope)) {
+                throw new OAuth1Exception(400, "invalid_scope");
+            }
+        }
+    }
+
     private static String enc(String s) {
         return URLEncoder.encode(s, StandardCharsets.UTF_8);
     }

--- a/src/main/java/io/github/carlos_emr/carlos/login/OscarRequestTokenService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/login/OscarRequestTokenService.java
@@ -141,8 +141,10 @@ public class OscarRequestTokenService {
 
         reg.setCallback(cbToStore);   // <-- store plain URL now (not encoded)
 
+        // trim before splitting so leading/trailing whitespace does not yield an empty token that
+        // would otherwise be rejected as an unknown scope under enforcement
         String[] requestedScopes = (oreq.scopesCsv != null && !oreq.scopesCsv.isBlank())
-                ? oreq.scopesCsv.split("\\s+")
+                ? oreq.scopesCsv.trim().split("\\s+")
                 : new String[0];
         validateRequestedScopes(requestedScopes);
         if (requestedScopes.length > 0) {

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/oauth/OAuthScopes.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/oauth/OAuthScopes.java
@@ -155,12 +155,14 @@ public final class OAuthScopes {
         return normalized != null && KNOWN_SCOPES.contains(normalized);
     }
 
+    /** The RFC 7231 safe (read-only) methods. {@code TRACE} is included for completeness even though the
+     *  container normally rejects it and no JAX-RS resource handles it. */
     private static boolean isSafeMethod(String httpMethod) {
         if (httpMethod == null) {
             return false;
         }
         String m = asciiLowerCase(httpMethod.trim());
-        return m.equals("get") || m.equals("head") || m.equals("options");
+        return m.equals("get") || m.equals("head") || m.equals("options") || m.equals("trace");
     }
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/oauth/OAuthScopes.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/oauth/OAuthScopes.java
@@ -21,7 +21,9 @@
  */
 package io.github.carlos_emr.carlos.webserv.oauth;
 
+import java.util.ArrayDeque;
 import java.util.Collection;
+import java.util.Deque;
 import java.util.Map;
 import java.util.Set;
 
@@ -166,11 +168,12 @@ public final class OAuthScopes {
      * The domain root of the request: the first non-empty path segment after the {@code /services/} marker,
      * lower-cased; {@code null} if the URI has no {@code /services/} segment or nothing usable follows it.
      *
-     * <p>The segment is percent-decoded and has any matrix parameters ({@code ;k=v}) stripped <b>before</b>
-     * it is matched, so it reflects what JAX-RS/CXF actually routes to. Without this, requests such as
-     * {@code /ws/services/%73chedule/...} or {@code /ws/services/schedule;x=1/...} would resolve to a
+     * <p>Each segment is percent-decoded and has any matrix parameters ({@code ;k=v}) stripped, and
+     * {@code .}/{@code ..} segments are resolved away, <b>before</b> the root is matched — so it reflects
+     * what JAX-RS/CXF actually routes to. Without this, requests such as {@code /ws/services/%73chedule/...},
+     * {@code /ws/services/schedule;x=1/...}, or {@code /ws/services/./schedule/...} would resolve to a
      * non-matching root, fall back to {@link #NO_SCOPE_REQUIRED}, and silently bypass scope enforcement
-     * while still reaching the {@code schedule} resource.
+     * while still reaching the {@code schedule} resource. Resolution errs toward enforcement, never bypass.
      */
     private static String pathRootUnderServices(String requestUri) {
         if (requestUri == null) {
@@ -187,18 +190,25 @@ public final class OAuthScopes {
         if (q >= 0) {
             rest = rest.substring(0, q);
         }
+        Deque<String> segments = new ArrayDeque<>();
         for (String rawSegment : rest.split("/")) {
             if (rawSegment.isEmpty()) {
                 continue;
             }
             // Decode first so a percent-encoded matrix delimiter (%3B) is also stripped, then drop
-            // matrix parameters. Resolving aggressively here errs toward enforcement, never toward bypass.
+            // matrix parameters, then collapse dot-segments — mirroring container/JAX-RS path resolution.
             String segment = stripMatrixParameters(percentDecode(rawSegment));
-            if (!segment.isEmpty()) {
-                return asciiLowerCase(segment);
+            if (segment.isEmpty() || segment.equals(".")) {
+                continue;
             }
+            if (segment.equals("..")) {
+                segments.pollLast();
+                continue;
+            }
+            segments.addLast(segment);
         }
-        return null;
+        String root = segments.peekFirst();
+        return root == null ? null : asciiLowerCase(root);
     }
 
     private static String stripMatrixParameters(String segment) {

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/oauth/OAuthScopes.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/oauth/OAuthScopes.java
@@ -171,49 +171,48 @@ public final class OAuthScopes {
      * + JAX-RS address {@code /services}) so an unrelated earlier {@code services} path segment cannot
      * misanchor the root.
      *
-     * <p>Each segment is percent-decoded and has any matrix parameters ({@code ;k=v}) stripped, and
-     * {@code .}/{@code ..} segments are resolved away, <b>before</b> the root is matched — so it reflects
-     * what JAX-RS/CXF actually routes to. Decoded segments are re-split on {@code /} so a percent-encoded
-     * slash ({@code %2F}, or {@code %2e%2e%2f} → {@code ../}) is treated as a path boundary too. Without
-     * this, requests such as {@code /ws/services/%73chedule/...}, {@code /ws/services/schedule;x=1/...},
-     * {@code /ws/services/./schedule/...}, or {@code /ws/services/%2e%2e%2fschedule/...} would resolve to a
-     * non-matching root, fall back to {@link #NO_SCOPE_REQUIRED}, and silently bypass scope enforcement
-     * while still reaching the {@code schedule} resource. Resolution errs toward enforcement, never bypass.
+     * <p>The whole path is percent-decoded <b>before</b> the marker is located, so an encoded mount prefix
+     * (e.g. {@code /ws/%73ervices/...} → {@code /ws/services/...}) still maps to the routed path the
+     * container sees. Each resulting segment then has matrix parameters ({@code ;k=v}) stripped and
+     * {@code .}/{@code ..} segments resolved away, and decoding turns an encoded slash ({@code %2F}, or
+     * {@code %2e%2e%2f} → {@code ../}) back into a path boundary. Without this, requests such as
+     * {@code /ws/%73ervices/schedule/...}, {@code /ws/services/%73chedule/...},
+     * {@code /ws/services/schedule;x=1/...}, {@code /ws/services/./schedule/...}, or
+     * {@code /ws/services/%2e%2e%2fschedule/...} would fall back to {@link #NO_SCOPE_REQUIRED} and silently
+     * bypass scope enforcement while still reaching the {@code schedule} resource. Resolution errs toward
+     * enforcement, never bypass.
      */
     private static String pathRootUnderServices(String requestUri) {
         if (requestUri == null) {
             return null;
         }
+        // Drop the query string (at the first literal '?') before decoding, so a marker-looking value in a
+        // query parameter cannot misanchor the root; the query never affects the routed path anyway.
+        String path = requestUri;
+        int q = path.indexOf('?');
+        if (q >= 0) {
+            path = path.substring(0, q);
+        }
+        // Decode once (matching the container's single-pass decode) so an encoded mount prefix or an
+        // encoded slash maps to what JAX-RS/CXF actually routes to, then anchor on the /ws/services/ mount.
+        String decoded = percentDecode(path);
         String marker = "/ws/services/";
-        int idx = requestUri.indexOf(marker);
+        int idx = decoded.indexOf(marker);
         if (idx < 0) {
             return null;
         }
-        String rest = requestUri.substring(idx + marker.length());
-        // strip any query string before splitting on path separators
-        int q = rest.indexOf('?');
-        if (q >= 0) {
-            rest = rest.substring(0, q);
-        }
+        String rest = decoded.substring(idx + marker.length());
         Deque<String> segments = new ArrayDeque<>();
         for (String rawSegment : rest.split("/")) {
-            if (rawSegment.isEmpty()) {
+            String segment = stripMatrixParameters(rawSegment);
+            if (segment.isEmpty() || segment.equals(".")) {
                 continue;
             }
-            // Decode first so a percent-encoded matrix delimiter (%3B) or slash (%2F) is revealed, then
-            // re-split on any decoded '/' so an encoded slash is a path boundary, drop matrix parameters,
-            // and collapse dot-segments — mirroring container/JAX-RS path resolution.
-            for (String part : percentDecode(rawSegment).split("/")) {
-                String segment = stripMatrixParameters(part);
-                if (segment.isEmpty() || segment.equals(".")) {
-                    continue;
-                }
-                if (segment.equals("..")) {
-                    segments.pollLast();
-                    continue;
-                }
-                segments.addLast(segment);
+            if (segment.equals("..")) {
+                segments.pollLast();
+                continue;
             }
+            segments.addLast(segment);
         }
         String root = segments.peekFirst();
         return root == null ? null : asciiLowerCase(root);

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/oauth/OAuthScopes.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/oauth/OAuthScopes.java
@@ -21,9 +21,7 @@
  */
 package io.github.carlos_emr.carlos.webserv.oauth;
 
-import java.util.ArrayDeque;
 import java.util.Collection;
-import java.util.Deque;
 import java.util.Map;
 import java.util.Set;
 
@@ -59,9 +57,9 @@ public final class OAuthScopes {
     private static final String WRITE = "write";
 
     /**
-     * Path-root segment (the first path element under {@code /ws/services/}) → scope domain, for the
-     * endpoints currently in the enforcement pilot. Roots are matched case-insensitively. Anything not
-     * listed here is treated as {@link #NO_SCOPE_REQUIRED}.
+     * Path-root segment (the first path element under {@code /services/} in the servlet path info) → scope
+     * domain, for the endpoints currently in the enforcement pilot. Roots are matched case-insensitively.
+     * Anything not listed here is treated as {@link #NO_SCOPE_REQUIRED}.
      */
     private static final Map<String, String> PILOT_DOMAIN_BY_PATH_ROOT = Map.of(
         "schedule", "schedule",
@@ -88,18 +86,19 @@ public final class OAuthScopes {
      * The scope a request must carry to be authorized, or {@link #NO_SCOPE_REQUIRED} when the target
      * endpoint is outside the enforcement pilot.
      *
-     * <p>The domain is derived from the first path segment under {@code /ws/services/}; the read/write
+     * <p>The domain is derived from the first path segment under {@code /services/}; the read/write
      * qualifier is derived from the HTTP method (safe methods — {@code GET}/{@code HEAD}/{@code OPTIONS} —
      * require {@code .read}, everything else requires {@code .write}).
      *
-     * @param httpMethod the request method (case-insensitive); a {@code null}/blank method is treated as a
-     *                   write for fail-safe behaviour
-     * @param requestUri the request URI (e.g. {@code /carlos/ws/services/schedule/day/2026-06-29}); the
-     *                   segment after {@code /services/} selects the domain
+     * @param httpMethod  the request method (case-insensitive); a {@code null}/blank method is treated as a
+     *                    write for fail-safe behaviour
+     * @param servicePath the request's servlet path info (e.g. {@code /services/schedule/day/2026-06-29}
+     *                    from {@code HttpServletRequest.getPathInfo()}); the segment after {@code /services/}
+     *                    selects the domain
      * @return the required scope string, or {@link #NO_SCOPE_REQUIRED} if the endpoint is not piloted
      */
-    public static String requiredScope(String httpMethod, String requestUri) {
-        String root = pathRootUnderServices(requestUri);
+    public static String requiredScope(String httpMethod, String servicePath) {
+        String root = pathRootUnderServices(servicePath);
         if (root == null) {
             return NO_SCOPE_REQUIRED;
         }
@@ -165,85 +164,37 @@ public final class OAuthScopes {
     }
 
     /**
-     * The domain root of the request: the first non-empty path segment after the {@code /ws/services/}
-     * marker, lower-cased; {@code null} if the URI has no {@code /ws/services/} segment or nothing usable
-     * follows it. The marker is anchored to the full {@code /ws/services/} mount (CXF servlet {@code /ws/*}
-     * + JAX-RS address {@code /services}) so an unrelated earlier {@code services} path segment cannot
-     * misanchor the root.
+     * The domain root of the request: the first path segment after the {@code /services/} marker, lower-cased;
+     * {@code null} if the path has no {@code /services/} segment or nothing usable follows it.
      *
-     * <p>The whole path is percent-decoded <b>before</b> the marker is located, so an encoded mount prefix
-     * (e.g. {@code /ws/%73ervices/...} → {@code /ws/services/...}) still maps to the routed path the
-     * container sees. Each resulting segment then has matrix parameters ({@code ;k=v}) stripped and
-     * {@code .}/{@code ..} segments resolved away, and decoding turns an encoded slash ({@code %2F}, or
-     * {@code %2e%2e%2f} → {@code ../}) back into a path boundary. Without this, requests such as
-     * {@code /ws/%73ervices/schedule/...}, {@code /ws/services/%73chedule/...},
-     * {@code /ws/services/schedule;x=1/...}, {@code /ws/services/./schedule/...}, or
-     * {@code /ws/services/%2e%2e%2fschedule/...} would fall back to {@link #NO_SCOPE_REQUIRED} and silently
-     * bypass scope enforcement while still reaching the {@code schedule} resource. Resolution errs toward
-     * enforcement, never bypass.
+     * <p>The caller passes the request's <em>servlet path info</em>
+     * ({@link jakarta.servlet.http.HttpServletRequest#getPathInfo()}), which the servlet container has already
+     * URL-decoded and canonicalized — dot-segments collapsed, matrix/path parameters stripped — and which is
+     * the exact path JAX-RS/CXF route on. This method therefore does no decoding or normalization of its own:
+     * doing it here would only risk diverging from how the request is actually routed.
+     *
+     * <p>Verified live on the CARLOS stack (Tomcat 11 + CXF 4.1.5): inside a {@code PRE_INVOKE} interceptor,
+     * {@code getPathInfo()} is the raw container request's value, and for every routed request it is
+     * {@code /services/<domain>/...} regardless of how the client percent-encoded the URI; matrix params and
+     * {@code .}/{@code ..} segments are already resolved, and an encoded slash ({@code %2F}) is rejected by
+     * the container (HTTP 400) before the interceptor runs. So an encoded mount prefix or domain segment
+     * cannot reach a piloted resource while looking unpiloted here.
      */
-    private static String pathRootUnderServices(String requestUri) {
-        if (requestUri == null) {
+    private static String pathRootUnderServices(String servicePath) {
+        if (servicePath == null) {
             return null;
         }
-        // Drop the query string (at the first literal '?') before decoding, so a marker-looking value in a
-        // query parameter cannot misanchor the root; the query never affects the routed path anyway.
-        String path = requestUri;
-        int q = path.indexOf('?');
-        if (q >= 0) {
-            path = path.substring(0, q);
-        }
-        // Decode once (matching the container's single-pass decode) so an encoded mount prefix or an
-        // encoded slash maps to what JAX-RS/CXF actually routes to, then anchor on the /ws/services/ mount.
-        String decoded = percentDecode(path);
-        String marker = "/ws/services/";
-        int idx = decoded.indexOf(marker);
+        String marker = "/services/";
+        int idx = servicePath.indexOf(marker);
         if (idx < 0) {
             return null;
         }
-        String rest = decoded.substring(idx + marker.length());
-        Deque<String> segments = new ArrayDeque<>();
-        for (String rawSegment : rest.split("/")) {
-            String segment = stripMatrixParameters(rawSegment);
-            if (segment.isEmpty() || segment.equals(".")) {
-                continue;
-            }
-            if (segment.equals("..")) {
-                segments.pollLast();
-                continue;
-            }
-            segments.addLast(segment);
+        String rest = servicePath.substring(idx + marker.length());
+        int slash = rest.indexOf('/');
+        if (slash >= 0) {
+            rest = rest.substring(0, slash);
         }
-        String root = segments.peekFirst();
-        return root == null ? null : asciiLowerCase(root);
-    }
-
-    private static String stripMatrixParameters(String segment) {
-        int semi = segment.indexOf(';');
-        return semi >= 0 ? segment.substring(0, semi) : segment;
-    }
-
-    /** Decodes {@code %XX} escapes only; intentionally leaves {@code +} untouched (literal in path segments). */
-    private static String percentDecode(String value) {
-        if (value.indexOf('%') < 0) {
-            return value;
-        }
-        int n = value.length();
-        StringBuilder out = new StringBuilder(n);
-        for (int i = 0; i < n; i++) {
-            char c = value.charAt(i);
-            if (c == '%' && i + 2 < n) {
-                int hi = Character.digit(value.charAt(i + 1), 16);
-                int lo = Character.digit(value.charAt(i + 2), 16);
-                if (hi >= 0 && lo >= 0) {
-                    out.append((char) ((hi << 4) + lo));
-                    i += 2;
-                    continue;
-                }
-            }
-            out.append(c);
-        }
-        return out.toString();
+        return rest.isEmpty() ? null : asciiLowerCase(rest);
     }
 
     private static String normalize(String scope) {

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/oauth/OAuthScopes.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/oauth/OAuthScopes.java
@@ -22,7 +22,6 @@
 package io.github.carlos_emr.carlos.webserv.oauth;
 
 import java.util.Collection;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -159,13 +158,19 @@ public final class OAuthScopes {
         if (httpMethod == null) {
             return false;
         }
-        String m = httpMethod.trim().toUpperCase(Locale.ROOT);
-        return m.equals("GET") || m.equals("HEAD") || m.equals("OPTIONS");
+        String m = asciiLowerCase(httpMethod.trim());
+        return m.equals("get") || m.equals("head") || m.equals("options");
     }
 
     /**
-     * The first non-empty path segment after the {@code /services/} marker, lower-cased; {@code null} if
-     * the URI has no {@code /services/} segment or nothing follows it.
+     * The domain root of the request: the first non-empty path segment after the {@code /services/} marker,
+     * lower-cased; {@code null} if the URI has no {@code /services/} segment or nothing usable follows it.
+     *
+     * <p>The segment is percent-decoded and has any matrix parameters ({@code ;k=v}) stripped <b>before</b>
+     * it is matched, so it reflects what JAX-RS/CXF actually routes to. Without this, requests such as
+     * {@code /ws/services/%73chedule/...} or {@code /ws/services/schedule;x=1/...} would resolve to a
+     * non-matching root, fall back to {@link #NO_SCOPE_REQUIRED}, and silently bypass scope enforcement
+     * while still reaching the {@code schedule} resource.
      */
     private static String pathRootUnderServices(String requestUri) {
         if (requestUri == null) {
@@ -182,19 +187,67 @@ public final class OAuthScopes {
         if (q >= 0) {
             rest = rest.substring(0, q);
         }
-        for (String segment : rest.split("/")) {
+        for (String rawSegment : rest.split("/")) {
+            if (rawSegment.isEmpty()) {
+                continue;
+            }
+            // Decode first so a percent-encoded matrix delimiter (%3B) is also stripped, then drop
+            // matrix parameters. Resolving aggressively here errs toward enforcement, never toward bypass.
+            String segment = stripMatrixParameters(percentDecode(rawSegment));
             if (!segment.isEmpty()) {
-                return segment.toLowerCase(Locale.ROOT);
+                return asciiLowerCase(segment);
             }
         }
         return null;
+    }
+
+    private static String stripMatrixParameters(String segment) {
+        int semi = segment.indexOf(';');
+        return semi >= 0 ? segment.substring(0, semi) : segment;
+    }
+
+    /** Decodes {@code %XX} escapes only; intentionally leaves {@code +} untouched (literal in path segments). */
+    private static String percentDecode(String value) {
+        if (value.indexOf('%') < 0) {
+            return value;
+        }
+        int n = value.length();
+        StringBuilder out = new StringBuilder(n);
+        for (int i = 0; i < n; i++) {
+            char c = value.charAt(i);
+            if (c == '%' && i + 2 < n) {
+                int hi = Character.digit(value.charAt(i + 1), 16);
+                int lo = Character.digit(value.charAt(i + 2), 16);
+                if (hi >= 0 && lo >= 0) {
+                    out.append((char) ((hi << 4) + lo));
+                    i += 2;
+                    continue;
+                }
+            }
+            out.append(c);
+        }
+        return out.toString();
     }
 
     private static String normalize(String scope) {
         if (scope == null) {
             return null;
         }
-        String trimmed = scope.trim().toLowerCase(Locale.ROOT);
+        String trimmed = asciiLowerCase(scope.trim());
         return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    /**
+     * ASCII-only lower-casing. Scopes and HTTP methods are ASCII tokens, and folding them with the
+     * locale-sensitive {@code String.toLowerCase} adds no value while tripping locale/Unicode scanners; a
+     * fixed ASCII fold mirrors the existing OAuth helpers in this package.
+     */
+    private static String asciiLowerCase(String value) {
+        StringBuilder lowered = new StringBuilder(value.length());
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            lowered.append(c >= 'A' && c <= 'Z' ? (char) (c + ('a' - 'A')) : c);
+        }
+        return lowered.toString();
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/oauth/OAuthScopes.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/oauth/OAuthScopes.java
@@ -170,8 +170,10 @@ public final class OAuthScopes {
      *
      * <p>Each segment is percent-decoded and has any matrix parameters ({@code ;k=v}) stripped, and
      * {@code .}/{@code ..} segments are resolved away, <b>before</b> the root is matched — so it reflects
-     * what JAX-RS/CXF actually routes to. Without this, requests such as {@code /ws/services/%73chedule/...},
-     * {@code /ws/services/schedule;x=1/...}, or {@code /ws/services/./schedule/...} would resolve to a
+     * what JAX-RS/CXF actually routes to. Decoded segments are re-split on {@code /} so a percent-encoded
+     * slash ({@code %2F}, or {@code %2e%2e%2f} → {@code ../}) is treated as a path boundary too. Without
+     * this, requests such as {@code /ws/services/%73chedule/...}, {@code /ws/services/schedule;x=1/...},
+     * {@code /ws/services/./schedule/...}, or {@code /ws/services/%2e%2e%2fschedule/...} would resolve to a
      * non-matching root, fall back to {@link #NO_SCOPE_REQUIRED}, and silently bypass scope enforcement
      * while still reaching the {@code schedule} resource. Resolution errs toward enforcement, never bypass.
      */
@@ -195,17 +197,20 @@ public final class OAuthScopes {
             if (rawSegment.isEmpty()) {
                 continue;
             }
-            // Decode first so a percent-encoded matrix delimiter (%3B) is also stripped, then drop
-            // matrix parameters, then collapse dot-segments — mirroring container/JAX-RS path resolution.
-            String segment = stripMatrixParameters(percentDecode(rawSegment));
-            if (segment.isEmpty() || segment.equals(".")) {
-                continue;
+            // Decode first so a percent-encoded matrix delimiter (%3B) or slash (%2F) is revealed, then
+            // re-split on any decoded '/' so an encoded slash is a path boundary, drop matrix parameters,
+            // and collapse dot-segments — mirroring container/JAX-RS path resolution.
+            for (String part : percentDecode(rawSegment).split("/")) {
+                String segment = stripMatrixParameters(part);
+                if (segment.isEmpty() || segment.equals(".")) {
+                    continue;
+                }
+                if (segment.equals("..")) {
+                    segments.pollLast();
+                    continue;
+                }
+                segments.addLast(segment);
             }
-            if (segment.equals("..")) {
-                segments.pollLast();
-                continue;
-            }
-            segments.addLast(segment);
         }
         String root = segments.peekFirst();
         return root == null ? null : asciiLowerCase(root);

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/oauth/OAuthScopes.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/oauth/OAuthScopes.java
@@ -1,0 +1,200 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.webserv.oauth;
+
+import java.util.Collection;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Vocabulary and matching rules for OAuth 1.0a access-token scopes (issue #3083).
+ *
+ * <p>OAuth tokens persist the scopes a provider approved on the consent screen, but historically
+ * nothing read them: any valid token granted the full privileges of its provider across the entire
+ * {@code /ws/services/*} surface. This class is the single, side-effect-free source of truth used to
+ * close that gap, in two places:
+ *
+ * <ul>
+ *   <li>{@code OscarRequestTokenService} — to reject unknown/empty scopes at {@code /ws/oauth/initiate}
+ *       rather than persisting arbitrary strings; and</li>
+ *   <li>{@code OAuthInterceptor} — to require the scope a request needs before letting the call through.</li>
+ * </ul>
+ *
+ * <p><b>Coarse read/write model.</b> Scopes are {@code <domain>.read} / {@code <domain>.write}. A
+ * {@code .write} grant implies the matching {@code .read} (see {@link #isSatisfiedBy}). Enforcement is
+ * piloted on a deliberately small subset of domains; every other {@code /ws/services/*} endpoint maps to
+ * {@link #NO_SCOPE_REQUIRED} so enabling enforcement does not break the un-piloted surface. Extending the
+ * pilot to additional domains is tracked as follow-up to #3083.
+ *
+ * <p>All methods are pure functions of their arguments; this type holds no request state and is safe to
+ * call from any thread.
+ */
+public final class OAuthScopes {
+
+    /** Sentinel returned by {@link #requiredScope} for endpoints outside the enforcement pilot. */
+    public static final String NO_SCOPE_REQUIRED = null;
+
+    private static final String READ = "read";
+    private static final String WRITE = "write";
+
+    /**
+     * Path-root segment (the first path element under {@code /ws/services/}) → scope domain, for the
+     * endpoints currently in the enforcement pilot. Roots are matched case-insensitively. Anything not
+     * listed here is treated as {@link #NO_SCOPE_REQUIRED}.
+     */
+    private static final Map<String, String> PILOT_DOMAIN_BY_PATH_ROOT = Map.of(
+        "schedule", "schedule",
+        "tickler", "tickler"
+    );
+
+    /** The complete set of scope strings a client may request at {@code /initiate} while the pilot stands. */
+    private static final Set<String> KNOWN_SCOPES = buildKnownScopes();
+
+    private OAuthScopes() {
+        // static-utility holder; not instantiable
+    }
+
+    private static Set<String> buildKnownScopes() {
+        java.util.Set<String> scopes = new java.util.HashSet<>();
+        for (String domain : PILOT_DOMAIN_BY_PATH_ROOT.values()) {
+            scopes.add(domain + "." + READ);
+            scopes.add(domain + "." + WRITE);
+        }
+        return Set.copyOf(scopes);
+    }
+
+    /**
+     * The scope a request must carry to be authorized, or {@link #NO_SCOPE_REQUIRED} when the target
+     * endpoint is outside the enforcement pilot.
+     *
+     * <p>The domain is derived from the first path segment under {@code /ws/services/}; the read/write
+     * qualifier is derived from the HTTP method (safe methods — {@code GET}/{@code HEAD}/{@code OPTIONS} —
+     * require {@code .read}, everything else requires {@code .write}).
+     *
+     * @param httpMethod the request method (case-insensitive); a {@code null}/blank method is treated as a
+     *                   write for fail-safe behaviour
+     * @param requestUri the request URI (e.g. {@code /carlos/ws/services/schedule/day/2026-06-29}); the
+     *                   segment after {@code /services/} selects the domain
+     * @return the required scope string, or {@link #NO_SCOPE_REQUIRED} if the endpoint is not piloted
+     */
+    public static String requiredScope(String httpMethod, String requestUri) {
+        String root = pathRootUnderServices(requestUri);
+        if (root == null) {
+            return NO_SCOPE_REQUIRED;
+        }
+        String domain = PILOT_DOMAIN_BY_PATH_ROOT.get(root);
+        if (domain == null) {
+            return NO_SCOPE_REQUIRED;
+        }
+        return domain + "." + (isSafeMethod(httpMethod) ? READ : WRITE);
+    }
+
+    /**
+     * Whether the scopes granted on a token satisfy a {@code requiredScope}. A {@code null}
+     * {@code requiredScope} ({@link #NO_SCOPE_REQUIRED}) is always satisfied. Matching is exact, except
+     * that a {@code <domain>.write} grant also satisfies {@code <domain>.read}.
+     *
+     * @param requiredScope the scope the request needs, or {@link #NO_SCOPE_REQUIRED}
+     * @param grantedScopes the scopes present on the token (may be {@code null}/empty)
+     * @return {@code true} if the request is permitted by the granted scopes
+     */
+    public static boolean isSatisfiedBy(String requiredScope, Collection<String> grantedScopes) {
+        if (requiredScope == null) {
+            return true;
+        }
+        if (grantedScopes == null || grantedScopes.isEmpty()) {
+            return false;
+        }
+        String required = normalize(requiredScope);
+        for (String granted : grantedScopes) {
+            String g = normalize(granted);
+            if (g == null) {
+                continue;
+            }
+            if (g.equals(required)) {
+                return true;
+            }
+            // write implies read on the same domain
+            if (required.endsWith("." + READ)
+                    && g.equals(required.substring(0, required.length() - READ.length()) + WRITE)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Whether a scope string is part of the recognised vocabulary. Used to reject arbitrary scope strings
+     * at {@code /initiate} when enforcement is enabled.
+     *
+     * @param scope a single scope token
+     * @return {@code true} if {@code scope} is a known {@code <domain>.read}/{@code .write} value
+     */
+    public static boolean isKnownScope(String scope) {
+        String normalized = normalize(scope);
+        return normalized != null && KNOWN_SCOPES.contains(normalized);
+    }
+
+    private static boolean isSafeMethod(String httpMethod) {
+        if (httpMethod == null) {
+            return false;
+        }
+        String m = httpMethod.trim().toUpperCase(Locale.ROOT);
+        return m.equals("GET") || m.equals("HEAD") || m.equals("OPTIONS");
+    }
+
+    /**
+     * The first non-empty path segment after the {@code /services/} marker, lower-cased; {@code null} if
+     * the URI has no {@code /services/} segment or nothing follows it.
+     */
+    private static String pathRootUnderServices(String requestUri) {
+        if (requestUri == null) {
+            return null;
+        }
+        String marker = "/services/";
+        int idx = requestUri.indexOf(marker);
+        if (idx < 0) {
+            return null;
+        }
+        String rest = requestUri.substring(idx + marker.length());
+        // strip any query string before splitting on path separators
+        int q = rest.indexOf('?');
+        if (q >= 0) {
+            rest = rest.substring(0, q);
+        }
+        for (String segment : rest.split("/")) {
+            if (!segment.isEmpty()) {
+                return segment.toLowerCase(Locale.ROOT);
+            }
+        }
+        return null;
+    }
+
+    private static String normalize(String scope) {
+        if (scope == null) {
+            return null;
+        }
+        String trimmed = scope.trim().toLowerCase(Locale.ROOT);
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/oauth/OAuthScopes.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/oauth/OAuthScopes.java
@@ -165,8 +165,11 @@ public final class OAuthScopes {
     }
 
     /**
-     * The domain root of the request: the first non-empty path segment after the {@code /services/} marker,
-     * lower-cased; {@code null} if the URI has no {@code /services/} segment or nothing usable follows it.
+     * The domain root of the request: the first non-empty path segment after the {@code /ws/services/}
+     * marker, lower-cased; {@code null} if the URI has no {@code /ws/services/} segment or nothing usable
+     * follows it. The marker is anchored to the full {@code /ws/services/} mount (CXF servlet {@code /ws/*}
+     * + JAX-RS address {@code /services}) so an unrelated earlier {@code services} path segment cannot
+     * misanchor the root.
      *
      * <p>Each segment is percent-decoded and has any matrix parameters ({@code ;k=v}) stripped, and
      * {@code .}/{@code ..} segments are resolved away, <b>before</b> the root is matched — so it reflects
@@ -181,7 +184,7 @@ public final class OAuthScopes {
         if (requestUri == null) {
             return null;
         }
-        String marker = "/services/";
+        String marker = "/ws/services/";
         int idx = requestUri.indexOf(marker);
         if (idx < 0) {
             return null;

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/oauth/OAuthScopes.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/oauth/OAuthScopes.java
@@ -22,6 +22,7 @@
 package io.github.carlos_emr.carlos.webserv.oauth;
 
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -74,7 +75,7 @@ public final class OAuthScopes {
     }
 
     private static Set<String> buildKnownScopes() {
-        java.util.Set<String> scopes = new java.util.HashSet<>();
+        Set<String> scopes = new HashSet<>();
         for (String domain : PILOT_DOMAIN_BY_PATH_ROOT.values()) {
             scopes.add(domain + "." + READ);
             scopes.add(domain + "." + WRITE);

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/oauth/util/OAuthInterceptor.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/oauth/util/OAuthInterceptor.java
@@ -60,8 +60,10 @@
 
 package io.github.carlos_emr.carlos.webserv.oauth.util;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import jakarta.annotation.Resource;
@@ -88,7 +90,11 @@ import io.github.carlos_emr.carlos.commn.model.OscarLog;
 import io.github.carlos_emr.carlos.commn.model.Provider;
 import io.github.carlos_emr.carlos.log.LogAction;
 import io.github.carlos_emr.carlos.utility.LogSafe;
+import io.github.carlos_emr.carlos.webserv.oauth.AccessToken;
+import io.github.carlos_emr.carlos.webserv.oauth.OAuth1Permission;
 import io.github.carlos_emr.carlos.webserv.oauth.OAuth1SignatureVerifier;
+import io.github.carlos_emr.carlos.webserv.oauth.OAuthScopes;
+import io.github.carlos_emr.CarlosProperties;
 
 @Component
 public class OAuthInterceptor implements PhaseInterceptor<Message> {
@@ -99,6 +105,13 @@ public class OAuthInterceptor implements PhaseInterceptor<Message> {
     private static final String OAUTH_LOGIN_SUCCESS = "OAUTH_LOGIN_SUCCESS";
     /** OscarLog action recorded on a rejected REST OAuth authentication (parity with SOAP WS_LOGIN_FAILURE). */
     private static final String OAUTH_LOGIN_FAILURE = "OAUTH_LOGIN_FAILURE";
+
+    /**
+     * Config flag gating OAuth 1.0a scope enforcement (issue #3083). Absent/false (the default) preserves
+     * the historical behaviour where any valid token grants the provider's full API access; set to a
+     * truthy value to require the granted scope on piloted {@code /ws/services/*} endpoints.
+     */
+    private static final String SCOPE_ENFORCEMENT_PROPERTY = "oauth.scope.enforcement.enabled";
 
     @Autowired
     private OscarOAuthDataProvider oauthDataProvider;
@@ -169,6 +182,11 @@ public class OAuthInterceptor implements PhaseInterceptor<Message> {
                 throw new OAuth1Exception(401, "unknown_provider");
             }
 
+            // 5a) Enforce the granted OAuth scopes (issue #3083). No-op unless enforcement is enabled
+            //     AND the target endpoint is in the scope-enforcement pilot. Done before attaching
+            //     LoggedInInfo so an out-of-scope call never reaches the resource with a security context.
+            enforceScope(req, token);
+
             LoggedInInfo info = new LoggedInInfo();
             info.setLoggedInProvider(provider);
             req.setAttribute(info.getLoggedInInfoKey(), info);
@@ -237,6 +255,57 @@ public class OAuthInterceptor implements PhaseInterceptor<Message> {
         } catch (Exception e) {
             logger.error("Failed to write OAUTH_LOGIN_FAILURE audit entry", e);
         }
+    }
+
+    /**
+     * Enforces the granted OAuth 1.0a scopes for the current request (issue #3083).
+     *
+     * <p>Fast-exits when enforcement is disabled (the default) or when the target endpoint is outside
+     * the enforcement pilot ({@link OAuthScopes#requiredScope} returns {@link OAuthScopes#NO_SCOPE_REQUIRED}),
+     * so no extra token lookup happens on the un-piloted surface. When a scope is required and the token's
+     * granted scopes do not satisfy it, throws {@link OAuth1Exception} with HTTP 403 {@code insufficient_scope};
+     * the caller's catch block records the rejection in the audit trail.
+     */
+    private void enforceScope(HttpServletRequest req, String token) {
+        if (!isScopeEnforcementEnabled()) {
+            return;
+        }
+        String requiredScope = OAuthScopes.requiredScope(req.getMethod(), req.getRequestURI());
+        if (requiredScope == OAuthScopes.NO_SCOPE_REQUIRED) {
+            return;
+        }
+        if (!OAuthScopes.isSatisfiedBy(requiredScope, grantedScopes(token))) {
+            throw new OAuth1Exception(403, "insufficient_scope");
+        }
+    }
+
+    /**
+     * Whether OAuth scope enforcement is switched on. Reads {@link #SCOPE_ENFORCEMENT_PROPERTY}; a config
+     * read failure leaves enforcement disabled so a transient configuration problem cannot turn into a
+     * blanket denial of all OAuth API traffic (consistent with the default-off rollout).
+     */
+    private boolean isScopeEnforcementEnabled() {
+        try {
+            return CarlosProperties.getInstance().isPropertyActive(SCOPE_ENFORCEMENT_PROPERTY);
+        } catch (Exception e) {
+            logger.warn("Could not read OAuth scope-enforcement flag; leaving enforcement disabled", e);
+            return false;
+        }
+    }
+
+    /** The scope strings granted on the access token, or an empty list when none are present. */
+    private List<String> grantedScopes(String token) {
+        AccessToken at = oauthDataProvider.getAccessToken(token);
+        if (at == null || at.getScopes() == null) {
+            return Collections.emptyList();
+        }
+        List<String> scopes = new ArrayList<>();
+        for (OAuth1Permission perm : at.getScopes()) {
+            if (perm != null && perm.getPermission() != null) {
+                scopes.add(perm.getPermission());
+            }
+        }
+        return scopes;
     }
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/oauth/util/OAuthInterceptor.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/oauth/util/OAuthInterceptor.java
@@ -271,7 +271,7 @@ public class OAuthInterceptor implements PhaseInterceptor<Message> {
             return;
         }
         String requiredScope = OAuthScopes.requiredScope(req.getMethod(), req.getRequestURI());
-        if (requiredScope == OAuthScopes.NO_SCOPE_REQUIRED) {
+        if (requiredScope == null) {  // OAuthScopes.NO_SCOPE_REQUIRED: endpoint outside the pilot
             return;
         }
         if (!OAuthScopes.isSatisfiedBy(requiredScope, grantedScopes(token))) {

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/oauth/util/OAuthInterceptor.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/oauth/util/OAuthInterceptor.java
@@ -88,10 +88,9 @@ import io.github.carlos_emr.carlos.login.AppOAuth1Config;
 import io.github.carlos_emr.carlos.PMmodule.dao.ProviderDao;
 import io.github.carlos_emr.carlos.commn.model.OscarLog;
 import io.github.carlos_emr.carlos.commn.model.Provider;
+import io.github.carlos_emr.carlos.commn.model.ServiceAccessToken;
 import io.github.carlos_emr.carlos.log.LogAction;
 import io.github.carlos_emr.carlos.utility.LogSafe;
-import io.github.carlos_emr.carlos.webserv.oauth.AccessToken;
-import io.github.carlos_emr.carlos.webserv.oauth.OAuth1Permission;
 import io.github.carlos_emr.carlos.webserv.oauth.OAuth1SignatureVerifier;
 import io.github.carlos_emr.carlos.webserv.oauth.OAuthScopes;
 import io.github.carlos_emr.CarlosProperties;
@@ -175,8 +174,14 @@ public class OAuthInterceptor implements PhaseInterceptor<Message> {
                 throw new OAuth1Exception(401, "invalid_signature");
             }
 
-            // 5) Resolve provider from ACCESS token and attach LoggedInInfo
-            String providerNo = oauthDataProvider.getProviderNoByAccessToken(token);
+            // 5) Resolve provider AND scopes from a single access-token load (the token's provider and its
+            //    granted scopes both come off the same ServiceAccessToken, so we avoid a second lookup that
+            //    could race token expiry/revocation between the two reads).
+            ServiceAccessToken accessToken = oauthDataProvider.findUnexpiredAccessToken(token);
+            if (accessToken == null) {
+                throw new OAuth1Exception(401, "unknown_provider");
+            }
+            String providerNo = accessToken.getProviderNo();
             Provider provider = providerDao.getProvider(providerNo);
             if (provider == null) {
                 throw new OAuth1Exception(401, "unknown_provider");
@@ -185,7 +190,7 @@ public class OAuthInterceptor implements PhaseInterceptor<Message> {
             // 5a) Enforce the granted OAuth scopes (issue #3083). No-op unless enforcement is enabled
             //     AND the target endpoint is in the scope-enforcement pilot. Done before attaching
             //     LoggedInInfo so an out-of-scope call never reaches the resource with a security context.
-            enforceScope(req, token);
+            enforceScope(req, accessToken);
 
             LoggedInInfo info = new LoggedInInfo();
             info.setLoggedInProvider(provider);
@@ -266,7 +271,7 @@ public class OAuthInterceptor implements PhaseInterceptor<Message> {
      * granted scopes do not satisfy it, throws {@link OAuth1Exception} with HTTP 403 {@code insufficient_scope};
      * the caller's catch block records the rejection in the audit trail.
      */
-    private void enforceScope(HttpServletRequest req, String token) {
+    private void enforceScope(HttpServletRequest req, ServiceAccessToken accessToken) {
         if (!isScopeEnforcementEnabled()) {
             return;
         }
@@ -277,7 +282,7 @@ public class OAuthInterceptor implements PhaseInterceptor<Message> {
         if (requiredScope == null) {  // OAuthScopes.NO_SCOPE_REQUIRED: endpoint outside the pilot
             return;
         }
-        if (!OAuthScopes.isSatisfiedBy(requiredScope, grantedScopes(token))) {
+        if (!OAuthScopes.isSatisfiedBy(requiredScope, grantedScopes(accessToken))) {
             throw new OAuth1Exception(403, "insufficient_scope");
         }
     }
@@ -296,16 +301,20 @@ public class OAuthInterceptor implements PhaseInterceptor<Message> {
         }
     }
 
-    /** The scope strings granted on the access token, or an empty list when none are present. */
-    private List<String> grantedScopes(String token) {
-        AccessToken at = oauthDataProvider.getAccessToken(token);
-        if (at == null || at.getScopes() == null) {
+    /**
+     * The scope strings granted on the access token, or an empty list when none are present. Persisted
+     * scopes are a space-delimited string that may be null/blank (e.g. tokens minted before scopes carried
+     * meaning); that is treated as no granted scopes so enforcement fails closed (403) rather than NPE-ing.
+     */
+    private static List<String> grantedScopes(ServiceAccessToken accessToken) {
+        String raw = accessToken == null ? null : accessToken.getScopes();
+        if (raw == null || raw.isBlank()) {
             return Collections.emptyList();
         }
         List<String> scopes = new ArrayList<>();
-        for (OAuth1Permission perm : at.getScopes()) {
-            if (perm != null && perm.getPermission() != null) {
-                scopes.add(perm.getPermission());
+        for (String scope : raw.split(" ")) {
+            if (!scope.isEmpty()) {
+                scopes.add(scope);
             }
         }
         return scopes;

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/oauth/util/OAuthInterceptor.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/oauth/util/OAuthInterceptor.java
@@ -270,7 +270,10 @@ public class OAuthInterceptor implements PhaseInterceptor<Message> {
         if (!isScopeEnforcementEnabled()) {
             return;
         }
-        String requiredScope = OAuthScopes.requiredScope(req.getMethod(), req.getRequestURI());
+        // Resolve the scope from getPathInfo(): the container-decoded, canonicalized path (dot-segments
+        // collapsed, matrix params stripped) that JAX-RS/CXF actually routes on. Using the raw request URI
+        // here would force us to re-implement that normalization and risk diverging from the real routing.
+        String requiredScope = OAuthScopes.requiredScope(req.getMethod(), req.getPathInfo());
         if (requiredScope == null) {  // OAuthScopes.NO_SCOPE_REQUIRED: endpoint outside the pilot
             return;
         }

--- a/src/test/java/io/github/carlos_emr/carlos/login/OscarOAuthDataProviderUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/login/OscarOAuthDataProviderUnitTest.java
@@ -12,6 +12,7 @@ import io.github.carlos_emr.carlos.commn.dao.ServiceRequestTokenDao;
 import io.github.carlos_emr.carlos.commn.model.ServiceAccessToken;
 import io.github.carlos_emr.carlos.commn.model.ServiceClient;
 import io.github.carlos_emr.carlos.commn.model.ServiceOAuthNonce;
+import io.github.carlos_emr.carlos.webserv.oauth.AccessToken;
 import io.github.carlos_emr.carlos.webserv.oauth.Client;
 import io.github.carlos_emr.carlos.webserv.oauth.OAuth1Exception;
 import io.github.carlos_emr.carlos.webserv.oauth.RequestToken;
@@ -219,6 +220,33 @@ class OscarOAuthDataProviderUnitTest {
 
         assertThat(rt).isNotNull();
         assertThat(rt.getCallback()).isEqualTo(expectedCallback);
+    }
+
+    @Test
+    @DisplayName("should return a token with no scopes when persisted scopes are null")
+    void shouldReturnTokenWithoutScopes_whenPersistedScopesAreNull() {
+        ServiceAccessTokenDao accessTokenDao = mock(ServiceAccessTokenDao.class);
+        Integer clientId = 7;
+        ServiceAccessToken token = accessToken("scopeless-token", "secret", "999998",
+                System.currentTimeMillis() / 1000, 3600);
+        token.setClientId(clientId);
+        // scopes intentionally left unset -> getScopes() is null (legacy/empty token)
+        when(accessTokenDao.findByTokenId("scopeless-token")).thenReturn(token);
+
+        ServiceClientDao clientDao = mock(ServiceClientDao.class);
+        ServiceClient client = new ServiceClient();
+        client.setKey("consumer");
+        when(clientDao.find(clientId)).thenReturn(client);
+        when(clientDao.findByKey("consumer")).thenReturn(client);
+
+        OscarOAuthDataProvider provider = new OscarOAuthDataProvider();
+        ReflectionTestUtils.setField(provider, "serviceAccessTokenDao", accessTokenDao);
+        ReflectionTestUtils.setField(provider, "serviceClientDao", clientDao);
+
+        AccessToken at = provider.getAccessToken("scopeless-token");
+
+        assertThat(at).isNotNull();
+        assertThat(at.getScopes()).isEmpty();
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/login/OscarOAuthDataProviderUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/login/OscarOAuthDataProviderUnitTest.java
@@ -12,7 +12,6 @@ import io.github.carlos_emr.carlos.commn.dao.ServiceRequestTokenDao;
 import io.github.carlos_emr.carlos.commn.model.ServiceAccessToken;
 import io.github.carlos_emr.carlos.commn.model.ServiceClient;
 import io.github.carlos_emr.carlos.commn.model.ServiceOAuthNonce;
-import io.github.carlos_emr.carlos.webserv.oauth.AccessToken;
 import io.github.carlos_emr.carlos.webserv.oauth.Client;
 import io.github.carlos_emr.carlos.webserv.oauth.OAuth1Exception;
 import io.github.carlos_emr.carlos.webserv.oauth.RequestToken;
@@ -223,30 +222,34 @@ class OscarOAuthDataProviderUnitTest {
     }
 
     @Test
-    @DisplayName("should return a token with no scopes when persisted scopes are null")
-    void shouldReturnTokenWithoutScopes_whenPersistedScopesAreNull() {
+    @DisplayName("should return the unexpired access token entity for provider and scope reads")
+    void shouldReturnUnexpiredAccessToken_forProviderAndScopeReads() {
         ServiceAccessTokenDao accessTokenDao = mock(ServiceAccessTokenDao.class);
-        Integer clientId = 7;
-        ServiceAccessToken token = accessToken("scopeless-token", "secret", "999998",
+        ServiceAccessToken token = accessToken("live-token", "secret", "999998",
                 System.currentTimeMillis() / 1000, 3600);
-        token.setClientId(clientId);
-        // scopes intentionally left unset -> getScopes() is null (legacy/empty token)
-        when(accessTokenDao.findByTokenId("scopeless-token")).thenReturn(token);
+        token.setScopes("schedule.read");
+        when(accessTokenDao.findByTokenId("live-token")).thenReturn(token);
+        OscarOAuthDataProvider provider = provider(accessTokenDao);
 
-        ServiceClientDao clientDao = mock(ServiceClientDao.class);
-        ServiceClient client = new ServiceClient();
-        client.setKey("consumer");
-        when(clientDao.find(clientId)).thenReturn(client);
-        when(clientDao.findByKey("consumer")).thenReturn(client);
+        ServiceAccessToken found = provider.findUnexpiredAccessToken("live-token");
 
-        OscarOAuthDataProvider provider = new OscarOAuthDataProvider();
-        ReflectionTestUtils.setField(provider, "serviceAccessTokenDao", accessTokenDao);
-        ReflectionTestUtils.setField(provider, "serviceClientDao", clientDao);
+        // The interceptor reads both the provider and the granted scopes off this one entity.
+        assertThat(found).isNotNull();
+        assertThat(found.getProviderNo()).isEqualTo("999998");
+        assertThat(found.getScopes()).isEqualTo("schedule.read");
+    }
 
-        AccessToken at = provider.getAccessToken("scopeless-token");
+    @Test
+    @DisplayName("should return null from the unexpired lookup when the token is expired")
+    void shouldReturnNull_whenAccessTokenExpired() {
+        ServiceAccessTokenDao accessTokenDao = mock(ServiceAccessTokenDao.class);
+        ServiceAccessToken token = accessToken("expired-token", "secret", "999998",
+                (System.currentTimeMillis() / 1000) - 7200, 3600);
+        when(accessTokenDao.findByTokenId("expired-token")).thenReturn(token);
+        OscarOAuthDataProvider provider = provider(accessTokenDao);
 
-        assertThat(at).isNotNull();
-        assertThat(at.getScopes()).isEmpty();
+        assertThat(provider.findUnexpiredAccessToken("expired-token")).isNull();
+        verify(accessTokenDao).remove(token);
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/login/OscarRequestTokenServiceScopeValidationUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/login/OscarRequestTokenServiceScopeValidationUnitTest.java
@@ -15,6 +15,7 @@ import io.github.carlos_emr.carlos.webserv.oauth.util.OAuth1ParamParser;
 
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -42,9 +43,21 @@ class OscarRequestTokenServiceScopeValidationUnitTest {
     private static final String ENFORCEMENT_PROPERTY = "oauth.scope.enforcement.enabled";
     private static final String CONSUMER_KEY = "consumer-key";
 
+    private String previousEnforcementValue;
+
+    @BeforeEach
+    void captureEnforcementFlag() {
+        previousEnforcementValue = CarlosProperties.getInstance().getProperty(ENFORCEMENT_PROPERTY);
+    }
+
     @AfterEach
-    void clearEnforcementFlag() {
-        CarlosProperties.getInstance().remove(ENFORCEMENT_PROPERTY);
+    void restoreEnforcementFlag() {
+        // Restore (not just remove) so this test cannot clobber a pre-existing value in the shared singleton.
+        if (previousEnforcementValue == null) {
+            CarlosProperties.getInstance().remove(ENFORCEMENT_PROPERTY);
+        } else {
+            CarlosProperties.getInstance().setProperty(ENFORCEMENT_PROPERTY, previousEnforcementValue);
+        }
     }
 
     private void enableEnforcement() {

--- a/src/test/java/io/github/carlos_emr/carlos/login/OscarRequestTokenServiceScopeValidationUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/login/OscarRequestTokenServiceScopeValidationUnitTest.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ */
+package io.github.carlos_emr.carlos.login;
+
+import io.github.carlos_emr.CarlosProperties;
+import io.github.carlos_emr.carlos.webserv.oauth.Client;
+import io.github.carlos_emr.carlos.webserv.oauth.OAuth1Exception;
+import io.github.carlos_emr.carlos.webserv.oauth.OAuth1Request;
+import io.github.carlos_emr.carlos.webserv.oauth.OAuth1SignatureVerifier;
+import io.github.carlos_emr.carlos.webserv.oauth.RequestToken;
+import io.github.carlos_emr.carlos.webserv.oauth.util.OAuth1ParamParser;
+
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Pins the {@code /ws/oauth/initiate} scope vocabulary check (issue #3083): when enforcement is enabled an
+ * empty or unknown scope is rejected with HTTP 400 before any token is persisted, while a known scope is
+ * accepted and the historical lenient behaviour is preserved when the flag is off.
+ */
+@DisplayName("OscarRequestTokenService /initiate scope validation")
+@Tag("unit")
+@Tag("security")
+class OscarRequestTokenServiceScopeValidationUnitTest {
+
+    private static final String ENFORCEMENT_PROPERTY = "oauth.scope.enforcement.enabled";
+    private static final String CONSUMER_KEY = "consumer-key";
+
+    @AfterEach
+    void clearEnforcementFlag() {
+        CarlosProperties.getInstance().remove(ENFORCEMENT_PROPERTY);
+    }
+
+    private void enableEnforcement() {
+        CarlosProperties.getInstance().setProperty(ENFORCEMENT_PROPERTY, "true");
+    }
+
+    @Test
+    @DisplayName("should reject with HTTP 400 when an unknown scope is requested and enforcement is on")
+    void shouldReject_whenUnknownScopeRequested() {
+        enableEnforcement();
+        OscarOAuthDataProvider dataProvider = mock(OscarOAuthDataProvider.class);
+        OscarRequestTokenService service = serviceFor("totally_bogus_zzz", dataProvider);
+
+        OAuth1Exception ex = catchThrowableOfType(
+                () -> service.initiatePost(new MockHttpServletRequest()), OAuth1Exception.class);
+
+        assertThat(ex).isNotNull();
+        assertThat(ex.getHttpCode()).isEqualTo(400);
+        // The arbitrary scope must be rejected before any token is persisted.
+        verify(dataProvider, never()).createRequestToken(any());
+    }
+
+    @Test
+    @DisplayName("should reject with HTTP 400 when no scope is requested and enforcement is on")
+    void shouldReject_whenNoScopeRequested() {
+        enableEnforcement();
+        OscarOAuthDataProvider dataProvider = mock(OscarOAuthDataProvider.class);
+        OscarRequestTokenService service = serviceFor(null, dataProvider);
+
+        OAuth1Exception ex = catchThrowableOfType(
+                () -> service.initiatePost(new MockHttpServletRequest()), OAuth1Exception.class);
+
+        assertThat(ex).isNotNull();
+        assertThat(ex.getHttpCode()).isEqualTo(400);
+    }
+
+    @Test
+    @DisplayName("should issue a request token when a known scope is requested and enforcement is on")
+    void shouldIssueToken_whenKnownScopeRequested() {
+        enableEnforcement();
+        OscarOAuthDataProvider dataProvider = mock(OscarOAuthDataProvider.class);
+        OscarRequestTokenService service = serviceFor("schedule.read", dataProvider);
+
+        Response response = service.initiatePost(new MockHttpServletRequest());
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        verify(dataProvider).createRequestToken(any());
+    }
+
+    @Test
+    @DisplayName("should accept any scope when enforcement is disabled")
+    void shouldAccept_whenEnforcementDisabled() {
+        // Flag left unset (default). An unknown scope must still be accepted for backwards compatibility.
+        OscarOAuthDataProvider dataProvider = mock(OscarOAuthDataProvider.class);
+        OscarRequestTokenService service = serviceFor("totally_bogus_zzz", dataProvider);
+
+        Response response = service.initiatePost(new MockHttpServletRequest());
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        verify(dataProvider).createRequestToken(any());
+    }
+
+    /**
+     * Builds a service whose parser yields a request carrying {@code scopesCsv} and an out-of-band callback,
+     * with a known client and a passing signature so validation is the only gate exercised.
+     */
+    private OscarRequestTokenService serviceFor(String scopesCsv, OscarOAuthDataProvider dataProvider) {
+        when(dataProvider.getClient(CONSUMER_KEY)).thenReturn(mock(Client.class));
+
+        RequestToken requestToken = mock(RequestToken.class);
+        when(requestToken.getTokenKey()).thenReturn("request-token");
+        when(requestToken.getTokenSecret()).thenReturn("request-token-secret");
+        when(dataProvider.createRequestToken(any())).thenReturn(requestToken);
+
+        OAuth1ParamParser parser = mock(OAuth1ParamParser.class);
+        OAuth1Request oreq = new OAuth1Request();
+        oreq.consumerKey = CONSUMER_KEY;
+        oreq.callback = "oob";
+        oreq.scopesCsv = scopesCsv;
+        when(parser.parseFromRequest(any())).thenReturn(oreq);
+
+        OAuth1SignatureVerifier verifier = mock(OAuth1SignatureVerifier.class);
+        when(verifier.verifySignature(any(), any())).thenReturn(null);
+
+        OscarRequestTokenService service = new OscarRequestTokenService(dataProvider, parser);
+        ReflectionTestUtils.setField(service, "verifier", verifier);
+        return service;
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/login/OscarRequestTokenServiceScopeValidationUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/login/OscarRequestTokenServiceScopeValidationUnitTest.java
@@ -47,7 +47,7 @@ class OscarRequestTokenServiceScopeValidationUnitTest {
 
     @BeforeEach
     void captureEnforcementFlag() {
-        previousEnforcementValue = CarlosProperties.getInstance().getProperty(ENFORCEMENT_PROPERTY);
+        previousEnforcementValue = CarlosProperties.getInstance().getProperty(ENFORCEMENT_PROPERTY, null);
     }
 
     @AfterEach
@@ -92,6 +92,8 @@ class OscarRequestTokenServiceScopeValidationUnitTest {
 
         assertThat(ex).isNotNull();
         assertThat(ex.getHttpCode()).isEqualTo(400);
+        // An empty scope set must be rejected before any token is persisted.
+        verify(dataProvider, never()).createRequestToken(any());
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/login/OscarRequestTokenServiceScopeValidationUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/login/OscarRequestTokenServiceScopeValidationUnitTest.java
@@ -2,6 +2,22 @@
  * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
  *
  * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
  */
 package io.github.carlos_emr.carlos.login;
 

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/OAuthScopesUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/OAuthScopesUnitTest.java
@@ -50,6 +50,8 @@ class OAuthScopesUnitTest {
         @DisplayName("should treat a null/blank method as a write for fail-safe behaviour")
         void shouldRequireWrite_whenMethodMissing() {
             assertThat(OAuthScopes.requiredScope(null, SCHEDULE_DAY_PATH)).isEqualTo("schedule.write");
+            assertThat(OAuthScopes.requiredScope("", SCHEDULE_DAY_PATH)).isEqualTo("schedule.write");
+            assertThat(OAuthScopes.requiredScope("   ", SCHEDULE_DAY_PATH)).isEqualTo("schedule.write");
         }
 
         @Test

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/OAuthScopesUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/OAuthScopesUnitTest.java
@@ -22,133 +22,69 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Tag("security")
 class OAuthScopesUnitTest {
 
-    private static final String SCHEDULE_DAY_URI = "/carlos/ws/services/schedule/day/2026-06-29";
-    private static final String TICKLER_MINE_URI = "/carlos/ws/services/tickler/mine";
+    // The resolver consumes the servlet path info (HttpServletRequest.getPathInfo()), which the container
+    // has already decoded and canonicalized to /services/<domain>/... — so these inputs are pre-normalized.
+    private static final String SCHEDULE_DAY_PATH = "/services/schedule/day/2026-06-29";
+    private static final String TICKLER_MINE_PATH = "/services/tickler/mine";
 
     @Nested
-    @DisplayName("requiredScope(method, uri)")
+    @DisplayName("requiredScope(method, servicePath)")
     class RequiredScope {
 
         @Test
         @DisplayName("should require domain.read when method is a safe read on a piloted endpoint")
         void shouldRequireRead_whenSafeMethodOnPilotedEndpoint() {
-            assertThat(OAuthScopes.requiredScope("GET", SCHEDULE_DAY_URI)).isEqualTo("schedule.read");
-            assertThat(OAuthScopes.requiredScope("HEAD", TICKLER_MINE_URI)).isEqualTo("tickler.read");
+            assertThat(OAuthScopes.requiredScope("GET", SCHEDULE_DAY_PATH)).isEqualTo("schedule.read");
+            assertThat(OAuthScopes.requiredScope("HEAD", TICKLER_MINE_PATH)).isEqualTo("tickler.read");
         }
 
         @Test
         @DisplayName("should require domain.write when method mutates on a piloted endpoint")
         void shouldRequireWrite_whenMutatingMethodOnPilotedEndpoint() {
-            assertThat(OAuthScopes.requiredScope("POST", SCHEDULE_DAY_URI)).isEqualTo("schedule.write");
-            assertThat(OAuthScopes.requiredScope("DELETE", TICKLER_MINE_URI)).isEqualTo("tickler.write");
-            assertThat(OAuthScopes.requiredScope("PUT", SCHEDULE_DAY_URI)).isEqualTo("schedule.write");
+            assertThat(OAuthScopes.requiredScope("POST", SCHEDULE_DAY_PATH)).isEqualTo("schedule.write");
+            assertThat(OAuthScopes.requiredScope("DELETE", TICKLER_MINE_PATH)).isEqualTo("tickler.write");
+            assertThat(OAuthScopes.requiredScope("PUT", SCHEDULE_DAY_PATH)).isEqualTo("schedule.write");
         }
 
         @Test
         @DisplayName("should treat a null/blank method as a write for fail-safe behaviour")
         void shouldRequireWrite_whenMethodMissing() {
-            assertThat(OAuthScopes.requiredScope(null, SCHEDULE_DAY_URI)).isEqualTo("schedule.write");
+            assertThat(OAuthScopes.requiredScope(null, SCHEDULE_DAY_PATH)).isEqualTo("schedule.write");
+        }
+
+        @Test
+        @DisplayName("should resolve the domain regardless of casing")
+        void shouldResolveDomain_whenRootIsMixedCase() {
+            assertThat(OAuthScopes.requiredScope("GET", "/services/SCHEDULE/day")).isEqualTo("schedule.read");
+        }
+
+        @Test
+        @DisplayName("should resolve the domain when it is the only segment after services")
+        void shouldResolveDomain_whenDomainIsLastSegment() {
+            assertThat(OAuthScopes.requiredScope("POST", "/services/tickler")).isEqualTo("tickler.write");
         }
 
         @Test
         @DisplayName("should require no scope for an endpoint outside the pilot")
         void shouldRequireNoScope_forUnpilotedDomain() {
-            assertThat(OAuthScopes.requiredScope("GET", "/carlos/ws/services/demographic/1"))
+            assertThat(OAuthScopes.requiredScope("GET", "/services/demographic/1"))
                     .isEqualTo(OAuthScopes.NO_SCOPE_REQUIRED);
         }
 
         @Test
-        @DisplayName("should require no scope when the uri has no services segment")
+        @DisplayName("should require no scope when the path has no services segment")
         void shouldRequireNoScope_whenNoServicesSegment() {
-            assertThat(OAuthScopes.requiredScope("GET", "/carlos/ws/oauth/initiate"))
+            assertThat(OAuthScopes.requiredScope("GET", "/oauth/initiate"))
                     .isEqualTo(OAuthScopes.NO_SCOPE_REQUIRED);
             assertThat(OAuthScopes.requiredScope("GET", null))
                     .isEqualTo(OAuthScopes.NO_SCOPE_REQUIRED);
         }
 
         @Test
-        @DisplayName("should anchor on the ws/services mount and ignore an earlier services segment")
-        void shouldResolveDomain_whenEarlierServicesSegmentPresent() {
-            // The marker is the full /ws/services/ mount, so a decoy earlier 'services' segment must not
-            // misanchor the root and make the piloted endpoint look unpiloted.
-            assertThat(OAuthScopes.requiredScope("GET", "/services/decoy/ws/services/schedule/day"))
-                    .isEqualTo("schedule.read");
-        }
-
-        @Test
-        @DisplayName("should ignore a trailing query string when resolving the domain")
-        void shouldResolveDomain_whenQueryStringPresent() {
-            assertThat(OAuthScopes.requiredScope("GET", "/carlos/ws/services/schedule?date=today"))
-                    .isEqualTo("schedule.read");
-        }
-
-        @Test
-        @DisplayName("should resolve the domain when the path root is percent-encoded")
-        void shouldResolveDomain_whenPercentEncoded() {
-            // %73 decodes to 's' -> the request still routes to the schedule resource and must be enforced
-            assertThat(OAuthScopes.requiredScope("GET", "/carlos/ws/services/%73chedule/day/2026-06-29"))
-                    .isEqualTo("schedule.read");
-        }
-
-        @Test
-        @DisplayName("should strip matrix parameters from the path root")
-        void shouldResolveDomain_whenMatrixParameterPresent() {
-            assertThat(OAuthScopes.requiredScope("GET", "/carlos/ws/services/schedule;v=1/day"))
-                    .isEqualTo("schedule.read");
-        }
-
-        @Test
-        @DisplayName("should strip a percent-encoded matrix delimiter from the path root")
-        void shouldResolveDomain_whenMatrixDelimiterEncoded() {
-            // %3B decodes to ';' -> must still be treated as a matrix delimiter, not part of the domain
-            assertThat(OAuthScopes.requiredScope("POST", "/carlos/ws/services/tickler%3Bx=1/add"))
-                    .isEqualTo("tickler.write");
-        }
-
-        @Test
-        @DisplayName("should collapse a leading dot segment when resolving the domain")
-        void shouldResolveDomain_whenLeadingDotSegment() {
-            assertThat(OAuthScopes.requiredScope("GET", "/carlos/ws/services/./schedule/day"))
-                    .isEqualTo("schedule.read");
-        }
-
-        @Test
-        @DisplayName("should resolve dot-dot segments to the routed domain")
-        void shouldResolveDomain_whenDotDotSegmentPresent() {
-            assertThat(OAuthScopes.requiredScope("GET", "/carlos/ws/services/other/../schedule/day"))
-                    .isEqualTo("schedule.read");
-        }
-
-        @Test
-        @DisplayName("should not let a leading dot-dot segment hide a piloted domain")
-        void shouldResolveDomain_whenLeadingDotDotSegment() {
-            // A leading '..' must not pop the pilot domain off and make the request look unpiloted.
-            assertThat(OAuthScopes.requiredScope("GET", "/carlos/ws/services/../schedule/day"))
-                    .isEqualTo("schedule.read");
-            assertThat(OAuthScopes.requiredScope("POST", "/carlos/ws/services/../../tickler/add"))
-                    .isEqualTo("tickler.write");
-        }
-
-        @Test
-        @DisplayName("should treat an encoded slash as a path separator when resolving the domain")
-        void shouldResolveDomain_whenEncodedSlashPresent() {
-            // %2F decodes to '/'; a decoded slash must be re-split so it cannot mask the pilot root.
-            assertThat(OAuthScopes.requiredScope("GET", "/carlos/ws/services/schedule%2Fday"))
-                    .isEqualTo("schedule.read");
-            // %2e%2e%2f decodes to '../' -> must still resolve through the pilot root, not bypass it.
-            assertThat(OAuthScopes.requiredScope("GET", "/carlos/ws/services/%2e%2e%2fschedule/day"))
-                    .isEqualTo("schedule.read");
-        }
-
-        @Test
-        @DisplayName("should resolve the domain when the mount prefix is percent-encoded")
-        void shouldResolveDomain_whenEncodedMountPrefix() {
-            // %73 decodes to 's' -> /ws/%73ervices/ is the routed /ws/services/ mount and must be enforced.
-            assertThat(OAuthScopes.requiredScope("GET", "/carlos/ws/%73ervices/schedule/day"))
-                    .isEqualTo("schedule.read");
-            // An encoded slash in the mount prefix must also map back to the mount.
-            assertThat(OAuthScopes.requiredScope("POST", "/carlos/ws%2Fservices/tickler/add"))
-                    .isEqualTo("tickler.write");
+        @DisplayName("should require no scope when nothing follows the services segment")
+        void shouldRequireNoScope_whenNothingAfterServices() {
+            assertThat(OAuthScopes.requiredScope("GET", "/services/"))
+                    .isEqualTo(OAuthScopes.NO_SCOPE_REQUIRED);
         }
     }
 

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/OAuthScopesUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/OAuthScopesUnitTest.java
@@ -95,6 +95,20 @@ class OAuthScopesUnitTest {
             assertThat(OAuthScopes.requiredScope("POST", "/carlos/ws/services/tickler%3Bx=1/add"))
                     .isEqualTo("tickler.write");
         }
+
+        @Test
+        @DisplayName("should collapse a leading dot segment when resolving the domain")
+        void shouldResolveDomain_whenLeadingDotSegment() {
+            assertThat(OAuthScopes.requiredScope("GET", "/carlos/ws/services/./schedule/day"))
+                    .isEqualTo("schedule.read");
+        }
+
+        @Test
+        @DisplayName("should resolve dot-dot segments to the routed domain")
+        void shouldResolveDomain_whenDotDotSegmentPresent() {
+            assertThat(OAuthScopes.requiredScope("GET", "/carlos/ws/services/other/../schedule/day"))
+                    .isEqualTo("schedule.read");
+        }
     }
 
     @Nested

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/OAuthScopesUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/OAuthScopesUnitTest.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ */
+package io.github.carlos_emr.carlos.webserv.oauth;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit coverage for the OAuth 1.0a scope vocabulary and matching rules (issue #3083).
+ */
+@DisplayName("OAuthScopes vocabulary and matching")
+@Tag("unit")
+@Tag("security")
+class OAuthScopesUnitTest {
+
+    private static final String SCHEDULE_DAY_URI = "/carlos/ws/services/schedule/day/2026-06-29";
+    private static final String TICKLER_MINE_URI = "/carlos/ws/services/tickler/mine";
+
+    @Nested
+    @DisplayName("requiredScope(method, uri)")
+    class RequiredScope {
+
+        @Test
+        @DisplayName("should require domain.read when method is a safe read on a piloted endpoint")
+        void shouldRequireRead_whenSafeMethodOnPilotedEndpoint() {
+            assertThat(OAuthScopes.requiredScope("GET", SCHEDULE_DAY_URI)).isEqualTo("schedule.read");
+            assertThat(OAuthScopes.requiredScope("HEAD", TICKLER_MINE_URI)).isEqualTo("tickler.read");
+        }
+
+        @Test
+        @DisplayName("should require domain.write when method mutates on a piloted endpoint")
+        void shouldRequireWrite_whenMutatingMethodOnPilotedEndpoint() {
+            assertThat(OAuthScopes.requiredScope("POST", SCHEDULE_DAY_URI)).isEqualTo("schedule.write");
+            assertThat(OAuthScopes.requiredScope("DELETE", TICKLER_MINE_URI)).isEqualTo("tickler.write");
+            assertThat(OAuthScopes.requiredScope("PUT", SCHEDULE_DAY_URI)).isEqualTo("schedule.write");
+        }
+
+        @Test
+        @DisplayName("should treat a null/blank method as a write for fail-safe behaviour")
+        void shouldRequireWrite_whenMethodMissing() {
+            assertThat(OAuthScopes.requiredScope(null, SCHEDULE_DAY_URI)).isEqualTo("schedule.write");
+        }
+
+        @Test
+        @DisplayName("should require no scope for an endpoint outside the pilot")
+        void shouldRequireNoScope_forUnpilotedDomain() {
+            assertThat(OAuthScopes.requiredScope("GET", "/carlos/ws/services/demographic/1"))
+                    .isEqualTo(OAuthScopes.NO_SCOPE_REQUIRED);
+        }
+
+        @Test
+        @DisplayName("should require no scope when the uri has no services segment")
+        void shouldRequireNoScope_whenNoServicesSegment() {
+            assertThat(OAuthScopes.requiredScope("GET", "/carlos/ws/oauth/initiate"))
+                    .isEqualTo(OAuthScopes.NO_SCOPE_REQUIRED);
+            assertThat(OAuthScopes.requiredScope("GET", null))
+                    .isEqualTo(OAuthScopes.NO_SCOPE_REQUIRED);
+        }
+
+        @Test
+        @DisplayName("should ignore a trailing query string when resolving the domain")
+        void shouldResolveDomain_whenQueryStringPresent() {
+            assertThat(OAuthScopes.requiredScope("GET", "/carlos/ws/services/schedule?date=today"))
+                    .isEqualTo("schedule.read");
+        }
+    }
+
+    @Nested
+    @DisplayName("isKnownScope(scope)")
+    class IsKnownScope {
+
+        @Test
+        @DisplayName("should accept a recognised read/write scope case-insensitively")
+        void shouldAccept_forRecognisedScope() {
+            assertThat(OAuthScopes.isKnownScope("schedule.read")).isTrue();
+            assertThat(OAuthScopes.isKnownScope("tickler.write")).isTrue();
+            assertThat(OAuthScopes.isKnownScope("  SCHEDULE.READ  ")).isTrue();
+        }
+
+        @Test
+        @DisplayName("should reject an unknown, empty, or null scope")
+        void shouldReject_forUnknownScope() {
+            assertThat(OAuthScopes.isKnownScope("totally_bogus_zzz")).isFalse();
+            assertThat(OAuthScopes.isKnownScope("schedule")).isFalse();
+            assertThat(OAuthScopes.isKnownScope("")).isFalse();
+            assertThat(OAuthScopes.isKnownScope(null)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("isSatisfiedBy(required, granted)")
+    class IsSatisfiedBy {
+
+        @Test
+        @DisplayName("should be satisfied when no scope is required")
+        void shouldBeSatisfied_whenNoScopeRequired() {
+            assertThat(OAuthScopes.isSatisfiedBy(OAuthScopes.NO_SCOPE_REQUIRED, List.of())).isTrue();
+        }
+
+        @Test
+        @DisplayName("should be satisfied by an exact scope grant")
+        void shouldBeSatisfied_byExactGrant() {
+            assertThat(OAuthScopes.isSatisfiedBy("schedule.read", List.of("schedule.read"))).isTrue();
+        }
+
+        @Test
+        @DisplayName("should let a write grant satisfy the matching read requirement")
+        void shouldBeSatisfied_whenWriteGrantCoversRead() {
+            assertThat(OAuthScopes.isSatisfiedBy("schedule.read", List.of("schedule.write"))).isTrue();
+        }
+
+        @Test
+        @DisplayName("should not let a read grant satisfy a write requirement")
+        void shouldNotBeSatisfied_whenReadGrantForWriteRequirement() {
+            assertThat(OAuthScopes.isSatisfiedBy("schedule.write", List.of("schedule.read"))).isFalse();
+        }
+
+        @Test
+        @DisplayName("should not be satisfied by a scope for a different domain")
+        void shouldNotBeSatisfied_byDifferentDomain() {
+            assertThat(OAuthScopes.isSatisfiedBy("schedule.read", List.of("tickler.write"))).isFalse();
+        }
+
+        @Test
+        @DisplayName("should not be satisfied when no scopes are granted")
+        void shouldNotBeSatisfied_whenNoScopesGranted() {
+            assertThat(OAuthScopes.isSatisfiedBy("schedule.read", List.of())).isFalse();
+            assertThat(OAuthScopes.isSatisfiedBy("schedule.read", null)).isFalse();
+        }
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/OAuthScopesUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/OAuthScopesUnitTest.java
@@ -109,6 +109,16 @@ class OAuthScopesUnitTest {
             assertThat(OAuthScopes.requiredScope("GET", "/carlos/ws/services/other/../schedule/day"))
                     .isEqualTo("schedule.read");
         }
+
+        @Test
+        @DisplayName("should not let a leading dot-dot segment hide a piloted domain")
+        void shouldResolveDomain_whenLeadingDotDotSegment() {
+            // A leading '..' must not pop the pilot domain off and make the request look unpiloted.
+            assertThat(OAuthScopes.requiredScope("GET", "/carlos/ws/services/../schedule/day"))
+                    .isEqualTo("schedule.read");
+            assertThat(OAuthScopes.requiredScope("POST", "/carlos/ws/services/../../tickler/add"))
+                    .isEqualTo("tickler.write");
+        }
     }
 
     @Nested

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/OAuthScopesUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/OAuthScopesUnitTest.java
@@ -72,6 +72,29 @@ class OAuthScopesUnitTest {
             assertThat(OAuthScopes.requiredScope("GET", "/carlos/ws/services/schedule?date=today"))
                     .isEqualTo("schedule.read");
         }
+
+        @Test
+        @DisplayName("should resolve the domain when the path root is percent-encoded")
+        void shouldResolveDomain_whenPercentEncoded() {
+            // %73 decodes to 's' -> the request still routes to the schedule resource and must be enforced
+            assertThat(OAuthScopes.requiredScope("GET", "/carlos/ws/services/%73chedule/day/2026-06-29"))
+                    .isEqualTo("schedule.read");
+        }
+
+        @Test
+        @DisplayName("should strip matrix parameters from the path root")
+        void shouldResolveDomain_whenMatrixParameterPresent() {
+            assertThat(OAuthScopes.requiredScope("GET", "/carlos/ws/services/schedule;v=1/day"))
+                    .isEqualTo("schedule.read");
+        }
+
+        @Test
+        @DisplayName("should strip a percent-encoded matrix delimiter from the path root")
+        void shouldResolveDomain_whenMatrixDelimiterEncoded() {
+            // %3B decodes to ';' -> must still be treated as a matrix delimiter, not part of the domain
+            assertThat(OAuthScopes.requiredScope("POST", "/carlos/ws/services/tickler%3Bx=1/add"))
+                    .isEqualTo("tickler.write");
+        }
     }
 
     @Nested

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/OAuthScopesUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/OAuthScopesUnitTest.java
@@ -139,6 +139,17 @@ class OAuthScopesUnitTest {
             assertThat(OAuthScopes.requiredScope("GET", "/carlos/ws/services/%2e%2e%2fschedule/day"))
                     .isEqualTo("schedule.read");
         }
+
+        @Test
+        @DisplayName("should resolve the domain when the mount prefix is percent-encoded")
+        void shouldResolveDomain_whenEncodedMountPrefix() {
+            // %73 decodes to 's' -> /ws/%73ervices/ is the routed /ws/services/ mount and must be enforced.
+            assertThat(OAuthScopes.requiredScope("GET", "/carlos/ws/%73ervices/schedule/day"))
+                    .isEqualTo("schedule.read");
+            // An encoded slash in the mount prefix must also map back to the mount.
+            assertThat(OAuthScopes.requiredScope("POST", "/carlos/ws%2Fservices/tickler/add"))
+                    .isEqualTo("tickler.write");
+        }
     }
 
     @Nested

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/OAuthScopesUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/OAuthScopesUnitTest.java
@@ -67,6 +67,15 @@ class OAuthScopesUnitTest {
         }
 
         @Test
+        @DisplayName("should anchor on the ws/services mount and ignore an earlier services segment")
+        void shouldResolveDomain_whenEarlierServicesSegmentPresent() {
+            // The marker is the full /ws/services/ mount, so a decoy earlier 'services' segment must not
+            // misanchor the root and make the piloted endpoint look unpiloted.
+            assertThat(OAuthScopes.requiredScope("GET", "/services/decoy/ws/services/schedule/day"))
+                    .isEqualTo("schedule.read");
+        }
+
+        @Test
         @DisplayName("should ignore a trailing query string when resolving the domain")
         void shouldResolveDomain_whenQueryStringPresent() {
             assertThat(OAuthScopes.requiredScope("GET", "/carlos/ws/services/schedule?date=today"))

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/OAuthScopesUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/OAuthScopesUnitTest.java
@@ -36,6 +36,8 @@ class OAuthScopesUnitTest {
         void shouldRequireRead_whenSafeMethodOnPilotedEndpoint() {
             assertThat(OAuthScopes.requiredScope("GET", SCHEDULE_DAY_PATH)).isEqualTo("schedule.read");
             assertThat(OAuthScopes.requiredScope("HEAD", TICKLER_MINE_PATH)).isEqualTo("tickler.read");
+            assertThat(OAuthScopes.requiredScope("OPTIONS", SCHEDULE_DAY_PATH)).isEqualTo("schedule.read");
+            assertThat(OAuthScopes.requiredScope("TRACE", TICKLER_MINE_PATH)).isEqualTo("tickler.read");
         }
 
         @Test

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/OAuthScopesUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/OAuthScopesUnitTest.java
@@ -119,6 +119,17 @@ class OAuthScopesUnitTest {
             assertThat(OAuthScopes.requiredScope("POST", "/carlos/ws/services/../../tickler/add"))
                     .isEqualTo("tickler.write");
         }
+
+        @Test
+        @DisplayName("should treat an encoded slash as a path separator when resolving the domain")
+        void shouldResolveDomain_whenEncodedSlashPresent() {
+            // %2F decodes to '/'; a decoded slash must be re-split so it cannot mask the pilot root.
+            assertThat(OAuthScopes.requiredScope("GET", "/carlos/ws/services/schedule%2Fday"))
+                    .isEqualTo("schedule.read");
+            // %2e%2e%2f decodes to '../' -> must still resolve through the pilot root, not bypass it.
+            assertThat(OAuthScopes.requiredScope("GET", "/carlos/ws/services/%2e%2e%2fschedule/day"))
+                    .isEqualTo("schedule.read");
+        }
     }
 
     @Nested

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/OAuthScopesUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/OAuthScopesUnitTest.java
@@ -2,6 +2,22 @@
  * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
  *
  * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
  */
 package io.github.carlos_emr.carlos.webserv.oauth;
 

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/util/OAuthInterceptorAuditLoggingUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/util/OAuthInterceptorAuditLoggingUnitTest.java
@@ -24,6 +24,7 @@ package io.github.carlos_emr.carlos.webserv.oauth.util;
 import io.github.carlos_emr.carlos.PMmodule.dao.ProviderDao;
 import io.github.carlos_emr.carlos.commn.model.OscarLog;
 import io.github.carlos_emr.carlos.commn.model.Provider;
+import io.github.carlos_emr.carlos.commn.model.ServiceAccessToken;
 import io.github.carlos_emr.carlos.login.AppOAuth1Config;
 import io.github.carlos_emr.carlos.login.OscarOAuthDataProvider;
 import io.github.carlos_emr.carlos.log.LogAction;
@@ -129,7 +130,9 @@ class OAuthInterceptorAuditLoggingUnitTest extends CarlosUnitTestBase {
         Client client = new Client(CONSUMER_KEY, "secret", "test-app", "http://localhost");
         when(oauthDataProvider.getClient(CONSUMER_KEY)).thenReturn(client);
         when(verifier.verifySignature(eq(request), any(AppOAuth1Config.class))).thenReturn(ACCESS_TOKEN);
-        when(oauthDataProvider.getProviderNoByAccessToken(ACCESS_TOKEN)).thenReturn(PROVIDER_NO);
+        ServiceAccessToken sat = new ServiceAccessToken();
+        sat.setProviderNo(PROVIDER_NO);
+        when(oauthDataProvider.findUnexpiredAccessToken(ACCESS_TOKEN)).thenReturn(sat);
         when(providerDao.getProvider(PROVIDER_NO)).thenReturn(new Provider());
 
         interceptor.handleMessage(message);
@@ -148,7 +151,9 @@ class OAuthInterceptorAuditLoggingUnitTest extends CarlosUnitTestBase {
         Client client = new Client(CONSUMER_KEY, "secret", "test-app", "http://localhost");
         when(oauthDataProvider.getClient(CONSUMER_KEY)).thenReturn(client);
         when(verifier.verifySignature(eq(request), any(AppOAuth1Config.class))).thenReturn(ACCESS_TOKEN);
-        when(oauthDataProvider.getProviderNoByAccessToken(ACCESS_TOKEN)).thenReturn(PROVIDER_NO);
+        ServiceAccessToken sat = new ServiceAccessToken();
+        sat.setProviderNo(PROVIDER_NO);
+        when(oauthDataProvider.findUnexpiredAccessToken(ACCESS_TOKEN)).thenReturn(sat);
         when(providerDao.getProvider(PROVIDER_NO)).thenReturn(new Provider());
         // The audit write blows up (e.g. the audit store is unavailable).
         logActionMock.when(() -> LogAction.addLogSynchronous(any(OscarLog.class)))

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/util/OAuthInterceptorScopeEnforcementUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/util/OAuthInterceptorScopeEnforcementUnitTest.java
@@ -5,16 +5,13 @@
  */
 package io.github.carlos_emr.carlos.webserv.oauth.util;
 
-import java.util.List;
-
 import io.github.carlos_emr.CarlosProperties;
 import io.github.carlos_emr.carlos.PMmodule.dao.ProviderDao;
 import io.github.carlos_emr.carlos.commn.model.Provider;
+import io.github.carlos_emr.carlos.commn.model.ServiceAccessToken;
 import io.github.carlos_emr.carlos.login.OscarOAuthDataProvider;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
-import io.github.carlos_emr.carlos.webserv.oauth.AccessToken;
 import io.github.carlos_emr.carlos.webserv.oauth.Client;
-import io.github.carlos_emr.carlos.webserv.oauth.OAuth1Permission;
 import io.github.carlos_emr.carlos.webserv.oauth.OAuth1SignatureVerifier;
 
 import org.apache.cxf.interceptor.Fault;
@@ -92,9 +89,7 @@ class OAuthInterceptorScopeEnforcementUnitTest {
     @DisplayName("should fail closed with HTTP 403 when the token has no granted scopes")
     void shouldRaiseFault_withHttp403WhenTokenHasNoScopes() {
         enableEnforcement();
-        AccessToken noScopes = mock(AccessToken.class);
-        when(noScopes.getScopes()).thenReturn(null);
-        OAuthInterceptor interceptor = interceptorWith(noScopes);
+        OAuthInterceptor interceptor = interceptorWith(accessToken(null));  // null persisted scopes
         Message message = scheduleReadRequest();
 
         Fault fault = catchThrowableOfType(() -> interceptor.handleMessage(message), Fault.class);
@@ -133,13 +128,12 @@ class OAuthInterceptorScopeEnforcementUnitTest {
 
     /**
      * Builds an interceptor whose collaborators authenticate {@link #TOKEN} successfully (valid client,
-     * good signature, resolvable provider) and report the supplied granted scope on the access token.
+     * good signature, resolvable provider) and return the supplied access token from the single token load.
      */
-    private OAuthInterceptor interceptorWith(AccessToken accessToken) {
+    private OAuthInterceptor interceptorWith(ServiceAccessToken accessToken) {
         OscarOAuthDataProvider dataProvider = mock(OscarOAuthDataProvider.class);
         when(dataProvider.getClient(CONSUMER_KEY)).thenReturn(mock(Client.class));
-        when(dataProvider.getProviderNoByAccessToken(TOKEN)).thenReturn(PROVIDER_NO);
-        when(dataProvider.getAccessToken(TOKEN)).thenReturn(accessToken);
+        when(dataProvider.findUnexpiredAccessToken(TOKEN)).thenReturn(accessToken);
 
         ProviderDao providerDao = mock(ProviderDao.class);
         when(providerDao.getProvider(PROVIDER_NO)).thenReturn(mock(Provider.class));
@@ -154,10 +148,16 @@ class OAuthInterceptorScopeEnforcementUnitTest {
         return interceptor;
     }
 
-    private static AccessToken authenticatedTokenGranting(String scope) {
-        AccessToken accessToken = mock(AccessToken.class);
-        when(accessToken.getScopes()).thenReturn(List.of(new OAuth1Permission(scope, scope)));
-        return accessToken;
+    private static ServiceAccessToken authenticatedTokenGranting(String scopes) {
+        return accessToken(scopes);
+    }
+
+    /** A persisted access token bound to {@link #PROVIDER_NO} with the given space-delimited scopes. */
+    private static ServiceAccessToken accessToken(String scopes) {
+        ServiceAccessToken sat = new ServiceAccessToken();
+        sat.setProviderNo(PROVIDER_NO);
+        sat.setScopes(scopes);
+        return sat;
     }
 
     private static Message scheduleReadRequest() {

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/util/OAuthInterceptorScopeEnforcementUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/util/OAuthInterceptorScopeEnforcementUnitTest.java
@@ -50,6 +50,9 @@ class OAuthInterceptorScopeEnforcementUnitTest {
     private static final String TOKEN = "access-token-1";
     private static final String PROVIDER_NO = "999998";
     private static final String SCHEDULE_GET_URI = "/carlos/ws/services/schedule/day/2026-06-29";
+    // The interceptor resolves the scope from getPathInfo(), which the container exposes relative to the
+    // /ws/* servlet mapping (i.e. /services/<domain>/...), already decoded and canonicalized.
+    private static final String SCHEDULE_GET_PATHINFO = "/services/schedule/day/2026-06-29";
 
     private String previousEnforcementValue;
 
@@ -163,6 +166,7 @@ class OAuthInterceptorScopeEnforcementUnitTest {
 
     private static MockHttpServletRequest scheduleReadServletRequest() {
         MockHttpServletRequest request = new MockHttpServletRequest("GET", SCHEDULE_GET_URI);
+        request.setPathInfo(SCHEDULE_GET_PATHINFO);
         request.addParameter("oauth_consumer_key", CONSUMER_KEY);
         request.addParameter("oauth_token", TOKEN);
         return request;

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/util/OAuthInterceptorScopeEnforcementUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/util/OAuthInterceptorScopeEnforcementUnitTest.java
@@ -55,7 +55,7 @@ class OAuthInterceptorScopeEnforcementUnitTest {
 
     @BeforeEach
     void captureEnforcementFlag() {
-        previousEnforcementValue = CarlosProperties.getInstance().getProperty(ENFORCEMENT_PROPERTY);
+        previousEnforcementValue = CarlosProperties.getInstance().getProperty(ENFORCEMENT_PROPERTY, null);
     }
 
     @AfterEach
@@ -77,6 +77,21 @@ class OAuthInterceptorScopeEnforcementUnitTest {
     void shouldRaiseFault_withHttp403WhenScopeInsufficient() {
         enableEnforcement();
         OAuthInterceptor interceptor = interceptorWith(authenticatedTokenGranting("tickler.read"));
+        Message message = scheduleReadRequest();
+
+        Fault fault = catchThrowableOfType(() -> interceptor.handleMessage(message), Fault.class);
+
+        assertThat(fault).isNotNull();
+        assertThat(fault.getStatusCode()).isEqualTo(403);
+    }
+
+    @Test
+    @DisplayName("should fail closed with HTTP 403 when the token has no granted scopes")
+    void shouldRaiseFault_withHttp403WhenTokenHasNoScopes() {
+        enableEnforcement();
+        AccessToken noScopes = mock(AccessToken.class);
+        when(noScopes.getScopes()).thenReturn(null);
+        OAuthInterceptor interceptor = interceptorWith(noScopes);
         Message message = scheduleReadRequest();
 
         Fault fault = catchThrowableOfType(() -> interceptor.handleMessage(message), Fault.class);

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/util/OAuthInterceptorScopeEnforcementUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/util/OAuthInterceptorScopeEnforcementUnitTest.java
@@ -22,6 +22,7 @@ import org.apache.cxf.message.Message;
 import org.apache.cxf.message.MessageImpl;
 import org.apache.cxf.transport.http.AbstractHTTPDestination;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -50,9 +51,21 @@ class OAuthInterceptorScopeEnforcementUnitTest {
     private static final String PROVIDER_NO = "999998";
     private static final String SCHEDULE_GET_URI = "/carlos/ws/services/schedule/day/2026-06-29";
 
+    private String previousEnforcementValue;
+
+    @BeforeEach
+    void captureEnforcementFlag() {
+        previousEnforcementValue = CarlosProperties.getInstance().getProperty(ENFORCEMENT_PROPERTY);
+    }
+
     @AfterEach
-    void clearEnforcementFlag() {
-        CarlosProperties.getInstance().remove(ENFORCEMENT_PROPERTY);
+    void restoreEnforcementFlag() {
+        // Restore (not just remove) so this test cannot clobber a pre-existing value in the shared singleton.
+        if (previousEnforcementValue == null) {
+            CarlosProperties.getInstance().remove(ENFORCEMENT_PROPERTY);
+        } else {
+            CarlosProperties.getInstance().setProperty(ENFORCEMENT_PROPERTY, previousEnforcementValue);
+        }
     }
 
     private void enableEnforcement() {

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/util/OAuthInterceptorScopeEnforcementUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/util/OAuthInterceptorScopeEnforcementUnitTest.java
@@ -1,0 +1,148 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ */
+package io.github.carlos_emr.carlos.webserv.oauth.util;
+
+import java.util.List;
+
+import io.github.carlos_emr.CarlosProperties;
+import io.github.carlos_emr.carlos.PMmodule.dao.ProviderDao;
+import io.github.carlos_emr.carlos.commn.model.Provider;
+import io.github.carlos_emr.carlos.login.OscarOAuthDataProvider;
+import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import io.github.carlos_emr.carlos.webserv.oauth.AccessToken;
+import io.github.carlos_emr.carlos.webserv.oauth.Client;
+import io.github.carlos_emr.carlos.webserv.oauth.OAuth1Permission;
+import io.github.carlos_emr.carlos.webserv.oauth.OAuth1SignatureVerifier;
+
+import org.apache.cxf.interceptor.Fault;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.message.MessageImpl;
+import org.apache.cxf.transport.http.AbstractHTTPDestination;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Pins OAuth 1.0a scope enforcement in {@link OAuthInterceptor} (issue #3083): a token whose granted
+ * scopes do not cover the target endpoint is rejected with HTTP 403, an in-scope token is admitted, and
+ * the whole behaviour stays off unless the {@code oauth.scope.enforcement.enabled} flag is set.
+ */
+@DisplayName("OAuthInterceptor scope enforcement")
+@Tag("unit")
+@Tag("security")
+class OAuthInterceptorScopeEnforcementUnitTest {
+
+    private static final String ENFORCEMENT_PROPERTY = "oauth.scope.enforcement.enabled";
+    private static final String CONSUMER_KEY = "consumer-key";
+    private static final String TOKEN = "access-token-1";
+    private static final String PROVIDER_NO = "999998";
+    private static final String SCHEDULE_GET_URI = "/carlos/ws/services/schedule/day/2026-06-29";
+
+    @AfterEach
+    void clearEnforcementFlag() {
+        CarlosProperties.getInstance().remove(ENFORCEMENT_PROPERTY);
+    }
+
+    private void enableEnforcement() {
+        CarlosProperties.getInstance().setProperty(ENFORCEMENT_PROPERTY, "true");
+    }
+
+    @Test
+    @DisplayName("should raise fault with HTTP 403 when token scope does not cover the endpoint")
+    void shouldRaiseFault_withHttp403WhenScopeInsufficient() {
+        enableEnforcement();
+        OAuthInterceptor interceptor = interceptorWith(authenticatedTokenGranting("tickler.read"));
+        Message message = scheduleReadRequest();
+
+        Fault fault = catchThrowableOfType(() -> interceptor.handleMessage(message), Fault.class);
+
+        assertThat(fault).isNotNull();
+        assertThat(fault.getStatusCode()).isEqualTo(403);
+    }
+
+    @Test
+    @DisplayName("should admit the request when the token carries the required scope")
+    void shouldAdmitRequest_whenTokenHasRequiredScope() {
+        enableEnforcement();
+        OAuthInterceptor interceptor = interceptorWith(authenticatedTokenGranting("schedule.read"));
+        MockHttpServletRequest request = scheduleReadServletRequest();
+        Message message = messageWith(request);
+
+        interceptor.handleMessage(message);
+
+        Object attached = request.getAttribute(new LoggedInInfo().getLoggedInInfoKey());
+        assertThat(attached).isInstanceOf(LoggedInInfo.class);
+    }
+
+    @Test
+    @DisplayName("should admit the request without enforcement when the flag is off")
+    void shouldAdmitRequest_whenEnforcementDisabled() {
+        // Flag intentionally left unset (default). A narrow/irrelevant scope must still be admitted.
+        OAuthInterceptor interceptor = interceptorWith(authenticatedTokenGranting("tickler.read"));
+        MockHttpServletRequest request = scheduleReadServletRequest();
+        Message message = messageWith(request);
+
+        interceptor.handleMessage(message);
+
+        Object attached = request.getAttribute(new LoggedInInfo().getLoggedInInfoKey());
+        assertThat(attached).isInstanceOf(LoggedInInfo.class);
+    }
+
+    /**
+     * Builds an interceptor whose collaborators authenticate {@link #TOKEN} successfully (valid client,
+     * good signature, resolvable provider) and report the supplied granted scope on the access token.
+     */
+    private OAuthInterceptor interceptorWith(AccessToken accessToken) {
+        OscarOAuthDataProvider dataProvider = mock(OscarOAuthDataProvider.class);
+        when(dataProvider.getClient(CONSUMER_KEY)).thenReturn(mock(Client.class));
+        when(dataProvider.getProviderNoByAccessToken(TOKEN)).thenReturn(PROVIDER_NO);
+        when(dataProvider.getAccessToken(TOKEN)).thenReturn(accessToken);
+
+        ProviderDao providerDao = mock(ProviderDao.class);
+        when(providerDao.getProvider(PROVIDER_NO)).thenReturn(mock(Provider.class));
+
+        OAuth1SignatureVerifier verifier = mock(OAuth1SignatureVerifier.class);
+        when(verifier.verifySignature(any(), any())).thenReturn(TOKEN);
+
+        OAuthInterceptor interceptor = new OAuthInterceptor();
+        ReflectionTestUtils.setField(interceptor, "oauthDataProvider", dataProvider);
+        ReflectionTestUtils.setField(interceptor, "providerDao", providerDao);
+        ReflectionTestUtils.setField(interceptor, "verifier", verifier);
+        return interceptor;
+    }
+
+    private static AccessToken authenticatedTokenGranting(String scope) {
+        AccessToken accessToken = mock(AccessToken.class);
+        when(accessToken.getScopes()).thenReturn(List.of(new OAuth1Permission(scope, scope)));
+        return accessToken;
+    }
+
+    private static Message scheduleReadRequest() {
+        return messageWith(scheduleReadServletRequest());
+    }
+
+    private static MockHttpServletRequest scheduleReadServletRequest() {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", SCHEDULE_GET_URI);
+        request.addParameter("oauth_consumer_key", CONSUMER_KEY);
+        request.addParameter("oauth_token", TOKEN);
+        return request;
+    }
+
+    private static Message messageWith(MockHttpServletRequest request) {
+        Message message = new MessageImpl();
+        message.put(AbstractHTTPDestination.HTTP_REQUEST, request);
+        return message;
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/util/OAuthInterceptorScopeEnforcementUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/oauth/util/OAuthInterceptorScopeEnforcementUnitTest.java
@@ -2,6 +2,22 @@
  * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
  *
  * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
  */
 package io.github.carlos_emr.carlos.webserv.oauth.util;
 


### PR DESCRIPTION
fixes #3083

## Problem

OAuth 1.0a access tokens persist the **scopes** a provider approves on the consent screen, but nothing ever read them. Any valid token granted the provider's **full** privileges across the entire `/ws/services/*` surface, and `/ws/oauth/initiate` accepted arbitrary scope strings (even meaningless ones). The audit demonstrated `scope=appointment` and `scope=totally_bogus_zzz` behaving identically.

## Approach (design decisions confirmed with the maintainer)

This is a security-boundary change, so it ships **behind a feature flag, default OFF** — behaviour is unchanged unless an operator sets `oauth.scope.enforcement.enabled` truthy — and the vocabulary/enforcement is **piloted on a small subset** rather than mapping all ~37 services at once.

- **`OAuthScopes`** (new, pure utility): coarse `<domain>.read` / `<domain>.write` vocabulary with *write-implies-read*. Resolves a request's required scope from the HTTP method + the request's **servlet path info** (`getPathInfo()`). Piloted on the `schedule` and `tickler` domains; every other endpoint resolves to `NO_SCOPE_REQUIRED`, so turning the flag on does not break the un-piloted surface.
- **`OAuthInterceptor`**: when enabled, after the token authenticates, resolves the required scope and rejects tokens whose granted scopes don't satisfy it with **HTTP 403 `insufficient_scope`**. The check runs *before* `LoggedInInfo` is attached (an out-of-scope call never reaches the resource with a security context), skips the extra token lookup entirely on un-piloted endpoints, and a config-read failure **fails open** (enforcement stays off) to avoid a blanket OAuth API outage. The existing audit path records the rejection.
- **`OscarRequestTokenService`** (`/initiate`): when enabled, rejects empty or unknown scopes with **HTTP 400 `invalid_scope`** instead of persisting arbitrary strings.

Extending the pilot to the remaining `/ws/services/*` domains — and replacing the method-only read/write heuristic with per-endpoint classification — is tracked as follow-up in #3102.

### Path resolution: `getPathInfo()`, verified live

The scope domain is resolved from `HttpServletRequest.getPathInfo()` — the path the servlet container has already **URL-decoded and canonicalized** (dot-segments collapsed, matrix/path parameters stripped) and that JAX-RS/CXF actually route on — rather than re-parsing the raw `getRequestURI()`. This is strictly more correct (it reads the exact path used for routing) and avoids hand-rolling percent-decode / matrix-strip / dot-segment normalization that can diverge from the container.

Verified live on the CARLOS stack (**Tomcat 11.0.22 + CXF 4.1.5**) with a throwaway `/ws/*` CXF endpoint whose `PRE_INVOKE` interceptor mirrors `OAuthInterceptor`'s request retrieval:

- `message.get(AbstractHTTPDestination.HTTP_REQUEST)` returns the raw container request (`org.apache.catalina.connector.RequestFacade`), so `getPathInfo()` is the container's canonical value.
- For every routed variant — baseline, matrix params (`schedule;v=1`), `./schedule`, `other/../schedule`, encoded chars — the interceptor sees `pathInfo == /services/schedule/day/...`.
- Encoded-slash requests (`%2F`, `%2e%2e%2f`) are rejected by Tomcat with **HTTP 400 before the interceptor runs**; encoded-mount/encoded-domain variants **404** (never reach the resource).

So the earlier URI-normalization rounds were guarding inputs that either never route to the protected resource or are container-rejected. Reading `getPathInfo()` removes that whole class of concern and shrank the resolver + its tests by ~106 lines.

## Scope

- Config-gated (default OFF) OAuth scope enforcement; no behaviour change when the flag is unset.
- Coarse read/write vocabulary on a pilot subset (`schedule`, `tickler`) via a central resolver keyed off the canonical servlet path.
- Request-time enforcement (403) in the interceptor + initiate-time vocabulary validation (400).
- Unit tests for all three pieces.

## Tests added

- `OAuthScopesUnitTest` — vocabulary membership; method + canonical service path → required scope (read/write, mixed-case, unpiloted, no-`/services/`, empty-after-`/services/`); and `isSatisfiedBy` matching incl. write-implies-read and read-does-not-imply-write.
- `OAuthInterceptorScopeEnforcementUnitTest` — **403** when token scope doesn't cover the endpoint, **403 fail-closed** when the token has no scopes, **admit** when it does, and **passthrough** when the flag is off.
- `OscarRequestTokenServiceScopeValidationUnitTest` — **400** on empty/unknown scope (token never persisted), accept known scope, and lenient when the flag is off.

## Local verification

- `mvn test-compile` — BUILD SUCCESS.
- Full OAuth suite (`OAuthScopesUnitTest`, `OAuthInterceptorScopeEnforcementUnitTest`, `OscarRequestTokenServiceScopeValidationUnitTest`, `OscarOAuthDataProviderUnitTest`, `OAuthInterceptorUnitTest`, `OAuthInterceptorAuditLoggingUnitTest`): `Tests run: 62, Failures: 0, Errors: 0`.

## Conventions applied

- New `OAuthScopes` is a static-utility domain noun (no forbidden suffix); side-effect-free and thread-safe.
- New files carry the CARLOS project header; no `@author` tags.
- Audit side effect stays failure-isolated; scope denial throws before the success audit so it's recorded as a failure.
- No PHI in logs or error bodies; static error codes only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Gate OAuth 1.0a scope enforcement behind a configuration flag and pilot it on selected REST endpoints.

New Features:
- Introduce a central OAuthScopes utility defining a coarse <domain>.read/<domain>.write scope vocabulary and request-to-scope resolution for piloted services.
- Add request-time OAuth 1.0a scope checks in the OAuthInterceptor to reject out-of-scope access when enforcement is enabled.
- Add scope validation to OscarRequestTokenService so /ws/oauth/initiate only issues tokens with recognised, non-empty scopes when enforcement is enabled.

Enhancements:
- Ensure scope enforcement fails open when configuration cannot be read to avoid blocking all OAuth traffic.

Tests:
- Add unit tests covering OAuthScopes vocabulary, matching rules, and request URI/method mapping to required scopes.
- Add unit tests for OAuthInterceptor scope enforcement behaviour, including 403 insufficient_scope responses and flag-controlled passthrough.
- Add unit tests for OscarRequestTokenService scope validation at /initiate, including 400 invalid_scope responses and backwards-compatible behaviour when enforcement is disabled.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds config-gated OAuth 1.0a scope enforcement and scope validation. When enabled, `schedule` and `tickler` require `<domain>.read`/`<domain>.write` (TRACE counts as read), `/ws/oauth/initiate` rejects empty/unknown scopes, and the interceptor reads provider + scopes in a single access-token lookup. Progress on #3083.

- **New Features**
  - Feature flag: `oauth.scope.enforcement.enabled` (default off).
  - `OAuthScopes`: resolve required scope from HTTP method + servlet `getPathInfo()`; safe methods (GET/HEAD/OPTIONS/TRACE) require read; write implies read; pilot covers `schedule` and `tickler`.
  - `OAuthInterceptor`: enforce before `LoggedInInfo`; 403 `insufficient_scope`; single `findUnexpiredAccessToken` read for provider and scopes; fails open on config errors; skips unpiloted endpoints.
  - `OscarRequestTokenService`: `/initiate` trims and validates `scopesCsv`; rejects empty/unknown scopes with 400 `invalid_scope` when enforcement is on.

- **Bug Fixes**
  - Prevent scope-bypass by resolving from canonical `getPathInfo()` under the `/ws/*` mount (decoy segments don’t affect routing; encoded slashes are container-rejected).
  - Fail closed on null/blank persisted scopes; replace locale-sensitive case-folding with fixed ASCII folding.

<sup>Written for commit cf1528c8aced3dac53b55cc51feb1cbb8f4c062e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3094?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

