### PR TITLE
fix: escape email status popover errors

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/admin/emailStatusResults.jspf
+++ b/src/main/webapp/WEB-INF/jsp/admin/emailStatusResults.jspf
@@ -1,6 +1,5 @@
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
-<%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@ taglib uri="carlos" prefix="carlos" %>
 <c:if test="${not empty emailValidationError}">
 <div class="alert alert-danger mt-1" role="alert">${carlos:forHtml(emailValidationError)}</div>

--- a/src/main/webapp/WEB-INF/jsp/admin/emailStatusResults.jspf
+++ b/src/main/webapp/WEB-INF/jsp/admin/emailStatusResults.jspf
@@ -41,7 +41,7 @@
             <tr>
                 <td class="status-and-date">
                     <div class="status-tag status-tag-${fn:toLowerCase(emailStatusResult.status)}" id="emailStatus${emailStatusResult.logId}" 
-                        ${ empty emailStatusResult.errorMessage ? '' : "data-bs-toggle='popover'" } data-bs-trigger='hover click' data-bs-content="${emailStatusResult.errorMessage}">
+                        ${ empty emailStatusResult.errorMessage ? '' : "data-bs-toggle='popover'" } data-bs-trigger='hover click' data-bs-content="${carlos:forHtmlAttribute(emailStatusResult.errorMessage)}">
                         ${carlos:forHtml(emailStatusResult.status)}
                     </div>
                     <div class="date-time text-muted">

--- a/src/test/java/io/github/carlos_emr/carlos/admin/ManageEmailsJspEncodingRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/admin/ManageEmailsJspEncodingRegressionTest.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.admin;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.github.carlos_emr.carlos.utility.SafeEncode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression coverage for manage emails JSP encoding.
+ *
+ * @since 2026-07-20
+ */
+@DisplayName("Manage emails JSP encoding")
+@Tag("unit")
+@Tag("security")
+class ManageEmailsJspEncodingRegressionTest {
+    private static final String BASEDIR_PROPERTY = "basedir";
+    private static final Path EMAIL_STATUS_RESULTS_JSP_PATH =
+            Path.of("src/main/webapp/WEB-INF/jsp/admin/emailStatusResults.jspf");
+
+    @Test
+    void shouldEncodeEmailStatusErrorPopoverContent_inHtmlAttributeContext() throws Exception {
+        String jsp = Files.readString(resolveProjectPath(EMAIL_STATUS_RESULTS_JSP_PATH));
+        String dangerousErrorMessage = "Could not send: \" onmouseover=\"alert(1)";
+        String encodedErrorMessage = SafeEncode.forHtmlAttribute(dangerousErrorMessage);
+        String renderedAttribute = "data-bs-content=\"" + encodedErrorMessage + "\"";
+
+        assertThat(jsp)
+                .contains("<%@ taglib uri=\"carlos\" prefix=\"carlos\" %>")
+                .doesNotContain("<%@ taglib uri=\"owasp.encoder.jakarta.advanced\" prefix=\"e\" %>")
+                .contains("data-bs-content=\"${carlos:forHtmlAttribute(emailStatusResult.errorMessage)}\"")
+                .doesNotContain("data-bs-content=\"${emailStatusResult.errorMessage}\"");
+        assertThat(renderedAttribute)
+                .contains("onmouseover")
+                .doesNotContain("\" onmouseover=\"");
+    }
+
+    /**
+     * Resolves a project-relative path from the Maven {@code basedir} property or
+     * current working directory, walking parent directories for IDE and CLI runs.
+     *
+     * @param relativePath path relative to the project root
+     * @return resolved regular file or directory path
+     */
+    private static Path resolveProjectPath(Path relativePath) {
+        Path current = Path.of(System.getProperty(BASEDIR_PROPERTY, System.getProperty("user.dir")))
+                .toAbsolutePath()
+                .normalize();
+        for (int checkedParents = 0; current != null && checkedParents < 6; checkedParents++) {
+            Path candidate = current.resolve(relativePath).normalize();
+            if (Files.isRegularFile(candidate) || Files.isDirectory(candidate)) {
+                return candidate;
+            }
+            current = current.getParent();
+        }
+        throw new IllegalStateException("Unable to locate " + relativePath + " from "
+                + System.getProperty(BASEDIR_PROPERTY, System.getProperty("user.dir")));
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/admin/ManageEmailsJspEncodingRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/admin/ManageEmailsJspEncodingRegressionTest.java
@@ -57,8 +57,10 @@ class ManageEmailsJspEncodingRegressionTest {
                 .doesNotContain("<%@ taglib uri=\"owasp.encoder.jakarta.advanced\" prefix=\"e\" %>")
                 .contains("data-bs-content=\"${carlos:forHtmlAttribute(emailStatusResult.errorMessage)}\"")
                 .doesNotContain("data-bs-content=\"${emailStatusResult.errorMessage}\"");
-        assertThat(renderedAttribute)
+        assertThat(encodedErrorMessage)
                 .contains("onmouseover")
+                .doesNotContain("\"");
+        assertThat(renderedAttribute)
                 .doesNotContain("\" onmouseover=\"");
     }
 


### PR DESCRIPTION
## Description
Escapes the email status popover error message in an HTML attribute context using the CARLOS null-safe encoder. This prevents stored email transport/API error text from breaking out of `data-bs-content`.

Also removes the now-unused OWASP encoder taglib import from the JSP fragment and adds focused regression coverage for the popover escaping path.

## Related Issues
Fixes #3198

## How Was This Tested?
- `mvn -q -Dtest=ManageEmailsJspEncodingRegressionTest test`
- `scripts/lint/check-encoder-null-safety.sh`
- `git diff --check`

## Screenshots
Not applicable; no visual change intended.

## Checklist
- [x] My commits are signed off with DCO (`git commit -s`)
- [x] Commit message follows Conventional Commits format
- [x] No PHI or sensitive data included
- [x] Added focused regression coverage for the JSP popover escaping path
- [x] I have read CONTRIBUTING.md

## Summary by Sourcery

Ensure email status popover error messages are safely encoded in HTML attribute context and add regression coverage for the JSP encoding behavior.

Bug Fixes:
- Prevent stored email status error messages from breaking out of the popover data-bs-content attribute via unsafe HTML attribute encoding.

Enhancements:
- Replace legacy OWASP encoder usage in the email status JSP with the CARLOS null-safe HTML attribute encoder and remove the unused taglib import.

Tests:
- Add a ManageEmailsJspEncodingRegressionTest to verify the email status JSP uses the null-safe HTML attribute encoder and that dangerous error text is safely rendered in the popover.