### PR TITLE
[Fix] minimal change to align signature on Request PDF with its label

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/ConsultationPDFCreator.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/ConsultationPDFCreator.java
@@ -802,7 +802,7 @@ public class ConsultationPDFCreator extends PdfPageEventHelper {
         PdfPCell imageCell = new PdfPCell(image);
         imageCell.setBorder(0);
         imageCell.setPadding(0);
-        imageCell.setHorizontalAlignment(PdfPCell.ALIGN_RIGHT);
+        //imageCell.setHorizontalAlignment(PdfPCell.ALIGN_RIGHT);
         signatureBlock.addCell(imageCell);
 
         PdfPTable table = new PdfPTable(SIGNATURE_ROW_WIDTHS);


### PR DESCRIPTION
Comment out horizontal alignment setting for image cell to align preceding label with the signature image

<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description
This aligns the signature with the signature label
with the least amount of work (as the file is deprecated and scheduled to be rewritten)
<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues

<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?

<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots

BEFORE
<img width="967" height="423" alt="preSig" src="https://github.com/user-attachments/assets/eef79166-98df-46ac-b431-9a5587a9d613" />

AFTER
<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->
<img width="961" height="465" alt="sigAligned_NOT A PATIENT pdf" src="https://github.com/user-attachments/assets/6ad12c21-1764-4a75-9880-07f87fa7babe" />

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Bug Fixes:
- Fix misalignment between the signature label and the signature image in the consultation PDF output.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align the signature image with its preceding label in the consultation PDF by removing the forced right alignment on the image cell. This keeps the label and signature aligned.

<sup>Written for commit aa1e981487eee424fb61a0be79827c17709fdbda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

