### PR TITLE
fix: restore admin access to Import Form Data

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/form/gate/FormViewRoutes.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/gate/FormViewRoutes.java
@@ -39,6 +39,7 @@ public final class FormViewRoutes {
             "form/setupSelect",
             "form/select",
             "form/xmlUpload",
+            "form/formXmlUpload",
             "form/formname",
             "form/forwardshortcutname",
             "form/forwardname",
@@ -180,7 +181,6 @@ public final class FormViewRoutes {
                     "formSF36caregiver",
                     "formtreatmentpref",
                     "formVTForm",
-                    "formXmlUpload",
                     "graphHeadCirc",
                     "graphLengthWeight",
                     "patientEncounterWorksheet",
@@ -243,6 +243,9 @@ public final class FormViewRoutes {
         String pathOnly = queryIndex >= 0 ? trimmed.substring(0, queryIndex) : trimmed;
         String query = queryIndex >= 0 ? trimmed.substring(queryIndex) : "";
 
+        if ("/form/formXmlUpload.jsp".equals(pathOnly)) {
+            return "/form/formXmlUpload" + query;
+        }
         if ("/form/forwardshortcutname.jsp".equals(pathOnly)) {
             return "/form/forwardshortcutname" + query;
         }

--- a/src/main/java/io/github/carlos_emr/carlos/form/gate/ViewFormXmlUpload2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/gate/ViewFormXmlUpload2Action.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.form.gate;
+
+import java.io.IOException;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import io.github.carlos_emr.carlos.utility.SpringUtils;
+import org.apache.struts2.ActionSupport;
+import org.apache.struts2.ServletActionContext;
+
+/**
+ * Admin-gated view endpoint for the form XML import page.
+ *
+ * @since 2026-08-05
+ */
+public final class ViewFormXmlUpload2Action extends ActionSupport {
+
+    private final transient SecurityInfoManager securityInfoManager;
+
+    /**
+     * Creates the action with the application security manager.
+     */
+    public ViewFormXmlUpload2Action() {
+        this(SpringUtils.getBean(SecurityInfoManager.class));
+    }
+
+    /**
+     * Creates the action with a supplied security manager.
+     *
+     * @param securityInfoManager security manager used to authorize page access
+     */
+    ViewFormXmlUpload2Action(SecurityInfoManager securityInfoManager) {
+        this.securityInfoManager = securityInfoManager;
+    }
+
+    /**
+     * Forwards authorized GET and HEAD requests to the XML import page.
+     *
+     * @return {@link #NONE} after forwarding the page or returning a method error
+     * @throws ServletException if the request cannot be forwarded
+     * @throws IOException if the response cannot send a method error
+     * @throws SecurityException if the caller lacks the required administrative privilege
+     */
+    @Override
+    public String execute() throws ServletException, IOException {
+        HttpServletRequest request = ServletActionContext.getRequest();
+        HttpServletResponse response = ServletActionContext.getResponse();
+
+        String method = request.getMethod();
+        if (!"GET".equals(method) && !"HEAD".equals(method)) {
+            response.setHeader("Allow", "GET, HEAD");
+            response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+            return NONE;
+        }
+
+        LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
+        if (loggedInInfo == null) {
+            throw new SecurityException("missing required sec object (_admin.eform or _admin)");
+        }
+
+        boolean hasEformAdminWrite = securityInfoManager.hasPrivilege(
+                loggedInInfo, "_admin.eform", SecurityInfoManager.WRITE, null);
+        if (!hasEformAdminWrite && !securityInfoManager.hasPrivilege(
+                loggedInInfo, "_admin", SecurityInfoManager.WRITE, null)) {
+            throw new SecurityException("missing required sec object (_admin.eform or _admin)");
+        }
+
+        request.getRequestDispatcher("/WEB-INF/jsp/form/formXmlUpload.jsp").forward(request, response);
+        return NONE;
+    }
+}

--- a/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FrmXmlUpload2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FrmXmlUpload2Action.java
@@ -34,6 +34,7 @@ import org.apache.struts2.ActionSupport;
 import org.apache.struts2.ServletActionContext;
 import org.apache.struts2.action.UploadedFilesAware;
 import org.apache.struts2.dispatcher.multipart.UploadedFile;
+import io.github.carlos_emr.carlos.eform.EFormExportZip;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.utility.FileValidationException;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
@@ -42,7 +43,6 @@ import io.github.carlos_emr.carlos.utility.SpringUtils;
 import io.github.carlos_emr.carlos.util.JDBCUtil;
 
 import jakarta.servlet.ServletContext;
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.*;
@@ -63,7 +63,7 @@ public class FrmXmlUpload2Action extends ActionSupport implements UploadedFilesA
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
 
     public String execute()
-            throws ServletException, IOException {
+            throws Exception {
         if (!"POST".equals(request.getMethod())) {
             response.setHeader("Allow", "POST");
             response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED, "POST required");
@@ -114,18 +114,42 @@ public class FrmXmlUpload2Action extends ActionSupport implements UploadedFilesA
             }
         }
 
-        // Unzip and process entries
+        // eForm export ZIPs contain eform.properties. Import them through the eForm
+        // service so the template is persisted to the Manage eForms library; retain the
+        // established entry-by-entry importer for legacy clinical form data ZIPs.
         try (ZipFile zf = new ZipFile(tmpFile)) {
-            Enumeration<? extends ZipEntry> entries = zf.entries();
-            while (entries.hasMoreElements()) {
-                ZipEntry entry = entries.nextElement();
-                try (InputStream zis = zf.getInputStream(entry)) {
-                    JDBCUtil.toDataBase(zis, entry.getName());
+            if (isEFormArchive(zf)) {
+                List<String> errors;
+                try (InputStream is = new FileInputStream(tmpFile)) {
+                    errors = new EFormExportZip().importForm(is);
+                }
+                if (!errors.isEmpty()) {
+                    errors.forEach(this::addActionError);
+                    return ERROR;
+                }
+            } else {
+                Enumeration<? extends ZipEntry> entries = zf.entries();
+                while (entries.hasMoreElements()) {
+                    ZipEntry entry = entries.nextElement();
+                    try (InputStream zis = zf.getInputStream(entry)) {
+                        JDBCUtil.toDataBase(zis, entry.getName());
+                    }
                 }
             }
         }
 
         return SUCCESS;
+    }
+
+    private static boolean isEFormArchive(ZipFile zipFile) {
+        Enumeration<? extends ZipEntry> entries = zipFile.entries();
+        while (entries.hasMoreElements()) {
+            String entryName = entries.nextElement().getName();
+            if (entryName.equals("eform.properties") || entryName.endsWith("/eform.properties")) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private File file1; // Uploaded file

--- a/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FrmXmlUpload2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FrmXmlUpload2Action.java
@@ -39,9 +39,11 @@ import io.github.carlos_emr.carlos.eform.EFormExportZip;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.utility.FileValidationException;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.PathValidationUtils;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 import io.github.carlos_emr.carlos.util.JDBCUtil;
+import org.apache.logging.log4j.Logger;
 
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpServletRequest;
@@ -50,13 +52,17 @@ import java.io.*;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Locale;
+import java.util.MissingResourceException;
+import java.util.ResourceBundle;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
 public class FrmXmlUpload2Action extends ActionSupport implements UploadedFilesAware {
+    private static final Logger LOGGER = MiscUtils.getLogger();
     private static final String ADMIN_SECURITY_OBJECT = "_admin";
     private static final String ADMIN_EFORM_SECURITY_OBJECT = "_admin.eform";
     private static final String WRITE_PRIVILEGE = "w";
+    private static final String EFORM_IMPORT_FAILURE_KEY = "form.xmlUpload.failure";
 
     HttpServletRequest request = ServletActionContext.getRequest();
     HttpServletResponse response = ServletActionContext.getResponse();
@@ -146,7 +152,8 @@ public class FrmXmlUpload2Action extends ActionSupport implements UploadedFilesA
                 } catch (SecurityException e) {
                     throw e;
                 } catch (Exception e) {
-                    addActionError("Unable to import eForm archive.");
+                    LOGGER.error("Unable to import eForm archive.", e);
+                    addActionError(getEformImportFailureMessage());
                     return forwardActionErrors();
                 }
                 if (!errors.isEmpty()) {
@@ -177,6 +184,21 @@ public class FrmXmlUpload2Action extends ActionSupport implements UploadedFilesA
     private String forwardActionErrors() {
         request.setAttribute("actionErrors", getActionErrors());
         return ERROR;
+    }
+
+    /**
+     * Looks up the localized generic eForm import failure message from the
+     * {@code oscarResources} bundle, matching the {@code fmt:message} lookups the
+     * success page uses. Falls back to the English default if the key or bundle is
+     * unavailable so a resource-loading gap never blocks the retry flow.
+     */
+    private String getEformImportFailureMessage() {
+        try {
+            return ResourceBundle.getBundle("oscarResources", request.getLocale())
+                    .getString(EFORM_IMPORT_FAILURE_KEY);
+        } catch (MissingResourceException e) {
+            return "Unable to import eForm archive.";
+        }
     }
 
     // FindSecBugs IMPROPER_UNICODE: case-insensitive match against the fixed ASCII eForm

--- a/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FrmXmlUpload2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FrmXmlUpload2Action.java
@@ -34,6 +34,7 @@ import org.apache.struts2.ActionSupport;
 import org.apache.struts2.ServletActionContext;
 import org.apache.struts2.action.UploadedFilesAware;
 import org.apache.struts2.dispatcher.multipart.UploadedFile;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.github.carlos_emr.carlos.eform.EFormExportZip;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.utility.FileValidationException;
@@ -48,6 +49,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.*;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.Locale;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
@@ -62,6 +64,25 @@ public class FrmXmlUpload2Action extends ActionSupport implements UploadedFilesA
 
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
 
+    /**
+     * Processes a POSTed form/eForm XML archive upload.
+     *
+     * <p>Rejects non-POST requests with {@link #NONE} and a 405 response. Requires
+     * {@code _admin.eform} or {@code _admin} write privilege; unauthorized callers get a
+     * {@link SecurityException}, which the surrounding struts-form.xml mapping routes to
+     * the security error view. A rejected upload (e.g. an invalid filename caught by
+     * {@link #withUploadedFiles}) or a failed import returns {@link #ERROR} with the
+     * failure reasons published as request attribute {@code actionErrors} for
+     * {@code formXmlUpload.jsp} to render. On success the archive has been fully imported
+     * and {@link #SUCCESS} is returned.</p>
+     *
+     * @return {@link #NONE} for a rejected HTTP method, {@link #ERROR} for a validation or
+     *         import failure, or {@link #SUCCESS} once the archive is imported
+     * @throws SecurityException if the caller lacks the required administrative privilege
+     * @throws IllegalStateException if the servlet container's temp directory is unavailable
+     * @throws IllegalArgumentException if the uploaded file path fails validation
+     * @throws Exception if the legacy entry-by-entry import path fails
+     */
     public String execute()
             throws Exception {
         if (!"POST".equals(request.getMethod())) {
@@ -77,7 +98,7 @@ public class FrmXmlUpload2Action extends ActionSupport implements UploadedFilesA
         }
         if (uploadValidationError != null) {
             addActionError(uploadValidationError);
-            return ERROR;
+            return forwardActionErrors();
         }
 
         int BUFFER = 2048;
@@ -122,10 +143,15 @@ public class FrmXmlUpload2Action extends ActionSupport implements UploadedFilesA
                 List<String> errors;
                 try (InputStream is = new FileInputStream(tmpFile)) {
                     errors = new EFormExportZip().importForm(is);
+                } catch (SecurityException e) {
+                    throw e;
+                } catch (Exception e) {
+                    addActionError("Unable to import eForm archive.");
+                    return forwardActionErrors();
                 }
                 if (!errors.isEmpty()) {
                     errors.forEach(this::addActionError);
-                    return ERROR;
+                    return forwardActionErrors();
                 }
             } else {
                 Enumeration<? extends ZipEntry> entries = zf.entries();
@@ -141,11 +167,27 @@ public class FrmXmlUpload2Action extends ActionSupport implements UploadedFilesA
         return SUCCESS;
     }
 
+    /**
+     * Publishes the current Struts action errors onto the request so the plain-JSP
+     * error view ({@code formXmlUpload.jsp}, which has no Struts tag library) can
+     * render them; {@code addActionError()} alone only populates the value stack.
+     *
+     * @return {@link #ERROR}
+     */
+    private String forwardActionErrors() {
+        request.setAttribute("actionErrors", getActionErrors());
+        return ERROR;
+    }
+
+    // FindSecBugs IMPROPER_UNICODE: case-insensitive match against the fixed ASCII eForm
+    // export marker filename, not a security or authorization decision.
+    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive match against the fixed ASCII eForm export marker filename; not a security or authorization decision")
     private static boolean isEFormArchive(ZipFile zipFile) {
         Enumeration<? extends ZipEntry> entries = zipFile.entries();
         while (entries.hasMoreElements()) {
-            String entryName = entries.nextElement().getName();
-            if (entryName.equals("eform.properties") || entryName.endsWith("/eform.properties")) {
+            String entryName = entries.nextElement().getName().replace('\\', '/');
+            if (entryName.equalsIgnoreCase("eform.properties")
+                    || entryName.toLowerCase(Locale.ROOT).endsWith("/eform.properties")) {
                 return true;
             }
         }

--- a/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FrmXmlUpload2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FrmXmlUpload2Action.java
@@ -107,71 +107,91 @@ public class FrmXmlUpload2Action extends ActionSupport implements UploadedFilesA
             return forwardActionErrors();
         }
 
-        int BUFFER = 2048;
+        File tmpFile = stageUploadedArchive();
 
-        // Temporary file handling
+        try (ZipFile zf = new ZipFile(tmpFile)) {
+            String importResult = isEFormArchive(zf) ? importEFormArchive(tmpFile) : importLegacyArchive(zf);
+            if (importResult != null) {
+                return importResult;
+            }
+        }
+
+        return SUCCESS;
+    }
+
+    /**
+     * Copies the validated upload into a fresh temp file for zip processing.
+     *
+     * @return the staged temp file, ready to be opened as a {@link ZipFile}
+     * @throws IllegalStateException if the servlet container's temp directory is unavailable
+     * @throws IllegalArgumentException if the uploaded file path fails validation
+     * @throws IOException if the upload cannot be copied to the temp file
+     */
+    private File stageUploadedArchive() throws IOException {
         File tmpFile = File.createTempFile("tmp", ".zip");
         tmpFile.deleteOnExit();
 
-        // Get context of the temp directory, get the file path to the the temp directory
         ServletContext servletContext = ServletActionContext.getServletContext();
-
-        // Validate the paths
         File safeDir = (File) servletContext.getAttribute("jakarta.servlet.context.tempdir"); // Use a safe directory
-        
         if (safeDir == null) {
             throw new IllegalStateException("Temporary directory attribute is not set.");
         }
-        
-        File normalizedFile = file1.toPath().normalize().toFile();
 
-        // Validate file path using PathValidationUtils
+        File normalizedFile = file1.toPath().normalize().toFile();
         try {
             normalizedFile = PathValidationUtils.validateExistingPath(normalizedFile, safeDir);
         } catch (SecurityException e) {
             throw new IllegalArgumentException("Invalid file path: " + normalizedFile.getPath());
         }
 
-       try (InputStream is = new FileInputStream(normalizedFile);
-            OutputStream fos = new FileOutputStream(tmpFile)) {
-            byte[] data = new byte[BUFFER];
-            int count;
-            while ((count = is.read(data)) != -1) {
-                fos.write(data, 0, count);
+        try (InputStream is = new FileInputStream(normalizedFile);
+             OutputStream fos = new FileOutputStream(tmpFile)) {
+            is.transferTo(fos);
+        }
+        return tmpFile;
+    }
+
+    /**
+     * Imports an eForm export ZIP through the eForm service so the template is
+     * persisted to the Manage eForms library.
+     *
+     * @return the result to return from {@link #execute()} on failure, or {@code null}
+     *         to continue on to {@link #SUCCESS}
+     * @throws SecurityException propagated unchanged so struts-form.xml routes it to
+     *         the security error view instead of the retryable upload form
+     */
+    private String importEFormArchive(File tmpFile) throws IOException {
+        List<String> errors;
+        try (InputStream is = new FileInputStream(tmpFile)) {
+            errors = new EFormExportZip().importForm(is);
+        } catch (SecurityException e) {
+            throw e;
+        } catch (Exception e) {
+            LOGGER.error("Unable to import eForm archive.", e);
+            addActionError(getEformImportFailureMessage());
+            return forwardActionErrors();
+        }
+        if (!errors.isEmpty()) {
+            errors.forEach(this::addActionError);
+            return forwardActionErrors();
+        }
+        return null;
+    }
+
+    /**
+     * Imports a legacy clinical form data ZIP using the established entry-by-entry importer.
+     *
+     * @return {@code null} to continue on to {@link #SUCCESS}
+     */
+    private String importLegacyArchive(ZipFile zf) throws IOException {
+        Enumeration<? extends ZipEntry> entries = zf.entries();
+        while (entries.hasMoreElements()) {
+            ZipEntry entry = entries.nextElement();
+            try (InputStream zis = zf.getInputStream(entry)) {
+                JDBCUtil.toDataBase(zis, entry.getName());
             }
         }
-
-        // eForm export ZIPs contain eform.properties. Import them through the eForm
-        // service so the template is persisted to the Manage eForms library; retain the
-        // established entry-by-entry importer for legacy clinical form data ZIPs.
-        try (ZipFile zf = new ZipFile(tmpFile)) {
-            if (isEFormArchive(zf)) {
-                List<String> errors;
-                try (InputStream is = new FileInputStream(tmpFile)) {
-                    errors = new EFormExportZip().importForm(is);
-                } catch (SecurityException e) {
-                    throw e;
-                } catch (Exception e) {
-                    LOGGER.error("Unable to import eForm archive.", e);
-                    addActionError(getEformImportFailureMessage());
-                    return forwardActionErrors();
-                }
-                if (!errors.isEmpty()) {
-                    errors.forEach(this::addActionError);
-                    return forwardActionErrors();
-                }
-            } else {
-                Enumeration<? extends ZipEntry> entries = zf.entries();
-                while (entries.hasMoreElements()) {
-                    ZipEntry entry = entries.nextElement();
-                    try (InputStream zis = zf.getInputStream(entry)) {
-                        JDBCUtil.toDataBase(zis, entry.getName());
-                    }
-                }
-            }
-        }
-
-        return SUCCESS;
+        return null;
     }
 
     /**

--- a/src/main/resources/oscarResources_en.properties
+++ b/src/main/resources/oscarResources_en.properties
@@ -9466,6 +9466,11 @@ oscarResearch.oscarDxResearch.dxCustomization.automatchResultPrefix=Automatch ge
 
 admin.admin.btnImportFormData=Import Form Data
 
+form.xmlUploadSuccess.title=Import complete
+form.xmlUploadSuccess.heading=Import complete
+form.xmlUploadSuccess.message=Your form data import has completed. You will return to Administration in 3 seconds.
+form.xmlUploadSuccess.returnLink=Return to Administration now
+
 demographic.search.noResultsWereFound=No results were found\!
 
 demographic.record=Record

--- a/src/main/resources/oscarResources_en.properties
+++ b/src/main/resources/oscarResources_en.properties
@@ -9470,6 +9470,7 @@ form.xmlUploadSuccess.title=Import complete
 form.xmlUploadSuccess.heading=Import complete
 form.xmlUploadSuccess.message=Your form data import has completed. You will return to Administration in 3 seconds.
 form.xmlUploadSuccess.returnLink=Return to Administration now
+form.xmlUpload.failure=Unable to import eForm archive.
 
 demographic.search.noResultsWereFound=No results were found\!
 

--- a/src/main/resources/oscarResources_es.properties
+++ b/src/main/resources/oscarResources_es.properties
@@ -12847,3 +12847,9 @@ eform.download.approvalExpired=La aprobaci\u00F3n de la renderizaci\u00F3n incom
 eform.download.failure=No se pudo descargar este eForm ni sus archivos adjuntos, si los hubiera.
 eform.edoc.approvalExpired=La aprobaci\u00F3n de la renderizaci\u00F3n incompleta ya no es v\u00E1lida. Vuelva a agregar el eForm a los documentos para revisar y aprobar los problemas indicados.
 eform.edoc.failure=No se pudo agregar este eForm ni sus archivos adjuntos, si los hubiera, a los documentos del paciente.
+
+# TODO: translate
+form.xmlUploadSuccess.title=Import complete
+form.xmlUploadSuccess.heading=Import complete
+form.xmlUploadSuccess.message=Your form data import has completed. You will return to Administration in 3 seconds.
+form.xmlUploadSuccess.returnLink=Return to Administration now

--- a/src/main/resources/oscarResources_es.properties
+++ b/src/main/resources/oscarResources_es.properties
@@ -12853,3 +12853,4 @@ form.xmlUploadSuccess.title=Import complete
 form.xmlUploadSuccess.heading=Import complete
 form.xmlUploadSuccess.message=Your form data import has completed. You will return to Administration in 3 seconds.
 form.xmlUploadSuccess.returnLink=Return to Administration now
+form.xmlUpload.failure=Unable to import eForm archive.

--- a/src/main/resources/oscarResources_es.properties
+++ b/src/main/resources/oscarResources_es.properties
@@ -12850,7 +12850,11 @@ eform.edoc.failure=No se pudo agregar este eForm ni sus archivos adjuntos, si lo
 
 # TODO: translate
 form.xmlUploadSuccess.title=Import complete
+# TODO: translate
 form.xmlUploadSuccess.heading=Import complete
+# TODO: translate
 form.xmlUploadSuccess.message=Your form data import has completed. You will return to Administration in 3 seconds.
+# TODO: translate
 form.xmlUploadSuccess.returnLink=Return to Administration now
+# TODO: translate
 form.xmlUpload.failure=Unable to import eForm archive.

--- a/src/main/resources/oscarResources_fr.properties
+++ b/src/main/resources/oscarResources_fr.properties
@@ -13480,3 +13480,4 @@ form.xmlUploadSuccess.title=Import complete
 form.xmlUploadSuccess.heading=Import complete
 form.xmlUploadSuccess.message=Your form data import has completed. You will return to Administration in 3 seconds.
 form.xmlUploadSuccess.returnLink=Return to Administration now
+form.xmlUpload.failure=Unable to import eForm archive.

--- a/src/main/resources/oscarResources_fr.properties
+++ b/src/main/resources/oscarResources_fr.properties
@@ -13474,3 +13474,9 @@ eform.download.approvalExpired=L\u2019approbation du rendu incomplet n\u2019est 
 eform.download.failure=Ce eForm et ses pi\u00E8ces jointes, le cas \u00E9ch\u00E9ant, n\u2019ont pas pu \u00EAtre t\u00E9l\u00E9charg\u00E9s.
 eform.edoc.approvalExpired=L\u2019approbation du rendu incomplet n\u2019est plus valide. Ajoutez de nouveau le eForm aux documents pour examiner et approuver les probl\u00E8mes indiqu\u00E9s.
 eform.edoc.failure=Ce eForm et ses pi\u00E8ces jointes, le cas \u00E9ch\u00E9ant, n\u2019ont pas pu \u00EAtre ajout\u00E9s aux documents du patient.
+
+# TODO: translate
+form.xmlUploadSuccess.title=Import complete
+form.xmlUploadSuccess.heading=Import complete
+form.xmlUploadSuccess.message=Your form data import has completed. You will return to Administration in 3 seconds.
+form.xmlUploadSuccess.returnLink=Return to Administration now

--- a/src/main/resources/oscarResources_fr.properties
+++ b/src/main/resources/oscarResources_fr.properties
@@ -13477,7 +13477,11 @@ eform.edoc.failure=Ce eForm et ses pi\u00E8ces jointes, le cas \u00E9ch\u00E9ant
 
 # TODO: translate
 form.xmlUploadSuccess.title=Import complete
+# TODO: translate
 form.xmlUploadSuccess.heading=Import complete
+# TODO: translate
 form.xmlUploadSuccess.message=Your form data import has completed. You will return to Administration in 3 seconds.
+# TODO: translate
 form.xmlUploadSuccess.returnLink=Return to Administration now
+# TODO: translate
 form.xmlUpload.failure=Unable to import eForm archive.

--- a/src/main/resources/oscarResources_pl.properties
+++ b/src/main/resources/oscarResources_pl.properties
@@ -13094,3 +13094,9 @@ eform.download.approvalExpired=Zatwierdzenie niepe\u0142nego renderowania utraci
 eform.download.failure=Nie uda\u0142o si\u0119 pobra\u0107 tego eForm ani jego za\u0142\u0105cznik\u00F3w, je\u015Bli wyst\u0119puj\u0105.
 eform.edoc.approvalExpired=Zatwierdzenie niepe\u0142nego renderowania utraci\u0142o wa\u017Cno\u015B\u0107. Ponownie dodaj eForm do dokument\u00F3w, aby przejrze\u0107 i zatwierdzi\u0107 wskazane problemy.
 eform.edoc.failure=Nie uda\u0142o si\u0119 doda\u0107 tego eForm ani jego za\u0142\u0105cznik\u00F3w do dokument\u00F3w pacjenta.
+
+# TODO: translate
+form.xmlUploadSuccess.title=Import complete
+form.xmlUploadSuccess.heading=Import complete
+form.xmlUploadSuccess.message=Your form data import has completed. You will return to Administration in 3 seconds.
+form.xmlUploadSuccess.returnLink=Return to Administration now

--- a/src/main/resources/oscarResources_pl.properties
+++ b/src/main/resources/oscarResources_pl.properties
@@ -13100,3 +13100,4 @@ form.xmlUploadSuccess.title=Import complete
 form.xmlUploadSuccess.heading=Import complete
 form.xmlUploadSuccess.message=Your form data import has completed. You will return to Administration in 3 seconds.
 form.xmlUploadSuccess.returnLink=Return to Administration now
+form.xmlUpload.failure=Unable to import eForm archive.

--- a/src/main/resources/oscarResources_pl.properties
+++ b/src/main/resources/oscarResources_pl.properties
@@ -13097,7 +13097,11 @@ eform.edoc.failure=Nie uda\u0142o si\u0119 doda\u0107 tego eForm ani jego za\u01
 
 # TODO: translate
 form.xmlUploadSuccess.title=Import complete
+# TODO: translate
 form.xmlUploadSuccess.heading=Import complete
+# TODO: translate
 form.xmlUploadSuccess.message=Your form data import has completed. You will return to Administration in 3 seconds.
+# TODO: translate
 form.xmlUploadSuccess.returnLink=Return to Administration now
+# TODO: translate
 form.xmlUpload.failure=Unable to import eForm archive.

--- a/src/main/resources/oscarResources_pt_BR.properties
+++ b/src/main/resources/oscarResources_pt_BR.properties
@@ -13039,3 +13039,4 @@ form.xmlUploadSuccess.title=Import complete
 form.xmlUploadSuccess.heading=Import complete
 form.xmlUploadSuccess.message=Your form data import has completed. You will return to Administration in 3 seconds.
 form.xmlUploadSuccess.returnLink=Return to Administration now
+form.xmlUpload.failure=Unable to import eForm archive.

--- a/src/main/resources/oscarResources_pt_BR.properties
+++ b/src/main/resources/oscarResources_pt_BR.properties
@@ -13033,3 +13033,9 @@ eform.download.approvalExpired=A aprova\u00E7\u00E3o da renderiza\u00E7\u00E3o i
 eform.download.failure=N\u00E3o foi poss\u00EDvel baixar este eForm nem seus anexos, se houver.
 eform.edoc.approvalExpired=A aprova\u00E7\u00E3o da renderiza\u00E7\u00E3o incompleta n\u00E3o \u00E9 mais v\u00E1lida. Adicione o eForm aos documentos novamente para revisar e aprovar os problemas indicados.
 eform.edoc.failure=N\u00E3o foi poss\u00EDvel adicionar este eForm nem seus anexos aos documentos do paciente.
+
+# TODO: translate
+form.xmlUploadSuccess.title=Import complete
+form.xmlUploadSuccess.heading=Import complete
+form.xmlUploadSuccess.message=Your form data import has completed. You will return to Administration in 3 seconds.
+form.xmlUploadSuccess.returnLink=Return to Administration now

--- a/src/main/resources/oscarResources_pt_BR.properties
+++ b/src/main/resources/oscarResources_pt_BR.properties
@@ -13036,7 +13036,11 @@ eform.edoc.failure=N\u00E3o foi poss\u00EDvel adicionar este eForm nem seus anex
 
 # TODO: translate
 form.xmlUploadSuccess.title=Import complete
+# TODO: translate
 form.xmlUploadSuccess.heading=Import complete
+# TODO: translate
 form.xmlUploadSuccess.message=Your form data import has completed. You will return to Administration in 3 seconds.
+# TODO: translate
 form.xmlUploadSuccess.returnLink=Return to Administration now
+# TODO: translate
 form.xmlUpload.failure=Unable to import eForm archive.

--- a/src/main/webapp/WEB-INF/classes/struts-form.xml
+++ b/src/main/webapp/WEB-INF/classes/struts-form.xml
@@ -79,6 +79,7 @@
         </action>
         <action name="form/xmlUpload" class="io.github.carlos_emr.carlos.form.pageUtil.FrmXmlUpload2Action">
             <result name="success">/WEB-INF/jsp/form/formXmlUpload.jsp</result>
+            <result name="error">/WEB-INF/jsp/form/formXmlUpload.jsp</result>
         </action>
         <action name="form/formname" class="io.github.carlos_emr.carlos.form.Frm2Action">
             <result name="exit">/WEB-INF/jsp/encounter/close.jsp</result>

--- a/src/main/webapp/WEB-INF/classes/struts-form.xml
+++ b/src/main/webapp/WEB-INF/classes/struts-form.xml
@@ -78,7 +78,7 @@
             <result name="success">/form/setupSelect</result>
         </action>
         <action name="form/xmlUpload" class="io.github.carlos_emr.carlos.form.pageUtil.FrmXmlUpload2Action">
-            <result name="success">/WEB-INF/jsp/form/formXmlUpload.jsp</result>
+            <result name="success">/WEB-INF/jsp/form/formXmlUploadSuccess.jsp</result>
             <result name="error">/WEB-INF/jsp/form/formXmlUpload.jsp</result>
         </action>
         <action name="form/formname" class="io.github.carlos_emr.carlos.form.Frm2Action">

--- a/src/main/webapp/WEB-INF/classes/struts-form.xml
+++ b/src/main/webapp/WEB-INF/classes/struts-form.xml
@@ -28,6 +28,14 @@
 <struts>
     <package name="form" namespace="/" extends="struts-default" strict-method-invocation="true">
 
+        <global-results>
+            <result name="securityError">/WEB-INF/jsp/error/securityError.jsp</result>
+        </global-results>
+
+        <global-exception-mappings>
+            <exception-mapping exception="java.lang.SecurityException" result="securityError"/>
+        </global-exception-mappings>
+
         <action name="web/dashboard/display/DashboardDisplay" class="io.github.carlos_emr.carlos.dashboard.display.DisplayDashboard2Action">
             <result name="success">/WEB-INF/jsp/web/dashboard/display/DashboardDisplay.jsp</result>
             <result name="unauthorized">/WEB-INF/jsp/error/securityError.jsp</result>
@@ -101,6 +109,7 @@
             <result name="pg6">/WEB-INF/jsp/form/formBCAR2020Attachments.jsp</result>
             <result name="exit">/WEB-INF/jsp/encounter/close.jsp</result>
         </action>
+        <action name="form/formXmlUpload" class="io.github.carlos_emr.carlos.form.gate.ViewFormXmlUpload2Action"/>
         <action name="form/*" class="io.github.carlos_emr.carlos.form.gate.ViewForm2Action"/>
         <action name="admin/Flowsheet" class="io.github.carlos_emr.carlos.flowsheet.Flowsheet2Action"/>
 

--- a/src/main/webapp/WEB-INF/jsp/form/formXmlUpload.jsp
+++ b/src/main/webapp/WEB-INF/jsp/form/formXmlUpload.jsp
@@ -44,6 +44,7 @@
 %>
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="https://owasp.org/www-project-csrfguard/Owasp.CsrfGuard.tld" prefix="csrf" %>
 <fmt:setBundle basename="oscarResources"/>
 
 
@@ -106,6 +107,7 @@
         <h3><fmt:message key="admin.admin.btnImportFormData"/></h3>
 
         <form action="${pageContext.request.contextPath}/form/xmlUpload" method="POST" enctype="multipart/form-data">
+            <input type="hidden" name="<csrf:tokenname/>" value="<csrf:tokenvalue/>"/>
 
             <% 
     java.util.List<String> actionErrors = (java.util.List<String>) request.getAttribute("actionErrors");

--- a/src/main/webapp/WEB-INF/jsp/form/formXmlUpload.jsp
+++ b/src/main/webapp/WEB-INF/jsp/form/formXmlUpload.jsp
@@ -28,6 +28,33 @@
     CARLOS has no affiliation with OSCAR or McMaster University.
 
 --%>
+
+<%--
+/**
+ * Form XML Data Import
+ *
+ * Administrative page that lets an authorized admin upload a zip archive of
+ * form/eForm XML data for import into the CARLOS database. The upload form
+ * posts to the "/form/xmlUpload" action (FrmXmlUpload2Action), which is
+ * reached via this gated view served by ViewFormXmlUpload2Action.
+ *
+ * Main Features:
+ * - CSRF-protected multipart file upload form (zip archive, field name "file1")
+ * - Renders Struts actionErrors from a prior failed import attempt
+ * - Inline tooltip warning about upload behavior (global.uploadWarningBody)
+ *
+ * Security Requirements:
+ * - Requires "_admin" or "_admin.eform" write privilege via the security taglib;
+ *   unauthorized requests are redirected to /securityError
+ * - Requires an active user session; redirects to /logoutPage otherwise
+ * - Form submission carries a CSRFGuard token (csrf:tokenname / csrf:tokenvalue)
+ *
+ * Request Attributes:
+ * - actionErrors: optional List&lt;String&gt; of import errors rendered above the form
+ *
+ * @since 2026-08-05
+ */
+--%>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%
     String roleName2$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");

--- a/src/main/webapp/WEB-INF/jsp/form/formXmlUpload.jsp
+++ b/src/main/webapp/WEB-INF/jsp/form/formXmlUpload.jsp
@@ -1,4 +1,4 @@
-<%@ page import="io.github.carlos_emr.CarlosProperties" %><%--
+<%@ page import="io.github.carlos_emr.CarlosProperties" %><%@ page import="io.github.carlos_emr.carlos.utility.SafeEncode" %><%--
 
     Copyright (c) 2001-2002. Department of Family Medicine, McMaster University. All Rights Reserved.
     This software is published under the GPL GNU General Public License.
@@ -143,7 +143,7 @@
     <div class="action-errors">
         <ul>
             <% for (String error : actionErrors) { %>
-                <li><%= error %></li>
+                <li><%= SafeEncode.forHtmlContent(error) %></li>
             <% } %>
         </ul>
     </div>

--- a/src/main/webapp/WEB-INF/jsp/form/formXmlUploadSuccess.jsp
+++ b/src/main/webapp/WEB-INF/jsp/form/formXmlUploadSuccess.jsp
@@ -5,20 +5,42 @@
     CARLOS EMR Project
     https://github.com/carlos-emr/carlos
 --%>
+
+<%--
+/**
+ * Form XML Import Confirmation
+ *
+ * Confirmation page shown after a successful form/eForm XML archive import
+ * (see FrmXmlUpload2Action). Informs the admin that the import completed and
+ * automatically returns them to Administration after a short delay.
+ *
+ * Main Features:
+ * - Success message with a manual "Return to Administration now" link
+ * - Client-side redirect to /administration after 3 seconds (setTimeout, not
+ *   a meta refresh, so the delay is not silently forced on assistive tech)
+ *
+ * Request Attributes: none; this page renders unconditionally on the
+ * "success" result of the /form/xmlUpload action.
+ *
+ * @since 2026-08-05
+ */
+--%>
 <%@ page contentType="text/html; charset=UTF-8" %>
+<%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<fmt:setBundle basename="oscarResources"/>
 <!doctype html>
 <html lang="${pageContext.request.locale.language}">
 <head>
     <meta charset="UTF-8">
-    <title>Import complete</title>
+    <title><fmt:message key="form.xmlUploadSuccess.title"/></title>
     <link href="${pageContext.request.contextPath}/library/bootstrap/5.3.8/css/bootstrap.min.css" rel="stylesheet">
 </head>
 <body class="bg-body-tertiary">
     <main class="container py-5">
         <div class="alert alert-success">
-            <h1 class="h3">Import complete</h1>
-            <output class="d-block">Your form data import has completed. You will return to Administration in 3 seconds.</output>
-            <a class="btn btn-primary" href="${pageContext.request.contextPath}/administration">Return to Administration now</a>
+            <h1 class="h3"><fmt:message key="form.xmlUploadSuccess.heading"/></h1>
+            <output class="d-block"><fmt:message key="form.xmlUploadSuccess.message"/></output>
+            <a class="btn btn-primary" href="${pageContext.request.contextPath}/administration"><fmt:message key="form.xmlUploadSuccess.returnLink"/></a>
         </div>
     </main>
     <script>

--- a/src/main/webapp/WEB-INF/jsp/form/formXmlUploadSuccess.jsp
+++ b/src/main/webapp/WEB-INF/jsp/form/formXmlUploadSuccess.jsp
@@ -1,0 +1,26 @@
+<%--
+    Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+
+    This software is published under the GPL GNU General Public License.
+    CARLOS EMR Project
+    https://github.com/carlos-emr/carlos
+--%>
+<%@ page contentType="text/html; charset=UTF-8" %>
+<!doctype html>
+<html lang="${pageContext.request.locale.language}">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="3;url=${pageContext.request.contextPath}/administration">
+    <title>Import complete</title>
+    <link href="${pageContext.request.contextPath}/library/bootstrap/5.3.8/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-body-tertiary">
+    <main class="container py-5">
+        <div class="alert alert-success" role="status">
+            <h1 class="h3">Import complete</h1>
+            <p>Your form data import has completed. You will return to Administration in 3 seconds.</p>
+            <a class="btn btn-primary" href="${pageContext.request.contextPath}/administration">Return to Administration now</a>
+        </div>
+    </main>
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/jsp/form/formXmlUploadSuccess.jsp
+++ b/src/main/webapp/WEB-INF/jsp/form/formXmlUploadSuccess.jsp
@@ -27,6 +27,7 @@
 --%>
 <%@ page contentType="text/html; charset=UTF-8" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="carlos" prefix="carlos" %>
 <fmt:setBundle basename="oscarResources"/>
 <!doctype html>
 <html lang="${pageContext.request.locale.language}">
@@ -40,7 +41,7 @@
         <div class="alert alert-success">
             <h1 class="h3"><fmt:message key="form.xmlUploadSuccess.heading"/></h1>
             <output class="d-block"><fmt:message key="form.xmlUploadSuccess.message"/></output>
-            <a class="btn btn-primary" href="${pageContext.request.contextPath}/administration"><fmt:message key="form.xmlUploadSuccess.returnLink"/></a>
+            <a class="btn btn-primary" href="${carlos:forHtmlAttribute(pageContext.request.contextPath)}/administration"><fmt:message key="form.xmlUploadSuccess.returnLink"/></a>
         </div>
     </main>
     <script>

--- a/src/main/webapp/WEB-INF/jsp/form/formXmlUploadSuccess.jsp
+++ b/src/main/webapp/WEB-INF/jsp/form/formXmlUploadSuccess.jsp
@@ -10,17 +10,21 @@
 <html lang="${pageContext.request.locale.language}">
 <head>
     <meta charset="UTF-8">
-    <meta http-equiv="refresh" content="3;url=${pageContext.request.contextPath}/administration">
     <title>Import complete</title>
     <link href="${pageContext.request.contextPath}/library/bootstrap/5.3.8/css/bootstrap.min.css" rel="stylesheet">
 </head>
 <body class="bg-body-tertiary">
     <main class="container py-5">
-        <div class="alert alert-success" role="status">
+        <div class="alert alert-success">
             <h1 class="h3">Import complete</h1>
-            <p>Your form data import has completed. You will return to Administration in 3 seconds.</p>
+            <output class="d-block">Your form data import has completed. You will return to Administration in 3 seconds.</output>
             <a class="btn btn-primary" href="${pageContext.request.contextPath}/administration">Return to Administration now</a>
         </div>
     </main>
+    <script>
+        setTimeout(function () {
+            window.location.href = "${pageContext.request.contextPath}/administration";
+        }, 3000);
+    </script>
 </body>
 </html>

--- a/src/test/java/io/github/carlos_emr/carlos/app/security/UploadActionBindingSecurityUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/app/security/UploadActionBindingSecurityUnitTest.java
@@ -112,7 +112,9 @@ class UploadActionBindingSecurityUnitTest {
                 // View gates that render upload forms but do not receive multipart files.
                 "src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/ViewBenefitScheduleUpload2Action.java",
                 "src/main/java/io/github/carlos_emr/carlos/billings/ca/on/web/BillingOnUpload2Action.java",
-                "src/main/java/io/github/carlos_emr/carlos/lab/gate/ViewInsideLabUpload2Action.java"
+                "src/main/java/io/github/carlos_emr/carlos/lab/gate/ViewInsideLabUpload2Action.java",
+                // Form XML import page gate; the sibling FrmXmlUpload2Action receives multipart data.
+                "src/main/java/io/github/carlos_emr/carlos/form/gate/ViewFormXmlUpload2Action.java"
         );
     }
 

--- a/src/test/java/io/github/carlos_emr/carlos/form/FormXmlUploadJspMigrationRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/form/FormXmlUploadJspMigrationRegressionTest.java
@@ -93,6 +93,16 @@ class FormXmlUploadJspMigrationRegressionTest {
     }
 
     @Test
+    @DisplayName("formXmlUpload page should include a CSRF token in its upload form")
+    void shouldIncludeCsrfToken_inXmlUploadForm() throws IOException {
+        String jsp = Files.readString(FORM_XML_UPLOAD_JSP, StandardCharsets.UTF_8);
+
+        assertThat(jsp).contains("<%@ taglib uri=\"https://owasp.org/www-project-csrfguard/Owasp.CsrfGuard.tld\" prefix=\"csrf\" %>")
+                .contains("name=\"<csrf:tokenname/>\"")
+                .contains("value=\"<csrf:tokenvalue/>\"");
+    }
+
+    @Test
     @DisplayName("FormViewRoutes should map legacy /form/formXmlUpload.jsp onto the routed page")
     void shouldResolveLegacyFormXmlUploadJsp_toRoutedActionPath() {
         assertThat(FormViewRoutes.resolveActionPath("/form/formXmlUpload.jsp"))

--- a/src/test/java/io/github/carlos_emr/carlos/form/FormXmlUploadJspMigrationRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/form/FormXmlUploadJspMigrationRegressionTest.java
@@ -57,6 +57,8 @@ class FormXmlUploadJspMigrationRegressionTest {
             Path.of("src/main/webapp/WEB-INF/jsp/admin/admin.jsp");
     private static final Path FORM_XML_UPLOAD_JSP =
             Path.of("src/main/webapp/WEB-INF/jsp/form/formXmlUpload.jsp");
+    private static final Path FORM_XML_UPLOAD_SUCCESS_JSP =
+            Path.of("src/main/webapp/WEB-INF/jsp/form/formXmlUploadSuccess.jsp");
     private static final Path STRUTS_FORM_XML =
             Path.of("src/main/webapp/WEB-INF/classes/struts-form.xml");
 
@@ -110,6 +112,20 @@ class FormXmlUploadJspMigrationRegressionTest {
     }
 
     @Test
+    @DisplayName("successful form XML imports should confirm completion before returning to Administration")
+    void shouldConfirmSuccessfulImport_andReturnToAdministration() throws IOException {
+        String struts = Files.readString(STRUTS_FORM_XML, StandardCharsets.UTF_8);
+        String jsp = Files.readString(FORM_XML_UPLOAD_SUCCESS_JSP, StandardCharsets.UTF_8);
+
+        assertThat(struts).contains("<result name=\"success\">/WEB-INF/jsp/form/formXmlUploadSuccess.jsp</result>")
+                .contains("<result name=\"error\">/WEB-INF/jsp/form/formXmlUpload.jsp</result>");
+        assertThat(jsp).contains("Import complete")
+                .contains("href=\"${pageContext.request.contextPath}/administration\"")
+                .contains("http-equiv=\"refresh\"")
+                .contains("content=\"3;url=${pageContext.request.contextPath}/administration\"");
+    }
+
+    @Test
     @DisplayName("struts form config should map the import page to its dedicated view gate before the wildcard")
     void shouldMapImportPage_toDedicatedViewGateBeforeWildcard() throws IOException {
         String struts = Files.readString(STRUTS_FORM_XML, StandardCharsets.UTF_8);
@@ -138,7 +154,7 @@ class FormXmlUploadJspMigrationRegressionTest {
 
         assertThat(struts).contains("<action name=\"form/xmlUpload\"")
                 .contains("FrmXmlUpload2Action")
-                .contains("<result name=\"success\">/WEB-INF/jsp/form/formXmlUpload.jsp</result>")
+                .contains("<result name=\"success\">/WEB-INF/jsp/form/formXmlUploadSuccess.jsp</result>")
                 .contains("<result name=\"error\">/WEB-INF/jsp/form/formXmlUpload.jsp</result>");
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/form/FormXmlUploadJspMigrationRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/form/FormXmlUploadJspMigrationRegressionTest.java
@@ -127,7 +127,7 @@ class FormXmlUploadJspMigrationRegressionTest {
                 .contains("<result name=\"error\">/WEB-INF/jsp/form/formXmlUpload.jsp</result>");
         assertThat(jsp).contains("fmt:setBundle basename=\"oscarResources\"")
                 .contains("fmt:message key=\"form.xmlUploadSuccess.heading\"")
-                .contains("href=\"${pageContext.request.contextPath}/administration\"")
+                .contains("href=\"${carlos:forHtmlAttribute(pageContext.request.contextPath)}/administration\"")
                 .doesNotContain("http-equiv=\"refresh\"")
                 .contains("setTimeout(")
                 .contains("window.location.href = \"${pageContext.request.contextPath}/administration\"");

--- a/src/test/java/io/github/carlos_emr/carlos/form/FormXmlUploadJspMigrationRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/form/FormXmlUploadJspMigrationRegressionTest.java
@@ -138,6 +138,7 @@ class FormXmlUploadJspMigrationRegressionTest {
 
         assertThat(struts).contains("<action name=\"form/xmlUpload\"")
                 .contains("FrmXmlUpload2Action")
-                .contains("/WEB-INF/jsp/form/formXmlUpload.jsp");
+                .contains("<result name=\"success\">/WEB-INF/jsp/form/formXmlUpload.jsp</result>")
+                .contains("<result name=\"error\">/WEB-INF/jsp/form/formXmlUpload.jsp</result>");
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/form/FormXmlUploadJspMigrationRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/form/FormXmlUploadJspMigrationRegressionTest.java
@@ -100,12 +100,34 @@ class FormXmlUploadJspMigrationRegressionTest {
     }
 
     @Test
+    @DisplayName("struts form config should map the import page to its dedicated view gate before the wildcard")
+    void shouldMapImportPage_toDedicatedViewGateBeforeWildcard() throws IOException {
+        String struts = Files.readString(STRUTS_FORM_XML, StandardCharsets.UTF_8);
+        int pageRoute = struts.indexOf("<action name=\"form/formXmlUpload\"");
+        int wildcardRoute = struts.indexOf("<action name=\"form/*\"");
+
+        assertThat(wildcardRoute).isGreaterThanOrEqualTo(0);
+        assertThat(pageRoute).isGreaterThanOrEqualTo(0)
+                .isLessThan(wildcardRoute);
+        assertThat(struts).contains("ViewFormXmlUpload2Action");
+    }
+
+    @Test
+    @DisplayName("struts form config should render security errors from the import page")
+    void shouldMapImportPageSecurityException_toSecurityErrorView() throws IOException {
+        String struts = Files.readString(STRUTS_FORM_XML, StandardCharsets.UTF_8);
+
+        assertThat(struts).contains("<result name=\"securityError\">/WEB-INF/jsp/error/securityError.jsp</result>")
+                .contains("<exception-mapping exception=\"java.lang.SecurityException\" result=\"securityError\"/>");
+    }
+
+    @Test
     @DisplayName("struts form config should keep the explicit xmlUpload processing action with its internal JSP view")
     void shouldKeepXmlUploadProcessingAction_inStrutsConfig() throws IOException {
         String struts = Files.readString(STRUTS_FORM_XML, StandardCharsets.UTF_8);
 
-        assertThat(struts).contains("<action name=\"form/xmlUpload\"");
-        assertThat(struts).contains("FrmXmlUpload2Action");
-        assertThat(struts).contains("/WEB-INF/jsp/form/formXmlUpload.jsp");
+        assertThat(struts).contains("<action name=\"form/xmlUpload\"")
+                .contains("FrmXmlUpload2Action")
+                .contains("/WEB-INF/jsp/form/formXmlUpload.jsp");
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/form/FormXmlUploadJspMigrationRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/form/FormXmlUploadJspMigrationRegressionTest.java
@@ -25,6 +25,8 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import io.github.carlos_emr.carlos.form.gate.FormViewRoutes;
 import org.junit.jupiter.api.DisplayName;
@@ -101,7 +103,10 @@ class FormXmlUploadJspMigrationRegressionTest {
 
         assertThat(jsp).contains("<%@ taglib uri=\"https://owasp.org/www-project-csrfguard/Owasp.CsrfGuard.tld\" prefix=\"csrf\" %>")
                 .contains("name=\"<csrf:tokenname/>\"")
-                .contains("value=\"<csrf:tokenvalue/>\"");
+                .contains("value=\"<csrf:tokenvalue/>\"")
+                .contains("action=\"${pageContext.request.contextPath}/form/xmlUpload\"")
+                .containsPattern("(?is)<form\\b[^>]*\\bmethod\\s*=\\s*['\"]post['\"]")
+                .contains("enctype=\"multipart/form-data\"");
     }
 
     @Test
@@ -117,9 +122,11 @@ class FormXmlUploadJspMigrationRegressionTest {
         String struts = Files.readString(STRUTS_FORM_XML, StandardCharsets.UTF_8);
         String jsp = Files.readString(FORM_XML_UPLOAD_SUCCESS_JSP, StandardCharsets.UTF_8);
 
-        assertThat(struts).contains("<result name=\"success\">/WEB-INF/jsp/form/formXmlUploadSuccess.jsp</result>")
+        String xmlUploadAction = extractActionBlock(struts, "form/xmlUpload");
+        assertThat(xmlUploadAction).contains("<result name=\"success\">/WEB-INF/jsp/form/formXmlUploadSuccess.jsp</result>")
                 .contains("<result name=\"error\">/WEB-INF/jsp/form/formXmlUpload.jsp</result>");
-        assertThat(jsp).contains("Import complete")
+        assertThat(jsp).contains("fmt:setBundle basename=\"oscarResources\"")
+                .contains("fmt:message key=\"form.xmlUploadSuccess.heading\"")
                 .contains("href=\"${pageContext.request.contextPath}/administration\"")
                 .doesNotContain("http-equiv=\"refresh\"")
                 .contains("setTimeout(")
@@ -153,9 +160,25 @@ class FormXmlUploadJspMigrationRegressionTest {
     void shouldKeepXmlUploadProcessingAction_inStrutsConfig() throws IOException {
         String struts = Files.readString(STRUTS_FORM_XML, StandardCharsets.UTF_8);
 
-        assertThat(struts).contains("<action name=\"form/xmlUpload\"")
-                .contains("FrmXmlUpload2Action")
-                .contains("<result name=\"success\">/WEB-INF/jsp/form/formXmlUploadSuccess.jsp</result>")
+        String xmlUploadAction = extractActionBlock(struts, "form/xmlUpload");
+        assertThat(struts).contains("<action name=\"form/xmlUpload\" class=\"io.github.carlos_emr.carlos.form.pageUtil.FrmXmlUpload2Action\">");
+        assertThat(xmlUploadAction).contains("<result name=\"success\">/WEB-INF/jsp/form/formXmlUploadSuccess.jsp</result>")
                 .contains("<result name=\"error\">/WEB-INF/jsp/form/formXmlUpload.jsp</result>");
+    }
+
+    /**
+     * Extracts the body of a single {@code <action name="...">...</action>} block from
+     * struts-form.xml so assertions verify the mapping owned by that action instead of
+     * matching a same-named result string anywhere else in the file.
+     */
+    private static String extractActionBlock(String struts, String actionName) {
+        Pattern actionBlock = Pattern.compile(
+                "<action\\s+name=\"" + Pattern.quote(actionName) + "\"[^>]*>(.*?)</action>",
+                Pattern.DOTALL);
+        Matcher matcher = actionBlock.matcher(struts);
+        assertThat(matcher.find())
+                .as("struts-form.xml should declare an action named '%s'", actionName)
+                .isTrue();
+        return matcher.group(1);
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/form/FormXmlUploadJspMigrationRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/form/FormXmlUploadJspMigrationRegressionTest.java
@@ -121,8 +121,9 @@ class FormXmlUploadJspMigrationRegressionTest {
                 .contains("<result name=\"error\">/WEB-INF/jsp/form/formXmlUpload.jsp</result>");
         assertThat(jsp).contains("Import complete")
                 .contains("href=\"${pageContext.request.contextPath}/administration\"")
-                .contains("http-equiv=\"refresh\"")
-                .contains("content=\"3;url=${pageContext.request.contextPath}/administration\"");
+                .doesNotContain("http-equiv=\"refresh\"")
+                .contains("setTimeout(")
+                .contains("window.location.href = \"${pageContext.request.contextPath}/administration\"");
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/form/gate/FormViewRoutesTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/form/gate/FormViewRoutesTest.java
@@ -48,6 +48,14 @@ class FormViewRoutesTest {
     }
 
     @Test
+    void shouldResolveLegacyFormXmlUploadJsp_toExplicitPageRoute() {
+        assertThat(FormViewRoutes.resolveActionPath("/form/formXmlUpload.jsp"))
+                .isEqualTo("/form/formXmlUpload");
+        assertThat(FormViewRoutes.resolveActionPath("/form/formXmlUpload.jsp?source=legacy"))
+                .isEqualTo("/form/formXmlUpload?source=legacy");
+    }
+
+    @Test
     void shouldResolveSpecialLegacyRoutes() {
         assertThat(FormViewRoutes.resolveActionPath("../form/forwardshortcutname.jsp?formname=Rourke"))
                 .isEqualTo("/form/forwardshortcutname?formname=Rourke");
@@ -73,6 +81,7 @@ class FormViewRoutesTest {
         assertThat(FormViewRoutes.resolveActionPath("/form/eCARES/sections/info.jsp")).isNull();
         assertThat(FormViewRoutes.resolveActionPath("/form/formSaveAndExit.jsp")).isNull();
         assertThat(FormViewRoutes.isAllowedWildcardFormView("formannual")).isTrue();
+        assertThat(FormViewRoutes.isAllowedWildcardFormView("formXmlUpload")).isFalse();
         assertThat(FormViewRoutes.isAllowedWildcardFormView("eCARES/sections/info")).isFalse();
     }
 

--- a/src/test/java/io/github/carlos_emr/carlos/form/gate/ViewFormXmlUpload2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/form/gate/ViewFormXmlUpload2ActionUnitTest.java
@@ -1,0 +1,183 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.form.gate;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import org.apache.struts2.ActionSupport;
+import org.apache.struts2.ServletActionContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@DisplayName("ViewFormXmlUpload2Action tests")
+@Tag("unit")
+@Tag("form")
+@Tag("security")
+class ViewFormXmlUpload2ActionUnitTest {
+
+    private MockedStatic<ServletActionContext> servletActionContextMock;
+    private MockedStatic<LoggedInInfo> loggedInInfoMock;
+    private AutoCloseable mocks;
+
+    @Mock
+    private SecurityInfoManager securityInfoManager;
+    @Mock
+    private LoggedInInfo loggedInInfo;
+    @Mock
+    private HttpServletRequest request;
+    @Mock
+    private HttpServletResponse response;
+    @Mock
+    private RequestDispatcher dispatcher;
+
+    private ViewFormXmlUpload2Action action;
+
+    @BeforeEach
+    void setUp() {
+        mocks = MockitoAnnotations.openMocks(this);
+
+        servletActionContextMock = mockStatic(ServletActionContext.class);
+        servletActionContextMock.when(ServletActionContext::getRequest).thenReturn(request);
+        servletActionContextMock.when(ServletActionContext::getResponse).thenReturn(response);
+
+        loggedInInfoMock = mockStatic(LoggedInInfo.class);
+        loggedInInfoMock.when(() -> LoggedInInfo.getLoggedInInfoFromSession(any(HttpServletRequest.class)))
+                .thenReturn(loggedInInfo);
+
+        when(request.getMethod()).thenReturn("GET");
+        when(request.getRequestDispatcher("/WEB-INF/jsp/form/formXmlUpload.jsp")).thenReturn(dispatcher);
+        when(securityInfoManager.hasPrivilege(
+                any(LoggedInInfo.class), eq("_admin.eform"), eq("w"), isNull())).thenReturn(true);
+
+        action = new ViewFormXmlUpload2Action(securityInfoManager);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (loggedInInfoMock != null) {
+            loggedInInfoMock.close();
+        }
+        if (servletActionContextMock != null) {
+            servletActionContextMock.close();
+        }
+        if (mocks != null) {
+            mocks.close();
+        }
+    }
+
+    @Test
+    @DisplayName("should forward the import page when the caller has _admin eForm write")
+    void shouldForwardImportPage_whenAdminEformWriter() throws Exception {
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        verify(dispatcher).forward(request, response);
+        verify(securityInfoManager, never()).hasPrivilege(
+                any(LoggedInInfo.class), eq("_admin"), eq("w"), isNull());
+    }
+
+    @Test
+    @DisplayName("should forward the import page when the caller has full admin write")
+    void shouldForwardImportPage_whenAdminWriter() throws Exception {
+        when(securityInfoManager.hasPrivilege(
+                any(LoggedInInfo.class), eq("_admin.eform"), eq("w"), isNull())).thenReturn(false);
+        when(securityInfoManager.hasPrivilege(
+                any(LoggedInInfo.class), eq("_admin"), eq("w"), isNull())).thenReturn(true);
+
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        verify(dispatcher).forward(request, response);
+    }
+
+    @Test
+    @DisplayName("should reject the import page when the caller has neither admin privilege")
+    void shouldRejectImportPage_whenNoAdminPrivilege() {
+        when(securityInfoManager.hasPrivilege(
+                any(LoggedInInfo.class), eq("_admin.eform"), eq("w"), isNull())).thenReturn(false);
+        when(securityInfoManager.hasPrivilege(
+                any(LoggedInInfo.class), eq("_admin"), eq("w"), isNull())).thenReturn(false);
+
+        assertThatThrownBy(action::execute)
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("_admin.eform or _admin");
+    }
+
+    @Test
+    @DisplayName("should reject the import page without a logged-in session")
+    void shouldRejectImportPage_whenUnauthenticated() {
+        loggedInInfoMock.when(() -> LoggedInInfo.getLoggedInInfoFromSession(request)).thenReturn(null);
+
+        assertThatThrownBy(action::execute)
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("_admin.eform or _admin");
+        verifyNoInteractions(securityInfoManager);
+    }
+
+    @Test
+    @DisplayName("should forward the import page when the caller uses HEAD")
+    void shouldForwardImportPage_whenHead() throws Exception {
+        when(request.getMethod()).thenReturn("HEAD");
+
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        verify(dispatcher).forward(request, response);
+    }
+
+    @Test
+    @DisplayName("should return method not allowed when the page route receives POST")
+    void shouldReturnMethodNotAllowed_whenPost() throws Exception {
+        when(request.getMethod()).thenReturn("POST");
+
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        verify(response).setHeader("Allow", "GET, HEAD");
+        verify(response).sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+        verify(securityInfoManager, never()).hasPrivilege(
+                any(LoggedInInfo.class), any(String.class), any(String.class), isNull());
+    }
+
+    @Test
+    @DisplayName("should not serialize the Spring security manager")
+    void shouldNotSerializeSecurityInfoManager_whenActionIsSerialized() throws NoSuchFieldException {
+        Field securityInfoManagerField = ViewFormXmlUpload2Action.class.getDeclaredField("securityInfoManager");
+
+        assertThat(Modifier.isTransient(securityInfoManagerField.getModifiers())).isTrue();
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/form/gate/ViewFormXmlUpload2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/form/gate/ViewFormXmlUpload2ActionUnitTest.java
@@ -20,6 +20,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import org.apache.struts2.ActionSupport;
 import org.apache.struts2.ServletActionContext;
@@ -47,7 +48,7 @@ import static org.mockito.Mockito.when;
 @Tag("unit")
 @Tag("form")
 @Tag("security")
-class ViewFormXmlUpload2ActionUnitTest {
+class ViewFormXmlUpload2ActionUnitTest extends CarlosUnitTestBase {
 
     private MockedStatic<ServletActionContext> servletActionContextMock;
     private MockedStatic<LoggedInInfo> loggedInInfoMock;

--- a/src/test/java/io/github/carlos_emr/carlos/form/pageUtil/FrmXmlUpload2ActionSecurityUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/form/pageUtil/FrmXmlUpload2ActionSecurityUnitTest.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -160,6 +161,7 @@ class FrmXmlUpload2ActionSecurityUnitTest extends CarlosUnitTestBase {
 
         assertThat(action.execute()).isEqualTo(ActionSupport.ERROR);
         assertThat(action.getActionErrors()).contains(PathValidationUtils.INVALID_FILENAME_MESSAGE);
+        assertThat(request.getAttribute("actionErrors")).isEqualTo(action.getActionErrors());
         verify(securityInfoManager).hasPrivilege(any(LoggedInInfo.class), eq("_admin.eform"), eq("w"), isNull());
         verify(securityInfoManager, never()).hasPrivilege(any(LoggedInInfo.class), eq("_admin"), eq("w"), isNull());
     }
@@ -208,10 +210,86 @@ class FrmXmlUpload2ActionSecurityUnitTest extends CarlosUnitTestBase {
                         && eform.isCurrent()));
     }
 
-    private Path createEFormArchive() throws Exception {
-        Path archive = tempDir.resolve("issue-3071-eform.zip");
+    @Test
+    @DisplayName("should detect an eForm archive whose marker entry uses a different case or backslash separators")
+    void shouldSaveEFormArchive_whenMarkerEntryIsCaseVariant() throws Exception {
+        request.setMethod("POST");
+        when(securityInfoManager.hasPrivilege(any(LoggedInInfo.class), eq("_admin.eform"), eq("w"), isNull()))
+                .thenReturn(true);
+        Path archive = createEFormArchive("Issue3071\\EForm.Properties");
+
+        FrmXmlUpload2Action action = new FrmXmlUpload2Action();
+        action.setFile1(archive.toFile());
+
+        try (MockedStatic<ImageUpload2Action> imageUploadActionMock = org.mockito.Mockito.mockStatic(ImageUpload2Action.class)) {
+            imageUploadActionMock.when(ImageUpload2Action::getImageFolder).thenReturn(tempDir.toFile());
+
+            assertThat(action.execute()).isEqualTo(ActionSupport.SUCCESS);
+        }
+
+        verify(eformDao).persist(any(EForm.class));
+    }
+
+    @Test
+    @DisplayName("should return a friendly action error and not propagate exceptions from a failed eForm import")
+    void shouldReturnFriendlyError_whenEFormImportThrows() throws Exception {
+        request.setMethod("POST");
+        when(securityInfoManager.hasPrivilege(any(LoggedInInfo.class), eq("_admin.eform"), eq("w"), isNull()))
+                .thenReturn(true);
+        Path archive = createEFormArchive("Issue3071/eform.properties");
+
+        FrmXmlUpload2Action action = new FrmXmlUpload2Action();
+        action.setFile1(archive.toFile());
+
+        String result;
+        try (MockedStatic<ImageUpload2Action> imageUploadActionMock = org.mockito.Mockito.mockStatic(ImageUpload2Action.class)) {
+            imageUploadActionMock.when(ImageUpload2Action::getImageFolder).thenThrow(new IOException("boom"));
+
+            result = action.execute();
+        }
+
+        assertThat(result).isEqualTo(ActionSupport.ERROR);
+        assertThat(action.getActionErrors()).contains("Unable to import eForm archive.");
+        assertThat(request.getAttribute("actionErrors")).isEqualTo(action.getActionErrors());
+        verify(eformDao, never()).persist(any(EForm.class));
+    }
+
+    @Test
+    @DisplayName("should propagate a SecurityException from a path-traversing eForm archive entry")
+    void shouldPropagateSecurityException_whenEFormArchiveContainsPathTraversalEntry() throws Exception {
+        request.setMethod("POST");
+        when(securityInfoManager.hasPrivilege(any(LoggedInInfo.class), eq("_admin.eform"), eq("w"), isNull()))
+                .thenReturn(true);
+        Path archive = tempDir.resolve("path-traversal-eform.zip");
         try (ZipOutputStream output = new ZipOutputStream(Files.newOutputStream(archive))) {
             output.putNextEntry(new ZipEntry("Issue3071/eform.properties"));
+            output.write("form.name=Path Traversal\n".getBytes(StandardCharsets.UTF_8));
+            output.closeEntry();
+            output.putNextEntry(new ZipEntry("../evil.txt"));
+            output.write("payload".getBytes(StandardCharsets.UTF_8));
+            output.closeEntry();
+        }
+
+        FrmXmlUpload2Action action = new FrmXmlUpload2Action();
+        action.setFile1(archive.toFile());
+
+        try (MockedStatic<ImageUpload2Action> imageUploadActionMock = org.mockito.Mockito.mockStatic(ImageUpload2Action.class)) {
+            imageUploadActionMock.when(ImageUpload2Action::getImageFolder).thenReturn(tempDir.toFile());
+
+            assertThatThrownBy(action::execute).isInstanceOf(SecurityException.class);
+        }
+
+        verify(eformDao, never()).persist(any(EForm.class));
+    }
+
+    private Path createEFormArchive() throws Exception {
+        return createEFormArchive("Issue3071/eform.properties");
+    }
+
+    private Path createEFormArchive(String propertiesEntryName) throws Exception {
+        Path archive = tempDir.resolve("issue-3071-eform.zip");
+        try (ZipOutputStream output = new ZipOutputStream(Files.newOutputStream(archive))) {
+            output.putNextEntry(new ZipEntry(propertiesEntryName));
             output.write("""
                     form.name=Issue 3071 eForm import
                     form.htmlFilename=issue-3071-eform.html

--- a/src/test/java/io/github/carlos_emr/carlos/form/pageUtil/FrmXmlUpload2ActionSecurityUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/form/pageUtil/FrmXmlUpload2ActionSecurityUnitTest.java
@@ -212,9 +212,11 @@ class FrmXmlUpload2ActionSecurityUnitTest extends CarlosUnitTestBase {
         Path archive = tempDir.resolve("issue-3071-eform.zip");
         try (ZipOutputStream output = new ZipOutputStream(Files.newOutputStream(archive))) {
             output.putNextEntry(new ZipEntry("Issue3071/eform.properties"));
-            output.write(("form.name=Issue 3071 eForm import\n"
-                    + "form.htmlFilename=issue-3071-eform.html\n"
-                    + "form.details=Imported form\n").getBytes(StandardCharsets.UTF_8));
+            output.write("""
+                    form.name=Issue 3071 eForm import
+                    form.htmlFilename=issue-3071-eform.html
+                    form.details=Imported form
+                    """.getBytes(StandardCharsets.UTF_8));
             output.closeEntry();
             output.putNextEntry(new ZipEntry("Issue3071/issue-3071-eform.html"));
             output.write("<html><body>Issue 3071 eForm</body></html>".getBytes(StandardCharsets.UTF_8));

--- a/src/test/java/io/github/carlos_emr/carlos/form/pageUtil/FrmXmlUpload2ActionSecurityUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/form/pageUtil/FrmXmlUpload2ActionSecurityUnitTest.java
@@ -27,15 +27,20 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
+import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpServletResponse;
 
 import org.apache.struts2.ActionSupport;
@@ -52,7 +57,11 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.MockedStatic;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import io.github.carlos_emr.carlos.commn.dao.EFormDao;
+import io.github.carlos_emr.carlos.commn.model.EForm;
+import io.github.carlos_emr.carlos.eform.upload.ImageUpload2Action;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
@@ -67,7 +76,9 @@ class FrmXmlUpload2ActionSecurityUnitTest extends CarlosUnitTestBase {
     private MockedStatic<ServletActionContext> servletActionContextMock;
     private MockHttpServletRequest request;
     private MockHttpServletResponse response;
+    private ServletContext servletContext;
     private SecurityInfoManager securityInfoManager;
+    private EFormDao eformDao;
 
     @TempDir
     Path tempDir;
@@ -81,9 +92,18 @@ class FrmXmlUpload2ActionSecurityUnitTest extends CarlosUnitTestBase {
         servletActionContextMock = org.mockito.Mockito.mockStatic(ServletActionContext.class);
         servletActionContextMock.when(ServletActionContext::getRequest).thenReturn(request);
         servletActionContextMock.when(ServletActionContext::getResponse).thenReturn(response);
+        servletContext = mock(ServletContext.class);
+        when(servletContext.getAttribute("jakarta.servlet.context.tempdir")).thenReturn(tempDir.toFile());
+        servletActionContextMock.when(ServletActionContext::getServletContext).thenReturn(servletContext);
 
         securityInfoManager = mock(SecurityInfoManager.class);
         registerMock(SecurityInfoManager.class, securityInfoManager);
+        eformDao = mock(EFormDao.class);
+        registerMock(EFormDao.class, eformDao);
+        doAnswer(invocation -> {
+            ReflectionTestUtils.setField((EForm) invocation.getArgument(0), "id", 1);
+            return null;
+        }).when(eformDao).persist(any(EForm.class));
     }
 
     @AfterEach
@@ -162,6 +182,45 @@ class FrmXmlUpload2ActionSecurityUnitTest extends CarlosUnitTestBase {
         assertThat(action.getActionErrors()).contains(PathValidationUtils.INVALID_FILENAME_MESSAGE);
         verify(securityInfoManager).hasPrivilege(any(LoggedInInfo.class), eq("_admin.eform"), eq("w"), isNull());
         verify(securityInfoManager).hasPrivilege(any(LoggedInInfo.class), eq("_admin"), eq("w"), isNull());
+    }
+
+    @Test
+    @DisplayName("should save an imported eForm archive to the current eForm library")
+    void shouldSaveEFormArchive_toCurrentEFormLibrary() throws Exception {
+        request.setMethod("POST");
+        when(securityInfoManager.hasPrivilege(any(LoggedInInfo.class), eq("_admin.eform"), eq("w"), isNull()))
+                .thenReturn(true);
+        Path archive = createEFormArchive();
+
+        FrmXmlUpload2Action action = new FrmXmlUpload2Action();
+        action.setFile1(archive.toFile());
+
+        try (MockedStatic<ImageUpload2Action> imageUploadActionMock = org.mockito.Mockito.mockStatic(ImageUpload2Action.class)) {
+            imageUploadActionMock.when(ImageUpload2Action::getImageFolder).thenReturn(tempDir.toFile());
+
+            assertThat(action.execute()).isEqualTo(ActionSupport.SUCCESS);
+        }
+
+        verify(eformDao).persist(org.mockito.ArgumentMatchers.<EForm>argThat(eform ->
+                "Issue 3071 eForm import".equals(eform.getFormName())
+                        && "issue-3071-eform.html".equals(eform.getFileName())
+                        && "<html><body>Issue 3071 eForm</body></html>".equals(eform.getFormHtml())
+                        && eform.isCurrent()));
+    }
+
+    private Path createEFormArchive() throws Exception {
+        Path archive = tempDir.resolve("issue-3071-eform.zip");
+        try (ZipOutputStream output = new ZipOutputStream(Files.newOutputStream(archive))) {
+            output.putNextEntry(new ZipEntry("Issue3071/eform.properties"));
+            output.write(("form.name=Issue 3071 eForm import\n"
+                    + "form.htmlFilename=issue-3071-eform.html\n"
+                    + "form.details=Imported form\n").getBytes(StandardCharsets.UTF_8));
+            output.closeEntry();
+            output.putNextEntry(new ZipEntry("Issue3071/issue-3071-eform.html"));
+            output.write("<html><body>Issue 3071 eForm</body></html>".getBytes(StandardCharsets.UTF_8));
+            output.closeEntry();
+        }
+        return archive;
     }
 
     private static UploadedFile uploadedFile(Path content, String originalName, String contentType) {


### PR DESCRIPTION
## Issue
Fixes #3071 — authorized administrators received 403 responses when opening or submitting Import Form Data.

## Summary
- Add a dedicated, admin-gated `GET`/`HEAD` route for `/form/formXmlUpload`.
- Preserve legacy `/form/formXmlUpload.jsp` resolution while excluding the page from the generic `_form` wildcard gateway.
- Keep `/form/xmlUpload` as the POST-only import processor, now recognizing eForm-export ZIPs and persisting them via the established eForm importer so they are available in Manage eForms.
- Include the standard CSRF token in the multipart upload form so valid imports reach that processor.
- Render a confirmation page after successful imports, with a visible Administration link and a three-second automatic return to the Administration menu; upload errors remain on the retryable form.

## Root cause
The Import Form Data page fell through to the generic form-view gateway, which required `_form` read permission even for administrators authorized to import eForms. Once the page route was restored, its multipart form still lacked the CSRF token required by the application filter, so submissions were rejected with 403 before reaching the processor. After those were fixed, eForm-export ZIPs still returned 200 without saving anything because the legacy processor only understood clinical form-data XML entries; it silently skipped eForm archives. Finally, successful imports re-rendered the raw upload page instead of acknowledging completion and returning the administrator to their workflow.

## Validation
- Full Maven unit-test target: 9,425 tests passed, 0 failures/errors (49 skipped) before the confirmation-only JSP/mapping change.
- Focused Maven confirmation regression: 9 tests passed.
- Local Playwright: Import Form Data rendered the confirmation message after a successful ZIP import, exposed `/administration` as the return link, and automatically navigated to the Administration menu.
- Local Playwright: posting an eForm-export ZIP returned 200 and its `Issue 3071 eForm Probe` entry appeared in Manage eForms.

## Summary by Sourcery

Restore secure admin access to the Import Form Data page and ensure eForm ZIP imports are processed and acknowledged correctly.

New Features:
- Add an admin-gated view endpoint and route for the form XML import page with GET/HEAD support.
- Render a dedicated success confirmation page after completed form data imports with an automatic return to Administration.

Bug Fixes:
- Ensure the form XML upload page is excluded from the generic wildcard form gateway so authorized admins no longer receive 403 errors.
- Include a CSRF token in the multipart upload form so import submissions are accepted by CSRF filtering.
- Process eForm export ZIP archives via the eForm importer so imported templates are persisted to the Manage eForms library.
- Handle security exceptions from the import page through Struts global mappings to the standard security error view.

Enhancements:
- Keep the legacy /form/formXmlUpload.jsp path while routing it through the new dedicated view gate.
- Extend the XML upload action to distinguish eForm archives from legacy clinical ZIPs while reusing existing database import logic.
- Strengthen test coverage around import routing, CSRF inclusion, success/error views, and eForm ZIP persistence.

Tests:
- Add unit and regression tests for the new view gate, routing behavior, CSRF token presence, success confirmation page, and eForm archive import persistence.