### PR TITLE
fix: return from consultation print confirmation

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConfirmConsultationRequest.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConfirmConsultationRequest.jsp
@@ -110,11 +110,13 @@
                 <p class="text-muted mb-2" style="font-size:0.9rem;">Printing Consultation form...</p>
             <% } %>
 
-            <p class="text-muted mb-3" style="font-size:0.85rem;">
-                <fmt:message key="encounter.oscarConsultationRequest.ConfirmConsultationRequest.msgClose5Sec"/>
-                <br>
-                <span id="countdown" class="fw-semibold">5</span>s
-            </p>
+            <% if (!"true".equals(isPreview)) { %>
+                <p class="text-muted mb-3" style="font-size:0.85rem;">
+                    <fmt:message key="encounter.oscarConsultationRequest.ConfirmConsultationRequest.msgClose5Sec"/>
+                    <br>
+                    <span id="countdown" class="fw-semibold">5</span>s
+                </p>
+            <% } %>
 
             <button type="button" id="closeButton" class="btn btn-sm btn-outline-secondary">
                 <i class="fa-solid fa-xmark me-1"></i><fmt:message key="global.btnClose"/>
@@ -122,8 +124,7 @@
         </div>
 
     <script>
-        var PRINT_CLOSE_DELAY_MS = 10000;
-        var BLOB_URL_REVOKE_DELAY_MS = PRINT_CLOSE_DELAY_MS + 5000;
+        var BLOB_URL_REVOKE_DELAY_MS = 15000;
 
         function BackToOscar() {
             closeOrReturn();
@@ -147,7 +148,15 @@
         }
 
         function finishPage(secs) {
-            // Countdown display
+            // Print consultation request form
+            const consultPDFName = '<carlos:encode value='<%= String.valueOf(request.getAttribute("consultPDFName")) %>' context="javaScriptBlock"/>';
+            const consultPDF = '<carlos:encode value='<%= String.valueOf(request.getAttribute("consultPDF")) %>' context="javaScriptBlock"/>';
+            const isPreviewReady = '<carlos:encode value='<%= String.valueOf(request.getAttribute("isPreviewReady")) %>' context="javaScriptBlock"/>';
+            if (consultPDF !== 'null' && consultPDFName !== 'null' && isPreviewReady === 'true') {
+                downloadConsultForm(consultPDFName, consultPDF);
+                return;
+            }
+
             var remaining = secs;
             var countdownEl = document.getElementById('countdown');
             var timer = setInterval(function() {
@@ -155,18 +164,6 @@
                 if (countdownEl) countdownEl.textContent = remaining;
                 if (remaining <= 0) clearInterval(timer);
             }, 1000);
-
-            // Print consultation request form
-            const consultPDFName = '<carlos:encode value='<%= String.valueOf(request.getAttribute("consultPDFName")) %>' context="javaScriptBlock"/>';
-            const consultPDF = '<carlos:encode value='<%= String.valueOf(request.getAttribute("consultPDF")) %>' context="javaScriptBlock"/>';
-            const isPreviewReady = '<carlos:encode value='<%= String.valueOf(request.getAttribute("isPreviewReady")) %>' context="javaScriptBlock"/>';
-            if (consultPDF !== 'null' && consultPDFName !== 'null' && isPreviewReady === 'true') {
-                downloadConsultForm(consultPDFName, consultPDF, function () {
-                    window.setTimeout(closeOrReturn, PRINT_CLOSE_DELAY_MS);
-                });
-                return;
-            }
-
             window.setTimeout(closeOrReturn, secs * 1000);
         }
 
@@ -184,7 +181,9 @@
             window.setTimeout(function () {
                 URL.revokeObjectURL(objectUrl);
             }, BLOB_URL_REVOKE_DELAY_MS);
-            callback();
+            if (typeof callback === 'function') {
+                callback();
+            }
         }
 
         document.getElementById('closeButton').addEventListener('click', BackToOscar);

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConfirmConsultationRequest.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConfirmConsultationRequest.jsp
@@ -122,6 +122,9 @@
         </div>
 
     <script>
+        var PRINT_CLOSE_DELAY_MS = 10000;
+        var BLOB_URL_REVOKE_DELAY_MS = PRINT_CLOSE_DELAY_MS + 5000;
+
         function BackToOscar() {
             closeOrReturn();
         }
@@ -159,7 +162,7 @@
             const isPreviewReady = '<carlos:encode value='<%= String.valueOf(request.getAttribute("isPreviewReady")) %>' context="javaScriptBlock"/>';
             if (consultPDF !== 'null' && consultPDFName !== 'null' && isPreviewReady === 'true') {
                 downloadConsultForm(consultPDFName, consultPDF, function () {
-                    window.setTimeout(closeOrReturn, secs * 1000);
+                    window.setTimeout(closeOrReturn, PRINT_CLOSE_DELAY_MS);
                 });
                 return;
             }
@@ -171,10 +174,16 @@
             const pdfData = new Uint8Array(atob(consultPDF).split('').map(char => char.charCodeAt(0)));
             const pdfBlob = new Blob([pdfData], {type: 'application/pdf'});
             const downloadLink = document.createElement('a');
-            downloadLink.href = URL.createObjectURL(pdfBlob);
+            const objectUrl = URL.createObjectURL(pdfBlob);
+            downloadLink.href = objectUrl;
             downloadLink.download = consultPDFName;
+            downloadLink.style.display = 'none';
+            document.body.appendChild(downloadLink);
             downloadLink.click();
-            URL.revokeObjectURL(downloadLink.href);
+            document.body.removeChild(downloadLink);
+            window.setTimeout(function () {
+                URL.revokeObjectURL(objectUrl);
+            }, BLOB_URL_REVOKE_DELAY_MS);
             callback();
         }
 

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConfirmConsultationRequest.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConfirmConsultationRequest.jsp
@@ -55,7 +55,12 @@
     if (fallbackDemographicNo == null || fallbackDemographicNo.trim().isEmpty()) {
         fallbackDemographicNo = request.getParameter("de");
     }
-    if (fallbackDemographicNo == null) {
+    if (fallbackDemographicNo != null) {
+        fallbackDemographicNo = fallbackDemographicNo.trim();
+        if (!fallbackDemographicNo.matches("[1-9]\\d*")) {
+            fallbackDemographicNo = "";
+        }
+    } else {
         fallbackDemographicNo = "";
     }
     String fallbackUrl = request.getContextPath() + "/encounter/oscarConsultationRequest/ViewDisplayDemographicConsultationRequests";

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConfirmConsultationRequest.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConfirmConsultationRequest.jsp
@@ -51,6 +51,17 @@
     // Store transType as a local variable for safe comparison
     String transType = (String) request.getAttribute("transType");
     String isPreview = (String) request.getAttribute("isPreviewReady");
+    String fallbackDemographicNo = request.getParameter("demographicNo");
+    if (fallbackDemographicNo == null || fallbackDemographicNo.trim().isEmpty()) {
+        fallbackDemographicNo = request.getParameter("de");
+    }
+    if (fallbackDemographicNo == null) {
+        fallbackDemographicNo = "";
+    }
+    String fallbackUrl = request.getContextPath() + "/encounter/oscarConsultationRequest/ViewDisplayDemographicConsultationRequests";
+    if (!fallbackDemographicNo.trim().isEmpty()) {
+        fallbackUrl += "?de=" + java.net.URLEncoder.encode(fallbackDemographicNo, java.nio.charset.StandardCharsets.UTF_8);
+    }
 %>
 <!DOCTYPE html>
 <html>
@@ -61,7 +72,7 @@
         <script type="text/javascript" src="<%= request.getContextPath() %>/js/global.js"></script>
     </head>
 
-    <body onload="finishPage(5);" class="d-flex align-items-center justify-content-center" style="min-height:100vh; background-color:var(--carlos-bg-light);">
+    <body class="d-flex align-items-center justify-content-center" style="min-height:100vh; background-color:var(--carlos-bg-light);">
 
         <div class="text-center p-4" style="max-width:420px;">
             <div class="mb-3">
@@ -100,14 +111,31 @@
                 <span id="countdown" class="fw-semibold">5</span>s
             </p>
 
-            <a href="javascript:BackToOscar();" class="btn btn-sm btn-outline-secondary">
+            <button type="button" id="closeButton" class="btn btn-sm btn-outline-secondary">
                 <i class="fa-solid fa-xmark me-1"></i><fmt:message key="global.btnClose"/>
-            </a>
+            </button>
         </div>
 
     <script>
         function BackToOscar() {
-            window.close();
+            closeOrReturn();
+        }
+
+        function closeOrReturn() {
+            if (window.opener && !window.opener.closed) {
+                window.close();
+                window.setTimeout(returnToConsultations, 100);
+                return;
+            }
+            returnToConsultations();
+        }
+
+        function returnToConsultations() {
+            if (window.history.length > 1 && document.referrer) {
+                window.history.back();
+                return;
+            }
+            window.location.href = '<carlos:encode value='<%= fallbackUrl %>' context="javaScriptBlock"/>';
         }
 
         function finishPage(secs) {
@@ -126,12 +154,12 @@
             const isPreviewReady = '<carlos:encode value='<%= String.valueOf(request.getAttribute("isPreviewReady")) %>' context="javaScriptBlock"/>';
             if (consultPDF !== 'null' && consultPDFName !== 'null' && isPreviewReady === 'true') {
                 downloadConsultForm(consultPDFName, consultPDF, function () {
-                    setTimeout("window.close()", secs * 1000);
+                    window.setTimeout(closeOrReturn, secs * 1000);
                 });
                 return;
             }
 
-            setTimeout("window.close()", secs * 500);
+            window.setTimeout(closeOrReturn, secs * 1000);
         }
 
         function downloadConsultForm(consultPDFName, consultPDF, callback) {
@@ -144,6 +172,9 @@
             URL.revokeObjectURL(downloadLink.href);
             callback();
         }
+
+        document.getElementById('closeButton').addEventListener('click', BackToOscar);
+        finishPage(5);
     </script>
     </body>
 </html>


### PR DESCRIPTION
## Description

Fixes the consultation print confirmation screen so it does not get stuck when the browser will not allow `window.close()`.

The confirmation page still closes when it is running in a script-opened popup. If the page is in a normal tab or another non-closable context, Close/the countdown now returns through browser history when there is a referrer, or falls back to the patient's consultation request list.

This also removes the `javascript:` Close link and string-based `setTimeout("window.close()", ...)` calls from the confirmation page.

## Related Issues

None linked.

## How Was This Tested?

- `bash scripts/check-jsp-taglibs.sh`
- `git diff --check`
- `mvn -DskipTests compile`
- Focused Playwright check against the updated close/return logic:
  - direct same-origin navigation returns through history
  - direct landing without referrer falls back to the consultation list URL
  - script-opened popup still closes

## Screenshots

Not applicable. The confirmation screen layout is unchanged.

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the consultation print confirmation so it doesn’t hang when `window.close()` is blocked and improves PDF download handling. Popups still close; tabs go back or redirect to the patient’s consultation list, and PDF previews now stay open until the user clicks Close.

- **Bug Fixes**
  - Close-or-return flow: close if script-opened popup; otherwise go back when there’s a referrer/history, else redirect to the consultation list. Countdown is shown only for non-preview paths; the Close button triggers the same logic.
  - Safer downloads and fallbacks: replaced the `javascript:` link with a button and `setTimeout`, delayed PDF object URL revocation by 15s, stopped auto-closing after PDF preview downloads, and validated the fallback patient id (`demographicNo`/`de`) as numeric before building the encoded redirect URL.

<sup>Written for commit b8bc6c704ba0586fdafb7df4b235bdddc0c12703. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

