### PR TITLE
chore(devcontainer): add Administration test seed data

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -97,6 +97,7 @@ Exploded WAR".
     * Password: carlos2026
     * PIN: 2026
     * This account has the receptionist role and synthetic provider number `999996`; use `carlosdoc` for administration itself.
+* Administration seed fixtures include current and deleted patient-independent eForms under **Forms/eForms → Patient-independent eForm**.
 
 ### Subsequent Compilations
 

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -92,6 +92,11 @@ Exploded WAR".
     * Password: carlos2026
     * PIN     : 2026
     * **Note**: On first login, you will be forced to change the password. Use the same credentials above to complete the password reset process.
+* Administration test account (safe to intentionally lock while testing the Unlock Account screen):
+    * Username: locktest
+    * Password: carlos2026
+    * PIN: 2026
+    * This account has the receptionist role and synthetic provider number `999996`; use `carlosdoc` for administration itself.
 
 ### Subsequent Compilations
 

--- a/.devcontainer/db/Dockerfile
+++ b/.devcontainer/db/Dockerfile
@@ -14,6 +14,7 @@ LABEL description="OpenOSP-EMR Docker Image for Development Environment"
 COPY ./.devcontainer/db/scripts/populate_db.sh /docker-entrypoint-initdb.d/populate_db.sh
 RUN mkdir /scripts
 COPY ./.devcontainer/db/scripts/development.sql /scripts/development.sql
+COPY ./.devcontainer/db/scripts/admin_test_data.sql /scripts/admin_test_data.sql
 COPY ./database /database
 COPY ./.devcontainer/development/config/shared/my.cnf /etc/mysql/my.cnf
 

--- a/.devcontainer/db/scripts/admin_test_data.sql
+++ b/.devcontainer/db/scripts/admin_test_data.sql
@@ -315,8 +315,10 @@ WHERE NOT EXISTS (
 -- Administration > Default Encounter Issue stores a comma-separated list of
 -- issue_id values in one row per provider, and the action only ever reads the
 -- latest row. Resolve the ids from `issue.code` so the fixture survives the
--- auto-increment ordering of whatever dump seeded that table. HAVING drops the
--- all-NULL aggregate row when the guard or the code filter matches nothing.
+-- auto-increment ordering of whatever dump seeded that table. HAVING requires all
+-- three codes to be present: it drops the all-NULL aggregate row when the guard
+-- or the code filter matches nothing, and also refuses to seed a partial list if
+-- a dump ships only some of the CPP codes.
 INSERT INTO default_issue (assigned_time, issue_ids, provider_no, update_time)
 SELECT
     NOW(),
@@ -328,7 +330,7 @@ WHERE i.code IN ('OMeds', 'SocHistory', 'MedHistory')
   AND NOT EXISTS (
       SELECT 1 FROM default_issue WHERE provider_no = '999998'
   )
-HAVING GROUP_CONCAT(i.issue_id) IS NOT NULL;
+HAVING COUNT(DISTINCT i.code) = 3;
 
 -- Report by Template --------------------------------------------------------
 -- `reportTemplates` is a different table from `report_template` (which the demo

--- a/.devcontainer/db/scripts/admin_test_data.sql
+++ b/.devcontainer/db/scripts/admin_test_data.sql
@@ -80,29 +80,41 @@ WHERE NOT EXISTS (
 -- Labs / Inbox --------------------------------------------------------------
 -- One current rule exercises rendering, status editing, removal, and the
 -- per-message-type child collection on the forwarding-rules screen.
+--
+-- The rule forwards to the seeded `locktest` provider (999996) rather than to a
+-- real provider. 999996 only exists because this file created it, so the
+-- (999998 -> 999996, archive 0) discriminator below can only ever match a rule
+-- this seed owns. A hand-made rule from earlier local testing cannot collide
+-- with it, which keeps the child type rows scoped to our own fixture.
 INSERT INTO incomingLabRules (provider_no, status, frwdProvider_no, archive)
-SELECT '999998', 'N', '1', '0'
+SELECT '999998', 'N', '999996', '0'
 WHERE EXISTS (SELECT 1 FROM provider WHERE provider_no = '999998')
-  AND EXISTS (SELECT 1 FROM provider WHERE provider_no = '1')
+  AND EXISTS (SELECT 1 FROM provider WHERE provider_no = '999996')
   AND NOT EXISTS (
       SELECT 1
       FROM incomingLabRules
       WHERE provider_no = '999998'
-        AND frwdProvider_no = '1'
+        AND frwdProvider_no = '999996'
         AND archive = '0'
   );
 
+-- MIN(id) pins the type rows to a single rule. Without it a developer holding
+-- two matching rules would get the HL7/DOC/HRM rows fanned out across both.
 INSERT INTO incomingLabRulesType (forward_rule_id, type)
 SELECT r.id, t.type
-FROM incomingLabRules r
+FROM (
+    SELECT MIN(id) AS id
+    FROM incomingLabRules
+    WHERE provider_no = '999998'
+      AND frwdProvider_no = '999996'
+      AND archive = '0'
+) r
 CROSS JOIN (
     SELECT 'HL7' AS type
     UNION ALL SELECT 'DOC'
     UNION ALL SELECT 'HRM'
 ) t
-WHERE r.provider_no = '999998'
-  AND r.frwdProvider_no = '1'
-  AND r.archive = '0'
+WHERE r.id IS NOT NULL
   AND NOT EXISTS (
       SELECT 1
       FROM incomingLabRulesType rt
@@ -271,6 +283,73 @@ WHERE NOT EXISTS (
     FROM demographicQueryFavourites
     WHERE queryName = 'Local Test - Basic Demographics'
       AND archived = '1'
+);
+
+-- Referral doctors ----------------------------------------------------------
+-- Administration > Billing > Manage Referral Doctors reads `billingreferral`,
+-- which the demo snapshot leaves empty. These also populate the referral
+-- pickers reached from billing and consultation entry.
+INSERT INTO billingreferral
+    (referral_no, last_name, first_name, specialty, address1, city, province,
+     country, postal, phone, fax)
+SELECT
+    '999001', 'Local Test - Cardiology', 'Referral', 'Cardiology',
+    '100 Test Street', 'Testville', 'ON', 'Canada', 'A1A 1A1',
+    '555-555-0101', '555-555-0102'
+WHERE NOT EXISTS (
+    SELECT 1 FROM billingreferral WHERE referral_no = '999001'
+);
+
+INSERT INTO billingreferral
+    (referral_no, last_name, first_name, specialty, address1, city, province,
+     country, postal, phone, fax)
+SELECT
+    '999002', 'Local Test - Dermatology', 'Referral', 'Dermatology',
+    '200 Test Avenue', 'Testville', 'ON', 'Canada', 'A1A 1A2',
+    '555-555-0201', '555-555-0202'
+WHERE NOT EXISTS (
+    SELECT 1 FROM billingreferral WHERE referral_no = '999002'
+);
+
+-- Default encounter issues --------------------------------------------------
+-- Administration > Default Encounter Issue stores a comma-separated list of
+-- issue_id values in one row per provider, and the action only ever reads the
+-- latest row. Resolve the ids from `issue.code` so the fixture survives the
+-- auto-increment ordering of whatever dump seeded that table. HAVING drops the
+-- all-NULL aggregate row when the guard or the code filter matches nothing.
+INSERT INTO default_issue (assigned_time, issue_ids, provider_no, update_time)
+SELECT
+    NOW(),
+    GROUP_CONCAT(i.issue_id ORDER BY i.issue_id),
+    '999998',
+    NOW()
+FROM issue i
+WHERE i.code IN ('OMeds', 'SocHistory', 'MedHistory')
+  AND NOT EXISTS (
+      SELECT 1 FROM default_issue WHERE provider_no = '999998'
+  )
+HAVING GROUP_CONCAT(i.issue_id) IS NOT NULL;
+
+-- Report by Template --------------------------------------------------------
+-- `reportTemplates` is a different table from `report_template` (which the demo
+-- snapshot does populate). The list page renders title/description for active
+-- rows; running the report parses `templatexml` for <param> children and then
+-- executes `templatesql`. No <param> children means no prompt screen, which is
+-- what we want for a smoke fixture. The query stays off patient tables so a
+-- developer screenshot cannot leak demo PHI.
+INSERT INTO reportTemplates
+    (templatetitle, templatedescription, templatesql, templatexml, active,
+     `type`, uuid, `sequence`)
+SELECT
+    'Local Test - Provider Roster',
+    'Synthetic template for local Report by Template testing',
+    'SELECT provider_no, last_name, first_name, provider_type, status FROM provider ORDER BY last_name, first_name LIMIT 100;',
+    '<report id="9001" title="Local Test - Provider Roster" description="Synthetic template for local Report by Template testing" active="1"><query>SELECT provider_no, last_name, first_name, provider_type, status FROM provider ORDER BY last_name, first_name LIMIT 100;</query></report>',
+    1, '', 'local-test-provider-roster', 0
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM reportTemplates
+    WHERE templatetitle = 'Local Test - Provider Roster'
 );
 
 -- Schedule Management -------------------------------------------------------

--- a/.devcontainer/db/scripts/admin_test_data.sql
+++ b/.devcontainer/db/scripts/admin_test_data.sql
@@ -1,0 +1,230 @@
+-- CARLOS EMR local-development fixtures for the Administration panel.
+--
+-- development.sql already supplies the large clinical/demo dataset. This file
+-- fills the admin-only gaps with obviously synthetic records and is loaded last
+-- so it can reference the Rich Text Letter eForm installed by populate_db.sh.
+-- Every insert is repeatable to make the file safe to run by hand while working
+-- on an existing local database. It must never be used for production data.
+
+START TRANSACTION;
+
+-- User Management -----------------------------------------------------------
+-- A sacrificial account lets developers test login failures and the Unlock
+-- Account screen without locking carlosdoc. Account locks live in Tomcat's
+-- in-memory LoginList, so deliberately enter the wrong password for `locktest`
+-- until it appears in Administration > Unlock Account.
+INSERT INTO provider
+    (provider_no, last_name, first_name, provider_type, specialty, sex, status,
+     lastUpdateUser, lastUpdateDate)
+SELECT
+    '999996', 'Account', 'Lock Test', 'receptionist', 'Local testing', 'X', '1',
+    '999998', NOW()
+WHERE NOT EXISTS (
+    SELECT 1 FROM provider WHERE provider_no = '999996'
+);
+
+INSERT INTO security
+    (user_name, password, provider_no, pin, b_ExpireSet, forcePasswordReset,
+     passwordUpdateDate, pinUpdateDate, lastUpdateUser, lastUpdateDate)
+SELECT
+    'locktest',
+    '{bcrypt}$2a$10$RcoNeqhcLzkfBzAoTQ5C5.nnsOs15iOasQCp0/smjDAuTtkMQ.Uju',
+    '999996', '2026', 0, 0, NOW(), NOW(), '999998', NOW()
+WHERE NOT EXISTS (
+    SELECT 1 FROM security WHERE user_name = 'locktest'
+);
+
+INSERT INTO secUserRole
+    (provider_no, role_name, orgcd, activeyn, lastUpdateDate)
+SELECT '999996', 'receptionist', 'R0000001', 1, NOW()
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM secUserRole
+    WHERE provider_no = '999996'
+      AND role_name = 'receptionist'
+      AND activeyn = 1
+);
+
+INSERT INTO providersite (provider_no, site_id)
+SELECT '999996', s.site_id
+FROM site s
+WHERE s.site_id = 1
+  AND NOT EXISTS (
+      SELECT 1
+      FROM providersite ps
+      WHERE ps.provider_no = '999996'
+        AND ps.site_id = s.site_id
+  );
+
+-- Billing -------------------------------------------------------------------
+-- These cover active style listing, preview, editing, deletion, and use from
+-- Ontario service-code administration.
+INSERT INTO cssStyles (name, style, status)
+SELECT 'Local Test - Highlight', 'font-weight:bold;background-color:#fff3cd;', 'A'
+WHERE NOT EXISTS (
+    SELECT 1 FROM cssStyles WHERE name = 'Local Test - Highlight' AND status = 'A'
+);
+
+INSERT INTO cssStyles (name, style, status)
+SELECT 'Local Test - Muted', 'color:#6c757d;font-style:italic;', 'A'
+WHERE NOT EXISTS (
+    SELECT 1 FROM cssStyles WHERE name = 'Local Test - Muted' AND status = 'A'
+);
+
+INSERT INTO cssStyles (name, style, status)
+SELECT 'Local Test - Urgent', 'color:#b02a37;font-weight:bold;text-decoration:underline;', 'A'
+WHERE NOT EXISTS (
+    SELECT 1 FROM cssStyles WHERE name = 'Local Test - Urgent' AND status = 'A'
+);
+
+-- Labs / Inbox --------------------------------------------------------------
+-- One current rule exercises rendering, status editing, removal, and the
+-- per-message-type child collection on the forwarding-rules screen.
+INSERT INTO incomingLabRules (provider_no, status, frwdProvider_no, archive)
+SELECT '999998', 'N', '1', '0'
+WHERE EXISTS (SELECT 1 FROM provider WHERE provider_no = '999998')
+  AND EXISTS (SELECT 1 FROM provider WHERE provider_no = '1')
+  AND NOT EXISTS (
+      SELECT 1
+      FROM incomingLabRules
+      WHERE provider_no = '999998'
+        AND frwdProvider_no = '1'
+        AND archive = '0'
+  );
+
+INSERT INTO incomingLabRulesType (forward_rule_id, type)
+SELECT r.id, t.type
+FROM incomingLabRules r
+CROSS JOIN (
+    SELECT 'HL7' AS type
+    UNION ALL SELECT 'DOC'
+    UNION ALL SELECT 'HRM'
+) t
+WHERE r.provider_no = '999998'
+  AND r.frwdProvider_no = '1'
+  AND r.archive = '0'
+  AND NOT EXISTS (
+      SELECT 1
+      FROM incomingLabRulesType rt
+      WHERE rt.forward_rule_id = r.id
+        AND rt.type = t.type
+  );
+
+-- Forms / eForms ------------------------------------------------------------
+INSERT INTO eform_groups (fid, group_name)
+SELECT e.fid, 'Local Admin Tests'
+FROM eform e
+WHERE e.form_name = 'Rich Text Letter'
+  AND e.status = 1
+  AND NOT EXISTS (
+      SELECT 1
+      FROM eform_groups eg
+      WHERE eg.fid = e.fid
+        AND eg.group_name = 'Local Admin Tests'
+  )
+ORDER BY e.fid
+LIMIT 1;
+
+-- Reports -------------------------------------------------------------------
+-- Read-only examples are compatible with the Query By Example validator and
+-- avoid exposing patient information in a developer's screenshots.
+INSERT INTO reportByExamplesFavorite (providerNo, query, name)
+SELECT
+    '999998',
+    'SELECT provider_no, last_name, first_name, status FROM provider ORDER BY last_name, first_name LIMIT 100;',
+    'Local Test - Provider Directory'
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM reportByExamplesFavorite
+    WHERE providerNo = '999998'
+      AND name = 'Local Test - Provider Directory'
+);
+
+INSERT INTO reportByExamplesFavorite (providerNo, query, name)
+SELECT
+    '999998',
+    'SELECT name, duration, location FROM appointmentType ORDER BY name;',
+    'Local Test - Appointment Types'
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM reportByExamplesFavorite
+    WHERE providerNo = '999998'
+      AND name = 'Local Test - Appointment Types'
+);
+
+INSERT INTO demographicQueryFavourites
+    (selects, age, startYear, endYear, firstName, lastName, rosterStatus,
+     sex, providerNo, patientStatus, queryName, archived, demoIds)
+SELECT
+    '<root><item value="demographic_no"/><item value="last_name"/><item value="first_name"/><item value="provider_name"/><item value="patient_status"/></root>',
+    '0', '', '', '', '', '<root/>', '0', '<root/>', '<root/>',
+    'Local Test - Basic Demographics', '1', ''
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM demographicQueryFavourites
+    WHERE queryName = 'Local Test - Basic Demographics'
+      AND archived = '1'
+);
+
+-- Schedule Management -------------------------------------------------------
+INSERT INTO appointmentType
+    (name, notes, reason, location, resources, duration)
+SELECT
+    'Local Test - Standard Visit', 'Routine in-person test appointment',
+    'Routine follow-up', 'Exam Room 1', 'ROOM1', 15
+WHERE NOT EXISTS (
+    SELECT 1 FROM appointmentType WHERE name = 'Local Test - Standard Visit'
+);
+
+INSERT INTO appointmentType
+    (name, notes, reason, location, resources, duration)
+SELECT
+    'Local Test - Extended Visit', 'Longer in-person test appointment',
+    'Complex follow-up', 'Exam Room 2', 'ROOM2', 30
+WHERE NOT EXISTS (
+    SELECT 1 FROM appointmentType WHERE name = 'Local Test - Extended Visit'
+);
+
+INSERT INTO appointmentType
+    (name, notes, reason, location, resources, duration)
+SELECT
+    'Local Test - Virtual Visit', 'Video appointment test case',
+    'Virtual follow-up', 'Virtual', 'VIDEO', 20
+WHERE NOT EXISTS (
+    SELECT 1 FROM appointmentType WHERE name = 'Local Test - Virtual Visit'
+);
+
+-- System Management ---------------------------------------------------------
+-- Include active lots plus a soft-deleted lot so add/reactivate and search/
+-- delete paths can both be exercised.
+INSERT INTO PreventionsLotNrs
+    (creationDate, providerNo, preventionType, lotNr, deleted, lastUpdateDate)
+SELECT NOW(), '999998', 'Flu', 'LOCAL-FLU-2026-A', FALSE, NOW()
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM PreventionsLotNrs
+    WHERE preventionType = 'Flu'
+      AND lotNr = 'LOCAL-FLU-2026-A'
+);
+
+INSERT INTO PreventionsLotNrs
+    (creationDate, providerNo, preventionType, lotNr, deleted, lastUpdateDate)
+SELECT NOW(), '999998', 'COVID-19', 'LOCAL-COVID-2026-B', FALSE, NOW()
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM PreventionsLotNrs
+    WHERE preventionType = 'COVID-19'
+      AND lotNr = 'LOCAL-COVID-2026-B'
+);
+
+INSERT INTO PreventionsLotNrs
+    (creationDate, providerNo, preventionType, lotNr, deleted, lastUpdateDate)
+SELECT NOW(), '999998', 'DTaP', 'LOCAL-DTAP-ARCHIVED', TRUE, NOW()
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM PreventionsLotNrs
+    WHERE preventionType = 'DTaP'
+      AND lotNr = 'LOCAL-DTAP-ARCHIVED'
+);
+
+COMMIT;

--- a/.devcontainer/db/scripts/admin_test_data.sql
+++ b/.devcontainer/db/scripts/admin_test_data.sql
@@ -125,6 +125,113 @@ WHERE e.form_name = 'Rich Text Letter'
 ORDER BY e.fid
 LIMIT 1;
 
+-- Patient-independent eForms are backed by saved eform_data rows rather than
+-- the eform library alone. Seed two small, self-contained definitions and a
+-- mix of current/deleted instances so both Administration views are useful.
+INSERT INTO eform
+    (form_name, file_name, subject, form_date, form_time, form_creator, status,
+     form_html, showLatestFormOnly, patient_independent, roleType, stable)
+SELECT
+    'Local Test - Independent Checklist',
+    'local-test-independent-checklist.html',
+    'Reusable checklist for local administration testing',
+    '2026-08-01', '09:00:00', '999998', 1,
+    '<!DOCTYPE html><html><head><meta charset="UTF-8"><title>Local Test - Independent Checklist</title></head><body><h1>Local Test - Independent Checklist</h1><form method="post" action="" name="LocalIndependentChecklist"><label>Review title <input type="text" name="review_title"></label><br><label><input type="checkbox" name="review_complete" value="1"> Review complete</label><br><label>Notes <textarea name="notes"></textarea></label><br><input type="submit" name="SubmitButton" value="Save"></form></body></html>',
+    0, 1, NULL, 1
+WHERE EXISTS (SELECT 1 FROM provider WHERE provider_no = '999998')
+  AND NOT EXISTS (
+      SELECT 1
+      FROM eform
+      WHERE form_name = 'Local Test - Independent Checklist'
+        AND patient_independent = 1
+  );
+
+INSERT INTO eform
+    (form_name, file_name, subject, form_date, form_time, form_creator, status,
+     form_html, showLatestFormOnly, patient_independent, roleType, stable)
+SELECT
+    'Local Test - Shared Operations Note',
+    'local-test-shared-operations-note.html',
+    'Shared note for local administration testing',
+    '2026-08-01', '09:05:00', '999998', 1,
+    '<!DOCTYPE html><html><head><meta charset="UTF-8"><title>Local Test - Shared Operations Note</title></head><body><h1>Local Test - Shared Operations Note</h1><form method="post" action="" name="LocalSharedOperationsNote"><label>Topic <input type="text" name="topic"></label><br><label>Details <textarea name="details"></textarea></label><br><input type="submit" name="SubmitButton" value="Save"></form></body></html>',
+    0, 1, NULL, 1
+WHERE EXISTS (SELECT 1 FROM provider WHERE provider_no = '999998')
+  AND NOT EXISTS (
+      SELECT 1
+      FROM eform
+      WHERE form_name = 'Local Test - Shared Operations Note'
+        AND patient_independent = 1
+  );
+
+-- Current patient-independent examples.
+INSERT INTO eform_data
+    (fid, form_name, subject, demographic_no, status, form_date, form_time,
+     form_provider, form_data, showLatestFormOnly, patient_independent, roleType)
+SELECT
+    e.fid, e.form_name, 'Local Test - Monthly Safety Review', 0, 1,
+    '2026-08-03', '09:30:00', '999998',
+    '<!DOCTYPE html><html><head><meta charset="UTF-8"><title>Local Test - Independent Checklist</title></head><body><h1>Local Test - Independent Checklist</h1><form method="post" action="" name="LocalIndependentChecklist"><label>Review title <input type="text" name="review_title" value="Monthly safety review"></label><br><label><input type="checkbox" name="review_complete" value="1" checked> Review complete</label><br><label>Notes <textarea name="notes">Synthetic current fixture for local testing.</textarea></label><br><input type="submit" name="SubmitButton" value="Save"></form></body></html>',
+    0, 1, NULL
+FROM eform e
+WHERE e.form_name = 'Local Test - Independent Checklist'
+  AND e.status = 1
+  AND e.patient_independent = 1
+  AND NOT EXISTS (
+      SELECT 1
+      FROM eform_data ed
+      WHERE ed.fid = e.fid
+        AND ed.subject = 'Local Test - Monthly Safety Review'
+        AND ed.patient_independent = 1
+  )
+ORDER BY e.fid
+LIMIT 1;
+
+INSERT INTO eform_data
+    (fid, form_name, subject, demographic_no, status, form_date, form_time,
+     form_provider, form_data, showLatestFormOnly, patient_independent, roleType)
+SELECT
+    e.fid, e.form_name, 'Local Test - Quarterly Operations Review', 0, 1,
+    '2026-07-15', '14:15:00', '999998',
+    '<!DOCTYPE html><html><head><meta charset="UTF-8"><title>Local Test - Shared Operations Note</title></head><body><h1>Local Test - Shared Operations Note</h1><form method="post" action="" name="LocalSharedOperationsNote"><label>Topic <input type="text" name="topic" value="Quarterly operations review"></label><br><label>Details <textarea name="details">Synthetic shared note for local testing.</textarea></label><br><input type="submit" name="SubmitButton" value="Save"></form></body></html>',
+    0, 1, NULL
+FROM eform e
+WHERE e.form_name = 'Local Test - Shared Operations Note'
+  AND e.status = 1
+  AND e.patient_independent = 1
+  AND NOT EXISTS (
+      SELECT 1
+      FROM eform_data ed
+      WHERE ed.fid = e.fid
+        AND ed.subject = 'Local Test - Quarterly Operations Review'
+        AND ed.patient_independent = 1
+  )
+ORDER BY e.fid
+LIMIT 1;
+
+-- Deleted patient-independent example for the Deleted eForms view.
+INSERT INTO eform_data
+    (fid, form_name, subject, demographic_no, status, form_date, form_time,
+     form_provider, form_data, showLatestFormOnly, patient_independent, roleType)
+SELECT
+    e.fid, e.form_name, 'Local Test - Archived Safety Draft', 0, 0,
+    '2026-06-30', '16:45:00', '999998',
+    '<!DOCTYPE html><html><head><meta charset="UTF-8"><title>Local Test - Independent Checklist</title></head><body><h1>Local Test - Independent Checklist</h1><form method="post" action="" name="LocalIndependentChecklist"><label>Review title <input type="text" name="review_title" value="Archived safety draft"></label><br><label><input type="checkbox" name="review_complete" value="1"> Review complete</label><br><label>Notes <textarea name="notes">Synthetic deleted fixture for local testing.</textarea></label><br><input type="submit" name="SubmitButton" value="Save"></form></body></html>',
+    0, 1, NULL
+FROM eform e
+WHERE e.form_name = 'Local Test - Independent Checklist'
+  AND e.status = 1
+  AND e.patient_independent = 1
+  AND NOT EXISTS (
+      SELECT 1
+      FROM eform_data ed
+      WHERE ed.fid = e.fid
+        AND ed.subject = 'Local Test - Archived Safety Draft'
+        AND ed.patient_independent = 1
+  )
+ORDER BY e.fid
+LIMIT 1;
+
 -- Reports -------------------------------------------------------------------
 -- Read-only examples are compatible with the Query By Example validator and
 -- avoid exposing patient information in a developer's screenshots.

--- a/.devcontainer/db/scripts/admin_test_data.sql
+++ b/.devcontainer/db/scripts/admin_test_data.sql
@@ -123,6 +123,19 @@ WHERE r.id IS NOT NULL
   );
 
 -- Forms / eForms ------------------------------------------------------------
+-- Administration > eForm Groups creates every group with a fid=0 marker row
+-- (AddGroup2Action passes fid "0"), and EFormUtil.getEFormGroups() reports the
+-- member count as count(*)-1 on the assumption that the marker is there.
+-- Seeding only the membership row would render the group with a count of 0.
+INSERT INTO eform_groups (fid, group_name)
+SELECT 0, 'Local Admin Tests'
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM eform_groups
+    WHERE fid = 0
+      AND group_name = 'Local Admin Tests'
+);
+
 INSERT INTO eform_groups (fid, group_name)
 SELECT e.fid, 'Local Admin Tests'
 FROM eform e

--- a/.devcontainer/db/scripts/populate_db.sh
+++ b/.devcontainer/db/scripts/populate_db.sh
@@ -86,4 +86,6 @@ $SQL oscar < /database/mysql/updates/update-2012-07-12.sql
 echo 'Modernizing Rich Text Letter eForm to 2026.3.0...'
 $SQL oscar < /database/mysql/updates/update-2026-03-22-rtl-2026.3.0-modernize.sql
 $SQL oscar < /database/mysql/updates/update-2026-03-12-rtl-enable-direct.sql
+echo 'Loading Administration test fixtures...'
+$SQL oscar < /scripts/admin_test_data.sql
 echo 'Database initialization complete!'

--- a/src/test/java/io/github/carlos_emr/carlos/admin/DevelopmentAdminSeedRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/admin/DevelopmentAdminSeedRegressionTest.java
@@ -80,6 +80,12 @@ class DevelopmentAdminSeedRegressionTest {
     void shouldSeedPatientIndependentEforms_forBothAdministrationViews() throws IOException {
         String seed = readProjectFile(ADMIN_SEED);
 
+        // EFormUtil.getEFormGroups() reports members as count(*)-1, so the group needs
+        // the same fid=0 marker row AddGroup2Action writes or it renders a count of 0.
+        assertThat(seed)
+                .as("eForm groups need the fid=0 marker row the Administration UI creates")
+                .contains("SELECT 0, 'Local Admin Tests'");
+
         assertThat(seed).contains(
                 "'Local Test - Independent Checklist'",
                 "'Local Test - Shared Operations Note'",

--- a/src/test/java/io/github/carlos_emr/carlos/admin/DevelopmentAdminSeedRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/admin/DevelopmentAdminSeedRegressionTest.java
@@ -35,15 +35,19 @@ class DevelopmentAdminSeedRegressionTest {
 
         assertThat(dockerfile)
                 .contains("COPY ./.devcontainer/db/scripts/admin_test_data.sql /scripts/admin_test_data.sql");
+        // Assert the path rather than the full command. populate_db.sh has carried
+        // both a "$SQL oscar < ..." form and a literal "mysql -u root -p..." form,
+        // and the load order is what this test actually cares about.
         assertThat(populate)
-                .contains("$SQL oscar < /scripts/admin_test_data.sql")
+                .contains("/scripts/admin_test_data.sql")
                 .satisfies(script -> assertThat(script.indexOf("/scripts/admin_test_data.sql"))
-                        .isGreaterThan(script.indexOf("update-2026-03-22-rtl-2026.3.0-modernize.sql")));
+                        .isGreaterThan(script.indexOf("update-2026-03-22-rtl-2026.3.0-modernize.sql"))
+                        .isGreaterThan(script.indexOf("update-2026-03-12-rtl-enable-direct.sql")));
     }
 
     @Test
     @DisplayName("should cover the data-backed Administration screens that are empty in the base dump")
-    void shouldCoverEmptyAdministrationScreens() throws IOException {
+    void shouldCoverAdministrationScreens_whenBaseDumpIsEmpty() throws IOException {
         String seed = Files.readString(ADMIN_SEED, StandardCharsets.UTF_8);
 
         assertThat(seed).contains(
@@ -53,6 +57,9 @@ class DevelopmentAdminSeedRegressionTest {
                 "INSERT INTO incomingLabRulesType",
                 "INSERT INTO eform_groups",
                 "INSERT INTO eform_data",
+                "INSERT INTO billingreferral",
+                "INSERT INTO default_issue",
+                "INSERT INTO reportTemplates",
                 "INSERT INTO reportByExamplesFavorite",
                 "INSERT INTO demographicQueryFavourites",
                 "INSERT INTO appointmentType",
@@ -67,10 +74,21 @@ class DevelopmentAdminSeedRegressionTest {
         assertThat(seed).contains(
                 "'Local Test - Independent Checklist'",
                 "'Local Test - Shared Operations Note'",
-                "'Local Test - Monthly Safety Review'",
-                "'Local Test - Quarterly Operations Review'",
-                "'Local Test - Archived Safety Draft'",
                 "patient_independent");
+
+        // Pin the status column, not just the subject. The eform_data column order
+        // is (subject, demographic_no, status), so the trailing pair below is
+        // "0, 1" for a current instance and "0, 0" for a deleted one. Asserting
+        // only the subject would let a fixture silently flip between the
+        // Administration "current" and "deleted" views.
+        assertThat(seed)
+                .as("current patient-independent eForms must keep status 1")
+                .contains(
+                        "'Local Test - Monthly Safety Review', 0, 1,",
+                        "'Local Test - Quarterly Operations Review', 0, 1,");
+        assertThat(seed)
+                .as("the archived fixture must keep status 0 so the Deleted eForms view stays populated")
+                .contains("'Local Test - Archived Safety Draft', 0, 0,");
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/admin/DevelopmentAdminSeedRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/admin/DevelopmentAdminSeedRegressionTest.java
@@ -52,10 +52,25 @@ class DevelopmentAdminSeedRegressionTest {
                 "INSERT INTO incomingLabRules",
                 "INSERT INTO incomingLabRulesType",
                 "INSERT INTO eform_groups",
+                "INSERT INTO eform_data",
                 "INSERT INTO reportByExamplesFavorite",
                 "INSERT INTO demographicQueryFavourites",
                 "INSERT INTO appointmentType",
                 "INSERT INTO PreventionsLotNrs");
+    }
+
+    @Test
+    @DisplayName("should seed current and deleted patient-independent eForms")
+    void shouldSeedPatientIndependentEforms_forBothAdministrationViews() throws IOException {
+        String seed = Files.readString(ADMIN_SEED, StandardCharsets.UTF_8);
+
+        assertThat(seed).contains(
+                "'Local Test - Independent Checklist'",
+                "'Local Test - Shared Operations Note'",
+                "'Local Test - Monthly Safety Review'",
+                "'Local Test - Quarterly Operations Review'",
+                "'Local Test - Archived Safety Draft'",
+                "patient_independent");
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/admin/DevelopmentAdminSeedRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/admin/DevelopmentAdminSeedRegressionTest.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License;
+ * you can redistribute it and/or modify it under the terms of the GPL.
+ */
+package io.github.carlos_emr.carlos.admin;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Development Administration seed regressions")
+@Tag("unit")
+@Tag("admin")
+class DevelopmentAdminSeedRegressionTest {
+
+    private static final Path ADMIN_SEED = Path.of(
+            ".devcontainer", "db", "scripts", "admin_test_data.sql");
+
+    @Test
+    @DisplayName("should load admin fixtures after the eForm migrations")
+    void shouldLoadAdminFixtures_afterEformMigrations() throws IOException {
+        String dockerfile = Files.readString(
+                Path.of(".devcontainer", "db", "Dockerfile"), StandardCharsets.UTF_8);
+        String populate = Files.readString(
+                Path.of(".devcontainer", "db", "scripts", "populate_db.sh"), StandardCharsets.UTF_8);
+
+        assertThat(dockerfile)
+                .contains("COPY ./.devcontainer/db/scripts/admin_test_data.sql /scripts/admin_test_data.sql");
+        assertThat(populate)
+                .contains("$SQL oscar < /scripts/admin_test_data.sql")
+                .satisfies(script -> assertThat(script.indexOf("/scripts/admin_test_data.sql"))
+                        .isGreaterThan(script.indexOf("update-2026-03-22-rtl-2026.3.0-modernize.sql")));
+    }
+
+    @Test
+    @DisplayName("should cover the data-backed Administration screens that are empty in the base dump")
+    void shouldCoverEmptyAdministrationScreens() throws IOException {
+        String seed = Files.readString(ADMIN_SEED, StandardCharsets.UTF_8);
+
+        assertThat(seed).contains(
+                "'locktest'",
+                "INSERT INTO cssStyles",
+                "INSERT INTO incomingLabRules",
+                "INSERT INTO incomingLabRulesType",
+                "INSERT INTO eform_groups",
+                "INSERT INTO reportByExamplesFavorite",
+                "INSERT INTO demographicQueryFavourites",
+                "INSERT INTO appointmentType",
+                "INSERT INTO PreventionsLotNrs");
+    }
+
+    @Test
+    @DisplayName("should keep local admin fixtures repeatable and visibly synthetic")
+    void shouldKeepFixtures_repeatableAndSynthetic() throws IOException {
+        String seed = Files.readString(ADMIN_SEED, StandardCharsets.UTF_8);
+
+        assertThat(seed)
+                .contains("WHERE NOT EXISTS")
+                .contains("Local Test -")
+                .contains("LOCAL-FLU-2026-A")
+                .contains("LOCAL-COVID-2026-B")
+                .contains("LOCAL-DTAP-ARCHIVED")
+                .doesNotContain("INSERT INTO demographic ");
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/admin/DevelopmentAdminSeedRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/admin/DevelopmentAdminSeedRegressionTest.java
@@ -24,14 +24,23 @@ class DevelopmentAdminSeedRegressionTest {
 
     private static final Path ADMIN_SEED = Path.of(
             ".devcontainer", "db", "scripts", "admin_test_data.sql");
+    private static final Path DB_DOCKERFILE = Path.of(
+            ".devcontainer", "db", "Dockerfile");
+    private static final Path POPULATE_DB = Path.of(
+            ".devcontainer", "db", "scripts", "populate_db.sh");
+
+    /**
+     * Surefire and IDEs do not agree on the working directory, so source-tree
+     * fixtures are located by walking up from user.dir rather than assumed to sit
+     * under the repo root. Mirrors StrutsAdminConfigTest in this package.
+     */
+    private static final int MAX_PARENT_SEARCH_DEPTH = 8;
 
     @Test
     @DisplayName("should load admin fixtures after the eForm migrations")
     void shouldLoadAdminFixtures_afterEformMigrations() throws IOException {
-        String dockerfile = Files.readString(
-                Path.of(".devcontainer", "db", "Dockerfile"), StandardCharsets.UTF_8);
-        String populate = Files.readString(
-                Path.of(".devcontainer", "db", "scripts", "populate_db.sh"), StandardCharsets.UTF_8);
+        String dockerfile = readProjectFile(DB_DOCKERFILE);
+        String populate = readProjectFile(POPULATE_DB);
 
         assertThat(dockerfile)
                 .contains("COPY ./.devcontainer/db/scripts/admin_test_data.sql /scripts/admin_test_data.sql");
@@ -48,7 +57,7 @@ class DevelopmentAdminSeedRegressionTest {
     @Test
     @DisplayName("should cover the data-backed Administration screens that are empty in the base dump")
     void shouldCoverAdministrationScreens_whenBaseDumpIsEmpty() throws IOException {
-        String seed = Files.readString(ADMIN_SEED, StandardCharsets.UTF_8);
+        String seed = readProjectFile(ADMIN_SEED);
 
         assertThat(seed).contains(
                 "'locktest'",
@@ -69,7 +78,7 @@ class DevelopmentAdminSeedRegressionTest {
     @Test
     @DisplayName("should seed current and deleted patient-independent eForms")
     void shouldSeedPatientIndependentEforms_forBothAdministrationViews() throws IOException {
-        String seed = Files.readString(ADMIN_SEED, StandardCharsets.UTF_8);
+        String seed = readProjectFile(ADMIN_SEED);
 
         assertThat(seed).contains(
                 "'Local Test - Independent Checklist'",
@@ -94,7 +103,7 @@ class DevelopmentAdminSeedRegressionTest {
     @Test
     @DisplayName("should keep local admin fixtures repeatable and visibly synthetic")
     void shouldKeepFixtures_repeatableAndSynthetic() throws IOException {
-        String seed = Files.readString(ADMIN_SEED, StandardCharsets.UTF_8);
+        String seed = readProjectFile(ADMIN_SEED);
 
         assertThat(seed)
                 .contains("WHERE NOT EXISTS")
@@ -103,5 +112,25 @@ class DevelopmentAdminSeedRegressionTest {
                 .contains("LOCAL-COVID-2026-B")
                 .contains("LOCAL-DTAP-ARCHIVED")
                 .doesNotContain("INSERT INTO demographic ");
+    }
+
+    private static String readProjectFile(Path relativePath) throws IOException {
+        return Files.readString(resolveProjectPath(relativePath), StandardCharsets.UTF_8);
+    }
+
+    private static Path resolveProjectPath(Path relativePath) {
+        Path current = Path.of(System.getProperty("user.dir")).toAbsolutePath();
+        int checkedParents = 0;
+        while (current != null && checkedParents < MAX_PARENT_SEARCH_DEPTH) {
+            Path candidate = current.resolve(relativePath);
+            if (Files.isRegularFile(candidate)) {
+                return candidate;
+            }
+            current = current.getParent();
+            checkedParents++;
+        }
+        throw new IllegalStateException("Unable to locate " + relativePath
+                + " within " + MAX_PARENT_SEARCH_DEPTH + " parent directories from "
+                + System.getProperty("user.dir"));
     }
 }


### PR DESCRIPTION
## Description

Adds repeatable, synthetic development fixtures for locally testing data-backed Administration screens that are empty in the base demo snapshot.

The seed covers:

- a sacrificial `locktest` account for testing account lock and unlock flows
- billing CSS styles
- incoming lab forwarding rules
- eForm groups
- current and deleted patient-independent eForms
- referral doctors (`billingreferral`) for **Billing > Manage Referral Doctors**
- default encounter issues (`default_issue`) for **Default Encounter Issue**
- a report template (`reportTemplates`) for **Reports > Report by Template**
- report and demographic query favourites
- appointment types
- active and archived prevention lot numbers

The SQL is kept separate from the demo snapshot, copied only into the development database image, and loaded after the Rich Text Letter migrations. Every fixture uses `WHERE NOT EXISTS` so database initialization remains repeatable.

The documented `locktest` credentials are intentionally public development credentials and are not part of production database initialization.

### Scope notes

`reportTemplates` is a different table from `report_template`, which the demo snapshot does populate. The seeded template declares no `<param>` children, so it runs without a prompt screen, and its query stays off patient tables so developer screenshots cannot leak demo PHI.

The lab forwarding rule targets the seeded `locktest` provider (`999996`) rather than a real provider. `999996` exists only because this file creates it, so the `(999998 -> 999996, archive 0)` discriminator can only match a rule this seed owns, and the child type rows are pinned to a single rule id.

Deliberately not covered: Flowsheet Management reads built-in XML via `MeasurementTemplateFlowSheetConfig` rather than the `flowsheet*` tables, so it is not empty. `scheduledate` / `rschedule` are also empty in the demo snapshot, which leaves providers without assigned day schedules, but that is the Schedule module rather than Administration and belongs in its own change.

## Related Issues

None.

## How Was This Tested?

- `mvn -Dcheckstyle.skip=true -Dtest=DevelopmentAdminSeedRegressionTest test` (4/4 pass)
- Executed the seed against a throwaway MariaDB 10.11 instance with `sql_mode=""` (the devcontainer setting) rather than only asserting on file text:
  - applied three times with byte-identical row counts, confirming repeatability
  - `default_issue.issue_ids` resolves to `OMeds,SocHistory,MedHistory`
  - `eform_data` statuses are 1 / 1 / 0 (current, current, deleted)
  - `reportTemplates.templatexml` parses with a `<report>` root and zero `<param>` children
  - with a deliberately colliding lab rule present, the type rows stayed pinned to one rule, where the previous statement fanned them across both
- Verified the seeded CSS styles, lab forwarding rule, eForm group, query favourites, appointment types, and prevention lots through their Administration pages.
- Verified that `locktest` can sign in successfully before intentionally exercising the account-lock flow.
- `git diff --check origin/develop..HEAD`

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality
- [x] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Populate development databases with repeatable synthetic Administration fixtures for exercising otherwise empty screens.

New Features:
- Add repeatable synthetic fixtures for data-backed Administration screens, including account-lock testing, billing, lab forwarding, eForms, reports, referrals, scheduling, and prevention lot management.

Enhancements:
- Keep Administration fixtures isolated from the base demo snapshot and ensure they are safe to reload without duplicating data.

Build:
- Include the Administration fixture SQL in the development database image and load it after Rich Text Letter migrations.

Documentation:
- Document the synthetic lock-test account and patient-independent eForm fixtures for local development.

Tests:
- Add regression coverage for fixture loading order, Administration data coverage, eForm statuses, repeatability, and synthetic-data safeguards.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Populates dev databases with repeatable synthetic Administration fixtures so empty Admin screens are usable. Also seeds the fid=0 eForm group marker so “Local Admin Tests” shows the correct member count, and requires all three CPP codes for default encounter issues.

- Loads `/scripts/admin_test_data.sql` after the Rich Text Letter migrations; `.devcontainer/README.md` documents `locktest` (provider `999996`).
- Scopes the inbox forwarding rule to `999998 -> 999996` and pins HL7/DOC/HRM to a single rule via MIN(id).
- Seeds: patient‑independent eForms (two templates plus current and deleted instances) and the `Local Admin Tests` group with fid=0 marker; billing CSS styles; referral doctors; `default_issue` from `issue.code` with an all‑three‑codes guard; `reportTemplates`; report/demographic query favourites; appointment types; prevention lot numbers (includes an archived lot).
- Uses WHERE NOT EXISTS for repeatability; tests assert load order, eForm statuses and group marker, repeatability, lab‑rule scoping, the `default_issue` guard, and resilient test fixture path resolution.
- Migration: Rebuild the dev DB container, or run `/scripts/admin_test_data.sql` against your dev database.

<sup>Written for commit ec30fcb05428110fd38751c02b8e9e7a6f7a4d3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

