### PR TITLE
fix(appointment): correct last day boundary calculation

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/managers/AppointmentManagerImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/AppointmentManagerImpl.java
@@ -278,6 +278,22 @@ public class AppointmentManagerImpl implements AppointmentManager {
         return itemsList;
     }
 
+    /**
+     * Returns the provider's appointments for the given calendar month.
+     *
+     * <p>The query window is half-open: {@code startDate} is the first instant of the
+     * requested month (00:00:00.000) and {@code endDate} is the first instant of the
+     * following month (00:00:00.000). This matches the exclusive upper bound
+     * ({@code appointmentDate < endTime}) applied by
+     * {@link OscarAppointmentDao#findByDateRangeAndProvider(Date, Date, String)}, so
+     * every appointment on the last calendar day of the month is included.</p>
+     *
+     * @param loggedInInfo the logged-in user context used for audit logging
+     * @param providerNo   the provider whose appointments are queried
+     * @param year         the calendar year
+     * @param month        the zero-based calendar month ({@code 0} = January)
+     * @return the matching appointments, or an empty list when none are found
+     */
     public List<Appointment> findMonthlyAppointments(LoggedInInfo loggedInInfo, String providerNo, int year, int month) {
 
         Calendar cal = Calendar.getInstance();
@@ -287,20 +303,20 @@ public class AppointmentManagerImpl implements AppointmentManager {
         cal.set(Calendar.HOUR_OF_DAY, 0);
         cal.set(Calendar.MINUTE, 0);
         cal.set(Calendar.SECOND, 0);
+        cal.set(Calendar.MILLISECOND, 0);
         Date startDate = cal.getTime();
 
-        cal.set(Calendar.DAY_OF_MONTH, cal.getActualMaximum(Calendar.DAY_OF_MONTH));
-        //cal.add(Calendar.MINUTE,-1);  //this won't get the last day of the month
-
+        // Exclusive upper bound: the first instant of the next month. The DAO filters
+        // with appointmentDate < endTime, so this includes the entire last day of the month.
+        cal.set(Calendar.DAY_OF_MONTH, 1);
+        cal.add(Calendar.MONTH, 1);
         cal.set(Calendar.HOUR_OF_DAY, 0);
         cal.set(Calendar.MINUTE, 0);
         cal.set(Calendar.SECOND, 0);
-
-        cal.add(Calendar.SECOND, -1);
+        cal.set(Calendar.MILLISECOND, 0);
         Date endDate = cal.getTime();
 
-
-        logger.info("monthly - checking from " + startDate + " to " + endDate);
+        logger.info("monthly - checking from " + startDate + " (inclusive) to " + endDate + " (exclusive)");
 
 
         List<Appointment> results = appointmentDao.findByDateRangeAndProvider(startDate, endDate, providerNo);

--- a/src/test/java/io/github/carlos_emr/carlos/managers/AppointmentManagerUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/managers/AppointmentManagerUnitTest.java
@@ -33,6 +33,7 @@ import io.github.carlos_emr.carlos.commn.model.LookupListItem;
 
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -41,6 +42,7 @@ import org.mockito.quality.Strictness;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -1224,6 +1226,57 @@ public class AppointmentManagerUnitTest extends AppointmentUnitTestBase {
 
             // Then
             assertThat(result).isNotNull();
+        }
+
+        @Test
+        @DisplayName("should query a half-open month window normalized to midnight boundaries")
+        void shouldQueryHalfOpenMonthWindow_whenSearchingMonth() {
+            // Given - January 2026 (month index 0), a 31-day month
+            when(mockAppointmentDao.findByDateRangeAndProvider(any(Date.class), any(Date.class), anyString()))
+                .thenReturn(Collections.emptyList());
+            ArgumentCaptor<Date> startCaptor = ArgumentCaptor.forClass(Date.class);
+            ArgumentCaptor<Date> endCaptor = ArgumentCaptor.forClass(Date.class);
+
+            // When
+            appointmentManager.findMonthlyAppointments(mockLoggedInInfo, TEST_PROVIDER, 2026, 0);
+
+            // Then - start is the first instant of the month, end is the first instant of the next month
+            verify(mockAppointmentDao).findByDateRangeAndProvider(
+                startCaptor.capture(), endCaptor.capture(), eq(TEST_PROVIDER));
+            assertThat(startCaptor.getValue()).isEqualTo(firstInstantOfMonth(2026, 0));
+            assertThat(endCaptor.getValue()).isEqualTo(firstInstantOfMonth(2026, 1));
+        }
+
+        @Test
+        @DisplayName("should cover an appointment on the last day of the month within the query window")
+        void shouldCoverLastDay_whenMonthEndsOnLeapDay() {
+            // Given - February 2024 (month index 1), a leap year ending on the 29th
+            when(mockAppointmentDao.findByDateRangeAndProvider(any(Date.class), any(Date.class), anyString()))
+                .thenReturn(Collections.emptyList());
+            ArgumentCaptor<Date> startCaptor = ArgumentCaptor.forClass(Date.class);
+            ArgumentCaptor<Date> endCaptor = ArgumentCaptor.forClass(Date.class);
+
+            // When
+            appointmentManager.findMonthlyAppointments(mockLoggedInInfo, TEST_PROVIDER, 2024, 1);
+
+            // Then - an appointment late on Feb 29 falls inside the half-open [start, end) window
+            verify(mockAppointmentDao).findByDateRangeAndProvider(
+                startCaptor.capture(), endCaptor.capture(), eq(TEST_PROVIDER));
+            assertThat(endCaptor.getValue()).isEqualTo(firstInstantOfMonth(2024, 2));
+
+            Calendar lastDay = Calendar.getInstance();
+            lastDay.set(2024, Calendar.FEBRUARY, 29, 23, 59, 59);
+            lastDay.set(Calendar.MILLISECOND, 0);
+            Date lastDayAppointment = lastDay.getTime();
+            assertThat(lastDayAppointment).isAfterOrEqualTo(startCaptor.getValue());
+            assertThat(lastDayAppointment).isBefore(endCaptor.getValue());
+        }
+
+        private Date firstInstantOfMonth(int year, int month) {
+            Calendar cal = Calendar.getInstance();
+            cal.set(year, month, 1, 0, 0, 0);
+            cal.set(Calendar.MILLISECOND, 0);
+            return cal.getTime();
         }
     }
 


### PR DESCRIPTION
## Description

Fixes `AppointmentManagerImpl.findMonthlyAppointments` silently excluding appointments scheduled on the last calendar day of the month.

The previous logic set `endDate` to the last day of the month minus one second, which conflicts with `OscarAppointmentDao.findByDateRangeAndProvider`'s **exclusive** upper bound (`appointmentDate < endTime`). As a result, appointments on the final day were dropped.

**Changes:**
- `endDate` is now the first instant of the following month (`00:00:00.000`), so the half-open `[start, end)` window covers the entire last day.
- Millisecond field normalized to `0` on both bounds for consistent ranges.
- Added JavaDoc on the public entrypoint and an inline comment documenting the exclusive-boundary contract (addresses reviewer confusion on the original PR).
- Added `ArgumentCaptor` unit tests asserting the exact month window (31-day month and leap-year February), which the fork PR was missing.

## Provenance

Reproduces the work originally proposed in #2970 (authored by @ThanuH on a fork) onto a `carlos-emr` branch we control, since the fork branch cannot be pushed to directly. The production fix matches the accepted approach from that PR's discussion; the added unit coverage is new.

## Related Issues

Refs #2959

## Testing

`mvn -Dtest=AppointmentManagerUnitTest test` — 62 tests, 0 failures, including the two new boundary tests.

## Checklist
- [x] My commits are signed off for the DCO (`git commit -s`)
- [x] My commits follow Conventional Commits format
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality
- [x] I have read the contributing guide

## Summary by Sourcery

Correct monthly appointment query boundaries to use a half-open [start, end) month window aligned to midnight and verify behavior with new boundary tests.

Bug Fixes:
- Ensure appointments scheduled on the last calendar day of a month are included in monthly appointment queries by using an exclusive upper bound at the start of the next month.

Enhancements:
- Clarify the behavior of findMonthlyAppointments with JavaDoc and inline comments documenting the half-open date range contract.

Tests:
- Add unit tests using ArgumentCaptor to assert the exact monthly query window, including a 31-day month and leap-year February edge case.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes monthly appointment queries that dropped last-day appointments. Uses a half-open range that starts at the month’s midnight and ends at the next month’s midnight.

- **Bug Fixes**
  - In `AppointmentManagerImpl.findMonthlyAppointments`, set `endDate` to the first instant of the next month to align with `OscarAppointmentDao.findByDateRangeAndProvider`’s exclusive upper bound.
  - Normalize milliseconds to 0 on both bounds.
  - Add JavaDoc and an inline comment clarifying the exclusive end boundary.
  - Add `ArgumentCaptor` tests for a 31-day month and leap-year February to assert exact window boundaries.

<sup>Written for commit ef2a3f57da1cb93e5304f89462ea6b546c6ff2ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

