### PR TITLE
Escape email status popover content

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/admin/emailStatusResults.jspf
+++ b/src/main/webapp/WEB-INF/jsp/admin/emailStatusResults.jspf
@@ -41,7 +41,7 @@
             <tr>
                 <td class="status-and-date">
                     <div class="status-tag status-tag-${fn:toLowerCase(emailStatusResult.status)}" id="emailStatus${emailStatusResult.logId}" 
-                        ${ empty emailStatusResult.errorMessage ? '' : "data-bs-toggle='popover'" } data-bs-trigger='hover click' data-bs-content="${emailStatusResult.errorMessage}">
+                        ${ empty emailStatusResult.errorMessage ? '' : "data-bs-toggle='popover'" } data-bs-trigger='hover click' data-bs-content="${carlos:forHtmlAttribute(emailStatusResult.errorMessage)}">
                         ${carlos:forHtml(emailStatusResult.status)}
                     </div>
                     <div class="date-time text-muted">


### PR DESCRIPTION
﻿## What changed
- Escaped `emailStatusResult.errorMessage` with `carlos:forHtmlAttribute(...)` before writing it into the Bootstrap popover `data-bs-content` attribute.

## Why
Fixes #3198. Email delivery error messages can contain quotes or markup-like text, so the value needs HTML attribute-context escaping before being rendered into `data-bs-content`.

## Validation
- Compared `develop...xujunfeng1:agent/escape-email-status-popover` through the GitHub API.
- Verified the diff changes only `src/main/webapp/WEB-INF/jsp/admin/emailStatusResults.jspf` and replaces the raw EL expression with the existing attribute encoder.

## Summary by Sourcery

Bug Fixes:
- Ensure email delivery error messages in the popover are HTML-attribute escaped to prevent malformed content or unsafe rendering.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Escape email status popover content by encoding `emailStatusResult.errorMessage` with `carlos:forHtmlAttribute(...)`, so the `data-bs-content` attribute renders safely even with quotes or markup-like text. Fixes #3198.

<sup>Written for commit 80b3913e25f2b208f4befd6c09bb3a3477d1e652. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

