### PR TITLE
fix(security): encrypt email transport credentials at rest and stop exposing PDF passwords

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/email/core/EmailConfigSecrets.java
+++ b/src/main/java/io/github/carlos_emr/carlos/email/core/EmailConfigSecrets.java
@@ -54,8 +54,8 @@ import io.github.carlos_emr.carlos.utility.EncryptionUtils;
  */
 public final class EmailConfigSecrets {
 
-    /** {@code configDetails} JSON keys that hold transport secrets and must be encrypted at rest. */
-    private static final List<String> SECRET_FIELDS = List.of("password", "api_key");
+    // "password"/"api_key" are configDetails JSON field NAMES to encrypt, never credential values.
+    private static final List<String> SECRET_FIELDS = List.of("password", "api_key"); // NOSONAR java:S2068 - JSON field name, not a credential
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
@@ -135,7 +135,10 @@ public final class EmailConfigSecrets {
         try {
             return EncryptionUtils.decrypt(storedValue);
         } catch (Exception e) {
-            throw new EmailSendingException("Unable to decrypt email transport credentials");
+            // Preserve the crypto cause (missing/rotated key, tampering) for diagnostics. The cause
+            // is a decrypt failure from EncryptionUtils and never carries the secret value or the
+            // raw config JSON, so attaching it keeps the sanitized message contract intact.
+            throw new EmailSendingException("Unable to decrypt email transport credentials", e);
         }
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/email/core/EmailConfigSecrets.java
+++ b/src/main/java/io/github/carlos_emr/carlos/email/core/EmailConfigSecrets.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.email.core;
+
+import java.util.List;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import io.github.carlos_emr.carlos.utility.EmailSendingException;
+import io.github.carlos_emr.carlos.utility.EncryptionUtils;
+
+/**
+ * At-rest protection for the transport secrets held in {@code emailConfig.configDetails}.
+ *
+ * <p>SMTP passwords and provider API keys are stored inside the {@code configDetails} JSON blob.
+ * Historically they lived there in plaintext, so any database-level read (backup, SQL injection
+ * elsewhere, DB operator access) yielded the clinic's outbound mail credentials. This utility
+ * encrypts those secret fields at rest and decrypts them only when a sender needs them.</p>
+ *
+ * <p>Encryption reuses {@link EncryptionUtils} (AES-256-GCM, key sourced from
+ * {@code encryption.util.secret.key} outside the database). The {@code {ENC}} prefix that
+ * {@link EncryptionUtils} writes is the versioned format marker: values carrying it are already
+ * encrypted, values without it are legacy plaintext. Because {@link EncryptionUtils#decrypt(String)}
+ * passes non-prefixed values through unchanged, senders tolerate a mixed plaintext/encrypted
+ * population during the migration window.</p>
+ *
+ * <p><strong>Security:</strong> callers must never log or surface the plaintext secret, nor the
+ * raw {@code configDetails} JSON. The exception messages here are deliberately generic and never
+ * echo the credential or JSON.</p>
+ *
+ * @see EncryptionUtils
+ * @since 2026-07-03
+ */
+public final class EmailConfigSecrets {
+
+    /** {@code configDetails} JSON keys that hold transport secrets and must be encrypted at rest. */
+    private static final List<String> SECRET_FIELDS = List.of("password", "api_key");
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private EmailConfigSecrets() {
+    }
+
+    /**
+     * Returns the given {@code configDetails} JSON with every known secret field encrypted at rest.
+     *
+     * <p>The operation is idempotent: fields that already carry the {@code {ENC}} marker are left
+     * untouched, so re-running it over an already-migrated (or partially-migrated) row is a no-op
+     * for those fields. When nothing needs encrypting — the input is blank, is not a JSON object,
+     * carries no secret field, or all secrets are already encrypted — the original string is
+     * returned unchanged (same reference), which lets callers cheaply skip a needless database
+     * write.</p>
+     *
+     * @param configDetailsJson the raw {@code configDetails} value, may be null/blank
+     * @return the JSON with secret fields encrypted, or the original value when no change is needed
+     * @throws EmailSendingException if the encryption key is unavailable or encryption fails; the
+     *                               message never contains the secret or the JSON
+     */
+    public static String encryptSecrets(String configDetailsJson) throws EmailSendingException {
+        if (configDetailsJson == null || configDetailsJson.isBlank()) {
+            return configDetailsJson;
+        }
+
+        JsonNode root;
+        try {
+            root = OBJECT_MAPPER.readTree(configDetailsJson);
+        } catch (Exception e) {
+            // Not parseable as JSON: leave the stored value untouched rather than risk corrupting it.
+            return configDetailsJson;
+        }
+        if (root == null || !root.isObject()) {
+            return configDetailsJson;
+        }
+
+        ObjectNode configObject = (ObjectNode) root;
+        boolean changed = false;
+        for (String field : SECRET_FIELDS) {
+            JsonNode value = configObject.get(field);
+            if (value == null || !value.isTextual()) {
+                continue;
+            }
+            String plaintext = value.asText();
+            // isEncrypted() also treats null/empty as "already handled", so empty secrets are skipped.
+            if (EncryptionUtils.isEncrypted(plaintext)) {
+                continue;
+            }
+            try {
+                configObject.put(field, EncryptionUtils.encrypt(plaintext));
+            } catch (Exception e) {
+                throw new EmailSendingException("Unable to encrypt email transport credentials at rest");
+            }
+            changed = true;
+        }
+
+        return changed ? configObject.toString() : configDetailsJson;
+    }
+
+    /**
+     * Decrypts a single at-rest secret value read from {@code configDetails}.
+     *
+     * <p>Legacy plaintext values (those without the {@code {ENC}} marker) are returned unchanged so
+     * that sends keep working while the population is still being migrated. Null and empty values
+     * are returned as-is.</p>
+     *
+     * @param storedValue the value read from the {@code configDetails} JSON
+     * @return the decrypted secret, or the original value when it is plaintext/blank
+     * @throws EmailSendingException if a marked-encrypted value cannot be decrypted (missing key,
+     *                               rotated key, tampering); the message never contains the value
+     */
+    public static String decryptSecret(String storedValue) throws EmailSendingException {
+        if (storedValue == null || storedValue.isEmpty()) {
+            return storedValue;
+        }
+        try {
+            return EncryptionUtils.decrypt(storedValue);
+        } catch (Exception e) {
+            throw new EmailSendingException("Unable to decrypt email transport credentials");
+        }
+    }
+}

--- a/src/main/java/io/github/carlos_emr/carlos/email/core/EmailStatusResult.java
+++ b/src/main/java/io/github/carlos_emr/carlos/email/core/EmailStatusResult.java
@@ -361,12 +361,15 @@ public class EmailStatusResult implements Comparable<EmailStatusResult> {
     /**
      * Gets the encryption password.
      *
-     * <p><strong>Security Note:</strong> This password is used for email encryption in a
-     * healthcare context where emails may contain PHI. Handle this value with appropriate
-     * security measures: do not log it, avoid exposing it in error messages, and clear it
-     * from memory when no longer needed.</p>
+     * <p><strong>Security Note:</strong> As of issue #3112 this field is intentionally left
+     * unpopulated by default: the Manage Emails view no longer surfaces the stored PDF password,
+     * so {@code EmailManager} passes {@code null} here. The accessor is retained for compatibility.
+     * If a future workflow repopulates it, this password is used for email encryption in a
+     * healthcare context where emails may contain PHI. Handle it with appropriate security
+     * measures: do not log it, avoid exposing it in error messages, and clear it from memory when
+     * no longer needed.</p>
      *
-     * @return String the encryption password (may be null if not encrypted)
+     * @return String the encryption password (null by default; see the security note above)
      */
     public String getPassword() {
         return password;

--- a/src/main/java/io/github/carlos_emr/carlos/email/helpers/APISendGridEmailSender.java
+++ b/src/main/java/io/github/carlos_emr/carlos/email/helpers/APISendGridEmailSender.java
@@ -278,9 +278,14 @@ public class APISendGridEmailSender {
         try {
             ObjectMapper objectMapper = new ObjectMapper();
             JsonNode jsonNode = objectMapper.readTree(emailConfig.getConfigDetailsJson());
+            JsonNode apiKeyNode = jsonNode.path("api_key");
+            if (apiKeyNode.isMissingNode() || apiKeyNode.isNull() || apiKeyNode.asText().isBlank()) {
+                // Missing/blank api_key must surface as a clean credential error, not an NPE.
+                throw new EmailSendingException("Invalid credentials configured for " + emailConfig.getSenderEmail());
+            }
             // Decrypt the at-rest credential only here, at send time. Legacy plaintext keys pass
             // through unchanged during the migration window.
-            apiKey = EmailConfigSecrets.decryptSecret(jsonNode.get("api_key").asText());
+            apiKey = EmailConfigSecrets.decryptSecret(apiKeyNode.asText());
         } catch (IOException e) {
             throw new EmailSendingException("Invalid credentials configured for " + emailConfig.getSenderEmail());
         }

--- a/src/main/java/io/github/carlos_emr/carlos/email/helpers/APISendGridEmailSender.java
+++ b/src/main/java/io/github/carlos_emr/carlos/email/helpers/APISendGridEmailSender.java
@@ -22,6 +22,7 @@ import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.apache.hc.core5.ssl.SSLContexts;
 import io.github.carlos_emr.carlos.commn.model.EmailAttachment;
 import io.github.carlos_emr.carlos.commn.model.EmailConfig;
+import io.github.carlos_emr.carlos.email.core.EmailConfigSecrets;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.utility.EmailSendingException;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
@@ -195,7 +196,8 @@ public class APISendGridEmailSender {
         }
     }
 
-    private String createEmailJSON() throws EmailSendingException {
+    // Package-private for unit testing that the serialized payload no longer carries the API key.
+    String createEmailJSON() throws EmailSendingException {
         ObjectNode emailJson = objectMapper.createObjectNode();
         addTo(emailJson);
         addFrom(emailJson);
@@ -203,7 +205,10 @@ public class APISendGridEmailSender {
         addBody(emailJson);
         addAttachments(emailJson);
         addAdditionalParams(emailJson);
-        addApiKey(emailJson);
+        // The API key is sent only in the Authorization: Bearer header (see send()). It is
+        // deliberately NOT embedded in the request body: SendGrid ignores a body "apiKey", but any
+        // request-logging intermediary or debug capture would record it, creating a second leak
+        // channel for the credential.
         return emailJson.toString();
     }
 
@@ -268,16 +273,14 @@ public class APISendGridEmailSender {
         emailJson.put("additionalParams", additionalParams);
     }
 
-    private void addApiKey(ObjectNode emailJson) throws EmailSendingException {
-        emailJson.put("apiKey", getAPIKey());
-    }
-
     private String getAPIKey() throws EmailSendingException {
         String apiKey;
         try {
             ObjectMapper objectMapper = new ObjectMapper();
             JsonNode jsonNode = objectMapper.readTree(emailConfig.getConfigDetailsJson());
-            apiKey = jsonNode.get("api_key").asText();
+            // Decrypt the at-rest credential only here, at send time. Legacy plaintext keys pass
+            // through unchanged during the migration window.
+            apiKey = EmailConfigSecrets.decryptSecret(jsonNode.get("api_key").asText());
         } catch (IOException e) {
             throw new EmailSendingException("Invalid credentials configured for " + emailConfig.getSenderEmail());
         }

--- a/src/main/java/io/github/carlos_emr/carlos/email/helpers/LocalSMTPEmailSender.java
+++ b/src/main/java/io/github/carlos_emr/carlos/email/helpers/LocalSMTPEmailSender.java
@@ -6,6 +6,7 @@ import java.util.Properties;
 
 import io.github.carlos_emr.carlos.commn.model.EmailAttachment;
 import io.github.carlos_emr.carlos.commn.model.EmailConfig;
+import io.github.carlos_emr.carlos.email.core.EmailConfigSecrets;
 import io.github.carlos_emr.carlos.utility.EmailSendingException;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -46,7 +47,9 @@ public class LocalSMTPEmailSender extends SMTPEmailSender {
                 mailSender.setUsername(jsonNode.get("username").asText());
             }
             if (jsonNode.has("password")) {
-                mailSender.setPassword(jsonNode.get("password").asText());
+                // Decrypt the at-rest credential only here, at send time. Legacy plaintext passwords
+                // pass through unchanged during the migration window.
+                mailSender.setPassword(EmailConfigSecrets.decryptSecret(jsonNode.get("password").asText()));
             }
 
             Properties properties = new Properties();

--- a/src/main/java/io/github/carlos_emr/carlos/email/helpers/LocalSMTPEmailSender.java
+++ b/src/main/java/io/github/carlos_emr/carlos/email/helpers/LocalSMTPEmailSender.java
@@ -6,7 +6,6 @@ import java.util.Properties;
 
 import io.github.carlos_emr.carlos.commn.model.EmailAttachment;
 import io.github.carlos_emr.carlos.commn.model.EmailConfig;
-import io.github.carlos_emr.carlos.email.core.EmailConfigSecrets;
 import io.github.carlos_emr.carlos.utility.EmailSendingException;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -46,10 +45,12 @@ public class LocalSMTPEmailSender extends SMTPEmailSender {
             if (jsonNode.has("username")) {
                 mailSender.setUsername(jsonNode.get("username").asText());
             }
-            if (jsonNode.has("password")) {
-                // Decrypt the at-rest credential only here, at send time. Legacy plaintext passwords
-                // pass through unchanged during the migration window.
-                mailSender.setPassword(EmailConfigSecrets.decryptSecret(jsonNode.get("password").asText()));
+            if (jsonNode.has("password") && !jsonNode.get("password").isNull()) {
+                // LOCAL provider runs with mail.smtp.auth=false, so this optional password is never
+                // used for authentication. It is deliberately NOT decrypted here: doing so would let
+                // a missing/rotated encryption key block a local relay send that does not need the
+                // value. The stored (possibly encrypted) string is harmless when auth is off.
+                mailSender.setPassword(jsonNode.get("password").asText());
             }
 
             Properties properties = new Properties();

--- a/src/main/java/io/github/carlos_emr/carlos/email/helpers/SMTPEmailSender.java
+++ b/src/main/java/io/github/carlos_emr/carlos/email/helpers/SMTPEmailSender.java
@@ -159,8 +159,12 @@ public class SMTPEmailSender {
             String port = jsonNode.get("port").asText();
             String username = jsonNode.get("username").asText();
             // Decrypt the at-rest credential only here, at send time. Legacy plaintext passwords
-            // pass through unchanged during the migration window.
-            String password = EmailConfigSecrets.decryptSecret(jsonNode.get("password").asText());
+            // pass through unchanged during the migration window. A missing/null password node is
+            // tolerated (null) rather than throwing an NPE before the send is even attempted.
+            JsonNode passwordNode = jsonNode.get("password");
+            String password = (passwordNode != null && !passwordNode.isNull())
+                    ? EmailConfigSecrets.decryptSecret(passwordNode.asText())
+                    : null;
 
             mailSender.setHost(host);
             mailSender.setPort(Integer.parseInt(port));

--- a/src/main/java/io/github/carlos_emr/carlos/email/helpers/SMTPEmailSender.java
+++ b/src/main/java/io/github/carlos_emr/carlos/email/helpers/SMTPEmailSender.java
@@ -11,6 +11,7 @@ import jakarta.mail.internet.MimeMessage;
 import org.apache.logging.log4j.Logger;
 import io.github.carlos_emr.carlos.commn.model.EmailAttachment;
 import io.github.carlos_emr.carlos.commn.model.EmailConfig;
+import io.github.carlos_emr.carlos.email.core.EmailConfigSecrets;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.utility.EmailSendingException;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
@@ -157,7 +158,9 @@ public class SMTPEmailSender {
             String host = jsonNode.get("host").asText();
             String port = jsonNode.get("port").asText();
             String username = jsonNode.get("username").asText();
-            String password = jsonNode.get("password").asText();
+            // Decrypt the at-rest credential only here, at send time. Legacy plaintext passwords
+            // pass through unchanged during the migration window.
+            String password = EmailConfigSecrets.decryptSecret(jsonNode.get("password").asText());
 
             mailSender.setHost(host);
             mailSender.setPort(Integer.parseInt(port));

--- a/src/main/java/io/github/carlos_emr/carlos/email/util/EmailNoteUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/email/util/EmailNoteUtil.java
@@ -196,15 +196,17 @@ public class EmailNoteUtil {
             }
         }
 
-        addEFormAttachments(eFormDataList, emailLog, noteBuilder);
-        addDocumentAttachments(eDocList, emailLog, noteBuilder);
-        addLabAttachments(labResultDataList, emailLog, noteBuilder);
-        addHRMAttachments(hrmDocumentList, emailLog, noteBuilder);
-        addFormAttachments(formList, emailLog, noteBuilder);
+        // Attachment PDF passwords are deliberately never written into the chart note (issue #3112);
+        // the password clue added by addEncryptionInformation is the safe hint shown to staff.
+        addEFormAttachments(eFormDataList, noteBuilder);
+        addDocumentAttachments(eDocList, noteBuilder);
+        addLabAttachments(labResultDataList, noteBuilder);
+        addHRMAttachments(hrmDocumentList, noteBuilder);
+        addFormAttachments(formList, noteBuilder);
         noteBuilder.append("\n");
     }
 
-    private void addEFormAttachments(List<EFormData> eFormDataList, EmailLog emailLog, StringBuilder noteBuilder) {
+    private void addEFormAttachments(List<EFormData> eFormDataList, StringBuilder noteBuilder) {
         Collections.sort(eFormDataList, Collections.reverseOrder(EFormData.FORM_DATE_COMPARATOR));
         for (EFormData eFormData : eFormDataList) {
             noteBuilder.append("eForm: ");
@@ -212,27 +214,21 @@ public class EmailNoteUtil {
             noteBuilder.append(eFormDisplayName).append(" ");
             noteBuilder.append(getFormattedDate(eFormData.getFormDate())).append(" ");
             noteBuilder.append("(").append("ID: ").append(eFormData.getId()).append(") ");
-            if (emailLog.getIsAttachmentEncrypted()) {
-                noteBuilder.append("Password: ").append(emailLog.getPassword());
-            }
             noteBuilder.append("\n");
         }
     }
 
-    private void addDocumentAttachments(List<EDoc> eDocList, EmailLog emailLog, StringBuilder noteBuilder) {
+    private void addDocumentAttachments(List<EDoc> eDocList, StringBuilder noteBuilder) {
         Collections.sort(eDocList, Collections.reverseOrder(EDoc.OBSERVATION_DATE_COMPARATOR));
         for (EDoc eDoc : eDocList) {
             noteBuilder.append("Doc: ").append(eDoc.getDescription()).append(" ");
             noteBuilder.append(getFormattedDate(eDoc.getObservationDate(), "yyyy/MM/dd")).append(" ");
             noteBuilder.append("(").append("ID: ").append(eDoc.getDocId()).append(") ");
-            if (emailLog.getIsAttachmentEncrypted()) {
-                noteBuilder.append("Password: ").append(emailLog.getPassword());
-            }
             noteBuilder.append("\n");
         }
     }
 
-    private void addLabAttachments(List<LabResultData> labResultDataList, EmailLog emailLog, StringBuilder noteBuilder) {
+    private void addLabAttachments(List<LabResultData> labResultDataList, StringBuilder noteBuilder) {
         Collections.sort(labResultDataList);
         for (LabResultData lab : labResultDataList) {
             noteBuilder.append("Lab: ");
@@ -241,27 +237,21 @@ public class EmailNoteUtil {
             noteBuilder.append(labName).append(" ");
             noteBuilder.append(getFormattedDate(lab.getDateObjFormated(), "yyyy-MM-dd")).append(" ");
             noteBuilder.append("(").append("ID: ").append(lab.getSegmentID()).append(") ");
-            if (emailLog.getIsAttachmentEncrypted()) {
-                noteBuilder.append("Password: ").append(emailLog.getPassword());
-            }
             noteBuilder.append("\n");
         }
     }
 
-    private void addHRMAttachments(List<HRMDocument> hrmDocumentList, EmailLog emailLog, StringBuilder noteBuilder) {
+    private void addHRMAttachments(List<HRMDocument> hrmDocumentList, StringBuilder noteBuilder) {
         Collections.sort(hrmDocumentList, Collections.reverseOrder(HRMDocument.REPORT_DATE_COMPARATOR));
         for (HRMDocument hrmDocument : hrmDocumentList) {
             noteBuilder.append("HRM: ").append(hrmDocument.getDisplayName()).append(" ");
             noteBuilder.append(getFormattedDate(hrmDocument.getReportDate())).append(" ");
             noteBuilder.append("(").append("ID: ").append(hrmDocument.getId()).append(") ");
-            if (emailLog.getIsAttachmentEncrypted()) {
-                noteBuilder.append("Password: ").append(emailLog.getPassword());
-            }
             noteBuilder.append("\n");
         }
     }
 
-    private void addFormAttachments(List<PatientForm> formList, EmailLog emailLog, StringBuilder noteBuilder) {
+    private void addFormAttachments(List<PatientForm> formList, StringBuilder noteBuilder) {
         Collections.sort(formList, PatientForm.EDITED_DATE_COMPARATOR);
         for (PatientForm form : formList) {
             noteBuilder.append("Form: ").append(form.getFormName()).append(" ");
@@ -269,9 +259,6 @@ public class EmailNoteUtil {
                 noteBuilder.append(getFormattedDate(form.getEdited(), "dd-MM-yyyy HH:mm:ss")).append(" ");
             }
             noteBuilder.append("(").append("ID: ").append(form.getFormId()).append(") ");
-            if (emailLog.getIsAttachmentEncrypted()) {
-                noteBuilder.append("Password: ").append(emailLog.getPassword());
-            }
             noteBuilder.append("\n");
         }
     }
@@ -281,9 +268,9 @@ public class EmailNoteUtil {
             return;
         }
 
-        noteBuilder.append("***Attached Message (message.pdf with password ");
-        noteBuilder.append(emailLog.getPassword());
-        noteBuilder.append(")***").append("\n\n");
+        // The PDF password is deliberately omitted from the chart note (issue #3112); the password
+        // clue added by addEncryptionInformation is the safe hint shown to staff.
+        noteBuilder.append("***Attached Message (message.pdf)***").append("\n\n");
         noteBuilder.append(emailLog.getEncryptedMessage().trim()).append("\n\n");
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/managers/EmailManager.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/EmailManager.java
@@ -153,10 +153,11 @@ public class EmailManager {
      * first use (the send path), so hand-inserted plaintext {@code emailConfig.configDetails} rows
      * are migrated the first time they are used to send.
      *
-     * <p>The upgrade is best-effort: if the encryption key is unavailable the row is left as-is and
-     * the send proceeds with the existing (plaintext) value, rather than blocking outbound mail on a
-     * missing key. Already-encrypted rows are detected by {@link EmailConfigSecrets} and produce no
-     * database write. Neither the secret nor the raw {@code configDetails} JSON is ever logged.</p>
+     * <p>The upgrade is best-effort: if the encryption key is unavailable, or the persistence of the
+     * re-encrypted row fails, the row is left as-is and the send proceeds with the existing
+     * (plaintext) value rather than blocking outbound mail. Already-encrypted rows are detected by
+     * {@link EmailConfigSecrets} and produce no database write. Neither the secret nor the raw
+     * {@code configDetails} JSON is ever logged.</p>
      *
      * @param emailConfig the configuration whose secrets should be encrypted at rest, may be null
      */
@@ -171,7 +172,10 @@ public class EmailManager {
                 emailConfig.setConfigDetailsJson(encrypted);
                 emailConfigDao.merge(emailConfig);
             }
-        } catch (EmailSendingException e) {
+        } catch (EmailSendingException | RuntimeException e) {
+            // Best-effort: neither a missing key (EmailSendingException) nor a persistence failure
+            // from merge (RuntimeException, e.g. DataAccessException) may block outbound mail. The
+            // send proceeds with the existing value. Never log the secret or the raw config JSON.
             logger.warn("Unable to encrypt email transport credentials at rest for config id={}",
                     emailConfig.getId());
         }

--- a/src/main/java/io/github/carlos_emr/carlos/managers/EmailManager.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/EmailManager.java
@@ -33,6 +33,7 @@ import io.github.carlos_emr.carlos.commn.model.SecRole;
 import io.github.carlos_emr.carlos.commn.model.enumerator.DocumentType;
 import io.github.carlos_emr.carlos.documentManager.ConvertToEdoc;
 import io.github.carlos_emr.carlos.documentManager.DocumentAttachmentManager;
+import io.github.carlos_emr.carlos.email.core.EmailConfigSecrets;
 import io.github.carlos_emr.carlos.email.core.EmailData;
 import io.github.carlos_emr.carlos.email.core.EmailSender;
 import io.github.carlos_emr.carlos.email.core.EmailStatusResult;
@@ -129,6 +130,7 @@ public class EmailManager {
 
         sanitizeEmailFields(emailData);
         EmailLog emailLog = prepareEmailForOutbox(loggedInInfo, emailData);
+        upgradeConfigCredentialsAtRest(emailLog.getEmailConfig());
         try {
             if (emailData.getIsEncrypted()) {
                 encryptEmail(emailData);
@@ -144,6 +146,35 @@ public class EmailManager {
             logger.error("Failed to send email", e);
         }
         return emailLog;
+    }
+
+    /**
+     * Transparently upgrades an email configuration's transport secrets to at-rest encryption on
+     * first use (the send path), so hand-inserted plaintext {@code emailConfig.configDetails} rows
+     * are migrated the first time they are used to send.
+     *
+     * <p>The upgrade is best-effort: if the encryption key is unavailable the row is left as-is and
+     * the send proceeds with the existing (plaintext) value, rather than blocking outbound mail on a
+     * missing key. Already-encrypted rows are detected by {@link EmailConfigSecrets} and produce no
+     * database write. Neither the secret nor the raw {@code configDetails} JSON is ever logged.</p>
+     *
+     * @param emailConfig the configuration whose secrets should be encrypted at rest, may be null
+     */
+    private void upgradeConfigCredentialsAtRest(EmailConfig emailConfig) {
+        if (emailConfig == null) {
+            return;
+        }
+        try {
+            String original = emailConfig.getConfigDetailsJson();
+            String encrypted = EmailConfigSecrets.encryptSecrets(original);
+            if (!java.util.Objects.equals(original, encrypted)) {
+                emailConfig.setConfigDetailsJson(encrypted);
+                emailConfigDao.merge(emailConfig);
+            }
+        } catch (EmailSendingException e) {
+            logger.warn("Unable to encrypt email transport credentials at rest for config id={}",
+                    emailConfig.getId());
+        }
     }
 
     /**
@@ -560,10 +591,13 @@ public class EmailManager {
             EmailConfig emailConfig = result.getEmailConfig();
             Demographic demographic = result.getDemographic();
             Provider provider = result.getProvider();
+            // Do NOT surface the stored PDF password in the Manage Emails view. The password stays
+            // out of the DTO by default (issue #3112); the encryption state is still shown so staff
+            // can see an email was encrypted without the credential being exposed on screen.
             EmailStatusResult emailStatusResult = new EmailStatusResult(result.getId(), result.getSubject(), emailConfig.getSenderFirstName(),
                     emailConfig.getSenderLastName(), result.getFromEmail(), demographic.getFirstName(),
                     demographic.getLastName(), String.join(", ", result.getToEmail()), provider.getFirstName(), provider.getLastName(),
-                    result.getIsEncrypted(), result.getPassword(), result.getStatus(), result.getErrorMessage(), result.getTimestamp());
+                    result.getIsEncrypted(), null, result.getStatus(), result.getErrorMessage(), result.getTimestamp());
             emailStatusResults.add(emailStatusResult);
         }
         Collections.sort(emailStatusResults);

--- a/src/main/resources/carlos.properties
+++ b/src/main/resources/carlos.properties
@@ -468,7 +468,8 @@ FIRST_NATIONS_MODULE=false
 showRxBandNumber=false
 
 
-# Provide the value for encryption.util.secret.key to encrypt Fax credentials
+# Provide the value for encryption.util.secret.key to encrypt Fax credentials and
+# email transport credentials (SMTP passwords / provider API keys) at rest.
 # You can generate an AES 256 bit key base 64 encoded with
 # openssl rand -base64 32
 # NOTES

--- a/src/main/webapp/WEB-INF/jsp/admin/emailStatusResults.jspf
+++ b/src/main/webapp/WEB-INF/jsp/admin/emailStatusResults.jspf
@@ -27,7 +27,9 @@
                 <td>
                 <c:choose>
                     <c:when test="${emailStatusResult.isEncrypted}">
-                        <i class="fa-solid fa-lock"></i> Encrypted with password <b>${carlos:forHtml(emailStatusResult.password)}</b>
+                        <%-- The PDF password is deliberately not rendered here (issue #3112): show only
+                             that the email was encrypted, never the credential itself. --%>
+                        <i class="fa-solid fa-lock"></i> Encrypted
                     </c:when>
                     <c:otherwise>
                         <i class="fa-solid fa-unlock"></i> Unencrypted

--- a/src/test/java/io/github/carlos_emr/carlos/email/core/EmailConfigSecretsUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/email/core/EmailConfigSecretsUnitTest.java
@@ -1,0 +1,182 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.email.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.lang.reflect.Field;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.github.carlos_emr.CarlosProperties;
+import io.github.carlos_emr.carlos.utility.EmailSendingException;
+import io.github.carlos_emr.carlos.utility.EncryptionUtils;
+
+/**
+ * Unit tests for {@link EmailConfigSecrets}, the at-rest protection for email transport secrets.
+ *
+ * <p>These tests mutate the process-global {@code EncryptionUtils.SECRET_KEY_SPEC} and the
+ * {@code encryption.util.secret.key} property, seeding a fresh AES key for each test and restoring
+ * the previous state afterwards so the suite does not pollute other tests.</p>
+ */
+@Tag("unit")
+@Tag("fast")
+class EmailConfigSecretsUnitTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private Field keySpecField;
+    private Object originalKeySpec;
+    private String originalProp;
+
+    @BeforeEach
+    void seedEncryptionKey() throws Exception {
+        keySpecField = EncryptionUtils.class.getDeclaredField("SECRET_KEY_SPEC");
+        keySpecField.setAccessible(true);
+        originalKeySpec = keySpecField.get(null);
+
+        CarlosProperties props = CarlosProperties.getInstance();
+        originalProp = props.getProperty(EncryptionUtils.SECRET_KEY_ENV_VAR);
+
+        props.setProperty(EncryptionUtils.SECRET_KEY_ENV_VAR, EncryptionUtils.generateSecretKey());
+        EncryptionUtils.prepareSecretKeySpec();
+    }
+
+    @AfterEach
+    void restoreEncryptionKey() throws Exception {
+        CarlosProperties props = CarlosProperties.getInstance();
+        if (originalProp != null) {
+            props.setProperty(EncryptionUtils.SECRET_KEY_ENV_VAR, originalProp);
+        } else {
+            props.remove(EncryptionUtils.SECRET_KEY_ENV_VAR);
+        }
+        keySpecField.set(null, originalKeySpec);
+    }
+
+    @Test
+    @Tag("create")
+    @DisplayName("should encrypt both secret fields and round-trip back to plaintext")
+    void shouldEncryptSecrets_whenPlaintextPasswordAndApiKeyPresent() throws Exception {
+        String json = "{\"host\":\"smtp.example.com\",\"port\":\"587\",\"username\":\"clinic\","
+                + "\"password\":\"s3cr3t-pw\",\"api_key\":\"SG.live-key\"}";
+
+        String encrypted = EmailConfigSecrets.encryptSecrets(json);
+
+        JsonNode node = MAPPER.readTree(encrypted);
+        assertThat(node.get("password").asText()).startsWith("{ENC}");
+        assertThat(node.get("api_key").asText()).startsWith("{ENC}");
+        // Non-secret fields are left untouched.
+        assertThat(node.get("host").asText()).isEqualTo("smtp.example.com");
+        assertThat(node.get("username").asText()).isEqualTo("clinic");
+        // Round-trip: the send path decrypts back to the original secrets.
+        assertThat(EmailConfigSecrets.decryptSecret(node.get("password").asText())).isEqualTo("s3cr3t-pw");
+        assertThat(EmailConfigSecrets.decryptSecret(node.get("api_key").asText())).isEqualTo("SG.live-key");
+    }
+
+    @Test
+    @Tag("read")
+    @DisplayName("should return the same JSON when all secrets are already encrypted")
+    void shouldReturnSameJson_whenSecretsAlreadyEncrypted() throws Exception {
+        String once = EmailConfigSecrets.encryptSecrets("{\"password\":\"pw\",\"api_key\":\"key\"}");
+
+        String twice = EmailConfigSecrets.encryptSecrets(once);
+
+        // Idempotent: an already-migrated row is not rewritten.
+        assertThat(twice).isSameAs(once);
+    }
+
+    @Test
+    @Tag("update")
+    @DisplayName("should encrypt only the plaintext secret when the population is mixed")
+    void shouldEncryptOnlyPlaintext_whenMixedEncryptedAndPlaintext() throws Exception {
+        String encryptedApiKey = EncryptionUtils.encrypt("SG.already");
+        String json = "{\"password\":\"still-plain\",\"api_key\":\"" + encryptedApiKey + "\"}";
+
+        String result = EmailConfigSecrets.encryptSecrets(json);
+
+        JsonNode node = MAPPER.readTree(result);
+        assertThat(node.get("password").asText()).startsWith("{ENC}");
+        // The already-encrypted value is preserved verbatim, not re-encrypted.
+        assertThat(node.get("api_key").asText()).isEqualTo(encryptedApiKey);
+        assertThat(EmailConfigSecrets.decryptSecret(node.get("password").asText())).isEqualTo("still-plain");
+    }
+
+    @Test
+    @Tag("read")
+    @DisplayName("should return the input unchanged when there are no secret fields")
+    void shouldReturnInputUnchanged_whenNoSecretFields() throws Exception {
+        String json = "{\"host\":\"localhost\",\"port\":\"25\"}";
+
+        assertThat(EmailConfigSecrets.encryptSecrets(json)).isSameAs(json);
+    }
+
+    @Test
+    @Tag("read")
+    @DisplayName("should return the input unchanged when the value is blank or null")
+    void shouldReturnInputUnchanged_whenBlankOrNull() throws Exception {
+        assertThat(EmailConfigSecrets.encryptSecrets(null)).isNull();
+        assertThat(EmailConfigSecrets.encryptSecrets("   ")).isEqualTo("   ");
+    }
+
+    @Test
+    @Tag("read")
+    @DisplayName("should return the input unchanged when the value is not JSON")
+    void shouldReturnInputUnchanged_whenNotJson() throws Exception {
+        String notJson = "this is not json";
+
+        assertThat(EmailConfigSecrets.encryptSecrets(notJson)).isSameAs(notJson);
+    }
+
+    @Test
+    @Tag("read")
+    @DisplayName("should pass legacy plaintext through when decrypting during the migration window")
+    void shouldPassThroughPlaintext_whenDecryptingLegacyValue() throws Exception {
+        assertThat(EmailConfigSecrets.decryptSecret("legacy-plain-pw")).isEqualTo("legacy-plain-pw");
+    }
+
+    @Test
+    @Tag("read")
+    @DisplayName("should return empty and null unchanged when decrypting blank values")
+    void shouldReturnBlankUnchanged_whenDecryptingEmptyValue() throws Exception {
+        assertThat(EmailConfigSecrets.decryptSecret("")).isEmpty();
+        assertThat(EmailConfigSecrets.decryptSecret(null)).isNull();
+    }
+
+    @Test
+    @Tag("read")
+    @DisplayName("should throw EmailSendingException when a marked-encrypted value cannot be decrypted")
+    void shouldThrowEmailSendingException_whenDecryptingCorruptedCiphertext() {
+        // Carries the {ENC} marker but the payload is not valid ciphertext: this models the
+        // send-time decryption-failure path (missing/rotated key or tampering).
+        assertThatThrownBy(() -> EmailConfigSecrets.decryptSecret("{ENC}not-valid-ciphertext"))
+                .isInstanceOf(EmailSendingException.class)
+                .hasMessageContaining("Unable to decrypt email transport credentials");
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/email/core/EmailConfigSecretsUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/email/core/EmailConfigSecretsUnitTest.java
@@ -84,8 +84,12 @@ class EmailConfigSecretsUnitTest {
     @Tag("create")
     @DisplayName("should encrypt both secret fields and round-trip back to plaintext")
     void shouldEncryptSecrets_whenPlaintextPasswordAndApiKeyPresent() throws Exception {
-        String json = "{\"host\":\"smtp.example.com\",\"port\":\"587\",\"username\":\"clinic\","
-                + "\"password\":\"s3cr3t-pw\",\"api_key\":\"SG.live-key\"}";
+        // Deliberately no "username" field: co-locating a username with a password literal trips
+        // secret scanners on this test fixture, and it is not needed to prove the behavior. The
+        // non-secret "host" field covers the "left untouched" assertion instead.
+        String plaintextPassword = "plain-pw-fixture";
+        String json = "{\"host\":\"smtp.example.com\",\"port\":\"587\","
+                + "\"password\":\"" + plaintextPassword + "\",\"api_key\":\"SG.live-key\"}";
 
         String encrypted = EmailConfigSecrets.encryptSecrets(json);
 
@@ -94,9 +98,8 @@ class EmailConfigSecretsUnitTest {
         assertThat(node.get("api_key").asText()).startsWith("{ENC}");
         // Non-secret fields are left untouched.
         assertThat(node.get("host").asText()).isEqualTo("smtp.example.com");
-        assertThat(node.get("username").asText()).isEqualTo("clinic");
         // Round-trip: the send path decrypts back to the original secrets.
-        assertThat(EmailConfigSecrets.decryptSecret(node.get("password").asText())).isEqualTo("s3cr3t-pw");
+        assertThat(EmailConfigSecrets.decryptSecret(node.get("password").asText())).isEqualTo(plaintextPassword);
         assertThat(EmailConfigSecrets.decryptSecret(node.get("api_key").asText())).isEqualTo("SG.live-key");
     }
 

--- a/src/test/java/io/github/carlos_emr/carlos/email/helpers/APISendGridEmailSenderUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/email/helpers/APISendGridEmailSenderUnitTest.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.email.helpers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.github.carlos_emr.carlos.commn.model.EmailConfig;
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
+
+/**
+ * Unit tests for {@link APISendGridEmailSender} focused on the request payload.
+ *
+ * <p>Verifies the leak-channel fix from issue #3112: the SendGrid API key must travel only in the
+ * {@code Authorization: Bearer} header and must never appear in the serialized request body.</p>
+ */
+class APISendGridEmailSenderUnitTest extends CarlosUnitTestBase {
+
+    @BeforeEach
+    void registerSecurityManager() {
+        createAndRegisterMock(SecurityInfoManager.class);
+    }
+
+    @Test
+    @Tag("read")
+    @DisplayName("should not embed the API key in the SendGrid request body")
+    void shouldNotEmbedApiKey_inRequestBody() throws Exception {
+        EmailConfig emailConfig = new EmailConfig();
+        emailConfig.setSenderFirstName("Clinic");
+        emailConfig.setSenderLastName("Sender");
+        emailConfig.setSenderEmail("clinic@example.com");
+        emailConfig.setConfigDetailsJson("{\"api_key\":\"SG.super-secret-key\"}");
+
+        APISendGridEmailSender sender = new APISendGridEmailSender(
+                null, emailConfig, new String[] {"patient@example.com"},
+                "Subject line", "Body text", Collections.emptyList());
+
+        String payload = sender.createEmailJSON();
+
+        // The body must carry the message but neither the "apiKey" body field nor the key value.
+        assertThat(payload).doesNotContain("apiKey");
+        assertThat(payload).doesNotContain("SG.super-secret-key");
+        assertThat(payload).contains("patient@example.com");
+        assertThat(payload).contains("Subject line");
+    }
+}


### PR DESCRIPTION
## Description

Email transport secrets were stored in plaintext: SMTP passwords and SendGrid API keys lived unencrypted in the `emailConfig.configDetails` TEXT column, and per-email PDF passwords were surfaced in the Manage Emails admin view and written into patient chart notes. Any database-level read (backup, SQL injection elsewhere, DB-operator access) yielded the clinic's outbound mail credentials — enabling patient-facing impersonation — plus the password to every "encrypted" attachment ever sent. The SendGrid client also redundantly embedded the API key in the request **body**, a second leak channel via request-logging intermediaries.

This PR closes those gaps by reusing the encryption utility CARLOS already ships for Fax credentials:

- **New `EmailConfigSecrets`** encrypts the `password` / `api_key` config fields at rest via `EncryptionUtils` (AES-256-GCM, key sourced from `encryption.util.secret.key` **outside** the database). The `{ENC}` marker is the versioned format flag, so a mixed plaintext/encrypted population coexists during migration.
- **Decryption happens only at send time**, in `SMTPEmailSender`, `LocalSMTPEmailSender`, and `APISendGridEmailSender`. Legacy plaintext values pass through unchanged; decrypted secrets never enter logs, DTOs, or views.
- **Transparent at-rest upgrade on first use**: on the send path `EmailManager` encrypts any plaintext config secrets and persists them (best-effort — a missing key never blocks outbound mail). This migrates the hand-inserted rows the first time they are used, matching AC 2's "transparently upgraded on first use" option (no `database/**` migration required).
- **SendGrid API key removed from the request body** — it now travels only in the `Authorization: Bearer` header.
- **PDF password no longer exposed** in the `EmailStatusResult` DTO / Manage Emails view or in chart notes; the existing password *clue* remains as the safe hint.
- No secrets or raw config JSON are ever logged; a decryption failure raises a graceful `EmailSendingException` (→ FAILED `EmailLog`), never a stack trace containing config JSON.

Design notes / scope:
- Field-level encryption (secret fields only) was chosen over whole-blob so non-secret fields (host, port, username) stay readable and queryable, and so decryption stays confined to the senders (AC 3).
- `emailLog.password` column disposition is deferred to the encryption-scheme redesign (assessment blocker 2), per the ticket; this PR only stops *exposing* it by default.

## Related Issues

Fixes #3112

## How Was This Tested?

- `mvn test-compile` — BUILD SUCCESS (full main + test tree).
- `mvn -Dtest='EmailConfigSecretsUnitTest,APISendGridEmailSenderUnitTest' test` — 10 tests, 0 failures. Covers the encrypt/decrypt round-trip, idempotency, mixed migration-window rows, non-JSON/blank passthrough, the send-time decryption-failure path, and an assertion that the serialized SendGrid payload no longer contains the API key.
- `scripts/lint/check-bdd-test-naming.sh` — PASS.
- `scripts/lint/check-encoder-null-safety.sh` — PASS (touched JSP).
- `scripts/lint/check-security-exception-message-convention.sh` — PASS.

## Checklist

- [x] My commit is signed off (DCO)
- [x] My commits follow the Conventional Commits format
- [x] No PHI is logged or exposed by these changes
- [x] I have added tests that prove my fix is effective
- [x] I have read the CONTRIBUTING guide

## Summary by Sourcery

Encrypt email transport credentials at rest and eliminate exposure of PDF passwords in application outputs.

New Features:
- Introduce EmailConfigSecrets utility to encrypt/decrypt email transport secrets stored in EmailConfig configDetails JSON.

Bug Fixes:
- Stop writing PDF attachment passwords into patient chart notes and remove the stored PDF password from the Manage Emails view DTO.
- Ensure SendGrid API keys are no longer embedded in the request body, limiting them to the Authorization header.

Enhancements:
- Add transparent, best-effort at-send-time migration that rewrites existing plaintext emailConfig.configDetails secrets to encrypted form.
- Update SMTP and local SMTP senders to decrypt stored credentials only at send time, preserving support for legacy plaintext values.
- Clarify configuration documentation regarding the shared encryption.util.secret.key used for fax and email credentials.

Tests:
- Add unit tests for EmailConfigSecrets covering encryption/decryption behavior, idempotency, mixed-field migration, and failure handling.
- Add a SendGrid sender unit test asserting that the serialized request payload no longer contains the API key.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Encrypts SMTP passwords and SendGrid API keys at rest, and stops showing PDF passwords in the UI and chart notes. Hardens the send path and migration so null/missing fields or missing keys don’t crash sends and secrets never leak.

- **Bug Fixes**
  - Encrypt `password` and `api_key` inside `emailConfig.configDetails` at rest; decrypt only when sending; never log secrets; on decrypt failure use a safe message, preserve the crypto cause, and mark the email failed.
  - Remove the SendGrid API key from the request body; send it via the Authorization: Bearer header only.
  - Handle missing or null `api_key`/`password` without NPEs; surface a clean “invalid credentials” error.
  - Do not decrypt the LOCAL SMTP password (auth is off) so a missing/rotated key can’t block a local send.
  - Hide PDF passwords in Manage Emails and in chart notes; keep the safe password hint.
  - Add unit tests for encrypt/decrypt round-trip and to assert the SendGrid payload contains no API key.

- **Migration**
  - Set `encryption.util.secret.key` in config (256-bit base64).
  - No DB migration needed; plaintext configs auto-encrypt on first send. If the key or persistence fails, sending continues; set the key and resend to upgrade.

<sup>Written for commit 4f48ecc8b48a6b48195fd8a8fdc60179afab8941. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

