### PR TITLE
Fix Disease Registry status filters returning error page

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/DxresearchDAOImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/DxresearchDAOImpl.java
@@ -196,19 +196,47 @@ public class DxresearchDAOImpl extends AbstractDaoImpl<Dxresearch> implements Dx
         }
     }
 
+    /**
+     * Returns registry records whose status is active ({@code 'A'}).
+     *
+     * @param searchItems optional diagnosis-code filters
+     * @param doctorList provider numbers used to limit patients; {@code "*"} includes all providers
+     * @return matching registry patient information, or {@code null} when no records match
+     */
     public List<DxRegistedPTInfo> patientRegistedActive(List<dxCodeSearchBean> searchItems, List<String> doctorList) {
         return patientRegistedStatus('A', searchItems, doctorList);
     }
 
+    /**
+     * Returns registry records whose status is resolved ({@code 'C'}).
+     *
+     * @param searchItems optional diagnosis-code filters
+     * @param doctorList provider numbers used to limit patients; {@code "*"} includes all providers
+     * @return matching registry patient information, or {@code null} when no records match
+     */
     public List<DxRegistedPTInfo> patientRegistedResolve(List<dxCodeSearchBean> searchItems, List<String> doctorList) {
         return patientRegistedStatus('C', searchItems, doctorList);
     }
 
+    /**
+     * Returns registry records whose status is deleted ({@code 'D'}).
+     *
+     * @param searchItems optional diagnosis-code filters
+     * @param doctorList provider numbers used to limit patients; {@code "*"} includes all providers
+     * @return matching registry patient information, or {@code null} when no records match
+     */
     public List<DxRegistedPTInfo> patientRegistedDeleted(List<dxCodeSearchBean> searchItems, List<String> doctorList) {
         return patientRegistedStatus('D', searchItems, doctorList);
     }
 
-
+    /**
+     * Returns registry records matching one entity-level status code.
+     *
+     * @param status registry status stored by {@link Dxresearch}, normally {@code 'A'}, {@code 'C'}, or {@code 'D'}
+     * @param searchItems optional diagnosis-code filters
+     * @param doctorList provider numbers used to limit patients; {@code "*"} includes all providers
+     * @return matching registry patient information, or {@code null} when no records match
+     */
     public List<DxRegistedPTInfo> patientRegistedStatus(Character status, List<dxCodeSearchBean> searchItems, List<String> doctorList) {
         List<Dxresearch> dList = null;
 

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/DxresearchDAOImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/DxresearchDAOImpl.java
@@ -197,19 +197,19 @@ public class DxresearchDAOImpl extends AbstractDaoImpl<Dxresearch> implements Dx
     }
 
     public List<DxRegistedPTInfo> patientRegistedActive(List<dxCodeSearchBean> searchItems, List<String> doctorList) {
-        return patientRegistedStatus("A", searchItems, doctorList);
+        return patientRegistedStatus('A', searchItems, doctorList);
     }
 
     public List<DxRegistedPTInfo> patientRegistedResolve(List<dxCodeSearchBean> searchItems, List<String> doctorList) {
-        return patientRegistedStatus("C", searchItems, doctorList);
+        return patientRegistedStatus('C', searchItems, doctorList);
     }
 
     public List<DxRegistedPTInfo> patientRegistedDeleted(List<dxCodeSearchBean> searchItems, List<String> doctorList) {
-        return patientRegistedStatus("D", searchItems, doctorList);
+        return patientRegistedStatus('D', searchItems, doctorList);
     }
 
 
-    public List<DxRegistedPTInfo> patientRegistedStatus(String status, List<dxCodeSearchBean> searchItems, List<String> doctorList) {
+    public List<DxRegistedPTInfo> patientRegistedStatus(Character status, List<dxCodeSearchBean> searchItems, List<String> doctorList) {
         List<Dxresearch> dList = null;
 
         List<dxCodeSearchBean> listItems = searchItems;

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/DxresearchDAOImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/DxresearchDAOImpl.java
@@ -237,7 +237,7 @@ public class DxresearchDAOImpl extends AbstractDaoImpl<Dxresearch> implements Dx
      * @param doctorList provider numbers used to limit patients; {@code "*"} includes all providers
      * @return matching registry patient information, or {@code null} when no records match
      */
-    public List<DxRegistedPTInfo> patientRegistedStatus(Character status, List<dxCodeSearchBean> searchItems, List<String> doctorList) {
+    private List<DxRegistedPTInfo> patientRegistedStatus(Character status, List<dxCodeSearchBean> searchItems, List<String> doctorList) {
         List<Dxresearch> dList = null;
 
         List<dxCodeSearchBean> listItems = searchItems;

--- a/src/main/java/io/github/carlos_emr/carlos/commn/web/DxresearchReport2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/web/DxresearchReport2Action.java
@@ -260,7 +260,7 @@ public class DxresearchReport2Action extends ActionSupport {
 
         osc.fillDocumentStream(reportParams, outputStream, OscarDocumentCreator.EXCEL, reportInstream, patients);
 
-        return null;
+        return NONE;
     }
 
     public String patientRegistedDistincted() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/web/DxresearchReport2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/web/DxresearchReport2Action.java
@@ -255,8 +255,8 @@ public class DxresearchReport2Action extends ActionSupport {
 
         InputStream reportInstream = this.getClass().getClassLoader().getResourceAsStream(REPORTS_PATH);
 
-        response.setContentType("application/excel");
-        response.setHeader("Content-disposition", "inline; filename=dxResearchReport.xls");
+        response.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+        response.setHeader("Content-disposition", "attachment; filename=dxResearchReport.xlsx");
 
         osc.fillDocumentStream(reportParams, outputStream, OscarDocumentCreator.EXCEL, reportInstream, patients);
 

--- a/src/main/resources/org/oscarehr/common/web/DxResearchReport.jrxml
+++ b/src/main/resources/org/oscarehr/common/web/DxResearchReport.jrxml
@@ -1,43 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jasperReport name="DxResearchReport" columnCount="1" printOrder="Vertical" orientation="Portrait" pageWidth="595" pageHeight="842" columnWidth="535" columnSpacing="0" leftMargin="0" rightMargin="0" topMargin="20" bottomMargin="20" whenNoDataType="NoPages" isTitleNewPage="false" isSummaryNewPage="false">
+<jasperReport name="DxResearchReport" columnCount="1" printOrder="Vertical" orientation="Portrait" pageWidth="595" pageHeight="842" columnWidth="535" columnSpacing="0" leftMargin="0" rightMargin="0" topMargin="20" bottomMargin="20" whenNoDataType="NoPages">
 	<property name="ireport.scriptlethandling" value="0" />
 	<property name="ireport.encoding" value="UTF-8" />
 	<import value="java.util.*" />
 	<import value="net.sf.jasperreports.engine.*" />
 	<import value="net.sf.jasperreports.engine.data.*" />
-	<field name="strFirstName" class="java.lang.String">
-		<fieldDescription><![CDATA[strFirstName]]></fieldDescription>
-	</field>
-	<field name="strLastName" class="java.lang.String">
-		<fieldDescription><![CDATA[strLastName]]></fieldDescription>
-	</field>
-	<field name="strHIN" class="java.lang.String">
-		<fieldDescription><![CDATA[strHIN]]></fieldDescription>
-	</field>
-	<field name="strDOB" class="java.lang.String">
-		<fieldDescription><![CDATA[strDOB]]></fieldDescription>
-	</field>
-	<field name="strCodeSys" class="java.lang.String">
-		<fieldDescription><![CDATA[strCodeSys]]></fieldDescription>
-	</field>
-	<field name="strCode" class="java.lang.String">
-		<fieldDescription><![CDATA[strCode]]></fieldDescription>
-	</field>
-	<field name="strSex" class="java.lang.String">
-		<fieldDescription><![CDATA[strSex]]></fieldDescription>
-	</field>
-	<field name="strStartDate" class="java.lang.String">
-		<fieldDescription><![CDATA[strStartDate]]></fieldDescription>
-	</field>
-	<field name="strStatus" class="java.lang.String">
-		<fieldDescription><![CDATA[strStatus]]></fieldDescription>
-	</field>
-	<field name="strUpdateDate" class="java.lang.String">
-		<fieldDescription><![CDATA[strUpdateDate]]></fieldDescription>
-	</field>
-	<field name="strPhone" class="java.lang.String">
-		<fieldDescription><![CDATA[strPhone]]></fieldDescription>
-	</field>
+	<field name="strFirstName" class="java.lang.String" />
+	<field name="strLastName" class="java.lang.String" />
+	<field name="strHIN" class="java.lang.String" />
+	<field name="strDOB" class="java.lang.String" />
+	<field name="strCodeSys" class="java.lang.String" />
+	<field name="strCode" class="java.lang.String" />
+	<field name="strSex" class="java.lang.String" />
+	<field name="strStartDate" class="java.lang.String" />
+	<field name="strStatus" class="java.lang.String" />
+	<field name="strUpdateDate" class="java.lang.String" />
+	<field name="strPhone" class="java.lang.String" />
 	<background height="0">
 			</background>
 	<title height="25">

--- a/src/test/java/io/github/carlos_emr/carlos/commn/dao/DxresearchDAOImplUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/commn/dao/DxresearchDAOImplUnitTest.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.commn.dao;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@DisplayName("DxresearchDAOImpl Unit Tests")
+@Tag("unit")
+@Tag("dao")
+class DxresearchDAOImplUnitTest {
+
+    private DxresearchDAOImpl dao;
+    private Query query;
+
+    @BeforeEach
+    void setUp() {
+        dao = new DxresearchDAOImpl();
+        dao.entityManager = mock(EntityManager.class);
+        query = mock(Query.class);
+
+        when(dao.entityManager.createQuery(anyString())).thenReturn(query);
+        when(query.setParameter(anyString(), any())).thenReturn(query);
+        when(query.getResultList()).thenReturn(List.of());
+    }
+
+    @ParameterizedTest(name = "{0} report binds status {1} as a Character")
+    @CsvSource({
+        "active,A",
+        "resolved,C",
+        "deleted,D"
+    })
+    @DisplayName("should bind Disease Registry report statuses using the entity attribute type")
+    void shouldBindStatusAsCharacter(String report, char expectedStatus) {
+        switch (report) {
+            case "active" -> dao.patientRegistedActive(null, List.of("*"));
+            case "resolved" -> dao.patientRegistedResolve(null, List.of("*"));
+            case "deleted" -> dao.patientRegistedDeleted(null, List.of("*"));
+            default -> throw new IllegalArgumentException("Unknown report: " + report);
+        }
+
+        ArgumentCaptor<Object> statusCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(query).setParameter(eq("status"), statusCaptor.capture());
+        assertThat(statusCaptor.getValue())
+            .isInstanceOf(Character.class)
+            .isEqualTo(expectedStatus);
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/commn/dao/DxresearchDAOImplUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/commn/dao/DxresearchDAOImplUnitTest.java
@@ -21,6 +21,7 @@
  */
 package io.github.carlos_emr.carlos.commn.dao;
 
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
 import org.junit.jupiter.api.BeforeEach;
@@ -43,7 +44,7 @@ import static org.mockito.Mockito.when;
 @DisplayName("DxresearchDAOImpl Unit Tests")
 @Tag("unit")
 @Tag("dao")
-class DxresearchDAOImplUnitTest {
+class DxresearchDAOImplUnitTest extends CarlosUnitTestBase {
 
     private DxresearchDAOImpl dao;
     private Query query;
@@ -66,7 +67,7 @@ class DxresearchDAOImplUnitTest {
         "deleted,D"
     })
     @DisplayName("should bind Disease Registry report statuses using the entity attribute type")
-    void shouldBindStatusAsCharacter(String report, char expectedStatus) {
+    void shouldBindStatus_whenStatusSpecificReportIsRequested(String report, char expectedStatus) {
         switch (report) {
             case "active" -> dao.patientRegistedActive(null, List.of("*"));
             case "resolved" -> dao.patientRegistedResolve(null, List.of("*"));

--- a/src/test/java/io/github/carlos_emr/carlos/commn/web/DxresearchReport2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/commn/web/DxresearchReport2ActionTest.java
@@ -228,10 +228,10 @@ class DxresearchReport2ActionTest extends CarlosWebTestBase {
                     "icd9", "250", "2026-01-01", "2026-08-06", "A"))));
             setSessionAttribute("radiovaluestatus", "patientRegistedAll");
 
-            // patientExcelReport returns null (writes directly to output stream)
+            // patientExcelReport returns NONE after writing directly to the output stream
             String result = executeAction(action);
 
-            assertThat(result).isNull();
+            assertThat(result).isEqualTo(ActionSupport.NONE);
             assertThat(getMockResponse().getContentType())
                     .isEqualTo("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
             assertThat(getMockResponse().getHeader("Content-disposition"))

--- a/src/test/java/io/github/carlos_emr/carlos/commn/web/DxresearchReport2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/commn/web/DxresearchReport2ActionTest.java
@@ -23,6 +23,7 @@ package io.github.carlos_emr.carlos.commn.web;
 
 import io.github.carlos_emr.carlos.commn.dao.DxresearchDAO;
 import io.github.carlos_emr.carlos.commn.dao.MyGroupDao;
+import io.github.carlos_emr.carlos.commn.model.DxRegistedPTInfo;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.test.base.CarlosWebTestBase;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
@@ -222,13 +223,21 @@ class DxresearchReport2ActionTest extends CarlosWebTestBase {
         void shouldAccept_whenProviderNoIsValid() throws Exception {
             addRequestParameter("method", "patientExcelReport");
             addRequestParameter("provider_no", "doc1");
-            setSessionAttribute("listview", new ArrayList<>());
+            setSessionAttribute("listview", new ArrayList<>(List.of(new DxRegistedPTInfo(
+                    "Test", "Patient", "X", "2000-01-01", "555-0100", "TEST-HIN",
+                    "icd9", "250", "2026-01-01", "2026-08-06", "A"))));
             setSessionAttribute("radiovaluestatus", "patientRegistedAll");
 
             // patientExcelReport returns null (writes directly to output stream)
             String result = executeAction(action);
 
             assertThat(result).isNull();
+            assertThat(getMockResponse().getContentType())
+                    .isEqualTo("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+            assertThat(getMockResponse().getHeader("Content-disposition"))
+                    .isEqualTo("attachment; filename=dxResearchReport.xlsx");
+            assertThat(getMockResponse().getContentAsByteArray())
+                    .startsWith((byte) 0x50, (byte) 0x4B, (byte) 0x03, (byte) 0x04);
         }
     }
 


### PR DESCRIPTION
Closes #3350

## Summary

- bind Disease Registry status query parameters as `Character`, matching the `Dxresearch.status` entity attribute
- cover Active, Resolved, and Deleted status bindings with a parameterized regression test
- migrate the Disease Registry Jasper template to the JasperReports 7 JRXML format
- return the generated spreadsheet with the correct XLSX media type and filename

## Root cause

Hibernate 7 rejected the status parameter because the DAO supplied `String` values (`"A"`, `"C"`, and `"D"`) for a `Character`-mapped entity attribute. Live testing also found that the legacy report template used attributes and field descriptions no longer accepted by JasperReports 7, causing spreadsheet downloads to render the generic error page.

## Testing

- `MAVEN_OPTS="-Xms256m -Xmx2g" mvn -B -Dcheckstyle.skip=true -Dtest=DxresearchReport2ActionTest,DxresearchDAOImplUnitTest test` — 25 tests passed
- `MAVEN_OPTS="-Xms256m -Xmx2g" mvn -B -Dtest='DxresearchReport2ActionTest$PatientExcelReportValidation#shouldAccept_whenProviderNoIsValid' test` — checkstyle and XLSX regression passed
- authenticated live verification against seeded Disease Registry data:
  - All / All (distinct): 12 rows (`A=6`, `C=4`, `D=2`)
  - Active: 6 active rows only
  - Resolved: 4 resolved rows only
  - Deleted: 2 deleted rows only
  - ICD-9 `250` plus provider filter: expected active result only
  - spreadsheet export: HTTP 200, valid XLSX ZIP signature, correct media type and `.xlsx` attachment name

## Review findings

- **Must:** Hibernate status type mismatch; JasperReports 7 template incompatibility. Fixed and verified.
- **Should:** Spreadsheet advertised as legacy XLS despite generating XLSX. Fixed and covered.
- **Could:** No remaining in-scope findings.

