### PR TITLE
Add explicit Active search button; fix blank search ignoring status 

### DIFF
--- a/src/main/resources/oscarResources_en.properties
+++ b/src/main/resources/oscarResources_en.properties
@@ -8934,6 +8934,7 @@ errors.minlength=<li>{0} cannot be less than {1} characters</li>
 
 errors.numeric=<li>{0} must be a numerical value</li>
 
+demographic.search.Active=Active
 demographic.search.Inactive=Inactive
 
 demographic.search.All=All

--- a/src/main/webapp/WEB-INF/jsp/demographic/demographicsearch2apptresults.jsp
+++ b/src/main/webapp/WEB-INF/jsp/demographic/demographicsearch2apptresults.jsp
@@ -211,6 +211,11 @@
             if (checkTypeIn()) document.forms[0].submit()
         }
 
+        function searchActive() {
+            document.titlesearch.ptstatus.value = "active"
+            if (checkTypeIn()) document.forms[0].submit()
+        }
+
 
     </script>
 </head>
@@ -315,6 +320,10 @@
                 <input type="SUBMIT" class="btn btn-primary" name="displaymode"
                        value='<fmt:message key="global.search"/>'
                        title='<fmt:message key="demographic.zdemographicfulltitlesearch.tooltips.searchActive"/>'>
+                <INPUT TYPE="button" id="activeButton" class="btn btn-secondary"
+                       onclick="searchActive();"
+                       TITLE="<fmt:message key="demographic.zdemographicfulltitlesearch.tooltips.searchActive"/>"
+                       VALUE="<fmt:message key="demographic.search.Active"/>">
                 <INPUT TYPE="button" id="inactiveButton" class="btn btn-secondary"
                        onclick="searchInactive();"
                        TITLE="<fmt:message key="demographic.zdemographicfulltitlesearch.tooltips.searchInactive"/>"


### PR DESCRIPTION
- Add Active button beside Inactive/All in appointment search and main patient search box, mirroring existing button styling
- Fix demographicsearchresults.jsp and demographicsearch2apptresults.jsp so a blank keyword only falls back to the recent-patients view when status is 'active' (default), preserving Inactive/All filters instead of silently ignoring them

Closes #3282

## Summary by Sourcery

Introduce an explicit Active search control in demographic appointment search and fix blank searches so status filters are respected instead of being silently ignored.

New Features:
- Add an explicit Active patient search button alongside existing Inactive and All filters in the appointment search results page.

Bug Fixes:
- Ensure blank keyword searches only fall back to the recent-patients view when status is Active, preserving Inactive and All filters.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an explicit "Active" search button next to "Inactive" and "All", and fixes blank searches so the status filter is respected. Closes #3282.

- **New Features**
  - Added an "Active" button with matching styling; new i18n key `demographic.search.Active`.

- **Bug Fixes**
  - Blank keyword now only falls back to recent patients when status is "active" (default), preserving "Inactive" and "All" filters.

<sup>Written for commit 823ba5f6fe1fad9b921ff50a27dc6002caabdf9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

