### PR TITLE
Fix CSRF token in AJAX allergy form

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxAddAllergy2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxAddAllergy2Action.java
@@ -64,6 +64,23 @@ public final class RxAddAllergy2Action extends ActionSupport {
             throw new SecurityException("missing required sec object (_allergy)");
         }
 
+        String formDemographicNo = request.getParameter("formDemographicNo");
+        RxPatientData.Patient patient = (RxPatientData.Patient) request.getSession().getAttribute("Patient");
+        if (patient == null || formDemographicNo == null) {
+            response.sendError(HttpServletResponse.SC_FORBIDDEN);
+            return NONE;
+        }
+
+        try {
+            if (Integer.parseInt(formDemographicNo) != patient.getDemographicNo()) {
+                response.sendError(HttpServletResponse.SC_FORBIDDEN);
+                return NONE;
+            }
+        } catch (NumberFormatException e) {
+            response.sendError(HttpServletResponse.SC_FORBIDDEN);
+            return NONE;
+        }
+
         String id = request.getParameter("ID");
 
             if (id == null || "null".equals(id)) {
@@ -83,7 +100,6 @@ public final class RxAddAllergy2Action extends ActionSupport {
 
         String nonDrug = request.getParameter("nonDrug");
 
-        RxPatientData.Patient patient = (RxPatientData.Patient) request.getSession().getAttribute("Patient");
         Allergy allergy = new Allergy();
             allergy.setDrugrefId(id);
 			// this can be overwritten with the conditions further down this code block

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxAddAllergy2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxAddAllergy2Action.java
@@ -64,6 +64,12 @@ public final class RxAddAllergy2Action extends ActionSupport {
             throw new SecurityException("missing required sec object (_allergy)");
         }
 
+        if (!"POST".equalsIgnoreCase(request.getMethod())) {
+            response.setHeader("Allow", "POST");
+            response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+            return NONE;
+        }
+
         String formDemographicNo = request.getParameter("formDemographicNo");
         RxPatientData.Patient patient = (RxPatientData.Patient) request.getSession().getAttribute("Patient");
         if (patient == null || formDemographicNo == null) {

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxAddAllergy2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxAddAllergy2Action.java
@@ -59,6 +59,14 @@ public final class RxAddAllergy2Action extends ActionSupport {
 
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
 
+    /**
+     * Handles allergy mutations for users with {@code _allergy} write privilege.
+     * Requests must use {@code POST}; other methods return HTTP 405 with
+     * {@code Allow: POST} and {@link #NONE}. Missing, malformed, or
+     * mismatched rendered patient context returns HTTP 403 and {@link #NONE}.
+     * Valid add requests return {@link #SUCCESS}; archive requests return
+     * {@link #NONE} after the allergy list response is rendered.
+     */
     public String execute() throws IOException, ServletException {
         if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_allergy", "w", null)) {
             throw new SecurityException("missing required sec object (_allergy)");

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxAddAllergy2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxAddAllergy2Action.java
@@ -64,8 +64,7 @@ public final class RxAddAllergy2Action extends ActionSupport {
      * Requests must use {@code POST}; other methods return HTTP 405 with
      * {@code Allow: POST} and {@link #NONE}. Missing, malformed, or
      * mismatched rendered patient context returns HTTP 403 and {@link #NONE}.
-     * Valid add requests return {@link #SUCCESS}; archive requests return
-     * {@link #NONE} after the allergy list response is rendered.
+     * Valid add and archive requests return {@link #SUCCESS}.
      */
     public String execute() throws IOException, ServletException {
         if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_allergy", "w", null)) {

--- a/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxAddAllergy2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxAddAllergy2Action.java
@@ -64,7 +64,7 @@ public final class RxAddAllergy2Action extends ActionSupport {
             throw new SecurityException("missing required sec object (_allergy)");
         }
 
-        if (!"POST".equalsIgnoreCase(request.getMethod())) {
+        if (!"POST".equals(request.getMethod())) {
             response.setHeader("Allow", "POST");
             response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
             return NONE;

--- a/src/main/webapp/WEB-INF/jsp/rx/AddReaction2.jsp
+++ b/src/main/webapp/WEB-INF/jsp/rx/AddReaction2.jsp
@@ -37,6 +37,7 @@
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@ taglib uri="carlos" prefix="carlos" %>
+<%@ taglib uri="https://owasp.org/www-project-csrfguard/Owasp.CsrfGuard.tld" prefix="csrf" %>
 <%
     String roleName2$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;
@@ -137,6 +138,9 @@
                     <tr>
                         <td id="addAllergyDialogue"><form action="<%=request.getContextPath()%>/rx/addAllergy2" method="post"
                                                                name="RxAddAllergyForm" id="RxAddAllergyForm" focus="reactionDescription">
+                            <input type="hidden" name="<csrf:tokenname/>" value="<csrf:tokenvalue/>"/>
+                            <input type="hidden" name="formDemographicNo"
+                                   value="<carlos:encode value='<%= String.valueOf(patient.getDemographicNo()) %>' context="htmlAttribute"/>"/>
 
                             <script type="text/javascript">
                                 function checkStartDate() {
@@ -203,7 +207,6 @@
                                         <input type="hidden" name="ID" value="<carlos:encode value='<%= drugrefId %>' context="htmlAttribute"/>"/>
                                         <input type="hidden" name="name" id="name" value="<carlos:encode value='<%= name %>' context="htmlAttribute"/>"/>
                                         <input type="hidden" name="allergyToArchive" id="allergyToArchive" value="<carlos:encode value='<%= allergyToArchive %>' context="htmlAttribute"/>"/>
-                                        <%-- CSRF token auto-injected by CSRFGuard (injectIntoForms=true) --%>
                                     </td>
                                 </tr>
 

--- a/src/main/webapp/WEB-INF/jsp/rx/AddReaction2.jsp
+++ b/src/main/webapp/WEB-INF/jsp/rx/AddReaction2.jsp
@@ -1,6 +1,7 @@
 <%@ page import="io.github.carlos_emr.carlos.prescript.pageUtil.RxSessionBean" %>
 <%@ page import="io.github.carlos_emr.carlos.prescript.data.RxPatientData" %>
-<%@ page import="io.github.carlos_emr.carlos.commn.model.Allergy" %><%--
+<%@ page import="io.github.carlos_emr.carlos.commn.model.Allergy" %>
+<%@ page import="jakarta.servlet.http.HttpServletResponse" %><%--
 
     Copyright (c) 2001-2002. Department of Family Medicine, McMaster University. All Rights Reserved.
     This software is published under the GPL GNU General Public License.
@@ -72,6 +73,10 @@
         <%
             RxSessionBean bean = (RxSessionBean) pageContext.findAttribute("bean");
             RxPatientData.Patient patient = (RxPatientData.Patient) request.getSession().getAttribute("Patient");
+            if (patient == null) {
+                response.sendError(HttpServletResponse.SC_FORBIDDEN);
+                return;
+            }
             String name = (String) request.getAttribute("name");
             String type = (String) request.getAttribute("type");
             String drugrefId = (String) request.getAttribute("drugrefId");

--- a/src/test/java/io/github/carlos_emr/carlos/prescript/RxAllergyCsrfJspRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/prescript/RxAllergyCsrfJspRegressionTest.java
@@ -40,12 +40,30 @@ class RxAllergyCsrfJspRegressionTest {
 
     @Test
     @DisplayName("AJAX-rendered allergy form should include its CSRF token and rendered patient context")
-    void addReactionJspShouldRenderCsrfTokenAndPatientContext() throws IOException {
+    void shouldRenderCsrfTokenAndPatientContext_whenAddReactionJspIsRendered() throws IOException {
         String jsp = Files.readString(ADD_REACTION_JSP, StandardCharsets.UTF_8);
 
         assertThat(jsp).contains("<%@ taglib uri=\"https://owasp.org/www-project-csrfguard/Owasp.CsrfGuard.tld\" prefix=\"csrf\" %>");
         assertThat(jsp).contains("name=\"<csrf:tokenname/>\" value=\"<csrf:tokenvalue/>\"");
         assertThat(jsp).contains("name=\"formDemographicNo\"");
         assertThat(jsp).contains("patient.getDemographicNo()");
+    }
+
+    @Test
+    @DisplayName("AJAX-rendered allergy form should fail closed when the session patient is missing")
+    void shouldFailClosed_whenSessionPatientIsMissing() throws IOException {
+        String jsp = Files.readString(ADD_REACTION_JSP, StandardCharsets.UTF_8);
+
+        assertThat(jsp).contains("if (patient == null) {");
+        assertThat(jsp).contains("response.sendError(HttpServletResponse.SC_FORBIDDEN);");
+        assertThat(jsp).contains("return;");
+    }
+
+    @Test
+    @DisplayName("AJAX-rendered allergy form should declare only one server-rendered CSRF field")
+    void shouldDeclareOnlyOneServerRenderedCsrfField_whenAddReactionJspIsRendered() throws IOException {
+        String jsp = Files.readString(ADD_REACTION_JSP, StandardCharsets.UTF_8);
+
+        assertThat(jsp).containsOnlyOnce("name=\"<csrf:tokenname/>\" value=\"<csrf:tokenvalue/>\"");
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/prescript/RxAllergyCsrfJspRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/prescript/RxAllergyCsrfJspRegressionTest.java
@@ -17,8 +17,6 @@ import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.regex.Pattern;
-
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -43,13 +41,10 @@ class RxAllergyCsrfJspRegressionTest {
 
     private static final Path ADD_REACTION_JSP = projectRoot()
             .resolve(Path.of("src", "main", "webapp", "WEB-INF", "jsp", "rx", "AddReaction2.jsp"));
-    private static final Pattern PATIENT_LOOKUP = Pattern.compile(
-            "RxPatientData\\.Patient\\s+patient\\s*=\\s*\\(RxPatientData\\.Patient\\)\\s*"
-                    + "request\\.getSession\\(\\)\\.getAttribute\\(\\\"Patient\\\"\\)\\s*;");
-    private static final Pattern MISSING_PATIENT_GUARD = Pattern.compile(
-            "if\\s*\\(\\s*patient\\s*==\\s*null\\s*\\)\\s*\\{(?s:.*?)"
-                    + "response\\.sendError\\s*\\(\\s*HttpServletResponse\\.SC_FORBIDDEN\\s*\\)\\s*;(?s:.*?)"
-                    + "return\\s*;(?s:.*?)\\}");
+    private static final String PATIENT_LOOKUP = "RxPatientData.Patient patient = "
+            + "(RxPatientData.Patient) request.getSession().getAttribute(\"Patient\");";
+    private static final String MISSING_PATIENT_GUARD = "if (patient == null) { "
+            + "response.sendError(HttpServletResponse.SC_FORBIDDEN); return; }";
 
     @Test
     @DisplayName("AJAX-rendered allergy form should include its CSRF token and rendered patient context")
@@ -69,10 +64,10 @@ class RxAllergyCsrfJspRegressionTest {
     @Test
     @DisplayName("AJAX-rendered allergy form should fail closed when the session patient is missing")
     void shouldFailClosed_whenSessionPatientIsMissing() throws IOException {
-        String jsp = readAddReactionJsp();
+        String jsp = normalizeWhitespace(readAddReactionJsp());
         int patientLookup = indexOfRequired(jsp, PATIENT_LOOKUP);
         int missingPatientGuard = indexOfRequired(jsp, MISSING_PATIENT_GUARD);
-        int allergyForm = indexOfRequired(jsp, Pattern.compile("<form\\b(?s:.*?)\\bid=\\\"RxAddAllergyForm\\\""));
+        int allergyForm = indexOfRequired(jsp, "id=\"RxAddAllergyForm\"");
 
         assertThat(missingPatientGuard)
                 .as("missing-patient guard must run immediately after loading the session patient")
@@ -104,10 +99,14 @@ class RxAllergyCsrfJspRegressionTest {
         return Files.readString(ADD_REACTION_JSP, StandardCharsets.UTF_8);
     }
 
-    private static int indexOfRequired(String jsp, Pattern pattern) {
-        java.util.regex.Matcher matcher = pattern.matcher(jsp);
-        assertThat(matcher.find()).as("required JSP contract: %s", pattern).isTrue();
-        return matcher.start();
+    private static String normalizeWhitespace(String value) {
+        return value.replaceAll("\\s+", " ").trim();
+    }
+
+    private static int indexOfRequired(String jsp, String token) {
+        int index = jsp.indexOf(token);
+        assertThat(index).as("required JSP contract: %s", token).isGreaterThanOrEqualTo(0);
+        return index;
     }
 
     private static Path projectRoot() {

--- a/src/test/java/io/github/carlos_emr/carlos/prescript/RxAllergyCsrfJspRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/prescript/RxAllergyCsrfJspRegressionTest.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.github.carlos_emr.carlos.prescript;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Ensures the allergy form remains submit-safe when it is rendered as an
+ * AJAX fragment after the page-level CSRFGuard script has already initialized.
+ *
+ * @since 2026-08-07
+ */
+@DisplayName("Rx allergy CSRF JSP regression")
+@Tag("unit")
+@Tag("rx")
+@Tag("security")
+class RxAllergyCsrfJspRegressionTest {
+
+    private static final Path ADD_REACTION_JSP =
+            Path.of("src", "main", "webapp", "WEB-INF", "jsp", "rx", "AddReaction2.jsp");
+
+    @Test
+    @DisplayName("AJAX-rendered allergy form should include its CSRF token and rendered patient context")
+    void addReactionJspShouldRenderCsrfTokenAndPatientContext() throws IOException {
+        String jsp = Files.readString(ADD_REACTION_JSP, StandardCharsets.UTF_8);
+
+        assertThat(jsp).contains("<%@ taglib uri=\"https://owasp.org/www-project-csrfguard/Owasp.CsrfGuard.tld\" prefix=\"csrf\" %>");
+        assertThat(jsp).contains("name=\"<csrf:tokenname/>\" value=\"<csrf:tokenvalue/>\"");
+        assertThat(jsp).contains("name=\"formDemographicNo\"");
+        assertThat(jsp).contains("patient.getDemographicNo()");
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/prescript/RxAllergyCsrfJspRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/prescript/RxAllergyCsrfJspRegressionTest.java
@@ -43,10 +43,11 @@ class RxAllergyCsrfJspRegressionTest {
     void shouldRenderCsrfTokenAndPatientContext_whenAddReactionJspIsRendered() throws IOException {
         String jsp = Files.readString(ADD_REACTION_JSP, StandardCharsets.UTF_8);
 
-        assertThat(jsp).contains("<%@ taglib uri=\"https://owasp.org/www-project-csrfguard/Owasp.CsrfGuard.tld\" prefix=\"csrf\" %>");
-        assertThat(jsp).contains("name=\"<csrf:tokenname/>\" value=\"<csrf:tokenvalue/>\"");
-        assertThat(jsp).contains("name=\"formDemographicNo\"");
-        assertThat(jsp).contains("patient.getDemographicNo()");
+        assertThat(jsp)
+                .contains("<%@ taglib uri=\"https://owasp.org/www-project-csrfguard/Owasp.CsrfGuard.tld\" prefix=\"csrf\" %>")
+                .contains("name=\"<csrf:tokenname/>\" value=\"<csrf:tokenvalue/>\"")
+                .contains("name=\"formDemographicNo\"")
+                .contains("patient.getDemographicNo()");
     }
 
     @Test
@@ -54,9 +55,10 @@ class RxAllergyCsrfJspRegressionTest {
     void shouldFailClosed_whenSessionPatientIsMissing() throws IOException {
         String jsp = Files.readString(ADD_REACTION_JSP, StandardCharsets.UTF_8);
 
-        assertThat(jsp).contains("if (patient == null) {");
-        assertThat(jsp).contains("response.sendError(HttpServletResponse.SC_FORBIDDEN);");
-        assertThat(jsp).contains("return;");
+        assertThat(jsp)
+                .contains("if (patient == null) {")
+                .contains("response.sendError(HttpServletResponse.SC_FORBIDDEN);")
+                .contains("return;");
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/prescript/RxAllergyCsrfJspRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/prescript/RxAllergyCsrfJspRegressionTest.java
@@ -13,10 +13,16 @@
 package io.github.carlos_emr.carlos.prescript;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.regex.Pattern;
 
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -35,37 +41,92 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Tag("security")
 class RxAllergyCsrfJspRegressionTest {
 
-    private static final Path ADD_REACTION_JSP =
-            Path.of("src", "main", "webapp", "WEB-INF", "jsp", "rx", "AddReaction2.jsp");
+    private static final Path ADD_REACTION_JSP = projectRoot()
+            .resolve(Path.of("src", "main", "webapp", "WEB-INF", "jsp", "rx", "AddReaction2.jsp"));
+    private static final Pattern PATIENT_LOOKUP = Pattern.compile(
+            "RxPatientData\\.Patient\\s+patient\\s*=\\s*\\(RxPatientData\\.Patient\\)\\s*"
+                    + "request\\.getSession\\(\\)\\.getAttribute\\(\\\"Patient\\\"\\)\\s*;");
+    private static final Pattern MISSING_PATIENT_GUARD = Pattern.compile(
+            "if\\s*\\(\\s*patient\\s*==\\s*null\\s*\\)\\s*\\{(?s:.*?)"
+                    + "response\\.sendError\\s*\\(\\s*HttpServletResponse\\.SC_FORBIDDEN\\s*\\)\\s*;(?s:.*?)"
+                    + "return\\s*;(?s:.*?)\\}");
 
     @Test
     @DisplayName("AJAX-rendered allergy form should include its CSRF token and rendered patient context")
     void shouldRenderCsrfTokenAndPatientContext_whenAddReactionJspIsRendered() throws IOException {
-        String jsp = Files.readString(ADD_REACTION_JSP, StandardCharsets.UTF_8);
+        Element form = addAllergyForm();
+        Elements hiddenInputs = form.select("input[type=hidden]");
 
-        assertThat(jsp)
-                .contains("<%@ taglib uri=\"https://owasp.org/www-project-csrfguard/Owasp.CsrfGuard.tld\" prefix=\"csrf\" %>")
-                .contains("name=\"<csrf:tokenname/>\" value=\"<csrf:tokenvalue/>\"")
-                .contains("name=\"formDemographicNo\"")
-                .contains("patient.getDemographicNo()");
+        assertThat(hiddenInputs)
+                .filteredOn(input -> "<csrf:tokenname/>".equals(input.attr("name")))
+                .singleElement()
+                .satisfies(input -> assertThat(input.attr("value")).isEqualTo("<csrf:tokenvalue/>"));
+        assertThat(hiddenInputs)
+                .filteredOn(input -> "formDemographicNo".equals(input.attr("name")))
+                .singleElement();
     }
 
     @Test
     @DisplayName("AJAX-rendered allergy form should fail closed when the session patient is missing")
     void shouldFailClosed_whenSessionPatientIsMissing() throws IOException {
-        String jsp = Files.readString(ADD_REACTION_JSP, StandardCharsets.UTF_8);
+        String jsp = readAddReactionJsp();
+        int patientLookup = indexOfRequired(jsp, PATIENT_LOOKUP);
+        int missingPatientGuard = indexOfRequired(jsp, MISSING_PATIENT_GUARD);
+        int allergyForm = indexOfRequired(jsp, Pattern.compile("<form\\b(?s:.*?)\\bid=\\\"RxAddAllergyForm\\\""));
 
-        assertThat(jsp)
-                .contains("if (patient == null) {")
-                .contains("response.sendError(HttpServletResponse.SC_FORBIDDEN);")
-                .contains("return;");
+        assertThat(missingPatientGuard)
+                .as("missing-patient guard must run immediately after loading the session patient")
+                .isGreaterThan(patientLookup)
+                .isLessThan(allergyForm);
     }
 
     @Test
     @DisplayName("AJAX-rendered allergy form should declare only one server-rendered CSRF field")
     void shouldDeclareOnlyOneServerRenderedCsrfField_whenAddReactionJspIsRendered() throws IOException {
-        String jsp = Files.readString(ADD_REACTION_JSP, StandardCharsets.UTF_8);
+        Elements hiddenInputs = addAllergyForm().select("input[type=hidden]");
 
-        assertThat(jsp).containsOnlyOnce("name=\"<csrf:tokenname/>\" value=\"<csrf:tokenvalue/>\"");
+        assertThat(hiddenInputs)
+                .filteredOn(input -> "<csrf:tokenname/>".equals(input.attr("name")))
+                .singleElement();
+    }
+
+    private static Element addAllergyForm() throws IOException {
+        Document document = Jsoup.parse(readAddReactionJsp());
+        Element form = document.selectFirst("form#RxAddAllergyForm");
+
+        assertThat(form).as("AJAX add-allergy form").isNotNull();
+        assertThat(form.attr("action")).endsWith("/rx/addAllergy2");
+        assertThat(form.attr("method")).isEqualTo("post");
+        return form;
+    }
+
+    private static String readAddReactionJsp() throws IOException {
+        return Files.readString(ADD_REACTION_JSP, StandardCharsets.UTF_8);
+    }
+
+    private static int indexOfRequired(String jsp, Pattern pattern) {
+        java.util.regex.Matcher matcher = pattern.matcher(jsp);
+        assertThat(matcher.find()).as("required JSP contract: %s", pattern).isTrue();
+        return matcher.start();
+    }
+
+    private static Path projectRoot() {
+        try {
+            Path location = Path.of(RxAllergyCsrfJspRegressionTest.class
+                    .getProtectionDomain()
+                    .getCodeSource()
+                    .getLocation()
+                    .toURI());
+            Path current = Files.isRegularFile(location) ? location.getParent() : location;
+            while (current != null) {
+                if (Files.isRegularFile(current.resolve("src/main/webapp/WEB-INF/jsp/rx/AddReaction2.jsp"))) {
+                    return current;
+                }
+                current = current.getParent();
+            }
+        } catch (URISyntaxException e) {
+            throw new IllegalStateException("Unable to resolve test class location", e);
+        }
+        throw new IllegalStateException("Unable to locate CARLOS EMR project root from test classpath");
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/prescript/RxAllergyCsrfJspRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/prescript/RxAllergyCsrfJspRegressionTest.java
@@ -28,8 +28,9 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Ensures the allergy form remains submit-safe when it is rendered as an
- * AJAX fragment after the page-level CSRFGuard script has already initialized.
+ * Source-level guardrails for the AJAX allergy form fragment. Runtime CSRF
+ * token rendering is covered by the application-level page flow, while this
+ * test keeps the JSP contract wired to CSRFGuard and the session patient.
  *
  * @since 2026-08-07
  */
@@ -47,15 +48,16 @@ class RxAllergyCsrfJspRegressionTest {
             + "response.sendError(HttpServletResponse.SC_FORBIDDEN); return; }";
 
     @Test
-    @DisplayName("AJAX-rendered allergy form should include its CSRF token and rendered patient context")
-    void shouldRenderCsrfTokenAndPatientContext_whenAddReactionJspIsRendered() throws IOException {
+    @DisplayName("AJAX allergy form source should declare CSRFGuard tags and rendered patient context")
+    void shouldDeclareCsrfGuardTagsAndPatientContext_whenAddReactionJspSourceIsChecked() throws IOException {
         Element form = addAllergyForm();
         Elements hiddenInputs = form.select("input[type=hidden]");
 
         assertThat(hiddenInputs)
-                .filteredOn(input -> "<csrf:tokenname/>".equals(input.attr("name")))
-                .singleElement()
-                .satisfies(input -> assertThat(input.attr("value")).isEqualTo("<csrf:tokenvalue/>"));
+                .as("source-level CSRFGuard tag placeholder input")
+                .filteredOn(input -> "<csrf:tokenname/>".equals(input.attr("name"))
+                        && "<csrf:tokenvalue/>".equals(input.attr("value")))
+                .singleElement();
         assertThat(hiddenInputs)
                 .filteredOn(input -> "formDemographicNo".equals(input.attr("name")))
                 .singleElement();

--- a/src/test/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxAddAllergy2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxAddAllergy2ActionTest.java
@@ -88,6 +88,7 @@ class RxAddAllergy2ActionTest extends CarlosUnitTestBase {
         mocks = MockitoAnnotations.openMocks(this);
         mockRequest = new MockHttpServletRequest();
         mockResponse = new MockHttpServletResponse();
+        mockRequest.setMethod("POST");
 
         registerMock(SecurityInfoManager.class, mockSecurityInfoManager);
         when(mockSecurityInfoManager.hasPrivilege(any(LoggedInInfo.class), eq("_allergy"), eq("w"), isNull()))
@@ -137,9 +138,38 @@ class RxAddAllergy2ActionTest extends CarlosUnitTestBase {
     }
 
     @Test
+    @DisplayName("should reject a non-POST request before adding an allergy")
+    void shouldRejectAdd_whenRequestMethodIsNotPost() throws Exception {
+        mockRequest.setMethod("GET");
+
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(mockResponse.getStatus()).isEqualTo(405);
+        assertThat(mockResponse.getHeader("Allow")).isEqualTo("POST");
+        verify(mockRxPatient, never()).addAllergy(any(), any());
+        verify(mockRxPatient, never()).deleteAllergy(anyInt());
+        logActionMock.verifyNoInteractions();
+    }
+
+    @Test
     @DisplayName("should reject a missing rendered patient context before adding an allergy")
     void shouldRejectAdd_whenFormDemographicNoIsMissing() throws Exception {
         mockRequest.removeParameter("formDemographicNo");
+
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(mockResponse.getStatus()).isEqualTo(403);
+        verify(mockRxPatient, never()).addAllergy(any(), any());
+        verify(mockRxPatient, never()).deleteAllergy(anyInt());
+        logActionMock.verifyNoInteractions();
+    }
+
+    @Test
+    @DisplayName("should reject a missing session patient before adding an allergy")
+    void shouldRejectAdd_whenSessionPatientIsMissing() throws Exception {
+        mockRequest.getSession().removeAttribute("Patient");
 
         String result = action.execute();
 

--- a/src/test/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxAddAllergy2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxAddAllergy2ActionTest.java
@@ -153,6 +153,21 @@ class RxAddAllergy2ActionTest extends CarlosUnitTestBase {
     }
 
     @Test
+    @DisplayName("should reject a lower-case post request before adding an allergy")
+    void shouldRejectAdd_whenRequestMethodIsLowerCasePost() throws Exception {
+        mockRequest.setMethod("post");
+
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(mockResponse.getStatus()).isEqualTo(405);
+        assertThat(mockResponse.getHeader("Allow")).isEqualTo("POST");
+        verify(mockRxPatient, never()).addAllergy(any(), any());
+        verify(mockRxPatient, never()).deleteAllergy(anyInt());
+        logActionMock.verifyNoInteractions();
+    }
+
+    @Test
     @DisplayName("should reject a missing rendered patient context before adding an allergy")
     void shouldRejectAdd_whenFormDemographicNoIsMissing() throws Exception {
         mockRequest.removeParameter("formDemographicNo");

--- a/src/test/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxAddAllergy2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/prescript/pageUtil/RxAddAllergy2ActionTest.java
@@ -104,6 +104,7 @@ class RxAddAllergy2ActionTest extends CarlosUnitTestBase {
 
         mockRequest.setParameter("type", "1");
         mockRequest.setParameter("startDate", "");
+        mockRequest.setParameter("formDemographicNo", "123");
         mockRequest.getSession().setAttribute("Patient", mockRxPatient);
         when(mockRxPatient.getDemographicNo()).thenReturn(123);
 
@@ -133,6 +134,48 @@ class RxAddAllergy2ActionTest extends CarlosUnitTestBase {
                 .isInstanceOf(SecurityException.class)
                 .hasMessageContaining("_allergy");
         verify(mockRxPatient, never()).addAllergy(any(), any());
+    }
+
+    @Test
+    @DisplayName("should reject a missing rendered patient context before adding an allergy")
+    void shouldRejectAdd_whenFormDemographicNoIsMissing() throws Exception {
+        mockRequest.removeParameter("formDemographicNo");
+
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(mockResponse.getStatus()).isEqualTo(403);
+        verify(mockRxPatient, never()).addAllergy(any(), any());
+        verify(mockRxPatient, never()).deleteAllergy(anyInt());
+        logActionMock.verifyNoInteractions();
+    }
+
+    @Test
+    @DisplayName("should reject a stale rendered patient context before adding an allergy")
+    void shouldRejectAdd_whenFormDemographicNoDiffersFromSessionPatient() throws Exception {
+        mockRequest.setParameter("formDemographicNo", "456");
+
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(mockResponse.getStatus()).isEqualTo(403);
+        verify(mockRxPatient, never()).addAllergy(any(), any());
+        verify(mockRxPatient, never()).deleteAllergy(anyInt());
+        logActionMock.verifyNoInteractions();
+    }
+
+    @Test
+    @DisplayName("should reject a malformed rendered patient context before adding an allergy")
+    void shouldRejectAdd_whenFormDemographicNoIsMalformed() throws Exception {
+        mockRequest.setParameter("formDemographicNo", "not-a-number");
+
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(mockResponse.getStatus()).isEqualTo(403);
+        verify(mockRxPatient, never()).addAllergy(any(), any());
+        verify(mockRxPatient, never()).deleteAllergy(anyInt());
+        logActionMock.verifyNoInteractions();
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes #3355.

The add-allergy form is injected into the allergies page through AJAX, so the normal page-load CSRF bootstrapping can miss it. This PR renders the CSRF token server-side with the fragment and binds allergy submission to the selected session patient.

## Changes

- render the CSRF hidden field in `AddReaction2.jsp`
- render `formDemographicNo` with the form and fail closed when the session patient is missing
- enforce POST-only submission before allergy mutation
- reject missing, malformed, or mismatched patient bindings before any allergy mutation
- add action and JSP regression tests for the guarded paths

## Validation

- `mvn -q -DskipTests=false -Dtest=RxAddAllergy2ActionTest,RxAllergyCsrfJspRegressionTest test`
- `mvn -q -DskipTests -Dspotbugs.skip=true -Dcheckstyle.skip=true -Pjspc package`
- Playwright: authenticated as the local test user, opened the AJAX-injected custom-allergy form, verified a non-empty `CSRF-TOKEN` and `formDemographicNo=1`, submitted a uniquely named allergy successfully, confirmed it rendered, and removed the test data

No CSRF protection was weakened.
