### PR TITLE
docs: add javadoc and inline documentation to 40 java files

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/administration/GstReport.java
+++ b/src/main/java/io/github/carlos_emr/carlos/billings/ca/bc/administration/GstReport.java
@@ -18,6 +18,9 @@ import io.github.carlos_emr.carlos.util.ConversionUtils;
 import java.util.Properties;
 import java.util.Vector;
 
+/**
+ * Manages the generation and formatting of GST-related financial reports for BC billing.
+ */
 public class GstReport {
 
     public Vector<Properties> getGST(LoggedInInfo loggedInInfo, String[] providerNos, String startDate, String endDate) {
@@ -29,6 +32,7 @@ public class GstReport {
 
         // For every bill the providers is involved with, search the gst value, date, demo no within the chosen dates
         DateRange dateRange = new DateRange(ConversionUtils.fromDateString(startDate), ConversionUtils.fromDateString(endDate));
+        // Evaluates condition to determine the appropriate control flow path
         if (providerNos != null && providerNos.length > 0) {
             for (Object[] i : dao.findProviderBillingsWithGst(providerNos, dateRange)) {
                 Billingmaster bm = (Billingmaster) i[0];

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/EReferAttachmentDataDao.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/EReferAttachmentDataDao.java
@@ -4,6 +4,9 @@ import io.github.carlos_emr.carlos.commn.model.EReferAttachmentData;
 
 import java.util.Date;
 
+/**
+ * Data access object interface for managing eReferral attachment data persistence.
+ */
 public interface EReferAttachmentDataDao extends AbstractDao<EReferAttachmentData> {
     public EReferAttachmentData getRecentByDocumentId(Integer docId, String type, Date expiry);
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/EReferAttachment.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/EReferAttachment.java
@@ -12,6 +12,9 @@ import jakarta.persistence.Table;
 import java.util.Date;
 import java.util.List;
 
+/**
+ * Entity representing metadata and linking information for an eReferral attachment.
+ */
 @Entity
 @Table(name = "erefer_attachment")
 public class EReferAttachment extends AbstractModel<Integer> {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/EReferAttachmentData.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/EReferAttachmentData.java
@@ -8,6 +8,9 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
+/**
+ * Entity representing the binary data content of an eReferral attachment.
+ */
 @Entity
 @IdClass(EReferAttachmentDataCompositeKey.class)
 @Table(name = "erefer_attachment_data")

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/EReferAttachmentDataCompositeKey.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/EReferAttachmentDataCompositeKey.java
@@ -6,6 +6,9 @@ import jakarta.persistence.ManyToOne;
 import java.io.Serializable;
 import java.util.Objects;
 
+/**
+ * Composite primary key definition for the EReferAttachmentData entity.
+ */
 public class EReferAttachmentDataCompositeKey implements Serializable {
     @ManyToOne
     @JoinColumn(name = "erefer_attachment_id", referencedColumnName = "id")
@@ -52,6 +55,7 @@ public class EReferAttachmentDataCompositeKey implements Serializable {
 
     @Override
     public boolean equals(Object o) {
+        // Evaluates condition to determine the appropriate control flow path
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         EReferAttachmentDataCompositeKey that = (EReferAttachmentDataCompositeKey) o;

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/EmailAttachment.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/EmailAttachment.java
@@ -5,6 +5,9 @@ import jakarta.persistence.*;
 
 import io.github.carlos_emr.carlos.commn.model.enumerator.DocumentType;
 
+/**
+ * Entity representing a file attachment associated with an outgoing or incoming email.
+ */
 @Entity
 @Table(name = "emailAttachment")
 public class EmailAttachment extends AbstractModel<Integer> {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/EmailConfig.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/EmailConfig.java
@@ -5,6 +5,9 @@ import io.github.carlos_emr.carlos.commn.model.converter.EmailConfigTypeConverte
 import jakarta.persistence.*;
 import java.util.List;
 
+/**
+ * Entity containing configuration settings for SMTP and email provider integrations.
+ */
 @Entity
 @Table(name = "emailConfig")
 public class EmailConfig extends AbstractModel<Integer> {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/JSONAction.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/JSONAction.java
@@ -14,6 +14,9 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
 
+/**
+ * Base Struts action class for returning JSON responses to asynchronous frontend requests.
+ */
 public class JSONAction extends ActionSupport {
 
     private final String ENCODING = "UTF-8";
@@ -26,6 +29,7 @@ public class JSONAction extends ActionSupport {
     protected HttpServletResponse response;
 
     protected JSONAction() {
+        // Evaluates condition to determine the appropriate control flow path
         if (ActionContext.getContext() != null) {
             request = ServletActionContext.getRequest();
             response = ServletActionContext.getResponse();

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/AppointmentBookingSourceConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/AppointmentBookingSourceConverter.java
@@ -3,6 +3,9 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.Appointment.BookingSource;
 import jakarta.persistence.Converter;
 
+/**
+ * JPA converter for translating appointment source enum types to database columns.
+ */
 @Converter
 public class AppointmentBookingSourceConverter extends NullSafeEnumConverter<BookingSource> {
     public AppointmentBookingSourceConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/ClientLinkTypeConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/ClientLinkTypeConverter.java
@@ -3,6 +3,9 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.ClientLink.Type;
 import jakarta.persistence.Converter;
 
+/**
+ * JPA converter for translating client link type enums to database columns.
+ */
 @Converter
 public class ClientLinkTypeConverter extends NullSafeEnumConverter<Type> {
     public ClientLinkTypeConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/DigitalSignatureModuleTypeConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/DigitalSignatureModuleTypeConverter.java
@@ -3,6 +3,9 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.enumerator.ModuleType;
 import jakarta.persistence.Converter;
 
+/**
+ * JPA converter for translating digital signature module enum types to database columns.
+ */
 @Converter
 public class DigitalSignatureModuleTypeConverter extends NullSafeEnumConverter<ModuleType> {
     public DigitalSignatureModuleTypeConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailAttachmentDocumentTypeConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailAttachmentDocumentTypeConverter.java
@@ -3,6 +3,9 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.enumerator.DocumentType;
 import jakarta.persistence.Converter;
 
+/**
+ * JPA converter for translating email attachment document enum types to database columns.
+ */
 @Converter
 public class EmailAttachmentDocumentTypeConverter extends NullSafeEnumConverter<DocumentType> {
     public EmailAttachmentDocumentTypeConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailConfigProviderConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailConfigProviderConverter.java
@@ -3,6 +3,9 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.EmailConfig.EmailProvider;
 import jakarta.persistence.Converter;
 
+/**
+ * JPA converter for translating email provider enum types to database columns.
+ */
 @Converter
 public class EmailConfigProviderConverter extends NullSafeEnumConverter<EmailProvider> {
     public EmailConfigProviderConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailConfigTypeConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailConfigTypeConverter.java
@@ -3,6 +3,9 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.EmailConfig.EmailType;
 import jakarta.persistence.Converter;
 
+/**
+ * JPA converter for translating email configuration enum types to database columns.
+ */
 @Converter
 public class EmailConfigTypeConverter extends NullSafeEnumConverter<EmailType> {
     public EmailConfigTypeConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailLogChartDisplayOptionConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailLogChartDisplayOptionConverter.java
@@ -3,6 +3,9 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.EmailLog.ChartDisplayOption;
 import jakarta.persistence.Converter;
 
+/**
+ * JPA converter for translating email chart display enum types to database columns.
+ */
 @Converter
 public class EmailLogChartDisplayOptionConverter extends NullSafeEnumConverter<ChartDisplayOption> {
     public EmailLogChartDisplayOptionConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailLogStatusConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailLogStatusConverter.java
@@ -3,6 +3,9 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.EmailLog.EmailStatus;
 import jakarta.persistence.Converter;
 
+/**
+ * JPA converter for translating email log status enum types to database columns.
+ */
 @Converter
 public class EmailLogStatusConverter extends NullSafeEnumConverter<EmailStatus> {
     public EmailLogStatusConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailLogTransactionTypeConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/EmailLogTransactionTypeConverter.java
@@ -3,6 +3,9 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.EmailLog.TransactionType;
 import jakarta.persistence.Converter;
 
+/**
+ * JPA converter for translating email transaction enum types to database columns.
+ */
 @Converter
 public class EmailLogTransactionTypeConverter extends NullSafeEnumConverter<TransactionType> {
     public EmailLogTransactionTypeConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/FaxConfigProviderTypeConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/FaxConfigProviderTypeConverter.java
@@ -3,6 +3,9 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.FaxConfig.ProviderType;
 import jakarta.persistence.Converter;
 
+/**
+ * JPA converter for translating fax provider config enum types to database columns.
+ */
 @Converter
 public class FaxConfigProviderTypeConverter extends NullSafeEnumConverter<ProviderType> {
     public FaxConfigProviderTypeConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/FaxJobStatusConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/FaxJobStatusConverter.java
@@ -3,6 +3,9 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.FaxJob.STATUS;
 import jakarta.persistence.Converter;
 
+/**
+ * JPA converter for translating fax job status enum types to database columns.
+ */
 @Converter
 public class FaxJobStatusConverter extends NullSafeEnumConverter<STATUS> {
     public FaxJobStatusConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/HnrDataValidationTypeConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/HnrDataValidationTypeConverter.java
@@ -3,6 +3,9 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.HnrDataValidation.Type;
 import jakarta.persistence.Converter;
 
+/**
+ * JPA converter for translating HNR validation enum types to database columns.
+ */
 @Converter
 public class HnrDataValidationTypeConverter extends NullSafeEnumConverter<Type> {
     public HnrDataValidationTypeConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/TicklerPriorityConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/TicklerPriorityConverter.java
@@ -3,6 +3,9 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.Tickler.PRIORITY;
 import jakarta.persistence.Converter;
 
+/**
+ * JPA converter for translating tickler priority enum types to database columns.
+ */
 @Converter
 public class TicklerPriorityConverter extends NullSafeEnumConverter<PRIORITY> {
     public TicklerPriorityConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/TicklerStatusConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/converter/TicklerStatusConverter.java
@@ -3,6 +3,9 @@ package io.github.carlos_emr.carlos.commn.model.converter;
 import io.github.carlos_emr.carlos.commn.model.Tickler.STATUS;
 import jakarta.persistence.Converter;
 
+/**
+ * JPA converter for translating tickler (task) status enum types to database columns.
+ */
 @Converter
 public class TicklerStatusConverter extends NullSafeEnumConverter<STATUS> {
     public TicklerStatusConverter() {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/enumerator/ConsultationRequestExtKey.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/enumerator/ConsultationRequestExtKey.java
@@ -1,5 +1,8 @@
 package io.github.carlos_emr.carlos.commn.model.enumerator;
 
+/**
+ * Enumeration defining extended attribute keys for consultation requests.
+ */
 public enum ConsultationRequestExtKey {
     EREFERRAL_REF("ereferral_ref"),
     EREFERRAL_SERVICE("ereferral_service"),

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/enumerator/CppCode.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/enumerator/CppCode.java
@@ -3,6 +3,9 @@ package io.github.carlos_emr.carlos.commn.model.enumerator;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Enumeration defining Cumulative Patient Profile (CPP) categorization codes.
+ */
 public enum CppCode {
     OMEDS("OMeds"),
     SOC_HISTORY("SocHistory"),
@@ -27,6 +30,7 @@ public enum CppCode {
     public static String[] toArray() {
         CppCode[] values = CppCode.values();
         String[] array = new String[values.length];
+        // Processes iteration over elements to perform data extraction and transformation
         for (int i = 0; i < values.length; i++) {
             array[i] = values[i].getCode();
         }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/model/enumerator/DocumentType.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/model/enumerator/DocumentType.java
@@ -1,5 +1,8 @@
 package io.github.carlos_emr.carlos.commn.model.enumerator;
 
+/**
+ * Enumeration defining the various types of documents supported within the EMR system.
+ */
 public enum DocumentType {
     EFORM("E", "eForm"),
     DOC("D", "doc"),

--- a/src/main/java/io/github/carlos_emr/carlos/config/ServletContextConfig.java
+++ b/src/main/java/io/github/carlos_emr/carlos/config/ServletContextConfig.java
@@ -7,6 +7,9 @@ import jakarta.servlet.ServletContext;
 
 import org.springframework.web.context.ServletContextAware;
 
+/**
+ * Configures the Spring ServletContext, setting up web-related beans and resources.
+ */
 @Configuration
 public class ServletContextConfig implements ServletContextAware {
 

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/DocumentAttach.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/DocumentAttach.java
@@ -13,6 +13,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+/**
+ * Manages the linking of uploaded documents to specific patient records or consultations.
+ */
 public class DocumentAttach {
     private final ConsultDocsDao consultDocsDao = SpringUtils.getBean(ConsultDocsDao.class);
     private final EFormDocsDao eFormDocsDao = SpringUtils.getBean(EFormDocsDao.class);
@@ -41,6 +44,7 @@ public class DocumentAttach {
         List<String> currentList = new ArrayList<>(Arrays.asList(attachments));
         List<ConsultDocs> consultDocsList = consultDocsDao.findByRequestIdDocType(requestId, documentType.getType());
         List<String> oldList = new ArrayList<>();
+        // Processes iteration over elements to perform data extraction and transformation
         for (ConsultDocs consultDoc : consultDocsList) {
             oldList.add(Integer.toString(consultDoc.getDocumentNo()));
         }

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/EDocConverterInterface.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/EDocConverterInterface.java
@@ -2,6 +2,9 @@ package io.github.carlos_emr.carlos.documentManager;
 
 import java.io.OutputStream;
 
+/**
+ * Interface defining the contract for converting various electronic document formats.
+ */
 public interface EDocConverterInterface {
   void convert(String html, OutputStream os) throws Exception;
 }

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/data/AttachmentLabResultData.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/data/AttachmentLabResultData.java
@@ -6,6 +6,9 @@ import java.util.Map;
 
 import io.github.carlos_emr.carlos.utility.DateUtils;
 
+/**
+ * Data structure encapsulating lab result details when attached as a document.
+ */
 public class AttachmentLabResultData {
     private String segmentID;
     private String labName;

--- a/src/main/java/io/github/carlos_emr/carlos/email/helpers/LocalSMTPEmailSender.java
+++ b/src/main/java/io/github/carlos_emr/carlos/email/helpers/LocalSMTPEmailSender.java
@@ -15,6 +15,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+/**
+ * Implementation for sending emails via a locally configured SMTP server instance.
+ */
 public class LocalSMTPEmailSender extends SMTPEmailSender {
 
     public LocalSMTPEmailSender(LoggedInInfo loggedInInfo, EmailConfig emailConfig, 
@@ -27,6 +30,7 @@ public class LocalSMTPEmailSender extends SMTPEmailSender {
     protected JavaMailSender createTLSMailSender(EmailConfig emailConfig) throws EmailSendingException {
         JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
         ObjectMapper objectMapper = new ObjectMapper();
+        // Handles potential exceptions during execution to prevent unexpected failures
         try {
             JsonNode jsonNode = objectMapper.readTree(emailConfig.getConfigDetailsJson());
             String host = jsonNode.get("host").asText();

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oceanEReferal/pageUtil/OceanEReferralAttachmentUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oceanEReferal/pageUtil/OceanEReferralAttachmentUtil.java
@@ -10,6 +10,9 @@ import io.github.carlos_emr.carlos.commn.model.EReferAttachment;
 import io.github.carlos_emr.carlos.commn.model.EReferAttachmentData;
 import io.github.carlos_emr.carlos.utility.SpringUtils;
 
+/**
+ * Utility methods for processing and attaching documents to Ocean eReferrals.
+ */
 public class OceanEReferralAttachmentUtil {
     private static EReferAttachmentDataDaoImpl eReferAttachmentDataDao = SpringUtils.getBean(EReferAttachmentDataDaoImpl.class);
     private static EReferAttachmentDaoImpl eReferAttachmentDao = SpringUtils.getBean(EReferAttachmentDaoImpl.class);
@@ -18,6 +21,7 @@ public class OceanEReferralAttachmentUtil {
         Calendar calendar = Calendar.getInstance();
         calendar.add(Calendar.HOUR_OF_DAY, -1);
         EReferAttachmentData eReferAttachmentData = eReferAttachmentDataDao.getRecentByDocumentId(Integer.parseInt(docId), type, calendar.getTime());
+        // Evaluates condition to determine the appropriate control flow path
         if (eReferAttachmentData == null) {
             return;
         }

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/config/data/ConsultationServiceDto.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/config/data/ConsultationServiceDto.java
@@ -1,5 +1,8 @@
 package io.github.carlos_emr.carlos.encounter.oscarConsultationRequest.config.data;
 
+/**
+ * Data transfer object containing service details for a consultation request.
+ */
 public class ConsultationServiceDto {
     private Integer serviceId;
     private String serviceDesc;

--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/config/data/SpecialistDto.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/config/data/SpecialistDto.java
@@ -1,5 +1,8 @@
 package io.github.carlos_emr.carlos.encounter.oscarConsultationRequest.config.data;
 
+/**
+ * Data transfer object representing a specialist provider for consultation requests.
+ */
 public class SpecialistDto {
     private Integer specId;
     private String name;

--- a/src/main/java/io/github/carlos_emr/carlos/integration/ebs/App.java
+++ b/src/main/java/io/github/carlos_emr/carlos/integration/ebs/App.java
@@ -1,5 +1,8 @@
 package io.github.carlos_emr.carlos.integration.ebs;
 
+/**
+ * Serves as the main entry point for the Electronic Billing System (EBS) integration module.
+ */
 public class App
 {
     public static void main(final String[] args) {

--- a/src/main/java/io/github/carlos_emr/carlos/utility/EmailSendingException.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/EmailSendingException.java
@@ -1,5 +1,8 @@
 package io.github.carlos_emr.carlos.utility;
 
+/**
+ * Custom exception thrown when errors occur during the email transmission process.
+ */
 public class EmailSendingException extends Exception {
     public EmailSendingException() {
         super();

--- a/src/main/java/io/github/carlos_emr/carlos/utility/JsDateSerializer.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/JsDateSerializer.java
@@ -6,6 +6,9 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import java.io.IOException;
 import java.util.Calendar;
 
+/**
+ * Handles JSON serialization of Java Date objects into JavaScript-compatible formats.
+ */
 public class JsDateSerializer extends JsonSerializer<java.sql.Date> {
     @Override
     public void serialize(java.sql.Date value, JsonGenerator gen, SerializerProvider serializers) 

--- a/src/main/java/io/github/carlos_emr/carlos/utility/PDFEncryptionUtil.java
+++ b/src/main/java/io/github/carlos_emr/carlos/utility/PDFEncryptionUtil.java
@@ -9,6 +9,9 @@ import org.apache.pdfbox.pdmodel.encryption.AccessPermission;
 import org.apache.pdfbox.pdmodel.encryption.StandardProtectionPolicy;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+/**
+ * Provides utility functions for encrypting and securing PDF documents with passwords.
+ */
 public class PDFEncryptionUtil {
     // FindSecBugs PATH_TRAVERSAL_IN: path derived from trusted configuration/constant/DB value, not user-controllable input
     @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "path derived from trusted configuration/constant/DB value, not user-controllable input")

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/conversion/ConsultationRequestExtConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/conversion/ConsultationRequestExtConverter.java
@@ -4,12 +4,16 @@ import io.github.carlos_emr.carlos.commn.model.ConsultationRequestExt;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.webserv.rest.to.model.ConsultationRequestExtTo1;
 
+/**
+ * Utility for converting consultation request extended attributes to REST objects.
+ */
 public class ConsultationRequestExtConverter extends AbstractConverter<ConsultationRequestExt, ConsultationRequestExtTo1> {
     @Override
     public ConsultationRequestExt getAsDomainObject(LoggedInInfo loggedInInfo, ConsultationRequestExtTo1 t) throws ConversionException {
         ConsultationRequestExt d = new ConsultationRequestExt();
 
         //d.setId(t.getId());
+        // Evaluates condition to determine the appropriate control flow path
         if (t.getRequestId() != null) {
             d.setRequestId(t.getRequestId());
         }

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/conversion/MeasurementConverter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/conversion/MeasurementConverter.java
@@ -4,6 +4,9 @@ import io.github.carlos_emr.carlos.commn.model.Measurement;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.webserv.rest.to.model.MeasurementTo1;
 
+/**
+ * Utility for converting clinical measurement data into REST-compatible transfer objects.
+ */
 public class MeasurementConverter extends AbstractConverter<Measurement, MeasurementTo1> {
     @Override
     public Measurement getAsDomainObject(LoggedInInfo loggedInInfo, MeasurementTo1 t) throws ConversionException {

--- a/src/main/java/io/github/carlos_emr/carlos/webserv/rest/to/model/ConsultationRequestExtTo1.java
+++ b/src/main/java/io/github/carlos_emr/carlos/webserv/rest/to/model/ConsultationRequestExtTo1.java
@@ -2,6 +2,9 @@ package io.github.carlos_emr.carlos.webserv.rest.to.model;
 
 import java.util.Date;
 
+/**
+ * Transfer object for version 1 of consultation request extended attributes over REST.
+ */
 public class ConsultationRequestExtTo1 {
     private Integer id;
     private Integer requestId;


### PR DESCRIPTION
Added contextual javadoc and inline documentation to 40 java files across the codebase to improve documentation coverage without breaking existing compilation or conventions.

---
*PR created automatically by Jules for task [11972794346125687200](https://jules.google.com/task/11972794346125687200) started by @yingbull*

## Summary by Sourcery

Improve documentation coverage across core EMR, eReferral, email, fax, billing, and REST conversion modules without changing runtime behavior.

Documentation:
- Add descriptive class-level Javadoc to entities, DTOs, enum types, converters, utilities, and configuration classes involved in billing, eReferral attachments, document management, email/fax integration, and REST APIs.
- Introduce targeted inline comments in selected methods to clarify control flow and data processing responsibilities.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added Javadoc and inline comments to 40 Java files to improve readability and generated API docs. Updates span `commn` models/converters, `documentManager`, email helpers, billing, servlet config, and REST converters, with no behavior changes.

<sup>Written for commit 024f6fbc2f569619498591ad5da039bcc3ba71e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

