### PR TITLE
fix(test): encode the option-file password in the two remaining Playwright writers

### DIFF
--- a/scripts/add-login-account-playwright-checks.js
+++ b/scripts/add-login-account-playwright-checks.js
@@ -92,6 +92,16 @@ function playwrightBaseUrl() {
   return `${baseUrl.origin}${pathname}/`;
 }
 
+// A MariaDB option file is NOT a raw key=value format: in a value, '\' starts an
+// escape sequence ('\s' is a space, '\t' a tab) and an unquoted '#' starts a
+// comment that truncates the rest of the line. Writing the password verbatim
+// therefore silently corrupts it and the script dies on "Access denied".
+// Double-quoting the value neutralizes '#' and surrounding whitespace; '\' and
+// '"' still need escaping inside the quotes.
+function encodeOptionFileValue(value) {
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
 function createMysqlDefaultsFile() {
   if (/[\r\n]/.test(mysqlPassword)) {
     throw new Error('MYSQL_PASSWORD must not contain newline characters');
@@ -99,7 +109,11 @@ function createMysqlDefaultsFile() {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'carlos-add-login-mysql-'));
   const file = path.join(dir, 'client.cnf');
   try {
-    fs.writeFileSync(file, `[client]\npassword=${mysqlPassword}\n`, { mode: 0o600 });
+    fs.writeFileSync(
+      file,
+      `[client]\npassword=${encodeOptionFileValue(mysqlPassword)}\n`,
+      { mode: 0o600 }
+    );
     return { dir, file };
   } catch (error) {
     fs.rmSync(dir, { recursive: true, force: true });

--- a/scripts/tickler-crud-playwright-checks.js
+++ b/scripts/tickler-crud-playwright-checks.js
@@ -78,13 +78,27 @@ function appUrl(appPath, query = null) {
   return url.toString();
 }
 
+// A MariaDB option file is NOT a raw key=value format: in a value, '\' starts an
+// escape sequence ('\s' is a space, '\t' a tab) and an unquoted '#' starts a
+// comment that truncates the rest of the line. Writing the password verbatim
+// therefore silently corrupts it and the script dies on "Access denied".
+// Double-quoting the value neutralizes '#' and surrounding whitespace; '\' and
+// '"' still need escaping inside the quotes.
+function encodeOptionFileValue(value) {
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
 function createMysqlDefaultsFile() {
   if (/[\r\n]/.test(mysqlPassword)) {
     throw new Error('MYSQL_PASSWORD must not contain newline characters');
   }
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'carlos-tickler-mysql-'));
   const file = path.join(dir, 'client.cnf');
-  fs.writeFileSync(file, `[client]\npassword=${mysqlPassword}\n`, { mode: 0o600 });
+  fs.writeFileSync(
+    file,
+    `[client]\npassword=${encodeOptionFileValue(mysqlPassword)}\n`,
+    { mode: 0o600 }
+  );
   return { dir, file };
 }
 


### PR DESCRIPTION
## Description

Follow-up to **#3308**, which fixed `scripts/login-playwright-checks.js` only. CodeRabbit's review on that PR landed at 03:43, about a minute *after* it was merged, and correctly pointed out that two sibling scripts carry the identical defect. They are still broken on `develop` today:

```
scripts/tickler-crud-playwright-checks.js:87
scripts/add-login-account-playwright-checks.js:102
    fs.writeFileSync(file, `[client]\npassword=${mysqlPassword}\n`, { mode: 0o600 });
```

A MariaDB option file is **not** a raw `key=value` format. Inside a value:

- `\` starts an escape sequence — `\s` is a space, `\t` a tab
- an unquoted `#` starts a comment that truncates the rest of the line
- leading/trailing whitespace is trimmed

So any password containing `\` or `#` is silently corrupted before the client sees it, and the script dies on its first query with `ERROR 1045 (28000): Access denied` — a message that points at the *credential* rather than the *encoding*, which is what makes it expensive to diagnose.

A grep for `password=${` across `scripts/*.js` confirms these are the **only** three option-file writers in the tree, so this closes the class rather than one more instance of it.

Each script gets its own copy of `encodeOptionFileValue`, matching how these standalone checks already duplicate `escapeSql`, `createMysqlDefaultsFile` and `cleanupMysqlDefaultsFile`. A shared module was considered and deliberately **not** introduced: none of the ~12 scripts under `scripts/` requires a local module today, so extracting one would change the established self-contained-script pattern well beyond the scope of this fix. The three copies are byte-identical, so they collapse cleanly into one if that pattern is ever revisited.

## Related Issues

Follow-up to #3308 (merged). Not a new report — found by the review on that PR, which arrived after it merged.

## How Was This Tested?

**Measured against a live MariaDB 11.4**, not reasoned about. A throwaway container was given a root password exercising every option-file hazard at once — `p\a#b"c d` (backslash, hash, double quote, space). Each encoder was extracted *verbatim from its file* and exercised in isolation against that server:

| writer | result |
| --- | --- |
| baseline: password written verbatim | `DENIED` |
| `login-playwright-checks.js` (already on develop) | **AUTH OK** |
| `tickler-crud-playwright-checks.js` (this PR) | **AUTH OK** |
| `add-login-account-playwright-checks.js` (this PR) | **AUTH OK** |

Re-run after rebasing onto the merged `develop`, so the table above reflects exactly what this branch contains.

The three encoders are byte-identical (`md5` of the function body matches across all three), and `node --check` passes on every `*playwright-checks.js` in the tree.

Separately, the encoding itself was validated character by character against the same server while preparing #3308:

| password | verbatim | encoded |
| --- | --- | --- |
| `D3v@P\ss&"w0rd` | denied | ok |
| `a#b` | denied | ok |
| `a b` | ok | ok |
| `a"b` | ok | ok |

Note `a b` passes both ways — a literal space inside an option-file value parses fine. The characters that actually break are `\`, `#`, and leading/trailing whitespace; double-quoting plus escaping `\` and `"` covers all of them.

No JS unit-test harness exists for `scripts/` — per `CLAUDE.md` these are manual reference checks run against a live app — so the live-server matrix above is the regression evidence rather than an added test file.

## Screenshots

Not applicable — no visual changes.

## Checklist

- [ ] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`) — **see the note below**
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests — this *is* test infrastructure; verified against a live MariaDB (see above)
- [x] I have read the [contributing guide](CONTRIBUTING.md)

> **DCO note for the maintainer.** As with #3308, the commit carries no `Signed-off-by` trailer, so the DCO check will report failure. The repository's `CLAUDE.md` blocks history rewriting and force pushes for automated contributions, so the workflow's `git commit --amend -s` remedy was deliberately not used rather than routing around that rule. Either documented remedy clears it: post `Confirming DCO sign off for all commits` here, or amend with `-s` yourself. Prior Claude-authored commits on `develop` carry `Signed-off-by: Claude <noreply@anthropic.com>`, which is the trailer that would apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015WrsBeHd41Vp3kwAMP5LWo

---
_Generated by [Claude Code](https://claude.ai/code/session_015WrsBeHd41Vp3kwAMP5LWo)_

## Summary by Sourcery

Encode MariaDB option-file passwords safely in the remaining Playwright helper scripts to prevent credential corruption and access-denied errors.

Bug Fixes:
- Fix Playwright tickler CRUD checks writing raw MySQL passwords into MariaDB option files, which could corrupt passwords containing special characters.
- Fix Playwright add-login-account checks writing raw MySQL passwords into MariaDB option files, ensuring passwords with special characters are handled correctly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Encodes the MariaDB option-file password in the two remaining Playwright writers to prevent auth failures with passwords containing `\`, `#`, or surrounding whitespace. Completes the fix started in #3308 for the sibling scripts.

- Bug Fixes
  - Encode password values by double-quoting and escaping `\` and `"` to neutralize `#` and whitespace parsing.
  - Applied to `scripts/tickler-crud-playwright-checks.js` and `scripts/add-login-account-playwright-checks.js`; fixes Access Denied errors with special-character passwords.
  - Kept `encodeOptionFileValue` inline in each script to match the existing self-contained pattern.
  - Verified against MariaDB 11.4; both writers authenticate successfully.

<sup>Written for commit cc0f08d9c9fc48d34f0af23b93a512d3431dd3ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

