### PR TITLE
fix(devcontainer): restore baseline admin privileges

### DIFF
--- a/.devcontainer/db/Dockerfile
+++ b/.devcontainer/db/Dockerfile
@@ -14,6 +14,7 @@ LABEL description="OpenOSP-EMR Docker Image for Development Environment"
 COPY ./.devcontainer/db/scripts/populate_db.sh /docker-entrypoint-initdb.d/populate_db.sh
 RUN mkdir /scripts
 COPY ./.devcontainer/db/scripts/development.sql /scripts/development.sql
+COPY ./.devcontainer/db/scripts/development_privileges.sql /scripts/development_privileges.sql
 COPY ./database /database
 COPY ./.devcontainer/development/config/shared/my.cnf /etc/mysql/my.cnf
 

--- a/.devcontainer/db/scripts/development_privileges.sql
+++ b/.devcontainer/db/scripts/development_privileges.sql
@@ -1,3 +1,25 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+
 -- Restore current baseline Administration privileges after development.sql
 -- replaces secObjPrivilege with its older demo snapshot. This local-only seed
 -- is also safe to run against an existing development database.

--- a/.devcontainer/db/scripts/development_privileges.sql
+++ b/.devcontainer/db/scripts/development_privileges.sql
@@ -22,7 +22,9 @@
 
 -- Restore current baseline Administration privileges after development.sql
 -- replaces secObjPrivilege with its older demo snapshot. This local-only seed
--- is also safe to run against an existing development database.
+-- is also safe to run against an existing development database. The default
+-- carlosdoc account is intentionally a full administrator in development, so
+-- remove its production/demo schedule group-creation override below.
 
 INSERT IGNORE INTO `secObjectName`
     (`objectName`, `description`, `orgapplicable`)
@@ -40,12 +42,15 @@ VALUES
     ('admin', '_admin.misc', 'x', 0, '999998'),
     ('admin', '_admin.schedule', 'x', 0, '999998'),
     ('admin', '_admin.schedule.groupCreate', 'x', 0, '999998'),
-    ('admin', '_site_access_privacy', 'x', 0, '999998'),
-    ('999998', '_admin.schedule.groupCreate', 'o', 1, '999998')
+    ('admin', '_site_access_privacy', 'x', 0, '999998')
 ON DUPLICATE KEY UPDATE
     `privilege` = VALUES(`privilege`),
     `priority` = VALUES(`priority`),
     `provider_no` = VALUES(`provider_no`);
+
+DELETE FROM `secObjPrivilege`
+WHERE `roleUserGroup` = '999998'
+  AND `objectName` = '_admin.schedule.groupCreate';
 
 -- Keep the development snapshot aligned with the current baseline cleanup.
 DELETE FROM `secObjPrivilege`

--- a/.devcontainer/db/scripts/development_privileges.sql
+++ b/.devcontainer/db/scripts/development_privileges.sql
@@ -1,0 +1,33 @@
+-- Restore current baseline Administration privileges after development.sql
+-- replaces secObjPrivilege with its older demo snapshot. This local-only seed
+-- is also safe to run against an existing development database.
+
+INSERT IGNORE INTO `secObjectName`
+    (`objectName`, `description`, `orgapplicable`)
+VALUES
+    ('_admin.flowsheet', 'Manage Flowsheets', 0),
+    ('_admin.invoices', 'Restrict invoice admin to current provider', 0),
+    ('_admin.schedule.groupCreate', 'Create schedule provider groups', 0);
+
+INSERT INTO `secObjPrivilege`
+    (`roleUserGroup`, `objectName`, `privilege`, `priority`, `provider_no`)
+VALUES
+    ('admin', '_admin.auditLogPurge', 'x', 0, '999998'),
+    ('admin', '_admin.flowsheet', 'x', 0, '999998'),
+    ('admin', '_admin.invoices', 'r', 0, '999998'),
+    ('admin', '_admin.misc', 'x', 0, '999998'),
+    ('admin', '_admin.schedule', 'x', 0, '999998'),
+    ('admin', '_admin.schedule.groupCreate', 'x', 0, '999998'),
+    ('admin', '_site_access_privacy', 'x', 0, '999998'),
+    ('999998', '_admin.schedule.groupCreate', 'o', 1, '999998')
+ON DUPLICATE KEY UPDATE
+    `privilege` = VALUES(`privilege`),
+    `priority` = VALUES(`priority`),
+    `provider_no` = VALUES(`provider_no`);
+
+-- Keep the development snapshot aligned with the current baseline cleanup.
+DELETE FROM `secObjPrivilege`
+WHERE `objectName` = '_admin.traceability';
+
+DELETE FROM `secObjectName`
+WHERE `objectName` = '_admin.traceability';

--- a/.devcontainer/db/scripts/populate_db.sh
+++ b/.devcontainer/db/scripts/populate_db.sh
@@ -79,6 +79,8 @@ $SQL drugref2 < /database/mysql/drugref/2026-04-19-drugref-tc-atc-f.sql
 # the baseline reference rows with the demo dataset (patients, appointments, notes, etc.).
 echo 'Loading demo data for development...'
 $SQL oscar < /scripts/development.sql
+echo 'Restoring current Administration privileges...'
+$SQL oscar < /scripts/development_privileges.sql
 echo 'Preparing demographic names for development environment...'
 $SQL oscar < /database/mysql/updates/update-2025-11-06-demo-name-sanitization.sql
 echo 'Seeding Rich Text Letter eForm...'

--- a/.devcontainer/development/setup/seed_data.sh
+++ b/.devcontainer/development/setup/seed_data.sh
@@ -4,6 +4,13 @@ set -e  # Exit on any error
 
 echo "[Bootstrap] Seeding initial database files..."
 
+# The MariaDB entrypoint only runs database initialization against an empty
+# volume. Reapply the idempotent development privilege repair here so existing
+# local volumes receive new Administration grants after a devcontainer rebuild.
+export MYSQL_PWD="${MARIADB_ROOT_PASSWORD:-${MYSQL_ROOT_PASSWORD:-password}}"
+mariadb -h db -u root oscar \
+    < /workspace/.devcontainer/db/scripts/development_privileges.sql
+
 # The runtime document volume masks directories created in the image. Recreate
 # the configured incoming-document root in that mounted volume so fresh
 # devcontainers can render lazily-created queue children as empty queues.

--- a/src/main/webapp/WEB-INF/jsp/admin/admin.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/admin.jsp
@@ -632,7 +632,7 @@
                         <security:oscarSec roleName="<%=roleName$%>" objectName="_admin.schedule.groupCreate"
                                            rights="w" reverse="<%=false%>">
                             <li><a href="#"
-                                   onclick='popupPage(360,600, "${pageContext.request.contextPath}/admin/AdminNewGroup?submit=blank");return false;'><fmt:message key="admin.admin.btnAddGroupNoRecord"/></a></li>
+                                   onclick='popupPage(360,600, "${pageContext.request.contextPath}/admin/AdminNewGroup");return false;'><fmt:message key="admin.admin.btnAddGroupNoRecord"/></a></li>
                         </security:oscarSec>
                         <li><a href="#"
                                onclick='popupPage(360,600, "${pageContext.request.contextPath}/admin/ViewAdminDisplayMyGroup");return false;'><fmt:message key="admin.admin.btnSearchGroupNoRecords"/></a></li>

--- a/src/main/webapp/WEB-INF/jsp/admin/adminnewgroup.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/adminnewgroup.jsp
@@ -200,7 +200,9 @@
 
     <script>
         $(document).ready(function () {
-            parent.parent.resizeIframe($('html').height());
+            if (parent && parent.parent && typeof parent.parent.resizeIframe === 'function') {
+                parent.parent.resizeIframe($('html').height());
+            }
 
         });
     </script>

--- a/src/main/webapp/WEB-INF/jsp/administration/leftNav.jspf
+++ b/src/main/webapp/WEB-INF/jsp/administration/leftNav.jspf
@@ -470,7 +470,7 @@ Properties oscarVariables = CarlosProperties.getInstance();
 								
 					<security:oscarSec roleName="<%=roleName$%>" objectName="_admin.schedule.groupCreate" rights="w" reverse="<%=false%>">
 						<li><a href="javascript:void(0);"
-							class="xlink" rel="${ctx}/admin/AdminNewGroup?submit=blank"><fmt:message key="admin.admin.btnAddGroupNoRecord"/></a></li>
+							class="xlink" rel="${ctx}/admin/AdminNewGroup"><fmt:message key="admin.admin.btnAddGroupNoRecord"/></a></li>
 					</security:oscarSec>
 					<li><a href="javascript:void(0);"
 						class="xlink" rel="${ctx}/admin/ViewAdminDisplayMyGroup"><fmt:message key="admin.admin.btnSearchGroupNoRecords"/></a></li>

--- a/src/test/java/io/github/carlos_emr/carlos/admin/web/AdminGroupActionsTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/admin/web/AdminGroupActionsTest.java
@@ -64,10 +64,10 @@ class AdminGroupActionsTest extends CarlosWebTestBase {
                 Files.readString(ADMINISTRATION_LEFT_NAV, StandardCharsets.UTF_8);
 
         assertThat(legacyAdmin)
-                .contains("/admin/AdminNewGroup")
+                .contains("${pageContext.request.contextPath}/admin/AdminNewGroup")
                 .doesNotContain("AdminNewGroup?submit=");
         assertThat(administrationLeftNav)
-                .contains("/admin/AdminNewGroup")
+                .contains("${ctx}/admin/AdminNewGroup")
                 .doesNotContain("AdminNewGroup?submit=");
     }
 

--- a/src/test/java/io/github/carlos_emr/carlos/admin/web/AdminGroupActionsTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/admin/web/AdminGroupActionsTest.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.regex.Pattern;
 
 import io.github.carlos_emr.carlos.test.base.CarlosWebTestBase;
 
@@ -52,6 +53,8 @@ class AdminGroupActionsTest extends CarlosWebTestBase {
             Path.of("src/main/webapp/WEB-INF/jsp/admin/adminnewgroup.jsp");
     private static final Path ADMINISTRATION_LEFT_NAV =
             Path.of("src/main/webapp/WEB-INF/jsp/administration/leftNav.jspf");
+    private static final Pattern RESIZE_HELPER_FUNCTION_GUARD = Pattern.compile(
+            "typeof\\s+parent\\.parent\\.resizeIframe\\s*={2,3}\\s*(['\"])function\\1");
 
     @Test
     @DisplayName("should navigate to group create form without mutation parameters")
@@ -60,10 +63,12 @@ class AdminGroupActionsTest extends CarlosWebTestBase {
         String administrationLeftNav =
                 Files.readString(ADMINISTRATION_LEFT_NAV, StandardCharsets.UTF_8);
 
-        assertThat(legacyAdmin).contains("/admin/AdminNewGroup");
-        assertThat(administrationLeftNav).contains("rel=\"${ctx}/admin/AdminNewGroup\"");
-        assertThat(legacyAdmin).doesNotContain("AdminNewGroup?submit=");
-        assertThat(administrationLeftNav).doesNotContain("AdminNewGroup?submit=");
+        assertThat(legacyAdmin)
+                .contains("/admin/AdminNewGroup")
+                .doesNotContain("AdminNewGroup?submit=");
+        assertThat(administrationLeftNav)
+                .contains("/admin/AdminNewGroup")
+                .doesNotContain("AdminNewGroup?submit=");
     }
 
     @Test
@@ -71,7 +76,7 @@ class AdminGroupActionsTest extends CarlosWebTestBase {
     void shouldTolerateMissingResizeHelper_whenGroupCreateFormLoads() throws IOException {
         String newGroup = Files.readString(NEW_GROUP_JSP, StandardCharsets.UTF_8);
 
-        assertThat(newGroup).contains("typeof parent.parent.resizeIframe === 'function'");
+        assertThat(newGroup).containsPattern(RESIZE_HELPER_FUNCTION_GUARD);
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/admin/web/AdminGroupActionsTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/admin/web/AdminGroupActionsTest.java
@@ -17,6 +17,11 @@
  */
 package io.github.carlos_emr.carlos.admin.web;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 import io.github.carlos_emr.carlos.test.base.CarlosWebTestBase;
 
 import org.apache.struts2.ActionSupport;
@@ -41,6 +46,23 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class AdminGroupActionsTest extends CarlosWebTestBase {
 
     private static final String SCHEDULE_GROUP_CREATE_OBJECT = "_admin.schedule.groupCreate";
+    private static final Path LEGACY_ADMIN_JSP =
+            Path.of("src/main/webapp/WEB-INF/jsp/admin/admin.jsp");
+    private static final Path ADMINISTRATION_LEFT_NAV =
+            Path.of("src/main/webapp/WEB-INF/jsp/administration/leftNav.jspf");
+
+    @Test
+    @DisplayName("should navigate to group create form without mutation parameters")
+    void shouldNavigateWithoutMutationParameters_toGroupCreateForm() throws IOException {
+        String legacyAdmin = Files.readString(LEGACY_ADMIN_JSP, StandardCharsets.UTF_8);
+        String administrationLeftNav =
+                Files.readString(ADMINISTRATION_LEFT_NAV, StandardCharsets.UTF_8);
+
+        assertThat(legacyAdmin).contains("/admin/AdminNewGroup");
+        assertThat(administrationLeftNav).contains("rel=\"${ctx}/admin/AdminNewGroup\"");
+        assertThat(legacyAdmin).doesNotContain("AdminNewGroup?submit=");
+        assertThat(administrationLeftNav).doesNotContain("AdminNewGroup?submit=");
+    }
 
     @Test
     @DisplayName("should return success when group create privilege is granted")

--- a/src/test/java/io/github/carlos_emr/carlos/admin/web/AdminGroupActionsTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/admin/web/AdminGroupActionsTest.java
@@ -48,6 +48,8 @@ class AdminGroupActionsTest extends CarlosWebTestBase {
     private static final String SCHEDULE_GROUP_CREATE_OBJECT = "_admin.schedule.groupCreate";
     private static final Path LEGACY_ADMIN_JSP =
             Path.of("src/main/webapp/WEB-INF/jsp/admin/admin.jsp");
+    private static final Path NEW_GROUP_JSP =
+            Path.of("src/main/webapp/WEB-INF/jsp/admin/adminnewgroup.jsp");
     private static final Path ADMINISTRATION_LEFT_NAV =
             Path.of("src/main/webapp/WEB-INF/jsp/administration/leftNav.jspf");
 
@@ -62,6 +64,14 @@ class AdminGroupActionsTest extends CarlosWebTestBase {
         assertThat(administrationLeftNav).contains("rel=\"${ctx}/admin/AdminNewGroup\"");
         assertThat(legacyAdmin).doesNotContain("AdminNewGroup?submit=");
         assertThat(administrationLeftNav).doesNotContain("AdminNewGroup?submit=");
+    }
+
+    @Test
+    @DisplayName("should tolerate administration shells without legacy resize helper")
+    void shouldTolerateMissingResizeHelper_whenGroupCreateFormLoads() throws IOException {
+        String newGroup = Files.readString(NEW_GROUP_JSP, StandardCharsets.UTF_8);
+
+        assertThat(newGroup).contains("typeof parent.parent.resizeIframe === 'function'");
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/security/CarlosdocPrivilegeSeedRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/security/CarlosdocPrivilegeSeedRegressionTest.java
@@ -25,8 +25,13 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -68,12 +73,13 @@ class CarlosdocPrivilegeSeedRegressionTest {
     private static final Path BC_SEED = Path.of("database", "mysql", "migration", "bc", "V1.0.2__bc_data.sql");
     private static final Path MIGRATION = Path.of("database", "mysql", "updates",
             "update-2026-05-21-carlosdoc-schedule-group-privilege.sql");
+    private static final Set<String> ADMIN_ROLE_GROUPS = Set.of("admin", "999998");
     private static final Pattern SEC_OBJ_PRIVILEGE_INSERT = Pattern.compile(
             "INSERT\\s+INTO\\s+`?secObjPrivilege`?(?:\\s*\\([^)]*\\))?"
                     + "\\s+VALUES\\s+([^;]+)",
             Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
     private static final Pattern PRIVILEGE_TUPLE = Pattern.compile(
-            "\\(\\s*'(admin|999998)'\\s*,\\s*'([^']+)'\\s*,\\s*'([^']+)'\\s*,"
+            "\\(\\s*'([^']+)'\\s*,\\s*'([^']+)'\\s*,\\s*'([^']+)'\\s*,"
                     + "\\s*(\\d+)\\s*,\\s*'([^']+)'\\s*\\)");
     private static final Pattern PRIVILEGE_DELETE = Pattern.compile(
             "DELETE\\s+FROM\\s+`?secObjPrivilege`?\\s+WHERE\\s+`?objectName`?"
@@ -130,15 +136,20 @@ class CarlosdocPrivilegeSeedRegressionTest {
     @DisplayName("should restore baseline admin privileges after development snapshot")
     void shouldRestoreBaselineAdminPrivileges_afterDevelopmentSnapshot() throws IOException {
         String privilegeRepairSql = Files.readString(DEVELOPMENT_PRIVILEGES, StandardCharsets.UTF_8);
-        Map<PrivilegeKey, String> baselinePrivileges = privileges(seedSql);
-        Map<PrivilegeKey, String> bcBaselinePrivileges = privileges(bcSeedSql);
-        Map<PrivilegeKey, String> repairPrivileges = privileges(privilegeRepairSql);
-        Map<PrivilegeKey, String> repairedPrivileges = effectivePrivileges(
-                developmentSeedSql, privilegeRepairSql);
-        Map<PrivilegeKey, String> repairedExistingBaselinePrivileges = effectivePrivileges(
-                seedSql, privilegeRepairSql);
+        Map<PrivilegeKey, String> baselinePrivileges = administrationPrivileges(privileges(seedSql));
+        Map<PrivilegeKey, String> bcBaselinePrivileges = administrationPrivileges(privileges(bcSeedSql));
+        Map<PrivilegeKey, String> repairPrivileges =
+                administrationPrivileges(privileges(privilegeRepairSql));
+        Map<PrivilegeKey, String> allRepairedPrivileges =
+                effectivePrivileges(developmentSeedSql, privilegeRepairSql);
+        Map<PrivilegeKey, String> repairedPrivileges =
+                administrationPrivileges(allRepairedPrivileges);
+        Map<PrivilegeKey, String> repairedExistingBaselinePrivileges = administrationPrivileges(
+                effectivePrivileges(seedSql, privilegeRepairSql));
         PrivilegeKey carlosdocGroupCreation =
                 new PrivilegeKey("999998", "_admin.schedule.groupCreate");
+        PrivilegeKey doctorTraceability =
+                new PrivilegeKey("doctor", "_admin.traceability");
         Map<PrivilegeKey, String> expectedDevelopmentPrivileges =
                 new LinkedHashMap<>(baselinePrivileges);
         expectedDevelopmentPrivileges.remove(carlosdocGroupCreation);
@@ -156,6 +167,10 @@ class CarlosdocPrivilegeSeedRegressionTest {
         assertThat(repairedExistingBaselinePrivileges.keySet())
                 .isNotEmpty()
                 .doesNotContain(carlosdocGroupCreation);
+        assertThat(privileges(developmentSeedSql)).containsKey(doctorTraceability);
+        assertThat(allRepairedPrivileges.keySet())
+                .isNotEmpty()
+                .noneMatch(key -> key.objectName().equals("_admin.traceability"));
         assertThat(privilegeTupleCount(privilegeRepairSql))
                 .isEqualTo(privileges(privilegeRepairSql).size());
         assertThat(privilegeRepairSql)
@@ -222,15 +237,32 @@ class CarlosdocPrivilegeSeedRegressionTest {
         Map<PrivilegeKey, String> privileges = new LinkedHashMap<>();
         Matcher insert = SEC_OBJ_PRIVILEGE_INSERT.matcher(sql);
         while (insert.find()) {
-            Matcher tuple = PRIVILEGE_TUPLE.matcher(insert.group(1));
-            while (tuple.find()) {
-                // The table key is (roleUserGroup, objectName), so later repair upserts
-                // replace the effective tuple for the same role and security object.
-                privileges.put(new PrivilegeKey(tuple.group(1), tuple.group(2)),
-                        tuple.group(3) + '|' + tuple.group(4) + '|' + tuple.group(5));
-            }
+            privileges.putAll(privilegeTuples(insert.group(1)));
         }
         return privileges;
+    }
+
+    private static Map<PrivilegeKey, String> privilegeTuples(String sql) {
+        Map<PrivilegeKey, String> privileges = new LinkedHashMap<>();
+        Matcher tuple = PRIVILEGE_TUPLE.matcher(sql);
+        while (tuple.find()) {
+            // The table key is (roleUserGroup, objectName), so later repair upserts
+            // replace the effective tuple for the same role and security object.
+            privileges.put(new PrivilegeKey(tuple.group(1), tuple.group(2)),
+                    tuple.group(3) + '|' + tuple.group(4) + '|' + tuple.group(5));
+        }
+        return privileges;
+    }
+
+    private static Map<PrivilegeKey, String> administrationPrivileges(
+            Map<PrivilegeKey, String> allPrivileges) {
+        Map<PrivilegeKey, String> administrationPrivileges = new LinkedHashMap<>();
+        allPrivileges.forEach((key, value) -> {
+            if (ADMIN_ROLE_GROUPS.contains(key.roleUserGroup())) {
+                administrationPrivileges.put(key, value);
+            }
+        });
+        return administrationPrivileges;
     }
 
     private static long privilegeTupleCount(String sql) {
@@ -242,21 +274,43 @@ class CarlosdocPrivilegeSeedRegressionTest {
         return count;
     }
 
-    private static Map<PrivilegeKey, String> effectivePrivileges(String seed, String repair) {
-        Map<PrivilegeKey, String> privileges = privileges(seed);
-        privileges.putAll(privileges(repair));
+    private static Map<PrivilegeKey, String> effectivePrivileges(String... scripts) {
+        Map<PrivilegeKey, String> privileges = new LinkedHashMap<>();
+        for (String sql : scripts) {
+            List<PrivilegeMutation> mutations = new ArrayList<>();
+            Matcher insert = SEC_OBJ_PRIVILEGE_INSERT.matcher(sql);
+            while (insert.find()) {
+                Map<PrivilegeKey, String> insertedPrivileges = privilegeTuples(insert.group(1));
+                mutations.add(new PrivilegeMutation(
+                        insert.start(), current -> current.putAll(insertedPrivileges)));
+            }
 
-        Matcher deletedPrivilege = PRIVILEGE_DELETE.matcher(repair);
-        while (deletedPrivilege.find()) {
-            privileges.keySet().removeIf(key -> key.objectName().equals(deletedPrivilege.group(1)));
-        }
+            Matcher deletedPrivilege = PRIVILEGE_DELETE.matcher(sql);
+            while (deletedPrivilege.find()) {
+                String objectName = deletedPrivilege.group(1);
+                mutations.add(new PrivilegeMutation(deletedPrivilege.start(), current ->
+                        current.keySet().removeIf(key -> key.objectName().equals(objectName))));
+            }
 
-        Matcher deletedPrivilegeKey = PRIVILEGE_KEY_DELETE.matcher(repair);
-        while (deletedPrivilegeKey.find()) {
-            privileges.remove(new PrivilegeKey(
-                    deletedPrivilegeKey.group(1), deletedPrivilegeKey.group(2)));
+            Matcher deletedPrivilegeKey = PRIVILEGE_KEY_DELETE.matcher(sql);
+            while (deletedPrivilegeKey.find()) {
+                PrivilegeKey key = new PrivilegeKey(
+                        deletedPrivilegeKey.group(1), deletedPrivilegeKey.group(2));
+                mutations.add(new PrivilegeMutation(
+                        deletedPrivilegeKey.start(), current -> current.remove(key)));
+            }
+
+            mutations.sort(Comparator.comparingInt(PrivilegeMutation::position));
+            mutations.forEach(mutation -> mutation.applyTo(privileges));
         }
         return privileges;
+    }
+
+    private record PrivilegeMutation(
+            int position, Consumer<Map<PrivilegeKey, String>> operation) {
+        void applyTo(Map<PrivilegeKey, String> privileges) {
+            operation.accept(privileges);
+        }
     }
 
     private record PrivilegeKey(String roleUserGroup, String objectName) {}

--- a/src/test/java/io/github/carlos_emr/carlos/security/CarlosdocPrivilegeSeedRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/security/CarlosdocPrivilegeSeedRegressionTest.java
@@ -154,6 +154,7 @@ class CarlosdocPrivilegeSeedRegressionTest {
                 .doesNotContain(carlosdocGroupCreation)
                 .noneMatch(key -> key.objectName().equals("_admin.traceability"));
         assertThat(repairedExistingBaselinePrivileges.keySet())
+                .isNotEmpty()
                 .doesNotContain(carlosdocGroupCreation);
         assertThat(privilegeTupleCount(privilegeRepairSql))
                 .isEqualTo(privileges(privilegeRepairSql).size());

--- a/src/test/java/io/github/carlos_emr/carlos/security/CarlosdocPrivilegeSeedRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/security/CarlosdocPrivilegeSeedRegressionTest.java
@@ -163,6 +163,8 @@ class CarlosdocPrivilegeSeedRegressionTest {
                         "('admin', '_admin.schedule', 'x', 0, '999998')",
                         "WHERE `roleUserGroup` = '999998'",
                         "AND `objectName` = '_admin.schedule.groupCreate'",
+                        "DELETE FROM `secObjPrivilege`\n"
+                                + "WHERE `objectName` = '_admin.traceability';",
                         "ON DUPLICATE KEY UPDATE")
                 .doesNotContain("('999998', '_admin.schedule.groupCreate', 'o', 1, '999998')");
     }

--- a/src/test/java/io/github/carlos_emr/carlos/security/CarlosdocPrivilegeSeedRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/security/CarlosdocPrivilegeSeedRegressionTest.java
@@ -126,10 +126,14 @@ class CarlosdocPrivilegeSeedRegressionTest {
     void shouldRestoreBaselineAdminPrivileges_afterDevelopmentSnapshot() throws IOException {
         String privilegeRepairSql = Files.readString(DEVELOPMENT_PRIVILEGES, StandardCharsets.UTF_8);
         Map<PrivilegeKey, String> baselinePrivileges = privileges(seedSql);
+        Map<PrivilegeKey, String> bcBaselinePrivileges = privileges(bcSeedSql);
+        Map<PrivilegeKey, String> repairPrivileges = privileges(privilegeRepairSql);
         Map<PrivilegeKey, String> repairedPrivileges = effectivePrivileges(
                 developmentSeedSql, privilegeRepairSql);
 
         assertThat(repairedPrivileges).isEqualTo(baselinePrivileges);
+        assertThat(baselinePrivileges).containsAllEntriesOf(repairPrivileges);
+        assertThat(bcBaselinePrivileges).containsAllEntriesOf(repairPrivileges);
         assertThat(repairedPrivileges.keySet())
                 .noneMatch(key -> key.objectName().equals("_admin.traceability"));
         assertThat(privilegeTupleCount(privilegeRepairSql))

--- a/src/test/java/io/github/carlos_emr/carlos/security/CarlosdocPrivilegeSeedRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/security/CarlosdocPrivilegeSeedRegressionTest.java
@@ -25,6 +25,10 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
@@ -52,10 +56,21 @@ class CarlosdocPrivilegeSeedRegressionTest {
 
     private static final Path DEVELOPMENT_SEED =
             Path.of(".devcontainer", "db", "scripts", "development.sql");
+    private static final Path DEVELOPMENT_PRIVILEGES =
+            Path.of(".devcontainer", "db", "scripts", "development_privileges.sql");
+    private static final Path DATABASE_DOCKERFILE =
+            Path.of(".devcontainer", "db", "Dockerfile");
+    private static final Path POPULATE_SCRIPT =
+            Path.of(".devcontainer", "db", "scripts", "populate_db.sh");
+    private static final Path DEVCONTAINER_SEED =
+            Path.of(".devcontainer", "development", "setup", "seed_data.sh");
     private static final Path SEED = Path.of("database", "mysql", "migration", "on", "V1.0.2__on_data.sql");
     private static final Path BC_SEED = Path.of("database", "mysql", "migration", "bc", "V1.0.2__bc_data.sql");
     private static final Path MIGRATION = Path.of("database", "mysql", "updates",
             "update-2026-05-21-carlosdoc-schedule-group-privilege.sql");
+    private static final Pattern ADMIN_PRIVILEGE = Pattern.compile(
+            "\\(\\s*'admin'\\s*,\\s*'([^']+)'\\s*,\\s*'([^']+)'\\s*,"
+                    + "\\s*(\\d+)\\s*,\\s*'([^']+)'\\s*\\)");
 
     /** The seed dump is a multi-MB mysqldump — read once per class, not per test. */
     private static String developmentSeedSql;
@@ -99,6 +114,39 @@ class CarlosdocPrivilegeSeedRegressionTest {
     }
 
     @Test
+    @DisplayName("should restore baseline admin privileges after development snapshot")
+    void shouldRestoreBaselineAdminPrivileges_afterDevelopmentSnapshot() throws IOException {
+        String privilegeRepairSql = Files.readString(DEVELOPMENT_PRIVILEGES, StandardCharsets.UTF_8);
+        Map<String, String> baselinePrivileges = adminPrivileges(seedSql);
+
+        assertThat(adminPrivileges(bcSeedSql)).isEqualTo(baselinePrivileges);
+        assertThat(adminPrivileges(developmentSeedSql + privilegeRepairSql))
+                .containsAllEntriesOf(baselinePrivileges);
+        assertThat(privilegeRepairSql).contains(
+                "('admin', '_admin.schedule', 'x', 0, '999998')",
+                "('999998', '_admin.schedule.groupCreate', 'o', 1, '999998')",
+                "ON DUPLICATE KEY UPDATE");
+    }
+
+    @Test
+    @DisplayName("should apply development privilege repair to fresh and existing databases")
+    void shouldApplyDevelopmentPrivilegeRepair_toFreshAndExistingDatabases() throws IOException {
+        String databaseDockerfile = Files.readString(DATABASE_DOCKERFILE, StandardCharsets.UTF_8);
+        String populateScript = Files.readString(POPULATE_SCRIPT, StandardCharsets.UTF_8);
+        String devcontainerSeed = Files.readString(DEVCONTAINER_SEED, StandardCharsets.UTF_8);
+
+        assertThat(databaseDockerfile).contains(
+                "COPY ./.devcontainer/db/scripts/development_privileges.sql /scripts/development_privileges.sql");
+        assertThat(populateScript)
+                .contains("$SQL oscar < /scripts/development_privileges.sql")
+                .satisfies(script -> assertThat(script.indexOf("/scripts/development_privileges.sql"))
+                        .isGreaterThan(script.indexOf("/scripts/development.sql")));
+        assertThat(devcontainerSeed).contains(
+                "mariadb -h db -u root oscar \\",
+                "/workspace/.devcontainer/db/scripts/development_privileges.sql");
+    }
+
+    @Test
     @DisplayName("should deny carlosdoc schedule group creation in seed")
     void shouldDenyCarlosdocGroupCreation_whenSeeded() throws IOException {
         assertThat(seedSql).contains(
@@ -127,5 +175,15 @@ class CarlosdocPrivilegeSeedRegressionTest {
                 "('_admin.schedule.groupCreate', 'Create schedule provider groups', 0)",
                 "('admin', '_admin.schedule.groupCreate', 'x', 0, '999998')",
                 "('999998', '_admin.schedule.groupCreate', 'o', 1, '999998')");
+    }
+
+    private static Map<String, String> adminPrivileges(String sql) {
+        Map<String, String> privileges = new LinkedHashMap<>();
+        Matcher matcher = ADMIN_PRIVILEGE.matcher(sql);
+        while (matcher.find()) {
+            privileges.put(matcher.group(1),
+                    matcher.group(2) + '|' + matcher.group(3) + '|' + matcher.group(4));
+        }
+        return privileges;
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/security/CarlosdocPrivilegeSeedRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/security/CarlosdocPrivilegeSeedRegressionTest.java
@@ -150,6 +150,7 @@ class CarlosdocPrivilegeSeedRegressionTest {
         assertThat(baselinePrivileges).containsAllEntriesOf(repairPrivileges);
         assertThat(bcBaselinePrivileges).containsAllEntriesOf(repairPrivileges);
         assertThat(repairedPrivileges.keySet())
+                .isNotEmpty()
                 .doesNotContain(carlosdocGroupCreation)
                 .noneMatch(key -> key.objectName().equals("_admin.traceability"));
         assertThat(repairedExistingBaselinePrivileges.keySet())

--- a/src/test/java/io/github/carlos_emr/carlos/security/CarlosdocPrivilegeSeedRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/security/CarlosdocPrivilegeSeedRegressionTest.java
@@ -71,6 +71,10 @@ class CarlosdocPrivilegeSeedRegressionTest {
     private static final Pattern ADMIN_PRIVILEGE = Pattern.compile(
             "\\(\\s*'admin'\\s*,\\s*'([^']+)'\\s*,\\s*'([^']+)'\\s*,"
                     + "\\s*(\\d+)\\s*,\\s*'([^']+)'\\s*\\)");
+    private static final Pattern ADMIN_PRIVILEGE_DELETE = Pattern.compile(
+            "DELETE\\s+FROM\\s+`?secObjPrivilege`?\\s+WHERE\\s+`?objectName`?"
+                    + "\\s*=\\s*'([^']+)'\\s*;",
+            Pattern.CASE_INSENSITIVE);
 
     /** The seed dump is a multi-MB mysqldump — read once per class, not per test. */
     private static String developmentSeedSql;
@@ -118,10 +122,12 @@ class CarlosdocPrivilegeSeedRegressionTest {
     void shouldRestoreBaselineAdminPrivileges_afterDevelopmentSnapshot() throws IOException {
         String privilegeRepairSql = Files.readString(DEVELOPMENT_PRIVILEGES, StandardCharsets.UTF_8);
         Map<String, String> baselinePrivileges = adminPrivileges(seedSql);
+        Map<String, String> repairedPrivileges = effectiveAdminPrivileges(
+                developmentSeedSql, privilegeRepairSql);
 
-        assertThat(adminPrivileges(bcSeedSql)).isEqualTo(baselinePrivileges);
-        assertThat(adminPrivileges(developmentSeedSql + privilegeRepairSql))
-                .containsAllEntriesOf(baselinePrivileges);
+        assertThat(repairedPrivileges)
+                .isEqualTo(baselinePrivileges)
+                .doesNotContainKey("_admin.traceability");
         assertThat(privilegeRepairSql).contains(
                 "('admin', '_admin.schedule', 'x', 0, '999998')",
                 "('999998', '_admin.schedule.groupCreate', 'o', 1, '999998')",
@@ -183,6 +189,17 @@ class CarlosdocPrivilegeSeedRegressionTest {
         while (matcher.find()) {
             privileges.put(matcher.group(1),
                     matcher.group(2) + '|' + matcher.group(3) + '|' + matcher.group(4));
+        }
+        return privileges;
+    }
+
+    private static Map<String, String> effectiveAdminPrivileges(String seed, String repair) {
+        Map<String, String> privileges = adminPrivileges(seed);
+        privileges.putAll(adminPrivileges(repair));
+
+        Matcher deletedPrivilege = ADMIN_PRIVILEGE_DELETE.matcher(repair);
+        while (deletedPrivilege.find()) {
+            privileges.remove(deletedPrivilege.group(1));
         }
         return privileges;
     }

--- a/src/test/java/io/github/carlos_emr/carlos/security/CarlosdocPrivilegeSeedRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/security/CarlosdocPrivilegeSeedRegressionTest.java
@@ -79,6 +79,11 @@ class CarlosdocPrivilegeSeedRegressionTest {
             "DELETE\\s+FROM\\s+`?secObjPrivilege`?\\s+WHERE\\s+`?objectName`?"
                     + "\\s*=\\s*'([^']+)'\\s*;",
             Pattern.CASE_INSENSITIVE);
+    private static final Pattern PRIVILEGE_KEY_DELETE = Pattern.compile(
+            "DELETE\\s+FROM\\s+`?secObjPrivilege`?\\s+WHERE\\s+`?roleUserGroup`?"
+                    + "\\s*=\\s*'([^']+)'\\s+AND\\s+`?objectName`?"
+                    + "\\s*=\\s*'([^']+)'\\s*;",
+            Pattern.CASE_INSENSITIVE);
 
     /** The seed dump is a multi-MB mysqldump — read once per class, not per test. */
     private static String developmentSeedSql;
@@ -130,21 +135,34 @@ class CarlosdocPrivilegeSeedRegressionTest {
         Map<PrivilegeKey, String> repairPrivileges = privileges(privilegeRepairSql);
         Map<PrivilegeKey, String> repairedPrivileges = effectivePrivileges(
                 developmentSeedSql, privilegeRepairSql);
+        Map<PrivilegeKey, String> repairedExistingBaselinePrivileges = effectivePrivileges(
+                seedSql, privilegeRepairSql);
+        PrivilegeKey carlosdocGroupCreation =
+                new PrivilegeKey("999998", "_admin.schedule.groupCreate");
+        Map<PrivilegeKey, String> expectedDevelopmentPrivileges =
+                new LinkedHashMap<>(baselinePrivileges);
+        expectedDevelopmentPrivileges.remove(carlosdocGroupCreation);
 
         assertThat(baselinePrivileges).isNotEmpty();
         assertThat(bcBaselinePrivileges).isNotEmpty();
-        assertThat(repairPrivileges).hasSize(8);
-        assertThat(repairedPrivileges).isEqualTo(baselinePrivileges);
+        assertThat(repairPrivileges).hasSize(7);
+        assertThat(repairedPrivileges).isEqualTo(expectedDevelopmentPrivileges);
         assertThat(baselinePrivileges).containsAllEntriesOf(repairPrivileges);
         assertThat(bcBaselinePrivileges).containsAllEntriesOf(repairPrivileges);
         assertThat(repairedPrivileges.keySet())
+                .doesNotContain(carlosdocGroupCreation)
                 .noneMatch(key -> key.objectName().equals("_admin.traceability"));
+        assertThat(repairedExistingBaselinePrivileges.keySet())
+                .doesNotContain(carlosdocGroupCreation);
         assertThat(privilegeTupleCount(privilegeRepairSql))
                 .isEqualTo(privileges(privilegeRepairSql).size());
-        assertThat(privilegeRepairSql).contains(
-                "('admin', '_admin.schedule', 'x', 0, '999998')",
-                "('999998', '_admin.schedule.groupCreate', 'o', 1, '999998')",
-                "ON DUPLICATE KEY UPDATE");
+        assertThat(privilegeRepairSql)
+                .contains(
+                        "('admin', '_admin.schedule', 'x', 0, '999998')",
+                        "WHERE `roleUserGroup` = '999998'",
+                        "AND `objectName` = '_admin.schedule.groupCreate'",
+                        "ON DUPLICATE KEY UPDATE")
+                .doesNotContain("('999998', '_admin.schedule.groupCreate', 'o', 1, '999998')");
     }
 
     @Test
@@ -227,6 +245,12 @@ class CarlosdocPrivilegeSeedRegressionTest {
         Matcher deletedPrivilege = PRIVILEGE_DELETE.matcher(repair);
         while (deletedPrivilege.find()) {
             privileges.keySet().removeIf(key -> key.objectName().equals(deletedPrivilege.group(1)));
+        }
+
+        Matcher deletedPrivilegeKey = PRIVILEGE_KEY_DELETE.matcher(repair);
+        while (deletedPrivilegeKey.find()) {
+            privileges.remove(new PrivilegeKey(
+                    deletedPrivilegeKey.group(1), deletedPrivilegeKey.group(2)));
         }
         return privileges;
     }

--- a/src/test/java/io/github/carlos_emr/carlos/security/CarlosdocPrivilegeSeedRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/security/CarlosdocPrivilegeSeedRegressionTest.java
@@ -68,10 +68,14 @@ class CarlosdocPrivilegeSeedRegressionTest {
     private static final Path BC_SEED = Path.of("database", "mysql", "migration", "bc", "V1.0.2__bc_data.sql");
     private static final Path MIGRATION = Path.of("database", "mysql", "updates",
             "update-2026-05-21-carlosdoc-schedule-group-privilege.sql");
-    private static final Pattern ADMIN_PRIVILEGE = Pattern.compile(
-            "\\(\\s*'admin'\\s*,\\s*'([^']+)'\\s*,\\s*'([^']+)'\\s*,"
+    private static final Pattern SEC_OBJ_PRIVILEGE_INSERT = Pattern.compile(
+            "INSERT\\s+INTO\\s+`?secObjPrivilege`?(?:\\s*\\([^)]*\\))?"
+                    + "\\s+VALUES\\s+([^;]+)",
+            Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+    private static final Pattern PRIVILEGE_TUPLE = Pattern.compile(
+            "\\(\\s*'(admin|999998)'\\s*,\\s*'([^']+)'\\s*,\\s*'([^']+)'\\s*,"
                     + "\\s*(\\d+)\\s*,\\s*'([^']+)'\\s*\\)");
-    private static final Pattern ADMIN_PRIVILEGE_DELETE = Pattern.compile(
+    private static final Pattern PRIVILEGE_DELETE = Pattern.compile(
             "DELETE\\s+FROM\\s+`?secObjPrivilege`?\\s+WHERE\\s+`?objectName`?"
                     + "\\s*=\\s*'([^']+)'\\s*;",
             Pattern.CASE_INSENSITIVE);
@@ -121,15 +125,15 @@ class CarlosdocPrivilegeSeedRegressionTest {
     @DisplayName("should restore baseline admin privileges after development snapshot")
     void shouldRestoreBaselineAdminPrivileges_afterDevelopmentSnapshot() throws IOException {
         String privilegeRepairSql = Files.readString(DEVELOPMENT_PRIVILEGES, StandardCharsets.UTF_8);
-        Map<String, String> baselinePrivileges = adminPrivileges(seedSql);
-        Map<String, String> repairedPrivileges = effectiveAdminPrivileges(
+        Map<PrivilegeKey, String> baselinePrivileges = privileges(seedSql);
+        Map<PrivilegeKey, String> repairedPrivileges = effectivePrivileges(
                 developmentSeedSql, privilegeRepairSql);
 
-        assertThat(repairedPrivileges)
-                .isEqualTo(baselinePrivileges)
-                .doesNotContainKey("_admin.traceability");
-        assertThat(adminPrivilegeTupleCount(privilegeRepairSql))
-                .isEqualTo(adminPrivileges(privilegeRepairSql).size());
+        assertThat(repairedPrivileges).isEqualTo(baselinePrivileges);
+        assertThat(repairedPrivileges.keySet())
+                .noneMatch(key -> key.objectName().equals("_admin.traceability"));
+        assertThat(privilegeTupleCount(privilegeRepairSql))
+                .isEqualTo(privileges(privilegeRepairSql).size());
         assertThat(privilegeRepairSql).contains(
                 "('admin', '_admin.schedule', 'x', 0, '999998')",
                 "('999998', '_admin.schedule.groupCreate', 'o', 1, '999998')",
@@ -185,30 +189,40 @@ class CarlosdocPrivilegeSeedRegressionTest {
                 "('999998', '_admin.schedule.groupCreate', 'o', 1, '999998')");
     }
 
-    private static Map<String, String> adminPrivileges(String sql) {
-        Map<String, String> privileges = new LinkedHashMap<>();
-        Matcher matcher = ADMIN_PRIVILEGE.matcher(sql);
-        while (matcher.find()) {
-            // The table key is (roleUserGroup, objectName), so later repair upserts
-            // replace the effective tuple for the same admin object.
-            privileges.put(matcher.group(1),
-                    matcher.group(2) + '|' + matcher.group(3) + '|' + matcher.group(4));
+    private static Map<PrivilegeKey, String> privileges(String sql) {
+        Map<PrivilegeKey, String> privileges = new LinkedHashMap<>();
+        Matcher insert = SEC_OBJ_PRIVILEGE_INSERT.matcher(sql);
+        while (insert.find()) {
+            Matcher tuple = PRIVILEGE_TUPLE.matcher(insert.group(1));
+            while (tuple.find()) {
+                // The table key is (roleUserGroup, objectName), so later repair upserts
+                // replace the effective tuple for the same role and security object.
+                privileges.put(new PrivilegeKey(tuple.group(1), tuple.group(2)),
+                        tuple.group(3) + '|' + tuple.group(4) + '|' + tuple.group(5));
+            }
         }
         return privileges;
     }
 
-    private static long adminPrivilegeTupleCount(String sql) {
-        return ADMIN_PRIVILEGE.matcher(sql).results().count();
+    private static long privilegeTupleCount(String sql) {
+        long count = 0;
+        Matcher insert = SEC_OBJ_PRIVILEGE_INSERT.matcher(sql);
+        while (insert.find()) {
+            count += PRIVILEGE_TUPLE.matcher(insert.group(1)).results().count();
+        }
+        return count;
     }
 
-    private static Map<String, String> effectiveAdminPrivileges(String seed, String repair) {
-        Map<String, String> privileges = adminPrivileges(seed);
-        privileges.putAll(adminPrivileges(repair));
+    private static Map<PrivilegeKey, String> effectivePrivileges(String seed, String repair) {
+        Map<PrivilegeKey, String> privileges = privileges(seed);
+        privileges.putAll(privileges(repair));
 
-        Matcher deletedPrivilege = ADMIN_PRIVILEGE_DELETE.matcher(repair);
+        Matcher deletedPrivilege = PRIVILEGE_DELETE.matcher(repair);
         while (deletedPrivilege.find()) {
-            privileges.remove(deletedPrivilege.group(1));
+            privileges.keySet().removeIf(key -> key.objectName().equals(deletedPrivilege.group(1)));
         }
         return privileges;
     }
+
+    private record PrivilegeKey(String roleUserGroup, String objectName) {}
 }

--- a/src/test/java/io/github/carlos_emr/carlos/security/CarlosdocPrivilegeSeedRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/security/CarlosdocPrivilegeSeedRegressionTest.java
@@ -128,6 +128,8 @@ class CarlosdocPrivilegeSeedRegressionTest {
         assertThat(repairedPrivileges)
                 .isEqualTo(baselinePrivileges)
                 .doesNotContainKey("_admin.traceability");
+        assertThat(adminPrivilegeTupleCount(privilegeRepairSql))
+                .isEqualTo(adminPrivileges(privilegeRepairSql).size());
         assertThat(privilegeRepairSql).contains(
                 "('admin', '_admin.schedule', 'x', 0, '999998')",
                 "('999998', '_admin.schedule.groupCreate', 'o', 1, '999998')",
@@ -148,8 +150,8 @@ class CarlosdocPrivilegeSeedRegressionTest {
                 .satisfies(script -> assertThat(script.indexOf("/scripts/development_privileges.sql"))
                         .isGreaterThan(script.indexOf("/scripts/development.sql")));
         assertThat(devcontainerSeed).contains(
-                "mariadb -h db -u root oscar \\",
-                "/workspace/.devcontainer/db/scripts/development_privileges.sql");
+                "mariadb -h db -u root oscar \\\n"
+                        + "    < /workspace/.devcontainer/db/scripts/development_privileges.sql");
     }
 
     @Test
@@ -187,10 +189,16 @@ class CarlosdocPrivilegeSeedRegressionTest {
         Map<String, String> privileges = new LinkedHashMap<>();
         Matcher matcher = ADMIN_PRIVILEGE.matcher(sql);
         while (matcher.find()) {
+            // The table key is (roleUserGroup, objectName), so later repair upserts
+            // replace the effective tuple for the same admin object.
             privileges.put(matcher.group(1),
                     matcher.group(2) + '|' + matcher.group(3) + '|' + matcher.group(4));
         }
         return privileges;
+    }
+
+    private static long adminPrivilegeTupleCount(String sql) {
+        return ADMIN_PRIVILEGE.matcher(sql).results().count();
     }
 
     private static Map<String, String> effectiveAdminPrivileges(String seed, String repair) {

--- a/src/test/java/io/github/carlos_emr/carlos/security/CarlosdocPrivilegeSeedRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/security/CarlosdocPrivilegeSeedRegressionTest.java
@@ -131,6 +131,9 @@ class CarlosdocPrivilegeSeedRegressionTest {
         Map<PrivilegeKey, String> repairedPrivileges = effectivePrivileges(
                 developmentSeedSql, privilegeRepairSql);
 
+        assertThat(baselinePrivileges).isNotEmpty();
+        assertThat(bcBaselinePrivileges).isNotEmpty();
+        assertThat(repairPrivileges).hasSize(8);
         assertThat(repairedPrivileges).isEqualTo(baselinePrivileges);
         assertThat(baselinePrivileges).containsAllEntriesOf(repairPrivileges);
         assertThat(bcBaselinePrivileges).containsAllEntriesOf(repairPrivileges);


### PR DESCRIPTION
## Description

- Restore the current Ontario/BC baseline Administration grants after development.sql replaces secObjPrivilege with its older demo snapshot.
- Run the idempotent repair after fresh database initialization and during devcontainer bootstrap so persisted local volumes are repaired as well.
- Make the local carlosdoc account a full administrator by removing its provider-specific schedule group-creation denial; production baseline data remains unchanged.
- Remove the retired traceability permission and validate the effective development privilege set.
- Repair the Schedule Management Add a Group navigation and guard its optional parent-frame resize callback.

## Related Issues

Fixes #3380

## How Was This Tested?

- mvn -B -Dtest=AdminGroupActionsTest,CarlosdocPrivilegeSeedRegressionTest test (14 tests, 0 failures)
- mvn -B -Dtest=AdminGroupActionsTest test (7 tests, 0 failures)
- mvn -B -DskipTests package
- Shell syntax checks for the devcontainer bootstrap scripts
- Browser-tested the actual Administration > Schedule Management navigation on the exact PR head: Schedule Setting and Add a Group both returned HTTP 200 and rendered without console/page errors
- Static SQL tuple, upsert, targeted-delete, and execution-order regression coverage

## Checklist

- [x] Commits are signed off for DCO
- [x] Commits follow Conventional Commits format
- [x] No patient data is included
- [x] Regression coverage is included
- [x] The contributing guide was followed