### PR TITLE
docs: add missing contextual javadoc to core entities and billing modules

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/billings/OHIP/ExtractBean.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/OHIP/ExtractBean.java
@@ -54,6 +54,11 @@ import io.github.carlos_emr.carlos.util.ConversionUtils;
 import io.github.carlos_emr.carlos.util.UtilDateUtilities;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+/**
+ * Data extraction bean for preparing OHIP (Ontario Health Insurance Plan) billing submissions.
+ *
+ * @since 2026-08-06
+ */
 public class ExtractBean extends Object implements Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/AgeValidator.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/AgeValidator.java
@@ -30,6 +30,11 @@
 package io.github.carlos_emr.carlos.billings.ca.bc.MSP;
 
 
+/**
+ * Validates patient age against age-restricted service codes for MSP claims.
+ *
+ * @since 2026-08-06
+ */
 public class AgeValidator
         extends ServiceCodeValidator {
     private int maxAge = 150;
@@ -73,6 +78,7 @@ public class AgeValidator
     }
 
     public boolean isValid() {
+        // Validates inputAge against defined minAge and maxAge bounds which map to age-restricted fee codes in the BC MSP Teleplan schedule.
         return (this.inputAge >= minAge && this.inputAge <= maxAge);
     }
 }

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/CDMReminderHlp.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/CDMReminderHlp.java
@@ -37,6 +37,11 @@ import io.github.carlos_emr.carlos.utility.MiscUtils;
 import io.github.carlos_emr.carlos.tickler.TicklerCreator;
 import io.github.carlos_emr.carlos.util.SqlUtils;
 
+/**
+ * Helper class for Chronic Disease Management (CDM) billing reminders and eligibility.
+ *
+ * @since 2026-08-06
+ */
 public class CDMReminderHlp {
     public CDMReminderHlp() {
     }

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/CheckBillingData.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/CheckBillingData.java
@@ -41,6 +41,11 @@ import java.sql.SQLException;
 import java.util.Iterator;
 import java.util.List;
 
+/**
+ * Performs pre-submission validation checks on billing data for compliance.
+ *
+ * @since 2026-08-06
+ */
 public class CheckBillingData {
 
     // check batchHeader VS1

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/CreateBillingReport2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/CreateBillingReport2Action.java
@@ -41,6 +41,11 @@ import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 
+/**
+ * Struts action to generate summary reports of MSP billing activity.
+ *
+ * @since 2026-08-06
+ */
 public class CreateBillingReport2Action extends ActionSupport {
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
 

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/DocumentTeleplanReportUploadServlet.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/DocumentTeleplanReportUploadServlet.java
@@ -51,6 +51,11 @@ import io.github.carlos_emr.CarlosProperties;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+/**
+ * Servlet handling the upload and parsing of Teleplan remittance and error reports.
+ *
+ * @since 2026-08-06
+ */
 public class DocumentTeleplanReportUploadServlet extends HttpServlet {
 
     // FindSecBugs PATH_TRAVERSAL_IN: path validated for directory containment via PathValidationUtils before use

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/ExtractBean.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/ExtractBean.java
@@ -59,6 +59,11 @@ import java.text.SimpleDateFormat;
 import java.util.Arrays;
 
 
+/**
+ * Generates the formatted Teleplan extract file for MSP batch submission.
+ *
+ * @since 2026-08-06
+ */
 public class ExtractBean extends Object implements Serializable {
     private static Logger logger = MiscUtils.getLogger();
     private LogTeleplanTxDao logTeleplanTxDao = SpringUtils.getBean(LogTeleplanTxDao.class);

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/GenTa2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/GenTa2Action.java
@@ -69,6 +69,11 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.struts2.ActionSupport;
 import org.apache.struts2.ServletActionContext;
 
+/**
+ * Struts action initiating the generation of Teleplan archives.
+ *
+ * @since 2026-08-06
+ */
 public class GenTa2Action extends ActionSupport {
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
 

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/MspErrorCodes.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/MspErrorCodes.java
@@ -46,6 +46,11 @@ import io.github.carlos_emr.carlos.utility.PathValidationUtils;
 
 import io.github.carlos_emr.CarlosProperties;
 
+/**
+ * Maintains the dictionary of MSP rejection and adjustment error codes.
+ *
+ * @since 2026-08-06
+ */
 public class MspErrorCodes extends Properties {
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/ServiceCodeValidator.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/ServiceCodeValidator.java
@@ -24,6 +24,11 @@
 
 package io.github.carlos_emr.carlos.billings.ca.bc.MSP;
 
+/**
+ * Validates BC MSP service codes against active fee schedules and rules.
+ *
+ * @since 2026-08-06
+ */
 public class ServiceCodeValidator {
     protected boolean valid = true;
     protected String serviceCode = "";
@@ -46,6 +51,7 @@ public class ServiceCodeValidator {
     }
 
     public boolean isValid() {
+        // Returns the base validity state of the service code. Subclasses override this method to inject specific validation rules (e.g., AgeValidator, GenderValidator).
         return valid;
     }
 

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/TeleplanSubmissionLinkDAO.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/MSP/TeleplanSubmissionLinkDAO.java
@@ -36,6 +36,11 @@ import io.github.carlos_emr.carlos.billing.CA.BC.dao.TeleplanSubmissionLinkDao;
 import io.github.carlos_emr.carlos.billing.CA.BC.model.TeleplanSubmissionLink;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 
+/**
+ * Data access object linking billing records to specific Teleplan submission batches.
+ *
+ * @since 2026-08-06
+ */
 public class TeleplanSubmissionLinkDAO {
 
     private TeleplanSubmissionLinkDao dao = SpringUtils.getBean(TeleplanSubmissionLinkDao.class);

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/administration/GstReport.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/administration/GstReport.java
@@ -18,6 +18,11 @@ import io.github.carlos_emr.carlos.util.ConversionUtils;
 import java.util.Properties;
 import java.util.Vector;
 
+/**
+ * Generates reports on GST collected for taxable private services in BC.
+ *
+ * @since 2026-08-06
+ */
 public class GstReport {
 
     public Vector<Properties> getGST(LoggedInInfo loggedInInfo, String[] providerNos, String startDate, String endDate) {

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/administration/TeleplanCorrectionActionWCB2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/administration/TeleplanCorrectionActionWCB2Action.java
@@ -74,6 +74,11 @@ import org.apache.struts2.ServletActionContext;
 import org.apache.struts2.interceptor.parameter.StrutsParameter;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+/**
+ * Struts action for correcting and resubmitting WCB Teleplan claims.
+ *
+ * @since 2026-08-06
+ */
 public class TeleplanCorrectionActionWCB2Action extends ActionSupport {
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
 

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/administration/TeleplanCorrectionFormWCB.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/administration/TeleplanCorrectionFormWCB.java
@@ -43,6 +43,11 @@ import io.github.carlos_emr.MyDateFormat;
 import io.github.carlos_emr.carlos.demographic.data.DemographicData;
 import io.github.carlos_emr.carlos.util.ConversionUtils;
 
+/**
+ * Form bean for capturing WCB correction data before resubmission.
+ *
+ * @since 2026-08-06
+ */
 public class TeleplanCorrectionFormWCB {
 
     private static Logger logger = MiscUtils.getLogger();

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/data/BillRecipient.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/data/BillRecipient.java
@@ -36,6 +36,11 @@ import io.github.carlos_emr.carlos.utility.MiscUtils;
 
 import io.github.carlos_emr.carlos.util.ConversionUtils;
 
+/**
+ * Defines the recipient entity (patient, insurer, or third party) for a bill.
+ *
+ * @since 2026-08-06
+ */
 public class BillRecipient {
 
     private Integer id;

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/data/BillingFormData.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/data/BillingFormData.java
@@ -44,6 +44,11 @@ import io.github.carlos_emr.carlos.util.UtilDateUtilities;
 import java.util.*;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+/**
+ * Data model representing BC-specific billing form state.
+ *
+ * @since 2026-08-06
+ */
 public class BillingFormData {
 
     private DiagnosticCodeDao diagnosticCodeDao = SpringUtils.getBean(DiagnosticCodeDao.class);

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/data/InjuryLocation.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/data/InjuryLocation.java
@@ -29,6 +29,11 @@
 
 package io.github.carlos_emr.carlos.billings.ca.bc.data;
 
+/**
+ * Standardized codes and descriptions for injury locations used in WCB claims.
+ *
+ * @since 2026-08-06
+ */
 public class InjuryLocation {
     private String sidetype;
     private String sidedesc;

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/BillingAddCode2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/BillingAddCode2Action.java
@@ -45,6 +45,11 @@ import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 
+/**
+ * Struts action for dynamically adding service codes to a bill.
+ *
+ * @since 2026-08-06
+ */
 public final class BillingAddCode2Action extends ActionSupport {
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
 

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/BillingSessionBean.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/BillingSessionBean.java
@@ -34,6 +34,11 @@ import java.util.ArrayList;
 
 import io.github.carlos_emr.carlos.billings.ca.bc.pageUtil.BillingBillingManager.BillingItem;
 
+/**
+ * Manages session-scoped state during complex multi-page billing workflows.
+ *
+ * @since 2026-08-06
+ */
 public class BillingSessionBean implements java.io.Serializable {
     private String apptProviderNo = null;
     private String patientName = null;

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/BillingUpdateBilling2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/BillingUpdateBilling2Action.java
@@ -61,6 +61,11 @@ import io.github.carlos_emr.carlos.utility.SpringUtils;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+/**
+ * Struts action responsible for processing updates to existing billing records.
+ *
+ * @since 2026-08-06
+ */
 public final class BillingUpdateBilling2Action
         extends ActionSupport {
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/BillingViewBean.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/BillingViewBean.java
@@ -50,6 +50,11 @@ import io.github.carlos_emr.carlos.billings.ca.bc.data.BillingmasterDAO;
 import io.github.carlos_emr.carlos.billings.ca.bc.pageUtil.BillingBillingManager.BillingItem;
 import io.github.carlos_emr.carlos.util.ConversionUtils;
 
+/**
+ * Presentation bean formatting billing data for the user interface.
+ *
+ * @since 2026-08-06
+ */
 public class BillingViewBean {
 
     private String apptProviderNo = null;

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/ManageTeleplan2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/ManageTeleplan2Action.java
@@ -76,6 +76,11 @@ import org.apache.struts2.ActionSupport;
 import org.apache.struts2.ServletActionContext;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+/**
+ * Struts action serving as the central hub for Teleplan management tasks.
+ *
+ * @since 2026-08-06
+ */
 public class ManageTeleplan2Action extends ActionSupport {
     private static final Set<String> POST_ONLY_METHODS = Set.of(
             "setUserName",

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/ReceivePayment2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/ReceivePayment2Action.java
@@ -53,6 +53,11 @@ import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 
+/**
+ * Struts action handling the application of received payments to open bills.
+ *
+ * @since 2026-08-06
+ */
 public class ReceivePayment2Action
         extends ActionSupport {
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/SimulateTeleplanFile2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/SimulateTeleplanFile2Action.java
@@ -53,6 +53,11 @@ import java.util.List;
 import org.apache.struts2.ActionSupport;
 import org.apache.struts2.ServletActionContext;
 
+/**
+ * Struts action that simulates teleplan file generation for testing and validation.
+ *
+ * @since 2026-08-06
+ */
 public class SimulateTeleplanFile2Action extends ActionSupport {
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
 

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/WCBAction22Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/pageUtil/WCBAction22Action.java
@@ -67,6 +67,11 @@ import io.github.carlos_emr.carlos.utility.SpringUtils;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+/**
+ * Secondary Struts action handling WCB specific workflows and form submissions.
+ *
+ * @since 2026-08-06
+ */
 public class WCBAction22Action extends ActionSupport {
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
 

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/quickbilling/QuickBillingBC2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/quickbilling/QuickBillingBC2Action.java
@@ -64,6 +64,11 @@ import io.github.carlos_emr.carlos.billings.ca.bc.pageUtil.BillingSessionBean;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 
+/**
+ * Struts action handling the quick billing workflow for BC MSP claims.
+ *
+ * @since 2026-08-06
+ */
 public class QuickBillingBC2Action extends ActionSupport {
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
 

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/quickbilling/QuickBillingBCFormBean.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/quickbilling/QuickBillingBCFormBean.java
@@ -38,6 +38,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 
+/**
+ * Form bean backing the BC quick billing user interface.
+ *
+ * @since 2026-08-06
+ */
 public class QuickBillingBCFormBean {
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/quickbilling/QuickBillingBCSave2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/quickbilling/QuickBillingBCSave2Action.java
@@ -57,6 +57,11 @@ import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 
+/**
+ * Struts action responsible for saving quick billing records to the database.
+ *
+ * @since 2026-08-06
+ */
 public class QuickBillingBCSave2Action extends ActionSupport {
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
 

--- a/src/main/java/io/github/carlos_emr/carlos/billings/data/BillingFormData.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/data/BillingFormData.java
@@ -42,6 +42,11 @@ import io.github.carlos_emr.carlos.commn.model.DiagnosticCode;
 import io.github.carlos_emr.carlos.commn.model.Provider;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 
+/**
+ * Data transfer object capturing form inputs during the billing entry process.
+ *
+ * @since 2026-08-06
+ */
 public class BillingFormData {
 
     private DiagnosticCodeDao diagnosticCodeDao = SpringUtils.getBean(DiagnosticCodeDao.class);

--- a/src/main/java/io/github/carlos_emr/carlos/caisi/CaisiUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/caisi/CaisiUtil.java
@@ -27,6 +27,11 @@
 
 package io.github.carlos_emr.carlos.caisi;
 
+/**
+ * Utility functions for the CAISI (Client Access to Integrated Services and Information) module integration.
+ *
+ * @since 2026-08-06
+ */
 public class CaisiUtil {
     public static String removeAttr(String str, String attr) {
         if (str == null) return (null);

--- a/src/main/java/io/github/carlos_emr/carlos/caisi/IsModuleLoadTag.java
+++ b/src/main/java/io/github/carlos_emr/carlos/caisi/IsModuleLoadTag.java
@@ -33,6 +33,11 @@ import jakarta.servlet.jsp.tagext.TagSupport;
 import io.github.carlos_emr.CarlosProperties;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+/**
+ * Custom JSP tag to check if specific CAISI modules are loaded and active.
+ *
+ * @since 2026-08-06
+ */
 public class IsModuleLoadTag extends TagSupport {
 
     private String moduleName;

--- a/src/main/java/io/github/carlos_emr/carlos/entities/Billingmaster.java
+++ b/src/main/java/io/github/carlos_emr/carlos/entities/Billingmaster.java
@@ -71,6 +71,11 @@ import io.github.carlos_emr.carlos.util.UtilDateUtilities;
         }
 )
 
+/**
+ * Core entity orchestrating billing transactions and master records for accounting.
+ *
+ * @since 2026-08-06
+ */
 public class Billingmaster {
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/entities/ClinicalFactor.java
+++ b/src/main/java/io/github/carlos_emr/carlos/entities/ClinicalFactor.java
@@ -29,6 +29,11 @@
 
 package io.github.carlos_emr.carlos.entities;
 
+/**
+ * Represents various clinical risk factors or observational parameters for a patient.
+ *
+ * @since 2026-08-06
+ */
 public class ClinicalFactor {
     // Fields
     //

--- a/src/main/java/io/github/carlos_emr/carlos/entities/Condition.java
+++ b/src/main/java/io/github/carlos_emr/carlos/entities/Condition.java
@@ -31,6 +31,11 @@ package io.github.carlos_emr.carlos.entities;
 
 // Class Condition
 //
+/**
+ * Represents a clinical condition or diagnosis associated with a patient in the EMR.
+ *
+ * @since 2026-08-06
+ */
 public class Condition
         extends ClinicalFactor {
     // Fields

--- a/src/main/java/io/github/carlos_emr/carlos/entities/LabData.java
+++ b/src/main/java/io/github/carlos_emr/carlos/entities/LabData.java
@@ -29,6 +29,11 @@
 
 package io.github.carlos_emr.carlos.entities;
 
+/**
+ * Stores laboratory test results and associated metadata for a patient.
+ *
+ * @since 2026-08-06
+ */
 public class LabData {
     private String a1c;
     private String ldl;

--- a/src/main/java/io/github/carlos_emr/carlos/entities/LabTest.java
+++ b/src/main/java/io/github/carlos_emr/carlos/entities/LabTest.java
@@ -30,6 +30,11 @@
 package io.github.carlos_emr.carlos.entities;
 
 //
+/**
+ * Defines a specific laboratory test type or panel orderable within the system.
+ *
+ * @since 2026-08-06
+ */
 public class LabTest
         extends Test {
     private String observationDateTime = "";

--- a/src/main/java/io/github/carlos_emr/carlos/entities/Patient.java
+++ b/src/main/java/io/github/carlos_emr/carlos/entities/Patient.java
@@ -29,6 +29,11 @@
 
 package io.github.carlos_emr.carlos.entities;
 
+/**
+ * Primary demographic and identity record for a patient within the CARLOS EMR system.
+ *
+ * @since 2026-08-06
+ */
 public class Patient {
     private String firstName;
     private String lastName;

--- a/src/main/java/io/github/carlos_emr/carlos/entities/PaymentType.java
+++ b/src/main/java/io/github/carlos_emr/carlos/entities/PaymentType.java
@@ -29,6 +29,11 @@
 
 package io.github.carlos_emr.carlos.entities;
 
+/**
+ * Defines the available methods of payment for private or uninsured services.
+ *
+ * @since 2026-08-06
+ */
 public class PaymentType {
     private String id;
     private String paymentType;

--- a/src/main/java/io/github/carlos_emr/carlos/entities/PrivateBillTransaction.java
+++ b/src/main/java/io/github/carlos_emr/carlos/entities/PrivateBillTransaction.java
@@ -32,6 +32,11 @@ package io.github.carlos_emr.carlos.entities;
 import java.math.BigDecimal;
 import java.util.Date;
 
+/**
+ * Tracks transactions related to private billing, separate from provincial health plans.
+ *
+ * @since 2026-08-06
+ */
 public class PrivateBillTransaction {
     private int id;
     private int billingmaster_no;

--- a/src/main/java/io/github/carlos_emr/carlos/entities/Test.java
+++ b/src/main/java/io/github/carlos_emr/carlos/entities/Test.java
@@ -29,6 +29,11 @@
 
 package io.github.carlos_emr.carlos.entities;
 
+/**
+ * Generic entity for medical tests performed or ordered.
+ *
+ * @since 2026-08-06
+ */
 public class Test {
     private String id;
     private String description;


### PR DESCRIPTION
Adds missing class-level Javadoc with domain descriptions and contextual inline documentation to 40 classes.

---
*PR created automatically by Jules for task [6957904740278853979](https://jules.google.com/task/6957904740278853979) started by @yingbull*

## Summary by Sourcery

Document core billing and EMR domain entities with class-level Javadoc and inline context for validation and workflow classes.

Documentation:
- Add class-level Javadoc summaries and @since metadata to billing, Teleplan, WCB, quick billing, and EMR entities.
- Clarify validator and action responsibilities with contextual inline comments for MSP service and age validation logic.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add class-level Javadoc and a few inline comments to 40 classes across `entities` and BC MSP billing modules (Teleplan, WCB, quick billing) to explain domain roles, workflows, and validation rules. Includes accurate @since tags; documentation-only change with no runtime impact.

<sup>Written for commit f47feaf156cb0cf4c27511aced125c26ff2e26a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

