### PR TITLE
fix(admin): correct lot-number search onsub() form reference

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/admin/lotnrsearchrecordshtm.jsp
+++ b/src/main/webapp/WEB-INF/jsp/admin/lotnrsearchrecordshtm.jsp
@@ -77,9 +77,9 @@
             function onsub() {
 
                 // make keyword lower case
-                var keyword = document.searchprovider.keyword.value;
+                var keyword = document.searchlotnr.keyword.value;
                 var keywordLowerCase = keyword.toLowerCase();
-                document.searchprovider.keyword.value = keywordLowerCase;
+                document.searchlotnr.keyword.value = keywordLowerCase;
             }
 
             function upCaseCtrl(ctrl) {


### PR DESCRIPTION
## Description

The lot-number search page under Administration > System Management had a small bug in its inline onsub() JavaScript function. It referenced document.searchprovider, a form that doesn't actually exist on that page, instead of document.searchlotnr, which is the form's real name. Because of this, every time someone submitted a search, the browser console threw a "Cannot read properties of undefined (reading 'keyword')" error. The search itself still worked because the browser fell through to a normal form submission, so the bug was invisible to users but showed up as a console error every time. This change fixes both references in the onsub() function to point to document.searchlotnr, which matches the actual form name defined further down in the same file, and also matches the pattern already used correctly in the sibling results page, lotnrsearchresults.jsp.

## Related Issues

Closes #3403

## How Was This Tested?

I built and ran this locally in the CARLOS devcontainer, deployed it, logged in, and tested the search page directly in the browser with DevTools open. Before the fix the console error showed up on every submit. After the fix it's gone and the search still returns results normally. No other unrelated console errors were introduced by this change.

## Checklist

- [ ✓] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`)
- [ ✓] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [ ✓] I have not included any patient data (PHI) in this PR
- [ ✓] I have added tests for new functionality, or this change doesn't need new tests
- [ ✓] I have read the [contributing guide](CONTRIBUTING.md)

## Summary by Sourcery

Bug Fixes:
- Resolve console errors on the lot-number search page by using the correct form name in the onsub() handler.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix lot-number search onsub() to reference the `searchlotnr` form instead of a nonexistent `searchprovider`, eliminating the console error on submit. Search behavior is unchanged; the "Cannot read properties of undefined (reading 'keyword')" error no longer appears.

<sup>Written for commit 8b95928961affc9e8027ed927729e180d5cc0efd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

