### PR TITLE
fix(test): encode the MySQL option-file password in the login Playwright check

### DIFF
--- a/scripts/login-playwright-checks.js
+++ b/scripts/login-playwright-checks.js
@@ -102,13 +102,28 @@ async function gotoApp(page, path, options = {}, query = null) {
   return page.goto(targetUrl, options); // nosemgrep
 }
 
+// A MariaDB option file is NOT a raw key=value format: in a value, '\' starts an
+// escape sequence ('\s' is a space, '\t' a tab) and an unquoted '#' starts a
+// comment that truncates the rest of the line. Writing the password verbatim
+// therefore silently corrupts it and the script dies on "Access denied" —
+// verified live against a dev instance whose root password contained a
+// backslash. Double-quoting the value neutralizes '#' and surrounding
+// whitespace; '\' and '"' still need escaping inside the quotes.
+function encodeOptionFileValue(value) {
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
 function createMysqlDefaultsFile() {
   if (/[\r\n]/.test(mysqlPassword)) {
     throw new Error('MYSQL_PASSWORD must not contain newline characters');
   }
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'carlos-login-mysql-'));
   const file = path.join(dir, 'client.cnf');
-  fs.writeFileSync(file, `[client]\npassword=${mysqlPassword}\n`, { mode: 0o600 });
+  fs.writeFileSync(
+    file,
+    `[client]\npassword=${encodeOptionFileValue(mysqlPassword)}\n`,
+    { mode: 0o600 }
+  );
   return { dir, file };
 }
 


### PR DESCRIPTION
## Description

`createMysqlDefaultsFile` in `scripts/login-playwright-checks.js` wrote `password=${mysqlPassword}` verbatim into the `--defaults-extra-file` it hands to the `mysql` client.

A MariaDB option file is **not** a raw `key=value` format. Inside a value:

- `\` starts an escape sequence — `\s` is a space, `\t` a tab
- an unquoted `#` starts a comment that truncates the rest of the line
- leading/trailing whitespace is trimmed

So any password containing `\` or `#` is silently corrupted before the client ever sees it, and the script dies on its very first query with:

```
ERROR 1045 (28000): Access denied for user 'root'@'localhost' (using password: YES)
```

The failure points at the *credential* rather than at the *encoding*, which is what makes it expensive to diagnose — the password in the environment is correct.

The value is now double-quoted, with `\` and `"` escaped inside the quotes. Double-quoting neutralizes `#` and surrounding whitespace; the two remaining metacharacters are escaped explicitly.

This matters beyond one developer's machine. CARLOS' own credential writers already escape for this exact format — `properties_escape_value` in the `carlos-podman` deployment CLI documents itself as covering "a Java .properties line (and, compatibly, a MariaDB option-file value)" — and the deployment tooling accepts backslash-bearing root passwords by design. `login-playwright-checks.js` was the one component in the chain that could not run against them, which is unfortunate given `CLAUDE.md` designates it *"the reference browser/direct-POST regression check for login, failed login, forced reset, CSRF rejection, and provider schedule rendering."*

## Related Issues

None — found while doing an end-to-end review of `yingbull/carlos-podman`, where the deployed instance's MariaDB root password contained a backslash.

## How Was This Tested?

**Measured against a live MariaDB 11.4**, not reasoned about. A throwaway container was given a root password exercising all three option-file hazards at once — `p\a#b"c d` (backslash, hash, double quote, space) — and the encoder was extracted *verbatim from the committed file* and exercised both ways:

| option-file line | result |
| --- | --- |
| `password=p\a#b"c d` (previous behavior) | `ERROR 1045 (28000): Access denied` |
| `password="p\\a#b\"c d"` (this change) | **AUTH OK** |

Isolating each character against the same server:

| password | written verbatim | written with this change |
| --- | --- | --- |
| `D3v@P\ss&"w0rd` | denied | ok |
| `a#b` | denied | ok |
| `a b` | ok | ok |
| `a"b` | ok | ok |

**Full suite run against a real deployment.** `npm run test:login-playwright` was run against a rootless-podman CARLOS instance (Tomcat 11 / MariaDB 11.4, Ontario Flyway schema, 427 tables) whose MariaDB root password contained a backslash, a double quote and an ampersand — **14/14 checks passed, three times**:

1. on the fresh install;
2. after the deployment moved the webapp to a least-privilege DB account;
3. on a fully sealed install (`db_password=__SEALED__` on disk, real credential materialized into a tmpfs fragment) running a rolled-back image.

Each run ended with `Restored carlosdoc security row`, so the suite's `finally` restoration path was exercised too. Before this change the same invocation could not get past `securityRow()` — the first DB read — on that instance.

`node --check scripts/login-playwright-checks.js` passes. No other file is touched, and no behavior outside the option-file write changes.

## Screenshots

Not applicable — no visual changes.

## Checklist

- [ ] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`) — **see the note below**
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests — this *is* test infrastructure; it was verified against a live MariaDB and by three full runs of the suite it repairs
- [x] I have read the [contributing guide](CONTRIBUTING.md)

> **DCO note for the maintainer.** The commit on this branch does not carry a `Signed-off-by` trailer, so the DCO check will report failure. The repository's `CLAUDE.md` blocks history rewriting (`git commit --amend`) and force pushes for automated contributions, so the workflow's suggested `git commit --amend -s --no-edit && git push --force-with-lease` remedy was deliberately not used rather than routing around that rule. Either remedy documented in `.github/workflows/dco-check.yml` will clear it: post the manual confirmation phrase on this PR, or amend the commit with `-s` yourself. Prior Claude-authored commits on `develop` carry `Signed-off-by: Claude <noreply@anthropic.com>` (e.g. `af909f50`), which is the trailer that would apply here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015WrsBeHd41Vp3kwAMP5LWo

---
_Generated by [Claude Code](https://claude.ai/code/session_015WrsBeHd41Vp3kwAMP5LWo)_

## Summary by Sourcery

Bug Fixes:
- Prevent Playwright login check failures when the MariaDB/MySQL password contains backslashes, hashes, or quotes by encoding the option-file password safely.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Playwright login check by correctly encoding the MySQL/MariaDB option-file password. The password is now double-quoted with `\` and `"` escaped so values with backslashes, hashes, quotes, or surrounding spaces are parsed correctly.

- **Bug Fixes**
  - Added `encodeOptionFileValue()` to quote the password and escape `\` and `"`.
  - Prevents option-file parsing from treating `#` as a comment or trimming whitespace.
  - Eliminates false "Access denied" failures for passwords with special characters; verified against MariaDB 11.4 and the full `test:login-playwright` run.

<sup>Written for commit e24901d4dea95704c09cb16d8b97e91322ed31c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

