### PR TITLE
fix(appointment): reserve receipt popup before update

### DIFF
--- a/src/main/resources/oscarResources_en.properties
+++ b/src/main/resources/oscarResources_en.properties
@@ -661,6 +661,7 @@ appointment.editappointment.btnPrintReceipt=Update & Receipt
 appointment.appointmentupdatearecord.msgMainLabel=UPDATE AN APPOINTMENT RECORD
 appointment.appointmentupdatearecord.msgUpdateSuccess=Successful Update of an Appointment Record.
 appointment.appointmentupdatearecord.msgUpdateFailure=Sorry, update has failed.
+appointment.editappointment.msgReceiptPending=Preparing the appointment receipt. If the receipt does not appear, close this window and try again.
 appointment.editappointment.msgDeleteConfirmation=Are you sure to DELETE the appointment?
 appointment.editappointment.msgDeleteBilledConfirmation=Appointment has been billed.  Are you sure you want to delete appointment?
 appointment.editappointment.msgCanceledBilledConfirmation=Appointment has been Billed.  Are you sure you want to cancel appointment?

--- a/src/main/resources/oscarResources_es.properties
+++ b/src/main/resources/oscarResources_es.properties
@@ -645,6 +645,7 @@ appointment.editappointment.btnLabelPrint=Etiqueta
 appointment.appointmentupdatearecord.msgMainLabel=ACTUALIZAR UN TURNO
 appointment.appointmentupdatearecord.msgUpdateSuccess=Actualizacion del turno exitosa.
 appointment.appointmentupdatearecord.msgUpdateFailure=Lo siento, error al actualizar el turno.
+appointment.editappointment.msgReceiptPending=Preparando el recibo de la cita. Si el recibo no aparece, cierre esta ventana e int\u00e9ntelo de nuevo.
 appointment.editappointment.msgDeleteConfirmation=Va a BORRAR un turno, esta seguro?
 appointment.editappointment.msgDeleteBilledConfirmation=El turno fue facturado. Esta seguro de querer borrar el turno?
 appointment.editappointment.msgCanceledBilledConfirmation=El turno fue facturado. Esta seguro de querer cancelar el turno?

--- a/src/main/resources/oscarResources_fr.properties
+++ b/src/main/resources/oscarResources_fr.properties
@@ -536,6 +536,7 @@ appointment.editappointment.msgNotesTooBig=S'il vous pla\u00c3\u00aet entrer pas
 appointment.appointmentupdatearecord.msgMainLabel=MISE \u00c0 JOUR D'UN RENDEZ-VOUS
 appointment.appointmentupdatearecord.msgUpdateSuccess=Mise \u00e0 jour d'un rendez-vous compl\u00e9t\u00e9e avec succ\u00e8s.
 appointment.appointmentupdatearecord.msgUpdateFailure=D\u00e9sol\u00e9, la mise \u00e0 jour a \u00e9chou\u00e9.
+appointment.editappointment.msgReceiptPending=Pr\u00e9paration du re\u00e7u de rendez-vous. Si le re\u00e7u n\u2019appara\u00eet pas, fermez cette fen\u00eatre et r\u00e9essayez.
 appointment.editappointment.msgDeleteConfirmation=\u00cates-vous certain de vouloir suprimer le rendez-vous?
 appointment.editappointment.msgDeleteBilledConfirmation=Le rendez-vous a \u00e9t\u00e9 factur\u00e9. \u00cates-vous certain de vouloir supprimer le rendez-vous?
 appointment.editappointment.msgCanceledBilledConfirmation=Le rendez-vous a \u00e9t\u00e9 factur\u00e9. \u00cates-vous certain de vouloir annuler le rendez-vous?

--- a/src/main/resources/oscarResources_pl.properties
+++ b/src/main/resources/oscarResources_pl.properties
@@ -607,6 +607,7 @@ appointment.editappointment.btnLabelPrint=Label
 appointment.appointmentupdatearecord.msgMainLabel=Uaktualni\u0107 OBJ&#X118;CIEM REKORD
 appointment.appointmentupdatearecord.msgUpdateSuccess=Udane Aktualizacja Powo&#X142;anie Zapis.
 appointment.appointmentupdatearecord.msgUpdateFailure=Przepraszamy, aktualizacja nie powiod&#X142;a si&#X119;.
+appointment.editappointment.msgReceiptPending=Przygotowywanie potwierdzenia wizyty. Je\u015bli potwierdzenie si\u0119 nie pojawi, zamknij to okno i spr\u00f3buj ponownie.
 appointment.editappointment.msgDeleteConfirmation=Czy na pewno usun&#X105;&#X107; spotkanie?
 appointment.editappointment.msgDeleteBilledConfirmation=mianowanie zosta&#X142;o rozliczone.  Czy na pewno chcesz usun&#X105;&#X107; spotkanie?
 appointment.editappointment.msgCanceledBilledConfirmation=Nominacja zosta&#X142;a pobrana.  Czy na pewno chcesz anulowa&#X107; spotkanie?

--- a/src/main/resources/oscarResources_pt_BR.properties
+++ b/src/main/resources/oscarResources_pt_BR.properties
@@ -672,6 +672,7 @@ appointment.editappointment.btnPrintReceipt=Atualizar e receber
 appointment.appointmentupdatearecord.msgMainLabel=ATUALIZAR UM REGISTRO DE NOMEA\u00C7\u00C3O
 appointment.appointmentupdatearecord.msgUpdateSuccess=Atualiza\u00E7\u00E3o bem-sucedida de um registro de consulta.
 appointment.appointmentupdatearecord.msgUpdateFailure=Desculpe, a atualiza\u00E7\u00E3o falhou.
+appointment.editappointment.msgReceiptPending=Preparando o recibo da consulta. Se o recibo n\u00e3o aparecer, feche esta janela e tente novamente.
 appointment.editappointment.msgDeleteConfirmation=Tem a certeza de APAGAR a consulta?
 appointment.editappointment.msgDeleteBilledConfirmation=A consulta foi cobrado. Tem certeza de que deseja excluir a consulta?
 appointment.editappointment.msgCanceledBilledConfirmation=O consulta foi faturado. Tem certeza de que deseja cancelar o agendamento?

--- a/src/main/webapp/WEB-INF/jsp/appointment/appointmentupdatearecord.jsp
+++ b/src/main/webapp/WEB-INF/jsp/appointment/appointmentupdatearecord.jsp
@@ -64,7 +64,7 @@
                 <h1><fmt:message key="appointment.appointmentupdatearecord.msgUpdateSuccess"/></h1>
                 <script language="JavaScript">
                     <c:if test="${printReceipt}">
-                    popupPage(350, 750, '${pageContext.request.contextPath}/appointment/printappointment?appointment_no=${carlos:forJavaScript(carlos:forUriComponent(appointmentNo))}');
+                    popupFocusPage(350, 750, '${pageContext.request.contextPath}/appointment/printappointment?appointment_no=${carlos:forJavaScript(carlos:forUriComponent(appointmentNo))}', 'appointmentReceipt');
                     </c:if>
                     try { self.opener.refresh(); } catch (e) { /* opener may be closed or cross-origin */ }
                     self.close();

--- a/src/main/webapp/WEB-INF/jsp/appointment/editappointment.jsp
+++ b/src/main/webapp/WEB-INF/jsp/appointment/editappointment.jsp
@@ -417,9 +417,15 @@
                     }
                 }
                 if (saveTemp === 2) {
-                    return calculateEndTime();
-                } else
-                    return true;
+                    if (!calculateEndTime()) {
+                        document.EDITAPPT.printReceipt.value = '';
+                        return false;
+                    }
+                    if (document.EDITAPPT.printReceipt.value === '1') {
+                        popupFocusPage(350, 750, 'about:blank', 'appointmentReceipt');
+                    }
+                }
+                return true;
             }
 
             function calculateEndTime() {
@@ -1383,7 +1389,7 @@
                     <% }%>
                     <input type="submit" id="printReceiptButton" class="btn btn-secondary"
                            formaction="<%=request.getContextPath() %>/appointment/UpdateRecord"
-                           onclick="document.forms['EDITAPPT'].displaymode.value='Update Appt';document.forms['EDITAPPT'].printReceipt.value='1';popupFocusPage(350, 750, 'about:blank', 'appointmentReceipt');"
+                           onclick="document.forms['EDITAPPT'].displaymode.value='Update Appt';document.forms['EDITAPPT'].printReceipt.value='1';onButUpdate();"
                            value="<fmt:message key='appointment.editappointment.btnPrintReceipt'/>">
                     <input type="hidden" name="printReceipt" value="">
                     <input type="submit" class="btn btn-danger" id="deleteButton"

--- a/src/main/webapp/WEB-INF/jsp/appointment/editappointment.jsp
+++ b/src/main/webapp/WEB-INF/jsp/appointment/editappointment.jsp
@@ -1383,7 +1383,7 @@
                     <% }%>
                     <input type="submit" id="printReceiptButton" class="btn btn-secondary"
                            formaction="<%=request.getContextPath() %>/appointment/UpdateRecord"
-                           onclick="document.forms['EDITAPPT'].displaymode.value='Update Appt';document.forms['EDITAPPT'].printReceipt.value='1';"
+                           onclick="document.forms['EDITAPPT'].displaymode.value='Update Appt';document.forms['EDITAPPT'].printReceipt.value='1';popupPage(350, 750, 'about:blank');"
                            value="<fmt:message key='appointment.editappointment.btnPrintReceipt'/>">
                     <input type="hidden" name="printReceipt" value="">
                     <input type="submit" class="btn btn-danger" id="deleteButton"

--- a/src/main/webapp/WEB-INF/jsp/appointment/editappointment.jsp
+++ b/src/main/webapp/WEB-INF/jsp/appointment/editappointment.jsp
@@ -367,6 +367,7 @@
             }
 
             var saveTemp = 0;
+            var appointmentReceiptReservationTimeoutMs = 60000;
 
             function setfocus() {
                 this.focus();
@@ -401,6 +402,18 @@
                 saveTemp = 2;
             }
 
+            function reserveAppointmentReceiptWindow() {
+                var receiptWindow = popupFocusPage(350, 750, 'about:blank', 'appointmentReceipt');
+                if (receiptWindow != null) {
+                    // Successful receipt navigation replaces this document and cancels its timer.
+                    receiptWindow.setTimeout(function () {
+                        if (!receiptWindow.closed && receiptWindow.location.href === 'about:blank') {
+                            receiptWindow.close();
+                        }
+                    }, appointmentReceiptReservationTimeoutMs);
+                }
+            }
+
             function onButCancel() {
                 var aptStat = document.EDITAPPT.status.value;
                 if (aptStat.indexOf('B') === 0) {
@@ -433,7 +446,7 @@
                         return false;
                     }
                     if (document.EDITAPPT.printReceipt.value === '1') {
-                        popupFocusPage(350, 750, 'about:blank', 'appointmentReceipt');
+                        reserveAppointmentReceiptWindow();
                     }
                 }
                 return true;

--- a/src/main/webapp/WEB-INF/jsp/appointment/editappointment.jsp
+++ b/src/main/webapp/WEB-INF/jsp/appointment/editappointment.jsp
@@ -20,6 +20,17 @@
     CARLOS EMR Project
     https://github.com/carlos-emr/carlos
 --%>
+<%--
+    Edits an existing appointment, including scheduling details, status, notes,
+    recurring/group actions, and receipt generation.
+
+    Request parameters include appointment_no and the appointment's editable
+    demographic, provider, date, time, status, and scheduling fields. Update &
+    Receipt validates the form, reserves the named receipt window during the
+    user gesture, and reuses that window after the update succeeds.
+
+    @since 2026-07-30
+--%>
 <!DOCTYPE html>
 
 <%@page import="io.github.carlos_emr.carlos.casemgmt.service.CaseManagementManager" %>

--- a/src/main/webapp/WEB-INF/jsp/appointment/editappointment.jsp
+++ b/src/main/webapp/WEB-INF/jsp/appointment/editappointment.jsp
@@ -102,6 +102,8 @@
 <%@ taglib uri="jakarta.tags.core" prefix="c" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
 <fmt:setBundle basename="oscarResources"/>
+<fmt:message key="report.appointmentReceipt.title" var="appointmentReceiptTitle"/>
+<fmt:message key="appointment.editappointment.msgReceiptPending" var="appointmentReceiptPending"/>
 <%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 
 <%@ taglib uri="/WEB-INF/oscar-tag.tld" prefix="oscar" %>
@@ -367,7 +369,6 @@
             }
 
             var saveTemp = 0;
-            var appointmentReceiptReservationTimeoutMs = 60000;
 
             function setfocus() {
                 this.focus();
@@ -403,14 +404,11 @@
             }
 
             function reserveAppointmentReceiptWindow() {
-                var receiptWindow = popupFocusPage(350, 750, 'about:blank', 'appointmentReceipt');
+                var receiptWindow = popupFocusPage(350, 750, '', 'appointmentReceipt');
                 if (receiptWindow != null) {
-                    // Successful receipt navigation replaces this document and cancels its timer.
-                    receiptWindow.setTimeout(function () {
-                        if (!receiptWindow.closed && receiptWindow.location.href === 'about:blank') {
-                            receiptWindow.close();
-                        }
-                    }, appointmentReceiptReservationTimeoutMs);
+                    var receiptDocument = receiptWindow.document;
+                    receiptDocument.title = '${carlos:forJavaScript(appointmentReceiptTitle)}';
+                    receiptDocument.body.textContent = '${carlos:forJavaScript(appointmentReceiptPending)}';
                 }
             }
 

--- a/src/main/webapp/WEB-INF/jsp/appointment/editappointment.jsp
+++ b/src/main/webapp/WEB-INF/jsp/appointment/editappointment.jsp
@@ -1383,7 +1383,7 @@
                     <% }%>
                     <input type="submit" id="printReceiptButton" class="btn btn-secondary"
                            formaction="<%=request.getContextPath() %>/appointment/UpdateRecord"
-                           onclick="document.forms['EDITAPPT'].displaymode.value='Update Appt';document.forms['EDITAPPT'].printReceipt.value='1';popupPage(350, 750, 'about:blank');"
+                           onclick="document.forms['EDITAPPT'].displaymode.value='Update Appt';document.forms['EDITAPPT'].printReceipt.value='1';popupFocusPage(350, 750, 'about:blank', 'appointmentReceipt');"
                            value="<fmt:message key='appointment.editappointment.btnPrintReceipt'/>">
                     <input type="hidden" name="printReceipt" value="">
                     <input type="submit" class="btn btn-danger" id="deleteButton"

--- a/src/main/webapp/js/global.js
+++ b/src/main/webapp/js/global.js
@@ -52,6 +52,7 @@ function popupFocusPage(vheight, vwidth, varpage, pageTitle) {
         }
         popup.focus();
     }
+    return popup;
 }
 
 // Prompt user if exiting without saving

--- a/src/test/java/io/github/carlos_emr/carlos/appointment/AppointmentJspRoutingTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/appointment/AppointmentJspRoutingTest.java
@@ -26,7 +26,8 @@ class AppointmentJspRoutingTest {
     private static final Pattern FORCE_WINDOW_PATHS_PATTERN = Pattern.compile(
             "(?:(?:var|let|const)\\s+)?(?:window\\.)?forceWindowPaths\\s*=\\s*(?:(?:window\\.)?forceWindowPaths\\s*\\|\\|\\s*)?\\[(?<body>[\\s\\S]*?)]\\s*;?");
     private static final Pattern PRINT_RECEIPT_BUTTON_PATTERN = Pattern.compile(
-            "id=\"printReceiptButton\"[\\s\\S]*?value=\"<fmt:message key='appointment\\.editappointment\\.btnPrintReceipt'/>\"");
+            "id=\"printReceiptButton\"[\\s\\S]*?onclick=\"(?<handler>[^\"]*)\"\\s*"
+                    + "value=\"<fmt:message key='appointment\\.editappointment\\.btnPrintReceipt'/>\"");
 
     @Test
     void shouldRouteLiveAppointmentCallers_directlyToFinalTargets() throws IOException {
@@ -58,9 +59,12 @@ class AppointmentJspRoutingTest {
         assertThat(printReceiptButtonMatcher.find())
                 .as("the edit appointment page should contain the print receipt button")
                 .isTrue();
-        assertThat(printReceiptButtonMatcher.group())
+        assertThat(printReceiptButtonMatcher.group("handler"))
                 .as("the receipt window must be reserved during the click so popup blockers allow it")
-                .contains("popupPage(350, 750, 'about:blank')");
+                .contains(
+                        "displaymode.value='Update Appt'",
+                        "printReceipt.value='1'",
+                        "popupFocusPage(350, 750, 'about:blank', 'appointmentReceipt')");
 
         assertThat(addAppointment).contains("/appointment/AddRecord");
         assertThat(addAppointment).contains("/appointment/appointmentgrouprecords");
@@ -89,6 +93,9 @@ class AppointmentJspRoutingTest {
         assertThat(updateRecord).containsAnyOf("request.getContextPath()", "pageContext.request.contextPath");
         assertThat(updateRecord).contains("pageContext.request.contextPath");
         assertThat(updateRecord).contains("carlos:forJavaScript(carlos:forUriComponent(appointmentNo))");
+        assertThat(updateRecord)
+                .as("the update result must reuse the dedicated receipt window, not its own attachment window")
+                .contains("popupFocusPage(350, 750,", "'appointmentReceipt'");
         assertThat(updateRecord).doesNotContain("printappointment.jsp?appointment_no=");
 
         assertThat(providerDay).contains("/appointment/addappointment?");

--- a/src/test/java/io/github/carlos_emr/carlos/appointment/AppointmentJspRoutingTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/appointment/AppointmentJspRoutingTest.java
@@ -25,6 +25,8 @@ class AppointmentJspRoutingTest {
 
     private static final Pattern FORCE_WINDOW_PATHS_PATTERN = Pattern.compile(
             "(?:(?:var|let|const)\\s+)?(?:window\\.)?forceWindowPaths\\s*=\\s*(?:(?:window\\.)?forceWindowPaths\\s*\\|\\|\\s*)?\\[(?<body>[\\s\\S]*?)]\\s*;?");
+    private static final Pattern PRINT_RECEIPT_BUTTON_PATTERN = Pattern.compile(
+            "id=\"printReceiptButton\"[\\s\\S]*?value=\"<fmt:message key='appointment\\.editappointment\\.btnPrintReceipt'/>\"");
 
     @Test
     void shouldRouteLiveAppointmentCallers_directlyToFinalTargets() throws IOException {
@@ -52,6 +54,13 @@ class AppointmentJspRoutingTest {
         assertThat(editAppointment).doesNotContain("/appointment/appointmentcontrol");
         assertThat(editAppointment).contains("/appointment/appointmenteditrepeatbooking");
         assertThat(editAppointment).doesNotContain("appointmenteditrepeatbooking.jsp");
+        Matcher printReceiptButtonMatcher = PRINT_RECEIPT_BUTTON_PATTERN.matcher(editAppointment);
+        assertThat(printReceiptButtonMatcher.find())
+                .as("the edit appointment page should contain the print receipt button")
+                .isTrue();
+        assertThat(printReceiptButtonMatcher.group())
+                .as("the receipt window must be reserved during the click so popup blockers allow it")
+                .contains("popupPage(350, 750, 'about:blank')");
 
         assertThat(addAppointment).contains("/appointment/AddRecord");
         assertThat(addAppointment).contains("/appointment/appointmentgrouprecords");

--- a/src/test/java/io/github/carlos_emr/carlos/appointment/AppointmentJspRoutingTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/appointment/AppointmentJspRoutingTest.java
@@ -25,9 +25,6 @@ class AppointmentJspRoutingTest {
 
     private static final Pattern FORCE_WINDOW_PATHS_PATTERN = Pattern.compile(
             "(?:(?:var|let|const)\\s+)?(?:window\\.)?forceWindowPaths\\s*=\\s*(?:(?:window\\.)?forceWindowPaths\\s*\\|\\|\\s*)?\\[(?<body>[\\s\\S]*?)]\\s*;?");
-    private static final Pattern PRINT_RECEIPT_BUTTON_PATTERN = Pattern.compile(
-            "id=\"printReceiptButton\"[\\s\\S]*?onclick=\"(?<handler>[^\"]*)\"\\s*"
-                    + "value=\"<fmt:message key='appointment\\.editappointment\\.btnPrintReceipt'/>\"");
 
     @Test
     void shouldRouteLiveAppointmentCallers_directlyToFinalTargets() throws IOException {
@@ -55,15 +52,18 @@ class AppointmentJspRoutingTest {
         assertThat(editAppointment).doesNotContain("/appointment/appointmentcontrol");
         assertThat(editAppointment).contains("/appointment/appointmenteditrepeatbooking");
         assertThat(editAppointment).doesNotContain("appointmenteditrepeatbooking.jsp");
-        Matcher printReceiptButtonMatcher = PRINT_RECEIPT_BUTTON_PATTERN.matcher(editAppointment);
-        assertThat(printReceiptButtonMatcher.find())
-                .as("the edit appointment page should contain the print receipt button")
-                .isTrue();
-        assertThat(printReceiptButtonMatcher.group("handler"))
-                .as("the receipt window must be reserved during the click so popup blockers allow it")
+        String printReceiptButton = extractInputElement(editAppointment, "printReceiptButton");
+        assertThat(printReceiptButton)
+                .as("the receipt update must use the same validated submit path as a normal update")
                 .contains(
+                        "onclick=\"",
                         "displaymode.value='Update Appt'",
                         "printReceipt.value='1'",
+                        "onButUpdate()");
+        assertThat(editAppointment)
+                .as("the validated submit path must reserve the dedicated receipt window before navigation")
+                .contains(
+                        "if (document.EDITAPPT.printReceipt.value === '1')",
                         "popupFocusPage(350, 750, 'about:blank', 'appointmentReceipt')");
 
         assertThat(addAppointment).contains("/appointment/AddRecord");
@@ -164,5 +164,19 @@ class AppointmentJspRoutingTest {
 
     private String readJspContent(String path) throws IOException {
         return Files.readString(Path.of(path), StandardCharsets.UTF_8);
+    }
+
+    private String extractInputElement(String pageSource, String id) {
+        String idAttribute = "id=\"" + id + "\"";
+        int idIndex = pageSource.indexOf(idAttribute);
+        assertThat(idIndex)
+                .as("the page should contain input %s", id)
+                .isNotNegative();
+
+        int inputStart = pageSource.lastIndexOf("<input", idIndex);
+        int nextInput = pageSource.indexOf("<input", idIndex + idAttribute.length());
+        assertThat(inputStart).isNotNegative();
+        assertThat(nextInput).isGreaterThan(inputStart);
+        return pageSource.substring(inputStart, nextInput);
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/appointment/AppointmentJspRoutingTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/appointment/AppointmentJspRoutingTest.java
@@ -25,6 +25,8 @@ class AppointmentJspRoutingTest {
 
     private static final Pattern FORCE_WINDOW_PATHS_PATTERN = Pattern.compile(
             "(?:(?:var|let|const)\\s+)?(?:window\\.)?forceWindowPaths\\s*=\\s*(?:(?:window\\.)?forceWindowPaths\\s*\\|\\|\\s*)?\\[(?<body>[\\s\\S]*?)]\\s*;?");
+    private static final Pattern POPUP_FOCUS_PAGE_RETURN_PATTERN = Pattern.compile(
+            "function\\s+popupFocusPage\\s*\\([^)]*\\)\\s*\\{[\\s\\S]*?return\\s+popup;\\s*}");
 
     @Test
     void shouldRouteLiveAppointmentCallers_directlyToFinalTargets() throws IOException {
@@ -63,17 +65,16 @@ class AppointmentJspRoutingTest {
                         "printReceipt.value='1'",
                         "onButUpdate()");
         assertThat(editAppointment)
-                .as("the validated submit path must reserve the receipt window and close an unused reservation")
+                .as("the validated submit path must reserve the receipt window and explain a failed handoff")
                 .contains(
                         "if (document.EDITAPPT.printReceipt.value === '1')",
                         "reserveAppointmentReceiptWindow()",
-                        "popupFocusPage(350, 750, 'about:blank', 'appointmentReceipt')",
-                        "appointmentReceiptReservationTimeoutMs = 60000",
-                        "receiptWindow.location.href === 'about:blank'",
-                        "receiptWindow.close()");
+                        "popupFocusPage(350, 750, '', 'appointmentReceipt')",
+                        "receiptDocument.title = '${carlos:forJavaScript(appointmentReceiptTitle)}'",
+                        "receiptDocument.body.textContent = '${carlos:forJavaScript(appointmentReceiptPending)}'");
         assertThat(globalJs)
                 .as("popupFocusPage must return the reserved window so callers can manage its lifecycle")
-                .contains("return popup;");
+                .containsPattern(POPUP_FOCUS_PAGE_RETURN_PATTERN);
 
         assertThat(addAppointment).contains("/appointment/AddRecord");
         assertThat(addAppointment).contains("/appointment/appointmentgrouprecords");

--- a/src/test/java/io/github/carlos_emr/carlos/appointment/AppointmentJspRoutingTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/appointment/AppointmentJspRoutingTest.java
@@ -63,14 +63,11 @@ class AppointmentJspRoutingTest {
                         "printReceipt.value='1'",
                         "onButUpdate()");
         assertThat(editAppointment)
-                .as("the validated submit path must reserve the dedicated receipt window before navigation")
+                .as("the validated submit path must reserve the receipt window and close an unused reservation")
                 .contains(
                         "if (document.EDITAPPT.printReceipt.value === '1')",
                         "reserveAppointmentReceiptWindow()",
-                        "popupFocusPage(350, 750, 'about:blank', 'appointmentReceipt')");
-        assertThat(editAppointment)
-                .as("an unused receipt reservation must close after the update fails or stalls")
-                .contains(
+                        "popupFocusPage(350, 750, 'about:blank', 'appointmentReceipt')",
                         "appointmentReceiptReservationTimeoutMs = 60000",
                         "receiptWindow.location.href === 'about:blank'",
                         "receiptWindow.close()");

--- a/src/test/java/io/github/carlos_emr/carlos/appointment/AppointmentJspRoutingTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/appointment/AppointmentJspRoutingTest.java
@@ -56,6 +56,7 @@ class AppointmentJspRoutingTest {
         assertThat(printReceiptButton)
                 .as("the receipt update must use the same validated submit path as a normal update")
                 .contains(
+                        "formaction=\"<%=request.getContextPath() %>/appointment/UpdateRecord\"",
                         "onclick=\"",
                         "displaymode.value='Update Appt'",
                         "printReceipt.value='1'",

--- a/src/test/java/io/github/carlos_emr/carlos/appointment/AppointmentJspRoutingTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/appointment/AppointmentJspRoutingTest.java
@@ -40,6 +40,7 @@ class AppointmentJspRoutingTest {
         String ticklerAdd = readJspContent("src/main/webapp/WEB-INF/jsp/tickler/ticklerAdd.jsp");
         String addAlternateContact = readJspContent("src/main/webapp/WEB-INF/jsp/demographic/AddAlternateContact.jsp");
         String oscarJs = readJspContent("src/main/webapp/share/javascript/Oscar.js");
+        String globalJs = readJspContent("src/main/webapp/js/global.js");
         String schedulingStruts = readJspContent("src/main/webapp/WEB-INF/classes/struts-scheduling.xml");
 
         assertThat(editAppointment).contains("/demographic/DemographicSearch");
@@ -65,7 +66,17 @@ class AppointmentJspRoutingTest {
                 .as("the validated submit path must reserve the dedicated receipt window before navigation")
                 .contains(
                         "if (document.EDITAPPT.printReceipt.value === '1')",
+                        "reserveAppointmentReceiptWindow()",
                         "popupFocusPage(350, 750, 'about:blank', 'appointmentReceipt')");
+        assertThat(editAppointment)
+                .as("an unused receipt reservation must close after the update fails or stalls")
+                .contains(
+                        "appointmentReceiptReservationTimeoutMs = 60000",
+                        "receiptWindow.location.href === 'about:blank'",
+                        "receiptWindow.close()");
+        assertThat(globalJs)
+                .as("popupFocusPage must return the reserved window so callers can manage its lifecycle")
+                .contains("return popup;");
 
         assertThat(addAppointment).contains("/appointment/AddRecord");
         assertThat(addAppointment).contains("/appointment/appointmentgrouprecords");


### PR DESCRIPTION
## Description

Reserve the named appointment receipt window during the user's **Update & Receipt** click. The successful update response then reuses that permitted window for the receipt, preventing browsers from blocking the delayed `window.open` after form submission.

Adds a regression assertion for the user-activation requirement.

## Related Issues

Fixes #3251

## How Was This Tested?

- `mvn -q -Dtest=AppointmentJspRoutingTest test`
- `/scripts/make install --no-clean --skip-checks`
- Live Playwright test using a fake appointment with popup policy enforced:
  - control: update POST succeeded but the receipt page was blocked
  - patched: update, receipt page, and PDF requests all returned HTTP 200
  - PDF response was `application/pdf`, began with `%PDF-`, and contained 1,579 bytes
  - no console or page errors
- `git diff --check`

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality
- [x] I have read the [contributing guide](CONTRIBUTING.md)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reserve a dedicated receipt window during the validated Update & Receipt click, reuse it after the update, and show a short “receipt pending” message to ensure the popup isn’t blocked. Fixes #3251.

- **Bug Fixes**
  - In `editappointment.jsp`, Update & Receipt now calls `onButUpdate()`; on success with `printReceipt === '1'`, it reserves `'appointmentReceipt'` via `popupFocusPage(...)`, sets the window title from `report.appointmentReceipt.title`, and shows a localized “receipt pending” message; on validation failure, it clears `printReceipt`.
  - In `appointmentupdatearecord.jsp`, reuse `'appointmentReceipt'` with `popupFocusPage(...)` to load the print URL.
  - In `global.js`, `popupFocusPage` returns the window handle; tests assert the validated path, reservation title/message, and window reuse; new `appointment.editappointment.msgReceiptPending` is added in `en`, `es`, `fr`, `pl`, and `pt_BR`.

<sup>Written for commit a9a3a2f33545f8df65cad772912825e8b29dc34b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

