### PR TITLE
fix: harden provider settings updates with manager guard

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/managers/ProviderManager2.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/ProviderManager2.java
@@ -472,7 +472,28 @@ public class ProviderManager2 {
         }
     }
 
+    /**
+     * Updates settings for the authenticated provider and records a sanitized audit entry.
+     *
+     * <p>The target must match the provider identity from {@code loggedInInfo}. This
+     * manager-level check mirrors the REST endpoint as defense in depth; cross-provider
+     * administration requires a separate explicit endpoint.</p>
+     *
+     * @param loggedInInfo authenticated caller identity
+     * @param providerNo provider whose settings are being updated
+     * @param settings new provider settings
+     * @throws SecurityException when the caller is missing or targets another provider
+     * @since 2026-07-21
+     */
     public void updateProviderSettings(LoggedInInfo loggedInInfo, String providerNo, ProviderSettings settings) {
+
+        // Defense in depth: keep the self-only authorization rule with the operation so
+        // a future non-REST caller cannot bypass the ProviderService endpoint guard.
+        // Cross-provider editing belongs behind a separate explicit admin endpoint.
+        String currentProviderNo = loggedInInfo != null ? loggedInInfo.getLoggedInProviderNo() : null;
+        if (providerNo == null || !providerNo.equals(currentProviderNo)) {
+            throw new SecurityException("provider settings may only be saved for the authenticated provider");
+        }
 
         ProviderPreference pp = providerPreferenceDao.find(providerNo);
         if (pp == null) {
@@ -684,6 +705,13 @@ public class ProviderManager2 {
         providerExt.setSignature(settings.getSignature());
 
         providerExtDao.merge(providerExt);
+
+        // Audit trail: record who changed which provider's settings, placed after the DAO
+        // writes above. If any merge throws, the exception propagates and this line is never
+        // reached, so no audit entry is recorded for an update that did not complete. The
+        // target provider identifier is passed as the structured data field (no settings
+        // values) to avoid logging PHI-adjacent content.
+        LogAction.addLogSynchronous(loggedInInfo, "ProviderManager.updateProviderSettings", providerNo);
 
     }
 

--- a/src/test/java/io/github/carlos_emr/carlos/managers/ProviderManager2UnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/managers/ProviderManager2UnitTest.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.managers;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import io.github.carlos_emr.carlos.PMmodule.dao.ProviderDao;
+import io.github.carlos_emr.carlos.commn.dao.PropertyDao;
+import io.github.carlos_emr.carlos.commn.dao.ProviderExtDao;
+import io.github.carlos_emr.carlos.commn.dao.ProviderPreferenceDao;
+import io.github.carlos_emr.carlos.commn.model.Provider;
+import io.github.carlos_emr.carlos.managers.model.ProviderSettings;
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
+import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for {@link ProviderManager2}, focused on the manager-level (defense-in-depth)
+ * authorization contract of {@code updateProviderSettings} (issue #2821 — provider settings
+ * IDOR).
+ *
+ * <p>This test pins the self-only authorization rule at the manager boundary so it
+ * cannot be removed without a test failing.</p>
+ *
+ * <p>Scope note: only the deny path is exercised. It short-circuits before the ~100-field
+ * {@code ProviderSettings} mapping, so it stays a focused guard test; a bare mock of
+ * {@code ProviderSettings} would NPE partway through that mapping on the allow path.</p>
+ *
+ * @since 2026-07-30
+ * @see ProviderManager2#updateProviderSettings
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ProviderManager2 Unit Tests")
+@Tag("unit")
+@Tag("fast")
+@Tag("manager")
+class ProviderManager2UnitTest extends CarlosUnitTestBase {
+
+    private static final String TARGET_PROVIDER_NO = "1";
+
+    @Mock
+    private ProviderDao providerDao;
+
+    @Mock
+    private PropertyDao propertyDao;
+
+    @Mock
+    private ProviderPreferenceDao providerPreferenceDao;
+
+    @Mock
+    private ProviderExtDao providerExtDao;
+
+    @InjectMocks
+    private ProviderManager2 providerManager;
+
+    @Test
+    @Tag("update")
+    @DisplayName("should persist nothing when a provider targets another provider")
+    void shouldNotPersist_whenProviderTargetsAnotherProvider() {
+        LoggedInInfo loggedInInfo = new LoggedInInfo();
+        loggedInInfo.setLoggedInProvider(new Provider("999998"));
+        ProviderSettings settings = mock(ProviderSettings.class);
+
+        assertThatThrownBy(() -> providerManager.updateProviderSettings(loggedInInfo, TARGET_PROVIDER_NO, settings))
+            .isInstanceOf(SecurityException.class);
+
+        // A denied edit must block every persistence path. Deleting the manager-level
+        // guard makes this assertion fail.
+        verifyNoInteractions(providerPreferenceDao, providerExtDao, propertyDao);
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/ProviderServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/ProviderServiceUnitTest.java
@@ -1,0 +1,172 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.webserv.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import io.github.carlos_emr.CarlosProperties;
+import io.github.carlos_emr.carlos.commn.model.Provider;
+import io.github.carlos_emr.carlos.managers.ProviderManager2;
+import io.github.carlos_emr.carlos.managers.model.ProviderSettings;
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
+import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import io.github.carlos_emr.carlos.webserv.rest.to.GenericRestResponse.ResponseStatus;
+import io.github.carlos_emr.carlos.webserv.rest.to.RestResponse;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response.Status;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+/**
+ * Unit tests for {@link ProviderService}, focused on the authorization contract of
+ * {@code saveProviderSettings} (issue #2821 — IDOR).
+ *
+ * <p>Uses a testable subclass that overrides {@code getLoggedInInfo()} to bypass the
+ * CXF HTTP request context, and injects mocked collaborators via the package-private
+ * fields (this test lives in the same package as {@link ProviderService}).</p>
+ *
+ * @since 2026-07-21
+ * @see ProviderService
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("ProviderService Unit Tests")
+@Tag("unit")
+@Tag("fast")
+class ProviderServiceUnitTest extends CarlosUnitTestBase {
+
+    private static final String CALLER_PROVIDER_NO = "999998";
+    private static final String OTHER_PROVIDER_NO = "1";
+
+    @Mock
+    private ProviderManager2 mockProviderManager;
+
+    private LoggedInInfo loggedInInfo;
+    private ProviderService service;
+    private MockedStatic<CarlosProperties> carlosPropertiesMock;
+
+    @BeforeEach
+    void setUp() {
+        // RestResponse header construction reads these static properties.
+        carlosPropertiesMock = mockStatic(CarlosProperties.class);
+        carlosPropertiesMock.when(CarlosProperties::getBuildDate).thenReturn("2026-01-01");
+        carlosPropertiesMock.when(CarlosProperties::getBuildTag).thenReturn("test");
+
+        loggedInInfo = loggedInInfoFor(CALLER_PROVIDER_NO);
+
+        // Testable subclass: return the current test's LoggedInInfo (reassignable per test).
+        service = new ProviderService() {
+            @Override
+            protected LoggedInInfo getLoggedInInfo() {
+                return loggedInInfo;
+            }
+        };
+        service.providerManager = mockProviderManager;
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (carlosPropertiesMock != null) carlosPropertiesMock.close();
+    }
+
+    private static LoggedInInfo loggedInInfoFor(String providerNo) {
+        LoggedInInfo info = new LoggedInInfo();
+        if (providerNo != null) {
+            info.setLoggedInProvider(new Provider(providerNo));
+        }
+        return info;
+    }
+
+    @Nested
+    @DisplayName("saveProviderSettings authorization")
+    @Tag("update")
+    class SaveProviderSettings {
+
+        @Test
+        @DisplayName("should save settings when provider edits own settings")
+        void shouldSaveSettings_whenProviderEditsOwnSettings() {
+            ProviderSettings settings = mock(ProviderSettings.class);
+
+            RestResponse<String> response = service.saveProviderSettings(settings, CALLER_PROVIDER_NO);
+
+            assertThat(response.getStatus()).isEqualTo(ResponseStatus.SUCCESS);
+            verify(mockProviderManager).updateProviderSettings(eq(loggedInInfo), eq(CALLER_PROVIDER_NO), eq(settings));
+        }
+
+        @Test
+        @DisplayName("should return 403 when provider edits another provider")
+        void shouldReturn403_whenProviderEditsAnotherProvider() {
+            ProviderSettings settings = mock(ProviderSettings.class);
+
+            assertThatThrownBy(() -> service.saveProviderSettings(settings, OTHER_PROVIDER_NO))
+                    .isInstanceOf(WebApplicationException.class)
+                    .extracting(exception -> ((WebApplicationException) exception).getResponse().getStatus())
+                    .isEqualTo(Status.FORBIDDEN.getStatusCode());
+
+            verify(mockProviderManager, never()).updateProviderSettings(any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("should return 403 when target provider is null")
+        void shouldReturn403_whenTargetProviderIsNull() {
+            ProviderSettings settings = mock(ProviderSettings.class);
+
+            assertThatThrownBy(() -> service.saveProviderSettings(settings, (String) null))
+                    .isInstanceOf(WebApplicationException.class)
+                    .extracting(exception -> ((WebApplicationException) exception).getResponse().getStatus())
+                    .isEqualTo(Status.FORBIDDEN.getStatusCode());
+
+            verify(mockProviderManager, never()).updateProviderSettings(any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("should return 403 when session provider is null")
+        void shouldReturn403_whenSessionProviderIsNull() {
+            loggedInInfo = loggedInInfoFor(null);
+            ProviderSettings settings = mock(ProviderSettings.class);
+
+            assertThatThrownBy(() -> service.saveProviderSettings(settings, CALLER_PROVIDER_NO))
+                    .isInstanceOf(WebApplicationException.class)
+                    .extracting(exception -> ((WebApplicationException) exception).getResponse().getStatus())
+                    .isEqualTo(Status.FORBIDDEN.getStatusCode());
+
+            verify(mockProviderManager, never()).updateProviderSettings(any(), any(), any());
+        }
+    }
+}


### PR DESCRIPTION
## Description

The original endpoint-level IDOR fix was independently merged through #3193 while this PR was in review. This branch has been rebased onto current develop and narrowed to the useful follow-up hardening:

- Preserves the existing self-only ProviderService authorization and HTTP 403 response unchanged.
- Adds the same self-only authorization rule inside ProviderManager2.updateProviderSettings as defense in depth, preventing a future non-REST caller from bypassing the endpoint boundary.
- Fails closed when caller identity or the target provider is missing.
- Records a sanitized audit entry after the settings writes, containing only the target provider identifier and no settings values.
- Adds focused service and manager tests for self-edit success, cross-provider denial, missing caller identity, missing target provider, and persistence short-circuiting.

Cross-provider administration remains out of scope and should use a separate explicit admin endpoint if introduced.

## Related Issues

Fixes #2821

## Testing

mvn -q -Dtest=ProviderServiceUnitTest,ProviderManager2UnitTest test

Result: 5 tests, 0 failures, 0 errors, with the normal Checkstyle gate enabled.

## Attribution

The final commit retains Mahmuda Akter as the primary author.

## Checklist

- [x] Commits are DCO signed
- [x] Conventional commit format
- [x] No patient data included
- [x] Focused tests added
- [x] Rebased onto current develop
