### PR TITLE
fix: remove raw JSON request body logging from tickler mutation endpo…

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/TicklerWebService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/TicklerWebService.java
@@ -274,7 +274,7 @@ public class TicklerWebService extends AbstractServiceImpl {
         }
 
 
-        MiscUtils.getLogger().debug("completeTicklers called, count={}", json.has("ticklers") ? json.get("ticklers").size() : 0);
+        MiscUtils.getLogger().debug("completeTicklers called, count={}", json != null && json.has("ticklers") ? json.get("ticklers").size() : 0);
 
         List<Integer> ticklerIds;
         try {
@@ -300,7 +300,7 @@ public class TicklerWebService extends AbstractServiceImpl {
             throw new RuntimeException("Access Denied");
         }
 
-        MiscUtils.getLogger().debug("deleteTicklers called, count={}", json.has("ticklers") ? json.get("ticklers").size() : 0);
+        MiscUtils.getLogger().debug("deleteTicklers called, count={}", json != null && json.has("ticklers") ? json.get("ticklers").size() : 0);
 
         List<Integer> ticklerIds;
         try {
@@ -357,7 +357,7 @@ public class TicklerWebService extends AbstractServiceImpl {
             throw new RuntimeException("Access Denied");
         }
 
-        MiscUtils.getLogger().debug("updateTickler called, id={}", LogSafe.sanitize(json.has("id") ? json.get("id").asText() : "null"));
+        MiscUtils.getLogger().debug("updateTickler called, id={}", LogSafe.sanitize(json != null && json.has("id") ? json.get("id").asText() : "null"));
 
         Tickler tickler = ticklerManager.getTickler(getLoggedInInfo(), json.get("id") != null ? json.get("id").asInt() : null);
 

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/TicklerWebService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/TicklerWebService.java
@@ -65,6 +65,7 @@ import io.github.carlos_emr.carlos.webserv.rest.to.model.TicklerTextSuggestTo1;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.github.carlos_emr.carlos.utility.LogSafe;
 
 @Path("/tickler")
 @Component("ticklerWebService")
@@ -273,7 +274,7 @@ public class TicklerWebService extends AbstractServiceImpl {
         }
 
 
-        MiscUtils.getLogger().info(json.toString());
+        MiscUtils.getLogger().debug("completeTicklers called, count={}", json.has("ticklers") ? json.get("ticklers").size() : 0);
 
         List<Integer> ticklerIds;
         try {
@@ -299,7 +300,7 @@ public class TicklerWebService extends AbstractServiceImpl {
             throw new RuntimeException("Access Denied");
         }
 
-        MiscUtils.getLogger().info(json.toString());
+        MiscUtils.getLogger().debug("deleteTicklers called, count={}", json.has("ticklers") ? json.get("ticklers").size() : 0);
 
         List<Integer> ticklerIds;
         try {
@@ -356,7 +357,7 @@ public class TicklerWebService extends AbstractServiceImpl {
             throw new RuntimeException("Access Denied");
         }
 
-        MiscUtils.getLogger().info(json.toString());
+        MiscUtils.getLogger().debug("updateTickler called, id={}", LogSafe.sanitize(json.has("id") ? json.get("id").asText() : "null"));
 
         Tickler tickler = ticklerManager.getTickler(getLoggedInInfo(), json.get("id") != null ? json.get("id").asInt() : null);
 


### PR DESCRIPTION
## Description
`TicklerWebService` logged the full JSON request body verbatim at INFO level 
in three mutation endpoints via `MiscUtils.getLogger().info(json.toString())`. 
This caused patient-correlating data — including tickler IDs, message text, 
task assignments, and service dates — to be written to application logs on 
every request. Logs are not an appropriate store for PHI-correlating data and 
may be ingested by log aggregation systems or monitoring tools.

This PR removes the three raw log lines and replaces them with safe operational 
metadata logging at DEBUG level, following the `LogSafe.sanitize()` pattern 
established in PR #2611:
- `completeTicklers()` — logs count of tickler IDs only
- `deleteTicklers()` — logs count of tickler IDs only  
- `updateTickler()` — logs sanitized tickler ID only via `LogSafe.sanitize()`

## Related Issues
Fixes #2982

## How Was This Tested?
Reproduced the issue locally by sending authenticated curl requests to the 
three endpoints while tailing `catalina.out`. Before the fix, the log showed:

INFO rest.TicklerWebService (TicklerWebService.java:276) - {"ticklers":[1]}

After the fix, no request body content appears in the logs. The endpoints 
continue to return 200 SUCCESS. Rebuilt with `make install` — clean compile, 
no regressions.

## Screenshots
**Before — raw JSON logged at INFO level:**
<img width="424" height="88" alt="ss1" src="https://github.com/user-attachments/assets/481f52c4-e1d4-437e-af55-f4bb4eadc1be" />

**After — no request body content in logs (raw JSON line absent)**

## Checklist
- [x] My commits are signed off for the DCO (`git commit -s`)
- [x] My commits follow Conventional Commits format
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need 
      new tests.
- [x] I have read the contributing guide

## Summary by Sourcery

Restrict tickler mutation endpoint logging to non-PHI operational metadata and lower the log level to avoid recording raw request bodies.

Bug Fixes:
- Stop logging full JSON request bodies for tickler mutation endpoints to prevent patient-correlating data from being written to application logs.

Enhancements:
- Add debug-level logging for tickler completion and deletion that records only the count of tickler IDs processed.
- Add sanitized debug-level logging for tickler updates that records only a safe tickler ID identifier via the shared LogSafe utility.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes raw JSON request body logging from `TicklerWebService` mutation endpoints to prevent PHI in logs. Adds DEBUG-level, null-safe metadata logs instead. Fixes #2982.

- **Bug Fixes**
  - `completeTicklers`: log count of tickler IDs only (DEBUG), with null guard.
  - `deleteTicklers`: log count of tickler IDs only (DEBUG), with null guard.
  - `updateTickler`: log sanitized tickler ID via `LogSafe.sanitize()` (DEBUG), with null guard.

<sup>Written for commit 979ff6d40bd7cfb5292c4deb2f4ee5dc93200a1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

