### PR TITLE
[Bug]: Opening a document from the patient encounter window shows CARLOS Error: 0

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/EDocUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/EDocUtil.java
@@ -1429,7 +1429,7 @@ public final class EDocUtil {
 		// resolver instead of validateConfiguredDirectory, which hard-fails on a missing
 		// directory — nothing can have been refiled into a directory that doesn't exist.
 		File destDir = PathValidationUtils.resolveConfiguredDirectory(destPath, "incoming refile directory");
-		if (!destDir.isDirectory()) {
+		if (destDir == null || !destDir.isDirectory()) {
 			return false;
 		}
 		File destFile = PathValidationUtils.validateGeneratedChildPath("R" + PathValidationUtils.validateGeneratedFileName(destFileName), destDir);

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/EDocUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/EDocUtil.java
@@ -1410,11 +1410,18 @@ public final class EDocUtil {
 	/**
 	 * Checks if a document with the given filename has already been refiled in the specified queue.
 	 *
+	 * <p>Unlike most {@code PathValidationUtils.validateConfiguredDirectory} callers in this class,
+	 * a missing Refile directory here is not treated as a configuration failure: that subdirectory
+	 * is created lazily by {@link #refileDocument(String, String)} on its first use for a given
+	 * queue, so a queue that has never had a document refiled into it legitimately has no Refile
+	 * directory yet. This method treats that case (and any other resolution failure) the same as
+	 * "not yet refiled" and returns {@code false} rather than throwing.</p>
+	 *
 	 * @see #refileDocument(String, String)
 	 * @param filename The original filename of the document.
 	 * @param queueId  The ID of the queue where the document might have been refiled.
 	 * @return {@code true} if a document with the refiled name exists in the queue's refile directory,
-	 * {@code false} otherwise.
+	 * {@code false} otherwise, including when the queue's refile directory does not exist yet.
 	 */
 	public static boolean isDocumentAlreadyRefiledInQueue(String filename, int queueId) {
 		String destFileName = filename;

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/EDocUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/EDocUtil.java
@@ -1414,8 +1414,10 @@ public final class EDocUtil {
 	 * a missing Refile directory here is not treated as a configuration failure: that subdirectory
 	 * is created lazily by {@link #refileDocument(String, String)} on its first use for a given
 	 * queue, so a queue that has never had a document refiled into it legitimately has no Refile
-	 * directory yet. This method treats that case (and any other resolution failure) the same as
-	 * "not yet refiled" and returns {@code false} rather than throwing.</p>
+	 * directory yet. Only that specific case — the directory not existing — is treated as
+	 * "not yet refiled" and returns {@code false}. Genuine configuration errors (a blank path, an
+	 * existing path that is not a directory, or a canonicalization failure) still propagate as a
+	 * {@code SecurityException} from {@code PathValidationUtils.resolveConfiguredDirectory}.</p>
 	 *
 	 * @see #refileDocument(String, String)
 	 * @param filename The original filename of the document.

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/EDocUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/EDocUtil.java
@@ -1423,7 +1423,15 @@ public final class EDocUtil {
 		}
 
 		String destPath = IncomingDocUtil.getIncomingDocumentFilePath(String.valueOf(queueId), "Refile");
-		File destDir = PathValidationUtils.validateConfiguredDirectory(destPath, "incoming refile directory");
+		// The Refile subdirectory is created lazily by refileDocument() on first use (see
+		// FileUtils.copyFile's auto-mkdirs behavior there), so it legitimately does not exist
+		// for a queue that has never had a document refiled into it yet. Use the tolerant
+		// resolver instead of validateConfiguredDirectory, which hard-fails on a missing
+		// directory — nothing can have been refiled into a directory that doesn't exist.
+		File destDir = PathValidationUtils.resolveConfiguredDirectory(destPath, "incoming refile directory");
+		if (!destDir.isDirectory()) {
+			return false;
+		}
 		File destFile = PathValidationUtils.validateGeneratedChildPath("R" + PathValidationUtils.validateGeneratedFileName(destFileName), destDir);
 		return destFile.exists();
 	}

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/ProviderBeanResolver.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/ProviderBeanResolver.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.documentManager;
+
+import io.github.carlos_emr.carlos.utility.MiscUtils;
+import jakarta.servlet.http.HttpSession;
+
+import java.util.Properties;
+
+/**
+ * Resolves the session-scoped {@code providerBean} lookup map (provider number to display name)
+ * shared by document-viewer JSPs ({@code showDocument.jsp}, {@code MultiPageDocDisplay.jsp}).
+ *
+ * <p>Most pages in the app seed this session attribute via
+ * {@code <jsp:useBean id="providerBean" class="java.util.Properties" scope="session"/>}, which
+ * auto-creates an empty {@code Properties} the first time it's touched in a session. The document
+ * viewers instead read it directly so it can be null the first time a session opens a document
+ * without having visited one of those other pages first — this is expected, not a misconfiguration,
+ * so callers fall back to an empty map rather than failing.</p>
+ */
+public final class ProviderBeanResolver {
+
+    private static final String SESSION_ATTR = "providerBean";
+    private static final String MISSING_LOGGED_ATTR = "providerBeanMissingLogged";
+
+    private ProviderBeanResolver() {
+        // utility
+    }
+
+    /**
+     * @param session current HTTP session
+     * @param docId   document id being rendered, for diagnostic logging only
+     * @return the session's {@code providerBean} map, or a new empty {@code Properties} if the
+     *         session hasn't been seeded yet (callers' typical
+     *         {@code getProperty(providerNo, providerNo)} pattern then falls back to displaying
+     *         the raw provider number instead of a formatted name)
+     */
+    public static Properties resolve(HttpSession session, String docId) {
+        Properties p = (Properties) session.getAttribute(SESSION_ATTR);
+        if (p != null) {
+            return p;
+        }
+
+        // Log at INFO, once per session, since this is routinely hit on a session's first
+        // document view rather than being an unexpected failure — a WARN on every view would
+        // just be noise, and logging every occurrence isn't needed to diagnose the fallback.
+        Boolean alreadyLogged = (Boolean) session.getAttribute(MISSING_LOGGED_ATTR);
+        if (alreadyLogged == null || !alreadyLogged) {
+            MiscUtils.getLogger().info(
+                    "providerBean missing from session while rendering linked providers for document {}; falling back to provider IDs",
+                    docId);
+            session.setAttribute(MISSING_LOGGED_ATTR, Boolean.TRUE);
+        }
+        return new Properties();
+    }
+}

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/ProviderBeanResolver.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/ProviderBeanResolver.java
@@ -36,6 +36,8 @@ import java.util.Properties;
  * viewers instead read it directly so it can be null the first time a session opens a document
  * without having visited one of those other pages first — this is expected, not a misconfiguration,
  * so callers fall back to an empty map rather than failing.</p>
+ *
+ * @since 2026-07-16
  */
 public final class ProviderBeanResolver {
 
@@ -47,12 +49,16 @@ public final class ProviderBeanResolver {
     }
 
     /**
+     * Returns the session's {@code providerBean} map, or a new empty {@code Properties} instance
+     * (not stored back into the session) when the session doesn't have one yet.
+     *
      * @param session current HTTP session
      * @param docId   document id being rendered, for diagnostic logging only
      * @return the session's {@code providerBean} map, or a new empty {@code Properties} if the
      *         session hasn't been seeded yet (callers' typical
      *         {@code getProperty(providerNo, providerNo)} pattern then falls back to displaying
      *         the raw provider number instead of a formatted name)
+     * @since 2026-07-16
      */
     public static Properties resolve(HttpSession session, String docId) {
         Properties p = (Properties) session.getAttribute(SESSION_ATTR);

--- a/src/main/webapp/WEB-INF/jsp/documentManager/MultiPageDocDisplay.jsp
+++ b/src/main/webapp/WEB-INF/jsp/documentManager/MultiPageDocDisplay.jsp
@@ -30,6 +30,7 @@
 --%>
 
 <%@page import="io.github.carlos_emr.carlos.utility.LoggedInInfo" %>
+<%@ page import="io.github.carlos_emr.carlos.utility.MiscUtils" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
@@ -737,6 +738,9 @@
                                     <%
                                         Properties p = (Properties) session.getAttribute("providerBean");
                                         if (p == null) {
+                                            // See showDocument.jsp for why this can be null and why we
+                                            // still fall back to an empty map rather than failing.
+                                            MiscUtils.getLogger().warn("providerBean missing from session while rendering linked providers for document " + docId + "; falling back to provider IDs");
                                             p = new Properties();
                                         }
                                         List<ProviderInboxItem> routeList = providerInboxRoutingDao.getProvidersWithRoutingForDocument("DOC", Integer.parseInt(docId));

--- a/src/main/webapp/WEB-INF/jsp/documentManager/MultiPageDocDisplay.jsp
+++ b/src/main/webapp/WEB-INF/jsp/documentManager/MultiPageDocDisplay.jsp
@@ -736,6 +736,9 @@
                                     Linked Providers:
                                     <%
                                         Properties p = (Properties) session.getAttribute("providerBean");
+                                        if (p == null) {
+                                            p = new Properties();
+                                        }
                                         List<ProviderInboxItem> routeList = providerInboxRoutingDao.getProvidersWithRoutingForDocument("DOC", Integer.parseInt(docId));
                                     %>
                                     <ul>

--- a/src/main/webapp/WEB-INF/jsp/documentManager/MultiPageDocDisplay.jsp
+++ b/src/main/webapp/WEB-INF/jsp/documentManager/MultiPageDocDisplay.jsp
@@ -738,7 +738,7 @@
                                     <%
                                         Properties p = ProviderBeanResolver.resolve(session, docId);
                                         List<ProviderInboxItem> routeList = Collections.emptyList();
-                                        if (docId != null) {
+                                        if (docId != null && !docId.trim().isEmpty()) {
                                             routeList = providerInboxRoutingDao.getProvidersWithRoutingForDocument("DOC", Integer.parseInt(docId));
                                         }
                                     %>

--- a/src/main/webapp/WEB-INF/jsp/documentManager/MultiPageDocDisplay.jsp
+++ b/src/main/webapp/WEB-INF/jsp/documentManager/MultiPageDocDisplay.jsp
@@ -30,7 +30,7 @@
 --%>
 
 <%@page import="io.github.carlos_emr.carlos.utility.LoggedInInfo" %>
-<%@ page import="io.github.carlos_emr.carlos.utility.MiscUtils" %>
+<%@ page import="io.github.carlos_emr.carlos.documentManager.ProviderBeanResolver" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
@@ -736,14 +736,11 @@
                                 <td colspan="2">
                                     Linked Providers:
                                     <%
-                                        Properties p = (Properties) session.getAttribute("providerBean");
-                                        if (p == null) {
-                                            // See showDocument.jsp for why this can be null and why we
-                                            // still fall back to an empty map rather than failing.
-                                            MiscUtils.getLogger().warn("providerBean missing from session while rendering linked providers for document " + docId + "; falling back to provider IDs");
-                                            p = new Properties();
+                                        Properties p = ProviderBeanResolver.resolve(session, docId);
+                                        List<ProviderInboxItem> routeList = Collections.emptyList();
+                                        if (docId != null) {
+                                            routeList = providerInboxRoutingDao.getProvidersWithRoutingForDocument("DOC", Integer.parseInt(docId));
                                         }
-                                        List<ProviderInboxItem> routeList = providerInboxRoutingDao.getProvidersWithRoutingForDocument("DOC", Integer.parseInt(docId));
                                     %>
                                     <ul>
                                         <%

--- a/src/main/webapp/WEB-INF/jsp/documentManager/showDocument.jsp
+++ b/src/main/webapp/WEB-INF/jsp/documentManager/showDocument.jsp
@@ -771,7 +771,7 @@
                                     <%
                                         Properties p = ProviderBeanResolver.resolve(session, docId);
                                         List<ProviderInboxItem> routeList = Collections.emptyList();
-                                        if (docId != null) {
+                                        if (docId != null && !docId.trim().isEmpty()) {
                                             routeList = providerInboxRoutingDao.getProvidersWithRoutingForDocument("DOC", Integer.parseInt(docId));
                                         }
                                     %>

--- a/src/main/webapp/WEB-INF/jsp/documentManager/showDocument.jsp
+++ b/src/main/webapp/WEB-INF/jsp/documentManager/showDocument.jsp
@@ -769,6 +769,9 @@
                                     <fmt:message key="inboxmanager.document.LinkedProvidersMsg"/>
                                     <%
                                         Properties p = (Properties) session.getAttribute("providerBean");
+                                        if (p == null) {
+                                            p = new Properties();
+                                        }
                                         List<ProviderInboxItem> routeList = Collections.emptyList();
                                         if (docId != null) {
                                             routeList = providerInboxRoutingDao.getProvidersWithRoutingForDocument("DOC", Integer.parseInt(docId));

--- a/src/main/webapp/WEB-INF/jsp/documentManager/showDocument.jsp
+++ b/src/main/webapp/WEB-INF/jsp/documentManager/showDocument.jsp
@@ -128,6 +128,7 @@
 <%@ page import="io.github.carlos_emr.carlos.documentManager.EDoc" %>
 <%@ page import="io.github.carlos_emr.carlos.documentManager.EDocUtil" %>
 <%@ page import="io.github.carlos_emr.carlos.documentManager.IncomingDocUtil" %>
+<%@ page import="io.github.carlos_emr.carlos.documentManager.ProviderBeanResolver" %>
 <%@ page import="io.github.carlos_emr.carlos.lab.ca.all.*" %>
 <%@ page import="io.github.carlos_emr.carlos.log.*" %>
 <%@ page import="io.github.carlos_emr.carlos.managers.SecurityInfoManager" %>
@@ -768,17 +769,7 @@
                                 <td colspan="2">
                                     <fmt:message key="inboxmanager.document.LinkedProvidersMsg"/>
                                     <%
-                                        Properties p = (Properties) session.getAttribute("providerBean");
-                                        if (p == null) {
-                                            // Not populated yet for this session (only lazily seeded by
-                                            // other pages via <jsp:useBean scope="session">). Fall back to
-                                            // an empty map — getProperty(id, id) below still displays the
-                                            // raw provider number — but log it so a missing display-name
-                                            // lookup is visible instead of silently looking like no names
-                                            // were ever configured.
-                                            MiscUtils.getLogger().warn("providerBean missing from session while rendering linked providers for document " + docId + "; falling back to provider IDs");
-                                            p = new Properties();
-                                        }
+                                        Properties p = ProviderBeanResolver.resolve(session, docId);
                                         List<ProviderInboxItem> routeList = Collections.emptyList();
                                         if (docId != null) {
                                             routeList = providerInboxRoutingDao.getProvidersWithRoutingForDocument("DOC", Integer.parseInt(docId));

--- a/src/main/webapp/WEB-INF/jsp/documentManager/showDocument.jsp
+++ b/src/main/webapp/WEB-INF/jsp/documentManager/showDocument.jsp
@@ -770,6 +770,13 @@
                                     <%
                                         Properties p = (Properties) session.getAttribute("providerBean");
                                         if (p == null) {
+                                            // Not populated yet for this session (only lazily seeded by
+                                            // other pages via <jsp:useBean scope="session">). Fall back to
+                                            // an empty map — getProperty(id, id) below still displays the
+                                            // raw provider number — but log it so a missing display-name
+                                            // lookup is visible instead of silently looking like no names
+                                            // were ever configured.
+                                            MiscUtils.getLogger().warn("providerBean missing from session while rendering linked providers for document " + docId + "; falling back to provider IDs");
                                             p = new Properties();
                                         }
                                         List<ProviderInboxItem> routeList = Collections.emptyList();


### PR DESCRIPTION
<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description

This fixes the issue where opening a document from the patient encounter window shows `CARLOS Error: 0`.

The root cause was in `EDocUtil.isDocumentAlreadyRefiledInQueue()`, which is called from `showDocument.jsp` while rendering the document viewer. The method checked every configured document queue to decide whether the `Refile` button should be disabled. However, it used `PathValidationUtils.validateConfiguredDirectory()`, which throws if the queue's `Refile` directory does not already exist.

Those `Refile` directories are created lazily only when a document is first refiled into a queue. In environments where no document has been refiled yet, the read-only "is this document already refiled?" check threw a `SecurityException` instead of returning `false`. That exception was forwarded to the generic error page, resulting in `CARLOS Error: 0`.

To handle this, I changed the refile-status check to use `resolveConfiguredDirectory()` and return `false` when the queue's `Refile` directory does not exist.

I also noticed one other possible bug that I addressed here. I added a defensive `providerBean` null guard in the document display JSPs to avoid a separate latent NPE in provider-inbox routing scenarios.

## Related Issues

Fixes #3070

## How Was This Tested?

1. Open a patient's encounter window.
2. Go to the document area/list in the encounter UI.
3. Click a document to open it.

## Screenshots
Before:
<img width="1116" height="1017" alt="Screenshot 2026-07-12 at 4 50 44 PM" src="https://github.com/user-attachments/assets/fbd81090-01d9-4f7e-bbf7-951f8a4a9c9e" />
After:
<img width="1114" height="1024" alt="Screenshot 2026-07-12 at 6 46 41 PM" src="https://github.com/user-attachments/assets/0d4bf3e0-0dec-47e5-9b7a-474abbfa7dd8" />


## Checklist

- [X] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [X] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [X] I have not included any patient data (PHI) in this PR
- [X] I have added tests for new functionality, or this change doesn't need new tests
- [X] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Prevent CARLOS Error: 0 when opening encounter documents by tolerating missing refile directories and hardening provider display logic.

Bug Fixes:
- Ensure document refile status checks treat missing refile directories as "not refiled" instead of throwing errors.
- Avoid null-pointer failures in document viewer pages by safely handling missing providerBean session data and falling back to provider IDs.

Enhancements:
- Add logging when provider display-name lookup data is missing to make routing configuration issues visible in logs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the “CARLOS Error: 0” when opening a document from the patient encounter window by tolerating missing refile directories and centralizing provider lookup with a safe fallback. Users can open documents without errors in fresh environments. Fixes #3070.

- **Bug Fixes**
  - In `EDocUtil.isDocumentAlreadyRefiledInQueue()`, use `PathValidationUtils.resolveConfiguredDirectory()` and return `false` when the `Refile` directory is missing.
  - Add `ProviderBeanResolver` and use it in `MultiPageDocDisplay.jsp` and `showDocument.jsp` to safely handle a missing session `providerBean` (INFO log once per session, fallback to provider IDs) and to guard `docId` before parsing to prevent NPEs.

<sup>Written for commit 41d9f9772821909043c45bf124816e6080eb10c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

