### PR TITLE
feat: harden outbound email archive access

### DIFF
--- a/local_repo/com/github/librepdf/openpdf/openpdf-html/3.0.3/openpdf-html-3.0.3.pom
+++ b/local_repo/com/github/librepdf/openpdf/openpdf-html/3.0.3/openpdf-html-3.0.3.pom
@@ -15,7 +15,7 @@
   <licenses>
     <license>
       <name>GNU Lesser General Public License (LGPL), version 2.1 or later</name>
-      <url>https://www.gnu.org/licenses/lgpl-3.0.html</url>
+      <url>https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html</url>
     </license>
   </licenses>
   <dependencies>

--- a/local_repo/com/github/librepdf/openpdf/openpdf-html/3.0.3/openpdf-html-3.0.3.pom
+++ b/local_repo/com/github/librepdf/openpdf/openpdf-html/3.0.3/openpdf-html-3.0.3.pom
@@ -15,7 +15,7 @@
   <licenses>
     <license>
       <name>GNU Lesser General Public License (LGPL), version 2.1 or later</name>
-      <url>https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html</url>
+      <url>https://www.gnu.org/licenses/lgpl-3.0.html</url>
     </license>
   </licenses>
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <sonar.issue.ignore.multicriteria.pvuDocS6549.resourceKey>**/documentManager/**/DocumentUpload2Action.java</sonar.issue.ignore.multicriteria.pvuDocS6549.resourceKey>
         <!-- Outbound archive JPA mappings follow CARLOS Hibernate DATETIME conventions. -->
         <sonar.issue.ignore.multicriteria.outboundArchiveDate.ruleKey>java:S2143</sonar.issue.ignore.multicriteria.outboundArchiveDate.ruleKey>
-        <sonar.issue.ignore.multicriteria.outboundArchiveDate.resourceKey>**/OutboundEmailArchive*.java</sonar.issue.ignore.multicriteria.outboundArchiveDate.resourceKey>
+        <sonar.issue.ignore.multicriteria.outboundArchiveDate.resourceKey>**/commn/model/OutboundEmailArchive*.java</sonar.issue.ignore.multicriteria.outboundArchiveDate.resourceKey>
         <!-- Empty default so @{argLine} in surefire resolves even if JaCoCo prepare-agent hasn't run -->
         <argLine/>
         <!-- Log4j Version -->

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
             has already validated the path. This does NOT suppress the rule globally — any code
             that uses raw user input in file paths without PathValidationUtils will still be caught.
         -->
-        <sonar.issue.ignore.multicriteria>pvuSelf,pvuEform,pvuDoc,pvuLab,pvuInteg,pvuForm,pvuFax,pvuEncounter,pvuDx,pvuDemog,pvuBilling,pvuDocS6549</sonar.issue.ignore.multicriteria>
+        <sonar.issue.ignore.multicriteria>pvuSelf,pvuEform,pvuDoc,pvuLab,pvuInteg,pvuForm,pvuFax,pvuEncounter,pvuDx,pvuDemog,pvuBilling,pvuDocS6549,outboundArchiveDate</sonar.issue.ignore.multicriteria>
         <!-- PathValidationUtils itself (it IS the sanitizer) -->
         <sonar.issue.ignore.multicriteria.pvuSelf.ruleKey>javasecurity:S2083</sonar.issue.ignore.multicriteria.pvuSelf.ruleKey>
         <sonar.issue.ignore.multicriteria.pvuSelf.resourceKey>**/utility/PathValidationUtils.java</sonar.issue.ignore.multicriteria.pvuSelf.resourceKey>
@@ -82,6 +82,9 @@
              so path-construction findings remain visible for other documentManager files. -->
         <sonar.issue.ignore.multicriteria.pvuDocS6549.ruleKey>javasecurity:S6549</sonar.issue.ignore.multicriteria.pvuDocS6549.ruleKey>
         <sonar.issue.ignore.multicriteria.pvuDocS6549.resourceKey>**/documentManager/**/DocumentUpload2Action.java</sonar.issue.ignore.multicriteria.pvuDocS6549.resourceKey>
+        <!-- Outbound archive JPA mappings follow CARLOS Hibernate DATETIME conventions. -->
+        <sonar.issue.ignore.multicriteria.outboundArchiveDate.ruleKey>java:S2143</sonar.issue.ignore.multicriteria.outboundArchiveDate.ruleKey>
+        <sonar.issue.ignore.multicriteria.outboundArchiveDate.resourceKey>**/OutboundEmailArchive*.java</sonar.issue.ignore.multicriteria.outboundArchiveDate.resourceKey>
         <!-- Empty default so @{argLine} in surefire resolves even if JaCoCo prepare-agent hasn't run -->
         <argLine/>
         <!-- Log4j Version -->

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/CtlDocumentDao.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/CtlDocumentDao.java
@@ -42,6 +42,15 @@ public interface CtlDocumentDao extends AbstractDao<CtlDocument> {
 
     public List<CtlDocument> findByDocumentNoAndModule(Integer ctlDocNo, String module);
 
+    /**
+     * Finds every module link for the supplied document numbers.
+     * Null document numbers and duplicate values are ignored. A null, empty, or
+     * all-null collection returns an empty list. The returned list is never null
+     * and has no defined ordering.
+     *
+     * @param documentNos document numbers whose module links should be returned
+     * @return all matching module links, or an empty list when none match
+     */
     public List<CtlDocument> findByDocumentNos(Collection<Integer> documentNos);
 
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/CtlDocumentDao.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/CtlDocumentDao.java
@@ -42,6 +42,6 @@ public interface CtlDocumentDao extends AbstractDao<CtlDocument> {
 
     public List<CtlDocument> findByDocumentNoAndModule(Integer ctlDocNo, String module);
 
-    public List<CtlDocument> findByDocumentNosAndModule(Collection<Integer> documentNos, String module);
+    public List<CtlDocument> findByDocumentNos(Collection<Integer> documentNos);
 
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/CtlDocumentDao.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/CtlDocumentDao.java
@@ -31,6 +31,7 @@
  */
 package io.github.carlos_emr.carlos.commn.dao;
 
+import java.util.Collection;
 import java.util.List;
 
 import io.github.carlos_emr.carlos.commn.model.CtlDocument;
@@ -40,5 +41,7 @@ public interface CtlDocumentDao extends AbstractDao<CtlDocument> {
     public CtlDocument getCtrlDocument(Integer docId);
 
     public List<CtlDocument> findByDocumentNoAndModule(Integer ctlDocNo, String module);
+
+    public List<CtlDocument> findByDocumentNosAndModule(Collection<Integer> documentNos, String module);
 
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/CtlDocumentDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/CtlDocumentDaoImpl.java
@@ -31,9 +31,11 @@
  */
 package io.github.carlos_emr.carlos.commn.dao;
 
+import java.util.Collection;
 import java.util.List;
 
 import jakarta.persistence.Query;
+import jakarta.persistence.TypedQuery;
 
 import io.github.carlos_emr.carlos.commn.model.CtlDocument;
 import org.springframework.stereotype.Repository;
@@ -63,6 +65,26 @@ public class CtlDocumentDaoImpl extends AbstractDaoImpl<CtlDocument> implements 
         @SuppressWarnings("unchecked")
         List<CtlDocument> cList = query.getResultList();
         return cList;
+    }
+
+    @Override
+    public List<CtlDocument> findByDocumentNosAndModule(Collection<Integer> documentNos, String module) {
+        if (documentNos == null || documentNos.isEmpty()) {
+            return List.of();
+        }
+        List<Integer> candidates = documentNos.stream()
+                .filter(java.util.Objects::nonNull)
+                .distinct()
+                .toList();
+        if (candidates.isEmpty()) {
+            return List.of();
+        }
+        TypedQuery<CtlDocument> query = entityManager.createQuery(
+                "select x from CtlDocument x where x.id.documentNo in :documentNos and x.id.module = :module",
+                CtlDocument.class);
+        query.setParameter("documentNos", candidates);
+        query.setParameter("module", module);
+        return query.getResultList();
     }
 
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/CtlDocumentDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/CtlDocumentDaoImpl.java
@@ -68,7 +68,7 @@ public class CtlDocumentDaoImpl extends AbstractDaoImpl<CtlDocument> implements 
     }
 
     @Override
-    public List<CtlDocument> findByDocumentNosAndModule(Collection<Integer> documentNos, String module) {
+    public List<CtlDocument> findByDocumentNos(Collection<Integer> documentNos) {
         if (documentNos == null || documentNos.isEmpty()) {
             return List.of();
         }
@@ -80,10 +80,9 @@ public class CtlDocumentDaoImpl extends AbstractDaoImpl<CtlDocument> implements 
             return List.of();
         }
         TypedQuery<CtlDocument> query = entityManager.createQuery(
-                "select x from CtlDocument x where x.id.documentNo in :documentNos and x.id.module = :module",
+                "select x from CtlDocument x where x.id.documentNo in :documentNos",
                 CtlDocument.class);
         query.setParameter("documentNos", candidates);
-        query.setParameter("module", module);
         return query.getResultList();
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/DocumentDao.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/DocumentDao.java
@@ -145,6 +145,13 @@ public interface DocumentDao extends AbstractDao<Document> {
      */
     public List<Document> findByUpdateDate(Date updatedAfterThisDateExclusive, int itemsToReturn);
 
+    /**
+     * Finds ordinary documents updated after a specified date, excluding every eDoc used by an
+     * outbound email archive before applying the result limit.
+     */
+    List<Document> findByUpdateDateExcludingOutboundEmailArchives(
+            Date updatedAfterThisDateExclusive, int itemsToReturn);
+
     public List<Document> findByDemographicUpdateDate(Integer demographicId, Date updatedAfterThisDateInclusive);
 
     /**
@@ -185,6 +192,11 @@ public interface DocumentDao extends AbstractDao<Document> {
      * @return List&lt;String&gt; list of distinct matching document descriptions
      */
     public List<String> findDocumentDescriptions(String keyword);
+
+    /**
+     * Retrieves distinct descriptions belonging to ordinary, active documents only.
+     */
+    List<String> findDocumentDescriptionsExcludingOutboundEmailArchives(String keyword);
 
     /**
      * Returns lightweight document DTOs for a demographic, bypassing the EAGER

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/DocumentDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/DocumentDaoImpl.java
@@ -349,6 +349,23 @@ public class DocumentDaoImpl extends AbstractDaoImpl<Document> implements Docume
         return documents;
     }
 
+    @Override
+    public List<Document> findByUpdateDateExcludingOutboundEmailArchives(
+            Date updatedAfterThisDateExclusive, int itemsToReturn) {
+        String jpql = "SELECT d FROM Document d "
+                + "WHERE d.updatedatetime > :updatedAfter "
+                + "AND NOT EXISTS (SELECT archive.id FROM OutboundEmailArchive archive "
+                + "WHERE archive.document.documentNo = d.documentNo) "
+                + "ORDER BY d.updatedatetime";
+        Query query = entityManager.createQuery(jpql);
+        query.setParameter("updatedAfter", updatedAfterThisDateExclusive);
+        setLimit(query, itemsToReturn);
+
+        @SuppressWarnings("unchecked")
+        List<Document> documents = query.getResultList();
+        return documents;
+    }
+
     @SuppressWarnings("unchecked")
     @Override
     public List<Document> findByDemographicUpdateDate(Integer demographicId, Date updatedAfterThisDateInclusive) {
@@ -474,8 +491,6 @@ public class DocumentDaoImpl extends AbstractDaoImpl<Document> implements Docume
     }
 
     /**
-     * Returns distinct document descriptions matching the keyword, in descending document number order.
-    /**
      * Retrieves distinct document descriptions matching the keyword.
      */
     public List<String> findDocumentDescriptions(String keyword) {
@@ -487,6 +502,24 @@ public class DocumentDaoImpl extends AbstractDaoImpl<Document> implements Docume
         query.setParameter(1, keyword);
         query.setMaxResults(20);
         return query.getResultList();
+    }
+
+    @Override
+    public List<String> findDocumentDescriptionsExcludingOutboundEmailArchives(String keyword) {
+        String effectiveKeyword = keyword != null ? keyword : "%";
+        String jpql = "SELECT d.docdesc FROM Document d "
+                + "WHERE d.status != 'D' "
+                + "AND d.docdesc LIKE :keyword "
+                + "AND d.docdesc IS NOT NULL AND d.docdesc <> '' "
+                + "AND NOT EXISTS (SELECT archive.id FROM OutboundEmailArchive archive "
+                + "WHERE archive.document.documentNo = d.documentNo) "
+                + "GROUP BY d.docdesc ORDER BY MAX(d.documentNo) DESC";
+        Query query = entityManager.createQuery(jpql);
+        query.setParameter("keyword", effectiveKeyword);
+        query.setMaxResults(20);
+        @SuppressWarnings("unchecked")
+        List<String> descriptions = query.getResultList();
+        return descriptions;
     }
 
     @Override

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/OutboundEmailArchiveAttachmentDao.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/OutboundEmailArchiveAttachmentDao.java
@@ -24,8 +24,26 @@ package io.github.carlos_emr.carlos.commn.dao;
 
 import io.github.carlos_emr.carlos.commn.model.OutboundEmailArchiveAttachment;
 
+import java.util.List;
+
 /**
  * Data access contract for outbound email archive attachment metadata.
  */
 public interface OutboundEmailArchiveAttachmentDao extends AbstractDao<OutboundEmailArchiveAttachment> {
+
+    /** @throws UnsupportedOperationException always; archive attachment rows are immutable retention records */
+    @Override
+    void batchRemoveAtomically(List<OutboundEmailArchiveAttachment> attachments);
+
+    /** @throws UnsupportedOperationException always; archive attachment rows are immutable retention records */
+    @Override
+    void batchRemoveAtomically(List<OutboundEmailArchiveAttachment> attachments, int batchSize);
+
+    /** @throws UnsupportedOperationException always; archive attachment rows are immutable retention records */
+    @Override
+    void batchRemoveWithIndependentCommits(List<OutboundEmailArchiveAttachment> attachments);
+
+    /** @throws UnsupportedOperationException always; archive attachment rows are immutable retention records */
+    @Override
+    void batchRemoveWithIndependentCommits(List<OutboundEmailArchiveAttachment> attachments, int batchSize);
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/OutboundEmailArchiveAttachmentDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/OutboundEmailArchiveAttachmentDaoImpl.java
@@ -22,8 +22,11 @@
 
 package io.github.carlos_emr.carlos.commn.dao;
 
+import io.github.carlos_emr.carlos.commn.model.AbstractModel;
 import io.github.carlos_emr.carlos.commn.model.OutboundEmailArchiveAttachment;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 /**
  * JPA DAO implementation for outbound email archive attachment metadata.
@@ -31,7 +34,30 @@ import org.springframework.stereotype.Repository;
 @Repository
 public class OutboundEmailArchiveAttachmentDaoImpl extends AbstractDaoImpl<OutboundEmailArchiveAttachment> implements OutboundEmailArchiveAttachmentDao {
 
+    private static final String PHYSICAL_DELETE_DISABLED_MESSAGE =
+            "Outbound email archive attachments must be retained with their parent archive";
+
     public OutboundEmailArchiveAttachmentDaoImpl() {
         super(OutboundEmailArchiveAttachment.class);
+    }
+
+    @Override
+    public void remove(AbstractModel<?> o) {
+        throw new UnsupportedOperationException(PHYSICAL_DELETE_DISABLED_MESSAGE);
+    }
+
+    @Override
+    public boolean remove(Object id) {
+        throw new UnsupportedOperationException(PHYSICAL_DELETE_DISABLED_MESSAGE);
+    }
+
+    @Override
+    public void batchRemove(List<OutboundEmailArchiveAttachment> oList) {
+        throw new UnsupportedOperationException(PHYSICAL_DELETE_DISABLED_MESSAGE);
+    }
+
+    @Override
+    public void batchRemove(List<OutboundEmailArchiveAttachment> oList, int batchSize) {
+        throw new UnsupportedOperationException(PHYSICAL_DELETE_DISABLED_MESSAGE);
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/OutboundEmailArchiveAttachmentDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/OutboundEmailArchiveAttachmentDaoImpl.java
@@ -60,4 +60,24 @@ public class OutboundEmailArchiveAttachmentDaoImpl extends AbstractDaoImpl<Outbo
     public void batchRemove(List<OutboundEmailArchiveAttachment> oList, int batchSize) {
         throw new UnsupportedOperationException(PHYSICAL_DELETE_DISABLED_MESSAGE);
     }
+
+    @Override
+    public void batchRemoveAtomically(List<OutboundEmailArchiveAttachment> oList) {
+        throw new UnsupportedOperationException(PHYSICAL_DELETE_DISABLED_MESSAGE);
+    }
+
+    @Override
+    public void batchRemoveAtomically(List<OutboundEmailArchiveAttachment> oList, int batchSize) {
+        throw new UnsupportedOperationException(PHYSICAL_DELETE_DISABLED_MESSAGE);
+    }
+
+    @Override
+    public void batchRemoveWithIndependentCommits(List<OutboundEmailArchiveAttachment> oList) {
+        throw new UnsupportedOperationException(PHYSICAL_DELETE_DISABLED_MESSAGE);
+    }
+
+    @Override
+    public void batchRemoveWithIndependentCommits(List<OutboundEmailArchiveAttachment> oList, int batchSize) {
+        throw new UnsupportedOperationException(PHYSICAL_DELETE_DISABLED_MESSAGE);
+    }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/OutboundEmailArchiveDao.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/OutboundEmailArchiveDao.java
@@ -40,12 +40,44 @@ public interface OutboundEmailArchiveDao extends AbstractDao<OutboundEmailArchiv
     List<OutboundEmailArchive> findByEmailLogId(Integer emailLogId);
 
     /**
+     * Finds an archive row with the associations required for read authorization and file access initialized.
+     *
+     * @param archiveId persisted archive identifier
+     * @return archive row with demographic and document loaded, or {@code null} when no row exists
+     */
+    OutboundEmailArchive findForRead(Integer archiveId);
+
+    /**
      * Finds an archive row with a write lock for short controlled-deletion critical sections.
      *
      * @param archiveId persisted archive identifier
      * @return locked archive row, or {@code null} when no row exists
      */
     OutboundEmailArchive findForUpdate(Integer archiveId);
+
+    /**
+     * Checks whether a document is the backing eDoc for an active outbound email archive.
+     *
+     * @param documentNo persisted eDoc identifier
+     * @return {@code true} when the document is linked to a non-deleted archive row
+     */
+    boolean existsActiveByDocumentNo(Integer documentNo);
+
+    /**
+     * Checks whether a document is or was the backing eDoc for an outbound email archive.
+     *
+     * @param documentNo persisted eDoc identifier
+     * @return {@code true} when the document is linked to any archive row
+     */
+    boolean existsByDocumentNo(Integer documentNo);
+
+    /**
+     * Checks whether a stored eDoc filename is linked to an outbound email archive.
+     *
+     * @param fileName stored eDoc basename
+     * @return {@code true} when the filename is linked to any archive row
+     */
+    boolean existsByFileName(String fileName);
 
     /**
      * Finds archive rows for a patient demographic, newest archive first.

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/OutboundEmailArchiveDao.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/OutboundEmailArchiveDao.java
@@ -58,7 +58,7 @@ public interface OutboundEmailArchiveDao extends AbstractDao<OutboundEmailArchiv
     OutboundEmailArchive findForUpdate(Integer archiveId);
 
     /**
-     * Checks whether a document is the backing eDoc for an active outbound email archive.
+     * Checks whether a document is a retained artifact eDoc for an active outbound email archive.
      *
      * @param documentNo persisted eDoc identifier
      * @return {@code true} when the document is linked to a non-deleted archive row
@@ -66,7 +66,7 @@ public interface OutboundEmailArchiveDao extends AbstractDao<OutboundEmailArchiv
     boolean existsActiveByDocumentNo(Integer documentNo);
 
     /**
-     * Checks whether a document is or was the backing eDoc for an outbound email archive.
+     * Checks whether a document is or was a retained artifact eDoc for an outbound email archive.
      *
      * @param documentNo persisted eDoc identifier
      * @return {@code true} when the document is linked to any archive row
@@ -74,7 +74,7 @@ public interface OutboundEmailArchiveDao extends AbstractDao<OutboundEmailArchiv
     boolean existsByDocumentNo(Integer documentNo);
 
     /**
-     * Finds all archive-backed eDoc identifiers in the supplied candidates using one query.
+     * Finds all main-message and attachment archive eDoc identifiers in the supplied candidates using one query.
      *
      * @param documentNos candidate persisted eDoc identifiers
      * @return archive-backed identifiers, or an empty set for no candidates

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/OutboundEmailArchiveDao.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/OutboundEmailArchiveDao.java
@@ -24,7 +24,9 @@ package io.github.carlos_emr.carlos.commn.dao;
 
 import io.github.carlos_emr.carlos.commn.model.OutboundEmailArchive;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Data access contract for durable outbound email archive records.
@@ -70,6 +72,14 @@ public interface OutboundEmailArchiveDao extends AbstractDao<OutboundEmailArchiv
      * @return {@code true} when the document is linked to any archive row
      */
     boolean existsByDocumentNo(Integer documentNo);
+
+    /**
+     * Finds all archive-backed eDoc identifiers in the supplied candidates using one query.
+     *
+     * @param documentNos candidate persisted eDoc identifiers
+     * @return archive-backed identifiers, or an empty set for no candidates
+     */
+    Set<Integer> findExistingDocumentNos(Collection<Integer> documentNos);
 
     /**
      * Checks whether a stored eDoc filename is linked to an outbound email archive.

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/OutboundEmailArchiveDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/OutboundEmailArchiveDaoImpl.java
@@ -28,7 +28,10 @@ import jakarta.persistence.Query;
 import jakarta.persistence.TypedQuery;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * JPA DAO implementation for durable outbound email archive records.
@@ -60,6 +63,26 @@ public class OutboundEmailArchiveDaoImpl extends AbstractDaoImpl<OutboundEmailAr
 
     @Override
     public void batchRemove(List<OutboundEmailArchive> oList, int batchSize) {
+        throw new UnsupportedOperationException(PHYSICAL_DELETE_DISABLED_MESSAGE);
+    }
+
+    @Override
+    public void batchRemoveAtomically(List<OutboundEmailArchive> oList) {
+        throw new UnsupportedOperationException(PHYSICAL_DELETE_DISABLED_MESSAGE);
+    }
+
+    @Override
+    public void batchRemoveAtomically(List<OutboundEmailArchive> oList, int batchSize) {
+        throw new UnsupportedOperationException(PHYSICAL_DELETE_DISABLED_MESSAGE);
+    }
+
+    @Override
+    public void batchRemoveWithIndependentCommits(List<OutboundEmailArchive> oList) {
+        throw new UnsupportedOperationException(PHYSICAL_DELETE_DISABLED_MESSAGE);
+    }
+
+    @Override
+    public void batchRemoveWithIndependentCommits(List<OutboundEmailArchive> oList, int batchSize) {
         throw new UnsupportedOperationException(PHYSICAL_DELETE_DISABLED_MESSAGE);
     }
 
@@ -126,6 +149,26 @@ public class OutboundEmailArchiveDaoImpl extends AbstractDaoImpl<OutboundEmailAr
                 Long.class);
         query.setParameter("documentNo", documentNo);
         return query.getSingleResult() > 0L;
+    }
+
+    @Override
+    public Set<Integer> findExistingDocumentNos(Collection<Integer> documentNos) {
+        if (documentNos == null || documentNos.isEmpty()) {
+            return Set.of();
+        }
+        List<Integer> candidates = documentNos.stream()
+                .filter(java.util.Objects::nonNull)
+                .distinct()
+                .toList();
+        if (candidates.isEmpty()) {
+            return Set.of();
+        }
+        TypedQuery<Integer> query = entityManager.createQuery(
+                "SELECT DISTINCT archive.document.documentNo FROM OutboundEmailArchive archive "
+                        + "WHERE archive.document.documentNo IN :documentNos",
+                Integer.class);
+        query.setParameter("documentNos", candidates);
+        return new HashSet<>(query.getResultList());
     }
 
     @Override

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/OutboundEmailArchiveDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/OutboundEmailArchiveDaoImpl.java
@@ -22,6 +22,7 @@
 
 package io.github.carlos_emr.carlos.commn.dao;
 
+import io.github.carlos_emr.carlos.commn.model.AbstractModel;
 import io.github.carlos_emr.carlos.commn.model.OutboundEmailArchive;
 import jakarta.persistence.Query;
 import jakarta.persistence.TypedQuery;
@@ -35,8 +36,31 @@ import java.util.List;
 @Repository
 public class OutboundEmailArchiveDaoImpl extends AbstractDaoImpl<OutboundEmailArchive> implements OutboundEmailArchiveDao {
 
+    private static final String PHYSICAL_DELETE_DISABLED_MESSAGE =
+            "Outbound email archives must be deleted through the controlled tombstone workflow";
+
     public OutboundEmailArchiveDaoImpl() {
         super(OutboundEmailArchive.class);
+    }
+
+    @Override
+    public void remove(AbstractModel<?> o) {
+        throw new UnsupportedOperationException(PHYSICAL_DELETE_DISABLED_MESSAGE);
+    }
+
+    @Override
+    public boolean remove(Object id) {
+        throw new UnsupportedOperationException(PHYSICAL_DELETE_DISABLED_MESSAGE);
+    }
+
+    @Override
+    public void batchRemove(List<OutboundEmailArchive> oList) {
+        throw new UnsupportedOperationException(PHYSICAL_DELETE_DISABLED_MESSAGE);
+    }
+
+    @Override
+    public void batchRemove(List<OutboundEmailArchive> oList, int batchSize) {
+        throw new UnsupportedOperationException(PHYSICAL_DELETE_DISABLED_MESSAGE);
     }
 
     @Override
@@ -46,6 +70,22 @@ public class OutboundEmailArchiveDaoImpl extends AbstractDaoImpl<OutboundEmailAr
                 OutboundEmailArchive.class);
         query.setParameter("emailLogId", emailLogId);
         return query.getResultList();
+    }
+
+    @Override
+    public OutboundEmailArchive findForRead(Integer archiveId) {
+        if (archiveId == null) {
+            return null;
+        }
+        TypedQuery<OutboundEmailArchive> query = entityManager.createQuery(
+                "SELECT archive FROM OutboundEmailArchive archive "
+                        + "LEFT JOIN FETCH archive.demographic "
+                        + "LEFT JOIN FETCH archive.document "
+                        + "WHERE archive.id = :archiveId",
+                OutboundEmailArchive.class);
+        query.setParameter("archiveId", archiveId);
+        List<OutboundEmailArchive> rows = query.getResultList();
+        return rows.isEmpty() ? null : rows.get(0);
     }
 
     @Override
@@ -59,6 +99,46 @@ public class OutboundEmailArchiveDaoImpl extends AbstractDaoImpl<OutboundEmailAr
         query.setParameter(1, archiveId);
         List<OutboundEmailArchive> rows = query.getResultList();
         return rows.isEmpty() ? null : rows.get(0);
+    }
+
+    @Override
+    public boolean existsActiveByDocumentNo(Integer documentNo) {
+        if (documentNo == null) {
+            return false;
+        }
+        TypedQuery<Long> query = entityManager.createQuery(
+                "SELECT COUNT(archive) FROM OutboundEmailArchive archive "
+                        + "WHERE archive.document.documentNo = :documentNo "
+                        + "AND archive.deleted = false",
+                Long.class);
+        query.setParameter("documentNo", documentNo);
+        return query.getSingleResult() > 0L;
+    }
+
+    @Override
+    public boolean existsByDocumentNo(Integer documentNo) {
+        if (documentNo == null) {
+            return false;
+        }
+        TypedQuery<Long> query = entityManager.createQuery(
+                "SELECT COUNT(archive) FROM OutboundEmailArchive archive "
+                        + "WHERE archive.document.documentNo = :documentNo",
+                Long.class);
+        query.setParameter("documentNo", documentNo);
+        return query.getSingleResult() > 0L;
+    }
+
+    @Override
+    public boolean existsByFileName(String fileName) {
+        if (fileName == null || fileName.isBlank()) {
+            return false;
+        }
+        TypedQuery<Long> query = entityManager.createQuery(
+                "SELECT COUNT(archive) FROM OutboundEmailArchive archive "
+                        + "WHERE archive.fileName = :fileName",
+                Long.class);
+        query.setParameter("fileName", fileName);
+        return query.getSingleResult() > 0L;
     }
 
     @Override

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/OutboundEmailArchiveDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/OutboundEmailArchiveDaoImpl.java
@@ -171,8 +171,11 @@ public class OutboundEmailArchiveDaoImpl extends AbstractDaoImpl<OutboundEmailAr
         }
         TypedQuery<Long> query = entityManager.createQuery(
                 "SELECT COUNT(archive) FROM OutboundEmailArchive archive "
-                        + "WHERE archive.document.documentNo = :documentNo "
-                        + "AND archive.deleted = false",
+                        + "WHERE archive.deleted = false AND ("
+                        + "archive.document.documentNo = :documentNo "
+                        + "OR EXISTS (SELECT attachment.id FROM OutboundEmailArchiveAttachment attachment "
+                        + "WHERE attachment.archive = archive "
+                        + "AND attachment.document.documentNo = :documentNo))",
                 Long.class);
         query.setParameter("documentNo", documentNo);
         return query.getSingleResult() > 0L;
@@ -185,7 +188,10 @@ public class OutboundEmailArchiveDaoImpl extends AbstractDaoImpl<OutboundEmailAr
         }
         TypedQuery<Long> query = entityManager.createQuery(
                 "SELECT COUNT(archive) FROM OutboundEmailArchive archive "
-                        + "WHERE archive.document.documentNo = :documentNo",
+                        + "WHERE archive.document.documentNo = :documentNo "
+                        + "OR EXISTS (SELECT attachment.id FROM OutboundEmailArchiveAttachment attachment "
+                        + "WHERE attachment.archive = archive "
+                        + "AND attachment.document.documentNo = :documentNo)",
                 Long.class);
         query.setParameter("documentNo", documentNo);
         return query.getSingleResult() > 0L;
@@ -204,8 +210,12 @@ public class OutboundEmailArchiveDaoImpl extends AbstractDaoImpl<OutboundEmailAr
             return Set.of();
         }
         TypedQuery<Integer> query = entityManager.createQuery(
-                "SELECT DISTINCT archive.document.documentNo FROM OutboundEmailArchive archive "
-                        + "WHERE archive.document.documentNo IN :documentNos",
+                "SELECT DISTINCT document.documentNo FROM Document document "
+                        + "WHERE document.documentNo IN :documentNos AND ("
+                        + "EXISTS (SELECT archive.id FROM OutboundEmailArchive archive "
+                        + "WHERE archive.document = document) "
+                        + "OR EXISTS (SELECT attachment.id FROM OutboundEmailArchiveAttachment attachment "
+                        + "WHERE attachment.document = document))",
                 Integer.class);
         query.setParameter("documentNos", candidates);
         return new HashSet<>(query.getResultList());
@@ -218,7 +228,9 @@ public class OutboundEmailArchiveDaoImpl extends AbstractDaoImpl<OutboundEmailAr
         }
         TypedQuery<Long> query = entityManager.createQuery(
                 "SELECT COUNT(archive) FROM OutboundEmailArchive archive "
-                        + "WHERE archive.fileName = :fileName",
+                        + "WHERE archive.fileName = :fileName "
+                        + "OR EXISTS (SELECT attachment.id FROM OutboundEmailArchiveAttachment attachment "
+                        + "WHERE attachment.archive = archive AND attachment.fileName = :fileName)",
                 Long.class);
         query.setParameter("fileName", fileName);
         return query.getSingleResult() > 0L;

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/OutboundEmailArchiveDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/OutboundEmailArchiveDaoImpl.java
@@ -46,41 +46,81 @@ public class OutboundEmailArchiveDaoImpl extends AbstractDaoImpl<OutboundEmailAr
         super(OutboundEmailArchive.class);
     }
 
+    /**
+     * Physical deletion is always disabled; use the controlled tombstone workflow.
+     *
+     * @throws UnsupportedOperationException always
+     */
     @Override
     public void remove(AbstractModel<?> o) {
         throw new UnsupportedOperationException(PHYSICAL_DELETE_DISABLED_MESSAGE);
     }
 
+    /**
+     * Physical deletion is always disabled; use the controlled tombstone workflow.
+     *
+     * @throws UnsupportedOperationException always
+     */
     @Override
     public boolean remove(Object id) {
         throw new UnsupportedOperationException(PHYSICAL_DELETE_DISABLED_MESSAGE);
     }
 
+    /**
+     * Physical deletion is always disabled; use the controlled tombstone workflow.
+     *
+     * @throws UnsupportedOperationException always
+     */
     @Override
     public void batchRemove(List<OutboundEmailArchive> oList) {
         throw new UnsupportedOperationException(PHYSICAL_DELETE_DISABLED_MESSAGE);
     }
 
+    /**
+     * Physical deletion is always disabled; use the controlled tombstone workflow.
+     *
+     * @throws UnsupportedOperationException always
+     */
     @Override
     public void batchRemove(List<OutboundEmailArchive> oList, int batchSize) {
         throw new UnsupportedOperationException(PHYSICAL_DELETE_DISABLED_MESSAGE);
     }
 
+    /**
+     * Physical deletion is always disabled; use the controlled tombstone workflow.
+     *
+     * @throws UnsupportedOperationException always
+     */
     @Override
     public void batchRemoveAtomically(List<OutboundEmailArchive> oList) {
         throw new UnsupportedOperationException(PHYSICAL_DELETE_DISABLED_MESSAGE);
     }
 
+    /**
+     * Physical deletion is always disabled; use the controlled tombstone workflow.
+     *
+     * @throws UnsupportedOperationException always
+     */
     @Override
     public void batchRemoveAtomically(List<OutboundEmailArchive> oList, int batchSize) {
         throw new UnsupportedOperationException(PHYSICAL_DELETE_DISABLED_MESSAGE);
     }
 
+    /**
+     * Physical deletion is always disabled; use the controlled tombstone workflow.
+     *
+     * @throws UnsupportedOperationException always
+     */
     @Override
     public void batchRemoveWithIndependentCommits(List<OutboundEmailArchive> oList) {
         throw new UnsupportedOperationException(PHYSICAL_DELETE_DISABLED_MESSAGE);
     }
 
+    /**
+     * Physical deletion is always disabled; use the controlled tombstone workflow.
+     *
+     * @throws UnsupportedOperationException always
+     */
     @Override
     public void batchRemoveWithIndependentCommits(List<OutboundEmailArchive> oList, int batchSize) {
         throw new UnsupportedOperationException(PHYSICAL_DELETE_DISABLED_MESSAGE);

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/OutboundEmailArchiveAttachment.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/OutboundEmailArchiveAttachment.java
@@ -28,6 +28,8 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreRemove;
+import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import jakarta.persistence.Temporal;
 import jakarta.persistence.TemporalType;
@@ -98,5 +100,15 @@ public class OutboundEmailArchiveAttachment extends OutboundEmailArchiveArtifact
         if (createdAt == null) {
             createdAt = new Date();
         }
+    }
+
+    /**
+     * Blocks mutation so attachment metadata remains with the parent archive audit record.
+     */
+    @PreUpdate
+    @PreRemove
+    protected void preventMutation() {
+        throw new UnsupportedOperationException(
+                "Outbound email archive attachments must be retained with their parent archive");
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/DocumentAttachmentManagerImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/DocumentAttachmentManagerImpl.java
@@ -8,6 +8,7 @@ import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm;
 import io.github.carlos_emr.carlos.commn.dao.ConsultDocsDao;
 import io.github.carlos_emr.carlos.commn.dao.EFormDocsDao;
+import io.github.carlos_emr.carlos.commn.dao.OutboundEmailArchiveDao;
 import io.github.carlos_emr.carlos.commn.model.ConsultDocs;
 import io.github.carlos_emr.carlos.commn.model.EFormData;
 import io.github.carlos_emr.carlos.commn.model.EFormDocs;
@@ -89,6 +90,9 @@ public class DocumentAttachmentManagerImpl implements DocumentAttachmentManager 
     private EFormDocsDao eFormDocsDao;
 
     @Autowired
+    private OutboundEmailArchiveDao outboundEmailArchiveDao;
+
+    @Autowired
     private ConsultationManager consultationManager;
     @Autowired
     private DocumentManager documentManager;
@@ -130,6 +134,9 @@ public class DocumentAttachmentManagerImpl implements DocumentAttachmentManager 
         List<String> consultAttachments = new ArrayList<>();
         List<ConsultDocs> consultDocs = consultDocsDao.findByRequestIdDocType(requestId, documentType.getType());
         for (ConsultDocs consultDocs1 : consultDocs) {
+            if (isOutboundEmailArchiveDocument(documentType, consultDocs1.getDocumentNo())) {
+                continue;
+            }
             consultAttachments.add(String.valueOf(consultDocs1.getDocumentNo()));
         }
         return consultAttachments;
@@ -157,6 +164,9 @@ public class DocumentAttachmentManagerImpl implements DocumentAttachmentManager 
         List<String> eFormAttachments = new ArrayList<>();
         List<EFormDocs> eFormDocs = eFormDocsDao.findByFdidIdDocType(fdid, documentType.getType());
         for (EFormDocs eFormDocs1 : eFormDocs) {
+            if (isOutboundEmailArchiveDocument(documentType, eFormDocs1.getDocumentNo())) {
+                continue;
+            }
             eFormAttachments.add(String.valueOf(eFormDocs1.getDocumentNo()));
         }
         return eFormAttachments;
@@ -327,6 +337,7 @@ public class DocumentAttachmentManagerImpl implements DocumentAttachmentManager 
             throw new SecurityException(MISSING_CONSULT_SECURITY_OBJECT);
         }
 
+        assertNoOutboundEmailArchiveAttachments(documentType, attachments);
         DocumentAttach documentAttach = new DocumentAttach();
         documentAttach.attachToConsult(attachments, documentType, providerNo, requestId);
     }
@@ -355,6 +366,7 @@ public class DocumentAttachmentManagerImpl implements DocumentAttachmentManager 
             throw new SecurityException(MISSING_CONSULT_SECURITY_OBJECT);
         }
 
+        assertNoOutboundEmailArchiveAttachments(documentType, attachments);
         DocumentAttach documentAttach = new DocumentAttach(demographicNo, editOnOcean);
         documentAttach.attachToConsult(attachments, documentType, providerNo, requestId);
     }
@@ -379,8 +391,34 @@ public class DocumentAttachmentManagerImpl implements DocumentAttachmentManager 
             throw new RuntimeException("missing required sec object (_eform)");
         }
 
+        assertNoOutboundEmailArchiveAttachments(documentType, attachments);
         DocumentAttach documentAttach = new DocumentAttach();
         documentAttach.attachToEForm(attachments, documentType, providerNo, fdid);
+    }
+
+    private void assertNoOutboundEmailArchiveAttachments(DocumentType documentType, String[] attachments) {
+        if (documentType != DocumentType.DOC || attachments == null) {
+            return;
+        }
+        for (String attachment : attachments) {
+            if (StringUtils.isNullOrEmpty(attachment)) {
+                continue;
+            }
+            try {
+                if (outboundEmailArchiveDao.existsByDocumentNo(Integer.valueOf(attachment))) {
+                    throw new SecurityException(
+                            "Outbound email archive eDocs must be managed through the controlled archive workflow");
+                }
+            } catch (NumberFormatException e) {
+                // Preserve existing invalid-id behavior in DocumentAttach.
+            }
+        }
+    }
+
+    private boolean isOutboundEmailArchiveDocument(DocumentType documentType, Integer documentNo) {
+        return documentType == DocumentType.DOC
+                && documentNo != null
+                && outboundEmailArchiveDao.existsByDocumentNo(documentNo);
     }
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/DocumentAttachmentManagerImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/DocumentAttachmentManagerImpl.java
@@ -133,8 +133,10 @@ public class DocumentAttachmentManagerImpl implements DocumentAttachmentManager 
 
         List<String> consultAttachments = new ArrayList<>();
         List<ConsultDocs> consultDocs = consultDocsDao.findByRequestIdDocType(requestId, documentType.getType());
+        Set<Integer> archiveDocumentNos = findArchiveDocumentNos(documentType,
+                consultDocs.stream().map(ConsultDocs::getDocumentNo).toList());
         for (ConsultDocs consultDocs1 : consultDocs) {
-            if (isOutboundEmailArchiveDocument(documentType, consultDocs1.getDocumentNo())) {
+            if (archiveDocumentNos.contains(consultDocs1.getDocumentNo())) {
                 continue;
             }
             consultAttachments.add(String.valueOf(consultDocs1.getDocumentNo()));
@@ -163,8 +165,10 @@ public class DocumentAttachmentManagerImpl implements DocumentAttachmentManager 
 
         List<String> eFormAttachments = new ArrayList<>();
         List<EFormDocs> eFormDocs = eFormDocsDao.findByFdidIdDocType(fdid, documentType.getType());
+        Set<Integer> archiveDocumentNos = findArchiveDocumentNos(documentType,
+                eFormDocs.stream().map(EFormDocs::getDocumentNo).toList());
         for (EFormDocs eFormDocs1 : eFormDocs) {
-            if (isOutboundEmailArchiveDocument(documentType, eFormDocs1.getDocumentNo())) {
+            if (archiveDocumentNos.contains(eFormDocs1.getDocumentNo())) {
                 continue;
             }
             eFormAttachments.add(String.valueOf(eFormDocs1.getDocumentNo()));
@@ -338,6 +342,10 @@ public class DocumentAttachmentManagerImpl implements DocumentAttachmentManager 
         }
 
         assertNoOutboundEmailArchiveAttachments(documentType, attachments);
+        attachments = preserveCurrentArchiveAttachments(documentType, attachments,
+                consultDocsDao.findByRequestIdDocType(requestId, documentType.getType()).stream()
+                        .map(ConsultDocs::getDocumentNo)
+                        .toList());
         DocumentAttach documentAttach = new DocumentAttach();
         documentAttach.attachToConsult(attachments, documentType, providerNo, requestId);
     }
@@ -367,6 +375,10 @@ public class DocumentAttachmentManagerImpl implements DocumentAttachmentManager 
         }
 
         assertNoOutboundEmailArchiveAttachments(documentType, attachments);
+        attachments = preserveCurrentArchiveAttachments(documentType, attachments,
+                consultDocsDao.findByRequestIdDocType(requestId, documentType.getType()).stream()
+                        .map(ConsultDocs::getDocumentNo)
+                        .toList());
         DocumentAttach documentAttach = new DocumentAttach(demographicNo, editOnOcean);
         documentAttach.attachToConsult(attachments, documentType, providerNo, requestId);
     }
@@ -392,6 +404,10 @@ public class DocumentAttachmentManagerImpl implements DocumentAttachmentManager 
         }
 
         assertNoOutboundEmailArchiveAttachments(documentType, attachments);
+        attachments = preserveCurrentArchiveAttachments(documentType, attachments,
+                eFormDocsDao.findByFdidIdDocType(fdid, documentType.getType()).stream()
+                        .map(EFormDocs::getDocumentNo)
+                        .toList());
         DocumentAttach documentAttach = new DocumentAttach();
         documentAttach.attachToEForm(attachments, documentType, providerNo, fdid);
     }
@@ -400,25 +416,43 @@ public class DocumentAttachmentManagerImpl implements DocumentAttachmentManager 
         if (documentType != DocumentType.DOC || attachments == null) {
             return;
         }
+        List<Integer> documentNos = new ArrayList<>();
         for (String attachment : attachments) {
             if (StringUtils.isNullOrEmpty(attachment)) {
                 continue;
             }
             try {
-                if (outboundEmailArchiveDao.existsByDocumentNo(Integer.valueOf(attachment))) {
-                    throw new SecurityException(
-                            "Outbound email archive eDocs must be managed through the controlled archive workflow");
-                }
+                documentNos.add(Integer.valueOf(attachment));
             } catch (NumberFormatException e) {
                 // Preserve existing invalid-id behavior in DocumentAttach.
             }
         }
+        if (!findArchiveDocumentNos(documentType, documentNos).isEmpty()) {
+            throw new SecurityException(
+                    "Outbound email archive eDocs must be managed through the controlled archive workflow");
+        }
     }
 
-    private boolean isOutboundEmailArchiveDocument(DocumentType documentType, Integer documentNo) {
-        return documentType == DocumentType.DOC
-                && documentNo != null
-                && outboundEmailArchiveDao.existsByDocumentNo(documentNo);
+    private String[] preserveCurrentArchiveAttachments(
+            DocumentType documentType, String[] submittedAttachments, Collection<Integer> currentDocumentNos) {
+        Set<Integer> archiveDocumentNos = findArchiveDocumentNos(documentType, currentDocumentNos);
+        if (archiveDocumentNos.isEmpty()) {
+            return submittedAttachments;
+        }
+        LinkedHashSet<String> preservedAttachments = new LinkedHashSet<>();
+        if (submittedAttachments != null) {
+            Collections.addAll(preservedAttachments, submittedAttachments);
+        }
+        archiveDocumentNos.stream().map(String::valueOf).forEach(preservedAttachments::add);
+        return preservedAttachments.toArray(new String[0]);
+    }
+
+    private Set<Integer> findArchiveDocumentNos(DocumentType documentType, Collection<Integer> documentNos) {
+        if (documentType != DocumentType.DOC || documentNos == null || documentNos.isEmpty()) {
+            return Set.of();
+        }
+        Set<Integer> archiveDocumentNos = outboundEmailArchiveDao.findExistingDocumentNos(documentNos);
+        return archiveDocumentNos != null ? archiveDocumentNos : Set.of();
     }
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/EDocUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/EDocUtil.java
@@ -45,10 +45,12 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.ResourceBundle;
+import java.util.Set;
 
 import io.github.carlos_emr.carlos.commn.dao.*;
 import org.owasp.encoder.Encode;
@@ -517,10 +519,14 @@ public final class EDocUtil {
     private static ArrayList<EDoc> listDocs(LoggedInInfo loggedInInfo, boolean attached, List<Object[]> docs, List<Object[]> ctlDocs) {
         ArrayList<EDoc> resultDocs = new ArrayList<EDoc>();
         ArrayList<EDoc> attachedDocs = new ArrayList<EDoc>();
+        List<Integer> candidateDocumentNos = new ArrayList<>();
+        addDocumentNos(candidateDocumentNos, docs, 0);
+        addDocumentNos(candidateDocumentNos, ctlDocs, 1);
+        Set<Integer> archiveDocumentNos = findOutboundEmailArchiveDocumentNos(candidateDocumentNos);
 
         for (Object[] o : docs) {
             Document d = (Document) o[0];
-            if (isOutboundEmailArchiveDocument(d)) {
+            if (d != null && archiveDocumentNos.contains(d.getDocumentNo())) {
                 continue;
             }
 
@@ -559,7 +565,7 @@ public final class EDocUtil {
         } else { //remove attached documents from full document list
             for (Object[] o : ctlDocs) {
                 Document d = (Document) o[1];
-                if (isOutboundEmailArchiveDocument(d)) {
+                if (d != null && archiveDocumentNos.contains(d.getDocumentNo())) {
                     continue;
                 }
 
@@ -654,8 +660,13 @@ public final class EDocUtil {
     public static ArrayList<EDoc> listDocsPreviewInbox(List<String> docIds) {
 
         ArrayList<EDoc> resultDocs = new ArrayList<EDoc>();
+        List<Integer> candidateDocumentNos = docIds.stream()
+                .map(EDocUtil::parseDocumentNo)
+                .filter(java.util.Objects::nonNull)
+                .toList();
+        Set<Integer> archiveDocumentNos = findOutboundEmailArchiveDocumentNos(candidateDocumentNos);
         for (String docId : docIds) {
-            if (!isOutboundEmailArchiveDocumentId(docId)) {
+            if (!archiveDocumentNos.contains(parseDocumentNo(docId))) {
                 resultDocs.add(getEDocFromDocId(docId));
             }
         }
@@ -668,11 +679,12 @@ public final class EDocUtil {
         boolean includeDeleted = viewstatus.equals("deleted");
         boolean includeActive = viewstatus.equals("active");
         List<Object[]> documents = getDocumentDao().findDocuments(module, moduleid, docType, includePublic, includeDeleted, includeActive, sort, null);
+        Set<Integer> archiveDocumentNos = findOutboundEmailArchiveDocumentNos(documentNos(documents, 1));
 
         ArrayList<EDoc> resultDocs = new ArrayList<EDoc>();
         for (Object[] o : documents) {
             Document d = (Document) o[1];
-            if (isOutboundEmailArchiveDocument(d)) {
+            if (d != null && archiveDocumentNos.contains(d.getDocumentNo())) {
                 continue;
             }
             EDoc currentdoc = toEDoc(d);
@@ -692,10 +704,12 @@ public final class EDocUtil {
     public static List<EDoc> listAllDemographicDocsSince(LoggedInInfo loggedInInfo, int demographicNo, Date since) {
 
         List<Document> documents = getDocumentDao().findByDemographicUpdateDate(demographicNo, since);
+        Set<Integer> archiveDocumentNos = findOutboundEmailArchiveDocumentNos(
+                documents.stream().filter(java.util.Objects::nonNull).map(Document::getDocumentNo).toList());
 
         List<EDoc> edocList = new ArrayList<EDoc>();
         for (Document document : documents) {
-            if (!isOutboundEmailArchiveDocument(document)) {
+            if (document == null || !archiveDocumentNos.contains(document.getDocumentNo())) {
                 edocList.add(toEDoc(document));
             }
         }
@@ -715,11 +729,12 @@ public final class EDocUtil {
 
 
         List<Object[]> documents = getDocumentDao().findDocuments(module, moduleid, docType, includePublic, includeDeleted, includeActive, sort, since);
+        Set<Integer> archiveDocumentNos = findOutboundEmailArchiveDocumentNos(documentNos(documents, 1));
 
         ArrayList<EDoc> resultDocs = new ArrayList<EDoc>();
         for (Object[] o : documents) {
             Document d = (Document) o[1];
-            if (isOutboundEmailArchiveDocument(d)) {
+            if (d != null && archiveDocumentNos.contains(d.getDocumentNo())) {
                 continue;
             }
             EDoc currentdoc = toEDoc(d);
@@ -773,9 +788,12 @@ public final class EDocUtil {
 
         DocumentDao dao = SpringUtils.getBean(DocumentDao.class);
 
-        for (Object[] o : dao.findCtlDocsAndDocsByModuleCreatorResponsibleAndDates(Module.DEMOGRAPHIC, creator, responsible, startDate, endDate, unmatchedDemographics)) {
+        List<Object[]> unmatchedDocuments = dao.findCtlDocsAndDocsByModuleCreatorResponsibleAndDates(
+                Module.DEMOGRAPHIC, creator, responsible, startDate, endDate, unmatchedDemographics);
+        Set<Integer> archiveDocumentNos = findOutboundEmailArchiveDocumentNos(documentNos(unmatchedDocuments, 0));
+        for (Object[] o : unmatchedDocuments) {
             Document d = (Document) o[0];
-            if (isOutboundEmailArchiveDocument(d)) {
+            if (d != null && archiveDocumentNos.contains(d.getDocumentNo())) {
                 continue;
             }
             CtlDocument c = (CtlDocument) o[1];
@@ -849,9 +867,12 @@ public final class EDocUtil {
     public static ArrayList<EDoc> listDemoDocs(LoggedInInfo loggedInInfo, String moduleid) {
         DocumentDao dao = SpringUtils.getBean(DocumentDao.class);
         ArrayList<EDoc> resultDocs = new ArrayList<EDoc>();
-        for (Object[] o : dao.findConstultDocsDocsAndProvidersByModule(Module.DEMOGRAPHIC, ConversionUtils.fromIntString(moduleid))) {
+        List<Object[]> documents = dao.findConstultDocsDocsAndProvidersByModule(
+                Module.DEMOGRAPHIC, ConversionUtils.fromIntString(moduleid));
+        Set<Integer> archiveDocumentNos = findOutboundEmailArchiveDocumentNos(documentNos(documents, 0));
+        for (Object[] o : documents) {
             Document d = (Document) o[0];
-            if (outboundEmailArchiveDao().existsByDocumentNo(d.getDocumentNo())) {
+            if (d != null && archiveDocumentNos.contains(d.getDocumentNo())) {
                 continue;
             }
 
@@ -1015,15 +1036,47 @@ public final class EDocUtil {
         return document != null && isOutboundEmailArchiveDocumentNo(document.getDocumentNo());
     }
 
-    private static boolean isOutboundEmailArchiveDocumentId(String documentId) {
+    private static void addDocumentNos(List<Integer> target, List<Object[]> rows, int documentIndex) {
+        if (rows != null) {
+            target.addAll(documentNos(rows, documentIndex));
+        }
+    }
+
+    private static List<Integer> documentNos(List<Object[]> rows, int documentIndex) {
+        if (rows == null || rows.isEmpty()) {
+            return List.of();
+        }
+        List<Integer> documentNos = new ArrayList<>();
+        for (Object[] row : rows) {
+            if (row != null && row.length > documentIndex && row[documentIndex] instanceof Document document
+                    && document.getDocumentNo() != null) {
+                documentNos.add(document.getDocumentNo());
+            }
+        }
+        return documentNos;
+    }
+
+    private static Set<Integer> findOutboundEmailArchiveDocumentNos(Collection<Integer> documentNos) {
+        if (documentNos == null || documentNos.isEmpty()) {
+            return Set.of();
+        }
+        Set<Integer> archiveDocumentNos = outboundEmailArchiveDao().findExistingDocumentNos(documentNos);
+        return archiveDocumentNos != null ? archiveDocumentNos : Set.of();
+    }
+
+    private static Integer parseDocumentNo(String documentId) {
         if (documentId == null || documentId.isBlank()) {
-            return false;
+            return null;
         }
         try {
-            return isOutboundEmailArchiveDocumentNo(Integer.valueOf(documentId));
+            return Integer.valueOf(documentId);
         } catch (NumberFormatException e) {
-            return false;
+            return null;
         }
+    }
+
+    private static boolean isOutboundEmailArchiveDocumentId(String documentId) {
+        return isOutboundEmailArchiveDocumentNo(parseDocumentNo(documentId));
     }
 
     private static boolean isOutboundEmailArchiveDocumentNo(Integer documentNo) {

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/EDocUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/EDocUtil.java
@@ -445,6 +445,7 @@ public final class EDocUtil {
 
         Integer parsedDocumentNo = ConversionUtils.fromIntString(newDocument.getDocId());
         assertNotOutboundEmailArchiveDocument(parsedDocumentNo);
+        assertNotOutboundEmailArchiveFileName(newDocument.getFileName());
         Document doc = getDocumentDao().find(parsedDocumentNo);
         if (doc != null) {
             doc.setDoctype(newDocument.getType());
@@ -1001,7 +1002,7 @@ public final class EDocUtil {
         Integer parsedDocumentNo = ConversionUtils.fromIntString(documentNo);
         Document d = getDocumentDao().find(parsedDocumentNo);
         if (d != null) {
-            assertNotActiveOutboundEmailArchiveDocument(parsedDocumentNo);
+            assertNotOutboundEmailArchiveDocument(parsedDocumentNo);
             d.setStatus('D');
             d.setUpdatedatetime(MyDateFormat.getSysDate(getDmsDateTime()));
             getDocumentDao().merge(d);
@@ -1089,22 +1090,23 @@ public final class EDocUtil {
 
     private static void assertNotOutboundEmailArchiveDocument(Integer documentNo) {
         if (isOutboundEmailArchiveDocumentNo(documentNo)) {
-            throw new IllegalStateException(
+            throw new OutboundEmailArchiveSecurityException(
                     "Outbound email archive eDocs must be managed through the controlled archive workflow");
         }
     }
 
     private static void assertNotOutboundEmailArchiveFileName(String fileName) {
         if (isOutboundEmailArchiveFileName(fileName)) {
-            throw new IllegalStateException(
+            throw new OutboundEmailArchiveSecurityException(
                     "Outbound email archive eDocs must be managed through the controlled archive workflow");
         }
     }
 
-    private static void assertNotActiveOutboundEmailArchiveDocument(Integer documentNo) {
-        if (outboundEmailArchiveDao().existsActiveByDocumentNo(documentNo)) {
-            throw new IllegalStateException(
-                    "Outbound email archive eDocs must be deleted through the controlled archive deletion workflow");
+    private static final class OutboundEmailArchiveSecurityException extends SecurityException {
+        private static final long serialVersionUID = 1L;
+
+        private OutboundEmailArchiveSecurityException(String message) {
+            super(message);
         }
     }
 
@@ -1453,10 +1455,11 @@ public final class EDocUtil {
         try {
             is = new BufferedInputStream(new FileInputStream(validateResolvedDocumentOrTempFile(fileName)));
             return IOUtils.toByteArray(is);
+        } catch (OutboundEmailArchiveSecurityException e) {
+            throw e;
         } catch (SecurityException e) {
-            // Honour the declared throws IOException: a rejected document path surfaces as a checked
-            // IOException rather than an unchecked SecurityException callers are not expecting. Throwing
-            // here also leaves is null, so the finally below must null-guard before closing.
+            // Preserve the historical checked failure for rejected filesystem paths while archive
+            // access denials retain their consistent SecurityException contract.
             throw new IOException("Unable to resolve document file", e);
         } finally {
             try {
@@ -1473,16 +1476,18 @@ public final class EDocUtil {
         File resolvedFile = new File(resolvePath(fileName));
         File documentDir = PathValidationUtils.resolveConfiguredDirectory(
                 CarlosProperties.getInstance().getProperty("DOCUMENT_DIR"), "DOCUMENT_DIR");
+        File trustedFile;
         try {
-            File documentFile = PathValidationUtils.validateExistingPath(resolvedFile, documentDir);
-            assertNotOutboundEmailArchiveFileName(documentFile.getName());
-            return documentFile;
+            trustedFile = PathValidationUtils.validateExistingPath(resolvedFile, documentDir);
         } catch (SecurityException e) {
             if (PathValidationUtils.isInAllowedTempDirectory(resolvedFile)) {
-                return PathValidationUtils.resolveTrustedPath(resolvedFile);
+                trustedFile = PathValidationUtils.resolveTrustedPath(resolvedFile);
+            } else {
+                throw e;
             }
-            throw e;
         }
+        assertNotOutboundEmailArchiveFileName(trustedFile.getName());
+        return trustedFile;
     }
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/EDocUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/EDocUtil.java
@@ -236,6 +236,7 @@ public final class EDocUtil {
     private static CtlDocTypeDao ctldoctypedao() { return SpringUtils.getBean(CtlDocTypeDao.class); }
     private static DemographicManager demographicManager() { return SpringUtils.getBean(DemographicManager.class); }
     private static CtlDocumentDao ctlDocumentDao() { return SpringUtils.getBean(CtlDocumentDao.class); }
+    private static OutboundEmailArchiveDao outboundEmailArchiveDao() { return SpringUtils.getBean(OutboundEmailArchiveDao.class); }
 
     public static String getProviderName(String providerNo) {
         if (providerNo == null || providerNo.length() == 0) {
@@ -243,7 +244,7 @@ public final class EDocUtil {
         }
         Provider p = providerDao().getProvider(providerNo);
         if (p != null) {
-            return p.getLastName().toUpperCase() + ", " + p.getFirstName().toUpperCase();
+            return formatUpperLastFirst(p.getLastName(), p.getFirstName());
         }
         return "";
     }
@@ -254,9 +255,36 @@ public final class EDocUtil {
         }
         Demographic d = demographicManager().getDemographic(loggedInInfo, demographicNo);
         if (d != null) {
-            return d.getLastName().toUpperCase() + ", " + d.getFirstName().toUpperCase();
+            return formatUpperLastFirstWithAlias(d.getLastName(), d.getFirstName(), d.getAlias());
         }
         return "";
+    }
+
+    private static String formatUpperLastFirst(String lastName, String firstName) {
+        String last = StringUtils.trimToEmpty(lastName).toUpperCase(Locale.ROOT);
+        String first = StringUtils.trimToEmpty(firstName).toUpperCase(Locale.ROOT);
+        if (last.isEmpty()) {
+            return first;
+        }
+        if (first.isEmpty()) {
+            return last;
+        }
+        return last + ", " + first;
+    }
+
+    private static String formatUpperLastFirstWithAlias(String lastName, String firstName, String alias) {
+        String name = formatUpperLastFirst(lastName, firstName);
+        String trimmedAlias = StringUtils.trimToEmpty(alias);
+        if (name.isEmpty() && trimmedAlias.isEmpty()) {
+            return "N/A";
+        }
+        if (trimmedAlias.isEmpty()) {
+            return name;
+        }
+        if (name.isEmpty()) {
+            return "(" + trimmedAlias + ")";
+        }
+        return name + " (" + trimmedAlias + ")";
     }
 
     public static Provider getProvider(String providerNo) {
@@ -302,6 +330,7 @@ public final class EDocUtil {
      * @return the new documentId
      */
     public static String addDocumentSQL(EDoc newDocument) {
+        assertNotOutboundEmailArchiveFileName(newDocument.getFileName());
         Document doc = new Document();
         doc.setDoctype(newDocument.getType());
         doc.setDocClass(newDocument.getDocClass());
@@ -367,7 +396,9 @@ public final class EDocUtil {
     }
 
     public static void detachDocConsult(String docNo, String consultId) {
-        List<ConsultDocs> consultDocs = getConsultDocsDao().findByRequestIdDocNoDocType(ConversionUtils.fromIntString(consultId), ConversionUtils.fromIntString(docNo), ConsultDocs.DOCTYPE_DOC);
+        Integer parsedDocumentNo = ConversionUtils.fromIntString(docNo);
+        assertNotOutboundEmailArchiveDocument(parsedDocumentNo);
+        List<ConsultDocs> consultDocs = getConsultDocsDao().findByRequestIdDocNoDocType(ConversionUtils.fromIntString(consultId), parsedDocumentNo, ConsultDocs.DOCTYPE_DOC);
         for (ConsultDocs consultDoc : consultDocs) {
             consultDoc.setDeleted("Y");
             getConsultDocsDao().merge(consultDoc);
@@ -375,7 +406,9 @@ public final class EDocUtil {
     }
 
     public static void detachDocEForm(String docNo, String consultId) {
-        List<EFormDocs> eformDocs = getEformDocsDao().findByFdidIdDocNoDocType(ConversionUtils.fromIntString(consultId), ConversionUtils.fromIntString(docNo), EFormDocs.DOCTYPE_DOC);
+        Integer parsedDocumentNo = ConversionUtils.fromIntString(docNo);
+        assertNotOutboundEmailArchiveDocument(parsedDocumentNo);
+        List<EFormDocs> eformDocs = getEformDocsDao().findByFdidIdDocNoDocType(ConversionUtils.fromIntString(consultId), parsedDocumentNo, EFormDocs.DOCTYPE_DOC);
         for (EFormDocs eformDoc : eformDocs) {
             eformDoc.setDeleted("Y");
             getEformDocsDao().merge(eformDoc);
@@ -383,9 +416,11 @@ public final class EDocUtil {
     }
 
     public static void attachDocConsult(String providerNo, String docNo, String consultId) {
+        int parsedDocumentNo = ConversionUtils.fromIntString(docNo);
+        assertNotOutboundEmailArchiveDocument(parsedDocumentNo);
         ConsultDocs consultDoc = new ConsultDocs();
         consultDoc.setRequestId(ConversionUtils.fromIntString(consultId));
-        consultDoc.setDocumentNo(ConversionUtils.fromIntString(docNo));
+        consultDoc.setDocumentNo(parsedDocumentNo);
         consultDoc.setDocType(ConsultDocs.DOCTYPE_DOC);
         consultDoc.setAttachDate(new Date());
         consultDoc.setProviderNo(providerNo);
@@ -393,9 +428,11 @@ public final class EDocUtil {
     }
 
     public static void attachDocEForm(String providerNo, String docNo, String consultId) {
+        int parsedDocumentNo = ConversionUtils.fromIntString(docNo);
+        assertNotOutboundEmailArchiveDocument(parsedDocumentNo);
         EFormDocs eformDoc = new EFormDocs();
         eformDoc.setFdid(ConversionUtils.fromIntString(consultId));
-        eformDoc.setDocumentNo(ConversionUtils.fromIntString(docNo));
+        eformDoc.setDocumentNo(parsedDocumentNo);
         eformDoc.setDocType(ConsultDocs.DOCTYPE_DOC);
         eformDoc.setAttachDate(new Date());
         eformDoc.setProviderNo(providerNo);
@@ -404,7 +441,9 @@ public final class EDocUtil {
 
     public static void editDocumentSQL(EDoc newDocument, boolean doReview) {
 
-        Document doc = getDocumentDao().find(ConversionUtils.fromIntString(newDocument.getDocId()));
+        Integer parsedDocumentNo = ConversionUtils.fromIntString(newDocument.getDocId());
+        assertNotOutboundEmailArchiveDocument(parsedDocumentNo);
+        Document doc = getDocumentDao().find(parsedDocumentNo);
         if (doc != null) {
             doc.setDoctype(newDocument.getType());
             doc.setDocClass(newDocument.getDocClass());
@@ -481,6 +520,9 @@ public final class EDocUtil {
 
         for (Object[] o : docs) {
             Document d = (Document) o[0];
+            if (isOutboundEmailArchiveDocument(d)) {
+                continue;
+            }
 
             EDoc currentdoc = new EDoc();
             currentdoc.setDocId("" + d.getDocumentNo());
@@ -517,6 +559,9 @@ public final class EDocUtil {
         } else { //remove attached documents from full document list
             for (Object[] o : ctlDocs) {
                 Document d = (Document) o[1];
+                if (isOutboundEmailArchiveDocument(d)) {
+                    continue;
+                }
 
                 EDoc currentdoc = new EDoc();
                 currentdoc.setDocId("" + d.getDocumentNo());
@@ -565,6 +610,9 @@ public final class EDocUtil {
     public static EDoc getEDocFromDocId(String docId) {
         DocumentDao dao = SpringUtils.getBean(DocumentDao.class);
         EDoc currentdoc = new EDoc();
+        if (isOutboundEmailArchiveDocumentId(docId)) {
+            return currentdoc;
+        }
 
         for (Object[] o : dao.findCtlDocsAndDocsByDocNo(ConversionUtils.fromIntString(docId))) {
             Document d = (Document) o[0];
@@ -607,9 +655,9 @@ public final class EDocUtil {
 
         ArrayList<EDoc> resultDocs = new ArrayList<EDoc>();
         for (String docId : docIds) {
-            EDoc currentdoc = new EDoc();
-            currentdoc = getEDocFromDocId(docId);
-            resultDocs.add(currentdoc);
+            if (!isOutboundEmailArchiveDocumentId(docId)) {
+                resultDocs.add(getEDocFromDocId(docId));
+            }
         }
         return resultDocs;
     }
@@ -624,6 +672,9 @@ public final class EDocUtil {
         ArrayList<EDoc> resultDocs = new ArrayList<EDoc>();
         for (Object[] o : documents) {
             Document d = (Document) o[1];
+            if (isOutboundEmailArchiveDocument(d)) {
+                continue;
+            }
             EDoc currentdoc = toEDoc(d);
             resultDocs.add(currentdoc);
         }
@@ -644,8 +695,9 @@ public final class EDocUtil {
 
         List<EDoc> edocList = new ArrayList<EDoc>();
         for (Document document : documents) {
-            EDoc edoc = toEDoc(document);
-            edocList.add(edoc);
+            if (!isOutboundEmailArchiveDocument(document)) {
+                edocList.add(toEDoc(document));
+            }
         }
 
         if (CarlosProperties.getInstance().getBooleanProperty("FILTER_ON_FACILITY", "true")) {
@@ -667,6 +719,9 @@ public final class EDocUtil {
         ArrayList<EDoc> resultDocs = new ArrayList<EDoc>();
         for (Object[] o : documents) {
             Document d = (Document) o[1];
+            if (isOutboundEmailArchiveDocument(d)) {
+                continue;
+            }
             EDoc currentdoc = toEDoc(d);
             resultDocs.add(currentdoc);
         }
@@ -720,6 +775,9 @@ public final class EDocUtil {
 
         for (Object[] o : dao.findCtlDocsAndDocsByModuleCreatorResponsibleAndDates(Module.DEMOGRAPHIC, creator, responsible, startDate, endDate, unmatchedDemographics)) {
             Document d = (Document) o[0];
+            if (isOutboundEmailArchiveDocument(d)) {
+                continue;
+            }
             CtlDocument c = (CtlDocument) o[1];
 
             EDoc currentdoc = new EDoc();
@@ -793,6 +851,9 @@ public final class EDocUtil {
         ArrayList<EDoc> resultDocs = new ArrayList<EDoc>();
         for (Object[] o : dao.findConstultDocsDocsAndProvidersByModule(Module.DEMOGRAPHIC, ConversionUtils.fromIntString(moduleid))) {
             Document d = (Document) o[0];
+            if (outboundEmailArchiveDao().existsByDocumentNo(d.getDocumentNo())) {
+                continue;
+            }
 
             EDoc currentdoc = new EDoc();
             currentdoc.setDocId("" + d.getDocumentNo());
@@ -837,6 +898,9 @@ public final class EDocUtil {
         DocumentDao dao = SpringUtils.getBean(DocumentDao.class);
 
         EDoc currentdoc = new EDoc();
+        if (isOutboundEmailArchiveDocumentId(documentNo)) {
+            return currentdoc;
+        }
 
         for (Object[] o : dao.findCtlDocsAndDocsByDocNo(ConversionUtils.fromIntString(documentNo))) {
             Document d = (Document) o[0];
@@ -879,7 +943,11 @@ public final class EDocUtil {
     }
 
     public String getDocumentName(String id) {
-        Document d = getDocumentDao().find(ConversionUtils.fromIntString(id));
+        Integer documentNo = ConversionUtils.fromIntString(id);
+        if (isOutboundEmailArchiveDocumentNo(documentNo)) {
+            return null;
+        }
+        Document d = getDocumentDao().find(documentNo);
         if (d != null) {
             return d.getDocfilename();
         }
@@ -887,23 +955,32 @@ public final class EDocUtil {
     }
 
     public static void undeleteDocument(String documentNo) {
-        CtlDocument cd = ctlDocumentDao().getCtrlDocument(ConversionUtils.fromIntString(documentNo));
-        String status = "";
-        if (cd != null) {
-            status = cd.getStatus();
-        }
+        Integer parsedDocumentNo = ConversionUtils.fromIntString(documentNo);
+        assertNotOutboundEmailArchiveDocument(parsedDocumentNo);
+        CtlDocument cd = ctlDocumentDao().getCtrlDocument(parsedDocumentNo);
+        char status = undeleteStatus(cd);
 
-        Document d = getDocumentDao().find(ConversionUtils.fromIntString(documentNo));
+        Document d = getDocumentDao().find(parsedDocumentNo);
         if (d != null) {
-            d.setStatus(status.toCharArray()[0]);
+            d.setStatus(status);
             d.setUpdatedatetime(MyDateFormat.getSysDate(getDmsDateTime()));
             getDocumentDao().merge(d);
         }
     }
 
+    private static char undeleteStatus(CtlDocument cd) {
+        String status = cd == null ? null : cd.getStatus();
+        if (status == null || status.isEmpty()) {
+            return Document.STATUS_ACTIVE;
+        }
+        return status.charAt(0);
+    }
+
     public static void deleteDocument(String documentNo) {
-        Document d = getDocumentDao().find(ConversionUtils.fromIntString(documentNo));
+        Integer parsedDocumentNo = ConversionUtils.fromIntString(documentNo);
+        Document d = getDocumentDao().find(parsedDocumentNo);
         if (d != null) {
+            assertNotActiveOutboundEmailArchiveDocument(parsedDocumentNo);
             d.setStatus('D');
             d.setUpdatedatetime(MyDateFormat.getSysDate(getDmsDateTime()));
             getDocumentDao().merge(d);
@@ -934,12 +1011,57 @@ public final class EDocUtil {
         return PathValidationUtils.validatePathComponent(baseName, "stored document filename");
     }
 
+    private static boolean isOutboundEmailArchiveDocument(Document document) {
+        return document != null && isOutboundEmailArchiveDocumentNo(document.getDocumentNo());
+    }
+
+    private static boolean isOutboundEmailArchiveDocumentId(String documentId) {
+        if (documentId == null || documentId.isBlank()) {
+            return false;
+        }
+        try {
+            return isOutboundEmailArchiveDocumentNo(Integer.valueOf(documentId));
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
+    private static boolean isOutboundEmailArchiveDocumentNo(Integer documentNo) {
+        return documentNo != null && outboundEmailArchiveDao().existsByDocumentNo(documentNo);
+    }
+
+    private static boolean isOutboundEmailArchiveFileName(String fileName) {
+        return fileName != null && !fileName.isBlank() && outboundEmailArchiveDao().existsByFileName(fileName);
+    }
+
+    private static void assertNotOutboundEmailArchiveDocument(Integer documentNo) {
+        if (isOutboundEmailArchiveDocumentNo(documentNo)) {
+            throw new IllegalStateException(
+                    "Outbound email archive eDocs must be managed through the controlled archive workflow");
+        }
+    }
+
+    private static void assertNotOutboundEmailArchiveFileName(String fileName) {
+        if (isOutboundEmailArchiveFileName(fileName)) {
+            throw new IllegalStateException(
+                    "Outbound email archive eDocs must be managed through the controlled archive workflow");
+        }
+    }
+
+    private static void assertNotActiveOutboundEmailArchiveDocument(Integer documentNo) {
+        if (outboundEmailArchiveDao().existsActiveByDocumentNo(documentNo)) {
+            throw new IllegalStateException(
+                    "Outbound email archive eDocs must be deleted through the controlled archive deletion workflow");
+        }
+    }
+
     // FindSecBugs PATH_TRAVERSAL_IN: path validated for directory containment via PathValidationUtils before use
     @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "path validated for directory containment via PathValidationUtils before use")
     public static void refileDocument(String documentNo, String queueId) throws Exception {
 
         File sourceBaseDir = new File(CarlosProperties.getInstance().getProperty("DOCUMENT_DIR"));
         int parsedDocumentNo = parsePositiveId(documentNo, "documentNo");
+        assertNotOutboundEmailArchiveDocument(parsedDocumentNo);
         Document d = getDocumentDao().find(parsedDocumentNo);
         if (d == null) {
             throw new FileNotFoundException("Document not found");
@@ -1028,6 +1150,7 @@ public final class EDocUtil {
     }
 
     public static int addDocument(String demoNo, String docFileName, String docDesc, String docType, String docClass, String docSubClass, String contentType, String contentDateTime, String observationDate, String updateDateTime, String docCreator, String responsible, String reviewer, String reviewDateTime, String source, String sourceFacility, String receivedDate) {
+        assertNotOutboundEmailArchiveFileName(docFileName);
 
         Document doc = new Document();
         doc.setDoctype(docType);
@@ -1084,7 +1207,7 @@ public final class EDocUtil {
         String docNumber = EDocUtil.getLastDocumentNo();
         DocumentDao dao = SpringUtils.getBean(DocumentDao.class);
         Document d = dao.find(ConversionUtils.fromIntString(docNumber));
-        if (d != null) {
+        if (d != null && !isOutboundEmailArchiveDocument(d)) {
             return d.getDocdesc();
         }
         return null;
@@ -1160,6 +1283,9 @@ public final class EDocUtil {
         Long docIdL = getTableIdFromNoteId(noteId);
         if (docIdL > 0L) {
             Integer docId = docIdL.intValue();
+            if (isOutboundEmailArchiveDocumentNo(docId)) {
+                return doc;
+            }
 
             DocumentDao dao = SpringUtils.getBean(DocumentDao.class);
             Document d = dao.find(docId);
@@ -1174,7 +1300,9 @@ public final class EDocUtil {
     }
 
     public static void subtractOnePage(String docId) {
-        Document doc = getDocumentDao().find(ConversionUtils.fromIntString(docId));
+        Integer parsedDocumentNo = ConversionUtils.fromIntString(docId);
+        assertNotOutboundEmailArchiveDocument(parsedDocumentNo);
+        Document doc = getDocumentDao().find(parsedDocumentNo);
         doc.setNumberofpages(doc.getNumberofpages() - 1);
 
         getDocumentDao().merge(doc);
@@ -1182,6 +1310,7 @@ public final class EDocUtil {
 
     public static String getHtmlTicklers(LoggedInInfo loggedInInfo, String docId) {
 
+        assertNotOutboundEmailArchiveDocument(ConversionUtils.fromIntString(docId));
         Long table_id = Long.valueOf(docId);
         List<TicklerLink> linkList = ticklerLinkDao().getLinkByTableId("DOC", table_id);
         String HtmlTickler = "";
@@ -1199,6 +1328,7 @@ public final class EDocUtil {
 
     public static String getHtmlAcknowledgement(Locale locale, String docId) {
 
+        assertNotOutboundEmailArchiveDocument(ConversionUtils.fromIntString(docId));
         ArrayList<ReportStatus> ackList = AcknowledgementData.getAcknowledgements("DOC", docId);
         String HtmlAcknowledgement = "";
         String comment = "";
@@ -1231,6 +1361,7 @@ public final class EDocUtil {
 
     public static String getHtmlAnnotation(String docId) {
 
+        assertNotOutboundEmailArchiveDocument(ConversionUtils.fromIntString(docId));
         Long tableId = 0L;
         String note = "";
 
@@ -1290,7 +1421,9 @@ public final class EDocUtil {
         File documentDir = PathValidationUtils.resolveConfiguredDirectory(
                 CarlosProperties.getInstance().getProperty("DOCUMENT_DIR"), "DOCUMENT_DIR");
         try {
-            return PathValidationUtils.validateExistingPath(resolvedFile, documentDir);
+            File documentFile = PathValidationUtils.validateExistingPath(resolvedFile, documentDir);
+            assertNotOutboundEmailArchiveFileName(documentFile.getName());
+            return documentFile;
         } catch (SecurityException e) {
             if (PathValidationUtils.isInAllowedTempDirectory(resolvedFile)) {
                 return PathValidationUtils.resolveTrustedPath(resolvedFile);
@@ -1311,6 +1444,7 @@ public final class EDocUtil {
     // FindSecBugs PATH_TRAVERSAL_IN: path validated for directory containment via PathValidationUtils before use
     @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "path validated for directory containment via PathValidationUtils before use")
     public static void writeDocContent(String fileName, byte[] content) throws IOException {
+        assertNotOutboundEmailArchiveFileName(fileName);
         String docDir = CarlosProperties.getInstance().getProperty("DOCUMENT_DIR");
         File docDirFile = new File(docDir);
         File file = PathValidationUtils.validatePath(fileName, docDirFile);

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2Action.java
@@ -204,7 +204,7 @@ public class CombinePDF2Action extends ActionSupport {
         for (CtlDocument documentLink : documentLinks) {
             String module = documentLink.getId().getModule();
             Integer moduleId = documentLink.getId().getModuleId();
-            if ("demographic".equals(module)) {
+            if (isDemographicModule(module)) {
                 hasDemographicLink = true;
                 if (moduleId == null
                         || !securityInfoManager.isAllowedAccessToPatientRecord(loggedInInfo, moduleId)) {
@@ -228,6 +228,11 @@ public class CombinePDF2Action extends ActionSupport {
         return providerNo != null && documentLinks.stream()
                 .anyMatch(documentLink -> EDocUtil.isProviderModule(documentLink.getId().getModule())
                         && providerNo.equals(documentLink.getId().getModuleId()));
+    }
+
+    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "ASCII database module identifier is matched case-insensitively for legacy compatibility")
+    private boolean isDemographicModule(String module) {
+        return "demographic".equalsIgnoreCase(module);
     }
 
     private Integer parseProviderNo(String providerNo) {

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2Action.java
@@ -49,6 +49,7 @@ import io.github.carlos_emr.carlos.commn.dao.DocumentDao;
 import io.github.carlos_emr.carlos.commn.dao.OutboundEmailArchiveDao;
 import io.github.carlos_emr.carlos.commn.model.CtlDocument;
 import io.github.carlos_emr.carlos.commn.model.Document;
+import io.github.carlos_emr.carlos.documentManager.EDocUtil;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
@@ -216,7 +217,7 @@ public class CombinePDF2Action extends ActionSupport {
         }
 
         boolean hasProviderLink = documentLinks.stream()
-                .anyMatch(documentLink -> isProviderModule(documentLink.getId().getModule()));
+                .anyMatch(documentLink -> EDocUtil.isProviderModule(documentLink.getId().getModule()));
         if (!hasProviderLink) {
             return false;
         }
@@ -225,12 +226,8 @@ public class CombinePDF2Action extends ActionSupport {
         }
         Integer providerNo = parseProviderNo(loggedInInfo.getLoggedInProviderNo());
         return providerNo != null && documentLinks.stream()
-                .anyMatch(documentLink -> isProviderModule(documentLink.getId().getModule())
+                .anyMatch(documentLink -> EDocUtil.isProviderModule(documentLink.getId().getModule())
                         && providerNo.equals(documentLink.getId().getModuleId()));
-    }
-
-    private boolean isProviderModule(String module) {
-        return "provider".equals(module) || "providers".equals(module);
     }
 
     private Integer parseProviderNo(String providerNo) {

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2Action.java
@@ -104,41 +104,26 @@ public class CombinePDF2Action extends ActionSupport {
                 response.setStatus(HttpServletResponse.SC_FORBIDDEN);
                 return NONE;
             }
-            List<CtlDocument> demographicLinks = ctlDocumentDao.findByDocumentNosAndModule(
-                    documentNos, "demographic");
-            if (demographicLinks == null) {
-                response.setStatus(HttpServletResponse.SC_FORBIDDEN);
-                return NONE;
-            }
-            Map<Integer, List<Integer>> demographicNosByDocumentNo = new HashMap<>();
-            for (CtlDocument demographicLink : demographicLinks) {
-                if (demographicLink == null || demographicLink.getId() == null
-                        || demographicLink.getId().getDocumentNo() == null
-                        || demographicLink.getId().getModuleId() == null) {
+            List<CtlDocument> documentLinks = ctlDocumentDao.findByDocumentNos(documentNos);
+            Map<Integer, List<CtlDocument>> linksByDocumentNo = new HashMap<>();
+            for (CtlDocument documentLink : documentLinks) {
+                if (documentLink == null || documentLink.getId() == null
+                        || documentLink.getId().getDocumentNo() == null) {
                     continue;
                 }
-                demographicNosByDocumentNo
-                        .computeIfAbsent(demographicLink.getId().getDocumentNo(), ignored -> new ArrayList<>())
-                        .add(demographicLink.getId().getModuleId());
-            }
-            for (Integer documentNo : documentNos) {
-                List<Integer> demographicNos = demographicNosByDocumentNo.get(documentNo);
-                if (demographicNos == null || demographicNos.isEmpty()) {
-                    response.setStatus(HttpServletResponse.SC_FORBIDDEN);
-                    return NONE;
-                }
-                for (Integer demographicNo : demographicNos) {
-                    if (!securityInfoManager.isAllowedAccessToPatientRecord(loggedInInfo, demographicNo)) {
-                        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
-                        return NONE;
-                    }
-                }
+                linksByDocumentNo
+                        .computeIfAbsent(documentLink.getId().getDocumentNo(), ignored -> new ArrayList<>())
+                        .add(documentLink);
             }
             List<Document> documents = new ArrayList<>();
             for (Integer documentNo : documentNos) {
-                Document document = documentDao.find(documentNo);
+                Document document = documentDao.find(documentNo.intValue());
                 if (document == null || document.getDocfilename() == null || document.getDocfilename().isBlank()) {
                     response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+                    return NONE;
+                }
+                if (!isAuthorizedDocumentScope(loggedInInfo, document, linksByDocumentNo.get(documentNo))) {
+                    response.setStatus(HttpServletResponse.SC_FORBIDDEN);
                     return NONE;
                 }
                 documents.add(document);
@@ -206,6 +191,54 @@ public class CombinePDF2Action extends ActionSupport {
             }
         }
         return SUCCESS;
+    }
+
+    boolean isAuthorizedDocumentScope(
+            LoggedInInfo loggedInInfo, Document document, List<CtlDocument> documentLinks) {
+        if (documentLinks == null || documentLinks.isEmpty()) {
+            return false;
+        }
+
+        boolean hasDemographicLink = false;
+        for (CtlDocument documentLink : documentLinks) {
+            String module = documentLink.getId().getModule();
+            Integer moduleId = documentLink.getId().getModuleId();
+            if ("demographic".equals(module)) {
+                hasDemographicLink = true;
+                if (moduleId == null
+                        || !securityInfoManager.isAllowedAccessToPatientRecord(loggedInInfo, moduleId)) {
+                    return false;
+                }
+            }
+        }
+        if (hasDemographicLink) {
+            return true;
+        }
+
+        boolean hasProviderLink = documentLinks.stream()
+                .anyMatch(documentLink -> isProviderModule(documentLink.getId().getModule()));
+        if (!hasProviderLink) {
+            return false;
+        }
+        if (document.getPublic1() == 1) {
+            return true;
+        }
+        Integer providerNo = parseProviderNo(loggedInInfo.getLoggedInProviderNo());
+        return providerNo != null && documentLinks.stream()
+                .anyMatch(documentLink -> isProviderModule(documentLink.getId().getModule())
+                        && providerNo.equals(documentLink.getId().getModuleId()));
+    }
+
+    private boolean isProviderModule(String module) {
+        return "provider".equals(module) || "providers".equals(module);
+    }
+
+    private Integer parseProviderNo(String providerNo) {
+        try {
+            return providerNo != null ? Integer.valueOf(providerNo) : null;
+        } catch (NumberFormatException e) {
+            return null;
+        }
     }
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2Action.java
@@ -53,7 +53,6 @@ import io.github.carlos_emr.carlos.utility.SpringUtils;
 
 import io.github.carlos_emr.CarlosProperties;
 import io.github.carlos_emr.carlos.util.ConcatPDF;
-import io.github.carlos_emr.carlos.util.ConversionUtils;
 import io.github.carlos_emr.carlos.util.UtilDateUtilities;
 
 /**
@@ -90,7 +89,8 @@ public class CombinePDF2Action extends ActionSupport {
                 try {
                     documentNos.add(Integer.valueOf(file));
                 } catch (NumberFormatException e) {
-                    // Invalid IDs are omitted from the archive query and normalize to document 0 below.
+                    response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+                    return NONE;
                 }
             }
             Set<Integer> archiveDocumentNos = outboundEmailArchiveDao.findExistingDocumentNos(documentNos);
@@ -98,12 +98,20 @@ public class CombinePDF2Action extends ActionSupport {
                 response.setStatus(HttpServletResponse.SC_FORBIDDEN);
                 return NONE;
             }
+            List<Document> documents = new ArrayList<>();
+            for (Integer documentNo : documentNos) {
+                Document document = documentDao.find(documentNo);
+                if (document == null || document.getDocfilename() == null || document.getDocfilename().isBlank()) {
+                    response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+                    return NONE;
+                }
+                documents.add(document);
+            }
             File documentDir = PathValidationUtils.resolveConfiguredDirectory(CarlosProperties.getInstance().getProperty("DOCUMENT_DIR"), "DOCUMENT_DIR");
             Path filePath;
-            for (int i = 0; i < files.length; i++) {
-                Document document = documentDao.find(ConversionUtils.fromIntString(files[i]));
-                String filename = document != null ? document.getDocfilename() : null;
-                filePath = PathValidationUtils.validateExistingPath(new File(documentDir, filename), documentDir).toPath();
+            for (Document document : documents) {
+                filePath = PathValidationUtils.validateExistingPath(
+                        new File(documentDir, document.getDocfilename()), documentDir).toPath();
                 alist.add(filePath.toAbsolutePath().toString());
             }
             if (alist.size() > 0) {

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2Action.java
@@ -42,8 +42,9 @@ import java.util.Set;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import io.github.carlos_emr.carlos.commn.dao.DocumentDao;
 import io.github.carlos_emr.carlos.commn.dao.OutboundEmailArchiveDao;
-import io.github.carlos_emr.carlos.documentManager.EDocUtil;
+import io.github.carlos_emr.carlos.commn.model.Document;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
@@ -52,6 +53,7 @@ import io.github.carlos_emr.carlos.utility.SpringUtils;
 
 import io.github.carlos_emr.CarlosProperties;
 import io.github.carlos_emr.carlos.util.ConcatPDF;
+import io.github.carlos_emr.carlos.util.ConversionUtils;
 import io.github.carlos_emr.carlos.util.UtilDateUtilities;
 
 /**
@@ -67,6 +69,7 @@ public class CombinePDF2Action extends ActionSupport {
 
 
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
+    private transient DocumentDao documentDao = SpringUtils.getBean(DocumentDao.class);
     private transient OutboundEmailArchiveDao outboundEmailArchiveDao = SpringUtils.getBean(OutboundEmailArchiveDao.class);
 
     // FindSecBugs PATH_TRAVERSAL_IN: path validated for directory containment via PathValidationUtils before use
@@ -95,11 +98,11 @@ public class CombinePDF2Action extends ActionSupport {
                 response.setStatus(HttpServletResponse.SC_FORBIDDEN);
                 return NONE;
             }
-            EDocUtil docData = new EDocUtil();
             File documentDir = PathValidationUtils.resolveConfiguredDirectory(CarlosProperties.getInstance().getProperty("DOCUMENT_DIR"), "DOCUMENT_DIR");
             Path filePath;
             for (int i = 0; i < files.length; i++) {
-                String filename = docData.getDocumentName(files[i]);
+                Document document = documentDao.find(ConversionUtils.fromIntString(files[i]));
+                String filename = document != null ? document.getDocfilename() : null;
                 filePath = PathValidationUtils.validateExistingPath(new File(documentDir, filename), documentDir).toPath();
                 alist.add(filePath.toAbsolutePath().toString());
             }

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2Action.java
@@ -90,7 +90,7 @@ public class CombinePDF2Action extends ActionSupport {
                 try {
                     documentNos.add(Integer.valueOf(file));
                 } catch (NumberFormatException e) {
-                    // Preserve the existing invalid-id handling in EDocUtil below.
+                    // Invalid IDs are omitted from the archive query and normalize to document 0 below.
                 }
             }
             Set<Integer> archiveDocumentNos = outboundEmailArchiveDao.findExistingDocumentNos(documentNos);

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2Action.java
@@ -36,12 +36,13 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import io.github.carlos_emr.carlos.commn.dao.OutboundEmailArchiveDao;
-import io.github.carlos_emr.carlos.email.archive.OutboundEmailArchiveDocumentGuard;
 import io.github.carlos_emr.carlos.documentManager.EDocUtil;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
@@ -81,14 +82,23 @@ public class CombinePDF2Action extends ActionSupport {
         ArrayList<Object> alist = new ArrayList<Object>();
         if (files != null) {
             MiscUtils.getLogger().debug("size = " + files.length);
+            List<Integer> documentNos = new ArrayList<>();
+            for (String file : files) {
+                try {
+                    documentNos.add(Integer.valueOf(file));
+                } catch (NumberFormatException e) {
+                    // Preserve the existing invalid-id handling in EDocUtil below.
+                }
+            }
+            Set<Integer> archiveDocumentNos = outboundEmailArchiveDao.findExistingDocumentNos(documentNos);
+            if (archiveDocumentNos != null && !archiveDocumentNos.isEmpty()) {
+                response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+                return NONE;
+            }
             EDocUtil docData = new EDocUtil();
             File documentDir = PathValidationUtils.resolveConfiguredDirectory(CarlosProperties.getInstance().getProperty("DOCUMENT_DIR"), "DOCUMENT_DIR");
             Path filePath;
             for (int i = 0; i < files.length; i++) {
-                if (isOutboundEmailArchiveDocument(files[i])) {
-                    response.setStatus(HttpServletResponse.SC_FORBIDDEN);
-                    return NONE;
-                }
                 String filename = docData.getDocumentName(files[i]);
                 filePath = PathValidationUtils.validateExistingPath(new File(documentDir, filename), documentDir).toPath();
                 alist.add(filePath.toAbsolutePath().toString());
@@ -149,10 +159,6 @@ public class CombinePDF2Action extends ActionSupport {
             }
         }
         return SUCCESS;
-    }
-
-    private boolean isOutboundEmailArchiveDocument(String documentNo) {
-        return OutboundEmailArchiveDocumentGuard.isArchiveDocument(outboundEmailArchiveDao, documentNo);
     }
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2Action.java
@@ -41,6 +41,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import io.github.carlos_emr.carlos.commn.dao.OutboundEmailArchiveDao;
+import io.github.carlos_emr.carlos.email.archive.OutboundEmailArchiveDocumentGuard;
 import io.github.carlos_emr.carlos.documentManager.EDocUtil;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
@@ -151,14 +152,7 @@ public class CombinePDF2Action extends ActionSupport {
     }
 
     private boolean isOutboundEmailArchiveDocument(String documentNo) {
-        if (documentNo == null || documentNo.isBlank()) {
-            return false;
-        }
-        try {
-            return outboundEmailArchiveDao.existsByDocumentNo(Integer.valueOf(documentNo));
-        } catch (NumberFormatException e) {
-            return false;
-        }
+        return OutboundEmailArchiveDocumentGuard.isArchiveDocument(outboundEmailArchiveDao, documentNo);
     }
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2Action.java
@@ -40,6 +40,7 @@ import java.util.ArrayList;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import io.github.carlos_emr.carlos.commn.dao.OutboundEmailArchiveDao;
 import io.github.carlos_emr.carlos.documentManager.EDocUtil;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
@@ -64,6 +65,7 @@ public class CombinePDF2Action extends ActionSupport {
 
 
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
+    private transient OutboundEmailArchiveDao outboundEmailArchiveDao = SpringUtils.getBean(OutboundEmailArchiveDao.class);
 
     // FindSecBugs PATH_TRAVERSAL_IN: path validated for directory containment via PathValidationUtils before use
     @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "path validated for directory containment via PathValidationUtils before use")
@@ -82,6 +84,10 @@ public class CombinePDF2Action extends ActionSupport {
             File documentDir = PathValidationUtils.resolveConfiguredDirectory(CarlosProperties.getInstance().getProperty("DOCUMENT_DIR"), "DOCUMENT_DIR");
             Path filePath;
             for (int i = 0; i < files.length; i++) {
+                if (isOutboundEmailArchiveDocument(files[i])) {
+                    response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+                    return NONE;
+                }
                 String filename = docData.getDocumentName(files[i]);
                 filePath = PathValidationUtils.validateExistingPath(new File(documentDir, filename), documentDir).toPath();
                 alist.add(filePath.toAbsolutePath().toString());
@@ -142,6 +148,17 @@ public class CombinePDF2Action extends ActionSupport {
             }
         }
         return SUCCESS;
+    }
+
+    private boolean isOutboundEmailArchiveDocument(String documentNo) {
+        if (documentNo == null || documentNo.isBlank()) {
+            return false;
+        }
+        try {
+            return outboundEmailArchiveDao.existsByDocumentNo(Integer.valueOf(documentNo));
+        } catch (NumberFormatException e) {
+            return false;
+        }
     }
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2Action.java
@@ -36,14 +36,18 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import io.github.carlos_emr.carlos.commn.dao.CtlDocumentDao;
 import io.github.carlos_emr.carlos.commn.dao.DocumentDao;
 import io.github.carlos_emr.carlos.commn.dao.OutboundEmailArchiveDao;
+import io.github.carlos_emr.carlos.commn.model.CtlDocument;
 import io.github.carlos_emr.carlos.commn.model.Document;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
@@ -68,6 +72,7 @@ public class CombinePDF2Action extends ActionSupport {
 
 
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
+    private transient CtlDocumentDao ctlDocumentDao = SpringUtils.getBean(CtlDocumentDao.class);
     private transient DocumentDao documentDao = SpringUtils.getBean(DocumentDao.class);
     private transient OutboundEmailArchiveDao outboundEmailArchiveDao = SpringUtils.getBean(OutboundEmailArchiveDao.class);
 
@@ -75,7 +80,8 @@ public class CombinePDF2Action extends ActionSupport {
     @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "path validated for directory containment via PathValidationUtils before use")
     public String execute() {
 
-        if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_edoc", "w", null)) {
+        LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_edoc", "w", null)) {
             throw new SecurityException("missing required sec object (_edoc)");
         }
 
@@ -97,6 +103,36 @@ public class CombinePDF2Action extends ActionSupport {
             if (archiveDocumentNos != null && !archiveDocumentNos.isEmpty()) {
                 response.setStatus(HttpServletResponse.SC_FORBIDDEN);
                 return NONE;
+            }
+            List<CtlDocument> demographicLinks = ctlDocumentDao.findByDocumentNosAndModule(
+                    documentNos, "demographic");
+            if (demographicLinks == null) {
+                response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+                return NONE;
+            }
+            Map<Integer, List<Integer>> demographicNosByDocumentNo = new HashMap<>();
+            for (CtlDocument demographicLink : demographicLinks) {
+                if (demographicLink == null || demographicLink.getId() == null
+                        || demographicLink.getId().getDocumentNo() == null
+                        || demographicLink.getId().getModuleId() == null) {
+                    continue;
+                }
+                demographicNosByDocumentNo
+                        .computeIfAbsent(demographicLink.getId().getDocumentNo(), ignored -> new ArrayList<>())
+                        .add(demographicLink.getId().getModuleId());
+            }
+            for (Integer documentNo : documentNos) {
+                List<Integer> demographicNos = demographicNosByDocumentNo.get(documentNo);
+                if (demographicNos == null || demographicNos.isEmpty()) {
+                    response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+                    return NONE;
+                }
+                for (Integer demographicNo : demographicNos) {
+                    if (!securityInfoManager.isAllowedAccessToPatientRecord(loggedInInfo, demographicNo)) {
+                        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+                        return NONE;
+                    }
+                }
             }
             List<Document> documents = new ArrayList<>();
             for (Integer documentNo : documentNos) {

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2Action.java
@@ -76,7 +76,7 @@ public class CombinePDF2Action extends ActionSupport {
     public String execute() {
 
         if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_edoc", "w", null)) {
-            throw new SecurityException("missing required sec object (_doc)");
+            throw new SecurityException("missing required sec object (_edoc)");
         }
 
         String[] files = request.getParameterValues("docNo");

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentPreview2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentPreview2Action.java
@@ -1,5 +1,7 @@
 package io.github.carlos_emr.carlos.documentManager.actions;
 
+import io.github.carlos_emr.CarlosProperties;
+
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.carlos_emr.carlos.eform.EFormUtil;
 import io.github.carlos_emr.carlos.encounter.data.EctFormData;
@@ -11,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.apache.logging.log4j.Logger;
 import io.github.carlos_emr.carlos.commn.dao.EFormDataDao;
+import io.github.carlos_emr.carlos.commn.dao.OutboundEmailArchiveDao;
 import io.github.carlos_emr.carlos.commn.dao.PatientLabRoutingDao;
 import io.github.carlos_emr.carlos.commn.model.EFormData;
 import io.github.carlos_emr.carlos.commn.model.PatientLabRouting;
@@ -29,6 +32,7 @@ import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.EformContentUnavailableException;
 import io.github.carlos_emr.carlos.utility.PDFGenerationException;
+import io.github.carlos_emr.carlos.utility.PathValidationUtils;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 
 import io.github.carlos_emr.carlos.util.StringUtils;
@@ -38,6 +42,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import java.io.BufferedInputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -70,6 +75,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * @see DocumentType
  */
 public class DocumentPreview2Action extends ActionSupport {
+    private static final String DOCUMENT_DIR_PROPERTY = "DOCUMENT_DIR";
+
     private static final String FETCH_CONSULT_DOCUMENTS = "fetchConsultDocuments";
     private static final String DEMOGRAPHIC_NO_PARAMETER = "demographicNo";
     private static final String EFORM_SECURITY_OBJECT = "_eform";
@@ -110,6 +117,7 @@ public class DocumentPreview2Action extends ActionSupport {
     private final transient EFormDataDao eFormDataDao = SpringUtils.getBean(EFormDataDao.class);
     private final transient PatientLabRoutingDao patientLabRoutingDao = SpringUtils.getBean(PatientLabRoutingDao.class);
     private final transient HRMDocumentToDemographicDao hrmDocumentToDemographicDao = SpringUtils.getBean(HRMDocumentToDemographicDao.class);
+    private final transient OutboundEmailArchiveDao outboundEmailArchiveDao = SpringUtils.getBean(OutboundEmailArchiveDao.class);
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     /**
@@ -388,6 +396,12 @@ public class DocumentPreview2Action extends ActionSupport {
             response.setStatus(HttpServletResponse.SC_FORBIDDEN);
             return;
         }
+        if (isOutboundEmailArchiveDocumentPath(pdfPath)) {
+            logger.warn("Blocked direct preview of outbound email archive eDoc: {}",
+                    LogSafe.sanitizeObject(pdfPath.getFileName()));
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+            return;
+        }
 
         try {
             response.setContentType("application/pdf");
@@ -406,6 +420,32 @@ public class DocumentPreview2Action extends ActionSupport {
             logger.error("Error processing authorized PDF preview", e);
             response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
         }
+    }
+
+    private boolean isOutboundEmailArchiveDocumentPath(Path canonicalPdfPath) {
+        Path fileName = canonicalPdfPath.getFileName();
+        if (fileName == null) {
+            return false;
+        }
+        String documentDirectoryPath = CarlosProperties.getInstance().getProperty(DOCUMENT_DIR_PROPERTY, "/var/lib/OscarDocument/");
+        if (documentDirectoryPath == null || documentDirectoryPath.isBlank()) {
+            return false;
+        }
+        File documentDirectory;
+        try {
+            documentDirectory = PathValidationUtils.resolveConfiguredDirectory(documentDirectoryPath, DOCUMENT_DIR_PROPERTY);
+        } catch (SecurityException e) {
+            return false;
+        }
+        if (!documentDirectory.exists()) {
+            return false;
+        }
+        try {
+            PathValidationUtils.validateExistingPath(canonicalPdfPath.toFile(), documentDirectory);
+        } catch (SecurityException e) {
+            return false;
+        }
+        return outboundEmailArchiveDao.existsByFileName(fileName.toString());
     }
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/ManageDocument2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/ManageDocument2Action.java
@@ -127,6 +127,7 @@ public class ManageDocument2Action extends ActionSupport {
     private final DocumentDao documentDao = SpringUtils.getBean(DocumentDao.class);
     private final QueueDao queueDao = SpringUtils.getBean(QueueDao.class);
     private final CtlDocumentDao ctlDocumentDao = SpringUtils.getBean(CtlDocumentDao.class);
+    private final transient OutboundEmailArchiveDao outboundEmailArchiveDao = SpringUtils.getBean(OutboundEmailArchiveDao.class);
     private final ProviderInboxRoutingDao providerInboxRoutingDAO = SpringUtils.getBean(ProviderInboxRoutingDao.class);
     private final SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
 
@@ -275,6 +276,7 @@ public class ManageDocument2Action extends ActionSupport {
             log.warn("documentUpdateAjax: invalid or missing demog");
             return;
         }
+        assertNotOutboundEmailArchiveDocument(documentId);
 
         LogAction.addLog(LoggedInInfo.getLoggedInInfoFromSession(request).getLoggedInProviderNo(), LogConst.ADD, LogConst.CON_DOCUMENT, documentId, request.getRemoteAddr(), demog);
 
@@ -424,6 +426,7 @@ public class ManageDocument2Action extends ActionSupport {
             throw new SecurityException("missing required sec object (_edoc)");
         }
 
+        assertNotOutboundEmailArchiveRoutingDocument(docType, docId);
         providerInboxRoutingDAO.removeLinkFromDocument(docType, Integer.parseInt(docId), providerNo);
         HashMap hm = new HashMap();
         hm.put("linkedProviders", providerInboxRoutingDAO.getProvidersWithRoutingForDocument(docType, Integer.parseInt(docId)));
@@ -489,6 +492,7 @@ public class ManageDocument2Action extends ActionSupport {
             return NONE;
         }
 
+        assertNotOutboundEmailArchiveDocument(documentId);
         try {
             EDocUtil.refileDocument(documentId, queueId);
         } catch (SecurityException e) {
@@ -548,6 +552,7 @@ public class ManageDocument2Action extends ActionSupport {
             addActionError("Document ID is missing. Cannot process document update.");
             return "error";
         }
+        assertNotOutboundEmailArchiveDocument(documentId);
 
         LogAction.addLog(LoggedInInfo.getLoggedInInfoFromSession(request).getLoggedInProviderNo(), LogConst.ADD, LogConst.CON_DOCUMENT, documentId, request.getRemoteAddr());
 
@@ -862,6 +867,7 @@ public class ManageDocument2Action extends ActionSupport {
         }
 
         String doc_no = request.getParameter("doc_no");
+        assertNotOutboundEmailArchiveDocument(doc_no);
         log.debug("Document No :{}", LogSafe.sanitize(doc_no));
         LoggedInInfo liPage = LoggedInInfo.getLoggedInInfoFromSession(request);
         LogAction.addLog(liPage != null ? liPage.getLoggedInProviderNo() : null, LogConst.READ, LogConst.CON_DOCUMENT, doc_no, request.getRemoteAddr());
@@ -896,6 +902,7 @@ public class ManageDocument2Action extends ActionSupport {
         log.debug("in viewDocPage");
 
         String doc_no = request.getParameter("doc_no");
+        assertNotOutboundEmailArchiveDocument(doc_no);
         String pageNum = request.getParameter("curPage");
         if (pageNum == null) {
             pageNum = "1";
@@ -955,6 +962,7 @@ public class ManageDocument2Action extends ActionSupport {
         }
 
         String doc_no = request.getParameter("doc_no");
+        assertNotOutboundEmailArchiveDocument(doc_no);
         String docdownload = CarlosProperties.getInstance().getProperty("DOCUMENT_DIR");
         // File documentDir = new File(docdownload);
         Document d = documentDao.getDocument(doc_no);
@@ -995,6 +1003,7 @@ public class ManageDocument2Action extends ActionSupport {
         }
 
         String doc_no = request.getParameter("doc_no");
+        assertNotOutboundEmailArchiveDocument(doc_no);
         log.debug("Document No :{}", LogSafe.sanitize(doc_no)); // nosemgrep: crlf-injection-logs-deepsemgrep, crlf-injection-logs
         String demoNo = request.getParameter("demoNo");
 
@@ -1074,6 +1083,46 @@ public class ManageDocument2Action extends ActionSupport {
         }
     }
 
+    private void assertNotOutboundEmailArchiveDocument(String documentNo) {
+        if (documentNo == null || documentNo.isBlank()) {
+            return;
+        }
+        try {
+            Integer parsedDocumentNo = Integer.valueOf(documentNo);
+            if (outboundEmailArchiveDao.existsByDocumentNo(parsedDocumentNo)) {
+                throw new SecurityException(
+                        "Outbound email archive eDocs must be read through the outbound email archive workflow");
+            }
+        } catch (NumberFormatException e) {
+            // Preserve existing invalid-id behavior in the caller.
+        }
+    }
+
+    private void assertNotOutboundEmailArchiveRoutingDocument(String docType, String documentNo) {
+        if (docType == null || asciiEqualsIgnoreCase(LabResultData.DOCUMENT, docType)) {
+            assertNotOutboundEmailArchiveDocument(documentNo);
+        }
+    }
+
+    private boolean asciiEqualsIgnoreCase(String expected, String actual) {
+        if (expected == null || actual == null || expected.length() != actual.length()) {
+            return false;
+        }
+        for (int i = 0; i < expected.length(); i++) {
+            if (toLowerAscii(expected.charAt(i)) != toLowerAscii(actual.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private char toLowerAscii(char value) {
+        if (value >= 'A' && value <= 'Z') {
+            return (char) (value + ('a' - 'A'));
+        }
+        return value;
+    }
+
     /**
      * Renders both document annotations/acknowledgements/ticklers and document description
      * metadata as an HTML fragment.
@@ -1128,6 +1177,7 @@ public class ManageDocument2Action extends ActionSupport {
         }
 
         String doc_no = request.getParameter("doc_no");
+        assertNotOutboundEmailArchiveDocument(doc_no);
         Locale locale = request.getLocale();
 
         String annotation = "", acknowledgement = "", tickler = "";

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/ManageDocument2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/ManageDocument2Action.java
@@ -427,7 +427,7 @@ public class ManageDocument2Action extends ActionSupport {
             throw new SecurityException("missing required sec object (_edoc)");
         }
 
-        assertNotOutboundEmailArchiveRoutingDocument(docType, docId);
+        assertNotOutboundEmailArchiveDocument(docId);
         providerInboxRoutingDAO.removeLinkFromDocument(docType, Integer.parseInt(docId), providerNo);
         HashMap hm = new HashMap();
         hm.put("linkedProviders", providerInboxRoutingDAO.getProvidersWithRoutingForDocument(docType, Integer.parseInt(docId)));
@@ -1089,31 +1089,6 @@ public class ManageDocument2Action extends ActionSupport {
             throw new SecurityException(
                     "Outbound email archive eDocs must be read through the outbound email archive workflow");
         }
-    }
-
-    private void assertNotOutboundEmailArchiveRoutingDocument(String docType, String documentNo) {
-        if (docType == null || asciiEqualsIgnoreCase(LabResultData.DOCUMENT, docType)) {
-            assertNotOutboundEmailArchiveDocument(documentNo);
-        }
-    }
-
-    private boolean asciiEqualsIgnoreCase(String expected, String actual) {
-        if (expected == null || actual == null || expected.length() != actual.length()) {
-            return false;
-        }
-        for (int i = 0; i < expected.length(); i++) {
-            if (toLowerAscii(expected.charAt(i)) != toLowerAscii(actual.charAt(i))) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    private char toLowerAscii(char value) {
-        if (value >= 'A' && value <= 'Z') {
-            return (char) (value + ('a' - 'A'));
-        }
-        return value;
     }
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/ManageDocument2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/ManageDocument2Action.java
@@ -2010,7 +2010,7 @@ public class ManageDocument2Action extends ActionSupport {
             keyword = "%" + keyword.trim() + "%";
         }
 
-        List<String> descriptions = documentDao.findDocumentDescriptions(keyword);
+        List<String> descriptions = documentDao.findDocumentDescriptionsExcludingOutboundEmailArchives(keyword);
 
         LogAction.addLogSynchronous(LoggedInInfo.getLoggedInInfoFromSession(request).getLoggedInProviderNo(), LogConst.READ, LogConst.CON_DOCUMENT, "document_description_lookup", request.getRemoteAddr());
 

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/ManageDocument2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/ManageDocument2Action.java
@@ -49,6 +49,7 @@ import io.github.carlos_emr.carlos.casemgmt.service.CaseManagementManager;
 import io.github.carlos_emr.carlos.documentManager.EDoc;
 import io.github.carlos_emr.carlos.documentManager.EDocUtil;
 import io.github.carlos_emr.carlos.documentManager.IncomingDocUtil;
+import io.github.carlos_emr.carlos.email.archive.OutboundEmailArchiveDocumentGuard;
 import io.github.carlos_emr.carlos.managers.ProgramManager2;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
@@ -1084,17 +1085,9 @@ public class ManageDocument2Action extends ActionSupport {
     }
 
     private void assertNotOutboundEmailArchiveDocument(String documentNo) {
-        if (documentNo == null || documentNo.isBlank()) {
-            return;
-        }
-        try {
-            Integer parsedDocumentNo = Integer.valueOf(documentNo);
-            if (outboundEmailArchiveDao.existsByDocumentNo(parsedDocumentNo)) {
-                throw new SecurityException(
-                        "Outbound email archive eDocs must be read through the outbound email archive workflow");
-            }
-        } catch (NumberFormatException e) {
-            // Preserve existing invalid-id behavior in the caller.
+        if (OutboundEmailArchiveDocumentGuard.isArchiveDocument(outboundEmailArchiveDao, documentNo)) {
+            throw new SecurityException(
+                    "Outbound email archive eDocs must be read through the outbound email archive workflow");
         }
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/SplitDocument2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/SplitDocument2Action.java
@@ -39,6 +39,7 @@ import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDPageTree;
 import io.github.carlos_emr.carlos.commn.dao.CtlDocumentDao;
 import io.github.carlos_emr.carlos.commn.dao.DocumentDao;
+import io.github.carlos_emr.carlos.commn.dao.OutboundEmailArchiveDao;
 import io.github.carlos_emr.carlos.commn.dao.PatientLabRoutingDao;
 import io.github.carlos_emr.carlos.commn.dao.ProviderInboxRoutingDao;
 import io.github.carlos_emr.carlos.commn.dao.ProviderLabRoutingDao;
@@ -73,6 +74,7 @@ public class SplitDocument2Action extends ActionSupport {
     HttpServletResponse response = ServletActionContext.getResponse();
 
     private DocumentDao documentDao = SpringUtils.getBean(DocumentDao.class);
+    private transient OutboundEmailArchiveDao outboundEmailArchiveDao = SpringUtils.getBean(OutboundEmailArchiveDao.class);
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
     private static final Set<PosixFilePermission> OWNER_RW_ONLY = PosixFilePermissions.fromString("rw-------");
@@ -101,6 +103,7 @@ public class SplitDocument2Action extends ActionSupport {
     @SuppressFBWarnings(value = {"XSS_SERVLET", "PATH_TRAVERSAL_IN"}, justification = "XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink. path validated for directory containment via PathValidationUtils before use")
     public String split() {
         String docNum = request.getParameter("document");
+        assertNotOutboundEmailArchiveDocument(docNum);
         String[] commands = request.getParameterValues("page");
         String queueId = request.getParameter("queueID");
 
@@ -258,7 +261,9 @@ public class SplitDocument2Action extends ActionSupport {
     // FindSecBugs PATH_TRAVERSAL_IN: path validated for directory containment via PathValidationUtils before use
     @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "path validated for directory containment via PathValidationUtils before use")
     public String rotate180() throws Exception {
-        Document doc = documentDao.getDocument(request.getParameter("document"));
+        String documentNo = request.getParameter("document");
+        assertNotOutboundEmailArchiveDocument(documentNo);
+        Document doc = documentDao.getDocument(documentNo);
 
         String docdownload = CarlosProperties.getInstance().getProperty("DOCUMENT_DIR");
         File docDir = new File(docdownload);
@@ -283,7 +288,9 @@ public class SplitDocument2Action extends ActionSupport {
     // FindSecBugs PATH_TRAVERSAL_IN: path validated for directory containment via PathValidationUtils before use
     @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "path validated for directory containment via PathValidationUtils before use")
     public String rotate90() throws Exception {
-        Document doc = documentDao.getDocument(request.getParameter("document"));
+        String documentNo = request.getParameter("document");
+        assertNotOutboundEmailArchiveDocument(documentNo);
+        Document doc = documentDao.getDocument(documentNo);
 
         String docdownload = CarlosProperties.getInstance().getProperty("DOCUMENT_DIR");
         File docDir = new File(docdownload);
@@ -308,7 +315,9 @@ public class SplitDocument2Action extends ActionSupport {
     // FindSecBugs PATH_TRAVERSAL_IN: path validated for directory containment via PathValidationUtils before use
     @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "path validated for directory containment via PathValidationUtils before use")
     public String removeFirstPage() throws Exception {
-        Document doc = documentDao.getDocument(request.getParameter("document"));
+        String documentNo = request.getParameter("document");
+        assertNotOutboundEmailArchiveDocument(documentNo);
+        Document doc = documentDao.getDocument(documentNo);
 
         String docdownload = CarlosProperties.getInstance().getProperty("DOCUMENT_DIR");
         File docDir = new File(docdownload);
@@ -364,6 +373,20 @@ public class SplitDocument2Action extends ActionSupport {
             } else {
                 return true;
             }
+        }
+    }
+
+    private void assertNotOutboundEmailArchiveDocument(String documentNo) {
+        if (documentNo == null || documentNo.isBlank()) {
+            return;
+        }
+        try {
+            if (outboundEmailArchiveDao.existsByDocumentNo(Integer.valueOf(documentNo))) {
+                throw new SecurityException(
+                        "Outbound email archive eDocs must be managed through the controlled archive workflow");
+            }
+        } catch (NumberFormatException e) {
+            // Preserve existing invalid-id behavior in the caller.
         }
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/SplitDocument2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/SplitDocument2Action.java
@@ -40,6 +40,7 @@ import org.apache.pdfbox.pdmodel.PDPageTree;
 import io.github.carlos_emr.carlos.commn.dao.CtlDocumentDao;
 import io.github.carlos_emr.carlos.commn.dao.DocumentDao;
 import io.github.carlos_emr.carlos.commn.dao.OutboundEmailArchiveDao;
+import io.github.carlos_emr.carlos.email.archive.OutboundEmailArchiveDocumentGuard;
 import io.github.carlos_emr.carlos.commn.dao.PatientLabRoutingDao;
 import io.github.carlos_emr.carlos.commn.dao.ProviderInboxRoutingDao;
 import io.github.carlos_emr.carlos.commn.dao.ProviderLabRoutingDao;
@@ -377,16 +378,9 @@ public class SplitDocument2Action extends ActionSupport {
     }
 
     private void assertNotOutboundEmailArchiveDocument(String documentNo) {
-        if (documentNo == null || documentNo.isBlank()) {
-            return;
-        }
-        try {
-            if (outboundEmailArchiveDao.existsByDocumentNo(Integer.valueOf(documentNo))) {
-                throw new SecurityException(
-                        "Outbound email archive eDocs must be managed through the controlled archive workflow");
-            }
-        } catch (NumberFormatException e) {
-            // Preserve existing invalid-id behavior in the caller.
+        if (OutboundEmailArchiveDocumentGuard.isArchiveDocument(outboundEmailArchiveDao, documentNo)) {
+            throw new SecurityException(
+                    "Outbound email archive eDocs must be managed through the controlled archive workflow");
         }
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/eform/EFormAttachDocs2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/eform/EFormAttachDocs2Action.java
@@ -71,6 +71,11 @@ public class EFormAttachDocs2Action extends ActionSupport {
      */
     @Override
     public String execute() throws ServletException, IOException {
+        if (!"POST".equals(request.getMethod())) {
+            response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+            return NONE;
+        }
+
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
         if (!securityInfoManager.hasPrivilege(loggedInInfo, "_eform", "u", null)) {
             throw new SecurityException("missing required sec object (_eform)");

--- a/src/main/java/io/github/carlos_emr/carlos/eform/EFormAttachDocs2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/eform/EFormAttachDocs2Action.java
@@ -72,6 +72,7 @@ public class EFormAttachDocs2Action extends ActionSupport {
     @Override
     public String execute() throws ServletException, IOException {
         if (!"POST".equals(request.getMethod())) {
+            response.setHeader("Allow", "POST");
             response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
             return NONE;
         }

--- a/src/main/java/io/github/carlos_emr/carlos/email/archive/OutboundEmailArchiveDocumentGuard.java
+++ b/src/main/java/io/github/carlos_emr/carlos/email/archive/OutboundEmailArchiveDocumentGuard.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.email.archive;
+
+import io.github.carlos_emr.carlos.commn.dao.OutboundEmailArchiveDao;
+
+/** Shared parsing and lookup for request-supplied archive eDoc identifiers. */
+public final class OutboundEmailArchiveDocumentGuard {
+
+    private OutboundEmailArchiveDocumentGuard() {
+    }
+
+    public static boolean isArchiveDocument(OutboundEmailArchiveDao archiveDao, String documentId) {
+        if (documentId == null || documentId.isBlank()) {
+            return false;
+        }
+        try {
+            return archiveDao.existsByDocumentNo(Integer.valueOf(documentId));
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/io/github/carlos_emr/carlos/log/LogAction.java
+++ b/src/main/java/io/github/carlos_emr/carlos/log/LogAction.java
@@ -193,6 +193,39 @@ public class LogAction {
     }
 
     /**
+     * Adds a fully attributed audit entry in the calling thread and transaction.
+     */
+    public static void addLogSynchronous(
+            LoggedInInfo loggedInInfo,
+            String action,
+            String content,
+            String contentId,
+            String demographicNo,
+            String data) {
+        OscarLog logEntry = new OscarLog();
+        if (loggedInInfo.getLoggedInSecurity() != null) {
+            logEntry.setSecurityId(loggedInInfo.getLoggedInSecurity().getSecurityNo());
+        }
+        if (loggedInInfo.getLoggedInProvider() != null) {
+            logEntry.setProviderNo(loggedInInfo.getLoggedInProviderNo());
+        }
+        logEntry.setAction(action);
+        logEntry.setContent(content);
+        logEntry.setContentId(contentId);
+        logEntry.setIp(loggedInInfo.getIp());
+        try {
+            String normalizedDemographicNo = StringUtils.trimToNull(demographicNo);
+            if (normalizedDemographicNo != null) {
+                logEntry.setDemographicId(Integer.parseInt(normalizedDemographicNo));
+            }
+        } catch (NumberFormatException e) {
+            logger.error("Unexpected demographic number in audit log", e);
+        }
+        logEntry.setData(data);
+        addLogSynchronous(logEntry);
+    }
+
+    /**
      * This method will add a log entry asynchronously in a separate thread.
      */
     public static void addLog(String provider_no, String action, String content, String contentId, String ip, String demographicNo, String data) {

--- a/src/main/java/io/github/carlos_emr/carlos/managers/DocumentManagerImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/DocumentManagerImpl.java
@@ -41,6 +41,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
 import io.github.carlos_emr.carlos.commn.dao.*;
@@ -286,8 +287,8 @@ public class DocumentManagerImpl implements DocumentManager {
             throw new RuntimeException("Read Access Denied _edoc for provider " + loggedInInfo.getLoggedInProviderNo());
         }
 
-        List<Document> results = documentDao.findByUpdateDate(updatedAfterThisDateExclusive, itemsToReturn);
-        results = withoutOutboundEmailArchiveDocuments(results);
+        List<Document> results = findUpdatedDocumentsExcludingArchives(
+                updatedAfterThisDateExclusive, itemsToReturn);
 
         LogAction.addLog(loggedInInfo, "DocumentManager.getUpdateAfterDate", "updatedAfterThisDateExclusive=" + updatedAfterThisDateExclusive, "", "", "Number items " + itemsToReturn);
 
@@ -672,14 +673,47 @@ public class DocumentManagerImpl implements DocumentManager {
         if (documents == null || documents.isEmpty()) {
             return documents;
         }
+        List<Integer> documentNos = documents.stream()
+                .filter(java.util.Objects::nonNull)
+                .map(Document::getDocumentNo)
+                .filter(java.util.Objects::nonNull)
+                .toList();
+        Set<Integer> archiveDocumentNos = outboundEmailArchiveDao.findExistingDocumentNos(documentNos);
+        if (archiveDocumentNos == null) {
+            archiveDocumentNos = Set.of();
+        }
         List<Document> filteredDocuments = new ArrayList<Document>();
         for (Document document : documents) {
             if (document == null || document.getDocumentNo() == null
-                    || !outboundEmailArchiveDao.existsByDocumentNo(document.getDocumentNo())) {
+                    || !archiveDocumentNos.contains(document.getDocumentNo())) {
                 filteredDocuments.add(document);
             }
         }
         return filteredDocuments;
+    }
+
+    private List<Document> findUpdatedDocumentsExcludingArchives(Date updatedAfter, int itemsToReturn) {
+        if (itemsToReturn <= 0) {
+            return withoutOutboundEmailArchiveDocuments(
+                    documentDao.findByUpdateDate(updatedAfter, itemsToReturn));
+        }
+
+        int fetchLimit = itemsToReturn;
+        while (true) {
+            List<Document> candidates = documentDao.findByUpdateDate(updatedAfter, fetchLimit);
+            List<Document> visibleDocuments = withoutOutboundEmailArchiveDocuments(candidates);
+            if (visibleDocuments.size() >= itemsToReturn) {
+                return new ArrayList<>(visibleDocuments.subList(0, itemsToReturn));
+            }
+            if (candidates.size() < fetchLimit || fetchLimit >= AbstractDao.MAX_LIST_RETURN_SIZE) {
+                return visibleDocuments;
+            }
+            int nextFetchLimit = Math.min(AbstractDao.MAX_LIST_RETURN_SIZE, fetchLimit * 2);
+            if (nextFetchLimit == fetchLimit) {
+                return visibleDocuments;
+            }
+            fetchLimit = nextFetchLimit;
+        }
     }
 
     // FindSecBugs PATH_TRAVERSAL_IN: path validated for directory containment via PathValidationUtils before use
@@ -739,11 +773,20 @@ public class DocumentManagerImpl implements DocumentManager {
         if (documents == null || documents.isEmpty()) {
             return documents;
         }
+        Set<Integer> archiveDocumentNos = outboundEmailArchiveDao.findExistingDocumentNos(
+                documents.stream()
+                        .filter(java.util.Objects::nonNull)
+                        .map(DocumentListItemDTO::getDocumentNo)
+                        .filter(java.util.Objects::nonNull)
+                        .toList());
+        if (archiveDocumentNos == null) {
+            archiveDocumentNos = Set.of();
+        }
         List<DocumentListItemDTO> filteredDocuments = new ArrayList<DocumentListItemDTO>();
         boolean removedDocument = false;
         for (DocumentListItemDTO document : documents) {
             if (document == null || document.getDocumentNo() == null
-                    || !outboundEmailArchiveDao.existsByDocumentNo(document.getDocumentNo())) {
+                    || !archiveDocumentNos.contains(document.getDocumentNo())) {
                 filteredDocuments.add(document);
             } else {
                 removedDocument = true;

--- a/src/main/java/io/github/carlos_emr/carlos/managers/DocumentManagerImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/DocumentManagerImpl.java
@@ -92,6 +92,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 public class DocumentManagerImpl implements DocumentManager {
 
     private static final String PARENT_DIR = CarlosProperties.getInstance().getProperty("DOCUMENT_DIR");
+    private static final String OUTBOUND_ARCHIVE_READ_MESSAGE =
+            "Outbound email archive eDocs must be read through the outbound email archive workflow";
     private final Logger logger = MiscUtils.getLogger();
 
     /**
@@ -107,6 +109,9 @@ public class DocumentManagerImpl implements DocumentManager {
 
     @Autowired
     private CtlDocumentDao ctlDocumentDao;
+
+    @Autowired
+    private OutboundEmailArchiveDao outboundEmailArchiveDao;
 
     @Autowired
     private NioFileManager nioFileManager;
@@ -138,6 +143,7 @@ public class DocumentManagerImpl implements DocumentManager {
 
         //--- log action ---
         if (result != null) {
+            assertNotOutboundEmailArchiveDocument(result);
             LogAction.addLog(loggedInInfo, "DocumentManager.getDocument", "id=" + id, "", "", "");
         }
 
@@ -146,6 +152,7 @@ public class DocumentManagerImpl implements DocumentManager {
 
     public List<Document> getDocumentsByDemographicNo(LoggedInInfo loggedInInfo, Integer demographicNo) {
         List<Document> result = documentDao.findByDemographicId(demographicNo + "");
+        result = withoutOutboundEmailArchiveDocuments(result);
 
         //--- log action ---
         if (result != null) {
@@ -160,6 +167,7 @@ public class DocumentManagerImpl implements DocumentManager {
         if (!securityInfoManager.hasPrivilege(loggedInInfo, "_edoc", "r", "")) {
             throw new RuntimeException("Read Access Denied _edoc for provider " + loggedInInfo.getLoggedInProviderNo());
         }
+        assertNotOutboundEmailArchiveDocument(documentId);
 
         CtlDocument result = ctlDocumentDao.getCtrlDocument(documentId);
 
@@ -199,10 +207,12 @@ public class DocumentManagerImpl implements DocumentManager {
             fileName = file.getName();
             document.setDocfilename(fileName);
         } catch (SecurityException e) {
+            if (OUTBOUND_ARCHIVE_READ_MESSAGE.equals(e.getMessage())) {
+                throw e;
+            }
             logger.error("Document filename failed path validation: {}", Encode.forJava(rawFileName));
             throw new IOException("Document filename failed path validation", e);
         }
-
         // Gets the number of pages for the document
         int numberOfPages = 1;
         if (fileName.toLowerCase().endsWith("pdf")) {
@@ -244,6 +254,7 @@ public class DocumentManagerImpl implements DocumentManager {
         for (int attempt = 0; attempt < UNIQUE_FILENAME_MAX_ATTEMPTS; attempt++) {
             String candidateName = buildUniqueDocumentFilename(normalizedFileName);
             File candidate = PathValidationUtils.validateUserFilePath(candidateName, destinationDir);
+            assertNotOutboundEmailArchiveFileName(candidateName);
             try {
                 Files.write(candidate.toPath(), documentData, StandardOpenOption.CREATE_NEW);
                 return candidate;
@@ -276,6 +287,7 @@ public class DocumentManagerImpl implements DocumentManager {
         }
 
         List<Document> results = documentDao.findByUpdateDate(updatedAfterThisDateExclusive, itemsToReturn);
+        results = withoutOutboundEmailArchiveDocuments(results);
 
         LogAction.addLog(loggedInInfo, "DocumentManager.getUpdateAfterDate", "updatedAfterThisDateExclusive=" + updatedAfterThisDateExclusive, "", "", "Number items " + itemsToReturn);
 
@@ -288,6 +300,7 @@ public class DocumentManagerImpl implements DocumentManager {
         boolean hasConsent = patientConsentManager.hasProviderSpecificConsent(loggedInInfo) || patientConsentManager.getConsentType(ConsentType.PROVIDER_CONSENT_FILTER) == null;
         if (hasConsent) {
             results = documentDao.findByDemographicUpdateAfterDate(demographicId, updatedAfterThisDateExclusive);
+            results = withoutOutboundEmailArchiveDocuments(results);
             LogAction.addLogSynchronous(loggedInInfo, "DocumentManager.getDocumentsByDemographicIdUpdateAfterDate", "demographicId=" + demographicId + " updatedAfterThisDateExclusive=" + updatedAfterThisDateExclusive);
         }
         return (results);
@@ -300,6 +313,7 @@ public class DocumentManagerImpl implements DocumentManager {
         }
 
         List<Document> results = documentDao.findByProgramProviderDemographicUpdateDate(programId, providerNo, demographicId, updatedAfterThisDateExclusive.getTime(), itemsToReturn);
+        results = withoutOutboundEmailArchiveDocuments(results);
 
         LogAction.addLog(loggedInInfo, "DocumentManager.getDocumentsByProgramProviderDemographicDate", "programId=" + programId, "providerNo=" + providerNo, demographicId + "", "updatedAfterThisDateExclusive=" + updatedAfterThisDateExclusive.getTime());
 
@@ -314,6 +328,10 @@ public class DocumentManagerImpl implements DocumentManager {
     public Integer saveDocument(LoggedInInfo loggedInInfo, Document document, CtlDocument ctlDocument) {
         if (!securityInfoManager.hasPrivilege(loggedInInfo, "_edoc", "w", "")) {
             throw new RuntimeException("Write Access Denied _edoc for provider " + loggedInInfo.getLoggedInProviderNo());
+        }
+        assertNotOutboundEmailArchiveDocument(document);
+        if (document != null) {
+            assertNotOutboundEmailArchiveFileName(document.getDocfilename());
         }
 
         Integer savedId = null;
@@ -406,6 +424,10 @@ public class DocumentManagerImpl implements DocumentManager {
         if (!securityInfoManager.hasPrivilege(loggedInInfo, "_edoc", "x", "")) {
             throw new RuntimeException("Read and Write Access Denied _edoc for provider " + loggedInInfo.getLoggedInProviderNo());
         }
+        assertNotOutboundEmailArchiveDocument(document);
+        if (document != null) {
+            assertNotOutboundEmailArchiveFileName(document.getDocfilename());
+        }
 
         // move the PDF from the temp location to CARLOS document directory.
         try {
@@ -441,6 +463,7 @@ public class DocumentManagerImpl implements DocumentManager {
         String path = null;
 
         if (document != null) {
+            assertNotOutboundEmailArchiveDocument(documentId);
             path = getFullPathToDocument(document.getDocfilename());
         }
 
@@ -466,6 +489,7 @@ public class DocumentManagerImpl implements DocumentManager {
             logger.error("Document filename contains path separator, rejected: {}", Encode.forJava(filename));
             return null;
         }
+        assertNotOutboundEmailArchiveFileName(filename);
 
         String documentDir = CarlosProperties.getInstance().getProperty("DOCUMENT_DIR");
 
@@ -495,7 +519,7 @@ public class DocumentManagerImpl implements DocumentManager {
 
         LogAction.addLogSynchronous(loggedInInfo, "DocumentManager.getDemographicDocumentsByDocumentType", "fetching documents of type " + documentType.getName() + " for demographic " + demographicNo);
 
-        return documentDao.findByDemographicAndDoctype(demographicNo, documentType);
+        return withoutOutboundEmailArchiveDocuments(documentDao.findByDemographicAndDoctype(demographicNo, documentType));
     }
 
     public Document getDocumentByDemographicAndFilename(LoggedInInfo loggedInInfo, int demographicNo, String fileName) {
@@ -505,7 +529,9 @@ public class DocumentManagerImpl implements DocumentManager {
 
         LogAction.addLogSynchronous(loggedInInfo, "DocumentManager.getDocumentByDemographicAndFilename", "fetching document with filename " + fileName + " for demographic " + demographicNo);
 
-        return documentDao.findByDemographicAndFilename(demographicNo, fileName);
+        Document document = documentDao.findByDemographicAndFilename(demographicNo, fileName);
+        assertNotOutboundEmailArchiveDocument(document);
+        return document;
     }
 
     /**
@@ -534,6 +560,7 @@ public class DocumentManagerImpl implements DocumentManager {
             if (existingDocument != null && existingDocument.getId() != null && existingDocument.getId() > 0) {
                 document.setDocumentNo(existingDocument.getId());
             }
+            assertNotOutboundEmailArchiveFileName(document.getDocfilename());
 
             // Always write to file system, updates will overwrite.
             EDocUtil.writeDocContent(document.getDocfilename(), document.getBase64Binary());
@@ -575,6 +602,7 @@ public class DocumentManagerImpl implements DocumentManager {
     }
 
     public List<String> getProvidersThatHaveAcknowledgedDocument(LoggedInInfo loggedInInfo, Integer documentId) {
+        assertNotOutboundEmailArchiveDocument(documentId);
         List<ProviderInboxItem> inboxList = providerInboxRoutingDao.getProvidersWithRoutingForDocument("DOC", documentId);
         List<String> providerList = new ArrayList<String>();
         for (ProviderInboxItem item : inboxList) {
@@ -591,6 +619,7 @@ public class DocumentManagerImpl implements DocumentManager {
             throw new RuntimeException("Access Denied");
         }
 
+        assertNotOutboundEmailArchiveDocument(eDoc);
         return renderDocument(eDoc);
     }
 
@@ -599,8 +628,58 @@ public class DocumentManagerImpl implements DocumentManager {
             throw new RuntimeException("Access Denied");
         }
 
+        assertNotOutboundEmailArchiveDocument(documentId);
         EDoc eDoc = EDocUtil.getEDocFromDocId(String.valueOf(documentId));
         return renderDocument(eDoc);
+    }
+
+    private void assertNotOutboundEmailArchiveDocument(EDoc eDoc) {
+        if (eDoc != null) {
+            assertNotOutboundEmailArchiveDocument(eDoc.getDocId());
+        }
+    }
+
+    private void assertNotOutboundEmailArchiveDocument(Document document) {
+        if (document != null) {
+            assertNotOutboundEmailArchiveDocument(document.getDocumentNo());
+        }
+    }
+
+    private void assertNotOutboundEmailArchiveDocument(String documentId) {
+        if (documentId == null || documentId.isBlank()) {
+            return;
+        }
+        try {
+            assertNotOutboundEmailArchiveDocument(Integer.valueOf(documentId));
+        } catch (NumberFormatException e) {
+            // Preserve existing invalid-id behavior in the caller.
+        }
+    }
+
+    private void assertNotOutboundEmailArchiveDocument(Integer documentId) {
+        if (documentId != null && outboundEmailArchiveDao.existsByDocumentNo(documentId)) {
+            throw new SecurityException(OUTBOUND_ARCHIVE_READ_MESSAGE);
+        }
+    }
+
+    private void assertNotOutboundEmailArchiveFileName(String fileName) {
+        if (fileName != null && !fileName.isBlank() && outboundEmailArchiveDao.existsByFileName(fileName)) {
+            throw new SecurityException(OUTBOUND_ARCHIVE_READ_MESSAGE);
+        }
+    }
+
+    private List<Document> withoutOutboundEmailArchiveDocuments(List<Document> documents) {
+        if (documents == null || documents.isEmpty()) {
+            return documents;
+        }
+        List<Document> filteredDocuments = new ArrayList<Document>();
+        for (Document document : documents) {
+            if (document == null || document.getDocumentNo() == null
+                    || !outboundEmailArchiveDao.existsByDocumentNo(document.getDocumentNo())) {
+                filteredDocuments.add(document);
+            }
+        }
+        return filteredDocuments;
     }
 
     // FindSecBugs PATH_TRAVERSAL_IN: path validated for directory containment via PathValidationUtils before use
@@ -632,6 +711,7 @@ public class DocumentManagerImpl implements DocumentManager {
 		if (!securityInfoManager.hasPrivilege(loggedInInfo, "_edoc", "w", "")) {
 			throw new RuntimeException("Write Access Denied _edoc for provider " + loggedInInfo.getLoggedInProviderNo());
 		}
+		assertNotOutboundEmailArchiveDocument(documentId);
 
 		if (queueId != null && queueId > 0) {
 			queueDocumentLinkDAO.addActiveQueueDocumentLink(queueId, documentId);
@@ -648,9 +728,27 @@ public class DocumentManagerImpl implements DocumentManager {
         if (!securityInfoManager.hasPrivilege(loggedInInfo, "_edoc", "r", null)) {
             throw new SecurityException("missing required sec object (_edoc)");
         }
-        List<DocumentListItemDTO> results = documentDao.findDocumentDTOsByDemographicNo(demographicNo);
+        List<DocumentListItemDTO> results = withoutOutboundEmailArchiveDocumentDTOs(
+                documentDao.findDocumentDTOsByDemographicNo(demographicNo));
         LogAction.addLogSynchronous(loggedInInfo, "DocumentManager.getDocumentDTOs",
                 "demographicNo=" + demographicNo);
         return results;
+    }
+
+    private List<DocumentListItemDTO> withoutOutboundEmailArchiveDocumentDTOs(List<DocumentListItemDTO> documents) {
+        if (documents == null || documents.isEmpty()) {
+            return documents;
+        }
+        List<DocumentListItemDTO> filteredDocuments = new ArrayList<DocumentListItemDTO>();
+        boolean removedDocument = false;
+        for (DocumentListItemDTO document : documents) {
+            if (document == null || document.getDocumentNo() == null
+                    || !outboundEmailArchiveDao.existsByDocumentNo(document.getDocumentNo())) {
+                filteredDocuments.add(document);
+            } else {
+                removedDocument = true;
+            }
+        }
+        return removedDocument ? filteredDocuments : documents;
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/managers/DocumentManagerImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/DocumentManagerImpl.java
@@ -287,7 +287,7 @@ public class DocumentManagerImpl implements DocumentManager {
             throw new RuntimeException("Read Access Denied _edoc for provider " + loggedInInfo.getLoggedInProviderNo());
         }
 
-        List<Document> results = findUpdatedDocumentsExcludingArchives(
+        List<Document> results = documentDao.findByUpdateDateExcludingOutboundEmailArchives(
                 updatedAfterThisDateExclusive, itemsToReturn);
 
         LogAction.addLog(loggedInInfo, "DocumentManager.getUpdateAfterDate", "updatedAfterThisDateExclusive=" + updatedAfterThisDateExclusive, "", "", "Number items " + itemsToReturn);
@@ -690,30 +690,6 @@ public class DocumentManagerImpl implements DocumentManager {
             }
         }
         return filteredDocuments;
-    }
-
-    private List<Document> findUpdatedDocumentsExcludingArchives(Date updatedAfter, int itemsToReturn) {
-        if (itemsToReturn <= 0) {
-            return withoutOutboundEmailArchiveDocuments(
-                    documentDao.findByUpdateDate(updatedAfter, itemsToReturn));
-        }
-
-        int fetchLimit = itemsToReturn;
-        while (true) {
-            List<Document> candidates = documentDao.findByUpdateDate(updatedAfter, fetchLimit);
-            List<Document> visibleDocuments = withoutOutboundEmailArchiveDocuments(candidates);
-            if (visibleDocuments.size() >= itemsToReturn) {
-                return new ArrayList<>(visibleDocuments.subList(0, itemsToReturn));
-            }
-            if (candidates.size() < fetchLimit || fetchLimit >= AbstractDao.MAX_LIST_RETURN_SIZE) {
-                return visibleDocuments;
-            }
-            int nextFetchLimit = Math.min(AbstractDao.MAX_LIST_RETURN_SIZE, fetchLimit * 2);
-            if (nextFetchLimit == fetchLimit) {
-                return visibleDocuments;
-            }
-            fetchLimit = nextFetchLimit;
-        }
     }
 
     // FindSecBugs PATH_TRAVERSAL_IN: path validated for directory containment via PathValidationUtils before use

--- a/src/main/java/io/github/carlos_emr/carlos/managers/OutboundEmailArchiveService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/OutboundEmailArchiveService.java
@@ -56,6 +56,7 @@ public interface OutboundEmailArchiveService {
      * @return active archive metadata
      * @throws IllegalArgumentException when the archive identifier is missing or not found
      * @throws IllegalStateException when the archive has been controlled-deleted
+     * @throws SecurityException when the caller lacks eDoc or patient-record read access
      */
     OutboundEmailArchive getActiveArchive(LoggedInInfo loggedInInfo, Integer archiveId);
 
@@ -65,8 +66,10 @@ public interface OutboundEmailArchiveService {
      * @param loggedInInfo current user context for permissions and audit logging
      * @param archiveId archive metadata identifier
      * @return archived artifact bytes
-     * @throws IOException when the archived eDoc file cannot be read or does not match archive metadata
-     * @throws IllegalStateException when required archive metadata is missing
+     * @throws IOException when the archived eDoc file cannot be read, required integrity metadata
+     *         is missing or invalid, or the stored bytes do not match that metadata
+     * @throws IllegalStateException when the archive or its backing eDoc has been controlled-deleted
+     * @throws SecurityException when the caller lacks eDoc or patient-record read access
      */
     byte[] readArchivedArtifact(LoggedInInfo loggedInInfo, Integer archiveId) throws IOException;
 
@@ -79,6 +82,7 @@ public interface OutboundEmailArchiveService {
      * @return immutable deletion tombstone
      * @throws IllegalArgumentException when the archive identifier or deletion reason is missing
      * @throws IllegalStateException when deletion is blocked by legal hold or the archive is already deleted
+     * @throws SecurityException when the caller lacks deletion authority or patient-record access
      */
     OutboundEmailArchiveDeletion recordControlledDeletion(LoggedInInfo loggedInInfo, Integer archiveId, String deleteReason);
 }

--- a/src/main/java/io/github/carlos_emr/carlos/managers/OutboundEmailArchiveService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/OutboundEmailArchiveService.java
@@ -49,6 +49,28 @@ public interface OutboundEmailArchiveService {
     OutboundEmailArchive archive(LoggedInInfo loggedInInfo, OutboundEmailArchiveDto request) throws IOException;
 
     /**
+     * Loads active archive metadata for view/download workflows after enforcing patient and eDoc read access.
+     *
+     * @param loggedInInfo current user context for permissions and audit logging
+     * @param archiveId archive metadata identifier
+     * @return active archive metadata
+     * @throws IllegalArgumentException when the archive identifier is missing or not found
+     * @throws IllegalStateException when the archive has been controlled-deleted
+     */
+    OutboundEmailArchive getActiveArchive(LoggedInInfo loggedInInfo, Integer archiveId);
+
+    /**
+     * Reads the archived outbound artifact bytes from eDoc storage after enforcing access checks.
+     *
+     * @param loggedInInfo current user context for permissions and audit logging
+     * @param archiveId archive metadata identifier
+     * @return archived artifact bytes
+     * @throws IOException when the archived eDoc file cannot be read or does not match archive metadata
+     * @throws IllegalStateException when required archive metadata is missing
+     */
+    byte[] readArchivedArtifact(LoggedInInfo loggedInInfo, Integer archiveId) throws IOException;
+
+    /**
      * Marks an archive as deleted and persists a permanent tombstone.
      *
      * @param loggedInInfo deleting user context

--- a/src/main/java/io/github/carlos_emr/carlos/managers/OutboundEmailArchiveServiceImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/OutboundEmailArchiveServiceImpl.java
@@ -283,26 +283,36 @@ public class OutboundEmailArchiveServiceImpl implements OutboundEmailArchiveServ
     public byte[] readArchivedArtifact(LoggedInInfo loggedInInfo, Integer archiveId) throws IOException {
         OutboundEmailArchive archive = loadActiveArchiveForArtifactRead(loggedInInfo, archiveId);
         Document document = archive.getDocument();
-        if (document == null || document.getDocfilename() == null || document.getDocfilename().isBlank()) {
-            throw new IllegalStateException("Outbound email archive document is required");
-        }
-        Long expectedByteSize = archive.getByteSize();
-        if (expectedByteSize == null) {
-            throw new IllegalStateException("Outbound email archive byte size is required");
-        }
-        String expectedSha256Hash = normalizeSha256Hex(archive.getSha256Hash(), AUDIT_ARCHIVE_LABEL + " SHA-256 hash");
-        String auditDetails = AUDIT_ARCHIVE_ID_PREFIX + archive.getId() + AUDIT_DOCUMENT_NO_PREFIX + document.getId();
-        String auditDemographicNo = demographicNo(archive);
-
-        Path archivePath = resolveArchivedArtifactPath(document.getDocfilename());
         byte[] artifactBytes;
         try {
+            if (document == null || document.getDocfilename() == null || document.getDocfilename().isBlank()) {
+                throw new IOException("Archived artifact document metadata is missing");
+            }
+            Long expectedByteSize = archive.getByteSize();
+            if (expectedByteSize == null) {
+                throw new IOException("Archived artifact byte size is missing");
+            }
+            String expectedSha256Hash;
+            try {
+                expectedSha256Hash = normalizeSha256Hex(
+                        archive.getSha256Hash(), AUDIT_ARCHIVE_LABEL + " SHA-256 hash");
+            } catch (IllegalArgumentException e) {
+                throw new IOException("Archived artifact SHA-256 hash is invalid", e);
+            }
+            Path archivePath;
+            try {
+                archivePath = resolveArchivedArtifactPath(document.getDocfilename());
+            } catch (RuntimeException e) {
+                throw new IOException("Archived artifact path is invalid", e);
+            }
             artifactBytes = readArchivedArtifactBytes(archivePath, expectedByteSize);
             validateArchiveHash(expectedSha256Hash, artifactBytes);
         } catch (IOException e) {
             auditArtifactReadIntegrityFailure(loggedInInfo, archive, document, e);
             throw e;
         }
+        String auditDetails = AUDIT_ARCHIVE_ID_PREFIX + archive.getId() + AUDIT_DOCUMENT_NO_PREFIX + document.getId();
+        String auditDemographicNo = demographicNo(archive);
         registerAfterCommitLog(() -> LogAction.addLog(loggedInInfo,
                 "OutboundEmailArchiveService.readArchivedArtifact",
                 AUDIT_ARCHIVE_LABEL,

--- a/src/main/java/io/github/carlos_emr/carlos/managers/OutboundEmailArchiveServiceImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/OutboundEmailArchiveServiceImpl.java
@@ -841,7 +841,7 @@ public class OutboundEmailArchiveServiceImpl implements OutboundEmailArchiveServ
                 "Outbound email archive artifact integrity failure archiveId={}: {}",
                 archive.getId(),
                 failure.getMessage());
-        LogAction.addLog(loggedInInfo,
+        LogAction.addLogSynchronous(loggedInInfo,
                 "OutboundEmailArchiveService.readArchivedArtifact.integrityFailure",
                 AUDIT_ARCHIVE_LABEL,
                 AUDIT_ARCHIVE_ID_PREFIX + archive.getId()

--- a/src/main/java/io/github/carlos_emr/carlos/managers/OutboundEmailArchiveServiceImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/OutboundEmailArchiveServiceImpl.java
@@ -48,15 +48,21 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HexFormat;
 import java.util.List;
+import java.util.Objects;
+import java.util.Properties;
 import java.util.UUID;
 
 /**
@@ -69,11 +75,19 @@ import java.util.UUID;
 public class OutboundEmailArchiveServiceImpl implements OutboundEmailArchiveService {
 
     private static final HexFormat HEX_FORMAT = HexFormat.of();
+    private static final String AUDIT_ARCHIVE_ID_PREFIX = "archiveId=";
+    private static final String AUDIT_ARCHIVE_LABEL = "Outbound email archive";
+    private static final String AUDIT_DOCUMENT_NO_PREFIX = " documentNo=";
     private static final String DEFAULT_CONTENT_TYPE = "application/octet-stream";
     private static final int MAX_CONTENT_TYPE_LENGTH = 100;
+    private static final String DOCUMENT_DIR_PROPERTY = "DOCUMENT_DIR";
     private static final String DOCUMENT_DOCTYPE = "email";
     private static final String DOCUMENT_SOURCE = "Outbound Email Archive";
+    private static final String ADMIN_EDOC_DELETE_SECURITY_OBJECT = "_admin.edocdelete";
+    private static final String EDOC_SECURITY_OBJECT = "_edoc";
     private static final String CTL_DOCUMENT_MODULE_DEMOGRAPHIC = "demographic";
+    private static final String SOURCE_DOCUMENT_TYPE_DOCUMENT = "DOCUMENT";
+    private static final long DEFAULT_MAX_ARCHIVED_ARTIFACT_BYTES = 50L * 1024L * 1024L;
 
     private final DocumentManager documentManager;
 
@@ -87,6 +101,10 @@ public class OutboundEmailArchiveServiceImpl implements OutboundEmailArchiveServ
 
     private final SecurityInfoManager securityInfoManager;
 
+    private final Properties carlosProperties;
+
+    private final long maxArchivedArtifactBytes;
+
     @Autowired
     public OutboundEmailArchiveServiceImpl(
             DocumentManager documentManager,
@@ -95,12 +113,54 @@ public class OutboundEmailArchiveServiceImpl implements OutboundEmailArchiveServ
             OutboundEmailArchiveDeletionDao outboundEmailArchiveDeletionDao,
             CtlDocumentDao ctlDocumentDao,
             SecurityInfoManager securityInfoManager) {
+        this(documentManager,
+                emailLogDao,
+                outboundEmailArchiveDao,
+                outboundEmailArchiveDeletionDao,
+                ctlDocumentDao,
+                securityInfoManager,
+                CarlosProperties.getInstance(),
+                DEFAULT_MAX_ARCHIVED_ARTIFACT_BYTES);
+    }
+
+    OutboundEmailArchiveServiceImpl(
+            DocumentManager documentManager,
+            EmailLogDao emailLogDao,
+            OutboundEmailArchiveDao outboundEmailArchiveDao,
+            OutboundEmailArchiveDeletionDao outboundEmailArchiveDeletionDao,
+            CtlDocumentDao ctlDocumentDao,
+            SecurityInfoManager securityInfoManager,
+            Properties carlosProperties) {
+        this(documentManager,
+                emailLogDao,
+                outboundEmailArchiveDao,
+                outboundEmailArchiveDeletionDao,
+                ctlDocumentDao,
+                securityInfoManager,
+                carlosProperties,
+                DEFAULT_MAX_ARCHIVED_ARTIFACT_BYTES);
+    }
+
+    OutboundEmailArchiveServiceImpl(
+            DocumentManager documentManager,
+            EmailLogDao emailLogDao,
+            OutboundEmailArchiveDao outboundEmailArchiveDao,
+            OutboundEmailArchiveDeletionDao outboundEmailArchiveDeletionDao,
+            CtlDocumentDao ctlDocumentDao,
+            SecurityInfoManager securityInfoManager,
+            Properties carlosProperties,
+            long maxArchivedArtifactBytes) {
         this.documentManager = documentManager;
         this.emailLogDao = emailLogDao;
         this.outboundEmailArchiveDao = outboundEmailArchiveDao;
         this.outboundEmailArchiveDeletionDao = outboundEmailArchiveDeletionDao;
         this.ctlDocumentDao = ctlDocumentDao;
         this.securityInfoManager = securityInfoManager;
+        this.carlosProperties = Objects.requireNonNull(carlosProperties, "carlosProperties");
+        if (maxArchivedArtifactBytes < 1L) {
+            throw new IllegalArgumentException("maxArchivedArtifactBytes must be positive");
+        }
+        this.maxArchivedArtifactBytes = maxArchivedArtifactBytes;
     }
 
     @SuppressWarnings("java:S6206") // A record would generate byte[] identity-based equals/hashCode/toString for artifactBytes.
@@ -194,12 +254,62 @@ public class OutboundEmailArchiveServiceImpl implements OutboundEmailArchiveServ
 
         registerAfterCommitLog(() -> LogAction.addLog(loggedInInfo,
                 "OutboundEmailArchiveService.archive",
-                "Outbound email archive",
-                "archiveId=" + archive.getId() + " emailLogId=" + emailLog.getId() + " documentNo=" + savedDocument.getId(),
+                AUDIT_ARCHIVE_LABEL,
+                AUDIT_ARCHIVE_ID_PREFIX + archive.getId() + " emailLogId=" + emailLog.getId()
+                        + AUDIT_DOCUMENT_NO_PREFIX + savedDocument.getId(),
                 String.valueOf(demographicNo),
                 ""));
 
         return archive;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public OutboundEmailArchive getActiveArchive(LoggedInInfo loggedInInfo, Integer archiveId) {
+        OutboundEmailArchive archive = loadActiveArchiveForRead(loggedInInfo, archiveId);
+        String auditDetails = AUDIT_ARCHIVE_ID_PREFIX + archive.getId() + AUDIT_DOCUMENT_NO_PREFIX + documentId(archive);
+        String auditDemographicNo = demographicNo(archive);
+        registerAfterCommitLog(() -> LogAction.addLog(loggedInInfo,
+                "OutboundEmailArchiveService.getActiveArchive",
+                AUDIT_ARCHIVE_LABEL,
+                auditDetails,
+                auditDemographicNo,
+                ""));
+        return archive;
+    }
+
+    @Override
+    @Transactional(noRollbackFor = IOException.class)
+    public byte[] readArchivedArtifact(LoggedInInfo loggedInInfo, Integer archiveId) throws IOException {
+        OutboundEmailArchive archive = loadActiveArchiveForArtifactRead(loggedInInfo, archiveId);
+        Document document = archive.getDocument();
+        if (document == null || document.getDocfilename() == null || document.getDocfilename().isBlank()) {
+            throw new IllegalStateException("Outbound email archive document is required");
+        }
+        Long expectedByteSize = archive.getByteSize();
+        if (expectedByteSize == null) {
+            throw new IllegalStateException("Outbound email archive byte size is required");
+        }
+        String expectedSha256Hash = normalizeSha256Hex(archive.getSha256Hash(), AUDIT_ARCHIVE_LABEL + " SHA-256 hash");
+        String auditDetails = AUDIT_ARCHIVE_ID_PREFIX + archive.getId() + AUDIT_DOCUMENT_NO_PREFIX + document.getId();
+        String auditDemographicNo = demographicNo(archive);
+
+        Path archivePath = resolveArchivedArtifactPath(document.getDocfilename());
+        byte[] artifactBytes;
+        try {
+            artifactBytes = readArchivedArtifactBytes(archivePath, expectedByteSize);
+            validateArchiveHash(expectedSha256Hash, artifactBytes);
+        } catch (IOException e) {
+            auditArtifactReadIntegrityFailure(loggedInInfo, archive, document, e);
+            throw e;
+        }
+        registerAfterCommitLog(() -> LogAction.addLog(loggedInInfo,
+                "OutboundEmailArchiveService.readArchivedArtifact",
+                AUDIT_ARCHIVE_LABEL,
+                auditDetails,
+                auditDemographicNo,
+                ""));
+        return artifactBytes;
     }
 
     @Override
@@ -232,7 +342,7 @@ public class OutboundEmailArchiveServiceImpl implements OutboundEmailArchiveServ
         registerAfterCommitLog(() -> LogAction.addLog(loggedInInfo,
                 "OutboundEmailArchiveService.recordControlledDeletion",
                 "Outbound email archive tombstone",
-                "archiveId=" + archive.getId() + " documentNo=" + documentId(archive),
+                AUDIT_ARCHIVE_ID_PREFIX + archive.getId() + AUDIT_DOCUMENT_NO_PREFIX + documentId(archive),
                 demographicNo(archive),
                 ""));
 
@@ -254,8 +364,16 @@ public class OutboundEmailArchiveServiceImpl implements OutboundEmailArchiveServ
         if (artifactBytes == null || artifactBytes.length == 0) {
             throw new IllegalArgumentException("Outbound artifact bytes are required");
         }
+        validateArchiveRequestArtifactSize(artifactBytes.length);
         if (request.getArtifactType() == null || request.getArtifactType().isBlank()) {
             throw new IllegalArgumentException("Artifact type is required");
+        }
+    }
+
+    private void validateArchiveRequestArtifactSize(long byteSize) {
+        if (byteSize > maxArchivedArtifactBytes) {
+            throw new IllegalArgumentException("Outbound artifact exceeds maximum archive size of "
+                    + maxArchivedArtifactBytes + " bytes");
         }
     }
 
@@ -351,14 +469,17 @@ public class OutboundEmailArchiveServiceImpl implements OutboundEmailArchiveServ
         if (attachmentBytes != null && attachmentDocument == null) {
             throw new IllegalArgumentException("Persisted attachment document is required when attachment bytes are supplied");
         }
-        validateAttachmentDocumentDemographic(attachmentDocument, demographicNo);
+        String sourceDocumentType = request.getSourceDocumentType();
+        Integer sourceDocumentId = request.getSourceDocumentId();
+        validateAttachmentDocumentDemographic(attachmentDocument, sourceDocumentType, sourceDocumentId, demographicNo);
         String sha256Hash = request.getSha256Hash();
         Long byteSize = request.getByteSize();
         if (attachmentBytes != null) {
+            validateArchiveRequestArtifactSize(attachmentBytes.length);
             sha256Hash = sha256Hex(attachmentBytes);
             byteSize = (long) attachmentBytes.length;
         }
-        sha256Hash = normalizeSha256Hex(sha256Hash);
+        sha256Hash = normalizeSha256Hex(sha256Hash, "Attachment SHA-256 hash");
         if (byteSize == null || byteSize < 0) {
             throw new IllegalArgumentException("Attachment byte size is required");
         }
@@ -368,20 +489,36 @@ public class OutboundEmailArchiveServiceImpl implements OutboundEmailArchiveServ
         attachment.setContentType(truncate(request.getContentType(), 100));
         attachment.setSha256Hash(sha256Hash);
         attachment.setByteSize(byteSize);
-        attachment.setSourceDocumentType(truncate(request.getSourceDocumentType(), 50));
-        attachment.setSourceDocumentId(request.getSourceDocumentId());
+        attachment.setSourceDocumentType(truncate(sourceDocumentType, 50));
+        attachment.setSourceDocumentId(sourceDocumentId);
         attachment.setDocument(attachmentDocument);
         attachment.setLastUpdateUser(providerNo);
         return attachment;
     }
 
-    private void validateAttachmentDocumentDemographic(Document attachmentDocument, Integer demographicNo) {
-        if (attachmentDocument == null) {
-            return;
+    private void validateAttachmentDocumentDemographic(
+            Document attachmentDocument,
+            String sourceDocumentType,
+            Integer sourceDocumentId,
+            Integer demographicNo) {
+        Integer documentNo = null;
+        if (attachmentDocument != null) {
+            documentNo = attachmentDocument.getId();
+            if (documentNo == null) {
+                throw new IllegalArgumentException("Persisted attachment document is required when attachment document metadata is supplied");
+            }
+            if (isSourceDocument(sourceDocumentType) && sourceDocumentId != null && !sourceDocumentId.equals(documentNo)) {
+                throw new IllegalArgumentException("Attachment source document ID must match persisted attachment document");
+            }
+        } else if (isSourceDocument(sourceDocumentType)) {
+            if (sourceDocumentId == null) {
+                throw new IllegalArgumentException("Source document ID is required when attachment source document type is DOCUMENT");
+            }
+            documentNo = sourceDocumentId;
         }
-        Integer documentNo = attachmentDocument.getId();
+
         if (documentNo == null) {
-            throw new IllegalArgumentException("Persisted attachment document is required when attachment document metadata is supplied");
+            return;
         }
 
         List<CtlDocument> ctlDocuments = ctlDocumentDao.findByDocumentNoAndModule(documentNo, CTL_DOCUMENT_MODULE_DEMOGRAPHIC);
@@ -393,6 +530,11 @@ public class OutboundEmailArchiveServiceImpl implements OutboundEmailArchiveServ
             }
         }
         throw new SecurityException("attachment document is not linked to outbound email archive demographic");
+    }
+
+    private boolean isSourceDocument(String sourceDocumentType) {
+        return sourceDocumentType != null
+                && asciiEqualsIgnoreCase(sourceDocumentType.trim(), SOURCE_DOCUMENT_TYPE_DOCUMENT);
     }
 
     private String uniqueArchiveFileName(EmailLog emailLog, String contentType) {
@@ -464,19 +606,19 @@ public class OutboundEmailArchiveServiceImpl implements OutboundEmailArchiveServ
         return value.substring(0, value.offsetByCodePoints(0, maxCodePoints));
     }
 
-    private String normalizeSha256Hex(String sha256Hash) {
+    private String normalizeSha256Hex(String sha256Hash, String fieldName) {
         if (sha256Hash == null) {
-            throw new IllegalArgumentException("Attachment SHA-256 hash is required");
+            throw new IllegalArgumentException(fieldName + " is required");
         }
         String normalizedHash = sha256Hash.trim();
         if (normalizedHash.length() != 64) {
-            throw new IllegalArgumentException("Attachment SHA-256 hash must be 64 hex characters");
+            throw new IllegalArgumentException(fieldName + " must be 64 hex characters");
         }
         StringBuilder lowerCaseHash = new StringBuilder(64);
         for (int i = 0; i < normalizedHash.length(); i++) {
             char value = normalizedHash.charAt(i);
             if (!isAsciiHexDigit(value)) {
-                throw new IllegalArgumentException("Attachment SHA-256 hash must be 64 hex characters");
+                throw new IllegalArgumentException(fieldName + " must be 64 hex characters");
             }
             lowerCaseHash.append(toLowerAscii(value));
         }
@@ -507,9 +649,57 @@ public class OutboundEmailArchiveServiceImpl implements OutboundEmailArchiveServ
     }
 
     private void authorizeArchiveAccess(LoggedInInfo loggedInInfo, Integer demographicNo) {
-        if (!securityInfoManager.hasPrivilege(
-                loggedInInfo, "_edoc", SecurityInfoManager.WRITE, null)) {
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, EDOC_SECURITY_OBJECT, SecurityInfoManager.WRITE, null)) {
             throw new SecurityException("missing required sec object (_edoc w)");
+        }
+        if (!securityInfoManager.isAllowedAccessToPatientRecord(loggedInInfo, demographicNo)) {
+            throw new SecurityException("not authorized for outbound email archive demographic");
+        }
+    }
+
+    private OutboundEmailArchive loadActiveArchiveForArtifactRead(LoggedInInfo loggedInInfo, Integer archiveId) {
+        return loadActiveArchiveForRead(loggedInInfo, archiveId, true);
+    }
+
+    private OutboundEmailArchive loadActiveArchiveForRead(LoggedInInfo loggedInInfo, Integer archiveId) {
+        return loadActiveArchiveForRead(loggedInInfo, archiveId, false);
+    }
+
+    private OutboundEmailArchive loadActiveArchiveForRead(LoggedInInfo loggedInInfo, Integer archiveId, boolean lockForUpdate) {
+        if (loggedInInfo == null) {
+            throw new IllegalArgumentException("Logged-in user context is required");
+        }
+        if (archiveId == null) {
+            throw new IllegalArgumentException("Archive ID is required");
+        }
+        OutboundEmailArchive archive = lockForUpdate
+                ? outboundEmailArchiveDao.findForUpdate(archiveId)
+                : outboundEmailArchiveDao.findForRead(archiveId);
+        if (archive == null) {
+            throw new IllegalArgumentException("Outbound email archive not found: " + archiveId);
+        }
+        if (archive.isDeleted()) {
+            throw new IllegalStateException("Outbound email archive has been deleted");
+        }
+        Integer demographicNo = archive.getDemographic() != null ? archive.getDemographic().getDemographicNo() : null;
+        if (demographicNo == null) {
+            throw new IllegalStateException("Outbound email archive demographic is required");
+        }
+        authorizeArchiveReadAccess(loggedInInfo, demographicNo);
+        validateArchiveDocumentNotDeleted(archive);
+        return archive;
+    }
+
+    private void validateArchiveDocumentNotDeleted(OutboundEmailArchive archive) {
+        Document document = archive.getDocument();
+        if (document != null && document.getStatus() == Document.STATUS_DELETED) {
+            throw new IllegalStateException("Outbound email archive eDoc has been deleted");
+        }
+    }
+
+    private void authorizeArchiveReadAccess(LoggedInInfo loggedInInfo, Integer demographicNo) {
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, EDOC_SECURITY_OBJECT, SecurityInfoManager.READ, null)) {
+            throw new SecurityException("missing required sec object (_edoc)");
         }
         if (!securityInfoManager.isAllowedAccessToPatientRecord(loggedInInfo, demographicNo)) {
             throw new SecurityException("not authorized for outbound email archive demographic");
@@ -522,10 +712,13 @@ public class OutboundEmailArchiveServiceImpl implements OutboundEmailArchiveServ
             throw new IllegalStateException("Outbound email archive demographic is required");
         }
 
-        boolean canDeleteEdoc = securityInfoManager.hasPrivilege(loggedInInfo, "_admin.edocdelete", SecurityInfoManager.WRITE, null)
-                || securityInfoManager.hasPrivilege(loggedInInfo, "_edoc", SecurityInfoManager.WRITE, null);
+        boolean canDeleteEdoc = securityInfoManager.hasPrivilege(
+                loggedInInfo,
+                ADMIN_EDOC_DELETE_SECURITY_OBJECT,
+                SecurityInfoManager.WRITE,
+                null);
         if (!canDeleteEdoc) {
-            throw new SecurityException("missing required sec object (_admin.edocdelete w or _edoc w)");
+            throw new SecurityException("missing required sec object (_admin.edocdelete)");
         }
         if (!securityInfoManager.isAllowedAccessToPatientRecord(loggedInInfo, demographicNo)) {
             throw new SecurityException("not authorized for outbound email archive demographic");
@@ -562,12 +755,101 @@ public class OutboundEmailArchiveServiceImpl implements OutboundEmailArchiveServ
 
     @SuppressFBWarnings(
             value = "PATH_TRAVERSAL_IN",
+            justification = "Archive eDoc reads validate the generated filename as a single path component and revalidate DOCUMENT_DIR containment before reading.")
+    private Path resolveArchivedArtifactPath(String fileName) {
+        File documentDirectory = PathValidationUtils.resolveConfiguredDirectory(
+                carlosProperties.getProperty(DOCUMENT_DIR_PROPERTY),
+                DOCUMENT_DIR_PROPERTY);
+        String safeFileName = PathValidationUtils.validatePathComponent(fileName, "archive eDoc filename");
+        File archiveFile = PathValidationUtils.validateExistingPath(new File(documentDirectory, safeFileName), documentDirectory);
+        return archiveFile.toPath();
+    }
+
+    private byte[] readArchivedArtifactBytes(Path archivePath, long expectedByteSize) throws IOException {
+        validateArchivedArtifactSize(expectedByteSize);
+
+        long fileSize = Files.size(archivePath);
+        validateArchivedArtifactSize(fileSize);
+        if (fileSize != expectedByteSize) {
+            throw new IOException("Archived artifact size does not match archive metadata");
+        }
+
+        try (InputStream inputStream = Files.newInputStream(archivePath);
+                ByteArrayOutputStream outputStream = new ByteArrayOutputStream((int) fileSize)) {
+            byte[] buffer = new byte[8192];
+            long totalBytes = 0L;
+            int bytesRead;
+            while ((bytesRead = inputStream.read(buffer)) != -1) {
+                totalBytes += bytesRead;
+                if (totalBytes > maxArchivedArtifactBytes) {
+                    throw new IOException(
+                            "Archived artifact exceeds maximum read size of " + maxArchivedArtifactBytes + " bytes");
+                }
+                outputStream.write(buffer, 0, bytesRead);
+            }
+            if (totalBytes != expectedByteSize) {
+                throw new IOException("Archived artifact size does not match archive metadata");
+            }
+            return outputStream.toByteArray();
+        }
+    }
+
+    private void validateArchivedArtifactSize(long byteSize) throws IOException {
+        if (byteSize < 0) {
+            throw new IOException("Archived artifact size is invalid");
+        }
+        if (byteSize > maxArchivedArtifactBytes) {
+            throw new IOException("Archived artifact exceeds maximum read size of "
+                    + maxArchivedArtifactBytes + " bytes");
+        }
+    }
+
+    /**
+     * Records a size/hash integrity failure on a stored archive artifact as a security event.
+     *
+     * <p>A mismatch between the on-disk artifact and the persisted archive metadata can indicate
+     * tampering or storage corruption of retained PHI, so it must leave an audit trail rather than
+     * failing silently. The enclosing transaction is {@code noRollbackFor = IOException.class}, so
+     * this audit row commits alongside the aborted read. Every value logged here is either an
+     * internal surrogate identifier ({@code archiveId}/{@code documentNo}) or a fixed, non-PHI
+     * failure constant — no user input or clinical content is included.
+     */
+    private void auditArtifactReadIntegrityFailure(
+            LoggedInInfo loggedInInfo,
+            OutboundEmailArchive archive,
+            Document document,
+            IOException failure) {
+        MiscUtils.getLogger().warn(
+                "Outbound email archive artifact integrity failure archiveId={}: {}",
+                archive.getId(),
+                failure.getMessage());
+        LogAction.addLog(loggedInInfo,
+                "OutboundEmailArchiveService.readArchivedArtifact.integrityFailure",
+                AUDIT_ARCHIVE_LABEL,
+                AUDIT_ARCHIVE_ID_PREFIX + archive.getId()
+                        + AUDIT_DOCUMENT_NO_PREFIX + (document != null ? document.getId() : "")
+                        + " reason=" + failure.getMessage(),
+                demographicNo(archive),
+                "");
+    }
+
+    private void validateArchiveHash(String expectedSha256Hash, byte[] artifactBytes) throws IOException {
+        String actualSha256Hash = sha256Hex(artifactBytes);
+        if (!MessageDigest.isEqual(
+                expectedSha256Hash.getBytes(StandardCharsets.US_ASCII),
+                actualSha256Hash.getBytes(StandardCharsets.US_ASCII))) {
+            throw new IOException("Archived artifact hash does not match archive metadata");
+        }
+    }
+
+    @SuppressFBWarnings(
+            value = "PATH_TRAVERSAL_IN",
             justification = "Archive eDoc cleanup validates the generated filename as a single path component and revalidates DOCUMENT_DIR containment before deletion.")
     private void deleteArchivedDocumentFile(String fileName) {
         try {
             File documentDirectory = PathValidationUtils.resolveConfiguredDirectory(
-                    CarlosProperties.getInstance().getProperty("DOCUMENT_DIR"),
-                    "DOCUMENT_DIR");
+                    carlosProperties.getProperty(DOCUMENT_DIR_PROPERTY),
+                    DOCUMENT_DIR_PROPERTY);
             String safeFileName = PathValidationUtils.validatePathComponent(fileName, "archive eDoc filename");
             File archiveFile = PathValidationUtils.validateExistingPath(new File(documentDirectory, safeFileName), documentDirectory);
             Files.deleteIfExists(archiveFile.toPath());

--- a/src/main/java/io/github/carlos_emr/carlos/managers/OutboundEmailArchiveServiceImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/OutboundEmailArchiveServiceImpl.java
@@ -81,6 +81,7 @@ public class OutboundEmailArchiveServiceImpl implements OutboundEmailArchiveServ
     private static final String AUDIT_ARCHIVE_ID_PREFIX = "archiveId=";
     private static final String AUDIT_ARCHIVE_LABEL = "Outbound email archive";
     private static final String AUDIT_DOCUMENT_NO_PREFIX = " documentNo=";
+    private static final String AUDIT_INTEGRITY_FAILURE_REASON = " reason=integrity-check-failed";
     private static final String DEFAULT_CONTENT_TYPE = "application/octet-stream";
     private static final int MAX_CONTENT_TYPE_LENGTH = 100;
     private static final String DOCUMENT_DIR_PROPERTY = "DOCUMENT_DIR";
@@ -846,7 +847,7 @@ public class OutboundEmailArchiveServiceImpl implements OutboundEmailArchiveServ
                 AUDIT_ARCHIVE_LABEL,
                 AUDIT_ARCHIVE_ID_PREFIX + archive.getId()
                         + AUDIT_DOCUMENT_NO_PREFIX + (document != null ? document.getId() : "")
-                        + " reason=" + failure.getMessage(),
+                        + AUDIT_INTEGRITY_FAILURE_REASON,
                 demographicNo(archive),
                 "");
     }

--- a/src/main/java/io/github/carlos_emr/carlos/managers/OutboundEmailArchiveServiceImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/OutboundEmailArchiveServiceImpl.java
@@ -51,10 +51,13 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.nio.channels.FileChannel;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -778,24 +781,29 @@ public class OutboundEmailArchiveServiceImpl implements OutboundEmailArchiveServ
     private byte[] readArchivedArtifactBytes(Path archivePath, long expectedByteSize) throws IOException {
         validateArchivedArtifactSize(expectedByteSize);
 
-        long fileSize = Files.size(archivePath);
-        validateArchivedArtifactSize(fileSize);
-        if (fileSize != expectedByteSize) {
-            throw new IOException("Archived artifact size does not match archive metadata");
+        if (!Files.isRegularFile(archivePath, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException("Archived artifact is not a regular file");
         }
+        try (FileChannel channel = FileChannel.open(
+                    archivePath, StandardOpenOption.READ, LinkOption.NOFOLLOW_LINKS)) {
+            long fileSize = channel.size();
+            validateArchivedArtifactSize(fileSize);
+            if (fileSize != expectedByteSize) {
+                throw new IOException("Archived artifact size does not match archive metadata");
+            }
 
-        try (InputStream inputStream = Files.newInputStream(archivePath);
-                ByteArrayOutputStream outputStream = new ByteArrayOutputStream((int) fileSize)) {
-            byte[] buffer = new byte[8192];
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream((int) fileSize);
+            ByteBuffer buffer = ByteBuffer.allocate(8192);
             long totalBytes = 0L;
             int bytesRead;
-            while ((bytesRead = inputStream.read(buffer)) != -1) {
+            while ((bytesRead = channel.read(buffer)) != -1) {
                 totalBytes += bytesRead;
                 if (totalBytes > maxArchivedArtifactBytes) {
                     throw new IOException(
                             "Archived artifact exceeds maximum read size of " + maxArchivedArtifactBytes + " bytes");
                 }
-                outputStream.write(buffer, 0, bytesRead);
+                outputStream.write(buffer.array(), 0, bytesRead);
+                buffer.clear();
             }
             if (totalBytes != expectedByteSize) {
                 throw new IOException("Archived artifact size does not match archive metadata");

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/ConsultationWebService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/ConsultationWebService.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -772,11 +773,15 @@ public class ConsultationWebService extends AbstractServiceImpl {
         List<ConsultationAttachmentTo1> newAttachments = request.getAttachments();
         List<ConsultDocs> currentDocs = consultationManager.getConsultRequestDocs(getLoggedInInfo(), request.getId());
         if (newAttachments == null || currentDocs == null) return;
-        assertNoOutboundEmailArchiveAttachments(newAttachments);
+        Set<Integer> archiveDocumentNos = findOutboundEmailArchiveDocumentNos(
+                currentDocs.stream()
+                        .filter(doc -> ConsultationAttachmentTo1.TYPE_DOC.equals(doc.getDocType()))
+                        .map(ConsultDocs::getDocumentNo)
+                        .toList());
 
         //first assume all current docs detached (set delete)
         for (ConsultDocs doc : currentDocs) {
-            if (!isOutboundEmailArchiveAttachment(doc.getDocType(), doc.getDocumentNo())) {
+            if (!archiveDocumentNos.contains(doc.getDocumentNo())) {
                 doc.setDeleted(ConsultDocs.DELETED);
             }
         }
@@ -815,11 +820,15 @@ public class ConsultationWebService extends AbstractServiceImpl {
         List<ConsultationAttachmentTo1> newAttachments = response.getAttachments();
         List<ConsultResponseDoc> currentDocs = consultationManager.getConsultResponseDocs(getLoggedInInfo(), response.getId());
         if (newAttachments == null || currentDocs == null) return;
-        assertNoOutboundEmailArchiveAttachments(newAttachments);
+        Set<Integer> archiveDocumentNos = findOutboundEmailArchiveDocumentNos(
+                currentDocs.stream()
+                        .filter(doc -> ConsultationAttachmentTo1.TYPE_DOC.equals(doc.getDocType()))
+                        .map(ConsultResponseDoc::getDocumentNo)
+                        .toList());
 
         //first assume all current docs detached (set delete)
         for (ConsultResponseDoc doc : currentDocs) {
-            if (!isOutboundEmailArchiveAttachment(doc.getDocType(), doc.getDocumentNo())) {
+            if (!archiveDocumentNos.contains(doc.getDocumentNo())) {
                 doc.setDeleted(ConsultResponseDoc.DELETED);
             }
         }
@@ -846,28 +855,24 @@ public class ConsultationWebService extends AbstractServiceImpl {
     }
 
     private void assertNoOutboundEmailArchiveAttachments(List<ConsultationAttachmentTo1> attachments) {
-        if (attachments == null) {
-            return;
-        }
-        for (ConsultationAttachmentTo1 attachment : attachments) {
-            if (attachment != null) {
-                assertNotOutboundEmailArchiveAttachment(attachment);
-            }
-        }
-    }
-
-    private void assertNotOutboundEmailArchiveAttachment(ConsultationAttachmentTo1 attachment) {
-        if (attachment != null && isOutboundEmailArchiveAttachment(
-                attachment.getDocumentType(), attachment.getDocumentNo())) {
+        List<Integer> documentNos = attachments == null ? List.of() : attachments.stream()
+                .filter(java.util.Objects::nonNull)
+                .filter(attachment -> ConsultationAttachmentTo1.TYPE_DOC.equals(attachment.getDocumentType()))
+                .map(ConsultationAttachmentTo1::getDocumentNo)
+                .filter(java.util.Objects::nonNull)
+                .toList();
+        if (!findOutboundEmailArchiveDocumentNos(documentNos).isEmpty()) {
             throw new SecurityException(
                     "Outbound email archive eDocs must be managed through the controlled archive workflow");
         }
     }
 
-    private boolean isOutboundEmailArchiveAttachment(String documentType, Integer documentNo) {
-        return ConsultationAttachmentTo1.TYPE_DOC.equals(documentType)
-                && documentNo != null
-                && outboundEmailArchiveDao.existsByDocumentNo(documentNo);
+    private Set<Integer> findOutboundEmailArchiveDocumentNos(List<Integer> documentNos) {
+        if (documentNos == null || documentNos.isEmpty()) {
+            return Set.of();
+        }
+        Set<Integer> archiveDocumentNos = outboundEmailArchiveDao.findExistingDocumentNos(documentNos);
+        return archiveDocumentNos != null ? archiveDocumentNos : Set.of();
     }
 
     private void markAttachmentSaveFailure(List<ConsultationAttachmentTo1> attachments,

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/ConsultationWebService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/ConsultationWebService.java
@@ -257,6 +257,7 @@ public class ConsultationWebService extends AbstractServiceImpl {
         if (data.getReferralDate() == null || data.getServiceId() == null || data.getUrgency() == null || data.getStatus() == null) {
             return Response.status(Response.Status.BAD_REQUEST).entity("required fields: \"referralDate\", \"serviceId\", \"urgency\", \"status\"").build();
         }
+        assertNoOutboundEmailArchiveAttachments(data.getAttachments());
 
         ConsultationRequest request = requestConverter.getAsDomainObject(loggedInInfo, data);
 
@@ -289,6 +290,7 @@ public class ConsultationWebService extends AbstractServiceImpl {
         if (data.getReferralDate() == null || data.getServiceId() == null || data.getUrgency() == null || data.getStatus() == null) {
             return Response.status(Response.Status.BAD_REQUEST).entity("required fields: \"referralDate\" \"serviceId\" \"urgency\" \"status\"").build();
         }
+        assertNoOutboundEmailArchiveAttachments(data.getAttachments());
 
         ConsultationRequest request = requestConverter.getAsDomainObject(loggedInInfo, data, consultationManager.getRequest(loggedInInfo, data.getId()));
 
@@ -407,6 +409,7 @@ public class ConsultationWebService extends AbstractServiceImpl {
     @Produces(MediaType.APPLICATION_JSON)
     public ConsultationResponseTo1 saveResponse(ConsultationResponseTo1 data) {
         ConsultationResponse response = null;
+        assertNoOutboundEmailArchiveAttachments(data.getAttachments());
 
         if (data.getId() == null) { //new consultation response
             response = responseConverter.getAsDomainObject(getLoggedInInfo(), data);
@@ -773,7 +776,9 @@ public class ConsultationWebService extends AbstractServiceImpl {
 
         //first assume all current docs detached (set delete)
         for (ConsultDocs doc : currentDocs) {
-            doc.setDeleted(ConsultDocs.DELETED);
+            if (!isOutboundEmailArchiveAttachment(doc.getDocType(), doc.getDocumentNo())) {
+                doc.setDeleted(ConsultDocs.DELETED);
+            }
         }
 
         List<String> uniqueAttachments = new ArrayList<>();
@@ -814,7 +819,9 @@ public class ConsultationWebService extends AbstractServiceImpl {
 
         //first assume all current docs detached (set delete)
         for (ConsultResponseDoc doc : currentDocs) {
-            doc.setDeleted(ConsultResponseDoc.DELETED);
+            if (!isOutboundEmailArchiveAttachment(doc.getDocType(), doc.getDocumentNo())) {
+                doc.setDeleted(ConsultResponseDoc.DELETED);
+            }
         }
 
         //compare current & new, remove from current list the unchanged ones - no need to update them
@@ -839,6 +846,9 @@ public class ConsultationWebService extends AbstractServiceImpl {
     }
 
     private void assertNoOutboundEmailArchiveAttachments(List<ConsultationAttachmentTo1> attachments) {
+        if (attachments == null) {
+            return;
+        }
         for (ConsultationAttachmentTo1 attachment : attachments) {
             if (attachment != null) {
                 assertNotOutboundEmailArchiveAttachment(attachment);
@@ -847,12 +857,17 @@ public class ConsultationWebService extends AbstractServiceImpl {
     }
 
     private void assertNotOutboundEmailArchiveAttachment(ConsultationAttachmentTo1 attachment) {
-        if (attachment != null
-                && ConsultationAttachmentTo1.TYPE_DOC.equals(attachment.getDocumentType())
-                && outboundEmailArchiveDao.existsByDocumentNo(attachment.getDocumentNo())) {
+        if (attachment != null && isOutboundEmailArchiveAttachment(
+                attachment.getDocumentType(), attachment.getDocumentNo())) {
             throw new SecurityException(
                     "Outbound email archive eDocs must be managed through the controlled archive workflow");
         }
+    }
+
+    private boolean isOutboundEmailArchiveAttachment(String documentType, Integer documentNo) {
+        return ConsultationAttachmentTo1.TYPE_DOC.equals(documentType)
+                && documentNo != null
+                && outboundEmailArchiveDao.existsByDocumentNo(documentNo);
     }
 
     private void markAttachmentSaveFailure(List<ConsultationAttachmentTo1> attachments,

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/ConsultationWebService.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/ConsultationWebService.java
@@ -55,6 +55,7 @@ import io.github.carlos_emr.carlos.casemgmt.service.CaseManagementManager;
 import io.github.carlos_emr.carlos.commn.dao.ClinicDAO;
 import io.github.carlos_emr.carlos.commn.dao.ConsultationServiceDao;
 import io.github.carlos_emr.carlos.commn.dao.FaxConfigDao;
+import io.github.carlos_emr.carlos.commn.dao.OutboundEmailArchiveDao;
 import io.github.carlos_emr.carlos.commn.dao.UserPropertyDAO;
 import io.github.carlos_emr.carlos.commn.model.Clinic;
 import io.github.carlos_emr.carlos.commn.model.ConsultDocs;
@@ -128,6 +129,9 @@ public class ConsultationWebService extends AbstractServiceImpl {
 
     @Autowired
     private DocumentManager documentManager;
+
+    @Autowired
+    private OutboundEmailArchiveDao outboundEmailArchiveDao;
 
     @Autowired
     ProviderDao providerDao;
@@ -765,6 +769,7 @@ public class ConsultationWebService extends AbstractServiceImpl {
         List<ConsultationAttachmentTo1> newAttachments = request.getAttachments();
         List<ConsultDocs> currentDocs = consultationManager.getConsultRequestDocs(getLoggedInInfo(), request.getId());
         if (newAttachments == null || currentDocs == null) return;
+        assertNoOutboundEmailArchiveAttachments(newAttachments);
 
         //first assume all current docs detached (set delete)
         for (ConsultDocs doc : currentDocs) {
@@ -805,6 +810,7 @@ public class ConsultationWebService extends AbstractServiceImpl {
         List<ConsultationAttachmentTo1> newAttachments = response.getAttachments();
         List<ConsultResponseDoc> currentDocs = consultationManager.getConsultResponseDocs(getLoggedInInfo(), response.getId());
         if (newAttachments == null || currentDocs == null) return;
+        assertNoOutboundEmailArchiveAttachments(newAttachments);
 
         //first assume all current docs detached (set delete)
         for (ConsultResponseDoc doc : currentDocs) {
@@ -829,6 +835,23 @@ public class ConsultationWebService extends AbstractServiceImpl {
         //update what remains in current docs, they are detached (set delete)
         for (ConsultResponseDoc doc : currentDocs) {
             consultationManager.saveConsultResponseDoc(getLoggedInInfo(), doc);
+        }
+    }
+
+    private void assertNoOutboundEmailArchiveAttachments(List<ConsultationAttachmentTo1> attachments) {
+        for (ConsultationAttachmentTo1 attachment : attachments) {
+            if (attachment != null) {
+                assertNotOutboundEmailArchiveAttachment(attachment);
+            }
+        }
+    }
+
+    private void assertNotOutboundEmailArchiveAttachment(ConsultationAttachmentTo1 attachment) {
+        if (attachment != null
+                && ConsultationAttachmentTo1.TYPE_DOC.equals(attachment.getDocumentType())
+                && outboundEmailArchiveDao.existsByDocumentNo(attachment.getDocumentNo())) {
+            throw new SecurityException(
+                    "Outbound email archive eDocs must be managed through the controlled archive workflow");
         }
     }
 

--- a/src/test/java/io/github/carlos_emr/carlos/commn/dao/CtlDocumentDaoIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/commn/dao/CtlDocumentDaoIntegrationTest.java
@@ -102,6 +102,18 @@ public class CtlDocumentDaoIntegrationTest extends CarlosTestBase {
 
         @Test
         @Tag("query")
+        @DisplayName("should find multiple documents by document numbers and module")
+        void shouldFindDocuments_byDocumentNosAndModule() {
+            List<CtlDocument> results = ctlDocumentDao.findByDocumentNosAndModule(
+                    List.of(20001, 20002, 20003, 20001), "demographic");
+
+            assertThat(results)
+                    .extracting(document -> document.getId().getDocumentNo())
+                    .containsExactlyInAnyOrder(20001, 20002);
+        }
+
+        @Test
+        @Tag("query")
         @DisplayName("should return empty for non-existent document-module combination")
         void shouldReturnEmpty_whenDocumentModuleNotFound() {
             List<CtlDocument> results = ctlDocumentDao.findByDocumentNoAndModule(99999, "nonexistent");

--- a/src/test/java/io/github/carlos_emr/carlos/commn/dao/CtlDocumentDaoIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/commn/dao/CtlDocumentDaoIntegrationTest.java
@@ -102,14 +102,14 @@ public class CtlDocumentDaoIntegrationTest extends CarlosTestBase {
 
         @Test
         @Tag("query")
-        @DisplayName("should find multiple documents by document numbers and module")
-        void shouldFindDocuments_byDocumentNosAndModule() {
-            List<CtlDocument> results = ctlDocumentDao.findByDocumentNosAndModule(
-                    List.of(20001, 20002, 20003, 20001), "demographic");
+        @DisplayName("should find all module links for multiple document numbers")
+        void shouldFindDocuments_byDocumentNos() {
+            List<CtlDocument> results = ctlDocumentDao.findByDocumentNos(
+                    List.of(20001, 20002, 20003, 20001));
 
             assertThat(results)
                     .extracting(document -> document.getId().getDocumentNo())
-                    .containsExactlyInAnyOrder(20001, 20002);
+                    .containsExactlyInAnyOrder(20001, 20002, 20003);
         }
 
         @Test

--- a/src/test/java/io/github/carlos_emr/carlos/commn/dao/OutboundEmailArchiveAttachmentDaoImplUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/commn/dao/OutboundEmailArchiveAttachmentDaoImplUnitTest.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+
+package io.github.carlos_emr.carlos.commn.dao;
+
+import io.github.carlos_emr.carlos.commn.model.OutboundEmailArchiveAttachment;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@DisplayName("OutboundEmailArchiveAttachmentDaoImpl")
+@Tag("unit")
+@Tag("dao")
+class OutboundEmailArchiveAttachmentDaoImplUnitTest {
+
+    private OutboundEmailArchiveAttachmentDaoImpl dao;
+    private EntityManager entityManager;
+
+    @BeforeEach
+    void setUp() {
+        dao = new OutboundEmailArchiveAttachmentDaoImpl();
+        entityManager = mock(EntityManager.class);
+        dao.entityManager = entityManager;
+    }
+
+    @Test
+    void shouldRejectPhysicalDeletionMethods() {
+        OutboundEmailArchiveAttachment attachment = new OutboundEmailArchiveAttachment();
+        List<OutboundEmailArchiveAttachment> attachments = List.of(attachment);
+
+        assertThatThrownBy(() -> dao.remove(attachment))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("retained with their parent archive");
+        assertThatThrownBy(() -> dao.remove(888))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("retained with their parent archive");
+        assertThatThrownBy(() -> dao.batchRemove(attachments))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("retained with their parent archive");
+        assertThatThrownBy(() -> dao.batchRemove(attachments, 25))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("retained with their parent archive");
+        verifyNoInteractions(entityManager);
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/commn/dao/OutboundEmailArchiveAttachmentDaoImplUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/commn/dao/OutboundEmailArchiveAttachmentDaoImplUnitTest.java
@@ -67,6 +67,18 @@ class OutboundEmailArchiveAttachmentDaoImplUnitTest {
         assertThatThrownBy(() -> dao.batchRemove(attachments, 25))
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessageContaining("retained with their parent archive");
+        assertThatThrownBy(() -> dao.batchRemoveAtomically(attachments))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("retained with their parent archive");
+        assertThatThrownBy(() -> dao.batchRemoveAtomically(attachments, 25))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("retained with their parent archive");
+        assertThatThrownBy(() -> dao.batchRemoveWithIndependentCommits(attachments))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("retained with their parent archive");
+        assertThatThrownBy(() -> dao.batchRemoveWithIndependentCommits(attachments, 25))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("retained with their parent archive");
         verifyNoInteractions(entityManager);
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/commn/dao/OutboundEmailArchiveDaoImplUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/commn/dao/OutboundEmailArchiveDaoImplUnitTest.java
@@ -56,17 +56,29 @@ class OutboundEmailArchiveDaoImplUnitTest {
             "SELECT * FROM outboundEmailArchive WHERE id = ?1 FOR UPDATE";
     private static final String EXISTS_ACTIVE_BY_DOCUMENT_NO_JPQL =
             "SELECT COUNT(archive) FROM OutboundEmailArchive archive "
-                    + "WHERE archive.document.documentNo = :documentNo "
-                    + "AND archive.deleted = false";
+                    + "WHERE archive.deleted = false AND ("
+                    + "archive.document.documentNo = :documentNo "
+                    + "OR EXISTS (SELECT attachment.id FROM OutboundEmailArchiveAttachment attachment "
+                    + "WHERE attachment.archive = archive "
+                    + "AND attachment.document.documentNo = :documentNo))";
     private static final String EXISTS_BY_DOCUMENT_NO_JPQL =
             "SELECT COUNT(archive) FROM OutboundEmailArchive archive "
-                    + "WHERE archive.document.documentNo = :documentNo";
+                    + "WHERE archive.document.documentNo = :documentNo "
+                    + "OR EXISTS (SELECT attachment.id FROM OutboundEmailArchiveAttachment attachment "
+                    + "WHERE attachment.archive = archive "
+                    + "AND attachment.document.documentNo = :documentNo)";
     private static final String FIND_EXISTING_DOCUMENT_NOS_JPQL =
-            "SELECT DISTINCT archive.document.documentNo FROM OutboundEmailArchive archive "
-                    + "WHERE archive.document.documentNo IN :documentNos";
+            "SELECT DISTINCT document.documentNo FROM Document document "
+                    + "WHERE document.documentNo IN :documentNos AND ("
+                    + "EXISTS (SELECT archive.id FROM OutboundEmailArchive archive "
+                    + "WHERE archive.document = document) "
+                    + "OR EXISTS (SELECT attachment.id FROM OutboundEmailArchiveAttachment attachment "
+                    + "WHERE attachment.document = document))";
     private static final String EXISTS_BY_FILE_NAME_JPQL =
             "SELECT COUNT(archive) FROM OutboundEmailArchive archive "
-                    + "WHERE archive.fileName = :fileName";
+                    + "WHERE archive.fileName = :fileName "
+                    + "OR EXISTS (SELECT attachment.id FROM OutboundEmailArchiveAttachment attachment "
+                    + "WHERE attachment.archive = archive AND attachment.fileName = :fileName)";
 
     private OutboundEmailArchiveDaoImpl dao;
     private EntityManager entityManager;

--- a/src/test/java/io/github/carlos_emr/carlos/commn/dao/OutboundEmailArchiveDaoImplUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/commn/dao/OutboundEmailArchiveDaoImplUnitTest.java
@@ -25,6 +25,7 @@ package io.github.carlos_emr.carlos.commn.dao;
 import io.github.carlos_emr.carlos.commn.model.OutboundEmailArchive;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
+import jakarta.persistence.TypedQuery;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
@@ -33,9 +34,11 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @DisplayName("OutboundEmailArchiveDaoImpl")
@@ -43,20 +46,69 @@ import static org.mockito.Mockito.when;
 @Tag("dao")
 class OutboundEmailArchiveDaoImplUnitTest {
 
+    private static final String FIND_FOR_READ_JPQL =
+            "SELECT archive FROM OutboundEmailArchive archive "
+                    + "LEFT JOIN FETCH archive.demographic "
+                    + "LEFT JOIN FETCH archive.document "
+                    + "WHERE archive.id = :archiveId";
     private static final String FIND_FOR_UPDATE_SQL =
             "SELECT * FROM outboundEmailArchive WHERE id = ?1 FOR UPDATE";
+    private static final String EXISTS_ACTIVE_BY_DOCUMENT_NO_JPQL =
+            "SELECT COUNT(archive) FROM OutboundEmailArchive archive "
+                    + "WHERE archive.document.documentNo = :documentNo "
+                    + "AND archive.deleted = false";
+    private static final String EXISTS_BY_DOCUMENT_NO_JPQL =
+            "SELECT COUNT(archive) FROM OutboundEmailArchive archive "
+                    + "WHERE archive.document.documentNo = :documentNo";
+    private static final String EXISTS_BY_FILE_NAME_JPQL =
+            "SELECT COUNT(archive) FROM OutboundEmailArchive archive "
+                    + "WHERE archive.fileName = :fileName";
 
     private OutboundEmailArchiveDaoImpl dao;
     private EntityManager entityManager;
     private Query query;
+    private TypedQuery<OutboundEmailArchive> typedQuery;
+    private TypedQuery<Long> countQuery;
 
     @BeforeEach
     void setUp() {
         dao = new OutboundEmailArchiveDaoImpl();
         entityManager = mock(EntityManager.class);
         query = mock(Query.class);
+        typedQuery = mock(TypedQuery.class);
+        countQuery = mock(TypedQuery.class);
 
         dao.entityManager = entityManager;
+    }
+
+    @Test
+    void shouldFetchDocumentAndDemographic_whenFindingArchiveForRead() {
+        OutboundEmailArchive archive = new OutboundEmailArchive();
+        when(entityManager.createQuery(FIND_FOR_READ_JPQL, OutboundEmailArchive.class)).thenReturn(typedQuery);
+        when(typedQuery.setParameter("archiveId", 888)).thenReturn(typedQuery);
+        when(typedQuery.getResultList()).thenReturn(List.of(archive));
+
+        OutboundEmailArchive result = dao.findForRead(888);
+
+        assertThat(result).isSameAs(archive);
+        verify(entityManager).createQuery(FIND_FOR_READ_JPQL, OutboundEmailArchive.class);
+        verify(typedQuery).setParameter("archiveId", 888);
+        verify(typedQuery).getResultList();
+    }
+
+    @Test
+    void shouldReturnNull_whenReadArchiveDoesNotExist() {
+        when(entityManager.createQuery(FIND_FOR_READ_JPQL, OutboundEmailArchive.class)).thenReturn(typedQuery);
+        when(typedQuery.setParameter("archiveId", 888)).thenReturn(typedQuery);
+        when(typedQuery.getResultList()).thenReturn(List.of());
+
+        assertThat(dao.findForRead(888)).isNull();
+    }
+
+    @Test
+    void shouldReturnNull_whenReadArchiveIdIsNull() {
+        assertThat(dao.findForRead(null)).isNull();
+        verify(entityManager, never()).createQuery(FIND_FOR_READ_JPQL, OutboundEmailArchive.class);
     }
 
     @Test
@@ -71,6 +123,7 @@ class OutboundEmailArchiveDaoImplUnitTest {
         assertThat(result).isSameAs(archive);
         verify(entityManager).createNativeQuery(FIND_FOR_UPDATE_SQL, OutboundEmailArchive.class);
         verify(query).setParameter(1, 888);
+        verify(query).getResultList();
     }
 
     @Test
@@ -86,5 +139,109 @@ class OutboundEmailArchiveDaoImplUnitTest {
     void shouldReturnNull_whenForUpdateArchiveIdIsNull() {
         assertThat(dao.findForUpdate(null)).isNull();
         verify(entityManager, never()).createNativeQuery(FIND_FOR_UPDATE_SQL, OutboundEmailArchive.class);
+    }
+
+    @Test
+    void shouldReturnTrue_whenActiveArchiveExistsForDocumentNo() {
+        when(entityManager.createQuery(EXISTS_ACTIVE_BY_DOCUMENT_NO_JPQL, Long.class)).thenReturn(countQuery);
+        when(countQuery.setParameter("documentNo", 321)).thenReturn(countQuery);
+        when(countQuery.getSingleResult()).thenReturn(1L);
+
+        assertThat(dao.existsActiveByDocumentNo(321)).isTrue();
+
+        verify(entityManager).createQuery(EXISTS_ACTIVE_BY_DOCUMENT_NO_JPQL, Long.class);
+        verify(countQuery).setParameter("documentNo", 321);
+        verify(countQuery).getSingleResult();
+    }
+
+    @Test
+    void shouldReturnFalse_whenNoActiveArchiveExistsForDocumentNo() {
+        when(entityManager.createQuery(EXISTS_ACTIVE_BY_DOCUMENT_NO_JPQL, Long.class)).thenReturn(countQuery);
+        when(countQuery.setParameter("documentNo", 321)).thenReturn(countQuery);
+        when(countQuery.getSingleResult()).thenReturn(0L);
+
+        assertThat(dao.existsActiveByDocumentNo(321)).isFalse();
+    }
+
+    @Test
+    void shouldReturnFalse_whenDocumentNoIsNull() {
+        assertThat(dao.existsActiveByDocumentNo(null)).isFalse();
+        verify(entityManager, never()).createQuery(EXISTS_ACTIVE_BY_DOCUMENT_NO_JPQL, Long.class);
+    }
+
+    @Test
+    void shouldReturnTrue_whenAnyArchiveExistsForDocumentNo() {
+        when(entityManager.createQuery(EXISTS_BY_DOCUMENT_NO_JPQL, Long.class)).thenReturn(countQuery);
+        when(countQuery.setParameter("documentNo", 321)).thenReturn(countQuery);
+        when(countQuery.getSingleResult()).thenReturn(1L);
+
+        assertThat(dao.existsByDocumentNo(321)).isTrue();
+
+        verify(entityManager).createQuery(EXISTS_BY_DOCUMENT_NO_JPQL, Long.class);
+        verify(countQuery).setParameter("documentNo", 321);
+        verify(countQuery).getSingleResult();
+    }
+
+    @Test
+    void shouldReturnFalse_whenNoArchiveExistsForDocumentNo() {
+        when(entityManager.createQuery(EXISTS_BY_DOCUMENT_NO_JPQL, Long.class)).thenReturn(countQuery);
+        when(countQuery.setParameter("documentNo", 321)).thenReturn(countQuery);
+        when(countQuery.getSingleResult()).thenReturn(0L);
+
+        assertThat(dao.existsByDocumentNo(321)).isFalse();
+    }
+
+    @Test
+    void shouldReturnFalse_whenAnyArchiveDocumentNoIsNull() {
+        assertThat(dao.existsByDocumentNo(null)).isFalse();
+        verify(entityManager, never()).createQuery(EXISTS_BY_DOCUMENT_NO_JPQL, Long.class);
+    }
+
+    @Test
+    void shouldReturnTrue_whenArchiveExistsForFileName() {
+        when(entityManager.createQuery(EXISTS_BY_FILE_NAME_JPQL, Long.class)).thenReturn(countQuery);
+        when(countQuery.setParameter("fileName", "archive.eml")).thenReturn(countQuery);
+        when(countQuery.getSingleResult()).thenReturn(1L);
+
+        assertThat(dao.existsByFileName("archive.eml")).isTrue();
+
+        verify(entityManager).createQuery(EXISTS_BY_FILE_NAME_JPQL, Long.class);
+        verify(countQuery).setParameter("fileName", "archive.eml");
+        verify(countQuery).getSingleResult();
+    }
+
+    @Test
+    void shouldReturnFalse_whenNoArchiveExistsForFileName() {
+        when(entityManager.createQuery(EXISTS_BY_FILE_NAME_JPQL, Long.class)).thenReturn(countQuery);
+        when(countQuery.setParameter("fileName", "document.pdf")).thenReturn(countQuery);
+        when(countQuery.getSingleResult()).thenReturn(0L);
+
+        assertThat(dao.existsByFileName("document.pdf")).isFalse();
+    }
+
+    @Test
+    void shouldReturnFalse_whenArchiveFileNameIsBlank() {
+        assertThat(dao.existsByFileName(" ")).isFalse();
+        verify(entityManager, never()).createQuery(EXISTS_BY_FILE_NAME_JPQL, Long.class);
+    }
+
+    @Test
+    void shouldRejectPhysicalDeletionMethods() {
+        OutboundEmailArchive archive = new OutboundEmailArchive();
+        List<OutboundEmailArchive> archives = List.of(archive);
+
+        assertThatThrownBy(() -> dao.remove(archive))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("controlled tombstone workflow");
+        assertThatThrownBy(() -> dao.remove(888))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("controlled tombstone workflow");
+        assertThatThrownBy(() -> dao.batchRemove(archives))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("controlled tombstone workflow");
+        assertThatThrownBy(() -> dao.batchRemove(archives, 25))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("controlled tombstone workflow");
+        verifyNoInteractions(entityManager);
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/commn/dao/OutboundEmailArchiveDaoImplUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/commn/dao/OutboundEmailArchiveDaoImplUnitTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -60,6 +61,9 @@ class OutboundEmailArchiveDaoImplUnitTest {
     private static final String EXISTS_BY_DOCUMENT_NO_JPQL =
             "SELECT COUNT(archive) FROM OutboundEmailArchive archive "
                     + "WHERE archive.document.documentNo = :documentNo";
+    private static final String FIND_EXISTING_DOCUMENT_NOS_JPQL =
+            "SELECT DISTINCT archive.document.documentNo FROM OutboundEmailArchive archive "
+                    + "WHERE archive.document.documentNo IN :documentNos";
     private static final String EXISTS_BY_FILE_NAME_JPQL =
             "SELECT COUNT(archive) FROM OutboundEmailArchive archive "
                     + "WHERE archive.fileName = :fileName";
@@ -69,6 +73,7 @@ class OutboundEmailArchiveDaoImplUnitTest {
     private Query query;
     private TypedQuery<OutboundEmailArchive> typedQuery;
     private TypedQuery<Long> countQuery;
+    private TypedQuery<Integer> documentNoQuery;
 
     @BeforeEach
     void setUp() {
@@ -77,6 +82,7 @@ class OutboundEmailArchiveDaoImplUnitTest {
         query = mock(Query.class);
         typedQuery = mock(TypedQuery.class);
         countQuery = mock(TypedQuery.class);
+        documentNoQuery = mock(TypedQuery.class);
 
         dao.entityManager = entityManager;
     }
@@ -198,6 +204,19 @@ class OutboundEmailArchiveDaoImplUnitTest {
     }
 
     @Test
+    void shouldFindArchiveDocumentNumbersInOneQuery() {
+        when(entityManager.createQuery(FIND_EXISTING_DOCUMENT_NOS_JPQL, Integer.class))
+                .thenReturn(documentNoQuery);
+        when(documentNoQuery.setParameter("documentNos", List.of(321, 654)))
+                .thenReturn(documentNoQuery);
+        when(documentNoQuery.getResultList()).thenReturn(List.of(321));
+
+        assertThat(dao.findExistingDocumentNos(List.of(321, 654, 321))).isEqualTo(Set.of(321));
+
+        verify(documentNoQuery).setParameter("documentNos", List.of(321, 654));
+    }
+
+    @Test
     void shouldReturnTrue_whenArchiveExistsForFileName() {
         when(entityManager.createQuery(EXISTS_BY_FILE_NAME_JPQL, Long.class)).thenReturn(countQuery);
         when(countQuery.setParameter("fileName", "archive.eml")).thenReturn(countQuery);
@@ -240,6 +259,18 @@ class OutboundEmailArchiveDaoImplUnitTest {
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessageContaining("controlled tombstone workflow");
         assertThatThrownBy(() -> dao.batchRemove(archives, 25))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("controlled tombstone workflow");
+        assertThatThrownBy(() -> dao.batchRemoveAtomically(archives))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("controlled tombstone workflow");
+        assertThatThrownBy(() -> dao.batchRemoveAtomically(archives, 25))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("controlled tombstone workflow");
+        assertThatThrownBy(() -> dao.batchRemoveWithIndependentCommits(archives))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("controlled tombstone workflow");
+        assertThatThrownBy(() -> dao.batchRemoveWithIndependentCommits(archives, 25))
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessageContaining("controlled tombstone workflow");
         verifyNoInteractions(entityManager);

--- a/src/test/java/io/github/carlos_emr/carlos/commn/model/OutboundEmailArchiveAttachmentUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/commn/model/OutboundEmailArchiveAttachmentUnitTest.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+
+package io.github.carlos_emr.carlos.commn.model;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("OutboundEmailArchiveAttachment")
+@Tag("unit")
+class OutboundEmailArchiveAttachmentUnitTest {
+
+    @Test
+    void shouldRejectMutation() {
+        OutboundEmailArchiveAttachment attachment = new OutboundEmailArchiveAttachment();
+
+        assertThatThrownBy(attachment::preventMutation)
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("retained with their parent archive");
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/DocumentAttachmentManagerImplTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/DocumentAttachmentManagerImplTest.java
@@ -28,6 +28,7 @@ import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 
 import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -42,6 +43,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -117,7 +120,7 @@ class DocumentAttachmentManagerImplTest extends CarlosUnitTestBase {
 
         ArgumentCaptor<ConsultDocs> consultDocCaptor = ArgumentCaptor.forClass(ConsultDocs.class);
         verify(securityInfoManager).hasPrivilege(loggedInInfo, "_con", SecurityInfoManager.WRITE, demographicNo);
-        verify(consultDocsDao).findByRequestIdDocType(requestId, DocumentType.DOC.getType());
+        verify(consultDocsDao, times(2)).findByRequestIdDocType(requestId, DocumentType.DOC.getType());
         verify(consultDocsDao).persist(consultDocCaptor.capture());
         ConsultDocs persisted = consultDocCaptor.getValue();
         assertThat(persisted.getRequestId()).isEqualTo(requestId);
@@ -170,7 +173,7 @@ class DocumentAttachmentManagerImplTest extends CarlosUnitTestBase {
     @DisplayName("should reject archive-backed documents before consult attachment persistence")
     void shouldRejectArchiveDocsBeforeConsultAttach() {
         when(securityInfoManager.hasPrivilege(loggedInInfo, "_con", SecurityInfoManager.WRITE, 456)).thenReturn(true);
-        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+        when(outboundEmailArchiveDao.findExistingDocumentNos(List.of(321))).thenReturn(Set.of(321));
 
         assertThatThrownBy(() -> manager.attachToConsult(loggedInInfo, DocumentType.DOC,
                 new String[] {"321"}, "999998", 123, 456))
@@ -184,7 +187,7 @@ class DocumentAttachmentManagerImplTest extends CarlosUnitTestBase {
     @DisplayName("should reject archive-backed documents before Ocean consult attachment staging")
     void shouldRejectArchiveDocsBeforeOceanConsultAttach() {
         when(securityInfoManager.hasPrivilege(loggedInInfo, "_con", SecurityInfoManager.WRITE, 456)).thenReturn(true);
-        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+        when(outboundEmailArchiveDao.findExistingDocumentNos(List.of(321))).thenReturn(Set.of(321));
 
         assertThatThrownBy(() -> manager.attachToConsult(loggedInInfo, DocumentType.DOC,
                 new String[] {"321"}, "999998", 123, 456, true))
@@ -198,7 +201,7 @@ class DocumentAttachmentManagerImplTest extends CarlosUnitTestBase {
     @DisplayName("should reject archive-backed documents before eForm attachment persistence")
     void shouldRejectArchiveDocsBeforeEFormAttach() {
         when(securityInfoManager.hasPrivilege(loggedInInfo, "_eform", SecurityInfoManager.WRITE, 456)).thenReturn(true);
-        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+        when(outboundEmailArchiveDao.findExistingDocumentNos(List.of(321))).thenReturn(Set.of(321));
 
         assertThatThrownBy(() -> manager.attachToEForm(loggedInInfo, DocumentType.DOC,
                 new String[] {"321"}, "999998", 123, 456))
@@ -215,7 +218,7 @@ class DocumentAttachmentManagerImplTest extends CarlosUnitTestBase {
         when(consultDocsDao.findByRequestIdDocType(123, DocumentType.DOC.getType())).thenReturn(List.of(
                 consultDoc(321),
                 consultDoc(654)));
-        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+        when(outboundEmailArchiveDao.findExistingDocumentNos(List.of(321, 654))).thenReturn(Set.of(321));
 
         assertThat(manager.getConsultAttachments(loggedInInfo, 123, DocumentType.DOC, 456))
                 .containsExactly("654");
@@ -228,10 +231,27 @@ class DocumentAttachmentManagerImplTest extends CarlosUnitTestBase {
         when(eFormDocsDao.findByFdidIdDocType(123, DocumentType.DOC.getType())).thenReturn(List.of(
                 eFormDoc(321),
                 eFormDoc(654)));
-        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+        when(outboundEmailArchiveDao.findExistingDocumentNos(List.of(321, 654))).thenReturn(Set.of(321));
 
         assertThat(manager.getEFormAttachments(loggedInInfo, 123, DocumentType.DOC, 456))
                 .containsExactly("654");
+    }
+
+    @Test
+    @DisplayName("should preserve hidden archive-backed consult attachments during generic saves")
+    void shouldPreserveHiddenArchiveDocs_whenSavingConsultAttachments() {
+        ConsultDocs archiveAttachment = consultDoc(321);
+        when(securityInfoManager.hasPrivilege(loggedInInfo, "_con", SecurityInfoManager.WRITE, 456))
+                .thenReturn(true);
+        when(consultDocsDao.findByRequestIdDocType(123, DocumentType.DOC.getType()))
+                .thenReturn(List.of(archiveAttachment));
+        when(outboundEmailArchiveDao.findExistingDocumentNos(List.of(321))).thenReturn(Set.of(321));
+
+        manager.attachToConsult(
+                loggedInInfo, DocumentType.DOC, new String[0], "999998", 123, 456);
+
+        assertThat(archiveAttachment.getDeleted()).isNull();
+        verify(consultDocsDao, never()).merge(archiveAttachment);
     }
 
     private ConsultDocs consultDoc(int documentNo) {

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/DocumentAttachmentManagerImplTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/DocumentAttachmentManagerImplTest.java
@@ -19,7 +19,9 @@ package io.github.carlos_emr.carlos.documentManager;
 
 import io.github.carlos_emr.carlos.commn.dao.ConsultDocsDao;
 import io.github.carlos_emr.carlos.commn.dao.EFormDocsDao;
+import io.github.carlos_emr.carlos.commn.dao.OutboundEmailArchiveDao;
 import io.github.carlos_emr.carlos.commn.model.ConsultDocs;
+import io.github.carlos_emr.carlos.commn.model.EFormDocs;
 import io.github.carlos_emr.carlos.commn.model.enumerator.DocumentType;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
@@ -58,6 +60,9 @@ class DocumentAttachmentManagerImplTest extends CarlosUnitTestBase {
     private EFormDocsDao eFormDocsDao;
 
     @Mock
+    private OutboundEmailArchiveDao outboundEmailArchiveDao;
+
+    @Mock
     private LoggedInInfo loggedInInfo;
 
     private DocumentAttachmentManagerImpl manager;
@@ -67,6 +72,8 @@ class DocumentAttachmentManagerImplTest extends CarlosUnitTestBase {
         manager = new DocumentAttachmentManagerImpl();
         injectDependency(manager, "securityInfoManager", securityInfoManager);
         injectDependency(manager, "consultDocsDao", consultDocsDao);
+        injectDependency(manager, "eFormDocsDao", eFormDocsDao);
+        injectDependency(manager, "outboundEmailArchiveDao", outboundEmailArchiveDao);
         registerMock(ConsultDocsDao.class, consultDocsDao);
         registerMock(EFormDocsDao.class, eFormDocsDao);
     }
@@ -157,5 +164,87 @@ class DocumentAttachmentManagerImplTest extends CarlosUnitTestBase {
 
         verify(securityInfoManager).hasPrivilege(loggedInInfo, "_con", SecurityInfoManager.WRITE, demographicNo);
         verifyNoInteractions(consultDocsDao);
+    }
+
+    @Test
+    @DisplayName("should reject archive-backed documents before consult attachment persistence")
+    void shouldRejectArchiveDocsBeforeConsultAttach() {
+        when(securityInfoManager.hasPrivilege(loggedInInfo, "_con", SecurityInfoManager.WRITE, 456)).thenReturn(true);
+        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+
+        assertThatThrownBy(() -> manager.attachToConsult(loggedInInfo, DocumentType.DOC,
+                new String[] {"321"}, "999998", 123, 456))
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("controlled archive workflow");
+
+        verifyNoInteractions(consultDocsDao);
+    }
+
+    @Test
+    @DisplayName("should reject archive-backed documents before Ocean consult attachment staging")
+    void shouldRejectArchiveDocsBeforeOceanConsultAttach() {
+        when(securityInfoManager.hasPrivilege(loggedInInfo, "_con", SecurityInfoManager.WRITE, 456)).thenReturn(true);
+        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+
+        assertThatThrownBy(() -> manager.attachToConsult(loggedInInfo, DocumentType.DOC,
+                new String[] {"321"}, "999998", 123, 456, true))
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("controlled archive workflow");
+
+        verifyNoInteractions(consultDocsDao);
+    }
+
+    @Test
+    @DisplayName("should reject archive-backed documents before eForm attachment persistence")
+    void shouldRejectArchiveDocsBeforeEFormAttach() {
+        when(securityInfoManager.hasPrivilege(loggedInInfo, "_eform", SecurityInfoManager.WRITE, 456)).thenReturn(true);
+        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+
+        assertThatThrownBy(() -> manager.attachToEForm(loggedInInfo, DocumentType.DOC,
+                new String[] {"321"}, "999998", 123, 456))
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("controlled archive workflow");
+
+        verifyNoInteractions(eFormDocsDao);
+    }
+
+    @Test
+    @DisplayName("should filter archive-backed documents from consult attachment reads")
+    void shouldFilterArchiveDocsFromConsultAttachmentReads() {
+        when(securityInfoManager.hasPrivilege(loggedInInfo, "_con", SecurityInfoManager.READ, 456)).thenReturn(true);
+        when(consultDocsDao.findByRequestIdDocType(123, DocumentType.DOC.getType())).thenReturn(List.of(
+                consultDoc(321),
+                consultDoc(654)));
+        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+
+        assertThat(manager.getConsultAttachments(loggedInInfo, 123, DocumentType.DOC, 456))
+                .containsExactly("654");
+    }
+
+    @Test
+    @DisplayName("should filter archive-backed documents from eForm attachment reads")
+    void shouldFilterArchiveDocsFromEFormAttachmentReads() {
+        when(securityInfoManager.hasPrivilege(loggedInInfo, "_eform", SecurityInfoManager.READ, 456)).thenReturn(true);
+        when(eFormDocsDao.findByFdidIdDocType(123, DocumentType.DOC.getType())).thenReturn(List.of(
+                eFormDoc(321),
+                eFormDoc(654)));
+        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+
+        assertThat(manager.getEFormAttachments(loggedInInfo, 123, DocumentType.DOC, 456))
+                .containsExactly("654");
+    }
+
+    private ConsultDocs consultDoc(int documentNo) {
+        ConsultDocs consultDoc = new ConsultDocs();
+        consultDoc.setDocumentNo(documentNo);
+        consultDoc.setDocType(DocumentType.DOC.getType());
+        return consultDoc;
+    }
+
+    private EFormDocs eFormDoc(int documentNo) {
+        EFormDocs eFormDoc = new EFormDocs();
+        eFormDoc.setDocumentNo(documentNo);
+        eFormDoc.setDocType(DocumentType.DOC.getType());
+        return eFormDoc;
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/EDocUtilDeleteDocumentUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/EDocUtilDeleteDocumentUnitTest.java
@@ -76,6 +76,7 @@ class EDocUtilDeleteDocumentUnitTest extends CarlosUnitTestBase {
     private OutboundEmailArchiveDao outboundEmailArchiveDao;
     private ProgramManager2 programManager2;
     private ProviderDao providerDao;
+    private String previousDocumentDir;
     private String previousFilterOnFacility;
 
     @TempDir
@@ -84,6 +85,7 @@ class EDocUtilDeleteDocumentUnitTest extends CarlosUnitTestBase {
     @BeforeEach
     void setUp() throws Exception {
         clearCachedDocumentDao();
+        previousDocumentDir = CarlosProperties.getInstance().getProperty("DOCUMENT_DIR");
         previousFilterOnFacility = CarlosProperties.getInstance().getProperty("FILTER_ON_FACILITY");
         CarlosProperties.getInstance().setProperty("FILTER_ON_FACILITY", "false");
         ctlDocumentDao = mock(CtlDocumentDao.class);
@@ -109,6 +111,11 @@ class EDocUtilDeleteDocumentUnitTest extends CarlosUnitTestBase {
 
     @AfterEach
     void tearDown() throws Exception {
+        if (previousDocumentDir == null) {
+            CarlosProperties.getInstance().remove("DOCUMENT_DIR");
+        } else {
+            CarlosProperties.getInstance().setProperty("DOCUMENT_DIR", previousDocumentDir);
+        }
         if (previousFilterOnFacility == null) {
             CarlosProperties.getInstance().remove("FILTER_ON_FACILITY");
         } else {

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/EDocUtilDeleteDocumentUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/EDocUtilDeleteDocumentUnitTest.java
@@ -1,0 +1,504 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.documentManager;
+
+import io.github.carlos_emr.CarlosProperties;
+import io.github.carlos_emr.carlos.PMmodule.dao.ProviderDao;
+import io.github.carlos_emr.carlos.commn.dao.ConsultDocsDao;
+import io.github.carlos_emr.carlos.commn.dao.CtlDocumentDao;
+import io.github.carlos_emr.carlos.commn.dao.DocumentDao;
+import io.github.carlos_emr.carlos.commn.dao.EFormDocsDao;
+import io.github.carlos_emr.carlos.commn.dao.OutboundEmailArchiveDao;
+import io.github.carlos_emr.carlos.commn.model.ConsultDocs;
+import io.github.carlos_emr.carlos.commn.model.CtlDocument;
+import io.github.carlos_emr.carlos.commn.model.Demographic;
+import io.github.carlos_emr.carlos.commn.model.Document;
+import io.github.carlos_emr.carlos.commn.model.EFormDocs;
+import io.github.carlos_emr.carlos.commn.model.Provider;
+import io.github.carlos_emr.carlos.managers.DemographicManager;
+import io.github.carlos_emr.carlos.managers.ProgramManager2;
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
+import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@DisplayName("EDocUtil")
+@Tag("unit")
+@Tag("documentManager")
+class EDocUtilDeleteDocumentUnitTest extends CarlosUnitTestBase {
+
+    private CtlDocumentDao ctlDocumentDao;
+    private ConsultDocsDao consultDocsDao;
+    private DemographicManager demographicManager;
+    private DocumentDao documentDao;
+    private EFormDocsDao eFormDocsDao;
+    private LoggedInInfo loggedInInfo;
+    private OutboundEmailArchiveDao outboundEmailArchiveDao;
+    private ProgramManager2 programManager2;
+    private ProviderDao providerDao;
+    private String previousFilterOnFacility;
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        clearCachedDocumentDao();
+        previousFilterOnFacility = CarlosProperties.getInstance().getProperty("FILTER_ON_FACILITY");
+        CarlosProperties.getInstance().setProperty("FILTER_ON_FACILITY", "false");
+        ctlDocumentDao = mock(CtlDocumentDao.class);
+        consultDocsDao = mock(ConsultDocsDao.class);
+        demographicManager = mock(DemographicManager.class);
+        documentDao = mock(DocumentDao.class);
+        eFormDocsDao = mock(EFormDocsDao.class);
+        loggedInInfo = mock(LoggedInInfo.class);
+        outboundEmailArchiveDao = mock(OutboundEmailArchiveDao.class);
+        programManager2 = mock(ProgramManager2.class);
+        providerDao = mock(ProviderDao.class);
+        registerMock(CtlDocumentDao.class, ctlDocumentDao);
+        registerMock(ConsultDocsDao.class, consultDocsDao);
+        registerMock(DemographicManager.class, demographicManager);
+        registerMock(DocumentDao.class, documentDao);
+        registerMock(EFormDocsDao.class, eFormDocsDao);
+        registerMock(OutboundEmailArchiveDao.class, outboundEmailArchiveDao);
+        registerMock(ProgramManager2.class, programManager2);
+        registerMock(ProviderDao.class, providerDao);
+        when(loggedInInfo.getLoggedInProviderNo()).thenReturn("999998");
+        when(programManager2.getProgramDomain(loggedInInfo, "999998")).thenReturn(List.of());
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (previousFilterOnFacility == null) {
+            CarlosProperties.getInstance().remove("FILTER_ON_FACILITY");
+        } else {
+            CarlosProperties.getInstance().setProperty("FILTER_ON_FACILITY", previousFilterOnFacility);
+        }
+        clearCachedDocumentDao();
+    }
+
+    @Test
+    @DisplayName("should soft-delete document when it is not an active outbound email archive eDoc")
+    void shouldSoftDeleteDocument_whenNotActiveOutboundEmailArchiveEdoc() {
+        Document document = activeDocument();
+        when(documentDao.find((Object) Integer.valueOf(321))).thenReturn(document);
+        when(outboundEmailArchiveDao.existsActiveByDocumentNo(321)).thenReturn(false);
+
+        EDocUtil.deleteDocument("321");
+
+        assertThat(document.getStatus()).isEqualTo(Document.STATUS_DELETED);
+        assertThat(document.getUpdatedatetime()).isNotNull();
+        verify(outboundEmailArchiveDao).existsActiveByDocumentNo(321);
+        verify(documentDao).merge(document);
+    }
+
+    @Test
+    @DisplayName("should reject normal delete when document backs an active outbound email archive")
+    void shouldRejectDelete_whenDocumentBacksActiveOutboundEmailArchive() {
+        Document document = activeDocument();
+        when(documentDao.find((Object) Integer.valueOf(321))).thenReturn(document);
+        when(outboundEmailArchiveDao.existsActiveByDocumentNo(321)).thenReturn(true);
+
+        assertThatThrownBy(() -> EDocUtil.deleteDocument("321"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("controlled archive deletion workflow");
+
+        assertThat(document.getStatus()).isEqualTo(Document.STATUS_ACTIVE);
+        verify(documentDao, never()).merge(any(Document.class));
+    }
+
+    @Test
+    @DisplayName("should reject undelete when document backs an outbound email archive")
+    void shouldRejectUndelete_whenDocumentBacksOutboundEmailArchive() {
+        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+
+        assertThatThrownBy(() -> EDocUtil.undeleteDocument("321"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("controlled archive workflow");
+
+        verifyNoInteractions(ctlDocumentDao);
+        verify(documentDao, never()).find(any());
+    }
+
+    @Test
+    @DisplayName("should reject refile when document backs an outbound email archive")
+    void shouldRejectRefile_whenDocumentBacksOutboundEmailArchive() {
+        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+
+        assertThatThrownBy(() -> EDocUtil.refileDocument("321", "1"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("controlled archive workflow");
+
+        verify(documentDao, never()).find(any());
+    }
+
+    @Test
+    @DisplayName("should reject edit when document backs an outbound email archive")
+    void shouldRejectEdit_whenDocumentBacksOutboundEmailArchive() {
+        EDoc editedDocument = new EDoc();
+        editedDocument.setDocId("321");
+        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+
+        assertThatThrownBy(() -> EDocUtil.editDocumentSQL(editedDocument, false))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("controlled archive workflow");
+
+        verify(documentDao, never()).find(any());
+        verify(documentDao, never()).merge(any(Document.class));
+    }
+
+    @Test
+    @DisplayName("should reject document metadata creation when filename belongs to an outbound email archive")
+    void shouldRejectAddDocumentSql_whenFilenameBelongsToOutboundEmailArchive() {
+        EDoc newDocument = new EDoc();
+        newDocument.setFileName("archive.pdf");
+        when(outboundEmailArchiveDao.existsByFileName("archive.pdf")).thenReturn(true);
+
+        assertThatThrownBy(() -> EDocUtil.addDocumentSQL(newDocument))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("controlled archive workflow");
+
+        verify(documentDao, never()).persist(any(Document.class));
+    }
+
+    @Test
+    @DisplayName("should reject legacy document creation when filename belongs to an outbound email archive")
+    void shouldRejectAddDocument_whenFilenameBelongsToOutboundEmailArchive() {
+        when(outboundEmailArchiveDao.existsByFileName("archive.pdf")).thenReturn(true);
+
+        assertThatThrownBy(() -> EDocUtil.addDocument(
+                "123",
+                "archive.pdf",
+                "Archive",
+                "DOC",
+                null,
+                null,
+                "application/pdf",
+                null,
+                null,
+                null,
+                "999998",
+                "999998"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("controlled archive workflow");
+
+        verify(documentDao, never()).persist(any(Document.class));
+    }
+
+    @Test
+    @DisplayName("should reject document file writes when filename belongs to an outbound email archive")
+    void shouldRejectWriteDocContent_whenFilenameBelongsToOutboundEmailArchive() {
+        when(outboundEmailArchiveDao.existsByFileName("archive.pdf")).thenReturn(true);
+
+        assertThatThrownBy(() -> EDocUtil.writeDocContent("archive.pdf", new byte[] {1}))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("controlled archive workflow");
+    }
+
+    @Test
+    @DisplayName("should reject consult attachment when document backs an outbound email archive")
+    void shouldRejectConsultAttachment_whenDocumentBacksOutboundEmailArchive() {
+        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+
+        assertThatThrownBy(() -> EDocUtil.attachDocConsult("999998", "321", "456"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("controlled archive workflow");
+
+        verify(consultDocsDao, never()).persist(any(ConsultDocs.class));
+    }
+
+    @Test
+    @DisplayName("should reject eForm attachment when document backs an outbound email archive")
+    void shouldRejectEFormAttachment_whenDocumentBacksOutboundEmailArchive() {
+        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+
+        assertThatThrownBy(() -> EDocUtil.attachDocEForm("999998", "321", "456"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("controlled archive workflow");
+
+        verify(eFormDocsDao, never()).persist(any(EFormDocs.class));
+    }
+
+    @Test
+    @DisplayName("should reject consult detach when document backs an outbound email archive")
+    void shouldRejectConsultDetach_whenDocumentBacksOutboundEmailArchive() {
+        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+
+        assertThatThrownBy(() -> EDocUtil.detachDocConsult("321", "456"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("controlled archive workflow");
+
+        verifyNoInteractions(consultDocsDao);
+    }
+
+    @Test
+    @DisplayName("should reject eForm detach when document backs an outbound email archive")
+    void shouldRejectEFormDetach_whenDocumentBacksOutboundEmailArchive() {
+        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+
+        assertThatThrownBy(() -> EDocUtil.detachDocEForm("321", "456"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("controlled archive workflow");
+
+        verifyNoInteractions(eFormDocsDao);
+    }
+
+    @Test
+    @DisplayName("should reject page-count mutation when document backs an outbound email archive")
+    void shouldRejectSubtractOnePage_whenDocumentBacksOutboundEmailArchive() {
+        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+
+        assertThatThrownBy(() -> EDocUtil.subtractOnePage("321"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("controlled archive workflow");
+
+        verify(documentDao, never()).find(any());
+        verify(documentDao, never()).merge(any(Document.class));
+    }
+
+    @Test
+    @DisplayName("should reject tickler HTML reads when document backs an outbound email archive")
+    void shouldRejectHtmlTicklers_whenDocumentBacksOutboundEmailArchive() {
+        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+
+        assertThatThrownBy(() -> EDocUtil.getHtmlTicklers(loggedInInfo, "321"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("controlled archive workflow");
+    }
+
+    @Test
+    @DisplayName("should reject acknowledgement HTML reads when document backs an outbound email archive")
+    void shouldRejectHtmlAcknowledgement_whenDocumentBacksOutboundEmailArchive() {
+        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+
+        assertThatThrownBy(() -> EDocUtil.getHtmlAcknowledgement(Locale.CANADA, "321"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("controlled archive workflow");
+    }
+
+    @Test
+    @DisplayName("should reject annotation HTML reads when document backs an outbound email archive")
+    void shouldRejectHtmlAnnotation_whenDocumentBacksOutboundEmailArchive() {
+        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+
+        assertThatThrownBy(() -> EDocUtil.getHtmlAnnotation("321"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("controlled archive workflow");
+    }
+
+    @Test
+    @DisplayName("should hide last document description when newest document backs an outbound email archive")
+    void shouldHideLastDocumentDesc_whenNewestDocumentBacksOutboundEmailArchive() {
+        Document document = activeDocument();
+        document.setDocdesc("Outbound email archive 123");
+        when(documentDao.findMaxDocNo()).thenReturn(321);
+        when(documentDao.find((Object) Integer.valueOf(321))).thenReturn(document);
+        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+
+        assertThat(EDocUtil.getLastDocumentDesc()).isNull();
+    }
+
+    @Test
+    @DisplayName("should reject document directory reads when filename belongs to an outbound email archive")
+    void shouldRejectReadContent_whenFilenameBelongsToOutboundEmailArchive() throws Exception {
+        CarlosProperties.getInstance().setProperty("DOCUMENT_DIR", tempDir.toString());
+        Files.write(tempDir.resolve("archive.pdf"), new byte[] {1});
+        when(outboundEmailArchiveDao.existsByFileName("archive.pdf")).thenReturn(true);
+
+        assertThatThrownBy(() -> EDocUtil.readContent("archive.pdf"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("controlled archive workflow");
+    }
+
+    @Test
+    @DisplayName("should omit outbound archive eDocs from demographic export document lists")
+    void shouldOmitOutboundArchiveDocuments_whenListingDemographicDocumentsForExport() {
+        Document archiveDocument = activeDocument();
+        Document ordinaryDocument = activeDocument(654);
+        when(documentDao.findConstultDocsDocsAndProvidersByModule(DocumentDao.Module.DEMOGRAPHIC, 123))
+                .thenReturn(List.of(new Object[] {archiveDocument}, new Object[] {ordinaryDocument}));
+        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+
+        List<EDoc> documents = EDocUtil.listDemoDocs(loggedInInfo, "123");
+
+        assertThat(documents)
+                .extracting(EDoc::getDocId)
+                .containsExactly("654");
+    }
+
+    @Test
+    @DisplayName("should omit outbound archive eDocs from general demographic document lists")
+    void shouldOmitOutboundArchiveDocuments_whenListingDemographicDocuments() {
+        Document archiveDocument = activeDocument();
+        Document ordinaryDocument = activeDocument(654);
+        when(documentDao.findDocuments("demographic", "123", null, false, false, true, EDocUtil.EDocSort.OBSERVATIONDATE, null))
+                .thenReturn(List.of(new Object[] {new CtlDocument(), archiveDocument}, new Object[] {new CtlDocument(), ordinaryDocument}));
+        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+
+        List<EDoc> documents = EDocUtil.listDocs(
+                loggedInInfo,
+                "demographic",
+                "123",
+                null,
+                EDocUtil.PRIVATE,
+                EDocUtil.EDocSort.OBSERVATIONDATE);
+
+        assertThat(documents)
+                .extracting(EDoc::getDocId)
+                .containsExactly("654");
+    }
+
+    @Test
+    @DisplayName("should omit outbound archive eDocs from updated demographic document lists")
+    void shouldOmitOutboundArchiveDocuments_whenListingUpdatedDemographicDocuments() {
+        Date since = new Date();
+        Document archiveDocument = activeDocument();
+        Document ordinaryDocument = activeDocument(654);
+        when(documentDao.findByDemographicUpdateDate(123, since))
+                .thenReturn(List.of(archiveDocument, ordinaryDocument));
+        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+
+        List<EDoc> documents = EDocUtil.listAllDemographicDocsSince(loggedInInfo, 123, since);
+
+        assertThat(documents)
+                .extracting(EDoc::getDocId)
+                .containsExactly("654");
+    }
+
+    @Test
+    @DisplayName("should not query outbound archive metadata when document does not exist")
+    void shouldNotQueryOutboundArchiveMetadata_whenDocumentDoesNotExist() {
+        when(documentDao.find((Object) Integer.valueOf(321))).thenReturn(null);
+
+        EDocUtil.deleteDocument("321");
+
+        verifyNoInteractions(outboundEmailArchiveDao);
+        verify(documentDao, never()).merge(any(Document.class));
+    }
+
+    @Test
+    @DisplayName("should restore active status when undelete ctl status is empty")
+    void shouldRestoreActiveStatus_whenUndeleteCtlStatusIsEmpty() {
+        Document document = deletedDocument();
+        CtlDocument ctlDocument = new CtlDocument();
+        ctlDocument.setStatus("");
+        when(ctlDocumentDao.getCtrlDocument(321)).thenReturn(ctlDocument);
+        when(documentDao.find((Object) Integer.valueOf(321))).thenReturn(document);
+
+        EDocUtil.undeleteDocument("321");
+
+        assertThat(document.getStatus()).isEqualTo(Document.STATUS_ACTIVE);
+        assertThat(document.getUpdatedatetime()).isNotNull();
+        verify(documentDao).merge(document);
+    }
+
+    @Test
+    @DisplayName("should format provider name when one name part is missing")
+    void shouldFormatProviderName_whenOneNamePartIsMissing() {
+        Provider provider = new Provider();
+        provider.setFirstName("Alex");
+        provider.setLastName(null);
+        when(providerDao.getProvider("12")).thenReturn(provider);
+
+        String name = EDocUtil.getProviderName("12");
+
+        assertThat(name).isEqualTo("ALEX");
+    }
+
+    @Test
+    @DisplayName("should include alias when demographic name parts are missing")
+    void shouldIncludeAlias_whenDemographicNamePartsAreMissing() {
+        Demographic demographic = new Demographic(123);
+        demographic.setFirstName(null);
+        demographic.setLastName(null);
+        demographic.setAlias("Lex");
+        when(demographicManager.getDemographic(loggedInInfo, "123")).thenReturn(demographic);
+
+        String name = EDocUtil.getDemographicName(loggedInInfo, "123");
+
+        assertThat(name).isEqualTo("(Lex)");
+    }
+
+    @Test
+    @DisplayName("should return N/A when demographic name and alias are missing")
+    void shouldReturnNotAvailable_whenDemographicNameAndAliasAreMissing() {
+        Demographic demographic = new Demographic(123);
+        demographic.setFirstName(" ");
+        demographic.setLastName(null);
+        demographic.setAlias(" ");
+        when(demographicManager.getDemographic(loggedInInfo, "123")).thenReturn(demographic);
+
+        String name = EDocUtil.getDemographicName(loggedInInfo, "123");
+
+        assertThat(name).isEqualTo("N/A");
+    }
+
+    private Document activeDocument() {
+        return activeDocument(321);
+    }
+
+    private Document activeDocument(Integer documentNo) {
+        Document document = new Document();
+        document.setDocumentNo(documentNo);
+        document.setStatus(Document.STATUS_ACTIVE);
+        return document;
+    }
+
+    private Document deletedDocument() {
+        Document document = new Document();
+        document.setDocumentNo(321);
+        document.setStatus(Document.STATUS_DELETED);
+        return document;
+    }
+
+    private void clearCachedDocumentDao() throws Exception {
+        Field documentDaoField = EDocUtil.class.getDeclaredField("documentDao");
+        documentDaoField.setAccessible(true);
+        documentDaoField.set(null, null);
+        Field consultDocsDaoField = EDocUtil.class.getDeclaredField("consultDocsDao");
+        consultDocsDaoField.setAccessible(true);
+        consultDocsDaoField.set(null, null);
+        Field eformDocsDaoField = EDocUtil.class.getDeclaredField("eformDocsDao");
+        eformDocsDaoField.setAccessible(true);
+        eformDocsDaoField.set(null, null);
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/EDocUtilDeleteDocumentUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/EDocUtilDeleteDocumentUnitTest.java
@@ -51,6 +51,7 @@ import java.nio.file.Path;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -356,7 +357,7 @@ class EDocUtilDeleteDocumentUnitTest extends CarlosUnitTestBase {
         Document ordinaryDocument = activeDocument(654);
         when(documentDao.findConstultDocsDocsAndProvidersByModule(DocumentDao.Module.DEMOGRAPHIC, 123))
                 .thenReturn(List.of(new Object[] {archiveDocument}, new Object[] {ordinaryDocument}));
-        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+        when(outboundEmailArchiveDao.findExistingDocumentNos(List.of(321, 654))).thenReturn(Set.of(321));
 
         List<EDoc> documents = EDocUtil.listDemoDocs(loggedInInfo, "123");
 
@@ -372,7 +373,7 @@ class EDocUtilDeleteDocumentUnitTest extends CarlosUnitTestBase {
         Document ordinaryDocument = activeDocument(654);
         when(documentDao.findDocuments("demographic", "123", null, false, false, true, EDocUtil.EDocSort.OBSERVATIONDATE, null))
                 .thenReturn(List.of(new Object[] {new CtlDocument(), archiveDocument}, new Object[] {new CtlDocument(), ordinaryDocument}));
-        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+        when(outboundEmailArchiveDao.findExistingDocumentNos(List.of(321, 654))).thenReturn(Set.of(321));
 
         List<EDoc> documents = EDocUtil.listDocs(
                 loggedInInfo,
@@ -395,7 +396,7 @@ class EDocUtilDeleteDocumentUnitTest extends CarlosUnitTestBase {
         Document ordinaryDocument = activeDocument(654);
         when(documentDao.findByDemographicUpdateDate(123, since))
                 .thenReturn(List.of(archiveDocument, ordinaryDocument));
-        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+        when(outboundEmailArchiveDao.findExistingDocumentNos(List.of(321, 654))).thenReturn(Set.of(321));
 
         List<EDoc> documents = EDocUtil.listAllDemographicDocsSince(loggedInInfo, 123, since);
 

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/EDocUtilDeleteDocumentUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/EDocUtilDeleteDocumentUnitTest.java
@@ -118,30 +118,30 @@ class EDocUtilDeleteDocumentUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
-    @DisplayName("should soft-delete document when it is not an active outbound email archive eDoc")
-    void shouldSoftDeleteDocument_whenNotActiveOutboundEmailArchiveEdoc() {
+    @DisplayName("should soft-delete document when it is not an outbound email archive eDoc")
+    void shouldSoftDeleteDocument_whenNotOutboundEmailArchiveEdoc() {
         Document document = activeDocument();
         when(documentDao.find((Object) Integer.valueOf(321))).thenReturn(document);
-        when(outboundEmailArchiveDao.existsActiveByDocumentNo(321)).thenReturn(false);
+        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(false);
 
         EDocUtil.deleteDocument("321");
 
         assertThat(document.getStatus()).isEqualTo(Document.STATUS_DELETED);
         assertThat(document.getUpdatedatetime()).isNotNull();
-        verify(outboundEmailArchiveDao).existsActiveByDocumentNo(321);
+        verify(outboundEmailArchiveDao).existsByDocumentNo(321);
         verify(documentDao).merge(document);
     }
 
     @Test
-    @DisplayName("should reject normal delete when document backs an active outbound email archive")
-    void shouldRejectDelete_whenDocumentBacksActiveOutboundEmailArchive() {
+    @DisplayName("should reject normal delete when document backs any outbound email archive")
+    void shouldRejectDelete_whenDocumentBacksOutboundEmailArchive() {
         Document document = activeDocument();
         when(documentDao.find((Object) Integer.valueOf(321))).thenReturn(document);
-        when(outboundEmailArchiveDao.existsActiveByDocumentNo(321)).thenReturn(true);
+        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
 
         assertThatThrownBy(() -> EDocUtil.deleteDocument("321"))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("controlled archive deletion workflow");
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("controlled archive workflow");
 
         assertThat(document.getStatus()).isEqualTo(Document.STATUS_ACTIVE);
         verify(documentDao, never()).merge(any(Document.class));
@@ -153,7 +153,7 @@ class EDocUtilDeleteDocumentUnitTest extends CarlosUnitTestBase {
         when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
 
         assertThatThrownBy(() -> EDocUtil.undeleteDocument("321"))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(SecurityException.class)
                 .hasMessageContaining("controlled archive workflow");
 
         verifyNoInteractions(ctlDocumentDao);
@@ -166,7 +166,7 @@ class EDocUtilDeleteDocumentUnitTest extends CarlosUnitTestBase {
         when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
 
         assertThatThrownBy(() -> EDocUtil.refileDocument("321", "1"))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(SecurityException.class)
                 .hasMessageContaining("controlled archive workflow");
 
         verify(documentDao, never()).find(any());
@@ -180,7 +180,23 @@ class EDocUtilDeleteDocumentUnitTest extends CarlosUnitTestBase {
         when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
 
         assertThatThrownBy(() -> EDocUtil.editDocumentSQL(editedDocument, false))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("controlled archive workflow");
+
+        verify(documentDao, never()).find(any());
+        verify(documentDao, never()).merge(any(Document.class));
+    }
+
+    @Test
+    @DisplayName("should reject edit when an ordinary document is assigned an outbound archive filename")
+    void shouldRejectEdit_whenFileNameBelongsToOutboundEmailArchive() {
+        EDoc editedDocument = new EDoc();
+        editedDocument.setDocId("321");
+        editedDocument.setFileName("archive.pdf");
+        when(outboundEmailArchiveDao.existsByFileName("archive.pdf")).thenReturn(true);
+
+        assertThatThrownBy(() -> EDocUtil.editDocumentSQL(editedDocument, false))
+                .isInstanceOf(SecurityException.class)
                 .hasMessageContaining("controlled archive workflow");
 
         verify(documentDao, never()).find(any());
@@ -195,7 +211,7 @@ class EDocUtilDeleteDocumentUnitTest extends CarlosUnitTestBase {
         when(outboundEmailArchiveDao.existsByFileName("archive.pdf")).thenReturn(true);
 
         assertThatThrownBy(() -> EDocUtil.addDocumentSQL(newDocument))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(SecurityException.class)
                 .hasMessageContaining("controlled archive workflow");
 
         verify(documentDao, never()).persist(any(Document.class));
@@ -219,7 +235,7 @@ class EDocUtilDeleteDocumentUnitTest extends CarlosUnitTestBase {
                 null,
                 "999998",
                 "999998"))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(SecurityException.class)
                 .hasMessageContaining("controlled archive workflow");
 
         verify(documentDao, never()).persist(any(Document.class));
@@ -231,7 +247,7 @@ class EDocUtilDeleteDocumentUnitTest extends CarlosUnitTestBase {
         when(outboundEmailArchiveDao.existsByFileName("archive.pdf")).thenReturn(true);
 
         assertThatThrownBy(() -> EDocUtil.writeDocContent("archive.pdf", new byte[] {1}))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(SecurityException.class)
                 .hasMessageContaining("controlled archive workflow");
     }
 
@@ -241,7 +257,7 @@ class EDocUtilDeleteDocumentUnitTest extends CarlosUnitTestBase {
         when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
 
         assertThatThrownBy(() -> EDocUtil.attachDocConsult("999998", "321", "456"))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(SecurityException.class)
                 .hasMessageContaining("controlled archive workflow");
 
         verify(consultDocsDao, never()).persist(any(ConsultDocs.class));
@@ -253,7 +269,7 @@ class EDocUtilDeleteDocumentUnitTest extends CarlosUnitTestBase {
         when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
 
         assertThatThrownBy(() -> EDocUtil.attachDocEForm("999998", "321", "456"))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(SecurityException.class)
                 .hasMessageContaining("controlled archive workflow");
 
         verify(eFormDocsDao, never()).persist(any(EFormDocs.class));
@@ -265,7 +281,7 @@ class EDocUtilDeleteDocumentUnitTest extends CarlosUnitTestBase {
         when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
 
         assertThatThrownBy(() -> EDocUtil.detachDocConsult("321", "456"))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(SecurityException.class)
                 .hasMessageContaining("controlled archive workflow");
 
         verifyNoInteractions(consultDocsDao);
@@ -277,7 +293,7 @@ class EDocUtilDeleteDocumentUnitTest extends CarlosUnitTestBase {
         when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
 
         assertThatThrownBy(() -> EDocUtil.detachDocEForm("321", "456"))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(SecurityException.class)
                 .hasMessageContaining("controlled archive workflow");
 
         verifyNoInteractions(eFormDocsDao);
@@ -289,7 +305,7 @@ class EDocUtilDeleteDocumentUnitTest extends CarlosUnitTestBase {
         when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
 
         assertThatThrownBy(() -> EDocUtil.subtractOnePage("321"))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(SecurityException.class)
                 .hasMessageContaining("controlled archive workflow");
 
         verify(documentDao, never()).find(any());
@@ -302,7 +318,7 @@ class EDocUtilDeleteDocumentUnitTest extends CarlosUnitTestBase {
         when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
 
         assertThatThrownBy(() -> EDocUtil.getHtmlTicklers(loggedInInfo, "321"))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(SecurityException.class)
                 .hasMessageContaining("controlled archive workflow");
     }
 
@@ -312,7 +328,7 @@ class EDocUtilDeleteDocumentUnitTest extends CarlosUnitTestBase {
         when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
 
         assertThatThrownBy(() -> EDocUtil.getHtmlAcknowledgement(Locale.CANADA, "321"))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(SecurityException.class)
                 .hasMessageContaining("controlled archive workflow");
     }
 
@@ -322,7 +338,7 @@ class EDocUtilDeleteDocumentUnitTest extends CarlosUnitTestBase {
         when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
 
         assertThatThrownBy(() -> EDocUtil.getHtmlAnnotation("321"))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(SecurityException.class)
                 .hasMessageContaining("controlled archive workflow");
     }
 
@@ -346,7 +362,7 @@ class EDocUtilDeleteDocumentUnitTest extends CarlosUnitTestBase {
         when(outboundEmailArchiveDao.existsByFileName("archive.pdf")).thenReturn(true);
 
         assertThatThrownBy(() -> EDocUtil.readContent("archive.pdf"))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(SecurityException.class)
                 .hasMessageContaining("controlled archive workflow");
     }
 

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/EDocUtilTicklerHtmlUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/EDocUtilTicklerHtmlUnitTest.java
@@ -19,6 +19,7 @@ package io.github.carlos_emr.carlos.documentManager;
 
 import java.util.List;
 
+import io.github.carlos_emr.carlos.commn.dao.OutboundEmailArchiveDao;
 import io.github.carlos_emr.carlos.commn.dao.TicklerLinkDao;
 import io.github.carlos_emr.carlos.commn.model.Tickler;
 import io.github.carlos_emr.carlos.commn.model.TicklerLink;
@@ -56,12 +57,14 @@ class EDocUtilTicklerHtmlUnitTest extends CarlosUnitTestBase {
     @Mock private TicklerLinkDao mockTicklerLinkDao;
     @Mock private TicklerManager mockTicklerManager;
     @Mock private LoggedInInfo mockLoggedInInfo;
+    @Mock private OutboundEmailArchiveDao mockOutboundEmailArchiveDao;
     private AutoCloseable mockitoCloseable;
 
     @BeforeEach
     void setUp() {
         mockitoCloseable = MockitoAnnotations.openMocks(this);
         // The lazy accessors resolve these via SpringUtils.getBean on first use.
+        registerMock(OutboundEmailArchiveDao.class, mockOutboundEmailArchiveDao);
         registerMock(TicklerLinkDao.class, mockTicklerLinkDao);
         registerMock(TicklerManager.class, mockTicklerManager);
     }

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2ActionTest.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
@@ -58,11 +59,12 @@ class CombinePDF2ActionTest extends CarlosUnitTestBase {
     private MockHttpServletResponse response;
     private DocumentDao documentDao;
     private OutboundEmailArchiveDao outboundEmailArchiveDao;
+    private SecurityInfoManager securityInfoManager;
     private CombinePDF2Action action;
 
     @BeforeEach
     void setUp() {
-        SecurityInfoManager securityInfoManager = mock(SecurityInfoManager.class);
+        securityInfoManager = mock(SecurityInfoManager.class);
         documentDao = mock(DocumentDao.class);
         outboundEmailArchiveDao = mock(OutboundEmailArchiveDao.class);
         registerMock(SecurityInfoManager.class, securityInfoManager);
@@ -124,5 +126,18 @@ class CombinePDF2ActionTest extends CarlosUnitTestBase {
 
         assertThat(result).isEqualTo(ActionSupport.NONE);
         assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("should reject callers without eDoc write access before querying documents")
+    void shouldRejectCallerWithoutEdocWriteAccessBeforeQueryingDocuments() {
+        LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
+        when(securityInfoManager.hasPrivilege(loggedInInfo, "_edoc", "w", null)).thenReturn(false);
+
+        assertThatThrownBy(action::execute)
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("_edoc");
+
+        verifyNoInteractions(outboundEmailArchiveDao, documentDao);
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2ActionTest.java
@@ -183,6 +183,21 @@ class CombinePDF2ActionTest extends CarlosUnitTestBase {
     }
 
     @Test
+    @DisplayName("should enforce patient access for mixed-case demographic links")
+    void shouldEnforcePatientAccessForMixedCaseDemographicLinks() {
+        Document document = new Document();
+        document.setPublic1(1);
+        when(securityInfoManager.isAllowedAccessToPatientRecord(loggedInInfo, 123)).thenReturn(false);
+
+        boolean authorized = action.isAuthorizedDocumentScope(loggedInInfo, document, List.of(
+                demographicLink("DeMoGrApHiC", 321, 123),
+                providerLink(321, 999998)));
+
+        assertThat(authorized).isFalse();
+        verify(securityInfoManager).isAllowedAccessToPatientRecord(loggedInInfo, 123);
+    }
+
+    @Test
     @DisplayName("should allow private provider documents only for the linked provider")
     void shouldAllowPrivateProviderDocumentsOnlyForLinkedProvider() {
         Document document = new Document();
@@ -195,8 +210,12 @@ class CombinePDF2ActionTest extends CarlosUnitTestBase {
     }
 
     private CtlDocument demographicLink(Integer documentNo, Integer demographicNo) {
+        return demographicLink("demographic", documentNo, demographicNo);
+    }
+
+    private CtlDocument demographicLink(String module, Integer documentNo, Integer demographicNo) {
         CtlDocument ctlDocument = new CtlDocument();
-        ctlDocument.setId(new CtlDocumentPK("demographic", demographicNo, documentNo));
+        ctlDocument.setId(new CtlDocumentPK(module, demographicNo, documentNo));
         return ctlDocument;
     }
 

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2ActionTest.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.documentManager.actions;
+
+import io.github.carlos_emr.carlos.commn.dao.DocumentDao;
+import io.github.carlos_emr.carlos.commn.dao.OutboundEmailArchiveDao;
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
+import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import org.apache.struts2.ActionSupport;
+import org.apache.struts2.ServletActionContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import jakarta.servlet.http.HttpServletResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@DisplayName("CombinePDF2Action")
+@Tag("unit")
+@Tag("documentManager")
+class CombinePDF2ActionTest extends CarlosUnitTestBase {
+
+    private MockedStatic<ServletActionContext> servletActionContext;
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+    private DocumentDao documentDao;
+    private OutboundEmailArchiveDao outboundEmailArchiveDao;
+    private CombinePDF2Action action;
+
+    @BeforeEach
+    void setUp() {
+        SecurityInfoManager securityInfoManager = mock(SecurityInfoManager.class);
+        documentDao = mock(DocumentDao.class);
+        outboundEmailArchiveDao = mock(OutboundEmailArchiveDao.class);
+        registerMock(SecurityInfoManager.class, securityInfoManager);
+        registerMock(DocumentDao.class, documentDao);
+        registerMock(OutboundEmailArchiveDao.class, outboundEmailArchiveDao);
+
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+        LoggedInInfo loggedInInfo = mock(LoggedInInfo.class);
+        LoggedInInfo.setLoggedInInfoIntoSession(request.getSession(), loggedInInfo);
+        request.setParameter("docNo", "321");
+        when(securityInfoManager.hasPrivilege(loggedInInfo, "_edoc", "w", null)).thenReturn(true);
+
+        servletActionContext = mockStatic(ServletActionContext.class);
+        servletActionContext.when(ServletActionContext::getRequest).thenReturn(request);
+        servletActionContext.when(ServletActionContext::getResponse).thenReturn(response);
+        action = new CombinePDF2Action();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (servletActionContext != null) {
+            servletActionContext.close();
+        }
+    }
+
+    @Test
+    @DisplayName("should reject archive-backed documents before combining PDFs")
+    void shouldRejectOutboundArchiveDocumentsBeforeCombiningPdfs() {
+        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_FORBIDDEN);
+        verifyNoInteractions(documentDao);
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2ActionTest.java
@@ -171,13 +171,13 @@ class CombinePDF2ActionTest extends CarlosUnitTestBase {
     }
 
     @Test
-    @DisplayName("should allow public provider documents")
-    void shouldAllowPublicProviderDocuments() {
+    @DisplayName("should allow public provider documents with mixed-case legacy links")
+    void shouldAllowPublicProviderDocumentsWithMixedCaseLegacyLinks() {
         Document document = new Document();
         document.setPublic1(1);
 
         boolean authorized = action.isAuthorizedDocumentScope(
-                loggedInInfo, document, List.of(providerLink(321, 123456)));
+                loggedInInfo, document, List.of(providerLink("PrOvIdErS", 321, 123456)));
 
         assertThat(authorized).isTrue();
     }
@@ -201,8 +201,12 @@ class CombinePDF2ActionTest extends CarlosUnitTestBase {
     }
 
     private CtlDocument providerLink(Integer documentNo, Integer providerNo) {
+        return providerLink("provider", documentNo, providerNo);
+    }
+
+    private CtlDocument providerLink(String module, Integer documentNo, Integer providerNo) {
         CtlDocument ctlDocument = new CtlDocument();
-        ctlDocument.setId(new CtlDocumentPK("provider", providerNo, documentNo));
+        ctlDocument.setId(new CtlDocumentPK(module, providerNo, documentNo));
         return ctlDocument;
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2ActionTest.java
@@ -26,6 +26,7 @@ import io.github.carlos_emr.carlos.commn.dao.DocumentDao;
 import io.github.carlos_emr.carlos.commn.dao.OutboundEmailArchiveDao;
 import io.github.carlos_emr.carlos.commn.model.CtlDocument;
 import io.github.carlos_emr.carlos.commn.model.CtlDocumentPK;
+import io.github.carlos_emr.carlos.commn.model.Document;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
@@ -81,6 +82,7 @@ class CombinePDF2ActionTest extends CarlosUnitTestBase {
         request = new MockHttpServletRequest();
         response = new MockHttpServletResponse();
         loggedInInfo = mock(LoggedInInfo.class);
+        when(loggedInInfo.getLoggedInProviderNo()).thenReturn("999998");
         LoggedInInfo.setLoggedInInfoIntoSession(request.getSession(), loggedInInfo);
         request.setParameter("docNo", "321");
         when(securityInfoManager.hasPrivilege(loggedInInfo, "_edoc", "w", null)).thenReturn(true);
@@ -127,7 +129,7 @@ class CombinePDF2ActionTest extends CarlosUnitTestBase {
     @DisplayName("should reject missing documents before resolving their paths")
     void shouldRejectMissingDocumentsBeforeResolvingPaths() {
         when(outboundEmailArchiveDao.findExistingDocumentNos(List.of(321))).thenReturn(Set.of());
-        when(ctlDocumentDao.findByDocumentNosAndModule(List.of(321), "demographic"))
+        when(ctlDocumentDao.findByDocumentNos(List.of(321)))
                 .thenReturn(List.of(demographicLink(321, 123)));
         when(securityInfoManager.isAllowedAccessToPatientRecord(loggedInInfo, 123)).thenReturn(true);
         when(documentDao.find(321)).thenReturn(null);
@@ -153,21 +155,54 @@ class CombinePDF2ActionTest extends CarlosUnitTestBase {
     @Test
     @DisplayName("should reject documents outside the caller's patient-record access")
     void shouldRejectDocumentsOutsidePatientRecordAccess() {
+        Document document = new Document();
+        document.setDocfilename("patient-document.pdf");
         when(outboundEmailArchiveDao.findExistingDocumentNos(List.of(321))).thenReturn(Set.of());
-        when(ctlDocumentDao.findByDocumentNosAndModule(List.of(321), "demographic"))
+        when(ctlDocumentDao.findByDocumentNos(List.of(321)))
                 .thenReturn(List.of(demographicLink(321, 123)));
+        when(documentDao.find(321)).thenReturn(document);
         when(securityInfoManager.isAllowedAccessToPatientRecord(loggedInInfo, 123)).thenReturn(false);
 
         String result = action.execute();
 
         assertThat(result).isEqualTo(ActionSupport.NONE);
         assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_FORBIDDEN);
-        verifyNoInteractions(documentDao);
+        verify(documentDao).find(321);
+    }
+
+    @Test
+    @DisplayName("should allow public provider documents")
+    void shouldAllowPublicProviderDocuments() {
+        Document document = new Document();
+        document.setPublic1(1);
+
+        boolean authorized = action.isAuthorizedDocumentScope(
+                loggedInInfo, document, List.of(providerLink(321, 123456)));
+
+        assertThat(authorized).isTrue();
+    }
+
+    @Test
+    @DisplayName("should allow private provider documents only for the linked provider")
+    void shouldAllowPrivateProviderDocumentsOnlyForLinkedProvider() {
+        Document document = new Document();
+        document.setPublic1(0);
+
+        assertThat(action.isAuthorizedDocumentScope(
+                loggedInInfo, document, List.of(providerLink(321, 999998)))).isTrue();
+        assertThat(action.isAuthorizedDocumentScope(
+                loggedInInfo, document, List.of(providerLink(321, 123456)))).isFalse();
     }
 
     private CtlDocument demographicLink(Integer documentNo, Integer demographicNo) {
         CtlDocument ctlDocument = new CtlDocument();
         ctlDocument.setId(new CtlDocumentPK("demographic", demographicNo, documentNo));
+        return ctlDocument;
+    }
+
+    private CtlDocument providerLink(Integer documentNo, Integer providerNo) {
+        CtlDocument ctlDocument = new CtlDocument();
+        ctlDocument.setId(new CtlDocumentPK("provider", providerNo, documentNo));
         return ctlDocument;
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2ActionTest.java
@@ -101,4 +101,28 @@ class CombinePDF2ActionTest extends CarlosUnitTestBase {
         verify(outboundEmailArchiveDao).findExistingDocumentNos(List.of(321));
         verifyNoInteractions(documentDao);
     }
+
+    @Test
+    @DisplayName("should reject invalid document numbers before querying archives")
+    void shouldRejectInvalidDocumentNumbersBeforeQueryingArchives() {
+        request.setParameter("docNo", "not-a-number");
+
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_BAD_REQUEST);
+        verifyNoInteractions(outboundEmailArchiveDao, documentDao);
+    }
+
+    @Test
+    @DisplayName("should reject missing documents before resolving their paths")
+    void shouldRejectMissingDocumentsBeforeResolvingPaths() {
+        when(outboundEmailArchiveDao.findExistingDocumentNos(List.of(321))).thenReturn(Set.of());
+        when(documentDao.find(321)).thenReturn(null);
+
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_NOT_FOUND);
+    }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2ActionTest.java
@@ -38,10 +38,13 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
@@ -89,12 +92,13 @@ class CombinePDF2ActionTest extends CarlosUnitTestBase {
     @Test
     @DisplayName("should reject archive-backed documents before combining PDFs")
     void shouldRejectOutboundArchiveDocumentsBeforeCombiningPdfs() {
-        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+        when(outboundEmailArchiveDao.findExistingDocumentNos(List.of(321))).thenReturn(Set.of(321));
 
         String result = action.execute();
 
         assertThat(result).isEqualTo(ActionSupport.NONE);
         assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_FORBIDDEN);
+        verify(outboundEmailArchiveDao).findExistingDocumentNos(List.of(321));
         verifyNoInteractions(documentDao);
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2ActionTest.java
@@ -21,8 +21,11 @@
  */
 package io.github.carlos_emr.carlos.documentManager.actions;
 
+import io.github.carlos_emr.carlos.commn.dao.CtlDocumentDao;
 import io.github.carlos_emr.carlos.commn.dao.DocumentDao;
 import io.github.carlos_emr.carlos.commn.dao.OutboundEmailArchiveDao;
+import io.github.carlos_emr.carlos.commn.model.CtlDocument;
+import io.github.carlos_emr.carlos.commn.model.CtlDocumentPK;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
@@ -57,23 +60,27 @@ class CombinePDF2ActionTest extends CarlosUnitTestBase {
     private MockedStatic<ServletActionContext> servletActionContext;
     private MockHttpServletRequest request;
     private MockHttpServletResponse response;
+    private CtlDocumentDao ctlDocumentDao;
     private DocumentDao documentDao;
     private OutboundEmailArchiveDao outboundEmailArchiveDao;
     private SecurityInfoManager securityInfoManager;
+    private LoggedInInfo loggedInInfo;
     private CombinePDF2Action action;
 
     @BeforeEach
     void setUp() {
         securityInfoManager = mock(SecurityInfoManager.class);
+        ctlDocumentDao = mock(CtlDocumentDao.class);
         documentDao = mock(DocumentDao.class);
         outboundEmailArchiveDao = mock(OutboundEmailArchiveDao.class);
         registerMock(SecurityInfoManager.class, securityInfoManager);
+        registerMock(CtlDocumentDao.class, ctlDocumentDao);
         registerMock(DocumentDao.class, documentDao);
         registerMock(OutboundEmailArchiveDao.class, outboundEmailArchiveDao);
 
         request = new MockHttpServletRequest();
         response = new MockHttpServletResponse();
-        LoggedInInfo loggedInInfo = mock(LoggedInInfo.class);
+        loggedInInfo = mock(LoggedInInfo.class);
         LoggedInInfo.setLoggedInInfoIntoSession(request.getSession(), loggedInInfo);
         request.setParameter("docNo", "321");
         when(securityInfoManager.hasPrivilege(loggedInInfo, "_edoc", "w", null)).thenReturn(true);
@@ -101,7 +108,7 @@ class CombinePDF2ActionTest extends CarlosUnitTestBase {
         assertThat(result).isEqualTo(ActionSupport.NONE);
         assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_FORBIDDEN);
         verify(outboundEmailArchiveDao).findExistingDocumentNos(List.of(321));
-        verifyNoInteractions(documentDao);
+        verifyNoInteractions(ctlDocumentDao, documentDao);
     }
 
     @Test
@@ -113,13 +120,16 @@ class CombinePDF2ActionTest extends CarlosUnitTestBase {
 
         assertThat(result).isEqualTo(ActionSupport.NONE);
         assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_BAD_REQUEST);
-        verifyNoInteractions(outboundEmailArchiveDao, documentDao);
+        verifyNoInteractions(outboundEmailArchiveDao, ctlDocumentDao, documentDao);
     }
 
     @Test
     @DisplayName("should reject missing documents before resolving their paths")
     void shouldRejectMissingDocumentsBeforeResolvingPaths() {
         when(outboundEmailArchiveDao.findExistingDocumentNos(List.of(321))).thenReturn(Set.of());
+        when(ctlDocumentDao.findByDocumentNosAndModule(List.of(321), "demographic"))
+                .thenReturn(List.of(demographicLink(321, 123)));
+        when(securityInfoManager.isAllowedAccessToPatientRecord(loggedInInfo, 123)).thenReturn(true);
         when(documentDao.find(321)).thenReturn(null);
 
         String result = action.execute();
@@ -131,13 +141,33 @@ class CombinePDF2ActionTest extends CarlosUnitTestBase {
     @Test
     @DisplayName("should reject callers without eDoc write access before querying documents")
     void shouldRejectCallerWithoutEdocWriteAccessBeforeQueryingDocuments() {
-        LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
         when(securityInfoManager.hasPrivilege(loggedInInfo, "_edoc", "w", null)).thenReturn(false);
 
         assertThatThrownBy(action::execute)
                 .isInstanceOf(SecurityException.class)
                 .hasMessageContaining("_edoc");
 
-        verifyNoInteractions(outboundEmailArchiveDao, documentDao);
+        verifyNoInteractions(outboundEmailArchiveDao, ctlDocumentDao, documentDao);
+    }
+
+    @Test
+    @DisplayName("should reject documents outside the caller's patient-record access")
+    void shouldRejectDocumentsOutsidePatientRecordAccess() {
+        when(outboundEmailArchiveDao.findExistingDocumentNos(List.of(321))).thenReturn(Set.of());
+        when(ctlDocumentDao.findByDocumentNosAndModule(List.of(321), "demographic"))
+                .thenReturn(List.of(demographicLink(321, 123)));
+        when(securityInfoManager.isAllowedAccessToPatientRecord(loggedInInfo, 123)).thenReturn(false);
+
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_FORBIDDEN);
+        verifyNoInteractions(documentDao);
+    }
+
+    private CtlDocument demographicLink(Integer documentNo, Integer demographicNo) {
+        CtlDocument ctlDocument = new CtlDocument();
+        ctlDocument.setId(new CtlDocumentPK("demographic", demographicNo, documentNo));
+        return ctlDocument;
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentPreview2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/DocumentPreview2ActionUnitTest.java
@@ -21,7 +21,9 @@
  */
 package io.github.carlos_emr.carlos.documentManager.actions;
 
+import io.github.carlos_emr.CarlosProperties;
 import io.github.carlos_emr.carlos.commn.dao.EFormDataDao;
+import io.github.carlos_emr.carlos.commn.dao.OutboundEmailArchiveDao;
 import io.github.carlos_emr.carlos.commn.dao.PatientLabRoutingDao;
 import io.github.carlos_emr.carlos.commn.model.EFormData;
 import io.github.carlos_emr.carlos.commn.model.PatientLabRouting;
@@ -112,6 +114,9 @@ class DocumentPreview2ActionUnitTest extends CarlosUnitTestBase {
     private PdfPreviewCapabilityService mockPdfPreviewCapabilityService;
 
     @Mock
+    private OutboundEmailArchiveDao mockOutboundEmailArchiveDao;
+
+    @Mock
     private FormsManager mockFormsManager;
 
     @Mock
@@ -150,6 +155,7 @@ class DocumentPreview2ActionUnitTest extends CarlosUnitTestBase {
         registerMock(DocumentAttachmentManager.class, mockDocumentAttachmentManager);
         registerMock(EFormRenderApprovalService.class, mockEFormRenderApprovalService);
         registerMock(PdfPreviewCapabilityService.class, mockPdfPreviewCapabilityService);
+        registerMock(OutboundEmailArchiveDao.class, mockOutboundEmailArchiveDao);
         registerMock(FormsManager.class, mockFormsManager);
         registerMock(EFormDataDao.class, mockEFormDataDao);
         registerMock(PatientLabRoutingDao.class, mockPatientLabRoutingDao);
@@ -906,6 +912,34 @@ class DocumentPreview2ActionUnitTest extends CarlosUnitTestBase {
                     .startsWith("%PDF".getBytes(java.nio.charset.StandardCharsets.ISO_8859_1));
         } finally {
             java.nio.file.Files.deleteIfExists(pdf);
+        }
+    }
+
+    @Test
+    @DisplayName("should forbid a preview capability that resolves to an outbound archive eDoc")
+    void shouldForbidRenderPdf_whenCapabilityResolvesToOutboundArchiveDocument() throws Exception {
+        java.nio.file.Path documentDir = java.nio.file.Files.createTempDirectory("archive-preview-");
+        java.nio.file.Path archiveFile = java.nio.file.Files.writeString(
+                documentDir.resolve("archive.pdf"), "%PDF-1.4");
+        try (MockedStatic<CarlosProperties> propertiesMock = mockStatic(CarlosProperties.class)) {
+            CarlosProperties properties = org.mockito.Mockito.mock(CarlosProperties.class);
+            propertiesMock.when(CarlosProperties::getInstance).thenReturn(properties);
+            when(properties.getProperty("DOCUMENT_DIR", "/var/lib/OscarDocument/"))
+                    .thenReturn(documentDir.toString());
+            request.setParameter("method", "renderPDF");
+            request.setParameter("previewToken", "archive-token");
+            when(mockPdfPreviewCapabilityService.resolve(request, mockLoggedInInfo, "archive-token"))
+                    .thenReturn(archiveFile.toRealPath());
+            when(mockOutboundEmailArchiveDao.existsByFileName("archive.pdf")).thenReturn(true);
+
+            String result = action.execute();
+
+            assertThat(result).isEqualTo(ActionSupport.NONE);
+            assertThat(response.getStatus()).isEqualTo(403);
+            assertThat(response.getContentAsByteArray()).isEmpty();
+        } finally {
+            java.nio.file.Files.deleteIfExists(archiveFile);
+            java.nio.file.Files.deleteIfExists(documentDir);
         }
     }
 

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/ManageDocument2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/ManageDocument2ActionTest.java
@@ -414,9 +414,15 @@ class ManageDocument2ActionTest extends CarlosUnitTestBase {
 
     @Test
     void shouldReturnNoneAndSendForbidden_whenRefilingOutboundArchiveDocument() {
+        request.setMethod("POST");
         request.setParameter("method", "refileDocumentAjax");
         request.setParameter("documentId", "321");
         request.setParameter("queueId", "1");
+        Document document = new Document();
+        document.setDocumentNo(321);
+        document.setDocfilename("document.pdf");
+        when(documentDao.find(321)).thenReturn(document);
+        when(queueDao.find(1)).thenReturn(new Queue());
         when(securityInfoManager.hasPrivilege(any(), eq("_edoc"), eq("w"), isNull())).thenReturn(true);
         when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
 

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/ManageDocument2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/ManageDocument2ActionTest.java
@@ -225,6 +225,23 @@ class ManageDocument2ActionTest extends CarlosUnitTestBase {
     }
 
     @Test
+    @DisplayName("should use the archive-filtered description lookup for autocomplete")
+    void shouldExcludeOutboundArchiveDescriptions_whenSearchingDocumentDescriptions() throws Exception {
+        LoggedInInfo loggedInInfo = Mockito.mock(LoggedInInfo.class);
+        LoggedInInfo.setLoggedInInfoIntoSession(request.getSession(), loggedInInfo);
+        request.setParameter("term", "archive");
+        when(securityInfoManager.hasPrivilege(loggedInInfo, "_edoc", "w", null)).thenReturn(true);
+        when(documentDao.findDocumentDescriptionsExcludingOutboundEmailArchives("%archive%"))
+                .thenReturn(List.of("Ordinary report"));
+
+        action.searchDocumentDescriptions();
+
+        assertThat(response.getContentAsString()).contains("Ordinary report");
+        verify(documentDao).findDocumentDescriptionsExcludingOutboundEmailArchives("%archive%");
+        verify(documentDao, never()).findDocumentDescriptions(anyString());
+    }
+
+    @Test
     void shouldSendServerErrorAndKeepAjaxFailed_whenRefileCopyFails() throws Exception {
         authorizeEdocWrite();
         request.setMethod("POST");

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/ManageDocument2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/ManageDocument2ActionTest.java
@@ -430,6 +430,22 @@ class ManageDocument2ActionTest extends CarlosUnitTestBase {
     }
 
     @Test
+    void shouldReturnForbidden_whenArchiveRoutingRequestUsesUnexpectedDocumentType() {
+        request.setParameter("method", "removeLinkFromDocument");
+        request.setParameter("docType", "LAB");
+        request.setParameter("docId", "321");
+        request.setParameter("providerNo", "999998");
+        when(securityInfoManager.hasPrivilege(any(), eq("_edoc"), eq("w"), isNull())).thenReturn(true);
+        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_FORBIDDEN);
+        verify(providerInboxRoutingDao, never()).removeLinkFromDocument(anyString(), anyInt(), anyString());
+    }
+
+    @Test
     void shouldReturnNoneAndSendForbidden_whenRefilingOutboundArchiveDocument() {
         request.setMethod("POST");
         request.setParameter("method", "refileDocumentAjax");

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/ManageDocument2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/ManageDocument2ActionTest.java
@@ -8,6 +8,7 @@ import io.github.carlos_emr.carlos.casemgmt.dao.CaseManagementNoteLinkDAO;
 import io.github.carlos_emr.carlos.commn.dao.CtlDocTypeDao;
 import io.github.carlos_emr.carlos.commn.dao.CtlDocumentDao;
 import io.github.carlos_emr.carlos.commn.dao.DocumentDao;
+import io.github.carlos_emr.carlos.commn.dao.OutboundEmailArchiveDao;
 import io.github.carlos_emr.carlos.commn.dao.PatientLabRoutingDao;
 import io.github.carlos_emr.carlos.commn.dao.ProviderInboxRoutingDao;
 import io.github.carlos_emr.carlos.commn.dao.QueueDao;
@@ -67,6 +68,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -83,6 +85,9 @@ class ManageDocument2ActionTest extends CarlosUnitTestBase {
 
     @Mock
     private CtlDocumentDao ctlDocumentDao;
+
+    @Mock
+    private OutboundEmailArchiveDao outboundEmailArchiveDao;
 
     @Mock
     private ProviderInboxRoutingDao providerInboxRoutingDao;
@@ -139,6 +144,7 @@ class ManageDocument2ActionTest extends CarlosUnitTestBase {
         registerMock(DocumentDao.class, documentDao);
         registerMock(QueueDao.class, queueDao);
         registerMock(CtlDocumentDao.class, ctlDocumentDao);
+        registerMock(OutboundEmailArchiveDao.class, outboundEmailArchiveDao);
         registerMock(ProviderInboxRoutingDao.class, providerInboxRoutingDao);
         registerMock(PatientLabRoutingDao.class, patientLabRoutingDao);
         registerMock(ProgramManager2.class, programManager);
@@ -327,6 +333,111 @@ class ManageDocument2ActionTest extends CarlosUnitTestBase {
         assertThat(result).isEqualTo(ActionSupport.NONE);
         assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_FORBIDDEN);
         assertThat(action.getActionErrors()).isEmpty();
+    }
+
+    @Test
+    void shouldReturnNoneAndSendForbidden_whenDisplayingOutboundArchiveDocument() {
+        request.setParameter("method", "display");
+        request.setParameter("doc_no", "321");
+        when(securityInfoManager.hasPrivilege(any(), eq("_edoc"), eq("r"), isNull())).thenReturn(true);
+        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_FORBIDDEN);
+        verify(documentDao, never()).getDocument("321");
+    }
+
+    @Test
+    void shouldReturnNoneAndSendForbidden_whenRenderingOutboundArchiveDocumentPage() {
+        request.setParameter("method", "showPage");
+        request.setParameter("page", "1");
+        request.setParameter("doc_no", "321");
+        when(securityInfoManager.hasPrivilege(any(), eq("_edoc"), eq("r"), isNull())).thenReturn(true);
+        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_FORBIDDEN);
+        verify(documentDao, never()).getDocument("321");
+    }
+
+    @Test
+    void shouldReturnNoneAndSendForbidden_whenUpdatingOutboundArchiveDocumentAjax() {
+        request.setParameter("method", "documentUpdateAjax");
+        request.setParameter("documentId", "321");
+        request.setParameter("demog", "100");
+        request.setParameter("docType", "DOC");
+        when(securityInfoManager.hasPrivilege(any(), eq("_edoc"), eq("w"), isNull())).thenReturn(true);
+        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_FORBIDDEN);
+        verify(patientLabRoutingDao, never()).findByLabNoAndLabType(anyInt(), anyString());
+        verify(documentDao, never()).getDocument("321");
+    }
+
+    @Test
+    void shouldReturnNoneAndSendForbidden_whenUpdatingOutboundArchiveDocument() {
+        request.setParameter("method", "documentUpdate");
+        request.setParameter("documentId", "321");
+        request.setParameter("docType", "DOC");
+        when(securityInfoManager.hasPrivilege(any(), eq("_edoc"), eq("w"), isNull())).thenReturn(true);
+        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_FORBIDDEN);
+        verify(documentDao, never()).getDocument("321");
+    }
+
+    @Test
+    void shouldReturnNoneAndSendForbidden_whenRemovingOutboundArchiveDocumentRouting() {
+        request.setParameter("method", "removeLinkFromDocument");
+        request.setParameter("docType", LabResultData.DOCUMENT);
+        request.setParameter("docId", "321");
+        request.setParameter("providerNo", "999998");
+        when(securityInfoManager.hasPrivilege(any(), eq("_edoc"), eq("w"), isNull())).thenReturn(true);
+        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_FORBIDDEN);
+        verify(providerInboxRoutingDao, never()).removeLinkFromDocument(anyString(), anyInt(), anyString());
+    }
+
+    @Test
+    void shouldReturnNoneAndSendForbidden_whenRefilingOutboundArchiveDocument() {
+        request.setParameter("method", "refileDocumentAjax");
+        request.setParameter("documentId", "321");
+        request.setParameter("queueId", "1");
+        when(securityInfoManager.hasPrivilege(any(), eq("_edoc"), eq("w"), isNull())).thenReturn(true);
+        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_FORBIDDEN);
+    }
+
+    @Test
+    void shouldReturnNoneAndSendForbidden_whenViewingOutboundArchiveDocumentInfo() throws Exception {
+        request.setParameter("method", "viewDocumentDescription");
+        request.setParameter("doc_no", "321");
+        when(securityInfoManager.hasPrivilege(any(), eq("_edoc"), eq("r"), isNull())).thenReturn(true);
+        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_FORBIDDEN);
+        assertThat(response.getContentAsString()).isEmpty();
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/SplitDocument2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/SplitDocument2ActionTest.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.documentManager.actions;
+
+import io.github.carlos_emr.carlos.commn.dao.DocumentDao;
+import io.github.carlos_emr.carlos.commn.dao.OutboundEmailArchiveDao;
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
+import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import org.apache.struts2.ServletActionContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.MockedStatic;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@DisplayName("SplitDocument2Action")
+@Tag("unit")
+@Tag("documentManager")
+class SplitDocument2ActionTest extends CarlosUnitTestBase {
+
+    private DocumentDao documentDao;
+    private OutboundEmailArchiveDao outboundEmailArchiveDao;
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+    private SecurityInfoManager securityInfoManager;
+    private MockedStatic<ServletActionContext> servletActionContext;
+    private SplitDocument2Action action;
+
+    @BeforeEach
+    void setUp() {
+        documentDao = mock(DocumentDao.class);
+        outboundEmailArchiveDao = mock(OutboundEmailArchiveDao.class);
+        securityInfoManager = mock(SecurityInfoManager.class);
+        registerMock(DocumentDao.class, documentDao);
+        registerMock(OutboundEmailArchiveDao.class, outboundEmailArchiveDao);
+        registerMock(SecurityInfoManager.class, securityInfoManager);
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+        servletActionContext = mockStatic(ServletActionContext.class);
+        servletActionContext.when(ServletActionContext::getRequest).thenReturn(request);
+        servletActionContext.when(ServletActionContext::getResponse).thenReturn(response);
+        action = new SplitDocument2Action();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (servletActionContext != null) {
+            servletActionContext.close();
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"split", "rotate180", "rotate90", "removeFirstPage"})
+    @DisplayName("should reject archive-backed documents before direct PDF mutation")
+    void shouldRejectOutboundArchiveDocumentsBeforeDirectPdfMutation(String method) {
+        LoggedInInfo loggedInInfo = mock(LoggedInInfo.class);
+        LoggedInInfo.setLoggedInInfoIntoSession(request.getSession(), loggedInInfo);
+        request.setParameter("method", method);
+        request.setParameter("document", "321");
+        when(securityInfoManager.hasPrivilege(loggedInInfo, "_edoc", "w", null)).thenReturn(true);
+        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+
+        assertThatThrownBy(() -> action.execute())
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("controlled archive workflow");
+
+        verify(documentDao, never()).getDocument(anyString());
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/eform/EFormAttachDocs2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/eform/EFormAttachDocs2ActionTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -71,6 +72,7 @@ class EFormAttachDocs2ActionTest extends CarlosWebTestBase {
                 .thenReturn(true);
         when(mockLoggedInInfo.getLoggedInProviderNo()).thenReturn("999998");
 
+        mockRequest.setMethod("POST");
         action = new EFormAttachDocs2Action();
         action.setRequestId("123");
         action.setDemoNo("456");
@@ -81,6 +83,17 @@ class EFormAttachDocs2ActionTest extends CarlosWebTestBase {
         if (loggedInInfoMock != null) {
             loggedInInfoMock.close();
         }
+    }
+
+    @Test
+    void shouldRejectGetBeforeWritingAttachments() throws Exception {
+        mockRequest.setMethod("GET");
+
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(mockResponse.getStatus()).isEqualTo(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+        verify(mockDocumentAttachmentManager, never()).attachToEForm(any(), any(), any(), any(), any(), any());
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/log/LogActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/log/LogActionUnitTest.java
@@ -11,10 +11,14 @@ import org.junit.jupiter.api.Test;
 
 import io.github.carlos_emr.carlos.commn.dao.OscarLogDao;
 import io.github.carlos_emr.carlos.commn.model.OscarLog;
+import io.github.carlos_emr.carlos.commn.model.Provider;
+import io.github.carlos_emr.carlos.commn.model.Security;
+import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @Tag("unit")
 class LogActionUnitTest {
@@ -40,6 +44,33 @@ class LogActionUnitTest {
                         && "view".equals(log.getAction())
                         && "document".equals(log.getContent())
                         && "123".equals(log.getContentId())));
+    }
+
+    @Test
+    @Tag("create")
+    void shouldPersistFullyAttributedAuditSynchronously() {
+        OscarLogDao oscarLogDao = mock(OscarLogDao.class);
+        LoggedInInfo loggedInInfo = mock(LoggedInInfo.class);
+        Security security = mock(Security.class);
+        when(security.getSecurityNo()).thenReturn(17);
+        when(loggedInInfo.getLoggedInSecurity()).thenReturn(security);
+        when(loggedInInfo.getLoggedInProvider()).thenReturn(mock(Provider.class));
+        when(loggedInInfo.getLoggedInProviderNo()).thenReturn("999998");
+        when(loggedInInfo.getIp()).thenReturn("127.0.0.1");
+        LogAction.setOscarLogDaoForTesting(oscarLogDao);
+
+        LogAction.addLogSynchronous(
+                loggedInInfo, "integrityFailure", "archive", "archiveId=888", "123", "fixed reason");
+
+        verify(oscarLogDao).persist(argThat((OscarLog log) ->
+                Integer.valueOf(17).equals(log.getSecurityId())
+                        && "999998".equals(log.getProviderNo())
+                        && "integrityFailure".equals(log.getAction())
+                        && "archive".equals(log.getContent())
+                        && "archiveId=888".equals(log.getContentId())
+                        && "127.0.0.1".equals(log.getIp())
+                        && Integer.valueOf(123).equals(log.getDemographicId())
+                        && "fixed reason".equals(log.getData())));
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/managers/DocumentManagerImplFilenameValidationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/managers/DocumentManagerImplFilenameValidationTest.java
@@ -206,39 +206,36 @@ class DocumentManagerImplFilenameValidationTest extends CarlosUnitTestBase {
     @DisplayName("should filter outbound archive eDocs from generic document sync lists")
     void shouldFilterOutboundArchiveDocuments_whenListingUpdatedDocuments() {
         DocumentManagerImpl manager = newDocumentManager();
-        Document archiveDocument = document(321);
         Document ordinaryDocument = document(654);
         Date since = new Date(0L);
         when(securityInfoManager.hasPrivilege(eq(loggedInInfo), eq("_edoc"), eq("r"), eq("")))
                 .thenReturn(true);
-        when(documentDao.findByUpdateDate(since, 10)).thenReturn(List.of(archiveDocument, ordinaryDocument));
-        when(outboundEmailArchiveDao.findExistingDocumentNos(List.of(321, 654))).thenReturn(Set.of(321));
+        when(documentDao.findByUpdateDateExcludingOutboundEmailArchives(since, 10))
+                .thenReturn(List.of(ordinaryDocument));
 
         List<Document> documents = manager.getDocumentsUpdateAfterDate(loggedInInfo, since, 10);
 
         assertThat(documents).containsExactly(ordinaryDocument);
+        verify(documentDao).findByUpdateDateExcludingOutboundEmailArchives(since, 10);
     }
 
     @Test
-    @DisplayName("should continue fetching updated documents when archive rows consume the requested window")
-    void shouldContinueFetchingUpdatedDocuments_whenArchiveRowsConsumeRequestedWindow() {
+    @DisplayName("should apply the sync limit after excluding archive rows in the database")
+    void shouldApplySyncLimitAfterExcludingArchiveRows() {
         DocumentManagerImpl manager = newDocumentManager();
-        Document firstArchive = document(321);
-        Document secondArchive = document(322);
         Document firstOrdinary = document(654);
         Document secondOrdinary = document(655);
         Date since = new Date(0L);
         when(securityInfoManager.hasPrivilege(eq(loggedInInfo), eq("_edoc"), eq("r"), eq("")))
                 .thenReturn(true);
-        when(documentDao.findByUpdateDate(since, 2)).thenReturn(List.of(firstArchive, secondArchive));
-        when(documentDao.findByUpdateDate(since, 4))
-                .thenReturn(List.of(firstArchive, secondArchive, firstOrdinary, secondOrdinary));
-        when(outboundEmailArchiveDao.findExistingDocumentNos(any())).thenReturn(Set.of(321, 322));
+        when(documentDao.findByUpdateDateExcludingOutboundEmailArchives(since, 2))
+                .thenReturn(List.of(firstOrdinary, secondOrdinary));
 
         List<Document> documents = manager.getDocumentsUpdateAfterDate(loggedInInfo, since, 2);
 
         assertThat(documents).containsExactly(firstOrdinary, secondOrdinary);
-        verify(documentDao).findByUpdateDate(since, 4);
+        verify(documentDao).findByUpdateDateExcludingOutboundEmailArchives(since, 2);
+        verify(documentDao, never()).findByUpdateDate(since, 2);
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/managers/DocumentManagerImplFilenameValidationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/managers/DocumentManagerImplFilenameValidationTest.java
@@ -27,6 +27,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Date;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -211,11 +212,33 @@ class DocumentManagerImplFilenameValidationTest extends CarlosUnitTestBase {
         when(securityInfoManager.hasPrivilege(eq(loggedInInfo), eq("_edoc"), eq("r"), eq("")))
                 .thenReturn(true);
         when(documentDao.findByUpdateDate(since, 10)).thenReturn(List.of(archiveDocument, ordinaryDocument));
-        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+        when(outboundEmailArchiveDao.findExistingDocumentNos(List.of(321, 654))).thenReturn(Set.of(321));
 
         List<Document> documents = manager.getDocumentsUpdateAfterDate(loggedInInfo, since, 10);
 
         assertThat(documents).containsExactly(ordinaryDocument);
+    }
+
+    @Test
+    @DisplayName("should continue fetching updated documents when archive rows consume the requested window")
+    void shouldContinueFetchingUpdatedDocuments_whenArchiveRowsConsumeRequestedWindow() {
+        DocumentManagerImpl manager = newDocumentManager();
+        Document firstArchive = document(321);
+        Document secondArchive = document(322);
+        Document firstOrdinary = document(654);
+        Document secondOrdinary = document(655);
+        Date since = new Date(0L);
+        when(securityInfoManager.hasPrivilege(eq(loggedInInfo), eq("_edoc"), eq("r"), eq("")))
+                .thenReturn(true);
+        when(documentDao.findByUpdateDate(since, 2)).thenReturn(List.of(firstArchive, secondArchive));
+        when(documentDao.findByUpdateDate(since, 4))
+                .thenReturn(List.of(firstArchive, secondArchive, firstOrdinary, secondOrdinary));
+        when(outboundEmailArchiveDao.findExistingDocumentNos(any())).thenReturn(Set.of(321, 322));
+
+        List<Document> documents = manager.getDocumentsUpdateAfterDate(loggedInInfo, since, 2);
+
+        assertThat(documents).containsExactly(firstOrdinary, secondOrdinary);
+        verify(documentDao).findByUpdateDate(since, 4);
     }
 
     @Test
@@ -227,7 +250,7 @@ class DocumentManagerImplFilenameValidationTest extends CarlosUnitTestBase {
         when(securityInfoManager.hasPrivilege(eq(loggedInInfo), eq("_edoc"), eq("r"), isNull()))
                 .thenReturn(true);
         when(documentDao.findDocumentDTOsByDemographicNo(123)).thenReturn(List.of(archiveDocument, ordinaryDocument));
-        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+        when(outboundEmailArchiveDao.findExistingDocumentNos(List.of(321, 654))).thenReturn(Set.of(321));
 
         List<DocumentListItemDTO> documents = manager.getDocumentDTOs(loggedInInfo, 123);
 

--- a/src/test/java/io/github/carlos_emr/carlos/managers/DocumentManagerImplFilenameValidationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/managers/DocumentManagerImplFilenameValidationTest.java
@@ -3,9 +3,15 @@ package io.github.carlos_emr.carlos.managers;
 import io.github.carlos_emr.CarlosProperties;
 import io.github.carlos_emr.carlos.commn.dao.CtlDocumentDao;
 import io.github.carlos_emr.carlos.commn.dao.DocumentDao;
+import io.github.carlos_emr.carlos.commn.dao.OutboundEmailArchiveDao;
 import io.github.carlos_emr.carlos.commn.dao.PatientLabRoutingDao;
+import io.github.carlos_emr.carlos.commn.dao.ProviderInboxRoutingDao;
 import io.github.carlos_emr.carlos.commn.dao.ProviderLabRoutingDao;
+import io.github.carlos_emr.carlos.commn.dao.QueueDocumentLinkDao;
+import io.github.carlos_emr.carlos.commn.model.CtlDocument;
+import io.github.carlos_emr.carlos.commn.model.CtlDocumentPK;
 import io.github.carlos_emr.carlos.commn.model.Document;
+import io.github.carlos_emr.carlos.documentManager.dto.DocumentListItemDTO;
 import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 
@@ -19,13 +25,21 @@ import org.mockito.MockedStatic;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @DisplayName("DocumentManagerImpl filename validation")
@@ -38,8 +52,11 @@ class DocumentManagerImplFilenameValidationTest extends CarlosUnitTestBase {
     private SecurityInfoManager securityInfoManager;
     private DocumentDao documentDao;
     private CtlDocumentDao ctlDocumentDao;
+    private OutboundEmailArchiveDao outboundEmailArchiveDao;
     private PatientLabRoutingDao patientLabRoutingDao;
+    private ProviderInboxRoutingDao providerInboxRoutingDao;
     private ProviderLabRoutingDao providerLabRoutingDao;
+    private QueueDocumentLinkDao queueDocumentLinkDao;
     private LoggedInInfo loggedInInfo;
 
     @TempDir
@@ -50,12 +67,17 @@ class DocumentManagerImplFilenameValidationTest extends CarlosUnitTestBase {
         securityInfoManager = mock(SecurityInfoManager.class);
         documentDao = mock(DocumentDao.class);
         ctlDocumentDao = mock(CtlDocumentDao.class);
+        outboundEmailArchiveDao = mock(OutboundEmailArchiveDao.class);
         patientLabRoutingDao = mock(PatientLabRoutingDao.class);
+        providerInboxRoutingDao = mock(ProviderInboxRoutingDao.class);
         providerLabRoutingDao = mock(ProviderLabRoutingDao.class);
+        queueDocumentLinkDao = mock(QueueDocumentLinkDao.class);
         loggedInInfo = mock(LoggedInInfo.class);
 
         when(loggedInInfo.getLoggedInProviderNo()).thenReturn(PROVIDER_NO);
         when(securityInfoManager.hasPrivilege(eq(loggedInInfo), eq("_edoc"), eq("w"), eq("")))
+                .thenReturn(true);
+        when(securityInfoManager.hasPrivilege(eq(loggedInInfo), eq("_edoc"), eq("x"), eq("")))
                 .thenReturn(true);
         doAnswer(invocation -> {
             Document document = invocation.getArgument(0);
@@ -93,7 +115,6 @@ class DocumentManagerImplFilenameValidationTest extends CarlosUnitTestBase {
             CarlosProperties properties = mock(CarlosProperties.class);
             propertiesMock.when(CarlosProperties::getInstance).thenReturn(properties);
             when(properties.getProperty("DOCUMENT_DIR")).thenReturn(tempDir.toString());
-
             DocumentManagerImpl manager = newDocumentManager();
 
             Document first = new Document();
@@ -115,13 +136,227 @@ class DocumentManagerImplFilenameValidationTest extends CarlosUnitTestBase {
         }
     }
 
+    @Test
+    @DisplayName("should reject generated filenames that belong to outbound archive eDocs")
+    void shouldRejectCreateDocument_whenGeneratedFilenameBelongsToOutboundArchive() throws Exception {
+        try (MockedStatic<CarlosProperties> propertiesMock = mockStatic(CarlosProperties.class)) {
+            CarlosProperties properties = mock(CarlosProperties.class);
+            propertiesMock.when(CarlosProperties::getInstance).thenReturn(properties);
+            when(properties.getProperty("DOCUMENT_DIR")).thenReturn(tempDir.toString());
+            when(outboundEmailArchiveDao.existsByFileName(anyString())).thenReturn(true);
+
+            DocumentManagerImpl manager = newDocumentManager();
+            Document document = new Document();
+            document.setDocfilename("archive.pdf");
+
+            assertThatThrownBy(() -> manager.createDocument(loggedInInfo, document, null, null,
+                    "document body".getBytes(StandardCharsets.UTF_8)))
+                    .isInstanceOf(SecurityException.class)
+                    .hasMessageContaining("outbound email archive workflow");
+            try (Stream<Path> files = Files.list(tempDir)) {
+                assertThat(files).isEmpty();
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("should reject normal rendering for outbound archive backing eDocs")
+    void shouldRejectRenderDocument_whenDocumentBacksOutboundArchive() {
+        DocumentManagerImpl manager = newDocumentManager();
+        when(securityInfoManager.hasPrivilege(eq(loggedInInfo), eq("_newCasemgmt.documents"), eq(SecurityInfoManager.READ), isNull()))
+                .thenReturn(true);
+        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+
+        assertThatThrownBy(() -> manager.renderDocument(loggedInInfo, "321"))
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("outbound email archive workflow");
+    }
+
+    @Test
+    @DisplayName("should reject generic document reads for outbound archive backing eDocs")
+    void shouldRejectGetDocument_whenDocumentBacksOutboundArchive() {
+        DocumentManagerImpl manager = newDocumentManager();
+        Document document = document(321);
+        when(securityInfoManager.hasPrivilege(eq(loggedInInfo), eq("_edoc"), eq("r"), eq("")))
+                .thenReturn(true);
+        when(documentDao.find((Object) Integer.valueOf(321))).thenReturn(document);
+        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+
+        assertThatThrownBy(() -> manager.getDocument(loggedInInfo, 321))
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("outbound email archive workflow");
+    }
+
+    @Test
+    @DisplayName("should reject control-document reads for outbound archive backing eDocs")
+    void shouldRejectGetCtlDocument_whenDocumentBacksOutboundArchive() {
+        DocumentManagerImpl manager = newDocumentManager();
+        when(securityInfoManager.hasPrivilege(eq(loggedInInfo), eq("_edoc"), eq("r"), eq("")))
+                .thenReturn(true);
+        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+
+        assertThatThrownBy(() -> manager.getCtlDocumentByDocumentId(loggedInInfo, 321))
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("outbound email archive workflow");
+        verify(ctlDocumentDao, never()).getCtrlDocument(321);
+    }
+
+    @Test
+    @DisplayName("should filter outbound archive eDocs from generic document sync lists")
+    void shouldFilterOutboundArchiveDocuments_whenListingUpdatedDocuments() {
+        DocumentManagerImpl manager = newDocumentManager();
+        Document archiveDocument = document(321);
+        Document ordinaryDocument = document(654);
+        Date since = new Date(0L);
+        when(securityInfoManager.hasPrivilege(eq(loggedInInfo), eq("_edoc"), eq("r"), eq("")))
+                .thenReturn(true);
+        when(documentDao.findByUpdateDate(since, 10)).thenReturn(List.of(archiveDocument, ordinaryDocument));
+        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+
+        List<Document> documents = manager.getDocumentsUpdateAfterDate(loggedInInfo, since, 10);
+
+        assertThat(documents).containsExactly(ordinaryDocument);
+    }
+
+    @Test
+    @DisplayName("should filter outbound archive eDocs from generic document DTO lists")
+    void shouldFilterOutboundArchiveDocuments_whenListingDocumentDtos() {
+        DocumentManagerImpl manager = newDocumentManager();
+        DocumentListItemDTO archiveDocument = documentDto(321);
+        DocumentListItemDTO ordinaryDocument = documentDto(654);
+        when(securityInfoManager.hasPrivilege(eq(loggedInInfo), eq("_edoc"), eq("r"), isNull()))
+                .thenReturn(true);
+        when(documentDao.findDocumentDTOsByDemographicNo(123)).thenReturn(List.of(archiveDocument, ordinaryDocument));
+        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+
+        List<DocumentListItemDTO> documents = manager.getDocumentDTOs(loggedInInfo, 123);
+
+        assertThat(documents)
+                .extracting(DocumentListItemDTO::getDocumentNo)
+                .containsExactly(654);
+    }
+
+    @Test
+    @DisplayName("should reject moving outbound archive backing eDocs")
+    void shouldRejectMoveDocument_whenDocumentBacksOutboundArchive() {
+        DocumentManagerImpl manager = newDocumentManager();
+        Document document = document(321);
+        document.setDocfilename("ordinary.pdf");
+        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+
+        assertThatThrownBy(() -> manager.moveDocument(loggedInInfo, document, tempDir.toString(), tempDir.toString()))
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("outbound email archive workflow");
+    }
+
+    @Test
+    @DisplayName("should reject moving documents over outbound archive filenames")
+    void shouldRejectMoveDocument_whenFilenameBelongsToOutboundArchive() {
+        DocumentManagerImpl manager = newDocumentManager();
+        Document document = document(654);
+        document.setDocfilename("archive.pdf");
+        when(outboundEmailArchiveDao.existsByFileName("archive.pdf")).thenReturn(true);
+
+        assertThatThrownBy(() -> manager.moveDocument(loggedInInfo, document, tempDir.toString(), tempDir.toString()))
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("outbound email archive workflow");
+    }
+
+    @Test
+    @DisplayName("should reject saving outbound archive backing eDocs through generic updates")
+    void shouldRejectSaveDocument_whenDocumentBacksOutboundArchive() {
+        DocumentManagerImpl manager = newDocumentManager();
+        Document document = document(321);
+        document.setDocfilename("ordinary.pdf");
+        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+
+        assertThatThrownBy(() -> manager.saveDocument(loggedInInfo, document, ctlDocument(123)))
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("outbound email archive workflow");
+    }
+
+    @Test
+    @DisplayName("should reject saving documents over outbound archive filenames")
+    void shouldRejectSaveDocument_whenFilenameBelongsToOutboundArchive() {
+        DocumentManagerImpl manager = newDocumentManager();
+        Document document = document(654);
+        document.setDocfilename("archive.pdf");
+        when(outboundEmailArchiveDao.existsByFileName("archive.pdf")).thenReturn(true);
+
+        assertThatThrownBy(() -> manager.saveDocument(loggedInInfo, document, ctlDocument(123)))
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("outbound email archive workflow");
+    }
+
+    @Test
+    @DisplayName("should reject writing documents over outbound archive filenames")
+    void shouldRejectAddDocument_whenFilenameBelongsToOutboundArchive() {
+        DocumentManagerImpl manager = newDocumentManager();
+        Document document = document(null);
+        document.setDocfilename("archive.pdf");
+        when(securityInfoManager.hasPrivilege(eq(loggedInInfo), eq("_newCasemgmt.documents"),
+                eq(SecurityInfoManager.WRITE), isNull())).thenReturn(true);
+        when(securityInfoManager.hasPrivilege(eq(loggedInInfo), eq("_newCasemgmt.documents"),
+                eq(SecurityInfoManager.READ), isNull())).thenReturn(true);
+        when(outboundEmailArchiveDao.existsByFileName("archive.pdf")).thenReturn(true);
+
+        assertThatThrownBy(() -> manager.addDocument(loggedInInfo, document, ctlDocument(123)))
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("outbound email archive workflow");
+    }
+
+    @Test
+    @DisplayName("should reject queueing outbound archive backing eDocs")
+    void shouldRejectAddDocumentToQueue_whenDocumentBacksOutboundArchive() {
+        DocumentManagerImpl manager = newDocumentManager();
+        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+
+        assertThatThrownBy(() -> manager.addDocumentToQueue(loggedInInfo, 321, 7))
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("outbound email archive workflow");
+    }
+
+    @Test
+    @DisplayName("should reject acknowledgement-provider reads for outbound archive backing eDocs")
+    void shouldRejectAcknowledgedProviders_whenDocumentBacksOutboundArchive() {
+        DocumentManagerImpl manager = newDocumentManager();
+        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+
+        assertThatThrownBy(() -> manager.getProvidersThatHaveAcknowledgedDocument(loggedInInfo, 321))
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("outbound email archive workflow");
+        verify(providerInboxRoutingDao, never()).getProvidersWithRoutingForDocument(anyString(), eq(321));
+    }
+
+    private Document document(Integer documentNo) {
+        Document document = new Document();
+        document.setDocumentNo(documentNo);
+        document.setStatus(Document.STATUS_ACTIVE);
+        return document;
+    }
+
+    private DocumentListItemDTO documentDto(Integer documentNo) {
+        DocumentListItemDTO document = new DocumentListItemDTO();
+        document.setDocumentNo(documentNo);
+        return document;
+    }
+
+    private CtlDocument ctlDocument(Integer demographicNo) {
+        CtlDocument ctlDocument = new CtlDocument();
+        ctlDocument.setId(new CtlDocumentPK("demographic", demographicNo, null));
+        return ctlDocument;
+    }
+
     private DocumentManagerImpl newDocumentManager() {
         DocumentManagerImpl manager = new DocumentManagerImpl();
         injectDependency(manager, "securityInfoManager", securityInfoManager);
         injectDependency(manager, "documentDao", documentDao);
         injectDependency(manager, "ctlDocumentDao", ctlDocumentDao);
+        injectDependency(manager, "outboundEmailArchiveDao", outboundEmailArchiveDao);
         injectDependency(manager, "patientLabRoutingDao", patientLabRoutingDao);
+        injectDependency(manager, "providerInboxRoutingDao", providerInboxRoutingDao);
         injectDependency(manager, "providerLabRoutingDao", providerLabRoutingDao);
+        injectDependency(manager, "queueDocumentLinkDAO", queueDocumentLinkDao);
         return manager;
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/managers/DtoManagerSecurityUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/managers/DtoManagerSecurityUnitTest.java
@@ -35,6 +35,7 @@ import io.github.carlos_emr.carlos.commn.dao.ConsultationRequestDao;
 import io.github.carlos_emr.carlos.commn.dao.DocumentDao;
 import io.github.carlos_emr.carlos.commn.dao.DrugDao;
 import io.github.carlos_emr.carlos.commn.dao.OscarAppointmentDao;
+import io.github.carlos_emr.carlos.commn.dao.OutboundEmailArchiveDao;
 import io.github.carlos_emr.carlos.commn.dao.PreventionDao;
 import io.github.carlos_emr.carlos.commn.exception.AccessDeniedException;
 import io.github.carlos_emr.carlos.consultation.dto.ConsultationRequestListItemDTO;
@@ -324,10 +325,15 @@ public class DtoManagerSecurityUnitTest extends CarlosUnitTestBase {
     @DisplayName("DocumentManagerImpl.getDocumentDTOs should call DAO and log when _edoc granted")
     void documentManager_shouldCallDaoAndLog_whenEdocReadGranted() {
         DocumentDao dao = Mockito.mock(DocumentDao.class);
-        List<DocumentListItemDTO> expected = Collections.singletonList(new DocumentListItemDTO());
+        OutboundEmailArchiveDao outboundEmailArchiveDao = Mockito.mock(OutboundEmailArchiveDao.class);
+        DocumentListItemDTO document = new DocumentListItemDTO();
+        document.setDocumentNo(321);
+        List<DocumentListItemDTO> expected = Collections.singletonList(document);
         when(dao.findDocumentDTOsByDemographicNo(DEMO_NO)).thenReturn(expected);
+        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(false);
         DocumentManagerImpl manager = new DocumentManagerImpl();
         injectDependency(manager, "documentDao", dao);
+        injectDependency(manager, "outboundEmailArchiveDao", outboundEmailArchiveDao);
         injectDependency(manager, "securityInfoManager", mockSecurityInfoManager);
         grantPrivilege("_edoc");
 

--- a/src/test/java/io/github/carlos_emr/carlos/managers/OutboundEmailArchiveServiceImplUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/managers/OutboundEmailArchiveServiceImplUnitTest.java
@@ -623,7 +623,8 @@ class OutboundEmailArchiveServiceImplUnitTest extends CarlosUnitTestBase {
         try {
             Files.createSymbolicLink(archivePath, target.getFileName());
         } catch (UnsupportedOperationException | IOException e) {
-            return;
+            org.junit.jupiter.api.Assumptions.assumeTrue(
+                    false, "Symbolic links unavailable: " + e.getClass().getSimpleName());
         }
         when(outboundEmailArchiveDao.findForUpdate(888)).thenReturn(activeArchive());
 
@@ -674,8 +675,7 @@ class OutboundEmailArchiveServiceImplUnitTest extends CarlosUnitTestBase {
         logActionMock.verify(() -> LogAction.addLogSynchronous(loggedInInfo,
                 "OutboundEmailArchiveService.readArchivedArtifact.integrityFailure",
                 "Outbound email archive",
-                "archiveId=888 documentNo=321 reason=Archived artifact exceeds maximum read size of "
-                        + TEST_MAX_ARCHIVED_ARTIFACT_BYTES + " bytes",
+                "archiveId=888 documentNo=321 reason=integrity-check-failed",
                 "123",
                 ""));
     }
@@ -695,7 +695,7 @@ class OutboundEmailArchiveServiceImplUnitTest extends CarlosUnitTestBase {
         logActionMock.verify(() -> LogAction.addLogSynchronous(loggedInInfo,
                 "OutboundEmailArchiveService.readArchivedArtifact.integrityFailure",
                 "Outbound email archive",
-                "archiveId=888 documentNo=321 reason=Archived artifact size does not match archive metadata",
+                "archiveId=888 documentNo=321 reason=integrity-check-failed",
                 "123",
                 ""));
     }
@@ -717,7 +717,7 @@ class OutboundEmailArchiveServiceImplUnitTest extends CarlosUnitTestBase {
         logActionMock.verify(() -> LogAction.addLogSynchronous(loggedInInfo,
                 "OutboundEmailArchiveService.readArchivedArtifact.integrityFailure",
                 "Outbound email archive",
-                "archiveId=888 documentNo=321 reason=Archived artifact hash does not match archive metadata",
+                "archiveId=888 documentNo=321 reason=integrity-check-failed",
                 "123",
                 ""));
     }
@@ -736,7 +736,7 @@ class OutboundEmailArchiveServiceImplUnitTest extends CarlosUnitTestBase {
         logActionMock.verify(() -> LogAction.addLogSynchronous(loggedInInfo,
                 "OutboundEmailArchiveService.readArchivedArtifact.integrityFailure",
                 "Outbound email archive",
-                "archiveId=888 documentNo=321 reason=Archived artifact byte size is missing",
+                "archiveId=888 documentNo=321 reason=integrity-check-failed",
                 "123",
                 ""));
     }
@@ -755,7 +755,7 @@ class OutboundEmailArchiveServiceImplUnitTest extends CarlosUnitTestBase {
         logActionMock.verify(() -> LogAction.addLogSynchronous(loggedInInfo,
                 "OutboundEmailArchiveService.readArchivedArtifact.integrityFailure",
                 "Outbound email archive",
-                "archiveId=888 documentNo=321 reason=Archived artifact SHA-256 hash is invalid",
+                "archiveId=888 documentNo=321 reason=integrity-check-failed",
                 "123",
                 ""));
     }

--- a/src/test/java/io/github/carlos_emr/carlos/managers/OutboundEmailArchiveServiceImplUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/managers/OutboundEmailArchiveServiceImplUnitTest.java
@@ -552,21 +552,6 @@ class OutboundEmailArchiveServiceImplUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
-    @DisplayName("should reject archive without eDoc write authority")
-    void shouldRejectArchive_whenCallerLacksEdocWriteAuthority() {
-        when(securityInfoManager.hasPrivilege(loggedInInfo, "_edoc", SecurityInfoManager.WRITE, null)).thenReturn(false);
-        EmailLog emailLog = emailLog();
-        OutboundEmailArchiveDto request = archiveRequest(emailLog);
-
-        assertThatThrownBy(() -> service.archive(loggedInInfo, request))
-                .isInstanceOf(SecurityException.class)
-                .hasMessageContaining("missing required sec object (_edoc)");
-
-        verifyNoInteractions(documentManager);
-    }
-
-
-    @Test
     @DisplayName("should reject active archive metadata when logged-in context is missing")
     void shouldRejectActiveArchiveMetadata_whenLoggedInContextMissing() {
         assertThatThrownBy(() -> service.getActiveArchive(null, 888))
@@ -714,6 +699,44 @@ class OutboundEmailArchiveServiceImplUnitTest extends CarlosUnitTestBase {
                 "OutboundEmailArchiveService.readArchivedArtifact.integrityFailure",
                 "Outbound email archive",
                 "archiveId=888 documentNo=321 reason=Archived artifact hash does not match archive metadata",
+                "123",
+                ""));
+    }
+
+    @Test
+    @DisplayName("should audit archived artifact reads with missing byte-size metadata")
+    void shouldAuditArchivedArtifactRead_whenByteSizeMetadataIsMissing() {
+        OutboundEmailArchive archive = activeArchive();
+        archive.setByteSize(null);
+        when(outboundEmailArchiveDao.findForUpdate(888)).thenReturn(archive);
+
+        assertThatThrownBy(() -> service.readArchivedArtifact(loggedInInfo, 888))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("byte size is missing");
+
+        logActionMock.verify(() -> LogAction.addLog(loggedInInfo,
+                "OutboundEmailArchiveService.readArchivedArtifact.integrityFailure",
+                "Outbound email archive",
+                "archiveId=888 documentNo=321 reason=Archived artifact byte size is missing",
+                "123",
+                ""));
+    }
+
+    @Test
+    @DisplayName("should audit archived artifact reads with invalid hash metadata")
+    void shouldAuditArchivedArtifactRead_whenHashMetadataIsInvalid() {
+        OutboundEmailArchive archive = activeArchive();
+        archive.setSha256Hash("invalid");
+        when(outboundEmailArchiveDao.findForUpdate(888)).thenReturn(archive);
+
+        assertThatThrownBy(() -> service.readArchivedArtifact(loggedInInfo, 888))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("SHA-256 hash is invalid");
+
+        logActionMock.verify(() -> LogAction.addLog(loggedInInfo,
+                "OutboundEmailArchiveService.readArchivedArtifact.integrityFailure",
+                "Outbound email archive",
+                "archiveId=888 documentNo=321 reason=Archived artifact SHA-256 hash is invalid",
                 "123",
                 ""));
     }

--- a/src/test/java/io/github/carlos_emr/carlos/managers/OutboundEmailArchiveServiceImplUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/managers/OutboundEmailArchiveServiceImplUnitTest.java
@@ -614,6 +614,25 @@ class OutboundEmailArchiveServiceImplUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
+    @DisplayName("should reject archive artifact symlinks without following their targets")
+    void shouldRejectArchivedArtifactRead_whenArtifactPathIsSymlink(@TempDir Path documentDir) throws Exception {
+        testProperties.setProperty("DOCUMENT_DIR", documentDir.toString());
+        Path target = documentDir.resolve("real-message.eml");
+        Files.write(target, RFC822_BYTES);
+        Path archivePath = documentDir.resolve("20260707120000_outbound-email-44.eml");
+        try {
+            Files.createSymbolicLink(archivePath, target.getFileName());
+        } catch (UnsupportedOperationException e) {
+            return;
+        }
+        when(outboundEmailArchiveDao.findForUpdate(888)).thenReturn(activeArchive());
+
+        assertThatThrownBy(() -> service.readArchivedArtifact(loggedInInfo, 888))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("not a regular file");
+    }
+
+    @Test
     @DisplayName("should defer archived artifact read audit until transaction commit")
     void shouldDeferArchivedArtifactReadAudit_untilTransactionCommit(@TempDir Path documentDir) throws Exception {
         TransactionSynchronizationManager.initSynchronization();

--- a/src/test/java/io/github/carlos_emr/carlos/managers/OutboundEmailArchiveServiceImplUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/managers/OutboundEmailArchiveServiceImplUnitTest.java
@@ -622,7 +622,7 @@ class OutboundEmailArchiveServiceImplUnitTest extends CarlosUnitTestBase {
         Path archivePath = documentDir.resolve("20260707120000_outbound-email-44.eml");
         try {
             Files.createSymbolicLink(archivePath, target.getFileName());
-        } catch (UnsupportedOperationException e) {
+        } catch (UnsupportedOperationException | IOException e) {
             return;
         }
         when(outboundEmailArchiveDao.findForUpdate(888)).thenReturn(activeArchive());
@@ -671,7 +671,7 @@ class OutboundEmailArchiveServiceImplUnitTest extends CarlosUnitTestBase {
                 .isInstanceOf(IOException.class)
                 .hasMessageContaining("maximum read size");
 
-        logActionMock.verify(() -> LogAction.addLog(loggedInInfo,
+        logActionMock.verify(() -> LogAction.addLogSynchronous(loggedInInfo,
                 "OutboundEmailArchiveService.readArchivedArtifact.integrityFailure",
                 "Outbound email archive",
                 "archiveId=888 documentNo=321 reason=Archived artifact exceeds maximum read size of "
@@ -692,7 +692,7 @@ class OutboundEmailArchiveServiceImplUnitTest extends CarlosUnitTestBase {
                 .isInstanceOf(IOException.class)
                 .hasMessageContaining("size does not match");
 
-        logActionMock.verify(() -> LogAction.addLog(loggedInInfo,
+        logActionMock.verify(() -> LogAction.addLogSynchronous(loggedInInfo,
                 "OutboundEmailArchiveService.readArchivedArtifact.integrityFailure",
                 "Outbound email archive",
                 "archiveId=888 documentNo=321 reason=Archived artifact size does not match archive metadata",
@@ -714,7 +714,7 @@ class OutboundEmailArchiveServiceImplUnitTest extends CarlosUnitTestBase {
                 .isInstanceOf(IOException.class)
                 .hasMessageContaining("hash does not match");
 
-        logActionMock.verify(() -> LogAction.addLog(loggedInInfo,
+        logActionMock.verify(() -> LogAction.addLogSynchronous(loggedInInfo,
                 "OutboundEmailArchiveService.readArchivedArtifact.integrityFailure",
                 "Outbound email archive",
                 "archiveId=888 documentNo=321 reason=Archived artifact hash does not match archive metadata",
@@ -733,7 +733,7 @@ class OutboundEmailArchiveServiceImplUnitTest extends CarlosUnitTestBase {
                 .isInstanceOf(IOException.class)
                 .hasMessageContaining("byte size is missing");
 
-        logActionMock.verify(() -> LogAction.addLog(loggedInInfo,
+        logActionMock.verify(() -> LogAction.addLogSynchronous(loggedInInfo,
                 "OutboundEmailArchiveService.readArchivedArtifact.integrityFailure",
                 "Outbound email archive",
                 "archiveId=888 documentNo=321 reason=Archived artifact byte size is missing",
@@ -752,7 +752,7 @@ class OutboundEmailArchiveServiceImplUnitTest extends CarlosUnitTestBase {
                 .isInstanceOf(IOException.class)
                 .hasMessageContaining("SHA-256 hash is invalid");
 
-        logActionMock.verify(() -> LogAction.addLog(loggedInInfo,
+        logActionMock.verify(() -> LogAction.addLogSynchronous(loggedInInfo,
                 "OutboundEmailArchiveService.readArchivedArtifact.integrityFailure",
                 "Outbound email archive",
                 "archiveId=888 documentNo=321 reason=Archived artifact SHA-256 hash is invalid",

--- a/src/test/java/io/github/carlos_emr/carlos/managers/OutboundEmailArchiveServiceImplUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/managers/OutboundEmailArchiveServiceImplUnitTest.java
@@ -22,7 +22,6 @@
 
 package io.github.carlos_emr.carlos.managers;
 
-import io.github.carlos_emr.CarlosProperties;
 import io.github.carlos_emr.carlos.commn.dao.CtlDocumentDao;
 import io.github.carlos_emr.carlos.commn.dao.EmailLogDao;
 import io.github.carlos_emr.carlos.commn.dao.OutboundEmailArchiveDao;
@@ -52,12 +51,15 @@ import org.mockito.ArgumentCaptor;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
+import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.util.HexFormat;
 import java.util.List;
+import java.util.Properties;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -76,6 +78,7 @@ import static org.mockito.Mockito.when;
 class OutboundEmailArchiveServiceImplUnitTest extends CarlosUnitTestBase {
 
     private static final String PROVIDER_NO = "999998";
+    private static final long TEST_MAX_ARCHIVED_ARTIFACT_BYTES = 64L;
     private static final byte[] RFC822_BYTES = "Subject: Test\r\n\r\nBody".getBytes(StandardCharsets.UTF_8);
 
     private DocumentManager documentManager;
@@ -85,6 +88,7 @@ class OutboundEmailArchiveServiceImplUnitTest extends CarlosUnitTestBase {
     private CtlDocumentDao ctlDocumentDao;
     private SecurityInfoManager securityInfoManager;
     private LoggedInInfo loggedInInfo;
+    private Properties testProperties;
     private OutboundEmailArchiveServiceImpl service;
 
     @BeforeEach
@@ -96,7 +100,16 @@ class OutboundEmailArchiveServiceImplUnitTest extends CarlosUnitTestBase {
         ctlDocumentDao = mock(CtlDocumentDao.class);
         securityInfoManager = mock(SecurityInfoManager.class);
         loggedInInfo = mock(LoggedInInfo.class);
-        service = new OutboundEmailArchiveServiceImpl(documentManager, emailLogDao, outboundEmailArchiveDao, outboundEmailArchiveDeletionDao, ctlDocumentDao, securityInfoManager);
+        testProperties = new Properties();
+        service = new OutboundEmailArchiveServiceImpl(
+                documentManager,
+                emailLogDao,
+                outboundEmailArchiveDao,
+                outboundEmailArchiveDeletionDao,
+                ctlDocumentDao,
+                securityInfoManager,
+                testProperties,
+                TEST_MAX_ARCHIVED_ARTIFACT_BYTES);
 
         when(loggedInInfo.getLoggedInProviderNo()).thenReturn(PROVIDER_NO);
         allowControlledDeletion();
@@ -226,39 +239,28 @@ class OutboundEmailArchiveServiceImplUnitTest extends CarlosUnitTestBase {
     @Test
     @DisplayName("should delete final eDoc file when createDocument fails after filename normalization")
     void shouldDeleteFinalEdocFile_whenCreateDocumentFailsAfterFilenameNormalization(@TempDir Path documentDir) throws Exception {
-        CarlosProperties props = CarlosProperties.getInstance();
-        boolean hadDocumentDir = props.containsKey("DOCUMENT_DIR");
-        Object originalDocumentDir = props.get("DOCUMENT_DIR");
-        props.setProperty("DOCUMENT_DIR", documentDir.toString());
+        testProperties.setProperty("DOCUMENT_DIR", documentDir.toString());
+        EmailLog emailLog = emailLog();
+        OutboundEmailArchiveDto request = archiveRequest(emailLog);
+        AtomicReference<Path> createdFile = new AtomicReference<>();
+        doAnswer(invocation -> {
+            Document documentToCreate = invocation.getArgument(1);
+            documentToCreate.setDocfilename("20260707120000_" + documentToCreate.getDocfilename());
+            Path file = documentDir.resolve(documentToCreate.getDocfilename());
+            Files.write(file, RFC822_BYTES);
+            createdFile.set(file);
+            throw new RuntimeException("document database failed");
+        }).when(documentManager).createDocument(eq(loggedInInfo), any(Document.class), eq(123), eq(PROVIDER_NO), eq(RFC822_BYTES));
 
-        try {
-            EmailLog emailLog = emailLog();
-            OutboundEmailArchiveDto request = archiveRequest(emailLog);
-            AtomicReference<Path> createdFile = new AtomicReference<>();
-            doAnswer(invocation -> {
-                Document documentToCreate = invocation.getArgument(1);
-                documentToCreate.setDocfilename("20260707120000_" + documentToCreate.getDocfilename());
-                Path file = documentDir.resolve(documentToCreate.getDocfilename());
-                Files.write(file, RFC822_BYTES);
-                createdFile.set(file);
-                throw new RuntimeException("document database failed");
-            }).when(documentManager).createDocument(eq(loggedInInfo), any(Document.class), eq(123), eq(PROVIDER_NO), eq(RFC822_BYTES));
+        assertThatThrownBy(() -> service.archive(loggedInInfo, request))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("document database failed");
 
-            assertThatThrownBy(() -> service.archive(loggedInInfo, request))
-                    .isInstanceOf(RuntimeException.class)
-                    .hasMessageContaining("document database failed");
-
-            Path file = createdFile.get();
-            assertThat(file).isNotNull();
-            assertThat(file).doesNotExist();
-            verify(outboundEmailArchiveDao, never()).persist(any(OutboundEmailArchive.class));
-        } finally {
-            if (hadDocumentDir) {
-                props.put("DOCUMENT_DIR", originalDocumentDir);
-            } else {
-                props.remove("DOCUMENT_DIR");
-            }
-        }
+        Path file = createdFile.get();
+        assertThat(file)
+                .isNotNull()
+                .doesNotExist();
+        verify(outboundEmailArchiveDao, never()).persist(any(OutboundEmailArchive.class));
     }
 
     @Test
@@ -358,6 +360,34 @@ class OutboundEmailArchiveServiceImplUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
+    @DisplayName("should archive document source attachment metadata when source document belongs to demographic")
+    void shouldArchiveDocumentSourceAttachmentMetadata_whenDocumentBelongsToDemographic() throws Exception {
+        byte[] attachmentBytes = "existing document attachment bytes".getBytes(StandardCharsets.UTF_8);
+        EmailLog emailLog = emailLog();
+        OutboundEmailArchiveDto request = archiveRequest(emailLog);
+        OutboundEmailArchiveAttachmentDto attachmentRequest = new OutboundEmailArchiveAttachmentDto();
+        attachmentRequest.setFileName("existing-document.pdf");
+        attachmentRequest.setContentType("application/pdf");
+        attachmentRequest.setSha256Hash(sha256Hex(attachmentBytes));
+        attachmentRequest.setByteSize((long) attachmentBytes.length);
+        attachmentRequest.setSourceDocumentType("DOCUMENT");
+        attachmentRequest.setSourceDocumentId(777);
+        request.addAttachment(attachmentRequest);
+
+        when(ctlDocumentDao.findByDocumentNoAndModule(777, "demographic")).thenReturn(List.of(ctlDocument(123, 777)));
+        when(documentManager.createDocument(eq(loggedInInfo), any(Document.class), eq(123), eq(PROVIDER_NO), eq(RFC822_BYTES)))
+                .thenReturn(savedDocument());
+
+        OutboundEmailArchive archive = service.archive(loggedInInfo, request);
+
+        assertThat(archive.getAttachments()).hasSize(1);
+        OutboundEmailArchiveAttachment attachment = archive.getAttachments().get(0);
+        assertThat(attachment.getSourceDocumentType()).isEqualTo("DOCUMENT");
+        assertThat(attachment.getSourceDocumentId()).isEqualTo(777);
+        assertThat(attachment.getDocument()).isNull();
+    }
+
+    @Test
     @DisplayName("should reject attachment document from a different demographic before storing the eDoc")
     void shouldRejectAttachmentDocumentFromDifferentDemographic_beforeStoringEdoc() {
         byte[] attachmentBytes = "encrypted pdf bytes".getBytes(StandardCharsets.UTF_8);
@@ -368,6 +398,28 @@ class OutboundEmailArchiveServiceImplUnitTest extends CarlosUnitTestBase {
         attachmentRequest.setContentType("application/pdf");
         attachmentRequest.setArtifactBytes(attachmentBytes);
         attachmentRequest.setDocument(attachmentDocument());
+        request.addAttachment(attachmentRequest);
+        when(ctlDocumentDao.findByDocumentNoAndModule(777, "demographic")).thenReturn(List.of(ctlDocument(456, 777)));
+
+        assertThatThrownBy(() -> service.archive(loggedInInfo, request))
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("attachment document");
+        verifyNoInteractions(documentManager);
+    }
+
+    @Test
+    @DisplayName("should reject document source attachment metadata from a different demographic before storing the eDoc")
+    void shouldRejectDocumentSourceAttachmentMetadataFromDifferentDemographic_beforeStoringEdoc() {
+        byte[] attachmentBytes = "existing document attachment bytes".getBytes(StandardCharsets.UTF_8);
+        EmailLog emailLog = emailLog();
+        OutboundEmailArchiveDto request = archiveRequest(emailLog);
+        OutboundEmailArchiveAttachmentDto attachmentRequest = new OutboundEmailArchiveAttachmentDto();
+        attachmentRequest.setFileName("existing-document.pdf");
+        attachmentRequest.setContentType("application/pdf");
+        attachmentRequest.setSha256Hash(sha256Hex(attachmentBytes));
+        attachmentRequest.setByteSize((long) attachmentBytes.length);
+        attachmentRequest.setSourceDocumentType("DOCUMENT");
+        attachmentRequest.setSourceDocumentId(777);
         request.addAttachment(attachmentRequest);
         when(ctlDocumentDao.findByDocumentNoAndModule(777, "demographic")).thenReturn(List.of(ctlDocument(456, 777)));
 
@@ -391,6 +443,26 @@ class OutboundEmailArchiveServiceImplUnitTest extends CarlosUnitTestBase {
         assertThatThrownBy(() -> service.archive(loggedInInfo, request))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Persisted attachment document is required");
+        verifyNoInteractions(documentManager);
+    }
+
+    @Test
+    @DisplayName("should reject attachment bytes when attachment exceeds bounded archive size before storing the eDoc")
+    void shouldRejectAttachmentBytes_whenAttachmentExceedsBoundedArchiveSize() {
+        EmailLog emailLog = emailLog();
+        OutboundEmailArchiveDto request = archiveRequest(emailLog);
+        OutboundEmailArchiveAttachmentDto attachmentRequest = new OutboundEmailArchiveAttachmentDto();
+        attachmentRequest.setFileName("message.pdf");
+        attachmentRequest.setContentType("application/pdf");
+        attachmentRequest.setArtifactBytes(new byte[Math.toIntExact(TEST_MAX_ARCHIVED_ARTIFACT_BYTES + 1L)]);
+        attachmentRequest.setDocument(attachmentDocument());
+        request.addAttachment(attachmentRequest);
+        when(ctlDocumentDao.findByDocumentNoAndModule(777, "demographic")).thenReturn(List.of(ctlDocument(123, 777)));
+
+        assertThatThrownBy(() -> service.archive(loggedInInfo, request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("maximum archive size");
+
         verifyNoInteractions(documentManager);
     }
 
@@ -422,6 +494,19 @@ class OutboundEmailArchiveServiceImplUnitTest extends CarlosUnitTestBase {
         assertThatThrownBy(() -> service.archive(loggedInInfo, request))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Persisted EmailLog is required");
+    }
+
+    @Test
+    @DisplayName("should reject archive when artifact exceeds bounded archive size before storing the eDoc")
+    void shouldRejectArchive_whenArtifactExceedsBoundedArchiveSize() {
+        OutboundEmailArchiveDto request = archiveRequest(emailLog());
+        injectDependency(request, "artifactBytes", new byte[Math.toIntExact(TEST_MAX_ARCHIVED_ARTIFACT_BYTES + 1L)]);
+
+        assertThatThrownBy(() -> service.archive(loggedInInfo, request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("maximum archive size");
+
+        verifyNoInteractions(documentManager);
     }
 
     @Test
@@ -467,9 +552,228 @@ class OutboundEmailArchiveServiceImplUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
+    @DisplayName("should reject archive without eDoc write authority")
+    void shouldRejectArchive_whenCallerLacksEdocWriteAuthority() {
+        when(securityInfoManager.hasPrivilege(loggedInInfo, "_edoc", SecurityInfoManager.WRITE, null)).thenReturn(false);
+        EmailLog emailLog = emailLog();
+        OutboundEmailArchiveDto request = archiveRequest(emailLog);
+
+        assertThatThrownBy(() -> service.archive(loggedInInfo, request))
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("missing required sec object (_edoc)");
+
+        verifyNoInteractions(documentManager);
+    }
+
+
+    @Test
+    @DisplayName("should reject active archive metadata when logged-in context is missing")
+    void shouldRejectActiveArchiveMetadata_whenLoggedInContextMissing() {
+        assertThatThrownBy(() -> service.getActiveArchive(null, 888))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Logged-in user context is required");
+
+        verifyNoInteractions(outboundEmailArchiveDao);
+    }
+
+    @Test
+    @DisplayName("should return active archive metadata when read access is allowed")
+    void shouldReturnActiveArchiveMetadata_whenReadAccessAllowed() {
+        OutboundEmailArchive archive = activeArchive();
+        when(outboundEmailArchiveDao.findForRead(888)).thenReturn(archive);
+
+        OutboundEmailArchive result = service.getActiveArchive(loggedInInfo, 888);
+
+        assertThat(result).isSameAs(archive);
+        logActionMock.verify(() -> LogAction.addLog(loggedInInfo,
+                "OutboundEmailArchiveService.getActiveArchive",
+                "Outbound email archive",
+                "archiveId=888 documentNo=321",
+                "123",
+                ""));
+    }
+
+    @Test
+    @DisplayName("should reject active archive metadata without patient access")
+    void shouldRejectActiveArchiveMetadata_whenCallerCannotAccessPatientRecord() {
+        OutboundEmailArchive archive = activeArchive();
+        when(outboundEmailArchiveDao.findForRead(888)).thenReturn(archive);
+        when(securityInfoManager.isAllowedAccessToPatientRecord(loggedInInfo, 123)).thenReturn(false);
+
+        assertThatThrownBy(() -> service.getActiveArchive(loggedInInfo, 888))
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("archive demographic");
+
+        logActionMock.verifyNoInteractions();
+    }
+
+    @Test
+    @DisplayName("should read archived artifact bytes when read access is allowed")
+    void shouldReadArchivedArtifactBytes_whenReadAccessAllowed(@TempDir Path documentDir) throws Exception {
+        testProperties.setProperty("DOCUMENT_DIR", documentDir.toString());
+        OutboundEmailArchive archive = activeArchive();
+        Files.write(documentDir.resolve("20260707120000_outbound-email-44.eml"), RFC822_BYTES);
+        when(outboundEmailArchiveDao.findForUpdate(888)).thenReturn(archive);
+
+        byte[] artifactBytes = service.readArchivedArtifact(loggedInInfo, 888);
+
+        assertThat(artifactBytes).isEqualTo(RFC822_BYTES);
+        verify(outboundEmailArchiveDao).findForUpdate(888);
+        verify(outboundEmailArchiveDao, never()).findForRead(888);
+        logActionMock.verify(() -> LogAction.addLog(loggedInInfo,
+                "OutboundEmailArchiveService.readArchivedArtifact",
+                "Outbound email archive",
+                "archiveId=888 documentNo=321",
+                "123",
+                ""));
+    }
+
+    @Test
+    @DisplayName("should defer archived artifact read audit until transaction commit")
+    void shouldDeferArchivedArtifactReadAudit_untilTransactionCommit(@TempDir Path documentDir) throws Exception {
+        TransactionSynchronizationManager.initSynchronization();
+        testProperties.setProperty("DOCUMENT_DIR", documentDir.toString());
+        OutboundEmailArchive archive = activeArchive();
+        Files.write(documentDir.resolve("20260707120000_outbound-email-44.eml"), RFC822_BYTES);
+        when(outboundEmailArchiveDao.findForUpdate(888)).thenReturn(archive);
+
+        byte[] artifactBytes = service.readArchivedArtifact(loggedInInfo, 888);
+
+        assertThat(artifactBytes).isEqualTo(RFC822_BYTES);
+        logActionMock.verifyNoInteractions();
+        runAfterCommitSynchronizations();
+        logActionMock.verify(() -> LogAction.addLog(loggedInInfo,
+                "OutboundEmailArchiveService.readArchivedArtifact",
+                "Outbound email archive",
+                "archiveId=888 documentNo=321",
+                "123",
+                ""));
+    }
+
+    @Test
+    @DisplayName("should reject archived artifact read when file exceeds bounded read size")
+    void shouldRejectArchivedArtifactRead_whenFileExceedsBoundedReadSize(@TempDir Path documentDir) throws Exception {
+        testProperties.setProperty("DOCUMENT_DIR", documentDir.toString());
+        OutboundEmailArchive archive = activeArchive();
+        long oversizedLength = TEST_MAX_ARCHIVED_ARTIFACT_BYTES + 1L;
+        archive.setByteSize(oversizedLength);
+        Path artifact = documentDir.resolve("20260707120000_outbound-email-44.eml");
+        try (RandomAccessFile randomAccessFile = new RandomAccessFile(artifact.toFile(), "rw")) {
+            randomAccessFile.setLength(oversizedLength);
+        }
+        when(outboundEmailArchiveDao.findForUpdate(888)).thenReturn(archive);
+
+        assertThatThrownBy(() -> service.readArchivedArtifact(loggedInInfo, 888))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("maximum read size");
+
+        logActionMock.verify(() -> LogAction.addLog(loggedInInfo,
+                "OutboundEmailArchiveService.readArchivedArtifact.integrityFailure",
+                "Outbound email archive",
+                "archiveId=888 documentNo=321 reason=Archived artifact exceeds maximum read size of "
+                        + TEST_MAX_ARCHIVED_ARTIFACT_BYTES + " bytes",
+                "123",
+                ""));
+    }
+
+    @Test
+    @DisplayName("should reject archived artifact read when file size differs from archive metadata")
+    void shouldRejectArchivedArtifactRead_whenFileSizeDiffersFromMetadata(@TempDir Path documentDir) throws Exception {
+        testProperties.setProperty("DOCUMENT_DIR", documentDir.toString());
+        OutboundEmailArchive archive = activeArchive();
+        Files.write(documentDir.resolve("20260707120000_outbound-email-44.eml"), "tampered".getBytes(StandardCharsets.UTF_8));
+        when(outboundEmailArchiveDao.findForUpdate(888)).thenReturn(archive);
+
+        assertThatThrownBy(() -> service.readArchivedArtifact(loggedInInfo, 888))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("size does not match");
+
+        logActionMock.verify(() -> LogAction.addLog(loggedInInfo,
+                "OutboundEmailArchiveService.readArchivedArtifact.integrityFailure",
+                "Outbound email archive",
+                "archiveId=888 documentNo=321 reason=Archived artifact size does not match archive metadata",
+                "123",
+                ""));
+    }
+
+    @Test
+    @DisplayName("should reject archived artifact read when file hash differs from archive metadata")
+    void shouldRejectArchivedArtifactRead_whenFileHashDiffersFromMetadata(@TempDir Path documentDir) throws Exception {
+        testProperties.setProperty("DOCUMENT_DIR", documentDir.toString());
+        byte[] tamperedBytes = "Subject: Evil\r\n\r\nBody".getBytes(StandardCharsets.UTF_8);
+        OutboundEmailArchive archive = activeArchive();
+        archive.setByteSize((long) tamperedBytes.length);
+        Files.write(documentDir.resolve("20260707120000_outbound-email-44.eml"), tamperedBytes);
+        when(outboundEmailArchiveDao.findForUpdate(888)).thenReturn(archive);
+
+        assertThatThrownBy(() -> service.readArchivedArtifact(loggedInInfo, 888))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("hash does not match");
+
+        logActionMock.verify(() -> LogAction.addLog(loggedInInfo,
+                "OutboundEmailArchiveService.readArchivedArtifact.integrityFailure",
+                "Outbound email archive",
+                "archiveId=888 documentNo=321 reason=Archived artifact hash does not match archive metadata",
+                "123",
+                ""));
+    }
+
+    @Test
+    @DisplayName("should reject archived artifact read without patient access")
+    void shouldRejectArchivedArtifactRead_whenCallerCannotAccessPatientRecord() {
+        OutboundEmailArchive archive = activeArchive();
+        when(outboundEmailArchiveDao.findForUpdate(888)).thenReturn(archive);
+        when(securityInfoManager.isAllowedAccessToPatientRecord(loggedInInfo, 123)).thenReturn(false);
+
+        assertThatThrownBy(() -> service.readArchivedArtifact(loggedInInfo, 888))
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("archive demographic");
+
+        logActionMock.verifyNoInteractions();
+    }
+
+    @Test
+    @DisplayName("should reject active archive metadata without eDoc read authority")
+    void shouldRejectActiveArchiveMetadata_whenCallerLacksEdocReadAuthority() {
+        OutboundEmailArchive archive = activeArchive();
+        when(outboundEmailArchiveDao.findForRead(888)).thenReturn(archive);
+        when(securityInfoManager.hasPrivilege(loggedInInfo, "_edoc", SecurityInfoManager.READ, null)).thenReturn(false);
+
+        assertThatThrownBy(() -> service.getActiveArchive(loggedInInfo, 888))
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("_edoc");
+    }
+
+    @Test
+    @DisplayName("should reject reading a controlled-deleted archive")
+    void shouldRejectArchivedArtifactRead_whenArchiveIsDeleted() {
+        OutboundEmailArchive archive = activeArchive();
+        archive.markDeleted(PROVIDER_NO, "Patient requested cleanup");
+        when(outboundEmailArchiveDao.findForUpdate(888)).thenReturn(archive);
+
+        assertThatThrownBy(() -> service.readArchivedArtifact(loggedInInfo, 888))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("deleted");
+    }
+
+    @Test
+    @DisplayName("should reject archived artifact read when backing eDoc is deleted")
+    void shouldRejectArchivedArtifactRead_whenBackingEdocIsDeleted() {
+        OutboundEmailArchive archive = activeArchive();
+        archive.getDocument().setStatus(Document.STATUS_DELETED);
+        when(outboundEmailArchiveDao.findForUpdate(888)).thenReturn(archive);
+
+        assertThatThrownBy(() -> service.readArchivedArtifact(loggedInInfo, 888))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("eDoc has been deleted");
+
+        logActionMock.verifyNoInteractions();
+    }
+
+    @Test
     @DisplayName("should mark archive deleted and persist tombstone")
     void shouldMarkArchiveDeletedAndPersistTombstone_whenDeletionAllowed() {
-        OutboundEmailArchive archive = archiveForDeletion();
+        OutboundEmailArchive archive = activeArchive();
         when(outboundEmailArchiveDao.findForUpdate(888)).thenReturn(archive);
 
         OutboundEmailArchiveDeletion deletion = service.recordControlledDeletion(loggedInInfo, 888, "Patient requested cleanup");
@@ -497,7 +801,7 @@ class OutboundEmailArchiveServiceImplUnitTest extends CarlosUnitTestBase {
     @Test
     @DisplayName("should trim controlled deletion reason before truncating")
     void shouldTrimControlledDeletionReason_beforeTruncating() {
-        OutboundEmailArchive archive = archiveForDeletion();
+        OutboundEmailArchive archive = activeArchive();
         when(outboundEmailArchiveDao.findForUpdate(888)).thenReturn(archive);
 
         OutboundEmailArchiveDeletion deletion = service.recordControlledDeletion(loggedInInfo, 888, " ".repeat(1000) + "Meaningful reason");
@@ -510,7 +814,7 @@ class OutboundEmailArchiveServiceImplUnitTest extends CarlosUnitTestBase {
     @DisplayName("should defer controlled deletion audit until transaction commit")
     void shouldDeferControlledDeletionAudit_untilTransactionCommit() {
         TransactionSynchronizationManager.initSynchronization();
-        OutboundEmailArchive archive = archiveForDeletion();
+        OutboundEmailArchive archive = activeArchive();
         when(outboundEmailArchiveDao.findForUpdate(888)).thenReturn(archive);
 
         service.recordControlledDeletion(loggedInInfo, 888, "Patient requested cleanup");
@@ -526,12 +830,12 @@ class OutboundEmailArchiveServiceImplUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
-    @DisplayName("should reject controlled deletion without eDoc delete authority")
-    void shouldRejectDeletion_whenCallerLacksEdocDeleteAuthority() {
-        OutboundEmailArchive archive = archiveForDeletion();
+    @DisplayName("should reject controlled deletion with only eDoc write authority")
+    void shouldRejectDeletion_whenCallerOnlyHasEdocWriteAuthority() {
+        OutboundEmailArchive archive = activeArchive();
         when(outboundEmailArchiveDao.findForUpdate(888)).thenReturn(archive);
         when(securityInfoManager.hasPrivilege(loggedInInfo, "_admin.edocdelete", SecurityInfoManager.WRITE, null)).thenReturn(false);
-        when(securityInfoManager.hasPrivilege(loggedInInfo, "_edoc", SecurityInfoManager.WRITE, null)).thenReturn(false);
+        when(securityInfoManager.hasPrivilege(loggedInInfo, "_edoc", SecurityInfoManager.WRITE, null)).thenReturn(true);
 
         assertThatThrownBy(() -> service.recordControlledDeletion(loggedInInfo, 888, "cleanup"))
                 .isInstanceOf(SecurityException.class)
@@ -544,7 +848,7 @@ class OutboundEmailArchiveServiceImplUnitTest extends CarlosUnitTestBase {
     @Test
     @DisplayName("should reject controlled deletion without patient access")
     void shouldRejectDeletion_whenCallerCannotAccessPatientRecord() {
-        OutboundEmailArchive archive = archiveForDeletion();
+        OutboundEmailArchive archive = activeArchive();
         when(outboundEmailArchiveDao.findForUpdate(888)).thenReturn(archive);
         when(securityInfoManager.isAllowedAccessToPatientRecord(loggedInInfo, 123)).thenReturn(false);
 
@@ -559,7 +863,7 @@ class OutboundEmailArchiveServiceImplUnitTest extends CarlosUnitTestBase {
     @Test
     @DisplayName("should reject controlled deletion while legal hold is active")
     void shouldRejectDeletion_whenLegalHoldIsActive() {
-        OutboundEmailArchive archive = archiveForDeletion();
+        OutboundEmailArchive archive = activeArchive();
         archive.setLegalHold(true);
         when(outboundEmailArchiveDao.findForUpdate(888)).thenReturn(archive);
 
@@ -571,7 +875,7 @@ class OutboundEmailArchiveServiceImplUnitTest extends CarlosUnitTestBase {
     @Test
     @DisplayName("should reject repeated controlled deletion")
     void shouldRejectDeletion_whenArchiveAlreadyDeleted() {
-        OutboundEmailArchive archive = archiveForDeletion();
+        OutboundEmailArchive archive = activeArchive();
         archive.markDeleted(PROVIDER_NO, "previous cleanup");
         when(outboundEmailArchiveDao.findForUpdate(888)).thenReturn(archive);
 
@@ -596,7 +900,7 @@ class OutboundEmailArchiveServiceImplUnitTest extends CarlosUnitTestBase {
 
     private void runAfterCommitSynchronizations() {
         List<TransactionSynchronization> synchronizations = TransactionSynchronizationManager.getSynchronizations();
-        assertThat(synchronizations).isNotEmpty();
+        assertThat(synchronizations).isNotNull().isNotEmpty();
         for (TransactionSynchronization synchronization : synchronizations) {
             synchronization.afterCommit();
         }
@@ -648,6 +952,7 @@ class OutboundEmailArchiveServiceImplUnitTest extends CarlosUnitTestBase {
         document.setDocumentNo(321);
         document.setDocfilename("20260707120000_outbound-email-44.eml");
         document.setContenttype("message/rfc822");
+        document.setStatus(Document.STATUS_ACTIVE);
         return document;
     }
 
@@ -665,7 +970,7 @@ class OutboundEmailArchiveServiceImplUnitTest extends CarlosUnitTestBase {
         return ctlDocument;
     }
 
-    private OutboundEmailArchive archiveForDeletion() {
+    private OutboundEmailArchive activeArchive() {
         OutboundEmailArchive archive = new OutboundEmailArchive();
         archive.setId(888);
         archive.setEmailLog(emailLog());
@@ -687,8 +992,9 @@ class OutboundEmailArchiveServiceImplUnitTest extends CarlosUnitTestBase {
     }
 
     private void allowControlledDeletion() {
-        when(securityInfoManager.hasPrivilege(loggedInInfo, "_admin.edocdelete", SecurityInfoManager.WRITE, null)).thenReturn(false);
+        when(securityInfoManager.hasPrivilege(loggedInInfo, "_admin.edocdelete", SecurityInfoManager.WRITE, null)).thenReturn(true);
         when(securityInfoManager.hasPrivilege(loggedInInfo, "_edoc", SecurityInfoManager.WRITE, null)).thenReturn(true);
+        when(securityInfoManager.hasPrivilege(loggedInInfo, "_edoc", SecurityInfoManager.READ, null)).thenReturn(true);
         when(securityInfoManager.isAllowedAccessToPatientRecord(loggedInInfo, 123)).thenReturn(true);
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/ConsultationWebServiceRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/ConsultationWebServiceRegressionTest.java
@@ -45,6 +45,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
@@ -123,14 +124,15 @@ class ConsultationWebServiceRegressionTest {
         ConsultationRequestTo1 request = new ConsultationRequestTo1();
         request.setId(456);
         request.setDemographicId(DEMOGRAPHIC_NO);
-        request.setAttachments(List.of(existingDocumentAttachment(321)));
-        when(consultationManager.getConsultRequestDocs(loggedInInfo, request.getId())).thenReturn(new ArrayList<>());
-        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+        request.setAttachments(List.of(existingDocumentAttachment(321), existingDocumentAttachment(654)));
+        when(outboundEmailArchiveDao.findExistingDocumentNos(List.of(321, 654))).thenReturn(Set.of(321));
 
-        assertThatThrownBy(() -> ReflectionTestUtils.invokeMethod(service, "saveRequestAttachments", request))
+        assertThatThrownBy(() -> ReflectionTestUtils.invokeMethod(
+                service, "assertNoOutboundEmailArchiveAttachments", request.getAttachments()))
                 .isInstanceOf(SecurityException.class)
                 .hasMessageContaining("controlled archive workflow");
 
+        verify(outboundEmailArchiveDao).findExistingDocumentNos(List.of(321, 654));
         verify(consultationManager, never()).saveConsultRequestDoc(eq(loggedInInfo), any(ConsultDocs.class));
     }
 
@@ -140,10 +142,10 @@ class ConsultationWebServiceRegressionTest {
         ConsultationResponseTo1 response = new ConsultationResponseTo1();
         response.setId(789);
         response.setAttachments(List.of(existingDocumentAttachment(321)));
-        when(consultationManager.getConsultResponseDocs(loggedInInfo, response.getId())).thenReturn(new ArrayList<>());
-        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+        when(outboundEmailArchiveDao.findExistingDocumentNos(List.of(321))).thenReturn(Set.of(321));
 
-        assertThatThrownBy(() -> ReflectionTestUtils.invokeMethod(service, "saveResponseAttachments", response))
+        assertThatThrownBy(() -> ReflectionTestUtils.invokeMethod(
+                service, "assertNoOutboundEmailArchiveAttachments", response.getAttachments()))
                 .isInstanceOf(SecurityException.class)
                 .hasMessageContaining("controlled archive workflow");
 
@@ -158,10 +160,10 @@ class ConsultationWebServiceRegressionTest {
         ConsultationResponseTo1 response = new ConsultationResponseTo1();
         response.setId(789);
         response.setAttachments(List.of(attachment));
-        when(consultationManager.getConsultResponseDocs(loggedInInfo, response.getId())).thenReturn(new ArrayList<>());
-        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+        when(outboundEmailArchiveDao.findExistingDocumentNos(List.of(321))).thenReturn(Set.of(321));
 
-        assertThatThrownBy(() -> ReflectionTestUtils.invokeMethod(service, "saveResponseAttachments", response))
+        assertThatThrownBy(() -> ReflectionTestUtils.invokeMethod(
+                service, "assertNoOutboundEmailArchiveAttachments", response.getAttachments()))
                 .isInstanceOf(SecurityException.class)
                 .hasMessageContaining("controlled archive workflow");
 
@@ -180,7 +182,7 @@ class ConsultationWebServiceRegressionTest {
         List<ConsultDocs> currentDocs = new ArrayList<>(List.of(archiveAttachment));
         when(consultationManager.getConsultRequestDocs(loggedInInfo, request.getId()))
                 .thenReturn(currentDocs);
-        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+        when(outboundEmailArchiveDao.findExistingDocumentNos(List.of(321))).thenReturn(Set.of(321));
 
         ReflectionTestUtils.invokeMethod(service, "saveRequestAttachments", request);
 

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/ConsultationWebServiceRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/ConsultationWebServiceRegressionTest.java
@@ -168,6 +168,25 @@ class ConsultationWebServiceRegressionTest {
         verify(consultationManager, never()).saveConsultResponseDoc(eq(loggedInInfo), any(ConsultResponseDoc.class));
     }
 
+    @Test
+    @DisplayName("should preserve hidden outbound archive attachments during request saves")
+    void shouldPreserveHiddenOutboundArchiveAttachmentsDuringRequestSave() {
+        ConsultationRequestTo1 request = new ConsultationRequestTo1();
+        request.setId(456);
+        request.setDemographicId(DEMOGRAPHIC_NO);
+        request.setAttachments(new ArrayList<>());
+        ConsultDocs archiveAttachment = new ConsultDocs(
+                request.getId(), 321, ConsultationAttachmentTo1.TYPE_DOC, PROVIDER_NO);
+        List<ConsultDocs> currentDocs = new ArrayList<>(List.of(archiveAttachment));
+        when(consultationManager.getConsultRequestDocs(loggedInInfo, request.getId()))
+                .thenReturn(currentDocs);
+        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+
+        ReflectionTestUtils.invokeMethod(service, "saveRequestAttachments", request);
+
+        assertThat(archiveAttachment.getDeleted()).isNull();
+    }
+
     private static ConsultationAttachmentTo1 newDocumentAttachment() {
         ConsultationAttachmentTo1 attachment = new ConsultationAttachmentTo1();
         attachment.setDocumentType(ConsultationAttachmentTo1.TYPE_DOC);

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/ConsultationWebServiceRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/ConsultationWebServiceRegressionTest.java
@@ -22,10 +22,16 @@
 package io.github.carlos_emr.carlos.webserv.rest;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.github.carlos_emr.carlos.commn.dao.OutboundEmailArchiveDao;
+import io.github.carlos_emr.carlos.commn.model.ConsultDocs;
+import io.github.carlos_emr.carlos.commn.model.ConsultResponseDoc;
 import io.github.carlos_emr.carlos.commn.model.Document;
 import io.github.carlos_emr.carlos.managers.ConsultationManager;
 import io.github.carlos_emr.carlos.managers.DocumentManager;
@@ -33,9 +39,11 @@ import io.github.carlos_emr.carlos.utility.FileValidationException;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.webserv.rest.to.model.ConsultationAttachmentTo1;
 import io.github.carlos_emr.carlos.webserv.rest.to.model.ConsultationRequestTo1;
+import io.github.carlos_emr.carlos.webserv.rest.to.model.ConsultationResponseTo1;
 import io.github.carlos_emr.carlos.webserv.rest.to.model.DocumentTo1;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -69,6 +77,9 @@ class ConsultationWebServiceRegressionTest {
     private ConsultationManager consultationManager;
 
     @Mock
+    private OutboundEmailArchiveDao outboundEmailArchiveDao;
+
+    @Mock
     private LoggedInInfo loggedInInfo;
 
     private ConsultationWebService service;
@@ -83,6 +94,7 @@ class ConsultationWebServiceRegressionTest {
         };
         ReflectionTestUtils.setField(service, "documentManager", documentManager);
         ReflectionTestUtils.setField(service, "consultationManager", consultationManager);
+        ReflectionTestUtils.setField(service, "outboundEmailArchiveDao", outboundEmailArchiveDao);
     }
 
     @Test
@@ -105,11 +117,70 @@ class ConsultationWebServiceRegressionTest {
         assertThat(request.getAttachments().get(0).getDocumentNo()).isZero();
     }
 
+    @Test
+    @DisplayName("should reject outbound archive documents when saving request attachments")
+    void shouldRejectOutboundArchiveDocumentsWhenSavingRequestAttachments() {
+        ConsultationRequestTo1 request = new ConsultationRequestTo1();
+        request.setId(456);
+        request.setDemographicId(DEMOGRAPHIC_NO);
+        request.setAttachments(List.of(existingDocumentAttachment(321)));
+        when(consultationManager.getConsultRequestDocs(loggedInInfo, request.getId())).thenReturn(new ArrayList<>());
+        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+
+        assertThatThrownBy(() -> ReflectionTestUtils.invokeMethod(service, "saveRequestAttachments", request))
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("controlled archive workflow");
+
+        verify(consultationManager, never()).saveConsultRequestDoc(eq(loggedInInfo), any(ConsultDocs.class));
+    }
+
+    @Test
+    @DisplayName("should reject outbound archive documents when saving response attachments")
+    void shouldRejectOutboundArchiveDocumentsWhenSavingResponseAttachments() {
+        ConsultationResponseTo1 response = new ConsultationResponseTo1();
+        response.setId(789);
+        response.setAttachments(List.of(existingDocumentAttachment(321)));
+        when(consultationManager.getConsultResponseDocs(loggedInInfo, response.getId())).thenReturn(new ArrayList<>());
+        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+
+        assertThatThrownBy(() -> ReflectionTestUtils.invokeMethod(service, "saveResponseAttachments", response))
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("controlled archive workflow");
+
+        verify(consultationManager, never()).saveConsultResponseDoc(eq(loggedInInfo), any(ConsultResponseDoc.class));
+    }
+
+    @Test
+    @DisplayName("should reject outbound archive response attachments even when validationError is supplied")
+    void shouldRejectOutboundArchiveResponseAttachmentsEvenWithValidationError() {
+        ConsultationAttachmentTo1 attachment = existingDocumentAttachment(321);
+        attachment.setValidationError("client supplied validation error");
+        ConsultationResponseTo1 response = new ConsultationResponseTo1();
+        response.setId(789);
+        response.setAttachments(List.of(attachment));
+        when(consultationManager.getConsultResponseDocs(loggedInInfo, response.getId())).thenReturn(new ArrayList<>());
+        when(outboundEmailArchiveDao.existsByDocumentNo(321)).thenReturn(true);
+
+        assertThatThrownBy(() -> ReflectionTestUtils.invokeMethod(service, "saveResponseAttachments", response))
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("controlled archive workflow");
+
+        verify(consultationManager, never()).saveConsultResponseDoc(eq(loggedInInfo), any(ConsultResponseDoc.class));
+    }
+
     private static ConsultationAttachmentTo1 newDocumentAttachment() {
         ConsultationAttachmentTo1 attachment = new ConsultationAttachmentTo1();
         attachment.setDocumentType(ConsultationAttachmentTo1.TYPE_DOC);
         attachment.setAttached(true);
         attachment.setDocument(validDocument());
+        return attachment;
+    }
+
+    private static ConsultationAttachmentTo1 existingDocumentAttachment(int documentNo) {
+        ConsultationAttachmentTo1 attachment = new ConsultationAttachmentTo1();
+        attachment.setDocumentNo(documentNo);
+        attachment.setDocumentType(ConsultationAttachmentTo1.TYPE_DOC);
+        attachment.setAttached(true);
         return attachment;
     }
 


### PR DESCRIPTION
## Summary

Based on #3138 / depends on the archive foundation branch.

Part of #3114. This adds backend-first access and deletion hardening around the outbound email archive without adding UI.

- Add permission-checked metadata and artifact reads.
- Require `_edoc` read privilege plus patient-record access.
- Verify stored artifact size and SHA-256 before returning bytes and audit integrity failures without PHI.
- Hide archive eDocs from generic document, attachment, preview, split/combine, export, and deletion workflows.
- Require controlled deletion and preserve immutable attachment/deletion audit metadata.

## Rebuild notes

This PR is now one thin 32-file commit on #3138. The replay preserves newer `develop` protections for collision-resistant document writes, validated refile requests, and capability-based PDF previews. It no longer carries legacy schema/bootstrap files or the unrelated MariaDB workflow timeout tweak.

## Testing

- `mvn -q -DskipITs -Dtest=DocumentManagerImplFilenameValidationTest,DocumentPreview2ActionUnitTest,OutboundEmailArchiveServiceImplUnitTest,EDocUtilDeleteDocumentUnitTest test`
- 118 tests ran; one merge-boundary regression was corrected and its focused rerun passed.
- `git diff --check`
