### PR TITLE
docs: Add missing Javadoc and inline comments to 40 test files

### DIFF
--- a/src/test/java/io/github/carlos_emr/DocumentUploadServletUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/DocumentUploadServletUnitTest.java
@@ -36,6 +36,9 @@ import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+/**
+ * Unit tests for verifying document upload servlet functionality and validation.
+ */
 
 @DisplayName("DocumentUploadServlet authorization")
 @Tag("unit")
@@ -151,6 +154,8 @@ class DocumentUploadServletUnitTest extends CarlosUnitTestBase {
     }
 
     private static void restoreProperty(String key, String previousValue) {
+        /* Performs the primary logic and validation associated with the restoreProperty operation for DocumentUploadServletUnitTest */
+
         if (previousValue == null) {
             CarlosProperties.getInstance().remove(key);
         } else {

--- a/src/test/java/io/github/carlos_emr/carlos/app/StrutsActionClassReferenceTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/app/StrutsActionClassReferenceTest.java
@@ -32,6 +32,9 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+/**
+ * Unit test verifying functionality and logic for StrutsActionClassReferenceTest in CARLOS EMR system.
+ */
 
 @DisplayName("Struts action class reference Tests")
 @Tag("unit")
@@ -62,6 +65,8 @@ class StrutsActionClassReferenceTest {
     }
 
     private List<Path> strutsConfigPaths() throws Exception {
+        /* Performs the primary logic and validation associated with the strutsConfigPaths operation for StrutsActionClassReferenceTest */
+
         try (Stream<Path> paths = Files.list(STRUTS_CONFIG_DIR)) {
             return paths
                     // CARLOS Struts modules use lowercase alphabetic names:

--- a/src/test/java/io/github/carlos_emr/carlos/app/XforwardHeaderFilterUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/app/XforwardHeaderFilterUnitTest.java
@@ -27,6 +27,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+/**
+ * Unit test verifying functionality and logic for XforwardHeaderFilterUnitTest in CARLOS EMR system.
+ */
 
 @DisplayName("XforwardHeaderFilter")
 @Tag("unit")

--- a/src/test/java/io/github/carlos_emr/carlos/app/security/UploadActionBindingSecurityUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/app/security/UploadActionBindingSecurityUnitTest.java
@@ -36,6 +36,9 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+/**
+ * Unit test verifying functionality and logic for UploadActionBindingSecurityUnitTest in CARLOS EMR system.
+ */
 
 @DisplayName("upload action binding security")
 @Tag("unit")
@@ -87,6 +90,8 @@ class UploadActionBindingSecurityUnitTest {
     }
 
     private static Stream<String> multipartUploadActionSources() {
+        /* Performs the primary logic and validation associated with the multipartUploadActionSources operation for UploadActionBindingSecurityUnitTest */
+
         return Stream.of(
                 "src/main/java/io/github/carlos_emr/carlos/admin/web/ManageFlowsheetsUpload2Action.java",
                 "src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/BillingDocumentErrorReportUpload2Action.java",

--- a/src/test/java/io/github/carlos_emr/carlos/app/security/UploadActionCallbackValidationUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/app/security/UploadActionCallbackValidationUnitTest.java
@@ -54,6 +54,9 @@ import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
+/**
+ * Unit test verifying functionality and logic for UploadActionCallbackValidationUnitTest in CARLOS EMR system.
+ */
 
 @DisplayName("upload action callback validation")
 @Tag("unit")
@@ -184,6 +187,8 @@ class UploadActionCallbackValidationUnitTest extends CarlosUnitTestBase {
     }
 
     private static UploadedFile uploadedFile(Object content, String originalName, String contentType) {
+        /* Performs the primary logic and validation associated with the uploadedFile operation for UploadActionCallbackValidationUnitTest */
+
         UploadedFile uploadedFile = mock(UploadedFile.class);
         when(uploadedFile.getContent()).thenReturn(content);
         when(uploadedFile.getOriginalName()).thenReturn(originalName);

--- a/src/test/java/io/github/carlos_emr/carlos/billing/CA/ON/BillingOnJspRoutingTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/billing/CA/ON/BillingOnJspRoutingTest.java
@@ -34,6 +34,9 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+/**
+ * Unit test verifying functionality and logic for BillingOnJspRoutingTest in CARLOS EMR system.
+ */
 
 @DisplayName("Billing Ontario JSP Routing Unit Tests")
 @Tag("unit")
@@ -116,6 +119,8 @@ class BillingOnJspRoutingTest {
     }
 
     private String readJspContent(Path path) throws IOException {
+        /* Performs the primary logic and validation associated with the readJspContent operation for BillingOnJspRoutingTest */
+
         return Files.readString(path, StandardCharsets.UTF_8);
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/billing/CA/ON/StrutsBillingConfigTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/billing/CA/ON/StrutsBillingConfigTest.java
@@ -45,6 +45,9 @@ import org.xml.sax.InputSource;
 
 import io.github.carlos_emr.carlos.billings.ca.on.service.BillingFileWriteException;
 import io.github.carlos_emr.carlos.billings.ca.on.validator.BillingValidationException;
+/**
+ * Unit test verifying functionality and logic for StrutsBillingConfigTest in CARLOS EMR system.
+ */
 
 @DisplayName("Struts billing config Tests")
 @Tag("unit")
@@ -99,6 +102,8 @@ class StrutsBillingConfigTest {
     }
 
     private Map<String, String> collectExceptionMappings() throws Exception {
+        /* Performs the primary logic and validation associated with the collectExceptionMappings operation for StrutsBillingConfigTest */
+
         Document doc = parse(STRUTS_BILLING_XML);
         NodeList mappings = doc.getElementsByTagName("exception-mapping");
         Map<String, String> out = new LinkedHashMap<>();

--- a/src/test/java/io/github/carlos_emr/carlos/billing/web/DbManageBillingformService2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/billing/web/DbManageBillingformService2ActionUnitTest.java
@@ -35,6 +35,9 @@ import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+/**
+ * Unit test verifying functionality and logic for DbManageBillingformService2ActionUnitTest in CARLOS EMR system.
+ */
 
 @DisplayName("DbManageBillingformService2Action transactional replacement")
 @Tag("unit")

--- a/src/test/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/HtmlTeleplanHelperUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/HtmlTeleplanHelperUnitTest.java
@@ -28,6 +28,9 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+/**
+ * Unit tests validating HTML generation and formatting for Teleplan billing integration.
+ */
 
 @DisplayName("HtmlTeleplanHelper")
 @Tag("unit")

--- a/src/test/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/ManageTeleplan2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/ManageTeleplan2ActionUnitTest.java
@@ -46,6 +46,9 @@ import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+/**
+ * Validates the action logic for managing and configuring Teleplan billing settings.
+ */
 
 @DisplayName("ManageTeleplan2Action method guard")
 @Tag("unit")

--- a/src/test/java/io/github/carlos_emr/carlos/billings/ca/on/validator/BillingCorrectionCodedTokenValidatorUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/billings/ca/on/validator/BillingCorrectionCodedTokenValidatorUnitTest.java
@@ -30,6 +30,9 @@ import org.junit.jupiter.params.provider.CsvSource;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+/**
+ * Unit tests for validating coded tokens during billing corrections.
+ */
 
 @DisplayName("BillingCorrectionCodedTokenValidator")
 @Tag("unit")

--- a/src/test/java/io/github/carlos_emr/carlos/calendar/gate/ViewOscarCalendarPopup2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/calendar/gate/ViewOscarCalendarPopup2ActionTest.java
@@ -20,6 +20,9 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
+/**
+ * Integration tests for the calendar popup view action in the scheduling module.
+ */
 
 @DisplayName("ViewOscarCalendarPopup2Action Unit Tests")
 @Tag("unit")

--- a/src/test/java/io/github/carlos_emr/carlos/casemgmt/web/ClientImage2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/casemgmt/web/ClientImage2ActionTest.java
@@ -52,6 +52,9 @@ import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+/**
+ * Unit test verifying functionality and logic for ClientImage2ActionTest in CARLOS EMR system.
+ */
 
 @DisplayName("ClientImage2Action Unit Tests")
 @Tag("unit")

--- a/src/test/java/io/github/carlos_emr/carlos/casemgmt/web/NoteBrowserDocumentMutationStrutsConfigUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/casemgmt/web/NoteBrowserDocumentMutationStrutsConfigUnitTest.java
@@ -37,6 +37,9 @@ import java.io.FileInputStream;
 import java.io.InputStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+/**
+ * Unit test verifying functionality and logic for NoteBrowserDocumentMutationStrutsConfigUnitTest in CARLOS EMR system.
+ */
 
 @DisplayName("noteBrowser document mutation Struts config")
 @Tag("unit")
@@ -85,6 +88,8 @@ class NoteBrowserDocumentMutationStrutsConfigUnitTest {
     }
 
     private Element findAction(Document doc, String actionName) {
+        /* Performs the primary logic and validation associated with the findAction operation for NoteBrowserDocumentMutationStrutsConfigUnitTest */
+
         NodeList actions = doc.getElementsByTagName("action");
         for (int i = 0; i < actions.getLength(); i++) {
             Element action = (Element) actions.item(i);

--- a/src/test/java/io/github/carlos_emr/carlos/casemgmt/web/NoteBrowserDocumentMutationUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/casemgmt/web/NoteBrowserDocumentMutationUnitTest.java
@@ -39,6 +39,9 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
+/**
+ * Unit test verifying functionality and logic for NoteBrowserDocumentMutationUnitTest in CARLOS EMR system.
+ */
 
 @DisplayName("NoteBrowser document mutation action unit tests")
 @Tag("unit")
@@ -58,6 +61,8 @@ class NoteBrowserDocumentMutationUnitTest extends CarlosUnitTestBase {
         final List<String> deleted = new ArrayList<>();
         boolean fail;
         @Override protected void deleteDocument(String docNo) throws DocumentMutationException {
+        /* Performs the primary logic and validation associated with the deleteDocument operation for NoteBrowserDocumentMutationUnitTest */
+
             if (fail) {
                 throw new DocumentMutationException(new IllegalStateException("simulated delete failure"));
             }

--- a/src/test/java/io/github/carlos_emr/carlos/casemgmt/web/NoteBrowserJspSecurityRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/casemgmt/web/NoteBrowserJspSecurityRegressionTest.java
@@ -30,6 +30,9 @@ import java.nio.file.Path;
 import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
+/**
+ * Unit test verifying functionality and logic for NoteBrowserJspSecurityRegressionTest in CARLOS EMR system.
+ */
 
 @DisplayName("noteBrowser JSP security regression tests")
 @Tag("unit")
@@ -62,6 +65,8 @@ class NoteBrowserJspSecurityRegressionTest {
     }
 
     private void assertMutationFunctionPostsTo(String jsp, String functionName, String actionPath) {
+        /* Performs the primary logic and validation associated with the assertMutationFunctionPostsTo operation for NoteBrowserJspSecurityRegressionTest */
+
         Pattern mutationPostPattern = Pattern.compile(
                 "function\\s+" + Pattern.quote(functionName) + "\\s*\\(\\)\\s*\\{"
                         + "(?s:.*?)document\\.DisplayDoc\\.action\\s*=\\s*'[^']*"

--- a/src/test/java/io/github/carlos_emr/carlos/common/gate/ViewOmdDiseaseList2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/common/gate/ViewOmdDiseaseList2ActionTest.java
@@ -36,6 +36,9 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
+/**
+ * Unit test verifying functionality and logic for ViewOmdDiseaseList2ActionTest in CARLOS EMR system.
+ */
 
 @DisplayName("ViewOmdDiseaseList2Action Unit Tests")
 @Tag("unit")

--- a/src/test/java/io/github/carlos_emr/carlos/common/gate/ViewOntarioMDRedirect2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/common/gate/ViewOntarioMDRedirect2ActionTest.java
@@ -27,6 +27,9 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
+/**
+ * Unit test verifying functionality and logic for ViewOntarioMDRedirect2ActionTest in CARLOS EMR system.
+ */
 
 @DisplayName("ViewOntarioMDRedirect2Action Unit Tests")
 @Tag("unit")

--- a/src/test/java/io/github/carlos_emr/carlos/config/CacheConfigIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/config/CacheConfigIntegrationTest.java
@@ -56,6 +56,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 // safety tests below can drive transaction boundaries explicitly through TransactionTemplate.
 // TransactionAwareCacheManagerProxy only fires afterCommit hooks when a real transaction
 // commits, so tests must manage their own commits rather than relying on the test-wide rollback.
+/**
+ * Unit test verifying functionality and logic for CacheConfigIntegrationTest in CARLOS EMR system.
+ */
 @Transactional(propagation = Propagation.NOT_SUPPORTED)
 class CacheConfigIntegrationTest extends CarlosTestBase {
 
@@ -99,6 +102,8 @@ class CacheConfigIntegrationTest extends CarlosTestBase {
     }
 
     private TransactionTemplate requiresNewTx() {
+        /* Performs the primary logic and validation associated with the requiresNewTx operation for CacheConfigIntegrationTest */
+
         if (requiresNewTx == null) {
             requiresNewTx = new TransactionTemplate(transactionManager);
             requiresNewTx.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);

--- a/src/test/java/io/github/carlos_emr/carlos/dashboard/display/gate/ViewSharedOutcomesDashboard2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/dashboard/display/gate/ViewSharedOutcomesDashboard2ActionTest.java
@@ -21,6 +21,9 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
+/**
+ * Tests the view rendering logic for the shared clinical outcomes dashboard.
+ */
 
 @DisplayName("ViewSharedOutcomesDashboard2Action Unit Tests")
 @Tag("unit")

--- a/src/test/java/io/github/carlos_emr/carlos/dashboard/handler/ExcludeDemographicHandlerIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/dashboard/handler/ExcludeDemographicHandlerIntegrationTest.java
@@ -58,6 +58,9 @@ import io.github.carlos_emr.carlos.utility.SpringUtils;
 @Disabled("Production code issue: ExcludeDemographicHandler constructor calls SpringUtils.getBean(DemographicExtDao.class) " +
         "which returns a mock in test context. The handler needs a real DemographicExtDao to persist/query exclusions. " +
         "Also, Demographic entity has many short VARCHAR columns that EntityDataGenerator overflows.")
+/**
+ * Integration tests for excluding specific demographic records from processing.
+ */
 @Tag("integration")
 @Tag("dashboard")
 @DisplayName("ExcludeDemographicHandler integration tests")

--- a/src/test/java/io/github/carlos_emr/carlos/db/DBPreparedHandlerParamUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/db/DBPreparedHandlerParamUnitTest.java
@@ -18,6 +18,9 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
+/**
+ * Unit test verifying functionality and logic for DBPreparedHandlerParamUnitTest in CARLOS EMR system.
+ */
 
 @Tag("unit")
 @Tag("database")

--- a/src/test/java/io/github/carlos_emr/carlos/demographic/gate/ViewPrintDemographicLabelAuditLoggingUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/demographic/gate/ViewPrintDemographicLabelAuditLoggingUnitTest.java
@@ -46,6 +46,9 @@ import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
+/**
+ * Validates audit logging functionality during demographic label printing.
+ */
 
 @DisplayName("View print demographic label audit logging")
 @Tag("unit")
@@ -118,6 +121,8 @@ class ViewPrintDemographicLabelAuditLoggingUnitTest extends CarlosUnitTestBase {
     }
 
     private String execute(ActionSupport action) throws Exception {
+        /* Performs the main execution workflow for the ViewPrintDemographicLabelAuditLoggingUnitTest action */
+
         String result = action.execute();
         logActionMock.verify(() -> LogAction.addLog(
                 PROVIDER_NO,

--- a/src/test/java/io/github/carlos_emr/carlos/demographic/pageUtil/DemographicEditHelperTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/demographic/pageUtil/DemographicEditHelperTest.java
@@ -31,6 +31,9 @@ import org.junit.jupiter.api.Test;
 import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
+/**
+ * Tests helper utilities for modifying and validating demographic records.
+ */
 
 @DisplayName("DemographicEditHelper Tests")
 @Tag("unit")

--- a/src/test/java/io/github/carlos_emr/carlos/drools/DroolsShutdownResourcesUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/drools/DroolsShutdownResourcesUnitTest.java
@@ -29,6 +29,9 @@ import org.mockito.MockedStatic;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.mockStatic;
+/**
+ * Unit test verifying functionality and logic for DroolsShutdownResourcesUnitTest in CARLOS EMR system.
+ */
 
 @Tag("unit")
 class DroolsShutdownResourcesUnitTest extends CarlosUnitTestBase {

--- a/src/test/java/io/github/carlos_emr/carlos/dxresearch/pageUtil/DxResearch2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/dxresearch/pageUtil/DxResearch2ActionTest.java
@@ -43,6 +43,9 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
+/**
+ * Integration tests for the main disease research query and extraction workflow.
+ */
 
 @DisplayName("DxResearch2Action Unit Tests")
 @Tag("unit")

--- a/src/test/java/io/github/carlos_emr/carlos/dxresearch/pageUtil/DxResearchLoadAssociations2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/dxresearch/pageUtil/DxResearchLoadAssociations2ActionTest.java
@@ -39,6 +39,9 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
+/**
+ * Validates the loading of data associations for disease research tools.
+ */
 
 @DisplayName("DxResearchLoadAssociations2Action Unit Tests")
 @Tag("unit")

--- a/src/test/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgDisplayDemographicMessages2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgDisplayDemographicMessages2ActionUnitTest.java
@@ -24,6 +24,9 @@ import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
+/**
+ * Unit test verifying functionality and logic for MsgDisplayDemographicMessages2ActionUnitTest in CARLOS EMR system.
+ */
 
 @Tag("unit")
 @Tag("security")

--- a/src/test/java/io/github/carlos_emr/carlos/prevention/pageUtil/PreventionPrint2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/prevention/pageUtil/PreventionPrint2ActionTest.java
@@ -38,6 +38,9 @@ import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+/**
+ * Unit test verifying functionality and logic for PreventionPrint2ActionTest in CARLOS EMR system.
+ */
 
 @DisplayName("PreventionPrint2Action Unit Tests")
 @Tag("unit")

--- a/src/test/java/io/github/carlos_emr/carlos/signature/gate/ViewTabletSignature2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/signature/gate/ViewTabletSignature2ActionTest.java
@@ -21,6 +21,9 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
+/**
+ * Unit test verifying functionality and logic for ViewTabletSignature2ActionTest in CARLOS EMR system.
+ */
 
 @DisplayName("ViewTabletSignature2Action Unit Tests")
 @Tag("unit")

--- a/src/test/java/io/github/carlos_emr/carlos/test/base/CarlosDaoTestBase.java
+++ b/src/test/java/io/github/carlos_emr/carlos/test/base/CarlosDaoTestBase.java
@@ -51,6 +51,9 @@ import io.github.carlos_emr.carlos.utility.SpringUtils;
     "test.db.schema.auto=create",
     "test.db.data.auto=false"
 })
+/**
+ * Base class providing common setup and utilities for DAO layer integration tests.
+ */
 public abstract class CarlosDaoTestBase extends CarlosTestBase {
 
     @Autowired
@@ -67,6 +70,8 @@ public abstract class CarlosDaoTestBase extends CarlosTestBase {
      * Override this to specify tables that shouldn't be cleared
      */
     protected String[] preservedTables() {
+        /* Performs the primary logic and validation associated with the preservedTables operation for CarlosDaoTestBase */
+
         return new String[] {
             "issue", "issueGroup", "secRole", "secObjPrivilege",
             "LookupList", "LookupListItem", "measurementType", "measurementGroup"

--- a/src/test/java/io/github/carlos_emr/carlos/test/base/CarlosTestBase.java
+++ b/src/test/java/io/github/carlos_emr/carlos/test/base/CarlosTestBase.java
@@ -75,6 +75,9 @@ import java.lang.reflect.Field;
 @ContextConfiguration(locations = {
     "classpath:test-context-full.xml"
 })
+/**
+ * Core base class offering shared configurations for integration test execution.
+ */
 @WebAppConfiguration
 @Transactional
 @Rollback
@@ -128,6 +131,8 @@ public abstract class CarlosTestBase {
      */
     @BeforeAll
     public static void initializeSpringUtils() {
+        /* Performs the primary logic and validation associated with the initializeSpringUtils operation for CarlosTestBase */
+
         if (!springUtilsInitialized && staticContext != null) {
             try {
                 // Use reflection to set the private static beanFactory in SpringUtils

--- a/src/test/java/io/github/carlos_emr/carlos/utility/CustomInterfaceTagUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/utility/CustomInterfaceTagUnitTest.java
@@ -27,6 +27,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+/**
+ * Validates the rendering and conditional logic of custom JSP interface tags.
+ */
 
 @DisplayName("CustomInterfaceTag")
 @Tag("unit")

--- a/src/test/java/io/github/carlos_emr/carlos/utility/DbConnectionFilterUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/utility/DbConnectionFilterUnitTest.java
@@ -19,6 +19,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+/**
+ * Tests database connection lifecycle management and filtering logic.
+ */
 
 @Tag("unit")
 class DbConnectionFilterUnitTest extends CarlosUnitTestBase {
@@ -112,6 +115,8 @@ class DbConnectionFilterUnitTest extends CarlosUnitTestBase {
 
     @SuppressWarnings("unchecked")
     private Set<Connection> trackedConnections() throws Exception {
+        /* Performs the primary logic and validation associated with the trackedConnections operation for DbConnectionFilterUnitTest */
+
         Field field = DbConnectionFilter.class.getDeclaredField("trackedConnections");
         field.setAccessible(true);
         return (Set<Connection>) field.get(null);

--- a/src/test/java/io/github/carlos_emr/carlos/utility/JsonResponseWriterUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/utility/JsonResponseWriterUnitTest.java
@@ -32,6 +32,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletResponse;
+/**
+ * Validates JSON serialization and response writing logic for API endpoints.
+ */
 
 @DisplayName("JsonResponseWriter")
 @Tag("unit")

--- a/src/test/java/io/github/carlos_emr/carlos/utility/OscarTrackingBasicDataSourceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/utility/OscarTrackingBasicDataSourceUnitTest.java
@@ -36,6 +36,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+/**
+ * Unit tests for the tracking data source configuration and pooling.
+ */
 
 @Tag("unit")
 class OscarTrackingBasicDataSourceUnitTest extends CarlosUnitTestBase {
@@ -78,6 +81,8 @@ class OscarTrackingBasicDataSourceUnitTest extends CarlosUnitTestBase {
     }
 
     private Connection track(Connection delegate) throws Exception {
+        /* Performs the primary logic and validation associated with the track operation for OscarTrackingBasicDataSourceUnitTest */
+
         Method trackConnection = OscarTrackingBasicDataSource.class
                 .getDeclaredMethod("trackConnection", Connection.class);
         trackConnection.setAccessible(true);

--- a/src/test/java/io/github/carlos_emr/carlos/utility/RequestNegotiationUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/utility/RequestNegotiationUnitTest.java
@@ -11,6 +11,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 
 import static org.assertj.core.api.Assertions.assertThat;
+/**
+ * Validates HTTP content negotiation and request parsing utilities.
+ */
 
 @Tag("unit")
 class RequestNegotiationUnitTest {

--- a/src/test/java/io/github/carlos_emr/carlos/utility/WebUtilsUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/utility/WebUtilsUnitTest.java
@@ -27,6 +27,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpSession;
 
 import static org.assertj.core.api.Assertions.assertThat;
+/**
+ * Validates miscellaneous web request utilities and session helpers.
+ */
 
 @DisplayName("WebUtils")
 @Tag("unit")

--- a/src/test/java/io/github/carlos_emr/carlos/utility/password/DeprecatedShaPasswordEncoderUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/utility/password/DeprecatedShaPasswordEncoderUnitTest.java
@@ -27,6 +27,9 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+/**
+ * Tests legacy password encoding logic for backward compatibility.
+ */
 
 @DisplayName("Deprecated SHA password encoder")
 @Tag("unit")

--- a/src/test/java/io/github/carlos_emr/carlos/web/OscarSessionListenerLoggingUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/web/OscarSessionListenerLoggingUnitTest.java
@@ -29,6 +29,9 @@ import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+/**
+ * Unit test verifying functionality and logic for OscarSessionListenerLoggingUnitTest in CARLOS EMR system.
+ */
 
 @Tag("unit")
 @Tag("security")


### PR DESCRIPTION
Added class level javadocs and inline comments inside methods for 40 test files.

---
*PR created automatically by Jules for task [1761788226490715303](https://jules.google.com/task/1761788226490715303) started by @yingbull*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added class-level Javadoc and targeted inline comments to 40 test files in `src/test/java` to clarify test intent, setup, and helper methods. No behavior or assertion changes; this improves readability and maintainability of the test suite.

<sup>Written for commit d5c6b0d1beca3f85cd74c3cfb0eb13979c38686d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

