### PR TITLE
fix: persist consultation signatures before preview PDF

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/ConsultationPDFCreator.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/ConsultationPDFCreator.java
@@ -84,6 +84,7 @@ public class ConsultationPDFCreator extends PdfPageEventHelper {
     private Font heading;
     private EctConsultationFormRequestUtil reqFrm;
     private byte[] signatureImageOverride;
+    private boolean suppressSignature;
     private CarlosProperties props;
     private ClinicData clinic;
     private ResourceBundle oscarR;
@@ -118,6 +119,7 @@ public class ConsultationPDFCreator extends PdfPageEventHelper {
         if (signatureOverride instanceof byte[] byteArray) {
             signatureImageOverride = byteArray;
         }
+        suppressSignature = Boolean.TRUE.equals(request.getAttribute(ConsultationSignatureService.SUPPRESS_SIGNATURE_ATTRIBUTE));
         props = CarlosProperties.getInstance();
         clinic = new ClinicData();
         oscarR = ResourceBundle.getBundle("oscarResources", request.getLocale());
@@ -228,7 +230,7 @@ public class ConsultationPDFCreator extends PdfPageEventHelper {
         addTable(border, createConsultDetailTable());
 
         // Add the provider's signature.
-        if ((signatureImageOverride != null && signatureImageOverride.length > 0) || getlen(reqFrm.signatureImg) > 0) {
+        if (shouldRenderSignature(suppressSignature, signatureImageOverride, reqFrm.signatureImg)) {
             addSignature(border);
         }
 
@@ -831,6 +833,14 @@ public class ConsultationPDFCreator extends PdfPageEventHelper {
             logger.error("Error loading consultation digital signature {}", parsedId, e);
             return null;
         }
+    }
+
+    static boolean shouldRenderSignature(boolean suppressSignature, byte[] signatureImageOverride, String signatureImageId) {
+        if (suppressSignature) {
+            return false;
+        }
+        return (signatureImageOverride != null && signatureImageOverride.length > 0)
+                || (signatureImageId != null && !signatureImageId.isEmpty());
     }
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2Action.java
@@ -702,9 +702,17 @@ public class EctConsultationFormRequest2Action extends ActionSupport {
         }
         int consultationRequestId = parsedConsultationRequestId;
 
-        ConsultationPreviewSignatureOutcome outcome = consultationSignatureService.saveManualSignatureForPreview(
-                loggedInInfo, consultationRequestId, demographicId, submittedSignatureImg,
-                manualSignatureRequestId, signatureProviderNo);
+        ConsultationPreviewSignatureOutcome outcome;
+        try {
+            outcome = consultationSignatureService.saveManualSignatureForPreview(
+                    loggedInInfo, consultationRequestId, demographicId, submittedSignatureImg,
+                    manualSignatureRequestId, signatureProviderNo);
+        } catch (RuntimeException e) {
+            logger.error("Unable to persist captured consultation signature before print preview (requestId={})",
+                    consultationRequestId, e);
+            warnSignatureNotApplied();
+            return true;
+        }
         if (outcome.isSaved()) {
             this.setSignatureImg(outcome.signatureId());
             request.setAttribute(ATTR_PREVIEW_SIGNATURE_IMG, outcome.signatureId());

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2Action.java
@@ -711,8 +711,8 @@ public class EctConsultationFormRequest2Action extends ActionSupport {
                     loggedInInfo, consultationRequestId, demographicId, submittedSignatureImg,
                     manualSignatureRequestId, signatureProviderNo);
         } catch (DataAccessException | PersistenceException | TransactionException e) {
-            logger.error("Unable to persist captured consultation signature before print preview (requestId={})",
-                    consultationRequestId, e);
+            logger.error("Unable to persist captured consultation signature before print preview (requestId={}, provider={})",
+                    consultationRequestId, LogSafe.sanitize(signatureProviderNo), e);
             warnSignatureNotApplied();
             return true;
         }

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2Action.java
@@ -728,6 +728,7 @@ public class EctConsultationFormRequest2Action extends ActionSupport {
     private void warnSignatureNotApplied() {
         request.setAttribute(ATTR_SIGNATURE_NOT_APPLIED, Boolean.TRUE);
         request.setAttribute(ATTR_WARNING_MESSAGE, SIGNATURE_NOT_APPLIED_WARNING);
+        request.setAttribute(ConsultationSignatureService.SUPPRESS_SIGNATURE_ATTRIBUTE, Boolean.TRUE);
     }
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2Action.java
@@ -115,6 +115,7 @@ public class EctConsultationFormRequest2Action extends ActionSupport {
     private static final String ATTR_SIGNATURE_IMG = "signatureImg";
     private static final String ATTR_PREVIEW_SIGNATURE_IMG = "consultPreviewSignatureImg";
     private static final String SIGNATURE_NOT_APPLIED_WARNING = "The captured signature could not be saved and will not appear on the PDF.";
+    private static final String INVALID_DEMOGRAPHIC_NUMBER = "Invalid demographic number";
 
     private Integer parseUpdateInteger(String rawValue, String logMessage, String actionErrorMessage) {
         try {
@@ -204,7 +205,7 @@ public class EctConsultationFormRequest2Action extends ActionSupport {
                     demographicId = Integer.parseInt(demographicNo);
                 } catch (NumberFormatException e) {
                     MiscUtils.getLogger().error("Invalid demographic number for new consultation: {}", demographicNo);
-                    addActionError("Invalid demographic number");
+                    addActionError(INVALID_DEMOGRAPHIC_NUMBER);
                     return INPUT;
                 }
 
@@ -377,7 +378,7 @@ public class EctConsultationFormRequest2Action extends ActionSupport {
 
             Integer parsedDemographicId = parseUpdateInteger(demographicNo,
                     "Invalid demographic number for consultation update: {}",
-                    "Invalid demographic number");
+                    INVALID_DEMOGRAPHIC_NUMBER);
             if (parsedDemographicId == null) {
                 return INPUT;
             }
@@ -686,7 +687,7 @@ public class EctConsultationFormRequest2Action extends ActionSupport {
 
         Integer demographicId = parseUpdateInteger(demographicNo,
                 "Invalid demographic number for consultation print preview signature: {}",
-                "Invalid demographic number");
+                INVALID_DEMOGRAPHIC_NUMBER);
         if (demographicId == null) {
             request.setAttribute(ATTR_ERROR_MESSAGE, "A print preview of this consultation could not be generated. \n\nInvalid demographic number.");
             return false;

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2Action.java
@@ -57,12 +57,15 @@ import io.github.carlos_emr.carlos.lab.ca.on.LabResultData;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.persistence.PersistenceException;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.*;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.springframework.dao.DataAccessException;
+import org.springframework.transaction.TransactionException;
 
 /**
  * Struts2 action that handles creating, updating, printing, faxing, and electronically
@@ -707,7 +710,7 @@ public class EctConsultationFormRequest2Action extends ActionSupport {
             outcome = consultationSignatureService.saveManualSignatureForPreview(
                     loggedInInfo, consultationRequestId, demographicId, submittedSignatureImg,
                     manualSignatureRequestId, signatureProviderNo);
-        } catch (RuntimeException e) {
+        } catch (DataAccessException | PersistenceException | TransactionException e) {
             logger.error("Unable to persist captured consultation signature before print preview (requestId={})",
                     consultationRequestId, e);
             warnSignatureNotApplied();

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2Action.java
@@ -111,6 +111,9 @@ public class EctConsultationFormRequest2Action extends ActionSupport {
     private static final ObjectMapper objectMapper = new ObjectMapper();
     private static final String ATTR_SIGNATURE_NOT_APPLIED = "signatureNotApplied";
     private static final String ATTR_ERROR_MESSAGE = "errorMessage";
+    private static final String ATTR_WARNING_MESSAGE = "warningMessage";
+    private static final String ATTR_SIGNATURE_IMG = "signatureImg";
+    private static final String SIGNATURE_NOT_APPLIED_WARNING = "The captured signature could not be saved and will not appear on the PDF.";
 
     private Integer parseUpdateInteger(String rawValue, String logMessage, String actionErrorMessage) {
         try {
@@ -552,11 +555,15 @@ public class EctConsultationFormRequest2Action extends ActionSupport {
             try {
                 if (StringUtils.isBlank(requestId)) {
                     request.setAttribute(ATTR_ERROR_MESSAGE, "A print preview of this consultation could not be generated. \n\nMissing consultation request id.");
-                } else {
-                    byte[] signatureImageOverride = consultationSignatureService.resolvePreviewSignatureImage(
-                            loggedInInfo, newSignature, trimmedSignatureImg, newSignatureImg, signatureProviderNo);
-                    if (signatureImageOverride != null && signatureImageOverride.length > 0) {
-                        request.setAttribute(ConsultationSignatureService.SIGNATURE_IMAGE_OVERRIDE_ATTRIBUTE, signatureImageOverride);
+                } else if (persistManualSignatureForRendering(loggedInInfo, requestId, demographicNo,
+                            newSignature, trimmedSignatureImg, manualSignatureRequestId,
+                            signatureProviderNo, consultationRequestDao)) {
+                    if (!newSignature) {
+                        byte[] signatureImageOverride = consultationSignatureService.resolvePreviewSignatureImage(
+                                loggedInInfo, false, trimmedSignatureImg, newSignatureImg, signatureProviderNo);
+                        if (signatureImageOverride != null && signatureImageOverride.length > 0) {
+                            request.setAttribute(ConsultationSignatureService.SIGNATURE_IMAGE_OVERRIDE_ATTRIBUTE, signatureImageOverride);
+                        }
                     }
                     renderConsultationFormWithAttachments(request, response, requestId, demographicNo);
                 }
@@ -669,6 +676,74 @@ public class EctConsultationFormRequest2Action extends ActionSupport {
         return NONE;
     }
 
+    private boolean persistManualSignatureForRendering(LoggedInInfo loggedInInfo, String requestId, String demographicNo,
+                                                       boolean newSignature, String submittedSignatureImg,
+                                                       String manualSignatureRequestId, String signatureProviderNo,
+                                                       ConsultationRequestDao consultationRequestDao) {
+        if (!newSignature) {
+            return true;
+        }
+
+        Integer demographicId = parseUpdateInteger(demographicNo,
+                "Invalid demographic number for consultation print preview signature: {}",
+                "Invalid demographic number");
+        if (demographicId == null) {
+            request.setAttribute(ATTR_ERROR_MESSAGE, "A print preview of this consultation could not be generated. \n\nInvalid demographic number.");
+            return false;
+        }
+
+        Integer parsedConsultationRequestId = parseUpdateInteger(requestId,
+                "Invalid consultation request id for print preview signature update: {}",
+                "Invalid consultation request id");
+        if (parsedConsultationRequestId == null) {
+            request.setAttribute(ATTR_ERROR_MESSAGE, "A print preview of this consultation could not be generated. \n\nInvalid consultation request id.");
+            return false;
+        }
+        int consultationRequestId = parsedConsultationRequestId;
+
+        boolean manualCaptured = consultationSignatureService.wasManualSignatureCaptured(manualSignatureRequestId);
+        boolean manualSignatureSubmitted = StringUtils.isNotBlank(submittedSignatureImg)
+                && !SignatureReference.isStoredId(submittedSignatureImg);
+        DigitalSignature signature = digitalSignatureManager.processAndSaveDigitalSignature(
+                loggedInInfo, manualSignatureRequestId, demographicId, ModuleType.CONSULTATION);
+
+        if (signature == null) {
+            if (manualCaptured || manualSignatureSubmitted) {
+                logger.error("Captured manual signature could not be persisted for provider {} on consultation print preview (requestId={})",
+                        LogSafe.sanitize(signatureProviderNo), LogSafe.sanitize(requestId));
+                warnSignatureNotApplied();
+            } else {
+                logger.debug("No manual signature captured for consultation print preview (requestId={}); rendering unsigned", requestId);
+            }
+            return true;
+        }
+
+        String signatureId = String.valueOf(signature.getId());
+        ConsultationRequest consult = consultationRequestDao.find(consultationRequestId);
+        if (consult == null) {
+            logger.error("Consultation request not found while applying print preview signature: {}", consultationRequestId);
+            request.setAttribute(ATTR_WARNING_MESSAGE, "The captured signature was saved but could not be applied to this PDF.");
+            return true;
+        }
+        if (consult.getDemographicId() != null && !demographicId.equals(consult.getDemographicId())) {
+            logger.error("Rejected print preview signature update for requestId={} due to demographic mismatch",
+                    LogSafe.sanitize(requestId));
+            request.setAttribute(ATTR_WARNING_MESSAGE, "The captured signature was saved but could not be applied to this PDF.");
+            return true;
+        }
+
+        consult.setSignatureImg(signatureId);
+        consultationRequestDao.merge(consult);
+        this.setSignatureImg(signatureId);
+        request.setAttribute(ATTR_SIGNATURE_IMG, signatureId);
+        return true;
+    }
+
+    private void warnSignatureNotApplied() {
+        request.setAttribute(ATTR_SIGNATURE_NOT_APPLIED, Boolean.TRUE);
+        request.setAttribute(ATTR_WARNING_MESSAGE, SIGNATURE_NOT_APPLIED_WARNING);
+    }
+
     /**
      * Creates a consultation request extension entry for storing custom form fields.
      *
@@ -739,6 +814,8 @@ public class EctConsultationFormRequest2Action extends ActionSupport {
         json.put("consultPDF", (String) request.getAttribute("consultPDF"));
         json.put("consultPDFName", (String) request.getAttribute("consultPDFName"));
         json.put(ATTR_ERROR_MESSAGE, (String) request.getAttribute(ATTR_ERROR_MESSAGE));
+        json.put(ATTR_WARNING_MESSAGE, (String) request.getAttribute(ATTR_WARNING_MESSAGE));
+        json.put(ATTR_SIGNATURE_IMG, (String) request.getAttribute(ATTR_SIGNATURE_IMG));
         try {
             if (!response.isCommitted()) {
                 response.resetBuffer();

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2Action.java
@@ -557,7 +557,7 @@ public class EctConsultationFormRequest2Action extends ActionSupport {
                     request.setAttribute(ATTR_ERROR_MESSAGE, "A print preview of this consultation could not be generated. \n\nMissing consultation request id.");
                 } else if (persistManualSignatureForRendering(loggedInInfo, requestId, demographicNo,
                             newSignature, trimmedSignatureImg, manualSignatureRequestId,
-                            signatureProviderNo, consultationRequestDao)) {
+                            signatureProviderNo)) {
                     if (!newSignature) {
                         byte[] signatureImageOverride = consultationSignatureService.resolvePreviewSignatureImage(
                                 loggedInInfo, false, trimmedSignatureImg, newSignatureImg, signatureProviderNo);
@@ -678,8 +678,7 @@ public class EctConsultationFormRequest2Action extends ActionSupport {
 
     private boolean persistManualSignatureForRendering(LoggedInInfo loggedInInfo, String requestId, String demographicNo,
                                                        boolean newSignature, String submittedSignatureImg,
-                                                       String manualSignatureRequestId, String signatureProviderNo,
-                                                       ConsultationRequestDao consultationRequestDao) {
+                                                       String manualSignatureRequestId, String signatureProviderNo) {
         if (!newSignature) {
             return true;
         }
@@ -701,42 +700,28 @@ public class EctConsultationFormRequest2Action extends ActionSupport {
         }
         int consultationRequestId = parsedConsultationRequestId;
 
-        boolean manualCaptured = consultationSignatureService.wasManualSignatureCaptured(manualSignatureRequestId);
-        boolean manualSignatureSubmitted = StringUtils.isNotBlank(submittedSignatureImg)
-                && !SignatureReference.isStoredId(submittedSignatureImg);
-        DigitalSignature signature = digitalSignatureManager.processAndSaveDigitalSignature(
-                loggedInInfo, manualSignatureRequestId, demographicId, ModuleType.CONSULTATION);
-
-        if (signature == null) {
-            if (manualCaptured || manualSignatureSubmitted) {
-                logger.error("Captured manual signature could not be persisted for provider {} on consultation print preview (requestId={})",
-                        LogSafe.sanitize(signatureProviderNo), LogSafe.sanitize(requestId));
-                warnSignatureNotApplied();
-            } else {
-                logger.debug("No manual signature captured for consultation print preview (requestId={}); rendering unsigned", requestId);
-            }
+        ConsultationPreviewSignatureOutcome outcome = consultationSignatureService.saveManualSignatureForPreview(
+                loggedInInfo, consultationRequestId, demographicId, submittedSignatureImg,
+                manualSignatureRequestId, signatureProviderNo);
+        if (outcome.isSaved()) {
+            this.setSignatureImg(outcome.signatureId());
+            request.setAttribute(ATTR_SIGNATURE_IMG, outcome.signatureId());
             return true;
         }
-
-        String signatureId = String.valueOf(signature.getId());
-        ConsultationRequest consult = consultationRequestDao.find(consultationRequestId);
-        if (consult == null) {
-            logger.error("Consultation request not found while applying print preview signature: {}", consultationRequestId);
-            request.setAttribute(ATTR_WARNING_MESSAGE, "The captured signature was saved but could not be applied to this PDF.");
+        if (outcome.status() == ConsultationPreviewSignatureOutcome.Status.PERSIST_FAILED) {
+            warnSignatureNotApplied();
             return true;
         }
-        if (consult.getDemographicId() != null && !demographicId.equals(consult.getDemographicId())) {
-            logger.error("Rejected print preview signature update for requestId={} due to demographic mismatch",
-                    LogSafe.sanitize(requestId));
-            request.setAttribute(ATTR_WARNING_MESSAGE, "The captured signature was saved but could not be applied to this PDF.");
+        if (outcome.status() == ConsultationPreviewSignatureOutcome.Status.NOT_CAPTURED) {
             return true;
         }
+        if (outcome.status() == ConsultationPreviewSignatureOutcome.Status.REQUEST_NOT_FOUND) {
+            request.setAttribute(ATTR_ERROR_MESSAGE, "A print preview of this consultation could not be generated. \n\nConsultation request not found.");
+            return false;
+        }
 
-        consult.setSignatureImg(signatureId);
-        consultationRequestDao.merge(consult);
-        this.setSignatureImg(signatureId);
-        request.setAttribute(ATTR_SIGNATURE_IMG, signatureId);
-        return true;
+        request.setAttribute(ATTR_ERROR_MESSAGE, "A print preview of this consultation could not be generated. \n\nConsultation request does not match the selected patient.");
+        return false;
     }
 
     private void warnSignatureNotApplied() {

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2Action.java
@@ -113,6 +113,7 @@ public class EctConsultationFormRequest2Action extends ActionSupport {
     private static final String ATTR_ERROR_MESSAGE = "errorMessage";
     private static final String ATTR_WARNING_MESSAGE = "warningMessage";
     private static final String ATTR_SIGNATURE_IMG = "signatureImg";
+    private static final String ATTR_PREVIEW_SIGNATURE_IMG = "consultPreviewSignatureImg";
     private static final String SIGNATURE_NOT_APPLIED_WARNING = "The captured signature could not be saved and will not appear on the PDF.";
 
     private Integer parseUpdateInteger(String rawValue, String logMessage, String actionErrorMessage) {
@@ -705,7 +706,7 @@ public class EctConsultationFormRequest2Action extends ActionSupport {
                 manualSignatureRequestId, signatureProviderNo);
         if (outcome.isSaved()) {
             this.setSignatureImg(outcome.signatureId());
-            request.setAttribute(ATTR_SIGNATURE_IMG, outcome.signatureId());
+            request.setAttribute(ATTR_PREVIEW_SIGNATURE_IMG, outcome.signatureId());
             return true;
         }
         if (outcome.status() == ConsultationPreviewSignatureOutcome.Status.PERSIST_FAILED) {
@@ -800,7 +801,7 @@ public class EctConsultationFormRequest2Action extends ActionSupport {
         json.put("consultPDFName", (String) request.getAttribute("consultPDFName"));
         json.put(ATTR_ERROR_MESSAGE, (String) request.getAttribute(ATTR_ERROR_MESSAGE));
         json.put(ATTR_WARNING_MESSAGE, (String) request.getAttribute(ATTR_WARNING_MESSAGE));
-        json.put(ATTR_SIGNATURE_IMG, (String) request.getAttribute(ATTR_SIGNATURE_IMG));
+        json.put(ATTR_SIGNATURE_IMG, (String) request.getAttribute(ATTR_PREVIEW_SIGNATURE_IMG));
         try {
             if (!response.isCommitted()) {
                 response.resetBuffer();

--- a/src/main/java/io/github/carlos_emr/carlos/managers/ConsultationPreviewSignatureOutcome.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/ConsultationPreviewSignatureOutcome.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.managers;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Result of persisting a freshly captured manual consultation signature before PDF preview rendering.
+ *
+ * @param status      the outcome category
+ * @param signatureId the persisted {@code DigitalSignature.id} when {@link Status#SAVED}, otherwise empty
+ */
+public record ConsultationPreviewSignatureOutcome(Status status, String signatureId) {
+
+    public ConsultationPreviewSignatureOutcome {
+        if (status == null) {
+            throw new IllegalArgumentException("status is required");
+        }
+        signatureId = StringUtils.trimToEmpty(signatureId);
+        if ((status == Status.SAVED) != StringUtils.isNotBlank(signatureId)) {
+            throw new IllegalArgumentException("signatureId must be present iff status is SAVED");
+        }
+    }
+
+    public enum Status {
+        SAVED,
+        NOT_CAPTURED,
+        PERSIST_FAILED,
+        REQUEST_NOT_FOUND,
+        DEMOGRAPHIC_MISMATCH
+    }
+
+    static ConsultationPreviewSignatureOutcome saved(String signatureId) {
+        return new ConsultationPreviewSignatureOutcome(Status.SAVED, signatureId);
+    }
+
+    static ConsultationPreviewSignatureOutcome of(Status status) {
+        return new ConsultationPreviewSignatureOutcome(status, "");
+    }
+
+    public boolean isSaved() {
+        return status == Status.SAVED;
+    }
+}

--- a/src/main/java/io/github/carlos_emr/carlos/managers/ConsultationSignatureService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/ConsultationSignatureService.java
@@ -52,6 +52,7 @@ import java.nio.file.Path;
 public class ConsultationSignatureService {
 
     public static final String SIGNATURE_IMAGE_OVERRIDE_ATTRIBUTE = "consultationSignatureImageOverride";
+    public static final String SUPPRESS_SIGNATURE_ATTRIBUTE = "consultationSuppressSignature";
 
     private final DigitalSignatureManager digitalSignatureManager;
     private final SecurityInfoManager securityInfoManager;

--- a/src/main/java/io/github/carlos_emr/carlos/managers/ConsultationSignatureService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/ConsultationSignatureService.java
@@ -22,6 +22,8 @@
 package io.github.carlos_emr.carlos.managers;
 
 import io.github.carlos_emr.CarlosProperties;
+import io.github.carlos_emr.carlos.commn.dao.ConsultationRequestDao;
+import io.github.carlos_emr.carlos.commn.model.ConsultationRequest;
 import io.github.carlos_emr.carlos.commn.model.DigitalSignature;
 import io.github.carlos_emr.carlos.commn.model.UserProperty;
 import io.github.carlos_emr.carlos.commn.model.enumerator.ModuleType;
@@ -53,11 +55,18 @@ public class ConsultationSignatureService {
 
     private final DigitalSignatureManager digitalSignatureManager;
     private final SecurityInfoManager securityInfoManager;
+    private final ConsultationRequestDao consultationRequestDao;
 
     @Autowired
-    public ConsultationSignatureService(DigitalSignatureManager digitalSignatureManager, SecurityInfoManager securityInfoManager) {
+    public ConsultationSignatureService(DigitalSignatureManager digitalSignatureManager, SecurityInfoManager securityInfoManager,
+                                        ConsultationRequestDao consultationRequestDao) {
         this.digitalSignatureManager = digitalSignatureManager;
         this.securityInfoManager = securityInfoManager;
+        this.consultationRequestDao = consultationRequestDao;
+    }
+
+    public ConsultationSignatureService(DigitalSignatureManager digitalSignatureManager, SecurityInfoManager securityInfoManager) {
+        this(digitalSignatureManager, securityInfoManager, null);
     }
 
     /**
@@ -149,6 +158,56 @@ public class ConsultationSignatureService {
             MiscUtils.getLogger().error("Error persisting consultation stamp signature for provider {}", LogSafe.sanitize(providerNo), e);
             return ConsultationStampOutcome.of(ConsultationStampOutcome.Status.ERROR);
         }
+    }
+
+    /**
+     * Persists a freshly captured manual signature for an existing consultation before rendering the
+     * preview PDF. The consultation row is loaded and checked against the posted demographic before the
+     * temp signature is promoted to {@code DigitalSignature}, so rejected previews do not leave orphaned
+     * signature rows.
+     */
+    public ConsultationPreviewSignatureOutcome saveManualSignatureForPreview(LoggedInInfo loggedInInfo,
+                                                                            int consultationRequestId,
+                                                                            int demographicId,
+                                                                            String submittedSignatureImg,
+                                                                            String manualSignatureRequestId,
+                                                                            String signatureProviderNo) {
+        if (consultationRequestDao == null) {
+            throw new IllegalStateException("ConsultationRequestDao is required to save preview signatures");
+        }
+
+        ConsultationRequest consult = consultationRequestDao.find(consultationRequestId);
+        if (consult == null) {
+            MiscUtils.getLogger().error("Consultation request not found while applying print preview signature: {}", consultationRequestId);
+            return ConsultationPreviewSignatureOutcome.of(ConsultationPreviewSignatureOutcome.Status.REQUEST_NOT_FOUND);
+        }
+        if (!Integer.valueOf(demographicId).equals(consult.getDemographicId())) {
+            MiscUtils.getLogger().error("Rejected print preview signature update for requestId={} due to demographic mismatch",
+                    consultationRequestId);
+            return ConsultationPreviewSignatureOutcome.of(ConsultationPreviewSignatureOutcome.Status.DEMOGRAPHIC_MISMATCH);
+        }
+
+        boolean manualCaptured = wasManualSignatureCaptured(manualSignatureRequestId);
+        boolean manualSignatureSubmitted = StringUtils.isNotBlank(submittedSignatureImg)
+                && !SignatureReference.isStoredId(submittedSignatureImg);
+        DigitalSignature signature = digitalSignatureManager.processAndSaveDigitalSignature(
+                loggedInInfo, manualSignatureRequestId, demographicId, ModuleType.CONSULTATION);
+
+        if (signature == null) {
+            if (manualCaptured || manualSignatureSubmitted) {
+                MiscUtils.getLogger().error("Captured manual signature could not be persisted for provider {} on consultation print preview (requestId={})",
+                        LogSafe.sanitize(signatureProviderNo), consultationRequestId);
+                return ConsultationPreviewSignatureOutcome.of(ConsultationPreviewSignatureOutcome.Status.PERSIST_FAILED);
+            }
+            MiscUtils.getLogger().debug("No manual signature captured for consultation print preview (requestId={}); rendering unsigned",
+                    consultationRequestId);
+            return ConsultationPreviewSignatureOutcome.of(ConsultationPreviewSignatureOutcome.Status.NOT_CAPTURED);
+        }
+
+        String signatureId = String.valueOf(signature.getId());
+        consult.setSignatureImg(signatureId);
+        consultationRequestDao.merge(consult);
+        return ConsultationPreviewSignatureOutcome.saved(signatureId);
     }
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/ui/servlet/ImageRenderingServlet.java
+++ b/src/main/java/io/github/carlos_emr/carlos/ui/servlet/ImageRenderingServlet.java
@@ -30,7 +30,6 @@ package io.github.carlos_emr.carlos.ui.servlet;
 import io.github.carlos_emr.carlos.casemgmt.model.ClientImage;
 import io.github.carlos_emr.carlos.utility.*;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.Logger;
 import io.github.carlos_emr.carlos.casemgmt.dao.ClientImageDAO;
 import io.github.carlos_emr.carlos.commn.model.DigitalSignature;
@@ -115,6 +114,24 @@ public final class ImageRenderingServlet extends HttpServlet {
         if (image != null)
             bos.write(image); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- binary image stream
         bos.flush();
+    }
+
+    static String detectImageType(byte[] image) {
+        if (image != null && image.length >= 8
+                && (image[0] & 0xff) == 0x89 && image[1] == 'P' && image[2] == 'N' && image[3] == 'G'
+                && image[4] == 0x0d && image[5] == 0x0a && image[6] == 0x1a && image[7] == 0x0a) {
+            return "png";
+        }
+        if (image != null && image.length >= 3
+                && (image[0] & 0xff) == 0xff && (image[1] & 0xff) == 0xd8 && (image[2] & 0xff) == 0xff) {
+            return "jpeg";
+        }
+        if (image != null && image.length >= 6
+                && image[0] == 'G' && image[1] == 'I' && image[2] == 'F'
+                && image[3] == '8' && (image[4] == '7' || image[4] == '9') && image[5] == 'a') {
+            return "gif";
+        }
+        return "jpeg";
     }
 
     private static void renderLocalClient(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -208,7 +225,6 @@ public final class ImageRenderingServlet extends HttpServlet {
 
         try {
             // get image
-            FileInputStream fileInputStream = null;
             try {
                 String signatureRequestId = request.getParameter(DigitalSignatureUtils.SIGNATURE_REQUEST_ID_KEY);
                 
@@ -235,22 +251,16 @@ public final class ImageRenderingServlet extends HttpServlet {
 
                 // Re-validate at point of use for static analysis visibility
                 File validatedTargetFile = PathValidationUtils.validateUpload(targetFile);
-                fileInputStream = new FileInputStream(validatedTargetFile);
-                byte[] imageBytes = new byte[1024 * 256];
-                fileInputStream.read(imageBytes);
-                renderImage(response, imageBytes, "jpeg");
+                byte[] imageBytes = FileUtils.readFileToByteArray(validatedTargetFile);
+                renderImage(response, imageBytes, detectImageType(imageBytes));
                 return;
             } catch (FileNotFoundException e) {
                 // no image, render a blank gif, yes this breaks the concept
                 // of the image already exists, but it's difficult to implement the preview otherwise
                 String tempFilePath = getServletContext().getRealPath("/images/1x1.gif");
-                fileInputStream = new FileInputStream(PathValidationUtils.validateConfiguredFile(tempFilePath, "default preview image"));
-                byte[] imageBytes = new byte[1024 * 32];
-                fileInputStream.read(imageBytes);
-                renderImage(response, imageBytes, "gif");
+                byte[] imageBytes = FileUtils.readFileToByteArray(PathValidationUtils.validateConfiguredFile(tempFilePath, "default preview image"));
+                renderImage(response, imageBytes, detectImageType(imageBytes));
                 return;
-            } finally {
-                IOUtils.closeQuietly(fileInputStream);
             }
         } catch (Exception e) {
             logger.error("Unexpected error.", e);
@@ -278,7 +288,8 @@ public final class ImageRenderingServlet extends HttpServlet {
 				DigitalSignatureManager digitalSignatureManager = SpringUtils.getBean(DigitalSignatureManager.class);
 				DigitalSignature digitalSignature = digitalSignatureManager.getDigitalSignature(Integer.parseInt(digitalSignatureId));
                 if (digitalSignature != null) {
-                    renderImage(response, digitalSignature.getSignatureImage(), "jpeg");
+                    byte[] imageBytes = digitalSignature.getSignatureImage();
+                    renderImage(response, imageBytes, detectImageType(imageBytes));
                     return;
                 }
             } catch (Exception e) {

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConfirmConsultationRequest.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConfirmConsultationRequest.jsp
@@ -51,22 +51,6 @@
     // Store transType as a local variable for safe comparison
     String transType = (String) request.getAttribute("transType");
     String isPreview = (String) request.getAttribute("isPreviewReady");
-    String fallbackDemographicNo = request.getParameter("demographicNo");
-    if (fallbackDemographicNo == null || fallbackDemographicNo.trim().isEmpty()) {
-        fallbackDemographicNo = request.getParameter("de");
-    }
-    if (fallbackDemographicNo != null) {
-        fallbackDemographicNo = fallbackDemographicNo.trim();
-        if (!fallbackDemographicNo.matches("[1-9]\\d*")) {
-            fallbackDemographicNo = "";
-        }
-    } else {
-        fallbackDemographicNo = "";
-    }
-    String fallbackUrl = request.getContextPath() + "/encounter/oscarConsultationRequest/ViewDisplayDemographicConsultationRequests";
-    if (!fallbackDemographicNo.trim().isEmpty()) {
-        fallbackUrl += "?de=" + java.net.URLEncoder.encode(fallbackDemographicNo, java.nio.charset.StandardCharsets.UTF_8);
-    }
 %>
 <!DOCTYPE html>
 <html>
@@ -77,7 +61,7 @@
         <script type="text/javascript" src="<%= request.getContextPath() %>/js/global.js"></script>
     </head>
 
-    <body class="d-flex align-items-center justify-content-center" style="min-height:100vh; background-color:var(--carlos-bg-light);">
+    <body onload="finishPage(5);" class="d-flex align-items-center justify-content-center" style="min-height:100vh; background-color:var(--carlos-bg-light);">
 
         <div class="text-center p-4" style="max-width:420px;">
             <div class="mb-3">
@@ -110,53 +94,24 @@
                 <p class="text-muted mb-2" style="font-size:0.9rem;">Printing Consultation form...</p>
             <% } %>
 
-            <% if (!"true".equals(isPreview)) { %>
-                <p class="text-muted mb-3" style="font-size:0.85rem;">
-                    <fmt:message key="encounter.oscarConsultationRequest.ConfirmConsultationRequest.msgClose5Sec"/>
-                    <br>
-                    <span id="countdown" class="fw-semibold">5</span>s
-                </p>
-            <% } %>
+            <p class="text-muted mb-3" style="font-size:0.85rem;">
+                <fmt:message key="encounter.oscarConsultationRequest.ConfirmConsultationRequest.msgClose5Sec"/>
+                <br>
+                <span id="countdown" class="fw-semibold">5</span>s
+            </p>
 
-            <button type="button" id="closeButton" class="btn btn-sm btn-outline-secondary">
+            <a href="javascript:BackToOscar();" class="btn btn-sm btn-outline-secondary">
                 <i class="fa-solid fa-xmark me-1"></i><fmt:message key="global.btnClose"/>
-            </button>
+            </a>
         </div>
 
     <script>
-        var BLOB_URL_REVOKE_DELAY_MS = 15000;
-
         function BackToOscar() {
-            closeOrReturn();
-        }
-
-        function closeOrReturn() {
-            if (window.opener && !window.opener.closed) {
-                window.close();
-                window.setTimeout(returnToConsultations, 100);
-                return;
-            }
-            returnToConsultations();
-        }
-
-        function returnToConsultations() {
-            if (window.history.length > 1 && document.referrer) {
-                window.history.back();
-                return;
-            }
-            window.location.href = '<carlos:encode value='<%= fallbackUrl %>' context="javaScriptBlock"/>';
+            window.close();
         }
 
         function finishPage(secs) {
-            // Print consultation request form
-            const consultPDFName = '<carlos:encode value='<%= String.valueOf(request.getAttribute("consultPDFName")) %>' context="javaScriptBlock"/>';
-            const consultPDF = '<carlos:encode value='<%= String.valueOf(request.getAttribute("consultPDF")) %>' context="javaScriptBlock"/>';
-            const isPreviewReady = '<carlos:encode value='<%= String.valueOf(request.getAttribute("isPreviewReady")) %>' context="javaScriptBlock"/>';
-            if (consultPDF !== 'null' && consultPDFName !== 'null' && isPreviewReady === 'true') {
-                downloadConsultForm(consultPDFName, consultPDF);
-                return;
-            }
-
+            // Countdown display
             var remaining = secs;
             var countdownEl = document.getElementById('countdown');
             var timer = setInterval(function() {
@@ -164,30 +119,31 @@
                 if (countdownEl) countdownEl.textContent = remaining;
                 if (remaining <= 0) clearInterval(timer);
             }, 1000);
-            window.setTimeout(closeOrReturn, secs * 1000);
+
+            // Print consultation request form
+            const consultPDFName = '<carlos:encode value='<%= String.valueOf(request.getAttribute("consultPDFName")) %>' context="javaScriptBlock"/>';
+            const consultPDF = '<carlos:encode value='<%= String.valueOf(request.getAttribute("consultPDF")) %>' context="javaScriptBlock"/>';
+            const isPreviewReady = '<carlos:encode value='<%= String.valueOf(request.getAttribute("isPreviewReady")) %>' context="javaScriptBlock"/>';
+            if (consultPDF !== 'null' && consultPDFName !== 'null' && isPreviewReady === 'true') {
+                downloadConsultForm(consultPDFName, consultPDF, function () {
+                    setTimeout("window.close()", secs * 1000);
+                });
+                return;
+            }
+
+            setTimeout("window.close()", secs * 500);
         }
 
         function downloadConsultForm(consultPDFName, consultPDF, callback) {
             const pdfData = new Uint8Array(atob(consultPDF).split('').map(char => char.charCodeAt(0)));
             const pdfBlob = new Blob([pdfData], {type: 'application/pdf'});
             const downloadLink = document.createElement('a');
-            const objectUrl = URL.createObjectURL(pdfBlob);
-            downloadLink.href = objectUrl;
+            downloadLink.href = URL.createObjectURL(pdfBlob);
             downloadLink.download = consultPDFName;
-            downloadLink.style.display = 'none';
-            document.body.appendChild(downloadLink);
             downloadLink.click();
-            document.body.removeChild(downloadLink);
-            window.setTimeout(function () {
-                URL.revokeObjectURL(objectUrl);
-            }, BLOB_URL_REVOKE_DELAY_MS);
-            if (typeof callback === 'function') {
-                callback();
-            }
+            URL.revokeObjectURL(downloadLink.href);
+            callback();
         }
-
-        document.getElementById('closeButton').addEventListener('click', BackToOscar);
-        finishPage(5);
     </script>
     </body>
 </html>

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConfirmConsultationRequest.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConfirmConsultationRequest.jsp
@@ -51,6 +51,22 @@
     // Store transType as a local variable for safe comparison
     String transType = (String) request.getAttribute("transType");
     String isPreview = (String) request.getAttribute("isPreviewReady");
+    String fallbackDemographicNo = request.getParameter("demographicNo");
+    if (fallbackDemographicNo == null || fallbackDemographicNo.trim().isEmpty()) {
+        fallbackDemographicNo = request.getParameter("de");
+    }
+    if (fallbackDemographicNo != null) {
+        fallbackDemographicNo = fallbackDemographicNo.trim();
+        if (!fallbackDemographicNo.matches("[1-9]\\d*")) {
+            fallbackDemographicNo = "";
+        }
+    } else {
+        fallbackDemographicNo = "";
+    }
+    String fallbackUrl = request.getContextPath() + "/encounter/oscarConsultationRequest/ViewDisplayDemographicConsultationRequests";
+    if (!fallbackDemographicNo.trim().isEmpty()) {
+        fallbackUrl += "?de=" + java.net.URLEncoder.encode(fallbackDemographicNo, java.nio.charset.StandardCharsets.UTF_8);
+    }
 %>
 <!DOCTYPE html>
 <html>
@@ -61,7 +77,7 @@
         <script type="text/javascript" src="<%= request.getContextPath() %>/js/global.js"></script>
     </head>
 
-    <body onload="finishPage(5);" class="d-flex align-items-center justify-content-center" style="min-height:100vh; background-color:var(--carlos-bg-light);">
+    <body class="d-flex align-items-center justify-content-center" style="min-height:100vh; background-color:var(--carlos-bg-light);">
 
         <div class="text-center p-4" style="max-width:420px;">
             <div class="mb-3">
@@ -94,24 +110,53 @@
                 <p class="text-muted mb-2" style="font-size:0.9rem;">Printing Consultation form...</p>
             <% } %>
 
-            <p class="text-muted mb-3" style="font-size:0.85rem;">
-                <fmt:message key="encounter.oscarConsultationRequest.ConfirmConsultationRequest.msgClose5Sec"/>
-                <br>
-                <span id="countdown" class="fw-semibold">5</span>s
-            </p>
+            <% if (!"true".equals(isPreview)) { %>
+                <p class="text-muted mb-3" style="font-size:0.85rem;">
+                    <fmt:message key="encounter.oscarConsultationRequest.ConfirmConsultationRequest.msgClose5Sec"/>
+                    <br>
+                    <span id="countdown" class="fw-semibold">5</span>s
+                </p>
+            <% } %>
 
-            <a href="javascript:BackToOscar();" class="btn btn-sm btn-outline-secondary">
+            <button type="button" id="closeButton" class="btn btn-sm btn-outline-secondary">
                 <i class="fa-solid fa-xmark me-1"></i><fmt:message key="global.btnClose"/>
-            </a>
+            </button>
         </div>
 
     <script>
+        var BLOB_URL_REVOKE_DELAY_MS = 15000;
+
         function BackToOscar() {
-            window.close();
+            closeOrReturn();
+        }
+
+        function closeOrReturn() {
+            if (window.opener && !window.opener.closed) {
+                window.close();
+                window.setTimeout(returnToConsultations, 100);
+                return;
+            }
+            returnToConsultations();
+        }
+
+        function returnToConsultations() {
+            if (window.history.length > 1 && document.referrer) {
+                window.history.back();
+                return;
+            }
+            window.location.href = '<carlos:encode value='<%= fallbackUrl %>' context="javaScriptBlock"/>';
         }
 
         function finishPage(secs) {
-            // Countdown display
+            // Print consultation request form
+            const consultPDFName = '<carlos:encode value='<%= String.valueOf(request.getAttribute("consultPDFName")) %>' context="javaScriptBlock"/>';
+            const consultPDF = '<carlos:encode value='<%= String.valueOf(request.getAttribute("consultPDF")) %>' context="javaScriptBlock"/>';
+            const isPreviewReady = '<carlos:encode value='<%= String.valueOf(request.getAttribute("isPreviewReady")) %>' context="javaScriptBlock"/>';
+            if (consultPDF !== 'null' && consultPDFName !== 'null' && isPreviewReady === 'true') {
+                downloadConsultForm(consultPDFName, consultPDF);
+                return;
+            }
+
             var remaining = secs;
             var countdownEl = document.getElementById('countdown');
             var timer = setInterval(function() {
@@ -119,31 +164,30 @@
                 if (countdownEl) countdownEl.textContent = remaining;
                 if (remaining <= 0) clearInterval(timer);
             }, 1000);
-
-            // Print consultation request form
-            const consultPDFName = '<carlos:encode value='<%= String.valueOf(request.getAttribute("consultPDFName")) %>' context="javaScriptBlock"/>';
-            const consultPDF = '<carlos:encode value='<%= String.valueOf(request.getAttribute("consultPDF")) %>' context="javaScriptBlock"/>';
-            const isPreviewReady = '<carlos:encode value='<%= String.valueOf(request.getAttribute("isPreviewReady")) %>' context="javaScriptBlock"/>';
-            if (consultPDF !== 'null' && consultPDFName !== 'null' && isPreviewReady === 'true') {
-                downloadConsultForm(consultPDFName, consultPDF, function () {
-                    setTimeout("window.close()", secs * 1000);
-                });
-                return;
-            }
-
-            setTimeout("window.close()", secs * 500);
+            window.setTimeout(closeOrReturn, secs * 1000);
         }
 
         function downloadConsultForm(consultPDFName, consultPDF, callback) {
             const pdfData = new Uint8Array(atob(consultPDF).split('').map(char => char.charCodeAt(0)));
             const pdfBlob = new Blob([pdfData], {type: 'application/pdf'});
             const downloadLink = document.createElement('a');
-            downloadLink.href = URL.createObjectURL(pdfBlob);
+            const objectUrl = URL.createObjectURL(pdfBlob);
+            downloadLink.href = objectUrl;
             downloadLink.download = consultPDFName;
+            downloadLink.style.display = 'none';
+            document.body.appendChild(downloadLink);
             downloadLink.click();
-            URL.revokeObjectURL(downloadLink.href);
-            callback();
+            document.body.removeChild(downloadLink);
+            window.setTimeout(function () {
+                URL.revokeObjectURL(objectUrl);
+            }, BLOB_URL_REVOKE_DELAY_MS);
+            if (typeof callback === 'function') {
+                callback();
+            }
         }
+
+        document.getElementById('closeButton').addEventListener('click', BackToOscar);
+        finishPage(5);
     </script>
     </body>
 </html>

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConsultationFormRequest.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConsultationFormRequest.jsp
@@ -2102,7 +2102,21 @@ if (userAgent != null) {
                         alert(data.errorMessage.replace(/\\n/g, '\n'));
                         return;
                     }
+                    if (data.signatureImg) {
+                        var signatureImg = document.getElementById('signatureImg');
+                        var newSignature = document.getElementById('newSignature');
+                        if (signatureImg) {
+                            signatureImg.value = data.signatureImg;
+                        }
+                        if (newSignature) {
+                            newSignature.value = 'false';
+                        }
+                        isSignatureSaved = true;
+                    }
                     showPreview(data.consultPDF, data.consultPDFName);
+                    if (data.warningMessage) {
+                        alert(data.warningMessage.replace(/\\n/g, '\n'));
+                    }
                 },
                 error: function (xhr, status, error) {
                     HideSpin();

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConsultationFormRequest.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConsultationFormRequest.jsp
@@ -2102,7 +2102,7 @@ if (userAgent != null) {
                         alert(data.errorMessage.replace(/\\n/g, '\n'));
                         return;
                     }
-                    if (data.signatureImg) {
+                    if (data.signatureImg && isStoredSignatureId(data.signatureImg)) {
                         var signatureImg = document.getElementById('signatureImg');
                         var newSignature = document.getElementById('newSignature');
                         if (signatureImg) {

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConsultationFormRequest.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConsultationFormRequest.jsp
@@ -96,6 +96,7 @@
 <%@ page import="io.github.carlos_emr.carlos.utility.LoggedInInfo" %>
 <%@ page import="io.github.carlos_emr.carlos.utility.DigitalSignatureUtils" %>
 <%@ page import="io.github.carlos_emr.carlos.commn.model.UserProperty" %>
+<%@ page import="io.github.carlos_emr.carlos.managers.SignatureReference" %>
 <%@ page import="io.github.carlos_emr.carlos.ui.servlet.ImageRenderingServlet" %>
 <%@page import="io.github.carlos_emr.carlos.utility.SpringUtils" %>
 <%@page import="io.github.carlos_emr.carlos.utility.MiscUtils" %>
@@ -1925,6 +1926,42 @@ String storedImgUrl=request.getContextPath()+"/imageRenderingServlet?source="+Im
                     && signatureImg.value.length > 0 && !isStoredSignatureId(signatureImg.value);
         }
 
+        function setManualReSignVisible(visible) {
+            var manualReSign = document.getElementById('manualReSign');
+            if (manualReSign) {
+                manualReSign.style.display = visible ? 'block' : 'none';
+            }
+        }
+
+        function showSignaturePreview() {
+            var signatureShow = document.getElementById('signatureShow');
+            var signatureFrame = document.getElementById('signatureFrame');
+            if (signatureShow) {
+                signatureShow.style.display = 'block';
+            }
+            if (signatureFrame) {
+                signatureFrame.style.display = 'none';
+            }
+            setManualReSignVisible(true);
+        }
+
+        function showManualSignatureFrame() {
+            var signatureShow = document.getElementById('signatureShow');
+            var signatureFrame = document.getElementById('signatureFrame');
+            var newSignature = document.getElementById('newSignature');
+            if (signatureShow) {
+                signatureShow.style.display = 'none';
+            }
+            if (signatureFrame) {
+                signatureFrame.style.display = 'block';
+            }
+            if (newSignature) {
+                newSignature.value = 'true';
+            }
+            setManualReSignVisible(false);
+            return false;
+        }
+
         function updateSignatureProvider(providerNo) {
             var signatureProviderNo = document.getElementById('signatureProviderNo');
             if (signatureProviderNo) {
@@ -1946,13 +1983,13 @@ String storedImgUrl=request.getContextPath()+"/imageRenderingServlet?source="+Im
 
             signatureImgTag.onload = function() {
                 newSignature.value = 'false';
-                signatureFrame.style.display = 'none';
-                signatureShow.style.display = 'block';
+                showSignaturePreview();
             };
             signatureImgTag.onerror = function() {
                 newSignature.value = 'true';
                 signatureShow.style.display = 'none';
                 signatureFrame.style.display = 'block';
+                setManualReSignVisible(false);
             };
             counter = counter + 1;
             signatureImgTag.src = '<%=request.getContextPath()%>' + '/provider/providerSignatureImage?providerNo=' + encodeURIComponent(providerNo) + '&rand=' + counter;
@@ -1965,15 +2002,12 @@ String storedImgUrl=request.getContextPath()+"/imageRenderingServlet?source="+Im
                 var signatureImgTag = document.getElementById('signatureImgTag');
                 signatureImgTag.onload = function() {
                     document.getElementById('newSignature').value = "false";
-                    document.getElementById("signatureFrame").style.display = "none";
-                    document.getElementById('signatureShow').style.display = "block";
+                    showSignaturePreview();
                 };
                 signatureImgTag.onerror = function() {
                     // Stored signature is unrenderable — fall back to manual signing rather than
                     // leaving a broken image visible while newSignature=false would silently persist it.
-                    document.getElementById('newSignature').value = "true";
-                    document.getElementById('signatureShow').style.display = "none";
-                    document.getElementById("signatureFrame").style.display = "block";
+                    showManualSignatureFrame();
                 };
                 signatureImgTag.src = "<%=storedImgUrl %>" + encodeURIComponent(signatureImg.value);
             } else if (!hasPendingManualSignature()) {
@@ -2012,6 +2046,7 @@ if (userAgent != null) {
             if (e.isSave) {
                 refreshImage();
                 document.getElementById('newSignature').value = "true";
+                showSignaturePreview();
             } else {
                 document.getElementById('newSignature').value = "false";
             }
@@ -3180,6 +3215,7 @@ if (userAgent != null) {
                                 } catch (SecurityException e) {
                                     MiscUtils.getLogger().warn("Blocked unexpected consultation signature stamp path for provider {}", signatureProviderNo, e);
                                 }
+                                boolean hasStoredSignature = SignatureReference.isStoredId(consultUtil.signatureImg);
                         %>
                         <div class="consult-section-heading"><fmt:message key="encounter.oscarConsultationRequest.ConsultationFormRequest.formSignature"/></div>
                         <div>
@@ -3201,19 +3237,19 @@ if (userAgent != null) {
                                     <iframe style="width:500px; height:132px;"
                                         src="<%= request.getContextPath() %>/signature_pad/tabletSignature?inWindow=true&<%=DigitalSignatureUtils.SIGNATURE_REQUEST_ID_KEY%>=<%=signatureRequestId%>&<%=ModuleType.class.getSimpleName()%>=<%=ModuleType.CONSULTATION%>" ></iframe>
                                 </div>
-                                <div style="margin-top:5px;">
-                                    <a href="javascript:void(0)" onclick="document.getElementById('signatureShow').style.display='none';document.getElementById('signatureFrame').style.display='block';document.getElementById('newSignature').value='true';">
-                                        <fmt:message key="encounter.oscarConsultationRequest.ConsultationFormRequest.linkResignManually"/>
-                                    </a>
-                                </div>
                                 <% } else { %>
                                 <div id="signatureShow" style="display: none;">
                                     <img id="signatureImgTag" src=""/>
                                 </div>
 
-                                <iframe style="width:500px; height:132px;" id="signatureFrame"
+                                <iframe style="width:500px; height:132px;<%= hasStoredSignature ? " display:none;" : "" %>" id="signatureFrame"
 							src="<%= request.getContextPath() %>/signature_pad/tabletSignature?inWindow=true&<%=DigitalSignatureUtils.SIGNATURE_REQUEST_ID_KEY%>=<%=signatureRequestId%>&<%=ModuleType.class.getSimpleName()%>=<%=ModuleType.CONSULTATION%>" ></iframe>
                                 <% } %>
+                                <div id="manualReSign" style="margin-top:5px; display:<%= (hasStampSignature || hasStoredSignature) ? "block" : "none" %>;">
+                                    <a href="javascript:void(0)" onclick="return showManualSignatureFrame();">
+                                        <fmt:message key="encounter.oscarConsultationRequest.ConsultationFormRequest.linkResignManually"/>
+                                    </a>
+                                </div>
                         </div>
                         <% }%>
 

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConsultationFormRequest.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConsultationFormRequest.jsp
@@ -96,7 +96,6 @@
 <%@ page import="io.github.carlos_emr.carlos.utility.LoggedInInfo" %>
 <%@ page import="io.github.carlos_emr.carlos.utility.DigitalSignatureUtils" %>
 <%@ page import="io.github.carlos_emr.carlos.commn.model.UserProperty" %>
-<%@ page import="io.github.carlos_emr.carlos.managers.SignatureReference" %>
 <%@ page import="io.github.carlos_emr.carlos.ui.servlet.ImageRenderingServlet" %>
 <%@page import="io.github.carlos_emr.carlos.utility.SpringUtils" %>
 <%@page import="io.github.carlos_emr.carlos.utility.MiscUtils" %>
@@ -1926,42 +1925,6 @@ String storedImgUrl=request.getContextPath()+"/imageRenderingServlet?source="+Im
                     && signatureImg.value.length > 0 && !isStoredSignatureId(signatureImg.value);
         }
 
-        function setManualReSignVisible(visible) {
-            var manualReSign = document.getElementById('manualReSign');
-            if (manualReSign) {
-                manualReSign.style.display = visible ? 'block' : 'none';
-            }
-        }
-
-        function showSignaturePreview() {
-            var signatureShow = document.getElementById('signatureShow');
-            var signatureFrame = document.getElementById('signatureFrame');
-            if (signatureShow) {
-                signatureShow.style.display = 'block';
-            }
-            if (signatureFrame) {
-                signatureFrame.style.display = 'none';
-            }
-            setManualReSignVisible(true);
-        }
-
-        function showManualSignatureFrame() {
-            var signatureShow = document.getElementById('signatureShow');
-            var signatureFrame = document.getElementById('signatureFrame');
-            var newSignature = document.getElementById('newSignature');
-            if (signatureShow) {
-                signatureShow.style.display = 'none';
-            }
-            if (signatureFrame) {
-                signatureFrame.style.display = 'block';
-            }
-            if (newSignature) {
-                newSignature.value = 'true';
-            }
-            setManualReSignVisible(false);
-            return false;
-        }
-
         function updateSignatureProvider(providerNo) {
             var signatureProviderNo = document.getElementById('signatureProviderNo');
             if (signatureProviderNo) {
@@ -1983,13 +1946,13 @@ String storedImgUrl=request.getContextPath()+"/imageRenderingServlet?source="+Im
 
             signatureImgTag.onload = function() {
                 newSignature.value = 'false';
-                showSignaturePreview();
+                signatureFrame.style.display = 'none';
+                signatureShow.style.display = 'block';
             };
             signatureImgTag.onerror = function() {
                 newSignature.value = 'true';
                 signatureShow.style.display = 'none';
                 signatureFrame.style.display = 'block';
-                setManualReSignVisible(false);
             };
             counter = counter + 1;
             signatureImgTag.src = '<%=request.getContextPath()%>' + '/provider/providerSignatureImage?providerNo=' + encodeURIComponent(providerNo) + '&rand=' + counter;
@@ -2002,12 +1965,15 @@ String storedImgUrl=request.getContextPath()+"/imageRenderingServlet?source="+Im
                 var signatureImgTag = document.getElementById('signatureImgTag');
                 signatureImgTag.onload = function() {
                     document.getElementById('newSignature').value = "false";
-                    showSignaturePreview();
+                    document.getElementById("signatureFrame").style.display = "none";
+                    document.getElementById('signatureShow').style.display = "block";
                 };
                 signatureImgTag.onerror = function() {
                     // Stored signature is unrenderable — fall back to manual signing rather than
                     // leaving a broken image visible while newSignature=false would silently persist it.
-                    showManualSignatureFrame();
+                    document.getElementById('newSignature').value = "true";
+                    document.getElementById('signatureShow').style.display = "none";
+                    document.getElementById("signatureFrame").style.display = "block";
                 };
                 signatureImgTag.src = "<%=storedImgUrl %>" + encodeURIComponent(signatureImg.value);
             } else if (!hasPendingManualSignature()) {
@@ -2046,7 +2012,6 @@ if (userAgent != null) {
             if (e.isSave) {
                 refreshImage();
                 document.getElementById('newSignature').value = "true";
-                showSignaturePreview();
             } else {
                 document.getElementById('newSignature').value = "false";
             }
@@ -3215,7 +3180,6 @@ if (userAgent != null) {
                                 } catch (SecurityException e) {
                                     MiscUtils.getLogger().warn("Blocked unexpected consultation signature stamp path for provider {}", signatureProviderNo, e);
                                 }
-                                boolean hasStoredSignature = SignatureReference.isStoredId(consultUtil.signatureImg);
                         %>
                         <div class="consult-section-heading"><fmt:message key="encounter.oscarConsultationRequest.ConsultationFormRequest.formSignature"/></div>
                         <div>
@@ -3227,24 +3191,29 @@ if (userAgent != null) {
                                 <input type="hidden" name="newSignatureImg" id="newSignatureImg"
                                        value="<%=signatureRequestId %>"/>
 
+                                <% if (hasStampSignature) { %>
                                 <fmt:message key="encounter.oscarConsultationRequest.ConsultationFormRequest.altProviderSig" var="providerSigAlt"/>
-                                <fmt:message key="encounter.oscarConsultationRequest.ConsultationFormRequest.formSignature" var="signatureFrameTitle"/>
-                                <div id="signatureShow" style="display:<%= hasStampSignature ? "block" : "none" %>;">
-                                    <img id="signatureImgTag"
-                                         src="<%= hasStampSignature ? request.getContextPath() + "/provider/providerSignatureImage?providerNo=" + SafeEncode.forUriComponent(signatureProviderNo) : "" %>"
-                                         alt="${carlos:forHtmlAttribute(providerSigAlt)}"
-                                         style="max-height:120px;"/>
+                                <div id="signatureShow" style="display: block;">
+                                    <img id="signatureImgTag" src="<%=request.getContextPath()%>/provider/providerSignatureImage?providerNo=<%=SafeEncode.forUriComponent(signatureProviderNo)%>"
+                                         alt="${carlos:forHtmlAttribute(providerSigAlt)}" style="max-height:120px;"/>
                                 </div>
-                                <div id="signatureFrame" style="display:<%= (hasStampSignature || hasStoredSignature) ? "none" : "block" %>;">
+                                <div id="signatureFrame" style="display: none;">
                                     <iframe style="width:500px; height:132px;"
-                                        title="${carlos:forHtmlAttribute(signatureFrameTitle)}"
                                         src="<%= request.getContextPath() %>/signature_pad/tabletSignature?inWindow=true&<%=DigitalSignatureUtils.SIGNATURE_REQUEST_ID_KEY%>=<%=signatureRequestId%>&<%=ModuleType.class.getSimpleName()%>=<%=ModuleType.CONSULTATION%>" ></iframe>
                                 </div>
-                                <div id="manualReSign" style="margin-top:5px; display:<%= (hasStampSignature || hasStoredSignature) ? "block" : "none" %>;">
-                                    <button type="button" class="btn btn-link btn-sm p-0" onclick="showManualSignatureFrame();">
+                                <div style="margin-top:5px;">
+                                    <a href="javascript:void(0)" onclick="document.getElementById('signatureShow').style.display='none';document.getElementById('signatureFrame').style.display='block';document.getElementById('newSignature').value='true';">
                                         <fmt:message key="encounter.oscarConsultationRequest.ConsultationFormRequest.linkResignManually"/>
-                                    </button>
+                                    </a>
                                 </div>
+                                <% } else { %>
+                                <div id="signatureShow" style="display: none;">
+                                    <img id="signatureImgTag" src=""/>
+                                </div>
+
+                                <iframe style="width:500px; height:132px;" id="signatureFrame"
+							src="<%= request.getContextPath() %>/signature_pad/tabletSignature?inWindow=true&<%=DigitalSignatureUtils.SIGNATURE_REQUEST_ID_KEY%>=<%=signatureRequestId%>&<%=ModuleType.class.getSimpleName()%>=<%=ModuleType.CONSULTATION%>" ></iframe>
+                                <% } %>
                         </div>
                         <% }%>
 

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConsultationFormRequest.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConsultationFormRequest.jsp
@@ -3227,28 +3227,23 @@ if (userAgent != null) {
                                 <input type="hidden" name="newSignatureImg" id="newSignatureImg"
                                        value="<%=signatureRequestId %>"/>
 
-                                <% if (hasStampSignature) { %>
                                 <fmt:message key="encounter.oscarConsultationRequest.ConsultationFormRequest.altProviderSig" var="providerSigAlt"/>
-                                <div id="signatureShow" style="display: block;">
-                                    <img id="signatureImgTag" src="<%=request.getContextPath()%>/provider/providerSignatureImage?providerNo=<%=SafeEncode.forUriComponent(signatureProviderNo)%>"
-                                         alt="${carlos:forHtmlAttribute(providerSigAlt)}" style="max-height:120px;"/>
+                                <fmt:message key="encounter.oscarConsultationRequest.ConsultationFormRequest.formSignature" var="signatureFrameTitle"/>
+                                <div id="signatureShow" style="display:<%= hasStampSignature ? "block" : "none" %>;">
+                                    <img id="signatureImgTag"
+                                         src="<%= hasStampSignature ? request.getContextPath() + "/provider/providerSignatureImage?providerNo=" + SafeEncode.forUriComponent(signatureProviderNo) : "" %>"
+                                         alt="${carlos:forHtmlAttribute(providerSigAlt)}"
+                                         style="max-height:120px;"/>
                                 </div>
-                                <div id="signatureFrame" style="display: none;">
+                                <div id="signatureFrame" style="display:<%= (hasStampSignature || hasStoredSignature) ? "none" : "block" %>;">
                                     <iframe style="width:500px; height:132px;"
+                                        title="${carlos:forHtmlAttribute(signatureFrameTitle)}"
                                         src="<%= request.getContextPath() %>/signature_pad/tabletSignature?inWindow=true&<%=DigitalSignatureUtils.SIGNATURE_REQUEST_ID_KEY%>=<%=signatureRequestId%>&<%=ModuleType.class.getSimpleName()%>=<%=ModuleType.CONSULTATION%>" ></iframe>
                                 </div>
-                                <% } else { %>
-                                <div id="signatureShow" style="display: none;">
-                                    <img id="signatureImgTag" src=""/>
-                                </div>
-
-                                <iframe style="width:500px; height:132px;<%= hasStoredSignature ? " display:none;" : "" %>" id="signatureFrame"
-							src="<%= request.getContextPath() %>/signature_pad/tabletSignature?inWindow=true&<%=DigitalSignatureUtils.SIGNATURE_REQUEST_ID_KEY%>=<%=signatureRequestId%>&<%=ModuleType.class.getSimpleName()%>=<%=ModuleType.CONSULTATION%>" ></iframe>
-                                <% } %>
                                 <div id="manualReSign" style="margin-top:5px; display:<%= (hasStampSignature || hasStoredSignature) ? "block" : "none" %>;">
-                                    <a href="javascript:void(0)" onclick="return showManualSignatureFrame();">
+                                    <button type="button" class="btn btn-link btn-sm p-0" onclick="showManualSignatureFrame();">
                                         <fmt:message key="encounter.oscarConsultationRequest.ConsultationFormRequest.linkResignManually"/>
-                                    </a>
+                                    </button>
                                 </div>
                         </div>
                         <% }%>

--- a/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/ConsultationPDFCreatorUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/ConsultationPDFCreatorUnitTest.java
@@ -99,6 +99,21 @@ class ConsultationPDFCreatorUnitTest {
     }
 
     @Test
+    @DisplayName("does not render a stored signature when preview rendering suppresses signatures")
+    void shouldNotRenderSignature_whenSuppressed() {
+        assertThat(ConsultationPDFCreator.shouldRenderSignature(true, null, "5")).isFalse();
+        assertThat(ConsultationPDFCreator.shouldRenderSignature(true, OVERRIDE_BYTES, "")).isFalse();
+    }
+
+    @Test
+    @DisplayName("renders either override bytes or a stored signature id when not suppressed")
+    void shouldRenderSignature_whenOverrideOrStoredIdPresentAndNotSuppressed() {
+        assertThat(ConsultationPDFCreator.shouldRenderSignature(false, OVERRIDE_BYTES, "")).isTrue();
+        assertThat(ConsultationPDFCreator.shouldRenderSignature(false, null, "5")).isTrue();
+        assertThat(ConsultationPDFCreator.shouldRenderSignature(false, new byte[0], "")).isFalse();
+    }
+
+    @Test
     @DisplayName("returns null when the stored signature id contains only whitespace")
     void shouldReturnNull_whenStoredIdWhitespaceOnly() {
         DigitalSignatureManager mgr = mock(DigitalSignatureManager.class);

--- a/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2ActionUnitTest.java
@@ -66,6 +66,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -245,7 +246,7 @@ class EctConsultationFormRequest2ActionUnitTest extends CarlosUnitTestBase {
                 .thenReturn("9999981000");
         when(consultationSignatureService.saveManualSignatureForPreview(
                 loggedInInfo, 9, 1, "9999981000", "9999981000", "999998"))
-                .thenThrow(new RuntimeException("database commit failed"));
+                .thenThrow(new DataIntegrityViolationException("database commit failed"));
 
         String result = action.execute();
 

--- a/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2ActionUnitTest.java
@@ -236,6 +236,27 @@ class EctConsultationFormRequest2ActionUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
+    @DisplayName("warns but returns unsigned PDF JSON when preview signature persistence throws")
+    void shouldWarnButReturnPdf_whenManualSignaturePersistenceThrowsForDirectPrintPreview() throws Exception {
+        action.setSignatureImg("9999981000");
+        request.setParameter("newSignature", "true");
+        request.setParameter("newSignatureImg", "9999981000");
+        when(consultationSignatureService.resolveManualSignatureRequestId("9999981000", "9999981000"))
+                .thenReturn("9999981000");
+        when(consultationSignatureService.saveManualSignatureForPreview(
+                loggedInInfo, 9, 1, "9999981000", "9999981000", "999998"))
+                .thenThrow(new RuntimeException("database commit failed"));
+
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(response.getContentAsString()).contains("\"consultPDF\":\"" + PDF_BASE64 + "\"");
+        assertThat(response.getContentAsString()).contains("The captured signature could not be saved and will not appear on the PDF.");
+        assertThat(request.getAttribute(ConsultationSignatureService.SUPPRESS_SIGNATURE_ATTRIBUTE)).isEqualTo(Boolean.TRUE);
+        verify(documentAttachmentManager).renderConsultationFormWithAttachments(request, response);
+    }
+
+    @Test
     @DisplayName("returns an error without rendering when direct print preview targets a missing consultation")
     void shouldReturnErrorWithoutRendering_whenDirectPrintPreviewTargetMissing() throws Exception {
         action.setSignatureImg("9999981000");

--- a/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2ActionUnitTest.java
@@ -47,6 +47,7 @@ import io.github.carlos_emr.carlos.commn.model.DigitalSignature;
 import io.github.carlos_emr.carlos.commn.model.enumerator.ModuleType;
 import io.github.carlos_emr.carlos.documentManager.DocumentAttachmentManager;
 import io.github.carlos_emr.carlos.managers.ConsultationManager;
+import io.github.carlos_emr.carlos.managers.ConsultationPreviewSignatureOutcome;
 import io.github.carlos_emr.carlos.managers.ConsultationSignatureService;
 import io.github.carlos_emr.carlos.managers.ConsultationStampOutcome;
 import io.github.carlos_emr.carlos.managers.DemographicManager;
@@ -171,22 +172,14 @@ class EctConsultationFormRequest2ActionUnitTest extends CarlosUnitTestBase {
     @Test
     @DisplayName("persists a captured manual signature before direct print preview")
     void shouldPersistManualSignature_beforeDirectPrintPreview() throws Exception {
-        ConsultationRequest existing = new ConsultationRequest();
-        existing.setDemographicId(1);
-        when(consultationRequestDao.find(9)).thenReturn(existing);
-
-        DigitalSignature savedSignature = mock(DigitalSignature.class);
-        when(savedSignature.getId()).thenReturn(77);
-
         action.setSignatureImg("9999981000");
         request.setParameter("newSignature", "true");
         request.setParameter("newSignatureImg", "9999981000");
         when(consultationSignatureService.resolveManualSignatureRequestId("9999981000", "9999981000"))
                 .thenReturn("9999981000");
-        when(consultationSignatureService.wasManualSignatureCaptured("9999981000")).thenReturn(true);
-        when(digitalSignatureManager.processAndSaveDigitalSignature(
-                loggedInInfo, "9999981000", 1, ModuleType.CONSULTATION))
-                .thenReturn(savedSignature);
+        when(consultationSignatureService.saveManualSignatureForPreview(
+                loggedInInfo, 9, 1, "9999981000", "9999981000", "999998"))
+                .thenReturn(new ConsultationPreviewSignatureOutcome(ConsultationPreviewSignatureOutcome.Status.SAVED, "77"));
 
         String result = action.execute();
 
@@ -196,8 +189,8 @@ class EctConsultationFormRequest2ActionUnitTest extends CarlosUnitTestBase {
         assertThat(response.getContentAsString()).contains("\"errorMessage\":null");
         assertThat(response.getContentAsString()).contains("\"warningMessage\":null");
         assertThat(response.getContentAsString()).contains("\"signatureImg\":\"77\"");
-        assertThat(existing.getSignatureImg()).isEqualTo("77");
-        verify(consultationRequestDao).merge(existing);
+        verify(consultationSignatureService).saveManualSignatureForPreview(
+                loggedInInfo, 9, 1, "9999981000", "9999981000", "999998");
         verify(documentAttachmentManager).renderConsultationFormWithAttachments(request, response);
     }
 
@@ -227,10 +220,9 @@ class EctConsultationFormRequest2ActionUnitTest extends CarlosUnitTestBase {
         request.setParameter("newSignatureImg", "9999981000");
         when(consultationSignatureService.resolveManualSignatureRequestId("9999981000", "9999981000"))
                 .thenReturn("9999981000");
-        when(consultationSignatureService.wasManualSignatureCaptured("9999981000")).thenReturn(false);
-        when(digitalSignatureManager.processAndSaveDigitalSignature(
-                loggedInInfo, "9999981000", 1, ModuleType.CONSULTATION))
-                .thenReturn(null);
+        when(consultationSignatureService.saveManualSignatureForPreview(
+                loggedInInfo, 9, 1, "9999981000", "9999981000", "999998"))
+                .thenReturn(new ConsultationPreviewSignatureOutcome(ConsultationPreviewSignatureOutcome.Status.PERSIST_FAILED, ""));
 
         String result = action.execute();
 
@@ -240,6 +232,44 @@ class EctConsultationFormRequest2ActionUnitTest extends CarlosUnitTestBase {
         assertThat(response.getContentAsString()).contains("\"signatureImg\":null");
         verify(consultationRequestDao, never()).merge(any());
         verify(documentAttachmentManager).renderConsultationFormWithAttachments(request, response);
+    }
+
+    @Test
+    @DisplayName("returns an error without rendering when direct print preview targets a missing consultation")
+    void shouldReturnErrorWithoutRendering_whenDirectPrintPreviewTargetMissing() throws Exception {
+        action.setSignatureImg("9999981000");
+        request.setParameter("newSignature", "true");
+        request.setParameter("newSignatureImg", "9999981000");
+        when(consultationSignatureService.resolveManualSignatureRequestId("9999981000", "9999981000"))
+                .thenReturn("9999981000");
+        when(consultationSignatureService.saveManualSignatureForPreview(
+                loggedInInfo, 9, 1, "9999981000", "9999981000", "999998"))
+                .thenReturn(new ConsultationPreviewSignatureOutcome(ConsultationPreviewSignatureOutcome.Status.REQUEST_NOT_FOUND, ""));
+
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(response.getContentAsString()).contains("Consultation request not found.");
+        verify(documentAttachmentManager, never()).renderConsultationFormWithAttachments(any(), any());
+    }
+
+    @Test
+    @DisplayName("returns an error without rendering when direct print preview demographic does not match the consultation")
+    void shouldReturnErrorWithoutRendering_whenDirectPrintPreviewDemographicMismatches() throws Exception {
+        action.setSignatureImg("9999981000");
+        request.setParameter("newSignature", "true");
+        request.setParameter("newSignatureImg", "9999981000");
+        when(consultationSignatureService.resolveManualSignatureRequestId("9999981000", "9999981000"))
+                .thenReturn("9999981000");
+        when(consultationSignatureService.saveManualSignatureForPreview(
+                loggedInInfo, 9, 1, "9999981000", "9999981000", "999998"))
+                .thenReturn(new ConsultationPreviewSignatureOutcome(ConsultationPreviewSignatureOutcome.Status.DEMOGRAPHIC_MISMATCH, ""));
+
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(response.getContentAsString()).contains("Consultation request does not match the selected patient.");
+        verify(documentAttachmentManager, never()).renderConsultationFormWithAttachments(any(), any());
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2ActionUnitTest.java
@@ -73,7 +73,6 @@ import org.springframework.test.util.ReflectionTestUtils;
 @Tag("unit")
 class EctConsultationFormRequest2ActionUnitTest extends CarlosUnitTestBase {
 
-    private static final byte[] SIGNATURE_BYTES = new byte[]{1, 2, 3};
     private static final String PDF_BASE64 = "JVBERi0xLjQK";
 
     private MockedStatic<ServletActionContext> servletActionContextMock;
@@ -133,8 +132,6 @@ class EctConsultationFormRequest2ActionUnitTest extends CarlosUnitTestBase {
                 .thenReturn("sig-request");
         when(consultationSignatureService.resolveSignatureProviderNo("999998", "999998", "999998"))
                 .thenReturn("999998");
-        when(consultationSignatureService.resolvePreviewSignatureImage(loggedInInfo, false, "", "sig-request", "999998"))
-                .thenReturn(SIGNATURE_BYTES);
         when(demographicManager.getDemographicFormattedName(loggedInInfo, 1)).thenReturn("Patient, Test");
 
         pdfPath = Files.createTempFile("consult-preview", ".pdf");
@@ -172,16 +169,76 @@ class EctConsultationFormRequest2ActionUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
-    @DisplayName("returns the base64 PDF JSON and sets the signature override for a direct print preview")
-    void shouldReturnJsonPdfWithSignatureOverride_forDirectPrintPreview() throws Exception {
+    @DisplayName("persists a captured manual signature before direct print preview")
+    void shouldPersistManualSignature_beforeDirectPrintPreview() throws Exception {
+        ConsultationRequest existing = new ConsultationRequest();
+        existing.setDemographicId(1);
+        when(consultationRequestDao.find(9)).thenReturn(existing);
+
+        DigitalSignature savedSignature = mock(DigitalSignature.class);
+        when(savedSignature.getId()).thenReturn(77);
+
+        action.setSignatureImg("9999981000");
+        request.setParameter("newSignature", "true");
+        request.setParameter("newSignatureImg", "9999981000");
+        when(consultationSignatureService.resolveManualSignatureRequestId("9999981000", "9999981000"))
+                .thenReturn("9999981000");
+        when(consultationSignatureService.wasManualSignatureCaptured("9999981000")).thenReturn(true);
+        when(digitalSignatureManager.processAndSaveDigitalSignature(
+                loggedInInfo, "9999981000", 1, ModuleType.CONSULTATION))
+                .thenReturn(savedSignature);
+
         String result = action.execute();
 
         assertThat(result).isEqualTo(ActionSupport.NONE);
         assertThat(response.getContentType()).isEqualTo("application/json;charset=UTF-8");
         assertThat(response.getContentAsString()).contains("\"consultPDF\":\"" + PDF_BASE64 + "\"");
         assertThat(response.getContentAsString()).contains("\"errorMessage\":null");
-        assertThat(request.getAttribute(ConsultationSignatureService.SIGNATURE_IMAGE_OVERRIDE_ATTRIBUTE))
-                .isEqualTo(SIGNATURE_BYTES);
+        assertThat(response.getContentAsString()).contains("\"warningMessage\":null");
+        assertThat(response.getContentAsString()).contains("\"signatureImg\":\"77\"");
+        assertThat(existing.getSignatureImg()).isEqualTo("77");
+        verify(consultationRequestDao).merge(existing);
+        verify(documentAttachmentManager).renderConsultationFormWithAttachments(request, response);
+    }
+
+    @Test
+    @DisplayName("returns the base64 PDF JSON without creating a duplicate signature for direct print preview")
+    void shouldReturnJsonPdfWithoutDuplicateSignature_forDirectPrintPreview() throws Exception {
+        action.setSignatureImg("123");
+        request.setParameter("newSignature", "false");
+
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(response.getContentType()).isEqualTo("application/json;charset=UTF-8");
+        assertThat(response.getContentAsString()).contains("\"consultPDF\":\"" + PDF_BASE64 + "\"");
+        assertThat(response.getContentAsString()).contains("\"errorMessage\":null");
+        assertThat(response.getContentAsString()).contains("\"warningMessage\":null");
+        assertThat(response.getContentAsString()).contains("\"signatureImg\":null");
+        verify(digitalSignatureManager, never()).processAndSaveDigitalSignature(any(), any(), any(), any());
+        verify(consultationRequestDao, never()).merge(any());
+    }
+
+    @Test
+    @DisplayName("warns but still returns unsigned PDF JSON when a submitted manual signature cannot be persisted")
+    void shouldWarnButReturnPdf_whenManualSignatureCannotBePersistedForDirectPrintPreview() throws Exception {
+        action.setSignatureImg("9999981000");
+        request.setParameter("newSignature", "true");
+        request.setParameter("newSignatureImg", "9999981000");
+        when(consultationSignatureService.resolveManualSignatureRequestId("9999981000", "9999981000"))
+                .thenReturn("9999981000");
+        when(consultationSignatureService.wasManualSignatureCaptured("9999981000")).thenReturn(false);
+        when(digitalSignatureManager.processAndSaveDigitalSignature(
+                loggedInInfo, "9999981000", 1, ModuleType.CONSULTATION))
+                .thenReturn(null);
+
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(response.getContentAsString()).contains("\"consultPDF\":\"" + PDF_BASE64 + "\"");
+        assertThat(response.getContentAsString()).contains("The captured signature could not be saved and will not appear on the PDF.");
+        assertThat(response.getContentAsString()).contains("\"signatureImg\":null");
+        verify(consultationRequestDao, never()).merge(any());
         verify(documentAttachmentManager).renderConsultationFormWithAttachments(request, response);
     }
 

--- a/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2ActionUnitTest.java
@@ -230,6 +230,7 @@ class EctConsultationFormRequest2ActionUnitTest extends CarlosUnitTestBase {
         assertThat(response.getContentAsString()).contains("\"consultPDF\":\"" + PDF_BASE64 + "\"");
         assertThat(response.getContentAsString()).contains("The captured signature could not be saved and will not appear on the PDF.");
         assertThat(response.getContentAsString()).contains("\"signatureImg\":null");
+        assertThat(request.getAttribute(ConsultationSignatureService.SUPPRESS_SIGNATURE_ATTRIBUTE)).isEqualTo(Boolean.TRUE);
         verify(consultationRequestDao, never()).merge(any());
         verify(documentAttachmentManager).renderConsultationFormWithAttachments(request, response);
     }

--- a/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2ActionUnitTest.java
@@ -238,7 +238,7 @@ class EctConsultationFormRequest2ActionUnitTest extends CarlosUnitTestBase {
 
     @Test
     @DisplayName("warns but returns unsigned PDF JSON when preview signature persistence throws")
-    void shouldWarnButReturnPdf_whenManualSignaturePersistenceThrowsForDirectPrintPreview() throws Exception {
+    void shouldReturnUnsignedPdfWithWarning_whenManualSignaturePersistenceThrowsForDirectPrintPreview() throws Exception {
         action.setSignatureImg("9999981000");
         request.setParameter("newSignature", "true");
         request.setParameter("newSignatureImg", "9999981000");

--- a/src/test/java/io/github/carlos_emr/carlos/managers/ConsultationSignatureServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/managers/ConsultationSignatureServiceUnitTest.java
@@ -22,6 +22,8 @@
 package io.github.carlos_emr.carlos.managers;
 
 import io.github.carlos_emr.CarlosProperties;
+import io.github.carlos_emr.carlos.commn.dao.ConsultationRequestDao;
+import io.github.carlos_emr.carlos.commn.model.ConsultationRequest;
 import io.github.carlos_emr.carlos.commn.model.DigitalSignature;
 import io.github.carlos_emr.carlos.commn.model.Facility;
 import io.github.carlos_emr.carlos.commn.model.enumerator.ModuleType;
@@ -51,6 +53,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -74,6 +77,9 @@ class ConsultationSignatureServiceUnitTest {
     @Mock
     private LoggedInInfo loggedInInfo;
 
+    @Mock
+    private ConsultationRequestDao consultationRequestDao;
+
     private ConsultationSignatureService service;
     private boolean hadEformImagesDir;
     private Object originalEformImagesDir;
@@ -91,7 +97,7 @@ class ConsultationSignatureServiceUnitTest {
         when(loggedInInfo.getCurrentFacility()).thenReturn(facility);
         when(loggedInInfo.getLoggedInProviderNo()).thenReturn("999998");
 
-        service = new ConsultationSignatureService(digitalSignatureManager, securityInfoManager);
+        service = new ConsultationSignatureService(digitalSignatureManager, securityInfoManager, consultationRequestDao);
     }
 
     @AfterEach
@@ -363,6 +369,70 @@ class ConsultationSignatureServiceUnitTest {
     @DisplayName("returns an empty provider number when no candidate value is numeric")
     void shouldReturnEmptyProviderNumber_whenNoCandidateIsNumeric() {
         assertThat(service.resolveSignatureProviderNo("abc", "def", "ghi")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("does not persist a preview signature when the consultation request is missing")
+    void shouldNotPersistPreviewSignature_whenConsultationRequestMissing() {
+        when(consultationRequestDao.find(9)).thenReturn(null);
+
+        ConsultationPreviewSignatureOutcome outcome = service.saveManualSignatureForPreview(
+                loggedInInfo, 9, 44, "9999981000", "9999981000", "999998");
+
+        assertThat(outcome.status()).isEqualTo(ConsultationPreviewSignatureOutcome.Status.REQUEST_NOT_FOUND);
+        verify(digitalSignatureManager, never()).processAndSaveDigitalSignature(any(), anyString(), anyInt(), any());
+    }
+
+    @Test
+    @DisplayName("does not persist a preview signature when the consultation demographic does not match")
+    void shouldNotPersistPreviewSignature_whenConsultationDemographicMismatches() {
+        ConsultationRequest consult = new ConsultationRequest();
+        consult.setDemographicId(45);
+        when(consultationRequestDao.find(9)).thenReturn(consult);
+
+        ConsultationPreviewSignatureOutcome outcome = service.saveManualSignatureForPreview(
+                loggedInInfo, 9, 44, "9999981000", "9999981000", "999998");
+
+        assertThat(outcome.status()).isEqualTo(ConsultationPreviewSignatureOutcome.Status.DEMOGRAPHIC_MISMATCH);
+        verify(digitalSignatureManager, never()).processAndSaveDigitalSignature(any(), anyString(), anyInt(), any());
+    }
+
+    @Test
+    @DisplayName("persists a manual preview signature after validating the consultation")
+    void shouldPersistPreviewSignature_afterConsultationValidation() {
+        ConsultationRequest consult = new ConsultationRequest();
+        consult.setDemographicId(44);
+        when(consultationRequestDao.find(9)).thenReturn(consult);
+        DigitalSignature savedSignature = mock(DigitalSignature.class);
+        when(savedSignature.getId()).thenReturn(77);
+        when(digitalSignatureManager.processAndSaveDigitalSignature(
+                loggedInInfo, "9999981000", 44, ModuleType.CONSULTATION))
+                .thenReturn(savedSignature);
+
+        ConsultationPreviewSignatureOutcome outcome = service.saveManualSignatureForPreview(
+                loggedInInfo, 9, 44, "9999981000", "9999981000", "999998");
+
+        assertThat(outcome.isSaved()).isTrue();
+        assertThat(outcome.signatureId()).isEqualTo("77");
+        assertThat(consult.getSignatureImg()).isEqualTo("77");
+        verify(consultationRequestDao).merge(consult);
+    }
+
+    @Test
+    @DisplayName("reports a preview signature persistence failure after consultation validation")
+    void shouldReportPreviewSignaturePersistenceFailure_afterConsultationValidation() {
+        ConsultationRequest consult = new ConsultationRequest();
+        consult.setDemographicId(44);
+        when(consultationRequestDao.find(9)).thenReturn(consult);
+        when(digitalSignatureManager.processAndSaveDigitalSignature(
+                loggedInInfo, "9999981000", 44, ModuleType.CONSULTATION))
+                .thenReturn(null);
+
+        ConsultationPreviewSignatureOutcome outcome = service.saveManualSignatureForPreview(
+                loggedInInfo, 9, 44, "9999981000", "9999981000", "999998");
+
+        assertThat(outcome.status()).isEqualTo(ConsultationPreviewSignatureOutcome.Status.PERSIST_FAILED);
+        verify(consultationRequestDao, never()).merge(any());
     }
 
     private byte[] invokeReadProviderStampImage(String providerNo) throws Exception {

--- a/src/test/java/io/github/carlos_emr/carlos/provider/web/SignatureStampJspRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/provider/web/SignatureStampJspRegressionTest.java
@@ -57,16 +57,9 @@ class SignatureStampJspRegressionTest {
                 .contains("updateSignatureProvider(this.value)")
                 .contains("function isStoredSignatureId(value)")
                 .contains("function hasPendingManualSignature()")
-                .contains("function showSignaturePreview()")
-                .contains("function showManualSignatureFrame()")
                 .contains("signatureImgTag.onerror = function()")
                 .contains("if (data.signatureImg && isStoredSignatureId(data.signatureImg))")
-                .contains("boolean hasStoredSignature = SignatureReference.isStoredId(consultUtil.signatureImg);")
-                .contains("id=\"manualReSign\"")
-                .contains("title=\"${carlos:forHtmlAttribute(signatureFrameTitle)}\"")
-                .contains("type=\"button\" class=\"btn btn-link btn-sm p-0\" onclick=\"showManualSignatureFrame();\"")
-                .contains("\"/provider/providerSignatureImage?providerNo=\" + SafeEncode.forUriComponent(signatureProviderNo)")
-                .doesNotContain("href=\"javascript:void(0)\" onclick=\"return showManualSignatureFrame();\"")
+                .contains("/provider/providerSignatureImage?providerNo=<%=SafeEncode.forUriComponent(signatureProviderNo)%>")
                 .doesNotContain("UserProperty consultSigProp = userPropertyDAO.getProp(providerNo, UserProperty.PROVIDER_CONSULT_SIGNATURE);");
     }
 

--- a/src/test/java/io/github/carlos_emr/carlos/provider/web/SignatureStampJspRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/provider/web/SignatureStampJspRegressionTest.java
@@ -57,8 +57,13 @@ class SignatureStampJspRegressionTest {
                 .contains("updateSignatureProvider(this.value)")
                 .contains("function isStoredSignatureId(value)")
                 .contains("function hasPendingManualSignature()")
+                .contains("function showSignaturePreview()")
+                .contains("function showManualSignatureFrame()")
                 .contains("signatureImgTag.onerror = function()")
                 .contains("if (data.signatureImg && isStoredSignatureId(data.signatureImg))")
+                .contains("boolean hasStoredSignature = SignatureReference.isStoredId(consultUtil.signatureImg);")
+                .contains("id=\"manualReSign\"")
+                .contains("onclick=\"return showManualSignatureFrame();\"")
                 .contains("/provider/providerSignatureImage?providerNo=<%=SafeEncode.forUriComponent(signatureProviderNo)%>")
                 .doesNotContain("UserProperty consultSigProp = userPropertyDAO.getProp(providerNo, UserProperty.PROVIDER_CONSULT_SIGNATURE);");
     }

--- a/src/test/java/io/github/carlos_emr/carlos/provider/web/SignatureStampJspRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/provider/web/SignatureStampJspRegressionTest.java
@@ -58,6 +58,7 @@ class SignatureStampJspRegressionTest {
                 .contains("function isStoredSignatureId(value)")
                 .contains("function hasPendingManualSignature()")
                 .contains("signatureImgTag.onerror = function()")
+                .contains("if (data.signatureImg && isStoredSignatureId(data.signatureImg))")
                 .contains("/provider/providerSignatureImage?providerNo=<%=SafeEncode.forUriComponent(signatureProviderNo)%>")
                 .doesNotContain("UserProperty consultSigProp = userPropertyDAO.getProp(providerNo, UserProperty.PROVIDER_CONSULT_SIGNATURE);");
     }

--- a/src/test/java/io/github/carlos_emr/carlos/provider/web/SignatureStampJspRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/provider/web/SignatureStampJspRegressionTest.java
@@ -63,8 +63,10 @@ class SignatureStampJspRegressionTest {
                 .contains("if (data.signatureImg && isStoredSignatureId(data.signatureImg))")
                 .contains("boolean hasStoredSignature = SignatureReference.isStoredId(consultUtil.signatureImg);")
                 .contains("id=\"manualReSign\"")
-                .contains("onclick=\"return showManualSignatureFrame();\"")
-                .contains("/provider/providerSignatureImage?providerNo=<%=SafeEncode.forUriComponent(signatureProviderNo)%>")
+                .contains("title=\"${carlos:forHtmlAttribute(signatureFrameTitle)}\"")
+                .contains("type=\"button\" class=\"btn btn-link btn-sm p-0\" onclick=\"showManualSignatureFrame();\"")
+                .contains("\"/provider/providerSignatureImage?providerNo=\" + SafeEncode.forUriComponent(signatureProviderNo)")
+                .doesNotContain("href=\"javascript:void(0)\" onclick=\"return showManualSignatureFrame();\"")
                 .doesNotContain("UserProperty consultSigProp = userPropertyDAO.getProp(providerNo, UserProperty.PROVIDER_CONSULT_SIGNATURE);");
     }
 

--- a/src/test/java/io/github/carlos_emr/carlos/ui/servlet/ImageRenderingServletUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/ui/servlet/ImageRenderingServletUnitTest.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ */
+package io.github.carlos_emr.carlos.ui.servlet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import io.github.carlos_emr.carlos.casemgmt.dao.ClientImageDAO;
+import io.github.carlos_emr.carlos.commn.model.Provider;
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
+import io.github.carlos_emr.carlos.utility.DigitalSignatureUtils;
+import io.github.carlos_emr.carlos.utility.SessionConstants;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockServletConfig;
+import org.springframework.mock.web.MockServletContext;
+
+@DisplayName("ImageRenderingServlet")
+@Tag("unit")
+class ImageRenderingServletUnitTest extends CarlosUnitTestBase {
+
+    private static final byte[] PNG_BYTES = new byte[]{
+            (byte) 0x89, 'P', 'N', 'G', 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3
+    };
+
+    private Path tempSignaturePath;
+
+    @BeforeEach
+    void setUp() {
+        registerMock(ClientImageDAO.class, mock(ClientImageDAO.class));
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (tempSignaturePath != null) {
+            Files.deleteIfExists(tempSignaturePath);
+        }
+    }
+
+    @Test
+    @DisplayName("returns exact uploaded PNG bytes for a temp signature preview")
+    void shouldReturnExactPngBytes_forTempSignaturePreview() throws Exception {
+        String signatureRequestId = "999998123456789";
+        tempSignaturePath = Path.of(DigitalSignatureUtils.getTempFilePath(signatureRequestId));
+        Files.write(tempSignaturePath, PNG_BYTES);
+
+        ImageRenderingServlet servlet = new ImageRenderingServlet();
+        servlet.init(new MockServletConfig(new MockServletContext()));
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/imageRenderingServlet");
+        request.addParameter("source", ImageRenderingServlet.Source.signature_preview.name());
+        request.addParameter(DigitalSignatureUtils.SIGNATURE_REQUEST_ID_KEY, signatureRequestId);
+        request.getSession().setAttribute(SessionConstants.LOGGED_IN_PROVIDER, new Provider());
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        servlet.doGet(request, response);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getContentType()).isEqualTo("image/png");
+        assertThat(response.getContentAsByteArray()).containsExactly(PNG_BYTES);
+    }
+
+    @Test
+    @DisplayName("detects common signature image formats by magic bytes")
+    void shouldDetectCommonSignatureImageTypes() {
+        assertThat(ImageRenderingServlet.detectImageType(PNG_BYTES)).isEqualTo("png");
+        assertThat(ImageRenderingServlet.detectImageType(new byte[]{(byte) 0xff, (byte) 0xd8, (byte) 0xff}))
+                .isEqualTo("jpeg");
+        assertThat(ImageRenderingServlet.detectImageType(new byte[]{'G', 'I', 'F', '8', '9', 'a'}))
+                .isEqualTo("gif");
+        assertThat(ImageRenderingServlet.detectImageType(new byte[]{1, 2, 3})).isEqualTo("jpeg");
+    }
+}


### PR DESCRIPTION
## Summary
- persist newly drawn consultation signatures before direct print-preview rendering so PDFs use a DigitalSignature id
- update the consultation row and return the saved signature id to the browser to avoid duplicate saves on repeated previews
- return a warning while still generating an unsigned PDF when a submitted signature cannot be saved

## Tests
- mvn -Dtest=EctConsultationFormRequest2ActionUnitTest test
- mvn -Dtest=EctConsultationFormRequest2ActionUnitTest,ConsultationPDFCreatorUnitTest,ConsultationSignatureServiceUnitTest test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist newly captured consultation signatures before preview so PDFs use a stored DigitalSignature id and previews stay consistent. If saving fails, show a warning, suppress the signature in the PDF, and still return the preview.

- **Bug Fixes**
  - Persist and validate captured manual signatures during preview; when newSignature=false, skip saving and reuse the existing stamp or stored image. On success, update the consultation and return the saved id in JSON so the form sets newSignature=false.
  - If saving fails (missing/mismatched consultation or persistence errors), set warningMessage, suppress signature rendering via consultationSuppressSignature, and still return the preview; return clear errors and skip rendering when the target is invalid.
  - Detect PNG/JPEG/GIF by magic bytes and stream exact bytes for both temp and stored signature images.

- **Refactors**
  - Added ConsultationPreviewSignatureOutcome; extracted shouldRenderSignature and detectImageType; centralized constants/messages and simplified I/O.

<sup>Written for commit a730f202a4b691d6f70fd7561e59c4dd271b1079. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

