### PR TITLE
fix: reject only real mutation intent on AddRelation, fixing 405 popup

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/app/HttpMethodGuardFilter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/app/HttpMethodGuardFilter.java
@@ -154,11 +154,18 @@ public class HttpMethodGuardFilter implements Filter {
                                           // action name 'createdate' matches the unconditional
                                           // "create" mutator prefix, so we exempt it here and rely
                                           // on the action's own POST check for mutations.
-            "addappointment"             // ViewAppointmentWrite2Action — view gate that loads the
+            "addappointment",            // ViewAppointmentWrite2Action — view gate that loads the
                                           // add-appointment form. The name starts with "add" so it
                                           // matches MUTATOR_ACTION_PREFIXES, but the action itself
                                           // only renders a JSP — the actual write goes through
                                           // appointment/AddRecord (which IS a POST-only mutator).
+            "addrelation"                // AddDemographicRelationship2Action (demographic "Add
+                                          // Relation" popup, edit-view.jsp): GET with only `demo`
+                                          // renders the contact-search form (AddAlternateContact.jsp).
+                                          // The actual relationship persist only fires when
+                                          // linkingDemo+relation are present, and the action itself
+                                          // rejects that case with 405 unless the request is POST —
+                                          // see AddDemographicRelationship2Action.execute().
     );
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/AddDemographicRelationship2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/AddDemographicRelationship2Action.java
@@ -66,6 +66,22 @@ public class AddDemographicRelationship2Action extends ActionSupport {
 
     }
 
+    /**
+     * Renders the "Add Relation" contact-search/save form, or persists a new demographic
+     * relationship when the request is a genuine save.
+     *
+     * <p>Request-method contract: a bare GET (only {@code demo}/{@code origDemo} present) renders
+     * the form and never mutates. A request carrying non-blank {@code linkingDemo} and
+     * {@code relation} is treated as save intent and MUST be a POST — a non-POST save attempt is
+     * rejected with {@code 405} (and an {@code Allow: POST} header) before any DAO call. A POST
+     * save with a missing or non-numeric {@code origDemo}/{@code linkingDemo} is rejected with
+     * {@code 400} rather than persisting a relationship against demographic {@code 0}.</p>
+     *
+     * @return {@link #SUCCESS} to render/re-render the form (including after a successful save),
+     *         {@code "pmmClient"} when the request is the PMM client-finished callback, or
+     *         {@link #NONE} after writing a {@code 405}/{@code 400} error response directly
+     * @throws SecurityException if the caller lacks {@code _demographic w}
+     */
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
     @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
     @Override
@@ -86,16 +102,14 @@ public class AddDemographicRelationship2Action extends ActionSupport {
             request.setAttribute("demographicNo", origDemo);
         }
 
-        if ("Finished".equals(request.getParameter("pmmClient"))) {
-            return "pmmClient";
-        }
-
         // Creating a relationship is a mutation and must arrive via POST. The "Add Relation"
         // popup (edit-view.jsp) opens this action with a plain GET carrying only `demo` to
         // render the contact-search form (AddAlternateContact.jsp) — linkingDemo/relation are
         // only present once the form is actually submitted. Gating on their presence (rather
         // than method alone) also lets the intermediate "select a contact from search results"
         // POST step render without persisting a relationship row before the user has chosen one.
+        // This check runs before the pmmClient short-circuit below so a non-POST request cannot
+        // use pmmClient=Finished to slip a save attempt past the method gate.
         boolean isMutation = isNonBlank(linkingDemo) && isNonBlank(relation);
         if (isMutation && !"POST".equalsIgnoreCase(request.getMethod())) {
             // RFC 7231 §6.5.5: 405 responses MUST include the Allow header.
@@ -103,8 +117,21 @@ public class AddDemographicRelationship2Action extends ActionSupport {
             response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
             return NONE;
         }
+
+        if ("Finished".equals(request.getParameter("pmmClient"))) {
+            return "pmmClient";
+        }
+
         if (!isMutation) {
             return SUCCESS;
+        }
+
+        // origDemo/linkingDemo must be real demographic numbers before they reach persistence:
+        // ConversionUtils.fromIntString coerces a missing or non-numeric value to 0, which would
+        // otherwise persist a relationship row pointing at demographic 0.
+        if (!isValidDemographicNo(origDemo) || !isValidDemographicNo(linkingDemo)) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "origDemo and linkingDemo must be valid demographic numbers");
+            return NONE;
         }
 
         String providerNo = (String) request.getSession().getAttribute("user");
@@ -135,7 +162,7 @@ public class AddDemographicRelationship2Action extends ActionSupport {
     }
 
     private static boolean isValidDemographicNo(String demographicNo) {
-        return demographicNo != null && demographicNo.matches("[a-zA-Z0-9]+");
+        return demographicNo != null && demographicNo.matches("[0-9]+");
     }
 
     // Blank (as opposed to absent) linkingDemo/relation must not count as mutation intent either —

--- a/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/AddDemographicRelationship2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/AddDemographicRelationship2Action.java
@@ -162,7 +162,7 @@ public class AddDemographicRelationship2Action extends ActionSupport {
     }
 
     private static boolean isValidDemographicNo(String demographicNo) {
-        return demographicNo != null && demographicNo.matches("[0-9]+");
+        return demographicNo != null && demographicNo.matches("^\\d+$");
     }
 
     // Blank (as opposed to absent) linkingDemo/relation must not count as mutation intent either —

--- a/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/AddDemographicRelationship2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/AddDemographicRelationship2Action.java
@@ -82,11 +82,11 @@ public class AddDemographicRelationship2Action extends ActionSupport {
         String emergContact = request.getParameter("emergContact");
         String notes = request.getParameter("notes");
 
-	    if (origDemo != null && origDemo.matches("[a-zA-Z0-9]+")) {
-        request.setAttribute("demographicNo", origDemo);
-	    }
+        if (isValidDemographicNo(origDemo)) {
+            request.setAttribute("demographicNo", origDemo);
+        }
 
-        if (request.getParameter("pmmClient") != null && request.getParameter("pmmClient").equals("Finished")) {
+        if ("Finished".equals(request.getParameter("pmmClient"))) {
             return "pmmClient";
         }
 
@@ -107,14 +107,8 @@ public class AddDemographicRelationship2Action extends ActionSupport {
 
         String providerNo = (String) request.getSession().getAttribute("user");
 
-        boolean sdmBool = false;
-        boolean eBool = false;
-        if (sdm != null && sdm.equals("yes")) {
-            sdmBool = true;
-        }
-        if (emergContact != null && emergContact.equals("yes")) {
-            eBool = true;
-        }
+        boolean sdmBool = "yes".equals(sdm);
+        boolean eBool = "yes".equals(emergContact);
 
         // if we're in a facility tag this association with the facility
         Facility facility = (Facility) request.getSession().getAttribute(SessionConstants.CURRENT_FACILITY);
@@ -124,33 +118,24 @@ public class AddDemographicRelationship2Action extends ActionSupport {
         DemographicRelationship demo = new DemographicRelationship();
         demo.addDemographicRelationship(origDemo, linkingDemo, relation, sdmBool, eBool, notes, providerNo, facilityId);
 
-	    if (origDemo != null && origDemo.matches("[a-zA-Z0-9]+")) {
-		    request.setAttribute("demo", origDemo);
-	    }
-        // ***** NEW CODE *****
-        // Now link in the opposite direction
-        // First work out which pairs match up
-        // From AddAlternateConcact.jsp
+        if (isValidDemographicNo(origDemo)) {
+            request.setAttribute("demo", origDemo);
+        }
 
-        // Relations for the dropdowns should be stored in a table in the database and not hardcoded
+        linkInverseRelationship(origDemo, linkingDemo, relation, sdmBool, eBool, notes, providerNo, facilityId);
 
-         /*
-         This is better:
+        return SUCCESS;
+    }
 
-                Parent
-                StepParent
-                Child
-                Sibling
-                Spouse
-                Partner
-                Grandparent
-                Other Relative
-                Other
+    private static boolean isValidDemographicNo(String demographicNo) {
+        return demographicNo != null && demographicNo.matches("[a-zA-Z0-9]+");
+    }
 
-         Sex will determine whether it is a brother,
-        grandfather, wife, husband or spouse of the same sex
-          */
-
+    // Relations for the dropdowns should be stored in a table in the database and not hardcoded.
+    // Sex determines whether the inverse is e.g. brother/sister, grandfather/grandmother,
+    // husband/wife of the same relation (from AddAlternateContact.jsp's original logic).
+    private void linkInverseRelationship(String origDemo, String linkingDemo, String relation, boolean sdmBool,
+            boolean eBool, String notes, String providerNo, Integer facilityId) {
         boolean relationset = false;
 
         CtlRelationshipsDao ctlRelationshipsDao = SpringUtils.getBean(CtlRelationshipsDao.class);
@@ -166,14 +151,11 @@ public class AddDemographicRelationship2Action extends ActionSupport {
                 relation = cr.getFemaleInverse();
                 relationset = true;
             }
-
         }
-
 
         if (relationset) {
             // flip the demographics
-            String tempdemo;
-            tempdemo = origDemo;
+            String tempdemo = origDemo;
             origDemo = linkingDemo;
             linkingDemo = tempdemo;
 
@@ -181,9 +163,6 @@ public class AddDemographicRelationship2Action extends ActionSupport {
             DemographicRelationship demo2 = new DemographicRelationship();
             demo2.addDemographicRelationship(origDemo, linkingDemo, relation, sdmBool, eBool, notes, providerNo, facilityId);
         }
-
-
-        return SUCCESS;
     }
 
 }

--- a/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/AddDemographicRelationship2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/AddDemographicRelationship2Action.java
@@ -96,8 +96,10 @@ public class AddDemographicRelationship2Action extends ActionSupport {
         // only present once the form is actually submitted. Gating on their presence (rather
         // than method alone) also lets the intermediate "select a contact from search results"
         // POST step render without persisting a relationship row before the user has chosen one.
-        boolean isMutation = linkingDemo != null && relation != null;
+        boolean isMutation = isNonBlank(linkingDemo) && isNonBlank(relation);
         if (isMutation && !"POST".equalsIgnoreCase(request.getMethod())) {
+            // RFC 7231 §6.5.5: 405 responses MUST include the Allow header.
+            response.setHeader("Allow", "POST");
             response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
             return NONE;
         }
@@ -129,6 +131,13 @@ public class AddDemographicRelationship2Action extends ActionSupport {
 
     private static boolean isValidDemographicNo(String demographicNo) {
         return demographicNo != null && demographicNo.matches("[a-zA-Z0-9]+");
+    }
+
+    // Blank (as opposed to absent) linkingDemo/relation must not count as mutation intent either —
+    // ConversionUtils.fromIntString("") coerces to 0 the same as fromIntString(null), so treating a
+    // blank value as "real" would persist the same garbage relationship row this gate exists to stop.
+    private static boolean isNonBlank(String value) {
+        return value != null && !value.isBlank();
     }
 
     // Relations for the dropdowns should be stored in a table in the database and not hardcoded.

--- a/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/AddDemographicRelationship2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/AddDemographicRelationship2Action.java
@@ -81,6 +81,8 @@ public class AddDemographicRelationship2Action extends ActionSupport {
      *         {@code "pmmClient"} when the request is the PMM client-finished callback, or
      *         {@link #NONE} after writing a {@code 405}/{@code 400} error response directly
      * @throws SecurityException if the caller lacks {@code _demographic w}
+     * @throws IOException if writing the {@code 405}/{@code 400} error response fails
+     * @since 2005-10-05
      */
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
     @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
@@ -161,8 +163,19 @@ public class AddDemographicRelationship2Action extends ActionSupport {
         return SUCCESS;
     }
 
+    // A digit-only string that overflows int (e.g. "2147483648") still coerces to 0 in
+    // ConversionUtils.fromIntString via the caught NumberFormatException, so the digit check
+    // alone isn't enough -- confirm it actually parses as an int before accepting it.
     private static boolean isValidDemographicNo(String demographicNo) {
-        return demographicNo != null && demographicNo.matches("^\\d+$");
+        if (demographicNo == null || !demographicNo.matches("^\\d+$")) {
+            return false;
+        }
+        try {
+            Integer.parseInt(demographicNo);
+            return true;
+        } catch (NumberFormatException e) {
+            return false;
+        }
     }
 
     // Blank (as opposed to absent) linkingDemo/relation must not count as mutation intent either —

--- a/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/AddDemographicRelationship2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/AddDemographicRelationship2Action.java
@@ -30,6 +30,8 @@
 
 package io.github.carlos_emr.carlos.demographic.pageUtil;
 
+import java.io.IOException;
+
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
@@ -66,7 +68,7 @@ public class AddDemographicRelationship2Action extends ActionSupport {
 
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
     @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
-    public String execute() {
+    public String execute() throws IOException {
 
         if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_demographic", "w", null)) {
             throw new SecurityException("missing required sec object (_demographic)");
@@ -85,6 +87,21 @@ public class AddDemographicRelationship2Action extends ActionSupport {
 
         if (request.getParameter("pmmClient") != null && request.getParameter("pmmClient").equals("Finished")) {
             return "pmmClient";
+        }
+
+        // Creating a relationship is a mutation and must arrive via POST. The "Add Relation"
+        // popup (edit-view.jsp) opens this action with a plain GET carrying only `demo` to
+        // render the contact-search form (AddAlternateContact.jsp) — linkingDemo/relation are
+        // only present once the form is actually submitted. Gating on their presence (rather
+        // than method alone) also lets the intermediate "select a contact from search results"
+        // POST step render without persisting a relationship row before the user has chosen one.
+        boolean isMutation = linkingDemo != null && relation != null;
+        if (isMutation && !"POST".equalsIgnoreCase(request.getMethod())) {
+            response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+            return NONE;
+        }
+        if (!isMutation) {
+            return SUCCESS;
         }
 
         String providerNo = (String) request.getSession().getAttribute("user");

--- a/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/AddDemographicRelationship2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/AddDemographicRelationship2Action.java
@@ -68,6 +68,7 @@ public class AddDemographicRelationship2Action extends ActionSupport {
 
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
     @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
+    @Override
     public String execute() throws IOException {
 
         if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_demographic", "w", null)) {

--- a/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/AddDemographicRelationship2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/AddDemographicRelationship2Action.java
@@ -124,7 +124,12 @@ public class AddDemographicRelationship2Action extends ActionSupport {
             request.setAttribute("demo", origDemo);
         }
 
-        linkInverseRelationship(origDemo, linkingDemo, relation, sdmBool, eBool, notes, providerNo, facilityId);
+        InverseRelation inverse = computeInverseRelation(origDemo, linkingDemo, relation);
+        if (inverse != null) {
+            DemographicRelationship demo2 = new DemographicRelationship();
+            demo2.addDemographicRelationship(inverse.origDemo(), inverse.linkingDemo(), inverse.relation(),
+                    sdmBool, eBool, notes, providerNo, facilityId);
+        }
 
         return SUCCESS;
     }
@@ -143,8 +148,8 @@ public class AddDemographicRelationship2Action extends ActionSupport {
     // Relations for the dropdowns should be stored in a table in the database and not hardcoded.
     // Sex determines whether the inverse is e.g. brother/sister, grandfather/grandmother,
     // husband/wife of the same relation (from AddAlternateContact.jsp's original logic).
-    private void linkInverseRelationship(String origDemo, String linkingDemo, String relation, boolean sdmBool,
-            boolean eBool, String notes, String providerNo, Integer facilityId) {
+    // Returns null when no inverse relation applies (e.g. relation type has no sex-specific inverse).
+    private InverseRelation computeInverseRelation(String origDemo, String linkingDemo, String relation) {
         boolean relationset = false;
 
         CtlRelationshipsDao ctlRelationshipsDao = SpringUtils.getBean(CtlRelationshipsDao.class);
@@ -162,16 +167,14 @@ public class AddDemographicRelationship2Action extends ActionSupport {
             }
         }
 
-        if (relationset) {
-            // flip the demographics
-            String tempdemo = origDemo;
-            origDemo = linkingDemo;
-            linkingDemo = tempdemo;
-
-            //now save this
-            DemographicRelationship demo2 = new DemographicRelationship();
-            demo2.addDemographicRelationship(origDemo, linkingDemo, relation, sdmBool, eBool, notes, providerNo, facilityId);
+        if (!relationset) {
+            return null;
         }
+        // flip the demographics
+        return new InverseRelation(linkingDemo, origDemo, relation);
+    }
+
+    private record InverseRelation(String origDemo, String linkingDemo, String relation) {
     }
 
 }

--- a/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/AddDemographicRelationship2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/demographic/pageUtil/AddDemographicRelationship2Action.java
@@ -102,6 +102,7 @@ public class AddDemographicRelationship2Action extends ActionSupport {
 
         if (isValidDemographicNo(origDemo)) {
             request.setAttribute("demographicNo", origDemo);
+            request.setAttribute("demo", origDemo);
         }
 
         // Creating a relationship is a mutation and must arrive via POST. The "Add Relation"
@@ -149,10 +150,6 @@ public class AddDemographicRelationship2Action extends ActionSupport {
         DemographicRelationship demo = new DemographicRelationship();
         demo.addDemographicRelationship(origDemo, linkingDemo, relation, sdmBool, eBool, notes, providerNo, facilityId);
 
-        if (isValidDemographicNo(origDemo)) {
-            request.setAttribute("demo", origDemo);
-        }
-
         InverseRelation inverse = computeInverseRelation(origDemo, linkingDemo, relation);
         if (inverse != null) {
             DemographicRelationship demo2 = new DemographicRelationship();
@@ -165,14 +162,15 @@ public class AddDemographicRelationship2Action extends ActionSupport {
 
     // A digit-only string that overflows int (e.g. "2147483648") still coerces to 0 in
     // ConversionUtils.fromIntString via the caught NumberFormatException, so the digit check
-    // alone isn't enough -- confirm it actually parses as an int before accepting it.
+    // alone isn't enough -- confirm it actually parses as an int before accepting it. "0" is
+    // rejected too: demographic_no is an auto-increment PK starting at 1, so 0 is never a real
+    // patient -- it's the exact placeholder fromIntString(null/blank) coerces to.
     private static boolean isValidDemographicNo(String demographicNo) {
         if (demographicNo == null || !demographicNo.matches("^\\d+$")) {
             return false;
         }
         try {
-            Integer.parseInt(demographicNo);
-            return true;
+            return Integer.parseInt(demographicNo) > 0;
         } catch (NumberFormatException e) {
             return false;
         }

--- a/src/test/java/io/github/carlos_emr/carlos/app/HttpMethodGuardFilterUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/app/HttpMethodGuardFilterUnitTest.java
@@ -200,6 +200,23 @@ class HttpMethodGuardFilterUnitTest {
             verify(chain).doFilter(request, response);
             verify(response, never()).sendError(anyInt(), anyString());
         }
+
+        @Test
+        @DisplayName("should pass through GET to AddRelation popup render action")
+        void shouldPassThrough_forGetToAddRelationAction() throws Exception {
+            // AddRelation starts with "add" (a mutator prefix) but the "Add Relation" popup
+            // (edit-view.jsp) opens it via GET with only `demo` to render the contact-search
+            // form. AddDemographicRelationship2Action only persists when linkingDemo+relation
+            // are present, and rejects that case unless the request is POST.
+            when(request.getMethod()).thenReturn("GET");
+            when(request.getRequestURI()).thenReturn("/carlos/demographic/AddRelation");
+            when(request.getParameter("method")).thenReturn(null);
+
+            filter.doFilter(request, response, chain);
+
+            verify(chain).doFilter(request, response);
+            verify(response, never()).sendError(anyInt(), anyString());
+        }
     }
 
     @Nested

--- a/src/test/java/io/github/carlos_emr/carlos/app/contract/MutatorActionGetRejectionContractUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/app/contract/MutatorActionGetRejectionContractUnitTest.java
@@ -279,7 +279,10 @@ class MutatorActionGetRejectionContractUnitTest {
         "io.github.carlos_emr.carlos.fax.action.Fax2Action",
         // Security/MFA: execute() renders a view on a bare GET; only the method=resetMfa dispatch
         // (a privileged reset of another account's MFA) is POST-only (see MfaActions2ActionUnitTest).
-        "io.github.carlos_emr.carlos.security.MfaActions2Action"
+        "io.github.carlos_emr.carlos.security.MfaActions2Action",
+        // Demographic: AddRelation popup renders on a bare GET; only linkingDemo+relation mutation
+        // intent is POST-only (see AddDemographicRelationship2ActionUnitTest). Issue #3352.
+        "io.github.carlos_emr.carlos.demographic.pageUtil.AddDemographicRelationship2Action"
     );
 
     /**
@@ -372,7 +375,10 @@ class MutatorActionGetRejectionContractUnitTest {
         "io.github.carlos_emr.carlos.encounter.oscarConsultationRequest.pageUtil.EctConsultationFormFax2Action",
         // security slice: MfaActions2Action's resetMfa is a POST-only privileged mutation; the security
         // package is not in IN_SCOPE_PACKAGE_PREFIXES, so it registers explicitly (conditional mutator).
-        "io.github.carlos_emr.carlos.security.MfaActions2Action"
+        "io.github.carlos_emr.carlos.security.MfaActions2Action",
+        // demographic slice: AddDemographicRelationship2Action is the only migrated mutator gated so
+        // far; the demographic package is not in IN_SCOPE_PACKAGE_PREFIXES, so it registers explicitly.
+        "io.github.carlos_emr.carlos.demographic.pageUtil.AddDemographicRelationship2Action"
     );
 
     @ParameterizedTest(name = "{0} rejects GET and HEAD without side-effects")

--- a/src/test/java/io/github/carlos_emr/carlos/demographic/pageUtil/AddDemographicRelationship2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/demographic/pageUtil/AddDemographicRelationship2ActionUnitTest.java
@@ -23,6 +23,9 @@ package io.github.carlos_emr.carlos.demographic.pageUtil;
 
 import io.github.carlos_emr.carlos.commn.dao.CtlRelationshipsDao;
 import io.github.carlos_emr.carlos.commn.dao.RelationshipsDao;
+import io.github.carlos_emr.carlos.commn.model.CtlRelationships;
+import io.github.carlos_emr.carlos.commn.model.Demographic;
+import io.github.carlos_emr.carlos.commn.model.Relationships;
 import io.github.carlos_emr.carlos.managers.DemographicManager;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
@@ -41,20 +44,22 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
+import java.util.List;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -81,6 +86,7 @@ class AddDemographicRelationship2ActionUnitTest extends CarlosUnitTestBase {
     @Mock private SecurityInfoManager securityInfoManager;
     @Mock private RelationshipsDao relationshipsDao;
     @Mock private CtlRelationshipsDao ctlRelationshipsDao;
+    @Mock private DemographicManager demographicManager;
     @Mock private LoggedInInfo mockLoggedInInfo;
 
     private MockHttpServletRequest request;
@@ -104,7 +110,7 @@ class AddDemographicRelationship2ActionUnitTest extends CarlosUnitTestBase {
         registerMock(SecurityInfoManager.class, securityInfoManager);
         registerMock(RelationshipsDao.class, relationshipsDao);
         registerMock(CtlRelationshipsDao.class, ctlRelationshipsDao);
-        registerMock(DemographicManager.class, mock(DemographicManager.class));
+        registerMock(DemographicManager.class, demographicManager);
 
         when(securityInfoManager.hasPrivilege(
                 any(LoggedInInfo.class), eq("_demographic"), eq("w"), nullable(String.class)))
@@ -123,10 +129,15 @@ class AddDemographicRelationship2ActionUnitTest extends CarlosUnitTestBase {
     void shouldRenderContactSearchForm_whenGetWithoutMutationParams() throws Exception {
         request.setMethod("GET");
         request.setParameter("demo", "1373");
+        request.setParameter("origDemo", "1373");
 
         String result = new AddDemographicRelationship2Action().execute();
 
         assertThat(result).isEqualTo(ActionSupport.SUCCESS);
+        // The "demo" request attribute must populate on every render path (not just after a
+        // save) since AddAlternateContact.jsp falls back to it for creatorDemo when the demo/
+        // remarks query params are absent, e.g. the intermediate "select a contact" step.
+        assertThat(request.getAttribute("demo")).isEqualTo("1373");
         verifyNoInteractions(relationshipsDao);
         verifyNoInteractions(ctlRelationshipsDao);
     }
@@ -231,6 +242,25 @@ class AddDemographicRelationship2ActionUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
+    @DisplayName("should reject POST with linkingDemo=0 with 400 and never persist")
+    void shouldReject400_whenPostHasZeroLinkingDemo() throws Exception {
+        request.setMethod("POST");
+        request.setParameter("origDemo", "1373");
+        // "0" is digit-only and parses as a valid int, but demographic_no is an auto-increment
+        // PK starting at 1 -- 0 is the exact placeholder fromIntString(null/blank) coerces to.
+        request.setParameter("linkingDemo", "0");
+        request.setParameter("relation", "Spouse");
+        request.getSession().setAttribute("user", "999998");
+
+        String result = new AddDemographicRelationship2Action().execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_BAD_REQUEST);
+        verifyNoInteractions(relationshipsDao);
+        verifyNoInteractions(ctlRelationshipsDao);
+    }
+
+    @Test
     @DisplayName("should return pmmClient and never persist when GET carries the Finished param")
     void shouldReturnPmmClient_whenGetCarriesFinishedParam() throws Exception {
         request.setMethod("GET");
@@ -279,5 +309,45 @@ class AddDemographicRelationship2ActionUnitTest extends CarlosUnitTestBase {
 
         assertThat(result).isEqualTo(ActionSupport.SUCCESS);
         verify(relationshipsDao).persist(any());
+    }
+
+    @Test
+    @DisplayName("should persist a flipped inverse row when the relation has a sex-specific inverse")
+    void shouldPersistInverseRelationship_whenRelationHasMaleInverseAndOrigDemoIsMale() throws Exception {
+        request.setMethod("POST");
+        request.setParameter("origDemo", "1373");
+        request.setParameter("linkingDemo", "1374");
+        request.setParameter("relation", "Parent");
+        request.getSession().setAttribute("user", "999998");
+
+        CtlRelationships parentRelation = new CtlRelationships();
+        parentRelation.setValue("Parent");
+        parentRelation.setMaleInverse("Son");
+        parentRelation.setFemaleInverse("Daughter");
+        when(ctlRelationshipsDao.findByValue("Parent")).thenReturn(parentRelation);
+
+        Demographic origDemographic = new Demographic();
+        origDemographic.setSex("M");
+        when(demographicManager.getDemographic(eq(mockLoggedInInfo), eq("1373"))).thenReturn(origDemographic);
+
+        String result = new AddDemographicRelationship2Action().execute();
+
+        assertThat(result).isEqualTo(ActionSupport.SUCCESS);
+
+        ArgumentCaptor<Relationships> captor = ArgumentCaptor.forClass(Relationships.class);
+        verify(relationshipsDao, times(2)).persist(captor.capture());
+        List<Relationships> persisted = captor.getAllValues();
+
+        // Forward row: origDemo -> linkingDemo, the relation as submitted.
+        assertThat(persisted.get(0).getDemographicNo()).isEqualTo(1373);
+        assertThat(persisted.get(0).getRelationDemographicNo()).isEqualTo(1374);
+        assertThat(persisted.get(0).getRelation()).isEqualTo("Parent");
+
+        // Inverse row: flipped linkingDemo -> origDemo, using the male inverse since origDemo's
+        // sex is "M" (computeInverseRelation resolves the inverse relative to the ORIGINAL
+        // demographic's sex before flipping which side each demographic is on).
+        assertThat(persisted.get(1).getDemographicNo()).isEqualTo(1374);
+        assertThat(persisted.get(1).getRelationDemographicNo()).isEqualTo(1373);
+        assertThat(persisted.get(1).getRelation()).isEqualTo("Son");
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/demographic/pageUtil/AddDemographicRelationship2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/demographic/pageUtil/AddDemographicRelationship2ActionUnitTest.java
@@ -25,18 +25,22 @@ import io.github.carlos_emr.carlos.commn.dao.CtlRelationshipsDao;
 import io.github.carlos_emr.carlos.commn.dao.RelationshipsDao;
 import io.github.carlos_emr.carlos.managers.DemographicManager;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
-import io.github.carlos_emr.carlos.utility.SpringUtils;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import org.apache.struts2.ActionSupport;
 import org.apache.struts2.ServletActionContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
@@ -57,176 +61,136 @@ import static org.mockito.Mockito.when;
  * {@code demo} to render the contact-search form. {@code linkingDemo}/{@code relation} are only
  * present once the form is actually submitted. The action must render on the parameter-less GET
  * without persisting anything, must reject a GET that carries save data (linkingDemo + relation)
- * with 405, and must persist only on a genuine POST save. See issue #3352.</p>
+ * with 405, must not treat blank linkingDemo/relation as save data, and must persist only on a
+ * genuine POST save. See issue #3352.</p>
  */
 @Tag("unit")
 @Tag("security")
 @DisplayName("AddDemographicRelationship2Action GET/POST mutation gate")
-class AddDemographicRelationship2ActionUnitTest {
+class AddDemographicRelationship2ActionUnitTest extends CarlosUnitTestBase {
+
+    private MockedStatic<ServletActionContext> servletActionContextMock;
+    private MockedStatic<LoggedInInfo> loggedInInfoMock;
+    private AutoCloseable mocks;
+
+    @Mock private SecurityInfoManager securityInfoManager;
+    @Mock private RelationshipsDao relationshipsDao;
+    @Mock private CtlRelationshipsDao ctlRelationshipsDao;
+    @Mock private LoggedInInfo mockLoggedInInfo;
+
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+
+    @BeforeEach
+    void setUp() {
+        mocks = MockitoAnnotations.openMocks(this);
+
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+
+        servletActionContextMock = mockStatic(ServletActionContext.class);
+        servletActionContextMock.when(ServletActionContext::getRequest).thenReturn(request);
+        servletActionContextMock.when(ServletActionContext::getResponse).thenReturn(response);
+
+        loggedInInfoMock = mockStatic(LoggedInInfo.class);
+        loggedInInfoMock.when(() -> LoggedInInfo.getLoggedInInfoFromSession(any(HttpServletRequest.class)))
+                .thenReturn(mockLoggedInInfo);
+
+        registerMock(SecurityInfoManager.class, securityInfoManager);
+        registerMock(RelationshipsDao.class, relationshipsDao);
+        registerMock(CtlRelationshipsDao.class, ctlRelationshipsDao);
+        registerMock(DemographicManager.class, mock(DemographicManager.class));
+
+        when(securityInfoManager.hasPrivilege(
+                any(LoggedInInfo.class), eq("_demographic"), eq("w"), nullable(String.class)))
+                .thenReturn(true);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (loggedInInfoMock != null) loggedInInfoMock.close();
+        if (servletActionContextMock != null) servletActionContextMock.close();
+        if (mocks != null) mocks.close();
+    }
 
     @Test
     @DisplayName("should render contact-search form and never persist when GET has no mutation params")
     void shouldRenderContactSearchForm_whenGetWithoutMutationParams() throws Exception {
-        MockHttpServletRequest request = new MockHttpServletRequest();
         request.setMethod("GET");
         request.setParameter("demo", "1373");
-        MockHttpServletResponse response = new MockHttpServletResponse();
 
-        SecurityInfoManager securityInfoManager = mock(SecurityInfoManager.class);
-        RelationshipsDao relationshipsDao = mock(RelationshipsDao.class);
-        CtlRelationshipsDao ctlRelationshipsDao = mock(CtlRelationshipsDao.class);
+        String result = new AddDemographicRelationship2Action().execute();
 
-        try (MockedStatic<ServletActionContext> servletCtx = mockStatic(ServletActionContext.class);
-             MockedStatic<SpringUtils> springUtils = mockStatic(SpringUtils.class);
-             MockedStatic<LoggedInInfo> loggedInInfo = mockStatic(LoggedInInfo.class)) {
-
-            servletCtx.when(ServletActionContext::getRequest).thenReturn(request);
-            servletCtx.when(ServletActionContext::getResponse).thenReturn(response);
-            wireBeans(springUtils, securityInfoManager, relationshipsDao, ctlRelationshipsDao);
-            grantSession(loggedInInfo, securityInfoManager);
-
-            AddDemographicRelationship2Action action = new AddDemographicRelationship2Action();
-
-            String result = action.execute();
-
-            assertThat(result).isEqualTo(ActionSupport.SUCCESS);
-            verifyNoInteractions(relationshipsDao);
-            verifyNoInteractions(ctlRelationshipsDao);
-        }
+        assertThat(result).isEqualTo(ActionSupport.SUCCESS);
+        verifyNoInteractions(relationshipsDao);
+        verifyNoInteractions(ctlRelationshipsDao);
     }
 
     @Test
     @DisplayName("should reject GET carrying linkingDemo+relation mutation intent with 405 and never persist")
     void shouldReject405_whenGetCarriesLinkingDemoAndRelationMutationIntent() throws Exception {
-        MockHttpServletRequest request = new MockHttpServletRequest();
         request.setMethod("GET");
         // A GET carrying save data is the CSRF-via-GET attempt the gate must stop.
         request.setParameter("origDemo", "1373");
         request.setParameter("linkingDemo", "1374");
         request.setParameter("relation", "Spouse");
-        MockHttpServletResponse response = new MockHttpServletResponse();
 
-        SecurityInfoManager securityInfoManager = mock(SecurityInfoManager.class);
-        RelationshipsDao relationshipsDao = mock(RelationshipsDao.class);
-        CtlRelationshipsDao ctlRelationshipsDao = mock(CtlRelationshipsDao.class);
+        String result = new AddDemographicRelationship2Action().execute();
 
-        try (MockedStatic<ServletActionContext> servletCtx = mockStatic(ServletActionContext.class);
-             MockedStatic<SpringUtils> springUtils = mockStatic(SpringUtils.class);
-             MockedStatic<LoggedInInfo> loggedInInfo = mockStatic(LoggedInInfo.class)) {
+        // Rejected with 405 before any persist — the method gate runs ahead of the DAO calls.
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+        assertThat(response.getHeader("Allow")).isEqualTo("POST");
+        verifyNoInteractions(relationshipsDao);
+        verifyNoInteractions(ctlRelationshipsDao);
+    }
 
-            servletCtx.when(ServletActionContext::getRequest).thenReturn(request);
-            servletCtx.when(ServletActionContext::getResponse).thenReturn(response);
-            wireBeans(springUtils, securityInfoManager, relationshipsDao, ctlRelationshipsDao);
-            grantSession(loggedInInfo, securityInfoManager);
+    @Test
+    @DisplayName("should never persist when POST carries blank linkingDemo and relation")
+    void shouldNotPersist_whenPostCarriesBlankLinkingDemoAndRelation() throws Exception {
+        request.setMethod("POST");
+        request.setParameter("origDemo", "1373");
+        // Blank (present-but-empty) values must not count as mutation intent: fromIntString("")
+        // coerces to 0 the same as fromIntString(null), so this is the same garbage-row risk the
+        // null-value gate exists to stop.
+        request.setParameter("linkingDemo", "   ");
+        request.setParameter("relation", "");
 
-            AddDemographicRelationship2Action action = new AddDemographicRelationship2Action();
+        String result = new AddDemographicRelationship2Action().execute();
 
-            String result = action.execute();
-
-            // Rejected with 405 before any persist — the method gate runs ahead of the DAO calls.
-            assertThat(result).isEqualTo(ActionSupport.NONE);
-            assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
-            verifyNoInteractions(relationshipsDao);
-            verifyNoInteractions(ctlRelationshipsDao);
-        }
+        assertThat(result).isEqualTo(ActionSupport.SUCCESS);
+        verifyNoInteractions(relationshipsDao);
+        verifyNoInteractions(ctlRelationshipsDao);
     }
 
     @Test
     @DisplayName("should return pmmClient and never persist when GET carries the Finished param")
     void shouldReturnPmmClient_whenGetCarriesFinishedParam() throws Exception {
-        MockHttpServletRequest request = new MockHttpServletRequest();
         request.setMethod("GET");
         request.setParameter("origDemo", "1373");
         request.setParameter("pmmClient", "Finished");
-        MockHttpServletResponse response = new MockHttpServletResponse();
 
-        SecurityInfoManager securityInfoManager = mock(SecurityInfoManager.class);
-        RelationshipsDao relationshipsDao = mock(RelationshipsDao.class);
-        CtlRelationshipsDao ctlRelationshipsDao = mock(CtlRelationshipsDao.class);
+        String result = new AddDemographicRelationship2Action().execute();
 
-        try (MockedStatic<ServletActionContext> servletCtx = mockStatic(ServletActionContext.class);
-             MockedStatic<SpringUtils> springUtils = mockStatic(SpringUtils.class);
-             MockedStatic<LoggedInInfo> loggedInInfo = mockStatic(LoggedInInfo.class)) {
-
-            servletCtx.when(ServletActionContext::getRequest).thenReturn(request);
-            servletCtx.when(ServletActionContext::getResponse).thenReturn(response);
-            wireBeans(springUtils, securityInfoManager, relationshipsDao, ctlRelationshipsDao);
-            grantSession(loggedInInfo, securityInfoManager);
-
-            AddDemographicRelationship2Action action = new AddDemographicRelationship2Action();
-
-            String result = action.execute();
-
-            assertThat(result).isEqualTo("pmmClient");
-            verifyNoInteractions(relationshipsDao);
-            verifyNoInteractions(ctlRelationshipsDao);
-        }
+        assertThat(result).isEqualTo("pmmClient");
+        verifyNoInteractions(relationshipsDao);
+        verifyNoInteractions(ctlRelationshipsDao);
     }
 
     @Test
     @DisplayName("should persist the relationship when POST carries linkingDemo and relation")
     void shouldPersistRelationship_whenPostCarriesLinkingDemoAndRelation() throws Exception {
-        MockHttpServletRequest request = new MockHttpServletRequest();
         request.setMethod("POST");
         request.setParameter("origDemo", "1373");
         request.setParameter("linkingDemo", "1374");
         request.setParameter("relation", "Spouse");
         request.getSession().setAttribute("user", "999998");
-        MockHttpServletResponse response = new MockHttpServletResponse();
-
-        SecurityInfoManager securityInfoManager = mock(SecurityInfoManager.class);
-        RelationshipsDao relationshipsDao = mock(RelationshipsDao.class);
-        CtlRelationshipsDao ctlRelationshipsDao = mock(CtlRelationshipsDao.class);
         // No configured inverse relation: the inverse-linking branch is skipped cleanly.
         when(ctlRelationshipsDao.findByValue("Spouse")).thenReturn(null);
 
-        try (MockedStatic<ServletActionContext> servletCtx = mockStatic(ServletActionContext.class);
-             MockedStatic<SpringUtils> springUtils = mockStatic(SpringUtils.class);
-             MockedStatic<LoggedInInfo> loggedInInfo = mockStatic(LoggedInInfo.class)) {
+        String result = new AddDemographicRelationship2Action().execute();
 
-            servletCtx.when(ServletActionContext::getRequest).thenReturn(request);
-            servletCtx.when(ServletActionContext::getResponse).thenReturn(response);
-            wireBeans(springUtils, securityInfoManager, relationshipsDao, ctlRelationshipsDao);
-            grantSession(loggedInInfo, securityInfoManager);
-
-            AddDemographicRelationship2Action action = new AddDemographicRelationship2Action();
-
-            String result = action.execute();
-
-            assertThat(result).isEqualTo(ActionSupport.SUCCESS);
-            verify(relationshipsDao).persist(any());
-        }
-    }
-
-    private static void wireBeans(MockedStatic<SpringUtils> springUtils,
-            SecurityInfoManager securityInfoManager, RelationshipsDao relationshipsDao,
-            CtlRelationshipsDao ctlRelationshipsDao) {
-        springUtils.when(() -> SpringUtils.getBean(any(Class.class)))
-                .thenAnswer(inv -> {
-                    Class<?> beanType = inv.getArgument(0);
-                    if (beanType.equals(SecurityInfoManager.class)) {
-                        return securityInfoManager;
-                    }
-                    if (beanType.equals(RelationshipsDao.class)) {
-                        return relationshipsDao;
-                    }
-                    if (beanType.equals(CtlRelationshipsDao.class)) {
-                        return ctlRelationshipsDao;
-                    }
-                    if (beanType.equals(DemographicManager.class)) {
-                        return mock(DemographicManager.class);
-                    }
-                    return mock(beanType);
-                });
-    }
-
-    private static void grantSession(MockedStatic<LoggedInInfo> loggedInInfo,
-            SecurityInfoManager securityInfoManager) {
-        LoggedInInfo sessionInfo = mock(LoggedInInfo.class);
-        loggedInInfo.when(() -> LoggedInInfo.getLoggedInInfoFromSession(any(HttpServletRequest.class)))
-                .thenReturn(sessionInfo);
-        when(securityInfoManager.hasPrivilege(
-                any(LoggedInInfo.class), eq("_demographic"), eq("w"), nullable(String.class)))
-                .thenReturn(true);
+        assertThat(result).isEqualTo(ActionSupport.SUCCESS);
+        verify(relationshipsDao).persist(any());
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/demographic/pageUtil/AddDemographicRelationship2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/demographic/pageUtil/AddDemographicRelationship2ActionUnitTest.java
@@ -1,0 +1,232 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.demographic.pageUtil;
+
+import io.github.carlos_emr.carlos.commn.dao.CtlRelationshipsDao;
+import io.github.carlos_emr.carlos.commn.dao.RelationshipsDao;
+import io.github.carlos_emr.carlos.managers.DemographicManager;
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import io.github.carlos_emr.carlos.utility.SpringUtils;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.apache.struts2.ActionSupport;
+import org.apache.struts2.ServletActionContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link AddDemographicRelationship2Action}'s GET/POST mutation gate.
+ *
+ * <p>The "Add Relation" popup (edit-view.jsp) opens this action with a plain GET carrying only
+ * {@code demo} to render the contact-search form. {@code linkingDemo}/{@code relation} are only
+ * present once the form is actually submitted. The action must render on the parameter-less GET
+ * without persisting anything, must reject a GET that carries save data (linkingDemo + relation)
+ * with 405, and must persist only on a genuine POST save. See issue #3352.</p>
+ */
+@Tag("unit")
+@Tag("security")
+@DisplayName("AddDemographicRelationship2Action GET/POST mutation gate")
+class AddDemographicRelationship2ActionUnitTest {
+
+    @Test
+    @DisplayName("should render contact-search form and never persist when GET has no mutation params")
+    void shouldRenderContactSearchForm_whenGetWithoutMutationParams() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setMethod("GET");
+        request.setParameter("demo", "1373");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        SecurityInfoManager securityInfoManager = mock(SecurityInfoManager.class);
+        RelationshipsDao relationshipsDao = mock(RelationshipsDao.class);
+        CtlRelationshipsDao ctlRelationshipsDao = mock(CtlRelationshipsDao.class);
+
+        try (MockedStatic<ServletActionContext> servletCtx = mockStatic(ServletActionContext.class);
+             MockedStatic<SpringUtils> springUtils = mockStatic(SpringUtils.class);
+             MockedStatic<LoggedInInfo> loggedInInfo = mockStatic(LoggedInInfo.class)) {
+
+            servletCtx.when(ServletActionContext::getRequest).thenReturn(request);
+            servletCtx.when(ServletActionContext::getResponse).thenReturn(response);
+            wireBeans(springUtils, securityInfoManager, relationshipsDao, ctlRelationshipsDao);
+            grantSession(loggedInInfo, securityInfoManager);
+
+            AddDemographicRelationship2Action action = new AddDemographicRelationship2Action();
+
+            String result = action.execute();
+
+            assertThat(result).isEqualTo(ActionSupport.SUCCESS);
+            verifyNoInteractions(relationshipsDao);
+            verifyNoInteractions(ctlRelationshipsDao);
+        }
+    }
+
+    @Test
+    @DisplayName("should reject GET carrying linkingDemo+relation mutation intent with 405 and never persist")
+    void shouldReject405_whenGetCarriesLinkingDemoAndRelationMutationIntent() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setMethod("GET");
+        // A GET carrying save data is the CSRF-via-GET attempt the gate must stop.
+        request.setParameter("origDemo", "1373");
+        request.setParameter("linkingDemo", "1374");
+        request.setParameter("relation", "Spouse");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        SecurityInfoManager securityInfoManager = mock(SecurityInfoManager.class);
+        RelationshipsDao relationshipsDao = mock(RelationshipsDao.class);
+        CtlRelationshipsDao ctlRelationshipsDao = mock(CtlRelationshipsDao.class);
+
+        try (MockedStatic<ServletActionContext> servletCtx = mockStatic(ServletActionContext.class);
+             MockedStatic<SpringUtils> springUtils = mockStatic(SpringUtils.class);
+             MockedStatic<LoggedInInfo> loggedInInfo = mockStatic(LoggedInInfo.class)) {
+
+            servletCtx.when(ServletActionContext::getRequest).thenReturn(request);
+            servletCtx.when(ServletActionContext::getResponse).thenReturn(response);
+            wireBeans(springUtils, securityInfoManager, relationshipsDao, ctlRelationshipsDao);
+            grantSession(loggedInInfo, securityInfoManager);
+
+            AddDemographicRelationship2Action action = new AddDemographicRelationship2Action();
+
+            String result = action.execute();
+
+            // Rejected with 405 before any persist — the method gate runs ahead of the DAO calls.
+            assertThat(result).isEqualTo(ActionSupport.NONE);
+            assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+            verifyNoInteractions(relationshipsDao);
+            verifyNoInteractions(ctlRelationshipsDao);
+        }
+    }
+
+    @Test
+    @DisplayName("should return pmmClient and never persist when GET carries the Finished param")
+    void shouldReturnPmmClient_whenGetCarriesFinishedParam() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setMethod("GET");
+        request.setParameter("origDemo", "1373");
+        request.setParameter("pmmClient", "Finished");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        SecurityInfoManager securityInfoManager = mock(SecurityInfoManager.class);
+        RelationshipsDao relationshipsDao = mock(RelationshipsDao.class);
+        CtlRelationshipsDao ctlRelationshipsDao = mock(CtlRelationshipsDao.class);
+
+        try (MockedStatic<ServletActionContext> servletCtx = mockStatic(ServletActionContext.class);
+             MockedStatic<SpringUtils> springUtils = mockStatic(SpringUtils.class);
+             MockedStatic<LoggedInInfo> loggedInInfo = mockStatic(LoggedInInfo.class)) {
+
+            servletCtx.when(ServletActionContext::getRequest).thenReturn(request);
+            servletCtx.when(ServletActionContext::getResponse).thenReturn(response);
+            wireBeans(springUtils, securityInfoManager, relationshipsDao, ctlRelationshipsDao);
+            grantSession(loggedInInfo, securityInfoManager);
+
+            AddDemographicRelationship2Action action = new AddDemographicRelationship2Action();
+
+            String result = action.execute();
+
+            assertThat(result).isEqualTo("pmmClient");
+            verifyNoInteractions(relationshipsDao);
+            verifyNoInteractions(ctlRelationshipsDao);
+        }
+    }
+
+    @Test
+    @DisplayName("should persist the relationship when POST carries linkingDemo and relation")
+    void shouldPersistRelationship_whenPostCarriesLinkingDemoAndRelation() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setMethod("POST");
+        request.setParameter("origDemo", "1373");
+        request.setParameter("linkingDemo", "1374");
+        request.setParameter("relation", "Spouse");
+        request.getSession().setAttribute("user", "999998");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        SecurityInfoManager securityInfoManager = mock(SecurityInfoManager.class);
+        RelationshipsDao relationshipsDao = mock(RelationshipsDao.class);
+        CtlRelationshipsDao ctlRelationshipsDao = mock(CtlRelationshipsDao.class);
+        // No configured inverse relation: the inverse-linking branch is skipped cleanly.
+        when(ctlRelationshipsDao.findByValue("Spouse")).thenReturn(null);
+
+        try (MockedStatic<ServletActionContext> servletCtx = mockStatic(ServletActionContext.class);
+             MockedStatic<SpringUtils> springUtils = mockStatic(SpringUtils.class);
+             MockedStatic<LoggedInInfo> loggedInInfo = mockStatic(LoggedInInfo.class)) {
+
+            servletCtx.when(ServletActionContext::getRequest).thenReturn(request);
+            servletCtx.when(ServletActionContext::getResponse).thenReturn(response);
+            wireBeans(springUtils, securityInfoManager, relationshipsDao, ctlRelationshipsDao);
+            grantSession(loggedInInfo, securityInfoManager);
+
+            AddDemographicRelationship2Action action = new AddDemographicRelationship2Action();
+
+            String result = action.execute();
+
+            assertThat(result).isEqualTo(ActionSupport.SUCCESS);
+            verify(relationshipsDao).persist(any());
+        }
+    }
+
+    private static void wireBeans(MockedStatic<SpringUtils> springUtils,
+            SecurityInfoManager securityInfoManager, RelationshipsDao relationshipsDao,
+            CtlRelationshipsDao ctlRelationshipsDao) {
+        springUtils.when(() -> SpringUtils.getBean(any(Class.class)))
+                .thenAnswer(inv -> {
+                    Class<?> beanType = inv.getArgument(0);
+                    if (beanType.equals(SecurityInfoManager.class)) {
+                        return securityInfoManager;
+                    }
+                    if (beanType.equals(RelationshipsDao.class)) {
+                        return relationshipsDao;
+                    }
+                    if (beanType.equals(CtlRelationshipsDao.class)) {
+                        return ctlRelationshipsDao;
+                    }
+                    if (beanType.equals(DemographicManager.class)) {
+                        return mock(DemographicManager.class);
+                    }
+                    return mock(beanType);
+                });
+    }
+
+    private static void grantSession(MockedStatic<LoggedInInfo> loggedInInfo,
+            SecurityInfoManager securityInfoManager) {
+        LoggedInInfo sessionInfo = mock(LoggedInInfo.class);
+        loggedInInfo.when(() -> LoggedInInfo.getLoggedInInfoFromSession(any(HttpServletRequest.class)))
+                .thenReturn(sessionInfo);
+        when(securityInfoManager.hasPrivilege(
+                any(LoggedInInfo.class), eq("_demographic"), eq("w"), nullable(String.class)))
+                .thenReturn(true);
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/demographic/pageUtil/AddDemographicRelationship2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/demographic/pageUtil/AddDemographicRelationship2ActionUnitTest.java
@@ -164,6 +164,73 @@ class AddDemographicRelationship2ActionUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
+    @DisplayName("should never persist when POST carries blank linkingDemo but non-blank relation")
+    void shouldNotPersist_whenPostCarriesBlankLinkingDemoOnly() throws Exception {
+        // Guards the AND (not OR) semantics of the mutation gate.
+        request.setMethod("POST");
+        request.setParameter("origDemo", "1373");
+        request.setParameter("linkingDemo", "   ");
+        request.setParameter("relation", "Spouse");
+
+        String result = new AddDemographicRelationship2Action().execute();
+
+        assertThat(result).isEqualTo(ActionSupport.SUCCESS);
+        verifyNoInteractions(relationshipsDao);
+        verifyNoInteractions(ctlRelationshipsDao);
+    }
+
+    @Test
+    @DisplayName("should never persist when POST carries blank relation but non-blank linkingDemo")
+    void shouldNotPersist_whenPostCarriesBlankRelationOnly() throws Exception {
+        // Guards the AND (not OR) semantics of the mutation gate.
+        request.setMethod("POST");
+        request.setParameter("origDemo", "1373");
+        request.setParameter("linkingDemo", "1374");
+        request.setParameter("relation", "");
+
+        String result = new AddDemographicRelationship2Action().execute();
+
+        assertThat(result).isEqualTo(ActionSupport.SUCCESS);
+        verifyNoInteractions(relationshipsDao);
+        verifyNoInteractions(ctlRelationshipsDao);
+    }
+
+    @Test
+    @DisplayName("should reject POST with missing origDemo with 400 and never persist")
+    void shouldReject400_whenPostHasMissingOrigDemo() throws Exception {
+        request.setMethod("POST");
+        // origDemo intentionally omitted — fromIntString(null) would coerce to demographic 0.
+        request.setParameter("linkingDemo", "1374");
+        request.setParameter("relation", "Spouse");
+        request.getSession().setAttribute("user", "999998");
+
+        String result = new AddDemographicRelationship2Action().execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_BAD_REQUEST);
+        verifyNoInteractions(relationshipsDao);
+        verifyNoInteractions(ctlRelationshipsDao);
+    }
+
+    @Test
+    @DisplayName("should reject POST with non-numeric linkingDemo with 400 and never persist")
+    void shouldReject400_whenPostHasNonNumericLinkingDemo() throws Exception {
+        request.setMethod("POST");
+        request.setParameter("origDemo", "1373");
+        // Non-blank but non-numeric — fromIntString("abc") would also coerce to demographic 0.
+        request.setParameter("linkingDemo", "abc");
+        request.setParameter("relation", "Spouse");
+        request.getSession().setAttribute("user", "999998");
+
+        String result = new AddDemographicRelationship2Action().execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_BAD_REQUEST);
+        verifyNoInteractions(relationshipsDao);
+        verifyNoInteractions(ctlRelationshipsDao);
+    }
+
+    @Test
     @DisplayName("should return pmmClient and never persist when GET carries the Finished param")
     void shouldReturnPmmClient_whenGetCarriesFinishedParam() throws Exception {
         request.setMethod("GET");
@@ -173,6 +240,26 @@ class AddDemographicRelationship2ActionUnitTest extends CarlosUnitTestBase {
         String result = new AddDemographicRelationship2Action().execute();
 
         assertThat(result).isEqualTo("pmmClient");
+        verifyNoInteractions(relationshipsDao);
+        verifyNoInteractions(ctlRelationshipsDao);
+    }
+
+    @Test
+    @DisplayName("should reject GET carrying pmmClient=Finished with mutation intent with 405, not pmmClient")
+    void shouldReject405_whenGetCarriesPmmClientFinishedWithMutationIntent() throws Exception {
+        // The method gate must run before the pmmClient short-circuit, or pmmClient=Finished
+        // could be used to slip a non-POST save attempt past the 405 check.
+        request.setMethod("GET");
+        request.setParameter("origDemo", "1373");
+        request.setParameter("linkingDemo", "1374");
+        request.setParameter("relation", "Spouse");
+        request.setParameter("pmmClient", "Finished");
+
+        String result = new AddDemographicRelationship2Action().execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+        assertThat(response.getHeader("Allow")).isEqualTo("POST");
         verifyNoInteractions(relationshipsDao);
         verifyNoInteractions(ctlRelationshipsDao);
     }

--- a/src/test/java/io/github/carlos_emr/carlos/demographic/pageUtil/AddDemographicRelationship2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/demographic/pageUtil/AddDemographicRelationship2ActionUnitTest.java
@@ -38,11 +38,16 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -145,16 +150,18 @@ class AddDemographicRelationship2ActionUnitTest extends CarlosUnitTestBase {
         verifyNoInteractions(ctlRelationshipsDao);
     }
 
-    @Test
-    @DisplayName("should never persist when POST carries blank linkingDemo and relation")
-    void shouldNotPersist_whenPostCarriesBlankLinkingDemoAndRelation() throws Exception {
+    // Blank (present-but-empty) values must not count as mutation intent: fromIntString("")
+    // coerces to 0 the same as fromIntString(null), so this is the same garbage-row risk the
+    // null-value gate exists to stop. The AND (not OR) semantics of the gate are guarded by
+    // covering both-blank and each single-field-blank case.
+    @ParameterizedTest(name = "should never persist when POST carries {2}")
+    @MethodSource("blankMutationParams")
+    void shouldNotPersist_whenPostCarriesBlankMutationParam(String linkingDemo, String relation, String description)
+            throws Exception {
         request.setMethod("POST");
         request.setParameter("origDemo", "1373");
-        // Blank (present-but-empty) values must not count as mutation intent: fromIntString("")
-        // coerces to 0 the same as fromIntString(null), so this is the same garbage-row risk the
-        // null-value gate exists to stop.
-        request.setParameter("linkingDemo", "   ");
-        request.setParameter("relation", "");
+        request.setParameter("linkingDemo", linkingDemo);
+        request.setParameter("relation", relation);
 
         String result = new AddDemographicRelationship2Action().execute();
 
@@ -163,36 +170,11 @@ class AddDemographicRelationship2ActionUnitTest extends CarlosUnitTestBase {
         verifyNoInteractions(ctlRelationshipsDao);
     }
 
-    @Test
-    @DisplayName("should never persist when POST carries blank linkingDemo but non-blank relation")
-    void shouldNotPersist_whenPostCarriesBlankLinkingDemoOnly() throws Exception {
-        // Guards the AND (not OR) semantics of the mutation gate.
-        request.setMethod("POST");
-        request.setParameter("origDemo", "1373");
-        request.setParameter("linkingDemo", "   ");
-        request.setParameter("relation", "Spouse");
-
-        String result = new AddDemographicRelationship2Action().execute();
-
-        assertThat(result).isEqualTo(ActionSupport.SUCCESS);
-        verifyNoInteractions(relationshipsDao);
-        verifyNoInteractions(ctlRelationshipsDao);
-    }
-
-    @Test
-    @DisplayName("should never persist when POST carries blank relation but non-blank linkingDemo")
-    void shouldNotPersist_whenPostCarriesBlankRelationOnly() throws Exception {
-        // Guards the AND (not OR) semantics of the mutation gate.
-        request.setMethod("POST");
-        request.setParameter("origDemo", "1373");
-        request.setParameter("linkingDemo", "1374");
-        request.setParameter("relation", "");
-
-        String result = new AddDemographicRelationship2Action().execute();
-
-        assertThat(result).isEqualTo(ActionSupport.SUCCESS);
-        verifyNoInteractions(relationshipsDao);
-        verifyNoInteractions(ctlRelationshipsDao);
+    private static Stream<Arguments> blankMutationParams() {
+        return Stream.of(
+                Arguments.of("   ", "", "blank linkingDemo and relation"),
+                Arguments.of("   ", "Spouse", "blank linkingDemo only"),
+                Arguments.of("1374", "", "blank relation only"));
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/demographic/pageUtil/AddDemographicRelationship2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/demographic/pageUtil/AddDemographicRelationship2ActionUnitTest.java
@@ -212,6 +212,25 @@ class AddDemographicRelationship2ActionUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
+    @DisplayName("should reject POST with linkingDemo outside the int range with 400 and never persist")
+    void shouldReject400_whenPostHasLinkingDemoOutsideIntRange() throws Exception {
+        request.setMethod("POST");
+        request.setParameter("origDemo", "1373");
+        // Digit-only but overflows int — fromIntString would still coerce this to demographic 0
+        // via its caught NumberFormatException, so the digit-only regex alone isn't enough.
+        request.setParameter("linkingDemo", "2147483648");
+        request.setParameter("relation", "Spouse");
+        request.getSession().setAttribute("user", "999998");
+
+        String result = new AddDemographicRelationship2Action().execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_BAD_REQUEST);
+        verifyNoInteractions(relationshipsDao);
+        verifyNoInteractions(ctlRelationshipsDao);
+    }
+
+    @Test
     @DisplayName("should return pmmClient and never persist when GET carries the Finished param")
     void shouldReturnPmmClient_whenGetCarriesFinishedParam() throws Exception {
         request.setMethod("GET");

--- a/src/test/java/io/github/carlos_emr/carlos/demographic/pageUtil/AddDemographicRelationship2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/demographic/pageUtil/AddDemographicRelationship2ActionUnitTest.java
@@ -154,10 +154,9 @@ class AddDemographicRelationship2ActionUnitTest extends CarlosUnitTestBase {
     // coerces to 0 the same as fromIntString(null), so this is the same garbage-row risk the
     // null-value gate exists to stop. The AND (not OR) semantics of the gate are guarded by
     // covering both-blank and each single-field-blank case.
-    @ParameterizedTest(name = "should never persist when POST carries {2}")
+    @ParameterizedTest(name = "should never persist when POST carries linkingDemo=\"{0}\" relation=\"{1}\"")
     @MethodSource("blankMutationParams")
-    void shouldNotPersist_whenPostCarriesBlankMutationParam(String linkingDemo, String relation, String description)
-            throws Exception {
+    void shouldNotPersist_whenPostCarriesBlankMutationParam(String linkingDemo, String relation) throws Exception {
         request.setMethod("POST");
         request.setParameter("origDemo", "1373");
         request.setParameter("linkingDemo", linkingDemo);
@@ -172,9 +171,9 @@ class AddDemographicRelationship2ActionUnitTest extends CarlosUnitTestBase {
 
     private static Stream<Arguments> blankMutationParams() {
         return Stream.of(
-                Arguments.of("   ", "", "blank linkingDemo and relation"),
-                Arguments.of("   ", "Spouse", "blank linkingDemo only"),
-                Arguments.of("1374", "", "blank relation only"));
+                Arguments.of("   ", ""),      // blank linkingDemo and relation
+                Arguments.of("   ", "Spouse"), // blank linkingDemo only
+                Arguments.of("1374", ""));     // blank relation only
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `HttpMethodGuardFilter` blocked `GET /demographic/AddRelation` because the Struts action name `AddRelation` matches the `"add"` mutator prefix, so clicking **Add Relation** on a patient's demographic record always 405'd — the popup could never load.
- Simply allow-listing the action name wasn't safe on its own: `AddDemographicRelationship2Action.execute()` unconditionally called `demo.addDemographicRelationship(...)` → `RelationshipsDao.persist(...)` on every invocation, even when `linkingDemo`/`relation` were absent. Since `ConversionUtils.fromIntString(null)` returns `0` (not `null`), an unblocked bare GET would have silently inserted a garbage `relationships` row (`demographic_no=0`, `relation_demographic_no=0`, `relation=null`) every time the popup opened. The same gap already exists today on the intermediate "select a contact from search results" POST step, which also lacks `linkingDemo`/`relation`.
- Fixed by gating the real persist on `linkingDemo`+`relation` being present and requiring POST for that case (mirroring the existing `ScheduleCreateDate2Action` pattern), then exempting `addrelation` in `READ_ONLY_ACTION_NAMES` now that the action self-gates its own mutation.

## Changes
- `AddDemographicRelationship2Action.java`: mutation-intent gate before the persist call; rejects GET/HEAD carrying `linkingDemo`+`relation` with 405, renders normally otherwise.
- `HttpMethodGuardFilter.java`: added `addrelation` to `READ_ONLY_ACTION_NAMES`.
- `HttpMethodGuardFilterUnitTest.java`: new passthrough test for GET `/demographic/AddRelation`.
- New `AddDemographicRelationship2ActionUnitTest.java`: bare GET renders (no persist), GET+mutation-intent 405s (no persist), `pmmClient=Finished` still short-circuits, POST with real data persists.
- `MutatorActionGetRejectionContractUnitTest.java`: registered the action as a conditional mutator per repo convention.

Fixes #3352

## Test plan
- [x] `mvn test -Dtest=HttpMethodGuardFilterUnitTest` — 58/58 pass (new AddRelation case included)
- [x] `mvn test -Dtest=AddDemographicRelationship2ActionUnitTest` — 4/4 pass
- [x] `mvn test -Dtest=MutatorActionGetRejectionContractUnitTest` — 36/36 pass
- [x] Full `demographic`/`app` package test run — 175/175 pass
- [ ] Manual/Playwright check in devcontainer: open patient demographic edit page, click **Add Relation**, confirm popup loads, search + select a contact, fill relation, save; confirm no garbage row is created by opening/closing the popup without saving

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Gate AddDemographicRelationship2Action so only POSTs with valid demographic IDs and relationship data persist, and update HTTP method guards and tests to allow GET rendering of the Add Relation popup while still rejecting illegal mutation attempts.

Bug Fixes:
- Allow GET requests to the Add Relation demographic popup to render without triggering 405 responses while ensuring any relationship creation still requires POST.
- Prevent creation of garbage demographic relationship rows by rejecting save attempts lacking valid origDemo/linkingDemo or with blank/invalid mutation parameters.
- Ensure GET/HEAD requests carrying relationship mutation intent receive 405 responses with appropriate Allow headers before any DAO interaction.

Enhancements:
- Document AddDemographicRelationship2Action's request-method contract and factor inverse-relationship calculation into a helper for clearer control flow.

Tests:
- Add comprehensive unit tests around AddDemographicRelationship2Action's GET/POST mutation gate, including validation errors, PMM callbacks, and successful persist paths.
- Extend HttpMethodGuardFilter and contract tests to cover the AddRelation action as a conditional mutator and to verify GET pass-through behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the 405 on the “Add Relation” popup by letting GET render the form and only treating POSTs with real relationship data as mutations. Validates demographic IDs (rejects non-numeric, out-of-range, and 0) and restores the `demo` attribute on render paths; returns 400/405 as needed.

- **Bug Fixes**
  - AddDemographicRelationship2Action: Persist only when `linkingDemo` and `relation` are non-blank; require POST; GET/HEAD renders; 405 includes Allow: POST; method gate runs before `pmmClient`; validate `origDemo`/`linkingDemo` (reject missing, non-numeric, out-of-range, or zero) and always set `demo` on non-mutating paths.
  - HttpMethodGuardFilter: Added `addrelation` to READ_ONLY_ACTION_NAMES to allow the popup GET.
  - Tests: Added coverage for demographic 0 rejection, overflow IDs, blank-value gate, 405 with Allow header, `pmmClient`+GET mutation 405, partial-blank AND semantics, restored `demo` attribute on render, inverse-relation persist, and POST persist path.

- **Refactors**
  - Completed Javadoc on `execute()` with method contract and `IOException`; added `@Override`; kept inverse-link computation in `computeInverseRelation()` with persist in `execute()`.

<sup>Written for commit 5b41837df404531f9ce9ce723e6b5c1e13de91d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

