### PR TITLE
fix: show empty-state message in Issue History popup when no notes exist

### DIFF
--- a/src/main/resources/oscarResources_en.properties
+++ b/src/main/resources/oscarResources_en.properties
@@ -1189,6 +1189,7 @@ encounter.futureDate.Msg = Observation Date set in future, rolled back to curren
 encounter.noteReason.TelProgress = Tel-Progress Note
 encounter.noteHistory.title = Note Revision History
 encounter.history.title = History
+encounter.issueHistory.empty = No history has been recorded for this issue.
 encounter.quickChart.msg = View Quick Chart
 encounter.fullChart.msg = View Full Chart
 encounter.noteLockError.Msg = This note was already saved in another window.\\nPlease close the encounter and open it again if you wish to edit this note.

--- a/src/main/resources/oscarResources_es.properties
+++ b/src/main/resources/oscarResources_es.properties
@@ -1123,6 +1123,8 @@ encounter.futureDate.Msg = Fecha de consulta futura, se vuelve a fecha actual
 encounter.noteReason.TelProgress=Tel-Nota de progreso
 encounter.noteHistory.title = Historial de revisiones de nota
 encounter.history.title = Historial
+# TODO: translate
+encounter.issueHistory.empty = No history has been recorded for this issue.
 encounter.quickChart.msg = Ver historia acotada
 encounter.fullChart.msg = Ver historia completa
 

--- a/src/main/resources/oscarResources_es.properties
+++ b/src/main/resources/oscarResources_es.properties
@@ -1123,8 +1123,7 @@ encounter.futureDate.Msg = Fecha de consulta futura, se vuelve a fecha actual
 encounter.noteReason.TelProgress=Tel-Nota de progreso
 encounter.noteHistory.title = Historial de revisiones de nota
 encounter.history.title = Historial
-# TODO: translate
-encounter.issueHistory.empty = No history has been recorded for this issue.
+encounter.issueHistory.empty = No se ha registrado historial para este problema.
 encounter.quickChart.msg = Ver historia acotada
 encounter.fullChart.msg = Ver historia completa
 

--- a/src/main/resources/oscarResources_fr.properties
+++ b/src/main/resources/oscarResources_fr.properties
@@ -999,6 +999,8 @@ encounter.futureDate.Msg=Date d'observation est dans le future\!
 encounter.noteReason.TelProgress=Tel-Note sur le progres
 encounter.noteHistory.title=Note d'histoire de cas
 encounter.history.title=Histoire de cas
+# TODO: translate
+encounter.issueHistory.empty = No history has been recorded for this issue.
 encounter.quickChart.msg = Masquer les notes
 encounter.fullChart.msg = Voir toutes les notes
 

--- a/src/main/resources/oscarResources_fr.properties
+++ b/src/main/resources/oscarResources_fr.properties
@@ -999,8 +999,7 @@ encounter.futureDate.Msg=Date d'observation est dans le future\!
 encounter.noteReason.TelProgress=Tel-Note sur le progres
 encounter.noteHistory.title=Note d'histoire de cas
 encounter.history.title=Histoire de cas
-# TODO: translate
-encounter.issueHistory.empty = No history has been recorded for this issue.
+encounter.issueHistory.empty = Aucun historique n'a été enregistré pour ce problème.
 encounter.quickChart.msg = Masquer les notes
 encounter.fullChart.msg = Voir toutes les notes
 

--- a/src/main/resources/oscarResources_pl.properties
+++ b/src/main/resources/oscarResources_pl.properties
@@ -1019,6 +1019,8 @@ encounter.referenceIssues.title=referencyjny Zagadnienia
 encounter.removedIssue.Msg=Usuni&#X119;to nast&#X119;puj&#X105;cy problem (s)
 encounter.noteHistory.title Uwaga=Historia zmian
 encounter.history.title=Historia
+# TODO: translate
+encounter.issueHistory.empty = No history has been recorded for this issue.
 
 admin.admin.page.title=ADMINISTRACYJNE
 

--- a/src/main/resources/oscarResources_pl.properties
+++ b/src/main/resources/oscarResources_pl.properties
@@ -1019,8 +1019,7 @@ encounter.referenceIssues.title=referencyjny Zagadnienia
 encounter.removedIssue.Msg=Usuni&#X119;to nast&#X119;puj&#X105;cy problem (s)
 encounter.noteHistory.title Uwaga=Historia zmian
 encounter.history.title=Historia
-# TODO: translate
-encounter.issueHistory.empty = No history has been recorded for this issue.
+encounter.issueHistory.empty = Nie odnotowano historii dla tego problemu.
 
 admin.admin.page.title=ADMINISTRACYJNE
 

--- a/src/main/resources/oscarResources_pt_BR.properties
+++ b/src/main/resources/oscarResources_pt_BR.properties
@@ -1177,6 +1177,8 @@ encounter.futureDate.Msg =  Data de observa\u00E7\u00E3o definida no futuro, rev
 encounter.noteReason.TelProgress =  Data de observa\u00E7\u00E3o definida no futuro, revertida para a hora atual
 encounter.noteHistory.title = Hist\u00F3rico de revis\u00F5es de notas
 encounter.history.title = Hist\u00F3ria
+# TODO: translate
+encounter.issueHistory.empty = No history has been recorded for this issue.
 encounter.quickChart.msg = Ver gr\u00E1fico r\u00E1pido
 encounter.fullChart.msg = Ver gr\u00E1fico completo
 encounter.noteLockError.Msg = Esta nota j\u00E1 foi salva em outra janela.\\nPor favor, feche a consulta e abra-o novamente se desejar editar esta nota.

--- a/src/main/resources/oscarResources_pt_BR.properties
+++ b/src/main/resources/oscarResources_pt_BR.properties
@@ -1177,8 +1177,7 @@ encounter.futureDate.Msg =  Data de observa\u00E7\u00E3o definida no futuro, rev
 encounter.noteReason.TelProgress =  Data de observa\u00E7\u00E3o definida no futuro, revertida para a hora atual
 encounter.noteHistory.title = Hist\u00F3rico de revis\u00F5es de notas
 encounter.history.title = Hist\u00F3ria
-# TODO: translate
-encounter.issueHistory.empty = No history has been recorded for this issue.
+encounter.issueHistory.empty = Nenhum histórico foi registrado para este problema.
 encounter.quickChart.msg = Ver gr\u00E1fico r\u00E1pido
 encounter.fullChart.msg = Ver gr\u00E1fico completo
 encounter.noteLockError.Msg = Esta nota j\u00E1 foi salva em outra janela.\\nPor favor, feche a consulta e abra-o novamente se desejar editar esta nota.

--- a/src/main/webapp/WEB-INF/jsp/casemgmt/showHistory.jsp
+++ b/src/main/webapp/WEB-INF/jsp/casemgmt/showHistory.jsp
@@ -28,6 +28,21 @@
     CARLOS has no affiliation with OSCAR or McMaster University.
 
 --%>
+<%--
+    showHistory.jsp — Renders the "Note History" popup for a case management note
+    or CPP issue (e.g. Family History, Other Meds, Risk Factors).
+
+    Reached via CaseManagementEntry?method=notehistory (single note revision
+    history) or method=issuehistory (all notes linked to one or more issues).
+    The controller (CaseManagementEntry2Action) sets request attributes
+    "title", "demoName", "history" (List<CaseManagementNote>), and, for the
+    issuehistory path, "current" (parallel List<Boolean> flags).
+
+    When "history" is empty — a legitimate state when no unlocked notes exist
+    for the issue — an empty-state message is shown instead of a blank body.
+
+    @since 2026-08-07
+--%>
 <%@ taglib uri="jakarta.tags.functions" prefix="fn" %>
 <%@ taglib uri="carlos" prefix="carlos" %>
 <%@ include file="/WEB-INF/jsp/casemgmt/taglibs.jsp" %>

--- a/src/main/webapp/WEB-INF/jsp/casemgmt/showHistory.jsp
+++ b/src/main/webapp/WEB-INF/jsp/casemgmt/showHistory.jsp
@@ -31,6 +31,7 @@
 <%@ taglib uri="jakarta.tags.functions" prefix="fn" %>
 <%@ taglib uri="carlos" prefix="carlos" %>
 <%@ include file="/WEB-INF/jsp/casemgmt/taglibs.jsp" %>
+<fmt:setBundle basename="oscarResources"/>
 <%@page import="io.github.carlos_emr.carlos.casemgmt.model.CaseManagementNote" %>
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
@@ -62,6 +63,9 @@
 <body>
     <h3 style="text-align: center;">${title}</h3>
     <h3 style="text-align: center;">${demoName}</h3>
+    <c:if test="${empty history}">
+        <p style="text-align: center;"><fmt:message key="encounter.issueHistory.empty"/></p>
+    </c:if>
     <c:forEach var="note" items="${history}" varStatus="idx">
         <div style="width: 99%; background-color: #EFEFEF; font-size: 12px; border-left: thin groove #000000; border-bottom: thin groove #000000; border-right: thin groove #000000;">
             <div>


### PR DESCRIPTION
## Description

Clicking Family History / Other Meds / Risk Factors in the CPP panel opens the "Note History" popup (`CaseManagementEntry?method=issuehistory`), rendered by `showHistory.jsp`. When the returned `history` list is empty, the JSP's `<c:forEach>` simply renders nothing after the two headings, so the page looks broken instead of communicating "no history recorded."

I traced the data path end-to-end (`CaseManagementEntry2Action.issuehistory()` -> `CaseManagementManagerImpl.getIssueHistory()` -> `CaseManagementNoteDAOImpl.getIssueHistory()`) and confirmed the query and locked-note filtering are correct — an empty result for an issue with zero linked notes is legitimate, not a data bug. So the fix is scoped to the JSP's missing empty-state fallback, as the issue itself suggested.

## Changes

- `showHistory.jsp`: added a `<c:if test="${empty history}">` block that renders a localized message when there are no history entries, plus the `fmt:setBundle` declaration required to use `fmt:message` in this JSP.
- Added a new `encounter.issueHistory.empty` key to `oscarResources_en.properties` ("No history has been recorded for this issue.") and to the `es`/`fr`/`pl`/`pt_BR` bundles as English placeholders with `# TODO: translate`, per the i18n contribution guide.

## Related Issues

Fixes #3363

## How Was This Tested?

No devcontainer/Docker/Maven toolchain was available in this environment, so I could not build/deploy and click through the popup live, or run the JSP-compiling test suite. What I did verify:

- Read the actual `issuehistory()` action method and the `getIssueHistory` HQL query directly (not just the issue description) to confirm the empty list is a legitimate result, not a bug to fix upstream.
- Ran `scripts/check-i18n-properties.sh` locally — all locales report 100% key coverage, 0 missing, 0 orphaned after the new key was added.
- Manually reviewed the JSP change for correct JSTL syntax and consistency with the `fmt:setBundle` placement convention used in sibling JSPs (e.g. `ChartNotes.jsp`).

I could not find an existing automated test harness that exercises this specific JSP rendering path (`showHistory.jsp` / `issuehistory()`), so no new automated test was added — flagging this rather than fabricating a test run.

## Screenshots

N/A — could not run the app in this environment (no Docker/devcontainer available). Happy to add a screenshot if a reviewer can confirm on a running instance, or if guided to a way to run it headlessly here.

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have not included any patient data (PHI) in this PR
- [ ] I have added tests for new functionality, or this change doesn't need new tests — see note above; no applicable test harness found for this JSP path
- [x] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Add an empty-state message to the Issue History popup when no notes exist.

New Features:
- Display a localized "no history recorded" message in the Note History popup when the history list is empty.

Bug Fixes:
- Prevent the Issue History popup from appearing broken by explicitly handling the case where no history entries are returned.

Enhancements:
- Configure the showHistory.jsp view to use the shared oscarResources bundle for localized messages.

Chores:
- Add the encounter.issueHistory.empty localization key to all supported resource bundles, with English text and TODO translation markers where needed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows a localized empty-state message in the Issue History popup when an issue has no notes, replacing the previous blank body. Loads the `oscarResources` bundle and adds `encounter.issueHistory.empty` with translations for `en/es/fr/pl/pt_BR`.

- Review Notes
  - Change is limited to `showHistory.jsp`; controllers/DAOs are unchanged.
  - Verify the message appears for `CaseManagementEntry?method=issuehistory` when `history` is empty and renders correctly in all listed locales.

<sup>Written for commit a2e96d3a612ee993a1ca8061e2bebe88761c5963. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

