### PR TITLE
fix: resolve eform build errors

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/managers/EformDataManager.java
+++ b/src/main/java/io/github/carlos_emr/carlos/managers/EformDataManager.java
@@ -78,11 +78,12 @@ public interface EformDataManager {
      * Renders an eForm and returns the observed completeness alongside the PDF.
      *
      * <p>Use this where the caller can show the result to a clinician. A render that raises only
-     * advisory conditions — an uncaught exception from the form's own script — produces a PDF and
-     * never blocks, but the reader still needs to know the page reported an error, because a script
-     * that aborted midway leaves no other visible trace. Callers that stream bytes with no room for
-     * a notice (fax, direct download) can keep using {@link #createEformPDF(LoggedInInfo, int,
-     * EFormRenderApproval)}; the condition is recorded in the render log either way.</p>
+     * advisory conditions — suppressed browser interactions or failed legacy timers — produces a
+     * PDF and never blocks, but the reader still needs to know those conditions occurred. A severe
+     * page-script error is blocking because it can leave derived content incomplete, and proceeds
+     * only with an exact approval. Callers that stream bytes with no room for a notice (fax, direct
+     * download) can keep using {@link #createEformPDF(LoggedInInfo, int, EFormRenderApproval)}; the
+     * condition is recorded in the render log either way.</p>
      */
     public EformPdfRender createEformPdfWithCompleteness(
             LoggedInInfo loggedInInfo, int fdid, EFormRenderApproval approval) throws PDFGenerationException;

--- a/src/main/webapp/WEB-INF/jsp/documentManager/attachDocument.jsp
+++ b/src/main/webapp/WEB-INF/jsp/documentManager/attachDocument.jsp
@@ -655,10 +655,10 @@
                  silently blocked <object>-based PDF previews. Iframes are governed by frame-src,
                  which those pages open to 'self' and blob: for exactly this preview. --%>
             <%-- Advisory banner: shown when a render completed but reported a non-blocking
-                 condition (currently a page-script error in the form itself). The PDF is still
-                 delivered — this must never gate the preview — but the reader has to be told,
-                 because a script that aborted midway can omit content while every other check
-                 passes. --%>
+                 condition, such as a suppressed browser interaction or failed legacy timer. The
+                 PDF is still delivered — this must never gate the preview — but the reader has to
+                 be told. Severe page-script errors are blocking and reach this preview only after
+                 an exact approval. --%>
             <div id="preview-advisory" class="preview-advisory d-none" role="status"></div>
             <iframe id="pdfObject" class="d-none" title="Attachment preview"></iframe>
             <div id="preview-filler" class="preview-filler">

--- a/src/main/webapp/WEB-INF/jsp/eform/efmshowform_data.jsp
+++ b/src/main/webapp/WEB-INF/jsp/eform/efmshowform_data.jsp
@@ -177,10 +177,10 @@
     eForm.addHiddenInputElement("eFormPDFName", (String) request.getAttribute("eFormPDFName"));
     eForm.addHiddenInputElement("eFormPDF", (String) request.getAttribute("eFormPDF"));
     eForm.addHiddenInputElement("isDownloadEForm", (String) request.getAttribute("isDownload"));
-    // Advisory conditions (page-script errors, suppressed dialogs, failed legacy timers) deliver the
-    // PDF rather than blocking it, so the reader is told here instead of being silently handed a
-    // possibly-truncated document. A count only: console and dialog text are form-authored and can
-    // carry PHI, which is why the completeness report is counts-and-booleans in the first place.
+    // Advisory conditions (suppressed dialogs and failed legacy timers) deliver the PDF rather than
+    // blocking it, so the reader is told here instead of silently losing that context. A count only:
+    // dialog and script text are form-authored and can carry PHI, which is why the completeness
+    // report is counts-and-booleans in the first place. Severe page-script errors block separately.
     Object advisoryIssues = request.getAttribute("advisoryIssues");
     eForm.addHiddenInputElement("advisoryIssues",
             advisoryIssues == null ? null : String.valueOf(advisoryIssues));


### PR DESCRIPTION
## Summary by Sourcery

Clarify how advisory versus blocking eForm rendering conditions are reported and communicated to clinicians and users.

Enhancements:
- Align eForm rendering semantics so advisory conditions (suppressed interactions, failed timers) are distinguished from severe page-script errors that block without explicit approval.

Documentation:
- Update JavaDoc and JSP comments to accurately describe advisory vs blocking eForm conditions and how they affect PDF delivery and preview messaging.

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes eForm build errors by correcting Javadoc and JSP comments in the eForm render flow; no runtime changes. Clarifies that suppressed dialogs and failed legacy timers are advisory (PDF still delivered), while severe page-script errors block unless given exact approval.

<sup>Written for commit 236b1c3e847323d39533a6b0776f41bd798ef979. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

