### PR TITLE
fix: exclude eForm document routes from logout broadcast injection

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/app/LogoutBroadcastFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/app/LogoutBroadcastFilter.java
@@ -35,6 +35,7 @@ import java.util.Set;
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.FilterConfig;
+import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.ServletRequest;
@@ -348,6 +349,14 @@ public class LogoutBroadcastFilter implements Filter {
     /**
      * Returns a context-relative request path for filter matching.
      *
+     * <p>During a {@code RequestDispatcher.forward()} — e.g. a Struts action forwarding its route to
+     * an internal {@code /WEB-INF/jsp} view — {@code getServletPath()}/{@code getRequestURI()} reflect
+     * the forward <em>target</em> (the JSP), not the route the client requested. The exclusion list is
+     * configured with client-facing routes, and the heartbeat script is appended on the FORWARD
+     * dispatch, so matching against the forward target would silently miss excluded routes on the very
+     * dispatch where injection happens. When the original request URI is available via the standard
+     * {@link RequestDispatcher#FORWARD_REQUEST_URI} attribute, match against it instead (issue #3099).</p>
+     *
      * <p>Some servlet containers or tests leave {@code servletPath} empty for extensionless routes,
      * so this method falls back to {@code requestURI} and removes the context path before
      * normalizing.</p>
@@ -356,22 +365,38 @@ public class LogoutBroadcastFilter implements Filter {
      * @return normalized path beginning with {@code /}, or null when no path is available
      */
     private String getNormalizedRequestPath(HttpServletRequest request) {
-        String servletPath = request.getServletPath();
-        if (servletPath == null || servletPath.trim().isEmpty()) {
-            servletPath = request.getRequestURI();
-            String contextPath = request.getContextPath();
-            if (servletPath != null && contextPath != null && !contextPath.isEmpty()
-                    && servletPath.startsWith(contextPath)) {
-                servletPath = servletPath.substring(contextPath.length());
+        String path = (String) request.getAttribute(RequestDispatcher.FORWARD_REQUEST_URI);
+        if (path != null && !path.trim().isEmpty()) {
+            path = stripContextPath(path, request.getContextPath());
+        } else {
+            path = request.getServletPath();
+            if (path == null || path.trim().isEmpty()) {
+                path = stripContextPath(request.getRequestURI(), request.getContextPath());
             }
         }
 
-        if (servletPath == null || servletPath.trim().isEmpty()) {
+        if (path == null || path.trim().isEmpty()) {
             return null;
         }
 
-        servletPath = normalizeServletPath(servletPath);
-        return servletPath.startsWith("/") ? servletPath : "/" + servletPath;
+        path = normalizeServletPath(path);
+        return path.startsWith("/") ? path : "/" + path;
+    }
+
+    /**
+     * Removes the leading context path from an absolute request URI so it can be matched against the
+     * context-relative routes configured in the exclusion list.
+     *
+     * @param uri absolute request URI (may be null)
+     * @param contextPath servlet context path (may be null or empty for the root context)
+     * @return the context-relative path, or the original URI when no context path prefix applies
+     */
+    private String stripContextPath(String uri, String contextPath) {
+        if (uri != null && contextPath != null && !contextPath.isEmpty()
+                && uri.startsWith(contextPath)) {
+            return uri.substring(contextPath.length());
+        }
+        return uri;
     }
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/app/LogoutBroadcastFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/app/LogoutBroadcastFilter.java
@@ -379,6 +379,7 @@ public class LogoutBroadcastFilter implements Filter {
             return null;
         }
 
+        path = stripPathParameters(path);
         path = normalizeServletPath(path);
         return path.startsWith("/") ? path : "/" + path;
     }
@@ -397,6 +398,23 @@ public class LogoutBroadcastFilter implements Filter {
             return uri.substring(contextPath.length());
         }
         return uri;
+    }
+
+    /**
+     * Removes path/matrix parameters (e.g. {@code ;jsessionid=...}) from each path segment so a route
+     * matches the exclusion list regardless of URL-rewritten session ids. This mirrors the container's
+     * {@code getServletPath()}, which strips them on its own; the {@code requestURI} and
+     * {@code FORWARD_REQUEST_URI} fallbacks used above do not, so an excluded route carrying a rewritten
+     * {@code ;jsessionid} would otherwise fail to match.
+     *
+     * @param path context-relative path that may carry path parameters
+     * @return the path with any {@code ;param} suffix stripped from every segment
+     */
+    private String stripPathParameters(String path) {
+        if (path.indexOf(';') < 0) {
+            return path;
+        }
+        return path.replaceAll(";[^/]*", "");
     }
 
     /**

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -248,9 +248,16 @@
 	<filter>
 		<filter-name>LogoutBroadcastFilter</filter-name>
 		<filter-class>io.github.carlos_emr.carlos.app.LogoutBroadcastFilter</filter-class>
+		<!--
+		     eForm document routes are excluded because the Rich Text Letter editor reads the
+		     returned document HTML through innerHTML/textContent; appended logout/session
+		     heartbeat script would otherwise become editable letter content. See issue #3099.
+		     The .jsp alias is listed explicitly: the exclusion matcher treats it as a sibling
+		     of the extensionless route, not a child, so the bare path does not cover it.
+		-->
 		<init-param>
 			<param-name>exclusions</param-name>
-			<param-value>/logoutPage,/status/SessionHeartbeat</param-value>
+			<param-value>/logoutPage,/status/SessionHeartbeat,/eform/efmformadd_data,/eform/efmshowform_data,/eform/efmformrtl_templates,/eform/efmformrtl_templates.jsp</param-value>
 		</init-param>
 	</filter>
 

--- a/src/test/java/io/github/carlos_emr/carlos/app/LogoutBroadcastFilterUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/app/LogoutBroadcastFilterUnitTest.java
@@ -502,6 +502,42 @@ class LogoutBroadcastFilterUnitTest {
     }
 
     @Test
+    @DisplayName("should not inject logout script when an excluded eForm forward carries a rewritten jsessionid")
+    void shouldNotInjectLogoutScript_whenEformForwardCarriesRewrittenSessionId() throws Exception {
+        // With URL-rewritten sessions the original request URI carries ;jsessionid=...; path parameters
+        // must be stripped before matching so the excluded route still matches on the forward dispatch.
+        LogoutBroadcastFilter eformAwareFilter = eformExclusionFilter();
+        try {
+            MockHttpServletRequest request = authenticatedRequest("/eform/efmformadd_data");
+            request.setServletPath("/eform/efmformadd_data");
+            TrackingMockHttpServletResponse response = new TrackingMockHttpServletResponse();
+
+            FilterChain forwardingChain = (servletRequest, servletResponse) -> {
+                MockHttpServletRequest forwarded = (MockHttpServletRequest) servletRequest;
+                forwarded.setDispatcherType(DispatcherType.FORWARD);
+                forwarded.setAttribute(RequestDispatcher.FORWARD_REQUEST_URI,
+                        "/carlos/eform/efmformadd_data;jsessionid=ABC123");
+                forwarded.setServletPath("/WEB-INF/jsp/eform/efmformadd_data.jsp");
+                forwarded.setRequestURI("/carlos/WEB-INF/jsp/eform/efmformadd_data.jsp");
+                eformAwareFilter.doFilter(forwarded, servletResponse, (nestedRequest, nestedResponse) -> {
+                    nestedResponse.setContentType("text/html;charset=UTF-8");
+                    nestedResponse.getWriter().write("<html><body>eform document</body></html>");
+                });
+            };
+
+            eformAwareFilter.doFilter(request, response, forwardingChain);
+
+            assertThat(response.getContentAsString())
+                    .as("excluded eForm forward with a rewritten jsessionid must be returned verbatim")
+                    .isEqualTo("<html><body>eform document</body></html>");
+            assertThat(response.getContentAsString()).doesNotContain("window.__carlosLogoutActive=true;");
+            assertThat(response.getSetBufferSizeCallCount()).isZero();
+        } finally {
+            eformAwareFilter.destroy();
+        }
+    }
+
+    @Test
     @DisplayName("should suppress stale content length when logout script is appended")
     void shouldSuppressStaleContentLength_whenLogoutScriptIsAppended() throws Exception {
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/provider/providercontrol");

--- a/src/test/java/io/github/carlos_emr/carlos/app/LogoutBroadcastFilterUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/app/LogoutBroadcastFilterUnitTest.java
@@ -27,6 +27,7 @@ import io.github.carlos_emr.carlos.utility.ResponseSanitizationFilter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.FilterConfig;
+import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.WriteListener;
@@ -427,6 +428,77 @@ class LogoutBroadcastFilterUnitTest {
         LogoutBroadcastFilter eformAwareFilter = new LogoutBroadcastFilter();
         eformAwareFilter.init(config);
         return eformAwareFilter;
+    }
+
+    @Test
+    @DisplayName("should not inject logout script when an excluded eForm route is forwarded to its internal WEB-INF view")
+    void shouldNotInjectLogoutScript_whenEformRouteForwardedToInternalView() throws Exception {
+        // The eForm gate actions forward the client route (e.g. /eform/efmformadd_data) to an
+        // internal /WEB-INF/jsp view. The heartbeat script is appended on the FORWARD dispatch, where
+        // getServletPath() reflects the JSP target, not the excluded route — so exclusion must be
+        // resolved from the original request URI (issue #3099).
+        LogoutBroadcastFilter eformAwareFilter = eformExclusionFilter();
+        try {
+            MockHttpServletRequest request = authenticatedRequest("/eform/efmformadd_data");
+            request.setServletPath("/eform/efmformadd_data");
+            TrackingMockHttpServletResponse response = new TrackingMockHttpServletResponse();
+
+            FilterChain forwardingChain = (servletRequest, servletResponse) -> {
+                MockHttpServletRequest forwarded = (MockHttpServletRequest) servletRequest;
+                forwarded.setDispatcherType(DispatcherType.FORWARD);
+                forwarded.setAttribute(RequestDispatcher.FORWARD_REQUEST_URI, "/carlos/eform/efmformadd_data");
+                forwarded.setServletPath("/WEB-INF/jsp/eform/efmformadd_data.jsp");
+                forwarded.setRequestURI("/carlos/WEB-INF/jsp/eform/efmformadd_data.jsp");
+                eformAwareFilter.doFilter(forwarded, servletResponse, (nestedRequest, nestedResponse) -> {
+                    nestedResponse.setContentType("text/html;charset=UTF-8");
+                    nestedResponse.getWriter().write("<html><body>eform document</body></html>");
+                });
+            };
+
+            eformAwareFilter.doFilter(request, response, forwardingChain);
+
+            assertThat(response.getContentAsString())
+                    .as("eForm document forwarded to its internal view must be returned verbatim")
+                    .isEqualTo("<html><body>eform document</body></html>");
+            assertThat(response.getContentAsString()).doesNotContain("window.__carlosLogoutActive=true;");
+            assertThat(response.getSetBufferSizeCallCount())
+                    .as("excluded eForm forward must skip the injection buffer on both dispatches")
+                    .isZero();
+        } finally {
+            eformAwareFilter.destroy();
+        }
+    }
+
+    @Test
+    @DisplayName("should still inject logout script when a normal authenticated page is forwarded to its internal WEB-INF view")
+    void shouldStillInjectLogoutScript_whenNormalPageForwardedToInternalView() throws Exception {
+        LogoutBroadcastFilter eformAwareFilter = eformExclusionFilter();
+        try {
+            MockHttpServletRequest request = authenticatedRequest("/provider/providercontrol");
+            request.setServletPath("/provider/providercontrol");
+            TrackingMockHttpServletResponse response = new TrackingMockHttpServletResponse();
+
+            FilterChain forwardingChain = (servletRequest, servletResponse) -> {
+                MockHttpServletRequest forwarded = (MockHttpServletRequest) servletRequest;
+                forwarded.setDispatcherType(DispatcherType.FORWARD);
+                forwarded.setAttribute(RequestDispatcher.FORWARD_REQUEST_URI, "/carlos/provider/providercontrol");
+                forwarded.setServletPath("/WEB-INF/jsp/provider/providercontrol.jsp");
+                forwarded.setRequestURI("/carlos/WEB-INF/jsp/provider/providercontrol.jsp");
+                eformAwareFilter.doFilter(forwarded, servletResponse, (nestedRequest, nestedResponse) -> {
+                    nestedResponse.setContentType("text/html;charset=UTF-8");
+                    nestedResponse.getWriter().write("<html><body>schedule</body></html>");
+                });
+            };
+
+            eformAwareFilter.doFilter(request, response, forwardingChain);
+
+            String content = response.getContentAsString();
+            assertThat(content).contains("<html><body>schedule</body></html>");
+            assertThat(content).contains("window.__carlosLogoutActive=true;");
+            assertThat(content).contains("fetch(cp+'/status/SessionHeartbeat?autoRefresh=true')");
+        } finally {
+            eformAwareFilter.destroy();
+        }
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/app/LogoutBroadcastFilterUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/app/LogoutBroadcastFilterUnitTest.java
@@ -347,6 +347,88 @@ class LogoutBroadcastFilterUnitTest {
         }
     }
 
+    /**
+     * Exclusion list mirroring the production {@code web.xml} LogoutBroadcastFilter init-param.
+     * The eForm document routes must be excluded so the Rich Text Letter editor never reads the
+     * injected logout/session script as editable letter content (issue #3099). The {@code .jsp}
+     * alias is listed explicitly because the matcher treats it as a sibling, not a child, of the
+     * extensionless route.
+     */
+    private static final String EFORM_DOCUMENT_EXCLUSIONS =
+            "/logoutPage,/status/SessionHeartbeat,/eform/efmformadd_data,/eform/efmshowform_data,"
+            + "/eform/efmformrtl_templates,/eform/efmformrtl_templates.jsp";
+
+    @Test
+    @DisplayName("should not inject logout script into eForm Rich Text Letter document routes")
+    void shouldNotInjectLogoutScript_intoEformDocumentRoutes() throws Exception {
+        LogoutBroadcastFilter eformAwareFilter = eformExclusionFilter();
+        try {
+            for (String route : new String[]{
+                    "/eform/efmformadd_data",
+                    "/eform/efmshowform_data",
+                    "/eform/efmformrtl_templates",
+                    "/eform/efmformrtl_templates.jsp"}) {
+                MockHttpServletRequest request = authenticatedRequest(route);
+                TrackingMockHttpServletResponse response = new TrackingMockHttpServletResponse();
+
+                FilterChain chain = (servletRequest, servletResponse) -> {
+                    servletResponse.setContentType("text/html;charset=UTF-8");
+                    servletResponse.getWriter().write("<html><body>eform document</body></html>");
+                };
+
+                eformAwareFilter.doFilter(request, response, chain);
+
+                assertThat(response.getContentAsString())
+                        .as("eForm document route %s must be returned verbatim", route)
+                        .isEqualTo("<html><body>eform document</body></html>");
+                assertThat(response.getContentAsString()).doesNotContain("window.__carlosLogoutActive=true;");
+                assertThat(response.getSetBufferSizeCallCount())
+                        .as("excluded eForm route %s must skip the injection buffer", route)
+                        .isZero();
+            }
+        } finally {
+            eformAwareFilter.destroy();
+        }
+    }
+
+    @Test
+    @DisplayName("should still inject logout script on normal authenticated pages when eForm routes are excluded")
+    void shouldStillInjectLogoutScript_onNormalPagesWhenEformRoutesExcluded() throws Exception {
+        LogoutBroadcastFilter eformAwareFilter = eformExclusionFilter();
+        try {
+            MockHttpServletRequest request = authenticatedRequest("/provider/providercontrol");
+            TrackingMockHttpServletResponse response = new TrackingMockHttpServletResponse();
+
+            FilterChain chain = (servletRequest, servletResponse) -> {
+                servletResponse.setContentType("text/html;charset=UTF-8");
+                servletResponse.getWriter().write("<html><body>schedule</body></html>");
+            };
+
+            eformAwareFilter.doFilter(request, response, chain);
+
+            String content = response.getContentAsString();
+            assertThat(content).contains("<html><body>schedule</body></html>");
+            assertThat(content).contains("window.__carlosLogoutActive=true;");
+            assertThat(content).contains("fetch(cp+'/status/SessionHeartbeat?autoRefresh=true')");
+        } finally {
+            eformAwareFilter.destroy();
+        }
+    }
+
+    /**
+     * Builds a filter configured with the production eForm exclusion list.
+     *
+     * @return an initialized LogoutBroadcastFilter mirroring the web.xml exclusions
+     * @throws ServletException if filter initialization fails
+     */
+    private LogoutBroadcastFilter eformExclusionFilter() throws ServletException {
+        FilterConfig config = mock(FilterConfig.class);
+        when(config.getInitParameter("exclusions")).thenReturn(EFORM_DOCUMENT_EXCLUSIONS);
+        LogoutBroadcastFilter eformAwareFilter = new LogoutBroadcastFilter();
+        eformAwareFilter.init(config);
+        return eformAwareFilter;
+    }
+
     @Test
     @DisplayName("should suppress stale content length when logout script is appended")
     void shouldSuppressStaleContentLength_whenLogoutScriptIsAppended() throws Exception {


### PR DESCRIPTION
## Summary

Follow-up to investigation #3096 (separate concern from the email-compose layout PR). The eForm **Rich Text Letter** editor was displaying injected logout/session JavaScript as letter *content*.

`LogoutBroadcastFilter` appends session heartbeat / logout broadcast script to authenticated `text/html` responses. The eForm document routes return editable eForm document HTML, and the Rich Text Letter reads iframe/body content through `innerHTML`/`textContent` — so the injected app chrome became editable document content.

fixes #3099

## Scope

- Exclude the eForm document routes from logout-script injection via the filter's existing `exclusions` init-param.
- Make those route exclusions actually take effect on the dispatch where the script is appended (see below) without touching buffering, wrapper, `Content-Length`, or dispatcher-mapping behavior.
- Add focused regression coverage, including the forward dispatch.
- Verify the heartbeat still injects on normal authenticated pages.

## Changes

**`src/main/webapp/WEB-INF/web.xml`**
- Extended the `LogoutBroadcastFilter` `exclusions` init-param with `/eform/efmformadd_data`, `/eform/efmshowform_data`, `/eform/efmformrtl_templates`, and the `/eform/efmformrtl_templates.jsp` alias. The `.jsp` alias is listed explicitly because `matchesExcludedPath` treats it as a sibling (not a child) of the extensionless route, so the bare path would not cover it. Added an inline comment explaining why.

**`src/main/java/io/github/carlos_emr/carlos/app/LogoutBroadcastFilter.java`**
- `getNormalizedRequestPath()` now resolves the path used for exclusion matching from the original request URI (`RequestDispatcher.FORWARD_REQUEST_URI`) when the request is a forward, falling back to `servletPath`/`requestURI` otherwise. Extracted a small private `stripContextPath` helper. No buffering, wrapper, `Content-Length`, or dispatcher-mapping changes.
- Added a `stripPathParameters` helper and applied it before matching, so `;`-delimited path/matrix parameters (e.g. a URL-rewritten `;jsessionid=...`) are removed from each path segment. This mirrors what the container's `getServletPath()` already does; the `requestURI`/`FORWARD_REQUEST_URI` fallbacks do not, so an excluded route carrying a rewritten session id would otherwise fail to match.

**`src/test/java/io/github/carlos_emr/carlos/app/LogoutBroadcastFilterUnitTest.java`**
- `shouldNotInjectLogoutScript_intoEformDocumentRoutes` — each of the four eForm routes is returned verbatim with no injected script and no injection buffer reserved.
- `shouldStillInjectLogoutScript_onNormalPagesWhenEformRoutesExcluded` — a normal authenticated page (`/provider/providercontrol`) still receives the heartbeat/broadcast script with the same exclusion config.
- `shouldNotInjectLogoutScript_whenEformRouteForwardedToInternalView` — an excluded eForm route forwarded to its internal `/WEB-INF/jsp` view is returned verbatim with no injection and no buffer reserved.
- `shouldStillInjectLogoutScript_whenNormalPageForwardedToInternalView` — a normal authenticated page forwarded to its internal view still receives the heartbeat script.
- `shouldNotInjectLogoutScript_whenEformForwardCarriesRewrittenSessionId` — an excluded eForm route forwarded with a rewritten `;jsessionid` is returned verbatim with no injection and no buffer reserved.

## Why the filter also needed a code change

The exclusions are configured as client-facing routes (e.g. `/eform/efmformadd_data`). But the eForm gate actions serve those routes by `RequestDispatcher.forward()` to an internal `/WEB-INF/jsp` view, and the heartbeat script is appended on the **FORWARD** dispatch — where `getServletPath()`/`getRequestURI()` reflect the JSP target rather than the requested route. So a route-only exclusion never matched the dispatch where injection happens, and the script was still injected into eForm documents. Resolving the match path from `FORWARD_REQUEST_URI` (and stripping any path parameters before matching) makes the route exclusions apply on both the REQUEST and FORWARD dispatches and regardless of URL-rewritten session ids, which keeps the fix targeted by route as CLAUDE.md requires for response-rewriting infrastructure (`LogoutBroadcastFilter`).

## Testing

- `mvn -o test -Dtest=LogoutBroadcastFilterUnitTest` → **Tests run: 40, Failures: 0, Errors: 0, Skipped: 0** (35 existing + 5 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude eForm document routes from the `LogoutBroadcastFilter` and match exclusions against the original request on forwards. Also strip path parameters (e.g., ;jsessionid) before matching, so the logout/heartbeat script never appears in Rich Text Letter documents while staying on normal pages. Fixes #3099.

- **Bug Fixes**
  - Updated `web.xml` exclusions for `/eform/efmformadd_data`, `/eform/efmshowform_data`, `/eform/efmformrtl_templates`, and `/eform/efmformrtl_templates.jsp`.
  - `LogoutBroadcastFilter` now matches exclusions using the original URI on `RequestDispatcher.forward()` and strips path parameters before matching.
  - Added tests for direct and forwarded eForm routes and URL-rewritten sessions (no injection), and normal pages (still injects).

<sup>Written for commit e6c5c551acda95d2f0d34580929ecb39ad75e81f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


