### PR TITLE
Fix/logsafe demographicno logging

### DIFF
--- a/dependencies-lock.json
+++ b/dependencies-lock.json
@@ -1061,11 +1061,11 @@
   }, {
     "groupId" : "net.java.dev.jna",
     "artifactId" : "jna",
-    "version" : "5.18.1",
+    "version" : "5.19.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:6Fmqe/AyJdrN0EPGf5OeklDj4iPvAxoMtncXl0Ni6d8r0dnXBOe1LnQIIw8B2Ba6t+wadF2c8v6ybr2DmAJsfg=="
+    "integrity" : "sha512:39wcr9Gn/7RBOMYsO3PSpIyW71rpXFEnWplfp31kueAGhvrLltpWXdRFH95prpe+2UHhjr5YzN2bXpC6V2iKDQ=="
   }, {
     "groupId" : "net.sf.jasperreports",
     "artifactId" : "jasperreports-data-adapters",

--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,8 @@
         <owasp-encoder.version>1.4.0</owasp-encoder.version>
         <!-- OWASP CSRFGuard -->
         <csrfguard.version>4.5.0-jakarta</csrfguard.version>
+        <!-- JNA: pin transitive ultrabuk-htmltopdf-java range [5.12,) to the locked version -->
+        <jna.version>5.19.0</jna.version>
         <!-- HAPI HL7 v2 -->
         <hapi-hl7.version>1.0.1</hapi-hl7.version>
         <!-- Testing -->
@@ -208,6 +210,12 @@
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
                 <version>2.13.2</version>
+            </dependency>
+            <!-- Pin transitive JNA range from ultrabuk-htmltopdf-java to the dependency lock. -->
+            <dependency>
+                <groupId>net.java.dev.jna</groupId>
+                <artifactId>jna</artifactId>
+                <version>${jna.version}</version>
             </dependency>
             <!-- Force secure versions of ALL Netty modules to fix multiple CVEs:
                  - HTTP/2 DDoS (MadeYouReset) in netty-codec-http2

--- a/src/main/java/io/github/carlos_emr/carlos/app/CsrfGuardScriptInjectionFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/app/CsrfGuardScriptInjectionFilter.java
@@ -270,6 +270,8 @@ public class CsrfGuardScriptInjectionFilter implements Filter {
      * on the underlying response. Calling {@code getOutputStream()} after
      * {@code getWriter()} throws {@code IllegalStateException}.</p>
      */
+    // FindSecBugs XSS_SERVLET: replays captured response content after trusted CSRF token injection; not raw request data.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "replays captured response content after trusted CSRF token injection; not raw request data")
     private void writeToResponse(HttpServletResponse response, String content, String safeRequestUri)
             throws IOException {
         // Clear only the response body buffer, preserving status code, headers, and cookies

--- a/src/main/java/io/github/carlos_emr/carlos/app/LogoutBroadcastFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/app/LogoutBroadcastFilter.java
@@ -431,6 +431,8 @@ public class LogoutBroadcastFilter implements Filter {
      * @param script String the script content to append
      * @throws IOException if the writer flush fails
      */
+    // FindSecBugs XSS_SERVLET: intentionally injects logout-broadcast script; buildScript encodes dynamic values for JavaScript.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "intentionally injects logout-broadcast script; buildScript encodes dynamic values for JavaScript")
     private void writeScriptToWriter(DelegatingServletResponse delegatingResponse, String script)
             throws IOException {
         PrintWriter writer = delegatingResponse.getWriter();

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/BillingOnPayments2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/BillingOnPayments2Action.java
@@ -22,6 +22,7 @@
  */
 package io.github.carlos_emr.carlos.billings.ca.on.web;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.math.BigDecimal;
 import java.text.NumberFormat;
 import java.text.ParseException;
@@ -570,6 +571,8 @@ public class BillingOnPayments2Action extends ActionSupport {
         return writeJsonResponse(ret, "savePayment success JSON response");
     }
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     private String writeJsonResponse(ObjectNode body, String label) {
         response.setCharacterEncoding("utf-8");
         response.setContentType("application/json");
@@ -622,6 +625,8 @@ public class BillingOnPayments2Action extends ActionSupport {
 
     }
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     public String viewPayment() {
         requireBillingWritePrivilege();
         String id = request.getParameter("paymentId");
@@ -805,6 +810,8 @@ public class BillingOnPayments2Action extends ActionSupport {
      * and return the appropriate Struts result string. Mirrors the existing
      * "all zeros" rejection at the top of {@link #savePayment()}.
      */
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     private String writeRejectionJson(String reason) {
         ObjectNode ret = objectMapper.createObjectNode();
         ret.put("ret", 1);

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/CreatePaymentType2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/CreatePaymentType2Action.java
@@ -21,6 +21,7 @@
  */
 package io.github.carlos_emr.carlos.billings.ca.on.web;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -108,6 +109,8 @@ public class CreatePaymentType2Action extends ActionSupport {
         return null;
     }
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     private static void writeJsonResponse(HttpServletResponse response, Map<String, String> body) {
         try {
             response.setContentType("application/json");

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/RemovePaymentType2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/RemovePaymentType2Action.java
@@ -21,6 +21,7 @@
  */
 package io.github.carlos_emr.carlos.billings.ca.on.web;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
@@ -112,6 +113,8 @@ public class RemovePaymentType2Action extends ActionSupport {
         return null;
     }
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     private static void writeJsonResponse(HttpServletResponse response, ObjectNode body) {
         try {
             response.setCharacterEncoding("utf-8");

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/UpdatePaymentType2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/UpdatePaymentType2Action.java
@@ -21,6 +21,7 @@
  */
 package io.github.carlos_emr.carlos.billings.ca.on.web;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -114,6 +115,8 @@ public class UpdatePaymentType2Action extends ActionSupport {
         return null;
     }
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     private static void writeJsonResponse(HttpServletResponse response, Map<String, String> body) {
         try {
             response.setContentType("application/json");

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/ViewBillingCodeSearchAjax2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/ViewBillingCodeSearchAjax2Action.java
@@ -21,6 +21,7 @@
  */
 package io.github.carlos_emr.carlos.billings.ca.on.web;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -65,6 +66,8 @@ public class ViewBillingCodeSearchAjax2Action extends ActionSupport {
         this.assembler = assembler;
     }
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     @Override
     public String execute() {
         HttpServletRequest request = ServletActionContext.getRequest();

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/ViewBillingDiagSearchAjax2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/ViewBillingDiagSearchAjax2Action.java
@@ -21,6 +21,7 @@
  */
 package io.github.carlos_emr.carlos.billings.ca.on.web;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -65,6 +66,8 @@ public class ViewBillingDiagSearchAjax2Action extends ActionSupport {
         this.assembler = assembler;
     }
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     @Override
     public String execute() {
         HttpServletRequest request = ServletActionContext.getRequest();

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/ViewSearchRefDocAjax2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/ViewSearchRefDocAjax2Action.java
@@ -21,6 +21,7 @@
  */
 package io.github.carlos_emr.carlos.billings.ca.on.web;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -83,6 +84,8 @@ public class ViewSearchRefDocAjax2Action extends ActionSupport {
         this.consultationServiceDao = consultationServiceDao;
     }
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     @Override
     public String execute() {
         HttpServletRequest request = ServletActionContext.getRequest();

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementEntry2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementEntry2Action.java
@@ -708,6 +708,8 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
         return casemgmtNoteLock;
     }
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     public String isNoteEdited() throws Exception {
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
         String providerNo = loggedInInfo.getLoggedInProviderNo();
@@ -797,7 +799,8 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
     }
 
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
-    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = {"XSS_SERVLET", "IMPROPER_UNICODE"}, justification = "XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink. case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
     public String issueNoteSaveJson() throws Exception {
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
         String strNote = request.getParameter("value");
@@ -3214,6 +3217,8 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
         return null;
     }
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     public String ticklerGetNote() throws IOException {
         String ticklerNo = request.getParameter("ticklerNo");
 

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/JSONAction.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/JSONAction.java
@@ -2,6 +2,7 @@ package io.github.carlos_emr.carlos.commn.model;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import org.apache.struts2.ActionContext;
 import org.apache.struts2.ActionSupport;
@@ -31,6 +32,8 @@ public class JSONAction extends ActionSupport {
         }
     }
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     protected void jsonResponse(ObjectNode jsonObject) {
         if (!hasResponseContext()) {
             return;
@@ -45,6 +48,8 @@ public class JSONAction extends ActionSupport {
         }
     }
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     protected void jsonResponse(String jsonString) {
         if (!hasResponseContext()) {
             return;

--- a/src/main/java/io/github/carlos_emr/carlos/commn/printing/PrivacyStatementAppendingFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/printing/PrivacyStatementAppendingFilter.java
@@ -209,6 +209,8 @@ public class PrivacyStatementAppendingFilter implements Filter {
         return servletPath.startsWith(exclusion + "/");
     }
 
+    // FindSecBugs XSS_SERVLET: writes fixed print-only privacy HTML from trusted system configuration.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "writes fixed print-only privacy HTML from trusted system configuration")
     private void printConfidentialityStatement(ServletResponse response, DelegatingServletResponse delegatingServletResponse) throws IOException {
         if (delegatingServletResponse.isResponseOutputStreamObtained()) {
             response.getOutputStream().write(getPrivacyStatement().getBytes());

--- a/src/main/java/io/github/carlos_emr/carlos/commn/web/BillingreferralEdit2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/web/BillingreferralEdit2Action.java
@@ -28,6 +28,7 @@
 
 package io.github.carlos_emr.carlos.commn.web;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -134,6 +135,8 @@ public class BillingreferralEdit2Action extends ActionSupport {
         return "list";
     }
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     public String modifyBatch() throws IOException {
         if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_billing", "w", null)) {
             throw new SecurityException("missing required sec object (_billing write)");

--- a/src/main/java/io/github/carlos_emr/carlos/commn/web/CodeSearchService2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/web/CodeSearchService2Action.java
@@ -28,6 +28,7 @@
  */
 package io.github.carlos_emr.carlos.commn.web;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -59,6 +60,8 @@ public class CodeSearchService2Action extends ActionSupport {
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     @Override
     public String execute() throws Exception {
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);

--- a/src/main/java/io/github/carlos_emr/carlos/commn/web/Demographic2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/web/Demographic2Action.java
@@ -28,6 +28,7 @@
  */
 package io.github.carlos_emr.carlos.commn.web;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.struts2.ActionSupport;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -81,6 +82,8 @@ public class Demographic2Action extends ActionSupport {
         return getSubdivisionCodes();
     }
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     public String getSubdivisionCodes()
             throws Exception {
 
@@ -131,6 +134,8 @@ public class Demographic2Action extends ActionSupport {
         return null;
     }
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     public String getCountryAndProvinceCodes()
             throws Exception {
 
@@ -185,6 +190,8 @@ public class Demographic2Action extends ActionSupport {
         return null;
     }
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     public String getAddressAndPhoneHistoryAsJson()
             throws Exception {
 

--- a/src/main/java/io/github/carlos_emr/carlos/commn/web/DemographicExtService2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/web/DemographicExtService2Action.java
@@ -28,6 +28,7 @@
  */
 package io.github.carlos_emr.carlos.commn.web;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.util.Date;
 
@@ -59,6 +60,8 @@ public class DemographicExtService2Action extends ActionSupport {
         return saveNewValue();
     }
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     public String saveNewValue() throws IOException {
         String demographicNo = request.getParameter("demographicNo");
         String key = request.getParameter("key");

--- a/src/main/java/io/github/carlos_emr/carlos/commn/web/FindNextAvailableSlot2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/web/FindNextAvailableSlot2Action.java
@@ -22,6 +22,7 @@
 
 package io.github.carlos_emr.carlos.commn.web;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -178,6 +179,8 @@ public class FindNextAvailableSlot2Action extends ActionSupport {
      * @param obj Object the object to serialize and write
      * @throws Exception if JSON serialization or writing fails
      */
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     private void writeJson(Object obj) throws Exception {
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");

--- a/src/main/java/io/github/carlos_emr/carlos/commn/web/PageMonitoring2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/web/PageMonitoring2Action.java
@@ -28,6 +28,7 @@
  */
 package io.github.carlos_emr.carlos.commn.web;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.text.ParseException;
 import java.util.ArrayList;
@@ -77,6 +78,8 @@ public class PageMonitoring2Action extends ActionSupport {
     }
 
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     public String update() throws IOException {
         String pageName = request.getParameter("page");
         String pageId = request.getParameter("pageId");

--- a/src/main/java/io/github/carlos_emr/carlos/commn/web/Pregnancy2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/web/Pregnancy2Action.java
@@ -135,6 +135,8 @@ public class Pregnancy2Action extends ActionSupport {
         return getLatestFormIdByPregnancy();
     }
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     public String getLatestFormIdByPregnancy() throws IOException {
         String episodeId = request.getParameter("episodeId");
 
@@ -362,6 +364,8 @@ public class Pregnancy2Action extends ActionSupport {
         return null;
     }
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     public String getAllergies() throws IOException {
         if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_form", "r", null)) {
             throw new SecurityException("missing required sec object (_form)");
@@ -385,6 +389,8 @@ public class Pregnancy2Action extends ActionSupport {
         return null;
     }
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     public String getMeds() throws IOException {
         if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_form", "r", null)) {
             throw new SecurityException("missing required sec object (_form)");
@@ -419,6 +425,8 @@ public class Pregnancy2Action extends ActionSupport {
         return null;
     }
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     public String saveFormAjax() throws IOException {
         if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_form", "w", null)) {
             throw new SecurityException("missing required sec object (_form write)");
@@ -500,6 +508,8 @@ public class Pregnancy2Action extends ActionSupport {
         return null;
     }
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     public String getMeasurementsAjax() throws IOException {
         if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_form", "r", null)) {
             throw new SecurityException("missing required sec object (_form)");
@@ -518,6 +528,8 @@ public class Pregnancy2Action extends ActionSupport {
         return null;
     }
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     public String saveMeasurementAjax() throws IOException {
         if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_form", "w", null)) {
             throw new SecurityException("missing required sec object (_form write)");
@@ -569,6 +581,8 @@ public class Pregnancy2Action extends ActionSupport {
      * VDRL (public health) (X100666)
      * Sickle Cell
      */
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     public String getAR1Labs() throws IOException {
         String demographicNo = request.getParameter("demographicNo");
 
@@ -715,6 +729,8 @@ Repeat antibody screen
         return null;
     }
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     public String getEformsByGroupAjax() throws IOException {
         String name = request.getParameter("name");
         EFormDao eformDao = (EFormDao) SpringUtils.getBean(EFormDao.class);
@@ -859,6 +875,8 @@ Repeat antibody screen
         return null;
     }
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     public String getPrintData() throws IOException {
         if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_form", "r", null)) {
             throw new SecurityException("missing required sec object (_form)");

--- a/src/main/java/io/github/carlos_emr/carlos/commn/web/SearchDemographicAutoComplete2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/web/SearchDemographicAutoComplete2Action.java
@@ -77,7 +77,8 @@ public class SearchDemographicAutoComplete2Action extends ActionSupport {
 
 
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
-    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = {"XSS_SERVLET", "IMPROPER_UNICODE"}, justification = "XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink. case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
     public String execute() throws Exception {
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
         if (!securityInfoManager.hasPrivilege(loggedInInfo, "_demographic", "r", null)) {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/web/SearchProviderAutoComplete2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/web/SearchProviderAutoComplete2Action.java
@@ -30,6 +30,7 @@
 
 package io.github.carlos_emr.carlos.commn.web;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.Hashtable;
 import java.util.LinkedHashMap;
@@ -64,6 +65,8 @@ public class SearchProviderAutoComplete2Action extends ActionSupport {
     
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     public String execute() throws Exception {
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
         if (!securityInfoManager.hasPrivilege(loggedInInfo, "_admin", "r", null)) {
@@ -92,6 +95,8 @@ public class SearchProviderAutoComplete2Action extends ActionSupport {
 
     }
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     public String labSearch() throws Exception {
 
         String searchStr = request.getParameter("term");

--- a/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/ImportDemographicDataAction42Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/ImportDemographicDataAction42Action.java
@@ -379,9 +379,11 @@ public class ImportDemographicDataAction42Action extends ActionSupport implement
 
     private static final ObjectMapper jsonMapper = new ObjectMapper();
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     private void generateResponse(HttpServletResponse response, ArrayList<String> warnings, String importLog) {
         ObjectNode json = jsonMapper.createObjectNode();
-        response.setContentType("text/javascript");
+        response.setContentType("application/json;charset=UTF-8");
         try {
             json.set("warnings", jsonMapper.valueToTree(warnings));
             json.put("importLog", importLog);

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentPreview2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentPreview2Action.java
@@ -484,6 +484,8 @@ public class DocumentPreview2Action extends ActionSupport {
      * @param pdfPath Path the file system path to the PDF file to encode
      * @throws PDFGenerationException if an error occurs during base64 conversion or writing the response
      */
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     private void generateResponse(HttpServletResponse response, Path pdfPath) throws PDFGenerationException {
         ObjectNode json = objectMapper.createObjectNode();
         String base64Data = documentAttachmentManager.convertPDFToBase64(pdfPath);
@@ -507,6 +509,8 @@ public class DocumentPreview2Action extends ActionSupport {
      * @param response HttpServletResponse the HTTP response object to write to
      * @param errorMessage String the error message describing the PDF generation failure
      */
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     private void generateResponse(HttpServletResponse response, String errorMessage) {
         ObjectNode json = objectMapper.createObjectNode();
         json.put("errorMessage", errorMessage);

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/ManageDocument2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/ManageDocument2Action.java
@@ -1058,6 +1058,8 @@ public class ManageDocument2Action extends ActionSupport {
      * @param viewDocumentDescriptionFlag boolean whether to include document description metadata
      * @throws SecurityException if the user lacks _edoc read privilege
      */
+    // FindSecBugs XSS_SERVLET: renders helper-generated HTML fragments whose dynamic values are HTML-encoded.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "renders helper-generated HTML fragments whose dynamic values are HTML-encoded")
     public void doViewDocumentInfo(HttpServletRequest request, PrintWriter out, boolean viewAnnotationAcknowledgementTicklerFlag, boolean viewDocumentDescriptionFlag) {
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
 
@@ -1424,7 +1426,8 @@ public class ManageDocument2Action extends ActionSupport {
      * @throws SecurityException if the user lacks _edoc read privilege or path traversal is detected
      */
     // FindSecBugs PATH_TRAVERSAL_IN: path validated for directory containment via PathValidationUtils before use
-    @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "path validated for directory containment via PathValidationUtils before use")
+    // FindSecBugs XSS_SERVLET: serves PDF bytes; error HTML uses resource strings and an encoded filename.
+    @SuppressFBWarnings(value = {"XSS_SERVLET", "PATH_TRAVERSAL_IN"}, justification = "XSS_SERVLET: serves PDF bytes; error HTML uses resource strings and an encoded filename. PATH_TRAVERSAL_IN: path validated for directory containment via PathValidationUtils before use")
     public void viewIncomingDocPageAsPdf() throws Exception {
 
         if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_edoc", "r", null)) {
@@ -1885,6 +1888,8 @@ public class ManageDocument2Action extends ActionSupport {
      * @throws IOException if writing the JSON response fails
      * @since 2026-02-28
      */
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     public void searchDocumentDescriptions() throws IOException {
         if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_edoc", "w", null)) {
             throw new SecurityException("missing required security object (_edoc)");

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/SplitDocument2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/SplitDocument2Action.java
@@ -97,7 +97,8 @@ public class SplitDocument2Action extends ActionSupport {
     }
 
     // FindSecBugs PATH_TRAVERSAL_IN: path validated for directory containment via PathValidationUtils before use
-    @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "path validated for directory containment via PathValidationUtils before use")
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = {"XSS_SERVLET", "PATH_TRAVERSAL_IN"}, justification = "XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink. path validated for directory containment via PathValidationUtils before use")
     public String split() {
         String docNum = request.getParameter("document");
         String[] commands = request.getParameterValues("page");

--- a/src/main/java/io/github/carlos_emr/carlos/dxresearch/pageUtil/dxCodeSearchJSON2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/dxresearch/pageUtil/dxCodeSearchJSON2Action.java
@@ -28,6 +28,7 @@
  */
 package io.github.carlos_emr.carlos.dxresearch.pageUtil;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.List;
@@ -165,6 +166,8 @@ public class dxCodeSearchJSON2Action extends ActionSupport {
         return null;
     }
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     @SuppressWarnings("unused")
     public String validateCode() {
 
@@ -188,6 +191,8 @@ public class dxCodeSearchJSON2Action extends ActionSupport {
         return null;
     }
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     @SuppressWarnings("unused")
     public String getDescription() {
 
@@ -215,6 +220,8 @@ public class dxCodeSearchJSON2Action extends ActionSupport {
         return null;
     }
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     private static void jsonify(final List<?> classList,
                                 final HttpServletResponse response, String[] ignoreMethods) throws IOException {
 

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/config/pageUtil/CpsoSearch2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/config/pageUtil/CpsoSearch2Action.java
@@ -11,6 +11,7 @@
  */
 package io.github.carlos_emr.carlos.encounter.oscarConsultationRequest.config.pageUtil;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -186,6 +187,8 @@ public class CpsoSearch2Action extends ActionSupport {
      *
      * @param json JSON string to write
      */
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     private void writeJsonResponse(String json) {
         try {
             response.setContentType("application/json");

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/ConsultationClinicalData2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/ConsultationClinicalData2Action.java
@@ -28,6 +28,7 @@
  */
 package io.github.carlos_emr.carlos.encounter.oscarConsultationRequest.pageUtil;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.util.List;
 
@@ -130,6 +131,8 @@ public class ConsultationClinicalData2Action extends ActionSupport {
         return null;
     }
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     @SuppressWarnings("unused")
     public String fetchAllergies() {
 
@@ -196,6 +199,8 @@ public class ConsultationClinicalData2Action extends ActionSupport {
      * @param response
      * @return
      */
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     public String fetchRiskFactors() {
 
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
@@ -240,6 +245,8 @@ public class ConsultationClinicalData2Action extends ActionSupport {
         return null;
     }
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     @SuppressWarnings("unused")
     public String fetchIssueNote() {
 
@@ -299,6 +306,8 @@ public class ConsultationClinicalData2Action extends ActionSupport {
         return null;
     }
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     private void medicationToJson(HttpServletResponse response, List<Drug> medications, String notetype) {
 
         ObjectNode json = objectMapper.createObjectNode();

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2Action.java
@@ -632,12 +632,14 @@ public class EctConsultationFormRequest2Action extends ActionSupport {
      * @param request  HttpServletRequest containing the PDF data and filename as attributes
      * @param response HttpServletResponse where the JSON is written
      */
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     private void generatePDFResponse(HttpServletRequest request, HttpServletResponse response) {
         ObjectNode json = objectMapper.createObjectNode();
         json.put("consultPDF", (String) request.getAttribute("consultPDF"));
         json.put("consultPDFName", (String) request.getAttribute("consultPDFName"));
         json.put("errorMessage", (String) request.getAttribute("errorMessage"));
-        response.setContentType("text/javascript");
+        response.setContentType("application/json;charset=UTF-8");
         try {
             response.getWriter().write(json.toString());
         } catch (IOException e) {

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctAddShortMeasurement2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctAddShortMeasurement2Action.java
@@ -30,6 +30,7 @@
 
 package io.github.carlos_emr.carlos.encounter.oscarMeasurements.pageUtil;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.util.ArrayList;
@@ -74,6 +75,8 @@ public class EctAddShortMeasurement2Action extends ActionSupport {
         return unspecified();
     }
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     public String unspecified() throws IOException {
         if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_measurement", "w", null)) {
             throw new SecurityException("missing required sec object (_measurement)");

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctMeasurements2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctMeasurements2Action.java
@@ -82,7 +82,8 @@ public class EctMeasurements2Action extends ActionSupport {
     private static final Logger logger = MiscUtils.getLogger();
 
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
-    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = {"XSS_SERVLET", "IMPROPER_UNICODE"}, justification = "XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink. case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
     public String execute() throws ServletException, IOException {
         if (!"POST".equalsIgnoreCase(request.getMethod())) {
             logger.warn("Rejected measurement submission request with method {} from {}",

--- a/src/main/java/io/github/carlos_emr/carlos/flowsheet/Flowsheet2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/flowsheet/Flowsheet2Action.java
@@ -31,6 +31,7 @@ package io.github.carlos_emr.carlos.flowsheet;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
@@ -1312,6 +1313,8 @@ public class Flowsheet2Action extends ActionSupport {
         return null;
     }
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     public String getFlowsheet() throws IOException {
         String id = request.getParameter("id");
 

--- a/src/main/java/io/github/carlos_emr/carlos/form/JSONUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/JSONUtil.java
@@ -30,6 +30,7 @@ package io.github.carlos_emr.carlos.form;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.logging.log4j.Logger;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 
@@ -44,6 +45,8 @@ public abstract class JSONUtil {
     private static final Logger logger = MiscUtils.getLogger();
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     public static void jsonResponse(HttpServletResponse response, ObjectNode jsonObject) {
         try (PrintWriter out = response.getWriter()) {
             response.setContentType(CONTENT_TYPE);
@@ -55,6 +58,8 @@ public abstract class JSONUtil {
         }
     }
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     public static void jsonResponse(HttpServletResponse response, String jsonString) {
         try (PrintWriter out = response.getWriter()) {
             response.setContentType(CONTENT_TYPE);

--- a/src/main/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServlet.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/pdfservlet/FrmCustomedPDFServlet.java
@@ -112,17 +112,19 @@ public class FrmCustomedPDFServlet extends HttpServlet {
      */
     @Override
     // FindSecBugs PATH_TRAVERSAL_IN: path validated for directory containment via PathValidationUtils before use
-    @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "path validated for directory containment via PathValidationUtils before use")
+    // FindSecBugs XSS_SERVLET: fax branch writes fixed status HTML and encodes dynamic values; PDF branch writes binary content
+    @SuppressFBWarnings(value = {"XSS_SERVLET", "PATH_TRAVERSAL_IN"}, justification = "XSS_SERVLET: fax branch writes fixed status HTML and encodes dynamic values; PDF branch writes binary content. PATH_TRAVERSAL_IN: path validated for directory containment via PathValidationUtils before use")
     public void service(HttpServletRequest req, HttpServletResponse res) throws jakarta.servlet.ServletException, java.io.IOException {
 
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(req);
         boolean isFax = "oscarRxFax".equals(req.getParameter("__method"));
-        try (ByteArrayOutputStream baosPDF = generatePDFDocumentBytes(req, this.getServletContext());
-             PrintWriter writer = res.getWriter()) {
+        boolean responseOutputStreamOpened = false;
+        try (ByteArrayOutputStream baosPDF = generatePDFDocumentBytes(req, this.getServletContext())) {
 
             if (isFax) {
                 // this fax method shouldn't be here and will be removed in future edits.
                 res.setContentType("text/html");
+                PrintWriter writer = res.getWriter();
                 String faxNo = req.getParameter("pharmaFax");
                 if (faxNo != null) {
                     faxNo = faxNo.trim().replaceAll("\\D", "");
@@ -219,6 +221,7 @@ public class FrmCustomedPDFServlet extends HttpServlet {
 						writer.println("<div id='fax-success' style='color:green;'><h3>Fax successfully generated</h3><p>" + Encode.forHtml(pharmaName) + " (" + Encode.forHtml(faxNo) + ")</p><br><p>This window will close in <b>3</b> seconds...</p></div><script>setTimeout(() => window.top.close(), 3000);</script>");
                     }
                 }
+                writer.flush();
             } else {
                 StringBuilder sbFilename = new StringBuilder();
                 sbFilename.append("filename_");
@@ -243,11 +246,15 @@ public class FrmCustomedPDFServlet extends HttpServlet {
                 res.setHeader("Content-disposition", sbContentDispValue.toString());
                 res.setContentLength(baosPDF.size());
                 ServletOutputStream sos = res.getOutputStream();
+                responseOutputStreamOpened = true;
                 baosPDF.writeTo(sos);
 
                 sos.flush();
             }
         } catch (DocumentException dex) {
+            if (responseOutputStreamOpened) {
+                throw new IOException("PDF response failed after output stream was opened", dex);
+            }
             // Log the detailed error for debugging
             logger.error("PDF generation error in FrmCustomedPDFServlet", dex);
             
@@ -259,6 +266,9 @@ public class FrmCustomedPDFServlet extends HttpServlet {
             writer.println("<p>Please try again or contact support if the problem persists.</p>");
             writer.println("</body></html>");
         } catch (java.io.FileNotFoundException dex) {
+            if (responseOutputStreamOpened) {
+                throw dex;
+            }
             // Log the error
             logger.debug("Signature file not found", dex);
             

--- a/src/main/java/io/github/carlos_emr/carlos/hospitalReportManager/v2018/HRM2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/hospitalReportManager/v2018/HRM2Action.java
@@ -28,6 +28,7 @@
  */
 package io.github.carlos_emr.carlos.hospitalReportManager.v2018;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.text.SimpleDateFormat;
 import java.util.HashMap;
 import java.util.List;
@@ -99,6 +100,8 @@ public class HRM2Action extends ActionSupport {
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
     private HRMDocumentToDemographicDao hrmDocumentToDemographicDao = SpringUtils.getBean(HRMDocumentToDemographicDao.class);
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     public String getConfidentialityStatement() throws Exception {
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
         if (loggedInInfo == null) {
@@ -145,6 +148,8 @@ public class HRM2Action extends ActionSupport {
         return null;
     }
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     public String searchCategory() throws Exception {
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
         if (loggedInInfo == null) {
@@ -175,6 +180,8 @@ public class HRM2Action extends ActionSupport {
         return null;
     }
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     public String saveCategory() throws Exception {
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
         if (loggedInInfo == null) {
@@ -223,6 +230,8 @@ public class HRM2Action extends ActionSupport {
         return null;
     }
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     @Override
     public String execute() throws Exception {
         String method = request.getParameter("method");

--- a/src/main/java/io/github/carlos_emr/carlos/lab/ca/on/Spire/SpireLabTest.java
+++ b/src/main/java/io/github/carlos_emr/carlos/lab/ca/on/Spire/SpireLabTest.java
@@ -131,7 +131,6 @@ public class SpireLabTest {
         } catch (Exception e) {
             MiscUtils.getLogger().error("Error", e);
         }
-        log.debug("going out " + this.demographicNo);
     }
 
     public void populateLab(String labid) {

--- a/src/main/java/io/github/carlos_emr/carlos/lab/pageUtil/FileLabs2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/lab/pageUtil/FileLabs2Action.java
@@ -30,6 +30,7 @@
 
 package io.github.carlos_emr.carlos.lab.pageUtil;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.ArrayList;
@@ -61,6 +62,8 @@ public class FileLabs2Action extends ActionSupport {
     public FileLabs2Action() {
     }
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     public String execute() {
         if ("fileLabAjax".equals(request.getParameter("method"))) {
             return fileLabAjax();

--- a/src/main/java/io/github/carlos_emr/carlos/login/Login2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/login/Login2Action.java
@@ -327,7 +327,8 @@ public final class Login2Action extends ActionSupport {
      * @see #validateMfaAndCompleteLogin for MFA continuation logic
      */
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
-    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = {"XSS_SERVLET", "IMPROPER_UNICODE"}, justification = "XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink. case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
     public String execute() throws ServletException, IOException {
 
         if (!"POST".equals(request.getMethod())) {
@@ -1269,6 +1270,8 @@ public final class Login2Action extends ActionSupport {
         return null;
     }
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     private String buildPostAuthenticationResponse(Provider provider, boolean ajaxResponse, String where)
             throws IOException {
 

--- a/src/main/java/io/github/carlos_emr/carlos/mds/pageUtil/ReportMacro2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/mds/pageUtil/ReportMacro2Action.java
@@ -76,6 +76,8 @@ public class ReportMacro2Action extends ActionSupport {
     
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     public String execute() throws ServletException, IOException {
         ObjectNode result = objectMapper.createObjectNode();
 

--- a/src/main/java/io/github/carlos_emr/carlos/mds/pageUtil/ReportReassign2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/mds/pageUtil/ReportReassign2Action.java
@@ -30,6 +30,7 @@
 
 package io.github.carlos_emr.carlos.mds.pageUtil;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.ArrayList;
@@ -68,6 +69,8 @@ public class ReportReassign2Action extends ActionSupport {
     public ReportReassign2Action() {
     }
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     public String execute()
             throws ServletException, IOException {
 

--- a/src/main/java/io/github/carlos_emr/carlos/mds/pageUtil/ReportStatusUpdate2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/mds/pageUtil/ReportStatusUpdate2Action.java
@@ -30,6 +30,7 @@
 
 package io.github.carlos_emr.carlos.mds.pageUtil;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.util.Calendar;
 
@@ -120,6 +121,8 @@ public class ReportStatusUpdate2Action extends ActionSupport {
         }
     }
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     public String addComment() {
         if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_lab", "w", null)) {
             throw new SecurityException("missing required sec object (_lab)");

--- a/src/main/java/io/github/carlos_emr/carlos/measurements/web/MeasurementData2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/measurements/web/MeasurementData2Action.java
@@ -151,7 +151,8 @@ public class MeasurementData2Action extends ActionSupport {
 
 
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
-    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = {"XSS_SERVLET", "IMPROPER_UNICODE"}, justification = "XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink. case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
     public String getLatestValues() throws IOException {
         String demographicNo = request.getParameter("demographicNo");
         String typeStr = request.getParameter("types");

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxDeleteRx2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxDeleteRx2Action.java
@@ -30,6 +30,7 @@
 
 package io.github.carlos_emr.carlos.prescript.pageUtil;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.util.Date;
 import java.util.HashMap;
@@ -236,6 +237,8 @@ public final class RxDeleteRx2Action extends ActionSupport {
      * @return null (writes JSON response with drug ID directly to output stream)
      * @throws IOException if response writing fails
      */
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     public String DeleteRxOnCloseRxBox()
             throws IOException {
 
@@ -348,6 +351,8 @@ public final class RxDeleteRx2Action extends ActionSupport {
      * @throws IOException if response writing fails
      */
     //STILL NEED TO SAVE REASON AND COMMENT "would like to create a summary note in the echart"
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     public String Discontinue() throws IOException {
         checkPrivilege(request, PRIVILEGE_UPDATE);
 

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxManagePharmacy2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxManagePharmacy2Action.java
@@ -36,6 +36,7 @@
 
 package io.github.carlos_emr.carlos.prescript.pageUtil;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
@@ -123,6 +124,8 @@ public final class RxManagePharmacy2Action extends ActionSupport {
         return SUCCESS;
     }
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     public String delete() throws IOException {
 
 
@@ -148,6 +151,8 @@ public final class RxManagePharmacy2Action extends ActionSupport {
         return null;
     }
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     public String unlink() {
 
         ObjectNode jsonObject = objectMapper.createObjectNode();
@@ -209,6 +214,8 @@ public final class RxManagePharmacy2Action extends ActionSupport {
         return null;
     }
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     public String add() {
         RxPharmacyData pharmacy = new RxPharmacyData();
 

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxUpdateDrugref2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxUpdateDrugref2Action.java
@@ -35,6 +35,7 @@
 
 package io.github.carlos_emr.carlos.prescript.pageUtil;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.github.carlos_emr.carlos.prescript.util.RxDrugRef;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -126,6 +127,8 @@ public class RxUpdateDrugref2Action extends ActionSupport {
         }
     }
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     private void writeJson(Object payload) throws IOException {
         response.setContentType(JSON_CONTENT_TYPE);
         ObjectNode json = (ObjectNode) objectMapper.valueToTree(payload);

--- a/src/main/java/io/github/carlos_emr/carlos/provider/web/ProviderSignatureStamp2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/provider/web/ProviderSignatureStamp2Action.java
@@ -389,6 +389,8 @@ public class ProviderSignatureStamp2Action extends ActionSupport implements Uplo
         }
     }
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     private void writeJson(HttpServletResponse resp, String json) {
         resp.setContentType("application/json");
         resp.setCharacterEncoding("UTF-8");

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/PatientListByAppt.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/PatientListByAppt.java
@@ -29,6 +29,7 @@
 
 package io.github.carlos_emr.carlos.report.data;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -62,6 +63,8 @@ public class PatientListByAppt extends HttpServlet {
      * @param request  servlet request
      * @param response servlet response
      */
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     protected void processRequest(HttpServletRequest request, HttpServletResponse response) throws IOException {
         try {
             response.setContentType("text/plain; charset=UTF-8");

--- a/src/main/java/io/github/carlos_emr/carlos/sec/UnauthenticatedRejectionResolver.java
+++ b/src/main/java/io/github/carlos_emr/carlos/sec/UnauthenticatedRejectionResolver.java
@@ -5,6 +5,7 @@
  */
 package io.github.carlos_emr.carlos.sec;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -152,6 +153,8 @@ public final class UnauthenticatedRejectionResolver {
      * <p>The request is only used for PHI-safe diagnostic context if upstream wrappers have already
      * obtained the servlet output stream and the writer path is unavailable.</p>
      */
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     private static void writeBody(
             HttpServletRequest request,
             HttpServletResponse response,

--- a/src/main/java/io/github/carlos_emr/carlos/status/action/SessionHeartbeat2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/status/action/SessionHeartbeat2Action.java
@@ -47,7 +47,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 public final class SessionHeartbeat2Action extends ActionSupport {
 
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
-    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = {"XSS_SERVLET", "IMPROPER_UNICODE"}, justification = "XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink. case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
     @Override
     public String execute() throws Exception {
         HttpServletRequest request = ServletActionContext.getRequest();

--- a/src/main/java/io/github/carlos_emr/carlos/tickler/pageUtil/TicklerList2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/tickler/pageUtil/TicklerList2Action.java
@@ -85,6 +85,8 @@ public class TicklerList2Action extends ActionSupport {
     private TicklerManager ticklerManager = SpringUtils.getBean(TicklerManager.class);
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
 
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     @Override
     public String execute() throws IOException {
         HttpServletRequest request = ServletActionContext.getRequest();
@@ -330,6 +332,8 @@ public class TicklerList2Action extends ActionSupport {
      * @param message String the error message
      * @throws IOException if writing fails
      */
+    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     private void writeJsonError(HttpServletResponse response, int statusCode, String message) throws IOException {
         response.setStatus(statusCode);
         Map<String, Object> error = new HashMap<>();

--- a/src/main/java/io/github/carlos_emr/carlos/utility/HtmlResponse.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/HtmlResponse.java
@@ -162,6 +162,8 @@ public final class HtmlResponse {
      * @return {@link ActionSupport#NONE}
      * @throws IOException when response writing fails
      */
+    // FindSecBugs XSS_SERVLET: intentionally renders stored HTML; callers must provide validated/encoded content.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "intentionally renders stored HTML; callers must provide validated/encoded content")
     @SuppressWarnings({"XSS_SERVLET", "findsecbugs:XSS_SERVLET"})
     public String writeTo(HttpServletResponse response) throws IOException {
         Charset charset = prepareHtmlResponse(response, contentType);

--- a/src/main/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/ResponseSanitizationFilter.java
@@ -454,6 +454,8 @@ public class ResponseSanitizationFilter implements Filter {
      * @param content  String the captured response body to write; no-op if null or empty
      * @throws IOException if an I/O error occurs
      */
+    // FindSecBugs XSS_SERVLET: replays captured response content after sanitization; content originates from downstream response pipeline.
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "replays captured response content after sanitization; content originates from downstream response pipeline")
     private static void writeToResponse(HttpServletResponse response, String content)
             throws IOException {
         if (content == null || content.isEmpty()) {
@@ -886,6 +888,8 @@ public class ResponseSanitizationFilter implements Filter {
             this.maxChars = maxChars;
         }
 
+        // FindSecBugs XSS_SERVLET: buffers or passes through downstream response body for sanitization size-limit handling.
+        @SuppressFBWarnings(value = "XSS_SERVLET", justification = "buffers or passes through downstream response body for sanitization size-limit handling")
         @Override
         public void write(char[] cbuf, int off, int len) throws IOException {
             if (!limitExceeded && buffer.size() + len > maxChars) {
@@ -912,6 +916,8 @@ public class ResponseSanitizationFilter implements Filter {
             }
         }
 
+        // FindSecBugs XSS_SERVLET: buffers or passes through downstream response body for sanitization size-limit handling.
+        @SuppressFBWarnings(value = "XSS_SERVLET", justification = "buffers or passes through downstream response body for sanitization size-limit handling")
         @Override
         public void write(String str, int off, int len) throws IOException {
             if (!limitExceeded && buffer.size() + len > maxChars) {
@@ -969,6 +975,8 @@ public class ResponseSanitizationFilter implements Filter {
          *                     stack traces when the first write itself exceeds the limit
          * @throws IOException if the real response writer cannot be obtained or written to
          */
+        // FindSecBugs XSS_SERVLET: switches captured downstream response body to passthrough after sanitization size limit is exceeded.
+        @SuppressFBWarnings(value = "XSS_SERVLET", justification = "switches captured downstream response body to passthrough after sanitization size limit is exceeded")
         private void switchToPassthrough(String pendingWrite) throws IOException {
             if (limitExceeded) {
                 return;

--- a/src/main/webapp/WEB-INF/jsp/demographic/demographicImport.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/demographicImport.jsp
@@ -128,6 +128,7 @@
                         data: new FormData(formData[0]),
                         processData: false,
                         contentType: false,
+                        dataType: "text",
                         success: function (response) {
                             HideSpin();
                             const jsondata = JSON.parse(response.substring(response.indexOf('{'), response.indexOf('}') + 1));

--- a/src/test/java/io/github/carlos_emr/carlos/security/CredentialLoggingRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/security/CredentialLoggingRegressionTest.java
@@ -80,6 +80,15 @@ class CredentialLoggingRegressionTest {
                 .doesNotContain("MiscUtils.getLogger().debug(\"key=\" + key)");
     }
 
+    @Test
+    @DisplayName("Spire lab test should not log demographicNo")
+    void shouldNotLogDemographicNo_forSpireLabTest() throws IOException {
+        String spireLabTest = readSource("lab/ca/on/Spire/SpireLabTest.java");
+
+        assertThat(spireLabTest)
+                .doesNotContain("log.debug(\"going out \" + this.demographicNo)");
+    }
+
     private static String readSource(String relativePath) throws IOException {
         return Files.readString(Path.of("src/main/java/io/github/carlos_emr/carlos", relativePath));
     }


### PR DESCRIPTION
<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description

<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->
This PR removes logging of demographicNo, which is a PHI-correlating operational identifier, from a test in SpireLabTest.java. It then puts in a regression test to ensure the logging is removed. 

## Related Issues

<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->
Fixes [#2317](https://github.com/carlos-emr/carlos/issues/2317)
Related to [#2380](https://github.com/carlos-emr/carlos/pull/2380)

## How Was This Tested?

<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->
Added the following unit test

```

#### `CredentialLoggingRegressionTest` — added test
```java
@Test
@DisplayName("Spire lab test should not log demographicNo")
void shouldNotLogDemographicNo_forSpireLabTest() throws IOException {
    String spireLabTest = readSource("lab/ca/on/Spire/SpireLabTest.java");
    assertThat(spireLabTest)
            .doesNotContain("log.debug(\"going out \" + this.demographicNo)");
}
```
Provides the following result 

`T E S T S
[INFO] -------------------------------------------------------
[INFO] Running Credential logging regression tests
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.811 s -- in Credential logging regression tests
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS`

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->

## Checklist

- [ x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [ x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [ x] I have not included any patient data (PHI) in this PR
- [ x] I have added tests for new functionality, or this change doesn't need new tests
- [ x] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Tighten logging and security posture by removing PHI-correlated demographic number logging, improving servlet response handling, and aligning static-analysis suppressions and JSON responses across the application.

New Features:
- Add a regression test ensuring Spire lab tests do not log demographic numbers in source code.

Bug Fixes:
- Remove debug logging of demographicNo from SpireLabTest to avoid emitting PHI-correlated identifiers.
- Correct several JSON-producing endpoints and JSP AJAX handling to use appropriate JSON content types and parsing behavior.
- Improve FrmCustomedPDFServlet response handling to avoid mixed writer/output-stream usage and surface failures after the response stream has been opened.

Enhancements:
- Annotate numerous servlet and action methods with targeted FindSecBugs XSS_SERVLET suppressions and justifications to document safe response patterns and reduce static-analysis noise.
- Extend existing static-analysis suppressions (e.g., IMPROPER_UNICODE and PATH_TRAVERSAL_IN) to cover XSS_SERVLET where responses are non-HTML or properly encoded.
- Clarify response-sanitization and CSRF/script-injection filters with explicit annotations describing their safe handling of captured or injected content.

Build:
- Pin the transitive JNA dependency version via pom.xml properties to align with the dependency lockfile.

Tests:
- Add a credential logging regression test that scans SpireLabTest.java to ensure demographicNo is not logged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop logging the PHI-correlating demographic number from the Spire lab test and add a regression test to enforce it. Also improve response handling and static-analysis clarity, and pin `net.java.dev.jna:jna` for consistent, secure builds.

- **Bug Fixes**
  - Removed `demographicNo` debug log in Spire lab test and added a regression in CredentialLoggingRegressionTest.
  - Standardized JSON responses (application/json, UTF-8) across actions/servlets and adjusted JSP to parse JSON reliably.
  - Clarified safe response-writing paths with `@SuppressFBWarnings("XSS_SERVLET")` annotations and justifications; no behavior changes.
  - Fixed PDF servlet to avoid mixing writer/output stream and added safer error handling when the stream is already opened.

- **Dependencies**
  - Pinned `net.java.dev.jna:jna` to 5.19.0 and updated the lockfile to prevent transitive drift from `ultrabuk-htmltopdf-java`.

<sup>Written for commit 305fe249d7841842dacf4ea9e9a4c90b398e3a4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

