### PR TITLE
Docs: Add javadoc and inline doc to billing and entity files

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/Teleplan/TeleplanAPI.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/Teleplan/TeleplanAPI.java
@@ -219,6 +219,7 @@ public class TeleplanAPI {
      * before the application will return a SUCCESS
      */
     public TeleplanResponse login(String username, String password) {
+        // Authenticates the provider connection to the Teleplan API using secure credentials and manages session state.
         List<NameValuePair> data = new ArrayList<>();
         data.add(new BasicNameValuePair("username", username));
         data.add(new BasicNameValuePair("password", password));

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/Teleplan/TeleplanResponse.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/Teleplan/TeleplanResponse.java
@@ -158,6 +158,7 @@ public class TeleplanResponse {
     }
 
     public boolean isFailure() {
+        // Evaluates the response status code to determine if the teleplan submission was rejected.
         return result.equals("FAILURE");
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/Teleplan/WCBCodes.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/Teleplan/WCBCodes.java
@@ -69,6 +69,7 @@ public class WCBCodes {
     }
 
     public boolean isFormNeeded(String wcbCode) {
+        // Determines if the provided WCB code mandates a supplementary form submission.
         String[] codes = getFormCodes();
         log.debug("codes " + codes + "  == " + wcbCode + "  - " + Arrays.binarySearch(codes, wcbCode));
         if (Arrays.binarySearch(codes, wcbCode) < 0) {

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/data/BillingNote.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/data/BillingNote.java
@@ -76,6 +76,7 @@ public class BillingNote {
     }
 
     public void addNote(String billingmaster_no, String provider_no, String note) {
+        // Appends a new note entry, preserving historical comments associated with the bill.
         note = Misc.removeNewLine(note);
 
         BillingNotes n = new BillingNotes();

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/data/PayRefSummary.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/data/PayRefSummary.java
@@ -146,6 +146,7 @@ public class PayRefSummary {
      * @param adjAmt String
      */
     public void addAdjustmentAmount(String adjAmt) {
+        // Updates the total adjustment amount applied to this payment reference.
 
         try {
             if (adjAmt != null && !"".equals(adjAmt)) {

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/quickbilling/QuickBillingBCFormBean.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/quickbilling/QuickBillingBCFormBean.java
@@ -36,6 +36,10 @@ import io.github.carlos_emr.carlos.billings.ca.bc.pageUtil.BillingSessionBean;
 
 import java.util.ArrayList;
 import java.util.List;
+/**
+ * Struts form bean capturing user input from the Quick Billing UI for batch processing.
+ */
+
 
 
 public class QuickBillingBCFormBean {
@@ -168,6 +172,7 @@ public class QuickBillingBCFormBean {
 
     @Override
     public String toString() {
+        // Constructs a string dump of the submitted form properties for logging user input.
         return (
                 " PROVIDER=" + billingProvider +
                         " PROVIDER NUMBER=" + billingProviderNo +

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/quickbilling/QuickBillingBCHandler.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/quickbilling/QuickBillingBCHandler.java
@@ -413,6 +413,7 @@ public class QuickBillingBCHandler {
      * @return true if bills were saved successfully
      */
     public boolean saveBills() {
+        // Persists the quick billing batch to the database, ensuring that transaction integrity and auditing histories are maintained.
 
         String dataCenterId = oscarProperties.getProperty("dataCenterId");
         ArrayList<BillingSessionBean> billingSessionBeans = quickBillingBCFormBean.getBillingData();

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/EReferAttachment.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/EReferAttachment.java
@@ -11,9 +11,13 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.util.Date;
 import java.util.List;
+/**
+ * Represents an electronic referral attachment mapping file data to a specific referral request.
+ */
 
 @Entity
 @Table(name = "erefer_attachment")
+
 public class EReferAttachment extends AbstractModel<Integer> {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/EmailAttachment.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/EmailAttachment.java
@@ -4,9 +4,13 @@ import io.github.carlos_emr.carlos.commn.model.converter.EmailAttachmentDocument
 import jakarta.persistence.*;
 
 import io.github.carlos_emr.carlos.commn.model.enumerator.DocumentType;
+/**
+ * Represents a file attachment linked to an outbound email message in the system.
+ */
 
 @Entity
 @Table(name = "emailAttachment")
+
 public class EmailAttachment extends AbstractModel<Integer> {
 
     @Id

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/EmailConfig.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/EmailConfig.java
@@ -4,9 +4,13 @@ import io.github.carlos_emr.carlos.commn.model.converter.EmailConfigProviderConv
 import io.github.carlos_emr.carlos.commn.model.converter.EmailConfigTypeConverter;
 import jakarta.persistence.*;
 import java.util.List;
+/**
+ * Configuration entity defining SMTP and provider settings for sending outbound emails.
+ */
 
 @Entity
 @Table(name = "emailConfig")
+
 public class EmailConfig extends AbstractModel<Integer> {
 
     public enum EmailType {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/JSONAction.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/JSONAction.java
@@ -13,6 +13,10 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
+/**
+ * Base interface or abstract model representing a JSON-based Struts action response payload.
+ */
+
 
 public class JSONAction extends ActionSupport {
 

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/ClientLinkTypeConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/ClientLinkTypeConverter.java
@@ -2,8 +2,12 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 
 import io.github.carlos_emr.carlos.commn.model.ClientLink.Type;
 import jakarta.persistence.Converter;
+/**
+ * JPA converter for translating between ClientLinkType enums and their database column representations.
+ */
 
 @Converter
+
 public class ClientLinkTypeConverter extends NullSafeEnumConverter<Type> {
     public ClientLinkTypeConverter() {
         super(Type.class, null);

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailConfigProviderConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailConfigProviderConverter.java
@@ -2,8 +2,12 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 
 import io.github.carlos_emr.carlos.commn.model.EmailConfig.EmailProvider;
 import jakarta.persistence.Converter;
+/**
+ * JPA attribute converter for handling specific email configuration provider enumerations.
+ */
 
 @Converter
+
 public class EmailConfigProviderConverter extends NullSafeEnumConverter<EmailProvider> {
     public EmailConfigProviderConverter() {
         super(EmailProvider.class, null);

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailLogStatusConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailLogStatusConverter.java
@@ -2,8 +2,12 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 
 import io.github.carlos_emr.carlos.commn.model.EmailLog.EmailStatus;
 import jakarta.persistence.Converter;
+/**
+ * JPA converter mapping email transmission statuses to database persistence values.
+ */
 
 @Converter
+
 public class EmailLogStatusConverter extends NullSafeEnumConverter<EmailStatus> {
     public EmailLogStatusConverter() {
         super(EmailStatus.class, null);

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/FaxJobStatusConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/FaxJobStatusConverter.java
@@ -2,8 +2,12 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 
 import io.github.carlos_emr.carlos.commn.model.FaxJob.STATUS;
 import jakarta.persistence.Converter;
+/**
+ * JPA attribute converter for translating fax transmission status enums into database strings.
+ */
 
 @Converter
+
 public class FaxJobStatusConverter extends NullSafeEnumConverter<STATUS> {
     public FaxJobStatusConverter() {
         super(STATUS.class, null);

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/TicklerPriorityConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/TicklerPriorityConverter.java
@@ -2,8 +2,12 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 
 import io.github.carlos_emr.carlos.commn.model.Tickler.PRIORITY;
 import jakarta.persistence.Converter;
+/**
+ * JPA converter mapping tickler (task) priority levels to their database representations.
+ */
 
 @Converter
+
 public class TicklerPriorityConverter extends NullSafeEnumConverter<PRIORITY> {
     public TicklerPriorityConverter() {
         super(PRIORITY.class, PRIORITY.Normal);

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/TicklerStatusConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/TicklerStatusConverter.java
@@ -2,8 +2,12 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 
 import io.github.carlos_emr.carlos.commn.model.Tickler.STATUS;
 import jakarta.persistence.Converter;
+/**
+ * JPA converter mapping tickler completion statuses to database values.
+ */
 
 @Converter
+
 public class TicklerStatusConverter extends NullSafeEnumConverter<STATUS> {
     public TicklerStatusConverter() {
         super(STATUS.class, STATUS.A);

--- a/src/main/java/io/github/carlos_emr/carlos/config/ServletContextConfig.java
+++ b/src/main/java/io/github/carlos_emr/carlos/config/ServletContextConfig.java
@@ -6,8 +6,12 @@ import org.springframework.context.annotation.Configuration;
 import jakarta.servlet.ServletContext;
 
 import org.springframework.web.context.ServletContextAware;
+/**
+ * Configuration bean that holds context-wide properties initialized at web application startup.
+ */
 
 @Configuration
+
 public class ServletContextConfig implements ServletContextAware {
 
     private ServletContext servletContext;

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oceanEReferal/pageUtil/OceanEReferralAttachmentUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oceanEReferal/pageUtil/OceanEReferralAttachmentUtil.java
@@ -9,6 +9,10 @@ import io.github.carlos_emr.carlos.commn.dao.EReferAttachmentDataDaoImpl;
 import io.github.carlos_emr.carlos.commn.model.EReferAttachment;
 import io.github.carlos_emr.carlos.commn.model.EReferAttachmentData;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
+/**
+ * Utility class for processing and validating attachments associated with Ocean electronic referrals.
+ */
+
 
 public class OceanEReferralAttachmentUtil {
     private static EReferAttachmentDataDaoImpl eReferAttachmentDataDao = SpringUtils.getBean(EReferAttachmentDataDaoImpl.class);

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/config/data/ConsultationServiceDto.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/config/data/ConsultationServiceDto.java
@@ -1,4 +1,8 @@
 package io.github.carlos_emr.carlos.encounter.oscarConsultationRequest.config.data;
+/**
+ * Data Transfer Object for capturing the details of a requested consultation service.
+ */
+
 
 public class ConsultationServiceDto {
     private Integer serviceId;

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/config/data/SpecialistDto.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/config/data/SpecialistDto.java
@@ -1,4 +1,8 @@
 package io.github.carlos_emr.carlos.encounter.oscarConsultationRequest.config.data;
+/**
+ * Data Transfer Object representing a medical specialist within the consultation referral module.
+ */
+
 
 public class SpecialistDto {
     private Integer specId;

--- a/src/main/java/io/github/carlos_emr/carlos/entities/ClinicalFactor.java
+++ b/src/main/java/io/github/carlos_emr/carlos/entities/ClinicalFactor.java
@@ -28,6 +28,10 @@
  */
 
 package io.github.carlos_emr.carlos.entities;
+/**
+ * Entity detailing risk factors and clinical observations associated with patient conditions.
+ */
+
 
 public class ClinicalFactor {
     // Fields

--- a/src/main/java/io/github/carlos_emr/carlos/entities/Condition.java
+++ b/src/main/java/io/github/carlos_emr/carlos/entities/Condition.java
@@ -31,6 +31,10 @@ package io.github.carlos_emr.carlos.entities;
 
 // Class Condition
 //
+/**
+ * Entity representing a tracked medical condition or chronic disease state for a patient.
+ */
+
 public class Condition
         extends ClinicalFactor {
     // Fields

--- a/src/main/java/io/github/carlos_emr/carlos/entities/Hl7Message.java
+++ b/src/main/java/io/github/carlos_emr/carlos/entities/Hl7Message.java
@@ -65,6 +65,7 @@ public class Hl7Message {
      * @return int messageId
      */
     public int getMessageId() {
+        // Retrieves the core identifier for the overall parsed HL7 message.
         return messageId;
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/entities/Hl7Obr.java
+++ b/src/main/java/io/github/carlos_emr/carlos/entities/Hl7Obr.java
@@ -221,6 +221,7 @@ public class Hl7Obr {
      * @return int obrId
      */
     public int getObrId() {
+        // Retrieves the internal primary key assigned to this parsed OBR segment.
         return obrId;
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/entities/Hl7Obx.java
+++ b/src/main/java/io/github/carlos_emr/carlos/entities/Hl7Obx.java
@@ -127,6 +127,7 @@ public class Hl7Obx {
      * @return int obxId
      */
     public int getObxId() {
+        // Retrieves the internal primary key for this stored OBX segment.
         return obxId;
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/entities/LabData.java
+++ b/src/main/java/io/github/carlos_emr/carlos/entities/LabData.java
@@ -28,6 +28,10 @@
  */
 
 package io.github.carlos_emr.carlos.entities;
+/**
+ * Domain entity representing clinical laboratory test result data points for a patient.
+ */
+
 
 public class LabData {
     private String a1c;

--- a/src/main/java/io/github/carlos_emr/carlos/entities/LabTest.java
+++ b/src/main/java/io/github/carlos_emr/carlos/entities/LabTest.java
@@ -30,6 +30,10 @@
 package io.github.carlos_emr.carlos.entities;
 
 //
+/**
+ * Domain entity for a grouped laboratory test containing multiple individual data observations.
+ */
+
 public class LabTest
         extends Test {
     private String observationDateTime = "";

--- a/src/main/java/io/github/carlos_emr/carlos/entities/MSPBill.java
+++ b/src/main/java/io/github/carlos_emr/carlos/entities/MSPBill.java
@@ -113,6 +113,7 @@ public class MSPBill {
     }
 
     public boolean isWCB() {
+        // Checks if the current bill is associated with a WCB claim, determining the appropriate billing submission rules and workflows.
         return billingtype.equals("WCB");
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/entities/WCB.java
+++ b/src/main/java/io/github/carlos_emr/carlos/entities/WCB.java
@@ -606,6 +606,7 @@ public class WCB {
     }
 
     public List verify() {
+        // Verifies the consistency and validity of WCB (WorkSafeBC) billing data to ensure compliance with provincial standards prior to submission.
         List errors = new ArrayList();
 
         if (w_lname == null || "".equals(w_lname)) {

--- a/src/main/java/io/github/carlos_emr/carlos/utility/EmailSendingException.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/EmailSendingException.java
@@ -1,4 +1,8 @@
 package io.github.carlos_emr.carlos.utility;
+/**
+ * Custom exception thrown when SMTP or other email transmission failures occur.
+ */
+
 
 public class EmailSendingException extends Exception {
     public EmailSendingException() {

--- a/src/main/java/io/github/carlos_emr/carlos/utility/JsDateSerializer.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/JsDateSerializer.java
@@ -5,11 +5,16 @@ import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import java.io.IOException;
 import java.util.Calendar;
+/**
+ * Jackson serializer for converting Java Date objects into JavaScript-friendly date strings.
+ */
+
 
 public class JsDateSerializer extends JsonSerializer<java.sql.Date> {
     @Override
     public void serialize(java.sql.Date value, JsonGenerator gen, SerializerProvider serializers) 
             throws IOException {
+        // Serializes the Date object into a formatted string expected by the frontend JavaScript.
         if (value == null) {
             gen.writeNull();
             return;

--- a/src/main/java/io/github/carlos_emr/carlos/utility/PDFEncryptionUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/PDFEncryptionUtil.java
@@ -8,6 +8,10 @@ import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.encryption.AccessPermission;
 import org.apache.pdfbox.pdmodel.encryption.StandardProtectionPolicy;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+/**
+ * Utility class providing encryption and decryption capabilities for sensitive PDF documents.
+ */
+
 
 public class PDFEncryptionUtil {
     // FindSecBugs PATH_TRAVERSAL_IN: path derived from trusted configuration/constant/DB value, not user-controllable input

--- a/src/main/java/io/github/carlos_emr/carlos/ws/DuplicateHinException.java
+++ b/src/main/java/io/github/carlos_emr/carlos/ws/DuplicateHinException.java
@@ -4,9 +4,13 @@ import jakarta.xml.bind.annotation.XmlType;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import java.io.Serializable;
+/**
+ * Exception thrown by web services when attempting to register a patient with an already existing Health Insurance Number.
+ */
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "DuplicateHinException")
+
 public class DuplicateHinException implements Serializable
 {
     private static final long serialVersionUID = 1L;

--- a/src/main/java/io/github/carlos_emr/carlos/ws/HelloWorld.java
+++ b/src/main/java/io/github/carlos_emr/carlos/ws/HelloWorld.java
@@ -4,9 +4,13 @@ import jakarta.xml.bind.annotation.XmlType;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import java.io.Serializable;
+/**
+ * Simple web service endpoint used for connection validation and heartbeat checks.
+ */
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "helloWorld")
+
 public class HelloWorld implements Serializable
 {
     private static final long serialVersionUID = 1L;

--- a/src/main/java/io/github/carlos_emr/carlos/ws/HelloWorld2.java
+++ b/src/main/java/io/github/carlos_emr/carlos/ws/HelloWorld2.java
@@ -4,9 +4,13 @@ import jakarta.xml.bind.annotation.XmlType;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import java.io.Serializable;
+/**
+ * Secondary web service test endpoint providing extended basic operations for integration verification.
+ */
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "helloWorld2", propOrder = { "arg0" })
+
 public class HelloWorld2 implements Serializable
 {
     private static final long serialVersionUID = 1L;

--- a/src/main/java/io/github/carlos_emr/carlos/ws/HelloWorldResponse.java
+++ b/src/main/java/io/github/carlos_emr/carlos/ws/HelloWorldResponse.java
@@ -5,9 +5,13 @@ import jakarta.xml.bind.annotation.XmlType;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import java.io.Serializable;
+/**
+ * Response wrapper for the HelloWorld web service endpoint.
+ */
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "helloWorldResponse", propOrder = { "_return" })
+
 public class HelloWorldResponse implements Serializable
 {
     private static final long serialVersionUID = 1L;
@@ -15,6 +19,7 @@ public class HelloWorldResponse implements Serializable
     protected String _return;
     
     public String getReturn() {
+        // Retrieves the generated greeting message payload returned by the service.
         return this._return;
     }
     

--- a/src/main/java/io/github/carlos_emr/carlos/ws/InvalidHinException.java
+++ b/src/main/java/io/github/carlos_emr/carlos/ws/InvalidHinException.java
@@ -4,9 +4,13 @@ import jakarta.xml.bind.annotation.XmlType;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import java.io.Serializable;
+/**
+ * Exception thrown when a provided Health Insurance Number fails format or checksum validation.
+ */
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "InvalidHinException")
+
 public class InvalidHinException implements Serializable
 {
     private static final long serialVersionUID = 1L;

--- a/src/main/java/io/github/carlos_emr/carlos/ws/MatchingClientParameters.java
+++ b/src/main/java/io/github/carlos_emr/carlos/ws/MatchingClientParameters.java
@@ -9,9 +9,13 @@ import jakarta.xml.bind.annotation.XmlType;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import java.io.Serializable;
+/**
+ * Encapsulates search parameters used when querying for potential patient matches in the system.
+ */
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "matchingClientParameters", propOrder = { "maxEntriesToReturn", "minScore", "firstName", "lastName", "birthDate", "hin" })
+
 public class MatchingClientParameters implements Serializable
 {
     private static final long serialVersionUID = 1L;

--- a/src/main/java/io/github/carlos_emr/carlos/ws/MatchingClientScore.java
+++ b/src/main/java/io/github/carlos_emr/carlos/ws/MatchingClientScore.java
@@ -4,9 +4,13 @@ import jakarta.xml.bind.annotation.XmlType;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import java.io.Serializable;
+/**
+ * Represents the computed confidence score of a potential patient demographic match.
+ */
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "matchingClientScore", propOrder = { "client", "score" })
+
 public class MatchingClientScore implements Serializable
 {
     private static final long serialVersionUID = 1L;
@@ -22,6 +26,7 @@ public class MatchingClientScore implements Serializable
     }
     
     public int getScore() {
+        // Retrieves the numerical score representing the confidence level of the demographic match.
         return this.score;
     }
     


### PR DESCRIPTION
Adds missing class-level javadoc and inline comments for 40 files in BC billings, model, and entities. Improved contextual documentation for exactly 40 Java files across the codebase in develop branch.

---
*PR created automatically by Jules for task [7626324265626269846](https://jules.google.com/task/7626324265626269846) started by @yingbull*

## Summary by Sourcery

Improve in-code documentation across billing, entities, web service DTOs/exceptions, utilities, and email/eReferral models with added class-level Javadoc and clarifying inline comments, without changing runtime behavior.

Documentation:
- Add class-level Javadoc to various billing, entity, web service, utility, and email/eReferral-related Java classes to describe their responsibilities and usage.
- Introduce targeted inline comments on key methods and getters to clarify intent, context, and behavior for maintainers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds class-level Javadoc and inline comments to 40 Java files across BC billing (Teleplan, WCB, QuickBilling), entities (HL7, labs, MSP/WCB), email/eReferral models, JPA converters, utilities (PDF encryption, JS date serializer), and WS DTOs/exceptions. Clarifies behavior and intent; no runtime or API changes.

<sup>Written for commit 961821b76cc203a6a532b43dbaf0511b4ea2fa7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

