### PR TITLE
fix(report): map flu billing patient columns

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "test:consultation-signature-playwright": "node scripts/consultation-signature-playwright-checks.js",
     "test:consultation-signature-submit-playwright": "node scripts/consultation-signature-submit-playwright-checks.js",
     "test:prescription-signature-playwright": "node scripts/prescription-signature-playwright-checks.js",
-    "test:report-demographic-navigation-playwright": "node scripts/report-demographic-navigation-playwright-checks.js"
+    "test:report-demographic-navigation-playwright": "node scripts/report-demographic-navigation-playwright-checks.js",
+    "test:flu-billing-report-playwright": "node scripts/flu-billing-report-playwright-checks.js"
   },
   "dependencies": {
     "@docusaurus/core": "^3.9.2",

--- a/scripts/flu-billing-report-playwright-checks.js
+++ b/scripts/flu-billing-report-playwright-checks.js
@@ -525,9 +525,12 @@ async function run() {
 
     assert(browserFindings.length === 0, `Browser findings: ${JSON.stringify(browserFindings)}`);
 
+    // The provider number is deliberately not reported: it is a real
+    // security.provider_no, a PHI-correlating identifier, and nothing about the
+    // result needs it. The seeded ids in cleanup diagnostics are different — those
+    // rows are synthetic and an operator needs the ids to remove them by hand.
     console.log(JSON.stringify({
       reportYear,
-      providerNo,
       assertions: [
         'all seven patient and billing columns map correctly',
         'latest valid selected-year flu claim is displayed',

--- a/scripts/flu-billing-report-playwright-checks.js
+++ b/scripts/flu-billing-report-playwright-checks.js
@@ -306,6 +306,25 @@ function cleanupSeedData() {
   return failures;
 }
 
+/*
+ * Cleanup runs from the normal finally block and from the signal handlers, so it
+ * is latched: whichever path arrives first does the work and the other gets an
+ * empty result rather than a second round of deletes.
+ */
+let cleanupCompleted = false;
+
+function runCleanupOnce() {
+  if (cleanupCompleted) {
+    return [];
+  }
+  cleanupCompleted = true;
+  try {
+    return cleanupSeedData();
+  } finally {
+    cleanupMysqlDefaultsFile();
+  }
+}
+
 function cleanupMysqlDefaultsFile() {
   if (mysqlDefaults) {
     fs.rmSync(mysqlDefaults.dir, { recursive: true, force: true });
@@ -390,10 +409,19 @@ async function reportRows(page, reportYear, providerNo, expectedSelectedProvider
     query.set('proNo', providerNo);
   }
   const suffix = query.toString() ? `?${query.toString()}` : '?orderby=';
-  await page.goto(appUrl(`/oscarReport/FluBilling${suffix}`), { // nosemgrep: javascript.playwright.security.audit.playwright-goto-injection.playwright-goto-injection -- reportYear and providerNo are database-derived validated values, and appUrl restricts the target host/path
-    waitUntil: 'domcontentloaded',
-    timeout: 30000,
-  });
+  // A navigation failure reports the URL it was loading, twice, and run()'s
+  // handler prints error.stack verbatim -- which would put the real provider
+  // number in the output that wirePage and the assertions are careful to keep it
+  // out of. Replace it with the path and the failure reason only.
+  try {
+    await page.goto(appUrl(`/oscarReport/FluBilling${suffix}`), { // nosemgrep: javascript.playwright.security.audit.playwright-goto-injection.playwright-goto-injection -- reportYear and providerNo are database-derived validated values, and appUrl restricts the target host/path
+      waitUntil: 'domcontentloaded',
+      timeout: 30000,
+    });
+  } catch (error) {
+    const reason = String(error.message).split('\n')[0].replace(/https?:\/\/\S+/g, '<url>');
+    throw new Error(`Navigation to the Flu Billing Report failed: ${reason}`);
+  }
   // Only a networkidle timeout is expected here (the report page keeps some
   // long-lived connections open). Anything else — a closed target, a failed
   // navigation — must surface rather than turn into a confusing failure on the
@@ -665,11 +693,7 @@ async function run() {
         console.error(`WARN failed to close browser: ${error.message}`);
       });
     }
-    try {
-      cleanupFailures = cleanupSeedData();
-    } finally {
-      cleanupMysqlDefaultsFile();
-    }
+    cleanupFailures = runCleanupOnce();
     cleanupFailures.forEach((failure) => console.error(`WARN ${failure}`));
   }
 
@@ -681,6 +705,25 @@ async function run() {
     );
   }
   console.log('PASS CARLOS EMR Flu Billing Report demographic mapping and provider filters');
+}
+
+// A run takes minutes, so Ctrl-C part way through is entirely likely. Without
+// this, Node exits without unwinding the finally block and leaves synthetic 65+
+// patients sitting in the schema -- exactly what the cleanup guarantee exists to
+// prevent. The browser is left to the OS; only the database and the cleartext
+// password file matter here.
+for (const signal of ['SIGINT', 'SIGTERM']) {
+  process.on(signal, () => {
+    console.error(`\n${signal} received; removing seeded rows before exiting.`);
+    let interrupted = [];
+    try {
+      interrupted = runCleanupOnce();
+    } catch (error) {
+      console.error(`WARN cleanup after ${signal} failed: ${error.message}`);
+    }
+    interrupted.forEach((failure) => console.error(`WARN ${failure}`));
+    process.exit(130);
+  });
 }
 
 run().catch((error) => {

--- a/scripts/flu-billing-report-playwright-checks.js
+++ b/scripts/flu-billing-report-playwright-checks.js
@@ -274,7 +274,9 @@ function wirePage(page) {
   page.on('response', (response) => {
     const responseUrl = response.url();
     if (response.status() >= 400 && !/\/favicon\.ico$|\/imageRenderingServlet\?/.test(responseUrl)) {
-      browserFindings.push({ type: 'http', status: response.status(), url: responseUrl });
+      // Path only: report URLs carry proNo, a real provider number, and these
+      // findings are printed on every failure.
+      browserFindings.push({ type: 'http', status: response.status(), path: new URL(responseUrl).pathname });
     }
   });
   page.on('console', (message) => {
@@ -517,11 +519,26 @@ async function run() {
 
     // A malformed year must fall back to the current year, not error and not
     // drive the year-select loop past Integer.MAX_VALUE.
-    for (const badYear of ['abc', '+2023', '2147483645', '-5']) {
+    const currentYear = sql('SELECT YEAR(CURRENT_DATE)');
+    for (const badYear of ['abc', '+2023', '2147483645', '-5', '0025']) {
       const rows = await reportRows(page, badYear, '-1');
       assert(rows.length > 0, `Malformed numMonth=${badYear} produced no rows at all`);
       fixtureRow(rows, primary.patientName);
+      // Assert what it fell back TO, not merely that it did not error.
+      const shownYear = await page.locator('select[name="numMonth"]').inputValue();
+      assert(shownYear === currentYear,
+        `Malformed numMonth=${badYear} fell back to ${shownYear} instead of the current year ${currentYear}`);
     }
+
+    // Whitespace around the provider must not turn into a literal filter. This is
+    // the same "empty worklist under an All Providers label" failure as an absent
+    // proNo, reachable from a hand-edited or copied URL.
+    const paddedAllRows = await reportRows(page, null, ' -1 ', '-1');
+    fixtureRow(paddedAllRows, primary.patientName);
+    const paddedProviderRows = await reportRows(page, null, ` ${providerNo} `, providerNo);
+    fixtureRow(paddedProviderRows, primary.patientName);
+    assert(!paddedProviderRows.some((row) => row[0] === secondary.patientName),
+      'Padded provider filter did not actually filter by provider');
 
     assert(browserFindings.length === 0, `Browser findings: ${JSON.stringify(browserFindings)}`);
 

--- a/scripts/flu-billing-report-playwright-checks.js
+++ b/scripts/flu-billing-report-playwright-checks.js
@@ -304,9 +304,25 @@ async function login(page) {
   ]);
 }
 
-async function reportRows(page, reportYear, providerNo) {
-  const query = new URLSearchParams({ numMonth: reportYear, proNo: providerNo });
-  await page.goto(appUrl(`/oscarReport/FluBilling?${query.toString()}`), { // nosemgrep: javascript.playwright.security.audit.playwright-goto-injection.playwright-goto-injection -- reportYear and providerNo are database-derived validated values, and appUrl restricts the target host/path
+/*
+ * Loads the report and returns its rows as arrays of cell text.
+ *
+ * Passing reportYear/providerNo as null omits the parameter entirely, which is
+ * how the real entry points link to this report (leftNav.jspf and admin.jsp both
+ * send only "?orderby="). Exercising that shape matters: an absent proNo used to
+ * filter on provider_no = '' and render an empty worklist under a dropdown that
+ * still read "All Providers".
+ */
+async function reportRows(page, reportYear, providerNo, expectedSelectedProvider) {
+  const query = new URLSearchParams();
+  if (reportYear !== null) {
+    query.set('numMonth', reportYear);
+  }
+  if (providerNo !== null) {
+    query.set('proNo', providerNo);
+  }
+  const suffix = query.toString() ? `?${query.toString()}` : '?orderby=';
+  await page.goto(appUrl(`/oscarReport/FluBilling${suffix}`), { // nosemgrep: javascript.playwright.security.audit.playwright-goto-injection.playwright-goto-injection -- reportYear and providerNo are database-derived validated values, and appUrl restricts the target host/path
     waitUntil: 'domcontentloaded',
     timeout: 30000,
   });
@@ -322,9 +338,12 @@ async function reportRows(page, reportYear, providerNo) {
   const body = await page.locator('body').innerText();
   assert(!/CARLOS has encountered an unexpected error|HTTP Status 500|Exception Report/i.test(body), 'Flu Billing Report rendered an error page');
   assert(await page.locator('table tbody').count(), 'Flu Billing Report result table was missing');
+  // The dropdown must agree with the filter that actually ran, so a mismatch
+  // between "All Providers" on screen and the applied filter cannot recur.
+  const expectedSelection = expectedSelectedProvider === undefined ? providerNo : expectedSelectedProvider;
   const selectedProvider = await page.locator('select[name="proNo"]').inputValue();
-  assert(selectedProvider === providerNo,
-    `Flu Billing Report selected provider ${selectedProvider} instead of ${providerNo}`);
+  assert(selectedProvider === expectedSelection,
+    `Flu Billing Report selected provider ${selectedProvider} instead of ${expectedSelection}`);
   return page.locator('table tbody tr').evaluateAll((rows) => rows.map((row) =>
     [...row.querySelectorAll('td')].map((cell) => cell.textContent.trim())
   ));
@@ -484,6 +503,26 @@ async function run() {
     });
     assert(!individualProviderRows.some((row) => row[0] === secondary.patientName),
       'Individual-provider filtering included the synthetic patient assigned to another provider');
+
+    // The shape both real entry points use: no numMonth, no proNo. This must list
+    // every eligible patient rather than filtering on an empty provider number.
+    // The year defaults to the current one, so the fixtures' previous-year claims
+    // correctly show as blank billing dates here.
+    const defaultEntryRows = await reportRows(page, null, null, '-1');
+    for (const fixture of [primary, secondary, unvaccinated]) {
+      const row = fixtureRow(defaultEntryRows, fixture.patientName);
+      assert(row[6] === '',
+        `Default entry point showed a billing date for ${fixture.patientName} whose only claims predate the current year`);
+    }
+
+    // A malformed year must fall back to the current year, not error and not
+    // drive the year-select loop past Integer.MAX_VALUE.
+    for (const badYear of ['abc', '+2023', '2147483645', '-5']) {
+      const rows = await reportRows(page, badYear, '-1');
+      assert(rows.length > 0, `Malformed numMonth=${badYear} produced no rows at all`);
+      fixtureRow(rows, primary.patientName);
+    }
+
     assert(browserFindings.length === 0, `Browser findings: ${JSON.stringify(browserFindings)}`);
 
     console.log(JSON.stringify({
@@ -495,6 +534,8 @@ async function run() {
         'a patient with no claim that year renders a blank billing date',
         'All Providers includes every synthetic patient',
         'individual provider keeps both of its assigned synthetic patients and excludes the other',
+        'the parameterless entry-point URL lists every patient and selects All Providers',
+        'a malformed report year falls back to the current year instead of erroring',
       ],
     }, null, 2));
   } finally {

--- a/scripts/flu-billing-report-playwright-checks.js
+++ b/scripts/flu-billing-report-playwright-checks.js
@@ -188,7 +188,14 @@ function createMysqlDefaultsFile() {
   }
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'carlos-flu-report-mysql-'));
   const file = path.join(dir, 'client.cnf');
-  fs.writeFileSync(file, `[client]\npassword=${encodeOptionFileValue(mysqlPassword)}\n`, { mode: 0o600 });
+  try {
+    fs.writeFileSync(file, `[client]\npassword=${encodeOptionFileValue(mysqlPassword)}\n`, { mode: 0o600 });
+  } catch (error) {
+    // This runs before the run-level cleanup exists, so a partial write would
+    // otherwise strand the directory -- possibly holding the password.
+    fs.rmSync(dir, { recursive: true, force: true });
+    throw error;
+  }
   return { dir, file };
 }
 
@@ -217,6 +224,8 @@ function describeMysqlFailure(error) {
     .replace(/\d{3,}/g, '###')
     .slice(0, 200);
 }
+
+const MYSQL_TIMEOUT_MS = 30000;
 
 function sql(query) {
   try {
@@ -659,7 +668,14 @@ async function run() {
 
     // A malformed year must fall back to the current year, not error and not
     // drive the year-select loop past Integer.MAX_VALUE.
-    const currentYear = sql('SELECT YEAR(CURRENT_DATE)');
+    // Read the current year from the report itself rather than from the database.
+    // The JSP derives it from the Tomcat JVM's clock while the fixtures come from
+    // MySQL's, and in the devcontainer those are separate images; comparing across
+    // them would fail at a year boundary even though the server behaved correctly.
+    // The parameterless URL loaded just above shows the server's own default year.
+    const currentYear = await page.locator('select[name="numMonth"]').inputValue();
+    assert(/^\d{4}$/.test(currentYear),
+      `Default report year was not a four-digit year: ${currentYear}`);
     for (const badYear of ['abc', '+2023', '2147483645', '-5', '0025']) {
       const rows = await reportRows(page, badYear, '-1');
       assert(rows.length > 0, `Malformed numMonth=${badYear} produced no rows at all`);

--- a/scripts/flu-billing-report-playwright-checks.js
+++ b/scripts/flu-billing-report-playwright-checks.js
@@ -20,12 +20,18 @@
 /*
  * Browser regression coverage for the Flu Billing Report demographic mapping.
  *
- * The check creates three synthetic patients and three valid flu claims, verifies
- * every displayed demographic field, the latest selected-year billing date, and
- * the blank billing-date cell of a patient with no claim that year, and exercises
- * both All Providers and individual-provider filters. Seeded rows are removed even
- * when an assertion fails; a delete that does not succeed fails the run rather
- * than leaving synthetic patients behind silently.
+ * The check creates three synthetic patients and three valid flu claims, then
+ * verifies every displayed demographic field, the latest selected-year billing
+ * date, and the blank billing-date cell of a patient with no claim that year.
+ *
+ * It also covers the input handling that repeatedly produced an empty worklist
+ * under an "All Providers" label: the parameterless URL both entry points
+ * actually link to, a whitespace-padded provider, a provider that is unknown or
+ * deactivated, malformed report years, and the year selector at both ends of its
+ * accepted range.
+ *
+ * Seeded rows are removed even when an assertion fails; a delete that does not
+ * succeed fails the run rather than leaving synthetic patients behind silently.
  *
  * Defaults are for the local devcontainer:
  *   npm run test:flu-billing-report-playwright
@@ -55,13 +61,15 @@ const os = require('os');
 const path = require('path');
 const { chromium } = require('playwright');
 
-// 'carlos' and 'db' are the devcontainer compose service names for the app and
-// the MariaDB container; both resolve only inside that private network.
+// Hosts reachable enough to browse against. 'carlos' and 'db' are the
+// devcontainer compose service names for the app and the MariaDB container, and
+// host.docker.internal reaches the developer's own machine; all resolve only
+// from inside that environment. 0.0.0.0 is deliberately absent: it is a bind
+// address rather than a connect target.
 const LOCAL_HOSTS = new Set([
   'localhost',
   '127.0.0.1',
   '::1',
-  '0.0.0.0',
   'host.docker.internal',
   'carlos',
   'db',
@@ -94,7 +102,7 @@ function isLocalHost(rawHost) {
  *
  * Deliberately excludes the private IPv4 ranges and host.docker.internal that
  * isLocalHost accepts, since those reach the developer's host or a shared
- * network, and 0.0.0.0, which is a bind address rather than a connect target.
+ * network.
  *
  * Two things key off this rather than the looser check:
  *   - the database target, because seeding writes patients and OHIP claims;
@@ -306,28 +314,27 @@ function cleanupMysqlDefaultsFile() {
 }
 
 /*
- * Browser text is captured from a rendered patient report, so it can carry names,
- * phone numbers, and demographic or provider numbers. Findings are printed on
- * every failure, so only JavaScript engine errors are reproduced: their messages
- * name code identifiers rather than data, and they are the diagnostic that
- * actually matters here -- "ReferenceError: registerFormSubmit is not defined" is
- * what a broken render looks like. Anything else, including arbitrary
- * console.error output that may embed patient data, is reduced to its category.
- * Digit runs are masked either way so identifiers cannot ride along.
+ * Browser text is captured from a rendered patient report, so any of it can carry
+ * names, phone numbers, or demographic and provider numbers, and findings are
+ * printed on every failure. No message body is reproduced: a finding records the
+ * error's class where the engine supplies one, and otherwise only that something
+ * was logged and how long it was.
  *
- * The residual is narrow but real: application code that throws a TypeError
- * built from a patient name would still surface that name. Widening the filter
- * to drop engine-error text as well would remove the one diagnostic this has
- * actually needed, so the trade is deliberate rather than overlooked.
+ * An earlier version kept engine-error text verbatim on the grounds that
+ * "ReferenceError: registerFormSubmit is not defined" was the diagnostic this
+ * check had needed. That reasoning no longer holds -- the typeof guard added to
+ * the JSP means the identifier is never dereferenced, so that error cannot fire
+ * -- and with the motivating case gone there is no reason to keep the residual
+ * risk that an application-thrown TypeError built from a patient name would
+ * surface that name. The error class plus the failing assertion is enough to
+ * reproduce by hand.
  */
-const JS_ENGINE_ERROR = /^(ReferenceError|TypeError|SyntaxError|RangeError|EvalError|URIError):/;
+const JS_ENGINE_ERROR = /^([A-Z][A-Za-z]*Error):/;
 
 function redactFinding(text) {
   const firstLine = String(text).split('\n')[0];
-  if (!JS_ENGINE_ERROR.test(firstLine)) {
-    return `[redacted ${firstLine.length} chars]`;
-  }
-  return firstLine.replace(/\d{3,}/g, '###').slice(0, 160);
+  const engineError = JS_ENGINE_ERROR.exec(firstLine);
+  return engineError ? engineError[1] : `[redacted ${firstLine.length} chars]`;
 }
 
 function wirePage(page) {

--- a/scripts/flu-billing-report-playwright-checks.js
+++ b/scripts/flu-billing-report-playwright-checks.js
@@ -428,6 +428,17 @@ async function run() {
       phone: primary.phone,
       billingDate: `${reportYear}-10-20`,
     });
+    // The no-claim fixture is assigned to this provider, so filtering must keep it
+    // and must keep its billing-date cell blank rather than dropping the row.
+    assertPatientRow(fixtureRow(individualProviderRows, unvaccinated.patientName), {
+      name: unvaccinated.patientName,
+      dateOfBirth: '1942-03-09',
+      age: expectedUnvaccinatedAge,
+      rosterStatus: unvaccinated.rosterStatus,
+      patientStatus: unvaccinated.patientStatus,
+      phone: unvaccinated.phone,
+      billingDate: '',
+    });
     assert(!individualProviderRows.some((row) => row[0] === secondary.patientName),
       'Individual-provider filtering included the synthetic patient assigned to another provider');
     assert(browserFindings.length === 0, `Browser findings: ${JSON.stringify(browserFindings)}`);
@@ -440,7 +451,7 @@ async function run() {
         'latest valid selected-year flu claim is displayed',
         'a patient with no claim that year renders a blank billing date',
         'All Providers includes every synthetic patient',
-        'individual provider includes only its assigned synthetic patients',
+        'individual provider keeps both of its assigned synthetic patients and excludes the other',
       ],
     }, null, 2));
   } finally {
@@ -467,11 +478,11 @@ async function run() {
       `Synthetic rows were left in the database and must be removed by hand:\n  ${cleanupFailures.join('\n  ')}`
     );
   }
-  console.log('PASS Flu Billing Report demographic mapping and provider filters');
+  console.log('PASS CARLOS EMR Flu Billing Report demographic mapping and provider filters');
 }
 
 run().catch((error) => {
-  console.error('FAIL Flu Billing Report Playwright check');
+  console.error('FAIL CARLOS EMR Flu Billing Report Playwright check');
   console.error(error.stack || error.message);
   // A row mismatch is usually caused by something the page already reported —
   // an HTTP 500 on the report action, a JS error that broke rendering. Print the

--- a/scripts/flu-billing-report-playwright-checks.js
+++ b/scripts/flu-billing-report-playwright-checks.js
@@ -363,6 +363,10 @@ async function reportRows(page, reportYear, providerNo, expectedSelectedProvider
   ));
 }
 
+function offeredYears(page) {
+  return page.locator('select[name="numMonth"] option').evaluateAll((options) => options.map((o) => o.value));
+}
+
 function fixtureRow(rows, expectedName) {
   const matches = rows.filter((row) => row[0] === expectedName);
   assert(matches.length === 1, `Expected exactly one synthetic row for ${expectedName}, found ${matches.length}`);
@@ -542,6 +546,27 @@ async function run() {
         `Malformed numMonth=${badYear} fell back to ${shownYear} instead of the current year ${currentYear}`);
     }
 
+    // The selector must never offer a year its own validation would reject.
+    // Both clamps are no-ops at the current year, so this has to drive the
+    // boundaries: every offered option must round-trip to itself rather than
+    // silently falling back.
+    const maxYear = String(Number(currentYear) + 2);
+    for (const boundaryYear of [maxYear, '1900']) {
+      await reportRows(page, boundaryYear, '-1');
+      const offered = await offeredYears(page);
+      assert(offered.length > 0, `No year options offered for numMonth=${boundaryYear}`);
+      assert(offered.every((year) => Number(year) >= 1900 && Number(year) <= Number(maxYear)),
+        `Year selector offered out-of-range options for numMonth=${boundaryYear}: ${offered.join(',')}`);
+      assert(offered.includes(boundaryYear),
+        `Year selector dropped the selected year ${boundaryYear}: ${offered.join(',')}`);
+      for (const offeredYear of offered) {
+        await reportRows(page, offeredYear, '-1');
+        const shown = await page.locator('select[name="numMonth"]').inputValue();
+        assert(shown === offeredYear,
+          `Year selector offered ${offeredYear} but selecting it fell back to ${shown}`);
+      }
+    }
+
     // Whitespace around the provider must not turn into a literal filter. This is
     // the same "empty worklist under an All Providers label" failure as an absent
     // proNo, reachable from a hand-edited or copied URL.
@@ -551,6 +576,13 @@ async function run() {
     fixtureRow(paddedProviderRows, primary.patientName);
     assert(!paddedProviderRows.some((row) => row[0] === secondary.patientName),
       'Padded provider filter did not actually filter by provider');
+
+    // A provider the dropdown cannot show -- unknown, or deactivated since a URL
+    // was bookmarked -- must fall back to All Providers rather than filtering the
+    // table to nothing while the dropdown still reads All Providers.
+    const unknownProviderRows = await reportRows(page, null, 'ZZZNOPE', '-1');
+    fixtureRow(unknownProviderRows, primary.patientName);
+    fixtureRow(unknownProviderRows, secondary.patientName);
 
     assert(browserFindings.length === 0, `Browser findings: ${JSON.stringify(browserFindings)}`);
 
@@ -568,6 +600,8 @@ async function run() {
         'individual provider keeps both of its assigned synthetic patients and excludes the other',
         'the parameterless entry-point URL lists every patient and selects All Providers',
         'a malformed report year falls back to the current year instead of erroring',
+        'every year the selector offers round-trips to itself at both boundaries',
+        'an unknown or deactivated provider falls back to All Providers',
       ],
     }, null, 2));
   } finally {

--- a/scripts/flu-billing-report-playwright-checks.js
+++ b/scripts/flu-billing-report-playwright-checks.js
@@ -193,13 +193,31 @@ function createMysqlDefaultsFile() {
 }
 
 /*
- * On failure, execFileSync builds its message from the whole argv -- which here
- * includes the SQL, and the seeding statements carry a real provider number. That
- * message would reach the console through run()'s error.stack. Only mysql's own
- * stderr is reported instead: it names the database error without echoing the
- * statement, and digit runs are masked in case a future statement's error text
- * quotes a value back.
+ * Reduces a failed mysql invocation to a reportable reason.
+ *
+ * Neither of the obvious sources is safe on its own. execFileSync builds its
+ * message from the whole argv, so it embeds the statement, and the seeding
+ * statements carry a real provider number. mysql's stderr is safe for errors
+ * like access-denied, but on a syntax error it echoes the offending statement on
+ * its own line and then quotes a fragment back in "near '...' at line 1".
+ *
+ * So: take only the ERROR line, drop the quoted fragment, mask digit runs, and
+ * cap the length. Taking the first stderr line instead would report the literal
+ * "--------------" that mysql prints above the echoed statement.
  */
+function describeMysqlFailure(error) {
+  const errorLine = String(error.stderr || '')
+    .split('\n')
+    .find((line) => line.startsWith('ERROR '));
+  if (!errorLine) {
+    return `mysql exited with status ${error.status}`;
+  }
+  return errorLine
+    .replace(/ near '.*$/, ' near <redacted>')
+    .replace(/\d{3,}/g, '###')
+    .slice(0, 200);
+}
+
 function sql(query) {
   try {
     return execFileSync('mysql', [
@@ -216,9 +234,7 @@ function sql(query) {
       stdio: ['ignore', 'pipe', 'pipe'],
     }).trim();
   } catch (error) {
-    const reason = String(error.stderr || '').split('\n')[0].replace(/\d{3,}/g, '###')
-      || `mysql exited with status ${error.status}`;
-    throw new Error(`mysql command failed: ${reason}`);
+    throw new Error(`mysql command failed: ${describeMysqlFailure(error)}`);
   }
 }
 

--- a/scripts/flu-billing-report-playwright-checks.js
+++ b/scripts/flu-billing-report-playwright-checks.js
@@ -386,17 +386,22 @@ function redactFinding(text) {
   return engineError ? engineError[1] : `[redacted ${firstLine.length} chars]`;
 }
 
-// Resource fetches whose failure says nothing about the report. Both handlers
-// below consult this: Chromium reports a failed subresource twice, once as a
-// response and once as a console error, so tolerating it in only one place would
-// fail the run on exactly the 404 the other is written to ignore -- and, since
-// console text is redacted, with nothing but "[redacted N chars]" to explain it.
+// Resource fetches that are allowed to be missing. Both handlers below consult
+// this: Chromium reports a failed subresource twice, once as a response and once
+// as a console error, so tolerating it in only one place would fail the run on
+// exactly the 404 the other is written to ignore -- and, since console text is
+// redacted, with nothing but "[redacted N chars]" to explain it.
+//
+// Only a 404 is benign. A 403 or 500 on these paths is a real signal and is
+// still reported by the response handler, which is the side that sees a status;
+// the console duplicate stays suppressed to avoid reporting it twice.
 const IGNORABLE_RESOURCE = /\/favicon\.ico$|\/imageRenderingServlet\?/;
 
 function wirePage(page) {
   page.on('response', (response) => {
     const responseUrl = response.url();
-    if (response.status() >= 400 && !IGNORABLE_RESOURCE.test(responseUrl)) {
+    if (response.status() >= 400
+        && !(response.status() === 404 && IGNORABLE_RESOURCE.test(responseUrl))) {
       // Path only: report URLs carry proNo, a real provider number.
       browserFindings.push({ type: 'http', status: response.status(), path: new URL(responseUrl).pathname });
     }
@@ -686,11 +691,13 @@ async function run() {
       }
     }
 
-    // Whitespace around the provider must not turn into a literal filter. This is
-    // the same "empty worklist under an All Providers label" failure as an absent
-    // proNo, reachable from a hand-edited or copied URL.
-    const paddedAllRows = await reportRows(page, null, ' -1 ', '-1');
-    fixtureRow(paddedAllRows, primary.patientName);
+    // Whitespace around a real provider must be trimmed rather than turned into a
+    // literal filter. A padded provider is the only shape that pins the trim: if
+    // it were not trimmed the value would be unselectable, fall back to All
+    // Providers, and admit the other provider's patient, which the exclusion
+    // below catches. Padding the "-1" sentinel proves nothing by comparison --
+    // trimmed or not it ends at All Providers, which the unknown-provider case
+    // already covers.
     const paddedProviderRows = await reportRows(page, null, ` ${providerNo} `, providerNo);
     fixtureRow(paddedProviderRows, primary.patientName);
     assert(!paddedProviderRows.some((row) => row[0] === secondary.patientName),

--- a/scripts/flu-billing-report-playwright-checks.js
+++ b/scripts/flu-billing-report-playwright-checks.js
@@ -40,9 +40,11 @@
  *   ALLOW_NON_LOCAL_BASE_URL=true only for an intentional non-local test target
  *   ALLOW_NON_LOCAL_MYSQL_HOST=true only for a disposable non-local test database
  *
- * BASE_URL and MYSQL_HOST are both restricted to local hosts by default. The
- * database opt-in is the one that matters most: this check inserts synthetic
- * patients and OHIP claims, so it must never be pointed at a real schema.
+ * BASE_URL and MYSQL_HOST are both restricted to local targets by default, but
+ * MYSQL_HOST is held to a stricter definition. Browsing accepts any private
+ * network address; seeding does not, because a shared clinic database usually
+ * lives on one. Only loopback and the devcontainer/docker service names reach
+ * the database without ALLOW_NON_LOCAL_MYSQL_HOST=true.
  */
 
 const { execFileSync } = require('child_process');
@@ -76,9 +78,24 @@ function isPrivateIpv4(host) {
   return a === 10 || (a === 192 && b === 168) || (a === 172 && b >= 16 && b <= 31);
 }
 
+function normalizeHost(rawHost) {
+  return rawHost.toLowerCase().replace(/^\[|\]$/g, '');
+}
+
 function isLocalHost(rawHost) {
-  const host = rawHost.toLowerCase().replace(/^\[|\]$/g, '');
+  const host = normalizeHost(rawHost);
   return LOCAL_HOSTS.has(host) || isPrivateIpv4(host);
+}
+
+/*
+ * Deliberately stricter than isLocalHost: no private-IPv4 carve-out. Browsing a
+ * private-network host is read-only and harmless, but a shared clinic database
+ * typically sits on exactly such an address, and this check writes patients and
+ * claims. Only loopback and the known devcontainer/docker service names pass
+ * without an explicit opt-in.
+ */
+function isLocalDatabaseHost(rawHost) {
+  return LOCAL_HOSTS.has(normalizeHost(rawHost));
 }
 
 function validateBaseUrl(rawBaseUrl) {
@@ -99,13 +116,13 @@ function validateBaseUrl(rawBaseUrl) {
 }
 
 /*
- * This check writes synthetic patients and OHIP claims, so the database target
- * gets the same local-by-default treatment as BASE_URL. Without this an
+ * This check writes synthetic patients and OHIP claims, so the database target is
+ * gated harder than the browsing target — see isLocalDatabaseHost. Without this an
  * exported MYSQL_HOST could seed fixtures straight into a shared or production
  * patient schema, which no amount of cleanup fully undoes.
  */
 function validateMysqlHost(rawHost) {
-  if (!isLocalHost(rawHost) && process.env.ALLOW_NON_LOCAL_MYSQL_HOST !== 'true') {
+  if (!isLocalDatabaseHost(rawHost) && process.env.ALLOW_NON_LOCAL_MYSQL_HOST !== 'true') {
     throw new Error(`Refusing to seed synthetic patients into non-local MYSQL_HOST ${rawHost}; set ALLOW_NON_LOCAL_MYSQL_HOST=true for a disposable test database`);
   }
   return rawHost;

--- a/scripts/flu-billing-report-playwright-checks.js
+++ b/scripts/flu-billing-report-playwright-checks.js
@@ -1,0 +1,416 @@
+#!/usr/bin/env node
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+
+/*
+ * Browser regression coverage for the Flu Billing Report demographic mapping.
+ *
+ * The check creates two synthetic patients and three valid flu claims, verifies
+ * every displayed demographic field and the latest selected-year billing date,
+ * and exercises both All Providers and individual-provider filters. All seeded
+ * rows are removed even when an assertion fails.
+ *
+ * Defaults are for the local devcontainer:
+ *   npm run test:flu-billing-report-playwright
+ *
+ * Optional environment:
+ *   BASE_URL=http://127.0.0.1:8080/carlos
+ *   CHROME_PATH=/path/to/chrome-or-chromium
+ *   TEST_USER=carlosdoc
+ *   TEST_PASSWORD=carlos2026
+ *   TEST_PIN=2026
+ *   MYSQL_HOST=db MYSQL_USER=root MYSQL_PASSWORD=password MYSQL_DATABASE=oscar
+ *   ALLOW_NON_LOCAL_BASE_URL=true only for an intentional non-local test target
+ */
+
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { chromium } = require('playwright');
+
+const LOCAL_HOSTS = new Set([
+  'localhost',
+  '127.0.0.1',
+  '::1',
+  '0.0.0.0',
+  'host.docker.internal',
+  'carlos',
+]);
+
+function isPrivateIpv4(host) {
+  const match = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
+  if (!match) {
+    return false;
+  }
+  const octets = match.slice(1).map(Number);
+  if (octets.some((octet) => octet > 255)) {
+    return false;
+  }
+  const [a, b] = octets;
+  return a === 10 || (a === 192 && b === 168) || (a === 172 && b >= 16 && b <= 31);
+}
+
+function isLocalHost(rawHost) {
+  const host = rawHost.toLowerCase().replace(/^\[|\]$/g, '');
+  return LOCAL_HOSTS.has(host) || isPrivateIpv4(host);
+}
+
+function validateBaseUrl(rawBaseUrl) {
+  const parsed = new URL(rawBaseUrl);
+  if (!['http:', 'https:'].includes(parsed.protocol)) {
+    throw new Error(`BASE_URL must use http or https, got ${parsed.protocol}`);
+  }
+  if (!isLocalHost(parsed.hostname) && process.env.ALLOW_NON_LOCAL_BASE_URL !== 'true') {
+    throw new Error(`Refusing non-local BASE_URL host ${parsed.hostname}`);
+  }
+  parsed.pathname = parsed.pathname.replace(/\/$/, '');
+  return parsed;
+}
+
+const baseUrl = validateBaseUrl(process.env.BASE_URL || 'http://127.0.0.1:8080/carlos');
+const chromePath = process.env.CHROME_PATH || '';
+const testUser = process.env.TEST_USER || 'carlosdoc';
+const testPassword = process.env.TEST_PASSWORD || 'carlos2026';
+const testPin = process.env.TEST_PIN || '2026';
+const mysqlHost = process.env.MYSQL_HOST || 'db';
+const mysqlUser = process.env.MYSQL_USER || 'root';
+const mysqlPassword = process.env.MYSQL_PASSWORD || 'password';
+const mysqlDatabase = process.env.MYSQL_DATABASE || 'oscar';
+
+const seededDemographicIds = [];
+const seededHeaderIds = [];
+const browserFindings = [];
+let mysqlDefaults = null;
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function encodeOptionFileValue(value) {
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+function createMysqlDefaultsFile() {
+  if (/[\r\n]/.test(mysqlPassword)) {
+    throw new Error('MYSQL_PASSWORD must not contain newline characters');
+  }
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'carlos-flu-report-mysql-'));
+  const file = path.join(dir, 'client.cnf');
+  fs.writeFileSync(file, `[client]\npassword=${encodeOptionFileValue(mysqlPassword)}\n`, { mode: 0o600 });
+  return { dir, file };
+}
+
+function sql(query) {
+  return execFileSync('mysql', [
+    `--defaults-extra-file=${mysqlDefaults.file}`,
+    '-h', mysqlHost,
+    '-u', mysqlUser,
+    mysqlDatabase,
+    '-N',
+    '-B',
+    '-e',
+    query,
+  ], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function escapeSql(value) {
+  return String(value).replace(/\\/g, '\\\\').replace(/'/g, "''");
+}
+
+function numericId(value, label) {
+  assert(/^\d+$/.test(value), `${label} was not a numeric database id`);
+  return Number(value);
+}
+
+function appUrl(appPath) {
+  assert(appPath.startsWith('/') && !appPath.startsWith('//'), `Invalid application path ${appPath}`);
+  const [pathPart, queryPart] = appPath.split('?');
+  const url = new URL(baseUrl.href);
+  url.pathname = `${baseUrl.pathname}${pathPart}`.replace(/\/{2,}/g, '/');
+  url.search = queryPart ? `?${queryPart}` : '';
+  return url.toString();
+}
+
+function providerNoForTestUser() {
+  const providerNo = sql(
+    `SELECT provider_no FROM security WHERE user_name='${escapeSql(testUser)}' ORDER BY security_no LIMIT 1`
+  );
+  assert(providerNo && /^[A-Za-z0-9_-]+$/.test(providerNo), `No valid provider number found for TEST_USER=${testUser}`);
+  return providerNo;
+}
+
+function seedDemographic(fixture) {
+  const demographicId = numericId(sql(
+    `INSERT INTO demographic`
+      + ` (last_name, first_name, phone, year_of_birth, month_of_birth, date_of_birth,`
+      + ` roster_status, patient_status, provider_no, sex, lastUpdateDate, pref_name)`
+      + ` VALUES ('${escapeSql(fixture.lastName)}', '${escapeSql(fixture.firstName)}',`
+      + ` '${escapeSql(fixture.phone)}', '${fixture.birthYear}', '${fixture.birthMonth}',`
+      + ` '${fixture.birthDay}', '${fixture.rosterStatus}', '${fixture.patientStatus}',`
+      + ` '${escapeSql(fixture.providerNo)}', 'F', NOW(), '');`
+      + ` SELECT LAST_INSERT_ID();`
+  ), 'demographic id');
+  seededDemographicIds.push(demographicId);
+  return demographicId;
+}
+
+function seedFluClaim(demographicId, providerNo, patientName, billingDate, serviceCode) {
+  assert(['G590A', 'G591A'].includes(serviceCode), `Unsupported flu service code ${serviceCode}`);
+  assert(/^\d{4}-\d{2}-\d{2}$/.test(billingDate), `Invalid billing date ${billingDate}`);
+  const headerId = numericId(sql(
+    `INSERT INTO billing_on_cheader1`
+      + ` (header_id, demographic_no, provider_no, demographic_name, billing_date, status)`
+      + ` VALUES (0, ${demographicId}, '${escapeSql(providerNo)}',`
+      + ` '${escapeSql(patientName)}', '${billingDate}', 'O');`
+      + ` SELECT LAST_INSERT_ID();`
+  ), 'billing header id');
+  seededHeaderIds.push(headerId);
+  sql(
+    `INSERT INTO billing_on_item (ch1_id, service_code, service_date, status)`
+      + ` VALUES (${headerId}, '${serviceCode}', '${billingDate}', 'O')`
+  );
+}
+
+function cleanupSeedData() {
+  for (const headerId of [...seededHeaderIds].reverse()) {
+    try {
+      sql(`DELETE FROM billing_on_item WHERE ch1_id=${headerId}`);
+      sql(`DELETE FROM billing_on_cheader1 WHERE id=${headerId}`);
+    } catch (error) {
+      console.error(`WARN failed to clean synthetic billing header ${headerId}: ${error.message}`);
+    }
+  }
+  for (const demographicId of [...seededDemographicIds].reverse()) {
+    try {
+      sql(`DELETE FROM demographic WHERE demographic_no=${demographicId}`);
+    } catch (error) {
+      console.error(`WARN failed to clean synthetic demographic ${demographicId}: ${error.message}`);
+    }
+  }
+}
+
+function cleanupMysqlDefaultsFile() {
+  if (mysqlDefaults) {
+    fs.rmSync(mysqlDefaults.dir, { recursive: true, force: true });
+    mysqlDefaults = null;
+  }
+}
+
+function wirePage(page) {
+  page.on('response', (response) => {
+    const responseUrl = response.url();
+    if (response.status() >= 400 && !/\/favicon\.ico$|\/imageRenderingServlet\?/.test(responseUrl)) {
+      browserFindings.push({ type: 'http', status: response.status(), url: responseUrl });
+    }
+  });
+  page.on('console', (message) => {
+    const text = message.text();
+    const expected = /Content Security Policy.*report-only|Master token \[CSRF-TOKEN\]|Hidden token fields .* updated/.test(text);
+    if (!expected && (message.type() === 'error' || /(ReferenceError|TypeError|SyntaxError)/.test(text))) {
+      browserFindings.push({ type: `console:${message.type()}`, text });
+    }
+  });
+  page.on('pageerror', (error) => {
+    browserFindings.push({ type: 'pageerror', text: error.message });
+  });
+  page.on('dialog', async (dialog) => {
+    browserFindings.push({ type: 'dialog', text: dialog.message() });
+    await dialog.dismiss();
+  });
+}
+
+async function login(page) {
+  await page.goto(appUrl('/'), { waitUntil: 'domcontentloaded', timeout: 30000 }); // nosemgrep: javascript.playwright.security.audit.playwright-goto-injection.playwright-goto-injection -- appUrl restricts paths and validateBaseUrl restricts hosts by default
+  await page.locator('#username').fill(testUser);
+  await page.locator('#password').fill(testPassword);
+  await page.locator('#pin').fill(testPin);
+  await Promise.all([
+    page.waitForURL(/providercontrol/, { timeout: 30000 }),
+    page.locator('input[type="submit"], button[type="submit"]').first().click(),
+  ]);
+}
+
+async function reportRows(page, reportYear, providerNo) {
+  const query = new URLSearchParams({ numMonth: reportYear, proNo: providerNo });
+  await page.goto(appUrl(`/oscarReport/FluBilling?${query.toString()}`), { // nosemgrep: javascript.playwright.security.audit.playwright-goto-injection.playwright-goto-injection -- reportYear and providerNo are database-derived validated values, and appUrl restricts the target host/path
+    waitUntil: 'domcontentloaded',
+    timeout: 30000,
+  });
+  await page.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+  const body = await page.locator('body').innerText();
+  assert(!/CARLOS has encountered an unexpected error|HTTP Status 500|Exception Report/i.test(body), 'Flu Billing Report rendered an error page');
+  assert(await page.locator('table tbody').count(), 'Flu Billing Report result table was missing');
+  const selectedProvider = await page.locator('select[name="proNo"]').inputValue();
+  assert(selectedProvider === providerNo,
+    `Flu Billing Report selected provider ${selectedProvider} instead of ${providerNo}`);
+  return page.locator('table tbody tr').evaluateAll((rows) => rows.map((row) =>
+    [...row.querySelectorAll('td')].map((cell) => cell.textContent.replace(/\u00a0/g, ' ').trim())
+  ));
+}
+
+function fixtureRow(rows, expectedName) {
+  const matches = rows.filter((row) => row[0] === expectedName);
+  assert(matches.length === 1, `Expected exactly one synthetic row for ${expectedName}, found ${matches.length}`);
+  return matches[0];
+}
+
+function assertPatientRow(row, expected) {
+  assert(row.length === 7, `Expected seven Flu Billing Report columns, found ${row.length}`);
+  const actual = {
+    name: row[0],
+    dateOfBirth: row[1],
+    age: row[2],
+    rosterStatus: row[3],
+    patientStatus: row[4],
+    phone: row[5],
+    billingDate: row[6],
+  };
+  assert(JSON.stringify(actual) === JSON.stringify(expected),
+    `Synthetic Flu Billing Report row did not match expected values: ${JSON.stringify({ actual, expected })}`);
+}
+
+async function run() {
+  let browser = null;
+  mysqlDefaults = createMysqlDefaultsFile();
+  try {
+    // Use a completed year so both seeded claims are valid historical data no
+    // matter when the check runs. The report offers the selected year plus or
+    // minus two, so the previous year remains a normal UI-supported choice.
+    const reportYear = sql('SELECT YEAR(CURRENT_DATE)-1');
+    assert(/^\d{4}$/.test(reportYear), `Database returned invalid current year ${reportYear}`);
+    const expectedAge = sql("SELECT YEAR(CURRENT_DATE)-1940-(DATE_FORMAT(CURRENT_DATE,'%m%d')<'0615')");
+    assert(/^\d{1,3}$/.test(expectedAge), `Database returned invalid fixture age ${expectedAge}`);
+    const expectedSecondaryAge = sql("SELECT YEAR(CURRENT_DATE)-1941-(DATE_FORMAT(CURRENT_DATE,'%m%d')<'0102')");
+    assert(/^\d{1,3}$/.test(expectedSecondaryAge), `Database returned invalid secondary fixture age ${expectedSecondaryAge}`);
+    const providerNo = providerNoForTestUser();
+    const suffix = Date.now().toString(36).slice(-8);
+    const primary = {
+      lastName: `Flu${suffix}A`,
+      firstName: 'Primary',
+      phone: '416-555-0714',
+      birthYear: '1940',
+      birthMonth: '06',
+      birthDay: '15',
+      rosterStatus: 'RO',
+      patientStatus: 'AC',
+      providerNo,
+    };
+    const secondary = {
+      lastName: `Flu${suffix}B`,
+      firstName: 'Secondary',
+      phone: '416-555-0715',
+      birthYear: '1941',
+      birthMonth: '01',
+      birthDay: '02',
+      rosterStatus: 'NR',
+      patientStatus: 'UHIP',
+      providerNo: 'PWNONE',
+    };
+    primary.patientName = `${primary.lastName},${primary.firstName}`;
+    secondary.patientName = `${secondary.lastName},${secondary.firstName}`;
+
+    const primaryId = seedDemographic(primary);
+    const secondaryId = seedDemographic(secondary);
+    seedFluClaim(primaryId, primary.providerNo, primary.patientName, `${reportYear}-01-15`, 'G590A');
+    seedFluClaim(primaryId, primary.providerNo, primary.patientName, `${reportYear}-10-20`, 'G591A');
+    seedFluClaim(secondaryId, secondary.providerNo, secondary.patientName, `${reportYear}-05-05`, 'G590A');
+
+    const launchOptions = {
+      headless: true,
+      args: ['--no-sandbox', '--disable-dev-shm-usage'],
+    };
+    if (chromePath) {
+      launchOptions.executablePath = chromePath;
+    }
+    browser = await chromium.launch(launchOptions);
+    const context = await browser.newContext({
+      ignoreHTTPSErrors: isLocalHost(baseUrl.hostname),
+      viewport: { width: 1440, height: 1000 },
+    });
+    const page = await context.newPage();
+    wirePage(page);
+    await login(page);
+
+    const allProviderRows = await reportRows(page, reportYear, '-1');
+    assertPatientRow(fixtureRow(allProviderRows, primary.patientName), {
+      name: primary.patientName,
+      dateOfBirth: '1940-06-15',
+      age: expectedAge,
+      rosterStatus: primary.rosterStatus,
+      patientStatus: primary.patientStatus,
+      phone: primary.phone,
+      billingDate: `${reportYear}-10-20`,
+    });
+    assertPatientRow(fixtureRow(allProviderRows, secondary.patientName), {
+      name: secondary.patientName,
+      dateOfBirth: '1941-01-02',
+      age: expectedSecondaryAge,
+      rosterStatus: secondary.rosterStatus,
+      patientStatus: secondary.patientStatus,
+      phone: secondary.phone,
+      billingDate: `${reportYear}-05-05`,
+    });
+
+    const individualProviderRows = await reportRows(page, reportYear, providerNo);
+    assertPatientRow(fixtureRow(individualProviderRows, primary.patientName), {
+      name: primary.patientName,
+      dateOfBirth: '1940-06-15',
+      age: expectedAge,
+      rosterStatus: primary.rosterStatus,
+      patientStatus: primary.patientStatus,
+      phone: primary.phone,
+      billingDate: `${reportYear}-10-20`,
+    });
+    assert(!individualProviderRows.some((row) => row[0] === secondary.patientName),
+      'Individual-provider filtering included the synthetic patient assigned to another provider');
+    assert(browserFindings.length === 0, `Browser findings: ${JSON.stringify(browserFindings)}`);
+
+    console.log(JSON.stringify({
+      reportYear,
+      providerNo,
+      assertions: [
+        'all seven patient and billing columns map correctly',
+        'latest valid selected-year flu claim is displayed',
+        'All Providers includes both synthetic patients',
+        'individual provider includes only its assigned synthetic patient',
+      ],
+    }, null, 2));
+    console.log('PASS Flu Billing Report demographic mapping and provider filters');
+  } finally {
+    if (browser) {
+      await browser.close();
+    }
+    try {
+      cleanupSeedData();
+    } finally {
+      cleanupMysqlDefaultsFile();
+    }
+  }
+}
+
+run().catch((error) => {
+  console.error('FAIL Flu Billing Report Playwright check');
+  console.error(error.stack || error.message);
+  process.exit(1);
+});

--- a/scripts/flu-billing-report-playwright-checks.js
+++ b/scripts/flu-billing-report-playwright-checks.js
@@ -51,6 +51,8 @@ const os = require('os');
 const path = require('path');
 const { chromium } = require('playwright');
 
+// 'carlos' and 'db' are the devcontainer compose service names for the app and
+// the MariaDB container; both resolve only inside that private network.
 const LOCAL_HOSTS = new Set([
   'localhost',
   '127.0.0.1',
@@ -58,6 +60,7 @@ const LOCAL_HOSTS = new Set([
   '0.0.0.0',
   'host.docker.internal',
   'carlos',
+  'db',
 ]);
 
 function isPrivateIpv4(host) {

--- a/scripts/flu-billing-report-playwright-checks.js
+++ b/scripts/flu-billing-report-playwright-checks.js
@@ -88,14 +88,26 @@ function isLocalHost(rawHost) {
 }
 
 /*
- * Deliberately stricter than isLocalHost: no private-IPv4 carve-out. Browsing a
- * private-network host is read-only and harmless, but a shared clinic database
- * typically sits on exactly such an address, and this check writes patients and
- * claims. Only loopback and the known devcontainer/docker service names pass
- * without an explicit opt-in.
+ * Deliberately stricter than isLocalHost, and deliberately its own list rather
+ * than a subset of LOCAL_HOSTS. Browsing a private-network host is read-only and
+ * harmless; seeding is not, and this check writes patients and OHIP claims.
+ *
+ * Excluded on purpose: private IPv4 ranges and host.docker.internal, which reach
+ * the developer's host or a shared network where a real schema may live, and
+ * 0.0.0.0, which is a bind address rather than a meaningful connect target.
+ * Only loopback and the two devcontainer compose service names pass without an
+ * explicit opt-in.
  */
+const LOCAL_DATABASE_HOSTS = new Set([
+  'localhost',
+  '127.0.0.1',
+  '::1',
+  'db',
+  'carlos',
+]);
+
 function isLocalDatabaseHost(rawHost) {
-  return LOCAL_HOSTS.has(normalizeHost(rawHost));
+  return LOCAL_DATABASE_HOSTS.has(normalizeHost(rawHost));
 }
 
 function validateBaseUrl(rawBaseUrl) {

--- a/scripts/flu-billing-report-playwright-checks.js
+++ b/scripts/flu-billing-report-playwright-checks.js
@@ -241,6 +241,10 @@ function sql(query) {
     ], {
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'pipe'],
+      // Without this an unreachable host blocks forever, and the signal handler
+      // calls straight back into here -- so an interrupted run would hang while
+      // trying to remove its own seeded rows.
+      timeout: MYSQL_TIMEOUT_MS,
     }).trim();
   } catch (error) {
     throw new Error(`mysql command failed: ${describeMysqlFailure(error)}`);

--- a/scripts/flu-billing-report-playwright-checks.js
+++ b/scripts/flu-billing-report-playwright-checks.js
@@ -577,6 +577,8 @@ async function run() {
       fixture.patientName = `${fixture.lastName},${fixture.firstName}`;
       fixture.expectedAge = expectedAgeFor(fixture);
       fixture.expectedDateOfBirth = `${fixture.birthYear}-${fixture.birthMonth}-${fixture.birthDay}`;
+      // Latest claim seeded below for this fixture, or blank where none is.
+      fixture.expectedBillingDate = '';
     }
 
     const primaryId = seedDemographic(primary);
@@ -584,7 +586,9 @@ async function run() {
     seedDemographic(unvaccinated);
     seedFluClaim(primaryId, primary.providerNo, primary.patientName, `${reportYear}-01-15`, 'G590A');
     seedFluClaim(primaryId, primary.providerNo, primary.patientName, `${reportYear}-10-20`, 'G591A');
+    primary.expectedBillingDate = `${reportYear}-10-20`;
     seedFluClaim(secondaryId, secondary.providerNo, secondary.patientName, `${reportYear}-05-05`, 'G590A');
+    secondary.expectedBillingDate = `${reportYear}-05-05`;
 
     const launchOptions = {
       headless: true,
@@ -657,17 +661,8 @@ async function run() {
 
     // The shape both real entry points use: no numMonth, no proNo. This must list
     // every eligible patient rather than filtering on an empty provider number.
-    // The year defaults to the current one, so the fixtures' previous-year claims
-    // correctly show as blank billing dates here.
     const defaultEntryRows = await reportRows(page, null, null, '-1');
-    for (const fixture of [primary, secondary, unvaccinated]) {
-      const row = fixtureRow(defaultEntryRows, fixture.patientName);
-      assert(row[6] === '',
-        `Default entry point showed a billing date for ${fixture.patientName} whose only claims predate the current year`);
-    }
 
-    // A malformed year must fall back to the current year, not error and not
-    // drive the year-select loop past Integer.MAX_VALUE.
     // Read the current year from the report itself rather than from the database.
     // The JSP derives it from the Tomcat JVM's clock while the fixtures come from
     // MySQL's, and in the devcontainer those are separate images; comparing across
@@ -676,6 +671,18 @@ async function run() {
     const currentYear = await page.locator('select[name="numMonth"]').inputValue();
     assert(/^\d{4}$/.test(currentYear),
       `Default report year was not a four-digit year: ${currentYear}`);
+
+    // Claims are seeded into reportYear, which is normally the year before the
+    // one this view defaults to, so the cells are blank. If the two clocks
+    // straddle a year boundary the years coincide and the claim is genuinely due
+    // to show -- expecting blank unconditionally would fail a correct server.
+    const defaultViewShowsSeededYear = currentYear === reportYear;
+    for (const fixture of [primary, secondary, unvaccinated]) {
+      const row = fixtureRow(defaultEntryRows, fixture.patientName);
+      const expected = defaultViewShowsSeededYear ? fixture.expectedBillingDate : '';
+      assert(row[6] === expected,
+        `Default entry point billing date for ${fixture.lastName} was "${row[6]}", expected "${expected}"`);
+    }
     for (const badYear of ['abc', '+2023', '2147483645', '-5', '0025']) {
       const rows = await reportRows(page, badYear, '-1');
       assert(rows.length > 0, `Malformed numMonth=${badYear} produced no rows at all`);

--- a/scripts/flu-billing-report-playwright-checks.js
+++ b/scripts/flu-billing-report-playwright-checks.js
@@ -192,20 +192,34 @@ function createMysqlDefaultsFile() {
   return { dir, file };
 }
 
+/*
+ * On failure, execFileSync builds its message from the whole argv -- which here
+ * includes the SQL, and the seeding statements carry a real provider number. That
+ * message would reach the console through run()'s error.stack. Only mysql's own
+ * stderr is reported instead: it names the database error without echoing the
+ * statement, and digit runs are masked in case a future statement's error text
+ * quotes a value back.
+ */
 function sql(query) {
-  return execFileSync('mysql', [
-    `--defaults-extra-file=${mysqlDefaults.file}`,
-    '-h', mysqlHost,
-    '-u', mysqlUser,
-    mysqlDatabase,
-    '-N',
-    '-B',
-    '-e',
-    query,
-  ], {
-    encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'pipe'],
-  }).trim();
+  try {
+    return execFileSync('mysql', [
+      `--defaults-extra-file=${mysqlDefaults.file}`,
+      '-h', mysqlHost,
+      '-u', mysqlUser,
+      mysqlDatabase,
+      '-N',
+      '-B',
+      '-e',
+      query,
+    ], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+  } catch (error) {
+    const reason = String(error.stderr || '').split('\n')[0].replace(/\d{3,}/g, '###')
+      || `mysql exited with status ${error.status}`;
+    throw new Error(`mysql command failed: ${reason}`);
+  }
 }
 
 function escapeSql(value) {

--- a/scripts/flu-billing-report-playwright-checks.js
+++ b/scripts/flu-billing-report-playwright-checks.js
@@ -386,10 +386,17 @@ function redactFinding(text) {
   return engineError ? engineError[1] : `[redacted ${firstLine.length} chars]`;
 }
 
+// Resource fetches whose failure says nothing about the report. Both handlers
+// below consult this: Chromium reports a failed subresource twice, once as a
+// response and once as a console error, so tolerating it in only one place would
+// fail the run on exactly the 404 the other is written to ignore -- and, since
+// console text is redacted, with nothing but "[redacted N chars]" to explain it.
+const IGNORABLE_RESOURCE = /\/favicon\.ico$|\/imageRenderingServlet\?/;
+
 function wirePage(page) {
   page.on('response', (response) => {
     const responseUrl = response.url();
-    if (response.status() >= 400 && !/\/favicon\.ico$|\/imageRenderingServlet\?/.test(responseUrl)) {
+    if (response.status() >= 400 && !IGNORABLE_RESOURCE.test(responseUrl)) {
       // Path only: report URLs carry proNo, a real provider number.
       browserFindings.push({ type: 'http', status: response.status(), path: new URL(responseUrl).pathname });
     }
@@ -397,7 +404,9 @@ function wirePage(page) {
   page.on('console', (message) => {
     const text = message.text();
     const expected = /Content Security Policy.*report-only|Master token \[CSRF-TOKEN\]|Hidden token fields .* updated/.test(text);
-    if (!expected && (message.type() === 'error' || /(ReferenceError|TypeError|SyntaxError)/.test(text))) {
+    const ignorableResource = IGNORABLE_RESOURCE.test((message.location() || {}).url || '');
+    if (!expected && !ignorableResource
+        && (message.type() === 'error' || /(ReferenceError|TypeError|SyntaxError)/.test(text))) {
       browserFindings.push({ type: `console:${message.type()}`, detail: redactFinding(text) });
     }
   });

--- a/scripts/flu-billing-report-playwright-checks.js
+++ b/scripts/flu-billing-report-playwright-checks.js
@@ -43,8 +43,10 @@
  * BASE_URL and MYSQL_HOST are both restricted to local targets by default, but
  * MYSQL_HOST is held to a stricter definition. Browsing accepts any private
  * network address; seeding does not, because a shared clinic database usually
- * lives on one. Only loopback and the devcontainer/docker service names reach
- * the database without ALLOW_NON_LOCAL_MYSQL_HOST=true.
+ * lives on one. Only loopback and the devcontainer service names reach the
+ * database without ALLOW_NON_LOCAL_MYSQL_HOST=true. A browse target that is not
+ * plainly loopback must additionally use https, since this script logs in with
+ * real credentials.
  */
 
 const { execFileSync } = require('child_process');
@@ -88,17 +90,18 @@ function isLocalHost(rawHost) {
 }
 
 /*
- * Deliberately stricter than isLocalHost, and deliberately its own list rather
- * than a subset of LOCAL_HOSTS. Browsing a private-network host is read-only and
- * harmless; seeding is not, and this check writes patients and OHIP claims.
+ * Hosts that are unambiguously this machine or its private compose network.
  *
- * Excluded on purpose: private IPv4 ranges and host.docker.internal, which reach
- * the developer's host or a shared network where a real schema may live, and
- * 0.0.0.0, which is a bind address rather than a meaningful connect target.
- * Only loopback and the two devcontainer compose service names pass without an
- * explicit opt-in.
+ * Deliberately excludes the private IPv4 ranges and host.docker.internal that
+ * isLocalHost accepts, since those reach the developer's host or a shared
+ * network, and 0.0.0.0, which is a bind address rather than a connect target.
+ *
+ * Two things key off this rather than the looser check:
+ *   - the database target, because seeding writes patients and OHIP claims;
+ *   - whether TLS verification may be skipped, because this script logs in with
+ *     real credentials and any non-loopback target must prove its certificate.
  */
-const LOCAL_DATABASE_HOSTS = new Set([
+const EXACT_LOCAL_HOSTS = new Set([
   'localhost',
   '127.0.0.1',
   '::1',
@@ -106,8 +109,8 @@ const LOCAL_DATABASE_HOSTS = new Set([
   'carlos',
 ]);
 
-function isLocalDatabaseHost(rawHost) {
-  return LOCAL_DATABASE_HOSTS.has(normalizeHost(rawHost));
+function isExactLocalHost(rawHost) {
+  return EXACT_LOCAL_HOSTS.has(normalizeHost(rawHost));
 }
 
 function validateBaseUrl(rawBaseUrl) {
@@ -123,18 +126,24 @@ function validateBaseUrl(rawBaseUrl) {
   if (!isLocalHost(parsed.hostname) && process.env.ALLOW_NON_LOCAL_BASE_URL !== 'true') {
     throw new Error(`Refusing non-local BASE_URL host ${parsed.hostname}; set ALLOW_NON_LOCAL_BASE_URL=true for an intentional test target`);
   }
+  // This script logs in with real credentials, so anything that is not plainly
+  // loopback has to prove its certificate. Matches the same rule in
+  // scripts/patient-search-dob-playwright-checks.js.
+  if (!isExactLocalHost(parsed.hostname) && parsed.protocol !== 'https:') {
+    throw new Error(`Non-loopback BASE_URL host ${parsed.hostname} must use https`);
+  }
   parsed.pathname = parsed.pathname.replace(/\/$/, '');
   return parsed;
 }
 
 /*
  * This check writes synthetic patients and OHIP claims, so the database target is
- * gated harder than the browsing target — see isLocalDatabaseHost. Without this an
+ * gated harder than the browsing target — see isExactLocalHost. Without this an
  * exported MYSQL_HOST could seed fixtures straight into a shared or production
  * patient schema, which no amount of cleanup fully undoes.
  */
 function validateMysqlHost(rawHost) {
-  if (!isLocalDatabaseHost(rawHost) && process.env.ALLOW_NON_LOCAL_MYSQL_HOST !== 'true') {
+  if (!isExactLocalHost(rawHost) && process.env.ALLOW_NON_LOCAL_MYSQL_HOST !== 'true') {
     throw new Error(`Refusing to seed synthetic patients into non-local MYSQL_HOST ${rawHost}; set ALLOW_NON_LOCAL_MYSQL_HOST=true for a disposable test database`);
   }
   return rawHost;
@@ -193,6 +202,20 @@ function sql(query) {
 
 function escapeSql(value) {
   return String(value).replace(/\\/g, '\\\\').replace(/'/g, "''");
+}
+
+/*
+ * Age the report should show for a fixture, derived from that fixture's own
+ * birth fields and evaluated by the database so it uses the same clock and the
+ * same birthday-adjustment rule as the report query. Deriving it from the
+ * fixture keeps the two from drifting; deriving it from the rendered report
+ * instead would make the age assertion tautological.
+ */
+function expectedAgeFor(fixture) {
+  const age = sql(`SELECT YEAR(CURRENT_DATE)-${fixture.birthYear}`
+    + `-(DATE_FORMAT(CURRENT_DATE,'%m%d')<'${fixture.birthMonth}${fixture.birthDay}')`);
+  assert(/^\d{1,3}$/.test(age), `Database returned an invalid expected age for ${fixture.lastName}`);
+  return age;
 }
 
 function numericId(value, label) {
@@ -282,12 +305,36 @@ function cleanupMysqlDefaultsFile() {
   }
 }
 
+/*
+ * Browser text is captured from a rendered patient report, so it can carry names,
+ * phone numbers, and demographic or provider numbers. Findings are printed on
+ * every failure, so only JavaScript engine errors are reproduced: their messages
+ * name code identifiers rather than data, and they are the diagnostic that
+ * actually matters here -- "ReferenceError: registerFormSubmit is not defined" is
+ * what a broken render looks like. Anything else, including arbitrary
+ * console.error output that may embed patient data, is reduced to its category.
+ * Digit runs are masked either way so identifiers cannot ride along.
+ *
+ * The residual is narrow but real: application code that throws a TypeError
+ * built from a patient name would still surface that name. Widening the filter
+ * to drop engine-error text as well would remove the one diagnostic this has
+ * actually needed, so the trade is deliberate rather than overlooked.
+ */
+const JS_ENGINE_ERROR = /^(ReferenceError|TypeError|SyntaxError|RangeError|EvalError|URIError):/;
+
+function redactFinding(text) {
+  const firstLine = String(text).split('\n')[0];
+  if (!JS_ENGINE_ERROR.test(firstLine)) {
+    return `[redacted ${firstLine.length} chars]`;
+  }
+  return firstLine.replace(/\d{3,}/g, '###').slice(0, 160);
+}
+
 function wirePage(page) {
   page.on('response', (response) => {
     const responseUrl = response.url();
     if (response.status() >= 400 && !/\/favicon\.ico$|\/imageRenderingServlet\?/.test(responseUrl)) {
-      // Path only: report URLs carry proNo, a real provider number, and these
-      // findings are printed on every failure.
+      // Path only: report URLs carry proNo, a real provider number.
       browserFindings.push({ type: 'http', status: response.status(), path: new URL(responseUrl).pathname });
     }
   });
@@ -295,14 +342,14 @@ function wirePage(page) {
     const text = message.text();
     const expected = /Content Security Policy.*report-only|Master token \[CSRF-TOKEN\]|Hidden token fields .* updated/.test(text);
     if (!expected && (message.type() === 'error' || /(ReferenceError|TypeError|SyntaxError)/.test(text))) {
-      browserFindings.push({ type: `console:${message.type()}`, text });
+      browserFindings.push({ type: `console:${message.type()}`, detail: redactFinding(text) });
     }
   });
   page.on('pageerror', (error) => {
-    browserFindings.push({ type: 'pageerror', text: error.message });
+    browserFindings.push({ type: 'pageerror', detail: redactFinding(error.message) });
   });
   page.on('dialog', async (dialog) => {
-    browserFindings.push({ type: 'dialog', text: dialog.message() });
+    browserFindings.push({ type: 'dialog', detail: redactFinding(dialog.message()) });
     await dialog.dismiss();
   });
 }
@@ -356,8 +403,10 @@ async function reportRows(page, reportYear, providerNo, expectedSelectedProvider
   // between "All Providers" on screen and the applied filter cannot recur.
   const expectedSelection = expectedSelectedProvider === undefined ? providerNo : expectedSelectedProvider;
   const selectedProvider = await page.locator('select[name="proNo"]').inputValue();
+  // Provider numbers are PHI-correlating, so report only whether the dropdown
+  // agreed with the requested filter, never the values themselves.
   assert(selectedProvider === expectedSelection,
-    `Flu Billing Report selected provider ${selectedProvider} instead of ${expectedSelection}`);
+    'Flu Billing Report provider dropdown did not match the filter that was applied');
   return page.locator('table tbody tr').evaluateAll((rows) => rows.map((row) =>
     [...row.querySelectorAll('td')].map((cell) => cell.textContent.trim())
   ));
@@ -398,12 +447,6 @@ async function run() {
     // minus two, so the previous year remains a normal UI-supported choice.
     const reportYear = sql('SELECT YEAR(CURRENT_DATE)-1');
     assert(/^\d{4}$/.test(reportYear), `Database returned invalid current year ${reportYear}`);
-    const expectedAge = sql("SELECT YEAR(CURRENT_DATE)-1940-(DATE_FORMAT(CURRENT_DATE,'%m%d')<'0615')");
-    assert(/^\d{1,3}$/.test(expectedAge), `Database returned invalid fixture age ${expectedAge}`);
-    const expectedSecondaryAge = sql("SELECT YEAR(CURRENT_DATE)-1941-(DATE_FORMAT(CURRENT_DATE,'%m%d')<'0102')");
-    assert(/^\d{1,3}$/.test(expectedSecondaryAge), `Database returned invalid secondary fixture age ${expectedSecondaryAge}`);
-    const expectedUnvaccinatedAge = sql("SELECT YEAR(CURRENT_DATE)-1942-(DATE_FORMAT(CURRENT_DATE,'%m%d')<'0309')");
-    assert(/^\d{1,3}$/.test(expectedUnvaccinatedAge), `Database returned invalid unvaccinated fixture age ${expectedUnvaccinatedAge}`);
     const providerNo = providerNoForTestUser();
     const suffix = Date.now().toString(36).slice(-8);
     const primary = {
@@ -442,9 +485,11 @@ async function run() {
       patientStatus: 'AC',
       providerNo,
     };
-    primary.patientName = `${primary.lastName},${primary.firstName}`;
-    secondary.patientName = `${secondary.lastName},${secondary.firstName}`;
-    unvaccinated.patientName = `${unvaccinated.lastName},${unvaccinated.firstName}`;
+    for (const fixture of [primary, secondary, unvaccinated]) {
+      fixture.patientName = `${fixture.lastName},${fixture.firstName}`;
+      fixture.expectedAge = expectedAgeFor(fixture);
+      fixture.expectedDateOfBirth = `${fixture.birthYear}-${fixture.birthMonth}-${fixture.birthDay}`;
+    }
 
     const primaryId = seedDemographic(primary);
     const secondaryId = seedDemographic(secondary);
@@ -462,7 +507,7 @@ async function run() {
     }
     browser = await chromium.launch(launchOptions);
     const context = await browser.newContext({
-      ignoreHTTPSErrors: isLocalHost(baseUrl.hostname),
+      ignoreHTTPSErrors: isExactLocalHost(baseUrl.hostname),
       viewport: { width: 1440, height: 1000 },
     });
     const page = await context.newPage();
@@ -472,8 +517,8 @@ async function run() {
     const allProviderRows = await reportRows(page, reportYear, '-1');
     assertPatientRow(fixtureRow(allProviderRows, primary.patientName), {
       name: primary.patientName,
-      dateOfBirth: '1940-06-15',
-      age: expectedAge,
+      dateOfBirth: primary.expectedDateOfBirth,
+      age: primary.expectedAge,
       rosterStatus: primary.rosterStatus,
       patientStatus: primary.patientStatus,
       phone: primary.phone,
@@ -481,8 +526,8 @@ async function run() {
     });
     assertPatientRow(fixtureRow(allProviderRows, secondary.patientName), {
       name: secondary.patientName,
-      dateOfBirth: '1941-01-02',
-      age: expectedSecondaryAge,
+      dateOfBirth: secondary.expectedDateOfBirth,
+      age: secondary.expectedAge,
       rosterStatus: secondary.rosterStatus,
       patientStatus: secondary.patientStatus,
       phone: secondary.phone,
@@ -490,8 +535,8 @@ async function run() {
     });
     assertPatientRow(fixtureRow(allProviderRows, unvaccinated.patientName), {
       name: unvaccinated.patientName,
-      dateOfBirth: '1942-03-09',
-      age: expectedUnvaccinatedAge,
+      dateOfBirth: unvaccinated.expectedDateOfBirth,
+      age: unvaccinated.expectedAge,
       rosterStatus: unvaccinated.rosterStatus,
       patientStatus: unvaccinated.patientStatus,
       phone: unvaccinated.phone,
@@ -501,8 +546,8 @@ async function run() {
     const individualProviderRows = await reportRows(page, reportYear, providerNo);
     assertPatientRow(fixtureRow(individualProviderRows, primary.patientName), {
       name: primary.patientName,
-      dateOfBirth: '1940-06-15',
-      age: expectedAge,
+      dateOfBirth: primary.expectedDateOfBirth,
+      age: primary.expectedAge,
       rosterStatus: primary.rosterStatus,
       patientStatus: primary.patientStatus,
       phone: primary.phone,
@@ -512,8 +557,8 @@ async function run() {
     // and must keep its billing-date cell blank rather than dropping the row.
     assertPatientRow(fixtureRow(individualProviderRows, unvaccinated.patientName), {
       name: unvaccinated.patientName,
-      dateOfBirth: '1942-03-09',
-      age: expectedUnvaccinatedAge,
+      dateOfBirth: unvaccinated.expectedDateOfBirth,
+      age: unvaccinated.expectedAge,
       rosterStatus: unvaccinated.rosterStatus,
       patientStatus: unvaccinated.patientStatus,
       phone: unvaccinated.phone,

--- a/scripts/flu-billing-report-playwright-checks.js
+++ b/scripts/flu-billing-report-playwright-checks.js
@@ -38,6 +38,11 @@
  *   TEST_PIN=2026
  *   MYSQL_HOST=db MYSQL_USER=root MYSQL_PASSWORD=password MYSQL_DATABASE=oscar
  *   ALLOW_NON_LOCAL_BASE_URL=true only for an intentional non-local test target
+ *   ALLOW_NON_LOCAL_MYSQL_HOST=true only for a disposable non-local test database
+ *
+ * BASE_URL and MYSQL_HOST are both restricted to local hosts by default. The
+ * database opt-in is the one that matters most: this check inserts synthetic
+ * patients and OHIP claims, so it must never be pointed at a real schema.
  */
 
 const { execFileSync } = require('child_process');
@@ -78,11 +83,29 @@ function validateBaseUrl(rawBaseUrl) {
   if (!['http:', 'https:'].includes(parsed.protocol)) {
     throw new Error(`BASE_URL must use http or https, got ${parsed.protocol}`);
   }
+  // Credentials in the URL would travel into Playwright navigations and can
+  // surface in request or failure logging, so reject them outright.
+  if (parsed.username || parsed.password) {
+    throw new Error('BASE_URL must not contain embedded credentials');
+  }
   if (!isLocalHost(parsed.hostname) && process.env.ALLOW_NON_LOCAL_BASE_URL !== 'true') {
-    throw new Error(`Refusing non-local BASE_URL host ${parsed.hostname}`);
+    throw new Error(`Refusing non-local BASE_URL host ${parsed.hostname}; set ALLOW_NON_LOCAL_BASE_URL=true for an intentional test target`);
   }
   parsed.pathname = parsed.pathname.replace(/\/$/, '');
   return parsed;
+}
+
+/*
+ * This check writes synthetic patients and OHIP claims, so the database target
+ * gets the same local-by-default treatment as BASE_URL. Without this an
+ * exported MYSQL_HOST could seed fixtures straight into a shared or production
+ * patient schema, which no amount of cleanup fully undoes.
+ */
+function validateMysqlHost(rawHost) {
+  if (!isLocalHost(rawHost) && process.env.ALLOW_NON_LOCAL_MYSQL_HOST !== 'true') {
+    throw new Error(`Refusing to seed synthetic patients into non-local MYSQL_HOST ${rawHost}; set ALLOW_NON_LOCAL_MYSQL_HOST=true for a disposable test database`);
+  }
+  return rawHost;
 }
 
 const baseUrl = validateBaseUrl(process.env.BASE_URL || 'http://127.0.0.1:8080/carlos');
@@ -90,7 +113,7 @@ const chromePath = process.env.CHROME_PATH || '';
 const testUser = process.env.TEST_USER || 'carlosdoc';
 const testPassword = process.env.TEST_PASSWORD || 'carlos2026';
 const testPin = process.env.TEST_PIN || '2026';
-const mysqlHost = process.env.MYSQL_HOST || 'db';
+const mysqlHost = validateMysqlHost(process.env.MYSQL_HOST || 'db');
 const mysqlUser = process.env.MYSQL_USER || 'root';
 const mysqlPassword = process.env.MYSQL_PASSWORD || 'password';
 const mysqlDatabase = process.env.MYSQL_DATABASE || 'oscar';

--- a/scripts/flu-billing-report-playwright-checks.js
+++ b/scripts/flu-billing-report-playwright-checks.js
@@ -20,10 +20,12 @@
 /*
  * Browser regression coverage for the Flu Billing Report demographic mapping.
  *
- * The check creates two synthetic patients and three valid flu claims, verifies
- * every displayed demographic field and the latest selected-year billing date,
- * and exercises both All Providers and individual-provider filters. All seeded
- * rows are removed even when an assertion fails.
+ * The check creates three synthetic patients and three valid flu claims, verifies
+ * every displayed demographic field, the latest selected-year billing date, and
+ * the blank billing-date cell of a patient with no claim that year, and exercises
+ * both All Providers and individual-provider filters. Seeded rows are removed even
+ * when an assertion fails; a delete that does not succeed fails the run rather
+ * than leaving synthetic patients behind silently.
  *
  * Defaults are for the local devcontainer:
  *   npm run test:flu-billing-report-playwright
@@ -192,22 +194,30 @@ function seedFluClaim(demographicId, providerNo, patientName, billingDate, servi
   );
 }
 
+/*
+ * Deletes every seeded row, continuing past individual failures so one blocked
+ * delete cannot orphan the rest. Failures are returned rather than only logged:
+ * leftover synthetic 65+ patients would show up in real Flu Billing Reports and
+ * patient searches, so the caller must fail the run instead of printing PASS.
+ */
 function cleanupSeedData() {
+  const failures = [];
   for (const headerId of [...seededHeaderIds].reverse()) {
     try {
       sql(`DELETE FROM billing_on_item WHERE ch1_id=${headerId}`);
       sql(`DELETE FROM billing_on_cheader1 WHERE id=${headerId}`);
     } catch (error) {
-      console.error(`WARN failed to clean synthetic billing header ${headerId}: ${error.message}`);
+      failures.push(`billing_on_cheader1 id=${headerId}: ${error.message}`);
     }
   }
   for (const demographicId of [...seededDemographicIds].reverse()) {
     try {
       sql(`DELETE FROM demographic WHERE demographic_no=${demographicId}`);
     } catch (error) {
-      console.error(`WARN failed to clean synthetic demographic ${demographicId}: ${error.message}`);
+      failures.push(`demographic demographic_no=${demographicId}: ${error.message}`);
     }
   }
+  return failures;
 }
 
 function cleanupMysqlDefaultsFile() {
@@ -257,7 +267,15 @@ async function reportRows(page, reportYear, providerNo) {
     waitUntil: 'domcontentloaded',
     timeout: 30000,
   });
-  await page.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+  // Only a networkidle timeout is expected here (the report page keeps some
+  // long-lived connections open). Anything else — a closed target, a failed
+  // navigation — must surface rather than turn into a confusing failure on the
+  // innerText() call below.
+  await page.waitForLoadState('networkidle', { timeout: 30000 }).catch((error) => {
+    if (!/Timeout .* exceeded/.test(error.message)) {
+      throw error;
+    }
+  });
   const body = await page.locator('body').innerText();
   assert(!/CARLOS has encountered an unexpected error|HTTP Status 500|Exception Report/i.test(body), 'Flu Billing Report rendered an error page');
   assert(await page.locator('table tbody').count(), 'Flu Billing Report result table was missing');
@@ -265,7 +283,7 @@ async function reportRows(page, reportYear, providerNo) {
   assert(selectedProvider === providerNo,
     `Flu Billing Report selected provider ${selectedProvider} instead of ${providerNo}`);
   return page.locator('table tbody tr').evaluateAll((rows) => rows.map((row) =>
-    [...row.querySelectorAll('td')].map((cell) => cell.textContent.replace(/\u00a0/g, ' ').trim())
+    [...row.querySelectorAll('td')].map((cell) => cell.textContent.trim())
   ));
 }
 
@@ -292,6 +310,7 @@ function assertPatientRow(row, expected) {
 
 async function run() {
   let browser = null;
+  let cleanupFailures = [];
   mysqlDefaults = createMysqlDefaultsFile();
   try {
     // Use a completed year so both seeded claims are valid historical data no
@@ -303,6 +322,8 @@ async function run() {
     assert(/^\d{1,3}$/.test(expectedAge), `Database returned invalid fixture age ${expectedAge}`);
     const expectedSecondaryAge = sql("SELECT YEAR(CURRENT_DATE)-1941-(DATE_FORMAT(CURRENT_DATE,'%m%d')<'0102')");
     assert(/^\d{1,3}$/.test(expectedSecondaryAge), `Database returned invalid secondary fixture age ${expectedSecondaryAge}`);
+    const expectedUnvaccinatedAge = sql("SELECT YEAR(CURRENT_DATE)-1942-(DATE_FORMAT(CURRENT_DATE,'%m%d')<'0309')");
+    assert(/^\d{1,3}$/.test(expectedUnvaccinatedAge), `Database returned invalid unvaccinated fixture age ${expectedUnvaccinatedAge}`);
     const providerNo = providerNoForTestUser();
     const suffix = Date.now().toString(36).slice(-8);
     const primary = {
@@ -327,11 +348,27 @@ async function run() {
       patientStatus: 'UHIP',
       providerNo: 'PWNONE',
     };
+    // Seeded with no flu claim at all: the unvaccinated 65+ patient this recall
+    // report exists to surface. Its Billing Date cell must be blank, not the
+    // literal text "&nbsp;".
+    const unvaccinated = {
+      lastName: `Flu${suffix}C`,
+      firstName: 'Unvaccinated',
+      phone: '416-555-0716',
+      birthYear: '1942',
+      birthMonth: '03',
+      birthDay: '09',
+      rosterStatus: 'FS',
+      patientStatus: 'AC',
+      providerNo,
+    };
     primary.patientName = `${primary.lastName},${primary.firstName}`;
     secondary.patientName = `${secondary.lastName},${secondary.firstName}`;
+    unvaccinated.patientName = `${unvaccinated.lastName},${unvaccinated.firstName}`;
 
     const primaryId = seedDemographic(primary);
     const secondaryId = seedDemographic(secondary);
+    seedDemographic(unvaccinated);
     seedFluClaim(primaryId, primary.providerNo, primary.patientName, `${reportYear}-01-15`, 'G590A');
     seedFluClaim(primaryId, primary.providerNo, primary.patientName, `${reportYear}-10-20`, 'G591A');
     seedFluClaim(secondaryId, secondary.providerNo, secondary.patientName, `${reportYear}-05-05`, 'G590A');
@@ -371,6 +408,15 @@ async function run() {
       phone: secondary.phone,
       billingDate: `${reportYear}-05-05`,
     });
+    assertPatientRow(fixtureRow(allProviderRows, unvaccinated.patientName), {
+      name: unvaccinated.patientName,
+      dateOfBirth: '1942-03-09',
+      age: expectedUnvaccinatedAge,
+      rosterStatus: unvaccinated.rosterStatus,
+      patientStatus: unvaccinated.patientStatus,
+      phone: unvaccinated.phone,
+      billingDate: '',
+    });
 
     const individualProviderRows = await reportRows(page, reportYear, providerNo);
     assertPatientRow(fixtureRow(individualProviderRows, primary.patientName), {
@@ -392,25 +438,46 @@ async function run() {
       assertions: [
         'all seven patient and billing columns map correctly',
         'latest valid selected-year flu claim is displayed',
-        'All Providers includes both synthetic patients',
-        'individual provider includes only its assigned synthetic patient',
+        'a patient with no claim that year renders a blank billing date',
+        'All Providers includes every synthetic patient',
+        'individual provider includes only its assigned synthetic patients',
       ],
     }, null, 2));
-    console.log('PASS Flu Billing Report demographic mapping and provider filters');
   } finally {
+    // browser.close() can reject (crashed target, close timeout). Swallow it here
+    // so the database and the cleartext MySQL password file are always cleaned up
+    // rather than the rest of this block being skipped.
     if (browser) {
-      await browser.close();
+      await browser.close().catch((error) => {
+        console.error(`WARN failed to close browser: ${error.message}`);
+      });
     }
     try {
-      cleanupSeedData();
+      cleanupFailures = cleanupSeedData();
     } finally {
       cleanupMysqlDefaultsFile();
     }
+    cleanupFailures.forEach((failure) => console.error(`WARN ${failure}`));
   }
+
+  // Reached only when every assertion passed. Left-behind synthetic 65+ patients
+  // would pollute real Flu Billing Reports, so a dirty database is a failed run.
+  if (cleanupFailures.length) {
+    throw new Error(
+      `Synthetic rows were left in the database and must be removed by hand:\n  ${cleanupFailures.join('\n  ')}`
+    );
+  }
+  console.log('PASS Flu Billing Report demographic mapping and provider filters');
 }
 
 run().catch((error) => {
   console.error('FAIL Flu Billing Report Playwright check');
   console.error(error.stack || error.message);
+  // A row mismatch is usually caused by something the page already reported —
+  // an HTTP 500 on the report action, a JS error that broke rendering. Print the
+  // collected findings on every failure, not only when they are the assertion.
+  if (browserFindings.length) {
+    console.error(`Browser findings during the run: ${JSON.stringify(browserFindings, null, 2)}`);
+  }
   process.exit(1);
 });

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDao.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDao.java
@@ -429,7 +429,7 @@ public interface DemographicDao {
      * results shift as patients cross the age-65 boundary.</p>
      *
      * @param providerNo the demographic's assigned provider to filter on;
-     *                   {@code "-1"} or {@code null} means all providers
+     *                   {@code "-1"}, {@code null}, or blank means all providers
      * @return one row per eligible patient, never {@code null}. Every component
      *         is a non-null String — a NULL column arrives as the empty string,
      *         so callers render blanks rather than the literal text "null".

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDao.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDao.java
@@ -422,6 +422,10 @@ public interface DemographicDao {
     /**
      * Patients eligible for an influenza (G590A/G591A) recall, for the Flu Billing Report.
      *
+     * <p>The typed {@link FluReportDemographicRow} return dates from 2026-08-06;
+     * before that this returned positional {@code Object[]} rows. The method
+     * itself is considerably older.</p>
+     *
      * <p>Selects demographics aged 65 or over whose {@code patient_status} is
      * {@code AC} or {@code UHIP} and whose {@code roster_status} is one of
      * {@code RO}, {@code NR}, {@code FS}, {@code RF}, or {@code PL}, ordered by
@@ -429,14 +433,13 @@ public interface DemographicDao {
      * results shift as patients cross the age-65 boundary.</p>
      *
      * @param providerNo the demographic's assigned provider to filter on;
-     *                   {@code "-1"}, {@code null}, or blank means all providers
+     *                   {@code "-1"}, {@code null}, or blank means all providers.
+     *                   Surrounding whitespace is trimmed before matching.
      * @return one row per eligible patient, never {@code null}. Every component
      *         is a non-null String — a NULL column arrives as the empty string,
      *         so callers render blanks rather than the literal text "null".
      *         The projection carries no billing data; the claim date per patient
      *         is resolved separately by the report layer.
-     * @since 2026-08-06 typed projection; the method itself predates the
-     *        {@code Object[]} to {@link FluReportDemographicRow} migration.
      */
     public List<FluReportDemographicRow> findDemographicsForFluReport(String providerNo);
 

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDao.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDao.java
@@ -435,6 +435,8 @@ public interface DemographicDao {
      *         so callers render blanks rather than the literal text "null".
      *         The projection carries no billing data; the claim date per patient
      *         is resolved separately by the report layer.
+     * @since 2026-08-06 typed projection; the method itself predates the
+     *        {@code Object[]} to {@link FluReportDemographicRow} migration.
      */
     public List<FluReportDemographicRow> findDemographicsForFluReport(String providerNo);
 

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDao.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDao.java
@@ -419,6 +419,23 @@ public interface DemographicDao {
 
     // public List<Demographic> findByCriterion(DemographicCriterion c);
 
+    /**
+     * Patients eligible for an influenza (G590A/G591A) recall, for the Flu Billing Report.
+     *
+     * <p>Selects demographics aged 65 or over whose {@code patient_status} is
+     * {@code AC} or {@code UHIP} and whose {@code roster_status} is one of
+     * {@code RO}, {@code NR}, {@code FS}, {@code RF}, or {@code PL}, ordered by
+     * last name. Age is computed in the database against the current date, so
+     * results shift as patients cross the age-65 boundary.</p>
+     *
+     * @param providerNo the demographic's assigned provider to filter on;
+     *                   {@code "-1"} or {@code null} means all providers
+     * @return one row per eligible patient, never {@code null}. Every component
+     *         is a non-null String — a NULL column arrives as the empty string,
+     *         so callers render blanks rather than the literal text "null".
+     *         The projection carries no billing data; the claim date per patient
+     *         is resolved separately by the report layer.
+     */
     public List<FluReportDemographicRow> findDemographicsForFluReport(String providerNo);
 
     public List<Integer> getActiveDemographicIdsOlderThan(int age);

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDao.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDao.java
@@ -37,6 +37,7 @@ import java.util.Set;
 
 import io.github.carlos_emr.carlos.PMmodule.web.formbean.ClientSearchFormBean;
 import io.github.carlos_emr.carlos.commn.Gender;
+import io.github.carlos_emr.carlos.commn.dao.projection.FluReportDemographicRow;
 import io.github.carlos_emr.carlos.commn.model.Demographic;
 import io.github.carlos_emr.carlos.commn.model.DemographicExt;
 import io.github.carlos_emr.carlos.demographic.dto.DemographicHeaderDTO;
@@ -418,7 +419,7 @@ public interface DemographicDao {
 
     // public List<Demographic> findByCriterion(DemographicCriterion c);
 
-    public List<Object[]> findDemographicsForFluReport(String providerNo);
+    public List<FluReportDemographicRow> findDemographicsForFluReport(String providerNo);
 
     public List<Integer> getActiveDemographicIdsOlderThan(int age);
 

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDaoImpl.java
@@ -2480,13 +2480,17 @@ public class DemographicDaoImpl extends AbstractJpaDao implements ApplicationEve
             + "RIGHT(DATE_FORMAT(CONCAT((year_of_birth), '-', (month_of_birth),'-',(date_of_birth)),'%Y-%m-%d'),5)) >= 65 "
             + "and (patient_status = 'AC' or patient_status = 'UHIP') "
             + "and (roster_status='RO' or roster_status='NR' or roster_status='FS' or roster_status='RF' or roster_status='PL')";
-        if (providerNo != null && !providerNo.equals("-1")) {
+        // Blank means "all providers", same as the "-1" sentinel. A blank value
+        // previously became a literal provider_no = '' filter, which matches no
+        // demographic and silently emptied the report.
+        boolean allProviders = StringUtils.isBlank(providerNo) || "-1".equals(providerNo);
+        if (!allProviders) {
             sql = sql + " and provider_no = :providerNo ";
         }
         sql = sql + " order by last_name ";
 
         Query sqlQuery = entityManager().createNativeQuery(sql, Tuple.class);
-        if (providerNo != null && !providerNo.equals("-1")) {
+        if (!allProviders) {
             sqlQuery.setParameter("providerNo", providerNo);
         }
 

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDaoImpl.java
@@ -92,7 +92,12 @@ public class DemographicDaoImpl extends AbstractJpaDao implements ApplicationEve
     private static final String FLU_PHONE = "phone";
     private static final String FLU_ROSTER_STATUS = "roster_status";
     private static final String FLU_PATIENT_STATUS = "patient_status";
-    private static final String FLU_DATE_OF_BIRTH = "date_of_birth";
+    // Deliberately not "date_of_birth": that is a real column on demographic
+    // holding only the day of month, and this alias covers the whole formatted
+    // date. MySQL resolves ORDER BY and HAVING against aliases first, so reusing
+    // the column name would silently change the meaning of any such clause added
+    // to this query later.
+    private static final String FLU_DATE_OF_BIRTH = "dob_formatted";
     private static final String FLU_AGE = "age";
 
     /** Parameter keys whose values contain PHI and must not appear in logs. */
@@ -2480,10 +2485,8 @@ public class DemographicDaoImpl extends AbstractJpaDao implements ApplicationEve
             + "RIGHT(DATE_FORMAT(CONCAT((year_of_birth), '-', (month_of_birth),'-',(date_of_birth)),'%Y-%m-%d'),5)) >= 65 "
             + "and (patient_status = 'AC' or patient_status = 'UHIP') "
             + "and (roster_status='RO' or roster_status='NR' or roster_status='FS' or roster_status='RF' or roster_status='PL')";
-        // Blank means "all providers", same as the "-1" sentinel. A blank value
-        // previously became a literal provider_no = '' filter, which matches no
-        // demographic and silently emptied the report.
-        boolean allProviders = StringUtils.isBlank(providerNo) || "-1".equals(providerNo);
+        String selectedProvider = StringUtils.trimToEmpty(providerNo);
+        boolean allProviders = isAllProvidersSelection(providerNo);
         if (!allProviders) {
             sql = sql + " and provider_no = :providerNo ";
         }
@@ -2491,12 +2494,26 @@ public class DemographicDaoImpl extends AbstractJpaDao implements ApplicationEve
 
         Query sqlQuery = entityManager().createNativeQuery(sql, Tuple.class);
         if (!allProviders) {
-            sqlQuery.setParameter("providerNo", providerNo);
+            sqlQuery.setParameter("providerNo", selectedProvider);
         }
 
         @SuppressWarnings("unchecked")
         List<Tuple> rows = sqlQuery.getResultList();
         return rows.stream().map(DemographicDaoImpl::toFluReportDemographicRow).toList();
+    }
+
+    /**
+     * Whether a Flu Billing Report request means "every provider".
+     *
+     * <p>Null, blank, and the {@code "-1"} sentinel all mean all providers, and
+     * surrounding whitespace is ignored. Untrimmed or blank values previously
+     * became a literal {@code provider_no = ''} filter, which matches no
+     * demographic and silently emptied the report while the UI still claimed to
+     * be showing every provider.</p>
+     */
+    static boolean isAllProvidersSelection(String providerNo) {
+        String trimmed = StringUtils.trimToEmpty(providerNo);
+        return trimmed.isEmpty() || "-1".equals(trimmed);
     }
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDaoImpl.java
@@ -2495,15 +2495,25 @@ public class DemographicDaoImpl extends AbstractJpaDao implements ApplicationEve
         return rows.stream().map(DemographicDaoImpl::toFluReportDemographicRow).toList();
     }
 
+    /**
+     * Maps one aliased result row onto the report projection.
+     *
+     * <p>Values are stringified but left null here; {@link FluReportDemographicRow}
+     * is the single place nulls become blank report cells. Alias lookups are
+     * deliberately not defended: {@code Tuple.get(String)} throws
+     * {@code IllegalArgumentException} for an unknown alias, so drift between the
+     * {@code FLU_*} constants and the generated SQL surfaces as a hard failure
+     * rather than a silently empty column.</p>
+     */
     static FluReportDemographicRow toFluReportDemographicRow(Tuple row) {
         return new FluReportDemographicRow(
-            Objects.toString(row.get(FLU_DEMOGRAPHIC_NO), ""),
-            Objects.toString(row.get(FLU_PATIENT_NAME), ""),
-            Objects.toString(row.get(FLU_PHONE), ""),
-            Objects.toString(row.get(FLU_ROSTER_STATUS), ""),
-            Objects.toString(row.get(FLU_PATIENT_STATUS), ""),
-            Objects.toString(row.get(FLU_DATE_OF_BIRTH), ""),
-            Objects.toString(row.get(FLU_AGE), "")
+            Objects.toString(row.get(FLU_DEMOGRAPHIC_NO), null),
+            Objects.toString(row.get(FLU_PATIENT_NAME), null),
+            Objects.toString(row.get(FLU_PHONE), null),
+            Objects.toString(row.get(FLU_ROSTER_STATUS), null),
+            Objects.toString(row.get(FLU_PATIENT_STATUS), null),
+            Objects.toString(row.get(FLU_DATE_OF_BIRTH), null),
+            Objects.toString(row.get(FLU_AGE), null)
         );
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDaoImpl.java
@@ -2486,7 +2486,7 @@ public class DemographicDaoImpl extends AbstractJpaDao implements ApplicationEve
             + "and (patient_status = 'AC' or patient_status = 'UHIP') "
             + "and (roster_status='RO' or roster_status='NR' or roster_status='FS' or roster_status='RF' or roster_status='PL')";
         String selectedProvider = StringUtils.trimToEmpty(providerNo);
-        boolean allProviders = isAllProvidersSelection(providerNo);
+        boolean allProviders = isAllProvidersSelection(selectedProvider);
         if (!allProviders) {
             sql = sql + " and provider_no = :providerNo ";
         }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/DemographicDaoImpl.java
@@ -46,6 +46,7 @@ import io.github.carlos_emr.carlos.utils.Utility;
 import org.apache.commons.lang3.StringUtils;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
+import jakarta.persistence.Tuple;
 
 import org.apache.logging.log4j.Logger;
 import org.hibernate.query.NativeQuery;
@@ -55,6 +56,7 @@ import io.github.carlos_emr.carlos.PMmodule.web.formbean.ClientSearchFormBean;
 import io.github.carlos_emr.carlos.commn.DemographicSearchResultTransformer;
 import io.github.carlos_emr.carlos.commn.Gender;
 import io.github.carlos_emr.carlos.commn.NativeSql;
+import io.github.carlos_emr.carlos.commn.dao.projection.FluReportDemographicRow;
 import io.github.carlos_emr.carlos.commn.model.Demographic;
 import io.github.carlos_emr.carlos.commn.model.DemographicExt;
 import io.github.carlos_emr.carlos.demographic.dto.DemographicHeaderDTO;
@@ -85,6 +87,13 @@ import io.github.carlos_emr.carlos.utility.LogSafe;
 public class DemographicDaoImpl extends AbstractJpaDao implements ApplicationEventPublisherAware, DemographicDao {
 
     private static final int MAX_SELECT_SIZE = 500;
+    private static final String FLU_DEMOGRAPHIC_NO = "demographic_no";
+    private static final String FLU_PATIENT_NAME = "patient_name";
+    private static final String FLU_PHONE = "phone";
+    private static final String FLU_ROSTER_STATUS = "roster_status";
+    private static final String FLU_PATIENT_STATUS = "patient_status";
+    private static final String FLU_DATE_OF_BIRTH = "date_of_birth";
+    private static final String FLU_AGE = "age";
 
     /** Parameter keys whose values contain PHI and must not appear in logs. */
     private static final Set<String> PHI_PARAM_KEYS = Set.of(
@@ -2454,13 +2463,18 @@ public class DemographicDaoImpl extends AbstractJpaDao implements ApplicationEve
         return (List<Demographic>) JpqlQueryHelper.find(entityManager(), sSQL, c.getAll(true));
     }
 
-    @SuppressWarnings("unchecked")
     @Override
-    public List<Object[]> findDemographicsForFluReport(String providerNo) {
-        String sql = "select demographic_no, CONCAT(last_name,',',first_name) as demoname, phone, roster_status, patient_status, "
-            + "DATE_FORMAT(CONCAT((year_of_birth), '-', (month_of_birth), '-',(date_of_birth)),'%Y-%m-%d') as dob, "
+    public List<FluReportDemographicRow> findDemographicsForFluReport(String providerNo) {
+        String sql = "select demographic_no as " + FLU_DEMOGRAPHIC_NO
+            + ", CONCAT(last_name,',',first_name) as " + FLU_PATIENT_NAME
+            + ", phone as " + FLU_PHONE
+            + ", roster_status as " + FLU_ROSTER_STATUS
+            + ", patient_status as " + FLU_PATIENT_STATUS + ", "
+            + "DATE_FORMAT(CONCAT((year_of_birth), '-', (month_of_birth), '-',(date_of_birth)),'%Y-%m-%d') as "
+            + FLU_DATE_OF_BIRTH + ", "
             + "(YEAR(CURRENT_DATE)-YEAR(DATE_FORMAT(CONCAT((year_of_birth), '-', (month_of_birth),'-',(date_of_birth)),'%Y-%m-%d')))-"
-            + "(RIGHT(CURRENT_DATE,5)<RIGHT(DATE_FORMAT(CONCAT((year_of_birth), '-', (month_of_birth),'-',(date_of_birth)),'%Y-%m-%d'),5)) as age "
+            + "(RIGHT(CURRENT_DATE,5)<RIGHT(DATE_FORMAT(CONCAT((year_of_birth), '-', (month_of_birth),'-',(date_of_birth)),'%Y-%m-%d'),5)) as "
+            + FLU_AGE + " "
             + "from demographic  where (YEAR(CURRENT_DATE)-YEAR(DATE_FORMAT(CONCAT((year_of_birth),'-', (month_of_birth),'-',(date_of_birth)),'%Y-%m-%d')))-"
             + "(RIGHT(CURRENT_DATE,5)<"
             + "RIGHT(DATE_FORMAT(CONCAT((year_of_birth), '-', (month_of_birth),'-',(date_of_birth)),'%Y-%m-%d'),5)) >= 65 "
@@ -2471,12 +2485,26 @@ public class DemographicDaoImpl extends AbstractJpaDao implements ApplicationEve
         }
         sql = sql + " order by last_name ";
 
-        EntityManager session = entityManager();
-            Query sqlQuery = session.createNativeQuery(sql);
-            if (providerNo != null && !providerNo.equals("-1")) {
-                sqlQuery.setParameter("providerNo", providerNo);
-            }
-            return sqlQuery.getResultList();
+        Query sqlQuery = entityManager().createNativeQuery(sql, Tuple.class);
+        if (providerNo != null && !providerNo.equals("-1")) {
+            sqlQuery.setParameter("providerNo", providerNo);
+        }
+
+        @SuppressWarnings("unchecked")
+        List<Tuple> rows = sqlQuery.getResultList();
+        return rows.stream().map(DemographicDaoImpl::toFluReportDemographicRow).toList();
+    }
+
+    static FluReportDemographicRow toFluReportDemographicRow(Tuple row) {
+        return new FluReportDemographicRow(
+            Objects.toString(row.get(FLU_DEMOGRAPHIC_NO), ""),
+            Objects.toString(row.get(FLU_PATIENT_NAME), ""),
+            Objects.toString(row.get(FLU_PHONE), ""),
+            Objects.toString(row.get(FLU_ROSTER_STATUS), ""),
+            Objects.toString(row.get(FLU_PATIENT_STATUS), ""),
+            Objects.toString(row.get(FLU_DATE_OF_BIRTH), ""),
+            Objects.toString(row.get(FLU_AGE), "")
+        );
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/projection/FluReportDemographicRow.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/projection/FluReportDemographicRow.java
@@ -18,11 +18,22 @@
 package io.github.carlos_emr.carlos.commn.dao.projection;
 
 /**
- * Demographic details required by the Flu Billing Report.
+ * One row from {@code DemographicDao.findDemographicsForFluReport} — the
+ * seven patient columns the Flu Billing Report renders for each 65-and-over
+ * patient eligible for a G590A/G591A influenza claim.
  *
  * <p>The typed projection keeps the native-query column contract inside the
  * DAO and prevents report consumers from depending on positional
  * {@code Object[]} indexes.</p>
+ *
+ * <p>Every component is null-coalesced to the empty string here, so this is
+ * the single place a missing database value becomes a blank report cell
+ * rather than the literal text {@code null}. Note that a mistyped query alias
+ * does <em>not</em> arrive here as a null — {@code Tuple.get(String)} throws
+ * {@code IllegalArgumentException} for an unknown alias, so alias drift fails
+ * loudly instead of silently blanking a column.</p>
+ *
+ * @since 2026-08-06
  */
 public record FluReportDemographicRow(
         String demographicNo,

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/projection/FluReportDemographicRow.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/projection/FluReportDemographicRow.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.commn.dao.projection;
+
+/**
+ * Demographic details required by the Flu Billing Report.
+ *
+ * <p>The typed projection keeps the native-query column contract inside the
+ * DAO and prevents report consumers from depending on positional
+ * {@code Object[]} indexes.</p>
+ */
+public record FluReportDemographicRow(
+        String demographicNo,
+        String patientName,
+        String phone,
+        String rosterStatus,
+        String patientStatus,
+        String dateOfBirth,
+        String age) {
+
+    public FluReportDemographicRow {
+        demographicNo = demographicNo == null ? "" : demographicNo;
+        patientName = patientName == null ? "" : patientName;
+        phone = phone == null ? "" : phone;
+        rosterStatus = rosterStatus == null ? "" : rosterStatus;
+        patientStatus = patientStatus == null ? "" : patientStatus;
+        dateOfBirth = dateOfBirth == null ? "" : dateOfBirth;
+        age = age == null ? "" : age;
+    }
+}

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/projection/FluReportDemographicRow.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/projection/FluReportDemographicRow.java
@@ -18,9 +18,13 @@
 package io.github.carlos_emr.carlos.commn.dao.projection;
 
 /**
- * One row from {@code DemographicDao.findDemographicsForFluReport} — the
- * seven patient columns the Flu Billing Report renders for each 65-and-over
- * patient eligible for a G590A/G591A influenza claim.
+ * One row from {@code DemographicDao.findDemographicsForFluReport}, for a
+ * 65-and-over patient eligible for a G590A/G591A influenza claim.
+ *
+ * <p>Six of the seven components are rendered by the Flu Billing Report:
+ * name, date of birth, age, roster status, patient status, and phone. The
+ * seventh, {@code demographicNo}, is never displayed — the report uses it only
+ * to resolve each row's Billing Date, which is not part of this projection.</p>
  *
  * <p>The typed projection keeps the native-query column contract inside the
  * DAO and prevents report consumers from depending on positional

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/RptFluReportData.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/RptFluReportData.java
@@ -73,6 +73,7 @@ public class RptFluReportData {
      *
      * @param s  the provider filter; {@code "-1"} means all providers
      * @param s1 the four-digit report year used to scope the billing lookup
+     * @since 2026-08-06 typed projection mapping; the method itself predates it.
      */
     public void fluReportGenerate(String s, String s1) {
         years = s1;

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/RptFluReportData.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/RptFluReportData.java
@@ -32,6 +32,7 @@ package io.github.carlos_emr.carlos.report.data;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 import io.github.carlos_emr.carlos.PMmodule.dao.ProviderDao;
 import io.github.carlos_emr.carlos.commn.dao.BillingDao;
@@ -70,20 +71,20 @@ public class RptFluReportData {
         demoList = new ArrayList<DemoFluDataStruct>();
         DemoFluDataStruct demofludatastruct;
         for (Object[] o : dao.findDemographicsForFluReport(s)) {
-            String demographic_no = String.valueOf(o[0]);
-            String demoname = String.valueOf(o[0]);
-            String phone = String.valueOf(o[0]);
-            String roster_status = String.valueOf(o[0]);
-            String patient_status = String.valueOf(o[0]);
-            String dob = String.valueOf(o[0]);
-            String age = String.valueOf(o[0]);
+            String demographicNo = Objects.toString(o[0], "");
+            String demoName = Objects.toString(o[1], "");
+            String phone = Objects.toString(o[2], "");
+            String rosterStatus = Objects.toString(o[3], "");
+            String patientStatus = Objects.toString(o[4], "");
+            String dob = Objects.toString(o[5], "");
+            String age = Objects.toString(o[6], "");
 
             demofludatastruct = new DemoFluDataStruct();
-            demofludatastruct.demoNo = demographic_no;
-            demofludatastruct.demoName = demoname;
+            demofludatastruct.demoNo = demographicNo;
+            demofludatastruct.demoName = demoName;
             demofludatastruct.demoPhone = phone;
-            demofludatastruct.demoRosterStatus = roster_status;
-            demofludatastruct.demoPatientStatus = patient_status;
+            demofludatastruct.demoRosterStatus = rosterStatus;
+            demofludatastruct.demoPatientStatus = patientStatus;
             demofludatastruct.demoDOB = dob;
             demofludatastruct.demoAge = age;
 

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/RptFluReportData.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/RptFluReportData.java
@@ -63,6 +63,19 @@ public class RptFluReportData {
         return pList;
     }
 
+    /**
+     * Loads the flu-recall patient list into {@link #demoList} and records the
+     * report year in {@link #years} for the JSP to read back.
+     *
+     * <p>Each {@link DemoFluDataStruct} carries the seven rendered patient
+     * columns — number, name, phone, roster status, patient status, date of
+     * birth, and age — all non-null. The Billing Date column is not loaded
+     * here; the JSP resolves it per row through
+     * {@link DemoFluDataStruct#getBillingDate(String)}.</p>
+     *
+     * @param s  the provider filter; {@code "-1"} means all providers
+     * @param s1 the four-digit report year used to scope the billing lookup
+     */
     public void fluReportGenerate(String s, String s1) {
         years = s1;
 

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/RptFluReportData.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/RptFluReportData.java
@@ -115,7 +115,10 @@ public class RptFluReportData {
         }
 
         public String getBillingDate() {
-            String s = "&nbsp;";
+            // Empty, not an "&nbsp;" markup sentinel: the JSP renders this through
+            // <carlos:encode context="html"/>, which escapes the ampersand and would
+            // print the literal characters "&nbsp;" in the cell.
+            String s = "";
 
             BillingDao dao = SpringUtils.getBean(BillingDao.class);
             for (Billing b : dao.findBillingsByDemoNoServiceCodeAndDate(ConversionUtils.fromIntString(demoNo), ConversionUtils.fromDateString("2003-04-01"), Arrays.asList(new String[]{"G590A", "G591A"}))) {
@@ -124,8 +127,14 @@ public class RptFluReportData {
             return s;
         }
 
+        /**
+         * Latest non-deleted G590A/G591A claim date for this patient inside
+         * {@code reportYear}, or the empty string when the patient has no flu
+         * claim that year — the "needs a flu shot" case this report exists to
+         * surface, so it must render as a blank cell rather than markup.
+         */
         public String getBillingDate(String reportYear) {
-            String s = "&nbsp;";
+            String s = "";
 
             String sDate = reportYear + "-01-01";
             String eDate = reportYear + "-12-31";

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/RptFluReportData.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/RptFluReportData.java
@@ -32,12 +32,12 @@ package io.github.carlos_emr.carlos.report.data;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 
 import io.github.carlos_emr.carlos.PMmodule.dao.ProviderDao;
 import io.github.carlos_emr.carlos.commn.dao.BillingDao;
 import io.github.carlos_emr.carlos.commn.dao.BillingONCHeader1Dao;
 import io.github.carlos_emr.carlos.commn.dao.DemographicDao;
+import io.github.carlos_emr.carlos.commn.dao.projection.FluReportDemographicRow;
 import io.github.carlos_emr.carlos.commn.model.Billing;
 import io.github.carlos_emr.carlos.commn.model.BillingONCHeader1;
 import io.github.carlos_emr.carlos.commn.model.Provider;
@@ -70,23 +70,15 @@ public class RptFluReportData {
 
         demoList = new ArrayList<DemoFluDataStruct>();
         DemoFluDataStruct demofludatastruct;
-        for (Object[] o : dao.findDemographicsForFluReport(s)) {
-            String demographicNo = Objects.toString(o[0], "");
-            String demoName = Objects.toString(o[1], "");
-            String phone = Objects.toString(o[2], "");
-            String rosterStatus = Objects.toString(o[3], "");
-            String patientStatus = Objects.toString(o[4], "");
-            String dob = Objects.toString(o[5], "");
-            String age = Objects.toString(o[6], "");
-
+        for (FluReportDemographicRow patient : dao.findDemographicsForFluReport(s)) {
             demofludatastruct = new DemoFluDataStruct();
-            demofludatastruct.demoNo = demographicNo;
-            demofludatastruct.demoName = demoName;
-            demofludatastruct.demoPhone = phone;
-            demofludatastruct.demoRosterStatus = rosterStatus;
-            demofludatastruct.demoPatientStatus = patientStatus;
-            demofludatastruct.demoDOB = dob;
-            demofludatastruct.demoAge = age;
+            demofludatastruct.demoNo = patient.demographicNo();
+            demofludatastruct.demoName = patient.patientName();
+            demofludatastruct.demoPhone = patient.phone();
+            demofludatastruct.demoRosterStatus = patient.rosterStatus();
+            demofludatastruct.demoPatientStatus = patient.patientStatus();
+            demofludatastruct.demoDOB = patient.dateOfBirth();
+            demofludatastruct.demoAge = patient.age();
 
             demoList.add(demofludatastruct);
         }

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/RptFluReportData.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/RptFluReportData.java
@@ -71,18 +71,20 @@ public class RptFluReportData {
      * here; the JSP resolves it per row through
      * {@link DemoFluDataStruct#getBillingDate(String)}.</p>
      *
-     * @param s  the provider filter; {@code "-1"} means all providers
-     * @param s1 the four-digit report year used to scope the billing lookup
-     * @since 2026-08-06 typed projection mapping; the method itself predates it.
+     * <p>The typed-projection mapping dates from 2026-08-06; the method itself
+     * is considerably older.</p>
+     *
+     * @param providerNo the provider filter; {@code "-1"} means all providers
+     * @param reportYear the four-digit report year used to scope the billing lookup
      */
-    public void fluReportGenerate(String s, String s1) {
-        years = s1;
+    public void fluReportGenerate(String providerNo, String reportYear) {
+        years = reportYear;
 
         DemographicDao dao = SpringUtils.getBean(DemographicDao.class);
 
         demoList = new ArrayList<DemoFluDataStruct>();
         DemoFluDataStruct demofludatastruct;
-        for (FluReportDemographicRow patient : dao.findDemographicsForFluReport(s)) {
+        for (FluReportDemographicRow patient : dao.findDemographicsForFluReport(providerNo)) {
             demofludatastruct = new DemoFluDataStruct();
             demofludatastruct.demoNo = patient.demographicNo();
             demofludatastruct.demoName = patient.patientName();

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/RptFluReportData.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/RptFluReportData.java
@@ -65,10 +65,11 @@ public class RptFluReportData {
      * Loads the flu-recall patient list into {@link #demoList} and records the
      * report year in {@link #years} for the JSP to read back.
      *
-     * <p>Each {@link DemoFluDataStruct} carries the seven rendered patient
-     * columns — number, name, phone, roster status, patient status, date of
-     * birth, and age — all non-null. The Billing Date column is not loaded
-     * here; the JSP resolves it per row through
+     * <p>Each {@link DemoFluDataStruct} carries the six rendered patient
+     * columns — name, phone, roster status, patient status, date of birth, and
+     * age — plus the demographic number, which is not displayed and exists only
+     * to resolve the Billing Date. All are non-null. The Billing Date itself is
+     * not loaded here; the JSP resolves it per row through
      * {@link DemoFluDataStruct#getBillingDate(String)}.</p>
      *
      * <p>The typed-projection mapping dates from 2026-08-06; the method itself

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/RptFluReportData.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/RptFluReportData.java
@@ -34,11 +34,9 @@ import java.util.Arrays;
 import java.util.List;
 
 import io.github.carlos_emr.carlos.PMmodule.dao.ProviderDao;
-import io.github.carlos_emr.carlos.commn.dao.BillingDao;
 import io.github.carlos_emr.carlos.commn.dao.BillingONCHeader1Dao;
 import io.github.carlos_emr.carlos.commn.dao.DemographicDao;
 import io.github.carlos_emr.carlos.commn.dao.projection.FluReportDemographicRow;
-import io.github.carlos_emr.carlos.commn.model.Billing;
 import io.github.carlos_emr.carlos.commn.model.BillingONCHeader1;
 import io.github.carlos_emr.carlos.commn.model.Provider;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
@@ -125,19 +123,6 @@ public class RptFluReportData {
 
         public String getDemoDOB() {
             return demoDOB;
-        }
-
-        public String getBillingDate() {
-            // Empty, not an "&nbsp;" markup sentinel: the JSP renders this through
-            // <carlos:encode context="html"/>, which escapes the ampersand and would
-            // print the literal characters "&nbsp;" in the cell.
-            String s = "";
-
-            BillingDao dao = SpringUtils.getBean(BillingDao.class);
-            for (Billing b : dao.findBillingsByDemoNoServiceCodeAndDate(ConversionUtils.fromIntString(demoNo), ConversionUtils.fromDateString("2003-04-01"), Arrays.asList(new String[]{"G590A", "G591A"}))) {
-                s = ConversionUtils.toDateString(b.getBillingDate());
-            }
-            return s;
         }
 
         /**

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/oscarReportFluBilling.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/oscarReportFluBilling.jsp
@@ -127,7 +127,7 @@
     </h4>
 </div>
 
-<form action="${ctx}/oscarReport/FluBilling" method="get" class="card card-body bg-body-tertiary d-flex flex-wrap align-items-center gap-2" id="fluForm">
+<form action="${carlos:forHtmlAttribute(ctx)}/oscarReport/FluBilling" method="get" class="card card-body bg-body-tertiary d-flex flex-wrap align-items-center gap-2" id="fluForm">
     <select name="numMonth" class="form-select form-select-sm d-inline-block w-auto">
         <%
             for (int i = curYear - 2; i <= curYear + 2; i++) {

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/oscarReportFluBilling.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/oscarReportFluBilling.jsp
@@ -42,15 +42,20 @@
     Features:
         - Seven patient columns: name, date of birth, age, enrolment (roster)
           status, patient status, phone, and billing date.
-        - Year selector spanning the selected year plus or minus two.
+        - Year selector spanning the selected year plus or minus two, clamped
+          to the range the validation accepts, so it never offers a year that
+          would fall back to the current one.
         - Provider filter defaulting to All Providers.
         - Renders as a fragment loaded into #dynamic-content by the
           administration left navigation, and standalone in the popup opened
           from admin/admin.jsp.
 
     Request parameters:
-        numMonth - four-digit report year; defaults to the current year.
-        proNo    - provider number to filter on; "-1" means all providers.
+        numMonth - four-digit report year, from 1900 to two years ahead of the
+                   current year. Anything else falls back to the current year.
+        proNo    - provider number to filter on. "-1", blank, or a provider not
+                   in the active list all mean all providers, so the dropdown
+                   label always matches the filter that ran.
 
     Security:
         RptFluBilling2Action is the authority and requires read rights on
@@ -106,14 +111,11 @@
     }
     String years = String.valueOf(curYear);
 
-    // An absent proNo means "All Providers", which the DAO spells "-1". Leaving
-    // it blank made the query filter on provider_no = '', which matches no one,
-    // so the report rendered empty while the dropdown still read All Providers.
+    // Trimmed here so a padded value can still match a real provider below; the
+    // selectability guard after the provider list is loaded is what turns every
+    // other unusable value -- absent, blank, unknown, deactivated -- into "-1".
     String pros = request.getParameter("proNo");
     pros = (pros == null) ? "-1" : pros.trim();
-    if (pros.isEmpty()) {
-        pros = "-1";
-    }
 
     RptFluReportData fluData = new RptFluReportData();
     List<Provider> providers = fluData.providerList();

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/oscarReportFluBilling.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/oscarReportFluBilling.jsp
@@ -100,7 +100,7 @@
     int curYear = thisYear;
     if (requestedYear != null && requestedYear.matches("\\d{4}")) {
         int parsedYear = Integer.parseInt(requestedYear);
-        if (parsedYear >= 1900 && parsedYear <= thisYear + 2) {
+        if (parsedYear >= MIN_REPORT_YEAR && parsedYear <= thisYear + MAX_FUTURE_REPORT_YEARS) {
             curYear = parsedYear;
         }
     }
@@ -120,6 +120,11 @@
     List<Provider> providers = fluData.providerList();
 %>
 <%!
+    // Bounds shared by the numMonth validation and the year dropdown, so the
+    // selector can never offer a year the validation would reject.
+    static final int MIN_REPORT_YEAR = 1900;
+    static final int MAX_FUTURE_REPORT_YEARS = 2;
+
     String selled(String i, String years) {
         String retval = "";
         if (i.equals(years)) {
@@ -140,7 +145,11 @@
 <form action="${carlos:forHtmlAttribute(ctx)}/oscarReport/FluBilling" method="get" class="card card-body bg-body-tertiary d-flex flex-wrap align-items-center gap-2" id="fluForm">
     <select name="numMonth" class="form-select form-select-sm d-inline-block w-auto">
         <%
-            for (int i = curYear - 2; i <= curYear + 2; i++) {
+            // Clamped to the same range the validation above accepts, so every
+            // offered year is actually selectable. Otherwise picking the highest
+            // year exposes options that silently fall back to the current year.
+            for (int i = Math.max(MIN_REPORT_YEAR, curYear - 2);
+                 i <= Math.min(thisYear + MAX_FUTURE_REPORT_YEARS, curYear + 2); i++) {
         %>
         <option value="<%=i%>" <%=selled(("" + i), years)%>><%=i%>
         </option>

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/oscarReportFluBilling.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/oscarReportFluBilling.jsp
@@ -97,7 +97,7 @@
     </h4>
 </div>
 
-<form action="${ctx}/oscarReport/FluBilling" class="card card-body bg-body-tertiary d-flex flex-wrap align-items-center gap-2" id="fluForm">
+<form action="${ctx}/oscarReport/FluBilling" method="get" class="card card-body bg-body-tertiary d-flex flex-wrap align-items-center gap-2" id="fluForm">
     <select name="numMonth" class="form-select form-select-sm d-inline-block w-auto">
         <%
             for (int i = curYear - 2; i <= curYear + 2; i++) {
@@ -170,7 +170,14 @@
 </table>
 
 <script>
+    // registerFormSubmit is defined on the administration/index.jsp parent, which
+    // loads this fragment into #dynamic-content via the leftNav contentLink handler.
+    // admin/admin.jsp opens the same report standalone in a popup, where the parent
+    // (and therefore the hook) does not exist; there the form falls back to its
+    // native GET submit against the same action, which is the intended degradation.
     if (typeof registerFormSubmit === 'function') {
         registerFormSubmit('fluForm', 'dynamic-content');
+    } else {
+        console.warn('registerFormSubmit unavailable; Flu Billing Report filters will full-page submit.');
     }
 </script>

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/oscarReportFluBilling.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/oscarReportFluBilling.jsp
@@ -88,21 +88,25 @@
     curUser_no = (String) session.getAttribute("user");
     int count = 0;
 
-    String years = null;
-    int curYear = 0;
+    // numMonth is attacker-controllable, so anything that is not literally a
+    // four-digit year falls back to the current year. Passing it straight to
+    // Integer.parseInt used to 500 on non-numeric input, and a value near
+    // Integer.MAX_VALUE overflowed the year-select loop below into an
+    // effectively unbounded render that pinned a request thread.
+    GregorianCalendar cal = new GregorianCalendar();
+    int thisYear = cal.get(Calendar.YEAR);
+    String requestedYear = request.getParameter("numMonth");
+    int curYear = (requestedYear != null && requestedYear.matches("\\d{4}"))
+            ? Integer.parseInt(requestedYear)
+            : thisYear;
+    String years = String.valueOf(curYear);
 
-    String pros = "";
-    if (request.getParameter("numMonth") != null) {
-        years = request.getParameter("numMonth");
-        curYear = Integer.parseInt(years);
-    } else {
-        GregorianCalendar cal = new GregorianCalendar();
-        curYear = cal.get(Calendar.YEAR);
-        years = "" + curYear; //"2003";
-    }
-
-    if (request.getParameter("proNo") != null) {
-        pros = request.getParameter("proNo");
+    // An absent proNo means "All Providers", which the DAO spells "-1". Leaving
+    // it blank made the query filter on provider_no = '', which matches no one,
+    // so the report rendered empty while the dropdown still read All Providers.
+    String pros = request.getParameter("proNo");
+    if (pros == null || pros.trim().isEmpty()) {
+        pros = "-1";
     }
 
     RptFluReportData fluData = new RptFluReportData();

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/oscarReportFluBilling.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/oscarReportFluBilling.jsp
@@ -116,8 +116,28 @@
     }
 
     RptFluReportData fluData = new RptFluReportData();
-    fluData.fluReportGenerate(pros, years);
     List<Provider> providers = fluData.providerList();
+
+    // Only a provider the dropdown can actually show is a filter we can label
+    // honestly. A proNo that is unknown or since-deactivated would otherwise
+    // filter the table to nothing while no <option> carried "selected", so the
+    // browser fell back to displaying "All Providers" over an empty worklist --
+    // the same misleading state as an absent proNo, reached from a bookmarked
+    // or shared URL.
+    if (!"-1".equals(pros)) {
+        boolean selectableProvider = false;
+        for (Provider candidate : providers) {
+            if (pros.equals(candidate.getProviderNo())) {
+                selectableProvider = true;
+                break;
+            }
+        }
+        if (!selectableProvider) {
+            pros = "-1";
+        }
+    }
+
+    fluData.fluReportGenerate(pros, years);
 %>
 <%!
     // Bounds shared by the numMonth validation and the year dropdown, so the

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/oscarReportFluBilling.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/oscarReportFluBilling.jsp
@@ -29,6 +29,36 @@
 
 --%>
 
+<%--
+    CARLOS EMR — Flu Billing Report
+
+    Purpose:
+        Influenza recall worklist. Lists every patient aged 65 or over who is
+        eligible for an Ontario G590A/G591A influenza claim, alongside the date
+        of their latest such claim in the selected year. A blank Billing Date
+        marks a patient who still needs a flu shot — the rows this report
+        exists to surface.
+
+    Features:
+        - Seven patient columns: name, date of birth, age, enrolment (roster)
+          status, patient status, phone, and billing date.
+        - Year selector spanning the selected year plus or minus two.
+        - Provider filter defaulting to All Providers.
+        - Renders as a fragment loaded into #dynamic-content by the
+          administration left navigation, and standalone in the popup opened
+          from admin/admin.jsp.
+
+    Request parameters:
+        numMonth - four-digit report year; defaults to the current year.
+        proNo    - provider number to filter on; "-1" means all providers.
+
+    Security:
+        Requires read rights on _report or _admin.reporting; unauthorized
+        requests are redirected to the security error page.
+
+    @since 2026-08-06
+--%>
+
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@ taglib uri="carlos" prefix="carlos" %>

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/oscarReportFluBilling.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/oscarReportFluBilling.jsp
@@ -53,8 +53,11 @@
         proNo    - provider number to filter on; "-1" means all providers.
 
     Security:
-        Requires read rights on _report or _admin.reporting; unauthorized
-        requests are redirected to the security error page.
+        RptFluBilling2Action is the authority and requires read rights on
+        _report, so that is the effective requirement. The <security:oscarSec>
+        gate below is defence in depth for direct dispatches and additionally
+        accepts _admin.reporting; a user holding only _admin.reporting is
+        already rejected by the action and never reaches it.
 
     @since 2026-08-06
 --%>
@@ -84,28 +87,31 @@
 <c:set var="ctx" value="${pageContext.request.contextPath}" scope="request"/>
 
 <%
-    String curUser_no, userfirstname, userlastname;
-    curUser_no = (String) session.getAttribute("user");
-    int count = 0;
-
-    // numMonth is attacker-controllable, so anything that is not literally a
+    // numMonth is attacker-controllable, so anything that is not a plausible
     // four-digit year falls back to the current year. Passing it straight to
     // Integer.parseInt used to 500 on non-numeric input, and a value near
     // Integer.MAX_VALUE overflowed the year-select loop below into an
-    // effectively unbounded render that pinned a request thread.
+    // effectively unbounded render that pinned a request thread. The lower bound
+    // keeps values such as 0025 out, which parse but render every billing date
+    // blank -- and a blank cell here means "this patient still needs a flu shot".
     GregorianCalendar cal = new GregorianCalendar();
     int thisYear = cal.get(Calendar.YEAR);
     String requestedYear = request.getParameter("numMonth");
-    int curYear = (requestedYear != null && requestedYear.matches("\\d{4}"))
-            ? Integer.parseInt(requestedYear)
-            : thisYear;
+    int curYear = thisYear;
+    if (requestedYear != null && requestedYear.matches("\\d{4}")) {
+        int parsedYear = Integer.parseInt(requestedYear);
+        if (parsedYear >= 1900 && parsedYear <= thisYear + 2) {
+            curYear = parsedYear;
+        }
+    }
     String years = String.valueOf(curYear);
 
     // An absent proNo means "All Providers", which the DAO spells "-1". Leaving
     // it blank made the query filter on provider_no = '', which matches no one,
     // so the report rendered empty while the dropdown still read All Providers.
     String pros = request.getParameter("proNo");
-    if (pros == null || pros.trim().isEmpty()) {
+    pros = (pros == null) ? "-1" : pros.trim();
+    if (pros.isEmpty()) {
         pros = "-1";
     }
 
@@ -179,7 +185,6 @@
         for (int i = 0; i < fluData.demoList.size(); i++) {
             demoData = (RptFluReportData.DemoFluDataStruct) fluData.demoList
                     .get(i);
-            count = count + 1;
     %>
     <tr>
         <td><carlos:encode value='<%= demoData.demoName %>' context="html"/>

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/oscarReportFluBilling.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/oscarReportFluBilling.jsp
@@ -170,5 +170,7 @@
 </table>
 
 <script>
-    registerFormSubmit('fluForm', 'dynamic-content');
+    if (typeof registerFormSubmit === 'function') {
+        registerFormSubmit('fluForm', 'dynamic-content');
+    }
 </script>

--- a/src/test/java/io/github/carlos_emr/carlos/commn/dao/DemographicDaoImplFluReportUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/commn/dao/DemographicDaoImplFluReportUnitTest.java
@@ -24,6 +24,9 @@ import jakarta.persistence.Tuple;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -59,7 +62,7 @@ class DemographicDaoImplFluReportUnitTest {
         when(tuple.get("phone")).thenReturn(phone);
         when(tuple.get("roster_status")).thenReturn(rosterStatus);
         when(tuple.get("patient_status")).thenReturn(patientStatus);
-        when(tuple.get("date_of_birth")).thenReturn(dateOfBirth);
+        when(tuple.get("dob_formatted")).thenReturn(dateOfBirth);
         when(tuple.get("age")).thenReturn(age);
         return tuple;
     }
@@ -89,6 +92,24 @@ class DemographicDaoImplFluReportUnitTest {
         assertThat(patient.patientName()).isEmpty();
         assertThat(patient.phone()).isEmpty();
         assertThat(patient.demographicNo()).isEqualTo("714");
+    }
+
+    @ParameterizedTest(name = "providerNo=\"{0}\"")
+    @NullSource
+    @ValueSource(strings = {"", "   ", "-1", " -1 "})
+    @DisplayName("should select every provider when no specific provider is requested")
+    void shouldSelectEveryProvider_whenNoSpecificProviderRequested(String providerNo) {
+        // Guards the regression where a blank provider became a literal
+        // provider_no = '' filter, matching nobody and emptying the report while
+        // the UI still claimed to show All Providers.
+        assertThat(DemographicDaoImpl.isAllProvidersSelection(providerNo)).isTrue();
+    }
+
+    @ParameterizedTest(name = "providerNo=\"{0}\"")
+    @ValueSource(strings = {"999998", " 999998 ", "P123"})
+    @DisplayName("should filter by provider when a specific provider is requested")
+    void shouldFilterByProvider_whenSpecificProviderRequested(String providerNo) {
+        assertThat(DemographicDaoImpl.isAllProvidersSelection(providerNo)).isFalse();
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/commn/dao/DemographicDaoImplFluReportUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/commn/dao/DemographicDaoImplFluReportUnitTest.java
@@ -41,9 +41,11 @@ import static org.mockito.Mockito.when;
  * reading them here would make the test move with any rename and pass against
  * a consistently wrong alias.</p>
  *
- * <p>These stubs reproduce real {@code Tuple} semantics — a value is null only
- * when the column itself is SQL NULL, and an unknown alias raises
- * {@code IllegalArgumentException}. Whether MariaDB actually reports these
+ * <p>{@code tupleReturning} stubs exactly the seven aliases the mapper reads, so
+ * a null there means a SQL NULL column, as in production. It does not reproduce
+ * the rest of the {@code Tuple} contract: an alias it does not stub returns
+ * Mockito's default null rather than throwing, which is why the unknown-alias
+ * behaviour is pinned separately below. Whether MariaDB actually reports these
  * seven labels is a database contract that only
  * {@code scripts/flu-billing-report-playwright-checks.js} exercises.</p>
  */

--- a/src/test/java/io/github/carlos_emr/carlos/commn/dao/DemographicDaoImplFluReportUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/commn/dao/DemographicDaoImplFluReportUnitTest.java
@@ -26,25 +26,48 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+/**
+ * Alias-mapping contract for {@code DemographicDaoImpl.toFluReportDemographicRow}.
+ *
+ * <p>The aliases are asserted as literals rather than through the
+ * {@code FLU_*} constants on purpose: the constants also build the SQL, so
+ * reading them here would make the test move with any rename and pass against
+ * a consistently wrong alias.</p>
+ *
+ * <p>These stubs reproduce real {@code Tuple} semantics — a value is null only
+ * when the column itself is SQL NULL, and an unknown alias raises
+ * {@code IllegalArgumentException}. Whether MariaDB actually reports these
+ * seven labels is a database contract that only
+ * {@code scripts/flu-billing-report-playwright-checks.js} exercises.</p>
+ */
 @Tag("unit")
 @Tag("fast")
+@Tag("dao")
 @DisplayName("Flu billing report DAO projection")
 class DemographicDaoImplFluReportUnitTest {
 
+    private static Tuple tupleReturning(Object demographicNo, Object patientName, Object phone,
+                                        Object rosterStatus, Object patientStatus,
+                                        Object dateOfBirth, Object age) {
+        Tuple tuple = mock(Tuple.class);
+        when(tuple.get("demographic_no")).thenReturn(demographicNo);
+        when(tuple.get("patient_name")).thenReturn(patientName);
+        when(tuple.get("phone")).thenReturn(phone);
+        when(tuple.get("roster_status")).thenReturn(rosterStatus);
+        when(tuple.get("patient_status")).thenReturn(patientStatus);
+        when(tuple.get("date_of_birth")).thenReturn(dateOfBirth);
+        when(tuple.get("age")).thenReturn(age);
+        return tuple;
+    }
+
     @Test
     @DisplayName("should map demographic values by query alias instead of column position")
-    void shouldMapDemographicValuesByQueryAlias() {
-        Tuple tuple = mock(Tuple.class);
-        when(tuple.get("demographic_no")).thenReturn(714);
-        when(tuple.get("patient_name")).thenReturn("Patient,Flu");
-        when(tuple.get("phone")).thenReturn("416-555-0714");
-        when(tuple.get("roster_status")).thenReturn("RO");
-        when(tuple.get("patient_status")).thenReturn("AC");
-        when(tuple.get("date_of_birth")).thenReturn("1940-06-15");
-        when(tuple.get("age")).thenReturn(85);
+    void shouldMapDemographicValues_byQueryAlias() {
+        Tuple tuple = tupleReturning(714, "Patient,Flu", "416-555-0714", "RO", "AC", "1940-06-15", 85);
 
         FluReportDemographicRow patient = DemographicDaoImpl.toFluReportDemographicRow(tuple);
 
@@ -54,12 +77,29 @@ class DemographicDaoImplFluReportUnitTest {
     }
 
     @Test
-    @DisplayName("should normalize null demographic query values to empty strings")
-    void shouldNormalizeNullDemographicQueryValues() {
-        Tuple tuple = mock(Tuple.class);
+    @DisplayName("should normalize null column values to empty strings")
+    void shouldNormalizeNullColumnValues_toEmptyStrings() {
+        // phone is the only nullable column reachable in production; the query's
+        // WHERE clause filters out rows with a null age, DOB, or status, and
+        // CONCAT() yields null only when a name part is missing.
+        Tuple tuple = tupleReturning(714, null, null, "RO", "AC", "1940-06-15", 85);
 
         FluReportDemographicRow patient = DemographicDaoImpl.toFluReportDemographicRow(tuple);
 
-        assertThat(patient).isEqualTo(new FluReportDemographicRow("", "", "", "", "", "", ""));
+        assertThat(patient.patientName()).isEmpty();
+        assertThat(patient.phone()).isEmpty();
+        assertThat(patient.demographicNo()).isEqualTo("714");
+    }
+
+    @Test
+    @DisplayName("should propagate the lookup failure when a query alias is missing")
+    void shouldPropagateLookupFailure_whenQueryAliasMissing() {
+        // Real Tuple.get(String) throws for an unknown alias rather than returning
+        // null, so alias drift must fail loudly instead of blanking a column.
+        Tuple tuple = mock(Tuple.class);
+        when(tuple.get("demographic_no")).thenThrow(new IllegalArgumentException("demographic_no"));
+
+        assertThatThrownBy(() -> DemographicDaoImpl.toFluReportDemographicRow(tuple))
+            .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/commn/dao/DemographicDaoImplFluReportUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/commn/dao/DemographicDaoImplFluReportUnitTest.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.commn.dao;
+
+import io.github.carlos_emr.carlos.commn.dao.projection.FluReportDemographicRow;
+
+import jakarta.persistence.Tuple;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@Tag("unit")
+@Tag("fast")
+@DisplayName("Flu billing report DAO projection")
+class DemographicDaoImplFluReportUnitTest {
+
+    @Test
+    @DisplayName("should map demographic values by query alias instead of column position")
+    void shouldMapDemographicValuesByQueryAlias() {
+        Tuple tuple = mock(Tuple.class);
+        when(tuple.get("demographic_no")).thenReturn(714);
+        when(tuple.get("patient_name")).thenReturn("Patient,Flu");
+        when(tuple.get("phone")).thenReturn("416-555-0714");
+        when(tuple.get("roster_status")).thenReturn("RO");
+        when(tuple.get("patient_status")).thenReturn("AC");
+        when(tuple.get("date_of_birth")).thenReturn("1940-06-15");
+        when(tuple.get("age")).thenReturn(85);
+
+        FluReportDemographicRow patient = DemographicDaoImpl.toFluReportDemographicRow(tuple);
+
+        assertThat(patient).isEqualTo(new FluReportDemographicRow(
+            "714", "Patient,Flu", "416-555-0714", "RO", "AC", "1940-06-15", "85"
+        ));
+    }
+
+    @Test
+    @DisplayName("should normalize null demographic query values to empty strings")
+    void shouldNormalizeNullDemographicQueryValues() {
+        Tuple tuple = mock(Tuple.class);
+
+        FluReportDemographicRow patient = DemographicDaoImpl.toFluReportDemographicRow(tuple);
+
+        assertThat(patient).isEqualTo(new FluReportDemographicRow("", "", "", "", "", "", ""));
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/report/data/RptFluReportDataUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/data/RptFluReportDataUnitTest.java
@@ -24,80 +24,74 @@ package io.github.carlos_emr.carlos.report.data;
 import io.github.carlos_emr.carlos.commn.dao.BillingONCHeader1Dao;
 import io.github.carlos_emr.carlos.commn.dao.DemographicDao;
 import io.github.carlos_emr.carlos.commn.dao.projection.FluReportDemographicRow;
-import io.github.carlos_emr.carlos.utility.SpringUtils;
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
 
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@Tag("unit")
-@Tag("fast")
+/**
+ * Mapping contract between the DAO projection and the fields the Flu Billing
+ * Report JSP renders.
+ *
+ * <p>{@code RptFluReportData} resolves its DAOs through {@code SpringUtils},
+ * so this extends {@link CarlosUnitTestBase} for the shared static mock and its
+ * deterministic teardown rather than opening its own.</p>
+ */
 @DisplayName("Flu billing report demographic projection mapping")
-class RptFluReportDataUnitTest {
+class RptFluReportDataUnitTest extends CarlosUnitTestBase {
 
     @Test
     @DisplayName("should map every demographic query column to its patient detail field")
     void shouldMapEveryQueryColumn_toItsPatientDetailField() {
-        DemographicDao demographicDao = mock(DemographicDao.class);
+        DemographicDao demographicDao = createAndRegisterMock(DemographicDao.class);
         when(demographicDao.findDemographicsForFluReport("-1"))
             .thenReturn(List.of(new FluReportDemographicRow(
                 "714", "Patient,Flu", "416-555-0714", "RO", "AC", "1940-06-15", "85"
             )));
 
-        try (MockedStatic<SpringUtils> springUtils = mockStatic(SpringUtils.class)) {
-            springUtils.when(() -> SpringUtils.getBean(DemographicDao.class)).thenReturn(demographicDao);
+        RptFluReportData reportData = new RptFluReportData();
+        reportData.fluReportGenerate("-1", "2026");
 
-            RptFluReportData reportData = new RptFluReportData();
-            reportData.fluReportGenerate("-1", "2026");
-
-            assertThat(reportData.years).isEqualTo("2026");
-            assertThat(reportData.demoList).singleElement().satisfies(patient -> {
-                assertThat(patient.demoNo).isEqualTo("714");
-                assertThat(patient.demoName).isEqualTo("Patient,Flu");
-                assertThat(patient.demoPhone).isEqualTo("416-555-0714");
-                assertThat(patient.demoRosterStatus).isEqualTo("RO");
-                assertThat(patient.demoPatientStatus).isEqualTo("AC");
-                assertThat(patient.demoDOB).isEqualTo("1940-06-15");
-                assertThat(patient.demoAge).isEqualTo("85");
-            });
-            verify(demographicDao).findDemographicsForFluReport("-1");
-        }
+        assertThat(reportData.years).isEqualTo("2026");
+        assertThat(reportData.demoList).singleElement().satisfies(patient -> {
+            assertThat(patient.demoNo).isEqualTo("714");
+            assertThat(patient.demoName).isEqualTo("Patient,Flu");
+            assertThat(patient.demoPhone).isEqualTo("416-555-0714");
+            assertThat(patient.demoRosterStatus).isEqualTo("RO");
+            assertThat(patient.demoPatientStatus).isEqualTo("AC");
+            assertThat(patient.demoDOB).isEqualTo("1940-06-15");
+            assertThat(patient.demoAge).isEqualTo("85");
+        });
+        verify(demographicDao).findDemographicsForFluReport("-1");
     }
 
     @Test
     @DisplayName("should render empty patient details instead of literal null values")
     void shouldRenderEmptyStrings_forNullQueryColumns() {
-        DemographicDao demographicDao = mock(DemographicDao.class);
+        DemographicDao demographicDao = createAndRegisterMock(DemographicDao.class);
         when(demographicDao.findDemographicsForFluReport("999998"))
             .thenReturn(List.of(new FluReportDemographicRow(null, null, null, null, null, null, null)));
 
-        try (MockedStatic<SpringUtils> springUtils = mockStatic(SpringUtils.class)) {
-            springUtils.when(() -> SpringUtils.getBean(DemographicDao.class)).thenReturn(demographicDao);
+        RptFluReportData reportData = new RptFluReportData();
+        reportData.fluReportGenerate("999998", "2026");
 
-            RptFluReportData reportData = new RptFluReportData();
-            reportData.fluReportGenerate("999998", "2026");
-
-            assertThat(reportData.demoList).singleElement().satisfies(patient -> {
-                assertThat(patient.demoNo).isEmpty();
-                assertThat(patient.demoName).isEmpty();
-                assertThat(patient.demoPhone).isEmpty();
-                assertThat(patient.demoRosterStatus).isEmpty();
-                assertThat(patient.demoPatientStatus).isEmpty();
-                assertThat(patient.demoDOB).isEmpty();
-                assertThat(patient.demoAge).isEmpty();
-            });
-        }
+        assertThat(reportData.demoList).singleElement().satisfies(patient -> {
+            assertThat(patient.demoNo).isEmpty();
+            assertThat(patient.demoName).isEmpty();
+            assertThat(patient.demoPhone).isEmpty();
+            assertThat(patient.demoRosterStatus).isEmpty();
+            assertThat(patient.demoPatientStatus).isEmpty();
+            assertThat(patient.demoDOB).isEmpty();
+            assertThat(patient.demoAge).isEmpty();
+        });
     }
 
     @Test
@@ -107,24 +101,19 @@ class RptFluReportDataUnitTest {
         // through <carlos:encode context="html"/>, which escapes the ampersand and
         // printed the literal characters "&nbsp;" for every unvaccinated patient —
         // exactly the rows this recall report exists to surface.
-        DemographicDao demographicDao = mock(DemographicDao.class);
+        DemographicDao demographicDao = createAndRegisterMock(DemographicDao.class);
         when(demographicDao.findDemographicsForFluReport("-1"))
             .thenReturn(List.of(new FluReportDemographicRow(
                 "714", "Patient,Flu", "416-555-0714", "RO", "AC", "1940-06-15", "85"
             )));
-        BillingONCHeader1Dao billingDao = mock(BillingONCHeader1Dao.class);
+        BillingONCHeader1Dao billingDao = createAndRegisterMock(BillingONCHeader1Dao.class);
         when(billingDao.findBillingsByDemoNoCh1HeaderServiceCodeAndDate(
             any(), anyList(), any(), any())).thenReturn(List.of());
 
-        try (MockedStatic<SpringUtils> springUtils = mockStatic(SpringUtils.class)) {
-            springUtils.when(() -> SpringUtils.getBean(DemographicDao.class)).thenReturn(demographicDao);
-            springUtils.when(() -> SpringUtils.getBean(BillingONCHeader1Dao.class)).thenReturn(billingDao);
+        RptFluReportData reportData = new RptFluReportData();
+        reportData.fluReportGenerate("-1", "2026");
 
-            RptFluReportData reportData = new RptFluReportData();
-            reportData.fluReportGenerate("-1", "2026");
-
-            assertThat(reportData.demoList).singleElement().satisfies(patient ->
-                assertThat(patient.getBillingDate("2026")).isEmpty());
-        }
+        assertThat(reportData.demoList).singleElement().satisfies(patient ->
+            assertThat(patient.getBillingDate("2026")).isEmpty());
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/report/data/RptFluReportDataUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/data/RptFluReportDataUnitTest.java
@@ -21,6 +21,7 @@
  */
 package io.github.carlos_emr.carlos.report.data;
 
+import io.github.carlos_emr.carlos.commn.dao.BillingONCHeader1Dao;
 import io.github.carlos_emr.carlos.commn.dao.DemographicDao;
 import io.github.carlos_emr.carlos.commn.dao.projection.FluReportDemographicRow;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
@@ -33,6 +34,8 @@ import org.mockito.MockedStatic;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
@@ -45,7 +48,7 @@ class RptFluReportDataUnitTest {
 
     @Test
     @DisplayName("should map every demographic query column to its patient detail field")
-    void shouldMapEveryQueryColumnToItsPatientDetailField() {
+    void shouldMapEveryQueryColumn_toItsPatientDetailField() {
         DemographicDao demographicDao = mock(DemographicDao.class);
         when(demographicDao.findDemographicsForFluReport("-1"))
             .thenReturn(List.of(new FluReportDemographicRow(
@@ -74,7 +77,7 @@ class RptFluReportDataUnitTest {
 
     @Test
     @DisplayName("should render empty patient details instead of literal null values")
-    void shouldRenderEmptyStringsForNullQueryColumns() {
+    void shouldRenderEmptyStrings_forNullQueryColumns() {
         DemographicDao demographicDao = mock(DemographicDao.class);
         when(demographicDao.findDemographicsForFluReport("999998"))
             .thenReturn(List.of(new FluReportDemographicRow(null, null, null, null, null, null, null)));
@@ -94,6 +97,34 @@ class RptFluReportDataUnitTest {
                 assertThat(patient.demoDOB).isEmpty();
                 assertThat(patient.demoAge).isEmpty();
             });
+        }
+    }
+
+    @Test
+    @DisplayName("should leave the billing date cell blank when the patient has no flu claim that year")
+    void shouldLeaveBillingDateBlank_whenNoClaimInReportYear() {
+        // Regression guard for the "&nbsp;" sentinel: the JSP renders this value
+        // through <carlos:encode context="html"/>, which escapes the ampersand and
+        // printed the literal characters "&nbsp;" for every unvaccinated patient —
+        // exactly the rows this recall report exists to surface.
+        DemographicDao demographicDao = mock(DemographicDao.class);
+        when(demographicDao.findDemographicsForFluReport("-1"))
+            .thenReturn(List.of(new FluReportDemographicRow(
+                "714", "Patient,Flu", "416-555-0714", "RO", "AC", "1940-06-15", "85"
+            )));
+        BillingONCHeader1Dao billingDao = mock(BillingONCHeader1Dao.class);
+        when(billingDao.findBillingsByDemoNoCh1HeaderServiceCodeAndDate(
+            any(), anyList(), any(), any())).thenReturn(List.of());
+
+        try (MockedStatic<SpringUtils> springUtils = mockStatic(SpringUtils.class)) {
+            springUtils.when(() -> SpringUtils.getBean(DemographicDao.class)).thenReturn(demographicDao);
+            springUtils.when(() -> SpringUtils.getBean(BillingONCHeader1Dao.class)).thenReturn(billingDao);
+
+            RptFluReportData reportData = new RptFluReportData();
+            reportData.fluReportGenerate("-1", "2026");
+
+            assertThat(reportData.demoList).singleElement().satisfies(patient ->
+                assertThat(patient.getBillingDate("2026")).isEmpty());
         }
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/report/data/RptFluReportDataUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/data/RptFluReportDataUnitTest.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ */
+package io.github.carlos_emr.carlos.report.data;
+
+import io.github.carlos_emr.carlos.commn.dao.DemographicDao;
+import io.github.carlos_emr.carlos.utility.SpringUtils;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@Tag("unit")
+@Tag("fast")
+@DisplayName("Flu billing report demographic projection mapping")
+class RptFluReportDataUnitTest {
+
+    @Test
+    @DisplayName("should map every demographic query column to its patient detail field")
+    void shouldMapEveryQueryColumnToItsPatientDetailField() {
+        DemographicDao demographicDao = mock(DemographicDao.class);
+        Object[] queryRow = {714, "Patient,Flu", "416-555-0714", "RO", "AC", "1940-06-15", 85};
+        when(demographicDao.findDemographicsForFluReport("-1"))
+            .thenReturn(Arrays.<Object[]>asList(queryRow));
+
+        try (MockedStatic<SpringUtils> springUtils = mockStatic(SpringUtils.class)) {
+            springUtils.when(() -> SpringUtils.getBean(DemographicDao.class)).thenReturn(demographicDao);
+
+            RptFluReportData reportData = new RptFluReportData();
+            reportData.fluReportGenerate("-1", "2026");
+
+            assertThat(reportData.years).isEqualTo("2026");
+            assertThat(reportData.demoList).singleElement().satisfies(patient -> {
+                assertThat(patient.demoNo).isEqualTo("714");
+                assertThat(patient.demoName).isEqualTo("Patient,Flu");
+                assertThat(patient.demoPhone).isEqualTo("416-555-0714");
+                assertThat(patient.demoRosterStatus).isEqualTo("RO");
+                assertThat(patient.demoPatientStatus).isEqualTo("AC");
+                assertThat(patient.demoDOB).isEqualTo("1940-06-15");
+                assertThat(patient.demoAge).isEqualTo("85");
+            });
+            verify(demographicDao).findDemographicsForFluReport("-1");
+        }
+    }
+
+    @Test
+    @DisplayName("should render empty patient details instead of literal null values")
+    void shouldRenderEmptyStringsForNullQueryColumns() {
+        DemographicDao demographicDao = mock(DemographicDao.class);
+        Object[] queryRow = {null, null, null, null, null, null, null};
+        when(demographicDao.findDemographicsForFluReport("999998"))
+            .thenReturn(Arrays.<Object[]>asList(queryRow));
+
+        try (MockedStatic<SpringUtils> springUtils = mockStatic(SpringUtils.class)) {
+            springUtils.when(() -> SpringUtils.getBean(DemographicDao.class)).thenReturn(demographicDao);
+
+            RptFluReportData reportData = new RptFluReportData();
+            reportData.fluReportGenerate("999998", "2026");
+
+            assertThat(reportData.demoList).singleElement().satisfies(patient -> {
+                assertThat(patient.demoNo).isEmpty();
+                assertThat(patient.demoName).isEmpty();
+                assertThat(patient.demoPhone).isEmpty();
+                assertThat(patient.demoRosterStatus).isEmpty();
+                assertThat(patient.demoPatientStatus).isEmpty();
+                assertThat(patient.demoDOB).isEmpty();
+                assertThat(patient.demoAge).isEmpty();
+            });
+        }
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/report/data/RptFluReportDataUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/data/RptFluReportDataUnitTest.java
@@ -6,6 +6,18 @@
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; either version 2
  * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
  */
 package io.github.carlos_emr.carlos.report.data;
 

--- a/src/test/java/io/github/carlos_emr/carlos/report/data/RptFluReportDataUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/data/RptFluReportDataUnitTest.java
@@ -22,6 +22,7 @@
 package io.github.carlos_emr.carlos.report.data;
 
 import io.github.carlos_emr.carlos.commn.dao.DemographicDao;
+import io.github.carlos_emr.carlos.commn.dao.projection.FluReportDemographicRow;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 
 import org.junit.jupiter.api.DisplayName;
@@ -29,7 +30,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
-import java.util.Arrays;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -46,9 +47,10 @@ class RptFluReportDataUnitTest {
     @DisplayName("should map every demographic query column to its patient detail field")
     void shouldMapEveryQueryColumnToItsPatientDetailField() {
         DemographicDao demographicDao = mock(DemographicDao.class);
-        Object[] queryRow = {714, "Patient,Flu", "416-555-0714", "RO", "AC", "1940-06-15", 85};
         when(demographicDao.findDemographicsForFluReport("-1"))
-            .thenReturn(Arrays.<Object[]>asList(queryRow));
+            .thenReturn(List.of(new FluReportDemographicRow(
+                "714", "Patient,Flu", "416-555-0714", "RO", "AC", "1940-06-15", "85"
+            )));
 
         try (MockedStatic<SpringUtils> springUtils = mockStatic(SpringUtils.class)) {
             springUtils.when(() -> SpringUtils.getBean(DemographicDao.class)).thenReturn(demographicDao);
@@ -74,9 +76,8 @@ class RptFluReportDataUnitTest {
     @DisplayName("should render empty patient details instead of literal null values")
     void shouldRenderEmptyStringsForNullQueryColumns() {
         DemographicDao demographicDao = mock(DemographicDao.class);
-        Object[] queryRow = {null, null, null, null, null, null, null};
         when(demographicDao.findDemographicsForFluReport("999998"))
-            .thenReturn(Arrays.<Object[]>asList(queryRow));
+            .thenReturn(List.of(new FluReportDemographicRow(null, null, null, null, null, null, null)));
 
         try (MockedStatic<SpringUtils> springUtils = mockStatic(SpringUtils.class)) {
             springUtils.when(() -> SpringUtils.getBean(DemographicDao.class)).thenReturn(demographicDao);

--- a/src/test/java/io/github/carlos_emr/carlos/report/data/RptFluReportDataUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/data/RptFluReportDataUnitTest.java
@@ -24,11 +24,15 @@ package io.github.carlos_emr.carlos.report.data;
 import io.github.carlos_emr.carlos.commn.dao.BillingONCHeader1Dao;
 import io.github.carlos_emr.carlos.commn.dao.DemographicDao;
 import io.github.carlos_emr.carlos.commn.dao.projection.FluReportDemographicRow;
+import io.github.carlos_emr.carlos.commn.model.BillingONCHeader1;
 import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
+import io.github.carlos_emr.carlos.util.ConversionUtils;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
+import java.util.Date;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -119,5 +123,42 @@ class RptFluReportDataUnitTest extends CarlosUnitTestBase {
 
         assertThat(reportData.demoList).singleElement().satisfies(patient ->
             assertThat(patient.getBillingDate("2026")).isEmpty());
+    }
+
+    @Test
+    @DisplayName("should scope the billing lookup to the report year and both flu service codes")
+    void shouldScopeBillingLookup_toTheReportYearAndFluCodes() {
+        // Pins the arguments, not just the outcome. With any() matchers a swapped
+        // date range, the current year in place of the report year, or a dropped
+        // G591A all still produced a plausible-looking blank cell -- and a blank
+        // cell in this report means "this patient still needs a flu shot".
+        DemographicDao demographicDao = createAndRegisterMock(DemographicDao.class);
+        when(demographicDao.findDemographicsForFluReport("-1"))
+            .thenReturn(List.of(new FluReportDemographicRow(
+                "714", "Patient,Flu", "416-555-0714", "RO", "AC", "1940-06-15", "85"
+            )));
+        BillingONCHeader1 claim = new BillingONCHeader1();
+        claim.setBillingDate(ConversionUtils.fromDateString("2025-10-20"));
+        BillingONCHeader1Dao billingDao = createAndRegisterMock(BillingONCHeader1Dao.class);
+        when(billingDao.findBillingsByDemoNoCh1HeaderServiceCodeAndDate(
+            any(), anyList(), any(), any())).thenReturn(List.of(claim));
+
+        RptFluReportData reportData = new RptFluReportData();
+        reportData.fluReportGenerate("-1", "2025");
+
+        assertThat(reportData.demoList).singleElement().satisfies(patient ->
+            assertThat(patient.getBillingDate("2025")).isEqualTo("2025-10-20"));
+
+        ArgumentCaptor<Integer> demographicNo = ArgumentCaptor.forClass(Integer.class);
+        ArgumentCaptor<List<String>> serviceCodes = ArgumentCaptor.captor();
+        ArgumentCaptor<Date> from = ArgumentCaptor.forClass(Date.class);
+        ArgumentCaptor<Date> to = ArgumentCaptor.forClass(Date.class);
+        verify(billingDao).findBillingsByDemoNoCh1HeaderServiceCodeAndDate(
+            demographicNo.capture(), serviceCodes.capture(), from.capture(), to.capture());
+
+        assertThat(demographicNo.getValue()).isEqualTo(714);
+        assertThat(serviceCodes.getValue()).containsExactlyInAnyOrder("G590A", "G591A");
+        assertThat(ConversionUtils.toDateString(from.getValue())).isEqualTo("2025-01-01");
+        assertThat(ConversionUtils.toDateString(to.getValue())).isEqualTo("2025-12-31");
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/report/data/RptFluReportDataUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/data/RptFluReportDataUnitTest.java
@@ -74,8 +74,12 @@ class RptFluReportDataUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
-    @DisplayName("should render empty patient details instead of literal null values")
-    void shouldRenderEmptyStrings_forNullQueryColumns() {
+    @DisplayName("should carry the projection's null-coalesced blanks through to the report struct")
+    void shouldCarryCoalescedBlanks_throughToTheReportStruct() {
+        // The null -> "" coalescing itself happens in the FluReportDemographicRow
+        // compact constructor, so this pins the end-to-end guarantee the JSP relies
+        // on — a NULL database column reaches the cell as a blank, never the literal
+        // text "null" — rather than any null handling inside fluReportGenerate.
         DemographicDao demographicDao = createAndRegisterMock(DemographicDao.class);
         when(demographicDao.findDemographicsForFluReport("999998"))
             .thenReturn(List.of(new FluReportDemographicRow(null, null, null, null, null, null, null)));


### PR DESCRIPTION
## Summary

- project Flu Billing demographics through named, typed query aliases instead of positional `Object[]` columns
- map and render all seven patient/report fields correctly while preserving null-as-empty behavior
- guard the optional dynamic-content form hook when the report opens standalone
- add DAO/report unit tests and a seeded Playwright regression for demographic fields, latest billing date, and provider filters

## Testing

- `mvn -B -Dskip.npm -DskipTests=false -Dtest=DemographicDaoImplFluReportUnitTest,RptFluReportDataUnitTest test`
- `mvn -B package -Pjspc -DskipTests` (973 JSPs, 0 compilation errors)
- `node --check scripts/flu-billing-report-playwright-checks.js`
- `scripts/lint/check-bdd-test-naming.sh`
- local seeded Playwright exercise of all seven columns, latest billing date, and all/individual provider filters

Closes #3344
