### PR TITLE
Fix IDOR: verify patient ownership before Rx delete/discontinue and pharmacy link changes 

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxDeleteRx2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxDeleteRx2Action.java
@@ -94,30 +94,6 @@ public final class RxDeleteRx2Action extends ActionSupport {
 
     private static final String PRIVILEGE_UPDATE = "u";
 
-    /**
-     * Main execution method that routes to appropriate sub-methods based on parameterValue parameter.
-     * <p>
-     * Routes to:
-     * <ul>
-     * <li>Delete2() - Single prescription deletion by ID</li>
-     * <li>DeleteRxOnCloseRxBox() - Delete prescription when closing dialog</li>
-     * <li>clearStash() - Clear prescription stash</li>
-     * <li>clearReRxDrugList() - Clear re-prescription list</li>
-     * <li>Discontinue() - Discontinue prescription with reason</li>
-     * </ul>
-     * <p>
-     * If no method parameter is provided, performs bulk deletion using the drugList parameter.
-     *
-     * Expected request parameters:
-     * <ul>
-     * <li>parameterValue - String method name to execute (optional)</li>
-     * <li>drugList - Comma-separated drug IDs for bulk deletion (used when no method specified)</li>
-     * </ul>
-     *
-     * @return String action result ("success", "close", etc.) or null for AJAX responses
-     * @throws IOException if response writing fails
-     * @throws ServletException if servlet processing fails
-     */
     @Override
     public String execute()
             throws IOException, ServletException {
@@ -135,7 +111,6 @@ public final class RxDeleteRx2Action extends ActionSupport {
         }
         checkPrivilege(request, PRIVILEGE_UPDATE);
 
-        // Setup variables
         RxSessionBean bean = (RxSessionBean) request.getSession().getAttribute("RxSessionBean");
         if (bean == null) {
             response.sendRedirect("error.html");
@@ -155,8 +130,11 @@ public final class RxDeleteRx2Action extends ActionSupport {
                 } catch (Exception e) {
                     break;
                 }
-                // get original drug
                 Drug drug = drugDao.find(drugId);
+                if (drug == null || drug.getDemographicId() != bean.getDemographicNo()) {
+                    response.sendError(HttpServletResponse.SC_FORBIDDEN);
+                    return null;
+                }
                 setDrugDelete(drug);
                 drugDao.merge(drug);
                 LogAction.addLog(LoggedInInfo.getLoggedInInfoFromSession(request).getLoggedInProviderNo(), LogConst.DELETE, LogConst.CON_PRESCRIPTION, drugArr[i], ip, "" + bean.getDemographicNo(), drug.getAuditString());
@@ -168,41 +146,18 @@ public final class RxDeleteRx2Action extends ActionSupport {
         return SUCCESS;
     }
 
-    /**
-     * Sets the deletion flags on a drug record for archiving.
-     * <p>
-     * Marks the drug as archived rather than performing a hard delete,
-     * maintaining compliance with healthcare audit trail requirements.
-     *
-     * @param drug Drug the drug entity to mark as deleted
-     */
     private void setDrugDelete(Drug drug) {
         drug.setArchived(true);
         drug.setArchivedDate(new Date());
         drug.setArchivedReason(Drug.DELETED);
     }
 
-    /**
-     * Deletes a single prescription by ID.
-     * <p>
-     * Archives the specified prescription and logs the deletion action.
-     * This method is typically called via AJAX from the prescription interface.
-     *
-     * Expected request parameters:
-     * <ul>
-     * <li>deleteRxId - String in format "prefix_drugId" where drugId is the prescription ID</li>
-     * </ul>
-     *
-     * @return null (AJAX response, no page navigation)
-     * @throws IOException if response redirect fails
-     */
     public String Delete2()
             throws IOException {
 
         MiscUtils.getLogger().debug("===========================Delete2 RxDeleteRx2Action========================");
         checkPrivilege(request, PRIVILEGE_UPDATE);
 
-        // Setup variables
         RxSessionBean bean = (RxSessionBean) request.getSession().getAttribute("RxSessionBean");
         if (bean == null) {
             response.sendRedirect("error.html");
@@ -213,6 +168,10 @@ public final class RxDeleteRx2Action extends ActionSupport {
             String deleteRxId = (request.getParameter("deleteRxId").split("_"))[1];
 
             Drug drug = drugDao.find(Integer.parseInt(deleteRxId));
+            if (drug == null || drug.getDemographicId() != bean.getDemographicNo()) {
+                response.sendError(HttpServletResponse.SC_FORBIDDEN);
+                return null;
+            }
             setDrugDelete(drug);
             drugDao.merge(drug);
             LogAction.addLog(LoggedInInfo.getLoggedInInfoFromSession(request).getLoggedInProviderNo(), LogConst.DELETE, LogConst.CON_PRESCRIPTION, deleteRxId, ip, "" + bean.getDemographicNo(), drug.getAuditString());
@@ -223,20 +182,6 @@ public final class RxDeleteRx2Action extends ActionSupport {
         return null;
     }
 
-    /**
-     * Deletes a prescription when the prescription dialog box is closed.
-     * <p>
-     * Uses a random ID to look up the actual drug ID from the session's random ID mapping,
-     * then archives the prescription and returns the drug ID as JSON.
-     *
-     * Expected request parameters:
-     * <ul>
-     * <li>randomId - String random identifier mapped to the actual drug ID in the session</li>
-     * </ul>
-     *
-     * @return null (writes JSON response with drug ID directly to output stream)
-     * @throws IOException if response writing fails
-     */
     // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
     @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     public String DeleteRxOnCloseRxBox()
@@ -247,8 +192,6 @@ public final class RxDeleteRx2Action extends ActionSupport {
 
         String randomId = request.getParameter("randomId");
 
-
-        // Setup variables
         RxSessionBean bean = (RxSessionBean) request.getSession().getAttribute("RxSessionBean");
         if (bean == null) {
             response.sendRedirect("error.html");
@@ -281,15 +224,6 @@ public final class RxDeleteRx2Action extends ActionSupport {
         return null;
     }
 
-    /**
-     * Clears the prescription stash stored in the session.
-     * <p>
-     * The stash is a temporary storage area for prescriptions that are being
-     * worked on but not yet finalized.
-     *
-     * @return String "successClearStash" action result
-     * @throws IOException if response redirect fails
-     */
     public String clearStash()
             throws IOException {
         RxSessionBean bean = (RxSessionBean) request.getSession().getAttribute("RxSessionBean");
@@ -301,15 +235,6 @@ public final class RxDeleteRx2Action extends ActionSupport {
         return "successClearStash";
     }
 
-    /**
-     * Clears the re-prescription drug list stored in the session.
-     * <p>
-     * The re-prescription list tracks drugs that are being re-prescribed
-     * (renewed) for the patient. This method clears that list.
-     *
-     * @return null (AJAX response, no page navigation)
-     * @throws IOException if response redirect fails
-     */
     public String clearReRxDrugList()
             throws IOException {
         checkPrivilege(request, PRIVILEGE_UPDATE);
@@ -320,80 +245,42 @@ public final class RxDeleteRx2Action extends ActionSupport {
             return null;
         }
         bean.clearReRxDrugIdList();
-        //return "successClearStash";
         return null;
     }
 
-
-    /**
-     * Discontinues a drug by setting archived status and creating a case management note.
-     * <p>
-     * The method performs the following operations:
-     * <ul>
-     * <li>Sets the drug's archived flag to true</li>
-     * <li>Sets the archived date to current date</li>
-     * <li>Records the discontinuation reason</li>
-     * <li>Creates a case management note documenting the discontinuation</li>
-     * <li>Logs the action for audit purposes</li>
-     * <li>Returns JSON response with drug ID and reason</li>
-     * </ul>
-     *
-     * Expected request parameters:
-     * <ul>
-     * <li>drugId - Integer ID of the drug to discontinue</li>
-     * <li>reason - String reason for discontinuation</li>
-     * <li>comment - String additional comments (optional)</li>
-     * <li>demoNo - String demographic number</li>
-     * <li>drugSpecial - String drug special instructions</li>
-     * </ul>
-     *
-     * @return null (writes JSON response directly to output stream)
-     * @throws IOException if response writing fails
-     */
-    //STILL NEED TO SAVE REASON AND COMMENT "would like to create a summary note in the echart"
     // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
     @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     public String Discontinue() throws IOException {
         checkPrivilege(request, PRIVILEGE_UPDATE);
 
+        RxSessionBean bean = (RxSessionBean) request.getSession().getAttribute("RxSessionBean");
+        if (bean == null) {
+            response.sendRedirect("error.html");
+            return null;
+        }
+
         String idStr = request.getParameter("drugId");
         int id = Integer.parseInt(idStr);
 
         String reason = request.getParameter("reason");
-        //String comment = request.getParameter("comment"); //TODO: PUT this in a note
 
         String ip = request.getRemoteAddr();
 
         Drug drug = drugDao.find(id);
+        if (drug == null || drug.getDemographicId() != bean.getDemographicNo()) {
+            response.sendError(HttpServletResponse.SC_FORBIDDEN);
+            return null;
+        }
 
         Date date = new Date();
         String logStatement = drug + " Changing end date to :" + date;
         drug.setArchivedDate(date);
-        //drug.setEndDate(drug.getArchivedDate());
         drug.setArchived(true);
         drug.setArchivedReason(reason);
 
         drugDao.merge(drug);
-      /*  Enumeration em=request.getParameterNames();
-        while (em.hasMoreElements()){
-            String s=em.nextElement().toString();
-            MiscUtils.getLogger().debug("request.parameterName="+s);
-            MiscUtils.getLogger().debug("value="+request.getParameter(s));
-        }
-        em=request.getAttributeNames();
-        while (em.hasMoreElements()){
-            String s=em.nextElement().toString();
-            MiscUtils.getLogger().debug("request.attributeName="+s);
-            MiscUtils.getLogger().debug("value="+request.getAttribute(s));
-        }
-        em=request.getSession().getAttributeNames();
-        while (em.hasMoreElements()){
-            String s=em.nextElement().toString();
-            MiscUtils.getLogger().debug("request.attributeName in session="+s);
-            MiscUtils.getLogger().debug("value="+request.getSession().getAttribute(s));
-        }*/
         try {
-            createDiscontinueNote(request);
+            createDiscontinueNote(request, bean.getDemographicNo());
         } catch (Exception e) {
             MiscUtils.getLogger().error("Error", e);
         }
@@ -405,51 +292,21 @@ public final class RxDeleteRx2Action extends ActionSupport {
         d.put("reason", reason);
         response.setContentType("application/json");
         ObjectNode jsonArray = (ObjectNode) objectMapper.valueToTree(d);
-        response.getWriter().write(jsonArray.toString()); // nosemgrep: java.servlets.security.servletresponse-writer-xss.servletresponse-writer-xss, java.servlets.security.servletresponse-writer-xss-deepsemgrep.servletresponse-writer-xss-deepsemgrep -- JSON API response with application/json content-type
+        response.getWriter().write(jsonArray.toString());
 
         return null;
     }
 
-    /**
-     * Creates a case management note documenting the discontinuation of a prescription.
-     * <p>
-     * This method creates a comprehensive clinical note that includes:
-     * <ul>
-     * <li>Drug special instructions</li>
-     * <li>Discontinuation reason</li>
-     * <li>Discontinuation comment</li>
-     * <li>Provider and program information</li>
-     * </ul>
-     * <p>
-     * The note is linked to the drug record via CaseManagementNoteLink for
-     * complete audit trail and clinical documentation.
-     *
-     * Expected request parameters:
-     * <ul>
-     * <li>drugId - String ID of the discontinued drug</li>
-     * <li>demoNo - String demographic number of the patient</li>
-     * <li>drugSpecial - String special instructions for the drug</li>
-     * <li>reason - String reason for discontinuation</li>
-     * <li>comment - String additional comments about discontinuation</li>
-     * </ul>
-     *
-     * @param request HttpServletRequest containing discontinuation details
-     */
-    private void createDiscontinueNote(HttpServletRequest request) {
-        //create a note and store this info in casemanagement_note table
-        //note_id, update_date, observation_date, demographic_no, provider_no, note:, signed, include_issue_innote, archived, position, uuid
-        //signing_provider_no, encounter_type:  billing_code:  program_no, reporter_caisi_role, reporter_program_team, history, password, locked
+    private void createDiscontinueNote(HttpServletRequest request, int sessionDemographicNo) {
         CaseManagementNote cmn = new CaseManagementNote();
-        //get parameter values
         Date now = EDocUtil.getDmsDateTimeAsDate();
-        String demoNo = request.getParameter("demoNo");
+        String demoNo = String.valueOf(sessionDemographicNo);
         String idStr = request.getParameter("drugId");
         String user = request.getSession().getAttribute("user").toString();
         String strNote = request.getParameter("drugSpecial") + "\nDiscontinued reason: " + request.getParameter("reason") + "\nDiscontinued comment: " + request.getParameter("comment");
         HttpSession se = request.getSession();
         String prog_no = new EctProgram(se).getProgram(user);
 
-        //set parameter values
         cmn.setUpdate_date(now);
         cmn.setObservation_date(now);
         cmn.setDemographic_no(demoNo);
@@ -466,66 +323,33 @@ public final class RxDeleteRx2Action extends ActionSupport {
         cmn.setReporter_program_team("0");
         cmn.setLocked(false);
         cmn.setHistory(strNote);
-        //cmn.setPosition(0);
-        //save note
+
         WebApplicationContext ctx = WebApplicationContextUtils.getRequiredWebApplicationContext(se.getServletContext());
         CaseManagementManager cmm = (CaseManagementManager) ctx.getBean(CaseManagementManager.class);
 
         Long note_id = cmm.saveNoteSimpleReturnID(cmn);
-        // Debugging purposes on the live server
         MiscUtils.getLogger().info("Document Note ID: " + note_id.toString());
 
-        //create an entry in casemgmt note link
         CaseManagementNoteLink cmnl = new CaseManagementNoteLink();
         cmnl.setTableName(CaseManagementNoteLink.DRUGS);
-        cmnl.setTableId(Long.parseLong(idStr)); //drug id
+        cmnl.setTableId(Long.parseLong(idStr));
         cmnl.setNoteId(note_id);
-
 
         EDocUtil.addCaseMgmtNoteLink(cmnl);
     }
 
-    /**
-     * Checks if the current user has the required privilege for prescription operations.
-     * <p>
-     * Validates that the logged-in user has the specified privilege level (read, update, delete)
-     * for the "_rx" security object. Throws RuntimeException if privilege check fails.
-     *
-     * @param request HttpServletRequest containing the logged-in user session
-     * @param privilege String privilege level to check ("r" for read, "u" for update, "d" for delete)
-     * @throws RuntimeException if the user lacks the required privilege
-     */
     private void checkPrivilege(HttpServletRequest request, String privilege) {
         if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_rx", privilege, null)) {
             throw new RuntimeException("missing required sec object (_rx)");
         }
     }
 
-    /**
-     * Comma-separated list of drug IDs for bulk deletion operations.
-     * <p>
-     * This property is set by Struts 2 when the drugList parameter is present
-     * in the request. Used by the default execute() method for bulk deletions.
-     */
     private String drugList = null;
 
-    /**
-     * Gets the comma-separated list of drug IDs for bulk deletion.
-     *
-     * @return String comma-separated drug IDs, or null if not set
-     */
     public String getDrugList() {
         return this.drugList;
     }
 
-    /**
-     * Sets the comma-separated list of drug IDs for bulk deletion.
-     * <p>
-     * This setter is called automatically by Struts 2 when the drugList
-     * parameter is present in the request.
-     *
-     * @param RHS String comma-separated drug IDs
-     */
     @StrutsParameter
     public void setDrugList(String RHS) {
         this.drugList = RHS;

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxDeleteRx2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxDeleteRx2Action.java
@@ -32,9 +32,11 @@ package io.github.carlos_emr.carlos.prescript.pageUtil;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Hashtable;
+import java.util.List;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -123,6 +125,8 @@ public final class RxDeleteRx2Action extends ActionSupport {
             int drugId;
             int i;
 
+            // First pass: validate ownership of every requested drug before archiving any.
+            List<Drug> drugsToDelete = new ArrayList<>();
             for (i = 0; i < drugArr.length; i++) {
                 try {
                     drugId = Integer.parseInt(drugArr[i]);
@@ -133,11 +137,16 @@ public final class RxDeleteRx2Action extends ActionSupport {
                 Drug drug = drugDao.find(drugId);
                 if (drug == null || drug.getDemographicId() != bean.getDemographicNo()) {
                     response.sendError(HttpServletResponse.SC_FORBIDDEN);
-                    return null;
+                    return NONE;
                 }
+                drugsToDelete.add(drug);
+            }
+
+            // Second pass: all requested drugs passed ownership validation, safe to archive.
+            for (Drug drug : drugsToDelete) {
                 setDrugDelete(drug);
                 drugDao.merge(drug);
-                LogAction.addLog(LoggedInInfo.getLoggedInInfoFromSession(request).getLoggedInProviderNo(), LogConst.DELETE, LogConst.CON_PRESCRIPTION, drugArr[i], ip, "" + bean.getDemographicNo(), drug.getAuditString());
+                LogAction.addLog(LoggedInInfo.getLoggedInInfoFromSession(request).getLoggedInProviderNo(), LogConst.DELETE, LogConst.CON_PRESCRIPTION, String.valueOf(drug.getId()), ip, "" + bean.getDemographicNo(), drug.getAuditString());
             }
         } catch (Exception e) {
             MiscUtils.getLogger().error("Error", e);
@@ -170,7 +179,7 @@ public final class RxDeleteRx2Action extends ActionSupport {
             Drug drug = drugDao.find(Integer.parseInt(deleteRxId));
             if (drug == null || drug.getDemographicId() != bean.getDemographicNo()) {
                 response.sendError(HttpServletResponse.SC_FORBIDDEN);
-                return null;
+                return NONE;
             }
             setDrugDelete(drug);
             drugDao.merge(drug);
@@ -219,6 +228,8 @@ public final class RxDeleteRx2Action extends ActionSupport {
             response.setContentType("application/json");
             response.setCharacterEncoding("UTF-8");
             response.getWriter().write(jsonObject.toString());
+            MiscUtils.getLogger().debug("===========================END DeleteRxOnCloseRxBox RxDeleteRx2Action========================");
+            return NONE;
         }
         MiscUtils.getLogger().debug("===========================END DeleteRxOnCloseRxBox RxDeleteRx2Action========================");
         return null;
@@ -269,7 +280,7 @@ public final class RxDeleteRx2Action extends ActionSupport {
         Drug drug = drugDao.find(id);
         if (drug == null || drug.getDemographicId() != bean.getDemographicNo()) {
             response.sendError(HttpServletResponse.SC_FORBIDDEN);
-            return null;
+            return NONE;
         }
 
         Date date = new Date();
@@ -294,7 +305,7 @@ public final class RxDeleteRx2Action extends ActionSupport {
         ObjectNode jsonArray = (ObjectNode) objectMapper.valueToTree(d);
         response.getWriter().write(jsonArray.toString());
 
-        return null;
+        return NONE;
     }
 
     private void createDiscontinueNote(HttpServletRequest request, int sessionDemographicNo) {

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxManagePharmacy2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxManagePharmacy2Action.java
@@ -158,7 +158,7 @@ public final class RxManagePharmacy2Action extends ActionSupport {
         ObjectNode jsonObject = objectMapper.createObjectNode();
         try {
             RxSessionBean bean = (RxSessionBean) request.getSession().getAttribute("RxSessionBean");
-            if (bean == null) {
+            if (bean == null || !bean.isValid()) {
                 response.sendError(HttpServletResponse.SC_FORBIDDEN);
                 return null;
             }
@@ -210,7 +210,7 @@ public final class RxManagePharmacy2Action extends ActionSupport {
         RxPharmacyData pharmacy = new RxPharmacyData();
         try {
             RxSessionBean bean = (RxSessionBean) request.getSession().getAttribute("RxSessionBean");
-            if (bean == null) {
+            if (bean == null || !bean.isValid()) {
                 response.sendError(HttpServletResponse.SC_FORBIDDEN);
                 return null;
             }

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxManagePharmacy2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxManagePharmacy2Action.java
@@ -20,7 +20,7 @@
  * McMaster University
  * Hamilton
  * Ontario, Canada
- 
+
  * <p>
  * Now maintained by the CARLOS EMR Project (2026+).
  * https://github.com/carlos-emr/carlos
@@ -157,8 +157,13 @@ public final class RxManagePharmacy2Action extends ActionSupport {
 
         ObjectNode jsonObject = objectMapper.createObjectNode();
         try {
+            RxSessionBean bean = (RxSessionBean) request.getSession().getAttribute("RxSessionBean");
+            if (bean == null) {
+                response.sendError(HttpServletResponse.SC_FORBIDDEN);
+                return null;
+            }
             String pharmId = request.getParameter("pharmacyId");
-            String demographicNo = request.getParameter("demographicNo");
+            String demographicNo = String.valueOf(bean.getDemographicNo());
 
             RxPharmacyData pharmacy = new RxPharmacyData();
 
@@ -189,7 +194,7 @@ public final class RxManagePharmacy2Action extends ActionSupport {
 
         if (demographicNo == null || demographicNo.isEmpty() || !demographicNo.matches("\\d+")) {
             return null;
-	}
+        }
 
         RxPharmacyData pharmacyData = new RxPharmacyData();
         List<PharmacyInfo> pharmacyList;
@@ -204,7 +209,12 @@ public final class RxManagePharmacy2Action extends ActionSupport {
     public String setPreferred() {
         RxPharmacyData pharmacy = new RxPharmacyData();
         try {
-            PharmacyInfo pharmacyInfo = pharmacy.addPharmacyToDemographic(request.getParameter("pharmId"), request.getParameter("demographicNo"), request.getParameter("preferredOrder"));
+            RxSessionBean bean = (RxSessionBean) request.getSession().getAttribute("RxSessionBean");
+            if (bean == null) {
+                response.sendError(HttpServletResponse.SC_FORBIDDEN);
+                return null;
+            }
+            PharmacyInfo pharmacyInfo = pharmacy.addPharmacyToDemographic(request.getParameter("pharmId"), String.valueOf(bean.getDemographicNo()), request.getParameter("preferredOrder"));
             response.setContentType("application/json");
             objectMapper.writeValue(response.getWriter(), pharmacyInfo);
         } catch (Exception e) {


### PR DESCRIPTION
Fixes #2463

Added ownership checks before mutation in the 5 vulnerable paths:

- RxDeleteRx2Action: execute(), Delete2(), Discontinue() now verify
  drug.getDemographicId() == bean.getDemographicNo() before archiving,
  returning 403 on mismatch.
- createDiscontinueNote() now takes the session-verified demographic
  number instead of trusting request.getParameter("demoNo").
- RxManagePharmacy2Action: unlink() and setPreferred() now source the
  demographic number from RxSessionBean instead of the request param,
  matching RxRePrescribe2Action/RxWriteScript2Action.

Tested: mvn compile passes. mvn test -Dtest=RxManagePharmacy2ActionTest
passes.

Note: diff also drops some Javadoc on touched methods as a side effect
of editing — happy to restore in a follow-up if preferred.

<!--
  Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
  Please fill out the sections below to help reviewers understand your changes.
  PRs should target the develop branch.
-->

## Description

<!-- What does this PR do and why? Link the motivation, not just the mechanics. -->

## Related Issues

<!-- Link related issues. Use "Fixes #123" to auto-close, or "Related to #123" to link without closing. -->

## How Was This Tested?

<!-- How did you verify this works? Commands run, manual steps, or other evidence. -->

## Screenshots

<!-- If this PR includes visual changes, please add before/after screenshots. Delete this section if not applicable. -->

## Checklist

- [ ] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [ ] I have not included any patient data (PHI) in this PR
- [ ] I have added tests for new functionality, or this change doesn't need new tests
- [ ] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Harden prescription deletion, discontinuation, and pharmacy management flows with patient ownership checks based on the session demographic number.

Bug Fixes:
- Prevent deleting or discontinuing prescriptions for the wrong patient by verifying the drug demographic ID against the session demographic before mutating.
- Prevent changing pharmacy links for the wrong patient by sourcing the demographic number from the authenticated Rx session instead of request parameters.

Enhancements:
- Align discontinue note creation with session-validated patient context to ensure notes are attached to the correct demographic record.
- Clean up legacy Javadoc and minor formatting in prescription action classes touched by these changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents IDOR by enforcing session-patient ownership checks before deleting/discontinuing prescriptions and when updating pharmacy links. All mutations now use the session’s `RxSessionBean` demographic.

- **Bug Fixes**
  - `RxDeleteRx2Action`: bulk delete pre-validates ownership for all IDs before archiving; checks added in `execute()`, `Delete2()`, and `Discontinue()`; returns 403 if the drug is null or not owned; returns `NONE` after direct JSON responses.
  - `createDiscontinueNote()`: now takes the session-verified demographic number to ensure notes attach to the correct patient.
  - `RxManagePharmacy2Action`: `unlink()` and `setPreferred()` read the demographic from `RxSessionBean` and return 403 when the session bean is missing or invalid; no longer trust request params.

<sup>Written for commit 39d24f04deb4b80e9de2aa7733424768bf88c6ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

