### PR TITLE
fix(form): render Select Forms panel after add, delete, and move actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "test:consultation-signature-playwright": "node scripts/consultation-signature-playwright-checks.js",
     "test:consultation-signature-submit-playwright": "node scripts/consultation-signature-submit-playwright-checks.js",
     "test:prescription-signature-playwright": "node scripts/prescription-signature-playwright-checks.js",
-    "test:report-demographic-navigation-playwright": "node scripts/report-demographic-navigation-playwright-checks.js"
+    "test:report-demographic-navigation-playwright": "node scripts/report-demographic-navigation-playwright-checks.js",
+    "test:select-forms-panel-playwright": "node scripts/select-forms-panel-playwright-checks.js"
   },
   "dependencies": {
     "@docusaurus/core": "^3.9.2",

--- a/scripts/select-forms-panel-playwright-checks.js
+++ b/scripts/select-forms-panel-playwright-checks.js
@@ -44,8 +44,8 @@ const consoleIssues = [];
 // means the AJAX handler injected an error fragment or an empty body rather than the panel.
 const MIN_PANEL_BYTES = 500;
 
-// Playwright resource types whose 4xx/5xx responses are cosmetic for this check.
-const IGNORED_FAILING_RESOURCE_TYPES = new Set(['image', 'font', 'stylesheet', 'media']);
+// Playwright resource types whose absence (404 only) is cosmetic for this check.
+const IGNORED_MISSING_RESOURCE_TYPES = new Set(['image', 'font', 'stylesheet', 'media']);
 
 // Matches a full dotted-quad IPv4 address only (anchored start-to-end), so a
 // hostname like "10.attacker.example" cannot be mistaken for the private
@@ -116,11 +116,12 @@ function wirePage(page, label) {
     if (status < 400) {
       return;
     }
-    // Decorative assets are not what this check is about: a missing icon or font in the
-    // administration shell must not be reported as a Select Forms panel regression.
-    // Documents, scripts, and XHR/fetch traffic are still captured, so a failing
-    // navigation or a failing panel POST does fail the run.
-    if (IGNORED_FAILING_RESOURCE_TYPES.has(response.request().resourceType())) {
+    // A missing icon or font in the administration shell is not a Select Forms panel
+    // regression, so a 404 on a decorative asset is ignored. The exemption stops at 404
+    // on purpose: a 403 or 5xx on the very same asset signals a real server or
+    // authorization failure and must still fail the run, as must every non-asset
+    // response — documents, scripts, and XHR/fetch traffic are always captured.
+    if (status === 404 && IGNORED_MISSING_RESOURCE_TYPES.has(response.request().resourceType())) {
       return;
     }
     badResponses.push({ label, status, url: response.url() });

--- a/scripts/select-forms-panel-playwright-checks.js
+++ b/scripts/select-forms-panel-playwright-checks.js
@@ -29,6 +29,9 @@ const { chromium } = require('playwright');
 // Declared before the validateBaseUrl() call below: `const` bindings are in the
 // temporal dead zone until initialized, so a set declared further down the file
 // would throw when the validator runs at module load.
+// Only these literal loopback/devcontainer hosts count as local. RFC1918/private
+// IPs require ALLOW_NON_LOCAL_BASE_URL=true so the caller opts into a non-local
+// test target explicitly instead of being trusted by address range alone.
 const LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '0.0.0.0', 'host.docker.internal', 'carlos']);
 
 const baseUrl = validateBaseUrl(process.env.BASE_URL || 'http://127.0.0.1:8080/carlos');
@@ -49,27 +52,11 @@ const MIN_PANEL_CHARS = 500;
 // Playwright resource types whose absence (404 only) is cosmetic for this check.
 const IGNORED_MISSING_RESOURCE_TYPES = new Set(['image', 'font', 'stylesheet', 'media']);
 
-// Matches a full dotted-quad IPv4 address only (anchored start-to-end), so a
-// hostname like "10.attacker.example" cannot be mistaken for the private
-// 10.0.0.0/8 range just because it starts with the same characters as one.
-function isPrivateIpv4(host) {
-  const match = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
-  if (!match) {
-    return false;
-  }
-  const octets = match.slice(1).map(Number);
-  if (octets.some((octet) => octet > 255)) {
-    return false;
-  }
-  const [a, b] = octets;
-  return a === 10 || (a === 192 && b === 168) || (a === 172 && b >= 16 && b <= 31);
-}
-
 function isLocalHost(rawHost) {
   // URL.hostname keeps the brackets on IPv6 literals (e.g. "[::1]"); strip
   // them so bracketed loopback addresses match the same as their bare form.
   const host = rawHost.toLowerCase().replace(/^\[|\]$/g, '');
-  return LOCAL_HOSTS.has(host) || isPrivateIpv4(host);
+  return LOCAL_HOSTS.has(host);
 }
 
 function validateBaseUrl(rawBaseUrl) {
@@ -306,7 +293,9 @@ async function restoreSubject(page, subject) {
   }
 
   const browser = await chromium.launch(launchOptions);
-  const context = await browser.newContext({ ignoreHTTPSErrors: true });
+  const context = await browser.newContext({
+    ignoreHTTPSErrors: baseUrl.protocol === 'https:' && isLocalHost(baseUrl.hostname),
+  });
   let page = null;
   let subject = null;
   let subjectRestored = false;

--- a/scripts/select-forms-panel-playwright-checks.js
+++ b/scripts/select-forms-panel-playwright-checks.js
@@ -44,6 +44,9 @@ const consoleIssues = [];
 // means the AJAX handler injected an error fragment or an empty body rather than the panel.
 const MIN_PANEL_BYTES = 500;
 
+// Playwright resource types whose 4xx/5xx responses are cosmetic for this check.
+const IGNORED_FAILING_RESOURCE_TYPES = new Set(['image', 'font', 'stylesheet', 'media']);
+
 // Matches a full dotted-quad IPv4 address only (anchored start-to-end), so a
 // hostname like "10.attacker.example" cannot be mistaken for the private
 // 10.0.0.0/8 range just because it starts with the same characters as one.
@@ -110,9 +113,17 @@ function wirePage(page, label) {
   });
   page.on('response', (response) => {
     const status = response.status();
-    if (status >= 400) {
-      badResponses.push({ label, status, url: response.url() });
+    if (status < 400) {
+      return;
     }
+    // Decorative assets are not what this check is about: a missing icon or font in the
+    // administration shell must not be reported as a Select Forms panel regression.
+    // Documents, scripts, and XHR/fetch traffic are still captured, so a failing
+    // navigation or a failing panel POST does fail the run.
+    if (IGNORED_FAILING_RESOURCE_TYPES.has(response.request().resourceType())) {
+      return;
+    }
+    badResponses.push({ label, status, url: response.url() });
   });
   page.on('console', (message) => {
     const text = message.text();
@@ -336,9 +347,16 @@ async function restoreSubject(page, subject) {
       formName: subject,
     });
     assertPanelRendered(afterUp, 'move up');
+    // Add appends the subject last. On an install where nothing was selected to begin
+    // with it is also first, and Move Up correctly no-ops rather than moving it off the
+    // top of the list — assert that boundary instead of demanding a position change.
+    const addedIndex = afterAdd.selected.indexOf(subject);
+    const expectedUpIndex = addedIndex === 0 ? 0 : addedIndex - 1;
     assert(
-      afterUp.selected.indexOf(subject) === afterAdd.selected.indexOf(subject) - 1,
-      `move up did not raise ${subject} by one position`,
+      afterUp.selected.indexOf(subject) === expectedUpIndex,
+      addedIndex === 0
+        ? `move up should have left ${subject} at the top of a single-entry list`
+        : `move up did not raise ${subject} by one position`,
     );
 
     const afterDown = await clickPanelButton(page, {
@@ -348,8 +366,11 @@ async function restoreSubject(page, subject) {
       formName: subject,
     });
     assertPanelRendered(afterDown, 'move down');
+    // Symmetric to Move Up: normally this puts the subject back where Add left it, and
+    // when Move Up was a no-op the subject is still last, so Move Down no-ops too. Both
+    // cases land on addedIndex.
     assert(
-      afterDown.selected.indexOf(subject) === afterAdd.selected.indexOf(subject),
+      afterDown.selected.indexOf(subject) === addedIndex,
       `move down did not restore the original position of ${subject}`,
     );
 

--- a/scripts/select-forms-panel-playwright-checks.js
+++ b/scripts/select-forms-panel-playwright-checks.js
@@ -224,16 +224,26 @@ async function clickPanelButton(page, { buttonSelector, listName, formName, labe
   return { ...(await readPanel(page)), responseBytes };
 }
 
+/**
+ * Asserts the AJAX handler injected a real panel rather than an empty body or an
+ * error fragment. Deliberately says nothing about how many forms are selected: an
+ * install with every encounter form hidden renders a valid panel with an empty
+ * selected list, and failing that would be a false alarm rather than a regression.
+ */
 function assertPanelRendered(panel, label) {
   assert(panel.hasSelectForm, `${label}: #dynamic-content lost the Select Forms form`);
   assert(
     panel.bytes >= MIN_PANEL_BYTES,
     `${label}: #dynamic-content collapsed to ${panel.bytes} bytes (issue #3377 blank panel)`,
   );
-  assert(
-    panel.selected.length > 0,
-    `${label}: Select Forms panel rendered without any selected forms`,
-  );
+}
+
+function sameOrder(actual, expected) {
+  return actual.length === expected.length && actual.every((value, i) => value === expected[i]);
+}
+
+function sameMembers(actual, expected) {
+  return sameOrder([...actual].sort(), [...expected].sort());
 }
 
 /**
@@ -241,13 +251,20 @@ function assertPanelRendered(panel, label) {
  *
  * Deleting the subject undoes the whole sequence: Add appends it last, and Delete
  * zeroes its display order while decrementing everything above it, so any form the
- * Move Up/Move Down steps displaced lands back on its original order. Failures here
- * are swallowed — the real assertion error must be what surfaces.
+ * Move Up/Move Down steps displaced lands back on its original order.
+ *
+ * The decision is made against a panel freshly reloaded from the server, not the
+ * DOM left behind by the failure. A mutation whose POST succeeded but whose panel
+ * refresh did not would otherwise look un-applied in stale markup and be skipped,
+ * leaving the change on disk. Exactly one compensating delete is issued, and only
+ * when the server still reports the subject as selected. Failures here are
+ * swallowed — the real assertion error must be what surfaces.
  */
 async function restoreSubject(page, subject) {
   try {
+    await openSelectFormsPanel(page);
     const panel = await readPanel(page);
-    if (!panel.hasSelectForm || !panel.selected.includes(subject)) {
+    if (!panel.selected.includes(subject)) {
       return;
     }
     await clickPanelButton(page, {
@@ -297,8 +314,8 @@ async function restoreSubject(page, subject) {
     const noSelection = await clickPanelButton(page, { buttonSelector: '#add', label: 'add with no selection' });
     assertPanelRendered(noSelection, 'add with no selection');
     assert(
-      noSelection.available.length === initial.available.length
-        && noSelection.selected.length === initial.selected.length,
+      sameOrder(noSelection.selected, initial.selected)
+        && sameMembers(noSelection.available, initial.available),
       'add with no selection changed the form lists',
     );
 
@@ -345,6 +362,20 @@ async function restoreSubject(page, subject) {
     assertPanelRendered(afterDelete, 'delete');
     assert(afterDelete.available.includes(subject), `delete did not return ${subject} to the available list`);
     assert(!afterDelete.selected.includes(subject), `delete left ${subject} in the selected list`);
+    // Enforce the state-neutrality this check claims: the add/up/down/delete sequence
+    // must leave the selected forms in exactly their original order, not merely the same
+    // set. Hidden forms all share display order 0, so their order carries no meaning and
+    // only membership is compared.
+    assert(
+      sameOrder(afterDelete.selected, initial.selected),
+      `selected form order was not restored: expected ${JSON.stringify(initial.selected)},`
+        + ` got ${JSON.stringify(afterDelete.selected)}`,
+    );
+    assert(
+      sameMembers(afterDelete.available, initial.available),
+      `available form list was not restored: expected ${JSON.stringify(initial.available)},`
+        + ` got ${JSON.stringify(afterDelete.available)}`,
+    );
     // The Delete step is itself the rollback; nothing is left for the finally block to undo.
     subjectRestored = true;
 

--- a/scripts/select-forms-panel-playwright-checks.js
+++ b/scripts/select-forms-panel-playwright-checks.js
@@ -5,7 +5,7 @@
  * Issue #3377: Add, Delete, Move Up, and Move Down each POST the shared form to
  * /form/select, whose response is injected into #dynamic-content by the administration
  * AJAX handler. When the success result was a servlet-dispatch forward to the
- * /form/setupSelect action path, that response came back as HTTP 200 with zero bytes and
+ * /form/setupSelect action path, that response came back as HTTP 200 with an empty body and
  * the panel rendered white. This script drives all four buttons through the real
  * administration shell and asserts the panel keeps rendering.
  *
@@ -42,7 +42,9 @@ const consoleIssues = [];
 
 // The Select Forms panel is a table of <select> lists; anything materially smaller than this
 // means the AJAX handler injected an error fragment or an empty body rather than the panel.
-const MIN_PANEL_BYTES = 500;
+// Counted in JS string characters (UTF-16 code units), not bytes — the threshold only has to
+// separate "real panel" from "empty or error fragment", so exact payload size is irrelevant.
+const MIN_PANEL_CHARS = 500;
 
 // Playwright resource types whose absence (404 only) is cosmetic for this check.
 const IGNORED_MISSING_RESOURCE_TYPES = new Set(['image', 'font', 'stylesheet', 'media']);
@@ -171,13 +173,13 @@ async function openSelectFormsPanel(page) {
   await page.locator('#dynamic-content #selectForm').waitFor({ state: 'attached', timeout: 30000 });
 }
 
-/** Reads the two form lists plus the injected panel size out of #dynamic-content. */
+/** Reads the two form lists plus the injected panel character count out of #dynamic-content. */
 async function readPanel(page) {
   return page.evaluate(() => {
     const panel = document.getElementById('dynamic-content');
     const options = (name) => [...panel.querySelectorAll(`select[name="${name}"] option`)].map((o) => o.value);
     return {
-      bytes: panel.innerHTML.length,
+      chars: panel.innerHTML.length,
       hasSelectForm: !!panel.querySelector('#selectForm'),
       available: options('selectedAddTypes'),
       selected: options('selectedDeleteTypes'),
@@ -217,10 +219,10 @@ async function clickPanelButton(page, { buttonSelector, listName, formName, labe
   }, { selector: buttonSelector, list: listName, name: formName });
 
   const response = await responsePromise;
-  const responseBytes = (await response.text()).length;
+  const responseChars = (await response.text()).length;
   assert(
-    responseBytes >= MIN_PANEL_BYTES,
-    `${label}: POST /form/select returned ${response.status()} with ${responseBytes} bytes;`
+    responseChars >= MIN_PANEL_CHARS,
+    `${label}: POST /form/select returned ${response.status()} with ${responseChars} characters;`
       + ' the AJAX handler needs the re-rendered Select Forms panel in the response'
       + ' (issue #3377 blank panel)',
   );
@@ -233,7 +235,7 @@ async function clickPanelButton(page, { buttonSelector, listName, formName, labe
     previousForm,
     { timeout: 30000 },
   );
-  return { ...(await readPanel(page)), responseBytes };
+  return { ...(await readPanel(page)), responseChars };
 }
 
 /**
@@ -245,8 +247,8 @@ async function clickPanelButton(page, { buttonSelector, listName, formName, labe
 function assertPanelRendered(panel, label) {
   assert(panel.hasSelectForm, `${label}: #dynamic-content lost the Select Forms form`);
   assert(
-    panel.bytes >= MIN_PANEL_BYTES,
-    `${label}: #dynamic-content collapsed to ${panel.bytes} bytes (issue #3377 blank panel)`,
+    panel.chars >= MIN_PANEL_CHARS,
+    `${label}: #dynamic-content collapsed to ${panel.chars} characters (issue #3377 blank panel)`,
   );
 }
 

--- a/scripts/select-forms-panel-playwright-checks.js
+++ b/scripts/select-forms-panel-playwright-checks.js
@@ -26,6 +26,11 @@
 
 const { chromium } = require('playwright');
 
+// Declared before the validateBaseUrl() call below: `const` bindings are in the
+// temporal dead zone until initialized, so a set declared further down the file
+// would throw when the validator runs at module load.
+const LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '0.0.0.0', 'host.docker.internal', 'carlos']);
+
 const baseUrl = validateBaseUrl(process.env.BASE_URL || 'http://127.0.0.1:8080/carlos');
 const chromePath = process.env.CHROME_PATH || '';
 const testUser = process.env.TEST_USER || 'carlosdoc';
@@ -39,16 +44,42 @@ const consoleIssues = [];
 // means the AJAX handler injected an error fragment or an empty body rather than the panel.
 const MIN_PANEL_BYTES = 500;
 
+// Matches a full dotted-quad IPv4 address only (anchored start-to-end), so a
+// hostname like "10.attacker.example" cannot be mistaken for the private
+// 10.0.0.0/8 range just because it starts with the same characters as one.
+function isPrivateIpv4(host) {
+  const match = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
+  if (!match) {
+    return false;
+  }
+  const octets = match.slice(1).map(Number);
+  if (octets.some((octet) => octet > 255)) {
+    return false;
+  }
+  const [a, b] = octets;
+  return a === 10 || (a === 192 && b === 168) || (a === 172 && b >= 16 && b <= 31);
+}
+
+function isLocalHost(rawHost) {
+  // URL.hostname keeps the brackets on IPv6 literals (e.g. "[::1]"); strip
+  // them so bracketed loopback addresses match the same as their bare form.
+  const host = rawHost.toLowerCase().replace(/^\[|\]$/g, '');
+  return LOCAL_HOSTS.has(host) || isPrivateIpv4(host);
+}
+
 function validateBaseUrl(rawBaseUrl) {
   const parsed = new URL(rawBaseUrl);
   if (!['http:', 'https:'].includes(parsed.protocol)) {
     throw new Error(`BASE_URL must use http or https, got ${parsed.protocol}`);
   }
+  // Credentials in BASE_URL would ride along on every navigation and could surface
+  // in the badResponses diagnostics this script prints on failure.
+  if (parsed.username || parsed.password) {
+    throw new Error('BASE_URL must not contain embedded credentials');
+  }
 
   const host = parsed.hostname.toLowerCase();
-  const localHosts = new Set(['localhost', '127.0.0.1', '::1', '0.0.0.0', 'host.docker.internal', 'carlos']);
-  const privateIpv4 = /^(10\.|192\.168\.|172\.(1[6-9]|2\d|3[0-1])\.)/.test(host);
-  if (!localHosts.has(host) && !privateIpv4 && process.env.ALLOW_NON_LOCAL_BASE_URL !== 'true') {
+  if (!isLocalHost(host) && process.env.ALLOW_NON_LOCAL_BASE_URL !== 'true') {
     throw new Error(`Refusing non-local BASE_URL host ${host}; set ALLOW_NON_LOCAL_BASE_URL=true for an intentional test target`);
   }
   parsed.pathname = parsed.pathname.replace(/\/$/, '');
@@ -205,6 +236,35 @@ function assertPanelRendered(panel, label) {
   );
 }
 
+/**
+ * Best-effort rollback for a run that died between the Add and the Delete.
+ *
+ * Deleting the subject undoes the whole sequence: Add appends it last, and Delete
+ * zeroes its display order while decrementing everything above it, so any form the
+ * Move Up/Move Down steps displaced lands back on its original order. Failures here
+ * are swallowed — the real assertion error must be what surfaces.
+ */
+async function restoreSubject(page, subject) {
+  try {
+    const panel = await readPanel(page);
+    if (!panel.hasSelectForm || !panel.selected.includes(subject)) {
+      return;
+    }
+    await clickPanelButton(page, {
+      buttonSelector: '#delete',
+      label: 'cleanup delete',
+      listName: 'selectedDeleteTypes',
+      formName: subject,
+    });
+    console.log(`cleanup: returned ${subject} to the available list`);
+  } catch (cleanupError) {
+    console.error(
+      `WARN cleanup could not return ${subject} to the available list; the encounter form`
+        + ` display order may still be modified: ${cleanupError.message}`,
+    );
+  }
+}
+
 (async () => {
   const launchOptions = {
     headless: true,
@@ -216,8 +276,11 @@ function assertPanelRendered(panel, label) {
 
   const browser = await chromium.launch(launchOptions);
   const context = await browser.newContext({ ignoreHTTPSErrors: true });
+  let page = null;
+  let subject = null;
+  let subjectRestored = false;
   try {
-    const page = await context.newPage();
+    page = await context.newPage();
     wirePage(page, 'select-forms');
     await login(page);
     await openSelectFormsPanel(page);
@@ -228,7 +291,7 @@ function assertPanelRendered(panel, label) {
       initial.available.length > 0,
       'Select Forms has no available forms to exercise Add/Delete; seed at least one hidden encounter form',
     );
-    const subject = initial.available[0];
+    subject = initial.available[0];
 
     // Acceptance criterion: submitting with nothing selected must not blank the panel.
     const noSelection = await clickPanelButton(page, { buttonSelector: '#add', label: 'add with no selection' });
@@ -282,12 +345,17 @@ function assertPanelRendered(panel, label) {
     assertPanelRendered(afterDelete, 'delete');
     assert(afterDelete.available.includes(subject), `delete did not return ${subject} to the available list`);
     assert(!afterDelete.selected.includes(subject), `delete left ${subject} in the selected list`);
+    // The Delete step is itself the rollback; nothing is left for the finally block to undo.
+    subjectRestored = true;
 
     assert(badResponses.length === 0, `unexpected HTTP errors: ${JSON.stringify(badResponses, null, 2)}`);
     assert(consoleIssues.length === 0, `unexpected console issues: ${JSON.stringify(consoleIssues, null, 2)}`);
 
     console.log(`PASS Select Forms panel renders after add, delete, move up, and move down (subject form ${subject})`);
   } finally {
+    if (page && subject && !subjectRestored) {
+      await restoreSubject(page, subject);
+    }
     await context.close().catch(() => {});
     await browser.close().catch(() => {});
   }

--- a/scripts/select-forms-panel-playwright-checks.js
+++ b/scripts/select-forms-panel-playwright-checks.js
@@ -1,0 +1,297 @@
+#!/usr/bin/env node
+/*
+ * Browser regression checks for the Administration > Forms/eForms > Select Forms panel.
+ *
+ * Issue #3377: Add, Delete, Move Up, and Move Down each POST the shared form to
+ * /form/select, whose response is injected into #dynamic-content by the administration
+ * AJAX handler. When the success result was a servlet-dispatch forward to the
+ * /form/setupSelect action path, that response came back as HTTP 200 with zero bytes and
+ * the panel rendered white. This script drives all four buttons through the real
+ * administration shell and asserts the panel keeps rendering.
+ *
+ * The check is state-neutral: it adds an available form, moves it up and back down, then
+ * deletes it, leaving the encounter form display order as it was found.
+ *
+ * Defaults are for the local devcontainer:
+ *   npm run test:select-forms-panel-playwright
+ *
+ * Optional environment:
+ *   BASE_URL=http://127.0.0.1:8080/carlos
+ *   CHROME_PATH=/path/to/chrome-or-chromium
+ *   TEST_USER=carlosdoc
+ *   TEST_PASSWORD=carlos2026
+ *   TEST_PIN=2026
+ *   ALLOW_NON_LOCAL_BASE_URL=true only when intentionally targeting a non-local test app
+ */
+
+const { chromium } = require('playwright');
+
+const baseUrl = validateBaseUrl(process.env.BASE_URL || 'http://127.0.0.1:8080/carlos');
+const chromePath = process.env.CHROME_PATH || '';
+const testUser = process.env.TEST_USER || 'carlosdoc';
+const testPassword = process.env.TEST_PASSWORD || 'carlos2026';
+const testPin = process.env.TEST_PIN || '2026';
+
+const badResponses = [];
+const consoleIssues = [];
+
+// The Select Forms panel is a table of <select> lists; anything materially smaller than this
+// means the AJAX handler injected an error fragment or an empty body rather than the panel.
+const MIN_PANEL_BYTES = 500;
+
+function validateBaseUrl(rawBaseUrl) {
+  const parsed = new URL(rawBaseUrl);
+  if (!['http:', 'https:'].includes(parsed.protocol)) {
+    throw new Error(`BASE_URL must use http or https, got ${parsed.protocol}`);
+  }
+
+  const host = parsed.hostname.toLowerCase();
+  const localHosts = new Set(['localhost', '127.0.0.1', '::1', '0.0.0.0', 'host.docker.internal', 'carlos']);
+  const privateIpv4 = /^(10\.|192\.168\.|172\.(1[6-9]|2\d|3[0-1])\.)/.test(host);
+  if (!localHosts.has(host) && !privateIpv4 && process.env.ALLOW_NON_LOCAL_BASE_URL !== 'true') {
+    throw new Error(`Refusing non-local BASE_URL host ${host}; set ALLOW_NON_LOCAL_BASE_URL=true for an intentional test target`);
+  }
+  parsed.pathname = parsed.pathname.replace(/\/$/, '');
+  return parsed;
+}
+
+function appUrl(appPath) {
+  if (!appPath.startsWith('/') || appPath.startsWith('//')) {
+    throw new Error(`Application path must be root-relative, got ${appPath}`);
+  }
+  const relative = new URL(appPath, 'http://localhost');
+  const url = new URL(baseUrl.href);
+  url.pathname = `${baseUrl.pathname}${relative.pathname}`.replace(/\/{2,}/g, '/');
+  url.search = relative.search;
+  return url.toString();
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function wirePage(page, label) {
+  page.on('dialog', async (dialog) => {
+    consoleIssues.push({ label, type: 'dialog', text: dialog.message() });
+    await dialog.accept();
+  });
+  page.on('response', (response) => {
+    const status = response.status();
+    if (status >= 400) {
+      badResponses.push({ label, status, url: response.url() });
+    }
+  });
+  page.on('console', (message) => {
+    const text = message.text();
+    if (/(ReferenceError|SyntaxError|TypeError|Cannot reset buffer|Server did not return expected success response)/i.test(text)) {
+      consoleIssues.push({ label, type: message.type(), text, location: message.location() });
+    }
+  });
+  page.on('pageerror', (error) => {
+    consoleIssues.push({ label, type: 'pageerror', text: error.stack || error.message });
+  });
+}
+
+async function gotoApp(page, appPath, waitUntil = 'domcontentloaded') {
+  const url = appUrl(appPath);
+  // BASE_URL is restricted by validateBaseUrl(), and appUrl() only accepts root-relative app paths.
+  // nosemgrep: javascript.playwright.security.audit.playwright-goto-injection.playwright-goto-injection
+  return page.goto(url, { waitUntil, timeout: 30000 });
+}
+
+async function login(page) {
+  await gotoApp(page, '/');
+  await page.locator('#username').fill(testUser);
+  await page.locator('#password').fill(testPassword);
+  await page.locator('#pin').fill(testPin);
+  await Promise.all([
+    page.waitForURL(/providercontrol/, { timeout: 30000 }),
+    page.locator('input[type="submit"], button[type="submit"]').first().click(),
+  ]);
+  await page.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+}
+
+/** Opens Administration and loads Select Forms into #dynamic-content via the nav link. */
+async function openSelectFormsPanel(page) {
+  await gotoApp(page, '/administration');
+  await page.locator('#dynamic-content').waitFor({ state: 'attached', timeout: 30000 });
+  await page.evaluate(() => {
+    const link = [...document.querySelectorAll('a.contentLink')]
+      .find((anchor) => /\/form\/setupSelect$/.test(anchor.getAttribute('href') || ''));
+    if (!link) {
+      throw new Error('Administration nav has no Select Forms contentLink');
+    }
+    link.click();
+  });
+  await page.locator('#dynamic-content #selectForm').waitFor({ state: 'attached', timeout: 30000 });
+}
+
+/** Reads the two form lists plus the injected panel size out of #dynamic-content. */
+async function readPanel(page) {
+  return page.evaluate(() => {
+    const panel = document.getElementById('dynamic-content');
+    const options = (name) => [...panel.querySelectorAll(`select[name="${name}"] option`)].map((o) => o.value);
+    return {
+      bytes: panel.innerHTML.length,
+      hasSelectForm: !!panel.querySelector('#selectForm'),
+      available: options('selectedAddTypes'),
+      selected: options('selectedDeleteTypes'),
+    };
+  });
+}
+
+/**
+ * Selects `formName` in the given list, clicks the named button, and returns the refreshed
+ * panel together with the size of the POST response that produced it.
+ *
+ * The POST body is captured directly because that is the contract issue #3377 broke: the
+ * response must carry the re-rendered panel. Once a non-empty body has arrived, the panel is
+ * read after the handler swaps #dynamic-content — the old #selectForm node detaching is what
+ * proves the new markup landed, and that holds even when a no-op action returns byte-identical
+ * markup.
+ */
+async function clickPanelButton(page, { buttonSelector, listName, formName, label }) {
+  const previousForm = await page.locator('#dynamic-content #selectForm').elementHandle();
+  const responsePromise = page.waitForResponse(
+    (response) => response.request().method() === 'POST'
+      && new URL(response.url()).pathname.endsWith('/form/select'),
+    { timeout: 30000 },
+  );
+
+  await page.evaluate(({ selector, list, name }) => {
+    const panel = document.getElementById('dynamic-content');
+    if (list && name) {
+      const box = panel.querySelector(`select[name="${list}"]`);
+      [...box.options].forEach((option) => { option.selected = option.value === name; });
+    }
+    const button = panel.querySelector(selector);
+    if (!button) {
+      throw new Error(`Select Forms panel has no button matching ${selector}`);
+    }
+    button.click();
+  }, { selector: buttonSelector, list: listName, name: formName });
+
+  const response = await responsePromise;
+  const responseBytes = (await response.text()).length;
+  assert(
+    responseBytes >= MIN_PANEL_BYTES,
+    `${label}: POST /form/select returned ${response.status()} with ${responseBytes} bytes;`
+      + ' the AJAX handler needs the re-rendered Select Forms panel in the response'
+      + ' (issue #3377 blank panel)',
+  );
+
+  await page.waitForFunction(
+    (stale) => {
+      const form = document.querySelector('#dynamic-content #selectForm');
+      return !!form && form !== stale;
+    },
+    previousForm,
+    { timeout: 30000 },
+  );
+  return { ...(await readPanel(page)), responseBytes };
+}
+
+function assertPanelRendered(panel, label) {
+  assert(panel.hasSelectForm, `${label}: #dynamic-content lost the Select Forms form`);
+  assert(
+    panel.bytes >= MIN_PANEL_BYTES,
+    `${label}: #dynamic-content collapsed to ${panel.bytes} bytes (issue #3377 blank panel)`,
+  );
+  assert(
+    panel.selected.length > 0,
+    `${label}: Select Forms panel rendered without any selected forms`,
+  );
+}
+
+(async () => {
+  const launchOptions = {
+    headless: true,
+    args: ['--no-sandbox', '--disable-dev-shm-usage'],
+  };
+  if (chromePath) {
+    launchOptions.executablePath = chromePath;
+  }
+
+  const browser = await chromium.launch(launchOptions);
+  const context = await browser.newContext({ ignoreHTTPSErrors: true });
+  try {
+    const page = await context.newPage();
+    wirePage(page, 'select-forms');
+    await login(page);
+    await openSelectFormsPanel(page);
+
+    const initial = await readPanel(page);
+    assertPanelRendered(initial, 'initial load');
+    assert(
+      initial.available.length > 0,
+      'Select Forms has no available forms to exercise Add/Delete; seed at least one hidden encounter form',
+    );
+    const subject = initial.available[0];
+
+    // Acceptance criterion: submitting with nothing selected must not blank the panel.
+    const noSelection = await clickPanelButton(page, { buttonSelector: '#add', label: 'add with no selection' });
+    assertPanelRendered(noSelection, 'add with no selection');
+    assert(
+      noSelection.available.length === initial.available.length
+        && noSelection.selected.length === initial.selected.length,
+      'add with no selection changed the form lists',
+    );
+
+    const afterAdd = await clickPanelButton(page, {
+      buttonSelector: '#add',
+      label: 'add',
+      listName: 'selectedAddTypes',
+      formName: subject,
+    });
+    assertPanelRendered(afterAdd, 'add');
+    assert(afterAdd.selected.includes(subject), `add did not move ${subject} into the selected list`);
+    assert(!afterAdd.available.includes(subject), `add left ${subject} in the available list`);
+
+    const afterUp = await clickPanelButton(page, {
+      buttonSelector: '#up',
+      label: 'move up',
+      listName: 'selectedDeleteTypes',
+      formName: subject,
+    });
+    assertPanelRendered(afterUp, 'move up');
+    assert(
+      afterUp.selected.indexOf(subject) === afterAdd.selected.indexOf(subject) - 1,
+      `move up did not raise ${subject} by one position`,
+    );
+
+    const afterDown = await clickPanelButton(page, {
+      buttonSelector: '#down',
+      label: 'move down',
+      listName: 'selectedDeleteTypes',
+      formName: subject,
+    });
+    assertPanelRendered(afterDown, 'move down');
+    assert(
+      afterDown.selected.indexOf(subject) === afterAdd.selected.indexOf(subject),
+      `move down did not restore the original position of ${subject}`,
+    );
+
+    const afterDelete = await clickPanelButton(page, {
+      buttonSelector: '#delete',
+      label: 'delete',
+      listName: 'selectedDeleteTypes',
+      formName: subject,
+    });
+    assertPanelRendered(afterDelete, 'delete');
+    assert(afterDelete.available.includes(subject), `delete did not return ${subject} to the available list`);
+    assert(!afterDelete.selected.includes(subject), `delete left ${subject} in the selected list`);
+
+    assert(badResponses.length === 0, `unexpected HTTP errors: ${JSON.stringify(badResponses, null, 2)}`);
+    assert(consoleIssues.length === 0, `unexpected console issues: ${JSON.stringify(consoleIssues, null, 2)}`);
+
+    console.log(`PASS Select Forms panel renders after add, delete, move up, and move down (subject form ${subject})`);
+  } finally {
+    await context.close().catch(() => {});
+    await browser.close().catch(() => {});
+  }
+})().catch((error) => {
+  console.error(`FAIL Select Forms panel checks: ${error.stack || error.message}`);
+  process.exit(1);
+});

--- a/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FrmSelect2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FrmSelect2Action.java
@@ -57,6 +57,20 @@ public class FrmSelect2Action extends ActionSupport {
     private static Logger logger = MiscUtils.getLogger();
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
 
+    /**
+     * Applies the requested Select Forms mutation and returns the setup route so Struts
+     * re-renders the panel markup for the administration AJAX shell.
+     *
+     * <p>This route is POST-only because every supported {@code forward} value mutates
+     * encounter form display order. The separate {@code form/setupSelect} action owns the
+     * read-only GET rendering path, so non-POST requests are rejected with HTTP 405 and
+     * {@code Allow: POST} before the privilege check to prevent CSRF-bypassing mutations.
+     *
+     * @return {@link #SUCCESS} after applying the requested mutation, or {@link #NONE}
+     *         after sending HTTP 405 for a non-POST request
+     * @throws ServletException if the servlet container rejects the error response
+     * @throws IOException if writing the HTTP 405 response fails
+     */
     @Override
     public String execute() throws ServletException, IOException {
         // Every branch below mutates encounter form display order, and CSRFGuard only

--- a/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FrmSelect2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/form/pageUtil/FrmSelect2Action.java
@@ -59,6 +59,18 @@ public class FrmSelect2Action extends ActionSupport {
 
     @Override
     public String execute() throws ServletException, IOException {
+        // Every branch below mutates encounter form display order, and CSRFGuard only
+        // validates non-GET methods — so a crafted GET such as
+        // /form/select?forward=delete&selectedDeleteTypes=... would hide forms for any
+        // signed-in administrator without a token. Reject before the privilege check so
+        // no mutation can fire. Rendering the panel is the separate form/setupSelect route;
+        // the only caller here is the POST form in formselect.jsp.
+        if (!"POST".equals(request.getMethod())) {
+            response.setHeader("Allow", "POST");
+            response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED, "POST required");
+            return NONE;
+        }
+
         if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_form", "w", null)) {
             throw new SecurityException("missing required sec object (_form)");
         }

--- a/src/main/webapp/WEB-INF/classes/struts-form.xml
+++ b/src/main/webapp/WEB-INF/classes/struts-form.xml
@@ -66,8 +66,16 @@
         <action name="form/setupSelect" class="io.github.carlos_emr.carlos.form.pageUtil.FrmSetupSelect2Action">
             <result name="continue">/WEB-INF/jsp/form/formselect.jsp</result>
         </action>
+        <!-- The Select Forms panel is loaded over AJAX into #dynamic-content, so the POST
+             response must carry the re-rendered panel. This must be a Struts chain, not a
+             servlet-dispatch result: forwarding to another action path nests a second FORWARD
+             dispatch inside the first, and CsrfGuardScriptInjectionFilter (FORWARD-mapped) then
+             wraps the response twice. The inner forward closes the outer capture wrapper's
+             writer, so the outer replay is discarded and the client receives HTTP 200 with a
+             zero-byte body. Chaining runs FrmSetupSelect2Action in the same invocation and
+             forwards exactly once — to formselect.jsp — matching the working GET route. -->
         <action name="form/select" class="io.github.carlos_emr.carlos.form.pageUtil.FrmSelect2Action">
-            <result name="success">/form/setupSelect</result>
+            <result name="success" type="chain">form/setupSelect</result>
         </action>
         <action name="form/xmlUpload" class="io.github.carlos_emr.carlos.form.pageUtil.FrmXmlUpload2Action">
             <result name="success">/WEB-INF/jsp/form/formXmlUpload.jsp</result>

--- a/src/main/webapp/WEB-INF/jsp/form/formXmlUploadSuccess.jsp
+++ b/src/main/webapp/WEB-INF/jsp/form/formXmlUploadSuccess.jsp
@@ -46,7 +46,7 @@
     </main>
     <script>
         setTimeout(function () {
-            window.location.href = "${pageContext.request.contextPath}/administration";
+            window.location.href = "${carlos:forJavaScript(pageContext.request.contextPath)}/administration";
         }, 3000);
     </script>
 </body>

--- a/src/main/webapp/WEB-INF/jsp/form/formXmlUploadSuccess.jsp
+++ b/src/main/webapp/WEB-INF/jsp/form/formXmlUploadSuccess.jsp
@@ -30,11 +30,11 @@
 <%@ taglib uri="carlos" prefix="carlos" %>
 <fmt:setBundle basename="oscarResources"/>
 <!doctype html>
-<html lang="${pageContext.request.locale.language}">
+<html lang="${carlos:forHtmlAttribute(pageContext.request.locale.language)}">
 <head>
     <meta charset="UTF-8">
     <title><fmt:message key="form.xmlUploadSuccess.title"/></title>
-    <link href="${pageContext.request.contextPath}/library/bootstrap/5.3.8/css/bootstrap.min.css" rel="stylesheet">
+    <link href="${carlos:forHtmlAttribute(pageContext.request.contextPath)}/library/bootstrap/5.3.8/css/bootstrap.min.css" rel="stylesheet">
 </head>
 <body class="bg-body-tertiary">
     <main class="container py-5">

--- a/src/main/webapp/WEB-INF/jsp/form/formselect.jsp
+++ b/src/main/webapp/WEB-INF/jsp/form/formselect.jsp
@@ -80,15 +80,19 @@
                                         <td>
                                             <table>
                                                 <tr>
+                                                    <%-- min-width, not width: these labels are localized, so a fixed box
+                                                         clips the text (English "<< Delete" overflowed 80px by 18px) and
+                                                         a longer translation would clip further. min-width keeps the
+                                                         buttons aligned at their original size and lets them grow. --%>
                                                     <td><input type="button" name="button" id="add" class="btn function"
-                                                               style="width:80px"
+                                                               style="min-width:80px"
                                                                value="<fmt:message key="encounter.oscarMeasurements.MeasurementsAction.addBtn"/> >>"
                                                     /></td>
                                                 </tr>
                                                 <tr>
                                                     <td>
                                                         <input type="button" name="button" class="btn function"
-                                                               id="delete" style="width:80px"
+                                                               id="delete" style="min-width:80px"
                                                                value="<< <fmt:message key="encounter.oscarMeasurements.MeasurementsAction.deleteBtn"/>"/>
                                                     </td>
                                                 </tr>
@@ -116,9 +120,11 @@
                         </table>
                     </td>
                     <td>
-                        <input type="button" name="button" class="btn function" value="Move Up" style="width:100px"
+                        <%-- min-width for the same reason as the Add/Delete buttons above:
+                             "Move Down" overflowed its 100px box by 7px. --%>
+                        <input type="button" name="button" class="btn function" value="Move Up" style="min-width:100px"
                                id="up"/> <br>
-                        <input type="button" name="button" class="btn function" value="Move Down" style="width:100px"
+                        <input type="button" name="button" class="btn function" value="Move Down" style="min-width:100px"
                                id="down"/></td>
                 </tr>
             </table>

--- a/src/test/java/io/github/carlos_emr/carlos/app/contract/MutatorActionGetRejectionContractUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/app/contract/MutatorActionGetRejectionContractUnitTest.java
@@ -171,6 +171,10 @@ class MutatorActionGetRejectionContractUnitTest {
                     "_admin", "w"),
             Arguments.of("io.github.carlos_emr.carlos.form.pageUtil.FrmXmlUpload2Action",
                     "_admin.eform", "w"),
+            // Every forward value (add/delete/up/down) reorders encounter forms; the
+            // Select Forms panel itself is rendered by the separate form/setupSelect route.
+            Arguments.of("io.github.carlos_emr.carlos.form.pageUtil.FrmSelect2Action",
+                    "_form", "w"),
             Arguments.of("io.github.carlos_emr.carlos.eform.actions.AddEForm2Action",
                     "_eform", "w"),
             // --- encounter / consultation ---
@@ -355,6 +359,7 @@ class MutatorActionGetRejectionContractUnitTest {
         "io.github.carlos_emr.carlos.commn.web.FlowSheetCustom2Action",
         "io.github.carlos_emr.carlos.encounter.oscarConsultationRequest.pageUtil.EctConsultationFormRequest2Action",
         "io.github.carlos_emr.carlos.encounter.oscarMeasurements.pageUtil.EctMeasurements2Action",
+        "io.github.carlos_emr.carlos.form.pageUtil.FrmSelect2Action",
         "io.github.carlos_emr.carlos.form.pageUtil.FrmXmlUpload2Action",
         "io.github.carlos_emr.carlos.login.gate.SelectFacility2Action",
         "io.github.carlos_emr.carlos.provider.web.DocumentDescriptionTemplate2Action",

--- a/src/test/java/io/github/carlos_emr/carlos/form/FormXmlUploadJspMigrationRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/form/FormXmlUploadJspMigrationRegressionTest.java
@@ -130,7 +130,7 @@ class FormXmlUploadJspMigrationRegressionTest {
                 .contains("href=\"${carlos:forHtmlAttribute(pageContext.request.contextPath)}/administration\"")
                 .doesNotContain("http-equiv=\"refresh\"")
                 .contains("setTimeout(")
-                .contains("window.location.href = \"${pageContext.request.contextPath}/administration\"");
+                .contains("window.location.href = \"${carlos:forJavaScript(pageContext.request.contextPath)}/administration\"");
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/form/StrutsFormSelectConfigUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/form/StrutsFormSelectConfigUnitTest.java
@@ -1,0 +1,175 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.form;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+/**
+ * Pins the Select Forms admin route so the four panel mutations (Add, Delete, Move Up,
+ * Move Down) keep returning rendered markup instead of an empty body.
+ *
+ * <p>The Select Forms panel is loaded over AJAX into {@code #dynamic-content}, so the POST
+ * response to {@code form/select} must itself carry the re-rendered panel. Issue #3377 was
+ * caused by declaring the success result as a plain servlet-dispatch forward to the
+ * {@code /form/setupSelect} action path. That nests a second FORWARD dispatch inside the
+ * first, and {@code CsrfGuardScriptInjectionFilter} — which is mapped for FORWARD dispatch —
+ * then wraps the response twice. The inner forward closes the outer capture wrapper's writer,
+ * so the outer replay is discarded and the browser receives HTTP 200 with zero bytes.
+ *
+ * <p>A Struts {@code chain} result runs {@code FrmSetupSelect2Action} inside the same
+ * invocation and forwards exactly once — to {@code formselect.jsp} — which is the same
+ * single-forward shape the working {@code GET /form/setupSelect} route already uses.
+ *
+ * @since 2026-08-07
+ */
+@DisplayName("struts-form.xml Select Forms route Tests")
+@Tag("unit")
+@Tag("form")
+class StrutsFormSelectConfigUnitTest {
+
+    private static final String BASEDIR_PROPERTY = "basedir";
+    private static final Path STRUTS_FORM_XML =
+            Path.of("src", "main", "webapp", "WEB-INF", "classes", "struts-form.xml");
+
+    @Test
+    @DisplayName("form/select success result should chain to form/setupSelect")
+    void shouldChainToSetupSelect_forSelectFormsMutations()
+            throws IOException, ParserConfigurationException, SAXException {
+        Element successResult = findResult("form/select", "success");
+
+        assertThat(successResult.getAttribute("type"))
+                .as("form/select must chain so FrmSetupSelect2Action re-renders the panel in the "
+                        + "same invocation; a servlet-dispatch forward to another action path "
+                        + "nests a second FORWARD and returns a zero-byte body (issue #3377)")
+                .isEqualTo("chain");
+        assertThat(successResult.getTextContent().trim())
+                .as("form/select must chain to the Select Forms setup action")
+                .isEqualTo("form/setupSelect");
+    }
+
+    @Test
+    @DisplayName("form/setupSelect should render the Select Forms JSP directly")
+    void shouldRenderFormSelectJsp_forSetupSelectRoute()
+            throws IOException, ParserConfigurationException, SAXException {
+        Element continueResult = findResult("form/setupSelect", "continue");
+
+        assertThat(continueResult.getAttribute("type"))
+                .as("form/setupSelect should keep the default dispatcher result so the chain "
+                        + "terminates in exactly one forward")
+                .isEmpty();
+        assertThat(continueResult.getTextContent().trim())
+                .isEqualTo("/WEB-INF/jsp/form/formselect.jsp");
+    }
+
+    private Element findResult(String actionName, String resultName)
+            throws IOException, ParserConfigurationException, SAXException {
+        Element action = findAction(parse(resolveProjectPath(STRUTS_FORM_XML)), actionName)
+                .orElseThrow(() -> new AssertionError(
+                        "struts-form.xml must declare action " + actionName));
+        NodeList results = action.getElementsByTagName("result");
+        for (int i = 0; i < results.getLength(); i++) {
+            if (results.item(i) instanceof Element result
+                    && resultName.equals(result.getAttribute("name"))) {
+                return result;
+            }
+        }
+        throw new AssertionError("action " + actionName
+                + " must declare a result named " + resultName);
+    }
+
+    private Optional<Element> findAction(Document doc, String actionName) {
+        NodeList actions = doc.getElementsByTagName("action");
+        for (int i = 0; i < actions.getLength(); i++) {
+            if (actions.item(i) instanceof Element element
+                    && actionName.equals(element.getAttribute("name"))) {
+                return Optional.of(element);
+            }
+        }
+        return Optional.empty();
+    }
+
+    private Document parse(Path absolutePath)
+            throws IOException, ParserConfigurationException, SAXException {
+        assertThat(absolutePath)
+                .as("Struts config file not found — run tests from project root or set "
+                        + "-Dbasedir=<project-root>")
+                .exists();
+        String xml = Files.readString(absolutePath, StandardCharsets.UTF_8);
+        return newHardenedDocumentBuilder().parse(new InputSource(new StringReader(xml)));
+    }
+
+    private static Path resolveProjectPath(Path relativePath) {
+        return Path.of(System.getProperty(BASEDIR_PROPERTY, System.getProperty("user.dir")))
+                .toAbsolutePath()
+                .resolve(relativePath)
+                .normalize();
+    }
+
+    private static DocumentBuilder newHardenedDocumentBuilder() throws ParserConfigurationException {
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        dbf.setValidating(false);
+        dbf.setNamespaceAware(false);
+        dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        setAttributeIfSupported(dbf, XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        setAttributeIfSupported(dbf, XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+        dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        // Struts config files intentionally declare the project-standard Struts 6.5 DTD.
+        // External DTD loading and entity expansion remain disabled above.
+        dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", false);
+        dbf.setXIncludeAware(false);
+        dbf.setExpandEntityReferences(false);
+        DocumentBuilder db = dbf.newDocumentBuilder();
+        db.setEntityResolver((publicId, systemId) -> new InputSource(new StringReader("")));
+        return db;
+    }
+
+    private static void setAttributeIfSupported(DocumentBuilderFactory dbf, String name, String value) {
+        try {
+            dbf.setAttribute(name, value);
+        } catch (IllegalArgumentException ignored) {
+            // Parser does not support the property; FEATURE_SECURE_PROCESSING still applies.
+        }
+    }
+}


### PR DESCRIPTION
Fixes #3377

## Problem

In **Administration → Forms/eForms → Select Forms**, clicking **Add**, **Delete**, **Move Up**, or **Move Down** blanked the panel. Each button POSTs the shared form to `/form/select`, and the administration AJAX handler injects the response into `#dynamic-content` — but the response was HTTP 200 with a **zero-byte body**, so the panel rendered white.

## Root cause

`struts-form.xml` declared the success result as a plain servlet-dispatch forward to another **action** path:

```xml
<result name="success">/form/setupSelect</result>
```

That nests a second FORWARD dispatch inside the first. `CsrfGuardScriptInjectionFilter` is mapped for FORWARD dispatch, so it wraps the response **twice**: once for the outer forward to `/form/setupSelect`, then again for the inner forward to `formselect.jsp`. Tomcat's `ApplicationDispatcher.forward()` closes the writer of a wrapped response when the inner forward completes, so the outer filter's CSRF-adjusted replay is discarded and nothing reaches the client.

The server log confirmed this on every affected POST:

```
WARN  app.CsrfGuardScriptInjectionFilter - writeToResponse: response buffer was already
committed before CSRF-adjusted replay; writing captured content without reset:
uri=/carlos/form/setupSelect, contentType=text/html;charset=UTF-8, committed=true
java.lang.IllegalStateException: Cannot reset buffer after response has been committed
  at org.apache.struts2.result.ServletDispatcherResult.doExecute(ServletDispatcherResult.java:169)
```

`GET /form/setupSelect` was never affected because it forwards exactly once, straight to the JSP.

## Fix

```xml
<result name="success" type="chain">form/setupSelect</result>
```

A Struts `chain` runs `FrmSetupSelect2Action` inside the same invocation and forwards exactly once — to `formselect.jsp` — matching the shape of the already-working GET route. `type="chain"` for action-to-action handoff is the established convention in this codebase (`struts-billing.xml` uses it throughout).

**Security is unchanged.** Both privilege checks still run: `_form` write on `FrmSelect2Action`, `_form` read on `FrmSetupSelect2Action`. `FrmSetupSelect2Action` declares no `@StrutsParameter` setters, so no POST parameters bind to the chained action.

## Verification

Against a local Tomcat build with the dev database:

| Button | Before | After |
|---|---:|---:|
| Add | 0 bytes | 45,175 bytes |
| Delete | 0 bytes | 45,175 bytes |
| Move Up | 0 bytes | 45,175 bytes |
| Move Down | 0 bytes | 45,175 bytes |

Driven through the real administration shell:
- **Add** moves the selected form out of *available* and into *selected*.
- **Delete** returns it to *available*.
- **Move Up** / **Move Down** shift its position by one and back.
- Submitting with **no selection** returns the panel unchanged rather than blanking it.
- The `Cannot reset buffer` warnings for `/carlos/form/setupSelect` no longer appear.

## Tests

- `StrutsFormSelectConfigUnitTest` (`@Tag("unit")`, `@Tag("form")`) pins the chain result and that `form/setupSelect` still terminates in a single dispatcher forward to `formselect.jsp`. `mvn test -Dtest=StrutsFormSelectConfigUnitTest` → `Tests run: 2, Failures: 0, Errors: 0`.
- `scripts/select-forms-panel-playwright-checks.js` (`npm run test:select-forms-panel-playwright`) drives all four buttons through the administration shell, asserts the POST body carries the rendered panel and that `#dynamic-content` stays populated, and is state-neutral — it adds a form, moves it up and back down, then deletes it, leaving the encounter form display order as found.

  Confirmed to fail against the unfixed config and pass against the fix:
  ```
  FAIL: add with no selection: POST /form/select returned 200 with 0 bytes; the AJAX
        handler needs the re-rendered Select Forms panel in the response
  PASS  Select Forms panel renders after add, delete, move up, and move down
  ```

## Second commit: GET/HEAD rejection (security)

Reviewing this route surfaced a pre-existing CSRF hole in the same action. Every `forward` value handled by `FrmSelect2Action` mutates encounter form display order, but the action accepted any HTTP method — and CSRFGuard only validates non-GET. Verified against a local build **before** the guard was added:

```
GET /carlos/form/select?forward=add&selectedAddTypes=2%20Minute%20Walk
-> 200, form moved from available to selected, no CSRF token supplied
```

`HttpMethodGuardFilter` does not catch it: the action name `select` matches no entry in `MUTATOR_ACTION_PREFIXES`, and the mutation intent rides on the `forward` parameter rather than the `method` parameter the filter inspects.

The action now rejects non-POST before the privilege check — so no mutation can fire — matching the sibling `FrmXmlUpload2Action` gate in the same package. The route is unconditionally POST-only: rendering is the separate `form/setupSelect` route, and the only caller is the POST form in `formselect.jsp`.

This is another instance of the class tracked by #3059 ([Umbrella] Legacy GET mutation and CSRF enforcement cleanup), alongside #2864, #2863, #2862, #2654, #2415, and #2332.

Registered in `MutatorActionGetRejectionContractUnitTest` as an unconditional mutator (`IN_SCOPE_EXPLICIT_CLASSES` plus the manifest entry) per the GET/HEAD rejection contract in `CLAUDE.md`. `Tests run: 37, Failures: 0` for that contract test.

Re-verified after the guard: `GET` and `HEAD` both return `405` with `Allow: POST` and leave the form lists unchanged, and the browser panel check still passes.

## Note for reviewers

The same action-path dispatcher-result pattern appears elsewhere in `struts-form.xml` (`form/AddRHWorkFlow` → `/form/RHPrevention`, `form/formname` save → `/form/forwardname`, `formBPMH` saved → `/formBPMH?method=fetch`). Those routes were **not** exercised here and are out of scope for this fix; they may deserve a follow-up audit for the same nested-forward failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure the Select Forms administration panel correctly re-renders after form list mutations and add regression coverage for the route configuration and browser behavior.

Bug Fixes:
- Fix the form/select Struts action so POST requests chain to form/setupSelect and return the rendered Select Forms panel instead of an empty response body.

Enhancements:
- Document the Select Forms action chaining behavior directly in struts-form.xml to clarify the CSRF and forwarding constraints.

Tests:
- Add a JUnit test to pin the struts-form.xml configuration for form/select and form/setupSelect, ensuring the chain result and JSP forward remain correct.
- Add a Playwright-based browser script and npm test command that exercise Add, Delete, Move Up, and Move Down in the Select Forms panel and verify the panel stays populated and HTTP responses are non-empty.

