### PR TITLE
Chore: Add missing Javadoc across 40 files

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/administration/GstReport.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/administration/GstReport.java
@@ -18,6 +18,9 @@ import io.github.carlos_emr.carlos.util.ConversionUtils;
 import java.util.Properties;
 import java.util.Vector;
 
+/**
+ * Handles the generation and processing of GST billing reports for the BC region.
+ */
 public class GstReport {
 
     public Vector<Properties> getGST(LoggedInInfo loggedInInfo, String[] providerNos, String startDate, String endDate) {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/EReferAttachmentDataDao.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/EReferAttachmentDataDao.java
@@ -4,6 +4,9 @@ import io.github.carlos_emr.carlos.commn.model.EReferAttachmentData;
 
 import java.util.Date;
 
+/**
+ * Data Access Object for managing persistence of EReferAttachmentData entities.
+ */
 public interface EReferAttachmentDataDao extends AbstractDao<EReferAttachmentData> {
     public EReferAttachmentData getRecentByDocumentId(Integer docId, String type, Date expiry);
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/EReferAttachment.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/EReferAttachment.java
@@ -12,6 +12,9 @@ import jakarta.persistence.Table;
 import java.util.Date;
 import java.util.List;
 
+/**
+ * Represents the EReferAttachment domain entity for persistence.
+ */
 @Entity
 @Table(name = "erefer_attachment")
 public class EReferAttachment extends AbstractModel<Integer> {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/EReferAttachmentData.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/EReferAttachmentData.java
@@ -8,6 +8,9 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
+/**
+ * Represents the EReferAttachmentData domain entity for persistence.
+ */
 @Entity
 @IdClass(EReferAttachmentDataCompositeKey.class)
 @Table(name = "erefer_attachment_data")

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/EReferAttachmentDataCompositeKey.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/EReferAttachmentDataCompositeKey.java
@@ -6,6 +6,9 @@ import jakarta.persistence.ManyToOne;
 import java.io.Serializable;
 import java.util.Objects;
 
+/**
+ * Represents the EReferAttachmentDataCompositeKey data transfer object.
+ */
 public class EReferAttachmentDataCompositeKey implements Serializable {
     @ManyToOne
     @JoinColumn(name = "erefer_attachment_id", referencedColumnName = "id")

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/EmailAttachment.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/EmailAttachment.java
@@ -5,6 +5,9 @@ import jakarta.persistence.*;
 
 import io.github.carlos_emr.carlos.commn.model.enumerator.DocumentType;
 
+/**
+ * Represents the EmailAttachment domain entity for persistence.
+ */
 @Entity
 @Table(name = "emailAttachment")
 public class EmailAttachment extends AbstractModel<Integer> {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/EmailConfig.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/EmailConfig.java
@@ -5,6 +5,9 @@ import io.github.carlos_emr.carlos.commn.model.converter.EmailConfigTypeConverte
 import jakarta.persistence.*;
 import java.util.List;
 
+/**
+ * Represents the EmailConfig domain entity for persistence.
+ */
 @Entity
 @Table(name = "emailConfig")
 public class EmailConfig extends AbstractModel<Integer> {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/JSONAction.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/JSONAction.java
@@ -14,6 +14,9 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
 
+/**
+ * Represents the JSONAction data transfer object.
+ */
 public class JSONAction extends ActionSupport {
 
     private final String ENCODING = "UTF-8";

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/AppointmentBookingSourceConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/AppointmentBookingSourceConverter.java
@@ -3,6 +3,9 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.Appointment.BookingSource;
 import jakarta.persistence.Converter;
 
+/**
+ * JPA AttributeConverter for AppointmentBookingSource to map entity attributes to database columns.
+ */
 @Converter
 public class AppointmentBookingSourceConverter extends NullSafeEnumConverter<BookingSource> {
     public AppointmentBookingSourceConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/ClientLinkTypeConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/ClientLinkTypeConverter.java
@@ -3,6 +3,9 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.ClientLink.Type;
 import jakarta.persistence.Converter;
 
+/**
+ * JPA AttributeConverter for ClientLinkType to map entity attributes to database columns.
+ */
 @Converter
 public class ClientLinkTypeConverter extends NullSafeEnumConverter<Type> {
     public ClientLinkTypeConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/DigitalSignatureModuleTypeConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/DigitalSignatureModuleTypeConverter.java
@@ -3,6 +3,9 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.enumerator.ModuleType;
 import jakarta.persistence.Converter;
 
+/**
+ * JPA AttributeConverter for DigitalSignatureModuleType to map entity attributes to database columns.
+ */
 @Converter
 public class DigitalSignatureModuleTypeConverter extends NullSafeEnumConverter<ModuleType> {
     public DigitalSignatureModuleTypeConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailAttachmentDocumentTypeConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailAttachmentDocumentTypeConverter.java
@@ -3,6 +3,9 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.enumerator.DocumentType;
 import jakarta.persistence.Converter;
 
+/**
+ * JPA AttributeConverter for EmailAttachmentDocumentType to map entity attributes to database columns.
+ */
 @Converter
 public class EmailAttachmentDocumentTypeConverter extends NullSafeEnumConverter<DocumentType> {
     public EmailAttachmentDocumentTypeConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailConfigProviderConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailConfigProviderConverter.java
@@ -3,6 +3,9 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.EmailConfig.EmailProvider;
 import jakarta.persistence.Converter;
 
+/**
+ * JPA AttributeConverter for EmailConfigProvider to map entity attributes to database columns.
+ */
 @Converter
 public class EmailConfigProviderConverter extends NullSafeEnumConverter<EmailProvider> {
     public EmailConfigProviderConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailConfigTypeConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailConfigTypeConverter.java
@@ -3,6 +3,9 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.EmailConfig.EmailType;
 import jakarta.persistence.Converter;
 
+/**
+ * JPA AttributeConverter for EmailConfigType to map entity attributes to database columns.
+ */
 @Converter
 public class EmailConfigTypeConverter extends NullSafeEnumConverter<EmailType> {
     public EmailConfigTypeConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailLogChartDisplayOptionConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailLogChartDisplayOptionConverter.java
@@ -3,6 +3,9 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.EmailLog.ChartDisplayOption;
 import jakarta.persistence.Converter;
 
+/**
+ * JPA AttributeConverter for EmailLogChartDisplayOption to map entity attributes to database columns.
+ */
 @Converter
 public class EmailLogChartDisplayOptionConverter extends NullSafeEnumConverter<ChartDisplayOption> {
     public EmailLogChartDisplayOptionConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailLogStatusConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailLogStatusConverter.java
@@ -3,6 +3,9 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.EmailLog.EmailStatus;
 import jakarta.persistence.Converter;
 
+/**
+ * JPA AttributeConverter for EmailLogStatus to map entity attributes to database columns.
+ */
 @Converter
 public class EmailLogStatusConverter extends NullSafeEnumConverter<EmailStatus> {
     public EmailLogStatusConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailLogTransactionTypeConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailLogTransactionTypeConverter.java
@@ -3,6 +3,9 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.EmailLog.TransactionType;
 import jakarta.persistence.Converter;
 
+/**
+ * JPA AttributeConverter for EmailLogTransactionType to map entity attributes to database columns.
+ */
 @Converter
 public class EmailLogTransactionTypeConverter extends NullSafeEnumConverter<TransactionType> {
     public EmailLogTransactionTypeConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/FaxConfigProviderTypeConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/FaxConfigProviderTypeConverter.java
@@ -3,6 +3,9 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.FaxConfig.ProviderType;
 import jakarta.persistence.Converter;
 
+/**
+ * JPA AttributeConverter for FaxConfigProviderType to map entity attributes to database columns.
+ */
 @Converter
 public class FaxConfigProviderTypeConverter extends NullSafeEnumConverter<ProviderType> {
     public FaxConfigProviderTypeConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/FaxJobStatusConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/FaxJobStatusConverter.java
@@ -3,6 +3,9 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.FaxJob.STATUS;
 import jakarta.persistence.Converter;
 
+/**
+ * JPA AttributeConverter for FaxJobStatus to map entity attributes to database columns.
+ */
 @Converter
 public class FaxJobStatusConverter extends NullSafeEnumConverter<STATUS> {
     public FaxJobStatusConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/HnrDataValidationTypeConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/HnrDataValidationTypeConverter.java
@@ -3,6 +3,9 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.HnrDataValidation.Type;
 import jakarta.persistence.Converter;
 
+/**
+ * JPA AttributeConverter for HnrDataValidationType to map entity attributes to database columns.
+ */
 @Converter
 public class HnrDataValidationTypeConverter extends NullSafeEnumConverter<Type> {
     public HnrDataValidationTypeConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/TicklerPriorityConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/TicklerPriorityConverter.java
@@ -3,6 +3,9 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.Tickler.PRIORITY;
 import jakarta.persistence.Converter;
 
+/**
+ * JPA AttributeConverter for TicklerPriority to map entity attributes to database columns.
+ */
 @Converter
 public class TicklerPriorityConverter extends NullSafeEnumConverter<PRIORITY> {
     public TicklerPriorityConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/TicklerStatusConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/TicklerStatusConverter.java
@@ -3,6 +3,9 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.Tickler.STATUS;
 import jakarta.persistence.Converter;
 
+/**
+ * JPA AttributeConverter for TicklerStatus to map entity attributes to database columns.
+ */
 @Converter
 public class TicklerStatusConverter extends NullSafeEnumConverter<STATUS> {
     public TicklerStatusConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/enumerator/ConsultationRequestExtKey.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/enumerator/ConsultationRequestExtKey.java
@@ -1,5 +1,8 @@
 package io.github.carlos_emr.carlos.commn.model.enumerator;
 
+/**
+ * Represents the ConsultationRequestExtKey data transfer object.
+ */
 public enum ConsultationRequestExtKey {
     EREFERRAL_REF("ereferral_ref"),
     EREFERRAL_SERVICE("ereferral_service"),

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/enumerator/CppCode.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/enumerator/CppCode.java
@@ -3,6 +3,9 @@ package io.github.carlos_emr.carlos.commn.model.enumerator;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Represents the CppCode data transfer object.
+ */
 public enum CppCode {
     OMEDS("OMeds"),
     SOC_HISTORY("SocHistory"),

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/enumerator/DocumentType.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/enumerator/DocumentType.java
@@ -1,5 +1,8 @@
 package io.github.carlos_emr.carlos.commn.model.enumerator;
 
+/**
+ * Represents the DocumentType data transfer object.
+ */
 public enum DocumentType {
     EFORM("E", "eForm"),
     DOC("D", "doc"),

--- a/src/main/java/io/github/carlos_emr/carlos/config/ServletContextConfig.java
+++ b/src/main/java/io/github/carlos_emr/carlos/config/ServletContextConfig.java
@@ -7,6 +7,9 @@ import jakarta.servlet.ServletContext;
 
 import org.springframework.web.context.ServletContextAware;
 
+/**
+ * Configures the Servlet context and initializes core beans for the web application.
+ */
 @Configuration
 public class ServletContextConfig implements ServletContextAware {
 

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/DocumentAttach.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/DocumentAttach.java
@@ -13,6 +13,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+/**
+ * Represents a document attachment entity within the document manager module.
+ */
 public class DocumentAttach {
     private final ConsultDocsDao consultDocsDao = SpringUtils.getBean(ConsultDocsDao.class);
     private final EFormDocsDao eFormDocsDao = SpringUtils.getBean(EFormDocsDao.class);

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/EDocConverterInterface.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/EDocConverterInterface.java
@@ -2,6 +2,9 @@ package io.github.carlos_emr.carlos.documentManager;
 
 import java.io.OutputStream;
 
+/**
+ * Defines the contract for converting electronic documents between various formats.
+ */
 public interface EDocConverterInterface {
   void convert(String html, OutputStream os) throws Exception;
 }

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/data/AttachmentLabResultData.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/data/AttachmentLabResultData.java
@@ -6,6 +6,9 @@ import java.util.Map;
 
 import io.github.carlos_emr.carlos.utility.DateUtils;
 
+/**
+ * Represents the AttachmentLabResultData data transfer object.
+ */
 public class AttachmentLabResultData {
     private String segmentID;
     private String labName;

--- a/src/main/java/io/github/carlos_emr/carlos/email/helpers/LocalSMTPEmailSender.java
+++ b/src/main/java/io/github/carlos_emr/carlos/email/helpers/LocalSMTPEmailSender.java
@@ -15,6 +15,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+/**
+ * Implementation of email sending via local SMTP server.
+ */
 public class LocalSMTPEmailSender extends SMTPEmailSender {
 
     public LocalSMTPEmailSender(LoggedInInfo loggedInInfo, EmailConfig emailConfig, 

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oceanEReferal/pageUtil/OceanEReferralAttachmentUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oceanEReferal/pageUtil/OceanEReferralAttachmentUtil.java
@@ -10,6 +10,9 @@ import io.github.carlos_emr.carlos.commn.model.EReferAttachment;
 import io.github.carlos_emr.carlos.commn.model.EReferAttachmentData;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 
+/**
+ * Utility methods and helper functions for OceanEReferralAttachment operations.
+ */
 public class OceanEReferralAttachmentUtil {
     private static EReferAttachmentDataDaoImpl eReferAttachmentDataDao = SpringUtils.getBean(EReferAttachmentDataDaoImpl.class);
     private static EReferAttachmentDaoImpl eReferAttachmentDao = SpringUtils.getBean(EReferAttachmentDaoImpl.class);

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/config/data/ConsultationServiceDto.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/config/data/ConsultationServiceDto.java
@@ -1,5 +1,8 @@
 package io.github.carlos_emr.carlos.encounter.oscarConsultationRequest.config.data;
 
+/**
+ * Represents the ConsultationServiceDto data transfer object.
+ */
 public class ConsultationServiceDto {
     private Integer serviceId;
     private String serviceDesc;

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/config/data/SpecialistDto.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/config/data/SpecialistDto.java
@@ -1,5 +1,8 @@
 package io.github.carlos_emr.carlos.encounter.oscarConsultationRequest.config.data;
 
+/**
+ * Represents the SpecialistDto data transfer object.
+ */
 public class SpecialistDto {
     private Integer specId;
     private String name;

--- a/src/main/java/io/github/carlos_emr/carlos/lab/ca/all/util/Hl7Utils.java
+++ b/src/main/java/io/github/carlos_emr/carlos/lab/ca/all/util/Hl7Utils.java
@@ -5,6 +5,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ca.uhn.hl7v2.HL7Exception;
 
+/**
+ * Utility methods and helper functions for Hl7s operations.
+ */
 public final class Hl7Utils {
 
     private static final Logger logger = LoggerFactory.getLogger(Hl7Utils.class);

--- a/src/main/java/io/github/carlos_emr/carlos/utility/EmailSendingException.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/EmailSendingException.java
@@ -1,5 +1,8 @@
 package io.github.carlos_emr.carlos.utility;
 
+/**
+ * Exception thrown when there is an issue with EmailSending.
+ */
 public class EmailSendingException extends Exception {
     public EmailSendingException() {
         super();

--- a/src/main/java/io/github/carlos_emr/carlos/utility/JsDateSerializer.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/JsDateSerializer.java
@@ -6,6 +6,9 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import java.io.IOException;
 import java.util.Calendar;
 
+/**
+ * Domain entity or service component: JsDateSerializer.
+ */
 public class JsDateSerializer extends JsonSerializer<java.sql.Date> {
     @Override
     public void serialize(java.sql.Date value, JsonGenerator gen, SerializerProvider serializers) 

--- a/src/main/java/io/github/carlos_emr/carlos/utility/PDFEncryptionUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/PDFEncryptionUtil.java
@@ -9,6 +9,9 @@ import org.apache.pdfbox.pdmodel.encryption.AccessPermission;
 import org.apache.pdfbox.pdmodel.encryption.StandardProtectionPolicy;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+/**
+ * Utility methods and helper functions for PDFEncryption operations.
+ */
 public class PDFEncryptionUtil {
     // FindSecBugs PATH_TRAVERSAL_IN: path derived from trusted configuration/constant/DB value, not user-controllable input
     @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "path derived from trusted configuration/constant/DB value, not user-controllable input")

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/conversion/ConsultationRequestExtConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/conversion/ConsultationRequestExtConverter.java
@@ -4,6 +4,9 @@ import io.github.carlos_emr.carlos.commn.model.ConsultationRequestExt;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.webserv.rest.to.model.ConsultationRequestExtTo1;
 
+/**
+ * Converts ConsultationRequestExt data between internal entities and external transfer objects.
+ */
 public class ConsultationRequestExtConverter extends AbstractConverter<ConsultationRequestExt, ConsultationRequestExtTo1> {
     @Override
     public ConsultationRequestExt getAsDomainObject(LoggedInInfo loggedInInfo, ConsultationRequestExtTo1 t) throws ConversionException {

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/conversion/MeasurementConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/conversion/MeasurementConverter.java
@@ -4,6 +4,9 @@ import io.github.carlos_emr.carlos.commn.model.Measurement;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.webserv.rest.to.model.MeasurementTo1;
 
+/**
+ * Provides conversion logic for measurement data in REST API requests and responses.
+ */
 public class MeasurementConverter extends AbstractConverter<Measurement, MeasurementTo1> {
     @Override
     public Measurement getAsDomainObject(LoggedInInfo loggedInInfo, MeasurementTo1 t) throws ConversionException {

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/to/model/ConsultationRequestExtTo1.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/to/model/ConsultationRequestExtTo1.java
@@ -2,6 +2,9 @@ package io.github.carlos_emr.carlos.webserv.rest.to.model;
 
 import java.util.Date;
 
+/**
+ * Represents the ConsultationRequestExtTo1 data transfer object.
+ */
 public class ConsultationRequestExtTo1 {
     private Integer id;
     private Integer requestId;


### PR DESCRIPTION
Added class-level Javadoc comments to 40 undocumented classes across the codebase to improve documentation coverage and meet project standards as requested. Validated via local compilation and checkstyle checks.

---
*PR created automatically by Jules for task [15017498442805313399](https://jules.google.com/task/15017498442805313399) started by @yingbull*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added class-level Javadoc to 40 previously undocumented classes across billing, email, document manager, REST converters, and utilities to meet documentation standards and pass Checkstyle. Improves readability and coverage with no functional changes.

<sup>Written for commit bf1cb5e998fcc49febb79e2e80a5e19634a8d4d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

