### PR TITLE
fix: refresh job types through DataTables API

### DIFF
--- a/src/main/resources/oscarResources_en.properties
+++ b/src/main/resources/oscarResources_en.properties
@@ -7846,6 +7846,7 @@ admin.jobTypes.className=JAVA Class Name
 admin.jobTypes.enabled=Enabled
 admin.jobTypes.save=Save Job Type
 admin.jobTypes.cancel=Cancel
+admin.jobTypes.saveError=Unable to save the job type. Please try again.
 admin.configureFax.title=Fax Configuration
 admin.configureFax.saved=Configuration saved!
 admin.configureFax.saveProblem=There was a problem saving your configuration. Check the logs for further details.

--- a/src/main/resources/oscarResources_es.properties
+++ b/src/main/resources/oscarResources_es.properties
@@ -10841,6 +10841,7 @@ admin.jobTypes.className=Nombre de clase JAVA
 admin.jobTypes.enabled=Habilitado
 admin.jobTypes.save=Guardar tipo de trabajo
 admin.jobTypes.cancel=Cancelar
+admin.jobTypes.saveError=No se pudo guardar el tipo de trabajo. Int\u00e9ntelo de nuevo.
 encounter.formFemaleAnnual.formSexualHealthRelationships=Sexual Health/Relationships:
 encounter.formFemaleAnnual.sectionSexualHealth=1. Sexual Health:
 encounter.formFemaleAnnual.preconceptiveCounselling=Preconceptive Counselling (A):

--- a/src/main/resources/oscarResources_fr.properties
+++ b/src/main/resources/oscarResources_fr.properties
@@ -11263,6 +11263,7 @@ admin.jobTypes.className=Nom de classe JAVA
 admin.jobTypes.enabled=Activ\u00e9
 admin.jobTypes.save=Enregistrer le type de travail
 admin.jobTypes.cancel=Annuler
+admin.jobTypes.saveError=Impossible d'enregistrer le type de travail. Veuillez r\u00e9essayer.
 admin.api.clients.title=G\u00e9rer les clients REST (OAuth)
 admin.api.clients.heading=G\u00e9rer les clients
 admin.api.clients.tokensHeading=Jetons

--- a/src/main/resources/oscarResources_pl.properties
+++ b/src/main/resources/oscarResources_pl.properties
@@ -10359,6 +10359,7 @@ admin.jobTypes.className=Nazwa klasy JAVA
 admin.jobTypes.enabled=W\u0142\u0105czone
 admin.jobTypes.save=Zapisz typ zadania
 admin.jobTypes.cancel=Anuluj
+admin.jobTypes.saveError=Nie uda\u0142o si\u0119 zapisa\u0107 typu zadania. Spr\u00f3buj ponownie.
 admin.logReport.title=Raport log\u00f3w
 admin.logReport.alertDates=Ustaw daty pocz\u0105tkow\u0105 i ko\u0144cow\u0105.
 admin.logReport.heading=Raport administracyjny log\u00f3w

--- a/src/main/resources/oscarResources_pt_BR.properties
+++ b/src/main/resources/oscarResources_pt_BR.properties
@@ -10619,6 +10619,7 @@ admin.jobTypes.className=Nome da classe JAVA
 admin.jobTypes.enabled=Habilitado
 admin.jobTypes.save=Salvar tipo de trabalho
 admin.jobTypes.cancel=Cancelar
+admin.jobTypes.saveError=N\u00e3o foi poss\u00edvel salvar o tipo de trabalho. Tente novamente.
 admin.logReport.title=Relat\u00f3rio de logs
 admin.logReport.alertDates=Defina as datas inicial e final.
 admin.logReport.heading=Relat\u00f3rio administrativo de logs

--- a/src/main/webapp/WEB-INF/jsp/admin/jobTypes.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/jobTypes.jsp
@@ -43,7 +43,11 @@
 
 
 <%@ taglib uri="jakarta.tags.fmt" prefix="fmt" %>
+<%@ taglib uri="carlos" prefix="carlos" %>
 <fmt:setBundle basename="oscarResources"/>
+<fmt:message key="admin.jobTypes.save" var="jobTypesSaveLabel"/>
+<fmt:message key="admin.jobTypes.cancel" var="jobTypesCancelLabel"/>
+<fmt:message key="admin.jobTypes.saveError" var="jobTypesSaveErrorLabel"/>
 
 
 <%@ page import="io.github.carlos_emr.carlos.utility.SpringUtils" %>
@@ -76,8 +80,10 @@
 
 
         <script>
-            const jobTypesSaveLabel = "<fmt:message key='admin.jobTypes.save'/>";
-            const jobTypesCancelLabel = "<fmt:message key='admin.jobTypes.cancel'/>";
+            const jobTypesSaveLabel = "${carlos:forJavaScript(jobTypesSaveLabel)}";
+            const jobTypesCancelLabel = "${carlos:forJavaScript(jobTypesCancelLabel)}";
+            const jobTypesSaveErrorLabel = "${carlos:forJavaScript(jobTypesSaveErrorLabel)}";
+            let jobTypeTable;
 
             function editJobType(jobTypeId) {
                 jQuery.getJSON("<%= request.getContextPath() %>/ws/rs/jobs/jobType/" + jobTypeId, {},
@@ -109,52 +115,53 @@
                 $('#new-jobtype').dialog('open');
             }
 
-            function clearJobs() {
-                $("#jobTypeTable tbody tr").remove();
-            }
-
             function listJobs() {
                 return getJobTypes();
             }
 
             function getJobTypes() {
-                jQuery.getJSON("${pageContext.request.contextPath}/ws/rs/jobs/types/all", {async: false},
+                return jQuery.getJSON("${pageContext.request.contextPath}/ws/rs/jobs/types/all", {async: false},
                     function (xml) {
+                        var arr = [];
                         if (xml.types) {
-                            var arr = new Array();
                             if (xml.types instanceof Array) {
                                 arr = xml.types;
                             } else {
                                 arr[0] = xml.types;
                             }
-
-                            for (var i = 0; i < arr.length; i++) {
-                                var job = arr[i];
-                                var $row = $('<tr>');
-                                var $nameLink = $('<a>').attr('href', 'javascript:void(0);')
-                                    .text(job.name)
-                                    .on('click', (function(id) { return function() { editJobType(id); }; })(job.id));
-                                $row.append($('<td>').append($('<u>').append($nameLink)));
-                                $row.append($('<td>').text(job.description));
-                                $row.append($('<td>').text(job.className));
-                                $row.append($('<td>').text(job.currentlyValid));
-                                $row.append($('<td>').text(job.enabled));
-                                $row.append($('<td>').text(new Date(job.updated)));
-
-                                $('#jobTypeTable tbody').append($row);
-
-                            }
-                            initiate();
                         }
 
+                        var rows = [];
+                        for (var i = 0; i < arr.length; i++) {
+                            var job = arr[i];
+                            var $row = $('<tr>');
+                            var $nameLink = $('<a>').attr('href', 'javascript:void(0);')
+                                .text(job.name)
+                                .on('click', (function(id) { return function() { editJobType(id); }; })(job.id));
+                            $row.append($('<td>').append($('<u>').append($nameLink)));
+                            $row.append($('<td>').text(job.description));
+                            $row.append($('<td>').text(job.className));
+                            $row.append($('<td>').text(job.currentlyValid));
+                            $row.append($('<td>').text(job.enabled));
+                            $row.append($('<td>').text(new Date(job.updated)));
+
+                            rows.push($row[0]);
+                        }
+
+                        var table = initiate();
+                        table.clear();
+                        table.rows.add(rows);
+                        table.draw();
                     });
             }
 
             function initiate() {
-                $('#jobTypeTable').DataTable({
-                    "order": []
-                });
-                return;
+                if (!jobTypeTable) {
+                    jobTypeTable = $('#jobTypeTable').DataTable({
+                        "order": []
+                    });
+                }
+                return jobTypeTable;
             }
 
             $(document).ready(function () {
@@ -169,12 +176,15 @@
                     buttons: {
                         saveJobType: {
                             class: "btn btn-primary", text: jobTypesSaveLabel, click: function () {
-                                $.post('${pageContext.request.contextPath}/ws/rs/jobs/saveJobType', $('#jobTypeForm').serialize(), function (data) {
-                                    clearJobs();
-                                    listJobs();
-                                });
-                                $(this).dialog("close");
-
+                                var $dialog = $(this);
+                                $.post('${pageContext.request.contextPath}/ws/rs/jobs/saveJobType', $('#jobTypeForm').serialize())
+                                    .done(function () {
+                                        listJobs();
+                                        $dialog.dialog("close");
+                                    })
+                                    .fail(function () {
+                                        window.alert(jobTypesSaveErrorLabel);
+                                    });
                             }
                         },
                         cancel: {

--- a/src/test/java/io/github/carlos_emr/carlos/admin/JobTypesJspRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/admin/JobTypesJspRegressionTest.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.admin;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression coverage for the Manage Job Types DataTables lifecycle.
+ *
+ * @since 2026-08-11
+ */
+@DisplayName("Manage Job Types JSP regressions")
+@Tag("unit")
+@Tag("regression")
+class JobTypesJspRegressionTest {
+    private static final Path JOB_TYPES_JSP = projectRoot()
+            .resolve("src/main/webapp/WEB-INF/jsp/admin/jobTypes.jsp");
+
+    @Test
+    void shouldRefreshRows_throughExistingDataTable() throws IOException {
+        String jsp = Files.readString(JOB_TYPES_JSP, StandardCharsets.UTF_8);
+
+        assertThat(jsp)
+                .contains("let jobTypeTable;")
+                .contains("if (!jobTypeTable)")
+                .contains("table.clear();")
+                .contains("table.rows.add(rows);")
+                .contains("table.draw();")
+                .doesNotContain("$(\"#jobTypeTable tbody tr\").remove();");
+        assertThat(countOccurrences(jsp, "$('#jobTypeTable').DataTable({"))
+                .as("the JSP should contain one DataTables initialization path")
+                .isEqualTo(1);
+    }
+
+    @Test
+    void shouldKeepDialogOpen_whenSaveFails() throws IOException {
+        String jsp = Files.readString(JOB_TYPES_JSP, StandardCharsets.UTF_8);
+        int saveRequestStart = jsp.indexOf("$.post('${pageContext.request.contextPath}/ws/rs/jobs/saveJobType'");
+        int cancelButtonStart = jsp.indexOf("cancel:", saveRequestStart);
+
+        assertThat(saveRequestStart).isGreaterThanOrEqualTo(0);
+        assertThat(cancelButtonStart).isGreaterThan(saveRequestStart);
+        assertThat(jsp.substring(saveRequestStart, cancelButtonStart))
+                .contains(".done(function () {")
+                .contains("listJobs();")
+                .contains("$dialog.dialog(\"close\");")
+                .contains(".fail(function () {")
+                .contains("window.alert(jobTypesSaveErrorLabel);");
+    }
+
+    private static int countOccurrences(String text, String needle) {
+        int count = 0;
+        int offset = 0;
+        while ((offset = text.indexOf(needle, offset)) >= 0) {
+            count++;
+            offset += needle.length();
+        }
+        return count;
+    }
+
+    private static Path projectRoot() {
+        return Path.of(System.getProperty(
+                "maven.multiModuleProjectDirectory",
+                System.getProperty("user.dir")));
+    }
+}


### PR DESCRIPTION
## Description

Keep one DataTables instance on Admin > Manage Job Types and refresh its rows through the DataTables API after loading or saving job types. The save dialog now closes only after a successful response and remains open with a localized error message when the request fails.

Translation strings are encoded with CARLOS's OWASP JavaScript encoder before entering JavaScript string literals.

## Related Issues

Fixes #3402

## How Was This Tested?

- `mvn -Dtest=JobTypesJspRegressionTest test` — 2 tests passed
- `mvn package -Pjspc -DskipTests=true` — 973 JSPs compiled, 0 errors
- `docker run --rm -v "$PWD:/workspace:ro" -w /workspace ubuntu:24.04 bash scripts/check-i18n-properties.sh` — 11,865 keys per locale, 0 missing/orphaned, UTF-8 valid
- `bash scripts/lint/check-bdd-test-naming.sh` — passed (270 files)
- `git diff --check` — passed

## Checklist

- [x] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added regression tests
- [x] I have read the [contributing guide](CONTRIBUTING.md)

## AI Assistance

Codex assisted with the implementation and test preparation. I reviewed the final diff and independently ran the validation commands above.

## Summary by Sourcery

Refresh the Manage Job Types table via a single persistent DataTables instance and improve the job type save workflow behavior and safety.

New Features:
- Introduce a localized 'save error' message for job type saves across supported locales.

Bug Fixes:
- Ensure the Manage Job Types table reloads its rows through the DataTables API instead of reinitializing or manually clearing DOM rows, avoiding multiple DataTables instances.
- Keep the job type save dialog open on failed save requests and display a localized error message instead of closing unconditionally.

Enhancements:
- Encode job type-related translation strings with the CARLOS OWASP JavaScript encoder before injecting them into JavaScript.
- Add a regression-focused JSP test to guard the DataTables lifecycle and save dialog behavior for Manage Job Types.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps a single DataTables instance on Admin > Manage Job Types and refreshes rows via the DataTables API after load/save to avoid re-inits and flicker. The save dialog now closes only on success and shows a localized error on failure.

- **Bug Fixes**
  - Maintain one DataTables instance; refresh with table.clear(), rows.add(), draw().
  - Save flow: refresh list and close dialog on success; keep open and alert on failure using `admin.jobTypes.saveError`.
  - Encode UI strings for JS with `carlos:forJavaScript` (OWASP JS encoder).
  - Add regression test `JobTypesJspRegressionTest` and the `admin.jobTypes.saveError` key across `oscarResources_*` (en, es, fr, pl, pt_BR).

<sup>Written for commit bd6218ee61495f617a8c3ff784ebbb338152f198. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

