### PR TITLE
fix(report): handle native eform record counts

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/EFormReportToolDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/EFormReportToolDaoImpl.java
@@ -28,6 +28,8 @@
  * Now maintained by the CARLOS EMR Project (2026+).
  * https://github.com/carlos-emr/carlos
  * CARLOS has no affiliation with OSCAR or McMaster University.
+ *
+ * Modifications by CARLOS Contributors, 2026.
  */
 package io.github.carlos_emr.carlos.commn.dao;
 
@@ -190,7 +192,7 @@ public class EFormReportToolDaoImpl extends AbstractDaoImpl<EFormReportTool> imp
         if (eformReportTool != null) {
             String tableName = getValidatedTableName(eformReportTool);
             Query q = entityManager.createNativeQuery("select count(*) from " + tableName);
-            List<BigInteger> results = q.getResultList();
+            List<Number> results = q.getResultList();
             if (!results.isEmpty()) {
                 return results.get(0).intValue();
             }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/EFormReportToolDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/EFormReportToolDaoImpl.java
@@ -192,9 +192,9 @@ public class EFormReportToolDaoImpl extends AbstractDaoImpl<EFormReportTool> imp
         if (eformReportTool != null) {
             String tableName = getValidatedTableName(eformReportTool);
             Query q = entityManager.createNativeQuery("select count(*) from " + tableName);
-            List<Number> results = q.getResultList();
+            List<?> results = q.getResultList();
             if (!results.isEmpty()) {
-                return results.get(0).intValue();
+                return ((Number) results.get(0)).intValue();
             }
         }
         return null;

--- a/src/test/java/io/github/carlos_emr/carlos/commn/dao/EFormReportToolRecordCountUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/commn/dao/EFormReportToolRecordCountUnitTest.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.commn.dao;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.github.carlos_emr.carlos.commn.model.EFormReportTool;
+
+@Tag("unit")
+@Tag("fast")
+@DisplayName("EForm Report Tool record count unit tests")
+class EFormReportToolRecordCountUnitTest {
+
+    @Test
+    @DisplayName("should return record count when native query produces a Long")
+    void shouldReturnRecordCount_whenNativeQueryProducesLong() {
+        EntityManager entityManager = mock(EntityManager.class);
+        Query query = mock(Query.class);
+        when(entityManager.createNativeQuery("select count(*) from ERT_safe")).thenReturn(query);
+        when(query.getResultList()).thenReturn(Collections.singletonList(0L));
+
+        TestEFormReportToolDao dao = new TestEFormReportToolDao(entityManager);
+        EFormReportTool reportTool = new EFormReportTool();
+        reportTool.setTableName("ERT_safe");
+
+        assertThat(dao.getNumRecords(reportTool)).isZero();
+    }
+
+    private static final class TestEFormReportToolDao extends EFormReportToolDaoImpl {
+
+        private TestEFormReportToolDao(EntityManager entityManager) {
+            this.entityManager = entityManager;
+        }
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/ReportingServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/ReportingServiceUnitTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Field;
+import java.util.List;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -44,7 +45,9 @@ import org.mockito.quality.Strictness;
 
 import io.github.carlos_emr.CarlosProperties;
 import io.github.carlos_emr.carlos.commn.dao.EFormDao;
+import io.github.carlos_emr.carlos.commn.dao.EFormReportToolDao;
 import io.github.carlos_emr.carlos.commn.dao.PreventionReportDao;
+import io.github.carlos_emr.carlos.commn.model.EFormReportTool;
 import io.github.carlos_emr.carlos.commn.model.PreventionReport;
 import io.github.carlos_emr.carlos.commn.model.Provider;
 import io.github.carlos_emr.carlos.managers.DemographicSetsManager;
@@ -53,6 +56,7 @@ import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.prev.reports.Report;
 import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import io.github.carlos_emr.carlos.webserv.rest.to.AbstractSearchResponse;
 import io.github.carlos_emr.carlos.webserv.rest.to.GenericRestResponse.ResponseStatus;
 import io.github.carlos_emr.carlos.webserv.rest.to.RestResponse;
 import io.github.carlos_emr.carlos.webserv.rest.to.model.EFormReportToolTo1;
@@ -137,6 +141,33 @@ class ReportingServiceUnitTest extends CarlosUnitTestBase {
     void tearDown() {
         if (carlosPropertiesMock != null) {
             carlosPropertiesMock.close();
+        }
+    }
+
+    @Nested
+    @DisplayName("eformReportToolList")
+    class EFormReportToolList {
+
+        @Test
+        @DisplayName("should return existing report with zero records")
+        void shouldReturnExistingReport_withZeroRecords() {
+            EFormReportTool reportTool = new EFormReportTool();
+            reportTool.setId(17);
+            reportTool.setName("empty_report");
+            reportTool.setEformId(23);
+
+            when(mockEFormReportToolManager.findAll(
+                    any(), eq(0), eq(EFormReportToolDao.MAX_LIST_RETURN_SIZE)))
+                    .thenReturn(List.of(reportTool));
+            when(mockEFormReportToolManager.getNumRecords(any(), eq(reportTool))).thenReturn(0);
+
+            AbstractSearchResponse<EFormReportToolTo1> response = service.eformReportToolList();
+
+            assertThat(response.getTotal()).isEqualTo(1);
+            assertThat(response.getContent()).singleElement().satisfies(result -> {
+                assertThat(result.getName()).isEqualTo("empty_report");
+                assertThat(result.getNumRecordsInTable()).isZero();
+            });
         }
     }
 

--- a/src/test/java/io/github/carlos_emr/carlos/webserv/rest/ReportingServiceUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/webserv/rest/ReportingServiceUnitTest.java
@@ -168,6 +168,7 @@ class ReportingServiceUnitTest extends CarlosUnitTestBase {
                 assertThat(result.getName()).isEqualTo("empty_report");
                 assertThat(result.getNumRecordsInTable()).isZero();
             });
+            verify(mockEFormReportToolManager).getNumRecords(loggedInInfo, reportTool);
         }
     }
 


### PR DESCRIPTION
## Description

- Treat native EForm Report Tool `COUNT(*)` values as `Number`, supporting the `Long` returned by the current Hibernate/database stack.
- Add focused regression coverage for the native count type and report-list conversion of an empty generated table.

## Related Issues

Fixes #3376

## How Was This Tested?

- `mvn -Dtest=EFormReportToolRecordCountUnitTest,ReportingServiceUnitTest test`
- 27 tests passed with 0 failures, errors, or skips.

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change does not need new tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Handle native EForm report COUNT(*) values as generic Numbers and ensure empty reports are correctly surfaced in report listings.

Bug Fixes:
- Ensure EForm report native COUNT(*) results are interpreted as Number to support Long-returning database drivers.
- Fix reporting of existing EForm reports whose generated tables contain zero records so they display correctly with a zero count.

Tests:
- Add a DAO-level unit test verifying record counts when native queries return Long values.
- Extend reporting service tests to cover listing of EForm reports with empty generated tables.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect record counts in the EForm Report Tool by reading native `COUNT(*)` results as `Number` (supports Hibernate `Long`). Also ensures reports from empty generated tables show zero records in the list.

- **Bug Fixes**
  - Read native count results as `Number` and return `intValue()`.
  - Strengthened tests for `Long` counts and zero-record report listing.

<sup>Written for commit 6b180bb029ceea7d9974fedaf67cfb863ef08973. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

