### PR TITLE
Fix cross-patient allergy archive/activate IDOR

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/prescript/data/RxPatientData.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/data/RxPatientData.java
@@ -205,8 +205,8 @@ public class RxPatientData {
                 return null;
             }
             if (allergy.getDemographicNo() != getDemographicNo()) {
-                MiscUtils.getLogger().warn("Blocked cross-patient allergy access: allergyId={} demographicNo={} sessionDemographicNo={}",
-                        id, allergy.getDemographicNo(), getDemographicNo());
+                MiscUtils.getLogger().warn("Blocked cross-patient allergy access: demographicNo={} sessionDemographicNo={}",
+                        allergy.getDemographicNo(), getDemographicNo());
                 return null;
             }
             PartialDate pd = partialDateDao.getPartialDate(PartialDate.ALLERGIES, allergy.getId(), PartialDate.ALLERGIES_STARTDATE);
@@ -239,8 +239,8 @@ public class RxPatientData {
                 return false;
             }
             if (allergy.getDemographicNo() != getDemographicNo()) {
-                MiscUtils.getLogger().warn("Blocked cross-patient allergy archive: allergyId={} demographicNo={} sessionDemographicNo={}",
-                        allergyId, allergy.getDemographicNo(), getDemographicNo());
+                MiscUtils.getLogger().warn("Blocked cross-patient allergy archive: demographicNo={} sessionDemographicNo={}",
+                        allergy.getDemographicNo(), getDemographicNo());
                 return false;
             }
             allergy.setArchived(archive);

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/data/RxPatientData.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/data/RxPatientData.java
@@ -192,6 +192,13 @@ public class RxPatientData {
             else return "";
         }
 
+        /**
+         * Finds an allergy only when it belongs to this patient.
+         *
+         * @param id allergy identifier
+         * @return the allergy when found and owned by this patient; {@code null} when the
+         *         allergy does not exist or belongs to a different patient
+         */
         public Allergy getAllergy(int id) {
             Allergy allergy = allergyDao.find(id);
             if (allergy == null) {

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/data/RxPatientData.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/data/RxPatientData.java
@@ -198,9 +198,8 @@ public class RxPatientData {
                 return null;
             }
             if (allergy.getDemographicNo() != getDemographicNo()) {
-                MiscUtils.getLogger().warn("Blocked cross-patient allergy access: allergyId=" + id
-                        + " demographicNo=" + allergy.getDemographicNo()
-                        + " sessionDemographicNo=" + getDemographicNo());
+                MiscUtils.getLogger().warn("Blocked cross-patient allergy access: allergyId={} demographicNo={} sessionDemographicNo={}",
+                        id, allergy.getDemographicNo(), getDemographicNo());
                 return null;
             }
             PartialDate pd = partialDateDao.getPartialDate(PartialDate.ALLERGIES, allergy.getId(), PartialDate.ALLERGIES_STARTDATE);
@@ -233,9 +232,8 @@ public class RxPatientData {
                 return false;
             }
             if (allergy.getDemographicNo() != getDemographicNo()) {
-                MiscUtils.getLogger().warn("Blocked cross-patient allergy archive: allergyId=" + allergyId
-                        + " demographicNo=" + allergy.getDemographicNo()
-                        + " sessionDemographicNo=" + getDemographicNo());
+                MiscUtils.getLogger().warn("Blocked cross-patient allergy archive: allergyId={} demographicNo={} sessionDemographicNo={}",
+                        allergyId, allergy.getDemographicNo(), getDemographicNo());
                 return false;
             }
             allergy.setArchived(archive);

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/data/RxPatientData.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/data/RxPatientData.java
@@ -194,6 +194,15 @@ public class RxPatientData {
 
         public Allergy getAllergy(int id) {
             Allergy allergy = allergyDao.find(id);
+            if (allergy == null) {
+                return null;
+            }
+            if (allergy.getDemographicNo() != getDemographicNo()) {
+                MiscUtils.getLogger().warn("Blocked cross-patient allergy access: allergyId=" + id
+                        + " demographicNo=" + allergy.getDemographicNo()
+                        + " sessionDemographicNo=" + getDemographicNo());
+                return null;
+            }
             PartialDate pd = partialDateDao.getPartialDate(PartialDate.ALLERGIES, allergy.getId(), PartialDate.ALLERGIES_STARTDATE);
             if (pd != null) allergy.setStartDateFormat(pd.getFormat());
 
@@ -218,15 +227,20 @@ public class RxPatientData {
             partialDateDao.setPartialDate(PartialDate.ALLERGIES, allergy.getId(), PartialDate.ALLERGIES_STARTDATE, allergy.getStartDateFormat());
         }
 
-        private static boolean setAllergyArchive(int allergyId, boolean archive) {
+        private boolean setAllergyArchive(int allergyId, boolean archive) {
             Allergy allergy = allergyDao.find(allergyId);
-            if (allergy != null) {
-                allergy.setArchived(archive);
-                allergyDao.merge(allergy);
-                return (true);
+            if (allergy == null) {
+                return false;
             }
-
-            return (false);
+            if (allergy.getDemographicNo() != getDemographicNo()) {
+                MiscUtils.getLogger().warn("Blocked cross-patient allergy archive: allergyId=" + allergyId
+                        + " demographicNo=" + allergy.getDemographicNo()
+                        + " sessionDemographicNo=" + getDemographicNo());
+                return false;
+            }
+            allergy.setArchived(archive);
+            allergyDao.merge(allergy);
+            return true;
         }
 
         public boolean deleteAllergy(int allergyId) {

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxAddAllergy2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxAddAllergy2Action.java
@@ -150,7 +150,7 @@ public final class RxAddAllergy2Action extends ActionSupport {
                     LogAction.addLog(LoggedInInfo.getLoggedInInfoFromSession(request).getLoggedInProviderNo(), LogConst.ARCHIVE, LogConst.CON_ALLERGY, "" + allergyToArchive, ip, "" + patient.getDemographicNo(), null);
                 }
             } catch (NumberFormatException e) {
-                MiscUtils.getLogger().warn("Ignoring non-numeric allergyToArchive parameter: " + allergyToArchive);
+                MiscUtils.getLogger().warn("Ignoring non-numeric allergyToArchive parameter: {}", allergyToArchive);
             }
         }
 

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxAddAllergy2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxAddAllergy2Action.java
@@ -61,7 +61,7 @@ public final class RxAddAllergy2Action extends ActionSupport {
 
     public String execute() throws IOException, ServletException {
         if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_allergy", "w", null)) {
-            throw new RuntimeException("missing required sec object (_allergy)");
+            throw new SecurityException("missing required sec object (_allergy)");
         }
 
         String id = request.getParameter("ID");
@@ -144,8 +144,10 @@ public final class RxAddAllergy2Action extends ActionSupport {
 
         // Archive old allergy if modifying an existing one
         if (allergyToArchive != null && !allergyToArchive.isEmpty() && !"null".equals(allergyToArchive)) {
-            patient.deleteAllergy(Integer.parseInt(allergyToArchive));
-            LogAction.addLog(LoggedInInfo.getLoggedInInfoFromSession(request).getLoggedInProviderNo(), LogConst.ARCHIVE, LogConst.CON_ALLERGY, "" + allergyToArchive, ip, "" + patient.getDemographicNo(), null);
+            boolean archived = patient.deleteAllergy(Integer.parseInt(allergyToArchive));
+            if (archived) {
+                LogAction.addLog(LoggedInInfo.getLoggedInInfoFromSession(request).getLoggedInProviderNo(), LogConst.ARCHIVE, LogConst.CON_ALLERGY, "" + allergyToArchive, ip, "" + patient.getDemographicNo(), null);
+            }
         }
 
         return SUCCESS;

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxAddAllergy2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxAddAllergy2Action.java
@@ -144,9 +144,13 @@ public final class RxAddAllergy2Action extends ActionSupport {
 
         // Archive old allergy if modifying an existing one
         if (allergyToArchive != null && !allergyToArchive.isEmpty() && !"null".equals(allergyToArchive)) {
-            boolean archived = patient.deleteAllergy(Integer.parseInt(allergyToArchive));
-            if (archived) {
-                LogAction.addLog(LoggedInInfo.getLoggedInInfoFromSession(request).getLoggedInProviderNo(), LogConst.ARCHIVE, LogConst.CON_ALLERGY, "" + allergyToArchive, ip, "" + patient.getDemographicNo(), null);
+            try {
+                boolean archived = patient.deleteAllergy(Integer.parseInt(allergyToArchive));
+                if (archived) {
+                    LogAction.addLog(LoggedInInfo.getLoggedInInfoFromSession(request).getLoggedInProviderNo(), LogConst.ARCHIVE, LogConst.CON_ALLERGY, "" + allergyToArchive, ip, "" + patient.getDemographicNo(), null);
+                }
+            } catch (NumberFormatException e) {
+                MiscUtils.getLogger().warn("Ignoring non-numeric allergyToArchive parameter: " + allergyToArchive);
             }
         }
 

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxDeleteAllergy2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxDeleteAllergy2Action.java
@@ -60,7 +60,7 @@ public final class RxDeleteAllergy2Action extends ActionSupport {
             throws IOException, ServletException {
 
         if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_allergy", "u", null)) {
-            throw new RuntimeException("missing required sec object (_allergy)");
+            throw new SecurityException("missing required sec object (_allergy)");
         }
 
 
@@ -86,6 +86,10 @@ public final class RxDeleteAllergy2Action extends ActionSupport {
         RxPatientData.Patient patient = (RxPatientData.Patient) request.getSession().getAttribute("Patient");
 
         Allergy allergy = patient.getAllergy(id);
+        if (allergy == null) {
+            response.sendError(HttpServletResponse.SC_FORBIDDEN);
+            return NONE;
+        }
         if (action != null && action.equals("activate")) {
             patient.activateAllergy(id);
             String ip = request.getRemoteAddr();

--- a/src/main/webapp/WEB-INF/jsp/rx/AddReaction2.jsp
+++ b/src/main/webapp/WEB-INF/jsp/rx/AddReaction2.jsp
@@ -96,7 +96,7 @@
                     onsetOfReaction = a.getOnsetOfReaction() != null ? a.getOnsetOfReaction() : "";
                     nonDrug = a.isNonDrug();
                 }
-                if (a.getArchived() && nkdaId != null) allergyToArchive = nkdaId;
+                if (a != null && a.getArchived() && nkdaId != null) allergyToArchive = nkdaId;
             } else {
                 if (nkdaId != null) allergyToArchive = nkdaId;
             }

--- a/src/test/java/io/github/carlos_emr/carlos/prescript/data/RxPatientDataAllergyOwnershipUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/prescript/data/RxPatientDataAllergyOwnershipUnitTest.java
@@ -30,6 +30,7 @@ import org.mockito.MockitoAnnotations;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -73,7 +74,7 @@ class RxPatientDataAllergyOwnershipUnitTest extends CarlosUnitTestBase {
         // initialized in this JVM/fork: its <clinit> resolves AllergyDao via
         // SpringUtils.getBean, and an unmocked failure here permanently poisons
         // the class (NoClassDefFoundError) for every other test in the same fork.
-        registerMock(AllergyDao.class, org.mockito.Mockito.mock(AllergyDao.class));
+        registerMock(AllergyDao.class, mock(AllergyDao.class));
 
         mocks = MockitoAnnotations.openMocks(this);
 

--- a/src/test/java/io/github/carlos_emr/carlos/prescript/data/RxPatientDataAllergyOwnershipUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/prescript/data/RxPatientDataAllergyOwnershipUnitTest.java
@@ -166,6 +166,7 @@ class RxPatientDataAllergyOwnershipUnitTest extends CarlosUnitTestBase {
     @DisplayName("activateAllergy should reactivate and return true when the allergy belongs to the session patient")
     void shouldActivateAndReturnTrue_whenDemographicNoMatches() {
         Allergy allergy = allergyOwnedBy(SESSION_DEMOGRAPHIC_NO);
+        allergy.setArchived(true);
         when(mockAllergyDao.find(ALLERGY_ID)).thenReturn(allergy);
 
         boolean result = patient.activateAllergy(ALLERGY_ID);

--- a/src/test/java/io/github/carlos_emr/carlos/prescript/data/RxPatientDataAllergyOwnershipUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/prescript/data/RxPatientDataAllergyOwnershipUnitTest.java
@@ -1,0 +1,188 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.prescript.data;
+
+import io.github.carlos_emr.carlos.commn.dao.AllergyDao;
+import io.github.carlos_emr.carlos.commn.dao.PartialDateDao;
+import io.github.carlos_emr.carlos.commn.model.Allergy;
+import io.github.carlos_emr.carlos.commn.model.Demographic;
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
+
+import java.lang.reflect.Field;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the allergy ownership check added to {@link RxPatientData.Patient}
+ * to close issue #2467 (cross-patient allergy archive/activate IDOR).
+ *
+ * <p>{@code Patient.allergyDao} is a {@code private static} field hydrated once
+ * from {@code SpringUtils.getBean(AllergyDao.class)} at class-load time, so it
+ * cannot be substituted through the normal {@link CarlosUnitTestBase#registerMock}
+ * flow. This test swaps it via reflection for the duration of the test and
+ * restores the original value afterward to avoid leaking state into other tests.
+ *
+ * @since 2026-07-06
+ */
+@DisplayName("RxPatientData.Patient allergy ownership unit tests")
+@Tag("unit")
+@Tag("rx")
+class RxPatientDataAllergyOwnershipUnitTest extends CarlosUnitTestBase {
+
+    private static final int SESSION_DEMOGRAPHIC_NO = 200;
+    private static final int OTHER_DEMOGRAPHIC_NO = 100;
+    private static final int ALLERGY_ID = 42;
+
+    private AutoCloseable mocks;
+    private Field allergyDaoField;
+    private Object originalAllergyDao;
+
+    @Mock
+    private AllergyDao mockAllergyDao;
+
+    @Mock
+    private PartialDateDao mockPartialDateDao;
+
+    private RxPatientData.Patient patient;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        // Bootstrap mock in case this is the first time RxPatientData.Patient is
+        // initialized in this JVM/fork: its <clinit> resolves AllergyDao via
+        // SpringUtils.getBean, and an unmocked failure here permanently poisons
+        // the class (NoClassDefFoundError) for every other test in the same fork.
+        registerMock(AllergyDao.class, org.mockito.Mockito.mock(AllergyDao.class));
+
+        mocks = MockitoAnnotations.openMocks(this);
+
+        allergyDaoField = RxPatientData.Patient.class.getDeclaredField("allergyDao");
+        allergyDaoField.setAccessible(true);
+        originalAllergyDao = allergyDaoField.get(null);
+        allergyDaoField.set(null, mockAllergyDao);
+
+        registerMock(PartialDateDao.class, mockPartialDateDao);
+
+        Demographic demographic = new Demographic();
+        demographic.setDemographicNo(SESSION_DEMOGRAPHIC_NO);
+        patient = new RxPatientData.Patient(demographic);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        allergyDaoField.set(null, originalAllergyDao);
+        if (mocks != null) {
+            mocks.close();
+        }
+    }
+
+    private Allergy allergyOwnedBy(int demographicNo) {
+        Allergy allergy = new Allergy();
+        allergy.setDemographicNo(demographicNo);
+        return allergy;
+    }
+
+    @Test
+    @DisplayName("getAllergy should return the allergy when it belongs to the session patient")
+    void shouldReturnAllergy_whenDemographicNoMatches() {
+        Allergy allergy = allergyOwnedBy(SESSION_DEMOGRAPHIC_NO);
+        when(mockAllergyDao.find(ALLERGY_ID)).thenReturn(allergy);
+
+        Allergy result = patient.getAllergy(ALLERGY_ID);
+
+        assertThat(result).isSameAs(allergy);
+    }
+
+    @Test
+    @DisplayName("getAllergy should return null when the allergy belongs to a different patient")
+    void shouldReturnNull_whenDemographicNoDiffers() {
+        Allergy allergy = allergyOwnedBy(OTHER_DEMOGRAPHIC_NO);
+        when(mockAllergyDao.find(ALLERGY_ID)).thenReturn(allergy);
+
+        Allergy result = patient.getAllergy(ALLERGY_ID);
+
+        assertThat(result).isNull();
+        verify(mockPartialDateDao, never()).getPartialDate(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("getAllergy should return null when the allergy does not exist")
+    void shouldReturnNull_whenAllergyNotFound() {
+        when(mockAllergyDao.find(ALLERGY_ID)).thenReturn(null);
+
+        Allergy result = patient.getAllergy(ALLERGY_ID);
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("deleteAllergy should archive and return true when the allergy belongs to the session patient")
+    void shouldArchiveAndReturnTrue_whenDemographicNoMatches() {
+        Allergy allergy = allergyOwnedBy(SESSION_DEMOGRAPHIC_NO);
+        when(mockAllergyDao.find(ALLERGY_ID)).thenReturn(allergy);
+
+        boolean result = patient.deleteAllergy(ALLERGY_ID);
+
+        assertThat(result).isTrue();
+        assertThat(allergy.getArchived()).isTrue();
+        verify(mockAllergyDao).merge(allergy);
+    }
+
+    @Test
+    @DisplayName("deleteAllergy should not archive and return false when the allergy belongs to a different patient")
+    void shouldNotArchiveAndReturnFalse_whenDemographicNoDiffers() {
+        Allergy allergy = allergyOwnedBy(OTHER_DEMOGRAPHIC_NO);
+        when(mockAllergyDao.find(ALLERGY_ID)).thenReturn(allergy);
+
+        boolean result = patient.deleteAllergy(ALLERGY_ID);
+
+        assertThat(result).isFalse();
+        verify(mockAllergyDao, never()).merge(any());
+    }
+
+    @Test
+    @DisplayName("activateAllergy should reactivate and return true when the allergy belongs to the session patient")
+    void shouldActivateAndReturnTrue_whenDemographicNoMatches() {
+        Allergy allergy = allergyOwnedBy(SESSION_DEMOGRAPHIC_NO);
+        when(mockAllergyDao.find(ALLERGY_ID)).thenReturn(allergy);
+
+        boolean result = patient.activateAllergy(ALLERGY_ID);
+
+        assertThat(result).isTrue();
+        assertThat(allergy.getArchived()).isFalse();
+        verify(mockAllergyDao).merge(allergy);
+    }
+
+    @Test
+    @DisplayName("activateAllergy should not reactivate and return false when the allergy belongs to a different patient")
+    void shouldNotActivateAndReturnFalse_whenDemographicNoDiffers() {
+        Allergy allergy = allergyOwnedBy(OTHER_DEMOGRAPHIC_NO);
+        when(mockAllergyDao.find(ALLERGY_ID)).thenReturn(allergy);
+
+        boolean result = patient.activateAllergy(ALLERGY_ID);
+
+        assertThat(result).isFalse();
+        verify(mockAllergyDao, never()).merge(any());
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxAddAllergy2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxAddAllergy2ActionTest.java
@@ -164,4 +164,18 @@ class RxAddAllergy2ActionTest extends CarlosUnitTestBase {
                 eq("provider1"), eq(LogConst.ARCHIVE), eq(LogConst.CON_ALLERGY),
                 eq("42"), any(String.class), eq("123"), isNull()));
     }
+
+    @Test
+    @DisplayName("should ignore a non-numeric allergyToArchive instead of throwing")
+    void shouldIgnoreArchiveAttempt_whenAllergyToArchiveIsNotNumeric() throws Exception {
+        mockRequest.setParameter("allergyToArchive", "abc");
+
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(ActionSupport.SUCCESS);
+        verify(mockRxPatient, never()).deleteAllergy(anyInt());
+        logActionMock.verify(() -> LogAction.addLog(
+                any(String.class), eq(LogConst.ARCHIVE), any(String.class),
+                any(String.class), any(String.class), any(String.class), any()), never());
+    }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxAddAllergy2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxAddAllergy2ActionTest.java
@@ -13,15 +13,14 @@
 package io.github.carlos_emr.carlos.prescript.pageUtil;
 
 import io.github.carlos_emr.carlos.commn.dao.AllergyDao;
-import io.github.carlos_emr.carlos.commn.model.Allergy;
 import io.github.carlos_emr.carlos.log.LogAction;
+import io.github.carlos_emr.carlos.log.LogConst;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.prescript.data.RxPatientData;
 import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 
 import org.apache.struts2.ActionSupport;
 import org.apache.struts2.ServletActionContext;
@@ -48,16 +47,17 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * Unit tests for {@link RxDeleteAllergy2Action} ID parameter validation and deletion flow.
- * Covers missing, blank, and invalid IDs returning bad request, plus successful deletion
- * with audit logging verification when the ID is valid.
+ * Unit tests for {@link RxAddAllergy2Action}, focused on the "archive old allergy"
+ * branch that regressed to an IDOR (issue #2467): the audit log must only record
+ * an archive when {@link RxPatientData.Patient#deleteAllergy(int)} actually
+ * archived a record owned by the session patient.
  *
- * @since 2026-05-29
+ * @since 2026-07-06
  */
-@DisplayName("RxDeleteAllergy2Action Unit Tests")
+@DisplayName("RxAddAllergy2Action Unit Tests")
 @Tag("unit")
 @Tag("rx")
-class RxDeleteAllergy2ActionTest extends CarlosUnitTestBase {
+class RxAddAllergy2ActionTest extends CarlosUnitTestBase {
 
     private MockedStatic<ServletActionContext> servletActionContextMock;
     private MockedStatic<LoggedInInfo> loggedInInfoMock;
@@ -72,12 +72,9 @@ class RxDeleteAllergy2ActionTest extends CarlosUnitTestBase {
     @Mock
     private RxPatientData.Patient mockRxPatient;
 
-    @Mock
-    private Allergy mockAllergy;
-
     private MockHttpServletRequest mockRequest;
     private MockHttpServletResponse mockResponse;
-    private RxDeleteAllergy2Action action;
+    private RxAddAllergy2Action action;
 
     @BeforeEach
     void setUp() {
@@ -92,18 +89,24 @@ class RxDeleteAllergy2ActionTest extends CarlosUnitTestBase {
         mockResponse = new MockHttpServletResponse();
 
         registerMock(SecurityInfoManager.class, mockSecurityInfoManager);
-        when(mockSecurityInfoManager.hasPrivilege(any(LoggedInInfo.class), eq("_allergy"), eq("u"), isNull()))
+        when(mockSecurityInfoManager.hasPrivilege(any(LoggedInInfo.class), eq("_allergy"), eq("w"), isNull()))
                 .thenReturn(true);
 
         loggedInInfoMock = mockStatic(LoggedInInfo.class);
         loggedInInfoMock.when(() -> LoggedInInfo.getLoggedInInfoFromSession(any(HttpServletRequest.class)))
                 .thenReturn(mockLoggedInInfo);
+        when(mockLoggedInInfo.getLoggedInProviderNo()).thenReturn("provider1");
 
         servletActionContextMock = mockStatic(ServletActionContext.class);
         servletActionContextMock.when(ServletActionContext::getRequest).thenReturn(mockRequest);
         servletActionContextMock.when(ServletActionContext::getResponse).thenReturn(mockResponse);
 
-        action = new RxDeleteAllergy2Action();
+        mockRequest.setParameter("type", "1");
+        mockRequest.setParameter("startDate", "");
+        mockRequest.getSession().setAttribute("Patient", mockRxPatient);
+        when(mockRxPatient.getDemographicNo()).thenReturn(123);
+
+        action = new RxAddAllergy2Action();
     }
 
     @AfterEach
@@ -120,80 +123,45 @@ class RxDeleteAllergy2ActionTest extends CarlosUnitTestBase {
     }
 
     @Test
-    @DisplayName("should return bad request when ID parameter is missing")
-    void shouldReturn400BadRequest_whenIdParameterIsMissing() throws Exception {
+    @DisplayName("should add allergy and log ADD when no prior allergy is archived")
+    void shouldAddAllergyAndLogAdd_whenNoAllergyToArchive() throws Exception {
         String result = action.execute();
 
-        assertThat(result).isEqualTo(ActionSupport.NONE);
-        assertThat(mockResponse.getStatus()).isEqualTo(HttpServletResponse.SC_BAD_REQUEST);
-        assertThat(mockResponse.getErrorMessage()).isEqualTo("Missing ID parameter");
+        assertThat(result).isEqualTo(ActionSupport.SUCCESS);
+        verify(mockRxPatient).addAllergy(any(), any());
+        logActionMock.verify(() -> LogAction.addLog(
+                eq("provider1"), eq(LogConst.ADD), eq(LogConst.CON_ALLERGY),
+                any(String.class), any(String.class), eq("123"), any(String.class)));
+        verify(mockRxPatient, never()).deleteAllergy(anyInt());
     }
 
     @Test
-    @DisplayName("should return bad request when ID parameter is blank")
-    void shouldReturn400BadRequest_whenIdParameterIsBlank() throws Exception {
-        mockRequest.setParameter("ID", " ");
-
-        String result = action.execute();
-
-        assertThat(result).isEqualTo(ActionSupport.NONE);
-        assertThat(mockResponse.getStatus()).isEqualTo(HttpServletResponse.SC_BAD_REQUEST);
-        assertThat(mockResponse.getErrorMessage()).isEqualTo("Missing ID parameter");
-    }
-
-    @Test
-    @DisplayName("should return bad request when ID parameter is invalid")
-    void shouldReturn400BadRequest_whenIdParameterIsInvalid() throws Exception {
-        mockRequest.setParameter("ID", "abc");
-
-        String result = action.execute();
-
-        assertThat(result).isEqualTo(ActionSupport.NONE);
-        assertThat(mockResponse.getStatus()).isEqualTo(HttpServletResponse.SC_BAD_REQUEST);
-        assertThat(mockResponse.getErrorMessage()).isEqualTo("Invalid ID parameter");
-    }
-
-    @Test
-    @DisplayName("should delete allergy when ID parameter is valid")
-    void shouldDeleteAllergy_whenIdParameterIsValid() throws Exception {
-        mockRequest.setParameter("ID", "42");
-        mockRequest.setParameter("demographicNo", "123");
-        mockRequest.getSession().setAttribute("Patient", mockRxPatient);
-        when(mockRxPatient.getAllergy(42)).thenReturn(mockAllergy);
-        when(mockRxPatient.deleteAllergy(42)).thenReturn(true);
-        when(mockRxPatient.getDemographicNo()).thenReturn(123);
-        when(mockLoggedInInfo.getLoggedInProviderNo()).thenReturn("provider1");
-        when(mockAllergy.getAuditString()).thenReturn("audit");
+    @DisplayName("should not log archive when archived allergy belongs to a different patient")
+    void shouldNotLogArchive_whenAllergyBelongsToDifferentPatient() throws Exception {
+        mockRequest.setParameter("allergyToArchive", "42");
+        when(mockRxPatient.deleteAllergy(42)).thenReturn(false);
 
         String result = action.execute();
 
         assertThat(result).isEqualTo(ActionSupport.SUCCESS);
-        assertThat(mockResponse.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
-        assertThat(mockRequest.getAttribute("demographicNo")).isEqualTo("123");
         verify(mockRxPatient).deleteAllergy(42);
         logActionMock.verify(() -> LogAction.addLog(
-                eq("provider1"),
-                eq("delete"),
-                eq("allergy"),
-                eq("42"),
-                any(String.class),
-                eq("123"),
-                eq("audit")));
+                any(String.class), eq(LogConst.ARCHIVE), any(String.class),
+                any(String.class), any(String.class), any(String.class), any()), never());
     }
 
     @Test
-    @DisplayName("should return forbidden when allergy does not belong to the session patient")
-    void shouldReturn403Forbidden_whenAllergyBelongsToDifferentPatient() throws Exception {
-        mockRequest.setParameter("ID", "42");
-        mockRequest.getSession().setAttribute("Patient", mockRxPatient);
-        when(mockRxPatient.getAllergy(42)).thenReturn(null);
+    @DisplayName("should log archive when archived allergy belongs to the session patient")
+    void shouldLogArchive_whenAllergyBelongsToSessionPatient() throws Exception {
+        mockRequest.setParameter("allergyToArchive", "42");
+        when(mockRxPatient.deleteAllergy(42)).thenReturn(true);
 
         String result = action.execute();
 
-        assertThat(result).isEqualTo(ActionSupport.NONE);
-        assertThat(mockResponse.getStatus()).isEqualTo(HttpServletResponse.SC_FORBIDDEN);
-        verify(mockRxPatient, never()).deleteAllergy(anyInt());
-        verify(mockRxPatient, never()).activateAllergy(anyInt());
-        logActionMock.verifyNoInteractions();
+        assertThat(result).isEqualTo(ActionSupport.SUCCESS);
+        verify(mockRxPatient).deleteAllergy(42);
+        logActionMock.verify(() -> LogAction.addLog(
+                eq("provider1"), eq(LogConst.ARCHIVE), eq(LogConst.CON_ALLERGY),
+                eq("42"), any(String.class), eq("123"), isNull()));
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxAddAllergy2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxAddAllergy2ActionTest.java
@@ -36,6 +36,7 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
@@ -120,6 +121,18 @@ class RxAddAllergy2ActionTest extends CarlosUnitTestBase {
         if (mocks != null) {
             mocks.close();
         }
+    }
+
+    @Test
+    @DisplayName("should throw SecurityException when missing _allergy privilege")
+    void shouldThrowSecurityException_whenPrivilegeMissing() {
+        when(mockSecurityInfoManager.hasPrivilege(any(LoggedInInfo.class), eq("_allergy"), eq("w"), isNull()))
+                .thenReturn(false);
+
+        assertThatThrownBy(() -> action.execute())
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("_allergy");
+        verify(mockRxPatient, never()).addAllergy(any(), any());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `RxPatientData.Patient.getAllergy(int)` and `setAllergyArchive(int, boolean)` fetched an `Allergy` by bare ID via `allergyDao.find(id)` without checking it belonged to the session patient. Any authenticated provider with `_allergy` rights could archive/reactivate, or read the clinical detail of, another patient's allergy by supplying an arbitrary ID.
- Both methods now compare `allergy.getDemographicNo()` against the session patient's `getDemographicNo()` and reject (`null`/`false`) on mismatch, logging a warning (IDs only) so the attempt is visible in logs — previously the audit log only ever recorded the session patient's demographic number, never the victim's.
- `RxDeleteAllergy2Action` now returns `403` (matching the existing `RxWriteScript2Action` precedent for this same shape of check) instead of proceeding/NPEing when the fetch is rejected.
- `RxAddAllergy2Action` only writes the `ARCHIVE` audit log entry when the archive actually succeeded, instead of unconditionally logging a fabricated entry. It also no longer throws an uncaught `NumberFormatException` if `allergyToArchive` is malformed (caught in review).
- `AddReaction2.jsp` guards a null dereference (`a.getArchived()`) that the fix would otherwise trigger on every blocked cross-patient attempt.
- Adjacent hygiene: the two existing privilege checks in the touched action files now throw `SecurityException` instead of `RuntimeException`, per project convention.

## Test plan
- [x] New `RxPatientDataAllergyOwnershipUnitTest` — direct coverage of the ownership check in `RxPatientData.Patient` (both match/mismatch cases for `getAllergy`, `deleteAllergy`, `activateAllergy`)
- [x] `RxDeleteAllergy2ActionTest` — added `shouldReturn403Forbidden_whenAllergyBelongsToDifferentPatient`
- [x] `RxAddAllergy2ActionTest` — covers add, archive logging gated on actual success, and the non-numeric `allergyToArchive` case
- [x] `mvn test -Dtest=RxDeleteAllergy2ActionTest,RxAddAllergy2ActionTest,RxPatientDataAllergyOwnershipUnitTest` passes (16/16), order-independent
- [x] `mvn test -Dtest="io.github.carlos_emr.carlos.prescript.**"` — 230 tests, no new failures (1 pre-existing unrelated failure confirmed present on `develop` before this change)

Supersedes #3129, which was accidentally branched off an unrelated in-progress branch and bundled ~70 unmerged commits. This PR is branched directly off `develop` and contains only the allergy-IDOR fix.

Fixes #2467

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cross-patient IDOR in allergy read/archive/activate by enforcing session-patient ownership and returning 403 on mismatches. Clarifies `getAllergy` null-on-forbidden behavior, tightens audit logs, and hardens input parsing (fixes #2467).

- **Bug Fixes**
  - `RxPatientData.Patient#getAllergy` and `#setAllergyArchive` now verify `demographicNo`; on mismatch return null/false and log a parameterized warning with demographic numbers only (no allergyId).
  - `RxDeleteAllergy2Action` returns 403 when the allergy does not belong to the session patient.
  - `RxAddAllergy2Action` only logs `ARCHIVE` when the archive succeeds; ignores non-numeric `allergyToArchive`.
  - `AddReaction2.jsp` adds a null check before `getArchived()` to avoid NPEs on blocked attempts.
  - Privilege checks in `RxAddAllergy2Action` and `RxDeleteAllergy2Action` now throw `SecurityException`.

- **Refactors**
  - Documented the null-on-forbidden contract in `RxPatientData.Patient#getAllergy`; strengthened tests by seeding the activate case with an archived allergy and adding a negative-path privilege test.

<sup>Written for commit 5d4411f141de58038a8fe7fd2455720679e98e43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

