### PR TITLE
docs(communications): add SMS mockups, vendor research, and consent data-structures report (#2443)

### DIFF
--- a/docs/communications-technical-terms-reference.md
+++ b/docs/communications-technical-terms-reference.md
@@ -1,0 +1,463 @@
+# CARLOS Communications Technical Terms Reference
+
+This reference explains common telecom, messaging, fax, cloud, and healthcare-compliance terms used in the vendor review.
+
+# Core Telecom Terms
+
+## DID
+
+**Stands for:** Direct Inward Dialing.
+
+**Simple meaning:** A real phone number that can receive calls or messages.
+
+**Why it matters for CARLOS:**  
+If CARLOS sends texts, receives replies, handles faxes, or routes calls, it usually needs one or more DIDs. A clinic might have its own DID so patients recognize the sender.
+
+## VoIP
+
+**Stands for:** Voice over Internet Protocol.
+
+**Simple meaning:** Phone calls sent over the internet instead of traditional phone lines.
+
+**Why it matters for CARLOS:**  
+VoIP can support clinic calling, call routing, voicemail, and sometimes fax/SMS depending on the provider.
+
+## SIP
+
+**Stands for:** Session Initiation Protocol.
+
+**Simple meaning:** A standard way for internet phone systems to start and manage phone calls.
+
+**Why it matters for CARLOS:**  
+SIP is common when connecting a phone system, PBX, or call-routing platform to a telecom provider.
+
+## SIP Trunk
+
+**Simple meaning:** A virtual phone line between a phone system and a telecom provider.
+
+**Why it matters for CARLOS:**  
+A clinic phone system may use SIP trunks to place and receive calls through a provider like VoIP.ms, Telnyx, Bandwidth, or Cloudli.
+
+## PBX
+
+**Stands for:** Private Branch Exchange.
+
+**Simple meaning:** A business phone system that manages extensions, call routing, voicemail, menus, and queues.
+
+**Why it matters for CARLOS:**  
+FreePBX is PBX software. It is useful for clinic phone systems, but it is not the same thing as an SMS/fax API provider.
+
+## FreePBX
+
+**Simple meaning:** Open-source software for managing a PBX phone system.
+
+**Why it matters for CARLOS:**  
+FreePBX may help with clinic calling, extensions, IVRs, and SIP trunks, but it would require hosting, maintenance, telecom configuration, and a separate carrier/provider.
+
+## IVR
+
+**Stands for:** Interactive Voice Response.
+
+**Simple meaning:** A phone menu like “Press 1 for appointments, press 2 for billing.”
+
+**Why it matters for CARLOS:**  
+Useful if CARLOS later needs phone workflows, but not central to SMS or fax delivery.
+
+## PSTN
+
+**Stands for:** Public Switched Telephone Network.
+
+**Simple meaning:** The traditional global phone network.
+
+**Why it matters for CARLOS:**  
+Even if CARLOS uses internet APIs, messages and calls often end up crossing the regular phone network.
+
+# SMS and Messaging Terms
+
+## SMS
+
+**Stands for:** Short Message Service.
+
+**Simple meaning:** Standard text messaging.
+
+**Why it matters for CARLOS:**  
+SMS would be used for appointment reminders, notifications, patient follow-ups, or links to secure messages.
+
+## MMS
+
+**Stands for:** Multimedia Messaging Service.
+
+**Simple meaning:** Text messaging with media attachments like images, PDFs, or longer rich content.
+
+**Why it matters for CARLOS:**  
+MMS may be useful for simple attachments, but healthcare content should usually be handled carefully because patient information may be exposed on a phone lock screen or carrier system.
+
+## A2P
+
+**Stands for:** Application-to-Person.
+
+**Simple meaning:** Messages sent by software to people.
+
+**Why it matters for CARLOS:**  
+CARLOS sending appointment reminders or patient notifications is A2P messaging. A2P traffic often requires registration and compliance checks.
+
+## P2P
+
+**Stands for:** Person-to-Person.
+
+**Simple meaning:** Normal texting between two individuals.
+
+**Why it matters for CARLOS:**  
+CARLOS messages are not usually P2P, because they are sent by an application on behalf of clinics.
+
+## 10DLC
+
+**Stands for:** 10-Digit Long Code.
+
+**Simple meaning:** A regular-looking 10-digit phone number used for business texting.
+
+**Why it matters for CARLOS:**  
+In the US, business texting over normal phone numbers usually requires 10DLC brand and campaign registration.
+
+## Toll-Free SMS
+
+**Simple meaning:** Texting from a toll-free number, such as a number starting with 800, 888, 877, etc.
+
+**Why it matters for CARLOS:**  
+Toll-free numbers can be used for business SMS, but they still require verification and have carrier rules.
+
+## Short Code
+
+**Simple meaning:** A short 5- or 6-digit texting number used by large organizations.
+
+**Why it matters for CARLOS:**  
+Short codes can support high-volume messaging but are expensive and require carrier approval.
+
+## Campaign Registration
+
+**Simple meaning:** Registering who is sending messages, what the messages are for, and how recipients gave consent.
+
+**Why it matters for CARLOS:**  
+At scale, CARLOS may need campaign registration for each clinic, organization, or message type depending on the provider and carrier rules.
+
+## TCR
+
+**Stands for:** The Campaign Registry.
+
+**Simple meaning:** The organization used in the US to register brands and campaigns for 10DLC business messaging.
+
+**Why it matters for CARLOS:**  
+If CARLOS sends US 10DLC messages, TCR registration may be required.
+
+## Carrier Fees
+
+**Simple meaning:** Extra fees charged by mobile carriers on top of the vendor’s messaging price.
+
+**Why it matters for CARLOS:**  
+The listed SMS price is often not the full cost. Carrier fees can materially change total cost at millions of messages.
+
+## Throughput
+
+**Simple meaning:** How many messages can be sent in a given time period.
+
+**Why it matters for CARLOS:**  
+Millions of patient messages require high throughput. A provider that is fine for 100 texts/day may not be suitable for national-scale reminders.
+
+## Deliverability
+
+**Simple meaning:** How reliably messages actually reach recipients.
+
+**Why it matters for CARLOS:**  
+Low price does not help if messages are filtered, delayed, blocked, or marked as spam.
+
+## Webhook
+
+**Simple meaning:** A callback from a provider to CARLOS when something happens.
+
+**Why it matters for CARLOS:**  
+Webhooks can tell CARLOS when a message was delivered, failed, received a reply, or got an opt-out like STOP.
+
+## Delivery Receipt
+
+**Simple meaning:** A status update saying whether a message was delivered, failed, queued, or rejected.
+
+**Why it matters for CARLOS:**  
+CARLOS should track message outcomes for support, auditability, and retry logic.
+
+## Opt-In
+
+**Simple meaning:** A patient agrees to receive messages.
+
+**Why it matters for CARLOS:**  
+Consent must be tracked before sending many types of patient communication.
+
+## Opt-Out
+
+**Simple meaning:** A patient says they no longer want messages, often by replying STOP.
+
+**Why it matters for CARLOS:**  
+CARLOS must stop sending messages when a patient opts out, unless a legally valid exception applies.
+
+## Consent
+
+**Simple meaning:** Permission from the patient to communicate in a certain way.
+
+**Why it matters for CARLOS:**  
+Consent should be tracked by channel, such as SMS, email, phone, fax, portal, and possibly by message type.
+
+# Fax Terms
+
+## Virtual Fax
+
+**Simple meaning:** Sending and receiving faxes through a web portal, email, or API instead of a physical fax machine.
+
+**Why it matters for CARLOS:**  
+Virtual fax could support clinics that still need to send documents to other healthcare organizations.
+
+## Fax DID
+
+**Simple meaning:** A phone number dedicated to sending or receiving faxes.
+
+**Why it matters for CARLOS:**  
+Some vendors require fax-specific numbers instead of reusing normal voice numbers.
+
+## T.38
+
+**Simple meaning:** A standard for sending fax over IP networks.
+
+**Why it matters for CARLOS:**  
+T.38 is useful for connecting traditional fax machines or fax servers, but status tracking may be weaker than API-based fax.
+
+## Fax API
+
+**Simple meaning:** A software interface for sending, receiving, and tracking faxes.
+
+**Why it matters for CARLOS:**  
+A fax API is better than manual faxing if CARLOS needs audit logs, delivery status, and automated workflows.
+
+## Fax Delivery Confirmation
+
+**Simple meaning:** Confirmation that a fax was sent successfully or failed.
+
+**Why it matters for CARLOS:**  
+Healthcare workflows often need proof that a document was transmitted.
+
+# Cloud and API Terms
+
+## API
+
+**Stands for:** Application Programming Interface.
+
+**Simple meaning:** A way for one software system to talk to another.
+
+**Why it matters for CARLOS:**  
+CARLOS would use vendor APIs to send messages, send faxes, receive replies, and check delivery status.
+
+## SDK
+
+**Stands for:** Software Development Kit.
+
+**Simple meaning:** Prebuilt code from a vendor that makes their API easier to use.
+
+**Why it matters for CARLOS:**  
+Good SDKs reduce implementation time and bugs.
+
+## CPaaS
+
+**Stands for:** Communications Platform as a Service.
+
+**Simple meaning:** A cloud service that lets applications send texts, make calls, verify users, or manage communications through APIs.
+
+**Why it matters for CARLOS:**  
+Twilio, Telnyx, Plivo, Sinch, SignalWire, and Bandwidth are examples of CPaaS-style vendors.
+
+## UCaaS
+
+**Stands for:** Unified Communications as a Service.
+
+**Simple meaning:** Cloud-based business phone, messaging, meetings, voicemail, and collaboration tools.
+
+**Why it matters for CARLOS:**  
+Cloudli, RingCentral, Zoom Phone, and similar tools are often better for office phone systems than embedded patient messaging APIs.
+
+## Contact Center
+
+**Simple meaning:** Software for managing support calls, queues, agents, recordings, and customer interactions.
+
+**Why it matters for CARLOS:**  
+Could matter if CARLOS later supports call-center workflows for clinics.
+
+## Data Residency
+
+**Simple meaning:** Where data is stored geographically.
+
+**Why it matters for CARLOS:**  
+Canadian healthcare customers may prefer or require Canadian data storage.
+
+## Data Retention
+
+**Simple meaning:** How long a vendor keeps message content, fax files, logs, or metadata.
+
+**Why it matters for CARLOS:**  
+Patient information should not be stored longer than necessary, and retention should match legal and clinical requirements.
+
+## Metadata
+
+**Simple meaning:** Information about a message, not necessarily the message content itself.
+
+**Examples:** sender, recipient, timestamp, status, message ID.
+
+**Why it matters for CARLOS:**  
+Even metadata can be sensitive in healthcare because it may reveal patient-provider relationships.
+
+## SLA
+
+**Stands for:** Service Level Agreement.
+
+**Simple meaning:** A vendor’s formal uptime or support commitment.
+
+**Why it matters for CARLOS:**  
+At large scale, CARLOS needs reliable vendor support and clear commitments around outages.
+
+# Healthcare and Compliance Terms
+
+## PHI
+
+**Stands for:** Protected Health Information.
+
+**Simple meaning:** Health information that can identify a patient.
+
+**Why it matters for CARLOS:**  
+SMS, email, fax, logs, and message metadata can all involve PHI.
+
+## PII
+
+**Stands for:** Personally Identifiable Information.
+
+**Simple meaning:** Information that can identify a person, such as name, phone number, email, or address.
+
+**Why it matters for CARLOS:**  
+Even a phone number or appointment reminder may be sensitive when tied to healthcare.
+
+## HIPAA
+
+**Stands for:** Health Insurance Portability and Accountability Act.
+
+**Simple meaning:** US law that governs health information privacy and security.
+
+**Why it matters for CARLOS:**  
+Relevant if CARLOS serves US healthcare providers or patients.
+
+## BAA
+
+**Stands for:** Business Associate Agreement.
+
+**Simple meaning:** A legal agreement required under HIPAA when a vendor handles PHI for a healthcare organization.
+
+**Why it matters for CARLOS:**  
+If a US healthcare customer uses CARLOS and CARLOS uses a messaging vendor, the vendor may need to sign a BAA.
+
+## PHIPA
+
+**Stands for:** Personal Health Information Protection Act.
+
+**Simple meaning:** Ontario health privacy law.
+
+**Why it matters for CARLOS:**  
+Relevant if CARLOS serves Ontario healthcare providers or patients.
+
+## PIPEDA
+
+**Stands for:** Personal Information Protection and Electronic Documents Act.
+
+**Simple meaning:** Canadian federal private-sector privacy law.
+
+**Why it matters for CARLOS:**  
+Relevant to how CARLOS handles personal information in Canada.
+
+## CASL
+
+**Stands for:** Canada's Anti-Spam Legislation.
+
+**Simple meaning:** Canadian law covering commercial electronic messages, including texts and emails.
+
+**Why it matters for CARLOS:**  
+Consent, sender identification, and unsubscribe/opt-out handling may be required depending on message type.
+
+## Audit Log
+
+**Simple meaning:** A record of who did what and when.
+
+**Why it matters for CARLOS:**  
+CARLOS should track message sends, delivery results, consent changes, opt-outs, user actions, and vendor callbacks.
+
+## Tenant Separation
+
+**Simple meaning:** Keeping each clinic or organization’s data separated from others.
+
+**Why it matters for CARLOS:**  
+CARLOS is intended for many doctors/clinics, so one clinic should not see or affect another clinic’s communications.
+
+# Vendor Categories
+
+## Carrier API Provider
+
+**Simple meaning:** A vendor that connects directly or closely to telecom networks and exposes APIs for messaging or voice.
+
+**Examples:** Bandwidth, Telnyx.
+
+**Why it matters for CARLOS:**  
+Often stronger for scale, deliverability, and enterprise telecom operations.
+
+## CPaaS Provider
+
+**Simple meaning:** A developer-friendly communications API platform.
+
+**Examples:** Twilio, Telnyx, Plivo, Sinch, SignalWire.
+
+**Why it matters for CARLOS:**  
+Usually fastest path to embedding SMS, voice, verification, and sometimes fax into an application.
+
+## Healthcare Platform
+
+**Simple meaning:** A product built around healthcare workflows like patient reminders, intake forms, referrals, booking, or secure messaging.
+
+**Examples:** OceanMD, Cortico.
+
+**Why it matters for CARLOS:**  
+These may be competitors, integration partners, or benchmarks, but they are not usually raw telecom infrastructure providers.
+
+## Cloud Platform
+
+**Simple meaning:** A broad infrastructure provider for hosting, storage, databases, email, analytics, identity, and sometimes communications.
+
+**Examples:** AWS, Azure, Google Cloud.
+
+**Why it matters for CARLOS:**  
+Cloud platforms may host CARLOS and provide email/SMS pieces, but may not offer complete telecom workflows such as fax.
+
+# Terms to Watch Closely in Vendor Reviews
+
+## “HIPAA compliant”
+
+This can be vague. Ask which products are eligible, whether the vendor signs a BAA, and whether SMS/fax/email are included.
+
+## “Canadian”
+
+This can mean different things: Canadian company, Canadian office, Canadian data center, Canadian support, or Canadian legal entity. These are not the same.
+
+## “Unlimited”
+
+Usually subject to fair-use limits, carrier rules, or acceptable-use policies.
+
+## “Starting at”
+
+Usually excludes carrier fees, registration fees, number rental, support plans, or enterprise requirements.
+
+## “SMS support”
+
+This does not automatically mean high-volume A2P support, healthcare suitability, two-way messaging, opt-out automation, or Canadian carrier compliance.
+
+## “Fax support”
+
+This may mean email-to-fax, portal fax, SIP/T.38 fax, or a true fax API. These are different implementation models.

--- a/docs/communications-vendor-research.md
+++ b/docs/communications-vendor-research.md
@@ -1,0 +1,620 @@
+# CARLOS Communications Vendor Research Brief
+
+Pricing is based on public vendor docs as of May 28, 2026 and should be rechecked before procurement.
+
+# High-Level Fit
+
+## Quick Comparison
+
+**VoIP.ms**
+- Category: VoIP/SMS/fax API
+- Canadian fit: High
+- Services: SMS/MMS, fax, voice
+- Email: No
+- CARLOS setup: Medium
+- Scale confidence: Low-Medium
+
+**Telnyx**
+- Category: CPaaS carrier API
+- Canadian fit: Low
+- Services: SMS/MMS, fax, voice
+- Email: No
+- CARLOS setup: Medium
+- Scale confidence: High
+
+**Twilio**
+- Category: CPaaS API suite
+- Canadian fit: Low
+- Services: SMS/MMS, voice, email via SendGrid
+- Fax: No
+- CARLOS setup: Low-Medium
+- Scale confidence: High
+
+**Bandwidth**
+- Category: Carrier-grade API
+- Canadian fit: Low
+- Services: SMS/MMS, voice
+- Fax: No/unclear
+- Email: No
+- CARLOS setup: Medium-High
+- Scale confidence: High
+
+**AWS**
+- Category: Cloud platform
+- Canadian fit: Low
+- Services: SMS/MMS, email via SES, voice
+- Fax: No
+- CARLOS setup: Medium
+- Scale confidence: High
+
+**Microsoft / Azure**
+- Category: Cloud + communications APIs
+- Canadian fit: Medium
+- Services: SMS, email, voice, video/chat
+- Fax: No
+- CARLOS setup: Medium
+- Scale confidence: Medium
+
+**Google Cloud**
+- Category: Cloud/health infrastructure
+- Canadian fit: Medium
+- Services: healthcare cloud APIs, cloud hosting, Google Voice/Workspace adjacent services
+- SMS/MMS: No direct CPaaS equivalent found
+- Fax: No
+- Email: Partner/Gmail API route
+- CARLOS setup: High
+- Scale confidence for SMS: Low
+
+**Cloudli**
+- Category: Canadian UC/fax
+- Canadian fit: High
+- Services: SMS/MMS, fax, voice
+- Email: No
+- CARLOS setup: Medium
+- Scale confidence: Low-Medium
+
+**FreePBX**
+- Category: PBX software
+- Canadian fit: Medium via Sangoma
+- Services: PBX, SIP, voice, fax-to-email, voicemail/email notifications
+- SMS/MMS: Via add-ons/provider
+- CARLOS setup: High
+- Scale confidence for patient SMS: Low
+
+**OceanMD**
+- Category: Canadian healthcare platform
+- Canadian fit: High
+- Services: secure patient messaging, reminders, forms, eReferrals, secure links
+- SMS/MMS: Partial/reminders
+- Fax: No
+- Voice: No
+- CARLOS setup: Medium
+- Scale confidence: Medium
+
+**Cortico**
+- Category: Canadian healthcare platform
+- Canadian fit: High
+- Services: SMS/email reminders, secure messaging, telehealth, EMR plug-ins
+- Fax: No
+- CARLOS setup: Medium
+- Scale confidence: Medium
+
+**Plivo**
+- Category: CPaaS API
+- Canadian fit: Low
+- Services: SMS/MMS, voice
+- Fax: No
+- Email: No
+- CARLOS setup: Low-Medium
+- Scale confidence: High
+
+**Sinch**
+- Category: CPaaS/omnichannel
+- Canadian fit: Low
+- Services: SMS, voice, email/omnichannel
+- Fax: Unknown
+- CARLOS setup: Medium
+- Scale confidence: High
+
+**SignalWire**
+- Category: CPaaS voice/SMS/fax
+- Canadian fit: Low
+- Services: SMS/MMS, fax, voice, SIP, WebRTC
+- Email: No
+- CARLOS setup: Medium
+- Scale confidence: Medium-High
+
+# Vendor Details
+
+## VoIP.ms
+
+**What it is:**  
+Montreal-based Canadian VoIP provider offering DIDs, voice, SMS/MMS, virtual fax, SIP trunking, and APIs.
+
+**Key facts:**
+
+- SMS/MMS via API is supported.
+- SMS pricing is around $0.0075 USD sent or received.
+- MMS pricing is around $0.02 USD sent or received.
+- Virtual fax pricing is around $1.99 USD/month per fax DID plus $0.029 USD/min sent or received.
+- Local phone numbers are around $1.10 USD/month depending on number type.
+- API SMS/MMS has a default 100 messages/day limit, raisable after verification.
+- Sources: https://voip.ms/pricing, https://wiki.voip.ms/article/SMS, https://wiki.voip.ms/article/Virtual_Fax, https://wiki.voip.ms/article/API_Overview
+
+**Pros:**
+
+- Canadian company.
+- Inexpensive.
+- Straightforward API.
+- Supports SMS, MMS, fax, and voice.
+- Good pilot candidate.
+
+**Cons / risks:**
+
+- Public docs do not prove easy scaling to millions of patients.
+- Multi-clinic A2P registration needs direct confirmation.
+- Deliverability, support SLAs, healthcare agreements, and data residency need direct confirmation.
+
+**CARLOS fit:**  
+Good for pilot or low-volume Canadian SMS/fax. Risky as the assumed production backbone for millions of patients.
+
+---
+
+## Telnyx
+
+**What it is:**  
+Programmable communications API provider for messaging, voice, SIP, fax, numbers, lookup, verification, AI voice, and networking.
+
+**Key facts:**
+
+- Messaging pricing starts around $0.004 USD/message part plus carrier fees for SMS.
+- MMS starts around $0.015 outbound plus carrier fees.
+- Fax API is around $0.007/page plus SIP trunking usage.
+- Telnyx advertises automatic discounts and contract pricing at scale.
+- Sources: https://telnyx.com/pricing/messaging, https://telnyx.com/pricing/fax, https://telnyx.com/pricing
+
+**Pros:**
+
+- Strong API surface.
+- High-volume pricing model.
+- Fax API.
+- Voice and SIP support.
+- Better infrastructure fit than VoIP.ms for large A2P messaging.
+
+**Cons / risks:**
+
+- Not Canadian.
+- Healthcare compliance and data residency need confirmation.
+- Carrier fees and campaign registration still apply.
+
+**CARLOS fit:**  
+Strong production candidate for SMS/MMS/fax infrastructure if compliance and Canadian data concerns are acceptable.
+
+---
+
+## Twilio
+
+**What it is:**  
+Large global CPaaS provider for SMS/MMS, voice, WhatsApp, verification, conversations, email via SendGrid, Flex/contact center, and data products.
+
+**Key facts:**
+
+- Canada SMS pricing lists long-code/toll-free outbound and inbound SMS at $0.0083 USD/message segment.
+- MMS outbound is around $0.0220.
+- Canadian carrier fees are extra.
+- Canadian long-code numbers are around $1.15/month.
+- Toll-free numbers are around $2.15/month.
+- Random short codes are around $1,000/month plus setup.
+- Twilio SendGrid covers email.
+- Twilio Programmable Fax was sunset in 2021.
+- Sources: https://www.twilio.com/en-us/sms/pricing/ca, https://www.twilio.com/en-us/pricing, https://sendgrid.com/en-us/pricing, https://help.twilio.com/articles/223136667
+
+**Pros:**
+
+- Mature docs and SDKs.
+- Good webhook support.
+- Compliance tooling.
+- SendGrid email.
+- Enterprise scale.
+- Broad developer familiarity.
+
+**Cons / risks:**
+
+- Not Canadian.
+- Often more expensive after carrier fees.
+- No current fax API.
+- HIPAA/healthcare requires BAA and eligible-product review.
+
+**CARLOS fit:**  
+Strong production SMS/email candidate, but not fax. Likely higher cost than Telnyx or Plivo at large volume.
+
+---
+
+## Bandwidth
+
+**What it is:**  
+Carrier-grade communications platform for voice, messaging, emergency calling, number management, and enterprise integrations.
+
+**Key facts:**
+
+- Offers SMS, MMS, RCS, Voice API, Emergency Calling API, number management, campaign registration, Microsoft Teams/Zoom/Webex integrations, and global SIP.
+- Pricing page emphasizes quote/volume pricing and a direct-carrier model.
+- Public pricing detail is less transparent than Twilio/Telnyx.
+- Messaging API sends SMS/MMS over HTTP.
+- Docs say Bandwidth does not store message body content, only metadata.
+- Sources: https://www.bandwidth.com/products/, https://www.bandwidth.com/pricing/, https://dev.bandwidth.com/docs/messaging/, https://www.bandwidth.com/support/en/articles/12823993-hipaa-eligible-products-and-services
+
+**Pros:**
+
+- Strong scale story.
+- Direct carrier/network positioning.
+- Enterprise support.
+- Good for SaaS platforms needing serious messaging and voice infrastructure.
+
+**Cons / risks:**
+
+- Pricing likely requires sales.
+- Not Canadian.
+- Fax and email are not core strengths.
+- More enterprise procurement effort.
+
+**CARLOS fit:**  
+Strong contender for production SMS/voice at high scale, especially if CARLOS wants carrier-grade support.
+
+---
+
+## AWS
+
+**What it is:**  
+Cloud platform with End User Messaging, SES email, Amazon Connect, Pinpoint-related messaging, voice, push, WhatsApp, RCS, storage, and healthcare/cloud infrastructure.
+
+**Key facts:**
+
+- AWS End User Messaging supports SMS, MMS, RCS, WhatsApp, push, and voice.
+- Example Canadian toll-free SMS pricing shows $0.00581/message fee plus $0.00705 carrier fee.
+- SES is pay-as-you-go email.
+- AWS has no native fax API comparable to Telnyx or VoIP.ms.
+- Sources: https://aws.amazon.com/end-user-messaging/pricing, https://aws.amazon.com/end-user-messaging/faqs/, https://aws.amazon.com/ses/pricing/
+
+**Pros:**
+
+- Excellent cloud ecosystem.
+- SES is cheap for email.
+- Strong security/compliance tooling.
+- Good fit if CARLOS is already on AWS.
+
+**Cons / risks:**
+
+- Messaging setup can be more complex than Twilio.
+- Fax is missing.
+- Support/compliance questions may require AWS enterprise processes.
+
+**CARLOS fit:**  
+Good for email/cloud backbone and possibly SMS at scale, less attractive if the team wants a simple telecom-first vendor.
+
+---
+
+## Microsoft / Azure
+
+**What it is:**  
+Cloud platform with Azure Communication Services, Teams Phone, email, SMS, voice/video/chat, and Microsoft 365/OneDrive/SharePoint.
+
+**Key facts:**
+
+- Azure Communication Services supports SMS, email, voice/video, and chat.
+- Toll-free SMS leasing is listed at $2/month for US/Canada/Puerto Rico.
+- US/Canada SMS usage is $0.0075 sent or received.
+- Canadian carrier surcharge is listed at $0.0085 outbound.
+- Canada short codes are $1,000/month.
+- Canada short-code usage is $0.0268 outbound and $0.0061 inbound before surcharge.
+- Sources: https://learn.microsoft.com/en-us/azure/communication-services/concepts/sms-pricing, https://azure.microsoft.com/en-us/pricing/details/communication-services/, https://azure.microsoft.com/en-us/products/communication-services/
+
+**Pros:**
+
+- Good if CARLOS already uses Microsoft 365/Azure.
+- Email, Teams, cloud storage, identity, and compliance tooling are nearby.
+- Strong enterprise trust posture.
+
+**Cons / risks:**
+
+- SMS footprint is narrower than Twilio/Telnyx.
+- No fax API.
+- More cloud-platform setup than telecom-only API.
+
+**CARLOS fit:**  
+Good broader enterprise/cloud option; moderate SMS fit; weak fax fit.
+
+---
+
+## Google Cloud
+
+**What it is:**  
+Cloud and healthcare infrastructure platform, not a first-party CPaaS SMS/fax provider.
+
+**Key facts:**
+
+- Google Cloud has Cloud Healthcare API with FHIR, HL7, DICOM, consent features, and regional data controls.
+- Google recommends third-party SMTP/email services such as SendGrid, Mailgun, or Mailjet for high-volume email from App Engine.
+- No first-party Google Cloud SMS/fax API comparable to Twilio or Telnyx was found.
+- Sources: https://cloud.google.com/healthcare-api/pricing, https://docs.cloud.google.com/healthcare-api/docs/regions, https://docs.cloud.google.com/appengine/docs/standard/services/mail
+
+**Pros:**
+
+- Strong healthcare/cloud/data platform.
+- Canadian region options.
+- Good for hosting CARLOS infrastructure.
+
+**Cons / risks:**
+
+- Not a direct SMS/fax answer.
+- Would still need Twilio, Telnyx, Bandwidth, or similar for telecom.
+
+**CARLOS fit:**  
+Good cloud/health-data platform, poor direct patient messaging provider.
+
+---
+
+## Cloudli
+
+**What it is:**  
+Canadian business communications provider offering cloud phone, SMS/MMS, virtual fax, IP fax, SIP/voice, and Microsoft 365 contact sync.
+
+**Key facts:**
+
+- Cloudli lists Canadian contact/address in Montreal in its terms.
+- Cloudli Connect plans include local number, extensions, unlimited Canada/US calling subject to fair use, SMS-enabled numbers, and virtual fax on some bundles.
+- Pricing is mostly “Contact for Pricing.”
+- Fax docs support email-to-fax and portal fax.
+- Sent/received fax copies are retained for 10 days; history is retained for 60 days.
+- Sources: https://www.cloudli.com/en-ca/solutions/cloud/business-phone/, https://support.cloudli.com/hc/en-ca/sections/360005049233-SMS-MMS-FAQ, https://support.cloudli.com/hc/en-ca/articles/1500001519182-Quick-Start-Guide-for-Virtual-Fax-Desktop-Fax, https://www.cloudli.com/en-ca/terms-of-service
+
+**Pros:**
+
+- Canadian.
+- Strong fax/voice positioning.
+- Practical clinic-office communications vendor.
+
+**Cons / risks:**
+
+- Public API story and pricing are less clear.
+- More UC/phone-system oriented than embedded developer API.
+
+**CARLOS fit:**  
+Worth investigating for Canadian fax/voice, less obvious as the core CARLOS messaging API.
+
+---
+
+## FreePBX
+
+**What it is:**  
+Open-source PBX management software for Asterisk, sponsored by Sangoma. It is software, not a telecom carrier.
+
+**Key facts:**
+
+- FreePBX is free/open source.
+- Manages PBX functions such as extensions, IVR, queues, voicemail, SIP trunks, and fax-to-email.
+- SMS requires provider/module support, such as Sangoma SIPStation or third-party trunk integrations.
+- PBXact Cloud examples show $22.95/month trunk + user, $8.95/month user-only, inbound numbers $1/month, Lite Faxing $9.95/month, and High Volume Faxing $24.99/month.
+- Sources: https://www.freepbx.org/, https://www.freepbx.org/get-started/, https://www.freepbx.org/sms-plus-enhanced-sms-functionality-for-freepbx-pbxact/, https://store.cloud.pbxact.com/
+
+**Pros:**
+
+- Flexible.
+- Low software cost.
+- Good for clinic phone systems.
+- Supports SIP, IVR, and call routing.
+
+**Cons / risks:**
+
+- High operational burden.
+- Not a patient messaging API.
+- Requires carrier/provider, security hardening, maintenance, and telecom expertise.
+
+**CARLOS fit:**  
+Not recommended as core patient messaging infrastructure. Could be relevant if CARLOS later needs a clinic PBX integration story.
+
+---
+
+## OceanMD
+
+**What it is:**  
+Canadian healthcare platform for patient engagement, secure messages, forms, reminders, eReferrals, booking, and EMR integration.
+
+**Key facts:**
+
+- Pricing is in CAD.
+- Patient Engagement Basic is $31/provider or schedule/month.
+- Basic includes secure messaging, attachments/PDFs, customized reminders, optional SMS reminders at $0.11 each, and support staff.
+- Plus is $60/schedule/month.
+- Ocean supports secure patient messages, email/SMS reminders, forms, eReferral workflows, and APIs.
+- Ocean says customer data is stored in AWS Montreal for Canadian residency.
+- Sources: https://www.oceanmd.com/pricing/, https://www.oceanmd.com/patient-messages/, https://www.oceanmd.com/patient-reminders/, https://support.cognisantmd.com/hc/en-us/sections/360006922672-API-Integrations, https://www.oceanmd.com/security/
+
+**Pros:**
+
+- Canadian healthcare fit.
+- EMR-aware.
+- Secure messaging/forms.
+- PHIPA-oriented posture.
+- Good patient workflow layer.
+
+**Cons / risks:**
+
+- Not a raw SMS/fax carrier.
+- Cohort/group messaging has documented operational limits.
+- May compete with CARLOS rather than just supply infrastructure.
+
+**CARLOS fit:**  
+Strong benchmark or integration candidate for Canadian patient engagement, not the telecom backbone.
+
+---
+
+## Cortico
+
+**What it is:**  
+Canadian healthcare patient engagement and workflow automation platform with online booking, reminders, secure messaging, file sending, telehealth, and EMR plug-ins.
+
+**Key facts:**
+
+- Essentials: $86/FTE/month.
+- Premium: $119/FTE/month.
+- Elite: $199/FTE/month.
+- Features include SMS/email reminders, secure patient messaging/file sending, telehealth, intake forms, mass email, and EMR plug-ins.
+- Cortico documents consent/subscription handling for SMS/email and audit trails/read receipts.
+- Sources: https://cortico.health/pricing/, https://help.cortico.ca/doc/cortico-privacy-practices-for-patients, https://help.cortico.ca/help/consent-to-use-electronic-communication, https://help.cortico.ca/help/cortico-plug-in-for-healthcare-providers
+
+**Pros:**
+
+- Canadian healthcare focus.
+- Consent handling.
+- Audit trails.
+- Secure messaging.
+- EMR workflow fit.
+
+**Cons / risks:**
+
+- Not a general telecom API provider.
+- May overlap/compete with CARLOS product scope.
+- Fax not evident.
+
+**CARLOS fit:**  
+Good product benchmark and possible integration/partner candidate; not the SMS carrier layer.
+
+---
+
+## Plivo
+
+**What it is:**  
+CPaaS provider for SMS and voice APIs.
+
+**Key facts:**
+
+- Canada long-code SMS outbound/inbound is $0.0077.
+- Toll-free outbound SMS is $0.0079.
+- MMS long-code is $0.018.
+- Toll-free MMS is $0.020.
+- Carrier surcharges apply.
+- Number rental lists long codes at $0.75/month and toll-free numbers at $1/month.
+- Short code is $700/month plus $4,000 one-time setup.
+- Sources: https://www.plivo.com/sms/pricing/ca/, https://www.plivo.com/voice/pricing/ca/, https://docs.plivo.com/docs/account/api/pricing
+
+**Pros:**
+
+- Strong SMS pricing.
+- Simple API.
+- Credible Twilio alternative.
+
+**Cons / risks:**
+
+- Not Canadian.
+- Fax/email are not core.
+- Healthcare/BAA/data residency requires confirmation.
+
+**CARLOS fit:**  
+Strong SMS cost competitor for production comparison.
+
+---
+
+## Sinch
+
+**What it is:**  
+Large global CPaaS/omnichannel communications provider for SMS, voice, email, verification, WhatsApp/RCS, and engagement tooling.
+
+**Key facts:**
+
+- Sinch has SMS API, Voice API, email/messaging products, and pricing pages.
+- Canadian detailed pricing was less directly exposed in public docs than Twilio/Plivo.
+- Sinch documents toll-free registration requirements for Canada in messaging guidance.
+- Sources: https://sinch.com/pricing/, https://developers.sinch.com/docs/sms/api-reference/sms, https://sinch.com/
+
+**Pros:**
+
+- Enterprise-scale global messaging.
+- Broad channel support.
+- Likely strong deliverability.
+
+**Cons / risks:**
+
+- Pricing is less transparent.
+- Not Canadian.
+- Procurement may be sales-led.
+
+**CARLOS fit:**  
+Worth including in enterprise RFP, less ideal for quick implementation without sales contact.
+
+---
+
+## SignalWire
+
+**What it is:**  
+Programmable communications provider for voice, SMS/MMS, fax, SIP, WebRTC, AI voice, and hosted messaging.
+
+**Key facts:**
+
+- Local voice inbound: $0.0066/min.
+- Local voice outbound: $0.008/min.
+- SIP: $0.003/min.
+- Local numbers: $0.50/month.
+- Toll-free numbers: $0.80/month.
+- Messaging API supports SMS/MMS and hosted messaging.
+- Fax API supports status webhooks and claims HIPAA-compliant PHI handling.
+- Public fax price table was not fully visible in search results.
+- Sources: https://signalwire.com/pricing/voice, https://signalwire.com/products/cloud-messaging, https://signalwire.com/docs/platform/messaging, https://signalwire.com/products/cloud-fax
+
+**Pros:**
+
+- Broad programmable stack.
+- Fax API.
+- Voice/SIP support.
+- Hosted messaging.
+- Developer-friendly.
+
+**Cons / risks:**
+
+- Not Canadian.
+- Pricing transparency for fax/SMS needs confirmation.
+- Smaller ecosystem than Twilio.
+
+**CARLOS fit:**  
+Good alternate for voice/fax/SMS evaluation, especially if fax API matters.
+
+# Shortlist Recommendation
+
+For CARLOS patient messaging at large scale, do not pick a single vendor yet.
+
+Best candidates to evaluate deeply:
+
+**Production SMS/MMS:**  
+Telnyx, Bandwidth, Twilio, Plivo.
+
+**Canadian pilot / simple fax + SMS:**  
+VoIP.ms.
+
+**Production fax:**  
+Telnyx, Cloudli, SignalWire, plus fax-specialists like SRFax, Documo, and etherFAX in a second pass.
+
+**Email:**  
+AWS SES, Twilio SendGrid, Azure Communication Services Email.
+
+**Canadian healthcare workflow benchmark:**  
+OceanMD and Cortico.
+
+**Cloud/platform fit:**  
+AWS, Azure, or Google Cloud, depending on where CARLOS is hosted.
+
+# Main Risk
+
+The hard part is not sending messages.
+
+The hard parts are:
+
+- consent tracking
+- opt-outs
+- A2P/campaign registration
+- deliverability
+- PHI-safe message content
+- audit logs
+- tenant separation
+- data residency
+- healthcare compliance
+- vendor support at millions-of-patients scale

--- a/docs/consent-data-structures-report.md
+++ b/docs/consent-data-structures-report.md
@@ -1,0 +1,301 @@
+# CARLOS Consent Data Structures: Practical Short Version
+
+Date: 2026-06-02
+
+This is the minimum you need to understand before adding more consent types or building the consent UI further.
+
+## 1. There Are Two Main Consent Tables
+
+CARLOS uses:
+
+```text
+consentType = what kinds of consent exist
+Consent     = what one patient answered for one consent type
+```
+
+Example:
+
+```text
+consentType says:
+"Email consent exists."
+
+Consent says:
+"Patient 20 opted in to Email consent."
+```
+
+## 2. `consentType` Means "The Consent Menu"
+
+This table defines the options that can show in the UI.
+
+Important fields:
+
+| Field | What it means |
+|---|---|
+| `id` | The database id. |
+| `type` | The code name. Example: `electronic_communication_consent`. |
+| `name` | The display name. Example: `Email consent`. |
+| `description` | The explanation shown to users. |
+| `active` | `1` means show/use it. `0` means inactive. |
+
+Current useful row:
+
+```text
+id: 2
+type: electronic_communication_consent
+name: Email consent
+active: 1
+```
+
+To add a basic consent type today, add a new active row to `consentType`.
+
+## 3. `Consent` Means "The Patient's Answer"
+
+This table stores a patient's answer for a consent type.
+
+Important fields:
+
+| Field | What it means |
+|---|---|
+| `demographic_no` | The patient id. |
+| `consent_type_id` | Links to `consentType.id`. |
+| `optout` | The actual yes/no answer. |
+| `deleted` | Whether the answer was reset/cleared. |
+| `last_entered_by` | Who last changed it. |
+| `consent_date` | When the patient opted in. |
+| `optout_date` | When the patient opted out. |
+| `edit_date` | Last change date/time. |
+
+## 4. How CARLOS Decides Consent Status
+
+There is no real `status` field today.
+
+CARLOS mainly uses:
+
+```text
+optout
+deleted
+```
+
+Meaning:
+
+| Data state | Meaning |
+|---|---|
+| No `Consent` row | No answer / unknown. |
+| `deleted = 1` | Reset/cleared. Ignore this answer. |
+| `deleted = 0`, `optout = 0` | Patient opted in. |
+| `deleted = 0`, `optout = 1` | Patient opted out. |
+
+So:
+
+```text
+optout = 0 means Opt In
+optout = 1 means Opt Out
+deleted = 1 means Reset/Cleared
+```
+
+## 5. What The Current Demographic UI Sends
+
+The UI uses `consentType.type` as the form field name.
+
+Example:
+
+```text
+electronic_communication_consent
+```
+
+Radio values:
+
+| UI choice | Submitted value | Saved result |
+|---|---:|---|
+| Opt In | `0` | `optout = false` |
+| Opt Out | `1` | `optout = true` |
+
+Reset/clear sends:
+
+```text
+deleteConsent_<type> = 1
+```
+
+That sets:
+
+```text
+deleted = true
+```
+
+So `Reset answer` is the right label. It does not hard-delete the row. It marks it ignored.
+
+## 6. Two Config Flags Must Be On
+
+For the consent section to show:
+
+```text
+privateConsentEnabled=true
+USE_NEW_PATIENT_CONSENT_MODULE=true
+```
+
+`USE_NEW_PATIENT_CONSENT_MODULE` enables the dynamic consent system.
+
+`privateConsentEnabled` controls whether the demographic consent area appears.
+
+## 7. Older Consent Fields Are Separate
+
+These older fields are not part of the new consent table:
+
+```text
+privacyConsent
+informedConsent
+usSigned
+given_consent
+```
+
+They live in `demographicExt`, which is a general key/value table.
+
+Do not build new consent-type UI on those old fields.
+
+## 8. Consent Documents Do Not Really Exist Yet
+
+CARLOS can store general patient documents.
+
+It can classify a document as:
+
+```text
+Other Letter / Consent from Patient
+```
+
+But there is no direct link between:
+
+```text
+a document
+and
+a specific consent type
+```
+
+There is no current `ConsentDocument` table.
+
+So the mock's "Consent documents" section needs new backend structure.
+
+## 9. What The Current Data Model Cannot Store
+
+The current consent tables cannot cleanly store:
+
+| UI need | Current support |
+|---|---|
+| Note beside a consent | Missing |
+| Needs review | Missing |
+| Reviewed by / reviewed date | Missing |
+| Consent expiry | Missing |
+| Required document flag | Missing |
+| Document linked to consent type | Missing |
+
+## 10. What To Build Next
+
+To make the mock real, add three things.
+
+### A. Add fields to `Consent`
+
+Recommended:
+
+```text
+status
+note
+reviewed_by
+reviewed_date
+expiry_date
+```
+
+This supports:
+
+```text
+Not set
+Consented
+Opted out
+Needs review
+Expired
+```
+
+### B. Add fields to `consentType`
+
+Recommended:
+
+```text
+requiresDocument
+sortOrder
+defaultStatus
+```
+
+This supports:
+
+```text
+document required
+display order
+new rows start as Not set or Needs review
+```
+
+### C. Add a new `ConsentDocument` table
+
+Recommended fields:
+
+```text
+id
+demographic_no
+consent_type_id
+consent_id
+document_no
+status
+source
+note
+created_by
+created_date
+deleted
+```
+
+This lets CARLOS say:
+
+```text
+This PDF belongs to this patient's SMS consent.
+```
+
+## 11. Main Risk
+
+The database does not currently guarantee one active consent answer per patient/type.
+
+The code assumes this:
+
+```text
+one patient + one consent type = one current answer
+```
+
+But the database does not enforce it.
+
+If expanding this module, add a constraint or application guard so duplicate current consent rows cannot happen.
+
+## 12. Files That Matter
+
+Most important files:
+
+```text
+src/main/java/io/github/carlos_emr/carlos/commn/model/Consent.java
+src/main/java/io/github/carlos_emr/carlos/commn/model/ConsentType.java
+src/main/java/io/github/carlos_emr/carlos/managers/PatientConsentManagerImpl.java
+src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/DemographicUpdate2Action.java
+src/main/webapp/WEB-INF/jsp/demographic/edit-form-clinical.jsp
+database/mysql/oscarinit.sql
+```
+
+## Bottom Line
+
+For simple new consent types:
+
+```text
+Add active rows to consentType.
+CARLOS saves patient answers in Consent.
+```
+
+For the improved UI mock:
+
+```text
+Add status/note fields to Consent.
+Add document metadata to consentType.
+Add a new ConsentDocument table.
+```
+

--- a/docs/consent-data-structures-report.md
+++ b/docs/consent-data-structures-report.md
@@ -265,9 +265,14 @@ The code assumes this:
 one patient + one consent type = one current answer
 ```
 
-But the database does not enforce it.
+But the database does not enforce it. The `Consent` table only has the primary key on `id` and an index on `demographic_no` — nothing stops two rows for the same patient/type pair.
 
-If expanding this module, add a constraint or application guard so duplicate current consent rows cannot happen.
+The code today maintains the invariant by convention: `PatientConsentManagerImpl` looks up the existing row via `ConsentDao.findByDemographicAndConsentTypeId(...)` (which returns a single `Consent`), then persists a new row only when none exists and merges otherwise. Deletes are soft (`deleted` flag on the same row), so the pair stays unique — as long as every writer goes through that path.
+
+If expanding this module, make the guard explicit with **both** of:
+
+1. A composite unique key on `Consent (demographic_no, consent_type_id)` via a date-based migration (`database/mysql/updates/update-YYYY-MM-DD-consent-unique-pair.sql`). This is safe with the current soft-delete lifecycle because opt-out/delete updates the existing row rather than inserting a replacement.
+2. Keeping all writes routed through the `PatientConsentManagerImpl` lookup-then-persist/merge path — new code must not insert `Consent` rows directly.
 
 ## 12. Files That Matter
 

--- a/docs/consent-data-structures-report.md
+++ b/docs/consent-data-structures-report.md
@@ -60,7 +60,7 @@ Important fields:
 |---|---|
 | `demographic_no` | The patient id. |
 | `consent_type_id` | Links to `consentType.id`. |
-| `explicit` | `1` means the patient gave direct (verbal/written) consent. `0` means consent was implied or assumed. Tracked separately from the opt-in/opt-out answer; `PatientConsentManagerImpl.addEditConsentRecord(...)` sets it on every write. |
+| `explicit` | `1` means the patient gave direct (verbal/written) consent. `0` means consent was implied or assumed. Tracked separately from the opt-in/opt-out answer; `PatientConsentManagerImpl.addEditConsentRecord(...)` sets it when a new `Consent` row is created. |
 | `optout` | The actual yes/no answer. |
 | `deleted` | Whether the answer was reset/cleared. |
 | `last_entered_by` | Who last changed it. |
@@ -306,4 +306,3 @@ Add status/note fields to Consent.
 Add document metadata to consentType.
 Add a new ConsentDocument table.
 ```
-

--- a/docs/consent-data-structures-report.md
+++ b/docs/consent-data-structures-report.md
@@ -36,6 +36,8 @@ Important fields:
 | `name` | The display name. Example: `Email consent`. |
 | `description` | The explanation shown to users. |
 | `active` | `1` means show/use it. `0` means inactive. |
+| `providerNo` | Optional. Scopes the consent type to one provider — `ConsentTypeDao.findConsentTypeForProvider(...)` filters on it. Leave empty for a general consent type. |
+| `remoteEnabled` | Whether this consent type applies to Integrator/remote sharing. Defaults to `0` (off). |
 
 Current useful row:
 
@@ -58,6 +60,7 @@ Important fields:
 |---|---|
 | `demographic_no` | The patient id. |
 | `consent_type_id` | Links to `consentType.id`. |
+| `explicit` | `1` means the patient gave direct (verbal/written) consent. `0` means consent was implied or assumed. Tracked separately from the opt-in/opt-out answer; `PatientConsentManagerImpl.addEditConsentRecord(...)` sets it on every write. |
 | `optout` | The actual yes/no answer. |
 | `deleted` | Whether the answer was reset/cleared. |
 | `last_entered_by` | Who last changed it. |
@@ -271,7 +274,7 @@ The code today maintains the invariant by convention: `PatientConsentManagerImpl
 
 If expanding this module, make the guard explicit with **both** of:
 
-1. A composite unique key on `Consent (demographic_no, consent_type_id)` via a date-based migration (`database/mysql/updates/update-YYYY-MM-DD-consent-unique-pair.sql`). This is safe with the current soft-delete lifecycle because opt-out/delete updates the existing row rather than inserting a replacement.
+1. A composite unique key on `Consent (demographic_no, consent_type_id)` via a date-based migration (`database/mysql/updates/update-YYYY-MM-DD-consent-unique-pair.sql`). This is safe with the current soft-delete lifecycle because opt-out/delete updates the existing row rather than inserting a replacement. The constraint can only be added once the table already satisfies the invariant, so the migration must first dedupe any legacy duplicate patient/type rows (keep the newest by `edit_date`, soft-delete or remove the rest) — or gate the `ALTER TABLE` on a preflight duplicate check — otherwise it fails before the guard lands.
 2. Keeping all writes routed through the `PatientConsentManagerImpl` lookup-then-persist/merge path — new code must not insert `Consent` rows directly.
 
 ## 12. Files That Matter

--- a/docs/mockups/consent-document-mock.pdf
+++ b/docs/mockups/consent-document-mock.pdf
@@ -1,0 +1,62 @@
+%PDF-1.4
+%‚„œ”
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>
+endobj
+4 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+5 0 obj
+<< /Length 664 >>
+stream
+BT
+/F1 18 Tf
+72 740 Td
+(CARLOS EMR - Mock Consent Document) Tj
+/F1 11 Tf
+0 -28 Td
+(Patient: FAKE-Olivia, FAKE-Lee    Demographic #: 14) Tj
+0 -18 Td
+(Consent type: Email consent) Tj
+0 -18 Td
+(Status: Signed / Consented) Tj
+0 -18 Td
+(Stored date: 2024-05-23) Tj
+0 -18 Td
+() Tj
+0 -18 Td
+(I consent to electronic communication with the clinic, including email,) Tj
+0 -18 Td
+(telephone, video conferencing, and related administrative messages.) Tj
+0 -18 Td
+() Tj
+0 -18 Td
+(This is mock content for the consent document popup in the UI prototype.) Tj
+0 -18 Td
+() Tj
+0 -18 Td
+(Patient signature: __________________________) Tj
+0 -18 Td
+(Witness/provider: carlosdoc) Tj
+ET
+endstream
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000015 00000 n 
+0000000064 00000 n 
+0000000121 00000 n 
+0000000247 00000 n 
+0000000317 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+1032
+%%EOF

--- a/docs/mockups/sms-message-history-mock.html
+++ b/docs/mockups/sms-message-history-mock.html
@@ -1,0 +1,691 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>CARLOS SMS Message History Mock</title>
+    <style>
+        * {
+            box-sizing: border-box;
+        }
+
+        html,
+        body {
+            margin: 0;
+            min-height: 100%;
+            background: #f3f3f3;
+            color: #111;
+            font-family: system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif;
+            font-size: 12px;
+            line-height: 1.35;
+        }
+
+        a,
+        a:visited {
+            color: #1f66ad;
+            font-weight: 600;
+            text-decoration: none;
+        }
+
+        button,
+        input,
+        select,
+        textarea {
+            font: inherit;
+        }
+
+        button,
+        input[type="button"] {
+            border: 1px solid #2d74b6;
+            border-radius: 4px;
+            background: #337ab7;
+            color: #fff;
+            font-weight: 600;
+            cursor: pointer;
+        }
+
+        button:hover,
+        input[type="button"]:hover {
+            background: #286090;
+        }
+
+        .patient-shell {
+            min-height: 100vh;
+            display: grid;
+            grid-template-columns: 245px 1fr;
+            grid-template-rows: 56px 1fr;
+        }
+
+        .patient-header {
+            grid-column: 1 / -1;
+            display: flex;
+            align-items: center;
+            gap: 18px;
+            padding: 0 24px;
+            background: #337ab7;
+            color: #fff;
+        }
+
+        .patient-name {
+            margin: 0;
+            font-size: 18px;
+            font-weight: 700;
+            line-height: 1;
+        }
+
+        .patient-meta {
+            font-size: 13px;
+        }
+
+        .header-actions {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            margin-left: auto;
+        }
+
+        .header-button,
+        .header-button:visited {
+            min-height: 30px;
+            padding: 6px 10px;
+            border: 1px solid #155d9c;
+            border-radius: 4px;
+            background: #fff;
+            color: #155d9c;
+            font-weight: 700;
+        }
+
+        .header-button:hover {
+            background: #e9f3ff;
+            color: #0d4776;
+        }
+
+        .side-nav {
+            grid-row: 2;
+            background: #337ab7;
+            color: #fff;
+            border-right: 1px solid #d5d5d5;
+        }
+
+        .side-nav a {
+            display: block;
+            padding: 8px 12px;
+            border-bottom: 1px solid rgba(255, 255, 255, 0.18);
+            color: #fff;
+            font-weight: 700;
+        }
+
+        .side-nav a.active,
+        .side-nav a:hover {
+            background: #286090;
+        }
+
+        .main-content {
+            grid-row: 2;
+            padding: 0 6px 46px;
+            background: #f3f3f3;
+        }
+
+        .search-row {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            height: 36px;
+            padding: 0 8px;
+            border-bottom: 1px solid #ddd;
+            background: #f8f8f8;
+        }
+
+        .record-toolbar {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            min-height: 40px;
+            margin: 0 0 10px;
+            padding: 7px 12px;
+            border: 1px solid #d5d5d5;
+            border-radius: 4px;
+            background: #f8f8f8;
+        }
+
+        .record-title {
+            display: flex;
+            align-items: baseline;
+            gap: 10px;
+        }
+
+        .record-title h2 {
+            margin: 0;
+            font-size: 16px;
+        }
+
+        .content-band {
+            min-height: 780px;
+            padding: 18px;
+            background: #ececec;
+        }
+
+        .panel {
+            margin: 0 0 10px;
+            border: 1px solid #d5d5d5;
+            border-radius: 4px;
+            background: #fff;
+            overflow: hidden;
+        }
+
+        .panel-title {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 8px;
+            min-height: 34px;
+            padding: 7px 13px;
+            background: #337ab7;
+            color: #fff;
+            font-weight: 700;
+        }
+
+        .panel-title-actions {
+            display: inline-flex;
+            gap: 8px;
+        }
+
+        .panel-title-button,
+        .panel-title-button:visited {
+            min-height: 22px;
+            padding: 3px 8px;
+            border: 1px solid rgba(255, 255, 255, 0.75);
+            border-radius: 4px;
+            background: #fff;
+            color: #155d9c;
+            font-size: 11px;
+            font-weight: 700;
+            line-height: 1.2;
+        }
+
+        .panel-body {
+            padding: 12px;
+        }
+
+        .summary-grid {
+            display: grid;
+            grid-template-columns: repeat(4, minmax(0, 1fr));
+            gap: 8px;
+        }
+
+        .summary-cell {
+            min-height: 58px;
+            padding: 9px;
+            border: 1px solid #d7d7d7;
+            border-radius: 4px;
+            background: #f8f8f8;
+        }
+
+        .summary-cell strong {
+            display: block;
+            margin-bottom: 4px;
+            color: #333;
+        }
+
+        .filter-grid {
+            display: grid;
+            grid-template-columns: 1.2fr repeat(4, minmax(120px, 1fr)) auto;
+            gap: 8px;
+            align-items: end;
+        }
+
+        .field {
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+        }
+
+        .field label {
+            font-weight: 700;
+        }
+
+        .field input,
+        .field select {
+            width: 100%;
+            height: 31px;
+            padding: 5px 7px;
+            border: 1px solid #b7c5d2;
+            border-radius: 3px;
+            background: #fff;
+        }
+
+        .filter-button {
+            min-height: 31px;
+            padding: 5px 12px;
+        }
+
+        .history-layout {
+            display: grid;
+            grid-template-columns: minmax(620px, 1.35fr) minmax(320px, 0.65fr);
+            gap: 12px;
+            align-items: start;
+        }
+
+        .message-table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+
+        .message-table th,
+        .message-table td {
+            padding: 7px 8px;
+            border-bottom: 1px solid #e7e7e7;
+            text-align: left;
+            vertical-align: top;
+        }
+
+        .message-table th {
+            background: #fafafa;
+            font-weight: 700;
+            white-space: nowrap;
+        }
+
+        .message-table tr.selected {
+            background: #e9f3ff;
+        }
+
+        .message-preview {
+            max-width: 310px;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        .status-pill {
+            display: inline-block;
+            min-width: 58px;
+            padding: 3px 7px;
+            border: 1px solid #6ea76e;
+            border-radius: 3px;
+            background: #e5f4df;
+            color: #225b22;
+            font-size: 11px;
+            font-weight: 700;
+            text-align: center;
+            white-space: nowrap;
+        }
+
+        .status-pill.queued {
+            border-color: #cc9a2c;
+            background: #fff2c2;
+            color: #684800;
+        }
+
+        .status-pill.failed {
+            border-color: #b94a48;
+            background: #f7dddd;
+            color: #7d1d1b;
+        }
+
+        .status-pill.received {
+            border-color: #6f8fb7;
+            background: #e5eef9;
+            color: #244d7a;
+        }
+
+        .status-pill.event {
+            border-color: #aaa;
+            background: #ededed;
+            color: #555;
+        }
+
+        .detail-list {
+            display: grid;
+            grid-template-columns: 120px 1fr;
+            gap: 7px 10px;
+            margin-bottom: 12px;
+        }
+
+        .detail-label {
+            color: #555;
+            font-weight: 700;
+        }
+
+        .message-bubble {
+            margin: 0 0 8px;
+            padding: 9px 10px;
+            border: 1px solid #d7d7d7;
+            border-radius: 4px;
+            background: #f8f8f8;
+        }
+
+        .message-bubble.inbound {
+            background: #eef5ff;
+            border-color: #c8d8ee;
+        }
+
+        .bubble-meta {
+            display: flex;
+            justify-content: space-between;
+            gap: 8px;
+            margin-bottom: 5px;
+            color: #555;
+            font-size: 11px;
+            font-weight: 700;
+        }
+
+        .footer-toolbar {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 8px;
+            margin-top: 10px;
+            padding: 10px 0 0;
+            border-top: 1px solid #d1d1d1;
+        }
+
+        .footer-left,
+        .footer-right {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .secondary-button {
+            min-height: 32px;
+            padding: 6px 14px;
+        }
+
+        .back-button {
+            min-height: 32px;
+            padding: 6px 14px;
+            border-color: #777;
+            background: #6f7478;
+        }
+
+        .back-button:hover {
+            background: #5f6468;
+        }
+
+        @media (max-width: 1050px) {
+            .filter-grid,
+            .history-layout,
+            .summary-grid {
+                grid-template-columns: 1fr;
+            }
+        }
+
+        @media (max-width: 900px) {
+            .patient-shell {
+                grid-template-columns: 1fr;
+                grid-template-rows: auto auto 1fr;
+            }
+
+            .patient-header {
+                flex-wrap: wrap;
+                min-height: 62px;
+                padding: 10px 14px;
+            }
+
+            .header-actions {
+                margin-left: 0;
+            }
+
+            .side-nav {
+                grid-row: 2;
+                display: flex;
+                overflow-x: auto;
+            }
+
+            .side-nav a {
+                flex: 0 0 auto;
+                border-right: 1px solid rgba(255, 255, 255, 0.18);
+            }
+
+            .main-content {
+                grid-row: 3;
+            }
+        }
+    </style>
+</head>
+<body>
+<div class="patient-shell">
+    <header class="patient-header">
+        <h1 class="patient-name">FAKE-Olivia, FAKE-Lee</h1>
+        <span class="patient-meta">Other &middot; 59 years &middot; DOB: 1966-06-06</span>
+        <div class="header-actions">
+            <a class="header-button" href="sms-patient-master-mock.html">Back to master file</a>
+            <button class="header-button" type="button">Text patient</button>
+        </div>
+    </header>
+
+    <nav class="side-nav" aria-label="Patient actions">
+        <a href="#">Appointment History</a>
+        <a href="#">Billing History</a>
+        <a href="#">Create Invoice</a>
+        <a href="#">Consultations</a>
+        <a href="#">Prescriptions</a>
+        <a href="#">E-Chart</a>
+        <a href="#">Preventions</a>
+        <a href="#">Tickler</a>
+        <a href="#">Documents</a>
+        <a class="active" href="#">Message History</a>
+        <a href="#">Current eForms</a>
+    </nav>
+
+    <main class="main-content">
+        <div class="search-row">
+            <a href="#">Search Patient</a>
+            <a href="sms-patient-master-mock.html">#14</a>
+        </div>
+
+        <section class="record-toolbar">
+            <div class="record-title">
+                <h2>Patient Communication History</h2>
+                <span>SMS and MMS for demographic #14</span>
+            </div>
+            <button type="button">Export CSV</button>
+        </section>
+
+        <section class="content-band">
+            <section class="panel">
+                <div class="panel-title">Communication Summary</div>
+                <div class="panel-body">
+                    <div class="summary-grid">
+                        <div class="summary-cell">
+                            <strong>Default number</strong>
+                            Cell 6476476471
+                        </div>
+                        <div class="summary-cell">
+                            <strong>SMS consent</strong>
+                            Active since 2026-05-14
+                        </div>
+                        <div class="summary-cell">
+                            <strong>Last outbound</strong>
+                            2026-05-28 16:42
+                        </div>
+                        <div class="summary-cell">
+                            <strong>Last inbound</strong>
+                            2026-05-22 09:21
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <section class="panel">
+                <div class="panel-title">Filters</div>
+                <div class="panel-body">
+                    <div class="filter-grid">
+                        <div class="field">
+                            <label for="query">Search</label>
+                            <input id="query" type="search" value="" placeholder="Template, status, linked record">
+                        </div>
+                        <div class="field">
+                            <label for="channel">Channel</label>
+                            <select id="channel">
+                                <option>SMS and MMS</option>
+                                <option>SMS only</option>
+                                <option>MMS only</option>
+                            </select>
+                        </div>
+                        <div class="field">
+                            <label for="direction">Direction</label>
+                            <select id="direction">
+                                <option>All</option>
+                                <option>Outbound</option>
+                                <option>Inbound</option>
+                                <option>Consent events</option>
+                            </select>
+                        </div>
+                        <div class="field">
+                            <label for="status">Status</label>
+                            <select id="status">
+                                <option>All statuses</option>
+                                <option>Sent</option>
+                                <option>Queued</option>
+                                <option>Failed</option>
+                                <option>Received</option>
+                            </select>
+                        </div>
+                        <div class="field">
+                            <label for="range">Date range</label>
+                            <select id="range">
+                                <option>Last 90 days</option>
+                                <option>Last 30 days</option>
+                                <option>This year</option>
+                                <option>All history</option>
+                            </select>
+                        </div>
+                        <button class="filter-button" type="button">Apply</button>
+                    </div>
+                </div>
+            </section>
+
+            <div class="history-layout">
+                <section class="panel">
+                    <div class="panel-title">
+                        <span>Messages</span>
+                        <span class="panel-title-actions">
+                            <a class="panel-title-button" href="#">Show consent log</a>
+                        </span>
+                    </div>
+                    <table class="message-table">
+                        <thead>
+                            <tr>
+                                <th>Date/time</th>
+                                <th>Dir</th>
+                                <th>Type</th>
+                                <th>Status</th>
+                                <th>Linked to</th>
+                                <th>Preview</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr class="selected">
+                                <td>2026-05-28 16:42</td>
+                                <td>Out</td>
+                                <td>Appointment reminder</td>
+                                <td><span class="status-pill">Sent</span></td>
+                                <td>Appt 2026-05-29</td>
+                                <td><div class="message-preview">Reminder from Riverside Clinic: you have an appointment tomorrow...</div></td>
+                            </tr>
+                            <tr>
+                                <td>2026-05-22 09:21</td>
+                                <td>In</td>
+                                <td>Patient reply</td>
+                                <td><span class="status-pill received">Received</span></td>
+                                <td>Tickler #812</td>
+                                <td><div class="message-preview">I can come Tuesday morning if there is still an opening.</div></td>
+                            </tr>
+                            <tr>
+                                <td>2026-05-22 09:15</td>
+                                <td>Out</td>
+                                <td>Call-back request</td>
+                                <td><span class="status-pill queued">Queued</span></td>
+                                <td>Tickler #812</td>
+                                <td><div class="message-preview">Riverside Clinic: we tried to reach you. Please call...</div></td>
+                            </tr>
+                            <tr>
+                                <td>2026-05-14 13:04</td>
+                                <td>Event</td>
+                                <td>Consent captured</td>
+                                <td><span class="status-pill event">Logged</span></td>
+                                <td>Master file</td>
+                                <td><div class="message-preview">SMS consent active. Source: front desk confirmation.</div></td>
+                            </tr>
+                            <tr>
+                                <td>2026-05-10 08:32</td>
+                                <td>Out</td>
+                                <td>Form reminder</td>
+                                <td><span class="status-pill failed">Failed</span></td>
+                                <td>eForm intake</td>
+                                <td><div class="message-preview">Please complete your intake form before your visit.</div></td>
+                            </tr>
+                            <tr>
+                                <td>2026-04-17 15:12</td>
+                                <td>Out</td>
+                                <td>Results notice</td>
+                                <td><span class="status-pill">Sent</span></td>
+                                <td>E-Chart note</td>
+                                <td><div class="message-preview">Please call the clinic about your recent results.</div></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </section>
+
+                <aside class="panel">
+                    <div class="panel-title">Selected Message</div>
+                    <div class="panel-body">
+                        <div class="detail-list">
+                            <span class="detail-label">Status</span>
+                            <span><span class="status-pill">Sent</span></span>
+                            <span class="detail-label">Channel</span>
+                            <span>SMS</span>
+                            <span class="detail-label">To</span>
+                            <span>6476476471</span>
+                            <span class="detail-label">From</span>
+                            <span>Main clinic line</span>
+                            <span class="detail-label">Provider</span>
+                            <span>doctor carlosdoc</span>
+                            <span class="detail-label">Linked record</span>
+                            <span>Appointment 2026-05-29</span>
+                        </div>
+
+                        <div class="message-bubble">
+                            <div class="bubble-meta">
+                                <span>Outbound</span>
+                                <span>2026-05-28 16:42</span>
+                            </div>
+                            <div>Reminder from Riverside Clinic: you have an appointment on Fri May 29. Reply STOP to opt out.</div>
+                        </div>
+
+                        <div class="message-bubble inbound">
+                            <div class="bubble-meta">
+                                <span>Delivery receipt</span>
+                                <span>2026-05-28 16:43</span>
+                            </div>
+                            <div>Carrier accepted message. Provider reference: SM-82741.</div>
+                        </div>
+
+                        <div class="footer-toolbar">
+                            <div class="footer-left">
+                                <button class="secondary-button" type="button">Open linked appt</button>
+                            </div>
+                            <div class="footer-right">
+                                <button class="secondary-button" type="button">Resend</button>
+                            </div>
+                        </div>
+                    </div>
+                </aside>
+            </div>
+
+            <footer class="footer-toolbar">
+                <div class="footer-left">
+                    <button class="secondary-button" type="button">Print history</button>
+                    <button class="secondary-button" type="button">Audit log</button>
+                </div>
+                <div class="footer-right">
+                    <a class="header-button" href="sms-patient-master-mock.html">Back to master file</a>
+                    <button class="back-button" type="button">Back</button>
+                </div>
+            </footer>
+        </section>
+    </main>
+</div>
+</body>
+</html>

--- a/docs/mockups/sms-message-history-mock.html
+++ b/docs/mockups/sms-message-history-mock.html
@@ -1,4 +1,33 @@
 <!doctype html>
+<!--
+    Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+
+    This software is published under the GPL GNU General Public License.
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+    CARLOS EMR Project
+    https://github.com/carlos-emr/carlos
+-->
+<!--
+    Static design mockup: patient communication / SMS message history view.
+
+    Discussion artifact for the proposed SMS features (issue #2443).
+    Not shipped UI; all patient data shown is synthetic.
+
+    @since 2026-07-02
+-->
 <html lang="en">
 <head>
     <meta charset="utf-8">
@@ -464,7 +493,7 @@
         <a href="#">Preventions</a>
         <a href="#">Tickler</a>
         <a href="#">Documents</a>
-        <a class="active" href="#">Message History</a>
+        <a class="active" href="#" aria-current="page">Message History</a>
         <a href="#">Current eForms</a>
     </nav>
 

--- a/docs/mockups/sms-patient-master-consent-mock.html
+++ b/docs/mockups/sms-patient-master-consent-mock.html
@@ -1146,7 +1146,7 @@
     <section class="sms-modal">
         <header>
             <div>
-                <h2 id="smsTitle">Text FAKE-Lee FAKE-Olivia</h2>
+                <h2 id="smsTitle">Text FAKE-Olivia, FAKE-Lee</h2>
                 <p id="smsContext">Patient master file</p>
             </div>
             <button type="button" data-close aria-label="Close">x</button>

--- a/docs/mockups/sms-patient-master-consent-mock.html
+++ b/docs/mockups/sms-patient-master-consent-mock.html
@@ -1,4 +1,33 @@
 <!doctype html>
+<!--
+    Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+
+    This software is published under the GPL GNU General Public License.
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+    CARLOS EMR Project
+    https://github.com/carlos-emr/carlos
+-->
+<!--
+    Interactive design mockup: patient master consent management (consent statuses, consent documents, and a consent PDF popup).
+
+    Discussion artifact for the proposed SMS features (issue #2443).
+    Not shipped UI; all patient data shown is synthetic.
+
+    @since 2026-07-02
+-->
 <html lang="en">
 <head>
     <meta charset="utf-8">
@@ -1075,7 +1104,7 @@
                     </section>
 
                     <section class="panel">
-                        <div class="panel-title">???demographic.manageHealthCareTeam.heading???</div>
+                        <div class="panel-title">Health Care Team</div>
                     </section>
 
                     <section class="panel">
@@ -1307,10 +1336,6 @@
             modal.classList.add('open');
         }
 
-        function closeSms() {
-            modal.classList.remove('open');
-        }
-
         function closeAllModals() {
             modal.classList.remove('open');
             docModal.classList.remove('open');
@@ -1533,7 +1558,7 @@
             closeAllModals();
         }
 
-        function openDocumentPdf(row) {
+        function openDocumentPdf() {
             var binary = atob(mockConsentPdfBase64);
             var bytes = new Uint8Array(binary.length);
             var i;
@@ -1549,6 +1574,9 @@
 
             if (popup) {
                 popup.focus();
+                // Release the blob URL once the popup has had time to load it,
+                // so repeated document views don't accumulate blob references.
+                setTimeout(function () { URL.revokeObjectURL(pdfUrl); }, 60000);
             } else {
                 window.location.href = pdfUrl;
             }
@@ -1672,7 +1700,7 @@
             }
 
             if (viewDocumentButton) {
-                openDocumentPdf(viewDocumentButton.closest('tr'));
+                openDocumentPdf();
                 return;
             }
 

--- a/docs/mockups/sms-patient-master-consent-mock.html
+++ b/docs/mockups/sms-patient-master-consent-mock.html
@@ -905,7 +905,7 @@
                         </div>
                         <div class="info-row">
                             <span class="info-label">Province :</span>
-                            <span class="info-value">Ontario,Canada</span>
+                            <span class="info-value">Ontario, Canada</span>
                             <span></span>
                         </div>
                         <div class="info-row">
@@ -915,7 +915,7 @@
                         </div>
                         <div class="info-row">
                             <span class="info-label">Residential Province:</span>
-                            <span class="info-value">Ontario,Canada</span>
+                            <span class="info-value">Ontario, Canada</span>
                             <span></span>
                         </div>
                         <div class="info-row">

--- a/docs/mockups/sms-patient-master-consent-mock.html
+++ b/docs/mockups/sms-patient-master-consent-mock.html
@@ -904,7 +904,7 @@
                             <span></span>
                         </div>
                         <div class="info-row">
-                            <span class="info-label">Province :</span>
+                            <span class="info-label">Province:</span>
                             <span class="info-value">Ontario, Canada</span>
                             <span></span>
                         </div>

--- a/docs/mockups/sms-patient-master-consent-mock.html
+++ b/docs/mockups/sms-patient-master-consent-mock.html
@@ -1057,6 +1057,7 @@
                                     <th>Consent documents</th>
                                     <th>Consent type</th>
                                     <th>Stored</th>
+                                    <th>Source / note</th>
                                     <th>Status</th>
                                     <th>Action</th>
                                 </tr>
@@ -1066,6 +1067,7 @@
                                     <td>Email consent signed form.pdf</td>
                                     <td>Email consent</td>
                                     <td>2024-05-23</td>
+                                    <td>Scanned paper form</td>
                                     <td><span class="status-pill">Signed</span></td>
                                     <td><button class="document-action" type="button" data-view-document>View</button></td>
                                 </tr>
@@ -1073,6 +1075,7 @@
                                     <td>SMS verbal consent note</td>
                                     <td>SMS/Text messaging</td>
                                     <td>2026-05-14</td>
+                                    <td>Phone call note</td>
                                     <td><span class="status-pill warn">Verbal</span></td>
                                     <td><button class="document-action" type="button" data-view-document>View</button></td>
                                 </tr>
@@ -1136,7 +1139,7 @@
     </main>
 </div>
 
-<div class="modal-backdrop" id="smsModal" role="dialog" aria-modal="true" aria-labelledby="smsTitle">
+<div class="modal-backdrop" id="smsModal" role="dialog" aria-modal="true" aria-labelledby="smsTitle" aria-describedby="smsContext">
     <section class="sms-modal">
         <header>
             <div>
@@ -1548,11 +1551,12 @@
             row.setAttribute('data-doc-status', status);
             row.setAttribute('data-doc-stored', storedDate);
             row.setAttribute('data-doc-source', source);
-            row.innerHTML = '<td></td><td></td><td></td><td><span class="status-pill' + statusClass(status) + '"></span></td><td><button class="document-action" type="button" data-view-document>View</button></td>';
+            row.innerHTML = '<td></td><td></td><td></td><td></td><td><span class="status-pill' + statusClass(status) + '"></span></td><td><button class="document-action" type="button" data-view-document>View</button></td>';
             row.children[0].textContent = fileName;
             row.children[1].textContent = consentLabels[consentType];
             row.children[2].textContent = storedDate;
-            row.children[3].querySelector('span').textContent = status;
+            row.children[3].textContent = source;
+            row.children[4].querySelector('span').textContent = status;
             docRows.appendChild(row);
             updateDocumentCounts();
             closeAllModals();

--- a/docs/mockups/sms-patient-master-consent-mock.html
+++ b/docs/mockups/sms-patient-master-consent-mock.html
@@ -1,0 +1,1708 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>CARLOS Patient Master Consent Mock</title>
+    <style>
+        * {
+            box-sizing: border-box;
+        }
+
+        html,
+        body {
+            margin: 0;
+            min-height: 100%;
+            background: #f3f3f3;
+            color: #111;
+            font-family: system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif;
+            font-size: 12px;
+            line-height: 1.35;
+        }
+
+        a,
+        a:visited {
+            color: #1f66ad;
+            font-weight: 600;
+            text-decoration: none;
+        }
+
+        button,
+        input,
+        select,
+        textarea {
+            font: inherit;
+        }
+
+        button,
+        input[type="button"] {
+            border: 1px solid #2d74b6;
+            border-radius: 4px;
+            background: #337ab7;
+            color: #fff;
+            font-weight: 600;
+            cursor: pointer;
+        }
+
+        button:hover,
+        input[type="button"]:hover {
+            background: #286090;
+        }
+
+        .patient-shell {
+            min-height: 100vh;
+            display: grid;
+            grid-template-columns: 245px 1fr;
+            grid-template-rows: 56px 1fr;
+        }
+
+        .patient-header {
+            grid-column: 1 / -1;
+            display: flex;
+            align-items: center;
+            gap: 18px;
+            padding: 0 24px;
+            background: #337ab7;
+            color: #fff;
+        }
+
+        .patient-name {
+            margin: 0;
+            font-size: 18px;
+            font-weight: 700;
+            line-height: 1;
+        }
+
+        .patient-meta {
+            font-size: 13px;
+        }
+
+        .next-appt {
+            margin-left: 4px;
+            color: #dceeff;
+            font-style: italic;
+        }
+
+        .header-actions {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            margin-left: auto;
+        }
+
+        .header-sms {
+            height: 30px;
+            padding: 0 10px;
+            border-color: #155d9c;
+            background: #fff;
+            color: #155d9c;
+        }
+
+        .header-sms:hover {
+            background: #e9f3ff;
+            color: #0d4776;
+        }
+
+        .side-nav {
+            grid-row: 2;
+            background: #337ab7;
+            color: #fff;
+            border-right: 1px solid #d5d5d5;
+        }
+
+        .side-nav a {
+            display: block;
+            padding: 8px 12px;
+            border-bottom: 1px solid rgba(255, 255, 255, 0.18);
+            color: #fff;
+            font-weight: 700;
+        }
+
+        .side-nav a:hover {
+            background: #286090;
+        }
+
+        .main-content {
+            grid-row: 2;
+            padding: 0 6px 46px;
+            background: #f3f3f3;
+        }
+
+        .search-row {
+            display: flex;
+            align-items: center;
+            height: 36px;
+            padding: 0 8px;
+            border-bottom: 1px solid #ddd;
+            background: #f8f8f8;
+        }
+
+        .search-row a {
+            color: #1f66ad;
+            font-size: 13px;
+        }
+
+        .record-toolbar {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            min-height: 40px;
+            margin: 0 0 10px;
+            padding: 7px 12px;
+            border: 1px solid #d5d5d5;
+            border-radius: 4px;
+            background: #f8f8f8;
+        }
+
+        .record-toolbar button {
+            min-height: 26px;
+            padding: 4px 10px;
+        }
+
+        .show-fields {
+            display: block;
+            margin: 4px 14px 10px auto;
+            width: max-content;
+        }
+
+        .content-band {
+            min-height: 668px;
+            padding: 18px;
+            background: #ececec;
+        }
+
+        .two-column {
+            display: grid;
+            grid-template-columns: minmax(360px, 1fr) minmax(360px, 1fr);
+            gap: 14px;
+            align-items: start;
+        }
+
+        .panel {
+            margin: 0 0 8px;
+            border: 1px solid #d5d5d5;
+            border-radius: 4px;
+            background: #fff;
+            overflow: hidden;
+        }
+
+        .panel-title {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            justify-content: space-between;
+            min-height: 34px;
+            padding: 7px 13px;
+            background: #337ab7;
+            color: #fff;
+            font-weight: 700;
+        }
+
+        .panel-title .pill {
+            height: 21px;
+            padding: 2px 8px;
+            border: 1px solid rgba(255, 255, 255, 0.7);
+            border-radius: 4px;
+            background: transparent;
+            color: #fff;
+            font-size: 11px;
+        }
+
+        .panel-title-left,
+        .panel-title-actions {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .panel-title-button,
+        .panel-title-button:visited {
+            min-height: 22px;
+            padding: 3px 8px;
+            border: 1px solid rgba(255, 255, 255, 0.75);
+            border-radius: 4px;
+            background: #fff;
+            color: #155d9c;
+            font-size: 11px;
+            font-weight: 700;
+            line-height: 1.2;
+        }
+
+        .panel-title-button:hover {
+            background: #e9f3ff;
+            color: #0d4776;
+        }
+
+        .info-row {
+            display: grid;
+            grid-template-columns: minmax(145px, auto) 1fr auto;
+            align-items: center;
+            gap: 8px;
+            min-height: 30px;
+            padding: 7px 12px;
+            border-bottom: 1px solid #e9e9e9;
+        }
+
+        .info-row:last-child {
+            border-bottom: 0;
+        }
+
+        .info-label {
+            font-weight: 400;
+        }
+
+        .info-value {
+            min-width: 0;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        .row-actions {
+            display: inline-flex;
+            align-items: center;
+            gap: 5px;
+            white-space: nowrap;
+        }
+
+        .sms-row-button,
+        .sms-ghost-button {
+            min-height: 23px;
+            padding: 3px 8px;
+            font-size: 11px;
+            line-height: 1;
+        }
+
+        .sms-ghost-button {
+            border-color: #b7c5d2;
+            background: #fff;
+            color: #1f66ad;
+        }
+
+        .sms-ghost-button:hover {
+            background: #e9f3ff;
+            color: #155d9c;
+        }
+
+        .sms-disabled {
+            border-color: #aaa;
+            background: #e7e7e7;
+            color: #777;
+            cursor: not-allowed;
+        }
+
+        .sms-disabled:hover {
+            background: #e7e7e7;
+            color: #777;
+        }
+
+        .status-pill {
+            display: inline-block;
+            min-width: 58px;
+            padding: 3px 7px;
+            border: 1px solid #6ea76e;
+            border-radius: 3px;
+            background: #e5f4df;
+            color: #225b22;
+            font-size: 11px;
+            font-weight: 700;
+            text-align: center;
+        }
+
+        .status-pill.warn {
+            border-color: #cc9a2c;
+            background: #fff2c2;
+            color: #684800;
+        }
+
+        .status-pill.muted {
+            border-color: #bbb;
+            background: #ededed;
+            color: #666;
+        }
+
+        .communication-summary {
+            display: grid;
+            grid-template-columns: repeat(3, minmax(0, 1fr));
+            gap: 8px;
+            padding: 10px 12px;
+            border-bottom: 1px solid #e9e9e9;
+        }
+
+        .consent-list {
+            display: grid;
+            gap: 0;
+        }
+
+        .consent-item {
+            display: grid;
+            grid-template-columns: minmax(180px, 1fr) minmax(130px, auto) minmax(250px, auto);
+            gap: 8px 12px;
+            align-items: start;
+            padding: 10px 12px;
+            border-bottom: 1px solid #e9e9e9;
+        }
+
+        .consent-item:last-child {
+            border-bottom: 0;
+        }
+
+        .consent-name {
+            display: block;
+            margin-bottom: 3px;
+            font-weight: 700;
+        }
+
+        .consent-note {
+            display: block;
+            color: #555;
+            font-size: 11px;
+        }
+
+        .consent-meta,
+        .consent-recorder {
+            display: block;
+            margin-top: 4px;
+            color: #666;
+            font-size: 11px;
+        }
+
+        .consent-status {
+            display: grid;
+            justify-items: start;
+            gap: 2px;
+        }
+
+        .consent-controls {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            justify-content: end;
+            white-space: nowrap;
+        }
+
+        .consent-controls label {
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+        }
+
+        .consent-controls button {
+            min-height: 23px;
+            padding: 3px 8px;
+            border-color: #b7c5d2;
+            background: #fff;
+            color: #1f66ad;
+            font-size: 11px;
+        }
+
+        .consent-controls button:hover {
+            background: #e9f3ff;
+            color: #155d9c;
+        }
+
+        .review-action {
+            border-color: #cc9a2c;
+            color: #684800;
+        }
+
+        .review-action:hover {
+            background: #fff2c2;
+            color: #684800;
+        }
+
+        .consent-context {
+            grid-column: 1 / -1;
+            display: grid;
+            grid-template-columns: 42px minmax(0, 1fr);
+            gap: 8px;
+            align-items: center;
+            color: #555;
+            font-size: 11px;
+        }
+
+        .consent-context input {
+            width: 100%;
+            min-height: 26px;
+            padding: 4px 6px;
+            border: 1px solid #b7c5d2;
+            border-radius: 3px;
+            background: #fff;
+        }
+
+        .document-toolbar {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 8px;
+            padding: 9px 12px;
+            border-top: 1px solid #e9e9e9;
+            border-bottom: 1px solid #e9e9e9;
+            background: #fafafa;
+        }
+
+        .document-toolbar strong {
+            font-size: 12px;
+        }
+
+        .document-toolbar button,
+        .document-action {
+            min-height: 24px;
+            padding: 3px 8px;
+            border-color: #b7c5d2;
+            background: #fff;
+            color: #1f66ad;
+            font-size: 11px;
+        }
+
+        .document-toolbar button:hover,
+        .document-action:hover {
+            background: #e9f3ff;
+            color: #155d9c;
+        }
+
+        .document-empty {
+            display: none;
+            padding: 12px;
+            color: #555;
+        }
+
+        .document-empty.visible {
+            display: block;
+        }
+
+        .summary-cell {
+            min-height: 52px;
+            padding: 8px;
+            border: 1px solid #d7d7d7;
+            border-radius: 4px;
+            background: #f8f8f8;
+        }
+
+        .summary-cell strong {
+            display: block;
+            margin-bottom: 3px;
+            color: #333;
+        }
+
+        .log-table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+
+        .consent-documents-table {
+            border-top: 2px solid #1f66ad;
+        }
+
+        .log-table th,
+        .log-table td {
+            padding: 7px 8px;
+            border-bottom: 1px solid #e7e7e7;
+            text-align: left;
+            vertical-align: top;
+        }
+
+        .log-table th {
+            background: #fafafa;
+            font-weight: 700;
+        }
+
+        .footer-toolbar {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 8px;
+            margin-top: 10px;
+            padding: 10px 0 0;
+            border-top: 1px solid #d1d1d1;
+        }
+
+        .footer-left,
+        .footer-right {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .secondary-button {
+            min-height: 32px;
+            padding: 6px 14px;
+        }
+
+        .back-button {
+            min-height: 32px;
+            padding: 6px 14px;
+            border-color: #777;
+            background: #6f7478;
+        }
+
+        .back-button:hover {
+            background: #5f6468;
+        }
+
+        .modal-backdrop {
+            position: fixed;
+            inset: 0;
+            z-index: 2000;
+            display: none;
+            align-items: center;
+            justify-content: center;
+            padding: 22px;
+            background: rgba(0, 0, 0, 0.42);
+        }
+
+        .modal-backdrop.open {
+            display: flex;
+        }
+
+        .sms-modal {
+            width: min(720px, 100%);
+            max-height: 90vh;
+            overflow: auto;
+            border: 1px solid #777;
+            border-radius: 4px;
+            background: #fff;
+            box-shadow: 0 14px 35px rgba(0, 0, 0, 0.35);
+        }
+
+        .sms-modal header,
+        .sms-modal footer {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 8px;
+            padding: 10px 12px;
+            border-bottom: 1px solid #d1d1d1;
+            background: #f8f8f8;
+        }
+
+        .sms-modal footer {
+            justify-content: flex-end;
+            border-top: 1px solid #d1d1d1;
+            border-bottom: 0;
+        }
+
+        .sms-modal h2 {
+            margin: 0;
+            font-size: 16px;
+        }
+
+        .sms-modal p {
+            margin: 3px 0 0;
+            color: #555;
+        }
+
+        .modal-body {
+            padding: 12px;
+        }
+
+        .modal-grid {
+            display: grid;
+            grid-template-columns: repeat(3, minmax(0, 1fr));
+            gap: 8px;
+            margin-bottom: 10px;
+        }
+
+        .modal-field-grid {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 9px;
+        }
+
+        .field {
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+        }
+
+        .field.full {
+            grid-column: 1 / -1;
+        }
+
+        .checkbox-field {
+            flex-direction: row;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .field.checkbox-field input {
+            width: auto;
+        }
+
+        .field-error {
+            display: none;
+            margin-top: 8px;
+            color: #9f2f25;
+            font-weight: 700;
+        }
+
+        .field-error.visible {
+            display: block;
+        }
+
+        .field label {
+            font-weight: 700;
+        }
+
+        .field input,
+        .field select,
+        .field textarea {
+            width: 100%;
+            padding: 6px;
+            border: 1px solid #b7c5d2;
+            border-radius: 3px;
+            background: #fff;
+        }
+
+        .field textarea {
+            min-height: 96px;
+            resize: vertical;
+        }
+
+        @media (max-width: 900px) {
+            .patient-shell {
+                grid-template-columns: 1fr;
+                grid-template-rows: auto auto 1fr;
+            }
+
+            .patient-header {
+                flex-wrap: wrap;
+                min-height: 62px;
+                padding: 10px 14px;
+            }
+
+            .header-actions {
+                margin-left: 0;
+            }
+
+            .side-nav {
+                grid-row: 2;
+                display: flex;
+                overflow-x: auto;
+            }
+
+            .side-nav a {
+                flex: 0 0 auto;
+                border-right: 1px solid rgba(255, 255, 255, 0.18);
+            }
+
+            .main-content {
+                grid-row: 3;
+            }
+
+            .two-column,
+            .communication-summary,
+            .consent-item,
+            .modal-grid,
+            .modal-field-grid {
+                grid-template-columns: 1fr;
+            }
+
+            .consent-controls {
+                justify-content: start;
+            }
+        }
+    </style>
+</head>
+<body>
+<div class="patient-shell">
+    <header class="patient-header">
+        <h1 class="patient-name">FAKE-Olivia, FAKE-Lee</h1>
+        <span class="patient-meta">Other &middot; 59 years &middot; DOB: 1966-06-06</span>
+        <span class="next-appt">Next Appointment:</span>
+        <div class="header-actions">
+            <span class="status-pill">SMS OK</span>
+            <button class="header-sms" type="button" data-open-sms data-template="general" data-context="Patient master file">Text patient</button>
+        </div>
+    </header>
+
+    <nav class="side-nav" aria-label="Patient actions">
+        <a href="#">Appointment History</a>
+        <a href="#">Billing History</a>
+        <a href="#">Create Invoice</a>
+        <a href="#">Consultations</a>
+        <a href="#">Prescriptions</a>
+        <a href="#">E-Chart</a>
+        <a href="#">Preventions</a>
+        <a href="#">Tickler</a>
+        <a href="#">Documents</a>
+        <a href="#">Current eForms</a>
+    </nav>
+
+    <main class="main-content">
+        <div class="search-row">
+            <a href="#">Search Patient</a>
+        </div>
+
+        <section class="record-toolbar">
+            <a href="#">#14</a>
+            <button type="button">Edit</button>
+        </section>
+
+        <a class="show-fields" href="#">Show all fields</a>
+
+        <section class="content-band">
+            <div class="two-column">
+                <div>
+                    <section class="panel">
+                        <div class="panel-title">Demographic</div>
+                        <div class="info-row">
+                            <span class="info-label">Title:</span>
+                            <span class="info-value">Ms</span>
+                            <span></span>
+                        </div>
+                        <div class="info-row">
+                            <span class="info-label">Last Name:</span>
+                            <span class="info-value">FAKE-Olivia</span>
+                            <span></span>
+                        </div>
+                        <div class="info-row">
+                            <span class="info-label">First Name:</span>
+                            <span class="info-value">FAKE-Lee</span>
+                            <span></span>
+                        </div>
+                        <div class="info-row">
+                            <span class="info-label">Sex:</span>
+                            <span class="info-value">Other</span>
+                            <span></span>
+                        </div>
+                        <div class="info-row">
+                            <span class="info-label">Age:</span>
+                            <span class="info-value">59 years ( DOB: 1966-06-06)</span>
+                            <span></span>
+                        </div>
+                        <div class="info-row">
+                            <span class="info-label">Language:</span>
+                            <span class="info-value">English</span>
+                            <span></span>
+                        </div>
+                        <div class="info-row">
+                            <span class="info-label">Spoken Language:</span>
+                            <span class="info-value">Amharic</span>
+                            <span></span>
+                        </div>
+                    </section>
+
+                    <section class="panel">
+                        <div class="panel-title">
+                            Other Contacts
+                            <button class="pill" type="button">Add Relation</button>
+                        </div>
+                    </section>
+
+                    <section class="panel">
+                        <div class="panel-title">
+                            Clinic Status
+                            <button class="pill" type="button">Enrollment History</button>
+                        </div>
+                        <div class="info-row">
+                            <span class="info-label">Enrolment Status:</span>
+                            <span class="info-value">Rostered</span>
+                            <span></span>
+                        </div>
+                        <div class="info-row">
+                            <span class="info-label">Enrolment Date:</span>
+                            <span class="info-value">2023-11-13</span>
+                            <span></span>
+                        </div>
+                        <div class="info-row">
+                            <span class="info-label">Patient Status:</span>
+                            <span class="info-value">AC</span>
+                            <span></span>
+                        </div>
+                        <div class="info-row">
+                            <span class="info-label">Patient Status Date:</span>
+                            <span class="info-value">2023-11-13</span>
+                            <span></span>
+                        </div>
+                    </section>
+
+                    <section class="panel">
+                        <div class="panel-title">Alerts</div>
+                        <div class="info-row">
+                            <span class="info-label">&nbsp;</span>
+                            <span class="info-value"></span>
+                            <span></span>
+                        </div>
+                    </section>
+
+                    <section class="panel">
+                        <div class="panel-title">Rx Interaction Warning Level</div>
+                        <div class="info-row">
+                            <span class="info-label">Rx Interaction Warning Level:</span>
+                            <span class="info-value">Not Specified</span>
+                            <span></span>
+                        </div>
+                    </section>
+
+                    <section class="panel">
+                        <div class="panel-title">Paper Chart</div>
+                    </section>
+
+                    <section class="panel">
+                        <div class="panel-title">Custom</div>
+                    </section>
+                </div>
+
+                <div>
+                    <section class="panel">
+                        <div class="panel-title">Contact Information</div>
+                        <div class="info-row">
+                            <span class="info-label">Phone(H)(History):</span>
+                            <span class="info-value">555-555-5555</span>
+                            <span class="row-actions">
+                                <button class="sms-ghost-button sms-disabled" type="button" disabled title="Landline not marked SMS-capable">SMS</button>
+                            </span>
+                        </div>
+                        <div class="info-row">
+                            <span class="info-label">Phone(W)(History):</span>
+                            <span class="info-value">555-555-5555</span>
+                            <span class="row-actions">
+                                <button class="sms-ghost-button" type="button" data-open-sms data-template="call-back" data-context="Work phone">Text</button>
+                            </span>
+                        </div>
+                        <div class="info-row">
+                            <span class="info-label">Cell Phone(History):</span>
+                            <span class="info-value">6476476471</span>
+                            <span class="row-actions">
+                                <span class="status-pill">Verified</span>
+                                <button class="sms-row-button" type="button" data-open-sms data-template="general" data-context="Mobile number on master file">SMS</button>
+                            </span>
+                        </div>
+                        <div class="info-row">
+                            <span class="info-label">City:</span>
+                            <span class="info-value">Toronto</span>
+                            <span></span>
+                        </div>
+                        <div class="info-row">
+                            <span class="info-label">Province :</span>
+                            <span class="info-value">Ontario,Canada</span>
+                            <span></span>
+                        </div>
+                        <div class="info-row">
+                            <span class="info-label">Residential City:</span>
+                            <span class="info-value">Toronto</span>
+                            <span></span>
+                        </div>
+                        <div class="info-row">
+                            <span class="info-label">Residential Province:</span>
+                            <span class="info-value">Ontario,Canada</span>
+                            <span></span>
+                        </div>
+                        <div class="info-row">
+                            <span class="info-label">Email:</span>
+                            <span class="info-value">generic@gmail.com</span>
+                            <span></span>
+                        </div>
+                        <div class="info-row">
+                            <span class="info-label">Newsletter:</span>
+                            <span class="info-value">Unknown</span>
+                            <span></span>
+                        </div>
+                    </section>
+
+                    <section class="panel">
+                        <div class="panel-title">
+                            <span class="panel-title-left">Patient Communication</span>
+                            <span class="panel-title-actions">
+                                <a class="panel-title-button" href="sms-message-history-mock.html">Message history</a>
+                            </span>
+                        </div>
+                        <div class="communication-summary">
+                            <div class="summary-cell">
+                                <strong>SMS consent</strong>
+                                Active since 2026-05-14
+                            </div>
+                            <div class="summary-cell">
+                                <strong>Opt-out</strong>
+                                No STOP recorded
+                            </div>
+                            <div class="summary-cell">
+                                <strong>Default number</strong>
+                                Cell 6476476471
+                            </div>
+                        </div>
+                        <table class="log-table">
+                            <thead>
+                                <tr>
+                                    <th>Date</th>
+                                    <th>Type</th>
+                                    <th>Status</th>
+                                    <th>Logged to</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>2026-05-28</td>
+                                    <td>Appointment reminder</td>
+                                    <td><span class="status-pill">Sent</span></td>
+                                    <td>Master file</td>
+                                </tr>
+                                <tr>
+                                    <td>2026-05-22</td>
+                                    <td>Call-back request</td>
+                                    <td><span class="status-pill warn">Queued</span></td>
+                                    <td>Tickler</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </section>
+
+                    <section class="panel">
+                        <div class="panel-title">
+                            <span class="panel-title-left">Consent</span>
+                            <span class="panel-title-actions">
+                                <button class="pill" type="button" data-open-doc-upload>Add document</button>
+                                <button class="pill" type="button" data-open-type>Add type</button>
+                            </span>
+                        </div>
+                        <div class="consent-list" id="consentList">
+                            <div class="consent-item" data-consent-row="email_consent">
+                                <div>
+                                    <span class="consent-name">Email consent</span>
+                                    <span class="consent-note">Electronic communication including email, telephone, and video conferencing.</span>
+                                    <span class="consent-meta" data-consent-updated="email_consent">Last updated 2026-05-14</span>
+                                </div>
+                                <div class="consent-status">
+                                    <span class="status-pill" data-consent-status="email_consent">Consented</span>
+                                    <span class="consent-recorder" data-consent-recorder="email_consent">Recorded by carlosdoc</span>
+                                </div>
+                                <div class="consent-controls">
+                                    <label><input type="radio" name="email_consent" value="opt_in" checked data-consent-choice> Opt In</label>
+                                    <label><input type="radio" name="email_consent" value="opt_out" data-consent-choice> Opt Out</label>
+                                    <button type="button" data-reset-consent="email_consent">Reset answer</button>
+                                    <button type="button" data-show-documents="email_consent">Docs (<span data-doc-count="email_consent">1</span>)</button>
+                                </div>
+                                <label class="consent-context" for="emailConsentNote">
+                                    <span>Note</span>
+                                    <input id="emailConsentNote" type="text" data-consent-note="email_consent" value="Patient agreed to receive clinic email reminders and administrative messages.">
+                                </label>
+                            </div>
+                            <div class="consent-item" data-consent-row="sms_consent">
+                                <div>
+                                    <span class="consent-name">SMS/Text messaging</span>
+                                    <span class="consent-note">Messages to the verified mobile number on the patient master file.</span>
+                                    <span class="consent-meta" data-consent-updated="sms_consent">Last updated 2026-05-28</span>
+                                </div>
+                                <div class="consent-status">
+                                    <span class="status-pill warn" data-consent-status="sms_consent">Needs review</span>
+                                    <span class="consent-recorder" data-consent-recorder="sms_consent">Recorded by frontdesk</span>
+                                </div>
+                                <div class="consent-controls">
+                                    <label><input type="radio" name="sms_consent" value="opt_in" data-consent-choice> Opt In</label>
+                                    <label><input type="radio" name="sms_consent" value="opt_out" data-consent-choice> Opt Out</label>
+                                    <button class="review-action" type="button" data-review-consent="sms_consent">Review</button>
+                                    <button type="button" data-reset-consent="sms_consent">Reset answer</button>
+                                    <button type="button" data-show-documents="sms_consent">Docs (<span data-doc-count="sms_consent">1</span>)</button>
+                                </div>
+                                <label class="consent-context" for="smsConsentNote">
+                                    <span>Note</span>
+                                    <input id="smsConsentNote" type="text" data-consent-note="sms_consent" value="STOP status unclear; confirm preferred texting consent with patient.">
+                                </label>
+                            </div>
+                            <div class="consent-item" data-consent-row="dhir_consent">
+                                <div>
+                                    <span class="consent-name">DHIR vaccine reporting</span>
+                                    <span class="consent-note">Permission to submit ISPA and non-ISPA prevention records.</span>
+                                    <span class="consent-meta" data-consent-updated="dhir_consent">Last updated not recorded</span>
+                                </div>
+                                <div class="consent-status">
+                                    <span class="status-pill muted" data-consent-status="dhir_consent">Not set</span>
+                                    <span class="consent-recorder" data-consent-recorder="dhir_consent">Recorded by not recorded</span>
+                                </div>
+                                <div class="consent-controls">
+                                    <label><input type="radio" name="dhir_consent" value="opt_in" data-consent-choice> Opt In</label>
+                                    <label><input type="radio" name="dhir_consent" value="opt_out" data-consent-choice> Opt Out</label>
+                                    <button type="button" data-reset-consent="dhir_consent">Reset answer</button>
+                                    <button type="button" data-show-documents="dhir_consent">Docs (<span data-doc-count="dhir_consent">0</span>)</button>
+                                </div>
+                                <label class="consent-context" for="dhirConsentNote">
+                                    <span>Note</span>
+                                    <input id="dhirConsentNote" type="text" data-consent-note="dhir_consent" placeholder="Add context when the patient opts in or out.">
+                                </label>
+                            </div>
+                        </div>
+                        <table class="log-table consent-documents-table" id="consentDocuments">
+                            <thead>
+                                <tr>
+                                    <th>Consent documents</th>
+                                    <th>Consent type</th>
+                                    <th>Stored</th>
+                                    <th>Status</th>
+                                    <th>Action</th>
+                                </tr>
+                            </thead>
+                            <tbody id="consentDocumentRows">
+                                <tr data-doc-consent="email_consent" data-doc-name="Email consent signed form.pdf" data-doc-status="Signed" data-doc-stored="2024-05-23" data-doc-source="Scanned paper form">
+                                    <td>Email consent signed form.pdf</td>
+                                    <td>Email consent</td>
+                                    <td>2024-05-23</td>
+                                    <td><span class="status-pill">Signed</span></td>
+                                    <td><button class="document-action" type="button" data-view-document>View</button></td>
+                                </tr>
+                                <tr data-doc-consent="sms_consent" data-doc-name="SMS verbal consent note" data-doc-status="Verbal" data-doc-stored="2026-05-14" data-doc-source="Phone call note">
+                                    <td>SMS verbal consent note</td>
+                                    <td>SMS/Text messaging</td>
+                                    <td>2026-05-14</td>
+                                    <td><span class="status-pill warn">Verbal</span></td>
+                                    <td><button class="document-action" type="button" data-view-document>View</button></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <div class="document-empty" id="consentDocumentEmpty">No consent documents stored yet.</div>
+                        <table class="log-table">
+                            <thead>
+                                <tr>
+                                    <th>Last changed</th>
+                                    <th>Consent type</th>
+                                    <th>Changed by</th>
+                                    <th>Source</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>2024-05-23</td>
+                                    <td>Email consent</td>
+                                    <td>carlosdoc</td>
+                                    <td>Demographic edit</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </section>
+
+                    <section class="panel">
+                        <div class="panel-title">Health Insurance</div>
+                    </section>
+
+                    <section class="panel">
+                        <div class="panel-title">???demographic.manageHealthCareTeam.heading???</div>
+                    </section>
+
+                    <section class="panel">
+                        <div class="panel-title">Patient Clinic Status</div>
+                    </section>
+
+                    <section class="panel">
+                        <div class="panel-title">Notes</div>
+                        <div class="info-row">
+                            <span class="info-value">Testing the patient notes field</span>
+                            <span></span>
+                            <span></span>
+                        </div>
+                    </section>
+                </div>
+            </div>
+
+            <footer class="footer-toolbar">
+                <div class="footer-left">
+                    <button class="secondary-button" type="button">Export this Demographic</button>
+                    <button class="secondary-button" type="button">Audit Information</button>
+                </div>
+                <div class="footer-right">
+                    <button class="secondary-button" type="button">Print / Labels</button>
+                    <button class="back-button" type="button">Back</button>
+                </div>
+            </footer>
+        </section>
+    </main>
+</div>
+
+<div class="modal-backdrop" id="smsModal" role="dialog" aria-modal="true" aria-labelledby="smsTitle">
+    <section class="sms-modal">
+        <header>
+            <div>
+                <h2 id="smsTitle">Text FAKE-Lee FAKE-Olivia</h2>
+                <p id="smsContext">Patient master file</p>
+            </div>
+            <button type="button" data-close aria-label="Close">x</button>
+        </header>
+        <div class="modal-body">
+            <div class="modal-grid">
+                <div class="summary-cell">
+                    <strong>Mobile</strong>
+                    6476476471 verified
+                </div>
+                <div class="summary-cell">
+                    <strong>Consent</strong>
+                    SMS consent active
+                </div>
+                <div class="summary-cell">
+                    <strong>Chart</strong>
+                    Log to master file
+                </div>
+            </div>
+            <div class="modal-field-grid">
+                <div class="field">
+                    <label for="smsTemplate">Template</label>
+                    <select id="smsTemplate">
+                        <option value="general">General message</option>
+                        <option value="call-back">Please call clinic</option>
+                        <option value="booking">Book appointment</option>
+                        <option value="form">Complete form</option>
+                    </select>
+                </div>
+                <div class="field">
+                    <label for="smsFrom">Send from</label>
+                    <select id="smsFrom">
+                        <option>Main clinic line</option>
+                        <option>Reception desk</option>
+                        <option>Provider pool</option>
+                    </select>
+                </div>
+                <div class="field full">
+                    <label for="smsBody">Message</label>
+                    <textarea id="smsBody">Riverside Clinic: please call us when convenient. Reply STOP to opt out.</textarea>
+                </div>
+            </div>
+        </div>
+        <footer>
+            <button class="back-button" type="button" data-close>Cancel</button>
+            <button type="button">Preview</button>
+            <button type="button">Send SMS</button>
+        </footer>
+    </section>
+</div>
+
+<div class="modal-backdrop" id="consentDocumentModal" role="dialog" aria-modal="true" aria-labelledby="consentDocumentTitle">
+    <section class="sms-modal">
+        <header>
+            <div>
+                <h2 id="consentDocumentTitle">Add consent document</h2>
+                <p>Store a signed form, verbal consent note, or uploaded consent record with this patient.</p>
+            </div>
+            <button type="button" data-close aria-label="Close">x</button>
+        </header>
+        <div class="modal-body">
+            <div class="modal-field-grid">
+                <div class="field">
+                    <label for="documentConsentType">Consent type</label>
+                    <select id="documentConsentType">
+                        <option value="email_consent">Email consent</option>
+                        <option value="sms_consent">SMS/Text messaging</option>
+                        <option value="dhir_consent">DHIR vaccine reporting</option>
+                    </select>
+                </div>
+                <div class="field">
+                    <label for="documentStatus">Document status</label>
+                    <select id="documentStatus">
+                        <option>Signed</option>
+                        <option>Verbal</option>
+                        <option>Witnessed</option>
+                        <option>Refusal</option>
+                    </select>
+                </div>
+                <div class="field">
+                    <label for="documentStoredDate">Stored date</label>
+                    <input id="documentStoredDate" type="date" value="2026-06-02">
+                </div>
+                <div class="field">
+                    <label for="documentSource">Source</label>
+                    <select id="documentSource">
+                        <option>Scanned paper form</option>
+                        <option>Phone call note</option>
+                        <option>Patient portal upload</option>
+                        <option>Clinic staff entry</option>
+                    </select>
+                </div>
+                <div class="field full">
+                    <label for="documentFile">Document file</label>
+                    <input id="documentFile" type="file">
+                </div>
+                <div class="field full">
+                    <label for="documentNote">Note</label>
+                    <textarea id="documentNote">Consent reviewed with patient and stored with the demographic record.</textarea>
+                </div>
+            </div>
+        </div>
+        <footer>
+            <button class="back-button" type="button" data-close>Cancel</button>
+            <button type="button" id="saveConsentDocument">Store document</button>
+        </footer>
+    </section>
+</div>
+
+<div class="modal-backdrop" id="consentTypeModal" role="dialog" aria-modal="true" aria-labelledby="consentTypeTitle">
+    <section class="sms-modal">
+        <header>
+            <div>
+                <h2 id="consentTypeTitle">Add consent type</h2>
+                <p>Create another consent row for this patient and make it available for document storage.</p>
+            </div>
+            <button type="button" data-close aria-label="Close">x</button>
+        </header>
+        <div class="modal-body">
+            <div class="modal-field-grid">
+                <div class="field">
+                    <label for="newConsentTypeName">Consent type name</label>
+                    <input id="newConsentTypeName" type="text" value="Research participation">
+                </div>
+                <div class="field">
+                    <label for="newConsentTypeStatus">Starting status</label>
+                    <select id="newConsentTypeStatus">
+                        <option value="not_set">Not set</option>
+                        <option value="needs_review">Needs review</option>
+                    </select>
+                </div>
+                <div class="field full">
+                    <label for="newConsentTypeDescription">Description</label>
+                    <textarea id="newConsentTypeDescription">Permission to contact the patient about clinic-approved research opportunities.</textarea>
+                </div>
+                <label class="field checkbox-field full" for="newConsentTypeRequiresDocument">
+                    <input id="newConsentTypeRequiresDocument" type="checkbox" checked>
+                    Require a supporting document for this consent type
+                </label>
+            </div>
+            <div class="field-error" id="consentTypeError">Enter a consent type name.</div>
+        </div>
+        <footer>
+            <button class="back-button" type="button" data-close>Cancel</button>
+            <button type="button" id="saveConsentType">Add consent type</button>
+        </footer>
+    </section>
+</div>
+
+<script>
+    (function () {
+        var modal = document.getElementById('smsModal');
+        var contextText = document.getElementById('smsContext');
+        var template = document.getElementById('smsTemplate');
+        var smsBody = document.getElementById('smsBody');
+        var docModal = document.getElementById('consentDocumentModal');
+        var typeModal = document.getElementById('consentTypeModal');
+        var consentList = document.getElementById('consentList');
+        var docRows = document.getElementById('consentDocumentRows');
+        var docEmpty = document.getElementById('consentDocumentEmpty');
+        var docConsentType = document.getElementById('documentConsentType');
+        var docStatus = document.getElementById('documentStatus');
+        var docStoredDate = document.getElementById('documentStoredDate');
+        var docSource = document.getElementById('documentSource');
+        var docFile = document.getElementById('documentFile');
+        var docNote = document.getElementById('documentNote');
+        var saveConsentDocument = document.getElementById('saveConsentDocument');
+        var newConsentTypeName = document.getElementById('newConsentTypeName');
+        var newConsentTypeStatus = document.getElementById('newConsentTypeStatus');
+        var newConsentTypeDescription = document.getElementById('newConsentTypeDescription');
+        var newConsentTypeRequiresDocument = document.getElementById('newConsentTypeRequiresDocument');
+        var consentTypeError = document.getElementById('consentTypeError');
+        var saveConsentType = document.getElementById('saveConsentType');
+        var consentTypeCounter = 0;
+        var templateBodies = {
+            'general': 'Riverside Clinic: please call us when convenient. Reply STOP to opt out.',
+            'call-back': 'Riverside Clinic: we tried to reach you. Please call the clinic when convenient. Reply STOP to opt out.',
+            'booking': 'Riverside Clinic: please contact us to book your follow-up appointment. Reply STOP to opt out.',
+            'form': 'Riverside Clinic: please complete your intake form before your next visit. Reply STOP to opt out.'
+        };
+        var consentLabels = {
+            email_consent: 'Email consent',
+            sms_consent: 'SMS/Text messaging',
+            dhir_consent: 'DHIR vaccine reporting'
+        };
+        var mockConsentPdfBase64 = 'JVBERi0xLjQKJeLjz9MKMSAwIG9iago8PCAvVHlwZSAvQ2F0YWxvZyAvUGFnZXMgMiAwIFIgPj4KZW5kb2JqCjIgMCBvYmoKPDwgL1R5cGUgL1BhZ2VzIC9LaWRzIFszIDAgUl0gL0NvdW50IDEgPj4KZW5kb2JqCjMgMCBvYmoKPDwgL1R5cGUgL1BhZ2UgL1BhcmVudCAyIDAgUiAvTWVkaWFCb3ggWzAgMCA2MTIgNzkyXSAvUmVzb3VyY2VzIDw8IC9Gb250IDw8IC9GMSA0IDAgUiA+PiA+PiAvQ29udGVudHMgNSAwIFIgPj4KZW5kb2JqCjQgMCBvYmoKPDwgL1R5cGUgL0ZvbnQgL1N1YnR5cGUgL1R5cGUxIC9CYXNlRm9udCAvSGVsdmV0aWNhID4+CmVuZG9iago1IDAgb2JqCjw8IC9MZW5ndGggNjY0ID4+CnN0cmVhbQpCVAovRjEgMTggVGYKNzIgNzQwIFRkCihDQVJMT1MgRU1SIC0gTW9jayBDb25zZW50IERvY3VtZW50KSBUagovRjEgMTEgVGYKMCAtMjggVGQKKFBhdGllbnQ6IEZBS0UtT2xpdmlhLCBGQUtFLUxlZSAgICBEZW1vZ3JhcGhpYyAjOiAxNCkgVGoKMCAtMTggVGQKKENvbnNlbnQgdHlwZTogRW1haWwgY29uc2VudCkgVGoKMCAtMTggVGQKKFN0YXR1czogU2lnbmVkIC8gQ29uc2VudGVkKSBUagowIC0xOCBUZAooU3RvcmVkIGRhdGU6IDIwMjQtMDUtMjMpIFRqCjAgLTE4IFRkCigpIFRqCjAgLTE4IFRkCihJIGNvbnNlbnQgdG8gZWxlY3Ryb25pYyBjb21tdW5pY2F0aW9uIHdpdGggdGhlIGNsaW5pYywgaW5jbHVkaW5nIGVtYWlsLCkgVGoKMCAtMTggVGQKKHRlbGVwaG9uZSwgdmlkZW8gY29uZmVyZW5jaW5nLCBhbmQgcmVsYXRlZCBhZG1pbmlzdHJhdGl2ZSBtZXNzYWdlcy4pIFRqCjAgLTE4IFRkCigpIFRqCjAgLTE4IFRkCihUaGlzIGlzIG1vY2sgY29udGVudCBmb3IgdGhlIGNvbnNlbnQgZG9jdW1lbnQgcG9wdXAgaW4gdGhlIFVJIHByb3RvdHlwZS4pIFRqCjAgLTE4IFRkCigpIFRqCjAgLTE4IFRkCihQYXRpZW50IHNpZ25hdHVyZTogX19fX19fX19fX19fX19fX19fX19fX19fX18pIFRqCjAgLTE4IFRkCihXaXRuZXNzL3Byb3ZpZGVyOiBjYXJsb3Nkb2MpIFRqCkVUCmVuZHN0cmVhbQplbmRvYmoKeHJlZgowIDYKMDAwMDAwMDAwMCA2NTUzNSBmIAowMDAwMDAwMDE1IDAwMDAwIG4gCjAwMDAwMDAwNjQgMDAwMDAgbiAKMDAwMDAwMDEyMSAwMDAwMCBuIAowMDAwMDAwMjQ3IDAwMDAwIG4gCjAwMDAwMDAzMTcgMDAwMDAgbiAKdHJhaWxlcgo8PCAvU2l6ZSA2IC9Sb290IDEgMCBSID4+CnN0YXJ0eHJlZgoxMDMyCiUlRU9GCg==';
+
+        function openSms(button) {
+            var selectedTemplate = button.getAttribute('data-template') || 'general';
+            contextText.textContent = button.getAttribute('data-context') || 'Patient master file';
+            template.value = selectedTemplate;
+            smsBody.value = templateBodies[selectedTemplate] || templateBodies.general;
+            modal.classList.add('open');
+        }
+
+        function closeSms() {
+            modal.classList.remove('open');
+        }
+
+        function closeAllModals() {
+            modal.classList.remove('open');
+            docModal.classList.remove('open');
+            typeModal.classList.remove('open');
+        }
+
+        function openDocUpload(consentType) {
+            docConsentType.value = consentType || 'email_consent';
+            docModal.classList.add('open');
+        }
+
+        function openTypeModal() {
+            consentTypeError.classList.remove('visible');
+            typeModal.classList.add('open');
+            newConsentTypeName.focus();
+            newConsentTypeName.select();
+        }
+
+        function updateDocumentCounts() {
+            var counts = {};
+            var rows = docRows.querySelectorAll('tr[data-doc-consent]');
+            var countTargets = document.querySelectorAll('[data-doc-count]');
+            var i;
+            var key;
+
+            for (i = 0; i < rows.length; i++) {
+                key = rows[i].getAttribute('data-doc-consent');
+                counts[key] = (counts[key] || 0) + 1;
+            }
+
+            for (i = 0; i < countTargets.length; i++) {
+                key = countTargets[i].getAttribute('data-doc-count');
+                countTargets[i].textContent = counts[key] || 0;
+            }
+
+            docEmpty.classList.toggle('visible', rows.length === 0);
+        }
+
+        function statusClass(status) {
+            if (status === 'Signed') return '';
+            if (status === 'Verbal' || status === 'Witnessed') return ' warn';
+            return ' muted';
+        }
+
+        function consentKeyFromName(name) {
+            var base = name.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '') || 'custom';
+            var key;
+
+            if (base.indexOf('consent') === -1) {
+                base += '_consent';
+            }
+
+            key = base;
+
+            while (consentLabels[key]) {
+                consentTypeCounter += 1;
+                key = base + '_' + consentTypeCounter;
+            }
+
+            return key;
+        }
+
+        function appendConsentTypeOption(key, label) {
+            var option = document.createElement('option');
+
+            option.value = key;
+            option.textContent = label;
+            docConsentType.appendChild(option);
+        }
+
+        function appendText(parent, tagName, className, text) {
+            var node = document.createElement(tagName);
+
+            if (className) {
+                node.className = className;
+            }
+
+            node.textContent = text;
+            parent.appendChild(node);
+
+            return node;
+        }
+
+        function appendConsentRadio(controls, key, value, labelText) {
+            var label = document.createElement('label');
+            var input = document.createElement('input');
+
+            input.type = 'radio';
+            input.name = key;
+            input.value = value;
+            input.setAttribute('data-consent-choice', '');
+            label.appendChild(input);
+            label.appendChild(document.createTextNode(' ' + labelText));
+            controls.appendChild(label);
+        }
+
+        function appendConsentButton(controls, text, attributeName, key, className) {
+            var button = document.createElement('button');
+
+            button.type = 'button';
+            button.textContent = text;
+            button.setAttribute(attributeName, key);
+
+            if (className) {
+                button.className = className;
+            }
+
+            controls.appendChild(button);
+
+            return button;
+        }
+
+        function appendConsentTypeRow(key, label, description, startingStatus, requiresDocument) {
+            var row = document.createElement('div');
+            var details = document.createElement('div');
+            var status = document.createElement('div');
+            var statusPill;
+            var controls = document.createElement('div');
+            var docsButton;
+            var docsCount;
+            var context = document.createElement('label');
+            var contextLabel = document.createElement('span');
+            var note = document.createElement('input');
+            var isReview = startingStatus === 'needs_review';
+
+            row.className = 'consent-item';
+            row.setAttribute('data-consent-row', key);
+
+            appendText(details, 'span', 'consent-name', label);
+            appendText(details, 'span', 'consent-note', description || 'Patient-specific consent type.');
+
+            if (requiresDocument) {
+                appendText(details, 'span', 'consent-note', 'Supporting document required.');
+            }
+
+            appendText(details, 'span', 'consent-meta', 'Last updated not recorded').setAttribute('data-consent-updated', key);
+
+            status.className = 'consent-status';
+            statusPill = appendText(status, 'span', 'status-pill ' + (isReview ? 'warn' : 'muted'), isReview ? 'Needs review' : 'Not set');
+            statusPill.setAttribute('data-consent-status', key);
+            appendText(status, 'span', 'consent-recorder', 'Recorded by not recorded').setAttribute('data-consent-recorder', key);
+
+            controls.className = 'consent-controls';
+            appendConsentRadio(controls, key, 'opt_in', 'Opt In');
+            appendConsentRadio(controls, key, 'opt_out', 'Opt Out');
+
+            if (isReview) {
+                appendConsentButton(controls, 'Review', 'data-review-consent', key, 'review-action');
+            }
+
+            appendConsentButton(controls, 'Reset answer', 'data-reset-consent', key);
+            docsButton = appendConsentButton(controls, 'Docs (', 'data-show-documents', key);
+            docsCount = document.createElement('span');
+            docsCount.setAttribute('data-doc-count', key);
+            docsCount.textContent = '0';
+            docsButton.appendChild(docsCount);
+            docsButton.appendChild(document.createTextNode(')'));
+
+            context.className = 'consent-context';
+            context.htmlFor = key + 'Note';
+            contextLabel.textContent = 'Note';
+            note.id = key + 'Note';
+            note.type = 'text';
+            note.setAttribute('data-consent-note', key);
+            note.placeholder = requiresDocument ? 'Add document details and decision context.' : 'Add context when the patient opts in or out.';
+            context.appendChild(contextLabel);
+            context.appendChild(note);
+
+            row.appendChild(details);
+            row.appendChild(status);
+            row.appendChild(controls);
+            row.appendChild(context);
+            consentList.appendChild(row);
+        }
+
+        function addConsentType() {
+            var name = newConsentTypeName.value.trim();
+            var key;
+
+            if (!name) {
+                consentTypeError.classList.add('visible');
+                newConsentTypeName.focus();
+                return;
+            }
+
+            consentTypeError.classList.remove('visible');
+            key = consentKeyFromName(name);
+            consentLabels[key] = name;
+            appendConsentTypeOption(key, name);
+            appendConsentTypeRow(key, name, newConsentTypeDescription.value.trim(), newConsentTypeStatus.value, newConsentTypeRequiresDocument.checked);
+            updateDocumentCounts();
+            closeAllModals();
+
+            newConsentTypeName.value = '';
+            newConsentTypeStatus.value = 'not_set';
+            newConsentTypeDescription.value = '';
+            newConsentTypeRequiresDocument.checked = false;
+        }
+
+        function addDocumentRow() {
+            var row = document.createElement('tr');
+            var consentType = docConsentType.value;
+            var status = docStatus.value;
+            var fileName = docFile.files && docFile.files.length ? docFile.files[0].name : consentLabels[consentType] + ' document';
+            var storedDate = docStoredDate.value || '2026-06-02';
+            var source = docSource.value + (docNote.value ? ': ' + docNote.value : '');
+
+            row.setAttribute('data-doc-consent', consentType);
+            row.setAttribute('data-doc-name', fileName);
+            row.setAttribute('data-doc-status', status);
+            row.setAttribute('data-doc-stored', storedDate);
+            row.setAttribute('data-doc-source', source);
+            row.innerHTML = '<td></td><td></td><td></td><td><span class="status-pill' + statusClass(status) + '"></span></td><td><button class="document-action" type="button" data-view-document>View</button></td>';
+            row.children[0].textContent = fileName;
+            row.children[1].textContent = consentLabels[consentType];
+            row.children[2].textContent = storedDate;
+            row.children[3].querySelector('span').textContent = status;
+            docRows.appendChild(row);
+            updateDocumentCounts();
+            closeAllModals();
+        }
+
+        function openDocumentPdf(row) {
+            var binary = atob(mockConsentPdfBase64);
+            var bytes = new Uint8Array(binary.length);
+            var i;
+            var pdfUrl;
+            var popup;
+
+            for (i = 0; i < binary.length; i++) {
+                bytes[i] = binary.charCodeAt(i);
+            }
+
+            pdfUrl = URL.createObjectURL(new Blob([bytes], { type: 'application/pdf' }));
+            popup = window.open(pdfUrl, 'consentDocumentPdf', 'width=920,height=760,resizable=yes,scrollbars=yes');
+
+            if (popup) {
+                popup.focus();
+            } else {
+                window.location.href = pdfUrl;
+            }
+        }
+
+        function todayString() {
+            var today = new Date();
+            var month = String(today.getMonth() + 1).padStart(2, '0');
+            var day = String(today.getDate()).padStart(2, '0');
+
+            return today.getFullYear() + '-' + month + '-' + day;
+        }
+
+        function setConsentStatus(groupName, statusText, statusModifier) {
+            var status = document.querySelector('[data-consent-status="' + groupName + '"]');
+
+            if (!status) return;
+
+            status.className = 'status-pill' + (statusModifier ? ' ' + statusModifier : '');
+            status.textContent = statusText;
+        }
+
+        function setConsentMeta(groupName, updatedText, recorderText) {
+            var updated = document.querySelector('[data-consent-updated="' + groupName + '"]');
+            var recorder = document.querySelector('[data-consent-recorder="' + groupName + '"]');
+
+            if (updated) updated.textContent = updatedText;
+            if (recorder) recorder.textContent = recorderText;
+        }
+
+        function consentNote(groupName) {
+            return document.querySelector('[data-consent-note="' + groupName + '"]');
+        }
+
+        function resetConsent(groupName) {
+            var inputs = document.querySelectorAll('input[name="' + groupName + '"]');
+            var note = consentNote(groupName);
+            var i;
+
+            for (i = 0; i < inputs.length; i++) {
+                inputs[i].checked = false;
+            }
+
+            setConsentStatus(groupName, 'Not set', 'muted');
+            setConsentMeta(groupName, 'Last updated not recorded', 'Recorded by not recorded');
+
+            if (note) {
+                note.value = '';
+                note.placeholder = 'Add context when the patient opts in or out.';
+            }
+        }
+
+        function updateConsentChoice(input) {
+            var groupName = input.name;
+            var note = consentNote(groupName);
+            var statusText = input.value === 'opt_out' ? 'Opted out' : 'Consented';
+            var statusModifier = input.value === 'opt_out' ? 'muted' : '';
+
+            if (!input.checked) return;
+
+            setConsentStatus(groupName, statusText, statusModifier);
+            setConsentMeta(groupName, 'Last updated ' + todayString(), 'Recorded by current user');
+
+            if (note && !note.value) {
+                note.placeholder = 'Add context for this consent decision.';
+                note.focus();
+            }
+        }
+
+        function reviewConsent(groupName) {
+            var note = consentNote(groupName);
+
+            setConsentStatus(groupName, 'In review', 'warn');
+            setConsentMeta(groupName, 'Last reviewed ' + todayString(), 'Review started by current user');
+
+            if (note) {
+                note.focus();
+                note.select();
+            }
+        }
+
+        document.addEventListener('click', function (event) {
+            var opener = event.target.closest('[data-open-sms]');
+            var closer = event.target.closest('[data-close]');
+            var resetButton = event.target.closest('[data-reset-consent]');
+            var reviewButton = event.target.closest('[data-review-consent]');
+            var docUploadButton = event.target.closest('[data-open-doc-upload]');
+            var typeButton = event.target.closest('[data-open-type]');
+            var showDocumentsButton = event.target.closest('[data-show-documents]');
+            var viewDocumentButton = event.target.closest('[data-view-document]');
+
+            if (opener) {
+                event.preventDefault();
+                openSms(opener);
+                return;
+            }
+
+            if (resetButton) {
+                resetConsent(resetButton.getAttribute('data-reset-consent'));
+                return;
+            }
+
+            if (reviewButton) {
+                reviewConsent(reviewButton.getAttribute('data-review-consent'));
+                return;
+            }
+
+            if (docUploadButton) {
+                openDocUpload(docUploadButton.getAttribute('data-open-doc-upload'));
+                return;
+            }
+
+            if (typeButton) {
+                openTypeModal();
+                return;
+            }
+
+            if (showDocumentsButton) {
+                document.getElementById('consentDocuments').scrollIntoView({ behavior: 'smooth', block: 'start' });
+                return;
+            }
+
+            if (viewDocumentButton) {
+                openDocumentPdf(viewDocumentButton.closest('tr'));
+                return;
+            }
+
+            if (closer || event.target.classList.contains('modal-backdrop')) {
+                closeAllModals();
+            }
+        });
+
+        document.addEventListener('change', function (event) {
+            var consentChoice = event.target.closest('[data-consent-choice]');
+
+            if (consentChoice) {
+                updateConsentChoice(consentChoice);
+            }
+        });
+
+        document.addEventListener('keydown', function (event) {
+            if (event.key === 'Escape') {
+                closeAllModals();
+            }
+        });
+
+        template.addEventListener('change', function () {
+            smsBody.value = templateBodies[template.value] || templateBodies.general;
+        });
+
+        saveConsentDocument.addEventListener('click', addDocumentRow);
+        saveConsentType.addEventListener('click', addConsentType);
+        updateDocumentCounts();
+    })();
+</script>
+</body>
+</html>

--- a/docs/mockups/sms-patient-master-consent-mock.html
+++ b/docs/mockups/sms-patient-master-consent-mock.html
@@ -221,10 +221,13 @@
             gap: 8px;
             justify-content: space-between;
             min-height: 34px;
+            margin: 0;
             padding: 7px 13px;
             background: #337ab7;
             color: #fff;
+            font-size: 12px;
             font-weight: 700;
+            line-height: 1.35;
         }
 
         .panel-title .pill {
@@ -774,7 +777,7 @@
             <div class="two-column">
                 <div>
                     <section class="panel">
-                        <div class="panel-title">Demographic</div>
+                        <h2 class="panel-title">Demographic</h2>
                         <div class="info-row">
                             <span class="info-label">Title:</span>
                             <span class="info-value">Ms</span>
@@ -813,17 +816,17 @@
                     </section>
 
                     <section class="panel">
-                        <div class="panel-title">
+                        <h2 class="panel-title">
                             Other Contacts
                             <button class="pill" type="button">Add Relation</button>
-                        </div>
+                        </h2>
                     </section>
 
                     <section class="panel">
-                        <div class="panel-title">
+                        <h2 class="panel-title">
                             Clinic Status
                             <button class="pill" type="button">Enrollment History</button>
-                        </div>
+                        </h2>
                         <div class="info-row">
                             <span class="info-label">Enrolment Status:</span>
                             <span class="info-value">Rostered</span>
@@ -847,7 +850,7 @@
                     </section>
 
                     <section class="panel">
-                        <div class="panel-title">Alerts</div>
+                        <h2 class="panel-title">Alerts</h2>
                         <div class="info-row">
                             <span class="info-label">&nbsp;</span>
                             <span class="info-value"></span>
@@ -856,7 +859,7 @@
                     </section>
 
                     <section class="panel">
-                        <div class="panel-title">Rx Interaction Warning Level</div>
+                        <h2 class="panel-title">Rx Interaction Warning Level</h2>
                         <div class="info-row">
                             <span class="info-label">Rx Interaction Warning Level:</span>
                             <span class="info-value">Not Specified</span>
@@ -865,17 +868,17 @@
                     </section>
 
                     <section class="panel">
-                        <div class="panel-title">Paper Chart</div>
+                        <h2 class="panel-title">Paper Chart</h2>
                     </section>
 
                     <section class="panel">
-                        <div class="panel-title">Custom</div>
+                        <h2 class="panel-title">Custom</h2>
                     </section>
                 </div>
 
                 <div>
                     <section class="panel">
-                        <div class="panel-title">Contact Information</div>
+                        <h2 class="panel-title">Contact Information</h2>
                         <div class="info-row">
                             <span class="info-label">Phone(H)(History):</span>
                             <span class="info-value">555-555-5555</span>
@@ -931,12 +934,12 @@
                     </section>
 
                     <section class="panel">
-                        <div class="panel-title">
+                        <h2 class="panel-title">
                             <span class="panel-title-left">Patient Communication</span>
                             <span class="panel-title-actions">
                                 <a class="panel-title-button" href="sms-message-history-mock.html">Message history</a>
                             </span>
-                        </div>
+                        </h2>
                         <div class="communication-summary">
                             <div class="summary-cell">
                                 <strong>SMS consent</strong>
@@ -978,13 +981,13 @@
                     </section>
 
                     <section class="panel">
-                        <div class="panel-title">
+                        <h2 class="panel-title">
                             <span class="panel-title-left">Consent</span>
                             <span class="panel-title-actions">
                                 <button class="pill" type="button" data-open-doc-upload>Add document</button>
                                 <button class="pill" type="button" data-open-type>Add type</button>
                             </span>
-                        </div>
+                        </h2>
                         <div class="consent-list" id="consentList">
                             <div class="consent-item" data-consent-row="email_consent">
                                 <div>
@@ -1103,19 +1106,19 @@
                     </section>
 
                     <section class="panel">
-                        <div class="panel-title">Health Insurance</div>
+                        <h2 class="panel-title">Health Insurance</h2>
                     </section>
 
                     <section class="panel">
-                        <div class="panel-title">Health Care Team</div>
+                        <h2 class="panel-title">Health Care Team</h2>
                     </section>
 
                     <section class="panel">
-                        <div class="panel-title">Patient Clinic Status</div>
+                        <h2 class="panel-title">Patient Clinic Status</h2>
                     </section>
 
                     <section class="panel">
-                        <div class="panel-title">Notes</div>
+                        <h2 class="panel-title">Notes</h2>
                         <div class="info-row">
                             <span class="info-value">Testing the patient notes field</span>
                             <span></span>
@@ -1195,12 +1198,12 @@
     </section>
 </div>
 
-<div class="modal-backdrop" id="consentDocumentModal" role="dialog" aria-modal="true" aria-labelledby="consentDocumentTitle">
+<div class="modal-backdrop" id="consentDocumentModal" role="dialog" aria-modal="true" aria-labelledby="consentDocumentTitle" aria-describedby="consentDocumentDescription">
     <section class="sms-modal">
         <header>
             <div>
                 <h2 id="consentDocumentTitle">Add consent document</h2>
-                <p>Store a signed form, verbal consent note, or uploaded consent record with this patient.</p>
+                <p id="consentDocumentDescription">Store a signed form, verbal consent note, or uploaded consent record with this patient.</p>
             </div>
             <button type="button" data-close aria-label="Close">x</button>
         </header>
@@ -1253,12 +1256,12 @@
     </section>
 </div>
 
-<div class="modal-backdrop" id="consentTypeModal" role="dialog" aria-modal="true" aria-labelledby="consentTypeTitle">
+<div class="modal-backdrop" id="consentTypeModal" role="dialog" aria-modal="true" aria-labelledby="consentTypeTitle" aria-describedby="consentTypeDescription">
     <section class="sms-modal">
         <header>
             <div>
                 <h2 id="consentTypeTitle">Add consent type</h2>
-                <p>Create another consent row for this patient and make it available for document storage.</p>
+                <p id="consentTypeDescription">Create another consent row for this patient and make it available for document storage.</p>
             </div>
             <button type="button" data-close aria-label="Close">x</button>
         </header>
@@ -1337,6 +1340,7 @@
             template.value = selectedTemplate;
             smsBody.value = templateBodies[selectedTemplate] || templateBodies.general;
             modal.classList.add('open');
+            template.focus();
         }
 
         function closeAllModals() {
@@ -1348,6 +1352,7 @@
         function openDocUpload(consentType) {
             docConsentType.value = consentType || 'email_consent';
             docModal.classList.add('open');
+            docConsentType.focus();
         }
 
         function openTypeModal() {

--- a/docs/mockups/sms-patient-master-mock.html
+++ b/docs/mockups/sms-patient-master-mock.html
@@ -733,7 +733,7 @@
                         </div>
                         <div class="info-row">
                             <span class="info-label">Province :</span>
-                            <span class="info-value">Ontario,Canada</span>
+                            <span class="info-value">Ontario, Canada</span>
                             <span></span>
                         </div>
                         <div class="info-row">
@@ -743,7 +743,7 @@
                         </div>
                         <div class="info-row">
                             <span class="info-label">Residential Province:</span>
-                            <span class="info-value">Ontario,Canada</span>
+                            <span class="info-value">Ontario, Canada</span>
                             <span></span>
                         </div>
                         <div class="info-row">

--- a/docs/mockups/sms-patient-master-mock.html
+++ b/docs/mockups/sms-patient-master-mock.html
@@ -221,10 +221,13 @@
             gap: 8px;
             justify-content: space-between;
             min-height: 34px;
+            margin: 0;
             padding: 7px 13px;
             background: #337ab7;
             color: #fff;
+            font-size: 12px;
             font-weight: 700;
+            line-height: 1.35;
         }
 
         .panel-title .pill {
@@ -602,7 +605,7 @@
             <div class="two-column">
                 <div>
                     <section class="panel">
-                        <div class="panel-title">Demographic</div>
+                        <h2 class="panel-title">Demographic</h2>
                         <div class="info-row">
                             <span class="info-label">Title:</span>
                             <span class="info-value">Ms</span>
@@ -641,17 +644,17 @@
                     </section>
 
                     <section class="panel">
-                        <div class="panel-title">
+                        <h2 class="panel-title">
                             Other Contacts
                             <button class="pill" type="button">Add Relation</button>
-                        </div>
+                        </h2>
                     </section>
 
                     <section class="panel">
-                        <div class="panel-title">
+                        <h2 class="panel-title">
                             Clinic Status
                             <button class="pill" type="button">Enrollment History</button>
-                        </div>
+                        </h2>
                         <div class="info-row">
                             <span class="info-label">Enrolment Status:</span>
                             <span class="info-value">Rostered</span>
@@ -675,7 +678,7 @@
                     </section>
 
                     <section class="panel">
-                        <div class="panel-title">Alerts</div>
+                        <h2 class="panel-title">Alerts</h2>
                         <div class="info-row">
                             <span class="info-label">&nbsp;</span>
                             <span class="info-value"></span>
@@ -684,7 +687,7 @@
                     </section>
 
                     <section class="panel">
-                        <div class="panel-title">Rx Interaction Warning Level</div>
+                        <h2 class="panel-title">Rx Interaction Warning Level</h2>
                         <div class="info-row">
                             <span class="info-label">Rx Interaction Warning Level:</span>
                             <span class="info-value">Not Specified</span>
@@ -693,17 +696,17 @@
                     </section>
 
                     <section class="panel">
-                        <div class="panel-title">Paper Chart</div>
+                        <h2 class="panel-title">Paper Chart</h2>
                     </section>
 
                     <section class="panel">
-                        <div class="panel-title">Custom</div>
+                        <h2 class="panel-title">Custom</h2>
                     </section>
                 </div>
 
                 <div>
                     <section class="panel">
-                        <div class="panel-title">Contact Information</div>
+                        <h2 class="panel-title">Contact Information</h2>
                         <div class="info-row">
                             <span class="info-label">Phone(H)(History):</span>
                             <span class="info-value">555-555-5555</span>
@@ -759,12 +762,12 @@
                     </section>
 
                     <section class="panel">
-                        <div class="panel-title">
+                        <h2 class="panel-title">
                             <span class="panel-title-left">Patient Communication</span>
                             <span class="panel-title-actions">
                                 <a class="panel-title-button" href="sms-message-history-mock.html">Message history</a>
                             </span>
-                        </div>
+                        </h2>
                         <div class="communication-summary">
                             <div class="summary-cell">
                                 <strong>SMS consent</strong>
@@ -806,19 +809,19 @@
                     </section>
 
                     <section class="panel">
-                        <div class="panel-title">Health Insurance</div>
+                        <h2 class="panel-title">Health Insurance</h2>
                     </section>
 
                     <section class="panel">
-                        <div class="panel-title">Health Care Team</div>
+                        <h2 class="panel-title">Health Care Team</h2>
                     </section>
 
                     <section class="panel">
-                        <div class="panel-title">Patient Clinic Status</div>
+                        <h2 class="panel-title">Patient Clinic Status</h2>
                     </section>
 
                     <section class="panel">
-                        <div class="panel-title">Notes</div>
+                        <h2 class="panel-title">Notes</h2>
                         <div class="info-row">
                             <span class="info-value">Testing the patient notes field</span>
                             <span></span>
@@ -917,6 +920,7 @@
             template.value = selectedTemplate;
             smsBody.value = templateBodies[selectedTemplate] || templateBodies.general;
             modal.classList.add('open');
+            template.focus();
         }
 
         function closeSms() {

--- a/docs/mockups/sms-patient-master-mock.html
+++ b/docs/mockups/sms-patient-master-mock.html
@@ -842,7 +842,7 @@
     </main>
 </div>
 
-<div class="modal-backdrop" id="smsModal" role="dialog" aria-modal="true" aria-labelledby="smsTitle">
+<div class="modal-backdrop" id="smsModal" role="dialog" aria-modal="true" aria-labelledby="smsTitle" aria-describedby="smsContext">
     <section class="sms-modal">
         <header>
             <div>

--- a/docs/mockups/sms-patient-master-mock.html
+++ b/docs/mockups/sms-patient-master-mock.html
@@ -1,4 +1,33 @@
 <!doctype html>
+<!--
+    Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+
+    This software is published under the GPL GNU General Public License.
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+    CARLOS EMR Project
+    https://github.com/carlos-emr/carlos
+-->
+<!--
+    Static design mockup: patient master file with proposed SMS contact and consent entry points.
+
+    Discussion artifact for the proposed SMS features (issue #2443).
+    Not shipped UI; all patient data shown is synthetic.
+
+    @since 2026-07-02
+-->
 <html lang="en">
 <head>
     <meta charset="utf-8">
@@ -781,7 +810,7 @@
                     </section>
 
                     <section class="panel">
-                        <div class="panel-title">???demographic.manageHealthCareTeam.heading???</div>
+                        <div class="panel-title">Health Care Team</div>
                     </section>
 
                     <section class="panel">

--- a/docs/mockups/sms-patient-master-mock.html
+++ b/docs/mockups/sms-patient-master-mock.html
@@ -849,7 +849,7 @@
     <section class="sms-modal">
         <header>
             <div>
-                <h2 id="smsTitle">Text FAKE-Lee FAKE-Olivia</h2>
+                <h2 id="smsTitle">Text FAKE-Olivia, FAKE-Lee</h2>
                 <p id="smsContext">Patient master file</p>
             </div>
             <button type="button" data-close aria-label="Close">x</button>

--- a/docs/mockups/sms-patient-master-mock.html
+++ b/docs/mockups/sms-patient-master-mock.html
@@ -732,7 +732,7 @@
                             <span></span>
                         </div>
                         <div class="info-row">
-                            <span class="info-label">Province :</span>
+                            <span class="info-label">Province:</span>
                             <span class="info-value">Ontario, Canada</span>
                             <span></span>
                         </div>

--- a/docs/mockups/sms-patient-master-mock.html
+++ b/docs/mockups/sms-patient-master-mock.html
@@ -1,0 +1,924 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>CARLOS Patient Master SMS Mock</title>
+    <style>
+        * {
+            box-sizing: border-box;
+        }
+
+        html,
+        body {
+            margin: 0;
+            min-height: 100%;
+            background: #f3f3f3;
+            color: #111;
+            font-family: system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif;
+            font-size: 12px;
+            line-height: 1.35;
+        }
+
+        a,
+        a:visited {
+            color: #1f66ad;
+            font-weight: 600;
+            text-decoration: none;
+        }
+
+        button,
+        input,
+        select,
+        textarea {
+            font: inherit;
+        }
+
+        button,
+        input[type="button"] {
+            border: 1px solid #2d74b6;
+            border-radius: 4px;
+            background: #337ab7;
+            color: #fff;
+            font-weight: 600;
+            cursor: pointer;
+        }
+
+        button:hover,
+        input[type="button"]:hover {
+            background: #286090;
+        }
+
+        .patient-shell {
+            min-height: 100vh;
+            display: grid;
+            grid-template-columns: 245px 1fr;
+            grid-template-rows: 56px 1fr;
+        }
+
+        .patient-header {
+            grid-column: 1 / -1;
+            display: flex;
+            align-items: center;
+            gap: 18px;
+            padding: 0 24px;
+            background: #337ab7;
+            color: #fff;
+        }
+
+        .patient-name {
+            margin: 0;
+            font-size: 18px;
+            font-weight: 700;
+            line-height: 1;
+        }
+
+        .patient-meta {
+            font-size: 13px;
+        }
+
+        .next-appt {
+            margin-left: 4px;
+            color: #dceeff;
+            font-style: italic;
+        }
+
+        .header-actions {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            margin-left: auto;
+        }
+
+        .header-sms {
+            height: 30px;
+            padding: 0 10px;
+            border-color: #155d9c;
+            background: #fff;
+            color: #155d9c;
+        }
+
+        .header-sms:hover {
+            background: #e9f3ff;
+            color: #0d4776;
+        }
+
+        .side-nav {
+            grid-row: 2;
+            background: #337ab7;
+            color: #fff;
+            border-right: 1px solid #d5d5d5;
+        }
+
+        .side-nav a {
+            display: block;
+            padding: 8px 12px;
+            border-bottom: 1px solid rgba(255, 255, 255, 0.18);
+            color: #fff;
+            font-weight: 700;
+        }
+
+        .side-nav a:hover {
+            background: #286090;
+        }
+
+        .main-content {
+            grid-row: 2;
+            padding: 0 6px 46px;
+            background: #f3f3f3;
+        }
+
+        .search-row {
+            display: flex;
+            align-items: center;
+            height: 36px;
+            padding: 0 8px;
+            border-bottom: 1px solid #ddd;
+            background: #f8f8f8;
+        }
+
+        .search-row a {
+            color: #1f66ad;
+            font-size: 13px;
+        }
+
+        .record-toolbar {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            min-height: 40px;
+            margin: 0 0 10px;
+            padding: 7px 12px;
+            border: 1px solid #d5d5d5;
+            border-radius: 4px;
+            background: #f8f8f8;
+        }
+
+        .record-toolbar button {
+            min-height: 26px;
+            padding: 4px 10px;
+        }
+
+        .show-fields {
+            display: block;
+            margin: 4px 14px 10px auto;
+            width: max-content;
+        }
+
+        .content-band {
+            min-height: 668px;
+            padding: 18px;
+            background: #ececec;
+        }
+
+        .two-column {
+            display: grid;
+            grid-template-columns: minmax(360px, 1fr) minmax(360px, 1fr);
+            gap: 14px;
+            align-items: start;
+        }
+
+        .panel {
+            margin: 0 0 8px;
+            border: 1px solid #d5d5d5;
+            border-radius: 4px;
+            background: #fff;
+            overflow: hidden;
+        }
+
+        .panel-title {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            justify-content: space-between;
+            min-height: 34px;
+            padding: 7px 13px;
+            background: #337ab7;
+            color: #fff;
+            font-weight: 700;
+        }
+
+        .panel-title .pill {
+            height: 21px;
+            padding: 2px 8px;
+            border: 1px solid rgba(255, 255, 255, 0.7);
+            border-radius: 4px;
+            background: transparent;
+            color: #fff;
+            font-size: 11px;
+        }
+
+        .panel-title-left,
+        .panel-title-actions {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .panel-title-button,
+        .panel-title-button:visited {
+            min-height: 22px;
+            padding: 3px 8px;
+            border: 1px solid rgba(255, 255, 255, 0.75);
+            border-radius: 4px;
+            background: #fff;
+            color: #155d9c;
+            font-size: 11px;
+            font-weight: 700;
+            line-height: 1.2;
+        }
+
+        .panel-title-button:hover {
+            background: #e9f3ff;
+            color: #0d4776;
+        }
+
+        .info-row {
+            display: grid;
+            grid-template-columns: minmax(145px, auto) 1fr auto;
+            align-items: center;
+            gap: 8px;
+            min-height: 30px;
+            padding: 7px 12px;
+            border-bottom: 1px solid #e9e9e9;
+        }
+
+        .info-row:last-child {
+            border-bottom: 0;
+        }
+
+        .info-label {
+            font-weight: 400;
+        }
+
+        .info-value {
+            min-width: 0;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        .row-actions {
+            display: inline-flex;
+            align-items: center;
+            gap: 5px;
+            white-space: nowrap;
+        }
+
+        .sms-row-button,
+        .sms-ghost-button {
+            min-height: 23px;
+            padding: 3px 8px;
+            font-size: 11px;
+            line-height: 1;
+        }
+
+        .sms-ghost-button {
+            border-color: #b7c5d2;
+            background: #fff;
+            color: #1f66ad;
+        }
+
+        .sms-ghost-button:hover {
+            background: #e9f3ff;
+            color: #155d9c;
+        }
+
+        .sms-disabled {
+            border-color: #aaa;
+            background: #e7e7e7;
+            color: #777;
+            cursor: not-allowed;
+        }
+
+        .sms-disabled:hover {
+            background: #e7e7e7;
+            color: #777;
+        }
+
+        .status-pill {
+            display: inline-block;
+            min-width: 58px;
+            padding: 3px 7px;
+            border: 1px solid #6ea76e;
+            border-radius: 3px;
+            background: #e5f4df;
+            color: #225b22;
+            font-size: 11px;
+            font-weight: 700;
+            text-align: center;
+        }
+
+        .status-pill.warn {
+            border-color: #cc9a2c;
+            background: #fff2c2;
+            color: #684800;
+        }
+
+        .status-pill.muted {
+            border-color: #bbb;
+            background: #ededed;
+            color: #666;
+        }
+
+        .communication-summary {
+            display: grid;
+            grid-template-columns: repeat(3, minmax(0, 1fr));
+            gap: 8px;
+            padding: 10px 12px;
+            border-bottom: 1px solid #e9e9e9;
+        }
+
+        .summary-cell {
+            min-height: 52px;
+            padding: 8px;
+            border: 1px solid #d7d7d7;
+            border-radius: 4px;
+            background: #f8f8f8;
+        }
+
+        .summary-cell strong {
+            display: block;
+            margin-bottom: 3px;
+            color: #333;
+        }
+
+        .log-table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+
+        .log-table th,
+        .log-table td {
+            padding: 7px 8px;
+            border-bottom: 1px solid #e7e7e7;
+            text-align: left;
+            vertical-align: top;
+        }
+
+        .log-table th {
+            background: #fafafa;
+            font-weight: 700;
+        }
+
+        .footer-toolbar {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 8px;
+            margin-top: 10px;
+            padding: 10px 0 0;
+            border-top: 1px solid #d1d1d1;
+        }
+
+        .footer-left,
+        .footer-right {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .secondary-button {
+            min-height: 32px;
+            padding: 6px 14px;
+        }
+
+        .back-button {
+            min-height: 32px;
+            padding: 6px 14px;
+            border-color: #777;
+            background: #6f7478;
+        }
+
+        .back-button:hover {
+            background: #5f6468;
+        }
+
+        .modal-backdrop {
+            position: fixed;
+            inset: 0;
+            z-index: 2000;
+            display: none;
+            align-items: center;
+            justify-content: center;
+            padding: 22px;
+            background: rgba(0, 0, 0, 0.42);
+        }
+
+        .modal-backdrop.open {
+            display: flex;
+        }
+
+        .sms-modal {
+            width: min(720px, 100%);
+            max-height: 90vh;
+            overflow: auto;
+            border: 1px solid #777;
+            border-radius: 4px;
+            background: #fff;
+            box-shadow: 0 14px 35px rgba(0, 0, 0, 0.35);
+        }
+
+        .sms-modal header,
+        .sms-modal footer {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 8px;
+            padding: 10px 12px;
+            border-bottom: 1px solid #d1d1d1;
+            background: #f8f8f8;
+        }
+
+        .sms-modal footer {
+            justify-content: flex-end;
+            border-top: 1px solid #d1d1d1;
+            border-bottom: 0;
+        }
+
+        .sms-modal h2 {
+            margin: 0;
+            font-size: 16px;
+        }
+
+        .sms-modal p {
+            margin: 3px 0 0;
+            color: #555;
+        }
+
+        .modal-body {
+            padding: 12px;
+        }
+
+        .modal-grid {
+            display: grid;
+            grid-template-columns: repeat(3, minmax(0, 1fr));
+            gap: 8px;
+            margin-bottom: 10px;
+        }
+
+        .modal-field-grid {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 9px;
+        }
+
+        .field {
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+        }
+
+        .field.full {
+            grid-column: 1 / -1;
+        }
+
+        .field label {
+            font-weight: 700;
+        }
+
+        .field input,
+        .field select,
+        .field textarea {
+            width: 100%;
+            padding: 6px;
+            border: 1px solid #b7c5d2;
+            border-radius: 3px;
+            background: #fff;
+        }
+
+        .field textarea {
+            min-height: 96px;
+            resize: vertical;
+        }
+
+        @media (max-width: 900px) {
+            .patient-shell {
+                grid-template-columns: 1fr;
+                grid-template-rows: auto auto 1fr;
+            }
+
+            .patient-header {
+                flex-wrap: wrap;
+                min-height: 62px;
+                padding: 10px 14px;
+            }
+
+            .header-actions {
+                margin-left: 0;
+            }
+
+            .side-nav {
+                grid-row: 2;
+                display: flex;
+                overflow-x: auto;
+            }
+
+            .side-nav a {
+                flex: 0 0 auto;
+                border-right: 1px solid rgba(255, 255, 255, 0.18);
+            }
+
+            .main-content {
+                grid-row: 3;
+            }
+
+            .two-column,
+            .communication-summary,
+            .modal-grid,
+            .modal-field-grid {
+                grid-template-columns: 1fr;
+            }
+        }
+    </style>
+</head>
+<body>
+<div class="patient-shell">
+    <header class="patient-header">
+        <h1 class="patient-name">FAKE-Olivia, FAKE-Lee</h1>
+        <span class="patient-meta">Other &middot; 59 years &middot; DOB: 1966-06-06</span>
+        <span class="next-appt">Next Appointment:</span>
+        <div class="header-actions">
+            <span class="status-pill">SMS OK</span>
+            <button class="header-sms" type="button" data-open-sms data-template="general" data-context="Patient master file">Text patient</button>
+        </div>
+    </header>
+
+    <nav class="side-nav" aria-label="Patient actions">
+        <a href="#">Appointment History</a>
+        <a href="#">Billing History</a>
+        <a href="#">Create Invoice</a>
+        <a href="#">Consultations</a>
+        <a href="#">Prescriptions</a>
+        <a href="#">E-Chart</a>
+        <a href="#">Preventions</a>
+        <a href="#">Tickler</a>
+        <a href="#">Documents</a>
+        <a href="#">Current eForms</a>
+    </nav>
+
+    <main class="main-content">
+        <div class="search-row">
+            <a href="#">Search Patient</a>
+        </div>
+
+        <section class="record-toolbar">
+            <a href="#">#14</a>
+            <button type="button">Edit</button>
+        </section>
+
+        <a class="show-fields" href="#">Show all fields</a>
+
+        <section class="content-band">
+            <div class="two-column">
+                <div>
+                    <section class="panel">
+                        <div class="panel-title">Demographic</div>
+                        <div class="info-row">
+                            <span class="info-label">Title:</span>
+                            <span class="info-value">Ms</span>
+                            <span></span>
+                        </div>
+                        <div class="info-row">
+                            <span class="info-label">Last Name:</span>
+                            <span class="info-value">FAKE-Olivia</span>
+                            <span></span>
+                        </div>
+                        <div class="info-row">
+                            <span class="info-label">First Name:</span>
+                            <span class="info-value">FAKE-Lee</span>
+                            <span></span>
+                        </div>
+                        <div class="info-row">
+                            <span class="info-label">Sex:</span>
+                            <span class="info-value">Other</span>
+                            <span></span>
+                        </div>
+                        <div class="info-row">
+                            <span class="info-label">Age:</span>
+                            <span class="info-value">59 years ( DOB: 1966-06-06)</span>
+                            <span></span>
+                        </div>
+                        <div class="info-row">
+                            <span class="info-label">Language:</span>
+                            <span class="info-value">English</span>
+                            <span></span>
+                        </div>
+                        <div class="info-row">
+                            <span class="info-label">Spoken Language:</span>
+                            <span class="info-value">Amharic</span>
+                            <span></span>
+                        </div>
+                    </section>
+
+                    <section class="panel">
+                        <div class="panel-title">
+                            Other Contacts
+                            <button class="pill" type="button">Add Relation</button>
+                        </div>
+                    </section>
+
+                    <section class="panel">
+                        <div class="panel-title">
+                            Clinic Status
+                            <button class="pill" type="button">Enrollment History</button>
+                        </div>
+                        <div class="info-row">
+                            <span class="info-label">Enrolment Status:</span>
+                            <span class="info-value">Rostered</span>
+                            <span></span>
+                        </div>
+                        <div class="info-row">
+                            <span class="info-label">Enrolment Date:</span>
+                            <span class="info-value">2023-11-13</span>
+                            <span></span>
+                        </div>
+                        <div class="info-row">
+                            <span class="info-label">Patient Status:</span>
+                            <span class="info-value">AC</span>
+                            <span></span>
+                        </div>
+                        <div class="info-row">
+                            <span class="info-label">Patient Status Date:</span>
+                            <span class="info-value">2023-11-13</span>
+                            <span></span>
+                        </div>
+                    </section>
+
+                    <section class="panel">
+                        <div class="panel-title">Alerts</div>
+                        <div class="info-row">
+                            <span class="info-label">&nbsp;</span>
+                            <span class="info-value"></span>
+                            <span></span>
+                        </div>
+                    </section>
+
+                    <section class="panel">
+                        <div class="panel-title">Rx Interaction Warning Level</div>
+                        <div class="info-row">
+                            <span class="info-label">Rx Interaction Warning Level:</span>
+                            <span class="info-value">Not Specified</span>
+                            <span></span>
+                        </div>
+                    </section>
+
+                    <section class="panel">
+                        <div class="panel-title">Paper Chart</div>
+                    </section>
+
+                    <section class="panel">
+                        <div class="panel-title">Custom</div>
+                    </section>
+                </div>
+
+                <div>
+                    <section class="panel">
+                        <div class="panel-title">Contact Information</div>
+                        <div class="info-row">
+                            <span class="info-label">Phone(H)(History):</span>
+                            <span class="info-value">555-555-5555</span>
+                            <span class="row-actions">
+                                <button class="sms-ghost-button sms-disabled" type="button" disabled title="Landline not marked SMS-capable">SMS</button>
+                            </span>
+                        </div>
+                        <div class="info-row">
+                            <span class="info-label">Phone(W)(History):</span>
+                            <span class="info-value">555-555-5555</span>
+                            <span class="row-actions">
+                                <button class="sms-ghost-button" type="button" data-open-sms data-template="call-back" data-context="Work phone">Text</button>
+                            </span>
+                        </div>
+                        <div class="info-row">
+                            <span class="info-label">Cell Phone(History):</span>
+                            <span class="info-value">6476476471</span>
+                            <span class="row-actions">
+                                <span class="status-pill">Verified</span>
+                                <button class="sms-row-button" type="button" data-open-sms data-template="general" data-context="Mobile number on master file">SMS</button>
+                            </span>
+                        </div>
+                        <div class="info-row">
+                            <span class="info-label">City:</span>
+                            <span class="info-value">Toronto</span>
+                            <span></span>
+                        </div>
+                        <div class="info-row">
+                            <span class="info-label">Province :</span>
+                            <span class="info-value">Ontario,Canada</span>
+                            <span></span>
+                        </div>
+                        <div class="info-row">
+                            <span class="info-label">Residential City:</span>
+                            <span class="info-value">Toronto</span>
+                            <span></span>
+                        </div>
+                        <div class="info-row">
+                            <span class="info-label">Residential Province:</span>
+                            <span class="info-value">Ontario,Canada</span>
+                            <span></span>
+                        </div>
+                        <div class="info-row">
+                            <span class="info-label">Email:</span>
+                            <span class="info-value">generic@gmail.com</span>
+                            <span></span>
+                        </div>
+                        <div class="info-row">
+                            <span class="info-label">Newsletter:</span>
+                            <span class="info-value">Unknown</span>
+                            <span></span>
+                        </div>
+                    </section>
+
+                    <section class="panel">
+                        <div class="panel-title">
+                            <span class="panel-title-left">Patient Communication</span>
+                            <span class="panel-title-actions">
+                                <a class="panel-title-button" href="sms-message-history-mock.html">Message history</a>
+                            </span>
+                        </div>
+                        <div class="communication-summary">
+                            <div class="summary-cell">
+                                <strong>SMS consent</strong>
+                                Active since 2026-05-14
+                            </div>
+                            <div class="summary-cell">
+                                <strong>Opt-out</strong>
+                                No STOP recorded
+                            </div>
+                            <div class="summary-cell">
+                                <strong>Default number</strong>
+                                Cell 6476476471
+                            </div>
+                        </div>
+                        <table class="log-table">
+                            <thead>
+                                <tr>
+                                    <th>Date</th>
+                                    <th>Type</th>
+                                    <th>Status</th>
+                                    <th>Logged to</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>2026-05-28</td>
+                                    <td>Appointment reminder</td>
+                                    <td><span class="status-pill">Sent</span></td>
+                                    <td>Master file</td>
+                                </tr>
+                                <tr>
+                                    <td>2026-05-22</td>
+                                    <td>Call-back request</td>
+                                    <td><span class="status-pill warn">Queued</span></td>
+                                    <td>Tickler</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </section>
+
+                    <section class="panel">
+                        <div class="panel-title">Health Insurance</div>
+                    </section>
+
+                    <section class="panel">
+                        <div class="panel-title">???demographic.manageHealthCareTeam.heading???</div>
+                    </section>
+
+                    <section class="panel">
+                        <div class="panel-title">Patient Clinic Status</div>
+                    </section>
+
+                    <section class="panel">
+                        <div class="panel-title">Notes</div>
+                        <div class="info-row">
+                            <span class="info-value">Testing the patient notes field</span>
+                            <span></span>
+                            <span></span>
+                        </div>
+                    </section>
+                </div>
+            </div>
+
+            <footer class="footer-toolbar">
+                <div class="footer-left">
+                    <button class="secondary-button" type="button">Export this Demographic</button>
+                    <button class="secondary-button" type="button">Audit Information</button>
+                </div>
+                <div class="footer-right">
+                    <button class="secondary-button" type="button">Print / Labels</button>
+                    <button class="back-button" type="button">Back</button>
+                </div>
+            </footer>
+        </section>
+    </main>
+</div>
+
+<div class="modal-backdrop" id="smsModal" role="dialog" aria-modal="true" aria-labelledby="smsTitle">
+    <section class="sms-modal">
+        <header>
+            <div>
+                <h2 id="smsTitle">Text FAKE-Lee FAKE-Olivia</h2>
+                <p id="smsContext">Patient master file</p>
+            </div>
+            <button type="button" data-close aria-label="Close">x</button>
+        </header>
+        <div class="modal-body">
+            <div class="modal-grid">
+                <div class="summary-cell">
+                    <strong>Mobile</strong>
+                    6476476471 verified
+                </div>
+                <div class="summary-cell">
+                    <strong>Consent</strong>
+                    SMS consent active
+                </div>
+                <div class="summary-cell">
+                    <strong>Chart</strong>
+                    Log to master file
+                </div>
+            </div>
+            <div class="modal-field-grid">
+                <div class="field">
+                    <label for="smsTemplate">Template</label>
+                    <select id="smsTemplate">
+                        <option value="general">General message</option>
+                        <option value="call-back">Please call clinic</option>
+                        <option value="booking">Book appointment</option>
+                        <option value="form">Complete form</option>
+                    </select>
+                </div>
+                <div class="field">
+                    <label for="smsFrom">Send from</label>
+                    <select id="smsFrom">
+                        <option>Main clinic line</option>
+                        <option>Reception desk</option>
+                        <option>Provider pool</option>
+                    </select>
+                </div>
+                <div class="field full">
+                    <label for="smsBody">Message</label>
+                    <textarea id="smsBody">Riverside Clinic: please call us when convenient. Reply STOP to opt out.</textarea>
+                </div>
+            </div>
+        </div>
+        <footer>
+            <button class="back-button" type="button" data-close>Cancel</button>
+            <button type="button">Preview</button>
+            <button type="button">Send SMS</button>
+        </footer>
+    </section>
+</div>
+
+<script>
+    (function () {
+        var modal = document.getElementById('smsModal');
+        var contextText = document.getElementById('smsContext');
+        var template = document.getElementById('smsTemplate');
+        var smsBody = document.getElementById('smsBody');
+        var templateBodies = {
+            'general': 'Riverside Clinic: please call us when convenient. Reply STOP to opt out.',
+            'call-back': 'Riverside Clinic: we tried to reach you. Please call the clinic when convenient. Reply STOP to opt out.',
+            'booking': 'Riverside Clinic: please contact us to book your follow-up appointment. Reply STOP to opt out.',
+            'form': 'Riverside Clinic: please complete your intake form before your next visit. Reply STOP to opt out.'
+        };
+
+        function openSms(button) {
+            var selectedTemplate = button.getAttribute('data-template') || 'general';
+            contextText.textContent = button.getAttribute('data-context') || 'Patient master file';
+            template.value = selectedTemplate;
+            smsBody.value = templateBodies[selectedTemplate] || templateBodies.general;
+            modal.classList.add('open');
+        }
+
+        function closeSms() {
+            modal.classList.remove('open');
+        }
+
+        document.addEventListener('click', function (event) {
+            var opener = event.target.closest('[data-open-sms]');
+            var closer = event.target.closest('[data-close]');
+
+            if (opener) {
+                event.preventDefault();
+                openSms(opener);
+                return;
+            }
+
+            if (closer || event.target.classList.contains('modal-backdrop')) {
+                closeSms();
+            }
+        });
+
+        document.addEventListener('keydown', function (event) {
+            if (event.key === 'Escape') {
+                closeSms();
+            }
+        });
+
+        template.addEventListener('change', function () {
+            smsBody.value = templateBodies[template.value] || templateBodies.general;
+        });
+    })();
+</script>
+</body>
+</html>

--- a/docs/mockups/sms-schedule-base-mock.html
+++ b/docs/mockups/sms-schedule-base-mock.html
@@ -1,0 +1,1122 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>CARLOS Schedule Baseline Mock</title>
+    <style>
+        * {
+            box-sizing: border-box;
+        }
+
+        html,
+        body {
+            margin: 0;
+            padding: 0;
+            background: #486ebd;
+            color: #000;
+            font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif;
+            font-size: 12px;
+            line-height: 1 !important;
+            overscroll-behavior: none;
+        }
+
+        a,
+        a:visited,
+        a:active {
+            color: #00283c;
+            font-weight: bold;
+            text-decoration: none;
+        }
+
+        a:hover,
+        a:focus {
+            color: red;
+            text-decoration: none;
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+
+        input,
+        select,
+        textarea {
+            background-color: #f4ead7;
+            border: 1px solid #0097cf;
+            font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif;
+            font-size: 12px;
+        }
+
+        input[type="button"],
+        input[type="submit"],
+        button {
+            border: 1px solid #9aa8b6;
+            border-radius: 2px;
+            background: #f8f8f8;
+            color: #000;
+            font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif;
+            font-size: 12px;
+            line-height: 1;
+            padding: 2px 7px;
+            cursor: pointer;
+        }
+
+        #main-container {
+            position: absolute;
+            inset: 0;
+            overflow: auto;
+            background: #486ebd;
+        }
+
+        #fixedHeaderWrapper {
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+            display: flex;
+            flex-direction: column;
+        }
+
+        #firstTable {
+            width: 100%;
+            height: 24px;
+            background: #fff;
+        }
+
+        #firstTable tr {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            height: 25px;
+        }
+
+        #firstTable td {
+            display: flex;
+            align-items: center;
+            gap: 5px;
+            padding: 0;
+        }
+
+        #firstMenu {
+            margin-left: 10px;
+        }
+
+        #firstMenu .logo {
+            width: 19px;
+            height: 19px;
+            display: inline-block;
+            position: relative;
+            margin-right: 3px;
+        }
+
+        #firstMenu .logo::before {
+            content: "";
+            position: absolute;
+            left: 4px;
+            top: 3px;
+            width: 12px;
+            height: 8px;
+            border-top: 3px solid #486ebd;
+            border-left: 3px solid #486ebd;
+            transform: skew(-28deg) rotate(-18deg);
+        }
+
+        #firstMenu .logo::after {
+            content: "";
+            position: absolute;
+            left: 10px;
+            top: 10px;
+            width: 8px;
+            height: 4px;
+            border-top: 3px solid #486ebd;
+            transform: skew(-34deg) rotate(-25deg);
+        }
+
+        #navlist,
+        #userSettingsMenu {
+            display: flex;
+            align-items: center;
+            gap: 0;
+            margin: 0;
+            padding: 0;
+            white-space: nowrap;
+            list-style: none;
+        }
+
+        #navlist li,
+        #userSettingsMenu li {
+            display: inline-block;
+            line-height: 1;
+        }
+
+        #firstTable a,
+        #firstTable a:visited,
+        #firstTable a:active {
+            display: inline-block;
+            padding: 5px;
+            color: #00283c;
+            font-weight: bold;
+        }
+
+        #firstTable a:hover,
+        #firstTable a:focus {
+            color: #fff;
+            background: #486ebd;
+        }
+
+        .tabalert {
+            color: red !important;
+            font-weight: bold;
+        }
+
+        #userSettings {
+            margin-right: 8px;
+        }
+
+        #userSettings .mini-icon {
+            padding: 3px 4px;
+        }
+
+        .menu-icon {
+            width: 14px;
+            height: 10px;
+            display: inline-block;
+            position: relative;
+            border-top: 1px solid #00283c;
+            border-bottom: 1px solid #00283c;
+            vertical-align: middle;
+        }
+
+        .menu-icon::before {
+            content: "";
+            position: absolute;
+            left: 0;
+            right: 0;
+            top: 4px;
+            border-top: 1px solid #00283c;
+        }
+
+        .user-icon {
+            width: 12px;
+            height: 12px;
+            display: inline-block;
+            position: relative;
+            margin-right: 3px;
+            vertical-align: -2px;
+        }
+
+        .user-icon::before {
+            content: "";
+            position: absolute;
+            left: 4px;
+            top: 0;
+            width: 5px;
+            height: 5px;
+            border-radius: 50%;
+            background: #00283c;
+        }
+
+        .user-icon::after {
+            content: "";
+            position: absolute;
+            left: 1px;
+            bottom: 0;
+            width: 11px;
+            height: 6px;
+            border-radius: 7px 7px 2px 2px;
+            background: #00283c;
+        }
+
+        #logoutButton {
+            padding: 3px 4px !important;
+        }
+
+        .power-icon {
+            width: 14px;
+            height: 14px;
+            display: inline-block;
+            position: relative;
+            border: 2px solid #00283c;
+            border-top-color: transparent;
+            border-radius: 50%;
+            vertical-align: -3px;
+        }
+
+        .power-icon::before {
+            content: "";
+            position: absolute;
+            left: 4px;
+            top: -5px;
+            width: 2px;
+            height: 8px;
+            background: #00283c;
+        }
+
+        #scheduleNavigation {
+            width: 100%;
+            height: 25px;
+            background: whitesmoke;
+        }
+
+        #ivoryBar {
+            display: flex;
+            justify-content: space-between;
+            gap: 5px;
+            min-height: 29px;
+            background: whitesmoke;
+        }
+
+        #scheduleNavigation td {
+            padding: 3px 0;
+            white-space: nowrap;
+        }
+
+        #dateAndCalendar {
+            display: flex;
+            align-items: center;
+            gap: 5px;
+            margin-left: 10px;
+            min-width: 0;
+        }
+
+        #group {
+            display: flex;
+            align-items: center;
+            gap: 4px;
+            margin-right: 15px;
+        }
+
+        #quickSearchWrapper {
+            position: relative;
+            display: inline-flex;
+            align-items: center;
+            margin-right: 4px;
+            vertical-align: middle;
+        }
+
+        #quickSearch {
+            width: 170px;
+            height: 24px;
+            padding: 2px 26px 2px 6px;
+            border: 1px solid #adb5bd;
+            border-radius: 4px;
+            background: #fff;
+            font-size: 0.8rem;
+        }
+
+        .redArrow {
+            width: 12px;
+            height: 16px;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            padding: 0;
+            vertical-align: middle;
+        }
+
+        .step-icon {
+            position: relative;
+            width: 10px;
+            height: 10px;
+            display: inline-block;
+        }
+
+        .step-icon::before {
+            content: "";
+            position: absolute;
+            top: 1px;
+            width: 0;
+            height: 0;
+            border-top: 4px solid transparent;
+            border-bottom: 4px solid transparent;
+        }
+
+        .step-icon::after {
+            content: "";
+            position: absolute;
+            top: 1px;
+            width: 2px;
+            height: 8px;
+            background: #00283c;
+        }
+
+        .step-icon.prev::before {
+            left: 1px;
+            border-right: 6px solid #00283c;
+        }
+
+        .step-icon.prev::after {
+            left: 0;
+        }
+
+        .step-icon.next::before {
+            right: 1px;
+            border-left: 6px solid #00283c;
+        }
+
+        .step-icon.next::after {
+            right: 0;
+        }
+
+        .dateAppointment {
+            color: #00283c;
+            font-size: inherit;
+            font-weight: bold;
+        }
+
+        .quick-btn {
+            height: 20px;
+            min-width: 28px;
+            margin: 0 1px;
+            padding: 1px 6px;
+        }
+
+        #dateMultiplier {
+            width: 34px;
+            height: 20px;
+            text-align: center;
+        }
+
+        #toggleCancelledBtn {
+            width: 18px;
+            height: 18px;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            margin-left: 5px;
+            padding: 0;
+            vertical-align: middle;
+        }
+
+        .eye-icon {
+            width: 15px;
+            height: 9px;
+            display: inline-block;
+            position: relative;
+            border: 1px solid #777;
+            border-radius: 50% / 60%;
+        }
+
+        .eye-icon::after {
+            content: "";
+            position: absolute;
+            left: 5px;
+            top: 2px;
+            width: 3px;
+            height: 3px;
+            border-radius: 50%;
+            background: #777;
+        }
+
+        .title {
+            flex: 1 0 auto;
+            color: #000;
+            font-size: 14px;
+            text-align: center;
+        }
+
+        #findProviderInput {
+            width: 156px;
+            height: 20px;
+            padding: 1px 5px;
+        }
+
+        #group select {
+            width: 140px;
+            height: 21px;
+        }
+
+        #scheduleTable {
+            background: #c0c0c0;
+        }
+
+        #scheduleTable td,
+        #scheduleTable tr,
+        #scheduleTable th,
+        #scheduleTable thead,
+        #scheduleTable tbody,
+        #scheduleTable tfoot {
+            border-style: none;
+            border-width: 0;
+        }
+
+        #scheduleTable > tbody > tr > td,
+        #scheduleTable > tbody > tr > td > table > tbody > tr > td {
+            padding: 0;
+        }
+
+        .providerSchedule {
+            background: #486ebd;
+            border-collapse: collapse;
+        }
+
+        #providerSchedule,
+        #providerSchedule td {
+            border-collapse: collapse;
+        }
+
+        .infirmaryView {
+            position: sticky;
+            top: 50px;
+            left: 0;
+            right: 0;
+            height: 25px;
+            padding: 0 5px !important;
+            background: #c0c0c0;
+            text-align: center;
+            white-space: nowrap;
+        }
+
+        .infirmaryView input[type="button"] {
+            height: 19px;
+            padding: 1px 7px;
+            vertical-align: middle;
+        }
+
+        .infirmaryView input[type="radio"] {
+            margin: 0 2px;
+            vertical-align: middle;
+        }
+
+        .scheduleTime00,
+        .scheduleTimeNot00 {
+            width: 64px;
+            min-width: 64px;
+            border-top: #486ebd 2px solid;
+            border-right: #486ebd 2px solid;
+            border-bottom: #486ebd 2px solid;
+        }
+
+        .scheduleTime00 {
+            background: #3ea4e1;
+        }
+
+        .scheduleTimeNot00 {
+            background: #00a488;
+        }
+
+        .adhour {
+            display: block;
+            padding: 3px;
+            color: #fff !important;
+            font-size: 12px;
+            font-weight: bold;
+        }
+
+        .hourmin {
+            width: 14px;
+            min-width: 14px;
+            padding: 0 3px !important;
+            border-top: #486ebd 2px solid;
+            border-bottom: #486ebd 2px solid;
+            background: transparent;
+            color: #000;
+            text-align: center;
+        }
+
+        .hourmin.open {
+            background: #bfefff;
+        }
+
+        .hourmin.closed {
+            background: transparent;
+            color: #000;
+        }
+
+        td.appt {
+            overflow: hidden;
+            padding-top: 3px !important;
+            padding-right: 3px !important;
+            padding-left: 3px !important;
+            vertical-align: top;
+            border-top: #486ebd 2px solid !important;
+            border-right: #486ebd 2px solid !important;
+            border-bottom: #486ebd 2px solid !important;
+            border-left: #486ebd 2px solid !important;
+            background: #ffffc7;
+            white-space: nowrap;
+        }
+
+        td.appt a {
+            padding: 0 2px;
+        }
+
+        td.appt .folder {
+            display: inline-block;
+            margin: 0 4px 0 2px;
+            color: #836f00;
+            font-size: 13px;
+            vertical-align: -1px;
+        }
+
+        .apptStatus {
+            display: inline-block;
+            min-width: 9px;
+            color: #000;
+            text-align: center;
+        }
+
+        .reason {
+            color: #000;
+            font-style: italic;
+            font-weight: bold;
+        }
+
+        .timeline-marker {
+            height: 0;
+            margin: 0;
+            padding: 0;
+            border: none;
+            border-top: 2px dotted tomato;
+            color: tomato;
+            opacity: 1;
+        }
+
+        .noGrid {
+            border: none;
+        }
+
+        .slot-row td {
+            height: 20px;
+        }
+
+        .provider-spacer td {
+            height: 1px !important;
+            padding: 0 !important;
+            background: #486ebd;
+        }
+
+        .timeline-indicator td {
+            height: 2px !important;
+            padding: 0 !important;
+        }
+
+        .appointment-text {
+            display: block;
+            padding-top: 2px;
+            line-height: 1.1;
+        }
+
+        body.week-view #scheduleTable {
+            table-layout: fixed;
+        }
+
+        .weekDayCell {
+            width: 20%;
+            padding: 0 !important;
+            vertical-align: top;
+            background: #486ebd;
+        }
+
+        .weekDaySchedule {
+            width: 100%;
+            table-layout: fixed;
+        }
+
+        .weekDaySchedule .infirmaryView {
+            position: static;
+            top: auto;
+            right: auto;
+            left: auto;
+            height: 25px;
+        }
+
+        .weekDaySchedule .scheduleTime00,
+        .weekDaySchedule .scheduleTimeNot00 {
+            width: 51px;
+            min-width: 51px;
+        }
+
+        .weekDaySchedule .hourmin {
+            width: 14px;
+            min-width: 14px;
+        }
+
+        .weekDaySchedule .noGrid {
+            width: auto;
+        }
+
+        .week-appointment {
+            display: flex;
+            align-items: center;
+            gap: 3px;
+            min-width: 0;
+            overflow: hidden;
+        }
+
+        .week-appt-main {
+            flex: 1 1 auto;
+            min-width: 0;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        @media (max-width: 900px) {
+            #navlist {
+                max-width: calc(100vw - 145px);
+                overflow-x: auto;
+            }
+
+            #ivoryBar {
+                align-items: stretch;
+                flex-direction: column;
+            }
+
+            #dateAndCalendar,
+            #group {
+                margin: 0 8px;
+                overflow-x: auto;
+            }
+        }
+    </style>
+</head>
+<body>
+<div id="main-container">
+    <div id="fixedHeaderWrapper">
+        <table id="firstTable" class="noprint">
+            <tr>
+                <td id="firstMenu">
+                    <span class="logo" aria-hidden="true"></span>
+                    <ul id="navlist">
+                        <li><a href="#">Schedule</a></li>
+                        <li><a href="#">Search</a></li>
+                        <li><a href="#">Inbox</a></li>
+                        <li><a href="#"><span class="tabalert">U</span></a></li>
+                        <li><a href="#">Tickler<span class="tabalert">81</span></a></li>
+                        <li><a href="#">Msg</a></li>
+                        <li><a href="#">Consultations</a></li>
+                        <li><a href="#">eDoc</a></li>
+                        <li><a href="#">Report</a></li>
+                        <li><a href="#">Administration</a></li>
+                        <li><a href="#">Resources</a></li>
+                    </ul>
+                </td>
+                <td id="userSettings">
+                    <ul id="userSettingsMenu">
+                        <li><a href="#" class="mini-icon"><span class="menu-icon" aria-hidden="true"></span></a></li>
+                        <li><a href="#"><span class="user-icon" aria-hidden="true"></span>doctor carlosdoc</a></li>
+                    </ul>
+                    <a id="logoutButton" href="#" title="Logout"><span class="power-icon" aria-hidden="true"></span></a>
+                </td>
+            </tr>
+        </table>
+
+        <table id="scheduleNavigation">
+            <tr id="ivoryBar">
+                <td id="dateAndCalendar">
+                    <span id="quickSearchWrapper" class="quick-search-wrapper noprint">
+                        <input type="text" id="quickSearch" name="quickSearch" placeholder="Search" autocomplete="off">
+                    </span>
+                    <a class="redArrow" href="#" title="Previous day"><span class="step-icon prev" aria-hidden="true"></span></a>
+                    <b><a href="#" class="clickable-date"><span class="dateAppointment">Fri, 2026-05-29</span></a></b>
+                    <a class="redArrow" href="#" title="Next day"><span class="step-icon next" aria-hidden="true"></span></a>
+                    <input type="button" value="M-" class="quick-btn">
+                    <input type="button" value="W-" class="quick-btn">
+                    <input type="number" id="dateMultiplier" value="1" min="1" max="99">
+                    <input type="button" value="W+" class="quick-btn">
+                    <input type="button" value="M+" class="quick-btn">
+                    <span>|</span>
+                    <input type="button" value="2W" class="quick-btn">
+                    <input type="button" value="4W" class="quick-btn">
+                    <input type="button" value="3M" class="quick-btn">
+                    <input type="button" value="6M" class="quick-btn">
+                    <a id="toggleCancelledBtn" href="#" title="Hide cancelled"><span class="eye-icon" aria-hidden="true"></span></a>
+                    <u><a href="#">All</a></u>
+                    <a href="#">Today</a>
+                    <a href="#">Month</a>
+                </td>
+                <td class="title noprint"></td>
+                <td id="group">
+                    <form method="post" name="findprovider">
+                        <input id="findProviderInput" type="text" name="providername" value="" maxlength="10" placeholder="Enter Lastname">
+                        <input type="submit" name="Go" value="GO">
+                    </form>
+                    <form name="appointmentForm">
+                        <span>Group:</span>
+                        <select id="mygroup_no" name="mygroup_no">
+                            <option>.default</option>
+                            <option>carlosdoc, doctor</option>
+                            <option>openodoc, doctor</option>
+                        </select>
+                    </form>
+                </td>
+            </tr>
+        </table>
+    </div>
+
+    <table id="scheduleTable" bgcolor="#c0c0c0">
+        <tr>
+            <td colspan="3">
+                <table class="providerSchedule" id="providerSchedule" bgcolor="#486ebd">
+                    <tr>
+                        <td class="infirmaryView" nowrap align="center" bgcolor="#c0c0c0" colspan="3">
+                            <input type="button" value="W" name="weekview">
+                            <input type="button" value="S" name="searchview">
+                            <input type="radio" name="flipview">
+                            <a href="#">carlosdoc, doctor (0)</a>
+                            <a href="#" title="Expand reason">*</a>
+                        </td>
+                    </tr>
+                    <tr class="provider-spacer">
+                        <td colspan="3"></td>
+                    </tr>
+
+                    <tr class="slot-row">
+                        <td class="scheduleTime00"><a href="#" class="adhour">08:00</a></td>
+                        <td class="hourmin closed">-</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">08:15</a></td>
+                        <td class="hourmin closed">-</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">08:30</a></td>
+                        <td class="hourmin closed">-</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">08:45</a></td>
+                        <td class="hourmin closed">-</td>
+                        <td class="noGrid"></td>
+                    </tr>
+
+                    <tr class="slot-row">
+                        <td class="scheduleTime00"><a href="#" class="adhour">09:00</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">09:15</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">09:30</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">09:45</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="noGrid"></td>
+                    </tr>
+
+                    <tr class="slot-row">
+                        <td class="scheduleTime00"><a href="#" class="adhour">10:00</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">10:15</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">10:30</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="timeline-indicator noprint">
+                        <td colspan="3"><hr class="timeline-marker"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">10:45</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTime00"><a href="#" class="adhour">11:00</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">11:15</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">11:30</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">11:45</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTime00"><a href="#" class="adhour">12:00</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">12:15</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">12:30</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">12:45</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTime00"><a href="#" class="adhour">13:00</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">13:15</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">13:30</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">13:45</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTime00"><a href="#" class="adhour">14:00</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">14:15</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">14:30</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">14:45</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTime00"><a href="#" class="adhour">15:00</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">15:15</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">15:30</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">15:45</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTime00"><a href="#" class="adhour">16:00</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">16:15</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">16:30</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">16:45</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTime00"><a href="#" class="adhour">17:00</a></td>
+                        <td class="hourmin closed">-</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">17:15</a></td>
+                        <td class="hourmin closed">-</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">17:30</a></td>
+                        <td class="hourmin closed">-</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">17:45</a></td>
+                        <td class="hourmin closed">-</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTime00"><a href="#" class="adhour">18:00</a></td>
+                        <td class="hourmin closed">-</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">18:15</a></td>
+                        <td class="hourmin closed">-</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">18:30</a></td>
+                        <td class="hourmin closed">-</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">18:45</a></td>
+                        <td class="hourmin closed">-</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+</div>
+<script>
+    (function () {
+        var scheduleTable = document.getElementById('scheduleTable');
+        var dateLabel = document.querySelector('.dateAppointment');
+        var dayMarkup = scheduleTable.innerHTML;
+        var baseMonday = new Date(2026, 4, 25);
+        var weekOffset = 0;
+        var times = [
+            '08:00', '08:15', '08:30', '08:45',
+            '09:00', '09:15', '09:30', '09:45',
+            '10:00', '10:15', '10:30', '10:45',
+            '11:00', '11:15', '11:30', '11:45',
+            '12:00', '12:15', '12:30', '12:45',
+            '13:00', '13:15', '13:30', '13:45',
+            '14:00', '14:15', '14:30', '14:45',
+            '15:00', '15:15', '15:30', '15:45',
+            '16:00', '16:15', '16:30', '16:45',
+            '17:00', '17:15', '17:30', '17:45',
+            '18:00', '18:15', '18:30', '18:45'
+        ];
+        var dayNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+        function pad(value) {
+            return String(value).padStart(2, '0');
+        }
+
+        function formatDate(date) {
+            return dayNames[date.getDay()] + ', ' + date.getFullYear() + '-' + pad(date.getMonth() + 1) + '-' + pad(date.getDate());
+        }
+
+        function getWeekNumber(date) {
+            var weekDate = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+            var dayNumber = weekDate.getUTCDay() || 7;
+            weekDate.setUTCDate(weekDate.getUTCDate() + 4 - dayNumber);
+            var yearStart = new Date(Date.UTC(weekDate.getUTCFullYear(), 0, 1));
+            return Math.ceil((((weekDate - yearStart) / 86400000) + 1) / 7);
+        }
+
+        function isOpenSlot(time) {
+            var hour = parseInt(time.slice(0, 2), 10);
+            return hour >= 9 && hour < 17;
+        }
+
+        function buildSlot(time) {
+            var timeClass = time.slice(3) === '00' ? 'scheduleTime00' : 'scheduleTimeNot00';
+            var open = isOpenSlot(time);
+            return [
+                '<tr class="slot-row">',
+                    '<td class="' + timeClass + '"><a href="#" class="adhour">' + time + '</a></td>',
+                    '<td class="hourmin ' + (open ? 'open' : 'closed') + '">' + (open ? '1' : '-') + '</td>',
+                    '<td class="noGrid"></td>',
+                '</tr>'
+            ].join('');
+        }
+
+        function buildWeekDay(date) {
+            return [
+                '<table class="providerSchedule weekDaySchedule" bgcolor="#486ebd">',
+                    '<colgroup><col style="width:51px"><col style="width:14px"><col></colgroup>',
+                    '<tr>',
+                        '<td class="infirmaryView" nowrap align="center" bgcolor="#c0c0c0" colspan="3">',
+                            formatDate(date),
+                        '</td>',
+                    '</tr>',
+                    '<tr class="provider-spacer"><td colspan="3"></td></tr>',
+                    times.map(buildSlot).join(''),
+                '</table>'
+            ].join('');
+        }
+
+        function renderWeek(offset) {
+            var monday = new Date(baseMonday);
+            var columns = '';
+            var index;
+            weekOffset = offset;
+            monday.setDate(baseMonday.getDate() + (weekOffset * 7));
+
+            for (index = 0; index < 5; index += 1) {
+                var date = new Date(monday);
+                date.setDate(monday.getDate() + index);
+                columns += '<td class="weekDayCell">' + buildWeekDay(date) + '</td>';
+            }
+
+            document.body.classList.add('week-view');
+            dateLabel.textContent = 'Week ' + getWeekNumber(monday);
+            scheduleTable.innerHTML = '<tr>' + columns + '</tr>';
+        }
+
+        function renderDay() {
+            document.body.classList.remove('week-view');
+            dateLabel.textContent = 'Fri, 2026-05-29';
+            scheduleTable.innerHTML = dayMarkup;
+        }
+
+        document.addEventListener('click', function (event) {
+            var button = event.target.closest('input[type="button"]');
+            var link = event.target.closest('a');
+            var linkText = link ? link.textContent.trim() : '';
+
+            if (button && button.value === 'W') {
+                event.preventDefault();
+                renderWeek(weekOffset);
+                return;
+            }
+
+            if (button && button.value === 'W-') {
+                event.preventDefault();
+                renderWeek(weekOffset - 1);
+                return;
+            }
+
+            if (button && button.value === 'W+') {
+                event.preventDefault();
+                renderWeek(weekOffset + 1);
+                return;
+            }
+
+            if (linkText === 'Today') {
+                event.preventDefault();
+                weekOffset = 0;
+                renderDay();
+            }
+        });
+    })();
+</script>
+</body>
+</html>

--- a/docs/mockups/sms-schedule-base-mock.html
+++ b/docs/mockups/sms-schedule-base-mock.html
@@ -1,4 +1,33 @@
 <!doctype html>
+<!--
+    Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+
+    This software is published under the GPL GNU General Public License.
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+    CARLOS EMR Project
+    https://github.com/carlos-emr/carlos
+-->
+<!--
+    Static design mockup: baseline provider schedule without SMS additions, kept for side-by-side comparison with sms-schedule-mock.html.
+
+    Discussion artifact for the proposed SMS features (issue #2443).
+    Not shipped UI; all patient data shown is synthetic.
+
+    @since 2026-07-02
+-->
 <html lang="en">
 <head>
     <meta charset="utf-8">
@@ -1078,6 +1107,9 @@
 
             document.body.classList.add('week-view');
             dateLabel.textContent = 'Week ' + getWeekNumber(monday);
+            // Mockup-only: the interpolated values are hard-coded synthetic data.
+            // A real implementation fed by backend patient/appointment data must
+            // escape dynamic text or build rows via DOM APIs, not innerHTML.
             scheduleTable.innerHTML = '<tr>' + columns + '</tr>';
         }
 

--- a/docs/mockups/sms-schedule-mock.html
+++ b/docs/mockups/sms-schedule-mock.html
@@ -1,4 +1,33 @@
 <!doctype html>
+<!--
+    Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+
+    This software is published under the GPL GNU General Public License.
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+    CARLOS EMR Project
+    https://github.com/carlos-emr/carlos
+-->
+<!--
+    Interactive design mockup: SMS actions integrated into the provider schedule (per-appointment SMS buttons, action menus, and bulk-send modal variants shown on different weekdays for comparison).
+
+    Discussion artifact for the proposed SMS features (issue #2443).
+    Not shipped UI; all patient data shown is synthetic.
+
+    @since 2026-07-02
+-->
 <html lang="en">
 <head>
     <meta charset="utf-8">
@@ -1108,7 +1137,7 @@
                                 <a class="apptLink" href="#">Chen, Jamie</a>
                                 <span>|</span><a href="#">E</a>
                                 <span>|</span><a href="#">M</a>
-                                <button class="appt-more" type="button" data-menu="menu-jamie" data-patient="Jamie Chen" title="More appointment actions">...</button>
+                                <button class="appt-more" type="button" data-menu="apptActionsMenu" data-patient="Jamie Chen" title="More appointment actions">...</button>
                             </span>
                         </td>
                     </tr>
@@ -1395,7 +1424,7 @@
     </table>
 </div>
 
-<div class="sms-menu" id="menu-jamie">
+<div class="sms-menu" id="apptActionsMenu">
     <button type="button">Edit appointment</button>
     <button type="button">Open master file</button>
     <button type="button">Open eChart</button>
@@ -1714,7 +1743,7 @@
             if (appt.action === 'sms') {
                 action = '<button class="sms-inline" type="button" data-open="sms" data-patient="' + patientKey + '" title="Text ' + patientKey + '">SMS</button>';
             } else if (appt.action === 'menu') {
-                action = '<button class="appt-more" type="button" data-menu="menu-jamie" data-patient="' + patientKey + '" title="More appointment actions">...</button>';
+                action = '<button class="appt-more" type="button" data-menu="apptActionsMenu" data-patient="' + patientKey + '" title="More appointment actions">...</button>';
             } else if (appt.action === 'disabled') {
                 action = '<button class="sms-inline disabled" type="button" disabled title="SMS unavailable: consent missing">SMS</button>';
             } else if (appt.state) {
@@ -1795,6 +1824,9 @@
             closeModals();
             document.body.classList.add('week-view');
             dateLabel.textContent = 'Week ' + getWeekNumber(monday);
+            // Mockup-only: the interpolated values are hard-coded synthetic data.
+            // A real implementation fed by backend patient/appointment data must
+            // escape dynamic text or build rows via DOM APIs, not innerHTML.
             scheduleTable.innerHTML = '<tr>' + columns + '</tr>';
         }
 

--- a/docs/mockups/sms-schedule-mock.html
+++ b/docs/mockups/sms-schedule-mock.html
@@ -1,0 +1,1931 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>CARLOS Schedule Baseline Mock</title>
+    <style>
+        * {
+            box-sizing: border-box;
+        }
+
+        html,
+        body {
+            margin: 0;
+            padding: 0;
+            background: #486ebd;
+            color: #000;
+            font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif;
+            font-size: 12px;
+            line-height: 1 !important;
+            overscroll-behavior: none;
+        }
+
+        a,
+        a:visited,
+        a:active {
+            color: #00283c;
+            font-weight: bold;
+            text-decoration: none;
+        }
+
+        a:hover,
+        a:focus {
+            color: red;
+            text-decoration: none;
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+
+        input,
+        select,
+        textarea {
+            background-color: #f4ead7;
+            border: 1px solid #0097cf;
+            font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif;
+            font-size: 12px;
+        }
+
+        input[type="button"],
+        input[type="submit"],
+        button {
+            border: 1px solid #9aa8b6;
+            border-radius: 2px;
+            background: #f8f8f8;
+            color: #000;
+            font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif;
+            font-size: 12px;
+            line-height: 1;
+            padding: 2px 7px;
+            cursor: pointer;
+        }
+
+        #main-container {
+            position: absolute;
+            inset: 0;
+            overflow: auto;
+            background: #486ebd;
+        }
+
+        #fixedHeaderWrapper {
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+            display: flex;
+            flex-direction: column;
+        }
+
+        #firstTable {
+            width: 100%;
+            height: 24px;
+            background: #fff;
+        }
+
+        #firstTable tr {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            height: 25px;
+        }
+
+        #firstTable td {
+            display: flex;
+            align-items: center;
+            gap: 5px;
+            padding: 0;
+        }
+
+        #firstMenu {
+            margin-left: 10px;
+        }
+
+        #firstMenu .logo {
+            width: 19px;
+            height: 19px;
+            display: inline-block;
+            position: relative;
+            margin-right: 3px;
+        }
+
+        #firstMenu .logo::before {
+            content: "";
+            position: absolute;
+            left: 4px;
+            top: 3px;
+            width: 12px;
+            height: 8px;
+            border-top: 3px solid #486ebd;
+            border-left: 3px solid #486ebd;
+            transform: skew(-28deg) rotate(-18deg);
+        }
+
+        #firstMenu .logo::after {
+            content: "";
+            position: absolute;
+            left: 10px;
+            top: 10px;
+            width: 8px;
+            height: 4px;
+            border-top: 3px solid #486ebd;
+            transform: skew(-34deg) rotate(-25deg);
+        }
+
+        #navlist,
+        #userSettingsMenu {
+            display: flex;
+            align-items: center;
+            gap: 0;
+            margin: 0;
+            padding: 0;
+            white-space: nowrap;
+            list-style: none;
+        }
+
+        #navlist li,
+        #userSettingsMenu li {
+            display: inline-block;
+            line-height: 1;
+        }
+
+        #firstTable a,
+        #firstTable a:visited,
+        #firstTable a:active {
+            display: inline-block;
+            padding: 5px;
+            color: #00283c;
+            font-weight: bold;
+        }
+
+        #firstTable a:hover,
+        #firstTable a:focus {
+            color: #fff;
+            background: #486ebd;
+        }
+
+        .tabalert {
+            color: red !important;
+            font-weight: bold;
+        }
+
+        #userSettings {
+            margin-right: 8px;
+        }
+
+        #userSettings .mini-icon {
+            padding: 3px 4px;
+        }
+
+        .menu-icon {
+            width: 14px;
+            height: 10px;
+            display: inline-block;
+            position: relative;
+            border-top: 1px solid #00283c;
+            border-bottom: 1px solid #00283c;
+            vertical-align: middle;
+        }
+
+        .menu-icon::before {
+            content: "";
+            position: absolute;
+            left: 0;
+            right: 0;
+            top: 4px;
+            border-top: 1px solid #00283c;
+        }
+
+        .user-icon {
+            width: 12px;
+            height: 12px;
+            display: inline-block;
+            position: relative;
+            margin-right: 3px;
+            vertical-align: -2px;
+        }
+
+        .user-icon::before {
+            content: "";
+            position: absolute;
+            left: 4px;
+            top: 0;
+            width: 5px;
+            height: 5px;
+            border-radius: 50%;
+            background: #00283c;
+        }
+
+        .user-icon::after {
+            content: "";
+            position: absolute;
+            left: 1px;
+            bottom: 0;
+            width: 11px;
+            height: 6px;
+            border-radius: 7px 7px 2px 2px;
+            background: #00283c;
+        }
+
+        #logoutButton {
+            padding: 3px 4px !important;
+        }
+
+        .power-icon {
+            width: 14px;
+            height: 14px;
+            display: inline-block;
+            position: relative;
+            border: 2px solid #00283c;
+            border-top-color: transparent;
+            border-radius: 50%;
+            vertical-align: -3px;
+        }
+
+        .power-icon::before {
+            content: "";
+            position: absolute;
+            left: 4px;
+            top: -5px;
+            width: 2px;
+            height: 8px;
+            background: #00283c;
+        }
+
+        #scheduleNavigation {
+            width: 100%;
+            height: 25px;
+            background: whitesmoke;
+        }
+
+        #ivoryBar {
+            display: flex;
+            justify-content: space-between;
+            gap: 5px;
+            min-height: 29px;
+            background: whitesmoke;
+        }
+
+        #scheduleNavigation td {
+            padding: 3px 0;
+            white-space: nowrap;
+        }
+
+        #dateAndCalendar {
+            display: flex;
+            align-items: center;
+            gap: 5px;
+            margin-left: 10px;
+            min-width: 0;
+        }
+
+        #group {
+            display: flex;
+            align-items: center;
+            gap: 4px;
+            margin-right: 15px;
+        }
+
+        #quickSearchWrapper {
+            position: relative;
+            display: inline-flex;
+            align-items: center;
+            margin-right: 4px;
+            vertical-align: middle;
+        }
+
+        #quickSearch {
+            width: 170px;
+            height: 24px;
+            padding: 2px 26px 2px 6px;
+            border: 1px solid #adb5bd;
+            border-radius: 4px;
+            background: #fff;
+            font-size: 0.8rem;
+        }
+
+        .redArrow {
+            width: 12px;
+            height: 16px;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            padding: 0;
+            vertical-align: middle;
+        }
+
+        .step-icon {
+            position: relative;
+            width: 10px;
+            height: 10px;
+            display: inline-block;
+        }
+
+        .step-icon::before {
+            content: "";
+            position: absolute;
+            top: 1px;
+            width: 0;
+            height: 0;
+            border-top: 4px solid transparent;
+            border-bottom: 4px solid transparent;
+        }
+
+        .step-icon::after {
+            content: "";
+            position: absolute;
+            top: 1px;
+            width: 2px;
+            height: 8px;
+            background: #00283c;
+        }
+
+        .step-icon.prev::before {
+            left: 1px;
+            border-right: 6px solid #00283c;
+        }
+
+        .step-icon.prev::after {
+            left: 0;
+        }
+
+        .step-icon.next::before {
+            right: 1px;
+            border-left: 6px solid #00283c;
+        }
+
+        .step-icon.next::after {
+            right: 0;
+        }
+
+        .dateAppointment {
+            color: #00283c;
+            font-size: inherit;
+            font-weight: bold;
+        }
+
+        .quick-btn {
+            height: 20px;
+            min-width: 28px;
+            margin: 0 1px;
+            padding: 1px 6px;
+        }
+
+        #dateMultiplier {
+            width: 34px;
+            height: 20px;
+            text-align: center;
+        }
+
+        #toggleCancelledBtn {
+            width: 18px;
+            height: 18px;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            margin-left: 5px;
+            padding: 0;
+            vertical-align: middle;
+        }
+
+        .eye-icon {
+            width: 15px;
+            height: 9px;
+            display: inline-block;
+            position: relative;
+            border: 1px solid #777;
+            border-radius: 50% / 60%;
+        }
+
+        .eye-icon::after {
+            content: "";
+            position: absolute;
+            left: 5px;
+            top: 2px;
+            width: 3px;
+            height: 3px;
+            border-radius: 50%;
+            background: #777;
+        }
+
+        .sms-day-button {
+            width: 32px;
+            height: 21px;
+            margin-left: 2px;
+            padding: 1px 2px;
+            border: 1px solid #0097cf;
+            border-radius: 2px;
+            background: #f4ead7;
+            color: #00283c;
+            font-weight: bold;
+            line-height: 1;
+            vertical-align: middle;
+        }
+
+        .sms-day-button:hover,
+        .sms-inline:hover,
+        .appt-more:hover,
+        .sms-menu button:hover {
+            color: #fff;
+            background: #486ebd;
+        }
+
+        .title {
+            flex: 1 0 auto;
+            color: #000;
+            font-size: 14px;
+            text-align: center;
+        }
+
+        #findProviderInput {
+            width: 156px;
+            height: 20px;
+            padding: 1px 5px;
+        }
+
+        #group select {
+            width: 140px;
+            height: 21px;
+        }
+
+        #scheduleTable {
+            background: #c0c0c0;
+        }
+
+        #scheduleTable td,
+        #scheduleTable tr,
+        #scheduleTable th,
+        #scheduleTable thead,
+        #scheduleTable tbody,
+        #scheduleTable tfoot {
+            border-style: none;
+            border-width: 0;
+        }
+
+        #scheduleTable > tbody > tr > td,
+        #scheduleTable > tbody > tr > td > table > tbody > tr > td {
+            padding: 0;
+        }
+
+        .providerSchedule {
+            background: #486ebd;
+            border-collapse: collapse;
+        }
+
+        #providerSchedule,
+        #providerSchedule td {
+            border-collapse: collapse;
+        }
+
+        .infirmaryView {
+            position: sticky;
+            top: 50px;
+            left: 0;
+            right: 0;
+            height: 25px;
+            padding: 0 5px !important;
+            background: #c0c0c0;
+            text-align: center;
+            white-space: nowrap;
+        }
+
+        .infirmaryView input[type="button"] {
+            height: 19px;
+            padding: 1px 7px;
+            vertical-align: middle;
+        }
+
+        .infirmaryView input[type="radio"] {
+            margin: 0 2px;
+            vertical-align: middle;
+        }
+
+        .scheduleTime00,
+        .scheduleTimeNot00 {
+            width: 64px;
+            min-width: 64px;
+            border-top: #486ebd 2px solid;
+            border-right: #486ebd 2px solid;
+            border-bottom: #486ebd 2px solid;
+        }
+
+        .scheduleTime00 {
+            background: #3ea4e1;
+        }
+
+        .scheduleTimeNot00 {
+            background: #00a488;
+        }
+
+        .adhour {
+            display: block;
+            padding: 3px;
+            color: #fff !important;
+            font-size: 12px;
+            font-weight: bold;
+        }
+
+        .hourmin {
+            width: 14px;
+            min-width: 14px;
+            padding: 0 3px !important;
+            border-top: #486ebd 2px solid;
+            border-bottom: #486ebd 2px solid;
+            background: transparent;
+            color: #000;
+            text-align: center;
+        }
+
+        .hourmin.open {
+            background: #bfefff;
+        }
+
+        .hourmin.closed {
+            background: transparent;
+            color: #000;
+        }
+
+        td.appt {
+            overflow: hidden;
+            padding-top: 3px !important;
+            padding-right: 3px !important;
+            padding-left: 3px !important;
+            vertical-align: top;
+            border-top: #486ebd 2px solid !important;
+            border-right: #486ebd 2px solid !important;
+            border-bottom: #486ebd 2px solid !important;
+            border-left: #486ebd 2px solid !important;
+            background: #ffffc7;
+            white-space: nowrap;
+        }
+
+        td.blocked-appt {
+            background: #e9e2cf;
+            color: #333;
+            font-weight: bold;
+        }
+
+        td.appt a {
+            padding: 0 2px;
+        }
+
+        .sms-inline,
+        .appt-more {
+            display: inline-block;
+            min-width: 24px;
+            height: 16px;
+            margin-left: 2px;
+            padding: 1px 3px;
+            border: 1px solid #0097cf;
+            border-radius: 2px;
+            background: #fff;
+            color: #00283c;
+            font-size: 10px;
+            font-weight: bold;
+            line-height: 12px;
+            text-align: center;
+            vertical-align: 1px;
+        }
+
+        .appt-more {
+            width: 24px;
+            padding: 0 3px;
+            color: #000;
+            font-size: 14px;
+            line-height: 8px;
+        }
+
+        .sms-inline.disabled {
+            border-color: #aaa;
+            background: #e7e7e7;
+            color: #777;
+            cursor: not-allowed;
+        }
+
+        .sms-inline.disabled:hover {
+            background: #e7e7e7;
+            color: #777;
+        }
+
+        .sms-state {
+            display: inline-block;
+            flex: 0 0 auto;
+            min-width: 28px;
+            height: 16px;
+            margin-left: 2px;
+            padding: 2px 3px;
+            border: 1px solid #777;
+            border-radius: 2px;
+            background: #eef5ff;
+            color: #00283c;
+            font-size: 10px;
+            font-weight: bold;
+            line-height: 10px;
+            text-align: center;
+            vertical-align: 1px;
+        }
+
+        .sms-state.sent {
+            border-color: #58945a;
+            background: #e4f2df;
+            color: #19511c;
+        }
+
+        .sms-state.due {
+            border-color: #c28b00;
+            background: #fff2bd;
+            color: #5f4300;
+        }
+
+        .sms-state.none {
+            border-color: #aaa;
+            background: #e7e7e7;
+            color: #777;
+        }
+
+        .sms-menu {
+            position: fixed;
+            z-index: 2000;
+            display: none;
+            min-width: 160px;
+            padding: 3px;
+            border: 1px solid #777;
+            background: #fff;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+        }
+
+        .sms-menu.open {
+            display: block;
+        }
+
+        .sms-menu button {
+            display: block;
+            width: 100%;
+            min-height: 23px;
+            padding: 4px 6px;
+            border: 0;
+            border-radius: 0;
+            background: #fff;
+            color: #00283c;
+            font-weight: bold;
+            text-align: left;
+        }
+
+        td.appt .folder {
+            display: inline-block;
+            margin: 0 4px 0 2px;
+            color: #836f00;
+            font-size: 13px;
+            vertical-align: -1px;
+        }
+
+        .apptStatus {
+            display: inline-block;
+            min-width: 9px;
+            color: #000;
+            text-align: center;
+        }
+
+        .reason {
+            color: #000;
+            font-style: italic;
+            font-weight: bold;
+        }
+
+        .timeline-marker {
+            height: 0;
+            margin: 0;
+            padding: 0;
+            border: none;
+            border-top: 2px dotted tomato;
+            color: tomato;
+            opacity: 1;
+        }
+
+        .noGrid {
+            border: none;
+        }
+
+        .slot-row td {
+            height: 20px;
+        }
+
+        .provider-spacer td {
+            height: 1px !important;
+            padding: 0 !important;
+            background: #486ebd;
+        }
+
+        .timeline-indicator td {
+            height: 2px !important;
+            padding: 0 !important;
+        }
+
+        .appointment-text {
+            display: block;
+            padding-top: 2px;
+            line-height: 1.1;
+        }
+
+        body.week-view #scheduleTable {
+            table-layout: fixed;
+        }
+
+        .weekDayCell {
+            width: 20%;
+            padding: 0 !important;
+            vertical-align: top;
+            background: #486ebd;
+        }
+
+        .weekDaySchedule {
+            width: 100%;
+            table-layout: fixed;
+        }
+
+        .weekDaySchedule .infirmaryView {
+            position: static;
+            top: auto;
+            right: auto;
+            left: auto;
+            height: 25px;
+        }
+
+        .week-day-sms {
+            height: 17px;
+            margin-left: 4px;
+            padding: 1px 4px;
+            border: 1px solid #0097cf;
+            background: #fff;
+            color: #00283c;
+            font-size: 10px;
+            font-weight: bold;
+            line-height: 12px;
+            vertical-align: 1px;
+        }
+
+        .weekDaySchedule .scheduleTime00,
+        .weekDaySchedule .scheduleTimeNot00 {
+            width: 51px;
+            min-width: 51px;
+        }
+
+        .weekDaySchedule .hourmin {
+            width: 14px;
+            min-width: 14px;
+        }
+
+        .weekDaySchedule .noGrid {
+            width: auto;
+        }
+
+        .week-appointment {
+            display: flex;
+            align-items: center;
+            gap: 3px;
+            min-width: 0;
+            overflow: hidden;
+        }
+
+        .week-appt-main {
+            flex: 1 1 auto;
+            min-width: 0;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        .week-appointment .sms-inline,
+        .week-appointment .appt-more,
+        .week-appointment .sms-state {
+            flex: 0 0 auto;
+        }
+
+        .modal-backdrop {
+            position: fixed;
+            inset: 0;
+            z-index: 3000;
+            display: none;
+            align-items: center;
+            justify-content: center;
+            padding: 20px;
+            background: rgba(0, 0, 0, 0.42);
+        }
+
+        .modal-backdrop.open {
+            display: flex;
+        }
+
+        .sms-modal {
+            width: min(720px, 100%);
+            max-height: 88vh;
+            overflow: auto;
+            border: 1px solid #777;
+            background: #fff;
+            box-shadow: 0 12px 30px rgba(0, 0, 0, 0.35);
+            line-height: 1.25;
+        }
+
+        .sms-modal header,
+        .sms-modal footer {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 8px;
+            padding: 9px 10px;
+            background: whitesmoke;
+            border-bottom: 1px solid #c0c0c0;
+        }
+
+        .sms-modal footer {
+            justify-content: flex-end;
+            border-top: 1px solid #c0c0c0;
+            border-bottom: 0;
+        }
+
+        .sms-modal h2 {
+            margin: 0;
+            font-size: 16px;
+        }
+
+        .sms-modal p {
+            margin: 3px 0 0;
+            color: #555;
+        }
+
+        .sms-modal-body {
+            padding: 10px;
+        }
+
+        .sms-status-grid {
+            display: grid;
+            grid-template-columns: repeat(3, minmax(0, 1fr));
+            gap: 8px;
+            margin-bottom: 10px;
+        }
+
+        .sms-status-card {
+            min-height: 54px;
+            padding: 7px;
+            border: 1px solid #c0c0c0;
+            background: #f8fafc;
+        }
+
+        .sms-status-card strong {
+            display: block;
+            margin-bottom: 4px;
+        }
+
+        .sms-form-grid {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 8px;
+        }
+
+        .sms-field {
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+        }
+
+        .sms-field.full {
+            grid-column: 1 / -1;
+        }
+
+        .sms-field label {
+            font-weight: bold;
+        }
+
+        .sms-field input,
+        .sms-field select,
+        .sms-field textarea {
+            width: 100%;
+            padding: 5px;
+            background: #fff;
+        }
+
+        .sms-field textarea {
+            min-height: 88px;
+            resize: vertical;
+        }
+
+        .batch-table {
+            width: 100%;
+            margin-top: 8px;
+            border-collapse: collapse;
+        }
+
+        .batch-table th,
+        .batch-table td {
+            padding: 5px;
+            border: 1px solid #c0c0c0;
+            text-align: left;
+        }
+
+        .batch-table th {
+            background: whitesmoke;
+        }
+
+        @media (max-width: 900px) {
+            #navlist {
+                max-width: calc(100vw - 145px);
+                overflow-x: auto;
+            }
+
+            #ivoryBar {
+                align-items: stretch;
+                flex-direction: column;
+            }
+
+            #dateAndCalendar,
+            #group {
+                margin: 0 8px;
+                overflow-x: auto;
+            }
+        }
+    </style>
+</head>
+<body>
+<div id="main-container">
+    <div id="fixedHeaderWrapper">
+        <table id="firstTable" class="noprint">
+            <tr>
+                <td id="firstMenu">
+                    <span class="logo" aria-hidden="true"></span>
+                    <ul id="navlist">
+                        <li><a href="#">Schedule</a></li>
+                        <li><a href="#">Search</a></li>
+                        <li><a href="#">Inbox</a></li>
+                        <li><a href="#"><span class="tabalert">U</span></a></li>
+                        <li><a href="#">Tickler<span class="tabalert">81</span></a></li>
+                        <li><a href="#">Msg</a></li>
+                        <li><a href="#">Consultations</a></li>
+                        <li><a href="#">eDoc</a></li>
+                        <li><a href="#">Report</a></li>
+                        <li><a href="#">Administration</a></li>
+                        <li><a href="#">Resources</a></li>
+                    </ul>
+                </td>
+                <td id="userSettings">
+                    <ul id="userSettingsMenu">
+                        <li><a href="#" class="mini-icon"><span class="menu-icon" aria-hidden="true"></span></a></li>
+                        <li><a href="#"><span class="user-icon" aria-hidden="true"></span>doctor carlosdoc</a></li>
+                    </ul>
+                    <a id="logoutButton" href="#" title="Logout"><span class="power-icon" aria-hidden="true"></span></a>
+                </td>
+            </tr>
+        </table>
+
+        <table id="scheduleNavigation">
+            <tr id="ivoryBar">
+                <td id="dateAndCalendar">
+                    <span id="quickSearchWrapper" class="quick-search-wrapper noprint">
+                        <input type="text" id="quickSearch" name="quickSearch" placeholder="Search" autocomplete="off">
+                    </span>
+                    <a class="redArrow" href="#" title="Previous day"><span class="step-icon prev" aria-hidden="true"></span></a>
+                    <b><a href="#" class="clickable-date"><span class="dateAppointment">Fri, 2026-05-29</span></a></b>
+                    <a class="redArrow" href="#" title="Next day"><span class="step-icon next" aria-hidden="true"></span></a>
+                    <input type="button" value="M-" class="quick-btn">
+                    <input type="button" value="W-" class="quick-btn">
+                    <input type="number" id="dateMultiplier" value="1" min="1" max="99">
+                    <input type="button" value="W+" class="quick-btn">
+                    <input type="button" value="M+" class="quick-btn">
+                    <span>|</span>
+                    <input type="button" value="2W" class="quick-btn">
+                    <input type="button" value="4W" class="quick-btn">
+                    <input type="button" value="3M" class="quick-btn">
+                    <input type="button" value="6M" class="quick-btn">
+                    <a id="toggleCancelledBtn" href="#" title="Hide cancelled"><span class="eye-icon" aria-hidden="true"></span></a>
+                    <u><a href="#">All</a></u>
+                    <a href="#">Today</a>
+                    <a href="#">Month</a>
+                    <button class="sms-day-button" type="button" data-open="batch" title="Review and send SMS reminders for visible appointments">SMS</button>
+                </td>
+                <td class="title noprint"></td>
+                <td id="group">
+                    <form method="post" name="findprovider">
+                        <input id="findProviderInput" type="text" name="providername" value="" maxlength="10" placeholder="Enter Lastname">
+                        <input type="submit" name="Go" value="GO">
+                    </form>
+                    <form name="appointmentForm">
+                        <span>Group:</span>
+                        <select id="mygroup_no" name="mygroup_no">
+                            <option>.default</option>
+                            <option>carlosdoc, doctor</option>
+                            <option>openodoc, doctor</option>
+                        </select>
+                    </form>
+                </td>
+            </tr>
+        </table>
+    </div>
+
+    <table id="scheduleTable" bgcolor="#c0c0c0">
+        <tr>
+            <td colspan="3">
+                <table class="providerSchedule" id="providerSchedule" bgcolor="#486ebd">
+                    <tr>
+                        <td class="infirmaryView" nowrap align="center" bgcolor="#c0c0c0" colspan="3">
+                            <input type="button" value="W" name="weekview">
+                            <input type="button" value="S" name="searchview">
+                            <input type="radio" name="flipview">
+                            <a href="#">carlosdoc, doctor (14)</a>
+                            <a href="#" title="Expand reason">*</a>
+                        </td>
+                    </tr>
+                    <tr class="provider-spacer">
+                        <td colspan="3"></td>
+                    </tr>
+
+                    <tr class="slot-row">
+                        <td class="scheduleTime00"><a href="#" class="adhour">08:00</a></td>
+                        <td class="hourmin closed">-</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">08:15</a></td>
+                        <td class="hourmin closed">-</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">08:30</a></td>
+                        <td class="hourmin closed">-</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">08:45</a></td>
+                        <td class="hourmin closed">-</td>
+                        <td class="noGrid"></td>
+                    </tr>
+
+                    <tr class="slot-row">
+                        <td class="scheduleTime00"><a href="#" class="adhour">09:00</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="appt" rowspan="3" nowrap>
+                            <span class="appointment-text">
+                                <a class="apptStatus" href="#">[]</a>
+                                <span class="folder">[ ]</span>
+                                <a href="#">!</a>
+                                <a class="apptLink" href="#">Lee, Jordan</a>
+                                <span>|</span><a href="#">E</a>
+                                <span>|</span><a href="#">B</a>
+                                <span>|</span><a href="#">M</a>
+                                <span>|</span><a href="#">Rx</a>
+                                <span>|</span><span class="reason">Follow-Up</span>
+                                <button class="sms-inline" type="button" data-open="sms" data-patient="Jordan Lee" title="Text Jordan Lee">SMS</button>
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">09:15</a></td>
+                        <td class="hourmin open">1</td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">09:30</a></td>
+                        <td class="hourmin open">1</td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">09:45</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="appt" nowrap>
+                            <span class="appointment-text">
+                                <a class="apptStatus" href="#">[]</a>
+                                <a class="apptLink" href="#">Morales, Sofia</a>
+                                <span>|</span><a href="#">E</a>
+                                <span>|</span><a href="#">M</a>
+                                <span>|</span><span class="reason">Sore Throat</span>
+                            </span>
+                        </td>
+                    </tr>
+
+                    <tr class="slot-row">
+                        <td class="scheduleTime00"><a href="#" class="adhour">10:00</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="appt" nowrap>
+                            <span class="appointment-text">
+                                <a class="apptStatus" href="#">[]</a>
+                                <a class="apptLink" href="#">Chen, Jamie</a>
+                                <span>|</span><a href="#">E</a>
+                                <span>|</span><a href="#">M</a>
+                                <button class="appt-more" type="button" data-menu="menu-jamie" data-patient="Jamie Chen" title="More appointment actions">...</button>
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">10:15</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="appt" nowrap>
+                            <span class="appointment-text">
+                                <a class="apptStatus" href="#">[]</a>
+                                <a class="apptLink" href="#">Patil, Avery</a>
+                                <span>|</span><a href="#">E</a>
+                                <span>|</span><a href="#">M</a>
+                                <button class="sms-inline disabled" type="button" disabled title="SMS unavailable: consent missing">SMS</button>
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">10:30</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="timeline-indicator noprint">
+                        <td colspan="3"><hr class="timeline-marker"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">10:45</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="appt" nowrap>
+                            <span class="appointment-text">
+                                <a class="apptStatus" href="#">[]</a>
+                                <a class="apptLink" href="#">Garcia, Mateo</a>
+                                <span>|</span><a href="#">E</a>
+                                <span>|</span><a href="#">M</a>
+                                <span>|</span><span class="reason">Rash</span>
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTime00"><a href="#" class="adhour">11:00</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="appt" rowspan="2" nowrap>
+                            <span class="appointment-text">
+                                <a class="apptStatus" href="#">[]</a>
+                                <span class="folder">[ ]</span>
+                                <a class="apptLink" href="#">Brown, Taylor</a>
+                                <span>|</span><a href="#">E</a>
+                                <span>|</span><a href="#">B</a>
+                                <span>|</span><a href="#">M</a>
+                                <span>|</span><span class="reason">Annual Physical</span>
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">11:15</a></td>
+                        <td class="hourmin open">1</td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">11:30</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="appt" nowrap>
+                            <span class="appointment-text">
+                                <a class="apptStatus" href="#">[]</a>
+                                <a class="apptLink" href="#">Nguyen, Priya</a>
+                                <span>|</span><a href="#">E</a>
+                                <span>|</span><a href="#">M</a>
+                                <span>|</span><span class="reason">Prenatal</span>
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">11:45</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTime00"><a href="#" class="adhour">12:00</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="appt blocked-appt" rowspan="2" nowrap>
+                            <span class="appointment-text">
+                                Lunch / admin
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">12:15</a></td>
+                        <td class="hourmin open">1</td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">12:30</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">12:45</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTime00"><a href="#" class="adhour">13:00</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="appt" nowrap>
+                            <span class="appointment-text">
+                                <a class="apptStatus" href="#">[]</a>
+                                <a class="apptLink" href="#">Williams, Noah</a>
+                                <span>|</span><a href="#">E</a>
+                                <span>|</span><a href="#">M</a>
+                                <span>|</span><span class="reason">Cough</span>
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">13:15</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="appt" nowrap>
+                            <span class="appointment-text">
+                                <a class="apptStatus" href="#">[]</a>
+                                <a class="apptLink" href="#">Rossi, Eli</a>
+                                <span>|</span><a href="#">E</a>
+                                <span>|</span><a href="#">M</a>
+                                <span>|</span><span class="reason">Immunization</span>
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">13:30</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="appt" rowspan="2" nowrap>
+                            <span class="appointment-text">
+                                <a class="apptStatus" href="#">[]</a>
+                                <span class="folder">[ ]</span>
+                                <a class="apptLink" href="#">Ahmed, Lina</a>
+                                <span>|</span><a href="#">E</a>
+                                <span>|</span><a href="#">B</a>
+                                <span>|</span><a href="#">M</a>
+                                <span>|</span><span class="reason">Chronic Care</span>
+                                <button class="sms-inline" type="button" data-open="sms" data-patient="Lina Ahmed" title="Text Lina Ahmed">SMS</button>
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">13:45</a></td>
+                        <td class="hourmin open">1</td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTime00"><a href="#" class="adhour">14:00</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">14:15</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="appt" nowrap>
+                            <span class="appointment-text">
+                                <a class="apptStatus" href="#">[]</a>
+                                <a class="apptLink" href="#">Singh, Nara</a>
+                                <span>|</span><a href="#">E</a>
+                                <span>|</span><a href="#">M</a>
+                                <span>|</span><span class="reason">BP Check</span>
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">14:30</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">14:45</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="appt" nowrap>
+                            <span class="appointment-text">
+                                <a class="apptStatus" href="#">[]</a>
+                                <a class="apptLink" href="#">Davis, Harper</a>
+                                <span>|</span><a href="#">Phone</a>
+                                <span>|</span><span class="reason">Rx Renewal</span>
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTime00"><a href="#" class="adhour">15:00</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="appt" rowspan="2" nowrap>
+                            <span class="appointment-text">
+                                <a class="apptStatus" href="#">[]</a>
+                                <a class="apptLink" href="#">Murphy, Drew</a>
+                                <span>|</span><a href="#">E</a>
+                                <span>|</span><a href="#">M</a>
+                                <span>|</span><span class="reason">Mental Health</span>
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">15:15</a></td>
+                        <td class="hourmin open">1</td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">15:30</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">15:45</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="appt" nowrap>
+                            <span class="appointment-text">
+                                <a class="apptStatus" href="#">[]</a>
+                                <a class="apptLink" href="#">Zhou, Mei</a>
+                                <span>|</span><a href="#">Phone</a>
+                                <span>|</span><span class="reason">Results</span>
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTime00"><a href="#" class="adhour">16:00</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">16:15</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="appt" nowrap>
+                            <span class="appointment-text">
+                                <a class="apptStatus" href="#">[]</a>
+                                <a class="apptLink" href="#">Cooper, Quinn</a>
+                                <span>|</span><a href="#">E</a>
+                                <span>|</span><a href="#">M</a>
+                                <span>|</span><span class="reason">Same Day</span>
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">16:30</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">16:45</a></td>
+                        <td class="hourmin open">1</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTime00"><a href="#" class="adhour">17:00</a></td>
+                        <td class="hourmin closed">-</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">17:15</a></td>
+                        <td class="hourmin closed">-</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">17:30</a></td>
+                        <td class="hourmin closed">-</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">17:45</a></td>
+                        <td class="hourmin closed">-</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTime00"><a href="#" class="adhour">18:00</a></td>
+                        <td class="hourmin closed">-</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">18:15</a></td>
+                        <td class="hourmin closed">-</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">18:30</a></td>
+                        <td class="hourmin closed">-</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                    <tr class="slot-row">
+                        <td class="scheduleTimeNot00"><a href="#" class="adhour">18:45</a></td>
+                        <td class="hourmin closed">-</td>
+                        <td class="noGrid"></td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+</div>
+
+<div class="sms-menu" id="menu-jamie">
+    <button type="button">Edit appointment</button>
+    <button type="button">Open master file</button>
+    <button type="button">Open eChart</button>
+    <button type="button" data-open="sms" data-patient="Jamie Chen">Text patient</button>
+</div>
+
+<div class="modal-backdrop" id="smsModal" role="dialog" aria-modal="true" aria-labelledby="smsTitle">
+    <section class="sms-modal">
+        <header>
+            <div>
+                <h2 id="smsTitle">Text patient</h2>
+                <p id="smsSubtitle">Appointment context is attached to this message.</p>
+            </div>
+            <button type="button" data-close aria-label="Close">x</button>
+        </header>
+        <div class="sms-modal-body">
+            <div class="sms-status-grid">
+                <div class="sms-status-card">
+                    <strong>Mobile</strong>
+                    <span id="smsNumber">Verified mobile number on file</span>
+                </div>
+                <div class="sms-status-card">
+                    <strong>Consent</strong>
+                    <span id="smsConsent">SMS consent active. No STOP recorded.</span>
+                </div>
+                <div class="sms-status-card">
+                    <strong>Chart</strong>
+                    <span>Log message to this appointment and patient.</span>
+                </div>
+            </div>
+            <div class="sms-form-grid">
+                <div class="sms-field">
+                    <label for="smsTemplate">Template</label>
+                    <select id="smsTemplate">
+                        <option>Appointment reminder</option>
+                        <option>Appointment confirmation</option>
+                        <option>Cancellation notice</option>
+                        <option>Reschedule request</option>
+                    </select>
+                </div>
+                <div class="sms-field">
+                    <label for="smsSender">Send from</label>
+                    <select id="smsSender">
+                        <option>Main clinic line</option>
+                        <option>Reception desk</option>
+                        <option>Provider pool</option>
+                    </select>
+                </div>
+                <div class="sms-field full">
+                    <label for="smsBody">Message</label>
+                    <textarea id="smsBody">Reminder from Riverside Clinic: you have an appointment on Fri May 29. Reply STOP to opt out.</textarea>
+                </div>
+            </div>
+        </div>
+        <footer>
+            <button type="button" data-close>Cancel</button>
+            <button type="button">Preview</button>
+            <button type="button">Send SMS</button>
+        </footer>
+    </section>
+</div>
+
+<div class="modal-backdrop" id="batchModal" role="dialog" aria-modal="true" aria-labelledby="batchTitle">
+    <section class="sms-modal">
+        <header>
+            <div>
+                <h2 id="batchTitle">Send SMS reminders</h2>
+                <p>Review visible schedule appointments before sending.</p>
+            </div>
+            <button type="button" data-close aria-label="Close">x</button>
+        </header>
+        <div class="sms-modal-body">
+            <table class="batch-table">
+                <thead>
+                    <tr>
+                        <th>Patient</th>
+                        <th>Appointment</th>
+                        <th>SMS status</th>
+                        <th>Send</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Jordan Lee</td>
+                        <td>09:00 Follow-Up</td>
+                        <td>Eligible</td>
+                        <td><input type="checkbox" checked></td>
+                    </tr>
+                    <tr>
+                        <td>Sofia Morales</td>
+                        <td>09:45 Sore Throat</td>
+                        <td>Eligible</td>
+                        <td><input type="checkbox" checked></td>
+                    </tr>
+                    <tr>
+                        <td>Jamie Chen</td>
+                        <td>10:00</td>
+                        <td>Eligible</td>
+                        <td><input type="checkbox" checked></td>
+                    </tr>
+                    <tr>
+                        <td>Avery Patil</td>
+                        <td>10:15</td>
+                        <td>No SMS consent</td>
+                        <td>Excluded</td>
+                    </tr>
+                    <tr>
+                        <td>Mateo Garcia</td>
+                        <td>10:45 Rash</td>
+                        <td>Eligible</td>
+                        <td><input type="checkbox" checked></td>
+                    </tr>
+                    <tr>
+                        <td>Taylor Brown</td>
+                        <td>11:00 Annual Physical</td>
+                        <td>Eligible</td>
+                        <td><input type="checkbox" checked></td>
+                    </tr>
+                    <tr>
+                        <td>Priya Nguyen</td>
+                        <td>11:30 Prenatal</td>
+                        <td>Eligible</td>
+                        <td><input type="checkbox" checked></td>
+                    </tr>
+                    <tr>
+                        <td>Lina Ahmed</td>
+                        <td>13:30 Chronic Care</td>
+                        <td>Eligible</td>
+                        <td><input type="checkbox" checked></td>
+                    </tr>
+                    <tr>
+                        <td>Nara Singh</td>
+                        <td>14:15 BP Check</td>
+                        <td>Eligible</td>
+                        <td><input type="checkbox" checked></td>
+                    </tr>
+                    <tr>
+                        <td>Drew Murphy</td>
+                        <td>15:00 Mental Health</td>
+                        <td>Eligible</td>
+                        <td><input type="checkbox" checked></td>
+                    </tr>
+                    <tr>
+                        <td>Quinn Cooper</td>
+                        <td>16:15 Same Day</td>
+                        <td>Eligible</td>
+                        <td><input type="checkbox" checked></td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+        <footer>
+            <button type="button" data-close>Cancel</button>
+            <button type="button">Preview batch</button>
+            <button type="button">Send 10 SMS</button>
+        </footer>
+    </section>
+</div>
+
+<script>
+    (function () {
+        var smsModal = document.getElementById('smsModal');
+        var batchModal = document.getElementById('batchModal');
+        var activeMenu = null;
+        var smsTitle = document.getElementById('smsTitle');
+        var smsSubtitle = document.getElementById('smsSubtitle');
+        var smsNumber = document.getElementById('smsNumber');
+        var smsConsent = document.getElementById('smsConsent');
+        var scheduleTable = document.getElementById('scheduleTable');
+        var dateLabel = document.querySelector('.dateAppointment');
+        var dayMarkup = scheduleTable.innerHTML;
+        var baseMonday = new Date(2026, 4, 25);
+        var weekOffset = 0;
+        var times = [
+            '08:00', '08:15', '08:30', '08:45',
+            '09:00', '09:15', '09:30', '09:45',
+            '10:00', '10:15', '10:30', '10:45',
+            '11:00', '11:15', '11:30', '11:45',
+            '12:00', '12:15', '12:30', '12:45',
+            '13:00', '13:15', '13:30', '13:45',
+            '14:00', '14:15', '14:30', '14:45',
+            '15:00', '15:15', '15:30', '15:45',
+            '16:00', '16:15', '16:30', '16:45',
+            '17:00', '17:15', '17:30', '17:45',
+            '18:00', '18:15', '18:30', '18:45'
+        ];
+        var dayNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+        var patientState = {
+            'Jordan Lee': ['416-555-0132 verified', 'SMS consent active. No STOP recorded.', '09:00 Follow-Up with doctor carlosdoc'],
+            'Jamie Chen': ['416-555-0184 verified', 'SMS consent active. No STOP recorded.', '10:00 appointment with doctor carlosdoc'],
+            'Lina Ahmed': ['416-555-0198 verified', 'SMS consent active. No STOP recorded.', '13:30 Chronic Care with doctor carlosdoc']
+        };
+        var weekAppointments = {
+            '09:00': { patient: 'Lee, Jordan', patientKey: 'Jordan Lee', reason: 'Follow-Up', rowspan: 3, action: 'sms' },
+            '09:45': { patient: 'Morales, Sofia', reason: 'Sore Throat' },
+            '10:00': { patient: 'Chen, Jamie', action: 'menu' },
+            '10:15': { patient: 'Patil, Avery', action: 'disabled' },
+            '10:45': { patient: 'Garcia, Mateo', reason: 'Rash' },
+            '11:00': { patient: 'Brown, Taylor', reason: 'Annual Physical', rowspan: 2 },
+            '11:30': { patient: 'Nguyen, Priya', reason: 'Prenatal' },
+            '12:00': { block: 'Lunch / admin', rowspan: 2 },
+            '13:00': { patient: 'Williams, Noah', reason: 'Cough' },
+            '13:15': { patient: 'Rossi, Eli', reason: 'Immunization' },
+            '13:30': { patient: 'Ahmed, Lina', patientKey: 'Lina Ahmed', reason: 'Chronic Care', rowspan: 2, action: 'sms' },
+            '14:15': { patient: 'Singh, Nara', reason: 'BP Check' },
+            '14:45': { patient: 'Davis, Harper', reason: 'Rx Renewal' },
+            '15:00': { patient: 'Murphy, Drew', reason: 'Mental Health', rowspan: 2 },
+            '15:45': { patient: 'Zhou, Mei', reason: 'Results' },
+            '16:15': { patient: 'Cooper, Quinn', reason: 'Same Day' }
+        };
+        var weekSkipSlots = {
+            '09:15': true,
+            '09:30': true,
+            '11:15': true,
+            '12:15': true,
+            '13:45': true,
+            '15:15': true
+        };
+        var weekAppointmentsByDay = [
+            {
+                '09:00': { patient: 'Okafor, Amara', reason: 'Follow-Up', action: 'sms' },
+                '10:30': { patient: 'Li, Ethan', reason: 'Cough', action: 'sms' },
+                '11:00': { patient: 'Walsh, Erin', reason: 'Annual Physical', rowspan: 2, action: 'sms' },
+                '13:30': { patient: 'Patel, Rohan', reason: 'Diabetes', rowspan: 2, action: 'sms' },
+                '15:15': { patient: 'Martin, Claire', reason: 'Phone', action: 'sms' }
+            },
+            {
+                '09:15': { patient: 'Young, Theo', reason: 'Ear Pain', action: 'menu' },
+                '10:00': { patient: 'Robinson, Maya', reason: 'Prenatal', action: 'menu' },
+                '11:30': { patient: 'Clark, Owen', reason: 'Forms', action: 'menu' },
+                '14:00': { patient: 'Ibrahim, Noor', reason: 'Immunization', action: 'menu' },
+                '15:00': { patient: 'Ellis, June', reason: 'Mental Health', rowspan: 2, action: 'menu' }
+            },
+            {
+                '08:45': { patient: 'Campbell, Ari', reason: 'Rash', state: 'Sent' },
+                '09:30': { patient: 'Park, Hana', reason: 'Results', state: 'Due' },
+                '10:45': { patient: 'Bennett, Miles', reason: 'BP Check', state: 'No' },
+                '13:00': { patient: 'Scott, Remy', reason: 'Chronic Care', rowspan: 2, state: 'Sent' },
+                '15:30': { patient: 'Ortiz, Elena', reason: 'Same Day', state: 'Due' }
+            },
+            {
+                '09:00': { patient: 'Foster, Alex', reason: 'New Patient', rowspan: 2 },
+                '10:15': { patient: 'Tran, Kim', reason: 'Rx Renewal' },
+                '11:15': { patient: 'Hall, Morgan', reason: 'Phone' },
+                '13:30': { patient: 'Wright, Sam', reason: 'Procedure', rowspan: 3 },
+                '15:00': { patient: 'Morris, Jules', reason: 'Results' }
+            },
+            weekAppointments
+        ];
+        var weekDaySmsMode = ['inline', 'overflow', 'status', 'day', 'mixed'];
+        var weekSkipSlotsByDay = [
+            { '11:15': true, '13:45': true },
+            { '15:15': true },
+            { '13:15': true },
+            { '09:15': true, '13:45': true, '14:00': true },
+            weekSkipSlots
+        ];
+
+        function pad(value) {
+            return String(value).padStart(2, '0');
+        }
+
+        function formatDate(date) {
+            return dayNames[date.getDay()] + ', ' + date.getFullYear() + '-' + pad(date.getMonth() + 1) + '-' + pad(date.getDate());
+        }
+
+        function getWeekNumber(date) {
+            var weekDate = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+            var dayNumber = weekDate.getUTCDay() || 7;
+            weekDate.setUTCDate(weekDate.getUTCDate() + 4 - dayNumber);
+            var yearStart = new Date(Date.UTC(weekDate.getUTCFullYear(), 0, 1));
+            return Math.ceil((((weekDate - yearStart) / 86400000) + 1) / 7);
+        }
+
+        function isOpenSlot(time) {
+            var hour = parseInt(time.slice(0, 2), 10);
+            return hour >= 9 && hour < 17;
+        }
+
+        function getPatientKey(patient) {
+            var parts;
+            if (!patient) return 'Patient';
+            if (patient.indexOf(',') === -1) return patient;
+            parts = patient.split(',');
+            return (parts[1].trim() + ' ' + parts[0].trim()).trim();
+        }
+
+        function getSmsStateClass(state) {
+            if (state === 'No') return 'none';
+            return state.toLowerCase();
+        }
+
+        function buildAppointment(time, dayIndex) {
+            var action = '';
+            var dayAppointments = weekAppointmentsByDay[dayIndex] || {};
+            var appt = dayAppointments[time];
+            var patientKey = '';
+            var rowspan = '';
+
+            if (!appt) return '';
+
+            rowspan = appt.rowspan ? ' rowspan="' + appt.rowspan + '"' : '';
+
+            if (appt.block) {
+                return [
+                    '<td class="appt blocked-appt"' + rowspan + ' nowrap>',
+                        '<span class="appointment-text">',
+                            appt.block,
+                        '</span>',
+                    '</td>'
+                ].join('');
+            }
+
+            patientKey = appt.patientKey || getPatientKey(appt.patient);
+
+            if (appt.action === 'sms') {
+                action = '<button class="sms-inline" type="button" data-open="sms" data-patient="' + patientKey + '" title="Text ' + patientKey + '">SMS</button>';
+            } else if (appt.action === 'menu') {
+                action = '<button class="appt-more" type="button" data-menu="menu-jamie" data-patient="' + patientKey + '" title="More appointment actions">...</button>';
+            } else if (appt.action === 'disabled') {
+                action = '<button class="sms-inline disabled" type="button" disabled title="SMS unavailable: consent missing">SMS</button>';
+            } else if (appt.state) {
+                action = '<span class="sms-state ' + getSmsStateClass(appt.state) + '" title="SMS status">' + appt.state + '</span>';
+            }
+
+            return [
+                '<td class="appt"' + rowspan + ' nowrap>',
+                        '<span class="appointment-text week-appointment">',
+                            '<span class="week-appt-main">',
+                                '<a class="apptStatus" href="#">[]</a> ',
+                                '<a class="apptLink" href="#">' + appt.patient + '</a>',
+                                appt.reason ? ' <span>|</span> <span class="reason">' + appt.reason + '</span>' : '',
+                            '</span>',
+                            action,
+                        '</span>',
+                    '</td>'
+            ].join('');
+        }
+
+        function buildSlot(time, dayIndex) {
+            var timeClass = time.slice(3) === '00' ? 'scheduleTime00' : 'scheduleTimeNot00';
+            var open = isOpenSlot(time);
+            var appointment = buildAppointment(time, dayIndex);
+            var daySkipSlots = weekSkipSlotsByDay[dayIndex] || {};
+
+            if (daySkipSlots[time]) {
+                appointment = '';
+            } else if (!appointment) {
+                appointment = '<td class="noGrid"></td>';
+            }
+
+            return [
+                '<tr class="slot-row">',
+                    '<td class="' + timeClass + '"><a href="#" class="adhour">' + time + '</a></td>',
+                    '<td class="hourmin ' + (open ? 'open' : 'closed') + '">' + (open ? '1' : '-') + '</td>',
+                    appointment,
+                '</tr>'
+            ].join('');
+        }
+
+        function buildWeekDay(date, dayIndex) {
+            var headerAction = weekDaySmsMode[dayIndex] === 'day'
+                ? '<button class="week-day-sms" type="button" data-open="batch" title="Review SMS reminders for this day">SMS</button>'
+                : '';
+
+            return [
+                '<table class="providerSchedule weekDaySchedule" bgcolor="#486ebd">',
+                    '<colgroup><col style="width:51px"><col style="width:14px"><col></colgroup>',
+                    '<tr>',
+                        '<td class="infirmaryView" nowrap align="center" bgcolor="#c0c0c0" colspan="3">',
+                            formatDate(date),
+                            headerAction,
+                        '</td>',
+                    '</tr>',
+                    '<tr class="provider-spacer"><td colspan="3"></td></tr>',
+                    times.map(function (time) {
+                        return buildSlot(time, dayIndex);
+                    }).join(''),
+                '</table>'
+            ].join('');
+        }
+
+        function renderWeek(offset) {
+            var monday = new Date(baseMonday);
+            var columns = '';
+            var index;
+            weekOffset = offset;
+            monday.setDate(baseMonday.getDate() + (weekOffset * 7));
+
+            for (index = 0; index < 5; index += 1) {
+                var date = new Date(monday);
+                date.setDate(monday.getDate() + index);
+                columns += '<td class="weekDayCell">' + buildWeekDay(date, index) + '</td>';
+            }
+
+            closeMenus();
+            closeModals();
+            document.body.classList.add('week-view');
+            dateLabel.textContent = 'Week ' + getWeekNumber(monday);
+            scheduleTable.innerHTML = '<tr>' + columns + '</tr>';
+        }
+
+        function renderDay() {
+            closeMenus();
+            closeModals();
+            document.body.classList.remove('week-view');
+            dateLabel.textContent = 'Fri, 2026-05-29';
+            scheduleTable.innerHTML = dayMarkup;
+        }
+
+        function handleScheduleNavigation(event) {
+            var button = event.target.closest('input[type="button"]');
+            var link = event.target.closest('a');
+            var linkText = link ? link.textContent.trim() : '';
+
+            if (button && button.value === 'W') {
+                event.preventDefault();
+                renderWeek(weekOffset);
+                return true;
+            }
+
+            if (button && button.value === 'W-') {
+                event.preventDefault();
+                renderWeek(weekOffset - 1);
+                return true;
+            }
+
+            if (button && button.value === 'W+') {
+                event.preventDefault();
+                renderWeek(weekOffset + 1);
+                return true;
+            }
+
+            if (linkText === 'Today') {
+                event.preventDefault();
+                weekOffset = 0;
+                renderDay();
+                return true;
+            }
+
+            return false;
+        }
+
+        function closeMenus() {
+            if (activeMenu) {
+                activeMenu.classList.remove('open');
+                activeMenu = null;
+            }
+        }
+
+        function openMenu(button) {
+            var menu = document.getElementById(button.getAttribute('data-menu'));
+            var textPatientButton;
+            var patient = button.getAttribute('data-patient');
+            if (!menu) return;
+            closeMenus();
+            textPatientButton = menu.querySelector('[data-open="sms"]');
+            if (textPatientButton && patient) {
+                textPatientButton.setAttribute('data-patient', patient);
+            }
+            var rect = button.getBoundingClientRect();
+            menu.style.left = Math.min(rect.left, window.innerWidth - 180) + 'px';
+            menu.style.top = Math.min(rect.bottom + 2, window.innerHeight - 140) + 'px';
+            menu.classList.add('open');
+            activeMenu = menu;
+        }
+
+        function openSms(patient) {
+            var state = patientState[patient] || ['Mobile number on file', 'SMS consent available.', 'Selected appointment'];
+            smsTitle.textContent = 'Text ' + patient;
+            smsSubtitle.textContent = state[2];
+            smsNumber.textContent = state[0];
+            smsConsent.textContent = state[1];
+            smsModal.classList.add('open');
+            closeMenus();
+        }
+
+        function closeModals() {
+            smsModal.classList.remove('open');
+            batchModal.classList.remove('open');
+        }
+
+        document.addEventListener('click', function (event) {
+            var menuButton = event.target.closest('[data-menu]');
+            var opener = event.target.closest('[data-open]');
+            var closer = event.target.closest('[data-close]');
+
+            if (handleScheduleNavigation(event)) {
+                return;
+            }
+
+            if (menuButton) {
+                event.preventDefault();
+                openMenu(menuButton);
+                return;
+            }
+
+            if (opener) {
+                event.preventDefault();
+                if (opener.getAttribute('data-open') === 'sms') {
+                    openSms(opener.getAttribute('data-patient') || 'Patient');
+                } else if (opener.getAttribute('data-open') === 'batch') {
+                    batchModal.classList.add('open');
+                    closeMenus();
+                }
+                return;
+            }
+
+            if (closer) {
+                closeModals();
+                return;
+            }
+
+            if (event.target.classList.contains('modal-backdrop')) {
+                closeModals();
+                return;
+            }
+
+            if (!event.target.closest('.sms-menu')) {
+                closeMenus();
+            }
+        });
+
+        document.addEventListener('keydown', function (event) {
+            if (event.key === 'Escape') {
+                closeModals();
+                closeMenus();
+            }
+        });
+    })();
+</script>
+</body>
+</html>

--- a/docs/mockups/sms-schedule-mock.html
+++ b/docs/mockups/sms-schedule-mock.html
@@ -32,7 +32,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>CARLOS Schedule Baseline Mock</title>
+    <title>CARLOS Schedule with SMS Mock</title>
     <style>
         * {
             box-sizing: border-box;


### PR DESCRIPTION
refs #2443, refs #3110

## Problem

CARLOS is planning provider-to-patient SMS features (#2443) and consent-aware messaging work such as the server-side email consent enforcement in #3110, but the supporting research and design material so far lives only in issue comments and screenshots. Contributors evaluating vendors, reviewing the proposed SMS UI, or working with the consent tables have no in-repo reference to build on.

## What changed

Documentation and static mockups only — no code, routes, or schema changes:

- `docs/communications-vendor-research.md`: comparison of candidate SMS/fax/voice/email vendors (VoIP.ms, Telnyx, Twilio, and others) covering Canadian hosting fit, pricing notes (as of May 28, 2026), and CARLOS integration effort
- `docs/communications-technical-terms-reference.md`: glossary of the telecom, messaging, and healthcare-compliance terms used in the vendor review
- `docs/consent-data-structures-report.md`: practical guide to the `consentType` / `Consent` tables — background for consent-aware messaging and the email consent enforcement work in #3110
- `docs/mockups/`: static HTML mockups of the proposed SMS schedule integration, patient master view, consent management, and message history (the mocks discussed in #2443), plus a sample consent document PDF

All mock data is synthetic (generic names, obviously fake phone numbers) — no PHI. This PR deliberately does not implement any of #3110's enforcement work; it references both issues without closing them.

## How Was This Tested?

Documentation-only change; no tests apply. Ran the CI-parity lint scripts locally:

- `bash scripts/lint/check-encoder-null-safety.sh` — PASS
- `bash scripts/lint/check-security-exception-message-convention.sh` — PASS

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds in-repo communications docs and static HTML mockups to support provider-to-patient SMS (#2443) and consent-aware messaging/email consent enforcement (#3110). Docs-only with synthetic data; no code, routes, or schema changes.

- **Docs and Mockups**
  - Vendor research, telecom/compliance glossary, and a practical guide to `consentType`/`Consent`.
  - Static HTML mockups for SMS schedule, patient master, consent management, and message history, plus a sample consent PDF.

- **Review Updates**
  - Added GPL headers and purpose notes; fixed Health Care Team label; distinct schedule title; normalized province labels and Ontario, Canada spacing.
  - Removed unused mockup code, revoked Blob URLs, and renamed shared appt menu id to `apptActionsMenu`.
  - Accessibility: improved patient master mockups; added escaping notes; set aria-current="page" on the active nav item.
  - Consent report: named the duplicate-row guard (composite unique key on `demographic_no + consent_type_id` plus `PatientConsentManagerImpl` write path); documented `explicit`, `providerNo`, `remoteEnabled`; noted dedupe/preflight before the unique-key migration.
  - Aligned SMS modal patient name order; minor copy/layout fixes.

<sup>Written for commit e6fbc4fecd4c63a7e2eaeda83f90fe9ce50a21b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

