### PR TITLE
fix(eform): stop double-loading Bootstrap in admin-injected eForm pages

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/eform/efmformmanager.jsp
+++ b/src/main/webapp/WEB-INF/jsp/eform/efmformmanager.jsp
@@ -53,7 +53,7 @@
         <link rel="stylesheet" href="<%= request.getContextPath() %>/library/DataTables/DataTables-1.13.11/css/dataTables.bootstrap5.min.css">
         <script type="text/javascript" src="<%= request.getContextPath() %>/library/DataTables/DataTables-1.13.11/js/jquery.dataTables.min.js"></script>
         <script type="text/javascript" src="<%= request.getContextPath() %>/library/DataTables/DataTables-1.13.11/js/dataTables.bootstrap5.min.js"></script>
-        <script type="text/javascript" src="<%= request.getContextPath() %>/library/bootstrap/5.3.8/js/bootstrap.bundle.min.js"></script>
+<%@ include file="eformBootstrapScript.jspf" %>
         <script type="text/javascript" src="<%= request.getContextPath() %>/js/global.js"></script>
 
 

--- a/src/main/webapp/WEB-INF/jsp/eform/efmformmanagerdeleted.jsp
+++ b/src/main/webapp/WEB-INF/jsp/eform/efmformmanagerdeleted.jsp
@@ -47,7 +47,7 @@
     <link rel="icon" href="${pageContext.request.contextPath}/images/favicon.ico"/>
         <link rel="stylesheet" href="<%= request.getContextPath() %>/library/bootstrap/5.3.8/css/bootstrap.min.css">
         <link rel="stylesheet" href="<%= request.getContextPath() %>/css/fontawesome-all.min.css">
-        <script type="text/javascript" src="<%= request.getContextPath() %>/library/bootstrap/5.3.8/js/bootstrap.bundle.min.js"></script>
+<%@ include file="eformBootstrapScript.jspf" %>
         <script type="text/javascript" src="<%= request.getContextPath() %>/js/global.js"></script>
         <title><fmt:message key="eform.uploadhtml.title"/></title>
 

--- a/src/main/webapp/WEB-INF/jsp/eform/efmformmanageredit.jsp
+++ b/src/main/webapp/WEB-INF/jsp/eform/efmformmanageredit.jsp
@@ -117,7 +117,7 @@
             <%}%>
         </script>
     <link rel="stylesheet" href="<%=request.getContextPath() %>/css/fontawesome-all.min.css">
-    <script src="<%=request.getContextPath() %>/library/bootstrap/5.3.8/js/bootstrap.bundle.min.js"></script>
+<%@ include file="eformBootstrapScript.jspf" %>
 
     </head>
 

--- a/src/main/webapp/WEB-INF/jsp/eform/efmimagemanager.jsp
+++ b/src/main/webapp/WEB-INF/jsp/eform/efmimagemanager.jsp
@@ -68,7 +68,7 @@
     <script type="text/javascript" src="<%= request.getContextPath() %>/library/jquery/jquery-compat.js"></script>
     <script type="text/javascript" src="<%= request.getContextPath() %>/library/DataTables/DataTables-1.13.11/js/jquery.dataTables.min.js"></script>
     <script type="text/javascript" src="<%= request.getContextPath() %>/library/DataTables/DataTables-1.13.11/js/dataTables.bootstrap5.min.js"></script>
-    <script type="text/javascript" src="<%= request.getContextPath() %>/library/bootstrap/5.3.8/js/bootstrap.bundle.min.js"></script>
+<%@ include file="eformBootstrapScript.jspf" %>
     </head>
 
     <body topmargin="0" leftmargin="0" rightmargin="0">

--- a/src/main/webapp/WEB-INF/jsp/eform/efmmanageformgroups.jsp
+++ b/src/main/webapp/WEB-INF/jsp/eform/efmmanageformgroups.jsp
@@ -86,7 +86,7 @@
 
     <link rel="stylesheet" href="<%=request.getContextPath() %>/library/bootstrap/5.3.8/css/bootstrap.min.css">
     <link rel="stylesheet" href="<%=request.getContextPath() %>/css/fontawesome-all.min.css">
-    <script type="text/javascript" src="<%=request.getContextPath() %>/library/bootstrap/5.3.8/js/bootstrap.bundle.min.js"></script>
+<%@ include file="eformBootstrapScript.jspf" %>
     </head>
 
     <body>

--- a/src/main/webapp/WEB-INF/jsp/eform/efmmanageindependent.jsp
+++ b/src/main/webapp/WEB-INF/jsp/eform/efmmanageindependent.jsp
@@ -84,7 +84,7 @@
         </script>
     <link rel="stylesheet" href="<%=request.getContextPath() %>/library/bootstrap/5.3.8/css/bootstrap.min.css">
     <link rel="stylesheet" href="<%=request.getContextPath() %>/css/fontawesome-all.min.css">
-    <script type="text/javascript" src="<%=request.getContextPath() %>/library/bootstrap/5.3.8/js/bootstrap.bundle.min.js"></script>
+<%@ include file="eformBootstrapScript.jspf" %>
     </head>
 
     <body>

--- a/src/main/webapp/WEB-INF/jsp/eform/efmmanageindependentdeleted.jsp
+++ b/src/main/webapp/WEB-INF/jsp/eform/efmmanageindependentdeleted.jsp
@@ -58,7 +58,7 @@
         <title><fmt:message key="eform.showmyform.title"/></title>
         <link rel="stylesheet" href="<%= request.getContextPath() %>/library/bootstrap/5.3.8/css/bootstrap.min.css">
         <link rel="stylesheet" href="<%= request.getContextPath() %>/css/fontawesome-all.min.css">
-        <script type="text/javascript" src="<%= request.getContextPath() %>/library/bootstrap/5.3.8/js/bootstrap.bundle.min.js"></script>
+<%@ include file="eformBootstrapScript.jspf" %>
 
         <script type="text/javascript">
             function popupPage(varpage, windowname) {

--- a/src/main/webapp/WEB-INF/jsp/eform/eformBootstrapScript.jspf
+++ b/src/main/webapp/WEB-INF/jsp/eform/eformBootstrapScript.jspf
@@ -1,0 +1,41 @@
+<%--
+    Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+
+    This software is published under the GPL GNU General Public License.
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+    CARLOS EMR Project
+    https://github.com/carlos-emr/carlos
+--%>
+<%--
+  Fragment role: Loads the Bootstrap bundle for eForm admin pages, but ONLY when it
+  is not already present on the page.
+
+  Why the guard: these eForm pages render two ways. Standalone (direct URL / pop-out
+  window) they need their own Bootstrap. But administration/index.jsp also injects them
+  into #dynamic-content via jQuery .load(), and that shell already loads bootstrap.bundle.
+  jQuery executes the fragment's <script src> tags, so an unguarded include runs Bootstrap
+  a second time, which registers its data-api dropdown click handler twice — one click then
+  opens and immediately closes the "Create eForm" caret, so the menu never stays open.
+
+  When bootstrap is already loaded (window.bootstrap defined), skip the second copy. When it
+  is not (standalone), document.write emits the tag during parse so it loads synchronously
+  before the page's own Bootstrap-dependent scripts run.
+--%>
+<script type="text/javascript">
+    if (typeof window.bootstrap === "undefined") {
+        document.write('<script type="text/javascript" src="<%= request.getContextPath() %>/library/bootstrap/5.3.8/js/bootstrap.bundle.min.js"><\/script>');
+    }
+</script>

--- a/src/main/webapp/WEB-INF/jsp/eform/eformBootstrapScript.jspf
+++ b/src/main/webapp/WEB-INF/jsp/eform/eformBootstrapScript.jspf
@@ -30,12 +30,25 @@
   a second time, which registers its data-api dropdown click handler twice — one click then
   opens and immediately closes the "Create eForm" caret, so the menu never stays open.
 
-  When bootstrap is already loaded (window.bootstrap defined), skip the second copy. When it
-  is not (standalone), document.write emits the tag during parse so it loads synchronously
-  before the page's own Bootstrap-dependent scripts run.
+  When bootstrap is already loaded (window.bootstrap defined), skip the second copy.
+
+  Otherwise load it, but choose the method by document.readyState: during initial parse of a
+  standalone page (readyState "loading") document.write emits the tag synchronously so it is
+  ready before the page's own Bootstrap-dependent scripts run. If the fragment ever runs after
+  parsing has finished (e.g. injected via AJAX into a shell that has not provided Bootstrap),
+  document.write would implicitly call document.open() and wipe the page, so fall back to
+  appending a <script> element instead.
 --%>
 <script type="text/javascript">
     if (typeof window.bootstrap === "undefined") {
-        document.write('<script type="text/javascript" src="<%= request.getContextPath() %>/library/bootstrap/5.3.8/js/bootstrap.bundle.min.js"><\/script>');
+        var carlosBootstrapSrc = "<%= request.getContextPath() %>/library/bootstrap/5.3.8/js/bootstrap.bundle.min.js";
+        if (document.readyState === "loading") {
+            document.write('<script type="text/javascript" src="' + carlosBootstrapSrc + '"><\/script>');
+        } else {
+            var carlosBootstrapScript = document.createElement("script");
+            carlosBootstrapScript.type = "text/javascript";
+            carlosBootstrapScript.src = carlosBootstrapSrc;
+            document.head.appendChild(carlosBootstrapScript);
+        }
     }
 </script>


### PR DESCRIPTION
## Description

The **"Create eForm" dropdown (the ▼ caret)** on the **Administration → Manage eForms** screen (and the other eForm admin screens) does not open — one click makes the menu appear and immediately disappear.

**Root cause: Bootstrap's JS is loaded twice.** The Administration shell (`administration/index.jsp`) loads `bootstrap.bundle.min.js`, and it renders the eForm admin pages inside itself by AJAX-injecting them into `#dynamic-content` via jQuery `.load()`. jQuery executes the `<script src>` tags in the injected fragment, and each eForm admin page *also* loaded its own `bootstrap.bundle.min.js`. Running the bundle a second time registers Bootstrap's data-api dropdown click handler twice, so a single click toggles the menu twice (open → immediately closed).

Opening the same eForm Manager page directly (its own URL / pop-out) has only one Bootstrap copy and the caret works — which is why this only reproduces inside the Administration panel.

**Fix:** route the Bootstrap include for the eForm admin pages through a new shared fragment, `eformBootstrapScript.jspf`, that loads the bundle **only when it isn't already present** (`typeof window.bootstrap === "undefined"`). Pages opened standalone still load Bootstrap (synchronously, via `document.write` during parse, matching the existing guard pattern in `efmformmanageredit.jsp` for the Bootstrap CSS); pages injected into the already-bootstrapped admin shell skip the duplicate. The caret then opens on a single click in both contexts.

Applied to the seven eForm admin pages that render the `efmTopNav.jspf` "Create eForm" caret and are reachable inside the Administration panel:
`efmformmanager`, `efmformmanageredit`, `efmmanageformgroups`, `efmmanageindependent`, `efmimagemanager`, `efmformmanagerdeleted`, `efmmanageindependentdeleted`.

Note (out of scope): these pages also re-load jQuery and DataTables inside the shell; that duplication does not break the caret and is left for a separate follow-up to keep this change focused.

## Related Issues

Reported internally as "eForm admin — the Create eForm caret / down-arrow does not open." No linked GitHub issue.

## How Was This Tested?

- **Root cause reproduced in the running app** (logged in as `carlosdoc`), by counting Bootstrap scripts and observing the caret:

  | context | `document.querySelectorAll('script[src*="bootstrap.bundle"]').length` | caret opens on one click |
  |---|---|---|
  | Administration → Manage eForms (AJAX-injected) | 2 | no |
  | `/carlos/eform/efmformmanager` opened directly | 1 | yes |

- `scripts/lint/check-encoder-null-safety.sh` → **PASS**; no `<e:>` / `${e:}` / raw `Encode.forXxx()` introduced.
- Change is a standard `<%@ include %>` (the same mechanism these files already use for `efmTopNav.jspf` / `efmFooter.jspf`) plus a syntactically simple fragment; full JSP precompilation runs in the `jspc` CI check.

## Checklist

- [x] Signed off with DCO (`git commit -s`)
- [x] Conventional Commit message
- [x] No PHI in logs or output (no logging or user data touched; the guarded URL is the server context path, not user input)
- [x] Tests: no Java added; this is a front-end JSP script-loading fix verified by browser reproduction and the `jspc` precompile check
- [x] Read the contributing guide

## Summary by Sourcery

Guard Bootstrap script loading for eForm administration pages to prevent double initialization when rendered inside the Administration shell while preserving standalone behavior.

Bug Fixes:
- Fix the Create eForm dropdown caret in eForm admin pages so it opens reliably by avoiding duplicate Bootstrap JS loading in the Administration shell context.

Enhancements:
- Introduce a shared eForm JSP fragment for Bootstrap bundle inclusion and reuse it across all relevant eForm admin pages to centralize script loading behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the “Create eForm” dropdown not opening in Administration by preventing Bootstrap from loading twice on admin-injected eForm pages. Adds a guarded Bootstrap loader that safely loads during parse or appends after parse so the caret works in both embedded and standalone views.

- **Bug Fixes**
  - Added `eformBootstrapScript.jspf` to include `bootstrap.bundle.min.js` only when `window.bootstrap` is undefined; uses `document.readyState` to `document.write` during parse or append a script after parse.
  - Replaced direct Bootstrap script tags with the fragment in seven eForm admin JSPs.
  - Result: single click opens the dropdown; no duplicate Bootstrap handlers in the admin shell.

<sup>Written for commit d4959d0504cef09e726fc1825b0186da39e4ccee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

