### PR TITLE
fix(report): restore patient appointment list export

### DIFF
--- a/scripts/patient-list-by-appointment-export-playwright-checks.js
+++ b/scripts/patient-list-by-appointment-export-playwright-checks.js
@@ -38,6 +38,8 @@
  *   5. An empty date range still downloads a valid, empty attachment.
  *   6. An unauthenticated request is still rejected with 401 - excluding the
  *      route from Struts must not open a hole in the auth policy.
+ *   7. The visible form submits with POST so CSRF-TOKEN remains in the request
+ *      body instead of leaking into URLs, logs, and browser history.
  *
  * This script only reads; it seeds nothing and mutates nothing. It expects the
  * three LOCAL_SEED_OBEC_REPORT_* appointments (2026-08-07..2026-08-10) to be
@@ -255,6 +257,7 @@ async function exportViaForm(context, label, providerNo, dateFrom, dateTo) {
   const headers = await exportResponse.allHeaders();
   const downloadPath = download ? await download.path() : null;
   const result = {
+    method: exportResponse.request().method(),
     status: exportResponse.status(),
     url: exportResponse.url(),
     contentDisposition: headers['content-disposition'] || null,
@@ -274,6 +277,9 @@ function dataRows(body) {
 }
 
 function checkDownloadEnvelope(label, result) {
+  if (result.method !== 'POST') {
+    findings.push({ label, type: 'export-method', expected: 'POST', actual: result.method });
+  }
   if (result.status !== 200) {
     findings.push({ label, type: 'export-status', status: result.status, url: result.url });
   }

--- a/scripts/patient-list-by-appointment-export-playwright-checks.js
+++ b/scripts/patient-list-by-appointment-export-playwright-checks.js
@@ -57,35 +57,20 @@
  *   TEST_USER=carlosdoc
  *   TEST_PASSWORD=carlos2026
  *   TEST_PIN=2026
- *   ALLOW_NON_LOCAL_BASE_URL=true only when intentionally targeting a non-local test app
+ *   ALLOW_NON_LOCAL_BASE_URL=true only when intentionally targeting a non-loopback HTTPS test app
+ *   TEST_USER, TEST_PASSWORD, and TEST_PIN are all required for non-loopback targets
  */
 
 const { chromium } = require('playwright');
 const fs = require('fs');
 
-const LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '0.0.0.0', 'host.docker.internal', 'carlos']);
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1']);
 
-// Matches a full dotted-quad IPv4 address only (anchored start-to-end), so a
-// hostname like "10.attacker.example" cannot be mistaken for the private
-// 10.0.0.0/8 range just because it starts with the same characters as one.
-function isPrivateIpv4(host) {
-  const match = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
-  if (!match) {
-    return false;
-  }
-  const octets = match.slice(1).map(Number);
-  if (octets.some((octet) => octet > 255)) {
-    return false;
-  }
-  const [a, b] = octets;
-  return a === 10 || (a === 192 && b === 168) || (a === 172 && b >= 16 && b <= 31);
-}
-
-function isLocalHost(rawHost) {
+function isLoopbackHost(rawHost) {
   // URL.hostname keeps the brackets on IPv6 literals (e.g. "[::1]"); strip
   // them so bracketed loopback addresses match the same as their bare form.
   const host = rawHost.toLowerCase().replace(/^\[|\]$/g, '');
-  return LOCAL_HOSTS.has(host) || isPrivateIpv4(host);
+  return LOOPBACK_HOSTS.has(host);
 }
 
 function validateBaseUrl(rawBaseUrl) {
@@ -95,8 +80,12 @@ function validateBaseUrl(rawBaseUrl) {
   }
 
   const host = parsed.hostname.toLowerCase();
-  if (!isLocalHost(host) && process.env.ALLOW_NON_LOCAL_BASE_URL !== 'true') {
+  const loopback = isLoopbackHost(host);
+  if (!loopback && process.env.ALLOW_NON_LOCAL_BASE_URL !== 'true') {
     throw new Error(`Refusing non-local BASE_URL host ${host}; set ALLOW_NON_LOCAL_BASE_URL=true for an intentional test target`);
+  }
+  if (!loopback && parsed.protocol !== 'https:') {
+    throw new Error(`Non-loopback BASE_URL must use https, got ${parsed.protocol}`);
   }
   parsed.pathname = parsed.pathname.replace(/\/$/, '');
   return parsed;
@@ -104,6 +93,10 @@ function validateBaseUrl(rawBaseUrl) {
 
 const baseUrl = validateBaseUrl(process.env.BASE_URL || 'http://127.0.0.1:8080/carlos');
 const chromePath = process.env.CHROME_PATH || '';
+const loopbackTarget = isLoopbackHost(baseUrl.hostname);
+if (!loopbackTarget && ['TEST_USER', 'TEST_PASSWORD', 'TEST_PIN'].some((name) => !process.env[name])) {
+  throw new Error('TEST_USER, TEST_PASSWORD, and TEST_PIN are required for non-loopback targets');
+}
 const testUser = process.env.TEST_USER || 'carlosdoc';
 const testPassword = process.env.TEST_PASSWORD || 'carlos2026';
 const testPin = process.env.TEST_PIN || '2026';
@@ -363,7 +356,7 @@ function checkRows(label, rows, expected) {
 }
 
 async function checkUnauthenticatedRejection(browser) {
-  const anonymous = await browser.newContext({ ignoreHTTPSErrors: isLocalHost(baseUrl.hostname) });
+  const anonymous = await browser.newContext({ ignoreHTTPSErrors: loopbackTarget });
   try {
     const response = await anonymous.request.get(
       appUrl(`/patientlistbyappt?provider_no=all&date_from=${SEED_DATE_FROM}&date_to=${SEED_DATE_TO}`),
@@ -385,12 +378,12 @@ async function checkUnauthenticatedRejection(browser) {
   }
   const browser = await chromium.launch(launchOptions);
   try {
-    // Certificate validation is only relaxed for local targets (self-signed dev
-    // certs are common there). A non-local target reached via ALLOW_NON_LOCAL_BASE_URL
+    // Certificate validation is only relaxed for loopback targets (self-signed dev
+    // certs are common there). A non-loopback target reached via ALLOW_NON_LOCAL_BASE_URL
     // still gets full TLS validation, so a spoofed/invalid cert can't silently
     // intercept the credentialed login this script performs.
     const context = await browser.newContext({
-      ignoreHTTPSErrors: isLocalHost(baseUrl.hostname),
+      ignoreHTTPSErrors: loopbackTarget,
       viewport: { width: 1440, height: 1000 },
       acceptDownloads: true,
     });

--- a/scripts/patient-list-by-appointment-export-playwright-checks.js
+++ b/scripts/patient-list-by-appointment-export-playwright-checks.js
@@ -203,19 +203,25 @@ async function exportViaForm(context, label, providerNo, dateFrom, dateTo) {
 
   await page.locator('select[name="provider_no"]').selectOption(providerNo);
 
-  // flatpickr opens its calendar overlay on focus and keeps it open, so a
-  // focus-driven fill() leaves an overlay that swallows the next click - both
-  // the second date input and the Export button end up unreachable. Setting
-  // the value directly and dispatching input/change gives jQuery Validate the
-  // same signal without ever opening the calendar.
-  await page.evaluate(({ from, to }) => {
-    for (const [id, value] of [['date_from', from], ['date_to', to]]) {
-      const input = document.getElementById(id);
-      input.value = value;
-      input.dispatchEvent(new Event('input', { bubbles: true }));
-      input.dispatchEvent(new Event('change', { bubbles: true }));
+  // flatpickr opens its calendar overlay on focus. Use Playwright's typed DOM
+  // APIs, then close the overlay before moving on. This preserves the browser
+  // input/change events without passing values into page.evaluate(), which
+  // security scanners correctly treat as a risky trust-boundary primitive.
+  for (const [name, value] of [['date_from', dateFrom], ['date_to', dateTo]]) {
+    const input = page.locator(`input[name="${name}"]`);
+    await input.fill(value, { force: true });
+    await input.dispatchEvent('change');
+    await input.blur();
+    await input.evaluate((element) => element._flatpickr?.close());
+    const actualValue = await input.inputValue();
+    const valid = await input.evaluate((element) => element.checkValidity());
+    if (actualValue !== value || !valid) {
+      throw new Error(`${name} rejected ${value}; actual=${actualValue}; valid=${valid}`);
     }
-  }, { from: dateFrom, to: dateTo });
+  }
+  if (await page.locator('.flatpickr-calendar.open').count()) {
+    throw new Error('flatpickr calendar remained open after setting export dates');
+  }
 
   const exportResponsePromise = page.waitForResponse(
     (response) => /\/patientlistbyappt(\?|$)/.test(response.url()),

--- a/scripts/patient-list-by-appointment-export-playwright-checks.js
+++ b/scripts/patient-list-by-appointment-export-playwright-checks.js
@@ -43,13 +43,16 @@
  *   8. The report page has no JavaScript errors while wiring its client-side
  *      date validation.
  *
- * This script only reads; it seeds nothing and mutates nothing. It expects the
- * three LOCAL_SEED_OBEC_REPORT_* appointments (2026-08-07..2026-08-10) to be
- * present; missing seed data is reported as a test failure so the provider and
- * representative-content assertions cannot silently pass without coverage.
+ * This script only reads; it seeds nothing and mutates nothing. Its fixture set
+ * is not part of the repository's default database seed. Before running, provision
+ * the three LOCAL_SEED_OBEC_REPORT_* appointments represented in EXPECTED_ROWS
+ * (2026-08-07..2026-08-10), then explicitly select that fixture contract with
+ * PATIENT_LIST_FIXTURE_PROFILE=local-seed-obec-report-v1. Missing data remains a
+ * test failure so representative-content assertions cannot pass without coverage.
  *
- * Defaults are for the local devcontainer:
- *   node scripts/patient-list-by-appointment-export-playwright-checks.js
+ * Example for a local devcontainer after provisioning the required fixtures:
+ *   PATIENT_LIST_FIXTURE_PROFILE=local-seed-obec-report-v1 \
+ *     node scripts/patient-list-by-appointment-export-playwright-checks.js
  *
  * Optional environment:
  *   BASE_URL=http://127.0.0.1:8080/carlos
@@ -57,14 +60,17 @@
  *   TEST_USER=carlosdoc
  *   TEST_PASSWORD=carlos2026
  *   TEST_PIN=2026
+ *   PATIENT_LIST_FIXTURE_PROFILE=local-seed-obec-report-v1 (required)
  *   ALLOW_NON_LOCAL_BASE_URL=true only when intentionally targeting a non-loopback HTTPS test app
- *   TEST_USER, TEST_PASSWORD, and TEST_PIN are all required for non-loopback targets
+ *   TEST_USER and TEST_PASSWORD are required for non-loopback targets; TEST_PIN is
+ *   additionally required only when that target renders the legacy PIN field
  */
 
 const { chromium } = require('playwright');
 const fs = require('fs');
 
 const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1']);
+const REQUIRED_FIXTURE_PROFILE = 'local-seed-obec-report-v1';
 
 function isLoopbackHost(rawHost) {
   // URL.hostname keeps the brackets on IPv6 literals (e.g. "[::1]"); strip
@@ -97,12 +103,15 @@ function validateBaseUrl(rawBaseUrl) {
 const baseUrl = validateBaseUrl(process.env.BASE_URL || 'http://127.0.0.1:8080/carlos');
 const chromePath = process.env.CHROME_PATH || '';
 const loopbackTarget = isLoopbackHost(baseUrl.hostname);
-if (!loopbackTarget && ['TEST_USER', 'TEST_PASSWORD', 'TEST_PIN'].some((name) => !process.env[name])) {
-  throw new Error('TEST_USER, TEST_PASSWORD, and TEST_PIN are required for non-loopback targets');
+if (process.env.PATIENT_LIST_FIXTURE_PROFILE !== REQUIRED_FIXTURE_PROFILE) {
+  throw new Error(`PATIENT_LIST_FIXTURE_PROFILE must be ${REQUIRED_FIXTURE_PROFILE}; this harness does not seed its required appointments`);
+}
+if (!loopbackTarget && ['TEST_USER', 'TEST_PASSWORD'].some((name) => !process.env[name])) {
+  throw new Error('TEST_USER and TEST_PASSWORD are required for non-loopback targets');
 }
 const testUser = process.env.TEST_USER || 'carlosdoc';
 const testPassword = process.env.TEST_PASSWORD || 'carlos2026';
-const testPin = process.env.TEST_PIN || '2026';
+const testPin = process.env.TEST_PIN || (loopbackTarget ? '2026' : '');
 
 // The locally seeded LOCAL_SEED_OBEC_REPORT_* appointments, all with a NULL
 // appointment type on purpose. Names are FAKE-* synthetic dev data, not PHI.
@@ -200,7 +209,13 @@ async function login(context) {
   await safeGoto(page, '/', { waitUntil: 'domcontentloaded', timeout: 30000 });
   await page.locator('#username').fill(testUser);
   await page.locator('#password').fill(testPassword);
-  await page.locator('#pin').fill(testPin);
+  const pinInput = page.locator('#pin');
+  if (await pinInput.count()) {
+    if (!testPin) {
+      throw new Error('TEST_PIN is required because the target login page includes a PIN field');
+    }
+    await pinInput.fill(testPin);
+  }
   await Promise.all([
     page.waitForURL(/providercontrol/, { timeout: 30000 }),
     page.locator('input[type="submit"], button[type="submit"]').first().click(),

--- a/scripts/patient-list-by-appointment-export-playwright-checks.js
+++ b/scripts/patient-list-by-appointment-export-playwright-checks.js
@@ -40,6 +40,8 @@
  *      route from Struts must not open a hole in the auth policy.
  *   7. The visible form submits with POST so CSRF-TOKEN remains in the request
  *      body instead of leaking into URLs, logs, and browser history.
+ *   8. The report page has no JavaScript errors while wiring its client-side
+ *      date validation.
  *
  * This script only reads; it seeds nothing and mutates nothing. It expects the
  * three LOCAL_SEED_OBEC_REPORT_* appointments (2026-08-07..2026-08-10) to be
@@ -160,18 +162,6 @@ function isSevereConsoleMessage(message) {
   return /(ReferenceError|TypeError|SyntaxError|redeclaration|Cannot read|Cannot set)/i.test(text);
 }
 
-// patientlist.jsp calls $(document).ready(...) to wire jQuery Validate, but the
-// page never loads jQuery, so the block throws "$ is not defined" and the
-// required/oscarDate date validation silently never runs. That is a separate,
-// pre-existing defect - the same shape affects several other report JSPs, which
-// reference the custom "oscarDate" validator that only administration/index.jsp
-// ever registers - and it is NOT what issue #3346 fixed. It is allowed through
-// here (recorded, not blocking) so this script keeps failing on any NEW page
-// error; remove this allowance once the validation stack on these pages is fixed.
-function isKnownUnrelatedPageError(error) {
-  return /\$ is not defined/.test(error.message);
-}
-
 function wirePage(page, label) {
   page.on('response', (response) => {
     const status = response.status();
@@ -186,11 +176,6 @@ function wirePage(page, label) {
     }
   });
   page.on('pageerror', (error) => {
-    if (isKnownUnrelatedPageError(error)) {
-      // Recorded, not blocking: see isKnownUnrelatedPageError.
-      observed.push({ check: `${label}:known-page-error`, text: error.message });
-      return;
-    }
     findings.push({ label, type: 'pageerror', text: error.stack || error.message });
   });
   page.on('dialog', async (dialog) => {
@@ -270,6 +255,64 @@ async function exportViaForm(context, label, providerNo, dateFrom, dateTo) {
   }
   await page.close();
   return result;
+}
+
+async function checkClientDateValidation(context) {
+  const page = await context.newPage();
+  wirePage(page, 'client-date-validation');
+  await safeGoto(page, '/oscarReport/ViewPatientlist', { waitUntil: 'domcontentloaded', timeout: 30000 });
+
+  const validation = await page.evaluate(() => {
+    const form = document.getElementById('plForm');
+    const dateFrom = document.getElementById('date_from');
+    const dateTo = document.getElementById('date_to');
+    const setDate = (input, value) => {
+      input.value = value;
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    };
+
+    const blankValid = form.checkValidity();
+
+    setDate(dateFrom, '2026-08-11');
+    setDate(dateTo, '2026-08-10');
+    const reversedValid = form.checkValidity();
+    const reversedMessage = dateTo.validationMessage;
+
+    setDate(dateFrom, '08/07/2026');
+    setDate(dateTo, '2026-08-10');
+    const malformedValid = form.checkValidity();
+
+    setDate(dateFrom, '2026-02-29');
+    const invalidCalendarValid = form.checkValidity();
+
+    setDate(dateFrom, '2026-08-07');
+    const validRangeAccepted = form.checkValidity();
+
+    return { blankValid, reversedValid, reversedMessage, malformedValid, invalidCalendarValid, validRangeAccepted };
+  });
+
+  observed.push({ check: 'client-date-validation', ...validation });
+  if (validation.blankValid) {
+    findings.push({ label: 'client-date-validation', type: 'blank-dates-accepted' });
+  }
+  if (validation.reversedValid || !/on or after Date From/.test(validation.reversedMessage)) {
+    findings.push({
+      label: 'client-date-validation',
+      type: 'reversed-range-accepted',
+      valid: validation.reversedValid,
+      message: validation.reversedMessage,
+    });
+  }
+  if (validation.malformedValid) {
+    findings.push({ label: 'client-date-validation', type: 'malformed-date-accepted' });
+  }
+  if (validation.invalidCalendarValid) {
+    findings.push({ label: 'client-date-validation', type: 'invalid-calendar-date-accepted' });
+  }
+  if (!validation.validRangeAccepted) {
+    findings.push({ label: 'client-date-validation', type: 'valid-range-rejected' });
+  }
+  await page.close();
 }
 
 function dataRows(body) {
@@ -353,6 +396,8 @@ async function checkUnauthenticatedRejection(browser) {
     });
     const loginPage = await login(context);
     await loginPage.close();
+
+    await checkClientDateValidation(context);
 
     const allDoctors = await exportViaForm(context, 'all-doctors', PROVIDER_ALL, SEED_DATE_FROM, SEED_DATE_TO);
     checkDownloadEnvelope('all-doctors', allDoctors);

--- a/scripts/patient-list-by-appointment-export-playwright-checks.js
+++ b/scripts/patient-list-by-appointment-export-playwright-checks.js
@@ -1,0 +1,397 @@
+#!/usr/bin/env node
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+/*
+ * Browser regression checks for Administration > Reports > Patient List by
+ * Appointment Time (issue #3346).
+ *
+ * Before the fix, clicking Export issued
+ * GET /carlos/patientlistbyappt?... and Struts answered 404 ("There is no
+ * Action mapped for namespace [/] and action name [patientlistbyappt]"),
+ * because the global struts.action.excludePattern did not list this
+ * extensionless, web.xml-mapped servlet route. This script asserts that:
+ *   1. Export triggers a real browser download whose suggested filename is
+ *      patientlist.txt, served with HTTP 200.
+ *   2. All Doctors over the seeded range returns one row per appointment.
+ *   3. Provider filtering narrows the rows to that provider's patients only.
+ *   4. A null appointment type exports as an empty field (not "null", and not
+ *      a 500 from a NullPointerException).
+ *   5. An empty date range still downloads a valid, empty attachment.
+ *   6. An unauthenticated request is still rejected with 401 - excluding the
+ *      route from Struts must not open a hole in the auth policy.
+ *
+ * This script only reads; it seeds nothing and mutates nothing. It expects the
+ * three LOCAL_SEED_OBEC_REPORT_* appointments (2026-08-07..2026-08-10) to be
+ * present; missing seed data is reported as a test failure so the provider and
+ * representative-content assertions cannot silently pass without coverage.
+ *
+ * Defaults are for the local devcontainer:
+ *   node scripts/patient-list-by-appointment-export-playwright-checks.js
+ *
+ * Optional environment:
+ *   BASE_URL=http://127.0.0.1:8080/carlos
+ *   CHROME_PATH=/path/to/chrome-or-chromium
+ *   TEST_USER=carlosdoc
+ *   TEST_PASSWORD=carlos2026
+ *   TEST_PIN=2026
+ *   ALLOW_NON_LOCAL_BASE_URL=true only when intentionally targeting a non-local test app
+ */
+
+const { chromium } = require('playwright');
+const fs = require('fs');
+
+const LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '0.0.0.0', 'host.docker.internal', 'carlos']);
+
+// Matches a full dotted-quad IPv4 address only (anchored start-to-end), so a
+// hostname like "10.attacker.example" cannot be mistaken for the private
+// 10.0.0.0/8 range just because it starts with the same characters as one.
+function isPrivateIpv4(host) {
+  const match = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
+  if (!match) {
+    return false;
+  }
+  const octets = match.slice(1).map(Number);
+  if (octets.some((octet) => octet > 255)) {
+    return false;
+  }
+  const [a, b] = octets;
+  return a === 10 || (a === 192 && b === 168) || (a === 172 && b >= 16 && b <= 31);
+}
+
+function isLocalHost(rawHost) {
+  // URL.hostname keeps the brackets on IPv6 literals (e.g. "[::1]"); strip
+  // them so bracketed loopback addresses match the same as their bare form.
+  const host = rawHost.toLowerCase().replace(/^\[|\]$/g, '');
+  return LOCAL_HOSTS.has(host) || isPrivateIpv4(host);
+}
+
+function validateBaseUrl(rawBaseUrl) {
+  const parsed = new URL(rawBaseUrl);
+  if (!['http:', 'https:'].includes(parsed.protocol)) {
+    throw new Error(`BASE_URL must use http or https, got ${parsed.protocol}`);
+  }
+
+  const host = parsed.hostname.toLowerCase();
+  if (!isLocalHost(host) && process.env.ALLOW_NON_LOCAL_BASE_URL !== 'true') {
+    throw new Error(`Refusing non-local BASE_URL host ${host}; set ALLOW_NON_LOCAL_BASE_URL=true for an intentional test target`);
+  }
+  parsed.pathname = parsed.pathname.replace(/\/$/, '');
+  return parsed;
+}
+
+const baseUrl = validateBaseUrl(process.env.BASE_URL || 'http://127.0.0.1:8080/carlos');
+const chromePath = process.env.CHROME_PATH || '';
+const testUser = process.env.TEST_USER || 'carlosdoc';
+const testPassword = process.env.TEST_PASSWORD || 'carlos2026';
+const testPin = process.env.TEST_PIN || '2026';
+
+// The locally seeded LOCAL_SEED_OBEC_REPORT_* appointments, all with a NULL
+// appointment type on purpose. Names are FAKE-* synthetic dev data, not PHI.
+const SEED_DATE_FROM = '2026-08-07';
+const SEED_DATE_TO = '2026-08-10';
+const PROVIDER_ALL = 'all';
+const PROVIDER_WELCH = '9';
+const PROVIDER_CARLOSDOC = '999998';
+const EXPECTED_ROWS = {
+  [PROVIDER_WELCH]: ['FAKE-Abbott,FAKE-Jerilyn,555-555-5555,555-555-5555,09:00:00,2026-08-07,,Kristen Welch,'],
+  [PROVIDER_CARLOSDOC]: [
+    'FAKE-Altenwerth,FAKE-Izola,555-555-5555,555-555-5555,10:00:00,2026-08-08,,doctor carlosdoc,',
+    'FAKE-Altenwerth,FAKE-Josh,555-555-5555,555-555-5555,11:00:00,2026-08-10,,doctor carlosdoc,',
+  ],
+};
+
+const findings = [];
+const observed = [];
+
+function appUrl(appPath) {
+  if (!appPath.startsWith('/') || appPath.startsWith('//')) {
+    throw new Error(`Application path must be root-relative, got ${appPath}`);
+  }
+  // Split off the query string before assigning to url.pathname: the pathname
+  // setter percent-encodes "?" instead of treating it as a query separator,
+  // which silently mangles any appPath that carries query parameters.
+  const [pathPart, queryPart] = appPath.split('?');
+  const url = new URL(baseUrl.href);
+  url.pathname = `${baseUrl.pathname}${pathPart}`.replace(/\/{2,}/g, '/');
+  url.search = queryPart ? `?${queryPart}` : '';
+  return url.toString();
+}
+
+function safeGoto(page, appPath, options) {
+  return page.goto(appUrl(appPath), options); // nosemgrep // NOSONAR - appUrl validates local-only BASE_URL and root-relative paths.
+}
+
+function isExpectedConsoleNoise(message) {
+  const text = message.text();
+  return /Content Security Policy.*report-only/i.test(text)
+    || /Master token \[CSRF-TOKEN\]/.test(text)
+    || /Hidden token fields .* were updated with new token value/.test(text);
+}
+
+function isSevereConsoleMessage(message) {
+  if (isExpectedConsoleNoise(message)) {
+    return false;
+  }
+  const text = message.text();
+  if (message.type() === 'error') {
+    return !/imageRenderingServlet\?|favicon\.ico/i.test(text);
+  }
+  return /(ReferenceError|TypeError|SyntaxError|redeclaration|Cannot read|Cannot set)/i.test(text);
+}
+
+// patientlist.jsp calls $(document).ready(...) to wire jQuery Validate, but the
+// page never loads jQuery, so the block throws "$ is not defined" and the
+// required/oscarDate date validation silently never runs. That is a separate,
+// pre-existing defect - the same shape affects several other report JSPs, which
+// reference the custom "oscarDate" validator that only administration/index.jsp
+// ever registers - and it is NOT what issue #3346 fixed. It is allowed through
+// here (recorded, not blocking) so this script keeps failing on any NEW page
+// error; remove this allowance once the validation stack on these pages is fixed.
+function isKnownUnrelatedPageError(error) {
+  return /\$ is not defined/.test(error.message);
+}
+
+function wirePage(page, label) {
+  page.on('response', (response) => {
+    const status = response.status();
+    const responseUrl = response.url();
+    if (status >= 400 && !/\/favicon\.ico$/.test(responseUrl)) {
+      findings.push({ label, type: 'http', status, url: responseUrl });
+    }
+  });
+  page.on('console', (message) => {
+    if (isSevereConsoleMessage(message)) {
+      findings.push({ label, type: `console:${message.type()}`, text: message.text() });
+    }
+  });
+  page.on('pageerror', (error) => {
+    if (isKnownUnrelatedPageError(error)) {
+      // Recorded, not blocking: see isKnownUnrelatedPageError.
+      observed.push({ check: `${label}:known-page-error`, text: error.message });
+      return;
+    }
+    findings.push({ label, type: 'pageerror', text: error.stack || error.message });
+  });
+  page.on('dialog', async (dialog) => {
+    findings.push({ label, type: 'dialog', text: dialog.message() });
+    await dialog.accept();
+  });
+}
+
+async function login(context) {
+  const page = await context.newPage();
+  wirePage(page, 'login');
+  await safeGoto(page, '/', { waitUntil: 'domcontentloaded', timeout: 30000 });
+  await page.locator('#username').fill(testUser);
+  await page.locator('#password').fill(testPassword);
+  await page.locator('#pin').fill(testPin);
+  await Promise.all([
+    page.waitForURL(/providercontrol/, { timeout: 30000 }),
+    page.locator('input[type="submit"], button[type="submit"]').first().click(),
+  ]);
+  await page.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+  return page;
+}
+
+/**
+ * Drives the real Patient List form: selects the provider, sets both dates,
+ * clicks Export, and returns the captured download plus the export response.
+ */
+async function exportViaForm(context, label, providerNo, dateFrom, dateTo) {
+  const page = await context.newPage();
+  wirePage(page, label);
+  await safeGoto(page, '/oscarReport/ViewPatientlist', { waitUntil: 'domcontentloaded', timeout: 30000 });
+
+  await page.locator('select[name="provider_no"]').selectOption(providerNo);
+
+  // flatpickr opens its calendar overlay on focus and keeps it open, so a
+  // focus-driven fill() leaves an overlay that swallows the next click - both
+  // the second date input and the Export button end up unreachable. Setting
+  // the value directly and dispatching input/change gives jQuery Validate the
+  // same signal without ever opening the calendar.
+  await page.evaluate(({ from, to }) => {
+    for (const [id, value] of [['date_from', from], ['date_to', to]]) {
+      const input = document.getElementById(id);
+      input.value = value;
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+    }
+  }, { from: dateFrom, to: dateTo });
+
+  const exportResponsePromise = page.waitForResponse(
+    (response) => /\/patientlistbyappt(\?|$)/.test(response.url()),
+    { timeout: 30000 },
+  );
+  const downloadPromise = page.waitForEvent('download', { timeout: 30000 });
+
+  await page.locator('button[type="submit"]').first().click();
+
+  const exportResponse = await exportResponsePromise;
+  const download = await downloadPromise.catch(() => null);
+
+  // Chromium hands an attachment response to the download manager, so its body
+  // is no longer readable through response.text() ("No resource with given
+  // identifier"). Read the bytes the user actually receives - the saved
+  // download - instead.
+  const headers = await exportResponse.allHeaders();
+  const downloadPath = download ? await download.path() : null;
+  const result = {
+    status: exportResponse.status(),
+    url: exportResponse.url(),
+    contentDisposition: headers['content-disposition'] || null,
+    contentType: headers['content-type'] || null,
+    suggestedFilename: download ? download.suggestedFilename() : null,
+    body: downloadPath ? fs.readFileSync(downloadPath, 'utf8') : await exportResponse.text().catch(() => ''),
+  };
+  if (download) {
+    await download.delete();
+  }
+  await page.close();
+  return result;
+}
+
+function dataRows(body) {
+  return body.split('\n').map((line) => line.trimEnd()).filter((line) => line.length > 0);
+}
+
+function checkDownloadEnvelope(label, result) {
+  if (result.status !== 200) {
+    findings.push({ label, type: 'export-status', status: result.status, url: result.url });
+  }
+  if (result.suggestedFilename !== 'patientlist.txt') {
+    findings.push({ label, type: 'suggested-filename', actual: result.suggestedFilename });
+  }
+  if (!/attachment;\s*filename=patientlist\.txt/i.test(result.contentDisposition || '')) {
+    findings.push({ label, type: 'content-disposition', actual: result.contentDisposition });
+  }
+  if (!/charset=UTF-8/i.test(result.contentType || '')) {
+    findings.push({ label, type: 'content-type', actual: result.contentType });
+  }
+  if (/no Action mapped for namespace/i.test(result.body) || /HTTP Status 404/i.test(result.body)) {
+    findings.push({ label, type: 'struts-404-body' });
+  }
+}
+
+function checkRows(label, rows, expected) {
+  if (rows.length !== expected.length) {
+    findings.push({ label, type: 'row-count', expected: expected.length, actual: rows.length, rows });
+    return;
+  }
+  const sortedRows = [...rows].sort();
+  const sortedExpected = [...expected].sort();
+  sortedExpected.forEach((expectedRow, index) => {
+    if (sortedRows[index] !== expectedRow) {
+      findings.push({ label, type: 'row-mismatch', expected: expectedRow, actual: sortedRows[index] });
+    }
+  });
+  // The seeded appointments all carry a NULL type; column 7 (0-indexed 6) must
+  // therefore be empty rather than the literal string "null".
+  rows.forEach((row) => {
+    const typeField = row.split(',')[6];
+    if (typeField !== '') {
+      findings.push({ label, type: 'null-type-field', actual: typeField, row });
+    }
+  });
+}
+
+async function checkUnauthenticatedRejection(browser) {
+  const anonymous = await browser.newContext({ ignoreHTTPSErrors: isLocalHost(baseUrl.hostname) });
+  try {
+    const response = await anonymous.request.get(
+      appUrl(`/patientlistbyappt?provider_no=all&date_from=${SEED_DATE_FROM}&date_to=${SEED_DATE_TO}`),
+      { maxRedirects: 0 },
+    );
+    observed.push({ check: 'unauthenticated', status: response.status() });
+    if (response.status() !== 401) {
+      findings.push({ label: 'unauthenticated', type: 'auth-policy', status: response.status() });
+    }
+  } finally {
+    await anonymous.close();
+  }
+}
+
+(async () => {
+  const launchOptions = { args: ['--no-sandbox', '--disable-dev-shm-usage'] };
+  if (chromePath) {
+    launchOptions.executablePath = chromePath;
+  }
+  const browser = await chromium.launch(launchOptions);
+  try {
+    // Certificate validation is only relaxed for local targets (self-signed dev
+    // certs are common there). A non-local target reached via ALLOW_NON_LOCAL_BASE_URL
+    // still gets full TLS validation, so a spoofed/invalid cert can't silently
+    // intercept the credentialed login this script performs.
+    const context = await browser.newContext({
+      ignoreHTTPSErrors: isLocalHost(baseUrl.hostname),
+      viewport: { width: 1440, height: 1000 },
+      acceptDownloads: true,
+    });
+    const loginPage = await login(context);
+    await loginPage.close();
+
+    const allDoctors = await exportViaForm(context, 'all-doctors', PROVIDER_ALL, SEED_DATE_FROM, SEED_DATE_TO);
+    checkDownloadEnvelope('all-doctors', allDoctors);
+    const allRows = dataRows(allDoctors.body);
+    observed.push({ check: 'all-doctors', status: allDoctors.status, rows: allRows });
+
+    const expectedAll = [...EXPECTED_ROWS[PROVIDER_WELCH], ...EXPECTED_ROWS[PROVIDER_CARLOSDOC]];
+    if (allRows.length === 0) {
+      findings.push({ label: 'all-doctors', type: 'seed-data-missing', detail: 'no rows for the seeded 2026-08-07..2026-08-10 range' });
+    } else {
+      checkRows('all-doctors', allRows, expectedAll);
+    }
+
+    for (const providerNo of [PROVIDER_WELCH, PROVIDER_CARLOSDOC]) {
+      const label = `provider-${providerNo}`;
+      const result = await exportViaForm(context, label, providerNo, SEED_DATE_FROM, SEED_DATE_TO);
+      checkDownloadEnvelope(label, result);
+      const rows = dataRows(result.body);
+      observed.push({ check: label, status: result.status, rows });
+      checkRows(label, rows, EXPECTED_ROWS[providerNo]);
+    }
+
+    const emptyRange = await exportViaForm(context, 'empty-range', PROVIDER_ALL, '2026-09-01', '2026-09-02');
+    checkDownloadEnvelope('empty-range', emptyRange);
+    const emptyRows = dataRows(emptyRange.body);
+    observed.push({ check: 'empty-range', status: emptyRange.status, rows: emptyRows });
+    if (emptyRows.length !== 0) {
+      findings.push({ label: 'empty-range', type: 'unexpected-rows', rows: emptyRows });
+    }
+
+    await checkUnauthenticatedRejection(browser);
+
+    console.log(JSON.stringify({ observed, findings }, null, 2));
+
+    const blockingFindings = findings.filter((finding) => finding.type !== 'dialog');
+    if (blockingFindings.length) {
+      throw new Error(`patient list export check found ${blockingFindings.length} issue(s)`);
+    }
+
+    console.log('PASS patient list by appointment time exports patientlist.txt with correct provider filtering');
+  } finally {
+    await browser.close();
+  }
+})().catch((error) => {
+  console.error('FAIL patient list by appointment time export Playwright check');
+  console.error(error.stack || error.message);
+  process.exit(1);
+});

--- a/scripts/patient-list-by-appointment-export-playwright-checks.js
+++ b/scripts/patient-list-by-appointment-export-playwright-checks.js
@@ -468,12 +468,12 @@ async function checkUnauthenticatedRejection(browser) {
       throw new Error(`patient list export check found ${blockingFindings.length} issue(s)`);
     }
 
-    console.log('PASS patient list by appointment time exports patientlist.txt with correct provider filtering');
+    console.log('PASS CARLOS EMR patient list by appointment time exports patientlist.txt with correct provider filtering');
   } finally {
     await browser.close();
   }
 })().catch((error) => {
-  console.error('FAIL patient list by appointment time export Playwright check');
+  console.error('FAIL CARLOS EMR patient list by appointment time export Playwright check');
   console.error(error.stack || error.message);
   process.exit(1);
 });

--- a/scripts/patient-list-by-appointment-export-playwright-checks.js
+++ b/scripts/patient-list-by-appointment-export-playwright-checks.js
@@ -78,6 +78,9 @@ function validateBaseUrl(rawBaseUrl) {
   if (!['http:', 'https:'].includes(parsed.protocol)) {
     throw new Error(`BASE_URL must use http or https, got ${parsed.protocol}`);
   }
+  if (parsed.username || parsed.password) {
+    throw new Error('BASE_URL must not contain embedded credentials');
+  }
 
   const host = parsed.hostname.toLowerCase();
   const loopback = isLoopbackHost(host);
@@ -133,8 +136,22 @@ function appUrl(appPath) {
   return url.toString();
 }
 
-function safeGoto(page, appPath, options) {
-  return page.goto(appUrl(appPath), options); // nosemgrep // NOSONAR - appUrl validates local-only BASE_URL and root-relative paths.
+function isWithinApplication(rawUrl) {
+  const candidate = new URL(rawUrl);
+  const applicationPath = baseUrl.pathname.replace(/\/$/, '');
+  return candidate.origin === baseUrl.origin
+    && (applicationPath === ''
+      || applicationPath === '/'
+      || candidate.pathname === applicationPath
+      || candidate.pathname.startsWith(`${applicationPath}/`));
+}
+
+async function safeGoto(page, appPath, options) {
+  const response = await page.goto(appUrl(appPath), options); // nosemgrep // NOSONAR - appUrl validates local-only BASE_URL and root-relative paths.
+  if (!isWithinApplication(page.url())) {
+    throw new Error('Navigation left the configured application boundary');
+  }
+  return response;
 }
 
 function isExpectedConsoleNoise(message) {
@@ -341,22 +358,22 @@ function checkDownloadEnvelope(label, result) {
 
 function checkRows(label, rows, expected) {
   if (rows.length !== expected.length) {
-    findings.push({ label, type: 'row-count', expected: expected.length, actual: rows.length, rows });
+    findings.push({ label, type: 'row-count', expected: expected.length, actual: rows.length });
     return;
   }
   const sortedRows = [...rows].sort();
   const sortedExpected = [...expected].sort();
   sortedExpected.forEach((expectedRow, index) => {
     if (sortedRows[index] !== expectedRow) {
-      findings.push({ label, type: 'row-mismatch', expected: expectedRow, actual: sortedRows[index] });
+      findings.push({ label, type: 'row-mismatch', rowIndex: index });
     }
   });
   // The seeded appointments all carry a NULL type; column 7 (0-indexed 6) must
   // therefore be empty rather than the literal string "null".
-  rows.forEach((row) => {
+  rows.forEach((row, rowIndex) => {
     const typeField = row.split(',')[6];
     if (typeField !== '') {
-      findings.push({ label, type: 'null-type-field', actual: typeField, row });
+      findings.push({ label, type: 'null-type-field', rowIndex });
     }
   });
 }
@@ -401,7 +418,7 @@ async function checkUnauthenticatedRejection(browser) {
     const allDoctors = await exportViaForm(context, 'all-doctors', PROVIDER_ALL, SEED_DATE_FROM, SEED_DATE_TO);
     checkDownloadEnvelope('all-doctors', allDoctors);
     const allRows = dataRows(allDoctors.body);
-    observed.push({ check: 'all-doctors', status: allDoctors.status, rows: allRows });
+    observed.push({ check: 'all-doctors', status: allDoctors.status, rowCount: allRows.length });
 
     const expectedAll = [...EXPECTED_ROWS[PROVIDER_WELCH], ...EXPECTED_ROWS[PROVIDER_CARLOSDOC]];
     if (allRows.length === 0) {
@@ -415,16 +432,16 @@ async function checkUnauthenticatedRejection(browser) {
       const result = await exportViaForm(context, label, providerNo, SEED_DATE_FROM, SEED_DATE_TO);
       checkDownloadEnvelope(label, result);
       const rows = dataRows(result.body);
-      observed.push({ check: label, status: result.status, rows });
+      observed.push({ check: label, status: result.status, rowCount: rows.length });
       checkRows(label, rows, EXPECTED_ROWS[providerNo]);
     }
 
     const emptyRange = await exportViaForm(context, 'empty-range', PROVIDER_ALL, '2026-09-01', '2026-09-02');
     checkDownloadEnvelope('empty-range', emptyRange);
     const emptyRows = dataRows(emptyRange.body);
-    observed.push({ check: 'empty-range', status: emptyRange.status, rows: emptyRows });
+    observed.push({ check: 'empty-range', status: emptyRange.status, rowCount: emptyRows.length });
     if (emptyRows.length !== 0) {
-      findings.push({ label: 'empty-range', type: 'unexpected-rows', rows: emptyRows });
+      findings.push({ label: 'empty-range', type: 'unexpected-rows', rowCount: emptyRows.length });
     }
 
     await checkUnauthenticatedRejection(browser);

--- a/src/main/java/io/github/carlos_emr/carlos/appointment/dto/PatientAppointmentExportRow.java
+++ b/src/main/java/io/github/carlos_emr/carlos/appointment/dto/PatientAppointmentExportRow.java
@@ -27,7 +27,10 @@ import java.util.Date;
  * Narrow projection of the fields required by the patient appointment export.
  * Keeping the cursor scalar avoids loading complete entities and triggering
  * relationship queries while a MySQL streaming result set is active.
+ * The legacy {@link Date} fields intentionally match the Hibernate entity
+ * projection constructor; accessors return defensive copies.
  */
+@SuppressWarnings("java:S2143")
 public record PatientAppointmentExportRow(
         String patientLastName,
         String patientFirstName,

--- a/src/main/java/io/github/carlos_emr/carlos/appointment/dto/PatientAppointmentExportRow.java
+++ b/src/main/java/io/github/carlos_emr/carlos/appointment/dto/PatientAppointmentExportRow.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ * <p>
+ * Now maintained by the CARLOS EMR Project (2026+).
+ * https://github.com/carlos-emr/carlos
+ * CARLOS has no affiliation with OSCAR or McMaster University.
+ */
+package io.github.carlos_emr.carlos.appointment.dto;
+
+import java.util.Date;
+
+/**
+ * Narrow projection of the fields required by the patient appointment export.
+ * Keeping the cursor scalar avoids loading complete entities and triggering
+ * relationship queries while a MySQL streaming result set is active.
+ */
+public record PatientAppointmentExportRow(
+        String patientLastName,
+        String patientFirstName,
+        String phone,
+        String alternatePhone,
+        Date startTime,
+        Date appointmentDate,
+        String appointmentType,
+        String providerFirstName,
+        String providerLastName,
+        String location) {
+
+    public PatientAppointmentExportRow {
+        startTime = copy(startTime);
+        appointmentDate = copy(appointmentDate);
+    }
+
+    @Override
+    public Date startTime() {
+        return copy(startTime);
+    }
+
+    @Override
+    public Date appointmentDate() {
+        return copy(appointmentDate);
+    }
+
+    private static Date copy(Date value) {
+        return value == null ? null : new Date(value.getTime());
+    }
+}

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/OscarAppointmentDao.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/OscarAppointmentDao.java
@@ -34,6 +34,9 @@ package io.github.carlos_emr.carlos.commn.dao;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Consumer;
+
+import io.github.carlos_emr.carlos.appointment.dto.PatientAppointmentExportRow;
 
 import io.github.carlos_emr.carlos.PMmodule.model.Program;
 import io.github.carlos_emr.carlos.appointment.dto.AppointmentListItemDTO;
@@ -108,6 +111,18 @@ public interface OscarAppointmentDao extends AbstractDao<Appointment> {
     public List<Object[]> findAppointments(Date sDate, Date eDate);
 
     public List<Object[]> findPatientAppointments(String providerNo, Date from, Date to);
+
+    /**
+     * Streams patient appointment rows through a transaction-scoped cursor so
+     * large report exports do not materialize the complete result set in memory.
+     *
+     * @param providerNo provider filter, or {@code null} for all providers
+     * @param from inclusive start date, or {@code null}
+     * @param to inclusive end date, or {@code null}
+     * @param rowConsumer invoked once for each projected export row
+     */
+    void streamPatientAppointments(String providerNo, Date from, Date to,
+                                   Consumer<PatientAppointmentExportRow> rowConsumer);
 
     public List<Appointment> search_unbill_history_daterange(String providerNo, Date startDate, Date endDate);
 

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/OscarAppointmentDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/OscarAppointmentDaoImpl.java
@@ -35,6 +35,7 @@ import org.apache.commons.lang3.StringUtils;
 import io.github.carlos_emr.carlos.PMmodule.model.Program;
 import io.github.carlos_emr.carlos.commn.NativeSql;
 import io.github.carlos_emr.carlos.appointment.dto.AppointmentListItemDTO;
+import io.github.carlos_emr.carlos.appointment.dto.PatientAppointmentExportRow;
 import io.github.carlos_emr.carlos.commn.model.Appointment;
 import io.github.carlos_emr.carlos.commn.model.AppointmentArchive;
 import io.github.carlos_emr.carlos.commn.model.Facility;
@@ -42,6 +43,8 @@ import io.github.carlos_emr.carlos.utility.MiscUtils;
 import org.springframework.beans.BeanUtils;
 import org.springframework.stereotype.Repository;
 import io.github.carlos_emr.carlos.util.UtilDateUtilities;
+import org.hibernate.ScrollMode;
+import org.hibernate.ScrollableResults;
 
 import jakarta.persistence.NoResultException;
 import jakarta.persistence.NonUniqueResultException;
@@ -49,6 +52,7 @@ import jakarta.persistence.PersistenceException;
 import jakarta.persistence.Query;
 import jakarta.persistence.TypedQuery;
 import java.util.*;
+import java.util.function.Consumer;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 @Repository
@@ -446,7 +450,51 @@ public class OscarAppointmentDaoImpl extends AbstractDaoImpl<Appointment> implem
 
     @Override
     public List<Object[]> findPatientAppointments(String providerNo, Date from, Date to) {
-        String baseHql = "SELECT d, a, p FROM Demographic d, Appointment a, Provider p WHERE a.demographicNo = d.demographicNo AND a.providerNo = p.providerNo ";
+        return createPatientAppointmentsQuery(providerNo, from, to).getResultList();
+    }
+
+    @Override
+    public void streamPatientAppointments(String providerNo, Date from, Date to,
+                                          Consumer<PatientAppointmentExportRow> rowConsumer) {
+        Objects.requireNonNull(rowConsumer, "rowConsumer");
+
+        org.hibernate.query.Query<PatientAppointmentExportRow> query =
+                createPatientAppointmentExportQuery(providerNo, from, to)
+                        .unwrap(org.hibernate.query.Query.class);
+        query.setReadOnly(true);
+        // Connector/J only streams a forward-only result set without
+        // useCursorFetch when the special MIN_VALUE fetch size is used. Keep a
+        // conventional batch hint for other JDBC drivers (including H2 tests).
+        boolean mysql = entityManager.unwrap(org.hibernate.Session.class)
+                .doReturningWork(connection -> "MySQL".equals(
+                        connection.getMetaData().getDatabaseProductName()));
+        query.setFetchSize(mysql ? Integer.MIN_VALUE : 500);
+
+        try (ScrollableResults<PatientAppointmentExportRow> cursor =
+                     query.scroll(ScrollMode.FORWARD_ONLY)) {
+            while (cursor.next()) {
+                rowConsumer.accept(cursor.get());
+            }
+        }
+    }
+
+    private Query createPatientAppointmentExportQuery(String providerNo, Date from, Date to) {
+        String projection = "SELECT new io.github.carlos_emr.carlos.appointment.dto."
+                + "PatientAppointmentExportRow(d.lastName, d.firstName, d.phone, d.phone2, "
+                + "a.startTime, a.appointmentDate, a.type, p.firstName, p.lastName, a.location) ";
+        return createPatientAppointmentsQuery(projection, providerNo, from, to);
+    }
+
+    private Query createPatientAppointmentsQuery(String providerNo, Date from, Date to) {
+        return createPatientAppointmentsQuery(
+                "SELECT d, a, p ", providerNo, from, to);
+    }
+
+    private Query createPatientAppointmentsQuery(String projection, String providerNo,
+                                                 Date from, Date to) {
+        String baseHql = projection
+                + "FROM Demographic d, Appointment a, Provider p "
+                + "WHERE a.demographicNo = d.demographicNo AND a.providerNo = p.providerNo ";
         StringBuilder sql = new StringBuilder(baseHql);
 
         List<Object> params = new ArrayList<>();
@@ -465,13 +513,13 @@ public class OscarAppointmentDaoImpl extends AbstractDaoImpl<Appointment> implem
             sql.append("AND a.appointmentDate <= ?" + paramIndex++ + " ");
             params.add(to);
         }
-        sql.append("ORDER BY a.appointmentDate");
+        sql.append("ORDER BY a.appointmentDate, a.startTime, a.id");
 
         Query query = entityManager.createQuery(sql.toString());
         for (int i = 0; i < params.size(); i++) {
             query.setParameter(i + 1, params.get(i));
         }
-        return query.getResultList();
+        return query;
     }
 
     @Override

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/PatientListByAppt.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/PatientListByAppt.java
@@ -99,8 +99,7 @@ public class PatientListByAppt extends HttpServlet {
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
         if (loggedInInfo == null) {
             UnauthenticatedRejectionResolver.rejectUnauthenticatedRequest(request, response);
-            auditExport(null, request.getRemoteAddr(), null, null, null,
-                    0, "rejected", "Unauthenticated");
+            auditUnauthenticatedExport(request.getRemoteAddr());
             return;
         }
 
@@ -165,7 +164,7 @@ public class PatientListByAppt extends HttpServlet {
             errorType = e.getClass().getSimpleName();
             throw e;
         } finally {
-            auditExport(loggedInInfo, loggedInInfo.getIp(), providerFilter, datefrom, dateto,
+            auditExport(loggedInInfo, providerFilter, datefrom, dateto,
                     rowCount[0], outcome, errorType);
         }
     }
@@ -220,14 +219,27 @@ public class PatientListByAppt extends HttpServlet {
         response.sendError(status, message);
         // Rejected parameters are deliberately omitted: malformed attacker-controlled
         // values must not become PHI or log-injection content in the audit record.
-        auditExport(loggedInInfo, loggedInInfo.getIp(), null, null, null,
-                0, "rejected", reason);
+        auditExport(loggedInInfo, null, null, null, 0, "rejected", reason);
     }
 
-    private void auditExport(LoggedInInfo loggedInInfo, String remoteAddress,
-                             String providerFilter,
+    private void auditUnauthenticatedExport(String remoteAddress) {
+        OscarLog auditLog = createExportAuditLog(null, remoteAddress, null);
+        persistExportAuditResult(auditLog, null, null, 0,
+                "rejected", "Unauthenticated");
+    }
+
+    private void auditExport(LoggedInInfo loggedInInfo, String providerFilter,
                              String dateFrom, String dateTo, int rowCount,
                              String outcome, String errorType) {
+        OscarLog auditLog = createExportAuditLog(
+                loggedInInfo, loggedInInfo.getIp(), providerFilter);
+        persistExportAuditResult(
+                auditLog, dateFrom, dateTo, rowCount, outcome, errorType);
+    }
+
+    private OscarLog createExportAuditLog(LoggedInInfo loggedInInfo,
+                                          String remoteAddress,
+                                          String providerFilter) {
         OscarLog auditLog = new OscarLog();
         if (loggedInInfo != null && loggedInInfo.getLoggedInSecurity() != null) {
             auditLog.setSecurityId(loggedInInfo.getLoggedInSecurity().getSecurityNo());
@@ -239,6 +251,12 @@ public class PatientListByAppt extends HttpServlet {
         auditLog.setContent("patient_list_by_appointment");
         auditLog.setContentId(providerFilter);
         auditLog.setIp(remoteAddress);
+        return auditLog;
+    }
+
+    private void persistExportAuditResult(OscarLog auditLog, String dateFrom,
+                                          String dateTo, int rowCount,
+                                          String outcome, String errorType) {
         String data = "dateFrom=" + dateFrom + "; dateTo=" + dateTo
                 + "; rows=" + rowCount + "; outcome=" + outcome;
         if (errorType != null) {

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/PatientListByAppt.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/PatientListByAppt.java
@@ -35,6 +35,7 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
+import java.util.Objects;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
@@ -101,7 +102,16 @@ public class PatientListByAppt extends HttpServlet {
                     pw.print(escapeCsv(d.getPhone2()) + ","); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download, escapeCsv applied
                     pw.print(ConversionUtils.toTimeString(a.getStartTime()) + ","); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download, formatted time
                     pw.print(ConversionUtils.toDateString(a.getAppointmentDate()) + ","); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download, formatted date
-                    pw.print(escapeCsv(a.getType().replaceAll("\r\n", "")) + ","); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download, escapeCsv applied
+                    // Appointment type is free text and optional. Strip CR and LF
+                    // individually — the legacy replaceAll("\r\n", "") only matched
+                    // CRLF pairs, so a lone newline survived, escapeCsv quoted the
+                    // field, and one appointment spilled across two output lines.
+                    // Objects.toString keeps this null-safe independently of the
+                    // entity getter's own null coalescing.
+                    String appointmentType = Objects.toString(a.getType(), "")
+                            .replace("\r", "")
+                            .replace("\n", "");
+                    pw.print(escapeCsv(appointmentType) + ","); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download, escapeCsv applied
                     pw.print(escapeCsv(p.getFirstName() + " " + p.getLastName()) + ","); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download, escapeCsv applied
                     pw.print(escapeCsv(a.getLocation())); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download, escapeCsv applied
                     pw.print("\n"); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download literal newline

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/PatientListByAppt.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/PatientListByAppt.java
@@ -119,17 +119,21 @@ public class PatientListByAppt extends HttpServlet {
             String errorType = null;
 
             try {
-                try (PrintWriter pw = new PrintWriter(new OutputStreamWriter(
-                        response.getOutputStream(), StandardCharsets.UTF_8), true)) {
-                    dao.streamPatientAppointments(providerNo, from, to, row -> {
-                        writeCsvRow(pw, row);
-                        rowCount[0]++;
-                    });
-                    if (pw.checkError()) {
-                        throw new IOException("Unable to complete patient appointment export response");
-                    }
-                    outcome = "success";
+                // The servlet container owns the response stream. Closing it while an
+                // exception unwinds can commit an empty 200 response before the outer
+                // error handler has a chance to send a 500. checkError() flushes a
+                // successful export; on failure, any uncommitted response buffer remains
+                // available for sendError() to reset.
+                PrintWriter pw = new PrintWriter(new OutputStreamWriter(
+                        response.getOutputStream(), StandardCharsets.UTF_8), true);
+                dao.streamPatientAppointments(providerNo, from, to, row -> {
+                    writeCsvRow(pw, row);
+                    rowCount[0]++;
+                });
+                if (pw.checkError()) {
+                    throw new IOException("Unable to complete patient appointment export response");
                 }
+                outcome = "success";
             } catch (IOException | RuntimeException e) {
                 errorType = e.getClass().getSimpleName();
                 throw e;

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/PatientListByAppt.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/PatientListByAppt.java
@@ -179,7 +179,7 @@ public class PatientListByAppt extends HttpServlet {
             throw e;
         } finally {
             deleteExportSpoolFile(spoolFile);
-            auditExport(loggedInInfo, validatedScope.providerFilter(),
+            auditExportSafely(loggedInInfo, validatedScope.providerFilter(),
                     validatedScope.dateFrom(), validatedScope.dateTo(),
                     rowCount[0], outcome, errorType);
         }
@@ -200,7 +200,7 @@ public class PatientListByAppt extends HttpServlet {
             return getSecurityInfoManager().hasPrivilege(
                     loggedInInfo, "_report,_admin.reporting", "r", null);
         } catch (RuntimeException e) {
-            auditExport(loggedInInfo, null, null, null,
+            auditExportSafely(loggedInInfo, null, null, null,
                     0, "error", e.getClass().getSimpleName());
             throw e;
         }
@@ -244,9 +244,22 @@ public class PatientListByAppt extends HttpServlet {
                               int status, String message, String reason,
                               ExportScope validatedScope) throws IOException {
         response.sendError(status, message);
-        auditExport(loggedInInfo, validatedScope.providerFilter(),
+        auditExportSafely(loggedInInfo, validatedScope.providerFilter(),
                 validatedScope.dateFrom(), validatedScope.dateTo(),
                 0, "rejected", reason);
+    }
+
+    private void auditExportSafely(LoggedInInfo loggedInInfo, String providerFilter,
+                                   String dateFrom, String dateTo, int rowCount,
+                                   String outcome, String errorType) {
+        try {
+            auditExport(loggedInInfo, providerFilter, dateFrom, dateTo,
+                    rowCount, outcome, errorType);
+        } catch (RuntimeException e) {
+            // Auditing is best-effort at this boundary: an audit-store outage must
+            // not mask the original export, authorization, or response failure.
+            log.error("Unable to persist patient export audit", e);
+        }
     }
 
     private void auditExport(LoggedInInfo loggedInInfo, String providerFilter,

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/PatientListByAppt.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/PatientListByAppt.java
@@ -29,12 +29,14 @@
 
 package io.github.carlos_emr.carlos.report.data;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.io.BufferedWriter;
 import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.io.PrintWriter;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
 import java.util.Date;
@@ -63,6 +65,8 @@ import io.github.carlos_emr.carlos.util.ConversionUtils;
 public class PatientListByAppt extends HttpServlet {
     private static final Pattern PROVIDER_FILTER_PATTERN =
             Pattern.compile("[A-Za-z0-9_-]{1,6}");
+    private static final ExportScope EMPTY_EXPORT_SCOPE =
+            new ExportScope(null, null, null);
 
     private static final Logger log = MiscUtils.getLogger();
 
@@ -89,37 +93,38 @@ public class PatientListByAppt extends HttpServlet {
     }
 
     /**
-     * Validates and streams one export request. The response output stream is
-     * container-owned and must remain open; closing it during exception unwinding
-     * can commit an empty success response before {@link HttpServletResponse#sendError}
-     * can replace it.
+     * Validates and processes one export request. Rows are streamed from the DAO
+     * into an owner-only spool file before the response is committed, preventing a
+     * database failure from returning a successful but truncated export. The
+     * container-owned response stream deliberately remains open.
      */
-    @SuppressWarnings("java:S2093")
     private void processExportRequest(HttpServletRequest request, HttpServletResponse response)
             throws IOException {
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
         if (loggedInInfo == null) {
             UnauthenticatedRejectionResolver.rejectUnauthenticatedRequest(request, response);
-            auditUnauthenticatedExport(request.getRemoteAddr());
+            // The shared resolver emits a sanitized rejection event. Do not add a
+            // synchronous database insert here: this public route would otherwise
+            // let anonymous traffic amplify writes to the clinical audit database.
             return;
         }
 
         if (!hasReportPrivilege(loggedInInfo)) {
             rejectExport(response, loggedInInfo, HttpServletResponse.SC_FORBIDDEN,
-                    "Report read privilege is required", "Forbidden");
+                    "Report read privilege is required", "Forbidden", EMPTY_EXPORT_SCOPE);
             return;
         }
 
         String providerFilter = request.getParameter("provider_no");
         if (providerFilter == null || providerFilter.isBlank()) {
             rejectExport(response, loggedInInfo, HttpServletResponse.SC_BAD_REQUEST,
-                    "provider_no is required", "MissingProvider");
+                    "provider_no is required", "MissingProvider", EMPTY_EXPORT_SCOPE);
             return;
         }
         if (!providerFilter.equals("all")
                 && !PROVIDER_FILTER_PATTERN.matcher(providerFilter).matches()) {
             rejectExport(response, loggedInInfo, HttpServletResponse.SC_BAD_REQUEST,
-                    "provider_no is invalid", "InvalidProvider");
+                    "provider_no is invalid", "InvalidProvider", EMPTY_EXPORT_SCOPE);
             return;
         }
         // clear dr no value for all doc's
@@ -129,42 +134,55 @@ public class PatientListByAppt extends HttpServlet {
 
         Date from = parseRequiredDate(datefrom);
         Date to = parseRequiredDate(dateto);
+        ExportScope validatedScope = new ExportScope(
+                providerFilter, canonicalDate(from), canonicalDate(to));
         if (from == null || to == null) {
             rejectExport(response, loggedInInfo, HttpServletResponse.SC_BAD_REQUEST,
-                    "date_from and date_to must use YYYY-MM-DD", "InvalidDate");
+                    "date_from and date_to must use YYYY-MM-DD", "InvalidDate",
+                    validatedScope);
             return;
         }
         if (from.after(to)) {
             rejectExport(response, loggedInInfo, HttpServletResponse.SC_BAD_REQUEST,
-                    "date_from must not be after date_to", "ReversedDateRange");
+                    "date_from must not be after date_to", "ReversedDateRange",
+                    validatedScope);
             return;
         }
-
-        response.setContentType("text/plain; charset=UTF-8");
-        response.setHeader("Content-disposition", "attachment; filename=patientlist.txt");
 
         int[] rowCount = {0};
         String outcome = "error";
         String errorType = null;
+        Path spoolFile = null;
 
         try {
+            spoolFile = createExportSpoolFile();
             OscarAppointmentDao dao = getAppointmentDao();
-            PrintWriter pw = new PrintWriter(new OutputStreamWriter(
-                    response.getOutputStream(), StandardCharsets.UTF_8), true);
-            dao.streamPatientAppointments(providerNo, from, to, row -> {
-                writeCsvRow(pw, row);
-                if (pw.checkError()) {
-                    throw new UncheckedIOException(new IOException(
-                            "Unable to write patient appointment export response"));
-                }
-                rowCount[0]++;
-            });
+            try (BufferedWriter writer = Files.newBufferedWriter(
+                    spoolFile, StandardCharsets.UTF_8)) {
+                dao.streamPatientAppointments(providerNo, from, to, row -> {
+                    try {
+                        writer.write(formatCsvRow(row));
+                        rowCount[0]++;
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                });
+            }
+
+            // Commit the response only after the DAO cursor and spool write have
+            // completed, so a database failure cannot look like a valid truncated
+            // HTTP 200 export to the caller.
+            response.setContentType("text/plain; charset=UTF-8");
+            response.setHeader("Content-disposition", "attachment; filename=patientlist.txt");
+            Files.copy(spoolFile, response.getOutputStream());
             outcome = "success";
         } catch (IOException | RuntimeException e) {
             errorType = e.getClass().getSimpleName();
             throw e;
         } finally {
-            auditExport(loggedInInfo, providerFilter, datefrom, dateto,
+            deleteExportSpoolFile(spoolFile);
+            auditExport(loggedInInfo, validatedScope.providerFilter(),
+                    validatedScope.dateFrom(), validatedScope.dateTo(),
                     rowCount[0], outcome, errorType);
         }
     }
@@ -190,21 +208,14 @@ public class PatientListByAppt extends HttpServlet {
         }
     }
 
-    // FindSecBugs XSS_SERVLET: this is an attachment-only CSV context and every
-    // database string passes through escapeCsv(), including formula protection.
-    @SuppressFBWarnings(value = "XSS_SERVLET",
-            justification = "attachment-only CSV output; all database strings use escapeCsv")
-    private static void writeCsvRow(PrintWriter pw, PatientAppointmentExportRow row) {
-        // CSV export rows — each pw.print() carries a full-id nosemgrep because
-        // Semgrep Cloud does not honor preceding-line suppressions for this rule.
-        // Content-Type is set to text/plain with Content-Disposition: attachment,
-        // values pass through escapeCsv(), not an HTML context.
-        pw.print(escapeCsv(row.patientLastName()) + ","); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download, escapeCsv applied
-        pw.print(escapeCsv(row.patientFirstName()) + ","); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download, escapeCsv applied
-        pw.print(escapeCsv(row.phone()) + ","); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download, escapeCsv applied
-        pw.print(escapeCsv(row.alternatePhone()) + ","); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download, escapeCsv applied
-        pw.print(ConversionUtils.toTimeString(row.startTime()) + ","); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download, formatted time
-        pw.print(ConversionUtils.toDateString(row.appointmentDate()) + ","); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download, formatted date
+    private static String formatCsvRow(PatientAppointmentExportRow row) {
+        StringBuilder csv = new StringBuilder();
+        csv.append(escapeCsv(row.patientLastName())).append(',');
+        csv.append(escapeCsv(row.patientFirstName())).append(',');
+        csv.append(escapeCsv(row.phone())).append(',');
+        csv.append(escapeCsv(row.alternatePhone())).append(',');
+        csv.append(ConversionUtils.toTimeString(row.startTime())).append(',');
+        csv.append(ConversionUtils.toDateString(row.appointmentDate())).append(',');
         // Appointment type is free text and optional. Strip CR and LF
         // individually — the legacy replaceAll("\r\n", "") only matched
         // CRLF pairs, so a lone newline survived, escapeCsv quoted the
@@ -214,10 +225,11 @@ public class PatientListByAppt extends HttpServlet {
         String appointmentType = Objects.toString(row.appointmentType(), "")
                 .replace("\r", "")
                 .replace("\n", "");
-        pw.print(escapeCsv(appointmentType) + ","); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download, escapeCsv applied
-        pw.print(escapeCsv(formatProviderName(row.providerFirstName(), row.providerLastName())) + ","); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download, escapeCsv applied
-        pw.print(escapeCsv(row.location())); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download, escapeCsv applied
-        pw.print("\n"); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download literal newline
+        csv.append(escapeCsv(appointmentType)).append(',');
+        csv.append(escapeCsv(formatProviderName(
+                row.providerFirstName(), row.providerLastName()))).append(',');
+        csv.append(escapeCsv(row.location())).append('\n');
+        return csv.toString();
     }
 
     private static String formatProviderName(String firstName, String lastName) {
@@ -231,17 +243,12 @@ public class PatientListByAppt extends HttpServlet {
     }
 
     private void rejectExport(HttpServletResponse response, LoggedInInfo loggedInInfo,
-                              int status, String message, String reason) throws IOException {
+                              int status, String message, String reason,
+                              ExportScope validatedScope) throws IOException {
         response.sendError(status, message);
-        // Rejected parameters are deliberately omitted: malformed attacker-controlled
-        // values must not become PHI or log-injection content in the audit record.
-        auditExport(loggedInInfo, null, null, null, 0, "rejected", reason);
-    }
-
-    private void auditUnauthenticatedExport(String remoteAddress) {
-        OscarLog auditLog = createExportAuditLog(null, remoteAddress, null);
-        persistExportAuditResult(auditLog, null, null, 0,
-                "rejected", "Unauthenticated");
+        auditExport(loggedInInfo, validatedScope.providerFilter(),
+                validatedScope.dateFrom(), validatedScope.dateTo(),
+                0, "rejected", reason);
     }
 
     private void auditExport(LoggedInInfo loggedInInfo, String providerFilter,
@@ -296,6 +303,33 @@ public class PatientListByAppt extends HttpServlet {
         } catch (DateTimeParseException | IllegalArgumentException e) {
             return null;
         }
+    }
+
+    private static String canonicalDate(Date value) {
+        return value == null ? null : ConversionUtils.toDateString(value);
+    }
+
+    private static Path createExportSpoolFile() throws IOException {
+        if (FileSystems.getDefault().supportedFileAttributeViews().contains("posix")) {
+            return Files.createTempFile("carlos-patient-export-", ".csv",
+                    PosixFilePermissions.asFileAttribute(
+                            PosixFilePermissions.fromString("rw-------")));
+        }
+        return Files.createTempFile("carlos-patient-export-", ".csv");
+    }
+
+    private static void deleteExportSpoolFile(Path spoolFile) {
+        if (spoolFile == null) {
+            return;
+        }
+        try {
+            Files.deleteIfExists(spoolFile);
+        } catch (IOException e) {
+            log.error("Unable to delete patient export spool file", e);
+        }
+    }
+
+    private record ExportScope(String providerFilter, String dateFrom, String dateTo) {
     }
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/PatientListByAppt.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/PatientListByAppt.java
@@ -102,15 +102,15 @@ public class PatientListByAppt extends HttpServlet {
         SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
         if (!securityInfoManager.hasPrivilege(
                 loggedInInfo, "_report,_admin.reporting", "r", null)) {
-            response.sendError(HttpServletResponse.SC_FORBIDDEN,
-                    "Report read privilege is required");
+            rejectExport(response, loggedInInfo, HttpServletResponse.SC_FORBIDDEN,
+                    "Report read privilege is required", "Forbidden");
             return;
         }
 
         String providerFilter = request.getParameter("provider_no");
         if (providerFilter == null || providerFilter.isBlank()) {
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST,
-                    "provider_no is required");
+            rejectExport(response, loggedInInfo, HttpServletResponse.SC_BAD_REQUEST,
+                    "provider_no is required", "MissingProvider");
             return;
         }
         // clear dr no value for all doc's
@@ -121,13 +121,13 @@ public class PatientListByAppt extends HttpServlet {
         Date from = parseRequiredDate(datefrom);
         Date to = parseRequiredDate(dateto);
         if (from == null || to == null) {
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST,
-                    "date_from and date_to must use YYYY-MM-DD");
+            rejectExport(response, loggedInInfo, HttpServletResponse.SC_BAD_REQUEST,
+                    "date_from and date_to must use YYYY-MM-DD", "InvalidDate");
             return;
         }
         if (from.after(to)) {
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST,
-                    "date_from must not be after date_to");
+            rejectExport(response, loggedInInfo, HttpServletResponse.SC_BAD_REQUEST,
+                    "date_from must not be after date_to", "ReversedDateRange");
             return;
         }
 
@@ -184,9 +184,27 @@ public class PatientListByAppt extends HttpServlet {
                 .replace("\r", "")
                 .replace("\n", "");
         pw.print(escapeCsv(appointmentType) + ","); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download, escapeCsv applied
-        pw.print(escapeCsv(row.providerFirstName() + " " + row.providerLastName()) + ","); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download, escapeCsv applied
+        pw.print(escapeCsv(formatProviderName(row.providerFirstName(), row.providerLastName())) + ","); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download, escapeCsv applied
         pw.print(escapeCsv(row.location())); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download, escapeCsv applied
         pw.print("\n"); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download literal newline
+    }
+
+    private static String formatProviderName(String firstName, String lastName) {
+        if (firstName == null || firstName.isEmpty()) {
+            return Objects.toString(lastName, "");
+        }
+        if (lastName == null || lastName.isEmpty()) {
+            return firstName;
+        }
+        return firstName + " " + lastName;
+    }
+
+    private void rejectExport(HttpServletResponse response, LoggedInInfo loggedInInfo,
+                              int status, String message, String reason) throws IOException {
+        response.sendError(status, message);
+        // Rejected parameters are deliberately omitted: malformed attacker-controlled
+        // values must not become PHI or log-injection content in the audit record.
+        auditExport(loggedInInfo, null, null, null, 0, "rejected", reason);
     }
 
     private void auditExport(LoggedInInfo loggedInInfo, String providerFilter,

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/PatientListByAppt.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/PatientListByAppt.java
@@ -33,10 +33,8 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.attribute.PosixFilePermissions;
 import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
 import java.util.Date;
@@ -56,11 +54,11 @@ import io.github.carlos_emr.carlos.log.LogAction;
 import io.github.carlos_emr.carlos.log.LogConst;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.sec.UnauthenticatedRejectionResolver;
+import io.github.carlos_emr.carlos.util.ConversionUtils;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
+import io.github.carlos_emr.carlos.utility.PathValidationUtils;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
-
-import io.github.carlos_emr.carlos.util.ConversionUtils;
 
 public class PatientListByAppt extends HttpServlet {
     private static final Pattern PROVIDER_FILTER_PATTERN =
@@ -310,12 +308,8 @@ public class PatientListByAppt extends HttpServlet {
     }
 
     private static Path createExportSpoolFile() throws IOException {
-        if (FileSystems.getDefault().supportedFileAttributeViews().contains("posix")) {
-            return Files.createTempFile("carlos-patient-export-", ".csv",
-                    PosixFilePermissions.asFileAttribute(
-                            PosixFilePermissions.fromString("rw-------")));
-        }
-        return Files.createTempFile("carlos-patient-export-", ".csv");
+        return PathValidationUtils.createSecureTempFile(
+                "carlos-patient-export-", ".csv").toPath();
     }
 
     private static void deleteExportSpoolFile(Path spoolFile) {

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/PatientListByAppt.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/PatientListByAppt.java
@@ -233,8 +233,9 @@ public class PatientListByAppt extends HttpServlet {
      * if it contains commas, double-quotes, or newlines, and escapes embedded
      * double-quotes by doubling them. Also prevents spreadsheet formula injection
      * by prefixing values that start with formula trigger characters (=, +, -, @,
-     * tab, carriage return) with a single quote so spreadsheet applications treat
-     * them as literal text rather than formulas.
+     * tab, carriage return, line feed, NUL, or their full-width variants) with a
+     * single quote so spreadsheet applications treat them as literal text rather
+     * than formulas.
      *
      * @param value the raw field value; null is treated as an empty string
      * @return the RFC 4180 escaped field value, safe from formula injection
@@ -249,7 +250,9 @@ public class PatientListByAppt extends HttpServlet {
         if (!value.isEmpty()) {
             char first = value.charAt(0);
             if (first == '=' || first == '+' || first == '-' || first == '@'
-                    || first == '\t' || first == '\r') {
+                    || first == '\t' || first == '\r' || first == '\n' || first == '\0'
+                    || first == '\uFF1D' || first == '\uFF0B'
+                    || first == '\uFF0D' || first == '\uFF20') {
                 value = "'" + value;
             }
         }

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/PatientListByAppt.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/PatientListByAppt.java
@@ -38,6 +38,7 @@ import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
 import java.util.Date;
 import java.util.Objects;
+import java.util.regex.Pattern;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
@@ -59,6 +60,8 @@ import io.github.carlos_emr.carlos.utility.SpringUtils;
 import io.github.carlos_emr.carlos.util.ConversionUtils;
 
 public class PatientListByAppt extends HttpServlet {
+    private static final Pattern PROVIDER_FILTER_PATTERN =
+            Pattern.compile("[A-Za-z0-9_-]{1,6}");
 
     private static final Logger log = MiscUtils.getLogger();
 
@@ -96,6 +99,8 @@ public class PatientListByAppt extends HttpServlet {
         LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
         if (loggedInInfo == null) {
             UnauthenticatedRejectionResolver.rejectUnauthenticatedRequest(request, response);
+            auditExport(null, request.getRemoteAddr(), null, null, null,
+                    0, "rejected", "Unauthenticated");
             return;
         }
 
@@ -111,6 +116,12 @@ public class PatientListByAppt extends HttpServlet {
         if (providerFilter == null || providerFilter.isBlank()) {
             rejectExport(response, loggedInInfo, HttpServletResponse.SC_BAD_REQUEST,
                     "provider_no is required", "MissingProvider");
+            return;
+        }
+        if (!providerFilter.equals("all")
+                && !PROVIDER_FILTER_PATTERN.matcher(providerFilter).matches()) {
+            rejectExport(response, loggedInInfo, HttpServletResponse.SC_BAD_REQUEST,
+                    "provider_no is invalid", "InvalidProvider");
             return;
         }
         // clear dr no value for all doc's
@@ -134,12 +145,12 @@ public class PatientListByAppt extends HttpServlet {
         response.setContentType("text/plain; charset=UTF-8");
         response.setHeader("Content-disposition", "attachment; filename=patientlist.txt");
 
-        OscarAppointmentDao dao = SpringUtils.getBean(OscarAppointmentDao.class);
         int[] rowCount = {0};
         String outcome = "error";
         String errorType = null;
 
         try {
+            OscarAppointmentDao dao = getAppointmentDao();
             PrintWriter pw = new PrintWriter(new OutputStreamWriter(
                     response.getOutputStream(), StandardCharsets.UTF_8), true);
             dao.streamPatientAppointments(providerNo, from, to, row -> {
@@ -154,9 +165,14 @@ public class PatientListByAppt extends HttpServlet {
             errorType = e.getClass().getSimpleName();
             throw e;
         } finally {
-            auditExport(loggedInInfo, providerFilter, datefrom, dateto,
+            auditExport(loggedInInfo, loggedInInfo.getIp(), providerFilter, datefrom, dateto,
                     rowCount[0], outcome, errorType);
         }
+    }
+
+    /** Test seam for exercising infrastructure failures during DAO resolution. */
+    protected OscarAppointmentDao getAppointmentDao() {
+        return SpringUtils.getBean(OscarAppointmentDao.class);
     }
 
     // FindSecBugs XSS_SERVLET: this is an attachment-only CSV context and every
@@ -204,23 +220,25 @@ public class PatientListByAppt extends HttpServlet {
         response.sendError(status, message);
         // Rejected parameters are deliberately omitted: malformed attacker-controlled
         // values must not become PHI or log-injection content in the audit record.
-        auditExport(loggedInInfo, null, null, null, 0, "rejected", reason);
+        auditExport(loggedInInfo, loggedInInfo.getIp(), null, null, null,
+                0, "rejected", reason);
     }
 
-    private void auditExport(LoggedInInfo loggedInInfo, String providerFilter,
+    private void auditExport(LoggedInInfo loggedInInfo, String remoteAddress,
+                             String providerFilter,
                              String dateFrom, String dateTo, int rowCount,
                              String outcome, String errorType) {
         OscarLog auditLog = new OscarLog();
-        if (loggedInInfo.getLoggedInSecurity() != null) {
+        if (loggedInInfo != null && loggedInInfo.getLoggedInSecurity() != null) {
             auditLog.setSecurityId(loggedInInfo.getLoggedInSecurity().getSecurityNo());
         }
-        if (loggedInInfo.getLoggedInProvider() != null) {
+        if (loggedInInfo != null && loggedInInfo.getLoggedInProvider() != null) {
             auditLog.setProviderNo(loggedInInfo.getLoggedInProviderNo());
         }
         auditLog.setAction(LogConst.EXPORT);
         auditLog.setContent("patient_list_by_appointment");
         auditLog.setContentId(providerFilter);
-        auditLog.setIp(loggedInInfo.getIp());
+        auditLog.setIp(remoteAddress);
         String data = "dateFrom=" + dateFrom + "; dateTo=" + dateTo
                 + "; rows=" + rowCount + "; outcome=" + outcome;
         if (errorType != null) {

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/PatientListByAppt.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/PatientListByAppt.java
@@ -33,6 +33,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
@@ -103,9 +104,7 @@ public class PatientListByAppt extends HttpServlet {
             return;
         }
 
-        SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
-        if (!securityInfoManager.hasPrivilege(
-                loggedInInfo, "_report,_admin.reporting", "r", null)) {
+        if (!hasReportPrivilege(loggedInInfo)) {
             rejectExport(response, loggedInInfo, HttpServletResponse.SC_FORBIDDEN,
                     "Report read privilege is required", "Forbidden");
             return;
@@ -154,11 +153,12 @@ public class PatientListByAppt extends HttpServlet {
                     response.getOutputStream(), StandardCharsets.UTF_8), true);
             dao.streamPatientAppointments(providerNo, from, to, row -> {
                 writeCsvRow(pw, row);
+                if (pw.checkError()) {
+                    throw new UncheckedIOException(new IOException(
+                            "Unable to write patient appointment export response"));
+                }
                 rowCount[0]++;
             });
-            if (pw.checkError()) {
-                throw new IOException("Unable to complete patient appointment export response");
-            }
             outcome = "success";
         } catch (IOException | RuntimeException e) {
             errorType = e.getClass().getSimpleName();
@@ -172,6 +172,22 @@ public class PatientListByAppt extends HttpServlet {
     /** Test seam for exercising infrastructure failures during DAO resolution. */
     protected OscarAppointmentDao getAppointmentDao() {
         return SpringUtils.getBean(OscarAppointmentDao.class);
+    }
+
+    /** Test seam for exercising authorization infrastructure failures. */
+    protected SecurityInfoManager getSecurityInfoManager() {
+        return SpringUtils.getBean(SecurityInfoManager.class);
+    }
+
+    private boolean hasReportPrivilege(LoggedInInfo loggedInInfo) {
+        try {
+            return getSecurityInfoManager().hasPrivilege(
+                    loggedInInfo, "_report,_admin.reporting", "r", null);
+        } catch (RuntimeException e) {
+            auditExport(loggedInInfo, null, null, null,
+                    0, "error", e.getClass().getSimpleName());
+            throw e;
+        }
     }
 
     // FindSecBugs XSS_SERVLET: this is an attachment-only CSV context and every

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/PatientListByAppt.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/PatientListByAppt.java
@@ -45,10 +45,11 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import org.apache.logging.log4j.Logger;
+import io.github.carlos_emr.carlos.appointment.dto.PatientAppointmentExportRow;
 import io.github.carlos_emr.carlos.commn.dao.OscarAppointmentDao;
-import io.github.carlos_emr.carlos.commn.model.Appointment;
-import io.github.carlos_emr.carlos.commn.model.Demographic;
-import io.github.carlos_emr.carlos.commn.model.Provider;
+import io.github.carlos_emr.carlos.commn.model.OscarLog;
+import io.github.carlos_emr.carlos.log.LogAction;
+import io.github.carlos_emr.carlos.log.LogConst;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.sec.UnauthenticatedRejectionResolver;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
@@ -69,8 +70,6 @@ public class PatientListByAppt extends HttpServlet {
      * @param request  servlet request
      * @param response servlet response
      */
-    // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
-    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     protected void processRequest(HttpServletRequest request, HttpServletResponse response) throws IOException {
         try {
             LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
@@ -87,16 +86,14 @@ public class PatientListByAppt extends HttpServlet {
                 return;
             }
 
-            String drNo = request.getParameter("provider_no");
-            if (drNo == null || drNo.isBlank()) {
+            String providerFilter = request.getParameter("provider_no");
+            if (providerFilter == null || providerFilter.isBlank()) {
                 response.sendError(HttpServletResponse.SC_BAD_REQUEST,
                         "provider_no is required");
                 return;
             }
             // clear dr no value for all doc's
-            if (drNo.equals("all")) {
-                drNo = null;
-            }
+            String providerNo = providerFilter.equals("all") ? null : providerFilter;
             String datefrom = request.getParameter("date_from");
             String dateto = request.getParameter("date_to");
 
@@ -117,40 +114,28 @@ public class PatientListByAppt extends HttpServlet {
             response.setHeader("Content-disposition", "attachment; filename=patientlist.txt");
 
             OscarAppointmentDao dao = SpringUtils.getBean(OscarAppointmentDao.class);
+            int[] rowCount = {0};
+            String outcome = "error";
+            String errorType = null;
 
-            try (PrintWriter pw = new PrintWriter(new OutputStreamWriter(
-                    response.getOutputStream(), StandardCharsets.UTF_8), true)) {
-
-                for (Object[] o : dao.findPatientAppointments(drNo, from, to)) {
-                    Demographic d = (Demographic) o[0];
-                    Appointment a = (Appointment) o[1];
-                    Provider p = (Provider) o[2];
-
-                    // CSV export rows — each pw.print() carries a full-id nosemgrep because
-                    // Semgrep Cloud does not honor preceding-line suppressions for this rule.
-                    // Content-Type is set to text/plain with Content-Disposition: attachment,
-                    // values pass through escapeCsv(), not an HTML context.
-                    pw.print(escapeCsv(d.getLastName()) + ","); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download, escapeCsv applied
-                    pw.print(escapeCsv(d.getFirstName()) + ","); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download, escapeCsv applied
-                    pw.print(escapeCsv(d.getPhone()) + ","); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download, escapeCsv applied
-                    pw.print(escapeCsv(d.getPhone2()) + ","); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download, escapeCsv applied
-                    pw.print(ConversionUtils.toTimeString(a.getStartTime()) + ","); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download, formatted time
-                    pw.print(ConversionUtils.toDateString(a.getAppointmentDate()) + ","); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download, formatted date
-                    // Appointment type is free text and optional. Strip CR and LF
-                    // individually — the legacy replaceAll("\r\n", "") only matched
-                    // CRLF pairs, so a lone newline survived, escapeCsv quoted the
-                    // field, and one appointment spilled across two output lines.
-                    // Objects.toString keeps this null-safe independently of the
-                    // entity getter's own null coalescing.
-                    String appointmentType = Objects.toString(a.getType(), "")
-                            .replace("\r", "")
-                            .replace("\n", "");
-                    pw.print(escapeCsv(appointmentType) + ","); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download, escapeCsv applied
-                    pw.print(escapeCsv(p.getFirstName() + " " + p.getLastName()) + ","); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download, escapeCsv applied
-                    pw.print(escapeCsv(a.getLocation())); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download, escapeCsv applied
-                    pw.print("\n"); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download literal newline
+            try {
+                try (PrintWriter pw = new PrintWriter(new OutputStreamWriter(
+                        response.getOutputStream(), StandardCharsets.UTF_8), true)) {
+                    dao.streamPatientAppointments(providerNo, from, to, row -> {
+                        writeCsvRow(pw, row);
+                        rowCount[0]++;
+                    });
+                    if (pw.checkError()) {
+                        throw new IOException("Unable to complete patient appointment export response");
+                    }
+                    outcome = "success";
                 }
-                pw.println("");
+            } catch (IOException | RuntimeException e) {
+                errorType = e.getClass().getSimpleName();
+                throw e;
+            } finally {
+                auditExport(loggedInInfo, providerFilter, datefrom, dateto,
+                        rowCount[0], outcome, errorType);
             }
         } catch (IOException e) {
             throw e;
@@ -161,6 +146,64 @@ public class PatientListByAppt extends HttpServlet {
                     "An internal error occurred. Please try again or contact your system administrator.");
             }
         }
+    }
+
+    // FindSecBugs XSS_SERVLET: this is an attachment-only CSV context and every
+    // database string passes through escapeCsv(), including formula protection.
+    @SuppressFBWarnings(value = "XSS_SERVLET",
+            justification = "attachment-only CSV output; all database strings use escapeCsv")
+    private static void writeCsvRow(PrintWriter pw, PatientAppointmentExportRow row) {
+        // CSV export rows — each pw.print() carries a full-id nosemgrep because
+        // Semgrep Cloud does not honor preceding-line suppressions for this rule.
+        // Content-Type is set to text/plain with Content-Disposition: attachment,
+        // values pass through escapeCsv(), not an HTML context.
+        pw.print(escapeCsv(row.patientLastName()) + ","); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download, escapeCsv applied
+        pw.print(escapeCsv(row.patientFirstName()) + ","); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download, escapeCsv applied
+        pw.print(escapeCsv(row.phone()) + ","); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download, escapeCsv applied
+        pw.print(escapeCsv(row.alternatePhone()) + ","); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download, escapeCsv applied
+        pw.print(ConversionUtils.toTimeString(row.startTime()) + ","); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download, formatted time
+        pw.print(ConversionUtils.toDateString(row.appointmentDate()) + ","); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download, formatted date
+        // Appointment type is free text and optional. Strip CR and LF
+        // individually — the legacy replaceAll("\r\n", "") only matched
+        // CRLF pairs, so a lone newline survived, escapeCsv quoted the
+        // field, and one appointment spilled across two output lines.
+        // Objects.toString keeps this null-safe independently of the
+        // entity getter's own null coalescing.
+        String appointmentType = Objects.toString(row.appointmentType(), "")
+                .replace("\r", "")
+                .replace("\n", "");
+        pw.print(escapeCsv(appointmentType) + ","); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download, escapeCsv applied
+        pw.print(escapeCsv(row.providerFirstName() + " " + row.providerLastName()) + ","); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download, escapeCsv applied
+        pw.print(escapeCsv(row.location())); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download, escapeCsv applied
+        pw.print("\n"); // nosemgrep: java.lang.security.audit.xss.no-direct-response-writer.no-direct-response-writer -- CSV download literal newline
+    }
+
+    private void auditExport(LoggedInInfo loggedInInfo, String providerFilter,
+                             String dateFrom, String dateTo, int rowCount,
+                             String outcome, String errorType) {
+        OscarLog auditLog = new OscarLog();
+        if (loggedInInfo.getLoggedInSecurity() != null) {
+            auditLog.setSecurityId(loggedInInfo.getLoggedInSecurity().getSecurityNo());
+        }
+        if (loggedInInfo.getLoggedInProvider() != null) {
+            auditLog.setProviderNo(loggedInInfo.getLoggedInProviderNo());
+        }
+        auditLog.setAction(LogConst.EXPORT);
+        auditLog.setContent("patient_list_by_appointment");
+        auditLog.setContentId(providerFilter);
+        auditLog.setIp(loggedInInfo.getIp());
+        String data = "dateFrom=" + dateFrom + "; dateTo=" + dateTo
+                + "; rows=" + rowCount + "; outcome=" + outcome;
+        if (errorType != null) {
+            data += "; error=" + errorType;
+        }
+        auditLog.setData(data);
+        persistExportAudit(auditLog);
+    }
+
+    /** Test seam for verifying audit contents without persisting them. */
+    protected void persistExportAudit(OscarLog auditLog) {
+        LogAction.addLogSynchronous(auditLog);
     }
 
     private static Date parseRequiredDate(String value) {

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/PatientListByAppt.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/PatientListByAppt.java
@@ -34,6 +34,8 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
 import java.util.Date;
 import java.util.Objects;
 
@@ -47,6 +49,9 @@ import io.github.carlos_emr.carlos.commn.dao.OscarAppointmentDao;
 import io.github.carlos_emr.carlos.commn.model.Appointment;
 import io.github.carlos_emr.carlos.commn.model.Demographic;
 import io.github.carlos_emr.carlos.commn.model.Provider;
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import io.github.carlos_emr.carlos.sec.UnauthenticatedRejectionResolver;
+import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 
@@ -68,19 +73,48 @@ public class PatientListByAppt extends HttpServlet {
     @SuppressFBWarnings(value = "XSS_SERVLET", justification = "response is JSON/encoded/static/binary/text content, not an HTML XSS sink")
     protected void processRequest(HttpServletRequest request, HttpServletResponse response) throws IOException {
         try {
-            response.setContentType("text/plain; charset=UTF-8");
-            response.setHeader("Content-disposition", "attachment; filename=patientlist.txt");
+            LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
+            if (loggedInInfo == null) {
+                UnauthenticatedRejectionResolver.rejectUnauthenticatedRequest(request, response);
+                return;
+            }
+
+            SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
+            if (!securityInfoManager.hasPrivilege(
+                    loggedInInfo, "_report,_admin.reporting", "r", null)) {
+                response.sendError(HttpServletResponse.SC_FORBIDDEN,
+                        "Report read privilege is required");
+                return;
+            }
 
             String drNo = request.getParameter("provider_no");
+            if (drNo == null || drNo.isBlank()) {
+                response.sendError(HttpServletResponse.SC_BAD_REQUEST,
+                        "provider_no is required");
+                return;
+            }
             // clear dr no value for all doc's
-            if (drNo != null && drNo.equals("all")) {
+            if (drNo.equals("all")) {
                 drNo = null;
             }
             String datefrom = request.getParameter("date_from");
             String dateto = request.getParameter("date_to");
 
-            Date from = datefrom != null ? ConversionUtils.fromDateString(datefrom) : null;
-            Date to = dateto != null ? ConversionUtils.fromDateString(dateto) : null;
+            Date from = parseRequiredDate(datefrom);
+            Date to = parseRequiredDate(dateto);
+            if (from == null || to == null) {
+                response.sendError(HttpServletResponse.SC_BAD_REQUEST,
+                        "date_from and date_to must use YYYY-MM-DD");
+                return;
+            }
+            if (from.after(to)) {
+                response.sendError(HttpServletResponse.SC_BAD_REQUEST,
+                        "date_from must not be after date_to");
+                return;
+            }
+
+            response.setContentType("text/plain; charset=UTF-8");
+            response.setHeader("Content-disposition", "attachment; filename=patientlist.txt");
 
             OscarAppointmentDao dao = SpringUtils.getBean(OscarAppointmentDao.class);
 
@@ -126,6 +160,17 @@ public class PatientListByAppt extends HttpServlet {
                 response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
                     "An internal error occurred. Please try again or contact your system administrator.");
             }
+        }
+    }
+
+    private static Date parseRequiredDate(String value) {
+        if (value == null || !value.matches("\\d{4}-\\d{2}-\\d{2}")) {
+            return null;
+        }
+        try {
+            return java.sql.Date.valueOf(LocalDate.parse(value));
+        } catch (DateTimeParseException | IllegalArgumentException e) {
+            return null;
         }
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/report/data/PatientListByAppt.java
+++ b/src/main/java/io/github/carlos_emr/carlos/report/data/PatientListByAppt.java
@@ -72,75 +72,7 @@ public class PatientListByAppt extends HttpServlet {
      */
     protected void processRequest(HttpServletRequest request, HttpServletResponse response) throws IOException {
         try {
-            LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
-            if (loggedInInfo == null) {
-                UnauthenticatedRejectionResolver.rejectUnauthenticatedRequest(request, response);
-                return;
-            }
-
-            SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
-            if (!securityInfoManager.hasPrivilege(
-                    loggedInInfo, "_report,_admin.reporting", "r", null)) {
-                response.sendError(HttpServletResponse.SC_FORBIDDEN,
-                        "Report read privilege is required");
-                return;
-            }
-
-            String providerFilter = request.getParameter("provider_no");
-            if (providerFilter == null || providerFilter.isBlank()) {
-                response.sendError(HttpServletResponse.SC_BAD_REQUEST,
-                        "provider_no is required");
-                return;
-            }
-            // clear dr no value for all doc's
-            String providerNo = providerFilter.equals("all") ? null : providerFilter;
-            String datefrom = request.getParameter("date_from");
-            String dateto = request.getParameter("date_to");
-
-            Date from = parseRequiredDate(datefrom);
-            Date to = parseRequiredDate(dateto);
-            if (from == null || to == null) {
-                response.sendError(HttpServletResponse.SC_BAD_REQUEST,
-                        "date_from and date_to must use YYYY-MM-DD");
-                return;
-            }
-            if (from.after(to)) {
-                response.sendError(HttpServletResponse.SC_BAD_REQUEST,
-                        "date_from must not be after date_to");
-                return;
-            }
-
-            response.setContentType("text/plain; charset=UTF-8");
-            response.setHeader("Content-disposition", "attachment; filename=patientlist.txt");
-
-            OscarAppointmentDao dao = SpringUtils.getBean(OscarAppointmentDao.class);
-            int[] rowCount = {0};
-            String outcome = "error";
-            String errorType = null;
-
-            try {
-                // The servlet container owns the response stream. Closing it while an
-                // exception unwinds can commit an empty 200 response before the outer
-                // error handler has a chance to send a 500. checkError() flushes a
-                // successful export; on failure, any uncommitted response buffer remains
-                // available for sendError() to reset.
-                PrintWriter pw = new PrintWriter(new OutputStreamWriter(
-                        response.getOutputStream(), StandardCharsets.UTF_8), true);
-                dao.streamPatientAppointments(providerNo, from, to, row -> {
-                    writeCsvRow(pw, row);
-                    rowCount[0]++;
-                });
-                if (pw.checkError()) {
-                    throw new IOException("Unable to complete patient appointment export response");
-                }
-                outcome = "success";
-            } catch (IOException | RuntimeException e) {
-                errorType = e.getClass().getSimpleName();
-                throw e;
-            } finally {
-                auditExport(loggedInInfo, providerFilter, datefrom, dateto,
-                        rowCount[0], outcome, errorType);
-            }
+            processExportRequest(request, response);
         } catch (IOException e) {
             throw e;
         } catch (Exception e) {
@@ -149,6 +81,81 @@ public class PatientListByAppt extends HttpServlet {
                 response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
                     "An internal error occurred. Please try again or contact your system administrator.");
             }
+        }
+    }
+
+    /**
+     * Validates and streams one export request. The response output stream is
+     * container-owned and must remain open; closing it during exception unwinding
+     * can commit an empty success response before {@link HttpServletResponse#sendError}
+     * can replace it.
+     */
+    @SuppressWarnings("java:S2093")
+    private void processExportRequest(HttpServletRequest request, HttpServletResponse response)
+            throws IOException {
+        LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
+        if (loggedInInfo == null) {
+            UnauthenticatedRejectionResolver.rejectUnauthenticatedRequest(request, response);
+            return;
+        }
+
+        SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
+        if (!securityInfoManager.hasPrivilege(
+                loggedInInfo, "_report,_admin.reporting", "r", null)) {
+            response.sendError(HttpServletResponse.SC_FORBIDDEN,
+                    "Report read privilege is required");
+            return;
+        }
+
+        String providerFilter = request.getParameter("provider_no");
+        if (providerFilter == null || providerFilter.isBlank()) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST,
+                    "provider_no is required");
+            return;
+        }
+        // clear dr no value for all doc's
+        String providerNo = providerFilter.equals("all") ? null : providerFilter;
+        String datefrom = request.getParameter("date_from");
+        String dateto = request.getParameter("date_to");
+
+        Date from = parseRequiredDate(datefrom);
+        Date to = parseRequiredDate(dateto);
+        if (from == null || to == null) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST,
+                    "date_from and date_to must use YYYY-MM-DD");
+            return;
+        }
+        if (from.after(to)) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST,
+                    "date_from must not be after date_to");
+            return;
+        }
+
+        response.setContentType("text/plain; charset=UTF-8");
+        response.setHeader("Content-disposition", "attachment; filename=patientlist.txt");
+
+        OscarAppointmentDao dao = SpringUtils.getBean(OscarAppointmentDao.class);
+        int[] rowCount = {0};
+        String outcome = "error";
+        String errorType = null;
+
+        try {
+            PrintWriter pw = new PrintWriter(new OutputStreamWriter(
+                    response.getOutputStream(), StandardCharsets.UTF_8), true);
+            dao.streamPatientAppointments(providerNo, from, to, row -> {
+                writeCsvRow(pw, row);
+                rowCount[0]++;
+            });
+            if (pw.checkError()) {
+                throw new IOException("Unable to complete patient appointment export response");
+            }
+            outcome = "success";
+        } catch (IOException | RuntimeException e) {
+            errorType = e.getClass().getSimpleName();
+            throw e;
+        } finally {
+            auditExport(loggedInInfo, providerFilter, datefrom, dateto,
+                    rowCount[0], outcome, errorType);
         }
     }
 

--- a/src/main/webapp/WEB-INF/classes/struts.xml
+++ b/src/main/webapp/WEB-INF/classes/struts.xml
@@ -50,8 +50,13 @@
             /library/eforms/signatureControl.jsp => allowed through to Struts.
          2. Exclude internal WEB-INF resources.
          3. Exclude non-Struts servlet and CSRFGuard endpoints handled elsewhere,
-            including rendering servlets that must reach their web.xml mappings. -->
-    <constant name="struts.action.excludePattern" value="^(?!(/[^/]+)?/(eform/efmformrtl_templates|library/eforms/signatureControl)\.jsp$).*\.(css|js|json|png|jpg|gif|svg|ico|map|woff|woff2|ttf|eot|html|htm|jsp|jspf)$|^(/[^/]+)?/WEB-INF/.*|^/ws/.*|^/servlet/.*|^(/[^/]+)?/(imageRenderingServlet|contentRenderingServlet(?:/.*)?|EFormSignatureViewForPdfGenerationServlet|EFormImageViewForPdfGenerationServlet|EFormApCacheForPdfGenerationServlet|EFormViewForPdfGenerationServlet|eformViewForPdfGenerationServlet)$|^/csrfguard$" />
+            including rendering servlets that must reach their web.xml mappings.
+            /patientlistbyappt is the extensionless Patient List by Appointment Time
+            export servlet; without this exclusion Struts claims the request and
+            answers 404 "no Action mapped for namespace [/]" (issue #3346). Its
+            authentication policy is enforced separately by LoginFilter /
+            UnauthenticatedRejectionResolver, which already list the same path. -->
+    <constant name="struts.action.excludePattern" value="^(?!(/[^/]+)?/(eform/efmformrtl_templates|library/eforms/signatureControl)\.jsp$).*\.(css|js|json|png|jpg|gif|svg|ico|map|woff|woff2|ttf|eot|html|htm|jsp|jspf)$|^(/[^/]+)?/WEB-INF/.*|^/ws/.*|^/servlet/.*|^(/[^/]+)?/(patientlistbyappt|imageRenderingServlet|contentRenderingServlet(?:/.*)?|EFormSignatureViewForPdfGenerationServlet|EFormImageViewForPdfGenerationServlet|EFormApCacheForPdfGenerationServlet|EFormViewForPdfGenerationServlet|eformViewForPdfGenerationServlet)$|^/csrfguard$" />
     <constant name="struts.custom.i18n.resources" value="oscarResources,MessageResources_mcedt"/>
     <constant name="struts.multipart.maxSize" value="52428800" />
     <!-- Use stream-based multipart parser (reads from getInputStream()) instead of the default

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/patientlist.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/patientlist.jsp
@@ -3,6 +3,7 @@
 <%@ page import="java.util.ArrayList" %>
 
 <%@ include file="/taglibs.jsp" %>
+<%@ taglib uri="carlos" prefix="carlos" %>
 <fmt:setBundle basename="oscarResources"/>
 <c:set var="ctx" value="${pageContext.request.contextPath}"
        scope="request"/>
@@ -54,7 +55,7 @@
                             for (int i = 0; i < dnl.size(); i++) {
                                 ProviderNameBean pb = (ProviderNameBean) dnl.get(i);
                         %>
-                        <option value="<%=pb.getProviderID()%>"><%=pb.getProviderName()%>
+                        <option value="<carlos:encode value='<%= pb.getProviderID() %>' context="htmlAttribute"/>"><carlos:encode value='<%= pb.getProviderName() %>' context="html"/>
                         </option>
                         <%
                             }

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/patientlist.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/patientlist.jsp
@@ -45,9 +45,9 @@
         </h4>
         <div class="row">
             <div class="mb-3">
-                <label class="form-label">Doctor</label>
+                <label class="form-label" for="provider_no">Doctor</label>
                 <div>
-                    <select name="provider_no" class="form-select">
+                    <select id="provider_no" name="provider_no" class="form-select">
                         <option value="all">All Doctors</option>
                         <%
                             ArrayList<ProviderNameBean> dnl = new DoctorList().getDoctorNameList();
@@ -63,17 +63,19 @@
                 </div>
             </div>
             <div class="mb-3">
-                <label class="form-label">Date From</label>
+                <label class="form-label" for="date_from">Date From</label>
                 <div>
                     <input id="date_from" name="date_from" size="10"
-                           type="text"/>
+                           type="text" required pattern="[0-9]{4}-[0-9]{2}-[0-9]{2}"
+                           title="Enter a date in YYYY-MM-DD format"/>
                 </div>
             </div>
             <div class="mb-3">
-                <label class="form-label">Date To</label>
+                <label class="form-label" for="date_to">Date To</label>
                 <div>
                     <input id="date_to" name="date_to" size="10"
-                           type="text"/>
+                           type="text" required pattern="[0-9]{4}-[0-9]{2}-[0-9]{2}"
+                           title="Enter a date in YYYY-MM-DD format"/>
                 </div>
             </div>
             <div class="mb-3">
@@ -91,22 +93,41 @@
     flatpickr("#date_from", {dateFormat: "Y-m-d", allowInput: true});
     flatpickr("#date_to", {dateFormat: "Y-m-d", allowInput: true});
 
-    $(document).ready(function () {
-        $('#plForm').validate({
-            rules: {
-                date_from: {
-                    required: true,
-                    oscarDate: true
-                },
-                date_to: {
-                    required: true,
-                    oscarDate: true
-                }
-            },
-            submitHandler: function (form) {
-                form.submit();
-            }
-        });
+    const reportForm = document.getElementById("plForm");
+    const dateFrom = document.getElementById("date_from");
+    const dateTo = document.getElementById("date_to");
+    const datePattern = /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/;
+
+    function isValidDate(value) {
+        if (!datePattern.test(value)) {
+            return false;
+        }
+        const parsed = new Date(value + "T00:00:00Z");
+        return !Number.isNaN(parsed.getTime()) && parsed.toISOString().substring(0, 10) === value;
+    }
+
+    function validateDateRange() {
+        dateFrom.setCustomValidity("");
+        dateTo.setCustomValidity("");
+        if (dateFrom.value && !isValidDate(dateFrom.value)) {
+            dateFrom.setCustomValidity("Date From must be a valid date in YYYY-MM-DD format.");
+        }
+        if (dateTo.value && !isValidDate(dateTo.value)) {
+            dateTo.setCustomValidity("Date To must be a valid date in YYYY-MM-DD format.");
+        }
+        if (isValidDate(dateFrom.value) && isValidDate(dateTo.value) && dateFrom.value > dateTo.value) {
+            dateTo.setCustomValidity("Date To must be on or after Date From.");
+        }
+    }
+
+    dateFrom.addEventListener("input", validateDateRange);
+    dateTo.addEventListener("input", validateDateRange);
+    reportForm.addEventListener("submit", function (event) {
+        validateDateRange();
+        if (!reportForm.checkValidity()) {
+            event.preventDefault();
+            reportForm.reportValidity();
+        }
     });
 </script>
 </body>

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/patientlist.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/patientlist.jsp
@@ -36,7 +36,7 @@
     <h4>Patient List</h4>
 </div>
 
-<form id="plForm" action="<%=request.getContextPath() %>/patientlistbyappt" class="card card-body bg-body-tertiary">
+<form id="plForm" method="post" action="<%=request.getContextPath() %>/patientlistbyappt" class="card card-body bg-body-tertiary">
 
     <fieldset>
         <h4>

--- a/src/main/webapp/WEB-INF/jsp/oscarReport/patientlist.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oscarReport/patientlist.jsp
@@ -37,7 +37,7 @@
     <h4>Patient List</h4>
 </div>
 
-<form id="plForm" method="post" action="<%=request.getContextPath() %>/patientlistbyappt" class="card card-body bg-body-tertiary">
+<form id="plForm" method="post" action="${carlos:forHtmlAttribute(ctx)}/patientlistbyappt" class="card card-body bg-body-tertiary">
 
     <fieldset>
         <h4>

--- a/src/test/java/io/github/carlos_emr/carlos/commn/dao/OscarAppointmentDaoQueryIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/commn/dao/OscarAppointmentDaoQueryIntegrationTest.java
@@ -22,6 +22,7 @@
 package io.github.carlos_emr.carlos.commn.dao;
 
 import io.github.carlos_emr.carlos.PMmodule.model.Program;
+import io.github.carlos_emr.carlos.appointment.dto.PatientAppointmentExportRow;
 import io.github.carlos_emr.carlos.commn.model.Appointment;
 import io.github.carlos_emr.carlos.commn.model.Demographic;
 import io.github.carlos_emr.carlos.commn.model.MyGroup;
@@ -934,6 +935,25 @@ public class OscarAppointmentDaoQueryIntegrationTest extends CarlosTestBase {
             assertThat(row[0]).isInstanceOf(Demographic.class);
             assertThat(row[1]).isInstanceOf(Appointment.class);
             assertThat(row[2]).isInstanceOf(Provider.class);
+        }
+
+        @Test
+        @DisplayName("should stream scalar export projections")
+        void shouldStreamProjection_whenAppointmentsExist() {
+            createAndPersistProvider(PROVIDER_NO, "John", "Smith");
+            Demographic demo = createAndPersistDemographic("Jane", "Doe", "ON", "4567890123");
+            createAndPersist(today, PROVIDER_NO, demo.getDemographicNo(), "A");
+            List<PatientAppointmentExportRow> streamedRows = new java.util.ArrayList<>();
+
+            oscarAppointmentDao.streamPatientAppointments(
+                    PROVIDER_NO, yesterday, tomorrow, streamedRows::add);
+
+            assertThat(streamedRows).isNotEmpty();
+            PatientAppointmentExportRow row = streamedRows.get(0);
+            assertThat(row.patientFirstName()).isEqualTo("Jane");
+            assertThat(row.patientLastName()).isEqualTo("Doe");
+            assertThat(row.providerFirstName()).isEqualTo("John");
+            assertThat(row.providerLastName()).isEqualTo("Smith");
         }
 
         @Test

--- a/src/test/java/io/github/carlos_emr/carlos/report/data/PatientListByApptExportUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/data/PatientListByApptExportUnitTest.java
@@ -147,6 +147,21 @@ class PatientListByApptExportUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
+    @DisplayName("visible export form should HTML-encode provider option values and labels")
+    void shouldEncodeProviderOptions_whenReadingPatientListJsp() throws IOException {
+        String patientListJsp = Files.readString(PATIENT_LIST_JSP, StandardCharsets.UTF_8);
+
+        assertThat(patientListJsp)
+                .contains("<%@ taglib uri=\"carlos\" prefix=\"carlos\" %>")
+                .contains("<carlos:encode value='<%= pb.getProviderID() %>' "
+                        + "context=\"htmlAttribute\"/>")
+                .contains("<carlos:encode value='<%= pb.getProviderName() %>' "
+                        + "context=\"html\"/>")
+                .doesNotContain("value=\"<%=pb.getProviderID()%>\"")
+                .doesNotContain("><%=pb.getProviderName()%>");
+    }
+
+    @Test
     @DisplayName("export should emit an empty type field when the appointment has no type")
     void shouldEmitEmptyTypeField_whenAppointmentTypeIsNull() throws Exception {
         Date appointmentDate = ConversionUtils.fromDateString("2026-08-07");

--- a/src/test/java/io/github/carlos_emr/carlos/report/data/PatientListByApptExportUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/data/PatientListByApptExportUnitTest.java
@@ -35,6 +35,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -45,6 +46,9 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.WriteListener;
 
 import io.github.carlos_emr.carlos.appointment.dto.PatientAppointmentExportRow;
 import io.github.carlos_emr.carlos.commn.dao.OscarAppointmentDao;
@@ -108,6 +112,7 @@ class PatientListByApptExportUnitTest extends CarlosUnitTestBase {
     private PatientListByAppt servlet;
     private OscarLog persistedAuditLog;
     private RuntimeException daoResolutionFailure;
+    private RuntimeException securityResolutionFailure;
 
     @BeforeEach
     void setUpServlet() {
@@ -117,6 +122,14 @@ class PatientListByApptExportUnitTest extends CarlosUnitTestBase {
                 loggedInInfo, "_report,_admin.reporting", "r", null))
                 .thenReturn(true);
         servlet = new PatientListByAppt() {
+            @Override
+            protected SecurityInfoManager getSecurityInfoManager() {
+                if (securityResolutionFailure != null) {
+                    throw securityResolutionFailure;
+                }
+                return securityInfoManager;
+            }
+
             @Override
             protected OscarAppointmentDao getAppointmentDao() {
                 if (daoResolutionFailure != null) {
@@ -390,6 +403,75 @@ class PatientListByApptExportUnitTest extends CarlosUnitTestBase {
                 .isEqualTo("dateFrom=2026-08-07; dateTo=2026-08-10; rows=0; "
                         + "outcome=error; error=IllegalStateException")
                 .doesNotContain("bean detail");
+    }
+
+    @Test
+    @DisplayName("authorization infrastructure failures should produce a PHI-free failure audit")
+    void shouldAuditFailureMetadata_whenAuthorizationInfrastructureFails() throws Exception {
+        securityResolutionFailure = new IllegalStateException(
+                "authorization detail must not be audited");
+
+        MockHttpServletResponse response = export("999998", "2026-08-07", "2026-08-10");
+
+        assertThat(response.getStatus()).isEqualTo(500);
+        verifyNoInteractions(appointmentDao);
+        assertThat(persistedAuditLog.getData())
+                .isEqualTo("dateFrom=null; dateTo=null; rows=0; "
+                        + "outcome=error; error=IllegalStateException")
+                .doesNotContain("authorization detail", "999998", "2026-08-07");
+    }
+
+    @Test
+    @DisplayName("response write failures should abort streaming before consuming another row")
+    void shouldAbortStreamingAndAuditPartialCount_whenResponseWriteFails() throws Exception {
+        Date appointmentDate = ConversionUtils.fromDateString("2026-08-07");
+        Date startTime = ConversionUtils.fromTimestampString("2026-08-07 09:00:00");
+        PatientAppointmentExportRow firstRow = row(
+                demographic("PrivateFirst", "PrivateLast", "555-0100", null),
+                appointment(appointmentDate, startTime, null, "PrivateLocation"),
+                provider("Doris", "Doctor"));
+        AtomicInteger consumedRows = new AtomicInteger();
+        org.mockito.Mockito.doAnswer(invocation -> {
+            Consumer<PatientAppointmentExportRow> rowConsumer = invocation.getArgument(3);
+            consumedRows.incrementAndGet();
+            rowConsumer.accept(firstRow);
+            consumedRows.incrementAndGet();
+            rowConsumer.accept(firstRow);
+            return null;
+        }).when(appointmentDao).streamPatientAppointments(any(), any(), any(), any());
+
+        MockHttpServletRequest request = exportRequest("all", "2026-08-07", "2026-08-10");
+        LoggedInInfo.setLoggedInInfoIntoSession(request.getSession(), loggedInInfo);
+        MockHttpServletResponse response = new MockHttpServletResponse() {
+            @Override
+            public ServletOutputStream getOutputStream() {
+                return new ServletOutputStream() {
+                    @Override
+                    public void write(int value) throws IOException {
+                        throw new IOException("disconnected client detail must not be audited");
+                    }
+
+                    @Override
+                    public boolean isReady() {
+                        return true;
+                    }
+
+                    @Override
+                    public void setWriteListener(WriteListener writeListener) {
+                        // Synchronous test stream; listener callbacks are not used.
+                    }
+                };
+            }
+        };
+
+        servlet.processRequest(request, response);
+
+        assertThat(consumedRows).hasValue(1);
+        assertThat(response.getStatus()).isEqualTo(500);
+        assertThat(persistedAuditLog.getData())
+                .isEqualTo("dateFrom=2026-08-07; dateTo=2026-08-10; rows=0; "
+                        + "outcome=error; error=UncheckedIOException")
+                .doesNotContain("disconnected client", "PrivateFirst", "PrivateLast");
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/report/data/PatientListByApptExportUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/data/PatientListByApptExportUnitTest.java
@@ -25,7 +25,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
@@ -229,7 +232,7 @@ class PatientListByApptExportUnitTest extends CarlosUnitTestBase {
 
         assertThat(response.getContentAsString().lines().findFirst()).hasValue(
                 "Dunn,Cara,555-0200,,10:00:00,2026-08-08,Follow Up,Ravi Singh,Annex");
-        org.mockito.Mockito.verify(appointmentDao).streamPatientAppointments(
+        verify(appointmentDao).streamPatientAppointments(
                 eq("999998"),
                 eq(ConversionUtils.fromDateString("2026-08-07")),
                 eq(ConversionUtils.fromDateString("2026-08-10")),
@@ -348,7 +351,7 @@ class PatientListByApptExportUnitTest extends CarlosUnitTestBase {
 
         export("all", "2026-08-07", "2026-08-10");
 
-        org.mockito.Mockito.verify(appointmentDao).streamPatientAppointments(
+        verify(appointmentDao).streamPatientAppointments(
                 eq(null),
                 eq(ConversionUtils.fromDateString("2026-08-07")),
                 eq(ConversionUtils.fromDateString("2026-08-10")),
@@ -380,7 +383,7 @@ class PatientListByApptExportUnitTest extends CarlosUnitTestBase {
     @Test
     @DisplayName("failed exports should audit the non-PHI failure type and partial row count")
     void shouldAuditFailureMetadata_whenStreamingFails() throws Exception {
-        org.mockito.Mockito.doThrow(new IllegalStateException("database detail must not be audited"))
+        doThrow(new IllegalStateException("database detail must not be audited"))
                 .when(appointmentDao).streamPatientAppointments(any(), any(), any(), any());
 
         MockHttpServletResponse response = export("999998", "2026-08-07", "2026-08-10");
@@ -424,7 +427,7 @@ class PatientListByApptExportUnitTest extends CarlosUnitTestBase {
 
     @Test
     @DisplayName("response write failures should occur only after DAO streaming completes")
-    void shouldAuditSpoolCount_whenResponseWriteFails() throws Exception {
+    void shouldAuditSpoolCount_whenResponseWriteFails() {
         Date appointmentDate = ConversionUtils.fromDateString("2026-08-07");
         Date startTime = ConversionUtils.fromTimestampString("2026-08-07 09:00:00");
         PatientAppointmentExportRow firstRow = row(
@@ -432,7 +435,7 @@ class PatientListByApptExportUnitTest extends CarlosUnitTestBase {
                 appointment(appointmentDate, startTime, null, "PrivateLocation"),
                 provider("Doris", "Doctor"));
         AtomicInteger consumedRows = new AtomicInteger();
-        org.mockito.Mockito.doAnswer(invocation -> {
+        doAnswer(invocation -> {
             Consumer<PatientAppointmentExportRow> rowConsumer = invocation.getArgument(3);
             consumedRows.incrementAndGet();
             rowConsumer.accept(firstRow);
@@ -485,7 +488,7 @@ class PatientListByApptExportUnitTest extends CarlosUnitTestBase {
                 demographic("PrivateFirst", "PrivateLast", "555-0100", null),
                 appointment(appointmentDate, startTime, null, "PrivateLocation"),
                 provider("Doris", "Doctor"));
-        org.mockito.Mockito.doAnswer(invocation -> {
+        doAnswer(invocation -> {
             Consumer<PatientAppointmentExportRow> rowConsumer = invocation.getArgument(3);
             rowConsumer.accept(firstRow);
             throw new IllegalStateException("database detail must not be audited");
@@ -554,7 +557,7 @@ class PatientListByApptExportUnitTest extends CarlosUnitTestBase {
 
         List<MockHttpServletResponse> responses = List.of(missing, invalid, reversed);
 
-        assertThat(responses).allSatisfy(response ->
+        assertThat(responses).hasSize(3).allSatisfy(response ->
                 assertThat(response.getStatus()).isEqualTo(400));
         verifyNoInteractions(appointmentDao);
     }
@@ -612,7 +615,7 @@ class PatientListByApptExportUnitTest extends CarlosUnitTestBase {
 
     private void stubAppointments(PatientAppointmentExportRow... rows) {
         List<PatientAppointmentExportRow> results = new ArrayList<>(List.of(rows));
-        org.mockito.Mockito.doAnswer(invocation -> {
+        doAnswer(invocation -> {
             Consumer<PatientAppointmentExportRow> rowConsumer = invocation.getArgument(3);
             results.forEach(rowConsumer);
             return null;

--- a/src/test/java/io/github/carlos_emr/carlos/report/data/PatientListByApptExportUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/data/PatientListByApptExportUnitTest.java
@@ -229,6 +229,24 @@ class PatientListByApptExportUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
+    @DisplayName("export should protect control and full-width spreadsheet formula prefixes")
+    void shouldProtectSpreadsheetFormulas_whenPrefixesUseControlOrFullWidthCharacters()
+            throws Exception {
+        Date appointmentDate = ConversionUtils.fromDateString("2026-08-09");
+        Date startTime = ConversionUtils.fromTimestampString("2026-08-09 10:30:00");
+        stubAppointments(row(
+                demographic("\n=1+1", "\uFF1D1+1", "\0=1+1", null),
+                appointment(appointmentDate, startTime, "\uFF0D1+1", "\uFF201+1"),
+                provider("\uFF0B1+1", "Doctor")));
+
+        MockHttpServletResponse response = export("999998", "2026-08-07", "2026-08-10");
+
+        assertThat(response.getContentAsString()).isEqualTo(
+                "'\uFF1D1+1,\"'\n=1+1\",'\0=1+1,,10:30:00,2026-08-09,"
+                        + "'\uFF0D1+1,'\uFF0B1+1 Doctor,'\uFF201+1\n");
+    }
+
+    @Test
     @DisplayName("export should emit empty fields for null optional phone, type, and location values")
     void shouldEmitEmptyFields_whenOptionalValuesAreNull() throws Exception {
         Date appointmentDate = ConversionUtils.fromDateString("2026-08-09");

--- a/src/test/java/io/github/carlos_emr/carlos/report/data/PatientListByApptExportUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/data/PatientListByApptExportUnitTest.java
@@ -35,6 +35,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -45,10 +46,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
+import io.github.carlos_emr.carlos.appointment.dto.PatientAppointmentExportRow;
 import io.github.carlos_emr.carlos.commn.dao.OscarAppointmentDao;
 import io.github.carlos_emr.carlos.commn.model.Appointment;
 import io.github.carlos_emr.carlos.commn.model.Demographic;
+import io.github.carlos_emr.carlos.commn.model.OscarLog;
 import io.github.carlos_emr.carlos.commn.model.Provider;
+import io.github.carlos_emr.carlos.log.LogConst;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
 import io.github.carlos_emr.carlos.util.ConversionUtils;
@@ -100,6 +104,7 @@ class PatientListByApptExportUnitTest extends CarlosUnitTestBase {
     private final LoggedInInfo loggedInInfo = mock(LoggedInInfo.class);
 
     private PatientListByAppt servlet;
+    private OscarLog persistedAuditLog;
 
     @BeforeEach
     void setUpServlet() {
@@ -108,7 +113,12 @@ class PatientListByApptExportUnitTest extends CarlosUnitTestBase {
         when(securityInfoManager.hasPrivilege(
                 loggedInInfo, "_report,_admin.reporting", "r", null))
                 .thenReturn(true);
-        servlet = new PatientListByAppt();
+        servlet = new PatientListByAppt() {
+            @Override
+            protected void persistExportAudit(OscarLog auditLog) {
+                persistedAuditLog = auditLog;
+            }
+        };
     }
 
     @Test
@@ -194,10 +204,11 @@ class PatientListByApptExportUnitTest extends CarlosUnitTestBase {
 
         assertThat(response.getContentAsString().lines().findFirst()).hasValue(
                 "Dunn,Cara,555-0200,,10:00:00,2026-08-08,Follow Up,Ravi Singh,Annex");
-        org.mockito.Mockito.verify(appointmentDao).findPatientAppointments(
+        org.mockito.Mockito.verify(appointmentDao).streamPatientAppointments(
                 eq("999998"),
                 eq(ConversionUtils.fromDateString("2026-08-07")),
-                eq(ConversionUtils.fromDateString("2026-08-10")));
+                eq(ConversionUtils.fromDateString("2026-08-10")),
+                any());
     }
 
     @Test
@@ -274,10 +285,47 @@ class PatientListByApptExportUnitTest extends CarlosUnitTestBase {
 
         export("all", "2026-08-07", "2026-08-10");
 
-        org.mockito.Mockito.verify(appointmentDao).findPatientAppointments(
+        org.mockito.Mockito.verify(appointmentDao).streamPatientAppointments(
                 eq(null),
                 eq(ConversionUtils.fromDateString("2026-08-07")),
-                eq(ConversionUtils.fromDateString("2026-08-10")));
+                eq(ConversionUtils.fromDateString("2026-08-10")),
+                any());
+    }
+
+    @Test
+    @DisplayName("successful exports should write a PHI-free audit record")
+    void shouldAuditExportMetadata_whenExportSucceeds() throws Exception {
+        Date appointmentDate = ConversionUtils.fromDateString("2026-08-07");
+        Date startTime = ConversionUtils.fromTimestampString("2026-08-07 09:00:00");
+        stubAppointments(row(
+                demographic("PrivateFirst", "PrivateLast", "555-0100", null),
+                appointment(appointmentDate, startTime, null, "PrivateLocation"),
+                provider("Doris", "Doctor")));
+
+        MockHttpServletResponse response = export("all", "2026-08-07", "2026-08-10");
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(persistedAuditLog).isNotNull();
+        assertThat(persistedAuditLog.getAction()).isEqualTo(LogConst.EXPORT);
+        assertThat(persistedAuditLog.getContent()).isEqualTo("patient_list_by_appointment");
+        assertThat(persistedAuditLog.getContentId()).isEqualTo("all");
+        assertThat(persistedAuditLog.getData())
+                .isEqualTo("dateFrom=2026-08-07; dateTo=2026-08-10; rows=1; outcome=success")
+                .doesNotContain("PrivateFirst", "PrivateLast", "PrivateLocation", "555-0100");
+    }
+
+    @Test
+    @DisplayName("failed exports should audit the non-PHI failure type and partial row count")
+    void shouldAuditFailureMetadata_whenStreamingFails() throws Exception {
+        org.mockito.Mockito.doThrow(new IllegalStateException("database detail must not be audited"))
+                .when(appointmentDao).streamPatientAppointments(any(), any(), any(), any());
+
+        export("999998", "2026-08-07", "2026-08-10");
+
+        assertThat(persistedAuditLog.getData())
+                .isEqualTo("dateFrom=2026-08-07; dateTo=2026-08-10; rows=0; "
+                        + "outcome=error; error=IllegalStateException")
+                .doesNotContain("database detail");
     }
 
     @Test
@@ -352,13 +400,22 @@ class PatientListByApptExportUnitTest extends CarlosUnitTestBase {
         return request;
     }
 
-    private void stubAppointments(Object[]... rows) {
-        List<Object[]> results = new ArrayList<>(List.of(rows));
-        when(appointmentDao.findPatientAppointments(any(), any(), any())).thenReturn(results);
+    private void stubAppointments(PatientAppointmentExportRow... rows) {
+        List<PatientAppointmentExportRow> results = new ArrayList<>(List.of(rows));
+        org.mockito.Mockito.doAnswer(invocation -> {
+            Consumer<PatientAppointmentExportRow> rowConsumer = invocation.getArgument(3);
+            results.forEach(rowConsumer);
+            return null;
+        }).when(appointmentDao).streamPatientAppointments(any(), any(), any(), any());
     }
 
-    private static Object[] row(Demographic demographic, Appointment appointment, Provider provider) {
-        return new Object[] { demographic, appointment, provider };
+    private static PatientAppointmentExportRow row(
+            Demographic demographic, Appointment appointment, Provider provider) {
+        return new PatientAppointmentExportRow(
+                demographic.getLastName(), demographic.getFirstName(),
+                demographic.getPhone(), demographic.getPhone2(), appointment.getStartTime(),
+                appointment.getAppointmentDate(), appointment.getType(), provider.getFirstName(),
+                provider.getLastName(), appointment.getLocation());
     }
 
     private static Demographic demographic(String firstName, String lastName, String phone, String phone2) {

--- a/src/test/java/io/github/carlos_emr/carlos/report/data/PatientListByApptExportUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/data/PatientListByApptExportUnitTest.java
@@ -153,7 +153,7 @@ class PatientListByApptExportUnitTest extends CarlosUnitTestBase {
 
         assertThat(patientListJsp).contains(
                 "<form id=\"plForm\" method=\"post\" "
-                        + "action=\"<%=request.getContextPath() %>/patientlistbyappt\"");
+                        + "action=\"${carlos:forHtmlAttribute(ctx)}/patientlistbyappt\"");
     }
 
     @Test
@@ -266,6 +266,25 @@ class PatientListByApptExportUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
+    @DisplayName("export should omit null provider-name parts instead of rendering null text")
+    void shouldOmitNullProviderNameParts_whenProviderNameIsIncomplete() throws Exception {
+        Date appointmentDate = ConversionUtils.fromDateString("2026-08-09");
+        Date startTime = ConversionUtils.fromTimestampString("2026-08-09 14:00:00");
+        stubAppointments(
+                row(demographic("Aaron", "Bell", null, null),
+                        appointment(appointmentDate, startTime, null, null),
+                        provider(null, "Doctor")),
+                row(demographic("Cara", "Dunn", null, null),
+                        appointment(appointmentDate, startTime, null, null),
+                        provider("Ravi", null)));
+
+        MockHttpServletResponse response = export("all", "2026-08-07", "2026-08-10");
+
+        assertThat(response.getContentAsString()).contains(",Doctor,\n", ",Ravi,\n")
+                .doesNotContain("null");
+    }
+
+    @Test
     @DisplayName("export should keep one row per appointment when the type contains line breaks")
     void shouldKeepOneRowPerAppointment_whenTypeContainsLineBreaks() throws Exception {
         Date appointmentDate = ConversionUtils.fromDateString("2026-08-10");
@@ -371,15 +390,27 @@ class PatientListByApptExportUnitTest extends CarlosUnitTestBase {
 
         assertThat(response.getStatus()).isEqualTo(403);
         verifyNoInteractions(appointmentDao);
+        assertThat(persistedAuditLog.getData())
+                .isEqualTo("dateFrom=null; dateTo=null; rows=0; "
+                        + "outcome=rejected; error=Forbidden");
     }
 
     @Test
     @DisplayName("export should reject missing or invalid dates instead of running an unbounded query")
     void shouldReturnBadRequestAndSkipQuery_whenDatesAreMissingInvalidOrReversed() throws Exception {
-        List<MockHttpServletResponse> responses = List.of(
-                export("all", null, "2026-08-10"),
-                export("all", "2026-02-30", "2026-08-10"),
-                export("all", "2026-08-11", "2026-08-10"));
+        MockHttpServletResponse missing = export("all", null, "2026-08-10");
+        assertThat(persistedAuditLog.getData())
+                .isEqualTo("dateFrom=null; dateTo=null; rows=0; "
+                        + "outcome=rejected; error=InvalidDate")
+                .doesNotContain("2026-08-10");
+        MockHttpServletResponse invalid = export("all", "private invalid date", "2026-08-10");
+        assertThat(persistedAuditLog.getData()).doesNotContain("private invalid date", "2026-08-10");
+        MockHttpServletResponse reversed = export("all", "2026-08-11", "2026-08-10");
+        assertThat(persistedAuditLog.getData())
+                .endsWith("outcome=rejected; error=ReversedDateRange")
+                .doesNotContain("2026-08-11", "2026-08-10");
+
+        List<MockHttpServletResponse> responses = List.of(missing, invalid, reversed);
 
         assertThat(responses).allSatisfy(response ->
                 assertThat(response.getStatus()).isEqualTo(400));
@@ -393,6 +424,9 @@ class PatientListByApptExportUnitTest extends CarlosUnitTestBase {
 
         assertThat(response.getStatus()).isEqualTo(400);
         verifyNoInteractions(appointmentDao);
+        assertThat(persistedAuditLog.getData())
+                .isEqualTo("dateFrom=null; dateTo=null; rows=0; "
+                        + "outcome=rejected; error=MissingProvider");
     }
 
     private MockHttpServletResponse export(String providerNo, String dateFrom, String dateTo)

--- a/src/test/java/io/github/carlos_emr/carlos/report/data/PatientListByApptExportUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/data/PatientListByApptExportUnitTest.java
@@ -117,6 +117,7 @@ class PatientListByApptExportUnitTest extends CarlosUnitTestBase {
     private OscarLog persistedAuditLog;
     private RuntimeException daoResolutionFailure;
     private RuntimeException securityResolutionFailure;
+    private RuntimeException auditPersistenceFailure;
 
     @BeforeEach
     void setUpServlet() {
@@ -145,6 +146,9 @@ class PatientListByApptExportUnitTest extends CarlosUnitTestBase {
             @Override
             protected void persistExportAudit(OscarLog auditLog) {
                 persistedAuditLog = auditLog;
+                if (auditPersistenceFailure != null) {
+                    throw auditPersistenceFailure;
+                }
             }
         };
     }
@@ -426,7 +430,7 @@ class PatientListByApptExportUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
-    @DisplayName("response write failures should occur only after DAO streaming completes")
+    @DisplayName("audit failures should not mask response failures after DAO streaming")
     void shouldAuditSpoolCount_whenResponseWriteFails() {
         Date appointmentDate = ConversionUtils.fromDateString("2026-08-07");
         Date startTime = ConversionUtils.fromTimestampString("2026-08-07 09:00:00");
@@ -443,6 +447,8 @@ class PatientListByApptExportUnitTest extends CarlosUnitTestBase {
             rowConsumer.accept(firstRow);
             return null;
         }).when(appointmentDao).streamPatientAppointments(any(), any(), any(), any());
+        auditPersistenceFailure = new IllegalStateException(
+                "audit persistence detail must not mask the response failure");
 
         MockHttpServletRequest request = exportRequest("all", "2026-08-07", "2026-08-10");
         LoggedInInfo.setLoggedInInfoIntoSession(request.getSession(), loggedInInfo);

--- a/src/test/java/io/github/carlos_emr/carlos/report/data/PatientListByApptExportUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/data/PatientListByApptExportUnitTest.java
@@ -320,8 +320,9 @@ class PatientListByApptExportUnitTest extends CarlosUnitTestBase {
         org.mockito.Mockito.doThrow(new IllegalStateException("database detail must not be audited"))
                 .when(appointmentDao).streamPatientAppointments(any(), any(), any(), any());
 
-        export("999998", "2026-08-07", "2026-08-10");
+        MockHttpServletResponse response = export("999998", "2026-08-07", "2026-08-10");
 
+        assertThat(response.getStatus()).isEqualTo(500);
         assertThat(persistedAuditLog.getData())
                 .isEqualTo("dateFrom=2026-08-07; dateTo=2026-08-10; rows=0; "
                         + "outcome=error; error=IllegalStateException")

--- a/src/test/java/io/github/carlos_emr/carlos/report/data/PatientListByApptExportUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/data/PatientListByApptExportUnitTest.java
@@ -22,6 +22,7 @@
 package io.github.carlos_emr.carlos.report.data;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -422,8 +423,8 @@ class PatientListByApptExportUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
-    @DisplayName("response write failures should abort streaming before consuming another row")
-    void shouldAbortStreamingAndAuditPartialCount_whenResponseWriteFails() throws Exception {
+    @DisplayName("response write failures should occur only after DAO streaming completes")
+    void shouldAuditSpoolCount_whenResponseWriteFails() throws Exception {
         Date appointmentDate = ConversionUtils.fromDateString("2026-08-07");
         Date startTime = ConversionUtils.fromTimestampString("2026-08-07 09:00:00");
         PatientAppointmentExportRow firstRow = row(
@@ -464,14 +465,41 @@ class PatientListByApptExportUnitTest extends CarlosUnitTestBase {
             }
         };
 
-        servlet.processRequest(request, response);
+        assertThatThrownBy(() -> servlet.processRequest(request, response))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("disconnected client detail");
 
-        assertThat(consumedRows).hasValue(1);
-        assertThat(response.getStatus()).isEqualTo(500);
+        assertThat(consumedRows).hasValue(2);
         assertThat(persistedAuditLog.getData())
-                .isEqualTo("dateFrom=2026-08-07; dateTo=2026-08-10; rows=0; "
-                        + "outcome=error; error=UncheckedIOException")
+                .isEqualTo("dateFrom=2026-08-07; dateTo=2026-08-10; rows=2; "
+                        + "outcome=error; error=IOException")
                 .doesNotContain("disconnected client", "PrivateFirst", "PrivateLast");
+    }
+
+    @Test
+    @DisplayName("DAO failures after a row should not return a partial successful export")
+    void shouldReturnErrorWithoutPartialExport_whenDaoFailsAfterFirstRow() throws Exception {
+        Date appointmentDate = ConversionUtils.fromDateString("2026-08-07");
+        Date startTime = ConversionUtils.fromTimestampString("2026-08-07 09:00:00");
+        PatientAppointmentExportRow firstRow = row(
+                demographic("PrivateFirst", "PrivateLast", "555-0100", null),
+                appointment(appointmentDate, startTime, null, "PrivateLocation"),
+                provider("Doris", "Doctor"));
+        org.mockito.Mockito.doAnswer(invocation -> {
+            Consumer<PatientAppointmentExportRow> rowConsumer = invocation.getArgument(3);
+            rowConsumer.accept(firstRow);
+            throw new IllegalStateException("database detail must not be audited");
+        }).when(appointmentDao).streamPatientAppointments(any(), any(), any(), any());
+
+        MockHttpServletResponse response = export("all", "2026-08-07", "2026-08-10");
+
+        assertThat(response.getStatus()).isEqualTo(500);
+        assertThat(response.getHeader("Content-disposition")).isNull();
+        assertThat(response.getContentAsString()).isBlank();
+        assertThat(persistedAuditLog.getData())
+                .isEqualTo("dateFrom=2026-08-07; dateTo=2026-08-10; rows=1; "
+                        + "outcome=error; error=IllegalStateException")
+                .doesNotContain("database detail", "PrivateFirst", "PrivateLast");
     }
 
     @Test
@@ -484,12 +512,7 @@ class PatientListByApptExportUnitTest extends CarlosUnitTestBase {
 
         assertThat(response.getStatus()).isEqualTo(401);
         verifyNoInteractions(appointmentDao);
-        assertThat(persistedAuditLog.getAction()).isEqualTo(LogConst.EXPORT);
-        assertThat(persistedAuditLog.getContent()).isEqualTo("patient_list_by_appointment");
-        assertThat(persistedAuditLog.getData())
-                .isEqualTo("dateFrom=null; dateTo=null; rows=0; "
-                        + "outcome=rejected; error=Unauthenticated")
-                .doesNotContain("2026-08-07", "2026-08-10", "all");
+        assertThat(persistedAuditLog).isNull();
     }
 
     @Test
@@ -512,16 +535,22 @@ class PatientListByApptExportUnitTest extends CarlosUnitTestBase {
     @DisplayName("export should reject missing or invalid dates instead of running an unbounded query")
     void shouldReturnBadRequestAndSkipQuery_whenDatesAreMissingInvalidOrReversed() throws Exception {
         MockHttpServletResponse missing = export("all", null, "2026-08-10");
+        assertThat(persistedAuditLog.getContentId()).isEqualTo("all");
         assertThat(persistedAuditLog.getData())
-                .isEqualTo("dateFrom=null; dateTo=null; rows=0; "
+                .isEqualTo("dateFrom=null; dateTo=2026-08-10; rows=0; "
                         + "outcome=rejected; error=InvalidDate")
-                .doesNotContain("2026-08-10");
+                .doesNotContain("private invalid date");
         MockHttpServletResponse invalid = export("all", "private invalid date", "2026-08-10");
-        assertThat(persistedAuditLog.getData()).doesNotContain("private invalid date", "2026-08-10");
-        MockHttpServletResponse reversed = export("all", "2026-08-11", "2026-08-10");
+        assertThat(persistedAuditLog.getContentId()).isEqualTo("all");
         assertThat(persistedAuditLog.getData())
-                .endsWith("outcome=rejected; error=ReversedDateRange")
-                .doesNotContain("2026-08-11", "2026-08-10");
+                .isEqualTo("dateFrom=null; dateTo=2026-08-10; rows=0; "
+                        + "outcome=rejected; error=InvalidDate")
+                .doesNotContain("private invalid date");
+        MockHttpServletResponse reversed = export("all", "2026-08-11", "2026-08-10");
+        assertThat(persistedAuditLog.getContentId()).isEqualTo("all");
+        assertThat(persistedAuditLog.getData())
+                .isEqualTo("dateFrom=2026-08-11; dateTo=2026-08-10; rows=0; "
+                        + "outcome=rejected; error=ReversedDateRange");
 
         List<MockHttpServletResponse> responses = List.of(missing, invalid, reversed);
 

--- a/src/test/java/io/github/carlos_emr/carlos/report/data/PatientListByApptExportUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/data/PatientListByApptExportUnitTest.java
@@ -83,10 +83,12 @@ import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 class PatientListByApptExportUnitTest extends CarlosUnitTestBase {
 
     private static final Path STRUTS_XML =
-            Path.of("src/main/webapp/WEB-INF/classes/struts.xml");
-    private static final Path WEB_XML = Path.of("src/main/webapp/WEB-INF/web.xml");
+            resolveProjectPath(Path.of("src/main/webapp/WEB-INF/classes/struts.xml"));
+    private static final Path WEB_XML =
+            resolveProjectPath(Path.of("src/main/webapp/WEB-INF/web.xml"));
     private static final Path PATIENT_LIST_JSP =
-            Path.of("src/main/webapp/WEB-INF/jsp/oscarReport/patientlist.jsp");
+            resolveProjectPath(Path.of(
+                    "src/main/webapp/WEB-INF/jsp/oscarReport/patientlist.jsp"));
     private static final Pattern STRUTS_ACTION_EXCLUDE_PATTERN = Pattern.compile(
             "<constant name=\"struts\\.action\\.excludePattern\" value=\"([^\"]+)\"\\s*/>");
     private static final Pattern PATIENT_LIST_SERVLET = Pattern.compile(
@@ -105,6 +107,7 @@ class PatientListByApptExportUnitTest extends CarlosUnitTestBase {
 
     private PatientListByAppt servlet;
     private OscarLog persistedAuditLog;
+    private RuntimeException daoResolutionFailure;
 
     @BeforeEach
     void setUpServlet() {
@@ -114,6 +117,14 @@ class PatientListByApptExportUnitTest extends CarlosUnitTestBase {
                 loggedInInfo, "_report,_admin.reporting", "r", null))
                 .thenReturn(true);
         servlet = new PatientListByAppt() {
+            @Override
+            protected OscarAppointmentDao getAppointmentDao() {
+                if (daoResolutionFailure != null) {
+                    throw daoResolutionFailure;
+                }
+                return appointmentDao;
+            }
+
             @Override
             protected void persistExportAudit(OscarLog auditLog) {
                 persistedAuditLog = auditLog;
@@ -368,6 +379,20 @@ class PatientListByApptExportUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
+    @DisplayName("DAO resolution failures should still produce a PHI-free failure audit")
+    void shouldAuditFailureMetadata_whenDaoResolutionFails() throws Exception {
+        daoResolutionFailure = new IllegalStateException("bean detail must not be audited");
+
+        MockHttpServletResponse response = export("999998", "2026-08-07", "2026-08-10");
+
+        assertThat(response.getStatus()).isEqualTo(500);
+        assertThat(persistedAuditLog.getData())
+                .isEqualTo("dateFrom=2026-08-07; dateTo=2026-08-10; rows=0; "
+                        + "outcome=error; error=IllegalStateException")
+                .doesNotContain("bean detail");
+    }
+
+    @Test
     @DisplayName("export should reject an unauthenticated direct servlet request")
     void shouldReturnUnauthorizedAndSkipQuery_whenSessionIsMissing() throws Exception {
         MockHttpServletRequest request = exportRequest("all", "2026-08-07", "2026-08-10");
@@ -377,6 +402,12 @@ class PatientListByApptExportUnitTest extends CarlosUnitTestBase {
 
         assertThat(response.getStatus()).isEqualTo(401);
         verifyNoInteractions(appointmentDao);
+        assertThat(persistedAuditLog.getAction()).isEqualTo(LogConst.EXPORT);
+        assertThat(persistedAuditLog.getContent()).isEqualTo("patient_list_by_appointment");
+        assertThat(persistedAuditLog.getData())
+                .isEqualTo("dateFrom=null; dateTo=null; rows=0; "
+                        + "outcome=rejected; error=Unauthenticated")
+                .doesNotContain("2026-08-07", "2026-08-10", "all");
     }
 
     @Test
@@ -429,6 +460,20 @@ class PatientListByApptExportUnitTest extends CarlosUnitTestBase {
                         + "outcome=rejected; error=MissingProvider");
     }
 
+    @Test
+    @DisplayName("export should reject provider filters that are unsafe for query and audit use")
+    void shouldReturnBadRequestAndSafeAudit_whenProviderFilterIsInvalid() throws Exception {
+        MockHttpServletResponse response = export(
+                "9\r\nForged audit content", "2026-08-07", "2026-08-10");
+
+        assertThat(response.getStatus()).isEqualTo(400);
+        verifyNoInteractions(appointmentDao);
+        assertThat(persistedAuditLog.getContentId()).isNull();
+        assertThat(persistedAuditLog.getData())
+                .endsWith("outcome=rejected; error=InvalidProvider")
+                .doesNotContain("Forged", "2026-08-07", "2026-08-10");
+    }
+
     private MockHttpServletResponse export(String providerNo, String dateFrom, String dateTo)
             throws IOException {
         MockHttpServletRequest request = exportRequest(providerNo, dateFrom, dateTo);
@@ -461,6 +506,20 @@ class PatientListByApptExportUnitTest extends CarlosUnitTestBase {
             results.forEach(rowConsumer);
             return null;
         }).when(appointmentDao).streamPatientAppointments(any(), any(), any(), any());
+    }
+
+    private static Path resolveProjectPath(Path relativePath) {
+        Path current = Path.of(System.getProperty("basedir", System.getProperty("user.dir")))
+                .toAbsolutePath()
+                .normalize();
+        for (int checkedParents = 0; current != null && checkedParents < 6; checkedParents++) {
+            Path candidate = current.resolve(relativePath).normalize();
+            if (Files.isRegularFile(candidate)) {
+                return candidate;
+            }
+            current = current.getParent();
+        }
+        throw new IllegalStateException("Unable to locate " + relativePath);
     }
 
     private static PatientAppointmentExportRow row(

--- a/src/test/java/io/github/carlos_emr/carlos/report/data/PatientListByApptExportUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/data/PatientListByApptExportUnitTest.java
@@ -1,0 +1,289 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.report.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import io.github.carlos_emr.carlos.commn.dao.OscarAppointmentDao;
+import io.github.carlos_emr.carlos.commn.model.Appointment;
+import io.github.carlos_emr.carlos.commn.model.Demographic;
+import io.github.carlos_emr.carlos.commn.model.Provider;
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
+import io.github.carlos_emr.carlos.util.ConversionUtils;
+
+/**
+ * Regression tests for the "Patient List by Appointment Time" export
+ * (issue #3346).
+ *
+ * <p>Two independent defects are pinned here:</p>
+ * <ul>
+ *   <li>Routing — {@code /patientlistbyappt} is a plain servlet declared in
+ *       {@code web.xml}. Struts' global {@code struts.action.excludePattern}
+ *       has to let it through, otherwise the Struts filter claims the request
+ *       and answers 404 ("no Action mapped for namespace [/]").</li>
+ *   <li>Null appointment type — {@code appointment.appointment_type} is
+ *       optional, so the export must not dereference it.</li>
+ * </ul>
+ *
+ * @since 2026-08-06
+ */
+@DisplayName("Patient List by Appointment Time export")
+@Tag("unit")
+@Tag("report")
+class PatientListByApptExportUnitTest extends CarlosUnitTestBase {
+
+    private static final Path STRUTS_XML =
+            Path.of("src/main/webapp/WEB-INF/classes/struts.xml");
+    private static final Path WEB_XML = Path.of("src/main/webapp/WEB-INF/web.xml");
+    private static final Pattern STRUTS_ACTION_EXCLUDE_PATTERN = Pattern.compile(
+            "<constant name=\"struts\\.action\\.excludePattern\" value=\"([^\"]+)\"\\s*/>");
+    private static final Pattern PATIENT_LIST_SERVLET = Pattern.compile(
+            "<servlet>\\s*<servlet-name>PatientListByAppt</servlet-name>\\s*"
+                    + "<servlet-class>io\\.github\\.carlos_emr\\.carlos\\.report\\.data\\."
+                    + "PatientListByAppt</servlet-class>\\s*</servlet>",
+            Pattern.DOTALL);
+    private static final Pattern PATIENT_LIST_SERVLET_MAPPING = Pattern.compile(
+            "<servlet-mapping>\\s*<servlet-name>PatientListByAppt</servlet-name>\\s*"
+                    + "<url-pattern>/patientlistbyappt</url-pattern>\\s*</servlet-mapping>",
+            Pattern.DOTALL);
+
+    private final OscarAppointmentDao appointmentDao = mock(OscarAppointmentDao.class);
+
+    private PatientListByAppt servlet;
+
+    @BeforeEach
+    void setUpServlet() {
+        registerMock(OscarAppointmentDao.class, appointmentDao);
+        servlet = new PatientListByAppt();
+    }
+
+    @Test
+    @DisplayName("struts global config should let the patient list servlet route reach its web.xml mapping")
+    void shouldExcludePatientListByApptRoute_whenReadingStrutsGlobalConfig() throws IOException {
+        String globalStruts = Files.readString(STRUTS_XML, StandardCharsets.UTF_8);
+        Matcher matcher = STRUTS_ACTION_EXCLUDE_PATTERN.matcher(globalStruts);
+
+        assertThat(matcher.find()).isTrue();
+
+        Pattern excludePattern = Pattern.compile(matcher.group(1));
+        assertThat(excludePattern.matcher("/patientlistbyappt").matches()).isTrue();
+        assertThat(excludePattern.matcher("/carlos/patientlistbyappt").matches()).isTrue();
+        // The exclusion must stay anchored to this exact route, not swallow
+        // sibling Struts actions that merely share the prefix.
+        assertThat(excludePattern.matcher("/patientlistbyapptExtra").matches()).isFalse();
+    }
+
+    @Test
+    @DisplayName("web.xml should map the patient list route to the export servlet")
+    void shouldMapPatientListRouteToExportServlet_whenReadingWebXml() throws IOException {
+        String webXml = Files.readString(WEB_XML, StandardCharsets.UTF_8);
+
+        assertThat(PATIENT_LIST_SERVLET.matcher(webXml).find()).isTrue();
+        assertThat(PATIENT_LIST_SERVLET_MAPPING.matcher(webXml).find()).isTrue();
+    }
+
+    @Test
+    @DisplayName("export should emit an empty type field when the appointment has no type")
+    void shouldEmitEmptyTypeField_whenAppointmentTypeIsNull() throws Exception {
+        Date appointmentDate = ConversionUtils.fromDateString("2026-08-07");
+        Date startTime = ConversionUtils.fromTimestampString("2026-08-07 09:00:00");
+        stubAppointments(row(
+                demographic("Aaron", "Bell", "555-0100", "555-0101"),
+                appointment(appointmentDate, startTime, null, "Main Office"),
+                provider("Doris", "Doctor")));
+
+        MockHttpServletResponse response = export("all", "2026-08-07", "2026-08-10");
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeader("Content-disposition"))
+                .isEqualTo("attachment; filename=patientlist.txt");
+        assertThat(response.getContentAsString().lines().findFirst()).hasValue(
+                "Bell,Aaron,555-0100,555-0101,09:00:00,2026-08-07,,Doris Doctor,Main Office");
+    }
+
+    @Test
+    @DisplayName("export should keep the documented column order for a populated appointment type")
+    void shouldKeepDocumentedColumnOrder_whenAppointmentTypeIsPresent() throws Exception {
+        Date appointmentDate = ConversionUtils.fromDateString("2026-08-08");
+        Date startTime = ConversionUtils.fromTimestampString("2026-08-08 10:00:00");
+        stubAppointments(row(
+                demographic("Cara", "Dunn", "555-0200", null),
+                appointment(appointmentDate, startTime, "Follow Up", "Annex"),
+                provider("Ravi", "Singh")));
+
+        MockHttpServletResponse response = export("999998", "2026-08-07", "2026-08-10");
+
+        assertThat(response.getContentAsString().lines().findFirst()).hasValue(
+                "Dunn,Cara,555-0200,,10:00:00,2026-08-08,Follow Up,Ravi Singh,Annex");
+        org.mockito.Mockito.verify(appointmentDao).findPatientAppointments(
+                eq("999998"),
+                eq(ConversionUtils.fromDateString("2026-08-07")),
+                eq(ConversionUtils.fromDateString("2026-08-10")));
+    }
+
+    @Test
+    @DisplayName("export should preserve CSV escaping and spreadsheet formula protection")
+    void shouldEscapeCsvAndProtectSpreadsheetFormulas_whenFieldsNeedEscaping() throws Exception {
+        Date appointmentDate = ConversionUtils.fromDateString("2026-08-09");
+        Date startTime = ConversionUtils.fromTimestampString("2026-08-09 10:30:00");
+        stubAppointments(row(
+                demographic("Comma, \"Cara\"", "=Dunn", "+15550200", null),
+                appointment(appointmentDate, startTime, "Follow, Up", "@Main"),
+                provider("Ravi", "Singh")));
+
+        MockHttpServletResponse response = export("999998", "2026-08-07", "2026-08-10");
+
+        assertThat(response.getContentAsString().lines().findFirst()).hasValue(
+                "'=Dunn,\"Comma, \"\"Cara\"\"\",'+15550200,,10:30:00,2026-08-09,"
+                        + "\"Follow, Up\",Ravi Singh,'@Main");
+    }
+
+    @Test
+    @DisplayName("export should emit empty fields for null optional phone, type, and location values")
+    void shouldEmitEmptyFields_whenOptionalValuesAreNull() throws Exception {
+        Date appointmentDate = ConversionUtils.fromDateString("2026-08-09");
+        Date startTime = ConversionUtils.fromTimestampString("2026-08-09 14:00:00");
+        stubAppointments(row(
+                demographic("Aaron", "Bell", null, null),
+                appointment(appointmentDate, startTime, null, null),
+                provider("Doris", "Doctor")));
+
+        MockHttpServletResponse response = export("all", "2026-08-07", "2026-08-10");
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getContentAsString().lines().findFirst()).hasValue(
+                "Bell,Aaron,,,14:00:00,2026-08-09,,Doris Doctor,");
+        assertThat(response.getContentAsString()).doesNotContain("null");
+    }
+
+    @Test
+    @DisplayName("export should keep one row per appointment when the type contains line breaks")
+    void shouldKeepOneRowPerAppointment_whenTypeContainsLineBreaks() throws Exception {
+        Date appointmentDate = ConversionUtils.fromDateString("2026-08-10");
+        Date startTime = ConversionUtils.fromTimestampString("2026-08-10 11:00:00");
+        // A lone LF (not a CRLF pair) is what free-text appointment types actually
+        // carry; the legacy replaceAll("\r\n", "") left it in place, and escapeCsv
+        // then quoted the field, splitting one appointment across two output lines.
+        stubAppointments(row(
+                demographic("Erin", "Fox", "555-0300", "555-0301"),
+                appointment(appointmentDate, startTime, "Lab\nreview\r\nvisit", "Annex"),
+                provider("Ravi", "Singh")));
+
+        MockHttpServletResponse response = export("999998", "2026-08-07", "2026-08-10");
+
+        assertThat(response.getContentAsString().lines().findFirst()).hasValue(
+                "Fox,Erin,555-0300,555-0301,11:00:00,2026-08-10,Labreviewvisit,Ravi Singh,Annex");
+    }
+
+    @Test
+    @DisplayName("export should return an empty attachment when the date range matches no appointments")
+    void shouldReturnEmptyAttachment_whenNoAppointmentsMatch() throws Exception {
+        stubAppointments();
+
+        MockHttpServletResponse response = export("all", "2026-09-01", "2026-09-02");
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeader("Content-disposition"))
+                .isEqualTo("attachment; filename=patientlist.txt");
+        assertThat(response.getContentAsString()).isBlank();
+    }
+
+    @Test
+    @DisplayName("export should drop the provider filter when All Doctors is selected")
+    void shouldDropProviderFilter_whenAllDoctorsSelected() throws Exception {
+        stubAppointments();
+
+        export("all", "2026-08-07", "2026-08-10");
+
+        org.mockito.Mockito.verify(appointmentDao).findPatientAppointments(
+                eq(null),
+                eq(ConversionUtils.fromDateString("2026-08-07")),
+                eq(ConversionUtils.fromDateString("2026-08-10")));
+    }
+
+    private MockHttpServletResponse export(String providerNo, String dateFrom, String dateTo)
+            throws IOException {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/patientlistbyappt");
+        request.setParameter("provider_no", providerNo);
+        request.setParameter("date_from", dateFrom);
+        request.setParameter("date_to", dateTo);
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        servlet.processRequest(request, response);
+        return response;
+    }
+
+    private void stubAppointments(Object[]... rows) {
+        List<Object[]> results = new ArrayList<>(List.of(rows));
+        when(appointmentDao.findPatientAppointments(any(), any(), any())).thenReturn(results);
+    }
+
+    private static Object[] row(Demographic demographic, Appointment appointment, Provider provider) {
+        return new Object[] { demographic, appointment, provider };
+    }
+
+    private static Demographic demographic(String firstName, String lastName, String phone, String phone2) {
+        Demographic demographic = new Demographic();
+        demographic.setFirstName(firstName);
+        demographic.setLastName(lastName);
+        demographic.setPhone(phone);
+        demographic.setPhone2(phone2);
+        return demographic;
+    }
+
+    private static Appointment appointment(Date appointmentDate, Date startTime, String type, String location) {
+        Appointment appointment = new Appointment();
+        appointment.setAppointmentDate(appointmentDate);
+        appointment.setStartTime(startTime);
+        appointment.setType(type);
+        appointment.setLocation(location);
+        return appointment;
+    }
+
+    private static Provider provider(String firstName, String lastName) {
+        Provider provider = new Provider();
+        provider.setFirstName(firstName);
+        provider.setLastName(lastName);
+        return provider;
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/report/data/PatientListByApptExportUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/data/PatientListByApptExportUnitTest.java
@@ -241,9 +241,10 @@ class PatientListByApptExportUnitTest extends CarlosUnitTestBase {
 
         MockHttpServletResponse response = export("999998", "2026-08-07", "2026-08-10");
 
-        assertThat(response.getContentAsString()).isEqualTo(
-                "'\uFF1D1+1,\"'\n=1+1\",'\0=1+1,,10:30:00,2026-08-09,"
-                        + "'\uFF0D1+1,'\uFF0B1+1 Doctor,'\uFF201+1\n");
+        assertThat(response.getContentAsString()).isEqualTo("""
+                '\uFF1D1+1,"'
+                =1+1",'\0=1+1,,10:30:00,2026-08-09,'\uFF0D1+1,'\uFF0B1+1 Doctor,'\uFF201+1
+                """);
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/report/data/PatientListByApptExportUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/report/data/PatientListByApptExportUnitTest.java
@@ -25,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
@@ -48,8 +49,10 @@ import io.github.carlos_emr.carlos.commn.dao.OscarAppointmentDao;
 import io.github.carlos_emr.carlos.commn.model.Appointment;
 import io.github.carlos_emr.carlos.commn.model.Demographic;
 import io.github.carlos_emr.carlos.commn.model.Provider;
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
 import io.github.carlos_emr.carlos.util.ConversionUtils;
+import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 
 /**
  * Regression tests for the "Patient List by Appointment Time" export
@@ -63,6 +66,9 @@ import io.github.carlos_emr.carlos.util.ConversionUtils;
  *       and answers 404 ("no Action mapped for namespace [/]").</li>
  *   <li>Null appointment type — {@code appointment.appointment_type} is
  *       optional, so the export must not dereference it.</li>
+ *   <li>Authorization — the servlet is directly addressable and must enforce
+ *       the same {@code _report} or {@code _admin.reporting} read policy as
+ *       the report form.</li>
  * </ul>
  *
  * @since 2026-08-06
@@ -75,6 +81,8 @@ class PatientListByApptExportUnitTest extends CarlosUnitTestBase {
     private static final Path STRUTS_XML =
             Path.of("src/main/webapp/WEB-INF/classes/struts.xml");
     private static final Path WEB_XML = Path.of("src/main/webapp/WEB-INF/web.xml");
+    private static final Path PATIENT_LIST_JSP =
+            Path.of("src/main/webapp/WEB-INF/jsp/oscarReport/patientlist.jsp");
     private static final Pattern STRUTS_ACTION_EXCLUDE_PATTERN = Pattern.compile(
             "<constant name=\"struts\\.action\\.excludePattern\" value=\"([^\"]+)\"\\s*/>");
     private static final Pattern PATIENT_LIST_SERVLET = Pattern.compile(
@@ -88,12 +96,18 @@ class PatientListByApptExportUnitTest extends CarlosUnitTestBase {
             Pattern.DOTALL);
 
     private final OscarAppointmentDao appointmentDao = mock(OscarAppointmentDao.class);
+    private final SecurityInfoManager securityInfoManager = mock(SecurityInfoManager.class);
+    private final LoggedInInfo loggedInInfo = mock(LoggedInInfo.class);
 
     private PatientListByAppt servlet;
 
     @BeforeEach
     void setUpServlet() {
         registerMock(OscarAppointmentDao.class, appointmentDao);
+        registerMock(SecurityInfoManager.class, securityInfoManager);
+        when(securityInfoManager.hasPrivilege(
+                loggedInInfo, "_report,_admin.reporting", "r", null))
+                .thenReturn(true);
         servlet = new PatientListByAppt();
     }
 
@@ -120,6 +134,16 @@ class PatientListByApptExportUnitTest extends CarlosUnitTestBase {
 
         assertThat(PATIENT_LIST_SERVLET.matcher(webXml).find()).isTrue();
         assertThat(PATIENT_LIST_SERVLET_MAPPING.matcher(webXml).find()).isTrue();
+    }
+
+    @Test
+    @DisplayName("visible export form should use POST so CSRF tokens do not enter the URL")
+    void shouldSubmitVisibleFormWithPost_whenReadingPatientListJsp() throws IOException {
+        String patientListJsp = Files.readString(PATIENT_LIST_JSP, StandardCharsets.UTF_8);
+
+        assertThat(patientListJsp).contains(
+                "<form id=\"plForm\" method=\"post\" "
+                        + "action=\"<%=request.getContextPath() %>/patientlistbyappt\"");
     }
 
     @Test
@@ -241,16 +265,76 @@ class PatientListByApptExportUnitTest extends CarlosUnitTestBase {
                 eq(ConversionUtils.fromDateString("2026-08-10")));
     }
 
+    @Test
+    @DisplayName("export should reject an unauthenticated direct servlet request")
+    void shouldReturnUnauthorizedAndSkipQuery_whenSessionIsMissing() throws Exception {
+        MockHttpServletRequest request = exportRequest("all", "2026-08-07", "2026-08-10");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        servlet.processRequest(request, response);
+
+        assertThat(response.getStatus()).isEqualTo(401);
+        verifyNoInteractions(appointmentDao);
+    }
+
+    @Test
+    @DisplayName("export should require report read privilege at the servlet boundary")
+    void shouldReturnForbiddenAndSkipQuery_whenReportPrivilegeIsDenied() throws Exception {
+        when(securityInfoManager.hasPrivilege(
+                loggedInInfo, "_report,_admin.reporting", "r", null))
+                .thenReturn(false);
+
+        MockHttpServletResponse response = export("all", "2026-08-07", "2026-08-10");
+
+        assertThat(response.getStatus()).isEqualTo(403);
+        verifyNoInteractions(appointmentDao);
+    }
+
+    @Test
+    @DisplayName("export should reject missing or invalid dates instead of running an unbounded query")
+    void shouldReturnBadRequestAndSkipQuery_whenDatesAreMissingInvalidOrReversed() throws Exception {
+        List<MockHttpServletResponse> responses = List.of(
+                export("all", null, "2026-08-10"),
+                export("all", "2026-02-30", "2026-08-10"),
+                export("all", "2026-08-11", "2026-08-10"));
+
+        assertThat(responses).allSatisfy(response ->
+                assertThat(response.getStatus()).isEqualTo(400));
+        verifyNoInteractions(appointmentDao);
+    }
+
+    @Test
+    @DisplayName("export should reject a missing provider instead of widening to all doctors")
+    void shouldReturnBadRequestAndSkipQuery_whenProviderIsMissing() throws Exception {
+        MockHttpServletResponse response = export(null, "2026-08-07", "2026-08-10");
+
+        assertThat(response.getStatus()).isEqualTo(400);
+        verifyNoInteractions(appointmentDao);
+    }
+
     private MockHttpServletResponse export(String providerNo, String dateFrom, String dateTo)
             throws IOException {
-        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/patientlistbyappt");
-        request.setParameter("provider_no", providerNo);
-        request.setParameter("date_from", dateFrom);
-        request.setParameter("date_to", dateTo);
+        MockHttpServletRequest request = exportRequest(providerNo, dateFrom, dateTo);
+        LoggedInInfo.setLoggedInInfoIntoSession(request.getSession(), loggedInInfo);
 
         MockHttpServletResponse response = new MockHttpServletResponse();
         servlet.processRequest(request, response);
         return response;
+    }
+
+    private static MockHttpServletRequest exportRequest(
+            String providerNo, String dateFrom, String dateTo) {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/patientlistbyappt");
+        if (providerNo != null) {
+            request.setParameter("provider_no", providerNo);
+        }
+        if (dateFrom != null) {
+            request.setParameter("date_from", dateFrom);
+        }
+        if (dateTo != null) {
+            request.setParameter("date_to", dateTo);
+        }
+        return request;
     }
 
     private void stubAppointments(Object[]... rows) {


### PR DESCRIPTION
## Description

- excludes the extensionless `/patientlistbyappt` servlet route from the Struts dispatcher so the existing authenticated `web.xml` mapping receives export requests
- enforces `_report` or `_admin.reporting` read privilege at the direct servlet boundary before querying PHI
- strictly requires provider and `YYYY-MM-DD` date filters, rejects reversed ranges, and prevents invalid input from widening into an unbounded export
- submits the visible form with POST so `CSRF-TOKEN` remains out of URLs, logs, and browser history
- restores dependency-free browser validation for required, malformed, impossible, and reversed dates
- HTML-encodes provider IDs and names in the visible selector to prevent stored markup injection
- exports null appointment types as empty fields, removes embedded CR/LF characters safely, and protects CSV consumers from formula injection
- streams a narrow scalar projection through a forward-only database cursor so large date ranges do not materialize full entities or the complete result set in memory
- writes synchronous, PHI-free audit records for successful and failed export attempts with provider filter, date range, row count, outcome, and exception type
- restricts the Playwright harness's default credentials and relaxed TLS handling to loopback targets; intentional non-loopback runs require HTTPS, explicit credentials, and opt-in
- adds focused servlet/config regression coverage, a DAO cursor integration test, and a Playwright check that validates client-side dates, POST downloads, provider filtering, empty results, null fields, browser errors, and anonymous rejection

## Related Issues

Fixes #3346

## How Was This Tested?

- `mvn -Dtest='PatientListByApptExportUnitTest,OscarAppointmentDaoQueryIntegrationTest$FindPatientAppointments#shouldStreamProjection_whenAppointmentsExist' test` — 18 tests passed (17 servlet/config unit tests and 1 Hibernate cursor integration test)
- `mvn pmd:pmd -DskipTests` — completed successfully with no findings in changed code
- focused SpotBugs + FindSecBugs analysis of `PatientListByAppt`, `OscarAppointmentDaoImpl`, and `PatientAppointmentExportRow` — no findings in changed code (four pre-existing findings remain in unrelated DAO methods)
- `mvn -DskipTests package war:exploded` — build and Checkstyle passed
- `mvn -Pjspc jspc:compile@jspc` — all 973 JSPs compiled with 0 errors
- `node --check scripts/patient-list-by-appointment-export-playwright-checks.js`
- harness boundary checks confirmed RFC1918/non-loopback targets are rejected without explicit opt-in, HTTPS, and credentials
- live Playwright run against local CARLOS/Tomcat with MySQL — all-doctors (3 rows), provider 9 (1), provider 999998 (2), empty range (0), null appointment type, POST/download envelope, unauthenticated 401, blank/malformed/impossible/reversed client dates, and browser/server error checks passed with no findings
- live database verification confirmed four matching `export` audit records with correct filters and row counts and no patient data
- `git diff --check`

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality
- [x] I have read the [contributing guide](CONTRIBUTING.md)
