### PR TITLE
fix(report): safely enable query by example

### DIFF
--- a/dependencies-lock.json
+++ b/dependencies-lock.json
@@ -1195,14 +1195,6 @@
     "optional" : false,
     "integrity" : "sha512:6oPQclFmUY/UxgXW0HXw/IcSjKRVy9/6wIVOBVKOeZpPu7OAUHGLCgbpQmwujcd/qVlLZXCDu1HHErGF1OiacQ=="
   }, {
-    "groupId" : "net.sf.jopt-simple",
-    "artifactId" : "jopt-simple",
-    "version" : "5.0.4",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:y8J+C22mrktiRTU9ZibS48FxwwJqVV+iHo72GzBxTihtuFCG0aV8FnAW6Kfwe+KiQ+NLOrUEsYd4BvO87F35hg=="
-  }, {
     "groupId" : "net.sf.saxon",
     "artifactId" : "Saxon-HE",
     "version" : "11.6",
@@ -3187,14 +3179,6 @@
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:H6mQ0VvRefB/+8Rg1YCm/QVi5F3ui9SpQFkXU2t49FwNb2RLZ/hdeBx1iqVu/5Cu8j7tzJvX9f+Ieme3Fgg+YQ=="
-  }, {
-    "groupId" : "org.openjdk.jmh",
-    "artifactId" : "jmh-core",
-    "version" : "1.37",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:jkNMyJ98ijA14XJnXZ+RRBUDmtjcQDqfSjBu++MknCDaA0OqUev547n4umdG6FRKxWH7zWLynbsWO38QyWwfNA=="
   }, {
     "groupId" : "org.opensaml",
     "artifactId" : "opensaml-core-api",

--- a/dependencies-lock.json
+++ b/dependencies-lock.json
@@ -256,6 +256,14 @@
     "optional" : false,
     "integrity" : "sha512:ak529k22lHqP1DCq+VRYn/k+WKRVFbfX2LPZlrBBSh6rRgD6olc8zroC3xwa2UkhjFSvQFFEUa7y3MbjkY24sQ=="
   }, {
+    "groupId" : "com.github.jsqlparser",
+    "artifactId" : "jsqlparser",
+    "version" : "5.3",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:YLJ1qDvLVOE0hRuDwPgQLT4mPEZjZnlObat+LOk5vNLw0dEZOkWdT+c6wYgSvyXpRPw7+iO2YK0XgVcYWESegA=="
+  }, {
     "groupId" : "com.github.librepdf.openpdf",
     "artifactId" : "openpdf-html",
     "version" : "3.0.3",
@@ -1186,6 +1194,14 @@
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:6oPQclFmUY/UxgXW0HXw/IcSjKRVy9/6wIVOBVKOeZpPu7OAUHGLCgbpQmwujcd/qVlLZXCDu1HHErGF1OiacQ=="
+  }, {
+    "groupId" : "net.sf.jopt-simple",
+    "artifactId" : "jopt-simple",
+    "version" : "5.0.4",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:y8J+C22mrktiRTU9ZibS48FxwwJqVV+iHo72GzBxTihtuFCG0aV8FnAW6Kfwe+KiQ+NLOrUEsYd4BvO87F35hg=="
   }, {
     "groupId" : "net.sf.saxon",
     "artifactId" : "Saxon-HE",
@@ -3171,6 +3187,14 @@
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:H6mQ0VvRefB/+8Rg1YCm/QVi5F3ui9SpQFkXU2t49FwNb2RLZ/hdeBx1iqVu/5Cu8j7tzJvX9f+Ieme3Fgg+YQ=="
+  }, {
+    "groupId" : "org.openjdk.jmh",
+    "artifactId" : "jmh-core",
+    "version" : "1.37",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:jkNMyJ98ijA14XJnXZ+RRBUDmtjcQDqfSjBu++MknCDaA0OqUev547n4umdG6FRKxWH7zWLynbsWO38QyWwfNA=="
   }, {
     "groupId" : "org.opensaml",
     "artifactId" : "opensaml-core-api",

--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,8 @@
         <owasp-encoder.version>1.4.0</owasp-encoder.version>
         <!-- OWASP CSRFGuard -->
         <csrfguard.version>4.5.0-jakarta</csrfguard.version>
+        <!-- Structural validation for authorized Query-by-Example SELECTs -->
+        <jsqlparser.version>5.3</jsqlparser.version>
         <!-- JNA: pin transitive ultrabuk-htmltopdf-java range [5.12,) to the locked version -->
         <jna.version>5.19.0</jna.version>
         <!-- HAPI HL7 v2 -->
@@ -444,6 +446,13 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-csv</artifactId>
             <version>1.14.1</version>
+        </dependency>
+
+        <!-- SQL parsing used to fail closed before Query-by-Example reaches JDBC -->
+        <dependency>
+            <groupId>com.github.jsqlparser</groupId>
+            <artifactId>jsqlparser</artifactId>
+            <version>${jsqlparser.version}</version>
         </dependency>
         <!-- ==================== HTTP Client ==================== -->
 
@@ -1446,6 +1455,13 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>0.8.14</version>
+                <configuration>
+                    <!-- JSqlParser's generated token-manager method exceeds the JVM method
+                         size after instrumentation; dependency code is outside our coverage scope. -->
+                    <excludes>
+                        <exclude>net.sf.jsqlparser.*</exclude>
+                    </excludes>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -453,6 +453,13 @@
             <groupId>com.github.jsqlparser</groupId>
             <artifactId>jsqlparser</artifactId>
             <version>${jsqlparser.version}</version>
+            <exclusions>
+                <!-- Benchmarking support is not used by the parser at runtime. -->
+                <exclusion>
+                    <groupId>org.openjdk.jmh</groupId>
+                    <artifactId>jmh-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- ==================== HTTP Client ==================== -->
 

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/ReportByExamplesFavoriteDao.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/ReportByExamplesFavoriteDao.java
@@ -36,6 +36,14 @@ import java.util.List;
 import io.github.carlos_emr.carlos.commn.model.ReportByExamplesFavorite;
 
 public interface ReportByExamplesFavoriteDao extends AbstractDao<ReportByExamplesFavorite> {
+    /**
+     * Finds favorites owned by one provider whose saved SQL exactly matches the supplied query.
+     *
+     * @param providerNo owner provider number
+     * @param query exact saved query text
+     * @return matching favorites owned by the provider, or an empty list when none exist
+     * @since 2026-08-06
+     */
     List<ReportByExamplesFavorite> findByProviderAndQuery(String providerNo, String query);
 
     List<ReportByExamplesFavorite> findByEverything(String providerNo, String favoriteName, String queryString);

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/ReportByExamplesFavoriteDao.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/ReportByExamplesFavoriteDao.java
@@ -36,7 +36,7 @@ import java.util.List;
 import io.github.carlos_emr.carlos.commn.model.ReportByExamplesFavorite;
 
 public interface ReportByExamplesFavoriteDao extends AbstractDao<ReportByExamplesFavorite> {
-    List<ReportByExamplesFavorite> findByQuery(String query);
+    List<ReportByExamplesFavorite> findByProviderAndQuery(String providerNo, String query);
 
     List<ReportByExamplesFavorite> findByEverything(String providerNo, String favoriteName, String queryString);
 

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/ReportByExamplesFavoriteDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/ReportByExamplesFavoriteDaoImpl.java
@@ -46,15 +46,16 @@ public class ReportByExamplesFavoriteDaoImpl extends AbstractDaoImpl<ReportByExa
     }
 
     @Override
-    public List<ReportByExamplesFavorite> findByQuery(String query) {
-        Query q = createQuery("ex", "ex.query LIKE ?1");
-        q.setParameter(1, query);
-        return q.getResultList();
+    public List<ReportByExamplesFavorite> findByProviderAndQuery(String providerNo, String queryString) {
+        Query query = createQuery("ex", "ex.providerNo = ?1 AND ex.query = ?2");
+        query.setParameter(1, providerNo);
+        query.setParameter(2, queryString);
+        return query.getResultList();
     }
 
     @Override
     public List<ReportByExamplesFavorite> findByEverything(String providerNo, String favoriteName, String queryString) {
-        Query query = createQuery("ex", "ex.providerNo = ?1 AND ex.name LIKE ?2 OR ex.query LIKE ?3");
+        Query query = createQuery("ex", "ex.providerNo = ?1 AND ex.name = ?2 AND ex.query = ?3");
         query.setParameter(1, providerNo);
         query.setParameter(2, favoriteName);
         query.setParameter(3, queryString);

--- a/src/main/java/io/github/carlos_emr/carlos/db/LegacyJdbcQuery.java
+++ b/src/main/java/io/github/carlos_emr/carlos/db/LegacyJdbcQuery.java
@@ -616,6 +616,12 @@ public final class LegacyJdbcQuery {
         return false;
     }
 
+    /**
+     * Masks quoted sections while preserving input length for keyword checks.
+     * Backslash escapes are handled here to match MySQL literal parsing. This intentionally differs
+     * from the Query-by-Example validator's scanner, which must match JSqlParser's configured parsing
+     * and therefore handles only doubled quote delimiters. The two scanners must not be merged.
+     */
     private static String stripQuotedSqlSections(String sql) {
         StringBuilder stripped = new StringBuilder(sql.length());
         char quote = '\0';

--- a/src/main/java/io/github/carlos_emr/carlos/db/LegacyJdbcQuery.java
+++ b/src/main/java/io/github/carlos_emr/carlos/db/LegacyJdbcQuery.java
@@ -627,20 +627,20 @@ public final class LegacyJdbcQuery {
                 quote = sqlQuoteDelimiter(current);
                 stripped.append(quote == '\0' ? current : ' ');
                 i++;
-                continue;
+            } else {
+                boolean escapedPair = (quote != '`' && current == '\\' && next != '\0')
+                        || (current == quote && next == quote);
+                if (escapedPair) {
+                    stripped.append("  ");
+                    i += 2;
+                } else {
+                    if (current == quote) {
+                        quote = '\0';
+                    }
+                    stripped.append(' ');
+                    i++;
+                }
             }
-            boolean escapedPair = (quote != '`' && current == '\\' && next != '\0')
-                    || (current == quote && next == quote);
-            if (escapedPair) {
-                stripped.append("  ");
-                i += 2;
-                continue;
-            }
-            if (current == quote) {
-                quote = '\0';
-            }
-            stripped.append(' ');
-            i++;
         }
         return stripped.toString();
     }

--- a/src/main/java/io/github/carlos_emr/carlos/db/LegacyJdbcQuery.java
+++ b/src/main/java/io/github/carlos_emr/carlos/db/LegacyJdbcQuery.java
@@ -633,22 +633,23 @@ public final class LegacyJdbcQuery {
                 quote = sqlQuoteDelimiter(current);
                 stripped.append(quote == '\0' ? current : ' ');
                 i++;
+            } else if (isSqlEscapedPair(quote, current, next)) {
+                stripped.append("  ");
+                i += 2;
             } else {
-                boolean escapedPair = (quote != '`' && current == '\\' && next != '\0')
-                        || (current == quote && next == quote);
-                if (escapedPair) {
-                    stripped.append("  ");
-                    i += 2;
-                } else {
-                    if (current == quote) {
-                        quote = '\0';
-                    }
-                    stripped.append(' ');
-                    i++;
+                if (current == quote) {
+                    quote = '\0';
                 }
+                stripped.append(' ');
+                i++;
             }
         }
         return stripped.toString();
+    }
+
+    private static boolean isSqlEscapedPair(char quote, char current, char next) {
+        return (quote != '`' && current == '\\' && next != '\0')
+                || (current == quote && next == quote);
     }
 
     private static char sqlQuoteDelimiter(char candidate) {

--- a/src/main/java/io/github/carlos_emr/carlos/db/LegacyJdbcQuery.java
+++ b/src/main/java/io/github/carlos_emr/carlos/db/LegacyJdbcQuery.java
@@ -418,6 +418,9 @@ public final class LegacyJdbcQuery {
                 char current = sql.charAt(position);
                 char next = nextChar();
                 if (insideQuotedLiteral()) {
+                    if (isSqlModeDependentEscape(current)) {
+                        return true;
+                    }
                     skipQuotedLiteralToken(current, next);
                 } else if (opensQuotedLiteral(current)) {
                     quote = current;
@@ -437,13 +440,15 @@ public final class LegacyJdbcQuery {
         }
 
         private void skipQuotedLiteralToken(char current, char next) {
-            if (quote != '`' && current == '\\' && next != '\0') {
-                position++;
-            } else if (current == quote && next == quote) {
+            if (current == quote && next == quote) {
                 position++;
             } else if (current == quote) {
                 quote = '\0';
             }
+        }
+
+        private boolean isSqlModeDependentEscape(char current) {
+            return quote != '`' && current == '\\';
         }
 
         private static boolean opensQuotedLiteral(char current) {
@@ -618,9 +623,10 @@ public final class LegacyJdbcQuery {
 
     /**
      * Masks quoted sections while preserving input length for keyword checks.
-     * Backslash escapes are handled here to match MySQL literal parsing. This intentionally differs
-     * from the Query-by-Example validator's scanner, which must match JSqlParser's configured parsing
-     * and therefore handles only doubled quote delimiters. The two scanners must not be merged.
+     * Backslash-containing string literals are rejected by the control-token scanner before this
+     * method is called because their boundaries depend on MySQL's {@code NO_BACKSLASH_ESCAPES} mode.
+     * This intentionally differs from the Query-by-Example validator's scanner, which must match
+     * JSqlParser's configured parsing. The two scanners must not be merged.
      */
     private static String stripQuotedSqlSections(String sql) {
         StringBuilder stripped = new StringBuilder(sql.length());
@@ -648,8 +654,7 @@ public final class LegacyJdbcQuery {
     }
 
     private static boolean isSqlEscapedPair(char quote, char current, char next) {
-        return (quote != '`' && current == '\\' && next != '\0')
-                || (current == quote && next == quote);
+        return current == quote && next == quote;
     }
 
     private static char sqlQuoteDelimiter(char candidate) {

--- a/src/main/java/io/github/carlos_emr/carlos/db/LegacyJdbcQuery.java
+++ b/src/main/java/io/github/carlos_emr/carlos/db/LegacyJdbcQuery.java
@@ -619,30 +619,34 @@ public final class LegacyJdbcQuery {
     private static String stripQuotedSqlSections(String sql) {
         StringBuilder stripped = new StringBuilder(sql.length());
         char quote = '\0';
-        for (int i = 0; i < sql.length(); i++) {
+        int i = 0;
+        while (i < sql.length()) {
             char current = sql.charAt(i);
             char next = i + 1 < sql.length() ? sql.charAt(i + 1) : '\0';
             if (quote == '\0') {
-                if (current == '\'' || current == '"' || current == '`') {
-                    quote = current;
-                    stripped.append(' ');
-                } else {
-                    stripped.append(current);
-                }
-            } else if (quote != '`' && current == '\\' && next != '\0') {
-                stripped.append("  ");
+                quote = sqlQuoteDelimiter(current);
+                stripped.append(quote == '\0' ? current : ' ');
                 i++;
-            } else if (current == quote && next == quote) {
-                stripped.append("  ");
-                i++;
-            } else if (current == quote) {
-                quote = '\0';
-                stripped.append(' ');
-            } else {
-                stripped.append(' ');
+                continue;
             }
+            boolean escapedPair = (quote != '`' && current == '\\' && next != '\0')
+                    || (current == quote && next == quote);
+            if (escapedPair) {
+                stripped.append("  ");
+                i += 2;
+                continue;
+            }
+            if (current == quote) {
+                quote = '\0';
+            }
+            stripped.append(' ');
+            i++;
         }
         return stripped.toString();
+    }
+
+    private static char sqlQuoteDelimiter(char candidate) {
+        return candidate == '\'' || candidate == '"' || candidate == '`' ? candidate : '\0';
     }
 
     private static boolean startsWithSqlWord(String sql, String word) {

--- a/src/main/java/io/github/carlos_emr/carlos/db/LegacyJdbcQuery.java
+++ b/src/main/java/io/github/carlos_emr/carlos/db/LegacyJdbcQuery.java
@@ -332,21 +332,22 @@ public final class LegacyJdbcQuery {
             throw new SQLException("Potential SQL injection pattern detected");
         }
 
-        if (containsSqlWord(normalized, "union")) {
+        String normalizedSqlSyntax = stripQuotedSqlSections(sql).toLowerCase(Locale.ROOT);
+        if (containsSqlWord(normalizedSqlSyntax, "union")) {
             throw new SQLException("Unsafe SQL detected: UNION not permitted");
         }
 
         String[] blockedWords = {"insert", "update", "delete", "drop", "alter", "create", "truncate",
                 "grant", "revoke", "exec", "execute", "call", "merge", "commit", "rollback"};
         for (String word : blockedWords) {
-            if (containsSqlWord(normalized, word)) {
+            if (containsSqlWord(normalizedSqlSyntax, word)) {
                 throw new SQLException("Unsafe SQL detected: prohibited keyword");
             }
         }
 
         String[] blockedPhrases = {"into outfile", "into dumpfile", "load_file", "load data"};
         for (String phrase : blockedPhrases) {
-            if (normalized.contains(phrase)) {
+            if (normalizedSqlSyntax.contains(phrase)) {
                 throw new SQLException("Unsafe SQL detected: prohibited keyword");
             }
         }
@@ -613,6 +614,35 @@ public final class LegacyJdbcQuery {
             index = sql.indexOf(word, index + 1);
         }
         return false;
+    }
+
+    private static String stripQuotedSqlSections(String sql) {
+        StringBuilder stripped = new StringBuilder(sql.length());
+        char quote = '\0';
+        for (int i = 0; i < sql.length(); i++) {
+            char current = sql.charAt(i);
+            char next = i + 1 < sql.length() ? sql.charAt(i + 1) : '\0';
+            if (quote == '\0') {
+                if (current == '\'' || current == '"' || current == '`') {
+                    quote = current;
+                    stripped.append(' ');
+                } else {
+                    stripped.append(current);
+                }
+            } else if (quote != '`' && current == '\\' && next != '\0') {
+                stripped.append("  ");
+                i++;
+            } else if (current == quote && next == quote) {
+                stripped.append("  ");
+                i++;
+            } else if (current == quote) {
+                quote = '\0';
+                stripped.append(' ');
+            } else {
+                stripped.append(' ');
+            }
+        }
+        return stripped.toString();
     }
 
     private static boolean startsWithSqlWord(String sql, String word) {

--- a/src/main/java/io/github/carlos_emr/carlos/report/bean/RptByExampleQueryBean.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/bean/RptByExampleQueryBean.java
@@ -31,7 +31,6 @@
 package io.github.carlos_emr.carlos.report.bean;
 
 import org.owasp.encoder.Encode;
-import io.github.carlos_emr.carlos.utility.MiscUtils;
 
 public class RptByExampleQueryBean {
 
@@ -52,7 +51,6 @@ public class RptByExampleQueryBean {
         this.query = query;
         this.queryName = queryName;
         this.queryWithEscapeChar = Encode.forJavaScript(query);
-        MiscUtils.getLogger().debug("query with javascript escape char: " + queryWithEscapeChar);
     }
 
     public RptByExampleQueryBean(String providerLastName, String providerFirstName, String query, String date) {

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/QueryByExampleSqlValidator.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/QueryByExampleSqlValidator.java
@@ -22,7 +22,6 @@
 package io.github.carlos_emr.carlos.report.data;
 
 import java.sql.SQLException;
-import java.util.Locale;
 import java.util.Properties;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -41,19 +40,17 @@ public final class QueryByExampleSqlValidator {
             "\\bfor\\s+(?:update|share)\\b|\\block\\s+in\\s+share\\s+mode\\b",
             Pattern.CASE_INSENSITIVE);
     private static final Pattern OUTPUT_OPERATION = Pattern.compile("\\binto\\b", Pattern.CASE_INSENSITIVE);
-    private static final Set<String> BLOCKED_FUNCTIONS = Set.of(
-            "sleep", "benchmark", "get_lock", "release_lock", "is_free_lock", "load_file");
+    private static final Pattern BLOCKED_FUNCTION = Pattern.compile(
+            "(?<![a-z0-9_$])`?(?:sleep|benchmark|get_lock|release_lock|is_free_lock|load_file)`?\\s*\\(",
+            Pattern.CASE_INSENSITIVE);
 
     private QueryByExampleSqlValidator() {
     }
 
     public static LegacyJdbcQuery.TrustedSql validate(String sql, Properties properties)
             throws QueryByExampleValidationException {
-        LegacyJdbcQuery.TrustedSql trustedSql;
-        try {
-            trustedSql = LegacyJdbcQuery.trustedSelectSql(sql);
-        } catch (SQLException e) {
-            throw new QueryByExampleValidationException(e.getMessage(), e);
+        if (sql == null || sql.isBlank()) {
+            throw new QueryByExampleValidationException("SQL query must not be empty");
         }
 
         Statement statement;
@@ -63,7 +60,7 @@ public final class QueryByExampleSqlValidator {
             throw new QueryByExampleValidationException("The query could not be parsed as a single SELECT", e);
         }
 
-        if (!(statement instanceof Select) || statement instanceof SetOperationList) {
+        if (!(statement instanceof Select select) || select instanceof SetOperationList) {
             throw new QueryByExampleValidationException("Only one SELECT statement is allowed");
         }
 
@@ -76,7 +73,11 @@ public final class QueryByExampleSqlValidator {
         }
         rejectBlockedFunctions(sqlWithoutStringLiterals);
         rejectOtherSchemas(statement, applicationSchema(properties));
-        return trustedSql;
+        try {
+            return LegacyJdbcQuery.trustedSelectSql(sql);
+        } catch (SQLException e) {
+            throw new QueryByExampleValidationException(e.getMessage(), e);
+        }
     }
 
     static String applicationSchema(Properties properties) throws QueryByExampleValidationException {
@@ -93,7 +94,12 @@ public final class QueryByExampleSqlValidator {
 
     private static void rejectOtherSchemas(Statement statement, String applicationSchema)
             throws QueryByExampleValidationException {
-        Set<String> tables = new TablesNamesFinder<Void>().getTables(statement);
+        Set<String> tables;
+        try {
+            tables = new TablesNamesFinder<Void>().getTables(statement);
+        } catch (RuntimeException e) {
+            throw new QueryByExampleValidationException("The query table references could not be validated", e);
+        }
         for (String table : tables) {
             String normalizedTable = unquoteIdentifier(table);
             int lastDot = normalizedTable.lastIndexOf('.');
@@ -107,13 +113,8 @@ public final class QueryByExampleSqlValidator {
     }
 
     private static void rejectBlockedFunctions(String sql) throws QueryByExampleValidationException {
-        String normalized = sql.toLowerCase(Locale.ROOT);
-        for (String function : BLOCKED_FUNCTIONS) {
-            Pattern invocation = Pattern.compile("(?<![a-z0-9_$])`?" + Pattern.quote(function)
-                    + "`?\\s*\\(", Pattern.CASE_INSENSITIVE);
-            if (invocation.matcher(normalized).find()) {
-                throw new QueryByExampleValidationException("The query uses a prohibited database function");
-            }
+        if (BLOCKED_FUNCTION.matcher(sql).find()) {
+            throw new QueryByExampleValidationException("The query uses a prohibited database function");
         }
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/QueryByExampleSqlValidator.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/QueryByExampleSqlValidator.java
@@ -101,6 +101,18 @@ public final class QueryByExampleSqlValidator {
      */
     public static LegacyJdbcQuery.TrustedSql validate(String sql, Properties properties)
             throws QueryByExampleValidationException {
+        validateSqlText(sql);
+        Select select = parseSingleSelect(sql);
+        rejectUnsafeTextOperations(sql);
+        rejectUnsafeExpressionsAndOtherSchemas(select, applicationSchema(properties));
+        try {
+            return LegacyJdbcQuery.trustedSelectSql(sql);
+        } catch (SQLException e) {
+            throw new QueryByExampleValidationException(e.getMessage(), e);
+        }
+    }
+
+    private static void validateSqlText(String sql) throws QueryByExampleValidationException {
         if (sql == null) {
             throw new QueryByExampleValidationException("SQL query must not be empty");
         }
@@ -110,7 +122,9 @@ public final class QueryByExampleSqlValidator {
         if (sql.isBlank()) {
             throw new QueryByExampleValidationException("SQL query must not be empty");
         }
+    }
 
+    private static Select parseSingleSelect(String sql) throws QueryByExampleValidationException {
         Statement statement;
         try {
             statement = CCJSqlParserUtil.parse(sql);
@@ -121,19 +135,16 @@ public final class QueryByExampleSqlValidator {
         if (!(statement instanceof Select select) || containsSetOperation(select)) {
             throw new QueryByExampleValidationException("Only one SELECT statement is allowed");
         }
+        return select;
+    }
 
+    private static void rejectUnsafeTextOperations(String sql) throws QueryByExampleValidationException {
         String sqlWithoutQuotedSections = stripQuotedSections(sql);
         if (LOCKING_SELECT.matcher(sqlWithoutQuotedSections).find()) {
             throw new QueryByExampleValidationException("Locking SELECT statements are not allowed");
         }
         if (OUTPUT_OR_PROCEDURE_OPERATION.matcher(sqlWithoutQuotedSections).find()) {
             throw new QueryByExampleValidationException("SELECT output operations are not allowed");
-        }
-        rejectUnsafeExpressionsAndOtherSchemas(statement, applicationSchema(properties));
-        try {
-            return LegacyJdbcQuery.trustedSelectSql(sql);
-        } catch (SQLException e) {
-            throw new QueryByExampleValidationException(e.getMessage(), e);
         }
     }
 
@@ -196,7 +207,8 @@ public final class QueryByExampleSqlValidator {
     private static String stripQuotedSections(String sql) {
         StringBuilder stripped = new StringBuilder(sql.length());
         char quote = '\0';
-        for (int i = 0; i < sql.length(); i++) {
+        int i = 0;
+        while (i < sql.length()) {
             char current = sql.charAt(i);
             char next = i + 1 < sql.length() ? sql.charAt(i + 1) : '\0';
             if (quote == '\0') {
@@ -206,15 +218,18 @@ public final class QueryByExampleSqlValidator {
                 } else {
                     stripped.append(current);
                 }
-            } else if (current == quote && next == quote) {
-                stripped.append("  ");
-                i++;
-            } else if (current == quote) {
-                quote = '\0';
-                stripped.append(' ');
             } else {
+                if (current == quote && next == quote) {
+                    stripped.append("  ");
+                    i += 2;
+                    continue;
+                }
+                if (current == quote) {
+                    quote = '\0';
+                }
                 stripped.append(' ');
             }
+            i++;
         }
         return stripped.toString();
     }

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/QueryByExampleSqlValidator.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/QueryByExampleSqlValidator.java
@@ -66,7 +66,7 @@ public final class QueryByExampleSqlValidator {
      * Query-by-Example is a reporting surface, so even administrators must use the
      * purpose-built management flows rather than exporting these records as report data.
      */
-    private static final Set<String> SECURITY_SENSITIVE_TABLES = Set.of(
+    static final Set<String> SECURITY_SENSITIVE_TABLES = Set.of(
             "appdefinition",
             "appuser",
             "emailconfig",

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/QueryByExampleSqlValidator.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/QueryByExampleSqlValidator.java
@@ -35,7 +35,16 @@ import net.sf.jsqlparser.statement.select.Select;
 import net.sf.jsqlparser.statement.select.SetOperationList;
 import net.sf.jsqlparser.util.TablesNamesFinder;
 
-/** Fail-closed validation for request-submitted Query-by-Example SQL. */
+/**
+ * Fail-closed validation for request-submitted Query-by-Example SQL.
+ *
+ * <p>Accepted input is one non-locking, non-output {@code SELECT} whose table
+ * references are unqualified or belong to the configured application schema.
+ * Comments, statement separators, set operations, write/control keywords, and
+ * prohibited database functions are rejected.</p>
+ *
+ * @since 2026-08-06
+ */
 public final class QueryByExampleSqlValidator {
     private static final Pattern LOCKING_SELECT = Pattern.compile(
             "\\bfor\\s+(?:update|share)\\b|\\block\\s+in\\s+share\\s+mode\\b",
@@ -48,6 +57,15 @@ public final class QueryByExampleSqlValidator {
     private QueryByExampleSqlValidator() {
     }
 
+    /**
+     * Validates SQL and returns the same text wrapped for the trusted JDBC boundary.
+     *
+     * @param sql request-submitted SQL to validate
+     * @param properties application properties containing a non-blank {@code db_name}
+     * @return the unchanged SQL represented as {@link LegacyJdbcQuery.TrustedSql}
+     * @throws QueryByExampleValidationException if the SQL is empty, cannot be parsed,
+     *         is not one allowed {@code SELECT}, or references an unapproved schema or operation
+     */
     public static LegacyJdbcQuery.TrustedSql validate(String sql, Properties properties)
             throws QueryByExampleValidationException {
         if (sql == null || sql.isBlank()) {

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/QueryByExampleSqlValidator.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/QueryByExampleSqlValidator.java
@@ -22,6 +22,7 @@
 package io.github.carlos_emr.carlos.report.data;
 
 import java.sql.SQLException;
+import java.util.List;
 import java.util.Locale;
 import java.util.Properties;
 import java.util.Set;
@@ -29,8 +30,13 @@ import java.util.regex.Pattern;
 
 import io.github.carlos_emr.carlos.db.LegacyJdbcQuery;
 import net.sf.jsqlparser.JSQLParserException;
+import net.sf.jsqlparser.expression.AnalyticExpression;
+import net.sf.jsqlparser.expression.Function;
+import net.sf.jsqlparser.expression.NextValExpression;
+import net.sf.jsqlparser.expression.UserVariable;
 import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import net.sf.jsqlparser.statement.Statement;
+import net.sf.jsqlparser.statement.select.PlainSelect;
 import net.sf.jsqlparser.statement.select.Select;
 import net.sf.jsqlparser.statement.select.SetOperationList;
 import net.sf.jsqlparser.util.TablesNamesFinder;
@@ -46,13 +52,39 @@ import net.sf.jsqlparser.util.TablesNamesFinder;
  * @since 2026-08-06
  */
 public final class QueryByExampleSqlValidator {
+    public static final int MAX_SQL_CHARACTERS = 16_384;
+
     private static final Pattern LOCKING_SELECT = Pattern.compile(
             "\\bfor\\s+(?:update|share)\\b|\\block\\s+in\\s+share\\s+mode\\b",
             Pattern.CASE_INSENSITIVE);
-    private static final Pattern OUTPUT_OPERATION = Pattern.compile("\\binto\\b", Pattern.CASE_INSENSITIVE);
-    private static final Pattern BLOCKED_FUNCTION = Pattern.compile(
-            "(?<![a-z0-9_$])`?(?:sleep|benchmark|get_lock|release_lock|is_free_lock|load_file)`?\\s*\\(",
-            Pattern.CASE_INSENSITIVE);
+    private static final Pattern OUTPUT_OR_PROCEDURE_OPERATION = Pattern.compile(
+            "\\b(?:into|procedure)\\b", Pattern.CASE_INSENSITIVE);
+
+    /**
+     * Reporting-safe built-ins. Anything not listed is rejected so stored functions and
+     * newly introduced vendor functions cannot silently cross the validation boundary.
+     */
+    private static final Set<String> ALLOWED_FUNCTIONS = Set.of(
+            "abs", "acos", "adddate", "addtime", "ascii", "asin", "atan", "atan2", "avg",
+            "bin", "bit_and", "bit_length", "bit_or", "bit_xor", "ceil", "ceiling", "char_length",
+            "character_length", "coalesce", "concat", "concat_ws", "conv", "convert_tz", "cos", "cot",
+            "count", "crc32", "curdate", "current_date", "current_time", "current_timestamp", "curtime",
+            "date", "date_add", "date_format", "date_sub", "datediff", "day", "dayname", "dayofmonth",
+            "dayofweek", "dayofyear", "degrees", "elt", "exp", "field", "find_in_set", "floor", "format",
+            "from_base64", "from_days", "from_unixtime", "get_format", "greatest", "hex", "hour", "if",
+            "ifnull", "instr", "lcase", "least", "left", "length", "ln", "localtime", "localtimestamp",
+            "locate", "log", "log10", "log2", "lower", "lpad", "ltrim", "makedate", "maketime", "max",
+            "md5", "microsecond", "mid", "min", "minute", "mod", "month", "monthname", "now", "nullif",
+            "oct", "octet_length", "ord", "period_add", "period_diff", "pi", "pow", "power", "quarter",
+            "quote", "radians", "rand", "repeat", "replace", "reverse", "right", "round", "rpad", "rtrim",
+            "sec_to_time", "second", "sha", "sha1", "sha2", "sign", "sin", "soundex", "space", "sqrt",
+            "std", "stddev", "stddev_pop", "stddev_samp", "str_to_date", "strcmp", "subdate", "substr",
+            "substring", "substring_index", "subtime", "sum", "sysdate", "tan", "time", "time_format",
+            "time_to_sec", "timediff", "timestamp", "timestampadd", "timestampdiff", "to_base64", "to_days",
+            "trim", "truncate", "ucase", "unhex", "unix_timestamp", "upper", "utc_date", "utc_time",
+            "utc_timestamp", "variance", "var_pop", "var_samp", "week", "weekday", "weekofyear", "year",
+            "yearweek", "cume_dist", "dense_rank", "first_value", "lag", "last_value", "lead", "nth_value",
+            "ntile", "percent_rank", "rank", "row_number");
 
     private QueryByExampleSqlValidator() {
     }
@@ -68,7 +100,13 @@ public final class QueryByExampleSqlValidator {
      */
     public static LegacyJdbcQuery.TrustedSql validate(String sql, Properties properties)
             throws QueryByExampleValidationException {
-        if (sql == null || sql.isBlank()) {
+        if (sql == null) {
+            throw new QueryByExampleValidationException("SQL query must not be empty");
+        }
+        if (sql.length() > MAX_SQL_CHARACTERS) {
+            throw new QueryByExampleValidationException("SQL query exceeds the allowed length");
+        }
+        if (sql.isBlank()) {
             throw new QueryByExampleValidationException("SQL query must not be empty");
         }
 
@@ -83,15 +121,14 @@ public final class QueryByExampleSqlValidator {
             throw new QueryByExampleValidationException("Only one SELECT statement is allowed");
         }
 
-        String sqlWithoutStringLiterals = stripStringLiterals(sql);
-        if (LOCKING_SELECT.matcher(sqlWithoutStringLiterals).find()) {
+        String sqlWithoutQuotedSections = stripQuotedSections(sql);
+        if (LOCKING_SELECT.matcher(sqlWithoutQuotedSections).find()) {
             throw new QueryByExampleValidationException("Locking SELECT statements are not allowed");
         }
-        if (OUTPUT_OPERATION.matcher(sqlWithoutStringLiterals).find()) {
+        if (OUTPUT_OR_PROCEDURE_OPERATION.matcher(sqlWithoutQuotedSections).find()) {
             throw new QueryByExampleValidationException("SELECT output operations are not allowed");
         }
-        rejectBlockedFunctions(sqlWithoutStringLiterals);
-        rejectOtherSchemas(statement, applicationSchema(properties));
+        rejectUnsafeExpressionsAndOtherSchemas(statement, applicationSchema(properties));
         try {
             return LegacyJdbcQuery.trustedSelectSql(sql);
         } catch (SQLException e) {
@@ -111,13 +148,23 @@ public final class QueryByExampleSqlValidator {
         return unquoteIdentifier(schema);
     }
 
-    private static void rejectOtherSchemas(Statement statement, String applicationSchema)
+    private static void rejectUnsafeExpressionsAndOtherSchemas(Statement statement, String applicationSchema)
             throws QueryByExampleValidationException {
         Set<String> tables;
+        SqlSafetyVisitor visitor = new SqlSafetyVisitor();
         try {
-            tables = new TablesNamesFinder<Void>().getTables(statement);
+            tables = visitor.getTables(statement);
         } catch (RuntimeException e) {
             throw new QueryByExampleValidationException("The query table references could not be validated", e);
+        }
+        if (visitor.hasOutputOperation()) {
+            throw new QueryByExampleValidationException("SELECT output operations are not allowed");
+        }
+        if (visitor.hasVariables()) {
+            throw new QueryByExampleValidationException("Session and system variables are not allowed");
+        }
+        if (!visitor.disallowedFunctions().isEmpty()) {
+            throw new QueryByExampleValidationException("The query uses a function outside the allowed set");
         }
         for (String table : tables) {
             String normalizedTable = unquoteIdentifier(table);
@@ -131,26 +178,20 @@ public final class QueryByExampleSqlValidator {
         }
     }
 
-    private static void rejectBlockedFunctions(String sql) throws QueryByExampleValidationException {
-        if (BLOCKED_FUNCTION.matcher(sql).find()) {
-            throw new QueryByExampleValidationException("The query uses a prohibited database function");
-        }
-    }
-
-    private static String stripStringLiterals(String sql) {
+    private static String stripQuotedSections(String sql) {
         StringBuilder stripped = new StringBuilder(sql.length());
         char quote = '\0';
         for (int i = 0; i < sql.length(); i++) {
             char current = sql.charAt(i);
             char next = i + 1 < sql.length() ? sql.charAt(i + 1) : '\0';
             if (quote == '\0') {
-                if (current == '\'' || current == '"') {
+                if (current == '\'' || current == '"' || current == '`') {
                     quote = current;
                     stripped.append(' ');
                 } else {
                     stripped.append(current);
                 }
-            } else if (current == '\\' && next != '\0') {
+            } else if (quote != '`' && current == '\\' && next != '\0') {
                 stripped.append("  ");
                 i++;
             } else if (current == quote && next == quote) {
@@ -172,5 +213,63 @@ public final class QueryByExampleSqlValidator {
 
     private static String canonicalIdentifier(String identifier) {
         return identifier.toLowerCase(Locale.ROOT);
+    }
+
+    private static final class SqlSafetyVisitor extends TablesNamesFinder<Void> {
+        private final Set<String> disallowedFunctions = new java.util.HashSet<>();
+        private boolean variables;
+        private boolean outputOperation;
+
+        @Override
+        public <S> Void visit(Function function, S context) {
+            List<String> nameParts = function.getMultipartName();
+            String functionName = canonicalIdentifier(unquoteIdentifier(function.getName()));
+            if (nameParts == null || nameParts.size() != 1 || !ALLOWED_FUNCTIONS.contains(functionName)) {
+                disallowedFunctions.add(functionName);
+            }
+            return super.visit(function, context);
+        }
+
+        @Override
+        public <S> Void visit(AnalyticExpression function, S context) {
+            String functionName = canonicalIdentifier(unquoteIdentifier(function.getName()));
+            if (!ALLOWED_FUNCTIONS.contains(functionName)) {
+                disallowedFunctions.add(functionName);
+            }
+            return super.visit(function, context);
+        }
+
+        @Override
+        public <S> Void visit(UserVariable variable, S context) {
+            variables = true;
+            return super.visit(variable, context);
+        }
+
+        @Override
+        public <S> Void visit(NextValExpression sequence, S context) {
+            variables = true;
+            return super.visit(sequence, context);
+        }
+
+        @Override
+        public <S> Void visit(PlainSelect select, S context) {
+            if ((select.getIntoTables() != null && !select.getIntoTables().isEmpty())
+                    || select.getIntoTempTable() != null) {
+                outputOperation = true;
+            }
+            return super.visit(select, context);
+        }
+
+        Set<String> disallowedFunctions() {
+            return disallowedFunctions;
+        }
+
+        boolean hasVariables() {
+            return variables;
+        }
+
+        boolean hasOutputOperation() {
+            return outputOperation;
+        }
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/QueryByExampleSqlValidator.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/QueryByExampleSqlValidator.java
@@ -215,18 +215,16 @@ public final class QueryByExampleSqlValidator {
                 quote = sqlQuoteDelimiter(current);
                 stripped.append(quote == '\0' ? current : ' ');
                 i++;
-                continue;
-            }
-            if (current == quote && next == quote) {
+            } else if (current == quote && next == quote) {
                 stripped.append("  ");
                 i += 2;
-                continue;
+            } else {
+                if (current == quote) {
+                    quote = '\0';
+                }
+                stripped.append(' ');
+                i++;
             }
-            if (current == quote) {
-                quote = '\0';
-            }
-            stripped.append(' ');
-            i++;
         }
         return stripped.toString();
     }

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/QueryByExampleSqlValidator.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/QueryByExampleSqlValidator.java
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.report.data;
+
+import java.sql.SQLException;
+import java.util.Locale;
+import java.util.Properties;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import io.github.carlos_emr.carlos.db.LegacyJdbcQuery;
+import net.sf.jsqlparser.JSQLParserException;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.statement.Statement;
+import net.sf.jsqlparser.statement.select.Select;
+import net.sf.jsqlparser.statement.select.SetOperationList;
+import net.sf.jsqlparser.util.TablesNamesFinder;
+
+/** Fail-closed validation for request-submitted Query-by-Example SQL. */
+public final class QueryByExampleSqlValidator {
+    private static final Pattern LOCKING_SELECT = Pattern.compile(
+            "\\bfor\\s+(?:update|share)\\b|\\block\\s+in\\s+share\\s+mode\\b",
+            Pattern.CASE_INSENSITIVE);
+    private static final Pattern OUTPUT_OPERATION = Pattern.compile("\\binto\\b", Pattern.CASE_INSENSITIVE);
+    private static final Set<String> BLOCKED_FUNCTIONS = Set.of(
+            "sleep", "benchmark", "get_lock", "release_lock", "is_free_lock", "load_file");
+
+    private QueryByExampleSqlValidator() {
+    }
+
+    public static LegacyJdbcQuery.TrustedSql validate(String sql, Properties properties)
+            throws QueryByExampleValidationException {
+        LegacyJdbcQuery.TrustedSql trustedSql;
+        try {
+            trustedSql = LegacyJdbcQuery.trustedSelectSql(sql);
+        } catch (SQLException e) {
+            throw new QueryByExampleValidationException(e.getMessage(), e);
+        }
+
+        Statement statement;
+        try {
+            statement = CCJSqlParserUtil.parse(sql);
+        } catch (JSQLParserException | RuntimeException e) {
+            throw new QueryByExampleValidationException("The query could not be parsed as a single SELECT", e);
+        }
+
+        if (!(statement instanceof Select) || statement instanceof SetOperationList) {
+            throw new QueryByExampleValidationException("Only one SELECT statement is allowed");
+        }
+
+        String sqlWithoutStringLiterals = stripStringLiterals(sql);
+        if (LOCKING_SELECT.matcher(sqlWithoutStringLiterals).find()) {
+            throw new QueryByExampleValidationException("Locking SELECT statements are not allowed");
+        }
+        if (OUTPUT_OPERATION.matcher(sqlWithoutStringLiterals).find()) {
+            throw new QueryByExampleValidationException("SELECT output operations are not allowed");
+        }
+        rejectBlockedFunctions(sqlWithoutStringLiterals);
+        rejectOtherSchemas(statement, applicationSchema(properties));
+        return trustedSql;
+    }
+
+    static String applicationSchema(Properties properties) throws QueryByExampleValidationException {
+        String configuredName = properties == null ? null : properties.getProperty("db_name");
+        if (configuredName == null || configuredName.isBlank()) {
+            throw new QueryByExampleValidationException("The application database schema is not configured");
+        }
+        String schema = configuredName.split("\\?", 2)[0].trim();
+        if (schema.isEmpty()) {
+            throw new QueryByExampleValidationException("The application database schema is not configured");
+        }
+        return unquoteIdentifier(schema);
+    }
+
+    private static void rejectOtherSchemas(Statement statement, String applicationSchema)
+            throws QueryByExampleValidationException {
+        Set<String> tables = new TablesNamesFinder<Void>().getTables(statement);
+        for (String table : tables) {
+            String normalizedTable = unquoteIdentifier(table);
+            int lastDot = normalizedTable.lastIndexOf('.');
+            if (lastDot > 0) {
+                String qualifier = normalizedTable.substring(0, lastDot);
+                if (!qualifier.equalsIgnoreCase(applicationSchema)) {
+                    throw new QueryByExampleValidationException("Queries may only read the application database schema");
+                }
+            }
+        }
+    }
+
+    private static void rejectBlockedFunctions(String sql) throws QueryByExampleValidationException {
+        String normalized = sql.toLowerCase(Locale.ROOT);
+        for (String function : BLOCKED_FUNCTIONS) {
+            Pattern invocation = Pattern.compile("(?<![a-z0-9_$])`?" + Pattern.quote(function)
+                    + "`?\\s*\\(", Pattern.CASE_INSENSITIVE);
+            if (invocation.matcher(normalized).find()) {
+                throw new QueryByExampleValidationException("The query uses a prohibited database function");
+            }
+        }
+    }
+
+    private static String stripStringLiterals(String sql) {
+        StringBuilder stripped = new StringBuilder(sql.length());
+        char quote = '\0';
+        for (int i = 0; i < sql.length(); i++) {
+            char current = sql.charAt(i);
+            char next = i + 1 < sql.length() ? sql.charAt(i + 1) : '\0';
+            if (quote == '\0') {
+                if (current == '\'' || current == '"') {
+                    quote = current;
+                    stripped.append(' ');
+                } else {
+                    stripped.append(current);
+                }
+            } else if (current == '\\' && next != '\0') {
+                stripped.append("  ");
+                i++;
+            } else if (current == quote && next == quote) {
+                stripped.append("  ");
+                i++;
+            } else if (current == quote) {
+                quote = '\0';
+                stripped.append(' ');
+            } else {
+                stripped.append(' ');
+            }
+        }
+        return stripped.toString();
+    }
+
+    private static String unquoteIdentifier(String identifier) {
+        return identifier.replace("`", "").replace("\"", "").trim();
+    }
+}

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/QueryByExampleSqlValidator.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/QueryByExampleSqlValidator.java
@@ -209,19 +209,24 @@ public final class QueryByExampleSqlValidator {
             throw new QueryByExampleValidationException("The query uses a function outside the allowed set");
         }
         for (String table : tables) {
-            String normalizedTable = unquoteIdentifier(table);
-            int lastDot = normalizedTable.lastIndexOf('.');
-            if (lastDot > 0) {
-                String qualifier = normalizedTable.substring(0, lastDot);
-                if (!canonicalIdentifier(qualifier).equals(canonicalIdentifier(applicationSchema))) {
-                    throw new QueryByExampleValidationException("Queries may only read the application database schema");
-                }
+            rejectUnsafeTableReference(table, applicationSchema);
+        }
+    }
+
+    private static void rejectUnsafeTableReference(String table, String applicationSchema)
+            throws QueryByExampleValidationException {
+        String normalizedTable = unquoteIdentifier(table);
+        int lastDot = normalizedTable.lastIndexOf('.');
+        if (lastDot > 0) {
+            String qualifier = normalizedTable.substring(0, lastDot);
+            if (!canonicalIdentifier(qualifier).equals(canonicalIdentifier(applicationSchema))) {
+                throw new QueryByExampleValidationException("Queries may only read the application database schema");
             }
-            String unqualifiedTable = lastDot >= 0 ? normalizedTable.substring(lastDot + 1) : normalizedTable;
-            if (SECURITY_SENSITIVE_TABLES.contains(canonicalIdentifier(unqualifiedTable))) {
-                throw new QueryByExampleValidationException(
-                        "Queries may not read tables containing authentication secrets");
-            }
+        }
+        String unqualifiedTable = lastDot >= 0 ? normalizedTable.substring(lastDot + 1) : normalizedTable;
+        if (SECURITY_SENSITIVE_TABLES.contains(canonicalIdentifier(unqualifiedTable))) {
+            throw new QueryByExampleValidationException(
+                    "Queries may not read tables containing authentication secrets");
         }
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/QueryByExampleSqlValidator.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/QueryByExampleSqlValidator.java
@@ -62,6 +62,30 @@ public final class QueryByExampleSqlValidator {
             "\\b(?:into|procedure)\\b", Pattern.CASE_INSENSITIVE);
 
     /**
+     * Tables containing reusable authentication material or private cryptographic keys.
+     * Query-by-Example is a reporting surface, so even administrators must use the
+     * purpose-built management flows rather than exporting these records as report data.
+     */
+    private static final Set<String> SECURITY_SENSITIVE_TABLES = Set.of(
+            "appdefinition",
+            "appuser",
+            "emailconfig",
+            "emaillog",
+            "fax_config",
+            "oscarcommlocations",
+            "oscarkeys",
+            "professionalspecialists",
+            "property",
+            "publickeys",
+            "security",
+            "securityarchive",
+            "securitytoken",
+            "serviceaccesstoken",
+            "serviceclient",
+            "serviceoauthnonce",
+            "servicerequesttoken");
+
+    /**
      * Reporting-safe built-ins. Anything not listed is rejected so stored functions and
      * newly introduced vendor functions cannot silently cross the validation boundary.
      */
@@ -74,11 +98,11 @@ public final class QueryByExampleSqlValidator {
             "dayofweek", "dayofyear", "degrees", "elt", "exp", "field", "find_in_set", "floor", "format",
             "from_base64", "from_days", "from_unixtime", "get_format", "greatest", "hex", "hour", "if",
             "ifnull", "instr", "lcase", "least", "left", "length", "ln", "localtime", "localtimestamp",
-            "locate", "log", "log10", "log2", "lower", "lpad", "ltrim", "makedate", "maketime", "max",
+            "locate", "log", "log10", "log2", "lower", "ltrim", "makedate", "maketime", "max",
             "md5", "microsecond", "mid", "min", "minute", "mod", "month", "monthname", "now", "nullif",
             "oct", "octet_length", "ord", "period_add", "period_diff", "pi", "pow", "power", "quarter",
-            "quote", "radians", "rand", "repeat", "replace", "reverse", "right", "round", "rpad", "rtrim",
-            "sec_to_time", "second", "sha", "sha1", "sha2", "sign", "sin", "soundex", "space", "sqrt",
+            "quote", "radians", "rand", "replace", "reverse", "right", "round", "rtrim", "sec_to_time",
+            "second", "sha", "sha1", "sha2", "sign", "sin", "soundex", "sqrt",
             "std", "stddev", "stddev_pop", "stddev_samp", "str_to_date", "strcmp", "subdate", "substr",
             "substring", "substring_index", "subtime", "sum", "sysdate", "tan", "time", "time_format",
             "time_to_sec", "timediff", "timestamp", "timestampadd", "timestampdiff", "to_base64", "to_days",
@@ -192,6 +216,11 @@ public final class QueryByExampleSqlValidator {
                 if (!canonicalIdentifier(qualifier).equals(canonicalIdentifier(applicationSchema))) {
                     throw new QueryByExampleValidationException("Queries may only read the application database schema");
                 }
+            }
+            String unqualifiedTable = lastDot >= 0 ? normalizedTable.substring(lastDot + 1) : normalizedTable;
+            if (SECURITY_SENSITIVE_TABLES.contains(canonicalIdentifier(unqualifiedTable))) {
+                throw new QueryByExampleValidationException(
+                        "Queries may not read tables containing authentication secrets");
             }
         }
     }

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/QueryByExampleSqlValidator.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/QueryByExampleSqlValidator.java
@@ -22,6 +22,7 @@
 package io.github.carlos_emr.carlos.report.data;
 
 import java.sql.SQLException;
+import java.util.Locale;
 import java.util.Properties;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -105,7 +106,7 @@ public final class QueryByExampleSqlValidator {
             int lastDot = normalizedTable.lastIndexOf('.');
             if (lastDot > 0) {
                 String qualifier = normalizedTable.substring(0, lastDot);
-                if (!qualifier.equalsIgnoreCase(applicationSchema)) {
+                if (!canonicalIdentifier(qualifier).equals(canonicalIdentifier(applicationSchema))) {
                     throw new QueryByExampleValidationException("Queries may only read the application database schema");
                 }
             }
@@ -149,5 +150,9 @@ public final class QueryByExampleSqlValidator {
 
     private static String unquoteIdentifier(String identifier) {
         return identifier.replace("`", "").replace("\"", "").trim();
+    }
+
+    private static String canonicalIdentifier(String identifier) {
+        return identifier.toLowerCase(Locale.ROOT);
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/QueryByExampleSqlValidator.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/QueryByExampleSqlValidator.java
@@ -36,6 +36,7 @@ import net.sf.jsqlparser.expression.NextValExpression;
 import net.sf.jsqlparser.expression.UserVariable;
 import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import net.sf.jsqlparser.statement.Statement;
+import net.sf.jsqlparser.statement.select.ParenthesedSelect;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 import net.sf.jsqlparser.statement.select.Select;
 import net.sf.jsqlparser.statement.select.SetOperationList;
@@ -117,7 +118,7 @@ public final class QueryByExampleSqlValidator {
             throw new QueryByExampleValidationException("The query could not be parsed as a single SELECT", e);
         }
 
-        if (!(statement instanceof Select select) || select instanceof SetOperationList) {
+        if (!(statement instanceof Select select) || containsSetOperation(select)) {
             throw new QueryByExampleValidationException("Only one SELECT statement is allowed");
         }
 
@@ -160,6 +161,12 @@ public final class QueryByExampleSqlValidator {
         if (visitor.hasOutputOperation()) {
             throw new QueryByExampleValidationException("SELECT output operations are not allowed");
         }
+        if (visitor.hasLockingOperation()) {
+            throw new QueryByExampleValidationException("Locking SELECT statements are not allowed");
+        }
+        if (visitor.hasSetOperation()) {
+            throw new QueryByExampleValidationException("Set operations are not allowed");
+        }
         if (visitor.hasVariables()) {
             throw new QueryByExampleValidationException("Session and system variables are not allowed");
         }
@@ -178,6 +185,14 @@ public final class QueryByExampleSqlValidator {
         }
     }
 
+    private static boolean containsSetOperation(Select select) {
+        if (select instanceof SetOperationList) {
+            return true;
+        }
+        return select instanceof ParenthesedSelect parenthesedSelect
+                && containsSetOperation(parenthesedSelect.getSelect());
+    }
+
     private static String stripQuotedSections(String sql) {
         StringBuilder stripped = new StringBuilder(sql.length());
         char quote = '\0';
@@ -191,9 +206,6 @@ public final class QueryByExampleSqlValidator {
                 } else {
                     stripped.append(current);
                 }
-            } else if (quote != '`' && current == '\\' && next != '\0') {
-                stripped.append("  ");
-                i++;
             } else if (current == quote && next == quote) {
                 stripped.append("  ");
                 i++;
@@ -219,6 +231,8 @@ public final class QueryByExampleSqlValidator {
         private final Set<String> disallowedFunctions = new java.util.HashSet<>();
         private boolean variables;
         private boolean outputOperation;
+        private boolean lockingOperation;
+        private boolean setOperation;
 
         @Override
         public <S> Void visit(Function function, S context) {
@@ -257,7 +271,18 @@ public final class QueryByExampleSqlValidator {
                     || select.getIntoTempTable() != null) {
                 outputOperation = true;
             }
+            if (select.getForMode() != null || select.getForClause() != null
+                    || select.getForUpdateTable() != null || select.isSkipLocked()
+                    || select.isNoWait() || select.getWait() != null) {
+                lockingOperation = true;
+            }
             return super.visit(select, context);
+        }
+
+        @Override
+        public <S> Void visit(SetOperationList operations, S context) {
+            setOperation = true;
+            return super.visit(operations, context);
         }
 
         Set<String> disallowedFunctions() {
@@ -270,6 +295,14 @@ public final class QueryByExampleSqlValidator {
 
         boolean hasOutputOperation() {
             return outputOperation;
+        }
+
+        boolean hasLockingOperation() {
+            return lockingOperation;
+        }
+
+        boolean hasSetOperation() {
+            return setOperation;
         }
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/QueryByExampleSqlValidator.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/QueryByExampleSqlValidator.java
@@ -212,26 +212,27 @@ public final class QueryByExampleSqlValidator {
             char current = sql.charAt(i);
             char next = i + 1 < sql.length() ? sql.charAt(i + 1) : '\0';
             if (quote == '\0') {
-                if (current == '\'' || current == '"' || current == '`') {
-                    quote = current;
-                    stripped.append(' ');
-                } else {
-                    stripped.append(current);
-                }
-            } else {
-                if (current == quote && next == quote) {
-                    stripped.append("  ");
-                    i += 2;
-                    continue;
-                }
-                if (current == quote) {
-                    quote = '\0';
-                }
-                stripped.append(' ');
+                quote = sqlQuoteDelimiter(current);
+                stripped.append(quote == '\0' ? current : ' ');
+                i++;
+                continue;
             }
+            if (current == quote && next == quote) {
+                stripped.append("  ");
+                i += 2;
+                continue;
+            }
+            if (current == quote) {
+                quote = '\0';
+            }
+            stripped.append(' ');
             i++;
         }
         return stripped.toString();
+    }
+
+    private static char sqlQuoteDelimiter(char candidate) {
+        return candidate == '\'' || candidate == '"' || candidate == '`' ? candidate : '\0';
     }
 
     private static String unquoteIdentifier(String identifier) {

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/QueryByExampleValidationException.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/QueryByExampleValidationException.java
@@ -29,6 +29,8 @@ import java.sql.SQLException;
  * @since 2026-08-06
  */
 public class QueryByExampleValidationException extends SQLException {
+    private static final long serialVersionUID = 1L;
+
     /**
      * Creates a validation exception with a user-safe diagnostic message.
      *

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/QueryByExampleValidationException.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/QueryByExampleValidationException.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.report.data;
+
+import java.sql.SQLException;
+
+/** Indicates that a Query-by-Example submission was rejected before execution. */
+public class QueryByExampleValidationException extends SQLException {
+    public QueryByExampleValidationException(String message) {
+        super(message);
+    }
+
+    public QueryByExampleValidationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/QueryByExampleValidationException.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/QueryByExampleValidationException.java
@@ -23,12 +23,27 @@ package io.github.carlos_emr.carlos.report.data;
 
 import java.sql.SQLException;
 
-/** Indicates that a Query-by-Example submission was rejected before execution. */
+/**
+ * Indicates that a Query-by-Example submission was rejected before execution.
+ *
+ * @since 2026-08-06
+ */
 public class QueryByExampleValidationException extends SQLException {
+    /**
+     * Creates a validation exception with a user-safe diagnostic message.
+     *
+     * @param message description of why validation failed
+     */
     public QueryByExampleValidationException(String message) {
         super(message);
     }
 
+    /**
+     * Creates a validation exception retaining the parser or validation failure.
+     *
+     * @param message description of why validation failed
+     * @param cause underlying parser or SQL validation failure
+     */
     public QueryByExampleValidationException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/RptByExampleData.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/RptByExampleData.java
@@ -81,38 +81,8 @@ public class RptByExampleData {
         int rowCount = 0;
         try {
             LegacyJdbcQuery.TrustedSql trustedSql = QueryByExampleSqlValidator.validate(sql, properties);
-            QueryResult queryResult;
-            try (Connection connection = connectionProvider.getConnection()) {
-                boolean originalReadOnly = connection.isReadOnly();
-                Exception executionFailure = null;
-                try {
-                    connection.setReadOnly(true);
-                    try (PreparedStatement statement = prepareValidatedStatement(connection, trustedSql)) {
-                        statement.setMaxRows(MAX_ROWS + 1);
-                        statement.setQueryTimeout(QUERY_TIMEOUT_SECONDS);
-                        try (ResultSet resultSet = statement.executeQuery()) {
-                            RptResultStruct.StructuredResult structured = RptResultStruct.getStructureWithCount(
-                                    resultSet, MAX_OUTPUT_CHARACTERS, MAX_ROWS);
-                            rowCount = structured.rowCount();
-                            queryResult = new QueryResult(structured.html(), rowCount, structured.truncated(),
-                                    structured.rowLimitReached(), 0);
-                        }
-                    }
-                } catch (SQLException | RuntimeException e) {
-                    executionFailure = e;
-                    throw e;
-                } finally {
-                    try {
-                        connection.setReadOnly(originalReadOnly);
-                    } catch (SQLException restoreFailure) {
-                        if (executionFailure != null) {
-                            executionFailure.addSuppressed(restoreFailure);
-                        } else {
-                            throw restoreFailure;
-                        }
-                    }
-                }
-            }
+            QueryResult queryResult = executeWithConnection(trustedSql);
+            rowCount = queryResult.rowCount();
             outcome = "success";
             return new QueryResult(queryResult.html(), queryResult.rowCount(), queryResult.truncated(),
                     queryResult.rowLimitReached(), elapsedMillis(startedAt));
@@ -143,6 +113,61 @@ public class RptByExampleData {
                 ResultSet.CONCUR_READ_ONLY); // nosemgrep: java.lang.security.audit.formatted-sql-string-deepsemgrep.formatted-sql-string-deepsemgrep -- validated TrustedSql boundary
     }
 
+    private QueryResult executeWithConnection(LegacyJdbcQuery.TrustedSql trustedSql) throws SQLException {
+        try (Connection connection = connectionProvider.getConnection()) {
+            return executeValidatedQuery(connection, trustedSql);
+        }
+    }
+
+    private static QueryResult executeValidatedQuery(Connection connection, LegacyJdbcQuery.TrustedSql trustedSql)
+            throws SQLException {
+        boolean originalReadOnly = connection.isReadOnly();
+        try {
+            connection.setReadOnly(true);
+        } catch (SQLException setupFailure) {
+            restoreReadOnlyAfterFailure(connection, originalReadOnly, setupFailure);
+            throw setupFailure;
+        }
+        QueryResult result;
+        try {
+            result = executeStatement(connection, trustedSql);
+        } catch (SQLException | RuntimeException executionFailure) {
+            restoreReadOnlyAfterFailure(connection, originalReadOnly, executionFailure);
+            throw executionFailure;
+        }
+        connection.setReadOnly(originalReadOnly);
+        return result;
+    }
+
+    private static QueryResult executeStatement(Connection connection, LegacyJdbcQuery.TrustedSql trustedSql)
+            throws SQLException {
+        try (PreparedStatement statement = prepareValidatedStatement(connection, trustedSql)) {
+            statement.setMaxRows(MAX_ROWS + 1);
+            statement.setQueryTimeout(QUERY_TIMEOUT_SECONDS);
+            return readStatementResult(statement);
+        }
+    }
+
+    private static QueryResult readStatementResult(PreparedStatement statement) throws SQLException {
+        try (ResultSet resultSet = statement.executeQuery()) {
+            RptResultStruct.StructuredResult structured = RptResultStruct.getStructureWithCount(
+                    resultSet, MAX_OUTPUT_CHARACTERS, MAX_ROWS);
+            return new QueryResult(structured.html(), structured.rowCount(), structured.truncated(),
+                    structured.rowLimitReached(), 0);
+        }
+    }
+
+    private static void restoreReadOnlyAfterFailure(Connection connection, boolean originalReadOnly,
+            Exception executionFailure) {
+        try {
+            connection.setReadOnly(originalReadOnly);
+        } catch (SQLException restoreFailure) {
+            if (restoreFailure != executionFailure) {
+                executionFailure.addSuppressed(restoreFailure);
+            }
+        }
+    }
+
     public static void audit(String providerNo, String sql, long durationMillis, int rowCount, String outcome) {
         String query = sql == null ? "" : sql;
         String queryHash = queryHash(query);
@@ -156,9 +181,11 @@ public class RptByExampleData {
     }
 
     private static void logFailure(String providerNo, String sql, String sqlState, String exceptionType) {
-        MiscUtils.getLogger().warn(
-                "Query-by-Example failure provider={} queryHash={} sqlState={} exceptionType={}",
-                providerNo, queryHash(sql), sqlState, exceptionType);
+        if (MiscUtils.getLogger().isWarnEnabled()) {
+            MiscUtils.getLogger().warn(
+                    "Query-by-Example failure provider={} queryHash={} sqlState={} exceptionType={}",
+                    providerNo, queryHash(sql), sqlState, exceptionType);
+        }
     }
 
     private static String queryHash(String sql) {

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/RptByExampleData.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/RptByExampleData.java
@@ -84,6 +84,20 @@ public class RptByExampleData {
         this.connectionProvider = connectionProvider;
     }
 
+    /**
+     * Validates and executes one bounded, read-only Query-by-Example submission.
+     * The outcome and elapsed time are audited in all cases; raw SQL text is not
+     * included in the audit event.
+     *
+     * @param sql request-submitted SQL; only one validated {@code SELECT} is permitted
+     * @param properties application properties used to resolve the allowed database schema
+     * @param providerNo requesting provider identifier used for audit metadata
+     * @return the encoded, size-bounded query result
+     * @throws QueryByExampleValidationException if the SQL fails structural validation
+     * @throws SQLTimeoutException if execution exceeds {@link #QUERY_TIMEOUT_SECONDS}
+     * @throws SQLException if the query or JDBC resource handling fails
+     * @throws RuntimeException if an unexpected validation, execution, or rendering failure occurs
+     */
     @SuppressFBWarnings(
             value = "THROWS_METHOD_THROWS_RUNTIMEEXCEPTION",
             justification = "Runtime failures are audited and handled by the action")

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/RptByExampleData.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/RptByExampleData.java
@@ -58,7 +58,8 @@ public class RptByExampleData {
         Connection getConnection() throws SQLException;
     }
 
-    public record QueryResult(String html, int rowCount, boolean truncated, long durationMillis) {
+    public record QueryResult(String html, int rowCount, boolean truncated, boolean rowLimitReached,
+            long durationMillis) {
     }
 
     private final ConnectionProvider connectionProvider;
@@ -87,13 +88,14 @@ public class RptByExampleData {
                 try {
                     connection.setReadOnly(true);
                     try (PreparedStatement statement = prepareValidatedStatement(connection, trustedSql)) {
-                        statement.setMaxRows(MAX_ROWS);
+                        statement.setMaxRows(MAX_ROWS + 1);
                         statement.setQueryTimeout(QUERY_TIMEOUT_SECONDS);
                         try (ResultSet resultSet = statement.executeQuery()) {
                             RptResultStruct.StructuredResult structured = RptResultStruct.getStructureWithCount(
-                                    resultSet, MAX_OUTPUT_CHARACTERS);
+                                    resultSet, MAX_OUTPUT_CHARACTERS, MAX_ROWS);
                             rowCount = structured.rowCount();
-                            queryResult = new QueryResult(structured.html(), rowCount, structured.truncated(), 0);
+                            queryResult = new QueryResult(structured.html(), rowCount, structured.truncated(),
+                                    structured.rowLimitReached(), 0);
                         }
                     }
                 } catch (SQLException | RuntimeException e) {
@@ -113,7 +115,7 @@ public class RptByExampleData {
             }
             outcome = "success";
             return new QueryResult(queryResult.html(), queryResult.rowCount(), queryResult.truncated(),
-                    elapsedMillis(startedAt));
+                    queryResult.rowLimitReached(), elapsedMillis(startedAt));
         } catch (QueryByExampleValidationException e) {
             outcome = "rejected";
             throw e;

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/RptByExampleData.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/RptByExampleData.java
@@ -76,6 +76,7 @@ public class RptByExampleData {
             QueryResult queryResult;
             try (Connection connection = connectionProvider.getConnection()) {
                 boolean originalReadOnly = connection.isReadOnly();
+                Exception executionFailure = null;
                 try {
                     connection.setReadOnly(true);
                     // codeql[java/sql-injection] -- TrustedSql is created only after structural SELECT validation.
@@ -89,8 +90,19 @@ public class RptByExampleData {
                             queryResult = new QueryResult(structured.html(), rowCount);
                         }
                     }
+                } catch (SQLException | RuntimeException e) {
+                    executionFailure = e;
+                    throw e;
                 } finally {
-                    connection.setReadOnly(originalReadOnly);
+                    try {
+                        connection.setReadOnly(originalReadOnly);
+                    } catch (SQLException restoreFailure) {
+                        if (executionFailure != null) {
+                            executionFailure.addSuppressed(restoreFailure);
+                        } else {
+                            throw restoreFailure;
+                        }
+                    }
                 }
             }
             outcome = "success";
@@ -101,6 +113,12 @@ public class RptByExampleData {
         } catch (SQLTimeoutException e) {
             outcome = "timeout";
             throw e;
+        } catch (SQLException e) {
+            logFailure(providerNo, sql, e.getSQLState(), e.getClass().getSimpleName());
+            throw e;
+        } catch (RuntimeException e) {
+            logFailure(providerNo, sql, null, e.getClass().getSimpleName());
+            throw e;
         } finally {
             audit(providerNo, sql, elapsedMillis(startedAt), rowCount, outcome);
         }
@@ -108,7 +126,7 @@ public class RptByExampleData {
 
     public static void audit(String providerNo, String sql, long durationMillis, int rowCount, String outcome) {
         String query = sql == null ? "" : sql;
-        String queryHash = DigestUtils.sha256Hex(query);
+        String queryHash = queryHash(query);
         MiscUtils.getLogger().info(
                 "Query-by-Example audit provider={} queryHash={} queryLength={} durationMs={} rowCount={} outcome={}",
                 providerNo, queryHash, query.length(), durationMillis, rowCount, outcome);
@@ -116,5 +134,15 @@ public class RptByExampleData {
 
     private static long elapsedMillis(long startedAt) {
         return (System.nanoTime() - startedAt) / 1_000_000L;
+    }
+
+    private static void logFailure(String providerNo, String sql, String sqlState, String exceptionType) {
+        MiscUtils.getLogger().warn(
+                "Query-by-Example failure provider={} queryHash={} sqlState={} exceptionType={}",
+                providerNo, queryHash(sql), sqlState, exceptionType);
+    }
+
+    private static String queryHash(String sql) {
+        return DigestUtils.sha256Hex(sql == null ? "" : sql);
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/RptByExampleData.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/RptByExampleData.java
@@ -39,6 +39,7 @@ import java.util.Properties;
 
 import org.apache.commons.codec.digest.DigestUtils;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.github.carlos_emr.carlos.db.LegacyJdbcQuery;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 
@@ -67,6 +68,13 @@ public class RptByExampleData {
         this.connectionProvider = connectionProvider;
     }
 
+    @SuppressFBWarnings(
+            value = {
+                    "SQL_INJECTION_JDBC",
+                    "SQL_PREPARED_STATEMENT_GENERATED_FROM_NONCONSTANT_STRING",
+                    "THROWS_METHOD_THROWS_RUNTIMEEXCEPTION"
+            },
+            justification = "Validated dynamic SQL is intentional; runtime failures are audited and handled by the action")
     public QueryResult execute(String sql, Properties properties, String providerNo) throws SQLException {
         long startedAt = System.nanoTime();
         String outcome = "failed";

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/RptByExampleData.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/RptByExampleData.java
@@ -50,6 +50,7 @@ import io.github.carlos_emr.carlos.utility.MiscUtils;
  */
 public class RptByExampleData {
     public static final int MAX_ROWS = 1_000;
+    public static final int MAX_OUTPUT_CHARACTERS = 1_000_000;
     public static final int QUERY_TIMEOUT_SECONDS = 15;
 
     @FunctionalInterface
@@ -57,7 +58,7 @@ public class RptByExampleData {
         Connection getConnection() throws SQLException;
     }
 
-    public record QueryResult(String html, int rowCount) {
+    public record QueryResult(String html, int rowCount, boolean truncated, long durationMillis) {
     }
 
     private final ConnectionProvider connectionProvider;
@@ -71,12 +72,8 @@ public class RptByExampleData {
     }
 
     @SuppressFBWarnings(
-            value = {
-                    "SQL_INJECTION_JDBC",
-                    "SQL_PREPARED_STATEMENT_GENERATED_FROM_NONCONSTANT_STRING",
-                    "THROWS_METHOD_THROWS_RUNTIMEEXCEPTION"
-            },
-            justification = "Validated dynamic SQL is intentional; runtime failures are audited and handled by the action")
+            value = "THROWS_METHOD_THROWS_RUNTIMEEXCEPTION",
+            justification = "Runtime failures are audited and handled by the action")
     public QueryResult execute(String sql, Properties properties, String providerNo) throws SQLException {
         long startedAt = System.nanoTime();
         String outcome = "failed";
@@ -89,15 +86,14 @@ public class RptByExampleData {
                 Exception executionFailure = null;
                 try {
                     connection.setReadOnly(true);
-                    // codeql[java/sql-injection] -- TrustedSql is created only after structural SELECT validation.
-                    try (PreparedStatement statement = connection.prepareStatement(trustedSql.sql(),
-                            ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY)) { // nosemgrep: java.lang.security.audit.formatted-sql-string-deepsemgrep.formatted-sql-string-deepsemgrep -- validated TrustedSql boundary
+                    try (PreparedStatement statement = prepareValidatedStatement(connection, trustedSql)) {
                         statement.setMaxRows(MAX_ROWS);
                         statement.setQueryTimeout(QUERY_TIMEOUT_SECONDS);
-                        try (ResultSet resultSet = statement.executeQuery()) { // NOSONAR javasecurity:S3649 -- validated, read-only SELECT boundary
-                            RptResultStruct.StructuredResult structured = RptResultStruct.getStructureWithCount(resultSet);
+                        try (ResultSet resultSet = statement.executeQuery()) {
+                            RptResultStruct.StructuredResult structured = RptResultStruct.getStructureWithCount(
+                                    resultSet, MAX_OUTPUT_CHARACTERS);
                             rowCount = structured.rowCount();
-                            queryResult = new QueryResult(structured.html(), rowCount);
+                            queryResult = new QueryResult(structured.html(), rowCount, structured.truncated(), 0);
                         }
                     }
                 } catch (SQLException | RuntimeException e) {
@@ -116,7 +112,8 @@ public class RptByExampleData {
                 }
             }
             outcome = "success";
-            return queryResult;
+            return new QueryResult(queryResult.html(), queryResult.rowCount(), queryResult.truncated(),
+                    elapsedMillis(startedAt));
         } catch (QueryByExampleValidationException e) {
             outcome = "rejected";
             throw e;
@@ -132,6 +129,16 @@ public class RptByExampleData {
         } finally {
             audit(providerNo, sql, elapsedMillis(startedAt), rowCount, outcome);
         }
+    }
+
+    @SuppressFBWarnings(
+            value = {"SQL_INJECTION_JDBC", "SQL_PREPARED_STATEMENT_GENERATED_FROM_NONCONSTANT_STRING"},
+            justification = "This narrow sink accepts only TrustedSql created by structural SELECT validation")
+    private static PreparedStatement prepareValidatedStatement(Connection connection,
+            LegacyJdbcQuery.TrustedSql trustedSql) throws SQLException {
+        // codeql[java/sql-injection] -- TrustedSql is created only after structural SELECT validation.
+        return connection.prepareStatement(trustedSql.sql(), ResultSet.TYPE_FORWARD_ONLY,
+                ResultSet.CONCUR_READ_ONLY); // nosemgrep: java.lang.security.audit.formatted-sql-string-deepsemgrep.formatted-sql-string-deepsemgrep -- validated TrustedSql boundary
     }
 
     public static void audit(String providerNo, String sql, long durationMillis, int rowCount, String outcome) {

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/RptByExampleData.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/RptByExampleData.java
@@ -93,10 +93,10 @@ public class RptByExampleData {
         ExecutionProgress progress = new ExecutionProgress();
         try {
             LegacyJdbcQuery.TrustedSql trustedSql = QueryByExampleSqlValidator.validate(sql, properties);
-            QueryResult queryResult = executeWithConnection(trustedSql, progress);
+            RptResultStruct.StructuredResult structured = executeWithConnection(trustedSql, progress);
             outcome = "success";
-            return new QueryResult(queryResult.html(), queryResult.rowCount(), queryResult.truncated(),
-                    queryResult.rowLimitReached(), elapsedMillis(startedAt));
+            return new QueryResult(structured.html(), structured.rowCount(), structured.truncated(),
+                    structured.rowLimitReached(), elapsedMillis(startedAt));
         } catch (QueryByExampleValidationException e) {
             outcome = "rejected";
             throw e;
@@ -124,15 +124,16 @@ public class RptByExampleData {
                 ResultSet.CONCUR_READ_ONLY); // nosemgrep: java.lang.security.audit.formatted-sql-string-deepsemgrep.formatted-sql-string-deepsemgrep -- validated TrustedSql boundary
     }
 
-    private QueryResult executeWithConnection(LegacyJdbcQuery.TrustedSql trustedSql, ExecutionProgress progress)
+    private RptResultStruct.StructuredResult executeWithConnection(LegacyJdbcQuery.TrustedSql trustedSql,
+            ExecutionProgress progress)
             throws SQLException {
         try (Connection connection = connectionProvider.getConnection()) {
             return executeValidatedQuery(connection, trustedSql, progress);
         }
     }
 
-    private static QueryResult executeValidatedQuery(Connection connection, LegacyJdbcQuery.TrustedSql trustedSql,
-            ExecutionProgress progress) throws SQLException {
+    private static RptResultStruct.StructuredResult executeValidatedQuery(Connection connection,
+            LegacyJdbcQuery.TrustedSql trustedSql, ExecutionProgress progress) throws SQLException {
         boolean originalReadOnly = connection.isReadOnly();
         try {
             connection.setReadOnly(true);
@@ -140,7 +141,7 @@ public class RptByExampleData {
             restoreReadOnlyAfterFailure(connection, originalReadOnly, setupFailure);
             throw setupFailure;
         }
-        QueryResult result;
+        RptResultStruct.StructuredResult result;
         try {
             result = executeStatement(connection, trustedSql, progress);
         } catch (SQLException | RuntimeException executionFailure) {
@@ -151,8 +152,8 @@ public class RptByExampleData {
         return result;
     }
 
-    private static QueryResult executeStatement(Connection connection, LegacyJdbcQuery.TrustedSql trustedSql,
-            ExecutionProgress progress) throws SQLException {
+    private static RptResultStruct.StructuredResult executeStatement(Connection connection,
+            LegacyJdbcQuery.TrustedSql trustedSql, ExecutionProgress progress) throws SQLException {
         try (PreparedStatement statement = prepareValidatedStatement(connection, trustedSql)) {
             statement.setMaxRows(MAX_ROWS + 1);
             statement.setQueryTimeout(QUERY_TIMEOUT_SECONDS);
@@ -160,14 +161,14 @@ public class RptByExampleData {
         }
     }
 
-    private static QueryResult readStatementResult(PreparedStatement statement, ExecutionProgress progress)
+    private static RptResultStruct.StructuredResult readStatementResult(PreparedStatement statement,
+            ExecutionProgress progress)
             throws SQLException {
         try (ResultSet resultSet = statement.executeQuery()) {
             RptResultStruct.StructuredResult structured = RptResultStruct.getStructureWithCount(
                     resultSet, MAX_OUTPUT_CHARACTERS, MAX_ROWS);
             progress.recordRows(structured.rowCount());
-            return new QueryResult(structured.html(), structured.rowCount(), structured.truncated(),
-                    structured.rowLimitReached(), 0);
+            return structured;
         }
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/RptByExampleData.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/RptByExampleData.java
@@ -62,6 +62,18 @@ public class RptByExampleData {
             long durationMillis) {
     }
 
+    private static final class ExecutionProgress {
+        private int rowCount;
+
+        int rowCount() {
+            return rowCount;
+        }
+
+        void recordRows(int renderedRows) {
+            rowCount = renderedRows;
+        }
+    }
+
     private final ConnectionProvider connectionProvider;
 
     public RptByExampleData() {
@@ -78,11 +90,10 @@ public class RptByExampleData {
     public QueryResult execute(String sql, Properties properties, String providerNo) throws SQLException {
         long startedAt = System.nanoTime();
         String outcome = "failed";
-        int rowCount = 0;
+        ExecutionProgress progress = new ExecutionProgress();
         try {
             LegacyJdbcQuery.TrustedSql trustedSql = QueryByExampleSqlValidator.validate(sql, properties);
-            QueryResult queryResult = executeWithConnection(trustedSql);
-            rowCount = queryResult.rowCount();
+            QueryResult queryResult = executeWithConnection(trustedSql, progress);
             outcome = "success";
             return new QueryResult(queryResult.html(), queryResult.rowCount(), queryResult.truncated(),
                     queryResult.rowLimitReached(), elapsedMillis(startedAt));
@@ -99,7 +110,7 @@ public class RptByExampleData {
             logFailure(providerNo, sql, null, e.getClass().getSimpleName());
             throw e;
         } finally {
-            audit(providerNo, sql, elapsedMillis(startedAt), rowCount, outcome);
+            audit(providerNo, sql, elapsedMillis(startedAt), progress.rowCount(), outcome);
         }
     }
 
@@ -113,24 +124,25 @@ public class RptByExampleData {
                 ResultSet.CONCUR_READ_ONLY); // nosemgrep: java.lang.security.audit.formatted-sql-string-deepsemgrep.formatted-sql-string-deepsemgrep -- validated TrustedSql boundary
     }
 
-    private QueryResult executeWithConnection(LegacyJdbcQuery.TrustedSql trustedSql) throws SQLException {
+    private QueryResult executeWithConnection(LegacyJdbcQuery.TrustedSql trustedSql, ExecutionProgress progress)
+            throws SQLException {
         try (Connection connection = connectionProvider.getConnection()) {
-            return executeValidatedQuery(connection, trustedSql);
+            return executeValidatedQuery(connection, trustedSql, progress);
         }
     }
 
-    private static QueryResult executeValidatedQuery(Connection connection, LegacyJdbcQuery.TrustedSql trustedSql)
-            throws SQLException {
+    private static QueryResult executeValidatedQuery(Connection connection, LegacyJdbcQuery.TrustedSql trustedSql,
+            ExecutionProgress progress) throws SQLException {
         boolean originalReadOnly = connection.isReadOnly();
         try {
             connection.setReadOnly(true);
-        } catch (SQLException setupFailure) {
+        } catch (SQLException | RuntimeException setupFailure) {
             restoreReadOnlyAfterFailure(connection, originalReadOnly, setupFailure);
             throw setupFailure;
         }
         QueryResult result;
         try {
-            result = executeStatement(connection, trustedSql);
+            result = executeStatement(connection, trustedSql, progress);
         } catch (SQLException | RuntimeException executionFailure) {
             restoreReadOnlyAfterFailure(connection, originalReadOnly, executionFailure);
             throw executionFailure;
@@ -139,19 +151,21 @@ public class RptByExampleData {
         return result;
     }
 
-    private static QueryResult executeStatement(Connection connection, LegacyJdbcQuery.TrustedSql trustedSql)
-            throws SQLException {
+    private static QueryResult executeStatement(Connection connection, LegacyJdbcQuery.TrustedSql trustedSql,
+            ExecutionProgress progress) throws SQLException {
         try (PreparedStatement statement = prepareValidatedStatement(connection, trustedSql)) {
             statement.setMaxRows(MAX_ROWS + 1);
             statement.setQueryTimeout(QUERY_TIMEOUT_SECONDS);
-            return readStatementResult(statement);
+            return readStatementResult(statement, progress);
         }
     }
 
-    private static QueryResult readStatementResult(PreparedStatement statement) throws SQLException {
+    private static QueryResult readStatementResult(PreparedStatement statement, ExecutionProgress progress)
+            throws SQLException {
         try (ResultSet resultSet = statement.executeQuery()) {
             RptResultStruct.StructuredResult structured = RptResultStruct.getStructureWithCount(
                     resultSet, MAX_OUTPUT_CHARACTERS, MAX_ROWS);
+            progress.recordRows(structured.rowCount());
             return new QueryResult(structured.html(), structured.rowCount(), structured.truncated(),
                     structured.rowLimitReached(), 0);
         }
@@ -161,7 +175,7 @@ public class RptByExampleData {
             Exception executionFailure) {
         try {
             connection.setReadOnly(originalReadOnly);
-        } catch (SQLException restoreFailure) {
+        } catch (SQLException | RuntimeException restoreFailure) {
             if (restoreFailure != executionFailure) {
                 executionFailure.addSuppressed(restoreFailure);
             }

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/RptByExampleData.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/RptByExampleData.java
@@ -30,64 +30,91 @@
 
 package io.github.carlos_emr.carlos.report.data;
 
-import java.util.ArrayList;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.SQLTimeoutException;
 import java.util.Properties;
 
+import org.apache.commons.codec.digest.DigestUtils;
+
+import io.github.carlos_emr.carlos.db.LegacyJdbcQuery;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 
 /**
  * This classes main function FluReportGenerate collects a group of patients with flu in the last specified date
  */
 public class RptByExampleData {
-    public static final String DIRECT_SQL_DISABLED_MESSAGE =
-            "Direct SQL execution has been disabled. Use curated report templates instead.";
+    public static final int MAX_ROWS = 1_000;
+    public static final int QUERY_TIMEOUT_SECONDS = 15;
 
-    public ArrayList demoList = null;
-    public String sql = "";
-    public String results = null;
-    public String connect = null;
-    Properties oscarVariables = null;
+    @FunctionalInterface
+    interface ConnectionProvider {
+        Connection getConnection() throws SQLException;
+    }
+
+    public record QueryResult(String html, int rowCount) {
+    }
+
+    private final ConnectionProvider connectionProvider;
 
     public RptByExampleData() {
+        this(LegacyJdbcQuery::getConnection);
     }
 
-    public String exampleTextGenerate(String sql, Properties oscarVariables) {
-        return exampleReportGenerate(sql, oscarVariables);
+    RptByExampleData(ConnectionProvider connectionProvider) {
+        this.connectionProvider = connectionProvider;
     }
 
-    public String exampleReportGenerate(String sql, Properties oscarVariables) {
-        if (sql == null || sql.trim().isEmpty()) {
-            return "";
-        }
-
-        this.sql = sql;
-        this.oscarVariables = oscarVariables;
-
-        // Direct request-submitted SQL is deliberately not executed. A
-        // denylist-validated SELECT can still read tables/columns outside the
-        // user's reporting workflow, so this legacy endpoint now preserves the
-        // page contract while blocking the unsafe database boundary.
-        MiscUtils.getLogger().warn("Blocked direct Query-by-Example SQL execution; queryLength={}", sql.length());
-        results = DIRECT_SQL_DISABLED_MESSAGE;
-        return results;
-    }
-
-    public static String replaceSQLString
-            (String oldString, String newString, String inputString) {
-
-        String outputString = "";
-        int i;
-        for (i = 0; i < inputString.length(); i++) {
-            if (!(inputString.regionMatches(true, i, oldString,
-                    0, oldString.length())))
-                outputString += inputString.charAt(i);
-            else {
-                outputString += newString;
-                i += oldString.length() - 1;
+    public QueryResult execute(String sql, Properties properties, String providerNo) throws SQLException {
+        long startedAt = System.nanoTime();
+        String outcome = "failed";
+        int rowCount = 0;
+        try {
+            LegacyJdbcQuery.TrustedSql trustedSql = QueryByExampleSqlValidator.validate(sql, properties);
+            QueryResult queryResult;
+            try (Connection connection = connectionProvider.getConnection()) {
+                boolean originalReadOnly = connection.isReadOnly();
+                try {
+                    connection.setReadOnly(true);
+                    // codeql[java/sql-injection] -- TrustedSql is created only after structural SELECT validation.
+                    try (PreparedStatement statement = connection.prepareStatement(trustedSql.sql(),
+                            ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY)) { // nosemgrep: java.lang.security.audit.formatted-sql-string-deepsemgrep.formatted-sql-string-deepsemgrep -- validated TrustedSql boundary
+                        statement.setMaxRows(MAX_ROWS);
+                        statement.setQueryTimeout(QUERY_TIMEOUT_SECONDS);
+                        try (ResultSet resultSet = statement.executeQuery()) { // NOSONAR javasecurity:S3649 -- validated, read-only SELECT boundary
+                            RptResultStruct.StructuredResult structured = RptResultStruct.getStructureWithCount(resultSet);
+                            rowCount = structured.rowCount();
+                            queryResult = new QueryResult(structured.html(), rowCount);
+                        }
+                    }
+                } finally {
+                    connection.setReadOnly(originalReadOnly);
+                }
             }
+            outcome = "success";
+            return queryResult;
+        } catch (QueryByExampleValidationException e) {
+            outcome = "rejected";
+            throw e;
+        } catch (SQLTimeoutException e) {
+            outcome = "timeout";
+            throw e;
+        } finally {
+            audit(providerNo, sql, elapsedMillis(startedAt), rowCount, outcome);
         }
-        return outputString;
     }
 
+    public static void audit(String providerNo, String sql, long durationMillis, int rowCount, String outcome) {
+        String query = sql == null ? "" : sql;
+        String queryHash = DigestUtils.sha256Hex(query);
+        MiscUtils.getLogger().info(
+                "Query-by-Example audit provider={} queryHash={} queryLength={} durationMs={} rowCount={} outcome={}",
+                providerNo, queryHash, query.length(), durationMillis, rowCount, outcome);
+    }
 
-};
+    private static long elapsedMillis(long startedAt) {
+        return (System.nanoTime() - startedAt) / 1_000_000L;
+    }
+}

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/RptByExampleData.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/RptByExampleData.java
@@ -44,7 +44,9 @@ import io.github.carlos_emr.carlos.db.LegacyJdbcQuery;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 
 /**
- * This classes main function FluReportGenerate collects a group of patients with flu in the last specified date
+ * Validates and executes Query-by-Example SQL for authorized report users.
+ * Queries run read-only with row and timeout limits, and every outcome is audited
+ * without recording the submitted SQL text.
  */
 public class RptByExampleData {
     public static final int MAX_ROWS = 1_000;

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/RptResultStruct.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/RptResultStruct.java
@@ -53,18 +53,14 @@ public class RptResultStruct {
         return getStructureWithCount(rs).html();
     }
 
-    public static StructuredResult getStructureWithCount(ResultSet rs) throws SQLException {
-        
     /**
-    * Generates an HTML table from a ResultSet with enhanced styling for report templates.
-    * Includes proper thead/tbody structure, alternating row classes, and XSS protection.
-    * Each column header and cell value is HTML-encoded using OWASP Encoder.
-    *
-    * `@param` rs the ResultSet containing data to display; must be positioned before the first row
-    * `@return` an HTML string containing a complete table with id="results" 
-    * `@throws` SQLException if a database access error occurs or the ResultSet is closed
-    * `@since` 1.0
-    */
+     * Generates an encoded HTML table and row count from a {@link ResultSet}.
+     *
+     * @param rs result set positioned before its first row
+     * @return encoded table markup and the number of rows rendered
+     * @throws SQLException if the result set cannot be read
+     */
+    public static StructuredResult getStructureWithCount(ResultSet rs) throws SQLException {
 
     // assuming  multiple rows in rs
         StringBuilder sb = new StringBuilder();
@@ -73,28 +69,28 @@ public class RptResultStruct {
 
         int columns = rsmd.getColumnCount();
         String rowColor = "rowColor1";
-        String[] columnNames = new String[columns];
+        String[] columnLabels = new String[columns];
         sb.append("<table id='results'>");
         for (int i = 0; i < columns; i++) {  // for each column in result set
-            columnNames[i] = rsmd.getColumnName(i + 1);
+            columnLabels[i] = rsmd.getColumnLabel(i + 1);
             // put names in array
             // use i+1 or else you're going to get an exception
             //  insert headings for table
             sb.append("<th class='headerColor'>");
-            sb.append(Encode.forHtml(columnNames[i]));
+            sb.append(Encode.forHtml(columnLabels[i]));
             sb.append("</th>");
         }
         int rowCount = 0;
         while (rs.next()) {
             rowCount++;
-            sb.append("<tr class='" + rowColor + "'>");
+            sb.append("<tr class='").append(rowColor).append("'>");
             for (int j = 0; j < columns; j++) {
                 sb.append("<td>");
-                sb.append(Encode.forHtml(Misc.getString(rs, columnNames[j])));
+                sb.append(Encode.forHtml(Misc.getString(rs, j + 1)));
                 sb.append("</td>");
 
             }
-            rowColor = rowColor.compareTo("rowColor1") == 0 ? "rowColor2" : "rowColor1";
+            rowColor = rowColor.equals("rowColor1") ? "rowColor2" : "rowColor1";
             sb.append("</tr>");
         }
         sb.append("</table>");

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/RptResultStruct.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/RptResultStruct.java
@@ -40,13 +40,18 @@ package io.github.carlos_emr.carlos.report.data;
 import io.github.carlos_emr.Misc;
 import org.owasp.encoder.Encode;
 
+import java.io.IOException;
+import java.io.Reader;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 
 public class RptResultStruct {
 
-    public record StructuredResult(String html, int rowCount) {
+    private static final int MIN_OUTPUT_CHARACTERS = 64;
+    private static final int CLOSING_MARKUP_RESERVE = 32;
+
+    public record StructuredResult(String html, int rowCount, boolean truncated) {
     }
     
     public static String getStructure(ResultSet rs) throws SQLException {
@@ -61,40 +66,146 @@ public class RptResultStruct {
      * @throws SQLException if the result set cannot be read
      */
     public static StructuredResult getStructureWithCount(ResultSet rs) throws SQLException {
+        return getStructureWithCount(rs, Integer.MAX_VALUE);
+    }
+
+    /**
+     * Generates an encoded HTML table within a fixed output budget.
+     *
+     * @param rs result set positioned before its first row
+     * @param maxOutputCharacters maximum number of rendered HTML characters
+     * @return encoded table markup, rendered row count, and whether output was truncated
+     * @throws SQLException if the result set cannot be read
+     */
+    public static StructuredResult getStructureWithCount(ResultSet rs, int maxOutputCharacters) throws SQLException {
+        if (maxOutputCharacters < MIN_OUTPUT_CHARACTERS) {
+            throw new IllegalArgumentException("HTML output limit is too small");
+        }
 
     // assuming  multiple rows in rs
-        StringBuilder sb = new StringBuilder();
+        LimitedHtmlBuilder html = new LimitedHtmlBuilder(maxOutputCharacters);
 
         ResultSetMetaData rsmd = rs.getMetaData();
 
         int columns = rsmd.getColumnCount();
         String rowColor = "rowColor1";
-        String[] columnLabels = new String[columns];
-        sb.append("<table id='results'>");
+        html.appendMarkup("<table id='results'>");
         for (int i = 0; i < columns; i++) {  // for each column in result set
-            columnLabels[i] = rsmd.getColumnLabel(i + 1);
-            // put names in array
-            // use i+1 or else you're going to get an exception
-            //  insert headings for table
-            sb.append("<th class='headerColor'>");
-            sb.append(Encode.forHtml(columnLabels[i]));
-            sb.append("</th>");
+            if (!html.appendMarkup("<th class='headerColor'>")
+                    || !html.appendEncoded(rsmd.getColumnLabel(i + 1))) {
+                html.appendClosingMarkup("</th></table>");
+                return new StructuredResult(html.toString(), 0, true);
+            }
+            if (!html.appendMarkup("</th>")) {
+                html.appendClosingMarkup("</th></table>");
+                return new StructuredResult(html.toString(), 0, true);
+            }
         }
         int rowCount = 0;
-        while (rs.next()) {
+        boolean stopRendering = false;
+        while (!stopRendering && rs.next()) {
             rowCount++;
-            sb.append("<tr class='").append(rowColor).append("'>");
+            if (!html.appendMarkup("<tr class='" + rowColor + "'>")) {
+                break;
+            }
             for (int j = 0; j < columns; j++) {
-                sb.append("<td>");
-                sb.append(Encode.forHtml(Misc.getString(rs, j + 1)));
-                sb.append("</td>");
-
+                if (!html.appendMarkup("<td>")) {
+                    stopRendering = true;
+                    break;
+                }
+                try (Reader value = rs.getCharacterStream(j + 1)) {
+                    if (value != null && !html.appendEncoded(value)) {
+                        stopRendering = true;
+                    }
+                } catch (IOException e) {
+                    throw new SQLException("Could not render query result", e);
+                }
+                if (stopRendering) {
+                    html.appendClosingMarkup("</td>");
+                    break;
+                }
+                if (!html.appendMarkup("</td>")) {
+                    html.appendClosingMarkup("</td>");
+                    stopRendering = true;
+                    break;
+                }
             }
             rowColor = rowColor.equals("rowColor1") ? "rowColor2" : "rowColor1";
-            sb.append("</tr>");
+            if (stopRendering || !html.appendMarkup("</tr>")) {
+                html.appendClosingMarkup("</tr>");
+                stopRendering = true;
+            }
         }
-        sb.append("</table>");
-        return new StructuredResult(sb.toString(), rowCount);
+        html.appendClosingMarkup("</table>");
+        return new StructuredResult(html.toString(), rowCount, html.isTruncated());
+    }
+
+    private static final class LimitedHtmlBuilder {
+        private static final int READ_BUFFER_SIZE = 2_048;
+
+        private final StringBuilder html;
+        private final int contentLimit;
+        private boolean truncated;
+
+        LimitedHtmlBuilder(int maxOutputCharacters) {
+            contentLimit = maxOutputCharacters - CLOSING_MARKUP_RESERVE;
+            html = new StringBuilder(Math.min(maxOutputCharacters, 8_192));
+        }
+
+        boolean appendMarkup(String markup) {
+            if (markup.length() > remaining()) {
+                truncated = true;
+                return false;
+            }
+            html.append(markup);
+            return true;
+        }
+
+        boolean appendEncoded(String value) {
+            return appendEncodedChunk(Encode.forHtml(value == null ? "" : value));
+        }
+
+        boolean appendEncoded(Reader value) throws IOException {
+            char[] buffer = new char[READ_BUFFER_SIZE];
+            int read;
+            while ((read = value.read(buffer)) != -1) {
+                if (!appendEncodedChunk(Encode.forHtml(new String(buffer, 0, read)))) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        private boolean appendEncodedChunk(String encoded) {
+            int remaining = remaining();
+            if (encoded.length() <= remaining) {
+                html.append(encoded);
+                return true;
+            }
+            if (remaining > 0) {
+                int contentCharacters = Math.max(0, remaining - 1);
+                html.append(encoded, 0, contentCharacters).append('\u2026');
+            }
+            truncated = true;
+            return false;
+        }
+
+        void appendClosingMarkup(String markup) {
+            html.append(markup);
+        }
+
+        boolean isTruncated() {
+            return truncated;
+        }
+
+        private int remaining() {
+            return contentLimit - html.length();
+        }
+
+        @Override
+        public String toString() {
+            return html.toString();
+        }
     }
 
     //improvement over getStructure() - changed CSS naming conventions, added enterspaces for cleaner html,

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/RptResultStruct.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/RptResultStruct.java
@@ -51,7 +51,7 @@ public class RptResultStruct {
     private static final int MIN_OUTPUT_CHARACTERS = 64;
     private static final int CLOSING_MARKUP_RESERVE = 32;
 
-    public record StructuredResult(String html, int rowCount, boolean truncated) {
+    public record StructuredResult(String html, int rowCount, boolean truncated, boolean rowLimitReached) {
     }
     
     public static String getStructure(ResultSet rs) throws SQLException {
@@ -66,7 +66,7 @@ public class RptResultStruct {
      * @throws SQLException if the result set cannot be read
      */
     public static StructuredResult getStructureWithCount(ResultSet rs) throws SQLException {
-        return getStructureWithCount(rs, Integer.MAX_VALUE);
+        return getStructureWithCount(rs, Integer.MAX_VALUE, Integer.MAX_VALUE);
     }
 
     /**
@@ -78,8 +78,25 @@ public class RptResultStruct {
      * @throws SQLException if the result set cannot be read
      */
     public static StructuredResult getStructureWithCount(ResultSet rs, int maxOutputCharacters) throws SQLException {
+        return getStructureWithCount(rs, maxOutputCharacters, Integer.MAX_VALUE);
+    }
+
+    /**
+     * Generates an encoded HTML table within output and row budgets.
+     *
+     * @param rs result set positioned before its first row
+     * @param maxOutputCharacters maximum number of rendered HTML characters
+     * @param maxRows maximum number of rows to render
+     * @return encoded table markup, rendered row count, and truncation state
+     * @throws SQLException if the result set cannot be read
+     */
+    public static StructuredResult getStructureWithCount(ResultSet rs, int maxOutputCharacters, int maxRows)
+            throws SQLException {
         if (maxOutputCharacters < MIN_OUTPUT_CHARACTERS) {
             throw new IllegalArgumentException("HTML output limit is too small");
+        }
+        if (maxRows < 1) {
+            throw new IllegalArgumentException("Row limit must be positive");
         }
 
     // assuming  multiple rows in rs
@@ -94,16 +111,16 @@ public class RptResultStruct {
             if (!html.appendMarkup("<th class='headerColor'>")
                     || !html.appendEncoded(rsmd.getColumnLabel(i + 1))) {
                 html.appendClosingMarkup("</th></table>");
-                return new StructuredResult(html.toString(), 0, true);
+                return new StructuredResult(html.toString(), 0, true, false);
             }
             if (!html.appendMarkup("</th>")) {
                 html.appendClosingMarkup("</th></table>");
-                return new StructuredResult(html.toString(), 0, true);
+                return new StructuredResult(html.toString(), 0, true, false);
             }
         }
         int rowCount = 0;
         boolean stopRendering = false;
-        while (!stopRendering && rs.next()) {
+        while (!stopRendering && rowCount < maxRows && rs.next()) {
             rowCount++;
             if (!html.appendMarkup("<tr class='" + rowColor + "'>")) {
                 break;
@@ -136,8 +153,9 @@ public class RptResultStruct {
                 stopRendering = true;
             }
         }
+        boolean rowLimitReached = !stopRendering && rowCount == maxRows && rs.next();
         html.appendClosingMarkup("</table>");
-        return new StructuredResult(html.toString(), rowCount, html.isTruncated());
+        return new StructuredResult(html.toString(), rowCount, html.isTruncated(), rowLimitReached);
     }
 
     private static final class LimitedHtmlBuilder {
@@ -184,10 +202,20 @@ public class RptResultStruct {
             }
             if (remaining > 0) {
                 int contentCharacters = Math.max(0, remaining - 1);
-                html.append(encoded, 0, contentCharacters).append('\u2026');
+                int safeCharacters = entitySafePrefixLength(encoded, contentCharacters);
+                html.append(encoded, 0, safeCharacters).append('\u2026');
             }
             truncated = true;
             return false;
+        }
+
+        private static int entitySafePrefixLength(String encoded, int requestedLength) {
+            if (requestedLength == 0) {
+                return 0;
+            }
+            int lastEntityStart = encoded.lastIndexOf('&', requestedLength - 1);
+            int lastEntityEnd = encoded.lastIndexOf(';', requestedLength - 1);
+            return lastEntityStart > lastEntityEnd ? lastEntityStart : requestedLength;
         }
 
         void appendClosingMarkup(String markup) {

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/RptResultStruct.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/RptResultStruct.java
@@ -45,8 +45,15 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 
 public class RptResultStruct {
+
+    public record StructuredResult(String html, int rowCount) {
+    }
     
     public static String getStructure(ResultSet rs) throws SQLException {
+        return getStructureWithCount(rs).html();
+    }
+
+    public static StructuredResult getStructureWithCount(ResultSet rs) throws SQLException {
         
     /**
     * Generates an HTML table from a ResultSet with enhanced styling for report templates.
@@ -77,7 +84,9 @@ public class RptResultStruct {
             sb.append(Encode.forHtml(columnNames[i]));
             sb.append("</th>");
         }
+        int rowCount = 0;
         while (rs.next()) {
+            rowCount++;
             sb.append("<tr class='" + rowColor + "'>");
             for (int j = 0; j < columns; j++) {
                 sb.append("<td>");
@@ -89,7 +98,7 @@ public class RptResultStruct {
             sb.append("</tr>");
         }
         sb.append("</table>");
-        return sb.toString();
+        return new StructuredResult(sb.toString(), rowCount);
     }
 
     //improvement over getStructure() - changed CSS naming conventions, added enterspaces for cleaner html,

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/RptResultStruct.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/RptResultStruct.java
@@ -45,6 +45,7 @@ import java.io.Reader;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.sql.Types;
 
 public class RptResultStruct {
 
@@ -101,6 +102,7 @@ public class RptResultStruct {
         LimitedHtmlBuilder html = new LimitedHtmlBuilder(maxOutputCharacters);
         ResultSetMetaData rsmd = rs.getMetaData();
         int columns = rsmd.getColumnCount();
+        int[] columnTypes = getColumnTypes(rsmd, columns);
         html.appendMarkup("<table id='results'>");
         if (!appendHeaders(html, rsmd, columns)) {
             html.appendClosingMarkup(TABLE_END);
@@ -112,7 +114,7 @@ public class RptResultStruct {
         String rowColor = "rowColor1";
         while (!stopRendering && rowCount < maxRows && rs.next()) {
             rowCount++;
-            stopRendering = !appendRow(html, rs, columns, rowColor);
+            stopRendering = !appendRow(html, rs, columnTypes, rowColor);
             rowColor = rowColor.equals("rowColor1") ? "rowColor2" : "rowColor1";
         }
         boolean rowLimitReached = !stopRendering && rowCount == maxRows && rs.next();
@@ -139,6 +141,14 @@ public class RptResultStruct {
         return true;
     }
 
+    private static int[] getColumnTypes(ResultSetMetaData metadata, int columns) throws SQLException {
+        int[] columnTypes = new int[columns];
+        for (int column = 1; column <= columns; column++) {
+            columnTypes[column - 1] = metadata.getColumnType(column);
+        }
+        return columnTypes;
+    }
+
     private static boolean appendHeader(LimitedHtmlBuilder html, String label) {
         if (!html.appendMarkup("<th class='headerColor'>")) {
             return false;
@@ -150,13 +160,13 @@ public class RptResultStruct {
         return true;
     }
 
-    private static boolean appendRow(LimitedHtmlBuilder html, ResultSet resultSet, int columns, String rowColor)
+    private static boolean appendRow(LimitedHtmlBuilder html, ResultSet resultSet, int[] columnTypes, String rowColor)
             throws SQLException {
         if (!html.appendMarkup("<tr class='" + rowColor + "'>")) {
             return false;
         }
-        for (int column = 1; column <= columns; column++) {
-            if (!appendCell(html, resultSet, column)) {
+        for (int column = 1; column <= columnTypes.length; column++) {
+            if (!appendCell(html, resultSet, column, columnTypes[column - 1])) {
                 html.appendClosingMarkup(ROW_END);
                 return false;
             }
@@ -168,21 +178,36 @@ public class RptResultStruct {
         return true;
     }
 
-    private static boolean appendCell(LimitedHtmlBuilder html, ResultSet resultSet, int column) throws SQLException {
+    private static boolean appendCell(LimitedHtmlBuilder html, ResultSet resultSet, int column, int columnType)
+            throws SQLException {
         if (!html.appendMarkup(CELL_START)) {
             return false;
         }
         boolean complete;
-        try (Reader value = resultSet.getCharacterStream(column)) {
-            complete = value == null || html.appendEncoded(value);
-        } catch (IOException e) {
-            throw new SQLException("Could not render query result", e);
+        if (supportsCharacterStream(columnType)) {
+            try (Reader value = resultSet.getCharacterStream(column)) {
+                complete = value == null || html.appendEncoded(value);
+            } catch (IOException e) {
+                throw new SQLException("Could not render query result", e);
+            }
+        } else {
+            complete = html.appendEncoded(resultSet.getString(column));
         }
         if (!complete || !html.appendMarkup(CELL_END)) {
             html.appendClosingMarkup(CELL_END);
             return false;
         }
         return true;
+    }
+
+    private static boolean supportsCharacterStream(int columnType) {
+        return switch (columnType) {
+            case Types.CHAR, Types.VARCHAR, Types.LONGVARCHAR,
+                    Types.NCHAR, Types.NVARCHAR, Types.LONGNVARCHAR,
+                    Types.CLOB, Types.NCLOB,
+                    Types.BINARY, Types.VARBINARY, Types.LONGVARBINARY, Types.BLOB -> true;
+            default -> false;
+        };
     }
 
     private static final class LimitedHtmlBuilder {

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/RptResultStruct.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/RptResultStruct.java
@@ -304,7 +304,7 @@ CSS:
             //  insert headings for table
             sb.append("<th class=\"reportHeader\">");
             sb.append(Encode.forHtml(columnNames[i]));
-            sb.append("</th>");
+            sb.append(HEADER_END);
         }
         sb.append("</tr></thead><tbody>");
 
@@ -317,10 +317,10 @@ CSS:
                 for (int j = 0; j < columns; j++) {
                     sb.append("<td>");
                     sb.append(Encode.forHtml(Misc.getString(rs, columnNames[j])));
-                    sb.append("</td>");
+                    sb.append(CELL_END);
 
                 }
-                sb.append("</tr>");
+                sb.append(ROW_END);
             } while (rs.next());
         }
         if (results) {

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/RptResultStruct.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/RptResultStruct.java
@@ -50,6 +50,11 @@ public class RptResultStruct {
 
     private static final int MIN_OUTPUT_CHARACTERS = 64;
     private static final int CLOSING_MARKUP_RESERVE = 32;
+    private static final String TABLE_END = "</table>";
+    private static final String HEADER_END = "</th>";
+    private static final String ROW_END = "</tr>";
+    private static final String CELL_START = "<td>";
+    private static final String CELL_END = "</td>";
 
     public record StructuredResult(String html, int rowCount, boolean truncated, boolean rowLimitReached) {
     }
@@ -92,70 +97,92 @@ public class RptResultStruct {
      */
     public static StructuredResult getStructureWithCount(ResultSet rs, int maxOutputCharacters, int maxRows)
             throws SQLException {
+        validateLimits(maxOutputCharacters, maxRows);
+        LimitedHtmlBuilder html = new LimitedHtmlBuilder(maxOutputCharacters);
+        ResultSetMetaData rsmd = rs.getMetaData();
+        int columns = rsmd.getColumnCount();
+        html.appendMarkup("<table id='results'>");
+        if (!appendHeaders(html, rsmd, columns)) {
+            html.appendClosingMarkup(TABLE_END);
+            return new StructuredResult(html.toString(), 0, true, false);
+        }
+
+        int rowCount = 0;
+        boolean stopRendering = false;
+        String rowColor = "rowColor1";
+        while (!stopRendering && rowCount < maxRows && rs.next()) {
+            rowCount++;
+            stopRendering = !appendRow(html, rs, columns, rowColor);
+            rowColor = rowColor.equals("rowColor1") ? "rowColor2" : "rowColor1";
+        }
+        boolean rowLimitReached = !stopRendering && rowCount == maxRows && rs.next();
+        html.appendClosingMarkup(TABLE_END);
+        return new StructuredResult(html.toString(), rowCount, html.isTruncated(), rowLimitReached);
+    }
+
+    private static void validateLimits(int maxOutputCharacters, int maxRows) {
         if (maxOutputCharacters < MIN_OUTPUT_CHARACTERS) {
             throw new IllegalArgumentException("HTML output limit is too small");
         }
         if (maxRows < 1) {
             throw new IllegalArgumentException("Row limit must be positive");
         }
+    }
 
-    // assuming  multiple rows in rs
-        LimitedHtmlBuilder html = new LimitedHtmlBuilder(maxOutputCharacters);
-
-        ResultSetMetaData rsmd = rs.getMetaData();
-
-        int columns = rsmd.getColumnCount();
-        String rowColor = "rowColor1";
-        html.appendMarkup("<table id='results'>");
-        for (int i = 0; i < columns; i++) {  // for each column in result set
-            if (!html.appendMarkup("<th class='headerColor'>")
-                    || !html.appendEncoded(rsmd.getColumnLabel(i + 1))) {
-                html.appendClosingMarkup("</th></table>");
-                return new StructuredResult(html.toString(), 0, true, false);
-            }
-            if (!html.appendMarkup("</th>")) {
-                html.appendClosingMarkup("</th></table>");
-                return new StructuredResult(html.toString(), 0, true, false);
+    private static boolean appendHeaders(LimitedHtmlBuilder html, ResultSetMetaData metadata, int columns)
+            throws SQLException {
+        for (int i = 1; i <= columns; i++) {
+            if (!appendHeader(html, metadata.getColumnLabel(i))) {
+                return false;
             }
         }
-        int rowCount = 0;
-        boolean stopRendering = false;
-        while (!stopRendering && rowCount < maxRows && rs.next()) {
-            rowCount++;
-            if (!html.appendMarkup("<tr class='" + rowColor + "'>")) {
-                break;
-            }
-            for (int j = 0; j < columns; j++) {
-                if (!html.appendMarkup("<td>")) {
-                    stopRendering = true;
-                    break;
-                }
-                try (Reader value = rs.getCharacterStream(j + 1)) {
-                    if (value != null && !html.appendEncoded(value)) {
-                        stopRendering = true;
-                    }
-                } catch (IOException e) {
-                    throw new SQLException("Could not render query result", e);
-                }
-                if (stopRendering) {
-                    html.appendClosingMarkup("</td>");
-                    break;
-                }
-                if (!html.appendMarkup("</td>")) {
-                    html.appendClosingMarkup("</td>");
-                    stopRendering = true;
-                    break;
-                }
-            }
-            rowColor = rowColor.equals("rowColor1") ? "rowColor2" : "rowColor1";
-            if (stopRendering || !html.appendMarkup("</tr>")) {
-                html.appendClosingMarkup("</tr>");
-                stopRendering = true;
+        return true;
+    }
+
+    private static boolean appendHeader(LimitedHtmlBuilder html, String label) {
+        if (!html.appendMarkup("<th class='headerColor'>")) {
+            return false;
+        }
+        if (!html.appendEncoded(label) || !html.appendMarkup(HEADER_END)) {
+            html.appendClosingMarkup(HEADER_END);
+            return false;
+        }
+        return true;
+    }
+
+    private static boolean appendRow(LimitedHtmlBuilder html, ResultSet resultSet, int columns, String rowColor)
+            throws SQLException {
+        if (!html.appendMarkup("<tr class='" + rowColor + "'>")) {
+            return false;
+        }
+        for (int column = 1; column <= columns; column++) {
+            if (!appendCell(html, resultSet, column)) {
+                html.appendClosingMarkup(ROW_END);
+                return false;
             }
         }
-        boolean rowLimitReached = !stopRendering && rowCount == maxRows && rs.next();
-        html.appendClosingMarkup("</table>");
-        return new StructuredResult(html.toString(), rowCount, html.isTruncated(), rowLimitReached);
+        if (!html.appendMarkup(ROW_END)) {
+            html.appendClosingMarkup(ROW_END);
+            return false;
+        }
+        return true;
+    }
+
+    private static boolean appendCell(LimitedHtmlBuilder html, ResultSet resultSet, int column) throws SQLException {
+        if (!html.appendMarkup(CELL_START)) {
+            return false;
+        }
+        boolean complete;
+        try (Reader value = resultSet.getCharacterStream(column)) {
+            complete = value == null || html.appendEncoded(value);
+        } catch (IOException e) {
+            throw new SQLException("Could not render query result", e);
+        }
+        if (!complete || !html.appendMarkup(CELL_END)) {
+            html.appendClosingMarkup(CELL_END);
+            return false;
+        }
+        return true;
     }
 
     private static final class LimitedHtmlBuilder {

--- a/src/main/java/io/github/carlos_emr/carlos/report/pageUtil/RptByExample2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/pageUtil/RptByExample2Action.java
@@ -122,17 +122,28 @@ public class RptByExample2Action extends ActionSupport {
             return SUCCESS;
         }
 
+        RptByExampleData.QueryResult result;
         try {
-            RptByExampleData.QueryResult result = new RptByExampleData().execute(sql, properties, providerNo);
-            request.setAttribute("results", result.html());
-            request.setAttribute("resultRowCount", result.rowCount());
-            write2Database(sql, providerNo);
+            result = new RptByExampleData().execute(sql, properties, providerNo);
         } catch (QueryByExampleValidationException e) {
             request.setAttribute("queryValidationError", true);
+            return SUCCESS;
         } catch (SQLTimeoutException e) {
             request.setAttribute("queryTimeout", true);
+            return SUCCESS;
         } catch (SQLException | RuntimeException e) {
             request.setAttribute("queryExecutionError", true);
+            return SUCCESS;
+        }
+
+        request.setAttribute("results", result.html());
+        request.setAttribute("resultRowCount", result.rowCount());
+        request.setAttribute("resultLimit", RptByExampleData.MAX_ROWS);
+        try {
+            write2Database(sql, providerNo);
+        } catch (RuntimeException e) {
+            request.setAttribute("queryHistoryError", true);
+            RptByExampleData.audit(providerNo, sql, 0, result.rowCount(), "history_failed");
         }
 
         return SUCCESS;
@@ -140,10 +151,13 @@ public class RptByExample2Action extends ActionSupport {
 
     static boolean isEnabled(Properties properties) {
         String configured = properties.getProperty(ENABLED_PROPERTY);
-        return configured == null || configured.isBlank()
-                || configured.equalsIgnoreCase("true")
-                || configured.equalsIgnoreCase("yes")
-                || configured.equalsIgnoreCase("on");
+        if (configured == null || configured.isBlank()) {
+            return true;
+        }
+        String normalized = configured.trim();
+        return normalized.equalsIgnoreCase("true")
+                || normalized.equalsIgnoreCase("yes")
+                || normalized.equalsIgnoreCase("on");
     }
 
     public void write2Database(String query, String providerNo) {

--- a/src/main/java/io/github/carlos_emr/carlos/report/pageUtil/RptByExample2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/pageUtil/RptByExample2Action.java
@@ -31,9 +31,10 @@
 package io.github.carlos_emr.carlos.report.pageUtil;
 
 import java.io.IOException;
+import java.sql.SQLException;
+import java.sql.SQLTimeoutException;
 import java.util.Collection;
 import java.util.Date;
-import java.util.List;
 import java.util.Properties;
 
 import jakarta.servlet.ServletException;
@@ -41,9 +42,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import io.github.carlos_emr.carlos.report.data.RptByExampleData;
+import io.github.carlos_emr.carlos.report.data.QueryByExampleValidationException;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
-import io.github.carlos_emr.carlos.PMmodule.dao.SecUserRoleDao;
-import io.github.carlos_emr.carlos.PMmodule.model.SecUserRole;
 import io.github.carlos_emr.carlos.commn.dao.ReportByExamplesDao;
 import io.github.carlos_emr.carlos.commn.model.ReportByExamples;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
@@ -59,12 +59,14 @@ import org.apache.struts2.interceptor.parameter.StrutsParameter;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
- * Struts2 action for the Query-by-Example report tool. Allows admin users to execute
- * custom SQL queries, persist them as recent searches, and display results.
+ * Struts2 action for the Query-by-Example report tool. Allows authorized report users
+ * to execute custom read-only SQL queries, persist successful searches, and display results.
  *
  * @since 2003-07-22
  */
 public class RptByExample2Action extends ActionSupport {
+    public static final String ENABLED_PROPERTY = "QUERY_BY_EXAMPLE_ENABLED";
+
     HttpServletRequest request = ServletActionContext.getRequest();
     HttpServletResponse response = ServletActionContext.getResponse();
 
@@ -96,32 +98,52 @@ public class RptByExample2Action extends ActionSupport {
 
         String providerNo = loggedInInfo.getLoggedInProviderNo();
 
-        SecUserRoleDao secUserRoleDao = SpringUtils.getBean(SecUserRoleDao.class);
-
-        List<SecUserRole> userRoles = secUserRoleDao.findByRoleNameAndProviderNo("admin", providerNo);
-        if (userRoles.isEmpty()) {
-            throw new SecurityException("missing required admin privileges to run query by example");
-        }
-
         RptByExampleQueryBeanHandler hd = new RptByExampleQueryBeanHandler();
         Collection favorites = hd.getFavoriteCollection(providerNo);
         request.setAttribute("favorites", favorites);
 
-        if (sql != null) {
+        sql = sql == null ? "" : sql;
+        request.setAttribute("submittedSql", sql);
+
+        if (!"POST".equalsIgnoreCase(request.getMethod())) {
+            return SUCCESS;
+        }
+
+        Properties properties = CarlosProperties.getInstance();
+        if (!isEnabled(properties)) {
+            request.setAttribute("queryDisabled", true);
+            RptByExampleData.audit(providerNo, sql, 0, 0, "disabled");
+            return SUCCESS;
+        }
+
+        if (sql.isBlank()) {
+            request.setAttribute("queryValidationError", true);
+            RptByExampleData.audit(providerNo, sql, 0, 0, "rejected");
+            return SUCCESS;
+        }
+
+        try {
+            RptByExampleData.QueryResult result = new RptByExampleData().execute(sql, properties, providerNo);
+            request.setAttribute("results", result.html());
+            request.setAttribute("resultRowCount", result.rowCount());
             write2Database(sql, providerNo);
-        } else
-            sql = "";
-
-        RptByExampleData exampleData = new RptByExampleData();
-        Properties proppies = CarlosProperties.getInstance();
-
-        String results = exampleData.exampleReportGenerate(sql, proppies) == null ? null : exampleData.exampleReportGenerate(sql, proppies);
-        String resultText = exampleData.exampleTextGenerate(sql, proppies) == null ? null : exampleData.exampleTextGenerate(sql, proppies);
-
-        request.setAttribute("results", results);
-        request.setAttribute("resultText", resultText);
+        } catch (QueryByExampleValidationException e) {
+            request.setAttribute("queryValidationError", true);
+        } catch (SQLTimeoutException e) {
+            request.setAttribute("queryTimeout", true);
+        } catch (SQLException | RuntimeException e) {
+            request.setAttribute("queryExecutionError", true);
+        }
 
         return SUCCESS;
+    }
+
+    static boolean isEnabled(Properties properties) {
+        String configured = properties.getProperty(ENABLED_PROPERTY);
+        return configured == null || configured.isBlank()
+                || configured.equalsIgnoreCase("true")
+                || configured.equalsIgnoreCase("yes")
+                || configured.equalsIgnoreCase("on");
     }
 
     public void write2Database(String query, String providerNo) {

--- a/src/main/java/io/github/carlos_emr/carlos/report/pageUtil/RptByExample2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/pageUtil/RptByExample2Action.java
@@ -35,6 +35,7 @@ import java.sql.SQLException;
 import java.sql.SQLTimeoutException;
 import java.util.Collection;
 import java.util.Date;
+import java.util.Locale;
 import java.util.Properties;
 
 import jakarta.servlet.ServletException;
@@ -105,7 +106,7 @@ public class RptByExample2Action extends ActionSupport {
         sql = sql == null ? "" : sql;
         request.setAttribute("submittedSql", sql);
 
-        if (!"POST".equalsIgnoreCase(request.getMethod())) {
+        if (!"POST".equals(request.getMethod())) {
             return SUCCESS;
         }
 
@@ -154,10 +155,8 @@ public class RptByExample2Action extends ActionSupport {
         if (configured == null || configured.isBlank()) {
             return true;
         }
-        String normalized = configured.trim();
-        return normalized.equalsIgnoreCase("true")
-                || normalized.equalsIgnoreCase("yes")
-                || normalized.equalsIgnoreCase("on");
+        String normalized = configured.trim().toLowerCase(Locale.ROOT);
+        return normalized.equals("true") || normalized.equals("yes") || normalized.equals("on");
     }
 
     public void write2Database(String query, String providerNo) {

--- a/src/main/java/io/github/carlos_emr/carlos/report/pageUtil/RptByExample2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/pageUtil/RptByExample2Action.java
@@ -141,11 +141,13 @@ public class RptByExample2Action extends ActionSupport {
         request.setAttribute("results", result.html());
         request.setAttribute("resultRowCount", result.rowCount());
         request.setAttribute("resultLimit", RptByExampleData.MAX_ROWS);
+        request.setAttribute("resultTruncated", result.truncated());
+        request.setAttribute("resultCharacterLimit", RptByExampleData.MAX_OUTPUT_CHARACTERS);
         try {
             write2Database(sql, providerNo);
         } catch (RuntimeException e) {
             request.setAttribute("queryHistoryError", true);
-            RptByExampleData.audit(providerNo, sql, 0, result.rowCount(), "history_failed");
+            RptByExampleData.audit(providerNo, sql, result.durationMillis(), result.rowCount(), "history_failed");
         }
 
         return SUCCESS;

--- a/src/main/java/io/github/carlos_emr/carlos/report/pageUtil/RptByExample2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/pageUtil/RptByExample2Action.java
@@ -142,6 +142,7 @@ public class RptByExample2Action extends ActionSupport {
         request.setAttribute("resultRowCount", result.rowCount());
         request.setAttribute("resultLimit", RptByExampleData.MAX_ROWS);
         request.setAttribute("resultTruncated", result.truncated());
+        request.setAttribute("resultRowLimitReached", result.rowLimitReached());
         request.setAttribute("resultCharacterLimit", RptByExampleData.MAX_OUTPUT_CHARACTERS);
         try {
             write2Database(sql, providerNo);

--- a/src/main/java/io/github/carlos_emr/carlos/report/pageUtil/RptByExample2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/pageUtil/RptByExample2Action.java
@@ -131,6 +131,7 @@ public class RptByExample2Action extends ActionSupport {
             return SUCCESS;
         } catch (SQLTimeoutException e) {
             request.setAttribute("queryTimeout", true);
+            request.setAttribute("queryTimeoutSeconds", RptByExampleData.QUERY_TIMEOUT_SECONDS);
             return SUCCESS;
         } catch (SQLException | RuntimeException e) {
             request.setAttribute("queryExecutionError", true);

--- a/src/main/java/io/github/carlos_emr/carlos/report/pageUtil/RptByExample2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/pageUtil/RptByExample2Action.java
@@ -150,6 +150,9 @@ public class RptByExample2Action extends ActionSupport {
         return SUCCESS;
     }
 
+    @SuppressFBWarnings(
+            value = "IMPROPER_UNICODE",
+            justification = "Locale.ROOT normalization is safe for controlled ASCII feature-flag values")
     static boolean isEnabled(Properties properties) {
         String configured = properties.getProperty(ENABLED_PROPERTY);
         if (configured == null || configured.isBlank()) {

--- a/src/main/java/io/github/carlos_emr/carlos/report/pageUtil/RptByExamplesAllFavorites2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/pageUtil/RptByExamplesAllFavorites2Action.java
@@ -61,7 +61,7 @@ public class RptByExamplesAllFavorites2Action extends ActionSupport {
         }
 
 
-        String providerNo = (String) request.getSession().getAttribute("user");
+        String providerNo = loggedInInfo.getLoggedInProviderNo();
         RptByExampleQueryBeanHandler hd = new RptByExampleQueryBeanHandler(providerNo);
         request.setAttribute("allFavorites", hd);
         return SUCCESS;

--- a/src/main/java/io/github/carlos_emr/carlos/report/pageUtil/RptByExamplesAllFavorites2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/pageUtil/RptByExamplesAllFavorites2Action.java
@@ -55,8 +55,9 @@ public class RptByExamplesAllFavorites2Action extends ActionSupport {
     public String execute()
             throws ServletException, IOException {
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
-        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_report", "r", null)) {
-            throw new SecurityException("missing required sec object (_report)");
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_admin", SecurityInfoManager.READ, null)
+                && !securityInfoManager.hasPrivilege(loggedInInfo, "_report", SecurityInfoManager.READ, null)) {
+            throw new SecurityException("missing required sec object (_admin or _report)");
         }
 
 

--- a/src/main/java/io/github/carlos_emr/carlos/report/pageUtil/RptByExamplesFavorite2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/pageUtil/RptByExamplesFavorite2Action.java
@@ -69,6 +69,7 @@ public class RptByExamplesFavorite2Action extends ActionSupport {
             throw new SecurityException("missing required sec object (_admin or _report)");
         }
         if (!"POST".equalsIgnoreCase(request.getMethod())) {
+            response.setHeader("Allow", "POST");
             response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
             return NONE;
         }

--- a/src/main/java/io/github/carlos_emr/carlos/report/pageUtil/RptByExamplesFavorite2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/pageUtil/RptByExamplesFavorite2Action.java
@@ -147,7 +147,7 @@ public class RptByExamplesFavorite2Action extends ActionSupport {
     private void updateFavorite(String providerNo, String id, String favoriteName, String query) {
         ReportByExamplesFavorite favorite = requireOwnedFavorite(providerNo, id);
         favorite.setName(favoriteName);
-        favorite.setQuery(StringUtils.defaultString(query));
+        favorite.setQuery(StringUtils.defaultIfEmpty(query, favorite.getQuery()));
         dao.merge(favorite);
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/report/pageUtil/RptByExamplesFavorite2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/pageUtil/RptByExamplesFavorite2Action.java
@@ -64,8 +64,9 @@ public class RptByExamplesFavorite2Action extends ActionSupport {
     @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
     public String execute() throws ServletException, IOException {
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
-        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_report", "r", null)) {
-            throw new SecurityException("missing required sec object (_report)");
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_admin", SecurityInfoManager.READ, null)
+                && !securityInfoManager.hasPrivilege(loggedInInfo, "_report", SecurityInfoManager.READ, null)) {
+            throw new SecurityException("missing required sec object (_admin or _report)");
         }
 
         String providerNo = (String) request.getSession().getAttribute("user");

--- a/src/main/java/io/github/carlos_emr/carlos/report/pageUtil/RptByExamplesFavorite2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/pageUtil/RptByExamplesFavorite2Action.java
@@ -68,6 +68,10 @@ public class RptByExamplesFavorite2Action extends ActionSupport {
                 && !securityInfoManager.hasPrivilege(loggedInInfo, "_report", SecurityInfoManager.READ, null)) {
             throw new SecurityException("missing required sec object (_admin or _report)");
         }
+        if (!"POST".equalsIgnoreCase(request.getMethod())) {
+            response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+            return NONE;
+        }
 
         String providerNo = (String) request.getSession().getAttribute("user");
 

--- a/src/main/java/io/github/carlos_emr/carlos/report/pageUtil/RptByExamplesFavorite2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/pageUtil/RptByExamplesFavorite2Action.java
@@ -31,6 +31,7 @@ package io.github.carlos_emr.carlos.report.pageUtil;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -39,7 +40,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.StringUtils;
 import io.github.carlos_emr.carlos.commn.dao.ReportByExamplesFavoriteDao;
 import io.github.carlos_emr.carlos.commn.model.ReportByExamplesFavorite;
-import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 
 import io.github.carlos_emr.carlos.report.bean.RptByExampleQueryBeanHandler;
@@ -74,23 +74,23 @@ public class RptByExamplesFavorite2Action extends ActionSupport {
             return NONE;
         }
 
-        String providerNo = (String) request.getSession().getAttribute("user");
+        String providerNo = loggedInInfo.getLoggedInProviderNo();
 
         if (!StringUtils.isEmpty(this.getNewQuery())) {
             // Edit case
-            this.setQuery(this.getNewQuery());
-            if (!StringUtils.isEmpty(this.getNewName())) {
-                this.setFavoriteName(this.getNewName());
+            if (hasFavoriteId()) {
+                ReportByExamplesFavorite favorite = requireOwnedFavorite(providerNo, this.getId());
+                this.setQuery(favorite.getQuery());
+                this.setFavoriteName(favorite.getName());
             } else {
-                ReportByExamplesFavoriteDao dao = SpringUtils.getBean(ReportByExamplesFavoriteDao.class);
-                for (ReportByExamplesFavorite f : dao.findByQuery(this.getNewQuery())) {
-                    this.setFavoriteName(f.getName());
-                }
+                prepareNewFavorite(providerNo);
             }
             return "edit";
         } else if ("true".equalsIgnoreCase(this.getToDelete())) {
             // Deletion case
-            deleteQuery(this.getId());
+            deleteQuery(providerNo, this.getId());
+        } else if (hasFavoriteId()) {
+            updateFavorite(providerNo, this.getId(), this.getFavoriteName(), this.getQuery());
         } else {
             // Add to favorite case
             String favoriteName = this.getFavoriteName();
@@ -110,9 +110,6 @@ public class RptByExamplesFavorite2Action extends ActionSupport {
             return;
         }
 
-        MiscUtils.getLogger().debug("Fav " + favoriteName + " query " + query);
-
-        ReportByExamplesFavoriteDao dao = SpringUtils.getBean(ReportByExamplesFavoriteDao.class);
         List<ReportByExamplesFavorite> favorites = dao.findByEverything(providerNo, favoriteName, query);
         if (favorites.isEmpty()) {
             ReportByExamplesFavorite r = new ReportByExamplesFavorite();
@@ -131,8 +128,45 @@ public class RptByExamplesFavorite2Action extends ActionSupport {
 
     }
 
-    public void deleteQuery(String id) {
-        dao.remove(Integer.parseInt(id));
+    public void deleteQuery(String providerNo, String id) {
+        dao.remove(requireOwnedFavorite(providerNo, id));
+    }
+
+    private void prepareNewFavorite(String providerNo) {
+        this.setQuery(this.getNewQuery());
+        if (!StringUtils.isEmpty(this.getNewName())) {
+            this.setFavoriteName(this.getNewName());
+            return;
+        }
+        List<ReportByExamplesFavorite> favorites = dao.findByProviderAndQuery(providerNo, this.getNewQuery());
+        if (!favorites.isEmpty()) {
+            this.setFavoriteName(favorites.get(0).getName());
+        }
+    }
+
+    private void updateFavorite(String providerNo, String id, String favoriteName, String query) {
+        ReportByExamplesFavorite favorite = requireOwnedFavorite(providerNo, id);
+        favorite.setName(favoriteName);
+        favorite.setQuery(StringUtils.defaultString(query));
+        dao.merge(favorite);
+    }
+
+    private ReportByExamplesFavorite requireOwnedFavorite(String providerNo, String id) {
+        final int favoriteId;
+        try {
+            favoriteId = Integer.parseInt(id);
+        } catch (NumberFormatException e) {
+            throw new SecurityException("Invalid favorite selection", e);
+        }
+        ReportByExamplesFavorite favorite = dao.find(favoriteId);
+        if (favorite == null || !Objects.equals(providerNo, favorite.getProviderNo())) {
+            throw new SecurityException("Favorite does not belong to the current provider");
+        }
+        return favorite;
+    }
+
+    private boolean hasFavoriteId() {
+        return StringUtils.isNotBlank(this.getId()) && !"error".equals(this.getId());
     }
 
 

--- a/src/main/java/io/github/carlos_emr/carlos/report/pageUtil/RptByExamplesFavorite2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/pageUtil/RptByExamplesFavorite2Action.java
@@ -60,6 +60,18 @@ public class RptByExamplesFavorite2Action extends ActionSupport {
 
     private ReportByExamplesFavoriteDao dao = SpringUtils.getBean(ReportByExamplesFavoriteDao.class);
 
+    /**
+     * Handles the POST-only create, edit, update, and delete workflows for the
+     * current provider's Query-by-Example favorites. The caller must hold
+     * {@code _admin} or {@code _report} read privilege, and stored records are
+     * checked for provider ownership before mutation.
+     *
+     * @return {@link #NONE} after rejecting a non-POST request, {@code "edit"}
+     *         when preparing the editor, or {@link #SUCCESS} after a completed mutation
+     * @throws ServletException if servlet processing fails
+     * @throws IOException if the method-rejection response cannot be written
+     * @throws SecurityException if authorization or provider ownership validation fails
+     */
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
     @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
     public String execute() throws ServletException, IOException {
@@ -105,6 +117,16 @@ public class RptByExamplesFavorite2Action extends ActionSupport {
         return SUCCESS;
     }
 
+    /**
+     * Creates a favorite or updates the first exact provider/name/query match.
+     * A null or empty query is ignored. Authorization is enforced by the calling
+     * {@link #execute()} workflow.
+     *
+     * @param providerNo owner of the favorite
+     * @param favoriteName display name for the favorite
+     * @param query SQL text to store
+     * @throws RuntimeException if favorite lookup or persistence fails
+     */
     public void write2Database(String providerNo, String favoriteName, String query) {
         if (query == null || query.compareTo("") == 0) {
             return;
@@ -128,6 +150,15 @@ public class RptByExamplesFavorite2Action extends ActionSupport {
 
     }
 
+    /**
+     * Deletes a favorite after verifying that it belongs to the supplied provider.
+     * Authorization is enforced by the calling {@link #execute()} workflow.
+     *
+     * @param providerNo expected owner of the favorite
+     * @param id numeric favorite identifier
+     * @throws SecurityException if the identifier is invalid or the favorite is not provider-owned
+     * @throws RuntimeException if persistence fails
+     */
     public void deleteQuery(String providerNo, String id) {
         dao.remove(requireOwnedFavorite(providerNo, id));
     }

--- a/src/main/java/io/github/carlos_emr/carlos/report/pageUtil/RptViewAllQueryByExamples2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/pageUtil/RptViewAllQueryByExamples2Action.java
@@ -59,8 +59,9 @@ public class RptViewAllQueryByExamples2Action extends ActionSupport {
     public String execute()
             throws ServletException, IOException {
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
-        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_report", "r", null)) {
-            throw new SecurityException("missing required sec object (_report)");
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_admin", SecurityInfoManager.READ, null)
+                && !securityInfoManager.hasPrivilege(loggedInInfo, "_report", SecurityInfoManager.READ, null)) {
+            throw new SecurityException("missing required sec object (_admin or _report)");
         }
 
         RptByExampleQueryBeanHandler hd = new RptByExampleQueryBeanHandler(startDate, endDate);

--- a/src/main/resources/carlos.properties
+++ b/src/main/resources/carlos.properties
@@ -50,6 +50,9 @@ buildVersion=${build.JOB_NAME} ${build.BUILD_NUMBER}
 #            legacy functionality. Ensure that you leave the tags behind the field when renaming the database.
 db_name = oscar_mcmaster?zeroDateTimeBehavior=round&useOldAliasMetadataBehavior=true&jdbcCompliantTruncation=false
 
+# Authorized Query-by-Example users may run validated, read-only SELECT queries.
+QUERY_BY_EXAMPLE_ENABLED = true
+
 # username
 db_username = root
 

--- a/src/main/resources/oscarResources_en.properties
+++ b/src/main/resources/oscarResources_en.properties
@@ -8925,10 +8925,10 @@ oscarReport.RptByExample.MsgLoadQuery=Load Query
 oscarReport.RptByExample.MsgRunQuery=Run Query
 oscarReport.RptByExample.MsgDisabled=Direct query execution is currently disabled. Your query has not been run.
 oscarReport.RptByExample.MsgValidationError=Only one read-only SELECT from the application database is allowed. Comments, UNION, locking, output operations, and prohibited functions are not permitted.
-oscarReport.RptByExample.MsgTimeout=The query exceeded the 15-second time limit and was stopped.
+oscarReport.RptByExample.MsgTimeout=The query exceeded the {0}-second time limit and was stopped.
 oscarReport.RptByExample.MsgExecutionError=The query could not be completed. Check the query and try again.
 oscarReport.RptByExample.MsgHistoryError=The query ran successfully, but it could not be saved to your query history.
-oscarReport.RptByExample.MsgResultLimit=Results are limited to {0} rows.
+oscarReport.RptByExample.MsgResultLimit=Returned {0} rows (limit: {1}).
 
 oscarReport.RptByExample.MsgConfirmDelete=Are you sure you want to delete the selected query?
 

--- a/src/main/resources/oscarResources_en.properties
+++ b/src/main/resources/oscarResources_en.properties
@@ -8930,7 +8930,7 @@ oscarReport.RptByExample.MsgExecutionError=The query could not be completed. Che
 oscarReport.RptByExample.MsgHistoryError=The query ran successfully, but it could not be saved to your query history.
 oscarReport.RptByExample.MsgResultLimit=Returned {0} rows (limit: {1}).
 oscarReport.RptByExample.MsgOutputTruncated=Output was truncated after {0} characters.
-oscarReport.RptByExample.MsgRowLimitReached=More than {0} rows matched. Only the first {0} rows are shown.
+oscarReport.RptByExample.MsgRowLimitReached=Additional rows were omitted after the {0}-row display limit was reached.
 
 oscarReport.RptByExample.MsgConfirmDelete=Are you sure you want to delete the selected query?
 

--- a/src/main/resources/oscarResources_en.properties
+++ b/src/main/resources/oscarResources_en.properties
@@ -8930,6 +8930,7 @@ oscarReport.RptByExample.MsgExecutionError=The query could not be completed. Che
 oscarReport.RptByExample.MsgHistoryError=The query ran successfully, but it could not be saved to your query history.
 oscarReport.RptByExample.MsgResultLimit=Returned {0} rows (limit: {1}).
 oscarReport.RptByExample.MsgOutputTruncated=Output was truncated after {0} characters.
+oscarReport.RptByExample.MsgRowLimitReached=More than {0} rows matched. Only the first {0} rows are shown.
 
 oscarReport.RptByExample.MsgConfirmDelete=Are you sure you want to delete the selected query?
 

--- a/src/main/resources/oscarResources_en.properties
+++ b/src/main/resources/oscarResources_en.properties
@@ -8927,6 +8927,7 @@ oscarReport.RptByExample.MsgDisabled=Direct query execution is currently disable
 oscarReport.RptByExample.MsgValidationError=Only one read-only SELECT from the application database is allowed. Comments, UNION, locking, output operations, and prohibited functions are not permitted.
 oscarReport.RptByExample.MsgTimeout=The query exceeded the 15-second time limit and was stopped.
 oscarReport.RptByExample.MsgExecutionError=The query could not be completed. Check the query and try again.
+oscarReport.RptByExample.MsgHistoryError=The query ran successfully, but it could not be saved to your query history.
 oscarReport.RptByExample.MsgResultLimit=Results are limited to {0} rows.
 
 oscarReport.RptByExample.MsgConfirmDelete=Are you sure you want to delete the selected query?

--- a/src/main/resources/oscarResources_en.properties
+++ b/src/main/resources/oscarResources_en.properties
@@ -8923,6 +8923,11 @@ oscarReport.RptByExample.MsgViewQueryHistory=View Query History
 oscarReport.RptByExample.MsgLoadQuery=Load Query
 
 oscarReport.RptByExample.MsgRunQuery=Run Query
+oscarReport.RptByExample.MsgDisabled=Direct query execution is currently disabled. Your query has not been run.
+oscarReport.RptByExample.MsgValidationError=Only one read-only SELECT from the application database is allowed. Comments, UNION, locking, output operations, and prohibited functions are not permitted.
+oscarReport.RptByExample.MsgTimeout=The query exceeded the 15-second time limit and was stopped.
+oscarReport.RptByExample.MsgExecutionError=The query could not be completed. Check the query and try again.
+oscarReport.RptByExample.MsgResultLimit=Results are limited to {0} rows.
 
 oscarReport.RptByExample.MsgConfirmDelete=Are you sure you want to delete the selected query?
 

--- a/src/main/resources/oscarResources_en.properties
+++ b/src/main/resources/oscarResources_en.properties
@@ -8929,6 +8929,7 @@ oscarReport.RptByExample.MsgTimeout=The query exceeded the {0}-second time limit
 oscarReport.RptByExample.MsgExecutionError=The query could not be completed. Check the query and try again.
 oscarReport.RptByExample.MsgHistoryError=The query ran successfully, but it could not be saved to your query history.
 oscarReport.RptByExample.MsgResultLimit=Returned {0} rows (limit: {1}).
+oscarReport.RptByExample.MsgOutputTruncated=Output was truncated after {0} characters.
 
 oscarReport.RptByExample.MsgConfirmDelete=Are you sure you want to delete the selected query?
 

--- a/src/main/resources/oscarResources_es.properties
+++ b/src/main/resources/oscarResources_es.properties
@@ -6446,6 +6446,11 @@ oscarReport.RptByExample.MsgViewQueryHistory=Ver historial de consultas
 oscarReport.RptByExample.MsgLoadQuery=Cargar consulta
 
 oscarReport.RptByExample.MsgRunQuery=Ejecutar
+oscarReport.RptByExample.MsgDisabled=La ejecuci\u00f3n directa de consultas est\u00e1 desactivada. Su consulta no se ha ejecutado.
+oscarReport.RptByExample.MsgValidationError=Solo se permite una consulta SELECT de solo lectura en la base de datos de la aplicaci\u00f3n. No se permiten comentarios, UNION, bloqueos, operaciones de salida ni funciones prohibidas.
+oscarReport.RptByExample.MsgTimeout=La consulta super\u00f3 el l\u00edmite de 15 segundos y se detuvo.
+oscarReport.RptByExample.MsgExecutionError=No se pudo completar la consulta. Rev\u00edsela e int\u00e9ntelo de nuevo.
+oscarReport.RptByExample.MsgResultLimit=Los resultados est\u00e1n limitados a {0} filas.
 
 oscarReport.RptByExample.MsgConfirmDelete=\u00bfEst\u00e1 seguro de que desea eliminar la consulta seleccionada?
 

--- a/src/main/resources/oscarResources_es.properties
+++ b/src/main/resources/oscarResources_es.properties
@@ -6449,10 +6449,10 @@ oscarReport.RptByExample.MsgRunQuery=Ejecutar
 # TODO: translate Query-by-Example execution messages.
 oscarReport.RptByExample.MsgDisabled=Direct query execution is currently disabled. Your query has not been run.
 oscarReport.RptByExample.MsgValidationError=Only one read-only SELECT from the application database is allowed. Comments, UNION, locking, output operations, and prohibited functions are not permitted.
-oscarReport.RptByExample.MsgTimeout=The query exceeded the 15-second time limit and was stopped.
+oscarReport.RptByExample.MsgTimeout=The query exceeded the {0}-second time limit and was stopped.
 oscarReport.RptByExample.MsgExecutionError=The query could not be completed. Check the query and try again.
 oscarReport.RptByExample.MsgHistoryError=The query ran successfully, but it could not be saved to your query history.
-oscarReport.RptByExample.MsgResultLimit=Results are limited to {0} rows.
+oscarReport.RptByExample.MsgResultLimit=Returned {0} rows (limit: {1}).
 
 oscarReport.RptByExample.MsgConfirmDelete=\u00bfEst\u00e1 seguro de que desea eliminar la consulta seleccionada?
 

--- a/src/main/resources/oscarResources_es.properties
+++ b/src/main/resources/oscarResources_es.properties
@@ -6455,6 +6455,8 @@ oscarReport.RptByExample.MsgHistoryError=The query ran successfully, but it coul
 oscarReport.RptByExample.MsgResultLimit=Returned {0} rows (limit: {1}).
 # TODO: translate
 oscarReport.RptByExample.MsgOutputTruncated=Output was truncated after {0} characters.
+# TODO: translate
+oscarReport.RptByExample.MsgRowLimitReached=More than {0} rows matched. Only the first {0} rows are shown.
 
 oscarReport.RptByExample.MsgConfirmDelete=\u00bfEst\u00e1 seguro de que desea eliminar la consulta seleccionada?
 

--- a/src/main/resources/oscarResources_es.properties
+++ b/src/main/resources/oscarResources_es.properties
@@ -6446,11 +6446,13 @@ oscarReport.RptByExample.MsgViewQueryHistory=Ver historial de consultas
 oscarReport.RptByExample.MsgLoadQuery=Cargar consulta
 
 oscarReport.RptByExample.MsgRunQuery=Ejecutar
-oscarReport.RptByExample.MsgDisabled=La ejecuci\u00f3n directa de consultas est\u00e1 desactivada. Su consulta no se ha ejecutado.
-oscarReport.RptByExample.MsgValidationError=Solo se permite una consulta SELECT de solo lectura en la base de datos de la aplicaci\u00f3n. No se permiten comentarios, UNION, bloqueos, operaciones de salida ni funciones prohibidas.
-oscarReport.RptByExample.MsgTimeout=La consulta super\u00f3 el l\u00edmite de 15 segundos y se detuvo.
-oscarReport.RptByExample.MsgExecutionError=No se pudo completar la consulta. Rev\u00edsela e int\u00e9ntelo de nuevo.
-oscarReport.RptByExample.MsgResultLimit=Los resultados est\u00e1n limitados a {0} filas.
+# TODO: translate Query-by-Example execution messages.
+oscarReport.RptByExample.MsgDisabled=Direct query execution is currently disabled. Your query has not been run.
+oscarReport.RptByExample.MsgValidationError=Only one read-only SELECT from the application database is allowed. Comments, UNION, locking, output operations, and prohibited functions are not permitted.
+oscarReport.RptByExample.MsgTimeout=The query exceeded the 15-second time limit and was stopped.
+oscarReport.RptByExample.MsgExecutionError=The query could not be completed. Check the query and try again.
+oscarReport.RptByExample.MsgHistoryError=The query ran successfully, but it could not be saved to your query history.
+oscarReport.RptByExample.MsgResultLimit=Results are limited to {0} rows.
 
 oscarReport.RptByExample.MsgConfirmDelete=\u00bfEst\u00e1 seguro de que desea eliminar la consulta seleccionada?
 

--- a/src/main/resources/oscarResources_es.properties
+++ b/src/main/resources/oscarResources_es.properties
@@ -6446,12 +6446,17 @@ oscarReport.RptByExample.MsgViewQueryHistory=Ver historial de consultas
 oscarReport.RptByExample.MsgLoadQuery=Cargar consulta
 
 oscarReport.RptByExample.MsgRunQuery=Ejecutar
-# TODO: translate Query-by-Example execution messages.
+# TODO: translate
 oscarReport.RptByExample.MsgDisabled=Direct query execution is currently disabled. Your query has not been run.
+# TODO: translate
 oscarReport.RptByExample.MsgValidationError=Only one read-only SELECT from the application database is allowed. Comments, UNION, locking, output operations, and prohibited functions are not permitted.
+# TODO: translate
 oscarReport.RptByExample.MsgTimeout=The query exceeded the {0}-second time limit and was stopped.
+# TODO: translate
 oscarReport.RptByExample.MsgExecutionError=The query could not be completed. Check the query and try again.
+# TODO: translate
 oscarReport.RptByExample.MsgHistoryError=The query ran successfully, but it could not be saved to your query history.
+# TODO: translate
 oscarReport.RptByExample.MsgResultLimit=Returned {0} rows (limit: {1}).
 # TODO: translate
 oscarReport.RptByExample.MsgOutputTruncated=Output was truncated after {0} characters.

--- a/src/main/resources/oscarResources_es.properties
+++ b/src/main/resources/oscarResources_es.properties
@@ -6453,6 +6453,8 @@ oscarReport.RptByExample.MsgTimeout=The query exceeded the {0}-second time limit
 oscarReport.RptByExample.MsgExecutionError=The query could not be completed. Check the query and try again.
 oscarReport.RptByExample.MsgHistoryError=The query ran successfully, but it could not be saved to your query history.
 oscarReport.RptByExample.MsgResultLimit=Returned {0} rows (limit: {1}).
+# TODO: translate
+oscarReport.RptByExample.MsgOutputTruncated=Output was truncated after {0} characters.
 
 oscarReport.RptByExample.MsgConfirmDelete=\u00bfEst\u00e1 seguro de que desea eliminar la consulta seleccionada?
 

--- a/src/main/resources/oscarResources_es.properties
+++ b/src/main/resources/oscarResources_es.properties
@@ -6456,7 +6456,7 @@ oscarReport.RptByExample.MsgResultLimit=Returned {0} rows (limit: {1}).
 # TODO: translate
 oscarReport.RptByExample.MsgOutputTruncated=Output was truncated after {0} characters.
 # TODO: translate
-oscarReport.RptByExample.MsgRowLimitReached=More than {0} rows matched. Only the first {0} rows are shown.
+oscarReport.RptByExample.MsgRowLimitReached=Additional rows were omitted after the {0}-row display limit was reached.
 
 oscarReport.RptByExample.MsgConfirmDelete=\u00bfEst\u00e1 seguro de que desea eliminar la consulta seleccionada?
 

--- a/src/main/resources/oscarResources_fr.properties
+++ b/src/main/resources/oscarResources_fr.properties
@@ -5638,7 +5638,7 @@ oscarReport.RptByExample.MsgResultLimit=Returned {0} rows (limit: {1}).
 # TODO: translate
 oscarReport.RptByExample.MsgOutputTruncated=Output was truncated after {0} characters.
 # TODO: translate
-oscarReport.RptByExample.MsgRowLimitReached=More than {0} rows matched. Only the first {0} rows are shown.
+oscarReport.RptByExample.MsgRowLimitReached=Additional rows were omitted after the {0}-row display limit was reached.
 
 oscarReport.RptByExample.MsgConfirmDelete=\u00cates-vous s\u00fbr de vouloir supprimer la requ\u00eate s\u00e9lectionn\u00e9e\u00a0?
 

--- a/src/main/resources/oscarResources_fr.properties
+++ b/src/main/resources/oscarResources_fr.properties
@@ -5628,12 +5628,17 @@ oscarReport.RptByExample.MsgRefresh=Actualiser
 oscarReport.RptByExample.MsgViewQueryHistory=Voir l\u2019historique des requ\u00eates
 oscarReport.RptByExample.MsgLoadQuery=Charger la requ\u00eate
 oscarReport.RptByExample.MsgRunQuery=Ex\u00e9cuter
-# TODO: translate Query-by-Example execution messages.
+# TODO: translate
 oscarReport.RptByExample.MsgDisabled=Direct query execution is currently disabled. Your query has not been run.
+# TODO: translate
 oscarReport.RptByExample.MsgValidationError=Only one read-only SELECT from the application database is allowed. Comments, UNION, locking, output operations, and prohibited functions are not permitted.
+# TODO: translate
 oscarReport.RptByExample.MsgTimeout=The query exceeded the {0}-second time limit and was stopped.
+# TODO: translate
 oscarReport.RptByExample.MsgExecutionError=The query could not be completed. Check the query and try again.
+# TODO: translate
 oscarReport.RptByExample.MsgHistoryError=The query ran successfully, but it could not be saved to your query history.
+# TODO: translate
 oscarReport.RptByExample.MsgResultLimit=Returned {0} rows (limit: {1}).
 # TODO: translate
 oscarReport.RptByExample.MsgOutputTruncated=Output was truncated after {0} characters.

--- a/src/main/resources/oscarResources_fr.properties
+++ b/src/main/resources/oscarResources_fr.properties
@@ -5628,6 +5628,11 @@ oscarReport.RptByExample.MsgRefresh=Actualiser
 oscarReport.RptByExample.MsgViewQueryHistory=Voir l\u2019historique des requ\u00eates
 oscarReport.RptByExample.MsgLoadQuery=Charger la requ\u00eate
 oscarReport.RptByExample.MsgRunQuery=Ex\u00e9cuter
+oscarReport.RptByExample.MsgDisabled=L\u2019ex\u00e9cution directe des requ\u00eates est actuellement d\u00e9sactiv\u00e9e. Votre requ\u00eate n\u2019a pas \u00e9t\u00e9 ex\u00e9cut\u00e9e.
+oscarReport.RptByExample.MsgValidationError=Une seule requ\u00eate SELECT en lecture seule dans la base de donn\u00e9es de l\u2019application est autoris\u00e9e. Les commentaires, UNION, verrouillages, op\u00e9rations de sortie et fonctions interdites ne sont pas permis.
+oscarReport.RptByExample.MsgTimeout=La requ\u00eate a d\u00e9pass\u00e9 la limite de 15 secondes et a \u00e9t\u00e9 arr\u00eat\u00e9e.
+oscarReport.RptByExample.MsgExecutionError=La requ\u00eate n\u2019a pas pu \u00eatre ex\u00e9cut\u00e9e. V\u00e9rifiez-la et r\u00e9essayez.
+oscarReport.RptByExample.MsgResultLimit=Les r\u00e9sultats sont limit\u00e9s \u00e0 {0} lignes.
 
 oscarReport.RptByExample.MsgConfirmDelete=\u00cates-vous s\u00fbr de vouloir supprimer la requ\u00eate s\u00e9lectionn\u00e9e\u00a0?
 

--- a/src/main/resources/oscarResources_fr.properties
+++ b/src/main/resources/oscarResources_fr.properties
@@ -5635,6 +5635,8 @@ oscarReport.RptByExample.MsgTimeout=The query exceeded the {0}-second time limit
 oscarReport.RptByExample.MsgExecutionError=The query could not be completed. Check the query and try again.
 oscarReport.RptByExample.MsgHistoryError=The query ran successfully, but it could not be saved to your query history.
 oscarReport.RptByExample.MsgResultLimit=Returned {0} rows (limit: {1}).
+# TODO: translate
+oscarReport.RptByExample.MsgOutputTruncated=Output was truncated after {0} characters.
 
 oscarReport.RptByExample.MsgConfirmDelete=\u00cates-vous s\u00fbr de vouloir supprimer la requ\u00eate s\u00e9lectionn\u00e9e\u00a0?
 

--- a/src/main/resources/oscarResources_fr.properties
+++ b/src/main/resources/oscarResources_fr.properties
@@ -5628,11 +5628,13 @@ oscarReport.RptByExample.MsgRefresh=Actualiser
 oscarReport.RptByExample.MsgViewQueryHistory=Voir l\u2019historique des requ\u00eates
 oscarReport.RptByExample.MsgLoadQuery=Charger la requ\u00eate
 oscarReport.RptByExample.MsgRunQuery=Ex\u00e9cuter
-oscarReport.RptByExample.MsgDisabled=L\u2019ex\u00e9cution directe des requ\u00eates est actuellement d\u00e9sactiv\u00e9e. Votre requ\u00eate n\u2019a pas \u00e9t\u00e9 ex\u00e9cut\u00e9e.
-oscarReport.RptByExample.MsgValidationError=Une seule requ\u00eate SELECT en lecture seule dans la base de donn\u00e9es de l\u2019application est autoris\u00e9e. Les commentaires, UNION, verrouillages, op\u00e9rations de sortie et fonctions interdites ne sont pas permis.
-oscarReport.RptByExample.MsgTimeout=La requ\u00eate a d\u00e9pass\u00e9 la limite de 15 secondes et a \u00e9t\u00e9 arr\u00eat\u00e9e.
-oscarReport.RptByExample.MsgExecutionError=La requ\u00eate n\u2019a pas pu \u00eatre ex\u00e9cut\u00e9e. V\u00e9rifiez-la et r\u00e9essayez.
-oscarReport.RptByExample.MsgResultLimit=Les r\u00e9sultats sont limit\u00e9s \u00e0 {0} lignes.
+# TODO: translate Query-by-Example execution messages.
+oscarReport.RptByExample.MsgDisabled=Direct query execution is currently disabled. Your query has not been run.
+oscarReport.RptByExample.MsgValidationError=Only one read-only SELECT from the application database is allowed. Comments, UNION, locking, output operations, and prohibited functions are not permitted.
+oscarReport.RptByExample.MsgTimeout=The query exceeded the 15-second time limit and was stopped.
+oscarReport.RptByExample.MsgExecutionError=The query could not be completed. Check the query and try again.
+oscarReport.RptByExample.MsgHistoryError=The query ran successfully, but it could not be saved to your query history.
+oscarReport.RptByExample.MsgResultLimit=Results are limited to {0} rows.
 
 oscarReport.RptByExample.MsgConfirmDelete=\u00cates-vous s\u00fbr de vouloir supprimer la requ\u00eate s\u00e9lectionn\u00e9e\u00a0?
 

--- a/src/main/resources/oscarResources_fr.properties
+++ b/src/main/resources/oscarResources_fr.properties
@@ -5631,10 +5631,10 @@ oscarReport.RptByExample.MsgRunQuery=Ex\u00e9cuter
 # TODO: translate Query-by-Example execution messages.
 oscarReport.RptByExample.MsgDisabled=Direct query execution is currently disabled. Your query has not been run.
 oscarReport.RptByExample.MsgValidationError=Only one read-only SELECT from the application database is allowed. Comments, UNION, locking, output operations, and prohibited functions are not permitted.
-oscarReport.RptByExample.MsgTimeout=The query exceeded the 15-second time limit and was stopped.
+oscarReport.RptByExample.MsgTimeout=The query exceeded the {0}-second time limit and was stopped.
 oscarReport.RptByExample.MsgExecutionError=The query could not be completed. Check the query and try again.
 oscarReport.RptByExample.MsgHistoryError=The query ran successfully, but it could not be saved to your query history.
-oscarReport.RptByExample.MsgResultLimit=Results are limited to {0} rows.
+oscarReport.RptByExample.MsgResultLimit=Returned {0} rows (limit: {1}).
 
 oscarReport.RptByExample.MsgConfirmDelete=\u00cates-vous s\u00fbr de vouloir supprimer la requ\u00eate s\u00e9lectionn\u00e9e\u00a0?
 

--- a/src/main/resources/oscarResources_fr.properties
+++ b/src/main/resources/oscarResources_fr.properties
@@ -5637,6 +5637,8 @@ oscarReport.RptByExample.MsgHistoryError=The query ran successfully, but it coul
 oscarReport.RptByExample.MsgResultLimit=Returned {0} rows (limit: {1}).
 # TODO: translate
 oscarReport.RptByExample.MsgOutputTruncated=Output was truncated after {0} characters.
+# TODO: translate
+oscarReport.RptByExample.MsgRowLimitReached=More than {0} rows matched. Only the first {0} rows are shown.
 
 oscarReport.RptByExample.MsgConfirmDelete=\u00cates-vous s\u00fbr de vouloir supprimer la requ\u00eate s\u00e9lectionn\u00e9e\u00a0?
 

--- a/src/main/resources/oscarResources_pl.properties
+++ b/src/main/resources/oscarResources_pl.properties
@@ -5864,6 +5864,11 @@ oscarReport.RptByExample.MsgViewQueryHistory=Historia zapyta\u0144
 oscarReport.RptByExample.MsgLoadQuery=Za\u0142aduj zapytanie
 
 oscarReport.RptByExample.MsgRunQuery=Wykonaj
+oscarReport.RptByExample.MsgDisabled=Bezpo\u015brednie wykonywanie zapyta\u0144 jest obecnie wy\u0142\u0105czone. Zapytanie nie zosta\u0142o wykonane.
+oscarReport.RptByExample.MsgValidationError=Dozwolone jest tylko jedno zapytanie SELECT w trybie tylko do odczytu w bazie aplikacji. Komentarze, UNION, blokady, operacje wyj\u015bciowe i zabronione funkcje nie s\u0105 dozwolone.
+oscarReport.RptByExample.MsgTimeout=Zapytanie przekroczy\u0142o limit 15 sekund i zosta\u0142o zatrzymane.
+oscarReport.RptByExample.MsgExecutionError=Nie uda\u0142o si\u0119 wykona\u0107 zapytania. Sprawd\u017a je i spr\u00f3buj ponownie.
+oscarReport.RptByExample.MsgResultLimit=Wyniki s\u0105 ograniczone do {0} wierszy.
 
 oscarReport.RptByExample.MsgConfirmDelete=Czy na pewno chcesz usun\u0105\u0107 wybran\u0105 kwerend\u0119?
 

--- a/src/main/resources/oscarResources_pl.properties
+++ b/src/main/resources/oscarResources_pl.properties
@@ -5874,7 +5874,7 @@ oscarReport.RptByExample.MsgResultLimit=Returned {0} rows (limit: {1}).
 # TODO: translate
 oscarReport.RptByExample.MsgOutputTruncated=Output was truncated after {0} characters.
 # TODO: translate
-oscarReport.RptByExample.MsgRowLimitReached=More than {0} rows matched. Only the first {0} rows are shown.
+oscarReport.RptByExample.MsgRowLimitReached=Additional rows were omitted after the {0}-row display limit was reached.
 
 oscarReport.RptByExample.MsgConfirmDelete=Czy na pewno chcesz usun\u0105\u0107 wybran\u0105 kwerend\u0119?
 

--- a/src/main/resources/oscarResources_pl.properties
+++ b/src/main/resources/oscarResources_pl.properties
@@ -5864,11 +5864,13 @@ oscarReport.RptByExample.MsgViewQueryHistory=Historia zapyta\u0144
 oscarReport.RptByExample.MsgLoadQuery=Za\u0142aduj zapytanie
 
 oscarReport.RptByExample.MsgRunQuery=Wykonaj
-oscarReport.RptByExample.MsgDisabled=Bezpo\u015brednie wykonywanie zapyta\u0144 jest obecnie wy\u0142\u0105czone. Zapytanie nie zosta\u0142o wykonane.
-oscarReport.RptByExample.MsgValidationError=Dozwolone jest tylko jedno zapytanie SELECT w trybie tylko do odczytu w bazie aplikacji. Komentarze, UNION, blokady, operacje wyj\u015bciowe i zabronione funkcje nie s\u0105 dozwolone.
-oscarReport.RptByExample.MsgTimeout=Zapytanie przekroczy\u0142o limit 15 sekund i zosta\u0142o zatrzymane.
-oscarReport.RptByExample.MsgExecutionError=Nie uda\u0142o si\u0119 wykona\u0107 zapytania. Sprawd\u017a je i spr\u00f3buj ponownie.
-oscarReport.RptByExample.MsgResultLimit=Wyniki s\u0105 ograniczone do {0} wierszy.
+# TODO: translate Query-by-Example execution messages.
+oscarReport.RptByExample.MsgDisabled=Direct query execution is currently disabled. Your query has not been run.
+oscarReport.RptByExample.MsgValidationError=Only one read-only SELECT from the application database is allowed. Comments, UNION, locking, output operations, and prohibited functions are not permitted.
+oscarReport.RptByExample.MsgTimeout=The query exceeded the 15-second time limit and was stopped.
+oscarReport.RptByExample.MsgExecutionError=The query could not be completed. Check the query and try again.
+oscarReport.RptByExample.MsgHistoryError=The query ran successfully, but it could not be saved to your query history.
+oscarReport.RptByExample.MsgResultLimit=Results are limited to {0} rows.
 
 oscarReport.RptByExample.MsgConfirmDelete=Czy na pewno chcesz usun\u0105\u0107 wybran\u0105 kwerend\u0119?
 

--- a/src/main/resources/oscarResources_pl.properties
+++ b/src/main/resources/oscarResources_pl.properties
@@ -5873,6 +5873,8 @@ oscarReport.RptByExample.MsgHistoryError=The query ran successfully, but it coul
 oscarReport.RptByExample.MsgResultLimit=Returned {0} rows (limit: {1}).
 # TODO: translate
 oscarReport.RptByExample.MsgOutputTruncated=Output was truncated after {0} characters.
+# TODO: translate
+oscarReport.RptByExample.MsgRowLimitReached=More than {0} rows matched. Only the first {0} rows are shown.
 
 oscarReport.RptByExample.MsgConfirmDelete=Czy na pewno chcesz usun\u0105\u0107 wybran\u0105 kwerend\u0119?
 

--- a/src/main/resources/oscarResources_pl.properties
+++ b/src/main/resources/oscarResources_pl.properties
@@ -5867,10 +5867,10 @@ oscarReport.RptByExample.MsgRunQuery=Wykonaj
 # TODO: translate Query-by-Example execution messages.
 oscarReport.RptByExample.MsgDisabled=Direct query execution is currently disabled. Your query has not been run.
 oscarReport.RptByExample.MsgValidationError=Only one read-only SELECT from the application database is allowed. Comments, UNION, locking, output operations, and prohibited functions are not permitted.
-oscarReport.RptByExample.MsgTimeout=The query exceeded the 15-second time limit and was stopped.
+oscarReport.RptByExample.MsgTimeout=The query exceeded the {0}-second time limit and was stopped.
 oscarReport.RptByExample.MsgExecutionError=The query could not be completed. Check the query and try again.
 oscarReport.RptByExample.MsgHistoryError=The query ran successfully, but it could not be saved to your query history.
-oscarReport.RptByExample.MsgResultLimit=Results are limited to {0} rows.
+oscarReport.RptByExample.MsgResultLimit=Returned {0} rows (limit: {1}).
 
 oscarReport.RptByExample.MsgConfirmDelete=Czy na pewno chcesz usun\u0105\u0107 wybran\u0105 kwerend\u0119?
 

--- a/src/main/resources/oscarResources_pl.properties
+++ b/src/main/resources/oscarResources_pl.properties
@@ -5864,12 +5864,17 @@ oscarReport.RptByExample.MsgViewQueryHistory=Historia zapyta\u0144
 oscarReport.RptByExample.MsgLoadQuery=Za\u0142aduj zapytanie
 
 oscarReport.RptByExample.MsgRunQuery=Wykonaj
-# TODO: translate Query-by-Example execution messages.
+# TODO: translate
 oscarReport.RptByExample.MsgDisabled=Direct query execution is currently disabled. Your query has not been run.
+# TODO: translate
 oscarReport.RptByExample.MsgValidationError=Only one read-only SELECT from the application database is allowed. Comments, UNION, locking, output operations, and prohibited functions are not permitted.
+# TODO: translate
 oscarReport.RptByExample.MsgTimeout=The query exceeded the {0}-second time limit and was stopped.
+# TODO: translate
 oscarReport.RptByExample.MsgExecutionError=The query could not be completed. Check the query and try again.
+# TODO: translate
 oscarReport.RptByExample.MsgHistoryError=The query ran successfully, but it could not be saved to your query history.
+# TODO: translate
 oscarReport.RptByExample.MsgResultLimit=Returned {0} rows (limit: {1}).
 # TODO: translate
 oscarReport.RptByExample.MsgOutputTruncated=Output was truncated after {0} characters.

--- a/src/main/resources/oscarResources_pl.properties
+++ b/src/main/resources/oscarResources_pl.properties
@@ -5871,6 +5871,8 @@ oscarReport.RptByExample.MsgTimeout=The query exceeded the {0}-second time limit
 oscarReport.RptByExample.MsgExecutionError=The query could not be completed. Check the query and try again.
 oscarReport.RptByExample.MsgHistoryError=The query ran successfully, but it could not be saved to your query history.
 oscarReport.RptByExample.MsgResultLimit=Returned {0} rows (limit: {1}).
+# TODO: translate
+oscarReport.RptByExample.MsgOutputTruncated=Output was truncated after {0} characters.
 
 oscarReport.RptByExample.MsgConfirmDelete=Czy na pewno chcesz usun\u0105\u0107 wybran\u0105 kwerend\u0119?
 

--- a/src/main/resources/oscarResources_pt_BR.properties
+++ b/src/main/resources/oscarResources_pt_BR.properties
@@ -7351,11 +7351,13 @@ oscarReport.RptByExample.MsgViewQueryHistory=Ver hist\u00f3rico de consultas
 oscarReport.RptByExample.MsgLoadQuery=Carregar consulta
 
 oscarReport.RptByExample.MsgRunQuery=Executar
-oscarReport.RptByExample.MsgDisabled=A execu\u00e7\u00e3o direta de consultas est\u00e1 desativada. Sua consulta n\u00e3o foi executada.
-oscarReport.RptByExample.MsgValidationError=Apenas uma consulta SELECT somente leitura no banco de dados do aplicativo \u00e9 permitida. Coment\u00e1rios, UNION, bloqueios, opera\u00e7\u00f5es de sa\u00edda e fun\u00e7\u00f5es proibidas n\u00e3o s\u00e3o permitidos.
-oscarReport.RptByExample.MsgTimeout=A consulta excedeu o limite de 15 segundos e foi interrompida.
-oscarReport.RptByExample.MsgExecutionError=N\u00e3o foi poss\u00edvel concluir a consulta. Verifique-a e tente novamente.
-oscarReport.RptByExample.MsgResultLimit=Os resultados est\u00e3o limitados a {0} linhas.
+# TODO: translate Query-by-Example execution messages.
+oscarReport.RptByExample.MsgDisabled=Direct query execution is currently disabled. Your query has not been run.
+oscarReport.RptByExample.MsgValidationError=Only one read-only SELECT from the application database is allowed. Comments, UNION, locking, output operations, and prohibited functions are not permitted.
+oscarReport.RptByExample.MsgTimeout=The query exceeded the 15-second time limit and was stopped.
+oscarReport.RptByExample.MsgExecutionError=The query could not be completed. Check the query and try again.
+oscarReport.RptByExample.MsgHistoryError=The query ran successfully, but it could not be saved to your query history.
+oscarReport.RptByExample.MsgResultLimit=Results are limited to {0} rows.
 
 oscarReport.RptByExample.MsgConfirmDelete=Tem certeza de que deseja excluir a consulta selecionada?
 

--- a/src/main/resources/oscarResources_pt_BR.properties
+++ b/src/main/resources/oscarResources_pt_BR.properties
@@ -7351,6 +7351,11 @@ oscarReport.RptByExample.MsgViewQueryHistory=Ver hist\u00f3rico de consultas
 oscarReport.RptByExample.MsgLoadQuery=Carregar consulta
 
 oscarReport.RptByExample.MsgRunQuery=Executar
+oscarReport.RptByExample.MsgDisabled=A execu\u00e7\u00e3o direta de consultas est\u00e1 desativada. Sua consulta n\u00e3o foi executada.
+oscarReport.RptByExample.MsgValidationError=Apenas uma consulta SELECT somente leitura no banco de dados do aplicativo \u00e9 permitida. Coment\u00e1rios, UNION, bloqueios, opera\u00e7\u00f5es de sa\u00edda e fun\u00e7\u00f5es proibidas n\u00e3o s\u00e3o permitidos.
+oscarReport.RptByExample.MsgTimeout=A consulta excedeu o limite de 15 segundos e foi interrompida.
+oscarReport.RptByExample.MsgExecutionError=N\u00e3o foi poss\u00edvel concluir a consulta. Verifique-a e tente novamente.
+oscarReport.RptByExample.MsgResultLimit=Os resultados est\u00e3o limitados a {0} linhas.
 
 oscarReport.RptByExample.MsgConfirmDelete=Tem certeza de que deseja excluir a consulta selecionada?
 

--- a/src/main/resources/oscarResources_pt_BR.properties
+++ b/src/main/resources/oscarResources_pt_BR.properties
@@ -7360,6 +7360,8 @@ oscarReport.RptByExample.MsgHistoryError=The query ran successfully, but it coul
 oscarReport.RptByExample.MsgResultLimit=Returned {0} rows (limit: {1}).
 # TODO: translate
 oscarReport.RptByExample.MsgOutputTruncated=Output was truncated after {0} characters.
+# TODO: translate
+oscarReport.RptByExample.MsgRowLimitReached=More than {0} rows matched. Only the first {0} rows are shown.
 
 oscarReport.RptByExample.MsgConfirmDelete=Tem certeza de que deseja excluir a consulta selecionada?
 

--- a/src/main/resources/oscarResources_pt_BR.properties
+++ b/src/main/resources/oscarResources_pt_BR.properties
@@ -7354,10 +7354,10 @@ oscarReport.RptByExample.MsgRunQuery=Executar
 # TODO: translate Query-by-Example execution messages.
 oscarReport.RptByExample.MsgDisabled=Direct query execution is currently disabled. Your query has not been run.
 oscarReport.RptByExample.MsgValidationError=Only one read-only SELECT from the application database is allowed. Comments, UNION, locking, output operations, and prohibited functions are not permitted.
-oscarReport.RptByExample.MsgTimeout=The query exceeded the 15-second time limit and was stopped.
+oscarReport.RptByExample.MsgTimeout=The query exceeded the {0}-second time limit and was stopped.
 oscarReport.RptByExample.MsgExecutionError=The query could not be completed. Check the query and try again.
 oscarReport.RptByExample.MsgHistoryError=The query ran successfully, but it could not be saved to your query history.
-oscarReport.RptByExample.MsgResultLimit=Results are limited to {0} rows.
+oscarReport.RptByExample.MsgResultLimit=Returned {0} rows (limit: {1}).
 
 oscarReport.RptByExample.MsgConfirmDelete=Tem certeza de que deseja excluir a consulta selecionada?
 

--- a/src/main/resources/oscarResources_pt_BR.properties
+++ b/src/main/resources/oscarResources_pt_BR.properties
@@ -7358,6 +7358,8 @@ oscarReport.RptByExample.MsgTimeout=The query exceeded the {0}-second time limit
 oscarReport.RptByExample.MsgExecutionError=The query could not be completed. Check the query and try again.
 oscarReport.RptByExample.MsgHistoryError=The query ran successfully, but it could not be saved to your query history.
 oscarReport.RptByExample.MsgResultLimit=Returned {0} rows (limit: {1}).
+# TODO: translate
+oscarReport.RptByExample.MsgOutputTruncated=Output was truncated after {0} characters.
 
 oscarReport.RptByExample.MsgConfirmDelete=Tem certeza de que deseja excluir a consulta selecionada?
 

--- a/src/main/resources/oscarResources_pt_BR.properties
+++ b/src/main/resources/oscarResources_pt_BR.properties
@@ -7351,12 +7351,17 @@ oscarReport.RptByExample.MsgViewQueryHistory=Ver hist\u00f3rico de consultas
 oscarReport.RptByExample.MsgLoadQuery=Carregar consulta
 
 oscarReport.RptByExample.MsgRunQuery=Executar
-# TODO: translate Query-by-Example execution messages.
+# TODO: translate
 oscarReport.RptByExample.MsgDisabled=Direct query execution is currently disabled. Your query has not been run.
+# TODO: translate
 oscarReport.RptByExample.MsgValidationError=Only one read-only SELECT from the application database is allowed. Comments, UNION, locking, output operations, and prohibited functions are not permitted.
+# TODO: translate
 oscarReport.RptByExample.MsgTimeout=The query exceeded the {0}-second time limit and was stopped.
+# TODO: translate
 oscarReport.RptByExample.MsgExecutionError=The query could not be completed. Check the query and try again.
+# TODO: translate
 oscarReport.RptByExample.MsgHistoryError=The query ran successfully, but it could not be saved to your query history.
+# TODO: translate
 oscarReport.RptByExample.MsgResultLimit=Returned {0} rows (limit: {1}).
 # TODO: translate
 oscarReport.RptByExample.MsgOutputTruncated=Output was truncated after {0} characters.

--- a/src/main/resources/oscarResources_pt_BR.properties
+++ b/src/main/resources/oscarResources_pt_BR.properties
@@ -7361,7 +7361,7 @@ oscarReport.RptByExample.MsgResultLimit=Returned {0} rows (limit: {1}).
 # TODO: translate
 oscarReport.RptByExample.MsgOutputTruncated=Output was truncated after {0} characters.
 # TODO: translate
-oscarReport.RptByExample.MsgRowLimitReached=More than {0} rows matched. Only the first {0} rows are shown.
+oscarReport.RptByExample.MsgRowLimitReached=Additional rows were omitted after the {0}-row display limit was reached.
 
 oscarReport.RptByExample.MsgConfirmDelete=Tem certeza de que deseja excluir a consulta selecionada?
 

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/RptByExample.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/RptByExample.jsp
@@ -176,7 +176,9 @@
                     </c:if>
                     <c:if test="${queryTimeout}">
                         <div class="alert alert-danger" role="alert">
-                            <fmt:message key="oscarReport.RptByExample.MsgTimeout"/>
+                            <fmt:message key="oscarReport.RptByExample.MsgTimeout">
+                                <fmt:param value="${queryTimeoutSeconds}"/>
+                            </fmt:message>
                         </div>
                     </c:if>
                     <c:if test="${queryExecutionError}">
@@ -239,6 +241,7 @@
                         <div class="mt-3">
                             <p class="text-muted small">
                                 <fmt:message key="oscarReport.RptByExample.MsgResultLimit">
+                                    <fmt:param value="${resultRowCount}"/>
                                     <fmt:param value="${resultLimit}"/>
                                 </fmt:message>
                             </p>

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/RptByExample.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/RptByExample.jsp
@@ -245,6 +245,13 @@
                                     <fmt:param value="${resultLimit}"/>
                                 </fmt:message>
                             </p>
+                            <c:if test="${resultTruncated}">
+                                <div class="alert alert-warning" role="alert">
+                                    <fmt:message key="oscarReport.RptByExample.MsgOutputTruncated">
+                                        <fmt:param value="${resultCharacterLimit}"/>
+                                    </fmt:message>
+                                </div>
+                            </c:if>
                             ${results}
                         </div>
                     </c:if>

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/RptByExample.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/RptByExample.jsp
@@ -49,7 +49,7 @@
     - results     — HTML string of query results (rendered unescaped; backend-generated)
 
     Security:
-    - Requires _report or _admin.reporting read privilege
+    - Requires _report or _admin read privilege
     - CSRF token auto-injected by CsrfGuardScriptInjectionFilter
 
     @since 2001-2002
@@ -68,9 +68,9 @@
     String roleName$ = session.getAttribute("userrole") + "," + session.getAttribute("user");
     boolean authed = true;
 %>
-<security:oscarSec roleName="<%=roleName$%>" objectName="_report,_admin.reporting" rights="r" reverse="<%=true%>">
+<security:oscarSec roleName="<%=roleName$%>" objectName="_report,_admin" rights="r" reverse="<%=true%>">
     <%authed = false; %>
-    <%response.sendRedirect(request.getContextPath() + "/securityError?type=_report&type=_admin.reporting");%>
+    <%response.sendRedirect(request.getContextPath() + "/securityError?type=_report&type=_admin");%>
 </security:oscarSec>
 <%
     if (!authed) {
@@ -161,8 +161,29 @@
                             <fmt:message key="oscarReport.RptByExample.MsgEnterAQuery"/>
                         </label>
                         <textarea id="sql" name="sql" rows="4"
-                                  class="form-control form-control-sm"></textarea>
+                                  class="form-control form-control-sm">${carlos:forHtml(submittedSql)}</textarea>
                     </div>
+
+                    <c:if test="${queryDisabled}">
+                        <div class="alert alert-warning" role="alert">
+                            <fmt:message key="oscarReport.RptByExample.MsgDisabled"/>
+                        </div>
+                    </c:if>
+                    <c:if test="${queryValidationError}">
+                        <div class="alert alert-danger" role="alert">
+                            <fmt:message key="oscarReport.RptByExample.MsgValidationError"/>
+                        </div>
+                    </c:if>
+                    <c:if test="${queryTimeout}">
+                        <div class="alert alert-danger" role="alert">
+                            <fmt:message key="oscarReport.RptByExample.MsgTimeout"/>
+                        </div>
+                    </c:if>
+                    <c:if test="${queryExecutionError}">
+                        <div class="alert alert-danger" role="alert">
+                            <fmt:message key="oscarReport.RptByExample.MsgExecutionError"/>
+                        </div>
+                    </c:if>
 
                     <!-- OR divider -->
                     <div class="mb-2">
@@ -211,6 +232,11 @@
                     <!-- Query results — rendered as backend-generated HTML -->
                     <c:if test="${not empty results}">
                         <div class="mt-3">
+                            <p class="text-muted small">
+                                <fmt:message key="oscarReport.RptByExample.MsgResultLimit">
+                                    <fmt:param value="1000"/>
+                                </fmt:message>
+                            </p>
                             ${results}
                         </div>
                     </c:if>

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/RptByExample.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/RptByExample.jsp
@@ -161,7 +161,7 @@
                             <fmt:message key="oscarReport.RptByExample.MsgEnterAQuery"/>
                         </label>
                         <textarea id="sql" name="sql" rows="4"
-                                  class="form-control form-control-sm">${carlos:forHtml(submittedSql)}</textarea>
+                                  class="form-control form-control-sm">${carlos:forHtmlContent(submittedSql)}</textarea>
                     </div>
 
                     <c:if test="${queryDisabled}">
@@ -182,6 +182,11 @@
                     <c:if test="${queryExecutionError}">
                         <div class="alert alert-danger" role="alert">
                             <fmt:message key="oscarReport.RptByExample.MsgExecutionError"/>
+                        </div>
+                    </c:if>
+                    <c:if test="${queryHistoryError}">
+                        <div class="alert alert-warning" role="alert">
+                            <fmt:message key="oscarReport.RptByExample.MsgHistoryError"/>
                         </div>
                     </c:if>
 
@@ -234,7 +239,7 @@
                         <div class="mt-3">
                             <p class="text-muted small">
                                 <fmt:message key="oscarReport.RptByExample.MsgResultLimit">
-                                    <fmt:param value="1000"/>
+                                    <fmt:param value="${resultLimit}"/>
                                 </fmt:message>
                             </p>
                             ${results}

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/RptByExample.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/RptByExample.jsp
@@ -252,6 +252,13 @@
                                     </fmt:message>
                                 </div>
                             </c:if>
+                            <c:if test="${resultRowLimitReached}">
+                                <div class="alert alert-warning" role="alert">
+                                    <fmt:message key="oscarReport.RptByExample.MsgRowLimitReached">
+                                        <fmt:param value="${resultLimit}"/>
+                                    </fmt:message>
+                                </div>
+                            </c:if>
                             ${results}
                         </div>
                     </c:if>

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/RptByExamplesAllFavorites.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/RptByExamplesAllFavorites.jsp
@@ -47,7 +47,7 @@
                      (items expose: id, queryName, query)
 
     Security:
-    - Requires _report or _admin.reporting read privilege
+    - Requires _report or _admin read privilege
     - CSRF token auto-injected by CsrfGuardScriptInjectionFilter
 
     @since 2001-2002
@@ -61,9 +61,9 @@
     String roleName$ = session.getAttribute("userrole") + "," + session.getAttribute("user");
     boolean authed = true;
 %>
-<security:oscarSec roleName="<%=roleName$%>" objectName="_report,_admin.reporting" rights="r" reverse="<%=true%>">
+<security:oscarSec roleName="<%=roleName$%>" objectName="_report,_admin" rights="r" reverse="<%=true%>">
     <%authed = false; %>
-    <%response.sendRedirect(request.getContextPath() + "/securityError?type=_report&type=_admin.reporting");%>
+    <%response.sendRedirect(request.getContextPath() + "/securityError?type=_report&type=_admin");%>
 </security:oscarSec>
 <%
     if (!authed) {

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/RptByExamplesAllFavorites.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/RptByExamplesAllFavorites.jsp
@@ -104,9 +104,10 @@
          * @param {string} text1 - The raw SQL query text (JS-attribute-encoded by JSP)
          * @param {string} text2 - The display name of the favourite (JS-attribute-encoded by JSP)
          */
-        function set(text1, text2) {
+        function set(text1, text2, id) {
             document.getElementById('favoritesForm').newQuery.value = text1;
             document.getElementById('favoritesForm').newName.value = text2;
+            document.getElementById('favoritesForm').id.value = id;
         }
 
         /**
@@ -189,7 +190,7 @@
                             <input type="button"
                                    class="btn btn-outline-secondary btn-sm"
                                    value="<fmt:message key='oscarReport.RptByExample.MsgEdit'/>"
-                                   onclick="set('${carlos:forJavaScript(favorite.query)}', '${carlos:forJavaScript(favorite.queryName)}'); document.getElementById('favoritesForm').submit(); return false;"/>
+                                   onclick="set('${carlos:forJavaScript(favorite.query)}', '${carlos:forJavaScript(favorite.queryName)}', '${carlos:forJavaScript(favorite.id)}'); document.getElementById('favoritesForm').submit(); return false;"/>
                             <input type="button"
                                    class="btn btn-danger btn-sm"
                                    value="<fmt:message key='oscarReport.RptByExample.MsgDelete'/>"

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/RptByExamplesAllFavorites.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/RptByExamplesAllFavorites.jsp
@@ -105,9 +105,10 @@
          * @param {string} text2 - The display name of the favourite (JS-attribute-encoded by JSP)
          */
         function set(text1, text2, id) {
-            document.getElementById('favoritesForm').newQuery.value = text1;
-            document.getElementById('favoritesForm').newName.value = text2;
-            document.getElementById('favoritesForm').id.value = id;
+            const form = document.getElementById('favoritesForm');
+            form.elements['newQuery'].value = text1;
+            form.elements['newName'].value = text2;
+            form.elements['id'].value = id;
         }
 
         /**
@@ -118,9 +119,10 @@
          */
         function confirmDelete(id) {
             if (confirm(msgConfirmDelete)) {
-                document.getElementById('favoritesForm').toDelete.value = 'true';
-                document.getElementById('favoritesForm').id.value = id;
-                document.getElementById('favoritesForm').submit();
+                const form = document.getElementById('favoritesForm');
+                form.elements['toDelete'].value = 'true';
+                form.elements['id'].value = id;
+                form.submit();
             }
         }
 

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/RptByExamplesFavorite.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/RptByExamplesFavorite.jsp
@@ -34,9 +34,9 @@
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;
 %>
-<security:oscarSec roleName="<%=roleName$%>" objectName="_report,_admin.reporting" rights="r" reverse="<%=true%>">
+<security:oscarSec roleName="<%=roleName$%>" objectName="_report,_admin" rights="r" reverse="<%=true%>">
     <%authed = false; %>
-    <%response.sendRedirect(request.getContextPath() + "/securityError?type=_report&type=_admin.reporting");%>
+    <%response.sendRedirect(request.getContextPath() + "/securityError?type=_report&type=_admin");%>
 </security:oscarSec>
 <%
     if (!authed) {

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/RptByExamplesFavorite.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/RptByExamplesFavorite.jsp
@@ -69,15 +69,15 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <link rel="icon" href="${pageContext.request.contextPath}/images/favicon.ico"/>
+        <link rel="icon" href="${carlos:forHtmlAttribute(pageContext.request.contextPath)}/images/favicon.ico"/>
         <link rel="stylesheet" type="text/css"
-              href="${pageContext.request.contextPath}/encounter/encounterStyles.css"/>
-        <script type="text/javascript" src="<%= request.getContextPath() %>/js/global.js"></script>
+              href="${carlos:forHtmlAttribute(pageContext.request.contextPath)}/encounter/encounterStyles.css"/>
+        <script type="text/javascript" src="${carlos:forHtmlAttribute(pageContext.request.contextPath)}/js/global.js"></script>
         <title><fmt:message key="oscarReport.RptByExample.MsgQueryByExamples"/> - <fmt:message key="oscarReport.RptByExample.MsgEditMyFavorite"/></title>
     </head>
 
     <body vlink="#0000FF" class="BodyStyle">
-    <form action="${pageContext.request.contextPath}/oscarReport/RptByExamplesFavorite" method="post">
+    <form action="${carlos:forHtmlAttribute(pageContext.request.contextPath)}/oscarReport/RptByExamplesFavorite" method="post">
         <input type="hidden" name="id" value="${carlos:forHtmlAttribute(id)}"/>
     <table class="MainTable" id="scrollNumber1">
         <tr class="MainTableTopRow">

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/RptByExamplesFavorite.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/RptByExamplesFavorite.jsp
@@ -62,26 +62,24 @@
     }
 %>
 
-<%@ page import="java.util.*,io.github.carlos_emr.carlos.report.data.*" %>
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="carlos" prefix="carlos" %>
 <fmt:setBundle basename="oscarResources"/>
 
-
-<link rel="stylesheet" type="text/css"
-      href="<%= request.getContextPath() %>/encounter/encounterStyles.css">
+<!DOCTYPE html>
 <html>
-    <script language="JavaScript" type="text/JavaScript">
-
-    </script>
     <head>
-    <link rel="icon" href="${pageContext.request.contextPath}/images/favicon.ico"/>
+        <link rel="icon" href="${pageContext.request.contextPath}/images/favicon.ico"/>
+        <link rel="stylesheet" type="text/css"
+              href="${pageContext.request.contextPath}/encounter/encounterStyles.css"/>
         <script type="text/javascript" src="<%= request.getContextPath() %>/js/global.js"></script>
         <title><fmt:message key="oscarReport.RptByExample.MsgQueryByExamples"/> - <fmt:message key="oscarReport.RptByExample.MsgEditMyFavorite"/></title>
     </head>
 
     <body vlink="#0000FF" class="BodyStyle">
-    <table class="MainTable" id="scrollNumber1" name="encounterTable">
-        <form action="${pageContext.request.contextPath}/oscarReport/RptByExamplesFavorite" method="post">
+    <form action="${pageContext.request.contextPath}/oscarReport/RptByExamplesFavorite" method="post">
+        <input type="hidden" name="id" value="${carlos:forHtmlAttribute(id)}"/>
+    <table class="MainTable" id="scrollNumber1">
         <tr class="MainTableTopRow">
             <td class="MainTableTopRowLeftColumn"><fmt:message key="oscarReport.CDMReport.msgReport"/></td>
             <td class="MainTableTopRowRightColumn">
@@ -97,16 +95,16 @@
             <td class="MainTableRightColumn">
                 <table>
                     <tr>
-                       <td><input type="text" name="favoriteName" size="40" value="${favoriteName}"/></td>
+                       <td><input type="text" name="favoriteName" size="40" value="${carlos:forHtmlAttribute(favoriteName)}"/></td>
                     </tr>
                     <tr>
-                        <td><textarea name="query" cols="80" rows="3">${newQuery}</textarea></td>
+                        <td><textarea name="query" cols="80" rows="3">${carlos:forHtmlContent(query)}</textarea></td>
                     </tr>
                     <tr>
-                        <td><input type="button" value="Add" onclick="submit();"/> <input
+                        <td><input type="submit" value="<fmt:message key='global.btnAdd'/>"/> <input
                                 type="button"
                                 value="<fmt:message key='oscarReport.RptByExample.MsgCancel'/>"
-                                onclick="javascript:history.back(1);"/></td>
+                                onclick="history.back();"/></td>
                     </tr>
                     <tr></tr>
 
@@ -118,7 +116,6 @@
             <td class="MainTableBottomRowRightColumn"></td>
         </tr>
     </table>
-
     </form>
     </body>
 </html>

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/RptByExamplesFavorite.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/RptByExamplesFavorite.jsp
@@ -29,6 +29,24 @@
 
 --%>
 
+<%--
+    RptByExamplesFavorite.jsp
+    =========================
+    Purpose: Edit a saved Query-by-Example favorite before returning to the
+             favorites list.
+
+    Features:
+    - Requires _report or _admin read privilege
+    - Localized favorite-name and SQL editing form
+    - POST-only submission to RptByExamplesFavorite
+
+    Parameters (set by backing action):
+    - favoriteName — Display name for the favorite
+    - newQuery     — SQL text being edited
+
+    @since 2001-2002
+--%>
+
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/RptByExamplesFavorite.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/RptByExamplesFavorite.jsp
@@ -73,54 +73,82 @@
         <link rel="stylesheet" type="text/css"
               href="${carlos:forHtmlAttribute(pageContext.request.contextPath)}/encounter/encounterStyles.css"/>
         <script type="text/javascript" src="${carlos:forHtmlAttribute(pageContext.request.contextPath)}/js/global.js"></script>
+        <style>
+            .report-favorite-layout {
+                display: grid;
+                grid-template-columns: minmax(0, 130px) minmax(400px, 1fr);
+            }
+            .report-favorite-layout > div {
+                box-sizing: border-box;
+            }
+            .report-favorite-title {
+                align-items: center;
+                display: flex;
+                padding: 0 6px;
+            }
+            .report-favorite-content {
+                height: auto;
+                padding: 8px 6px;
+            }
+            .report-favorite-fields {
+                display: grid;
+                gap: 8px;
+            }
+            .report-favorite-field {
+                align-items: center;
+                display: flex;
+                gap: 8px;
+            }
+            .report-favorite-field label {
+                flex: 0 0 100px;
+                font-weight: bold;
+            }
+            .report-favorite-query-field {
+                align-items: flex-start;
+            }
+            .report-favorite-actions {
+                padding-left: 108px;
+            }
+        </style>
         <title><fmt:message key="oscarReport.RptByExample.MsgQueryByExamples"/> - <fmt:message key="oscarReport.RptByExample.MsgEditMyFavorite"/></title>
     </head>
 
     <body vlink="#0000FF" class="BodyStyle">
     <form action="${carlos:forHtmlAttribute(pageContext.request.contextPath)}/oscarReport/RptByExamplesFavorite" method="post">
         <input type="hidden" name="id" value="${carlos:forHtmlAttribute(id)}"/>
-    <table class="MainTable" id="scrollNumber1" role="presentation">
-        <tr class="MainTableTopRow">
-            <td class="MainTableTopRowLeftColumn"><fmt:message key="oscarReport.CDMReport.msgReport"/></td>
-            <td class="MainTableTopRowRightColumn">
-                <table class="TopStatusBar" role="presentation">
-                    <tr>
-                        <td><fmt:message key="oscarReport.RptByExample.MsgQueryByExamples"/> - <fmt:message key="oscarReport.RptByExample.MsgEditMyFavorite"/></td>
-                    </tr>
-                </table>
-            </td>
-        </tr>
-        <tr>
-            <td class="MainTableLeftColumn" valign="top"></td>
-            <td class="MainTableRightColumn">
-                <table role="presentation">
-                    <tr>
-                       <td>
-                           <label for="favoriteName"><fmt:message key="oscarReport.RptByExample.MsgMyFavorites"/></label>
-                           <input id="favoriteName" type="text" name="favoriteName" size="40"
-                                  value="${carlos:forHtmlAttribute(favoriteName)}"/>
-                       </td>
-                    </tr>
-                    <tr>
-                        <td>
-                            <label for="query"><fmt:message key="oscarReport.RptByExample.MsgQuery"/></label>
-                            <textarea id="query" name="query" cols="80" rows="3">${carlos:forHtmlContent(query)}</textarea>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td><input type="submit" value="<fmt:message key='global.btnAdd'/>"/> <input
-                                type="button"
-                                value="<fmt:message key='oscarReport.RptByExample.MsgCancel'/>"
-                                onclick="history.back();"/></td>
-                    </tr>
-                </table>
-            </td>
-        </tr>
-        <tr>
-            <td class="MainTableBottomRowLeftColumn"></td>
-            <td class="MainTableBottomRowRightColumn"></td>
-        </tr>
-    </table>
+        <div class="MainTable report-favorite-layout" id="scrollNumber1">
+            <div class="MainTableTopRowLeftColumn report-favorite-title">
+                <fmt:message key="oscarReport.CDMReport.msgReport"/>
+            </div>
+            <div class="MainTableTopRowRightColumn report-favorite-title">
+                <div class="TopStatusBar report-favorite-title">
+                    <fmt:message key="oscarReport.RptByExample.MsgQueryByExamples"/> -
+                    <fmt:message key="oscarReport.RptByExample.MsgEditMyFavorite"/>
+                </div>
+            </div>
+            <div class="MainTableLeftColumn"></div>
+            <div class="MainTableRightColumn report-favorite-content">
+                <div class="report-favorite-fields">
+                    <div class="report-favorite-field">
+                        <label for="favoriteName"><fmt:message key="oscarReport.RptByExample.MsgMyFavorites"/></label>
+                        <input id="favoriteName" type="text" name="favoriteName" size="40"
+                               value="${carlos:forHtmlAttribute(favoriteName)}"/>
+                    </div>
+                    <div class="report-favorite-field report-favorite-query-field">
+                        <label for="query"><fmt:message key="oscarReport.RptByExample.MsgQuery"/></label>
+                        <textarea id="query" name="query" cols="80" rows="3">${carlos:forHtmlContent(query)}</textarea>
+                    </div>
+                    <div class="report-favorite-field report-favorite-actions">
+                        <input type="submit" value="<fmt:message key='global.btnAdd'/>"/>
+                        <input type="button"
+                               value="<fmt:message key='oscarReport.RptByExample.MsgCancel'/>"
+                               onclick="history.back();"/>
+                    </div>
+                </div>
+            </div>
+            <div class="MainTableBottomRowLeftColumn"></div>
+            <div class="MainTableBottomRowRightColumn"></div>
+        </div>
     </form>
     </body>
 </html>

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/RptByExamplesFavorite.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/RptByExamplesFavorite.jsp
@@ -79,11 +79,11 @@
     <body vlink="#0000FF" class="BodyStyle">
     <form action="${carlos:forHtmlAttribute(pageContext.request.contextPath)}/oscarReport/RptByExamplesFavorite" method="post">
         <input type="hidden" name="id" value="${carlos:forHtmlAttribute(id)}"/>
-    <table class="MainTable" id="scrollNumber1">
+    <table class="MainTable" id="scrollNumber1" role="presentation">
         <tr class="MainTableTopRow">
             <td class="MainTableTopRowLeftColumn"><fmt:message key="oscarReport.CDMReport.msgReport"/></td>
             <td class="MainTableTopRowRightColumn">
-                <table class="TopStatusBar">
+                <table class="TopStatusBar" role="presentation">
                     <tr>
                         <td><fmt:message key="oscarReport.RptByExample.MsgQueryByExamples"/> - <fmt:message key="oscarReport.RptByExample.MsgEditMyFavorite"/></td>
                     </tr>
@@ -93,12 +93,19 @@
         <tr>
             <td class="MainTableLeftColumn" valign="top"></td>
             <td class="MainTableRightColumn">
-                <table>
+                <table role="presentation">
                     <tr>
-                       <td><input type="text" name="favoriteName" size="40" value="${carlos:forHtmlAttribute(favoriteName)}"/></td>
+                       <td>
+                           <label for="favoriteName"><fmt:message key="oscarReport.RptByExample.MsgMyFavorites"/></label>
+                           <input id="favoriteName" type="text" name="favoriteName" size="40"
+                                  value="${carlos:forHtmlAttribute(favoriteName)}"/>
+                       </td>
                     </tr>
                     <tr>
-                        <td><textarea name="query" cols="80" rows="3">${carlos:forHtmlContent(query)}</textarea></td>
+                        <td>
+                            <label for="query"><fmt:message key="oscarReport.RptByExample.MsgQuery"/></label>
+                            <textarea id="query" name="query" cols="80" rows="3">${carlos:forHtmlContent(query)}</textarea>
+                        </td>
                     </tr>
                     <tr>
                         <td><input type="submit" value="<fmt:message key='global.btnAdd'/>"/> <input
@@ -106,8 +113,6 @@
                                 value="<fmt:message key='oscarReport.RptByExample.MsgCancel'/>"
                                 onclick="history.back();"/></td>
                     </tr>
-                    <tr></tr>
-
                 </table>
             </td>
         </tr>

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/RptViewAllQueryByExamples.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/RptViewAllQueryByExamples.jsp
@@ -48,7 +48,7 @@
     - endDate     — End date filter currently applied (String)
 
     Security:
-    - Requires _report or _admin.reporting read privilege
+    - Requires _report or _admin read privilege
     - CSRF token auto-injected by CsrfGuardScriptInjectionFilter
 
     @since 2001-2002
@@ -62,9 +62,9 @@
     String roleName$ = session.getAttribute("userrole") + "," + session.getAttribute("user");
     boolean authed = true;
 %>
-<security:oscarSec roleName="<%=roleName$%>" objectName="_report,_admin.reporting" rights="r" reverse="<%=true%>">
+<security:oscarSec roleName="<%=roleName$%>" objectName="_report,_admin" rights="r" reverse="<%=true%>">
     <%authed = false; %>
-    <%response.sendRedirect(request.getContextPath() + "/securityError?type=_report&type=_admin.reporting");%>
+    <%response.sendRedirect(request.getContextPath() + "/securityError?type=_report&type=_admin");%>
 </security:oscarSec>
 <%
     if (!authed) {

--- a/src/test/java/io/github/carlos_emr/carlos/app/contract/MutatorActionGetRejectionContractUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/app/contract/MutatorActionGetRejectionContractUnitTest.java
@@ -191,6 +191,8 @@ class MutatorActionGetRejectionContractUnitTest {
                     "_admin.reporting", "w"),
             Arguments.of("io.github.carlos_emr.carlos.report.pageUtil.DbReportAgeSex2Action",
                     "_report", "r"),
+            Arguments.of("io.github.carlos_emr.carlos.report.pageUtil.RptByExamplesFavorite2Action",
+                    "_admin", "r"),
             // --- signature ---
             Arguments.of("io.github.carlos_emr.carlos.signature.action.SaveSignatureUpload2Action",
                     "_con", "w"),

--- a/src/test/java/io/github/carlos_emr/carlos/commn/dao/ReportByExamplesFavoriteDaoIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/commn/dao/ReportByExamplesFavoriteDaoIntegrationTest.java
@@ -36,7 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Integration tests for {@link ReportByExamplesFavoriteDao} covering persist,
- * findByQuery, findByEverything, and findByProvider.
+ * provider-scoped lookup, findByEverything, and findByProvider.
  *
  * <p>Migrated from legacy {@code ReportByExamplesFavoriteDaoTest} (JUnit 4 / DaoTestFixtures).</p>
  *
@@ -92,32 +92,21 @@ public class ReportByExamplesFavoriteDaoIntegrationTest extends CarlosTestBase {
     }
 
     @Nested
-    @DisplayName("findByQuery")
-    class FindByQuery {
+    @DisplayName("findByProviderAndQuery")
+    class FindByProviderAndQuery {
 
         @Test
         @Tag("query")
-        @DisplayName("should return favorites with matching query string using LIKE")
-        void shouldReturnFavorites_whenQueryMatches() {
-            createFavorite("200001", "Fav1", "SELECT demographics");
-            createFavorite("200002", "Fav2", "SELECT appointments");
-            createFavorite("200003", "Fav3", "INSERT something");
+        @DisplayName("should not return another provider's matching query")
+        void shouldReturnOnlyCurrentProviderFavorites_whenQueryMatches() {
+            createFavorite("200010", "Mine", "SELECT appointments");
+            createFavorite("200011", "Theirs", "SELECT appointments");
 
-            List<ReportByExamplesFavorite> results = dao.findByQuery("SELECT%");
+            List<ReportByExamplesFavorite> results =
+                    dao.findByProviderAndQuery("200010", "SELECT appointments");
 
-            assertThat(results).hasSize(2);
-            assertThat(results).allMatch(f -> f.getQuery().startsWith("SELECT"));
-        }
-
-        @Test
-        @Tag("query")
-        @DisplayName("should return empty list when no query matches")
-        void shouldReturnEmptyList_whenNoQueryMatches() {
-            createFavorite("200001", "Fav1", "SELECT something");
-
-            List<ReportByExamplesFavorite> results = dao.findByQuery("NO_MATCH%");
-
-            assertThat(results).isEmpty();
+            assertThat(results).singleElement()
+                    .satisfies(favorite -> assertThat(favorite.getName()).isEqualTo("Mine"));
         }
     }
 
@@ -127,30 +116,27 @@ public class ReportByExamplesFavoriteDaoIntegrationTest extends CarlosTestBase {
 
         @Test
         @Tag("query")
-        @DisplayName("should return favorites matching provider and name")
-        void shouldReturnFavorites_whenProviderAndNameMatch() {
+        @DisplayName("should require provider, name, and query to match")
+        void shouldReturnFavorites_whenAllFieldsMatch() {
             createFavorite("300001", "MatchFav", "some query");
             createFavorite("300001", "OtherFav", "other query");
             createFavorite("300002", "MatchFav", "diff query");
 
-            List<ReportByExamplesFavorite> results = dao.findByEverything("300001", "MatchFav", "NO_MATCH");
+            List<ReportByExamplesFavorite> results = dao.findByEverything("300001", "MatchFav", "some query");
 
-            assertThat(results).isNotEmpty();
-            assertThat(results).anyMatch(f ->
-                    f.getProviderNo().equals("300001") && f.getName().equals("MatchFav"));
+            assertThat(results).singleElement()
+                    .satisfies(favorite -> assertThat(favorite.getProviderNo()).isEqualTo("300001"));
         }
 
         @Test
         @Tag("query")
-        @DisplayName("should return favorites matching query string via OR clause")
-        void shouldReturnFavorites_whenQueryStringMatchesViaOr() {
+        @DisplayName("should not return another provider's matching query")
+        void shouldReturnEmpty_whenOnlyQueryMatches() {
             createFavorite("300003", "SomeFav", "unique query string");
 
-            // The findByEverything method uses OR for query: providerNo = ?1 AND name LIKE ?2 OR query LIKE ?3
             List<ReportByExamplesFavorite> results = dao.findByEverything("NOPROVIDER", "NONAME", "unique query string");
 
-            assertThat(results).isNotEmpty();
-            assertThat(results).anyMatch(f -> f.getQuery().equals("unique query string"));
+            assertThat(results).isEmpty();
         }
     }
 

--- a/src/test/java/io/github/carlos_emr/carlos/db/LegacyJdbcQueryUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/db/LegacyJdbcQueryUnitTest.java
@@ -61,6 +61,9 @@ class LegacyJdbcQueryUnitTest extends CarlosUnitTestBase {
     void shouldAllowSelectOnlyQueries_forAdminReportBoundary() {
         assertThatCode(() -> validateSafeSelectQuery("select demographic_no from demographic"))
                 .doesNotThrowAnyException();
+        assertThatCode(() -> validateSafeSelectQuery(
+                "select 'update delete create drop' as instruction from demographic"))
+                .doesNotThrowAnyException();
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/db/LegacyJdbcQueryUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/db/LegacyJdbcQueryUnitTest.java
@@ -142,6 +142,20 @@ class LegacyJdbcQueryUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
+    @DisplayName("should reject SQL-mode-dependent backslash quote escapes")
+    void shouldRejectBackslashQuotedSql_whenSqlModeIsUnknown() {
+        String ambiguousSql = "select 'safe\\' union select provider_no from provider";
+
+        assertThatThrownBy(() -> LegacyJdbcQuery.trustedSelectSql(ambiguousSql))
+                .isInstanceOf(SQLException.class)
+                .hasMessageContaining("comment or statement separator");
+        assertThatThrownBy(() -> LegacyJdbcQuery.trustedReportSelectSql(ambiguousSql))
+                .isInstanceOf(SQLException.class)
+                .hasMessageContaining("comment or statement separator");
+        assertThat(LegacyJdbcQuery.containsUnsafeSqlControlToken(ambiguousSql)).isTrue();
+    }
+
+    @Test
     @DisplayName("shouldRejectBlockedPatterns_forAdminReportBoundary")
     void shouldRejectBlockedPatterns_forAdminReportBoundary() {
         List<String> unsafeSql = List.of(

--- a/src/test/java/io/github/carlos_emr/carlos/report/ReportActionSecurityMigrationUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/ReportActionSecurityMigrationUnitTest.java
@@ -31,6 +31,9 @@ import io.github.carlos_emr.carlos.commn.model.ReportByExamples;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.report.data.RptByExampleData;
 import io.github.carlos_emr.carlos.report.pageUtil.RptByExample2Action;
+import io.github.carlos_emr.carlos.report.pageUtil.RptByExamplesAllFavorites2Action;
+import io.github.carlos_emr.carlos.report.pageUtil.RptByExamplesFavorite2Action;
+import io.github.carlos_emr.carlos.report.pageUtil.RptViewAllQueryByExamples2Action;
 import io.github.carlos_emr.carlos.report.reportByTemplate.ReportFactory;
 import io.github.carlos_emr.carlos.report.reportByTemplate.ReportManager;
 import io.github.carlos_emr.carlos.report.reportByTemplate.Reporter;
@@ -136,14 +139,17 @@ class ReportActionSecurityMigrationUnitTest extends CarlosUnitTestBase {
         when(securityInfoManager.hasPrivilege(loggedInInfo, "_report", SecurityInfoManager.READ, null)).thenReturn(false);
 
         assertMissingPrivilegeFails(new RptByExample2Action());
+        assertMissingPrivilegeFails(new RptViewAllQueryByExamples2Action());
+        assertMissingPrivilegeFails(new RptByExamplesAllFavorites2Action());
+        assertMissingPrivilegeFails(new RptByExamplesFavorite2Action());
         assertMissingPrivilegeFails(new ExportTemplate2Action());
         assertMissingPrivilegeFails(new GenerateOutFiles2Action());
         assertMissingPrivilegeFails(new GenerateReport2Action());
         assertMissingPrivilegeFails(new UploadTemplates2Action());
 
-        verify(securityInfoManager, times(5))
+        verify(securityInfoManager, times(8))
                 .hasPrivilege(loggedInInfo, "_admin", SecurityInfoManager.READ, null);
-        verify(securityInfoManager, times(5))
+        verify(securityInfoManager, times(8))
                 .hasPrivilege(loggedInInfo, "_report", SecurityInfoManager.READ, null);
     }
 
@@ -155,7 +161,7 @@ class ReportActionSecurityMigrationUnitTest extends CarlosUnitTestBase {
 
         assertAuthorizedMigrationGateAllowsActionBody();
 
-        verify(securityInfoManager, times(5))
+        verify(securityInfoManager, times(8))
                 .hasPrivilege(loggedInInfo, "_admin", SecurityInfoManager.READ, null);
         verify(securityInfoManager, never())
                 .hasPrivilege(loggedInInfo, "_report", SecurityInfoManager.READ, null);
@@ -170,9 +176,9 @@ class ReportActionSecurityMigrationUnitTest extends CarlosUnitTestBase {
 
         assertAuthorizedMigrationGateAllowsActionBody();
 
-        verify(securityInfoManager, times(5))
+        verify(securityInfoManager, times(8))
                 .hasPrivilege(loggedInInfo, "_admin", SecurityInfoManager.READ, null);
-        verify(securityInfoManager, times(5))
+        verify(securityInfoManager, times(8))
                 .hasPrivilege(loggedInInfo, "_report", SecurityInfoManager.READ, null);
     }
 
@@ -222,7 +228,7 @@ class ReportActionSecurityMigrationUnitTest extends CarlosUnitTestBase {
                 RptByExampleData.class,
                 (mock, context) -> when(mock.execute(
                         eq("select demographic_no from demographic"), any(Properties.class), eq("999998")))
-                        .thenReturn(new RptByExampleData.QueryResult("<table></table>", 1)))) {
+                        .thenReturn(new RptByExampleData.QueryResult("<table></table>", 1, false, 23)))) {
             properties.setProperty(RptByExample2Action.ENABLED_PROPERTY, " yes ");
             assertThat(action.execute()).isEqualTo(ActionSupport.SUCCESS);
             assertThat(reportData.constructed()).hasSize(1);
@@ -280,6 +286,9 @@ class ReportActionSecurityMigrationUnitTest extends CarlosUnitTestBase {
 
     private void assertAuthorizedMigrationGateAllowsActionBody() throws Exception {
         assertThat(new RptByExample2Action().execute()).isEqualTo(ActionSupport.SUCCESS);
+        assertThat(new RptViewAllQueryByExamples2Action().execute()).isEqualTo(ActionSupport.SUCCESS);
+        assertThat(new RptByExamplesAllFavorites2Action().execute()).isEqualTo(ActionSupport.SUCCESS);
+        assertThat(new RptByExamplesFavorite2Action().execute()).isEqualTo(ActionSupport.SUCCESS);
 
         request.setParameter("templateid", "template-1");
         assertThat(new ExportTemplate2Action().execute()).isEqualTo(ActionSupport.SUCCESS);

--- a/src/test/java/io/github/carlos_emr/carlos/report/ReportActionSecurityMigrationUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/ReportActionSecurityMigrationUnitTest.java
@@ -197,9 +197,10 @@ class ReportActionSecurityMigrationUnitTest extends CarlosUnitTestBase {
 
         CarlosProperties properties = CarlosProperties.getInstance();
         String previousValue = properties.getProperty(RptByExample2Action.ENABLED_PROPERTY);
-        try {
+        try (MockedConstruction<RptByExampleData> reportData = mockConstruction(RptByExampleData.class)) {
             properties.setProperty(RptByExample2Action.ENABLED_PROPERTY, "false");
             assertThat(action.execute()).isEqualTo(ActionSupport.SUCCESS);
+            assertThat(reportData.constructed()).isEmpty();
         } finally {
             if (previousValue == null) {
                 properties.remove(RptByExample2Action.ENABLED_PROPERTY);

--- a/src/test/java/io/github/carlos_emr/carlos/report/ReportActionSecurityMigrationUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/ReportActionSecurityMigrationUnitTest.java
@@ -316,6 +316,25 @@ class ReportActionSecurityMigrationUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
+    @DisplayName("RptByExamplesFavorite preserves the saved query when an edit submits no query")
+    void shouldPreserveFavoriteQuery_whenEditedQueryIsEmpty() throws Exception {
+        authorizeFavoritePost();
+        ReportByExamplesFavorite favorite = favorite(42, "999998", "Old name", "select 1");
+        when(favoritesDao.find(42)).thenReturn(favorite);
+
+        RptByExamplesFavorite2Action action = new RptByExamplesFavorite2Action();
+        action.setId("42");
+        action.setFavoriteName("New name");
+        action.setQuery("");
+
+        assertThat(action.execute()).isEqualTo(ActionSupport.SUCCESS);
+
+        assertThat(favorite.getName()).isEqualTo("New name");
+        assertThat(favorite.getQuery()).isEqualTo("select 1");
+        verify(favoritesDao).merge(favorite);
+    }
+
+    @Test
     @DisplayName("RptByExample keeps successful results when query history cannot be saved")
     void shouldKeepResults_whenQueryHistorySaveFails() throws Exception {
         LoggedInInfo.setLoggedInInfoIntoSession(request.getSession(), loggedInInfo);

--- a/src/test/java/io/github/carlos_emr/carlos/report/ReportActionSecurityMigrationUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/ReportActionSecurityMigrationUnitTest.java
@@ -224,6 +224,7 @@ class ReportActionSecurityMigrationUnitTest extends CarlosUnitTestBase {
 
         assertThat(getAction.execute()).isEqualTo(ActionSupport.NONE);
         assertThat(response.getStatus()).isEqualTo(405);
+        assertThat(response.getHeader("Allow")).isEqualTo("POST");
         verify(getAction, never()).write2Database(any(), any(), any());
 
         response = new MockHttpServletResponse();
@@ -234,6 +235,7 @@ class ReportActionSecurityMigrationUnitTest extends CarlosUnitTestBase {
 
         assertThat(headAction.execute()).isEqualTo(ActionSupport.NONE);
         assertThat(response.getStatus()).isEqualTo(405);
+        assertThat(response.getHeader("Allow")).isEqualTo("POST");
         verify(headAction, never()).write2Database(any(), any(), any());
         verifyNoInteractions(reportByExamplesDao, favoritesDao);
     }

--- a/src/test/java/io/github/carlos_emr/carlos/report/ReportActionSecurityMigrationUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/ReportActionSecurityMigrationUnitTest.java
@@ -21,10 +21,9 @@
  */
 package io.github.carlos_emr.carlos.report;
 
-import java.util.Collections;
-
-import io.github.carlos_emr.carlos.PMmodule.dao.SecUserRoleDao;
+import io.github.carlos_emr.CarlosProperties;
 import io.github.carlos_emr.carlos.commn.dao.ReportByExamplesDao;
+import io.github.carlos_emr.carlos.commn.dao.ReportByExamplesFavoriteDao;
 import io.github.carlos_emr.carlos.commn.dao.ReportTemplatesDao;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.report.pageUtil.RptByExample2Action;
@@ -71,15 +70,16 @@ class ReportActionSecurityMigrationUnitTest extends CarlosUnitTestBase {
     private MockHttpServletResponse response;
     private SecurityInfoManager securityInfoManager;
     private LoggedInInfo loggedInInfo;
-    private SecUserRoleDao secUserRoleDao;
+    private ReportByExamplesDao reportByExamplesDao;
 
     @BeforeEach
     void setUp() {
         securityInfoManager = mock(SecurityInfoManager.class);
-        secUserRoleDao = mock(SecUserRoleDao.class);
+        reportByExamplesDao = mock(ReportByExamplesDao.class);
         registerMock(SecurityInfoManager.class, securityInfoManager);
-        registerMock(SecUserRoleDao.class, secUserRoleDao);
-        registerMock(ReportByExamplesDao.class, mock(ReportByExamplesDao.class));
+        registerMock(ReportByExamplesDao.class, reportByExamplesDao);
+        ReportByExamplesFavoriteDao favoritesDao = mock(ReportByExamplesFavoriteDao.class);
+        registerMock(ReportByExamplesFavoriteDao.class, favoritesDao);
         registerMock(ReportTemplatesDao.class, mock(ReportTemplatesDao.class));
 
         request = new MockHttpServletRequest();
@@ -92,7 +92,7 @@ class ReportActionSecurityMigrationUnitTest extends CarlosUnitTestBase {
 
         loggedInInfo = mock(LoggedInInfo.class);
         when(loggedInInfo.getLoggedInProviderNo()).thenReturn("999998");
-        when(secUserRoleDao.findByRoleNameAndProviderNo("admin", "999998")).thenReturn(Collections.emptyList());
+        when(favoritesDao.findByProvider("999998")).thenReturn(java.util.Collections.emptyList());
     }
 
     @AfterEach
@@ -142,7 +142,7 @@ class ReportActionSecurityMigrationUnitTest extends CarlosUnitTestBase {
 
     @Test
     @DisplayName("migrated actions skip report privilege check when admin read is present")
-    void shouldSkipReportReadPrivilege_whenAdminReadPrivilegeAllowsAccess() {
+    void shouldSkipReportReadPrivilege_whenAdminReadPrivilegeAllowsAccess() throws Exception {
         LoggedInInfo.setLoggedInInfoIntoSession(request.getSession(), loggedInInfo);
         when(securityInfoManager.hasPrivilege(loggedInInfo, "_admin", SecurityInfoManager.READ, null)).thenReturn(true);
 
@@ -156,7 +156,7 @@ class ReportActionSecurityMigrationUnitTest extends CarlosUnitTestBase {
 
     @Test
     @DisplayName("migrated actions allow report read privilege when admin read is missing")
-    void shouldAllowAccess_whenReportReadPrivilegeAllowsAccess() {
+    void shouldAllowAccess_whenReportReadPrivilegeAllowsAccess() throws Exception {
         LoggedInInfo.setLoggedInInfoIntoSession(request.getSession(), loggedInInfo);
         when(securityInfoManager.hasPrivilege(loggedInInfo, "_admin", SecurityInfoManager.READ, null)).thenReturn(false);
         when(securityInfoManager.hasPrivilege(loggedInInfo, "_report", SecurityInfoManager.READ, null)).thenReturn(true);
@@ -167,6 +167,34 @@ class ReportActionSecurityMigrationUnitTest extends CarlosUnitTestBase {
                 .hasPrivilege(loggedInInfo, "_admin", SecurityInfoManager.READ, null);
         verify(securityInfoManager, times(5))
                 .hasPrivilege(loggedInInfo, "_report", SecurityInfoManager.READ, null);
+    }
+
+    @Test
+    @DisplayName("RptByExample keeps the form available but does not execute or save when disabled")
+    void shouldKeepFormWithoutSaving_whenQueryByExampleIsDisabled() throws Exception {
+        LoggedInInfo.setLoggedInInfoIntoSession(request.getSession(), loggedInInfo);
+        when(securityInfoManager.hasPrivilege(loggedInInfo, "_admin", SecurityInfoManager.READ, null)).thenReturn(false);
+        when(securityInfoManager.hasPrivilege(loggedInInfo, "_report", SecurityInfoManager.READ, null)).thenReturn(true);
+        request.setMethod("POST");
+        RptByExample2Action action = new RptByExample2Action();
+        action.setSql("select demographic_no from demographic");
+
+        CarlosProperties properties = CarlosProperties.getInstance();
+        String previousValue = properties.getProperty(RptByExample2Action.ENABLED_PROPERTY);
+        try {
+            properties.setProperty(RptByExample2Action.ENABLED_PROPERTY, "false");
+            assertThat(action.execute()).isEqualTo(ActionSupport.SUCCESS);
+        } finally {
+            if (previousValue == null) {
+                properties.remove(RptByExample2Action.ENABLED_PROPERTY);
+            } else {
+                properties.setProperty(RptByExample2Action.ENABLED_PROPERTY, previousValue);
+            }
+        }
+
+        assertThat(request.getAttribute("queryDisabled")).isEqualTo(true);
+        assertThat(request.getAttribute("submittedSql")).isEqualTo("select demographic_no from demographic");
+        verifyNoInteractions(reportByExamplesDao);
     }
 
     @Test
@@ -206,10 +234,8 @@ class ReportActionSecurityMigrationUnitTest extends CarlosUnitTestBase {
                 .hasMessage(MISSING_ADMIN_OR_REPORT);
     }
 
-    private void assertAuthorizedMigrationGateAllowsActionBody() {
-        assertThatThrownBy(() -> new RptByExample2Action().execute())
-                .isInstanceOf(SecurityException.class)
-                .hasMessage("missing required admin privileges to run query by example");
+    private void assertAuthorizedMigrationGateAllowsActionBody() throws Exception {
+        assertThat(new RptByExample2Action().execute()).isEqualTo(ActionSupport.SUCCESS);
 
         request.setParameter("templateid", "template-1");
         assertThat(new ExportTemplate2Action().execute()).isEqualTo(ActionSupport.SUCCESS);

--- a/src/test/java/io/github/carlos_emr/carlos/report/ReportActionSecurityMigrationUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/ReportActionSecurityMigrationUnitTest.java
@@ -28,6 +28,7 @@ import io.github.carlos_emr.carlos.commn.dao.ReportByExamplesDao;
 import io.github.carlos_emr.carlos.commn.dao.ReportByExamplesFavoriteDao;
 import io.github.carlos_emr.carlos.commn.dao.ReportTemplatesDao;
 import io.github.carlos_emr.carlos.commn.model.ReportByExamples;
+import io.github.carlos_emr.carlos.commn.model.ReportByExamplesFavorite;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.report.data.RptByExampleData;
 import io.github.carlos_emr.carlos.report.pageUtil.RptByExample2Action;
@@ -260,6 +261,61 @@ class ReportActionSecurityMigrationUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
+    @DisplayName("RptByExamplesFavorite rejects deletion of another provider's favorite")
+    void shouldRejectFavoriteDelete_whenFavoriteBelongsToAnotherProvider() {
+        authorizeFavoritePost();
+        ReportByExamplesFavorite favorite = favorite(42, "100001", "Other provider", "select 1");
+        when(favoritesDao.find(42)).thenReturn(favorite);
+
+        RptByExamplesFavorite2Action action = new RptByExamplesFavorite2Action();
+        action.setToDelete("true");
+        action.setId("42");
+
+        assertThatThrownBy(action::execute)
+                .isInstanceOf(SecurityException.class)
+                .hasMessage("Favorite does not belong to the current provider");
+        verify(favoritesDao, never()).remove(favorite);
+    }
+
+    @Test
+    @DisplayName("RptByExamplesFavorite rejects editing another provider's favorite")
+    void shouldRejectFavoriteEdit_whenFavoriteBelongsToAnotherProvider() {
+        authorizeFavoritePost();
+        ReportByExamplesFavorite favorite = favorite(42, "100001", "Other provider", "select 1");
+        when(favoritesDao.find(42)).thenReturn(favorite);
+
+        RptByExamplesFavorite2Action action = new RptByExamplesFavorite2Action();
+        action.setId("42");
+        action.setNewName("Spoofed name");
+        action.setNewQuery("select 2");
+
+        assertThatThrownBy(action::execute)
+                .isInstanceOf(SecurityException.class)
+                .hasMessage("Favorite does not belong to the current provider");
+        verify(favoritesDao, never()).merge(favorite);
+    }
+
+    @Test
+    @DisplayName("RptByExamplesFavorite updates only the current provider's selected favorite")
+    void shouldUpdateFavorite_whenFavoriteBelongsToCurrentProvider() throws Exception {
+        authorizeFavoritePost();
+        ReportByExamplesFavorite favorite = favorite(42, "999998", "Old name", "select 1");
+        when(favoritesDao.find(42)).thenReturn(favorite);
+
+        RptByExamplesFavorite2Action action = new RptByExamplesFavorite2Action();
+        action.setId("42");
+        action.setFavoriteName("New name");
+        action.setQuery("select 2");
+
+        assertThat(action.execute()).isEqualTo(ActionSupport.SUCCESS);
+
+        assertThat(favorite.getName()).isEqualTo("New name");
+        assertThat(favorite.getQuery()).isEqualTo("select 2");
+        verify(favoritesDao).merge(favorite);
+        verify(favoritesDao).findByProvider("999998");
+    }
+
+    @Test
     @DisplayName("RptByExample keeps successful results when query history cannot be saved")
     void shouldKeepResults_whenQueryHistorySaveFails() throws Exception {
         LoggedInInfo.setLoggedInInfoIntoSession(request.getSession(), loggedInInfo);
@@ -325,6 +381,22 @@ class ReportActionSecurityMigrationUnitTest extends CarlosUnitTestBase {
         assertThatThrownBy(action::execute)
                 .isInstanceOf(SecurityException.class)
                 .hasMessage(MISSING_ADMIN_OR_REPORT);
+    }
+
+    private void authorizeFavoritePost() {
+        LoggedInInfo.setLoggedInInfoIntoSession(request.getSession(), loggedInInfo);
+        when(securityInfoManager.hasPrivilege(loggedInInfo, "_admin", SecurityInfoManager.READ, null))
+                .thenReturn(true);
+        request.setMethod("POST");
+    }
+
+    private static ReportByExamplesFavorite favorite(int id, String providerNo, String name, String query) {
+        ReportByExamplesFavorite favorite = new ReportByExamplesFavorite();
+        favorite.setId(id);
+        favorite.setProviderNo(providerNo);
+        favorite.setName(name);
+        favorite.setQuery(query);
+        return favorite;
     }
 
     private void assertMissingPrivilegeFails(ActionSupport action) {

--- a/src/test/java/io/github/carlos_emr/carlos/report/ReportActionSecurityMigrationUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/ReportActionSecurityMigrationUnitTest.java
@@ -64,6 +64,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -81,6 +82,7 @@ class ReportActionSecurityMigrationUnitTest extends CarlosUnitTestBase {
     private SecurityInfoManager securityInfoManager;
     private LoggedInInfo loggedInInfo;
     private ReportByExamplesDao reportByExamplesDao;
+    private ReportByExamplesFavoriteDao favoritesDao;
 
     @BeforeEach
     void setUp() {
@@ -88,7 +90,7 @@ class ReportActionSecurityMigrationUnitTest extends CarlosUnitTestBase {
         reportByExamplesDao = mock(ReportByExamplesDao.class);
         registerMock(SecurityInfoManager.class, securityInfoManager);
         registerMock(ReportByExamplesDao.class, reportByExamplesDao);
-        ReportByExamplesFavoriteDao favoritesDao = mock(ReportByExamplesFavoriteDao.class);
+        favoritesDao = mock(ReportByExamplesFavoriteDao.class);
         registerMock(ReportByExamplesFavoriteDao.class, favoritesDao);
         registerMock(ReportTemplatesDao.class, mock(ReportTemplatesDao.class));
 
@@ -161,7 +163,7 @@ class ReportActionSecurityMigrationUnitTest extends CarlosUnitTestBase {
 
         assertAuthorizedMigrationGateAllowsActionBody();
 
-        verify(securityInfoManager, times(8))
+        verify(securityInfoManager, times(7))
                 .hasPrivilege(loggedInInfo, "_admin", SecurityInfoManager.READ, null);
         verify(securityInfoManager, never())
                 .hasPrivilege(loggedInInfo, "_report", SecurityInfoManager.READ, null);
@@ -176,9 +178,9 @@ class ReportActionSecurityMigrationUnitTest extends CarlosUnitTestBase {
 
         assertAuthorizedMigrationGateAllowsActionBody();
 
-        verify(securityInfoManager, times(8))
+        verify(securityInfoManager, times(7))
                 .hasPrivilege(loggedInInfo, "_admin", SecurityInfoManager.READ, null);
-        verify(securityInfoManager, times(8))
+        verify(securityInfoManager, times(7))
                 .hasPrivilege(loggedInInfo, "_report", SecurityInfoManager.READ, null);
     }
 
@@ -208,6 +210,51 @@ class ReportActionSecurityMigrationUnitTest extends CarlosUnitTestBase {
         assertThat(request.getAttribute("queryDisabled")).isEqualTo(true);
         assertThat(request.getAttribute("submittedSql")).isEqualTo("select demographic_no from demographic");
         verifyNoInteractions(reportByExamplesDao);
+        verify(favoritesDao).findByProvider("999998");
+    }
+
+    @Test
+    @DisplayName("RptByExamplesFavorite rejects non-POST requests before writing")
+    void shouldRejectNonPostMethods_beforeFavoriteWrite() throws Exception {
+        LoggedInInfo.setLoggedInInfoIntoSession(request.getSession(), loggedInInfo);
+        when(securityInfoManager.hasPrivilege(loggedInInfo, "_admin", SecurityInfoManager.READ, null)).thenReturn(true);
+        request.setMethod("GET");
+        RptByExamplesFavorite2Action getAction = spy(new RptByExamplesFavorite2Action());
+        getAction.setQuery("select demographic_no from demographic");
+
+        assertThat(getAction.execute()).isEqualTo(ActionSupport.NONE);
+        assertThat(response.getStatus()).isEqualTo(405);
+        verify(getAction, never()).write2Database(any(), any(), any());
+
+        response = new MockHttpServletResponse();
+        servletActionContextMock.when(ServletActionContext::getResponse).thenReturn(response);
+        request.setMethod("HEAD");
+        RptByExamplesFavorite2Action headAction = spy(new RptByExamplesFavorite2Action());
+        headAction.setQuery("select demographic_no from demographic");
+
+        assertThat(headAction.execute()).isEqualTo(ActionSupport.NONE);
+        assertThat(response.getStatus()).isEqualTo(405);
+        verify(headAction, never()).write2Database(any(), any(), any());
+        verifyNoInteractions(reportByExamplesDao, favoritesDao);
+    }
+
+    @Test
+    @DisplayName("RptByExamplesFavorite permits an authorized POST mutation")
+    void shouldAllowFavoriteWrite_whenAuthorizedPostIsSubmitted() throws Exception {
+        LoggedInInfo.setLoggedInInfoIntoSession(request.getSession(), loggedInInfo);
+        when(securityInfoManager.hasPrivilege(loggedInInfo, "_admin", SecurityInfoManager.READ, null)).thenReturn(true);
+        request.getSession().setAttribute("user", "999998");
+        request.setMethod("POST");
+        RptByExamplesFavorite2Action action = spy(new RptByExamplesFavorite2Action());
+        action.setFavoriteName("Active patients");
+        action.setQuery("select demographic_no from demographic");
+        org.mockito.Mockito.doNothing().when(action).write2Database(
+                "999998", "Active patients", "select demographic_no from demographic");
+
+        assertThat(action.execute()).isEqualTo(ActionSupport.SUCCESS);
+
+        verify(action).write2Database("999998", "Active patients", "select demographic_no from demographic");
+        verify(favoritesDao).findByProvider("999998");
     }
 
     @Test
@@ -228,7 +275,7 @@ class ReportActionSecurityMigrationUnitTest extends CarlosUnitTestBase {
                 RptByExampleData.class,
                 (mock, context) -> when(mock.execute(
                         eq("select demographic_no from demographic"), any(Properties.class), eq("999998")))
-                        .thenReturn(new RptByExampleData.QueryResult("<table></table>", 1, false, 23)))) {
+                        .thenReturn(new RptByExampleData.QueryResult("<table></table>", 1, false, false, 23)))) {
             properties.setProperty(RptByExample2Action.ENABLED_PROPERTY, " yes ");
             assertThat(action.execute()).isEqualTo(ActionSupport.SUCCESS);
             assertThat(reportData.constructed()).hasSize(1);
@@ -288,7 +335,6 @@ class ReportActionSecurityMigrationUnitTest extends CarlosUnitTestBase {
         assertThat(new RptByExample2Action().execute()).isEqualTo(ActionSupport.SUCCESS);
         assertThat(new RptViewAllQueryByExamples2Action().execute()).isEqualTo(ActionSupport.SUCCESS);
         assertThat(new RptByExamplesAllFavorites2Action().execute()).isEqualTo(ActionSupport.SUCCESS);
-        assertThat(new RptByExamplesFavorite2Action().execute()).isEqualTo(ActionSupport.SUCCESS);
 
         request.setParameter("templateid", "template-1");
         assertThat(new ExportTemplate2Action().execute()).isEqualTo(ActionSupport.SUCCESS);

--- a/src/test/java/io/github/carlos_emr/carlos/report/ReportActionSecurityMigrationUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/ReportActionSecurityMigrationUnitTest.java
@@ -21,11 +21,15 @@
  */
 package io.github.carlos_emr.carlos.report;
 
+import java.util.Properties;
+
 import io.github.carlos_emr.CarlosProperties;
 import io.github.carlos_emr.carlos.commn.dao.ReportByExamplesDao;
 import io.github.carlos_emr.carlos.commn.dao.ReportByExamplesFavoriteDao;
 import io.github.carlos_emr.carlos.commn.dao.ReportTemplatesDao;
+import io.github.carlos_emr.carlos.commn.model.ReportByExamples;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import io.github.carlos_emr.carlos.report.data.RptByExampleData;
 import io.github.carlos_emr.carlos.report.pageUtil.RptByExample2Action;
 import io.github.carlos_emr.carlos.report.reportByTemplate.ReportFactory;
 import io.github.carlos_emr.carlos.report.reportByTemplate.ReportManager;
@@ -51,6 +55,9 @@ import org.springframework.mock.web.MockHttpServletResponse;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.never;
@@ -195,6 +202,43 @@ class ReportActionSecurityMigrationUnitTest extends CarlosUnitTestBase {
         assertThat(request.getAttribute("queryDisabled")).isEqualTo(true);
         assertThat(request.getAttribute("submittedSql")).isEqualTo("select demographic_no from demographic");
         verifyNoInteractions(reportByExamplesDao);
+    }
+
+    @Test
+    @DisplayName("RptByExample keeps successful results when query history cannot be saved")
+    void shouldKeepResults_whenQueryHistorySaveFails() throws Exception {
+        LoggedInInfo.setLoggedInInfoIntoSession(request.getSession(), loggedInInfo);
+        when(securityInfoManager.hasPrivilege(loggedInInfo, "_admin", SecurityInfoManager.READ, null)).thenReturn(false);
+        when(securityInfoManager.hasPrivilege(loggedInInfo, "_report", SecurityInfoManager.READ, null)).thenReturn(true);
+        request.setMethod("POST");
+        RptByExample2Action action = new RptByExample2Action();
+        action.setSql("select demographic_no from demographic");
+        doThrow(new IllegalStateException("history unavailable"))
+                .when(reportByExamplesDao).persist(any(ReportByExamples.class));
+
+        CarlosProperties properties = CarlosProperties.getInstance();
+        String previousValue = properties.getProperty(RptByExample2Action.ENABLED_PROPERTY);
+        try (MockedConstruction<RptByExampleData> reportData = mockConstruction(
+                RptByExampleData.class,
+                (mock, context) -> when(mock.execute(
+                        eq("select demographic_no from demographic"), any(Properties.class), eq("999998")))
+                        .thenReturn(new RptByExampleData.QueryResult("<table></table>", 1)))) {
+            properties.setProperty(RptByExample2Action.ENABLED_PROPERTY, " yes ");
+            assertThat(action.execute()).isEqualTo(ActionSupport.SUCCESS);
+            assertThat(reportData.constructed()).hasSize(1);
+        } finally {
+            if (previousValue == null) {
+                properties.remove(RptByExample2Action.ENABLED_PROPERTY);
+            } else {
+                properties.setProperty(RptByExample2Action.ENABLED_PROPERTY, previousValue);
+            }
+        }
+
+        assertThat(request.getAttribute("results")).isEqualTo("<table></table>");
+        assertThat(request.getAttribute("queryHistoryError")).isEqualTo(true);
+        assertThat(request.getAttribute("queryExecutionError")).isNull();
+        assertThat(request.getAttribute("resultLimit")).isEqualTo(RptByExampleData.MAX_ROWS);
+        verify(reportByExamplesDao).persist(any(ReportByExamples.class));
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/report/data/QueryByExampleSqlValidatorTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/data/QueryByExampleSqlValidatorTest.java
@@ -41,7 +41,7 @@ class QueryByExampleSqlValidatorTest {
 
     @Test
     @DisplayName("allows one SELECT using application tables, joins, and subqueries")
-    void shouldAllowReadOnlyApplicationSelects() {
+    void shouldAllowReadOnlyApplicationSelects_whenSchemaIsConfigured() {
         assertThatCode(() -> QueryByExampleSqlValidator.validate(
                 "select d.demographic_no from demographic d join provider p on p.provider_no=d.provider_no "
                         + "where exists (select 1 from appointment a where a.demographic_no=d.demographic_no)",
@@ -52,7 +52,7 @@ class QueryByExampleSqlValidatorTest {
 
     @Test
     @DisplayName("does not treat prohibited function names inside string literals as invocations")
-    void shouldAllowBlockedFunctionNameInsideLiteral() {
+    void shouldAllowBlockedFunctionNameInsideLiteral_whenFunctionTextIsQuoted() {
         assertThatCode(() -> QueryByExampleSqlValidator.validate("select 'sleep(1)'", properties))
                 .doesNotThrowAnyException();
         assertThatCode(() -> QueryByExampleSqlValidator.validate(
@@ -62,7 +62,7 @@ class QueryByExampleSqlValidatorTest {
 
     @Test
     @DisplayName("structurally rejects set-operation SELECTs")
-    void shouldRejectSetOperationSelects() {
+    void shouldRejectSetOperationSelects_whenMultipleQueriesAreCombined() {
         assertThatThrownBy(() -> QueryByExampleSqlValidator.validate(
                 "select demographic_no from demographic union select provider_no from provider", properties))
                 .isInstanceOf(QueryByExampleValidationException.class)
@@ -71,7 +71,7 @@ class QueryByExampleSqlValidatorTest {
 
     @Test
     @DisplayName("fails closed when the application schema is not configured")
-    void shouldRejectMissingApplicationSchema() {
+    void shouldRejectMissingApplicationSchema_whenSchemaIsUnavailable() {
         Properties missing = new Properties();
         Properties blank = properties("   ?useUnicode=true");
 

--- a/src/test/java/io/github/carlos_emr/carlos/report/data/QueryByExampleSqlValidatorTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/data/QueryByExampleSqlValidatorTest.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.report.data;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Properties;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@Tag("unit")
+@Tag("report")
+@Tag("security")
+class QueryByExampleSqlValidatorTest {
+    private final Properties properties = properties("oscar_mcmaster?useUnicode=true");
+
+    @Test
+    @DisplayName("allows one SELECT using application tables, joins, and subqueries")
+    void shouldAllowReadOnlyApplicationSelects() {
+        assertThatCode(() -> QueryByExampleSqlValidator.validate(
+                "select d.demographic_no from demographic d join provider p on p.provider_no=d.provider_no "
+                        + "where exists (select 1 from appointment a where a.demographic_no=d.demographic_no)",
+                properties)).doesNotThrowAnyException();
+        assertThatCode(() -> QueryByExampleSqlValidator.validate(
+                "select * from `oscar_mcmaster`.`demographic`", properties)).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("does not treat prohibited function names inside string literals as invocations")
+    void shouldAllowBlockedFunctionNameInsideLiteral() {
+        assertThatCode(() -> QueryByExampleSqlValidator.validate("select 'sleep(1)'", properties))
+                .doesNotThrowAnyException();
+    }
+
+    @ParameterizedTest(name = "rejects: {0}")
+    @MethodSource("unsafeQueries")
+    @DisplayName("rejects unsafe or out-of-scope SQL")
+    void shouldRejectUnsafeQueries(String sql) {
+        assertThatThrownBy(() -> QueryByExampleSqlValidator.validate(sql, properties))
+                .isInstanceOf(QueryByExampleValidationException.class);
+    }
+
+    private static Stream<String> unsafeQueries() {
+        return Stream.of(
+                "show tables",
+                "describe demographic",
+                "explain select * from demographic",
+                "update demographic set last_name='x'",
+                "select * from demographic union select * from provider",
+                "select * from demographic; select * from provider",
+                "select * from demographic -- comment",
+                "select * from other_database.demographic",
+                "select sleep(1)",
+                "select benchmark(1000, md5('x'))",
+                "select get_lock('qbe', 1)",
+                "select release_lock('qbe')",
+                "select is_free_lock('qbe')",
+                "select load_file('/etc/passwd')",
+                "select * from demographic for update",
+                "select * from demographic for share",
+                "select demographic_no into @number from demographic");
+    }
+
+    private static Properties properties(String databaseName) {
+        Properties properties = new Properties();
+        properties.setProperty("db_name", databaseName);
+        return properties;
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/report/data/QueryByExampleSqlValidatorTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/data/QueryByExampleSqlValidatorTest.java
@@ -55,6 +55,30 @@ class QueryByExampleSqlValidatorTest {
     void shouldAllowBlockedFunctionNameInsideLiteral() {
         assertThatCode(() -> QueryByExampleSqlValidator.validate("select 'sleep(1)'", properties))
                 .doesNotThrowAnyException();
+        assertThatCode(() -> QueryByExampleSqlValidator.validate(
+                "select 'update delete create drop' as instruction", properties))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("structurally rejects set-operation SELECTs")
+    void shouldRejectSetOperationSelects() {
+        assertThatThrownBy(() -> QueryByExampleSqlValidator.validate(
+                "select demographic_no from demographic union select provider_no from provider", properties))
+                .isInstanceOf(QueryByExampleValidationException.class)
+                .hasMessage("Only one SELECT statement is allowed");
+    }
+
+    @Test
+    @DisplayName("fails closed when the application schema is not configured")
+    void shouldRejectMissingApplicationSchema() {
+        Properties missing = new Properties();
+        Properties blank = properties("   ?useUnicode=true");
+
+        assertThatThrownBy(() -> QueryByExampleSqlValidator.applicationSchema(missing))
+                .isInstanceOf(QueryByExampleValidationException.class);
+        assertThatThrownBy(() -> QueryByExampleSqlValidator.applicationSchema(blank))
+                .isInstanceOf(QueryByExampleValidationException.class);
     }
 
     @ParameterizedTest(name = "rejects: {0}")
@@ -71,7 +95,6 @@ class QueryByExampleSqlValidatorTest {
                 "describe demographic",
                 "explain select * from demographic",
                 "update demographic set last_name='x'",
-                "select * from demographic union select * from provider",
                 "select * from demographic; select * from provider",
                 "select * from demographic -- comment",
                 "select * from other_database.demographic",

--- a/src/test/java/io/github/carlos_emr/carlos/report/data/QueryByExampleSqlValidatorTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/data/QueryByExampleSqlValidatorTest.java
@@ -98,6 +98,7 @@ class QueryByExampleSqlValidatorTest {
                 "select * from demographic; select * from provider",
                 "select * from demographic -- comment",
                 "select * from other_database.demographic",
+                "select * from o\u017Fcar_mcmaster.demographic",
                 "select sleep(1)",
                 "select benchmark(1000, md5('x'))",
                 "select get_lock('qbe', 1)",

--- a/src/test/java/io/github/carlos_emr/carlos/report/data/QueryByExampleSqlValidatorTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/data/QueryByExampleSqlValidatorTest.java
@@ -48,6 +48,14 @@ class QueryByExampleSqlValidatorTest {
                 properties)).doesNotThrowAnyException();
         assertThatCode(() -> QueryByExampleSqlValidator.validate(
                 "select * from `oscar_mcmaster`.`demographic`", properties)).doesNotThrowAnyException();
+        assertThatCode(() -> QueryByExampleSqlValidator.validate(
+                "select count(*), date_format(date_of_birth, '%Y') from demographic", properties))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> QueryByExampleSqlValidator.validate(
+                "select row_number() over (order by demographic_no) from demographic", properties))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> QueryByExampleSqlValidator.validate(
+                "select `into` from demographic", properties)).doesNotThrowAnyException();
     }
 
     @Test
@@ -81,6 +89,16 @@ class QueryByExampleSqlValidatorTest {
                 .isInstanceOf(QueryByExampleValidationException.class);
     }
 
+    @Test
+    @DisplayName("rejects over-limit SQL before parsing")
+    void shouldRejectOverLimitSql_whenSubmissionIsTooLarge() {
+        String sql = "select '" + "x".repeat(QueryByExampleSqlValidator.MAX_SQL_CHARACTERS) + "'";
+
+        assertThatThrownBy(() -> QueryByExampleSqlValidator.validate(sql, properties))
+                .isInstanceOf(QueryByExampleValidationException.class)
+                .hasMessage("SQL query exceeds the allowed length");
+    }
+
     @ParameterizedTest(name = "rejects: {0}")
     @MethodSource("unsafeQueries")
     @DisplayName("rejects unsafe or out-of-scope SQL")
@@ -105,6 +123,12 @@ class QueryByExampleSqlValidatorTest {
                 "select release_lock('qbe')",
                 "select is_free_lock('qbe')",
                 "select load_file('/etc/passwd')",
+                "select custom_reporting_udf(demographic_no) from demographic",
+                "select oscar_mcmaster.custom_reporting_udf(demographic_no) from demographic",
+                "select custom_reporting_udf(demographic_no) over () from demographic",
+                "select @query_by_example_variable",
+                "select @@version",
+                "select next value for report_sequence",
                 "select * from demographic for update",
                 "select * from demographic for share",
                 "select demographic_no into @number from demographic");

--- a/src/test/java/io/github/carlos_emr/carlos/report/data/QueryByExampleSqlValidatorTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/data/QueryByExampleSqlValidatorTest.java
@@ -114,6 +114,7 @@ class QueryByExampleSqlValidatorTest {
                 "explain select * from demographic",
                 "update demographic set last_name='x'",
                 "select * from demographic; select * from provider",
+                "(select demographic_no from demographic union select provider_no from provider)",
                 "select * from demographic -- comment",
                 "select * from other_database.demographic",
                 "select * from o\u017Fcar_mcmaster.demographic",
@@ -130,6 +131,7 @@ class QueryByExampleSqlValidatorTest {
                 "select @@version",
                 "select next value for report_sequence",
                 "select * from demographic for update",
+                "select '\\' as value from demographic for update",
                 "select * from demographic for share",
                 "select demographic_no into @number from demographic");
     }

--- a/src/test/java/io/github/carlos_emr/carlos/report/data/QueryByExampleSqlValidatorUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/data/QueryByExampleSqlValidatorUnitTest.java
@@ -131,7 +131,7 @@ class QueryByExampleSqlValidatorUnitTest {
                 "select @@version",
                 "select next value for report_sequence",
                 "select * from demographic for update",
-                "select '\\' as value from demographic for update",
+                "select '\\\\' as value from demographic for update",
                 "select * from demographic for share",
                 "select demographic_no into @number from demographic");
     }

--- a/src/test/java/io/github/carlos_emr/carlos/report/data/QueryByExampleSqlValidatorUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/data/QueryByExampleSqlValidatorUnitTest.java
@@ -21,10 +21,12 @@
  */
 package io.github.carlos_emr.carlos.report.data;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Properties;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.DisplayName;
@@ -38,6 +40,25 @@ import org.junit.jupiter.params.provider.MethodSource;
 @Tag("report")
 @Tag("security")
 class QueryByExampleSqlValidatorUnitTest {
+    private static final Set<String> EXPECTED_SECURITY_SENSITIVE_TABLES = Set.of(
+            "appdefinition",
+            "appuser",
+            "emailconfig",
+            "emaillog",
+            "fax_config",
+            "oscarcommlocations",
+            "oscarkeys",
+            "professionalspecialists",
+            "property",
+            "publickeys",
+            "security",
+            "securityarchive",
+            "securitytoken",
+            "serviceaccesstoken",
+            "serviceclient",
+            "serviceoauthnonce",
+            "servicerequesttoken");
+
     private final Properties properties = properties("oscar_mcmaster?useUnicode=true");
 
     @Test
@@ -118,6 +139,13 @@ class QueryByExampleSqlValidatorUnitTest {
     }
 
     @Test
+    @DisplayName("keeps the sensitive-table fixture synchronized with the validator policy")
+    void shouldMatchSensitiveTableFixture_whenValidatorPolicyChanges() {
+        assertThat(QueryByExampleSqlValidator.SECURITY_SENSITIVE_TABLES)
+                .containsExactlyInAnyOrderElementsOf(EXPECTED_SECURITY_SENSITIVE_TABLES);
+    }
+
+    @Test
     @DisplayName("rejects sensitive tables through qualified, quoted, and nested references")
     void shouldRejectSecuritySensitiveTables_whenReferenceIsObscured() {
         assertThatThrownBy(() -> QueryByExampleSqlValidator.validate(
@@ -165,24 +193,7 @@ class QueryByExampleSqlValidatorUnitTest {
     }
 
     private static Stream<Arguments> securitySensitiveTables() {
-        return Stream.of(
-                "AppDefinition",
-                "AppUser",
-                "emailConfig",
-                "emailLog",
-                "fax_config",
-                "oscarCommLocations",
-                "oscarKeys",
-                "professionalSpecialists",
-                "property",
-                "publicKeys",
-                "security",
-                "SecurityArchive",
-                "SecurityToken",
-                "ServiceAccessToken",
-                "ServiceClient",
-                "ServiceOAuthNonce",
-                "ServiceRequestToken")
+        return EXPECTED_SECURITY_SENSITIVE_TABLES.stream()
                 .map(Arguments::of);
     }
 

--- a/src/test/java/io/github/carlos_emr/carlos/report/data/QueryByExampleSqlValidatorUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/data/QueryByExampleSqlValidatorUnitTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 @Tag("unit")
@@ -107,6 +108,29 @@ class QueryByExampleSqlValidatorUnitTest {
                 .isInstanceOf(QueryByExampleValidationException.class);
     }
 
+    @ParameterizedTest(name = "rejects sensitive table: {0}")
+    @MethodSource("securitySensitiveTables")
+    @DisplayName("rejects tables containing authentication secrets")
+    void shouldRejectSecuritySensitiveTables(String table) {
+        assertThatThrownBy(() -> QueryByExampleSqlValidator.validate("select * from " + table, properties))
+                .isInstanceOf(QueryByExampleValidationException.class)
+                .hasMessage("Queries may not read tables containing authentication secrets");
+    }
+
+    @Test
+    @DisplayName("rejects sensitive tables through qualified, quoted, and nested references")
+    void shouldRejectSecuritySensitiveTables_whenReferenceIsObscured() {
+        assertThatThrownBy(() -> QueryByExampleSqlValidator.validate(
+                "select * from `oscar_mcmaster`.`Security`", properties))
+                .isInstanceOf(QueryByExampleValidationException.class);
+        assertThatThrownBy(() -> QueryByExampleSqlValidator.validate(
+                "select * from demographic where exists (select 1 from ServiceAccessToken)", properties))
+                .isInstanceOf(QueryByExampleValidationException.class);
+        assertThatThrownBy(() -> QueryByExampleSqlValidator.validate(
+                "with tokens as (select * from SecurityToken) select * from tokens", properties))
+                .isInstanceOf(QueryByExampleValidationException.class);
+    }
+
     private static Stream<String> unsafeQueries() {
         return Stream.of(
                 "show tables",
@@ -120,6 +144,10 @@ class QueryByExampleSqlValidatorUnitTest {
                 "select * from o\u017Fcar_mcmaster.demographic",
                 "select sleep(1)",
                 "select benchmark(1000, md5('x'))",
+                "select repeat('x', 2147483647)",
+                "select space(2147483647)",
+                "select lpad('x', 2147483647, 'x')",
+                "select rpad('x', 2147483647, 'x')",
                 "select get_lock('qbe', 1)",
                 "select release_lock('qbe')",
                 "select is_free_lock('qbe')",
@@ -134,6 +162,28 @@ class QueryByExampleSqlValidatorUnitTest {
                 "select '\\\\' as value from demographic for update",
                 "select * from demographic for share",
                 "select demographic_no into @number from demographic");
+    }
+
+    private static Stream<Arguments> securitySensitiveTables() {
+        return Stream.of(
+                "AppDefinition",
+                "AppUser",
+                "emailConfig",
+                "emailLog",
+                "fax_config",
+                "oscarCommLocations",
+                "oscarKeys",
+                "professionalSpecialists",
+                "property",
+                "publicKeys",
+                "security",
+                "SecurityArchive",
+                "SecurityToken",
+                "ServiceAccessToken",
+                "ServiceClient",
+                "ServiceOAuthNonce",
+                "ServiceRequestToken")
+                .map(Arguments::of);
     }
 
     private static Properties properties(String databaseName) {

--- a/src/test/java/io/github/carlos_emr/carlos/report/data/QueryByExampleSqlValidatorUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/data/QueryByExampleSqlValidatorUnitTest.java
@@ -36,7 +36,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 @Tag("unit")
 @Tag("report")
 @Tag("security")
-class QueryByExampleSqlValidatorTest {
+class QueryByExampleSqlValidatorUnitTest {
     private final Properties properties = properties("oscar_mcmaster?useUnicode=true");
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/report/data/RptByExampleDataTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/data/RptByExampleDataTest.java
@@ -78,7 +78,7 @@ class RptByExampleDataTest {
 
     @Test
     @DisplayName("executes once using a bounded read-only JDBC statement and restores connection state")
-    void shouldExecuteBoundedReadOnlyQueryAndRestoreConnection() throws SQLException {
+    void shouldExecuteBoundedReadOnlyQuery_whenConnectionStartsReadOnly() throws SQLException {
         RptByExampleData.QueryResult result = reportData.execute(
                 "select demographic_no from demographic", properties, "999998");
 
@@ -93,6 +93,22 @@ class RptByExampleDataTest {
         order.verify(resultSet).close();
         order.verify(statement).close();
         order.verify(connection).setReadOnly(true);
+        order.verify(connection).close();
+    }
+
+    @Test
+    @DisplayName("restores a writable connection after a successful query")
+    void shouldRestoreWritableConnection_whenQuerySucceeds() throws SQLException {
+        when(connection.isReadOnly()).thenReturn(false);
+
+        reportData.execute("select demographic_no from demographic", properties, "999998");
+
+        InOrder order = inOrder(connection, statement, resultSet);
+        order.verify(connection).setReadOnly(true);
+        order.verify(statement).executeQuery();
+        order.verify(resultSet).close();
+        order.verify(statement).close();
+        order.verify(connection).setReadOnly(false);
         order.verify(connection).close();
     }
 
@@ -131,7 +147,7 @@ class RptByExampleDataTest {
 
     @Test
     @DisplayName("rejects unsafe SQL before acquiring a database connection")
-    void shouldRejectBeforeConnecting() throws SQLException {
+    void shouldRejectBeforeConnecting_whenSqlIsUnsafe() throws SQLException {
         assertThatThrownBy(() -> reportData.execute("delete from demographic", properties, "999998"))
                 .isInstanceOf(QueryByExampleValidationException.class);
 

--- a/src/test/java/io/github/carlos_emr/carlos/report/data/RptByExampleDataTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/data/RptByExampleDataTest.java
@@ -23,6 +23,7 @@ package io.github.carlos_emr.carlos.report.data;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -34,6 +35,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.sql.SQLTimeoutException;
 import java.util.Properties;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -63,15 +65,15 @@ class RptByExampleDataTest {
         properties = new Properties();
         properties.setProperty("db_name", "oscar_mcmaster?useUnicode=true");
 
-        when(connection.isReadOnly()).thenReturn(false);
+        when(connection.isReadOnly()).thenReturn(true);
         when(connection.prepareStatement("select demographic_no from demographic",
                 ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY)).thenReturn(statement);
         when(statement.executeQuery()).thenReturn(resultSet);
         when(resultSet.getMetaData()).thenReturn(metadata);
         when(metadata.getColumnCount()).thenReturn(1);
-        when(metadata.getColumnName(1)).thenReturn("demographic_no");
+        when(metadata.getColumnLabel(1)).thenReturn("demographic_no");
         when(resultSet.next()).thenReturn(true, false);
-        when(resultSet.getString("demographic_no")).thenReturn("42");
+        when(resultSet.getString(1)).thenReturn("42");
     }
 
     @Test
@@ -90,8 +92,41 @@ class RptByExampleDataTest {
         order.verify(statement).executeQuery();
         order.verify(resultSet).close();
         order.verify(statement).close();
-        order.verify(connection).setReadOnly(false);
+        order.verify(connection).setReadOnly(true);
         order.verify(connection).close();
+    }
+
+    @Test
+    @DisplayName("preserves a timeout when restoring connection state also fails")
+    void shouldPreserveTimeout_whenReadOnlyRestoreFails() throws SQLException {
+        SQLTimeoutException timeout = new SQLTimeoutException("timed out");
+        SQLException restoreFailure = new SQLException("restore failed");
+        when(connection.isReadOnly()).thenReturn(false);
+        when(statement.executeQuery()).thenThrow(timeout);
+        doThrow(restoreFailure).when(connection).setReadOnly(false);
+
+        assertThatThrownBy(() -> reportData.execute(
+                "select demographic_no from demographic", properties, "999998"))
+                .isSameAs(timeout)
+                .satisfies(thrown -> assertThat(thrown.getSuppressed()).containsExactly(restoreFailure));
+
+        verify(connection).setReadOnly(false);
+        verify(connection).close();
+    }
+
+    @Test
+    @DisplayName("renders duplicate column labels using their positional values")
+    void shouldRenderPositionalValues_whenColumnLabelsAreDuplicated() throws SQLException {
+        when(metadata.getColumnCount()).thenReturn(2);
+        when(metadata.getColumnLabel(1)).thenReturn("id");
+        when(metadata.getColumnLabel(2)).thenReturn("id");
+        when(resultSet.getString(1)).thenReturn("first");
+        when(resultSet.getString(2)).thenReturn("second");
+
+        RptResultStruct.StructuredResult result = RptResultStruct.getStructureWithCount(resultSet);
+
+        assertThat(result.html()).contains("first").contains("second");
+        assertThat(result.rowCount()).isEqualTo(1);
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/report/data/RptByExampleDataTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/data/RptByExampleDataTest.java
@@ -85,7 +85,7 @@ class RptByExampleDataTest {
 
         assertThat(result.rowCount()).isEqualTo(1);
         assertThat(result.html()).contains("demographic_no").contains("42");
-        verify(statement).setMaxRows(RptByExampleData.MAX_ROWS);
+        verify(statement).setMaxRows(RptByExampleData.MAX_ROWS + 1);
         verify(statement).setQueryTimeout(RptByExampleData.QUERY_TIMEOUT_SECONDS);
 
         InOrder order = inOrder(connection, statement, resultSet);
@@ -174,6 +174,29 @@ class RptByExampleDataTest {
         assertThat(result.rowCount()).isEqualTo(1);
         assertThat(result.html()).hasSizeLessThanOrEqualTo(128).endsWith("</td></tr></table>");
         assertThat(result.html()).contains("&lt;");
+        String cell = result.html().substring(result.html().indexOf("<td>") + 4, result.html().indexOf("</td>"));
+        assertThat(cell).matches("(?:&lt;)*…");
+    }
+
+    @Test
+    @DisplayName("reports omitted rows when the result exceeds the rendering row limit")
+    void shouldReportRowLimit_whenResultContainsAnotherRow() throws SQLException {
+        when(resultSet.next()).thenReturn(true, true);
+
+        RptResultStruct.StructuredResult result = RptResultStruct.getStructureWithCount(resultSet, 1_000, 1);
+
+        assertThat(result.rowCount()).isEqualTo(1);
+        assertThat(result.rowLimitReached()).isTrue();
+        assertThat(result.html()).contains("42");
+    }
+
+    @Test
+    @DisplayName("does not report omitted rows when the result exactly reaches the row limit")
+    void shouldNotReportRowLimit_whenResultExactlyMatchesLimit() throws SQLException {
+        RptResultStruct.StructuredResult result = RptResultStruct.getStructureWithCount(resultSet, 1_000, 1);
+
+        assertThat(result.rowCount()).isEqualTo(1);
+        assertThat(result.rowLimitReached()).isFalse();
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/report/data/RptByExampleDataTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/data/RptByExampleDataTest.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.report.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.util.Properties;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+@Tag("unit")
+@Tag("report")
+@Tag("security")
+class RptByExampleDataTest {
+    private Connection connection;
+    private PreparedStatement statement;
+    private ResultSet resultSet;
+    private ResultSetMetaData metadata;
+    private RptByExampleData reportData;
+    private Properties properties;
+
+    @BeforeEach
+    void setUp() throws SQLException {
+        connection = mock(Connection.class);
+        statement = mock(PreparedStatement.class);
+        resultSet = mock(ResultSet.class);
+        metadata = mock(ResultSetMetaData.class);
+        reportData = new RptByExampleData(() -> connection);
+        properties = new Properties();
+        properties.setProperty("db_name", "oscar_mcmaster?useUnicode=true");
+
+        when(connection.isReadOnly()).thenReturn(false);
+        when(connection.prepareStatement("select demographic_no from demographic",
+                ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY)).thenReturn(statement);
+        when(statement.executeQuery()).thenReturn(resultSet);
+        when(resultSet.getMetaData()).thenReturn(metadata);
+        when(metadata.getColumnCount()).thenReturn(1);
+        when(metadata.getColumnName(1)).thenReturn("demographic_no");
+        when(resultSet.next()).thenReturn(true, false);
+        when(resultSet.getString("demographic_no")).thenReturn("42");
+    }
+
+    @Test
+    @DisplayName("executes once using a bounded read-only JDBC statement and restores connection state")
+    void shouldExecuteBoundedReadOnlyQueryAndRestoreConnection() throws SQLException {
+        RptByExampleData.QueryResult result = reportData.execute(
+                "select demographic_no from demographic", properties, "999998");
+
+        assertThat(result.rowCount()).isEqualTo(1);
+        assertThat(result.html()).contains("demographic_no").contains("42");
+        verify(statement).setMaxRows(RptByExampleData.MAX_ROWS);
+        verify(statement).setQueryTimeout(RptByExampleData.QUERY_TIMEOUT_SECONDS);
+
+        InOrder order = inOrder(connection, statement, resultSet);
+        order.verify(connection).setReadOnly(true);
+        order.verify(statement).executeQuery();
+        order.verify(resultSet).close();
+        order.verify(statement).close();
+        order.verify(connection).setReadOnly(false);
+        order.verify(connection).close();
+    }
+
+    @Test
+    @DisplayName("rejects unsafe SQL before acquiring a database connection")
+    void shouldRejectBeforeConnecting() throws SQLException {
+        assertThatThrownBy(() -> reportData.execute("delete from demographic", properties, "999998"))
+                .isInstanceOf(QueryByExampleValidationException.class);
+
+        verify(connection, never()).prepareStatement(org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.anyInt(), org.mockito.ArgumentMatchers.anyInt());
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/report/data/RptByExampleDataTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/data/RptByExampleDataTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.StringReader;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -73,7 +74,7 @@ class RptByExampleDataTest {
         when(metadata.getColumnCount()).thenReturn(1);
         when(metadata.getColumnLabel(1)).thenReturn("demographic_no");
         when(resultSet.next()).thenReturn(true, false);
-        when(resultSet.getString(1)).thenReturn("42");
+        when(resultSet.getCharacterStream(1)).thenAnswer(ignored -> new StringReader("42"));
     }
 
     @Test
@@ -131,18 +132,48 @@ class RptByExampleDataTest {
     }
 
     @Test
+    @DisplayName("preserves query failure when restoring an originally read-only connection also fails")
+    void shouldPreserveQueryFailure_whenOriginallyReadOnlyRestoreFails() throws SQLException {
+        SQLException queryFailure = new SQLException("query failed");
+        SQLException restoreFailure = new SQLException("restore failed");
+        when(statement.executeQuery()).thenThrow(queryFailure);
+        org.mockito.Mockito.doNothing().doThrow(restoreFailure).when(connection).setReadOnly(true);
+
+        assertThatThrownBy(() -> reportData.execute(
+                "select demographic_no from demographic", properties, "999998"))
+                .isSameAs(queryFailure)
+                .satisfies(thrown -> assertThat(thrown.getSuppressed()).containsExactly(restoreFailure));
+
+        verify(connection, org.mockito.Mockito.times(2)).setReadOnly(true);
+        verify(connection).close();
+    }
+
+    @Test
     @DisplayName("renders duplicate column labels using their positional values")
     void shouldRenderPositionalValues_whenColumnLabelsAreDuplicated() throws SQLException {
         when(metadata.getColumnCount()).thenReturn(2);
         when(metadata.getColumnLabel(1)).thenReturn("id");
         when(metadata.getColumnLabel(2)).thenReturn("id");
-        when(resultSet.getString(1)).thenReturn("first");
-        when(resultSet.getString(2)).thenReturn("second");
+        when(resultSet.getCharacterStream(1)).thenAnswer(ignored -> new StringReader("first"));
+        when(resultSet.getCharacterStream(2)).thenAnswer(ignored -> new StringReader("second"));
 
         RptResultStruct.StructuredResult result = RptResultStruct.getStructureWithCount(resultSet);
 
         assertThat(result.html()).contains("first").contains("second");
         assertThat(result.rowCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("truncates encoded result output at the configured character budget")
+    void shouldTruncateEncodedOutput_whenCellExceedsCharacterBudget() throws SQLException {
+        when(resultSet.getCharacterStream(1)).thenAnswer(ignored -> new StringReader("<".repeat(1_000)));
+
+        RptResultStruct.StructuredResult result = RptResultStruct.getStructureWithCount(resultSet, 128);
+
+        assertThat(result.truncated()).isTrue();
+        assertThat(result.rowCount()).isEqualTo(1);
+        assertThat(result.html()).hasSizeLessThanOrEqualTo(128).endsWith("</td></tr></table>");
+        assertThat(result.html()).contains("&lt;");
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/report/data/RptByExampleDataUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/data/RptByExampleDataUnitTest.java
@@ -23,9 +23,13 @@ package io.github.carlos_emr.carlos.report.data;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -40,11 +44,15 @@ import java.sql.SQLException;
 import java.sql.SQLTimeoutException;
 import java.util.Properties;
 
+import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
+import org.mockito.MockedStatic;
+
+import io.github.carlos_emr.carlos.utility.MiscUtils;
 
 @Tag("unit")
 @Tag("report")
@@ -132,19 +140,44 @@ class RptByExampleDataUnitTest {
     }
 
     @Test
+    @DisplayName("restores connection state after an unchecked read-only setup failure")
+    void shouldRestoreConnection_whenReadOnlySetupThrowsRuntimeException() throws SQLException {
+        IllegalStateException setupFailure = new IllegalStateException("read-only setup failed");
+        when(connection.isReadOnly()).thenReturn(false);
+        doThrow(setupFailure).when(connection).setReadOnly(true);
+
+        assertThatThrownBy(() -> reportData.execute(
+                "select demographic_no from demographic", properties, "999998"))
+                .isSameAs(setupFailure);
+
+        verify(connection).setReadOnly(false);
+        verify(connection).close();
+        verify(connection, never()).prepareStatement(org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.anyInt(), org.mockito.ArgumentMatchers.anyInt());
+    }
+
+    @Test
     @DisplayName("reports a connection restore failure after a successful query")
     void shouldReportRestoreFailure_whenQuerySucceeds() throws SQLException {
         SQLException restoreFailure = new SQLException("restore failed");
         when(connection.isReadOnly()).thenReturn(false);
         doThrow(restoreFailure).when(connection).setReadOnly(false);
+        Logger logger = mock(Logger.class);
 
-        assertThatThrownBy(() -> reportData.execute(
-                "select demographic_no from demographic", properties, "999998"))
-                .isSameAs(restoreFailure);
+        try (MockedStatic<MiscUtils> miscUtils = mockStatic(MiscUtils.class)) {
+            miscUtils.when(MiscUtils::getLogger).thenReturn(logger);
+
+            assertThatThrownBy(() -> reportData.execute(
+                    "select demographic_no from demographic", properties, "999998"))
+                    .isSameAs(restoreFailure);
+        }
 
         verify(statement).executeQuery();
         verify(connection).setReadOnly(false);
         verify(connection).close();
+        verify(logger).info(
+                eq("Query-by-Example audit provider={} queryHash={} queryLength={} durationMs={} rowCount={} outcome={}"),
+                eq("999998"), anyString(), eq(38), anyLong(), eq(1), eq("failed"));
     }
 
     @Test
@@ -159,6 +192,24 @@ class RptByExampleDataUnitTest {
         assertThatThrownBy(() -> reportData.execute(
                 "select demographic_no from demographic", properties, "999998"))
                 .isSameAs(timeout)
+                .satisfies(thrown -> assertThat(thrown.getSuppressed()).containsExactly(restoreFailure));
+
+        verify(connection).setReadOnly(false);
+        verify(connection).close();
+    }
+
+    @Test
+    @DisplayName("preserves query failure when restoring state throws an unchecked exception")
+    void shouldPreserveQueryFailure_whenRestoreThrowsRuntimeException() throws SQLException {
+        SQLException queryFailure = new SQLException("query failed");
+        IllegalStateException restoreFailure = new IllegalStateException("restore failed");
+        when(connection.isReadOnly()).thenReturn(false);
+        when(statement.executeQuery()).thenThrow(queryFailure);
+        doThrow(restoreFailure).when(connection).setReadOnly(false);
+
+        assertThatThrownBy(() -> reportData.execute(
+                "select demographic_no from demographic", properties, "999998"))
+                .isSameAs(queryFailure)
                 .satisfies(thrown -> assertThat(thrown.getSuppressed()).containsExactly(restoreFailure));
 
         verify(connection).setReadOnly(false);

--- a/src/test/java/io/github/carlos_emr/carlos/report/data/RptByExampleDataUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/data/RptByExampleDataUnitTest.java
@@ -48,7 +48,7 @@ import org.mockito.InOrder;
 @Tag("unit")
 @Tag("report")
 @Tag("security")
-class RptByExampleDataTest {
+class RptByExampleDataUnitTest {
     private Connection connection;
     private PreparedStatement statement;
     private ResultSet resultSet;

--- a/src/test/java/io/github/carlos_emr/carlos/report/data/RptByExampleDataUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/data/RptByExampleDataUnitTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -114,6 +115,39 @@ class RptByExampleDataUnitTest {
     }
 
     @Test
+    @DisplayName("reports a read-only setup failure without executing SQL")
+    void shouldNotExecuteQuery_whenReadOnlySetupFails() throws SQLException {
+        SQLException setupFailure = new SQLException("read-only setup failed");
+        when(connection.isReadOnly()).thenReturn(false);
+        doThrow(setupFailure).when(connection).setReadOnly(true);
+
+        assertThatThrownBy(() -> reportData.execute(
+                "select demographic_no from demographic", properties, "999998"))
+                .isSameAs(setupFailure);
+
+        verify(connection).setReadOnly(false);
+        verify(connection).close();
+        verify(connection, never()).prepareStatement(org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.anyInt(), org.mockito.ArgumentMatchers.anyInt());
+    }
+
+    @Test
+    @DisplayName("reports a connection restore failure after a successful query")
+    void shouldReportRestoreFailure_whenQuerySucceeds() throws SQLException {
+        SQLException restoreFailure = new SQLException("restore failed");
+        when(connection.isReadOnly()).thenReturn(false);
+        doThrow(restoreFailure).when(connection).setReadOnly(false);
+
+        assertThatThrownBy(() -> reportData.execute(
+                "select demographic_no from demographic", properties, "999998"))
+                .isSameAs(restoreFailure);
+
+        verify(statement).executeQuery();
+        verify(connection).setReadOnly(false);
+        verify(connection).close();
+    }
+
+    @Test
     @DisplayName("preserves a timeout when restoring connection state also fails")
     void shouldPreserveTimeout_whenReadOnlyRestoreFails() throws SQLException {
         SQLTimeoutException timeout = new SQLTimeoutException("timed out");
@@ -144,7 +178,7 @@ class RptByExampleDataUnitTest {
                 .isSameAs(queryFailure)
                 .satisfies(thrown -> assertThat(thrown.getSuppressed()).containsExactly(restoreFailure));
 
-        verify(connection, org.mockito.Mockito.times(2)).setReadOnly(true);
+        verify(connection, times(2)).setReadOnly(true);
         verify(connection).close();
     }
 
@@ -157,7 +191,10 @@ class RptByExampleDataUnitTest {
         when(resultSet.getCharacterStream(1)).thenAnswer(ignored -> new StringReader("first"));
         when(resultSet.getCharacterStream(2)).thenAnswer(ignored -> new StringReader("second"));
 
-        RptResultStruct.StructuredResult result = RptResultStruct.getStructureWithCount(resultSet);
+        RptResultStruct.StructuredResult result;
+        try (ResultSet closeableResultSet = resultSet) {
+            result = RptResultStruct.getStructureWithCount(closeableResultSet);
+        }
 
         assertThat(result.html()).contains("first").contains("second");
         assertThat(result.rowCount()).isEqualTo(1);
@@ -168,7 +205,10 @@ class RptByExampleDataUnitTest {
     void shouldTruncateEncodedOutput_whenCellExceedsCharacterBudget() throws SQLException {
         when(resultSet.getCharacterStream(1)).thenAnswer(ignored -> new StringReader("<".repeat(1_000)));
 
-        RptResultStruct.StructuredResult result = RptResultStruct.getStructureWithCount(resultSet, 128);
+        RptResultStruct.StructuredResult result;
+        try (ResultSet closeableResultSet = resultSet) {
+            result = RptResultStruct.getStructureWithCount(closeableResultSet, 128);
+        }
 
         assertThat(result.truncated()).isTrue();
         assertThat(result.rowCount()).isEqualTo(1);
@@ -183,7 +223,10 @@ class RptByExampleDataUnitTest {
     void shouldReportRowLimit_whenResultContainsAnotherRow() throws SQLException {
         when(resultSet.next()).thenReturn(true, true);
 
-        RptResultStruct.StructuredResult result = RptResultStruct.getStructureWithCount(resultSet, 1_000, 1);
+        RptResultStruct.StructuredResult result;
+        try (ResultSet closeableResultSet = resultSet) {
+            result = RptResultStruct.getStructureWithCount(closeableResultSet, 1_000, 1);
+        }
 
         assertThat(result.rowCount()).isEqualTo(1);
         assertThat(result.rowLimitReached()).isTrue();
@@ -193,7 +236,10 @@ class RptByExampleDataUnitTest {
     @Test
     @DisplayName("does not report omitted rows when the result exactly reaches the row limit")
     void shouldNotReportRowLimit_whenResultExactlyMatchesLimit() throws SQLException {
-        RptResultStruct.StructuredResult result = RptResultStruct.getStructureWithCount(resultSet, 1_000, 1);
+        RptResultStruct.StructuredResult result;
+        try (ResultSet closeableResultSet = resultSet) {
+            result = RptResultStruct.getStructureWithCount(closeableResultSet, 1_000, 1);
+        }
 
         assertThat(result.rowCount()).isEqualTo(1);
         assertThat(result.rowLimitReached()).isFalse();

--- a/src/test/java/io/github/carlos_emr/carlos/report/data/RptByExampleDataUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/data/RptByExampleDataUnitTest.java
@@ -42,6 +42,7 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.SQLTimeoutException;
+import java.sql.Types;
 import java.util.Properties;
 
 import org.apache.logging.log4j.Logger;
@@ -82,6 +83,7 @@ class RptByExampleDataUnitTest {
         when(resultSet.getMetaData()).thenReturn(metadata);
         when(metadata.getColumnCount()).thenReturn(1);
         when(metadata.getColumnLabel(1)).thenReturn("demographic_no");
+        when(metadata.getColumnType(1)).thenReturn(Types.VARCHAR);
         when(resultSet.next()).thenReturn(true, false);
         when(resultSet.getCharacterStream(1)).thenAnswer(ignored -> new StringReader("42"));
     }
@@ -247,6 +249,7 @@ class RptByExampleDataUnitTest {
         when(metadata.getColumnCount()).thenReturn(2);
         when(metadata.getColumnLabel(1)).thenReturn("id");
         when(metadata.getColumnLabel(2)).thenReturn("id");
+        when(metadata.getColumnType(2)).thenReturn(Types.VARCHAR);
         when(resultSet.getCharacterStream(1)).thenAnswer(ignored -> new StringReader("first"));
         when(resultSet.getCharacterStream(2)).thenAnswer(ignored -> new StringReader("second"));
 
@@ -257,6 +260,19 @@ class RptByExampleDataUnitTest {
 
         assertThat(result.html()).contains("first").contains("second");
         assertThat(result.rowCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("renders numeric columns without requesting an unsupported character stream")
+    void shouldRenderUsingStringValue_whenColumnIsNumeric() throws SQLException {
+        when(metadata.getColumnType(1)).thenReturn(Types.INTEGER);
+        when(resultSet.getString(1)).thenReturn("42");
+
+        RptResultStruct.StructuredResult result = RptResultStruct.getStructureWithCount(resultSet);
+
+        assertThat(result.html()).contains("42");
+        verify(resultSet).getString(1);
+        verify(resultSet, never()).getCharacterStream(1);
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/report/data/RptByExampleDataUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/data/RptByExampleDataUnitTest.java
@@ -89,8 +89,13 @@ class RptByExampleDataUnitTest {
     @Test
     @DisplayName("executes once using a bounded read-only JDBC statement and restores connection state")
     void shouldExecuteBoundedReadOnlyQuery_whenConnectionStartsReadOnly() throws SQLException {
-        RptByExampleData.QueryResult result = reportData.execute(
-                "select demographic_no from demographic", properties, "999998");
+        Logger logger = mock(Logger.class);
+        RptByExampleData.QueryResult result;
+        try (MockedStatic<MiscUtils> miscUtils = mockStatic(MiscUtils.class)) {
+            miscUtils.when(MiscUtils::getLogger).thenReturn(logger);
+            result = reportData.execute(
+                    "select demographic_no from demographic", properties, "999998");
+        }
 
         assertThat(result.rowCount()).isEqualTo(1);
         assertThat(result.html()).contains("demographic_no").contains("42");
@@ -104,6 +109,9 @@ class RptByExampleDataUnitTest {
         order.verify(statement).close();
         order.verify(connection).setReadOnly(true);
         order.verify(connection).close();
+        verify(logger).info(
+                eq("Query-by-Example audit provider={} queryHash={} queryLength={} durationMs={} rowCount={} outcome={}"),
+                eq("999998"), anyString(), eq(38), anyLong(), eq(1), eq("success"));
     }
 
     @Test


### PR DESCRIPTION
## Description

Re-enables Query by Example for providers with `_report` read or `_admin` read while keeping its existing Admin page links.

- Adds a default-on `QUERY_BY_EXAMPLE_ENABLED` kill switch; when disabled, the existing form, textarea, favorites, and history remain available and submissions show a localized disabled message without touching JDBC or history.
- Structurally parses submitted SQL and permits one read-only `SELECT` against the configured CARLOS schema only.
- Rejects comments, stacked statements, `UNION`, non-SELECT statements, cross-schema reads, locking/output clauses, and resource-control/file functions.
- Uses the normal CARLOS datasource with scoped read-only connection state, a read-only result set, a 1,000-row cap, and a 15-second timeout.
- Executes POST submissions exactly once, saves history only after success, encodes result output, localizes user-facing errors, and emits SQL-free audit metadata.

## Related Issues

Fixes #2568

## How Was This Tested?

`mvn -q -Dtest=QueryByExampleSqlValidatorTest,RptByExampleDataTest,ReportActionSecurityMigrationUnitTest,LegacyJdbcQueryUnitTest test`

47 tests passed. This also ran the dependency-lock check.

## Screenshots

Not included; the existing page layout and disabled-state form are intentionally preserved.

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality
- [x] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Re-enable the Query-by-Example reporting tool with strict, read-only SQL validation, bounded execution, and configurable kill switch while preserving the existing UI and history behavior.

New Features:
- Allow authorized report users to execute validated, read-only Query-by-Example SQL against the application schema with row and timeout limits.
- Introduce a default-on QUERY_BY_EXAMPLE_ENABLED configuration flag to globally disable Query-by-Example execution without removing the UI.

Enhancements:
- Replace legacy disabled Query-by-Example flow with a structured execution path that scopes read-only JDBC connections, captures row counts, and emits hashed audit logs without storing raw SQL.
- Update the Query-by-Example JSP to preserve submitted SQL, show localized validation/timeout/error/disabled messages, and display a user-facing results limit notice.
- Adjust report security to permit access with _report or _admin read privileges and clarify this in the JSP documentation.
- Extend result rendering utilities to return both HTML and row counts for use by Query-by-Example.

Build:
- Add the jsqlparser dependency for structural SQL parsing and exclude its generated classes from JaCoCo coverage to avoid instrumentation issues.

Tests:
- Add unit tests covering read-only, bounded Query-by-Example execution, validation rejection before DB access, and the disabled kill-switch behavior.
- Add parameterized tests for the SQL validator to accept safe application SELECTs and reject unsafe or out-of-scope SQL patterns.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-enables Query by Example for `_report`/`_admin` readers with strict single-SELECT validation via `com.github.jsqlparser:jsqlparser`, read-only bounded execution, localized feedback, and hashed audit logs. Adds a default-on `QUERY_BY_EXAMPLE_ENABLED` kill switch and fixes #2568.

- **New Features**
  - Validates one app-schema `SELECT`; rejects comments, set ops, non-`SELECT`, cross-schema, locking/output, variables, and non-whitelisted functions; ignores keywords in strings.
  - Executes read-only with 1,000-row cap, 15s timeout, and 1M-char output budget; returns HTML plus row count with truncation/limit flags; audits with hashed SQL; saves history only on success; localized disabled/validation/timeout/execution/history/limit messages; favorites are POST-only and provider-scoped exact matches; gates on `_admin` or `_report` read.

- **Bug Fixes**
  - Cuts false positives by stripping quoted sections; rejects ambiguous backslash-escaped quotes; hardens case-insensitive schema comparisons; preserves cleanup context across validation and execution.
  - Prevents secret exposure by removing query debug logs and avoiding raw SQL storage; safely truncates HTML at entity boundaries and renders duplicate column labels by position; DAO and JSP updates enforce exact matching and correct `_admin`/`_report` checks; resolves static analysis findings; adds tests confirming the kill switch prevents execution when disabled and enforcing sensitive-table restrictions.
  - Correctly renders numeric result types in Query by Example output.

<sup>Written for commit a15394ea4ee887095d6655bd81dde4eec240e7c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

