### PR TITLE
fix(test): honor self-signed TLS in login-check API request contexts

### DIFF
--- a/scripts/login-playwright-checks.js
+++ b/scripts/login-playwright-checks.js
@@ -286,7 +286,7 @@ async function expectSchedulePage(page, label) {
     });
 
     await record('public login entry route rejects POST and allows GET', async () => {
-      const api = await request.newContext();
+      const api = await request.newContext({ ignoreHTTPSErrors: true });
       const post = await api.post(appUrl('/index'), { form: { anything: 'x' } });
       assert(post.status() === 405, `POST /index expected 405, got ${post.status()}`);
       assert((post.headers().allow || '').includes('GET'), `POST /index missing Allow GET header`);
@@ -312,7 +312,7 @@ async function expectSchedulePage(page, label) {
     });
 
     await record('unauthenticated structured and download routes return 401', async () => {
-      const api = await request.newContext();
+      const api = await request.newContext({ ignoreHTTPSErrors: true });
       const ajax = await api.get(appUrl('/billing/CA/ON/ViewSearchRefDocAjax'), {
         headers: { 'X-Requested-With': 'XMLHttpRequest' },
       });
@@ -485,7 +485,7 @@ async function expectSchedulePage(page, label) {
 
     await record('legacy /login forced-reset POST cannot change password without reset cache token', async () => {
       setForcedResetBaseline(1);
-      const api = await request.newContext();
+      const api = await request.newContext({ ignoreHTTPSErrors: true });
       const res = await api.post(appUrl('/login'), {
         form: {
           forcedpasswordchange: 'true',


### PR DESCRIPTION
## Description

The Playwright login suite's browser contexts already pass `ignoreHTTPSErrors: true`, but the three direct `apiRequestContext` checks (public-route POST guard, unauthenticated 401 routes, legacy `/login` reset POST) did not. Against an https target with a self-signed certificate — exactly the topology the carlos-podman QUICKSTART points `BASE_URL` at (`https://127.0.0.1:8443/carlos`, in-pod self-signed keystore) — those three checks fail with `self-signed certificate` before reaching the app, while the eleven browser-context checks pass. This aligns the API contexts with the browser contexts so the suite runs unmodified against both the devcontainer (http) and the podman dev pod (https, self-signed).

## Related Issues

None — surfaced while live-verifying the carlos-podman QUICKSTART walk-through end-to-end.

## How Was This Tested?

Ran the full suite against a rootless-podman-style dev pod built from `develop@2cf46689` (carlos-podman `Containerfile`, MariaDB 11.4.12, Ontario Flyway migrations), with `BASE_URL=https://127.0.0.1:8443/carlos` and the seeded `carlosdoc` account:

- Before: 11/14 pass, the 3 API-context checks fail with `apiRequestContext.post: self-signed certificate`.
- After: **14/14 checks pass**, including forced reset, CSRF rejection, and old-vs-new password behavior; the suite's security-row restore ran cleanly.

The change is test-only (no production code touched) and does not alter behavior against plain-http targets.

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wo76RJ4MZtzzj6UKbMea2U