### PR TITLE
fix: prevent session IDs in messenger redirects

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgClearMessage2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgClearMessage2Action.java
@@ -113,7 +113,9 @@ public final class MsgClearMessage2Action extends ActionSupport {
         MsgSessionBean bean;
         bean = (MsgSessionBean) request.getSession().getAttribute("msgSessionBean");
         if (bean == null) {
-            response.sendRedirect(request.getContextPath() + "/messenger/DisplayMessages");
+            // A relative, constant target stays within the current /messenger/ path without
+            // accepting request-controlled redirect input or invoking URL-based session tracking.
+            response.sendRedirect("DisplayMessages");
             return NONE;
         }
 

--- a/src/main/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgClearMessage2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgClearMessage2Action.java
@@ -113,8 +113,7 @@ public final class MsgClearMessage2Action extends ActionSupport {
         MsgSessionBean bean;
         bean = (MsgSessionBean) request.getSession().getAttribute("msgSessionBean");
         if (bean == null) {
-            response.sendRedirect(response.encodeRedirectURL(
-                    request.getContextPath() + "/messenger/DisplayMessages"));
+            response.sendRedirect(request.getContextPath() + "/messenger/DisplayMessages");
             return NONE;
         }
 

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -606,6 +606,7 @@
 
   <session-config>
     <session-timeout>120</session-timeout>
+    <tracking-mode>COOKIE</tracking-mode>
   </session-config>
 
   <login-config>

--- a/src/test/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgClearMessage2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgClearMessage2ActionTest.java
@@ -13,6 +13,10 @@
 package io.github.carlos_emr.carlos.messenger.pageUtil;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 import java.io.StringReader;
 import java.net.URI;
@@ -22,15 +26,11 @@ import java.nio.file.Path;
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilderFactory;
 
-import jakarta.servlet.http.Cookie;
-
 import org.apache.struts2.ActionSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.MockitoAnnotations;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.w3c.dom.Document;
@@ -60,21 +60,17 @@ class MsgClearMessage2ActionTest extends CarlosWebTestBase {
         MockitoAnnotations.openMocks(this);
         replaceSpringUtilsBean(SecurityInfoManager.class, mockSecurityInfoManager);
 
-        mockResponse = new UrlRewritingResponse();
+        mockResponse = spy(new MockHttpServletResponse());
         setUpActionContext();
         action = new MsgClearMessage2Action();
     }
 
-    @ParameterizedTest(name = "existing session cookie: {0}")
-    @ValueSource(booleans = {false, true})
+    @Test
     @DisplayName("should redirect without a session identifier when the message bean is missing")
-    void shouldRedirectWithoutSessionId_whenMessageBeanIsMissing(boolean withSessionCookie) throws Exception {
+    void shouldRedirectWithoutSessionId_whenMessageBeanIsMissing() throws Exception {
         allowPrivilege("_msg", "w");
         getMockRequest().setContextPath("/carlos");
         getMockRequest().setRequestURI("/carlos/messenger/ClearMessage");
-        if (withSessionCookie) {
-            getMockRequest().setCookies(new Cookie("JSESSIONID", "existing-session"));
-        }
 
         String result = executeAction(action);
 
@@ -85,6 +81,7 @@ class MsgClearMessage2ActionTest extends CarlosWebTestBase {
                 .doesNotContainIgnoringCase("jsessionid");
         assertThat(URI.create(getMockRequest().getRequestURL().toString()).resolve(redirect).getPath())
                 .isEqualTo("/carlos/messenger/DisplayMessages");
+        verify(getMockResponse(), never()).encodeRedirectURL(anyString());
     }
 
     @Test
@@ -142,12 +139,5 @@ class MsgClearMessage2ActionTest extends CarlosWebTestBase {
             current = current.getParent();
         }
         throw new IllegalStateException("Unable to locate project file: " + relativePath);
-    }
-
-    private static final class UrlRewritingResponse extends MockHttpServletResponse {
-        @Override
-        public String encodeRedirectURL(String url) {
-            return url + ";jsessionid=simulated-url-session";
-        }
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgClearMessage2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgClearMessage2ActionTest.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.messenger.pageUtil;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import jakarta.servlet.http.Cookie;
+
+import org.apache.struts2.ActionSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.MockitoAnnotations;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import io.github.carlos_emr.carlos.test.base.CarlosWebTestBase;
+
+/**
+ * Regression coverage for clearing Messenger attachments and its missing-bean redirect.
+ *
+ * @since 2026-08-11
+ */
+@DisplayName("MsgClearMessage2Action")
+@Tag("integration")
+@Tag("messenger")
+class MsgClearMessage2ActionTest extends CarlosWebTestBase {
+
+    private MsgClearMessage2Action action;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        MockitoAnnotations.openMocks(this);
+        replaceSpringUtilsBean(SecurityInfoManager.class, mockSecurityInfoManager);
+
+        mockResponse = new UrlRewritingResponse();
+        setUpActionContext();
+        action = new MsgClearMessage2Action();
+
+        java.lang.reflect.Field securityManager =
+                MsgClearMessage2Action.class.getDeclaredField("securityInfoManager");
+        securityManager.setAccessible(true);
+        securityManager.set(action, mockSecurityInfoManager);
+    }
+
+    @ParameterizedTest(name = "existing session cookie: {0}")
+    @ValueSource(booleans = {false, true})
+    @DisplayName("should redirect without a session identifier when the message bean is missing")
+    void shouldRedirectWithoutSessionId_whenMessageBeanIsMissing(boolean withSessionCookie) throws Exception {
+        allowPrivilege("_msg", "w");
+        getMockRequest().setContextPath("/carlos");
+        if (withSessionCookie) {
+            getMockRequest().setCookies(new Cookie("JSESSIONID", "existing-session"));
+        }
+
+        String result = executeAction(action);
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(getMockResponse().getRedirectedUrl())
+                .isEqualTo("/carlos/messenger/DisplayMessages")
+                .doesNotContain(";jsessionid=");
+    }
+
+    @Test
+    @DisplayName("should clear every attachment when the message bean exists")
+    void shouldClearAttachments_whenMessageBeanExists() throws Exception {
+        allowPrivilege("_msg", "w");
+        MsgSessionBean bean = new MsgSessionBean();
+        bean.setAttachment("<item>document</item>");
+        bean.setPDFAttachment("encoded-pdf");
+        getMockSession().setAttribute("msgSessionBean", bean);
+
+        String result = executeAction(action);
+
+        assertThat(result).isEqualTo(ActionSupport.SUCCESS);
+        assertThat(bean.getAttachment()).isNull();
+        assertThat(bean.getPDFAttachment()).isNull();
+        assertThat(bean.getTotalAttachmentCount()).isZero();
+        assertThat(getMockResponse().getRedirectedUrl()).isNull();
+    }
+
+    @Test
+    @DisplayName("should configure the application for cookie-only session tracking")
+    void shouldUseCookieOnlySessionTracking_inDeploymentDescriptor() throws Exception {
+        String webXml = Files.readString(Path.of("src", "main", "webapp", "WEB-INF", "web.xml"));
+
+        assertThat(webXml)
+                .contains("<tracking-mode>COOKIE</tracking-mode>")
+                .doesNotContain("<tracking-mode>URL</tracking-mode>");
+    }
+
+    private static final class UrlRewritingResponse extends MockHttpServletResponse {
+        @Override
+        public String encodeRedirectURL(String url) {
+            return url + ";jsessionid=simulated-url-session";
+        }
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgClearMessage2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgClearMessage2ActionTest.java
@@ -15,6 +15,7 @@ package io.github.carlos_emr.carlos.messenger.pageUtil;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.StringReader;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -70,6 +71,7 @@ class MsgClearMessage2ActionTest extends CarlosWebTestBase {
     void shouldRedirectWithoutSessionId_whenMessageBeanIsMissing(boolean withSessionCookie) throws Exception {
         allowPrivilege("_msg", "w");
         getMockRequest().setContextPath("/carlos");
+        getMockRequest().setRequestURI("/carlos/messenger/ClearMessage");
         if (withSessionCookie) {
             getMockRequest().setCookies(new Cookie("JSESSIONID", "existing-session"));
         }
@@ -77,9 +79,12 @@ class MsgClearMessage2ActionTest extends CarlosWebTestBase {
         String result = executeAction(action);
 
         assertThat(result).isEqualTo(ActionSupport.NONE);
-        assertThat(getMockResponse().getRedirectedUrl())
-                .isEqualTo("/carlos/messenger/DisplayMessages")
+        String redirect = getMockResponse().getRedirectedUrl();
+        assertThat(redirect)
+                .isEqualTo("DisplayMessages")
                 .doesNotContainIgnoringCase("jsessionid");
+        assertThat(URI.create(getMockRequest().getRequestURL().toString()).resolve(redirect).getPath())
+                .isEqualTo("/carlos/messenger/DisplayMessages");
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgClearMessage2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgClearMessage2ActionTest.java
@@ -14,8 +14,12 @@ package io.github.carlos_emr.carlos.messenger.pageUtil;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.StringReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
 
 import jakarta.servlet.http.Cookie;
 
@@ -28,6 +32,9 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.MockitoAnnotations;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
 
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.test.base.CarlosWebTestBase;
@@ -42,6 +49,9 @@ import io.github.carlos_emr.carlos.test.base.CarlosWebTestBase;
 @Tag("messenger")
 class MsgClearMessage2ActionTest extends CarlosWebTestBase {
 
+    private static final int MAX_PARENT_SEARCH_DEPTH = 8;
+    private static final Path WEB_XML = resolveProjectPath(
+            Path.of("src", "main", "webapp", "WEB-INF", "web.xml"));
     private MsgClearMessage2Action action;
 
     @BeforeEach
@@ -52,11 +62,6 @@ class MsgClearMessage2ActionTest extends CarlosWebTestBase {
         mockResponse = new UrlRewritingResponse();
         setUpActionContext();
         action = new MsgClearMessage2Action();
-
-        java.lang.reflect.Field securityManager =
-                MsgClearMessage2Action.class.getDeclaredField("securityInfoManager");
-        securityManager.setAccessible(true);
-        securityManager.set(action, mockSecurityInfoManager);
     }
 
     @ParameterizedTest(name = "existing session cookie: {0}")
@@ -74,7 +79,7 @@ class MsgClearMessage2ActionTest extends CarlosWebTestBase {
         assertThat(result).isEqualTo(ActionSupport.NONE);
         assertThat(getMockResponse().getRedirectedUrl())
                 .isEqualTo("/carlos/messenger/DisplayMessages")
-                .doesNotContain(";jsessionid=");
+                .doesNotContainIgnoringCase("jsessionid");
     }
 
     @Test
@@ -84,6 +89,8 @@ class MsgClearMessage2ActionTest extends CarlosWebTestBase {
         MsgSessionBean bean = new MsgSessionBean();
         bean.setAttachment("<item>document</item>");
         bean.setPDFAttachment("encoded-pdf");
+        bean.setTotalAttachmentCount(3);
+        bean.setCurrentAttachmentCount(2);
         getMockSession().setAttribute("msgSessionBean", bean);
 
         String result = executeAction(action);
@@ -92,17 +99,44 @@ class MsgClearMessage2ActionTest extends CarlosWebTestBase {
         assertThat(bean.getAttachment()).isNull();
         assertThat(bean.getPDFAttachment()).isNull();
         assertThat(bean.getTotalAttachmentCount()).isZero();
+        assertThat(bean.getCurrentAttachmentCount()).isZero();
         assertThat(getMockResponse().getRedirectedUrl()).isNull();
     }
 
     @Test
     @DisplayName("should configure the application for cookie-only session tracking")
     void shouldUseCookieOnlySessionTracking_inDeploymentDescriptor() throws Exception {
-        String webXml = Files.readString(Path.of("src", "main", "webapp", "WEB-INF", "web.xml"));
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setValidating(false);
+        factory.setNamespaceAware(false);
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        factory.setXIncludeAware(false);
+        factory.setExpandEntityReferences(false);
+        var builder = factory.newDocumentBuilder();
+        builder.setEntityResolver((publicId, systemId) -> new InputSource(new StringReader("")));
+        Document webXml = builder.parse(WEB_XML.toFile());
+        NodeList trackingModes = webXml.getElementsByTagName("tracking-mode");
 
-        assertThat(webXml)
-                .contains("<tracking-mode>COOKIE</tracking-mode>")
-                .doesNotContain("<tracking-mode>URL</tracking-mode>");
+        assertThat(trackingModes.getLength()).isEqualTo(1);
+        assertThat(trackingModes.item(0).getTextContent().trim()).isEqualTo("COOKIE");
+    }
+
+    private static Path resolveProjectPath(Path relativePath) {
+        Path current = Path.of(System.getProperty("basedir", System.getProperty("user.dir")))
+                .toAbsolutePath()
+                .normalize();
+        for (int depth = 0; depth <= MAX_PARENT_SEARCH_DEPTH && current != null; depth++) {
+            Path candidate = current.resolve(relativePath);
+            if (Files.isRegularFile(candidate)) {
+                return candidate;
+            }
+            current = current.getParent();
+        }
+        throw new IllegalStateException("Unable to locate project file: " + relativePath);
     }
 
     private static final class UrlRewritingResponse extends MockHttpServletResponse {

--- a/src/test/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgClearMessage2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgClearMessage2ActionTest.java
@@ -57,7 +57,7 @@ class MsgClearMessage2ActionTest extends CarlosWebTestBase {
     private MsgClearMessage2Action action;
 
     @BeforeEach
-    void setUp() throws Exception {
+    void setUp() {
         MockitoAnnotations.openMocks(this);
         replaceSpringUtilsBean(SecurityInfoManager.class, mockSecurityInfoManager);
 

--- a/src/test/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgClearMessage2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgClearMessage2ActionTest.java
@@ -14,6 +14,7 @@ package io.github.carlos_emr.carlos.messenger.pageUtil;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -71,6 +72,9 @@ class MsgClearMessage2ActionTest extends CarlosWebTestBase {
         allowPrivilege("_msg", "w");
         getMockRequest().setContextPath("/carlos");
         getMockRequest().setRequestURI("/carlos/messenger/ClearMessage");
+        doAnswer(invocation -> invocation.<String>getArgument(0) + ";jsessionid=simulated-url-session")
+                .when(getMockResponse())
+                .encodeRedirectURL(anyString());
 
         String result = executeAction(action);
 


### PR DESCRIPTION
## Description

- remove `encodeRedirectURL` from the missing-message-bean redirect so a session identifier cannot enter the URL
- constrain the redirect to the constant same-directory target `DisplayMessages`, preserving the resolved Messenger inbox path without request-controlled input
- configure Servlet session tracking as cookie-only in the deployment descriptor
- add regression coverage that directly verifies redirect URL encoding is skipped while preserving attachment clearing
- audit nearby Messenger redirects; none of the other redirects use URL session rewriting

## Related Issues

Fixes #3412

## How Was This Tested?

- `mvn compiler:compile compiler:testCompile surefire:test -Dtest=MsgClearMessage2ActionTest` — passed
- final focused rerun: 3 tests, 0 failures, 0 errors
- `python3 scripts/lint/check-bdd-test-naming.py` — passed, 270 files scanned
- XML parse of `WEB-INF/web.xml` — passed
- `make jspc` — all 973 JSPs compiled with 0 errors; WAR build succeeded
- manual audit of all Messenger `sendRedirect`, `encodeRedirectURL`, and `encodeURL` calls

## Manual Review

- MUST: none remaining
- SHOULD: none remaining in scope
- COULD: review application-wide session cookie flags separately; this PR intentionally addresses URL rewriting and cookie-only tracking

## Checklist

- [x] My commits are signed off for the DCO
- [x] My commits follow Conventional Commits
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for the security regression
- [x] I have read the contributing guide

## Summary by Sourcery

Harden Messenger redirect behavior to avoid URL-based session identifiers and rely on cookie-only session tracking.

Bug Fixes:
- Prevent the missing-message-bean Messenger redirect from including URL-rewritten session IDs by using a constant relative target instead of an encoded redirect URL.

Enhancements:
- Configure the web application to use cookie-only HTTP session tracking via the deployment descriptor.

Tests:
- Add integration tests validating the missing-bean Messenger redirect avoids URL session rewriting while keeping attachment clearing behavior intact.
- Add a test that verifies the deployment descriptor is configured for cookie-only session tracking.