### PR TITLE
fix: compact consultation PDF signatures

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/ConsultationPDFCreator.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/ConsultationPDFCreator.java
@@ -75,6 +75,13 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  */
 public class ConsultationPDFCreator extends PdfPageEventHelper {
 
+    private static final float SIGNATURE_IMAGE_SCALE_PERCENT = 40f;
+    private static final float SIGNATURE_IMAGE_MAX_WIDTH = 200f;
+    private static final float SIGNATURE_IMAGE_MAX_HEIGHT = 60f;
+    private static final float[] SIGNATURE_ROW_WIDTHS = new float[]{1.55f, 1.0f};
+    private static final float SIGNATURE_TOP_PADDING = 10f;
+    private static final float SIGNATURE_LABEL_BOTTOM_PADDING = 2f;
+
     private static Logger logger = MiscUtils.getLogger();
     private OutputStream os;
     private Document document;
@@ -757,33 +764,65 @@ public class ConsultationPDFCreator extends PdfPageEventHelper {
         byte[] signatureImage = resolveSignatureBytes(signatureImageOverride, reqFrm.getSignatureImg(), digitalSignatureManager);
 
         if (signatureImage != null && signatureImage.length > 0) {
-            float[] tableWidths = new float[]{0.55f, 2.75f};
-            PdfPTable table = new PdfPTable(tableWidths);
-            PdfPCell cell = new PdfPCell();
-
-            cell.setPhrase(new Phrase(getResource("msgSignature")));
-            cell.setBorder(0);
-            cell.setPadding(0);
-            cell.setPaddingTop(10f);
-            cell.setHorizontalAlignment(PdfPCell.ALIGN_BOTTOM);
-            cell.setVerticalAlignment(PdfPCell.ALIGN_LEFT);
-            table.addCell(cell);
-
             try {
-                Image image = Image.getInstance(signatureImage);
-                image.scalePercent(80f);
-                image.setBorder(0);
-                cell = new PdfPCell(image);
-                cell.setBorder(0);
-                cell.setPadding(0);
-                cell.setPaddingTop(10f);
-                table.addCell(cell);
+                Image image = createScaledSignatureImage(signatureImage);
+                addTable(pdfPTable, createRightAlignedSignatureTable(getResource("msgSignature"), image, font));
             } catch (BadElementException | IOException e) {
                 logger.error("An error occurred while trying to create an image from the signature", e);
             }
-
-            addTable(pdfPTable, table);
         }
+    }
+
+    static Image createScaledSignatureImage(byte[] signatureImage) throws BadElementException, IOException {
+        Image image = Image.getInstance(signatureImage);
+        image.scalePercent(Math.min(SIGNATURE_IMAGE_SCALE_PERCENT, Math.min(
+                scalePercentToFit(image.getPlainWidth(), SIGNATURE_IMAGE_MAX_WIDTH),
+                scalePercentToFit(image.getPlainHeight(), SIGNATURE_IMAGE_MAX_HEIGHT))));
+        image.setBorder(0);
+        return image;
+    }
+
+    private static float scalePercentToFit(float sourceSize, float maxSize) {
+        if (sourceSize <= 0f) {
+            return SIGNATURE_IMAGE_SCALE_PERCENT;
+        }
+        return maxSize * 100f / sourceSize;
+    }
+
+    private static PdfPTable createRightAlignedSignatureTable(String signatureLabel, Image image, Font signatureFont) {
+        PdfPTable signatureBlock = new PdfPTable(1);
+        signatureBlock.setWidthPercentage(100f);
+
+        PdfPCell labelCell = new PdfPCell(new Phrase(signatureLabel, signatureFont));
+        labelCell.setBorder(0);
+        labelCell.setPadding(0);
+        labelCell.setPaddingBottom(SIGNATURE_LABEL_BOTTOM_PADDING);
+        signatureBlock.addCell(labelCell);
+
+        PdfPCell imageCell = new PdfPCell(image);
+        imageCell.setBorder(0);
+        imageCell.setPadding(0);
+        imageCell.setHorizontalAlignment(PdfPCell.ALIGN_RIGHT);
+        signatureBlock.addCell(imageCell);
+
+        PdfPTable table = new PdfPTable(SIGNATURE_ROW_WIDTHS);
+        table.setWidthPercentage(100f);
+        table.addCell(createSignatureSpacerCell());
+
+        PdfPCell signatureCell = new PdfPCell(signatureBlock);
+        signatureCell.setBorder(0);
+        signatureCell.setPadding(0);
+        signatureCell.setPaddingTop(SIGNATURE_TOP_PADDING);
+        table.addCell(signatureCell);
+        return table;
+    }
+
+    private static PdfPCell createSignatureSpacerCell() {
+        PdfPCell spacerCell = new PdfPCell(new Phrase(""));
+        spacerCell.setBorder(0);
+        spacerCell.setPadding(0);
+        spacerCell.setPaddingTop(SIGNATURE_TOP_PADDING);
+        return spacerCell;
     }
 
     /**

--- a/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/ConsultationPDFCreatorUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/ConsultationPDFCreatorUnitTest.java
@@ -29,10 +29,16 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import javax.imageio.ImageIO;
+
 import io.github.carlos_emr.carlos.commn.model.DigitalSignature;
 import io.github.carlos_emr.carlos.managers.DigitalSignatureManager;
 import io.github.carlos_emr.carlos.test.logging.LogCapture;
 
+import org.openpdf.text.Image;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -47,6 +53,10 @@ class ConsultationPDFCreatorUnitTest {
 
     private static final byte[] OVERRIDE_BYTES = new byte[]{1, 2, 3};
     private static final byte[] STORED_BYTES = new byte[]{9, 8, 7};
+    private static final int SIGNATURE_SOURCE_WIDTH = 500;
+    private static final int SIGNATURE_SOURCE_HEIGHT = 150;
+    private static final float SIGNATURE_MAX_WIDTH = 200f;
+    private static final float SIGNATURE_MAX_HEIGHT = 60f;
 
     @Test
     @DisplayName("prefers the non-mutating override and never loads the stored signature")
@@ -161,5 +171,65 @@ class ConsultationPDFCreatorUnitTest {
         byte[] result = ConsultationPDFCreator.resolveSignatureBytes(null, "5", mgr);
 
         assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("should scale signature image to the compact right-aligned footprint")
+    void shouldScaleSignatureImage_toCompactFootprint() throws Exception {
+        Image image = ConsultationPDFCreator.createScaledSignatureImage(
+                createPng(SIGNATURE_SOURCE_WIDTH, SIGNATURE_SOURCE_HEIGHT));
+
+        assertThat(image.getScaledWidth()).isEqualTo(SIGNATURE_MAX_WIDTH);
+        assertThat(image.getScaledHeight()).isEqualTo(SIGNATURE_MAX_HEIGHT);
+        assertThat(image.getBorder()).isZero();
+    }
+
+    @Test
+    @DisplayName("should cap wide signature image at the compact footprint width")
+    void shouldCapSignatureImage_whenSourceIsWide() throws Exception {
+        Image image = ConsultationPDFCreator.createScaledSignatureImage(createPng(1000, SIGNATURE_SOURCE_HEIGHT));
+
+        assertThat(image.getScaledWidth()).isEqualTo(SIGNATURE_MAX_WIDTH);
+        assertThat(image.getScaledHeight()).isEqualTo(30f);
+        assertThat(image.getScaledWidth()).isLessThanOrEqualTo(SIGNATURE_MAX_WIDTH);
+        assertThat(image.getScaledHeight()).isLessThanOrEqualTo(SIGNATURE_MAX_HEIGHT);
+    }
+
+    @Test
+    @DisplayName("should cap tall signature image at the compact footprint height")
+    void shouldCapSignatureImage_whenSourceIsTall() throws Exception {
+        Image image = ConsultationPDFCreator.createScaledSignatureImage(createPng(300, 600));
+
+        assertThat(image.getScaledWidth()).isEqualTo(30f);
+        assertThat(image.getScaledHeight()).isEqualTo(SIGNATURE_MAX_HEIGHT);
+        assertThat(image.getScaledWidth()).isLessThanOrEqualTo(SIGNATURE_MAX_WIDTH);
+        assertThat(image.getScaledHeight()).isLessThanOrEqualTo(SIGNATURE_MAX_HEIGHT);
+    }
+
+    @Test
+    @DisplayName("should cap accepted provider stamp maximum dimensions within the compact footprint")
+    void shouldCapSignatureImage_whenSourceMatchesProviderStampLimit() throws Exception {
+        Image image = ConsultationPDFCreator.createScaledSignatureImage(createPng(1000, 400));
+
+        assertThat(image.getScaledWidth()).isEqualTo(150f);
+        assertThat(image.getScaledHeight()).isEqualTo(SIGNATURE_MAX_HEIGHT);
+        assertThat(image.getScaledWidth()).isLessThanOrEqualTo(SIGNATURE_MAX_WIDTH);
+        assertThat(image.getScaledHeight()).isLessThanOrEqualTo(SIGNATURE_MAX_HEIGHT);
+    }
+
+    @Test
+    @DisplayName("should not upscale small signature image")
+    void shouldNotUpscaleSignatureImage_whenSourceIsSmall() throws Exception {
+        Image image = ConsultationPDFCreator.createScaledSignatureImage(createPng(100, 30));
+
+        assertThat(image.getScaledWidth()).isEqualTo(40f);
+        assertThat(image.getScaledHeight()).isEqualTo(12f);
+    }
+
+    private static byte[] createPng(int width, int height) throws IOException {
+        BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ImageIO.write(image, "png", out);
+        return out.toByteArray();
     }
 }


### PR DESCRIPTION
## Summary
- compact consultation PDF signatures to the reviewed Option 4A footprint: right-aligned sign-off block at 40% scale
- keep the signature after consultation details and before the referring practitioner/MRP footer
- factor signature image scaling/table creation into focused helpers and cover the compact footprint in unit tests

## Mock/layout note
- Implements the reviewed local mock Option 4A: right-aligned sign-off, 40%, approximately 200 x 60 pt for a 500 x 150 source signature.
- I did not commit the mock PDF to avoid adding a binary design artifact to the repo.

## Base
- PR #3146 has already been merged into `develop` and its head branch was deleted, so this PR targets `develop`, which contains #3146 at merge commit `571478a`.

## Tests
- `mvn -q -Dtest=ConsultationPDFCreatorUnitTest test`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compact the consultation PDF signature into a right‑aligned block at 40% scale with consistent spacing, capped at 200x60 pt, and stabilize direct print preview. Manual signatures are saved and validated before rendering; on failure we warn and render the preview unsigned.

- **Bug Fixes**
  - Save manual signatures before preview, validate the consultation and demographic, and on save failure show a warning and suppress the signature for that preview.
  - Prevent duplicate signatures by returning the stored `signatureImg` in preview JSON and updating the form; serve correct image types by detecting magic bytes.

- **Refactors**
  - Extract helpers and constants to scale the signature (40% default, capped at 200x60) and build a right‑aligned signature block; set row widths to 1.55:1.0, move the label above, and use tight padding.
  - Expand unit tests to lock the compact footprint and edge cases: wide, tall, provider‑stamp max, and no upscaling of small images.

<sup>Written for commit d3cbb106543cbcffe06cd9a51d5608d2b77dada5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

