### PR TITLE
Investigate provider-to-patient email functionality in CARLOS

### DIFF
--- a/docs/specs/provider-patient-email-investigation.md
+++ b/docs/specs/provider-patient-email-investigation.md
@@ -1,0 +1,28 @@
+# Provider-to-Patient Email Investigation
+
+## Purpose
+
+Investigate how provider-to-patient email functionality works in CARLOS, including available user flows, backend routing, configuration requirements, and expected behavior in local development.
+
+## Scope
+
+- Identify UI entry points for provider-to-patient email.
+- Trace backend actions and services used to compose and send email.
+- Confirm required permissions, patient data, consent, and sender configuration.
+- Verify whether email is available as a direct chart workflow, eForm workflow, or both.
+- Document local development behavior and expected setup requirements.
+- Capture gaps, confusing user experience, and failure modes for follow-up work.
+
+## Validation Plan
+
+- Test provider workflow from a patient chart.
+- Test eForm email workflow.
+- Confirm behavior when the patient has no email address.
+- Confirm behavior when consent is missing or not explicit opt-in.
+- Confirm behavior when no sender account is configured.
+- Confirm behavior when SMTP or API delivery is unavailable.
+- Review email logs and status handling after attempted sends.
+
+## Findings
+
+Detailed findings will be added as pull request comments as the workflow is traced and verified.


### PR DESCRIPTION
## Summary

This PR investigates how provider-to-patient email functionality currently works in CARLOS, including the available user flows, backend routing, configuration requirements, and expected behavior in local development.

## Scope

- Identify all UI entry points for provider-to-patient email.
- Trace the backend actions and services used to compose and send email.
- Confirm required permissions, patient data, consent, and sender configuration.
- Verify whether email is available as a direct chart workflow, eForm workflow, or both.
- Document local development behavior and any expected setup requirements.
- Capture gaps, confusing UX, or failure modes for follow-up work.

## Validation Plan

- Test the provider workflow from a patient chart.
- Test the eForm email workflow.
- Confirm behavior when the patient has no email address.
- Confirm behavior when consent is missing or not explicit opt-in.
- Confirm behavior when no sender account is configured.
- Confirm behavior when SMTP/API delivery is unavailable.
- Review email logs/status handling after attempted sends.

## Notes

Detailed findings will be added as PR comments as each part of the workflow is traced and verified.

## Summary by Sourcery

Documentation:
- Add a specification document outlining the purpose, scope, and validation plan for investigating provider-to-patient email workflows in CARLOS.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a documentation spec mapping provider‑to‑patient email in CARLOS: UI entry points, backend routes, required permissions/consent, sender config, and local setup. Includes a validation plan to test chart/eForm flows, edge cases (no email/consent, delivery outages), and review logs/status to capture gaps and failure modes.

<sup>Written for commit a5cbedc4327a095b0031af2bd7ad06dae3a34385. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3096?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

