### PR TITLE
fix(tickler): preserve schedule navigation after bulk actions

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/tickler/pageUtil/DbTicklerMain2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/tickler/pageUtil/DbTicklerMain2Action.java
@@ -111,9 +111,9 @@ public final class DbTicklerMain2Action extends ActionSupport {
                 sortOrder = TicklerManager.SORT_ASC;
             }
 
-            response.sendRedirect(request.getContextPath()
-                    + "/tickler/ViewTicklerMain?sort_column=" + Encode.forUriComponent(sortColumn)
-                    + "&sort_order=" + Encode.forUriComponent(sortOrder));
+            String redirect = request.getContextPath() + "/tickler/ViewTicklerMain?sort_column="
+                    + Encode.forUriComponent(sortColumn) + "&sort_order=" + Encode.forUriComponent(sortOrder);
+            response.sendRedirect(appendScheduleNav(redirect));
             return NONE;
         }
 
@@ -146,11 +146,18 @@ public final class DbTicklerMain2Action extends ActionSupport {
             }
         }
 
-        String redirect = request.getContextPath() + "/tickler/ViewTicklerMain";
+        String redirect = appendScheduleNav(request.getContextPath() + "/tickler/ViewTicklerMain");
         if (failCount > 0) {
-            redirect += "?failCount=" + failCount;
+            redirect += (redirect.contains("?") ? "&" : "?") + "failCount=" + failCount;
         }
         response.sendRedirect(redirect);
         return NONE;
+    }
+
+    private String appendScheduleNav(String redirect) {
+        if (!"1".equals(request.getParameter("scheduleNav"))) {
+            return redirect;
+        }
+        return redirect + (redirect.contains("?") ? "&" : "?") + "scheduleNav=1";
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/tickler/pageUtil/DbTicklerMain2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/tickler/pageUtil/DbTicklerMain2ActionTest.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * You may redistribute it and/or modify it under the terms of the GNU General
+ * Public License as published by the Free Software Foundation, either version 2
+ * of the License, or (at your option) any later version.
+ */
+package io.github.carlos_emr.carlos.tickler.pageUtil;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import io.github.carlos_emr.carlos.commn.model.Tickler;
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import io.github.carlos_emr.carlos.managers.TicklerManager;
+import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import io.github.carlos_emr.carlos.utility.SpringUtils;
+import org.apache.struts2.ActionSupport;
+import org.apache.struts2.ServletActionContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression coverage for redirects issued after Tickler Manager bulk actions.
+ *
+ * @since 2026-08-05
+ */
+@DisplayName("DbTicklerMain2Action redirects")
+@Tag("unit")
+@Tag("tickler")
+class DbTicklerMain2ActionTest {
+
+    @Mock
+    private TicklerManager ticklerManager;
+    @Mock
+    private SecurityInfoManager securityInfoManager;
+    @Mock
+    private LoggedInInfo loggedInInfo;
+
+    private AutoCloseable mockitoMocks;
+    private MockedStatic<ServletActionContext> servletActionContextMock;
+    private MockedStatic<SpringUtils> springUtilsMock;
+    private MockedStatic<LoggedInInfo> loggedInInfoMock;
+    private MockHttpServletRequest mockRequest;
+    private MockHttpServletResponse mockResponse;
+
+    @BeforeEach
+    void setUpAction() {
+        mockitoMocks = MockitoAnnotations.openMocks(this);
+        mockRequest = new MockHttpServletRequest("POST", "/carlos/tickler/DbTicklerMain");
+        mockRequest.setContextPath("/carlos");
+        mockResponse = new MockHttpServletResponse();
+
+        servletActionContextMock = mockStatic(ServletActionContext.class);
+        servletActionContextMock.when(ServletActionContext::getRequest).thenReturn(mockRequest);
+        servletActionContextMock.when(ServletActionContext::getResponse).thenReturn(mockResponse);
+
+        springUtilsMock = mockStatic(SpringUtils.class);
+        springUtilsMock.when(() -> SpringUtils.getBean(TicklerManager.class)).thenReturn(ticklerManager);
+        springUtilsMock.when(() -> SpringUtils.getBean(SecurityInfoManager.class)).thenReturn(securityInfoManager);
+
+        loggedInInfoMock = mockStatic(LoggedInInfo.class);
+        loggedInInfoMock.when(() -> LoggedInInfo.getLoggedInInfoFromSession(any(HttpServletRequest.class))).thenReturn(loggedInInfo);
+        when(securityInfoManager.hasPrivilege(any(LoggedInInfo.class), anyString(), anyString(), isNull()))
+                .thenReturn(true);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (loggedInInfoMock != null) loggedInInfoMock.close();
+        if (springUtilsMock != null) springUtilsMock.close();
+        if (servletActionContextMock != null) servletActionContextMock.close();
+        if (mockitoMocks != null) mockitoMocks.close();
+    }
+
+    @Test
+    @DisplayName("should preserve schedule navigation after completing selected ticklers")
+    void shouldPreserveScheduleNavigation_afterCompletingSelectedTicklers() throws Exception {
+        Tickler tickler = mock(Tickler.class);
+        when(tickler.getId()).thenReturn(123);
+        when(ticklerManager.getTickler(any(LoggedInInfo.class), anyInt())).thenReturn(tickler);
+        mockRequest.addParameter("checkbox", "123");
+        mockRequest.addParameter("submit_form", "Complete");
+        mockRequest.addParameter("scheduleNav", "1");
+
+        String result = new DbTicklerMain2Action().execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(mockResponse.getRedirectedUrl())
+                .isEqualTo("/carlos/tickler/ViewTicklerMain?scheduleNav=1");
+    }
+
+    @Test
+    @DisplayName("should retain schedule navigation with a bulk-update failure count")
+    void shouldRetainScheduleNavigation_withBulkUpdateFailureCount() throws Exception {
+        mockRequest.addParameter("checkbox", "not-a-tickler-id");
+        mockRequest.addParameter("submit_form", "Complete");
+        mockRequest.addParameter("scheduleNav", "1");
+
+        String result = new DbTicklerMain2Action().execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(mockResponse.getRedirectedUrl())
+                .isEqualTo("/carlos/tickler/ViewTicklerMain?scheduleNav=1&failCount=1");
+    }
+
+    @Test
+    @DisplayName("should preserve schedule navigation and sorting when no ticklers are selected")
+    void shouldPreserveScheduleNavigationAndSorting_whenNoTicklersAreSelected() throws Exception {
+        mockRequest.addParameter("sort_column", "service_date");
+        mockRequest.addParameter("sort_order", "ASC");
+        mockRequest.addParameter("scheduleNav", "1");
+
+        String result = new DbTicklerMain2Action().execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(mockResponse.getRedirectedUrl()).isEqualTo(
+                "/carlos/tickler/ViewTicklerMain?sort_column=service_date&sort_order=ASC&scheduleNav=1");
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/tickler/pageUtil/DbTicklerMain2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/tickler/pageUtil/DbTicklerMain2ActionTest.java
@@ -8,33 +8,21 @@
  */
 package io.github.carlos_emr.carlos.tickler.pageUtil;
 
-import jakarta.servlet.http.HttpServletRequest;
-
 import io.github.carlos_emr.carlos.commn.model.Tickler;
-import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.managers.TicklerManager;
+import io.github.carlos_emr.carlos.test.base.CarlosWebTestBase;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
-import io.github.carlos_emr.carlos.utility.SpringUtils;
 import org.apache.struts2.ActionSupport;
-import org.apache.struts2.ServletActionContext;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
-import org.mockito.MockedStatic;
-import org.mockito.MockitoAnnotations;
-import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.mock.web.MockHttpServletResponse;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 /**
@@ -43,51 +31,18 @@ import static org.mockito.Mockito.when;
  * @since 2026-08-05
  */
 @DisplayName("DbTicklerMain2Action redirects")
-@Tag("unit")
+@Tag("integration")
 @Tag("tickler")
-class DbTicklerMain2ActionTest {
+class DbTicklerMain2ActionTest extends CarlosWebTestBase {
 
     @Mock
     private TicklerManager ticklerManager;
-    @Mock
-    private SecurityInfoManager securityInfoManager;
-    @Mock
-    private LoggedInInfo loggedInInfo;
-
-    private AutoCloseable mockitoMocks;
-    private MockedStatic<ServletActionContext> servletActionContextMock;
-    private MockedStatic<SpringUtils> springUtilsMock;
-    private MockedStatic<LoggedInInfo> loggedInInfoMock;
-    private MockHttpServletRequest mockRequest;
-    private MockHttpServletResponse mockResponse;
 
     @BeforeEach
     void setUpAction() {
-        mockitoMocks = MockitoAnnotations.openMocks(this);
-        mockRequest = new MockHttpServletRequest("POST", "/carlos/tickler/DbTicklerMain");
+        replaceSpringUtilsBean(TicklerManager.class, ticklerManager);
         mockRequest.setContextPath("/carlos");
-        mockResponse = new MockHttpServletResponse();
-
-        servletActionContextMock = mockStatic(ServletActionContext.class);
-        servletActionContextMock.when(ServletActionContext::getRequest).thenReturn(mockRequest);
-        servletActionContextMock.when(ServletActionContext::getResponse).thenReturn(mockResponse);
-
-        springUtilsMock = mockStatic(SpringUtils.class);
-        springUtilsMock.when(() -> SpringUtils.getBean(TicklerManager.class)).thenReturn(ticklerManager);
-        springUtilsMock.when(() -> SpringUtils.getBean(SecurityInfoManager.class)).thenReturn(securityInfoManager);
-
-        loggedInInfoMock = mockStatic(LoggedInInfo.class);
-        loggedInInfoMock.when(() -> LoggedInInfo.getLoggedInInfoFromSession(any(HttpServletRequest.class))).thenReturn(loggedInInfo);
-        when(securityInfoManager.hasPrivilege(any(LoggedInInfo.class), anyString(), anyString(), isNull()))
-                .thenReturn(true);
-    }
-
-    @AfterEach
-    void tearDown() throws Exception {
-        if (loggedInInfoMock != null) loggedInInfoMock.close();
-        if (springUtilsMock != null) springUtilsMock.close();
-        if (servletActionContextMock != null) servletActionContextMock.close();
-        if (mockitoMocks != null) mockitoMocks.close();
+        mockRequest.setMethod("POST");
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Preserve `scheduleNav=1` when Tickler Manager redirects after bulk actions.
- Keep the navigation shell visible after completing selected ticklers, including failure-count and no-selection redirects.
- Add redirect-level regression coverage.

## Root cause

The bulk-action form submitted `scheduleNav=1`, but `DbTicklerMain2Action` discarded that parameter while redirecting back to Tickler Manager.

## Validation

- `mvn test` — 9,417 tests run; 0 failures; 0 errors; 49 skipped.

Fixes #3256.

## Summary by Sourcery

Ensure Tickler Manager preserves schedule navigation state across bulk-action redirects.

Bug Fixes:
- Preserve the scheduleNav parameter when redirecting from Tickler Manager bulk actions, including failure and no-selection cases.

Tests:
- Add regression tests verifying schedule navigation, sorting, and failure-count parameters are retained in DbTicklerMain2Action redirects.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the Tickler Manager schedule navigation shell after bulk actions by carrying `scheduleNav=1` through all redirects and keeping sort and `failCount` params, fixing #3256. Adds redirect regression tests using the web action test base that cover bulk-complete, no-selection, and failure cases.

<sup>Written for commit 4b5e9d4d8fdc7a3a7d4b7822ee14b41d4317507f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

