### PR TITLE
fix: standardize SecurityException messages to canonical format in encounter and casemgmt actions

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementEntry2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementEntry2Action.java
@@ -148,7 +148,7 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
         }
 
         if (!securityInfoManager.hasPrivilege(loggedInInfo, "_demographic", "r", null)) {
-            throw new SecurityException("missing required security object (_demographic)");
+            throw new SecurityException("missing required sec object (_demographic)");
         }
 
         restoreFromSession();
@@ -757,7 +757,7 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
             return null;
         }
         if (!securityInfoManager.hasPrivilege(loggedInInfo, "_demographic", "w", null)) {
-            throw new SecurityException("missing required security object (_demographic)");
+            throw new SecurityException("missing required sec object (_demographic)");
         }
 
         String demoNo = getDemographicNo(request);

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/ClientImage2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/ClientImage2Action.java
@@ -182,7 +182,7 @@ public class ClientImage2Action extends ActionSupport implements UploadedFilesAw
             throw new SecurityException("User session is not valid");
         }
         if (!securityInfoManager.hasPrivilege(loggedInInfo, "_demographic", "w", null)) {
-            throw new SecurityException("missing required security object (_demographic)");
+            throw new SecurityException("missing required sec object (_demographic)");
         }
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/config/pageUtil/ConsultationLookup2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/config/pageUtil/ConsultationLookup2Action.java
@@ -62,7 +62,7 @@ public class ConsultationLookup2Action extends ActionSupport {
     public String execute() {
         // Security check - user must have consultation read access
         if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_con", "r", null)) {
-            throw new SecurityException("missing required security object");
+            throw new SecurityException("missing required sec object (_con)");
         }
 
         String method = request.getParameter("method");

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/config/pageUtil/CpsoSearch2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/config/pageUtil/CpsoSearch2Action.java
@@ -79,7 +79,7 @@ public class CpsoSearch2Action extends ActionSupport {
     public String execute() {
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
         if (loggedInInfo == null || !securityInfoManager.hasPrivilege(loggedInInfo, "_admin,_admin.consult", "w", null)) {
-            throw new SecurityException("missing required security object _admin.consult");
+            throw new SecurityException("missing required sec object (_admin.consult)");
         }
 
         String lastName = request.getParameter("lastName");

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/ConsultationClinicalData2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/ConsultationClinicalData2Action.java
@@ -76,7 +76,7 @@ public class ConsultationClinicalData2Action extends ActionSupport {
 
     public String execute() {
         if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_con", "r", null)) {
-            throw new SecurityException("missing required security object _con");
+            throw new SecurityException("missing required sec object (_con)");
         }
         String method = request.getParameter("method");
         if ("fetchLongTermMedications".equals(method)) {

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctAddMeasurementGroup2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctAddMeasurementGroup2Action.java
@@ -108,7 +108,7 @@ public class EctAddMeasurementGroup2Action extends ActionSupport {
             return SUCCESS;
 
         } else {
-            throw new SecurityException("Access Denied!"); //missing required sec object (_admin)
+            throw new SecurityException("missing required sec object (_admin)");
         }
     }
     private String[] selectedAddTypes;

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctAddMeasurementMap2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctAddMeasurementMap2Action.java
@@ -97,7 +97,7 @@ public class EctAddMeasurementMap2Action extends ActionSupport {
             return outcome;
 
         } else {
-            throw new SecurityException("Access Denied!"); //missing required sec object (_admin)
+            throw new SecurityException("missing required sec object (_admin)");
 
         }
     }

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctAddMeasurementType2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctAddMeasurementType2Action.java
@@ -101,7 +101,7 @@ public class EctAddMeasurementType2Action extends ActionSupport {
             return SUCCESS;
 
         } else {
-            throw new SecurityException("Access Denied!"); //missing required sec object (_admin)
+            throw new SecurityException("missing required sec object (_admin)")
         }
 
     }

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctAddMeasuringInstruction2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctAddMeasuringInstruction2Action.java
@@ -149,7 +149,7 @@ public class EctAddMeasuringInstruction2Action extends ActionSupport {
             return SUCCESS;
 
         } else {
-            throw new SecurityException("Access Denied!"); //missing required sec object (_admin)
+            throw new SecurityException("missing required sec object (_admin)");
         }
 
     }

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctDefineNewMeasurementGroup2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctDefineNewMeasurementGroup2Action.java
@@ -94,8 +94,7 @@ public class EctDefineNewMeasurementGroup2Action extends ActionSupport {
             return "continue";
 
         } else {
-            throw new SecurityException("Access Denied!"); //missing required sec object (_admin)
-        }
+            throw new SecurityException("missing required sec object (_admin)");
     }
 
     /*****************************************************************************************

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctDeleteMeasurementStyleSheet2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctDeleteMeasurementStyleSheet2Action.java
@@ -92,7 +92,7 @@ public class EctDeleteMeasurementStyleSheet2Action extends ActionSupport {
             return SUCCESS;
 
         } else {
-            throw new SecurityException("Access Denied!"); //missing required sec object (_admin)
+            throw new SecurityException("missing required sec object (_admin)");
         }
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctDeleteMeasurementTypes2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctDeleteMeasurementTypes2Action.java
@@ -103,7 +103,7 @@ public class EctDeleteMeasurementTypes2Action extends ActionSupport {
             return SUCCESS;
 
         } else {
-            throw new SecurityException("Access Denied!"); //missing required sec object (_admin)
+            throw new SecurityException("missing required sec object (_admin)");
         }
     }
     private String[] deleteCheckbox;

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctEditMeasurementGroup2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctEditMeasurementGroup2Action.java
@@ -94,7 +94,7 @@ public class EctEditMeasurementGroup2Action extends ActionSupport {
             return SUCCESS;
 
         } else {
-            throw new SecurityException("Access Denied!"); //missing required sec object (_admin)
+            throw new SecurityException("missing required sec object (_admin)");
         }
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctEditMeasurementStyle2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctEditMeasurementStyle2Action.java
@@ -77,7 +77,7 @@ public class EctEditMeasurementStyle2Action extends ActionSupport {
             return "continue";
 
         } else {
-            throw new SecurityException("Access Denied!"); //missing required sec object (_admin)
+            throw new SecurityException("missing required sec object (_admin)");
         }
 
     }

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctRemoveMeasurementMap2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctRemoveMeasurementMap2Action.java
@@ -108,7 +108,7 @@ public class EctRemoveMeasurementMap2Action extends ActionSupport {
             return outcome;
 
         } else {
-            throw new SecurityException("Access Denied!"); //missing required sec object (_admin)
+            throw new SecurityException("missing required sec object (_admin)");
         }
 
     }

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSetupAddMeasurementGroup2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSetupAddMeasurementGroup2Action.java
@@ -80,7 +80,7 @@ public class EctSetupAddMeasurementGroup2Action extends ActionSupport {
             return "continue";
 
         } else {
-            throw new SecurityException("Access Denied!"); //missing required sec object (_admin)
+            throw new SecurityException("missing required sec object (_admin)");
         }
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSetupAddMeasurementStyleSheet2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSetupAddMeasurementStyleSheet2Action.java
@@ -56,7 +56,7 @@ public final class EctSetupAddMeasurementStyleSheet2Action extends ActionSupport
 
         if (!securityInfoManager.hasPrivilege(loggedInInfo, "_admin", "r", null)
                 && !securityInfoManager.hasPrivilege(loggedInInfo, "_admin.measurements", "r", null)) {
-            throw new SecurityException("missing required security object (_admin or _admin.measurements)");
+            throw new SecurityException("missing required sec object (_admin or _admin.measurements)");
         }
 
         return "continue";

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSetupDisplayMeasurementStyleSheet2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSetupDisplayMeasurementStyleSheet2Action.java
@@ -62,7 +62,7 @@ public final class EctSetupDisplayMeasurementStyleSheet2Action extends ActionSup
             return "continue";
 
         } else {
-            throw new SecurityException("Access Denied!"); //missing required sec object (_admin)
+            throw new SecurityException("missing required sec object (_admin)");
         }
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSetupDisplayMeasurementTypes2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSetupDisplayMeasurementTypes2Action.java
@@ -62,7 +62,7 @@ public final class EctSetupDisplayMeasurementTypes2Action extends ActionSupport 
             return "continue";
 
         } else {
-            throw new SecurityException("Access Denied!"); //missing required sec object (_admin)
+            throw new SecurityException("missing required sec object (_admin)");
 
         }
     }

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSetupEditMeasurementGroup2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSetupEditMeasurementGroup2Action.java
@@ -77,7 +77,7 @@ public class EctSetupEditMeasurementGroup2Action extends ActionSupport {
             return "continue";
 
         } else {
-            throw new SecurityException("Access Denied!"); //missing required sec object (_admin)
+            throw new SecurityException("missing required sec object (_admin)");
         }
 
     }

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSetupGroupList2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSetupGroupList2Action.java
@@ -65,7 +65,7 @@ public final class EctSetupGroupList2Action extends ActionSupport {
             return "continue";
 
         } else {
-            throw new SecurityException("Access Denied!"); //missing required sec object (_admin)
+            throw new SecurityException("missing required sec object (_admin)");
 
         }
     }

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSetupStyleSheetList2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarMeasurements/pageUtil/EctSetupStyleSheetList2Action.java
@@ -66,7 +66,6 @@ public final class EctSetupStyleSheetList2Action extends ActionSupport {
             return "continue";
 
         } else {
-            throw new SecurityException("Access Denied!"); //missing required sec object (_admin) or (_admin.measurements)
-        }
+            throw new SecurityException("missing required sec object (_admin)");
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/pageUtil/EctInsertTemplate2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/pageUtil/EctInsertTemplate2Action.java
@@ -49,7 +49,7 @@ public final class EctInsertTemplate2Action extends ActionSupport {
 
     public String execute() throws Exception {
         if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_newCasemgmt.templates", "r", null)) {
-            throw new SecurityException("missing required security object: _newCasemgmt.templates");
+            throw new SecurityException("missing required sec object (_newCasemgmt.templates)");
         }
 
         String templateName = request.getParameter("templateName");


### PR DESCRIPTION
## Description

Standardizes non-canonical `SecurityException` messages across encounter and case management action classes to match the format mandated by CLAUDE.md:

`missing required sec object (_objectname)`

Changes made:
- Replaced `"missing required security object"` (spelled out) with the abbreviated `"sec object"` form
- Added missing parentheses around object names where absent
- Fixed colon separator to parentheses in `EctInsertTemplate2Action`
- Replaced `"Access Denied!"` placeholder messages in 15 measurement admin actions with the correct canonical format, using the object name from the nearby `hasPrivilege()` check as the source of truth


## Related Issues

Fixes #2598

## How Was This Tested?

Verified with `grep -rn "missing required security object"` that all in-scope files no longer contain non-canonical messages. No functional logic was changed.

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Enhancements:
- Align security-related exception messages with the canonical format, including consistent use of abbreviated "sec object" wording and parenthesized object names in encounter and case management actions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized `SecurityException` messages to the canonical format "missing required sec object (...)" across encounter and case management actions for consistent error handling. No behavior changes.

- **Refactors**
  - Replaced non-canonical strings and "Access Denied!" placeholders with the canonical format in encounter, consultation, and measurement admin actions (e.g., `_demographic`, `_con`, `_admin`, `_admin.consult`, `_newCasemgmt.templates`).
  - Normalized formatting: added parentheses around object names and changed colon separators to parentheses where needed.

<sup>Written for commit 04d767f0c0c57609b810b5ed1ac82fdfa2d0d359. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

