### PR TITLE
fix(demographic): respect patient search status views

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/DemographicSearch2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/DemographicSearch2Action.java
@@ -34,8 +34,9 @@ import org.apache.struts2.ServletActionContext;
 /**
  * Struts2 action for demographic search. Replaces the {@code demographiccontrol.jsp}
  * {@code displaymode=Search} and {@code displaymode=Search } (trailing space) routes.
- * Performs security validation and routes to the appropriate result JSP. The target
- * JSPs handle their own data loading via Spring-managed DAOs and Managers.
+ * Performs security validation, identifies requests for the recent-patient shortcut,
+ * and routes to the appropriate result JSP. The target JSPs handle their own data
+ * loading via Spring-managed DAOs and Managers.
  *
  * <p>Routes to {@code demographicsearchresults.jsp} for general search, or
  * {@code demographicsearch2apptresults.jsp} for appointment-context search
@@ -46,6 +47,8 @@ import org.apache.struts2.ServletActionContext;
  */
 public class DemographicSearch2Action extends ActionSupport {
 
+    static final String RECENT_PATIENTS_ATTRIBUTE = "showRecentPatients";
+
     private static final Logger logger = MiscUtils.getLogger();
 
     HttpServletRequest request = ServletActionContext.getRequest();
@@ -54,8 +57,9 @@ public class DemographicSearch2Action extends ActionSupport {
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
 
     /**
-     * Validates session and demographic read privileges, then routes to the
-     * appropriate search results JSP based on the {@code displaymode} parameter.
+     * Validates session and demographic read privileges, identifies whether the
+     * general view should load recent patients, then routes to the appropriate
+     * search results JSP based on the {@code displaymode} parameter.
      *
      * @return {@link #SUCCESS} for general search results, or {@code "apptResults"}
      *         for appointment-context search (when {@code displaymode} is {@code "Search "})
@@ -75,6 +79,9 @@ public class DemographicSearch2Action extends ActionSupport {
             throw new SecurityException("missing required sec object (_demographic)");
         }
 
+        request.setAttribute(RECENT_PATIENTS_ATTRIBUTE, isRecentPatientsRequest(
+                request.getParameter("keyword"), request.getParameter("ptstatus")));
+
         // "Search " (with trailing space) is set by appointment-context forms
         // (addappointment.jsp, editappointment.jsp, ticklerAdd.jsp, PatientSearch.jsp, etc.)
         // so appointment workflows land on the appointment-specific search results view.
@@ -86,5 +93,11 @@ public class DemographicSearch2Action extends ActionSupport {
             logger.debug("DemographicSearch2Action: unexpected displaymode='{}', falling through to general search", displaymode);
         }
         return SUCCESS;
+    }
+
+    private static boolean isRecentPatientsRequest(String keyword, String patientStatus) {
+        // An empty status is the explicit "All" view, so only active/default blank searches use recents.
+        boolean activePatients = patientStatus == null || "active".equals(patientStatus);
+        return activePatients && keyword != null && keyword.isEmpty();
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/DemographicSearch2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/DemographicSearch2Action.java
@@ -58,7 +58,7 @@ public class DemographicSearch2Action extends ActionSupport {
 
     /**
      * Validates session and demographic read privileges, identifies whether the
-     * general view should load recent patients, then routes to the appropriate
+     * target view should load recent patients, then routes to the appropriate
      * search results JSP based on the {@code displaymode} parameter.
      *
      * @return {@link #SUCCESS} for general search results, or {@code "apptResults"}

--- a/src/main/webapp/WEB-INF/jsp/demographic/demographicsearch2apptresults.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/demographicsearch2apptresults.jsp
@@ -332,7 +332,7 @@
     <div id="searchResults" style="margin-bottom:10px;">
 
         <div>
-            <%if (request.getParameter("keyword") != null && request.getParameter("keyword").length() == 0) { %>
+            <%if (Boolean.TRUE.equals(request.getAttribute("showRecentPatients"))) { %>
             <fmt:message key="demographic.demographicsearch2apptresults.msgMostRecentPatients"/>
             <% } else { %>
             <fmt:message key="demographic.demographicsearch2apptresults.msgKeywords"/> <carlos:encode value='<%= request.getParameter("keyword") != null ? request.getParameter("keyword") : "" %>' context="html"/> <%}%><%-- nosemgrep: java.jsp.jsp-scriptlet-xss.jsp-scriptlet-xss --%>
@@ -421,7 +421,7 @@
                     pstatus = pstatus.replaceAll("'", "").replaceAll("\\s", "");
                     List<String> stati = Arrays.asList(pstatus.split(","));
 
-                    if (request.getParameter("keyword") != null && request.getParameter("keyword").length() == 0) {
+                    if (Boolean.TRUE.equals(request.getAttribute("showRecentPatients"))) {
                         int mostRecentPatientListSize = Integer.parseInt(CarlosProperties.getInstance().getProperty("MOST_RECENT_PATIENT_LIST_SIZE", "3"));
                         List<Integer> results = oscarLogDao.getRecentDemographicsAccessedByProvider(providerNo, 0, mostRecentPatientListSize);
                         demoList = new ArrayList<Demographic>();

--- a/src/main/webapp/WEB-INF/jsp/demographic/demographicsearchresults.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/demographicsearchresults.jsp
@@ -371,7 +371,7 @@
 
                     List<Demographic> demoList = null;
 
-                    if (keyword != null && keyword.length() == 0) {
+                    if (Boolean.TRUE.equals(request.getAttribute("showRecentPatients"))) {
                         int mostRecentPatientListSize = Integer.parseInt(CarlosProperties.getInstance().getProperty("MOST_RECENT_PATIENT_LIST_SIZE", "3"));
                         List<Integer> results = oscarLogDao.getRecentDemographicsAccessedByProvider(providerNo, 0, mostRecentPatientListSize);
                         demoList = new ArrayList<Demographic>();

--- a/src/test/java/io/github/carlos_emr/carlos/demographic/pageUtil/DemographicSearch2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/demographic/pageUtil/DemographicSearch2ActionTest.java
@@ -25,6 +25,10 @@ import io.github.carlos_emr.carlos.test.base.CarlosWebTestBase;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 import org.apache.struts2.ActionSupport;
 import org.junit.jupiter.api.*;
 import org.mockito.MockitoAnnotations;
@@ -48,6 +52,10 @@ import static org.mockito.Mockito.*;
 class DemographicSearch2ActionTest extends CarlosWebTestBase {
 
     private static final String TEST_PROVIDER = "999998";
+    private static final Path GENERAL_RESULTS_JSP = Path.of(
+            "src/main/webapp/WEB-INF/jsp/demographic/demographicsearchresults.jsp");
+    private static final Path APPOINTMENT_RESULTS_JSP = Path.of(
+            "src/main/webapp/WEB-INF/jsp/demographic/demographicsearch2apptresults.jsp");
     private DemographicSearch2Action action;
 
     @BeforeEach
@@ -244,6 +252,20 @@ class DemographicSearch2ActionTest extends CarlosWebTestBase {
 
             assertThat(mockRequest.getAttribute(DemographicSearch2Action.RECENT_PATIENTS_ATTRIBUTE))
                     .isEqualTo(false);
+        }
+
+        @Test
+        @DisplayName("should use the controller patient-list mode in every results view")
+        void shouldUseControllerPatientListMode_inEveryResultsView() throws Exception {
+            String attributeLookup = "request.getAttribute(\""
+                    + DemographicSearch2Action.RECENT_PATIENTS_ATTRIBUTE + "\")";
+
+            assertThat(Files.readString(GENERAL_RESULTS_JSP, StandardCharsets.UTF_8))
+                    .contains(attributeLookup)
+                    .doesNotContain("request.getParameter(\"keyword\").length() == 0");
+            assertThat(Files.readString(APPOINTMENT_RESULTS_JSP, StandardCharsets.UTF_8))
+                    .contains(attributeLookup)
+                    .doesNotContain("request.getParameter(\"keyword\").length() == 0");
         }
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/demographic/pageUtil/DemographicSearch2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/demographic/pageUtil/DemographicSearch2ActionTest.java
@@ -177,4 +177,73 @@ class DemographicSearch2ActionTest extends CarlosWebTestBase {
             assertThat(result).isNotEqualTo("apptResults");
         }
     }
+
+    @Nested
+    @DisplayName("Patient List Mode")
+    class PatientListMode {
+
+        @BeforeEach
+        void allowAccess() {
+            allowPrivilege("_demographic", "r");
+        }
+
+        @Test
+        @DisplayName("should show recent patients for a blank active search")
+        void shouldShowRecentPatients_forBlankActiveSearch() throws Exception {
+            addRequestParameter("keyword", "");
+            addRequestParameter("ptstatus", "active");
+
+            executeAction(action);
+
+            assertThat(mockRequest.getAttribute(DemographicSearch2Action.RECENT_PATIENTS_ATTRIBUTE))
+                    .isEqualTo(true);
+        }
+
+        @Test
+        @DisplayName("should preserve recent patients for a blank search with default status")
+        void shouldShowRecentPatients_forBlankSearchWithDefaultStatus() throws Exception {
+            addRequestParameter("keyword", "");
+
+            executeAction(action);
+
+            assertThat(mockRequest.getAttribute(DemographicSearch2Action.RECENT_PATIENTS_ATTRIBUTE))
+                    .isEqualTo(true);
+        }
+
+        @Test
+        @DisplayName("should search all patients for a blank all-status search")
+        void shouldSearchAllPatients_forBlankAllStatusSearch() throws Exception {
+            addRequestParameter("keyword", "");
+            addRequestParameter("ptstatus", "");
+
+            executeAction(action);
+
+            assertThat(mockRequest.getAttribute(DemographicSearch2Action.RECENT_PATIENTS_ATTRIBUTE))
+                    .isEqualTo(false);
+        }
+
+        @Test
+        @DisplayName("should search inactive patients for a blank inactive search")
+        void shouldSearchInactivePatients_forBlankInactiveSearch() throws Exception {
+            addRequestParameter("keyword", "");
+            addRequestParameter("ptstatus", "inactive");
+
+            executeAction(action);
+
+            assertThat(mockRequest.getAttribute(DemographicSearch2Action.RECENT_PATIENTS_ATTRIBUTE))
+                    .isEqualTo(false);
+        }
+
+        @Test
+        @DisplayName("should search matching patients for a populated active search")
+        void shouldSearchMatchingPatients_forPopulatedActiveSearch() throws Exception {
+            addRequestParameter("keyword", "fake");
+            addRequestParameter("ptstatus", "active");
+
+            executeAction(action);
+
+            assertThat(mockRequest.getAttribute(DemographicSearch2Action.RECENT_PATIENTS_ATTRIBUTE))
+                    .isEqualTo(false);
+        }
+    }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/demographic/pageUtil/DemographicSearch2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/demographic/pageUtil/DemographicSearch2ActionTest.java
@@ -24,10 +24,12 @@ package io.github.carlos_emr.carlos.demographic.pageUtil;
 import io.github.carlos_emr.carlos.test.base.CarlosWebTestBase;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import io.github.carlos_emr.carlos.utility.PathValidationUtils;
 
+import java.io.File;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.Path;
 
 import org.apache.struts2.ActionSupport;
 import org.junit.jupiter.api.*;
@@ -52,11 +54,24 @@ import static org.mockito.Mockito.*;
 class DemographicSearch2ActionTest extends CarlosWebTestBase {
 
     private static final String TEST_PROVIDER = "999998";
-    private static final Path GENERAL_RESULTS_JSP = Path.of(
-            "src/main/webapp/WEB-INF/jsp/demographic/demographicsearchresults.jsp");
-    private static final Path APPOINTMENT_RESULTS_JSP = Path.of(
-            "src/main/webapp/WEB-INF/jsp/demographic/demographicsearch2apptresults.jsp");
+    private static final File WEBAPP_ROOT = PathValidationUtils.resolveTrustedPath(
+            new File("src/main/webapp"), "test webapp root");
+    private static final File GENERAL_RESULTS_JSP =
+            validatedTemplate("WEB-INF/jsp/demographic/demographicsearchresults.jsp");
+    private static final File APPOINTMENT_RESULTS_JSP =
+            validatedTemplate("WEB-INF/jsp/demographic/demographicsearch2apptresults.jsp");
     private DemographicSearch2Action action;
+
+    private static File validatedTemplate(String relativePath) {
+        return PathValidationUtils.validateExistingPath(
+                new File(WEBAPP_ROOT, relativePath), WEBAPP_ROOT);
+    }
+
+    private static String readTemplate(File template) throws IOException {
+        File validatedTemplate =
+                PathValidationUtils.validateExistingPath(template, WEBAPP_ROOT);
+        return Files.readString(validatedTemplate.toPath(), StandardCharsets.UTF_8);
+    }
 
     @BeforeEach
     void setUp() throws Exception {
@@ -260,10 +275,10 @@ class DemographicSearch2ActionTest extends CarlosWebTestBase {
             String attributeLookup = "request.getAttribute(\""
                     + DemographicSearch2Action.RECENT_PATIENTS_ATTRIBUTE + "\")";
 
-            assertThat(Files.readString(GENERAL_RESULTS_JSP, StandardCharsets.UTF_8))
+            assertThat(readTemplate(GENERAL_RESULTS_JSP))
                     .contains(attributeLookup)
                     .doesNotContain("request.getParameter(\"keyword\").length() == 0");
-            assertThat(Files.readString(APPOINTMENT_RESULTS_JSP, StandardCharsets.UTF_8))
+            assertThat(readTemplate(APPOINTMENT_RESULTS_JSP))
                     .contains(attributeLookup)
                     .doesNotContain("request.getParameter(\"keyword\").length() == 0");
         }

--- a/src/test/java/io/github/carlos_emr/carlos/demographic/pageUtil/DemographicSearch2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/demographic/pageUtil/DemographicSearch2ActionUnitTest.java
@@ -51,7 +51,7 @@ import static org.mockito.Mockito.*;
 @Tag("unit")
 @Tag("web")
 @Tag("demographic")
-class DemographicSearch2ActionTest extends CarlosWebTestBase {
+class DemographicSearch2ActionUnitTest extends CarlosWebTestBase {
 
     private static final String TEST_PROVIDER = "999998";
     private static final File WEBAPP_ROOT = PathValidationUtils.resolveTrustedPath(

--- a/src/test/java/io/github/carlos_emr/carlos/eform/util/EFormBrowserPdfServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/eform/util/EFormBrowserPdfServiceUnitTest.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Semaphore;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -1609,6 +1610,7 @@ class EFormBrowserPdfServiceUnitTest {
 
         @Test
         @DisplayName("should release a render whose only conditions are advisory")
+        @Disabled("issue #3235: #3193 made severeConsoleErrors withhold; this pins the intended advisory behaviour and goes green again when the in-flight #3235 production fix restores it — re-enable there")
         void shouldRelease_whenOnlyAdvisoryConditionsPresent() {
             // A page-script error and a suppressed dialog are reported but never withhold, so an
             // approval is not required and none is supplied.

--- a/src/test/java/io/github/carlos_emr/carlos/eform/util/EFormRenderPdfHtmlComposerUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/eform/util/EFormRenderPdfHtmlComposerUnitTest.java
@@ -28,6 +28,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import org.mockito.MockedStatic;
+
+import io.github.carlos_emr.CarlosProperties;
 import io.github.carlos_emr.carlos.commn.model.EFormValue;
 import io.github.carlos_emr.carlos.eform.data.EForm;
 
@@ -37,6 +40,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 @DisplayName("EFormRenderPdfHtmlComposer unit tests")
@@ -720,19 +724,29 @@ class EFormRenderPdfHtmlComposerUnitTest {
         // `return Set.of();`, for `return fileNames;`, and for the loop with the catch deleted.
         // Verified by mutation: inverting the catch to fail-closed left the whole class green.
         //
-        // In a unit JVM DisplayImage2Action.getImageFile throws (no eForm image directory exists),
-        // which is the lookup failure being modelled. Asserting the name is RETAINED is what makes
-        // the fail-open behaviour falsifiable: were the catch removed or inverted, the result would
-        // be empty and this fails. Inverting it in production would make every provider stamp look
-        // absent, stripping #StampSignature from every rendered document and flagging every render.
-        assertThat(EFormRenderPdfHtmlComposer.existingImageFiles(
-                java.util.Set.of("consult_sig_999999.png")))
-                .describedAs("a lookup failure must not be read as proof the stamp is absent")
-                .containsExactly("consult_sig_999999.png");
+        // Force the lookup failure deterministically: point the eForm image directory at a path
+        // that cannot exist so DisplayImage2Action.getImageFile throws. Relying on the bare-JVM
+        // default was suite-order dependent — once an earlier test populated the CarlosProperties
+        // singleton the directory resolved, getImageFile stopped throwing, and this test asserted
+        // against the wrong branch. Asserting the name is RETAINED is what makes the fail-open
+        // behaviour falsifiable: were the catch removed or inverted, the result would be empty and
+        // this fails. Inverting it in production would make every provider stamp look absent,
+        // stripping #StampSignature from every rendered document and flagging every render.
+        CarlosProperties mockProperties = mock(CarlosProperties.class);
+        when(mockProperties.getEformImageDirectory())
+                .thenReturn("/nonexistent-eform-image-dir-for-unit-test");
+        try (MockedStatic<CarlosProperties> carlosPropertiesMock = mockStatic(CarlosProperties.class)) {
+            carlosPropertiesMock.when(CarlosProperties::getInstance).thenReturn(mockProperties);
 
-        assertThat(EFormRenderPdfHtmlComposer.existingImageFiles(java.util.Set.of()))
-                .describedAs("no names in, no names out")
-                .isEmpty();
+            assertThat(EFormRenderPdfHtmlComposer.existingImageFiles(
+                    java.util.Set.of("consult_sig_999999.png")))
+                    .describedAs("a lookup failure must not be read as proof the stamp is absent")
+                    .containsExactly("consult_sig_999999.png");
+
+            assertThat(EFormRenderPdfHtmlComposer.existingImageFiles(java.util.Set.of()))
+                    .describedAs("no names in, no names out")
+                    .isEmpty();
+        }
     }
 
 }

--- a/src/test/java/io/github/carlos_emr/carlos/managers/ConsultationManagerUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/managers/ConsultationManagerUnitTest.java
@@ -589,7 +589,7 @@ public class ConsultationManagerUnitTest extends CarlosUnitTestBase {
             consultationManager.saveConsultationRequest(mockLoggedInInfo, existingRequest);
 
             // Then - extras should be batch persisted since they are new
-            verify(mockConsultationRequestExtDao).batchPersist(any());
+            verify(mockConsultationRequestExtDao).batchPersistAtomically(any());
         }
     }
 
@@ -1435,7 +1435,7 @@ public class ConsultationManagerUnitTest extends CarlosUnitTestBase {
             consultationManager.saveOrUpdateExts(TEST_REQUEST_ID, newExtras);
 
             // Then
-            verify(mockConsultationRequestExtDao).batchPersist(any());
+            verify(mockConsultationRequestExtDao).batchPersistAtomically(any());
         }
 
         @Test
@@ -1473,7 +1473,7 @@ public class ConsultationManagerUnitTest extends CarlosUnitTestBase {
 
             // Then - no merge needed since value unchanged
             verify(mockConsultationRequestExtDao, never()).merge(any());
-            verify(mockConsultationRequestExtDao, never()).batchPersist(any());
+            verify(mockConsultationRequestExtDao, never()).batchPersistAtomically(any());
         }
 
         @Test
@@ -1493,7 +1493,7 @@ public class ConsultationManagerUnitTest extends CarlosUnitTestBase {
 
             // Then - existing updated via merge, new persisted via batch
             verify(mockConsultationRequestExtDao).merge(existing);
-            verify(mockConsultationRequestExtDao).batchPersist(any());
+            verify(mockConsultationRequestExtDao).batchPersistAtomically(any());
         }
     }
 

--- a/src/test/java/io/github/carlos_emr/carlos/report/data/RptReportCreatorUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/data/RptReportCreatorUnitTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 @Tag("unit")
 @Tag("report")
 @Tag("security")
-class RptReportCreatorTest {
+class RptReportCreatorUnitTest {
 
     @Test
     @DisplayName("should accept report SQL identifiers when identifier is valid")

--- a/src/test/resources/surefire-unmatched-baseline.txt
+++ b/src/test/resources/surefire-unmatched-baseline.txt
@@ -118,6 +118,7 @@ io.github.carlos_emr.carlos.report.ClinicalReports.DroolsNumeratorLifecycleTest
 io.github.carlos_emr.carlos.report.data.ParameterizedSqlTest
 io.github.carlos_emr.carlos.report.data.RptReportCreatorJoinPredicatesTest
 io.github.carlos_emr.carlos.report.data.RptReportCreatorParameterizedTest
+io.github.carlos_emr.carlos.report.data.RptReportCreatorTest
 io.github.carlos_emr.carlos.report.pageUtil.RptDownloadCSVServletTest
 io.github.carlos_emr.carlos.report.pageUtil.RptFormQueryTest
 io.github.carlos_emr.carlos.report.reportByTemplate.actions.GenerateOutFiles2ActionTest

--- a/src/test/resources/surefire-unmatched-baseline.txt
+++ b/src/test/resources/surefire-unmatched-baseline.txt
@@ -51,7 +51,6 @@ io.github.carlos_emr.carlos.demographic.pageUtil.DemographicExportAction42Action
 io.github.carlos_emr.carlos.demographic.pageUtil.DemographicExportAction42ActionRequestMethodTest
 io.github.carlos_emr.carlos.demographic.pageUtil.DemographicLinkMsg2ActionTest
 io.github.carlos_emr.carlos.demographic.pageUtil.DemographicPdfLabel2ActionTest
-io.github.carlos_emr.carlos.demographic.pageUtil.DemographicSearch2ActionTest
 io.github.carlos_emr.carlos.demographic.pageUtil.DemographicUpdate2ActionTest
 io.github.carlos_emr.carlos.documentManager.actions.DocumentDelete2ActionTest
 io.github.carlos_emr.carlos.documentManager.actions.DocumentRefile2ActionTest
@@ -118,7 +117,6 @@ io.github.carlos_emr.carlos.report.ClinicalReports.DroolsNumeratorLifecycleTest
 io.github.carlos_emr.carlos.report.data.ParameterizedSqlTest
 io.github.carlos_emr.carlos.report.data.RptReportCreatorJoinPredicatesTest
 io.github.carlos_emr.carlos.report.data.RptReportCreatorParameterizedTest
-io.github.carlos_emr.carlos.report.data.RptReportCreatorTest
 io.github.carlos_emr.carlos.report.pageUtil.RptDownloadCSVServletTest
 io.github.carlos_emr.carlos.report.pageUtil.RptFormQueryTest
 io.github.carlos_emr.carlos.report.reportByTemplate.actions.GenerateOutFiles2ActionTest


### PR DESCRIPTION
## Description

Patient search treated every blank keyword as a request for the three most recently accessed patients. That shortcut ran before status filtering, so the **All** and **Inactive** buttons could never return their full paginated result sets.

This change classifies the recent-patient shortcut in `DemographicSearch2Action`: only blank searches in the default/active view use recent patients. Blank **All** and **Inactive** requests now continue through the existing status-aware, paginated DAO search in both the general navbar and appointment-context result views.

This branch also carries the dedicated test-only CI repair commit from PR #3281 so the inherited reporting, eForm, and consultation test failures no longer block this PR. The demographic and report test classes use the repository's `*UnitTest` naming so their assertions run in the standard CI suite.

## Related Issues

Fixes #3236

## How Was This Tested?

- `mvn -q -Dtest=DemographicSearch2ActionUnitTest,RptReportCreatorUnitTest,SurefireIncludeCoverageUnitTest test` — 26 tests, 0 failures/errors
- `mvn -Dtest=SurefireIncludeCoverageUnitTest,EFormBrowserPdfServiceUnitTest,EFormRenderPdfHtmlComposerUnitTest,ConsultationManagerUnitTest,DemographicSearch2ActionUnitTest test` — 222 tests, 0 failures/errors, 1 intentionally disabled test tracked by #3235
- `make jspc` — 973 JSPs compiled, 0 errors; build successful
- `scripts/lint/check-bdd-test-naming.sh`
- `bash scripts/lint/check-encoder-null-safety.sh`
- `bash scripts/lint/check-security-exception-message-convention.sh`
- `git diff --check`

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality
- [x] I have read the [contributing guide](CONTRIBUTING.md)

Generated with Codex.
