### PR TITLE
fix(eform): harden PDF and HRM attachment handling

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/managers/EformDataManagerImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/EformDataManagerImpl.java
@@ -190,7 +190,7 @@ public class EformDataManagerImpl implements EformDataManager {
 
     public EFormData findByFdid(LoggedInInfo loggedInInfo, Integer fdid) {
         if (!securityInfoManager.hasPrivilege(loggedInInfo, "_eform", SecurityInfoManager.READ, null)) {
-            throw new RuntimeException("missing required sec object (_eform)");
+            throw new SecurityException("missing required sec object (_eform)");
         }
         return eFormDataDao.find(fdid);
     }
@@ -224,6 +224,9 @@ public class EformDataManagerImpl implements EformDataManager {
             LoggedInInfo loggedInInfo, int fdid, EFormRenderApproval approval) throws PDFGenerationException {
         EFormData eformData = eFormDataDao.find(fdid);
         if (eformData == null) {
+            if (!securityInfoManager.hasPrivilege(loggedInInfo, "_eform", SecurityInfoManager.READ, null)) {
+                throw new SecurityException("missing required sec object (_eform)");
+            }
             logger.warn("EForm PDF generation failed: no saved eForm found for fdid={}", fdid);
             throw new PDFGenerationException("EForm PDF generation failed because the eForm was not found.");
         }
@@ -297,14 +300,37 @@ public class EformDataManagerImpl implements EformDataManager {
         ArrayList<HashMap<String, ? extends Object>> allHRMDocuments = HRMUtil.listHRMDocuments(loggedInInfo, "report_date", false, demographicId, false);
         ArrayList<HashMap<String, ? extends Object>> filteredHRMDocuments = new ArrayList<>(attachedHRMDocumentIds.size());
         for (String hrmId : attachedHRMDocumentIds) {
+            Integer attachedHrmId = parseHrmAttachmentId(hrmId);
+            if (attachedHrmId == null) {
+                continue;
+            }
             for (HashMap<String, ? extends Object> hrmDocument : allHRMDocuments) {
-                if (Integer.parseInt(hrmId) == (Integer) hrmDocument.get("id")) {
+                if (attachedHrmId.equals(hrmAttachmentId(hrmDocument))) {
                     filteredHRMDocuments.add(hrmDocument);
+                    break;
                 }
             }
         }
         //return the subset of listHRMDocuments that is attached
         return filteredHRMDocuments;
+    }
+
+    private Integer hrmAttachmentId(HashMap<String, ? extends Object> hrmDocument) {
+        return hrmDocument == null ? null : parseHrmAttachmentId(hrmDocument.get("id"));
+    }
+
+    private Integer parseHrmAttachmentId(Object hrmDocumentId) {
+        if (hrmDocumentId instanceof Number) {
+            return ((Number) hrmDocumentId).intValue();
+        }
+        if (hrmDocumentId instanceof String) {
+            try {
+                return Integer.valueOf((String) hrmDocumentId);
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        }
+        return null;
     }
 
     public List<EctFormData.PatientForm> getFormsAttachedToEForm(LoggedInInfo loggedInInfo, String fdid, String demographicId) {

--- a/src/test/java/io/github/carlos_emr/carlos/managers/EformDataManagerImplCreatePdfUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/managers/EformDataManagerImplCreatePdfUnitTest.java
@@ -2,12 +2,17 @@ package io.github.carlos_emr.carlos.managers;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 
 import io.github.carlos_emr.carlos.commn.dao.EFormDataDao;
 import io.github.carlos_emr.carlos.commn.model.EFormData;
+import io.github.carlos_emr.carlos.commn.model.enumerator.DocumentType;
 import io.github.carlos_emr.carlos.documentManager.DocumentAttachmentManager;
 import io.github.carlos_emr.carlos.eform.util.EFormBrowserPdfService;
 import io.github.carlos_emr.carlos.eform.util.EFormRenderApproval;
+import io.github.carlos_emr.carlos.hospitalReportManager.HRMUtil;
 import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.PDFGenerationException;
@@ -17,17 +22,19 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-@DisplayName("EformDataManagerImpl createEformPDF")
+@DisplayName("EformDataManagerImpl PDF generation and lookup")
 @Tag("unit")
 @Tag("fast")
 class EformDataManagerImplCreatePdfUnitTest extends CarlosUnitTestBase {
@@ -155,5 +162,76 @@ class EformDataManagerImplCreatePdfUnitTest extends CarlosUnitTestBase {
 
         verify(securityInfoManager).hasPrivilege(loggedInInfo, "_eform", SecurityInfoManager.READ, "123");
         verifyNoInteractions(eFormBrowserPdfService);
+    }
+
+    @Test
+    @DisplayName("should throw SecurityException for missing eForm without broad read")
+    void shouldThrowSecurityException_whenMissingEform() {
+        assertThatThrownBy(() -> manager.createEformPDF(loggedInInfo, 404))
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("missing required sec object (_eform)");
+
+        verify(securityInfoManager).hasPrivilege(loggedInInfo, "_eform", SecurityInfoManager.READ, null);
+        verifyNoInteractions(eFormBrowserPdfService);
+    }
+
+    @Test
+    @DisplayName("should throw PDFGenerationException for missing eForm when broad read is allowed")
+    void shouldThrowPdfGenerationException_whenMissingEformAndBroadReadAllowed() {
+        when(securityInfoManager.hasPrivilege(loggedInInfo, "_eform", SecurityInfoManager.READ, null)).thenReturn(true);
+
+        assertThatThrownBy(() -> manager.createEformPDF(loggedInInfo, 404))
+                .isInstanceOf(PDFGenerationException.class)
+                .hasMessageContaining("eForm was not found");
+
+        verify(securityInfoManager).hasPrivilege(loggedInInfo, "_eform", SecurityInfoManager.READ, null);
+        verifyNoInteractions(eFormBrowserPdfService);
+    }
+
+    @Test
+    @DisplayName("should throw SecurityException when broad eForm read is denied for lookup")
+    void shouldThrowSecurityException_whenFindByFdidBroadReadDenied() {
+        when(securityInfoManager.hasPrivilege(loggedInInfo, "_eform", SecurityInfoManager.READ, null)).thenReturn(false);
+
+        assertThatThrownBy(() -> manager.findByFdid(loggedInInfo, 77))
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("missing required sec object (_eform)");
+
+        verify(eFormDataDao, never()).find(77);
+    }
+
+    @Test
+    @DisplayName("should match attached eForm HRMs when id metadata is numeric string")
+    void shouldMatchAttachedEFormHrmDocuments_whenIdMetadataIsNumericString() {
+        HashMap<String, Object> hrmDocument = new HashMap<>();
+        hrmDocument.put("id", "43");
+        ArrayList<HashMap<String, ? extends Object>> allHrmDocuments = new ArrayList<>();
+        allHrmDocuments.add(hrmDocument);
+        when(documentAttachmentManager.getEFormAttachments(loggedInInfo, 77, DocumentType.HRM, 123))
+                .thenReturn(List.of("43"));
+
+        try (MockedStatic<HRMUtil> hrmUtilMock = mockStatic(HRMUtil.class)) {
+            hrmUtilMock.when(() -> HRMUtil.listHRMDocuments(loggedInInfo, "report_date", false, "123", false))
+                    .thenReturn(allHrmDocuments);
+
+            ArrayList<HashMap<String, ? extends Object>> result =
+                    manager.getHRMDocumentsAttachedToEForm(loggedInInfo, "77", "123");
+
+            assertThat(result).containsExactly(hrmDocument);
+        }
+    }
+
+    @Test
+    @DisplayName("should ignore malformed attached eForm HRM ids")
+    void shouldIgnoreMalformedAttachedEFormHrmIds() {
+        when(documentAttachmentManager.getEFormAttachments(loggedInInfo, 77, DocumentType.HRM, 123))
+                .thenReturn(List.of("not-a-number"));
+
+        try (MockedStatic<HRMUtil> hrmUtilMock = mockStatic(HRMUtil.class)) {
+            hrmUtilMock.when(() -> HRMUtil.listHRMDocuments(loggedInInfo, "report_date", false, "123", false))
+                    .thenReturn(new ArrayList<>());
+
+            assertThat(manager.getHRMDocumentsAttachedToEForm(loggedInInfo, "77", "123")).isEmpty();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- preserve the eForm authorization boundary when a requested saved eForm is missing: unauthorized callers receive a security failure, while callers with broad eForm read access receive the explicit not-found PDF error
- report denied `findByFdid` lookups consistently as `SecurityException`
- normalize legacy HRM attachment IDs supplied as either numbers or numeric strings, and ignore malformed IDs instead of failing the entire attachment lookup

## Scope cleanup
The original consult-form metadata rendering behavior is already delivered by #3181. The old branch also carried stacked changes from #3145 and other merged work. This PR has been rebuilt from current `develop` so those superseded and overlapping changes are no longer in the diff.

The remaining change is independent of #3145 and is intentionally limited to `EformDataManagerImpl` plus its focused unit tests.

## Testing
- `mvn -q -Dtest=EformDataManagerImplCreatePdfUnitTest test` (10 tests, 0 failures)
