### PR TITLE
fix(lab): verify lab upload signature before storing; define v2 encryption migration

### DIFF
--- a/docs/security/lab-upload-authenticated-encryption-migration.md
+++ b/docs/security/lab-upload-authenticated-encryption-migration.md
@@ -49,21 +49,30 @@ Three legacy receiver behaviors are recorded here because version 2 changes them
 reviewer must not read the change as accidental. Each was reproduced against a running
 receiver; see the verification note below.
 
-- The legacy path decrypts and writes plaintext into `DOCUMENT_DIR` **before** the
-  signature is checked. A message that decrypts but fails signature verification still
-  lands on disk as readable plaintext. Because the receiver public key is public, the
-  sender signature is the only thing standing between an authorized `_lab` caller and an
-  arbitrary file in `DOCUMENT_DIR`, and it is checked too late. Version 2 forbids this
-  ordering.
-- A legacy signature failure leaves that already-written plaintext file on disk. Nothing
-  removes it. Version 2 must not create a stored artifact for a message it rejects.
-- An unrecognized `service` produces an empty client-info list, and the subsequent
-  element access throws out of `execute()`. The `lab` Struts package maps
-  `java.lang.Exception` to `errorpage.jsp` (`struts-lab.xml`), and that result is a JSP
-  forward, so the sender receives **HTTP 200 with an HTML error page**. A sender using
-  `use_http_response_code` reads that as a successful delivery. A misconfigured or
-  retired service therefore fails silently in the direction that loses labs. Version 2
-  requires the generic rejection outcome, with a rejection status, for unknown services.
+- The legacy path decrypted and wrote plaintext into `DOCUMENT_DIR` **before** the
+  signature was checked, and a message that decrypted but failed verification still landed
+  on disk as readable plaintext that nothing removed. The wrapping key is the receiver's
+  public key, which every sender organization holds, so producing a cleanly decrypting
+  message needs no secret — the signature was the only evidence of authenticity, and it was
+  checked too late. (CARLOS does not serve that key from an unauthenticated endpoint;
+  `GetPublicKey2Action` is `_admin`-gated and returns `publicKeys` rows, not the receiver
+  key. The exposure is that the key is distributed to third parties by design.)
+  **Fixed:** the receiver now stages the decrypted message in an owner-only temporary file,
+  verifies the signature, and only then persists it; the staged copy is always deleted.
+  Version 2 keeps this ordering.
+- An unrecognized `service` produced an empty client-info list, and the subsequent element
+  access threw out of `execute()`. The `lab` Struts package maps `java.lang.Exception` to
+  `errorpage.jsp` (`struts-lab.xml`), and that result is a JSP forward, so the sender
+  received **HTTP 200 with an HTML error page** and read a misconfigured or retired service
+  as a successful delivery — failing silently in the direction that loses labs.
+  **Fixed:** unknown services, unusable stored keys, and undecryptable messages now share
+  one non-specific `rejected` outcome with a rejection status, so a caller cannot probe
+  which services are configured. Version 2 keeps this behavior.
+
+These two fixes are receiver-local. They change no wire format, no field, and no algorithm,
+so senders are unaffected and they did not need the coordination gates below. They do not
+close alerts 6904 or 5637, which track the ECB cipher itself and close only on removal of
+the legacy path.
 
 ### Verification note
 

--- a/docs/security/lab-upload-authenticated-encryption-migration.md
+++ b/docs/security/lab-upload-authenticated-encryption-migration.md
@@ -1,0 +1,148 @@
+# Lab upload authenticated-encryption migration
+
+## Status
+
+The `/lab/newLabUpload` receiver still accepts the original, unversioned lab-upload
+protocol. Its message cipher is AES/ECB with PKCS#5 padding and its wrapped key uses
+RSA PKCS#1 v1.5. These algorithms cannot be changed in the receiver until every active
+sender has implemented and tested the same replacement protocol.
+
+This document is the coordination contract for that migration. It does not authorize a
+receiver-only cipher change. Code scanning alerts 6904 and 5637 remain valid until the
+legacy path is removed.
+
+## Current protocol
+
+An external sender posts a multipart request to `/lab/newLabUpload` with these fields:
+
+| Field | Current format |
+| --- | --- |
+| `file` | Raw AES/ECB/PKCS5Padding ciphertext |
+| `key` | Base64-encoded AES key wrapped with RSA/ECB/PKCS1Padding |
+| `signature` | Base64-encoded MD5withRSA signature of the plaintext file |
+| `service` | Sender identifier used to select a row from `publicKeys` |
+
+There is no protocol-version field, IV, nonce, or authenticated-encryption tag. The
+receiver selects a downstream parser from the `type` column of `publicKeys`. The source
+tree contains handlers for ALPHA, BIOTEST, CDL, CLS, CML, EPSILON, ExcellerisON, GDML,
+HHSEMR, IHA/IHAPOI, MDS, PATHL7, PDFDOC, PHS, Spire, TRUENORTH, MEDITECH, and
+FHIR_COMMUNICATION_REQUEST. Handler presence does not prove that a sender is active in a
+particular deployment.
+
+Sender implementations and vendor contacts are not stored in this repository. Each
+deployment must inventory its own `publicKeys` rows and resolve the optional
+`matchingProfessionalSpecialistId` contact before a cutoff can be scheduled.
+
+## Required owner inventory
+
+The deployment maintainer must create one row per configured `publicKeys.service` in the
+following register. Do not copy private keys or patient data into the register.
+
+| Service | Handler type | Deployment | Sender/vendor owner | Technical contact | v2 capable | Last legacy upload | Cutover approved |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| _Complete from each deployment_ | | | | | | | |
+
+Use the Key Manager and deployment database to build the inventory. The
+`matchingProfessionalSpecialistId` field may identify a contact in
+`professionalSpecialists`; a null value means CARLOS has no recorded return contact.
+Repository handler names are only discovery hints and must not be treated as a complete
+production sender list.
+
+The CARLOS maintainer owns the receiver rollout. The organization operating each sender
+owns its sender release, fixtures, and cutover approval. A named owner and technical
+contact are required for every active service before legacy removal.
+
+## Proposed version 2 contract
+
+This contract is a proposal until the sender owners approve it. Any change must update
+the fixtures and this document before receiver code is merged.
+
+### Multipart fields
+
+| Field | Version 2 format |
+| --- | --- |
+| `protocol_version` | ASCII `2`; required and covered by the signature |
+| `service` | Existing sender identifier; UTF-8 and covered by the signature and GCM AAD |
+| `key` | Base64url, without padding, of a 256-bit AES key wrapped with RSA-OAEP-SHA-256 |
+| `nonce` | Base64url, without padding, of a unique 12-byte random nonce |
+| `file` | AES-256-GCM ciphertext followed by the 16-byte authentication tag |
+| `signature` | Base64url RSA-PSS-SHA-256 signature of the canonical envelope |
+
+The GCM additional authenticated data is the byte sequence `carlos-lab-upload`, `0x00`,
+`2`, `0x00`, then the UTF-8 service identifier. The canonical signature input is the
+length-prefixed concatenation of the protocol marker, UTF-8 service, wrapped key, nonce,
+and ciphertext including the tag. Lengths are unsigned 32-bit big-endian byte counts.
+Binary values are decoded before canonicalization.
+
+Each sender must generate a fresh AES key and nonce for every upload. Nonce reuse with a
+key is forbidden. RSA-OAEP uses SHA-256 for both the message digest and MGF1, with an
+empty label. AES-GCM uses a 128-bit authentication tag.
+
+### Parsing and downgrade rules
+
+- An absent `protocol_version` is legacy only during the transition window.
+- A value of `2` is always parsed as version 2. Any missing, malformed, truncated,
+  unauthenticated, or unsupported version 2 field is rejected; it is never retried as
+  legacy.
+- Any other explicit version is rejected.
+- After strict field parsing, the receiver verifies the sender signature before
+  unwrapping the AES key, then authenticates and decrypts the file with GCM.
+- The receiver verifies the version 2 signature and GCM tag before exposing plaintext to
+  file storage or lab parsers.
+- External responses use one generic rejection outcome and do not disclose whether key
+  unwrap, signature verification, GCM authentication, or parsing failed.
+- Logs and metrics contain the service identifier, protocol version, and a coarse outcome
+  only. They must not contain keys, nonces, signatures, ciphertext, plaintext, or
+  cryptographic exception details.
+
+## Fixtures and conformance tests
+
+Sender and receiver implementations must share non-production fixtures covering:
+
+- one valid version 2 upload for every key size and handler type in active use;
+- modified service, wrapped key, nonce, ciphertext, tag, and signature;
+- truncated and oversized fields;
+- unknown and malformed versions;
+- a valid legacy upload during the transition window;
+- an explicit version 2 upload that cannot fall back to legacy; and
+- duplicate delivery behavior, which must remain compatible with `FileUploadCheck`.
+
+Fixtures must use generated test keys and synthetic lab content with no patient data.
+
+## Rollout, telemetry, and rollback
+
+1. Complete the owner inventory and obtain written approval of the version 2 contract.
+2. Merge receiver support for both formats, with protocol-version metrics and generic
+   decryption failures. Keep legacy behavior unchanged.
+3. Deploy the receiver before any sender. Confirm version 2 fixtures in a non-production
+   environment.
+4. Upgrade one sender at a time. Record its first and last successful version 2 upload,
+   then enforce version 2 for that service so it cannot downgrade.
+5. Monitor version counts and rejection counts through at least one normal delivery
+   cycle for every sender.
+6. Set and communicate a legacy removal date only after every active service is enforced
+   on version 2. Record that date in this document and in release notes.
+7. Remove the legacy decryptor, its configuration, and transition telemetry after the
+   cutoff. Confirm code scanning alerts 6904 and 5637 close.
+
+Before per-service enforcement, rollback means reverting a sender to its previous release
+while the receiver continues accepting both formats. After enforcement, rollback requires
+an explicit maintainer decision and configuration change; the receiver must never retry a
+message marked version 2 as legacy. Receiver rollback after any sender is enforced on
+version 2 is prohibited unless those senders are rolled back first.
+
+## Implementation gates
+
+Receiver implementation must not begin until all of these are recorded in this document:
+
+- [ ] Active-service owner inventory is complete for every supported deployment.
+- [ ] Sender owners approve the exact wire format and canonical signature input.
+- [ ] Shared fixtures are available without patient data.
+- [ ] Receiver-first deployment order and sender rollout order are approved.
+- [ ] Telemetry owner, dashboard, alert threshold, and retention are defined.
+- [ ] Per-service downgrade enforcement is designed.
+- [ ] Legacy removal date and emergency rollback owner are named.
+
+Until these gates are complete, replacing `Cipher.getInstance("AES")` in
+`LabUpload2Action` would cause an outage for every sender still using the unversioned
+protocol.

--- a/docs/security/lab-upload-authenticated-encryption-migration.md
+++ b/docs/security/lab-upload-authenticated-encryption-migration.md
@@ -22,6 +22,13 @@ An external sender posts a multipart request to `/lab/newLabUpload` with these f
 | `signature` | Base64-encoded MD5withRSA signature of the plaintext file |
 | `service` | Sender identifier used to select a row from `publicKeys` |
 
+Two distinct RSA keypairs are already in play, and version 2 keeps the same roles:
+
+- The **receiver keypair** is the `oscar` row of `oscarKey`. The sender wraps the message
+  key to the receiver public key; the receiver unwraps with its private key.
+- The **sender keypair** is per service. The sender signs with its private key; the
+  receiver verifies with `publicKeys.base64EncodedPublicKey` for the requested `service`.
+
 There is no protocol-version field, IV, nonce, or authenticated-encryption tag. The
 receiver selects a downstream parser from the `type` column of `publicKeys`. The source
 tree contains handlers for ALPHA, BIOTEST, CDL, CLS, CML, EPSILON, ExcellerisON, GDML,
@@ -33,14 +40,29 @@ Sender implementations and vendor contacts are not stored in this repository. Ea
 deployment must inventory its own `publicKeys` rows and resolve the optional
 `matchingProfessionalSpecialistId` contact before a cutoff can be scheduled.
 
+Three legacy receiver behaviors are recorded here because version 2 changes them and a
+reviewer must not read the change as accidental:
+
+- The legacy path decrypts and writes plaintext into `DOCUMENT_DIR` **before** the
+  signature is checked. Version 2 forbids this ordering.
+- A legacy signature failure leaves the already-written plaintext file on disk. Version 2
+  must not create a stored artifact for a message it rejects.
+- An unrecognized `service` yields an empty client-info list and an
+  `IndexOutOfBoundsException` out of `execute()` rather than a controlled rejection.
+  Version 2 requires the generic rejection outcome for unknown services as well.
+
 ## Required owner inventory
 
 The deployment maintainer must create one row per configured `publicKeys.service` in the
 following register. Do not copy private keys or patient data into the register.
 
-| Service | Handler type | Deployment | Sender/vendor owner | Technical contact | v2 capable | Last legacy upload | Cutover approved |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| _Complete from each deployment_ | | | | | | | |
+| Service | Handler type | Deployment | Sender/vendor owner | Technical contact | Key bits | Key rotated | v2 capable | Last legacy upload | Cutover approved |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| _Complete from each deployment_ | | | | | | | | | |
+
+Record the RSA modulus size of each `publicKeys` row and of the deployment's `oscarKey`
+receiver key. Anything below 2048 bits must be rotated before that service can be marked
+v2 capable.
 
 Use the Key Manager and deployment database to build the inventory. The
 `matchingProfessionalSpecialistId` field may identify a contact in
@@ -63,51 +85,148 @@ the fixtures and this document before receiver code is merged.
 | --- | --- |
 | `protocol_version` | ASCII `2`; required and covered by the signature |
 | `service` | Existing sender identifier; UTF-8 and covered by the signature and GCM AAD |
-| `key` | Base64url, without padding, of a 256-bit AES key wrapped with RSA-OAEP-SHA-256 |
+| `timestamp` | ASCII decimal seconds since the Unix epoch, UTC, no sign and no padding |
+| `key` | Base64url, without padding, of a 256-bit AES key wrapped to the **receiver** public key with RSA-OAEP-SHA-256 |
 | `nonce` | Base64url, without padding, of a unique 12-byte random nonce |
 | `file` | AES-256-GCM ciphertext followed by the 16-byte authentication tag |
-| `signature` | Base64url RSA-PSS-SHA-256 signature of the canonical envelope |
+| `signature` | Base64url, without padding, of the **sender** RSA-PSS-SHA-256 signature over the canonical signature input |
 
-The GCM additional authenticated data is the ASCII byte sequence `carlos-lab-upload`,
-one `0x00` byte, the ASCII byte `2` (`0x32`), one `0x00` byte, then the UTF-8 service
-identifier.
+`publicKeys.service` is `varchar(100)` with no character restriction, so version 2 adds
+one. The proposed bound is 1–100 characters from `[A-Za-z0-9._-]`, rejected before any
+key lookup or cryptographic operation. Confirm against the owner inventory before
+approval: any real service identifier outside that set either widens the rule or is
+renamed, and this must be settled while the contract is still a proposal.
 
-The canonical signature input contains these six fields in order: the ASCII protocol
+#### Key material and minimum strength
+
+The AES key is wrapped to the receiver public key (`oscarKey` row `oscar`) and unwrapped
+with the receiver private key. The signature is produced with the sender private key and
+verified with `publicKeys.base64EncodedPublicKey` for the requested `service`. Neither
+key is interchangeable with the other; a message wrapped to the sender's own key is not
+decryptable and must be rejected.
+
+Both keypairs must be RSA with a modulus of at least 2048 bits. A service whose
+`publicKeys` row holds a smaller key is not v2-capable and must rotate before cutover;
+see the rotation step in the rollout. Deployments whose `oscarKey` row predates the
+2048-bit generator must rotate the receiver keypair at rollout step 4, before any sender
+is upgraded, and that rotation is itself a coordinated change because every sender wraps
+to that key.
+
+#### Canonical encodings
+
+The GCM additional authenticated data is the ASCII protocol marker `carlos-lab-upload`,
+the one-byte ASCII protocol version `2` (`0x32`), the UTF-8 service identifier, and the
+ASCII timestamp, in that order, each prefixed with its unsigned 32-bit big-endian byte
+length. The AAD uses the same length-prefixed framing as the signature input so that a
+single serializer can produce both.
+
+The canonical signature input contains these seven fields in order: the ASCII protocol
 marker `carlos-lab-upload`, the one-byte ASCII protocol version `2` (`0x32`), the UTF-8
-service identifier, the wrapped key, the nonce, and the ciphertext including its tag.
-Each field is prefixed with its unsigned 32-bit big-endian byte length. Base64url fields
-are decoded to binary before their lengths are calculated and before they are added to
-the canonical input.
+service identifier, the ASCII timestamp, the wrapped key, the nonce, and the ciphertext
+including its tag. Each field is prefixed with its unsigned 32-bit big-endian byte
+length. Base64url fields are decoded to binary before their lengths are calculated and
+before they are added to the canonical input.
 
 Each sender must generate a fresh AES key and nonce for every upload. Nonce reuse with a
 key is forbidden. RSA-OAEP uses SHA-256 for both the message digest and MGF1, with an
-empty label. AES-GCM uses a 128-bit authentication tag.
+empty label. AES-GCM uses a 128-bit authentication tag. RSA-PSS uses SHA-256 as the
+message digest, MGF1 with SHA-256, a salt length of exactly 32 bytes, and the standard
+trailer field `0xBC`. Senders must not use a variable or maximum salt length; the
+receiver verifies against the fixed 32-byte salt and any other length fails.
+
+#### Size limits
+
+A version 2 message is rejected before decryption unless every decoded field is within
+these bounds: `key` is exactly the **receiver** modulus length in bytes; `signature` is
+exactly the **sender** modulus length in bytes; `nonce` is exactly 12 bytes; `file` is at
+least 16 bytes and no larger than the deployment's configured lab upload maximum;
+`timestamp` is 1–20 characters. These are parser guards, not a substitute for the
+container upload limit.
 
 ### Parsing and downgrade rules
 
-- An absent `protocol_version` is legacy only during the transition window.
+- Every field named above must appear exactly once. A request carrying a repeated
+  `protocol_version`, `service`, `timestamp`, `key`, `nonce`, `file`, or `signature` part
+  is rejected without inspecting any occurrence. The receiver must not silently take the
+  first value.
+- Field values are compared byte-for-byte with no whitespace trimming, no case folding,
+  and no base64 padding tolerance.
+- An absent `protocol_version` is legacy only during the transition window, and only if
+  the request also carries no `timestamp` and no `nonce`. A request that mixes legacy and
+  version 2 fields is rejected rather than resolved toward either format.
 - A value of `2` is always parsed as version 2. Any missing, malformed, truncated,
   unauthenticated, or unsupported version 2 field is rejected; it is never retried as
   legacy.
 - Any other explicit version is rejected.
 - After strict field parsing, the receiver verifies the sender signature before
-  unwrapping the AES key, then authenticates and decrypts the file with GCM.
+  unwrapping the AES key, then authenticates and decrypts the file with GCM. The
+  freshness-window and replay-cache checks sit between signature verification and key
+  unwrap: `timestamp` is only trustworthy once the signature over it has verified, and
+  neither check should cost an RSA private-key operation. A cheap window pre-filter before
+  verification is permitted as a denial-of-service guard, but never as a replacement for
+  the authenticated check.
 - The receiver verifies the version 2 signature and GCM tag before exposing plaintext to
-  file storage or lab parsers.
+  file storage or lab parsers. A message that fails any check leaves no stored artifact.
+- An unknown or malformed `service` produces the same generic rejection as a
+  cryptographic failure; it must not surface as an unhandled exception.
 - External responses use one generic rejection outcome and do not disclose whether key
-  unwrap, signature verification, GCM authentication, or parsing failed.
+  unwrap, signature verification, GCM authentication, or parsing failed. The existing
+  `use_http_response_code` behavior is narrowed for version 2: every rejection returns a
+  single status, and only the successful outcomes keep their present distinct codes so
+  that duplicate delivery stays observable to senders. Reconcile the exact codes with the
+  sender owners as part of contract approval and record them here.
 - Logs and metrics contain the service identifier, protocol version, and a coarse outcome
   only. They must not contain keys, nonces, signatures, ciphertext, plaintext, or
   cryptographic exception details.
+
+### Freshness and replay
+
+The legacy protocol has no replay protection: a captured upload can be re-posted and
+still verifies. Version 2 closes this because the signature and the GCM AAD both cover
+`timestamp`.
+
+- The receiver rejects a message whose `timestamp` is more than 300 seconds from receiver
+  clock time in either direction. The window is configurable per deployment but must be
+  bounded.
+- Within that window, the receiver recognizes exact repeats by the signature value, which
+  is unique per message because the AES key and nonce are freshly generated. A repeat is
+  **not** processed a second time.
+- A repeat is not a security rejection. Senders retry after network timeouts, and a retry
+  of the identical request is indistinguishable from a capture-replay — both are harmless
+  precisely because neither produces a second side effect. The receiver therefore replays
+  the *recorded outcome* of the first attempt rather than returning the generic rejection.
+  A retry of a message that succeeded reports the same success or duplicate outcome it
+  reported the first time, so timeout-and-retry keeps working unchanged.
+- The signature cache must retain entries for at least the freshness window plus the
+  allowed clock skew. A cache that expires sooner reopens the replay it exists to close.
+- This cache is separate from `FileUploadCheck`, which continues to deduplicate identical
+  lab *content* across the longer operational history. The cache is keyed on the envelope,
+  not the payload, so it does not affect distinct uploads that happen to carry equal
+  content.
+- Receiver clock skew is therefore an availability dependency. Deployments must run NTP,
+  and the telemetry owner must alert on a rise in timestamp-window rejections.
+
+The window and the cache are both required. The window bounds how long a captured message
+stays useful; the cache neutralizes repeats inside it. Neither alone is sufficient.
 
 ## Fixtures and conformance tests
 
 Sender and receiver implementations must share non-production fixtures covering:
 
-- one valid version 2 upload for every key size and handler type in active use;
-- modified service, wrapped key, nonce, ciphertext, tag, and signature;
-- truncated and oversized fields;
+- one valid version 2 upload per handler type in active use, at each approved RSA modulus
+  size of 2048 bits or more — sub-2048-bit keys are not fixtured because they are not
+  v2-capable;
+- modified service, timestamp, wrapped key, nonce, ciphertext, tag, and signature;
+- truncated and oversized fields, including a wrapped key or signature whose length does
+  not match the modulus, and a nonce that is not 12 bytes;
+- an RSA-PSS signature produced with a salt length other than 32 bytes, which must fail;
+- a message wrapped to the sender key instead of the receiver key, which must fail;
 - unknown and malformed versions;
+- a repeated `protocol_version` part and a request mixing legacy and version 2 fields,
+  both of which must be rejected without falling back;
+- a timestamp outside the freshness window; a verbatim replay inside it, asserting that no
+  second side effect occurs and that the first outcome is replayed; and a verbatim replay
+  after the cache retention has elapsed;
 - a valid legacy upload during the transition window;
 - an explicit version 2 upload that cannot fall back to legacy; and
 - duplicate delivery behavior, which must remain compatible with `FileUploadCheck`.
@@ -121,13 +240,16 @@ Fixtures must use generated test keys and synthetic lab content with no patient 
    decryption failures. Keep legacy behavior unchanged.
 3. Deploy the receiver before any sender. Confirm version 2 fixtures in a non-production
    environment.
-4. Upgrade one sender at a time. Record its first and last successful version 2 upload,
+4. Rotate any keypair below 2048 bits. Receiver-key rotation is coordinated across all
+   senders at once; sender-key rotation is per service and updates that `publicKeys` row.
+   Record each rotation date in the register.
+5. Upgrade one sender at a time. Record its first and last successful version 2 upload,
    then enforce version 2 for that service so it cannot downgrade.
-5. Monitor version counts and rejection counts through at least one normal delivery
-   cycle for every sender.
-6. Set and communicate a legacy removal date only after every active service is enforced
+6. Monitor version counts, rejection counts, and timestamp-window rejections through at
+   least one normal delivery cycle for every sender.
+7. Set and communicate a legacy removal date only after every active service is enforced
    on version 2. Record that date in this document and in release notes.
-7. Remove the legacy decryptor, its configuration, and transition telemetry after the
+8. Remove the legacy decryptor, its configuration, and transition telemetry after the
    cutoff. Confirm code scanning alerts 6904 and 5637 close.
 
 Before per-service enforcement, rollback means reverting a sender to its previous release
@@ -138,16 +260,28 @@ version 2 is prohibited unless those senders are rolled back first.
 
 ## Implementation gates
 
-Receiver implementation must not begin until all of these are recorded in this document:
+The gates are split because some of them can only be answered by a receiver that already
+exists. Do not treat the second list as a precondition for writing code.
+
+**Before receiver implementation begins**, all of these must be recorded here:
 
 - [ ] Active-service owner inventory is complete for every supported deployment.
-- [ ] Sender owners approve the exact wire format and canonical signature input.
+- [ ] Sender owners approve the exact wire format, canonical signature input, GCM AAD,
+      RSA-PSS parameters, and minimum key size.
 - [ ] Shared fixtures are available without patient data.
 - [ ] Receiver-first deployment order and sender rollout order are approved.
 - [ ] Telemetry owner, dashboard, alert threshold, and retention are defined.
 - [ ] Per-service downgrade enforcement is designed.
-- [ ] Legacy removal date and emergency rollback owner are named.
+- [ ] Freshness window, replay-cache retention, and receiver time-sync requirement are
+      agreed.
+- [ ] Emergency rollback owner is named.
 
-Until these gates are complete, replacing `Cipher.getInstance("AES")` in
+**Before the legacy path is removed**, all of these must additionally be recorded here:
+
+- [ ] Every active service is enforced on version 2, with its last legacy upload dated.
+- [ ] Every keypair below 2048 bits has been rotated.
+- [ ] Legacy removal date is set and communicated in release notes.
+
+Until the first list is complete, replacing `Cipher.getInstance("AES")` in
 `LabUpload2Action` would cause an outage for every sender still using the unversioned
 protocol.

--- a/docs/security/lab-upload-authenticated-encryption-migration.md
+++ b/docs/security/lab-upload-authenticated-encryption-migration.md
@@ -68,11 +68,16 @@ the fixtures and this document before receiver code is merged.
 | `file` | AES-256-GCM ciphertext followed by the 16-byte authentication tag |
 | `signature` | Base64url RSA-PSS-SHA-256 signature of the canonical envelope |
 
-The GCM additional authenticated data is the byte sequence `carlos-lab-upload`, `0x00`,
-`2`, `0x00`, then the UTF-8 service identifier. The canonical signature input is the
-length-prefixed concatenation of the protocol marker, UTF-8 service, wrapped key, nonce,
-and ciphertext including the tag. Lengths are unsigned 32-bit big-endian byte counts.
-Binary values are decoded before canonicalization.
+The GCM additional authenticated data is the ASCII byte sequence `carlos-lab-upload`,
+one `0x00` byte, the ASCII byte `2` (`0x32`), one `0x00` byte, then the UTF-8 service
+identifier.
+
+The canonical signature input contains these six fields in order: the ASCII protocol
+marker `carlos-lab-upload`, the one-byte ASCII protocol version `2` (`0x32`), the UTF-8
+service identifier, the wrapped key, the nonce, and the ciphertext including its tag.
+Each field is prefixed with its unsigned 32-bit big-endian byte length. Base64url fields
+are decoded to binary before their lengths are calculated and before they are added to
+the canonical input.
 
 Each sender must generate a fresh AES key and nonce for every upload. Nonce reuse with a
 key is forbidden. RSA-OAEP uses SHA-256 for both the message digest and MGF1, with an

--- a/docs/security/lab-upload-authenticated-encryption-migration.md
+++ b/docs/security/lab-upload-authenticated-encryption-migration.md
@@ -24,10 +24,15 @@ An external sender posts a multipart request to `/lab/newLabUpload` with these f
 
 Two distinct RSA keypairs are already in play, and version 2 keeps the same roles:
 
-- The **receiver keypair** is the `oscar` row of `oscarKey`. The sender wraps the message
-  key to the receiver public key; the receiver unwraps with its private key.
+- The **receiver keypair** is the row of `oscarKeys` whose `name` is `oscar`, held in
+  columns `pubKey` and `privKey`. The sender wraps the message key to the receiver public
+  key; the receiver unwraps with its private key.
 - The **sender keypair** is per service. The sender signs with its private key; the
-  receiver verifies with `publicKeys.base64EncodedPublicKey` for the requested `service`.
+  receiver verifies with `publicKeys.pubKey` for the requested `service`. Note that the
+  Java field is named `base64EncodedPublicKey`; the column it maps to is `pubKey`.
+
+Both public keys are base64 X.509 `SubjectPublicKeyInfo`; the private keys are base64
+PKCS#8. The table is `oscarKeys`, plural — there is no `oscarKey` table.
 
 There is no protocol-version field, IV, nonce, or authenticated-encryption tag. The
 receiver selects a downstream parser from the `type` column of `publicKeys`. The source
@@ -41,15 +46,40 @@ deployment must inventory its own `publicKeys` rows and resolve the optional
 `matchingProfessionalSpecialistId` contact before a cutoff can be scheduled.
 
 Three legacy receiver behaviors are recorded here because version 2 changes them and a
-reviewer must not read the change as accidental:
+reviewer must not read the change as accidental. Each was reproduced against a running
+receiver; see the verification note below.
 
 - The legacy path decrypts and writes plaintext into `DOCUMENT_DIR` **before** the
-  signature is checked. Version 2 forbids this ordering.
-- A legacy signature failure leaves the already-written plaintext file on disk. Version 2
-  must not create a stored artifact for a message it rejects.
-- An unrecognized `service` yields an empty client-info list and an
-  `IndexOutOfBoundsException` out of `execute()` rather than a controlled rejection.
-  Version 2 requires the generic rejection outcome for unknown services as well.
+  signature is checked. A message that decrypts but fails signature verification still
+  lands on disk as readable plaintext. Because the receiver public key is public, the
+  sender signature is the only thing standing between an authorized `_lab` caller and an
+  arbitrary file in `DOCUMENT_DIR`, and it is checked too late. Version 2 forbids this
+  ordering.
+- A legacy signature failure leaves that already-written plaintext file on disk. Nothing
+  removes it. Version 2 must not create a stored artifact for a message it rejects.
+- An unrecognized `service` produces an empty client-info list, and the subsequent
+  element access throws out of `execute()`. The `lab` Struts package maps
+  `java.lang.Exception` to `errorpage.jsp` (`struts-lab.xml`), and that result is a JSP
+  forward, so the sender receives **HTTP 200 with an HTML error page**. A sender using
+  `use_http_response_code` reads that as a successful delivery. A misconfigured or
+  retired service therefore fails silently in the direction that loses labs. Version 2
+  requires the generic rejection outcome, with a rejection status, for unknown services.
+
+### Verification note
+
+The current-protocol table and the three behaviors above were confirmed against a running
+receiver using an independently written sender built only from this document. Observed
+outcomes, with `use_http_response_code` set: valid signature `200`; invalid signature
+`406` with the decrypted file left in `DOCUMENT_DIR`; unknown service `200` with an error
+page; and re-delivery of identical lab content under a freshly generated message key
+`409`, confirming that `FileUploadCheck` deduplicates decrypted content rather than the
+envelope. Reproduce with synthetic keys and synthetic lab content only.
+
+In the default configuration, `/lab/newLabUpload` is a CSRFGuard-protected route: it is
+absent from the `org.owasp.csrfguard.unprotected.*` list, so a non-browser sender must
+present a valid session and `CSRF-TOKEN` in addition to the cryptographic material above.
+Each deployment must confirm how its senders satisfy this today, because it constrains how
+a version 2 sender is built and is not visible from the cryptographic contract alone.
 
 ## Required owner inventory
 
@@ -60,7 +90,7 @@ following register. Do not copy private keys or patient data into the register.
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | _Complete from each deployment_ | | | | | | | | | |
 
-Record the RSA modulus size of each `publicKeys` row and of the deployment's `oscarKey`
+Record the RSA modulus size of each `publicKeys` row and of the deployment's `oscarKeys`
 receiver key. Anything below 2048 bits must be rotated before that service can be marked
 v2 capable.
 
@@ -99,15 +129,15 @@ renamed, and this must be settled while the contract is still a proposal.
 
 #### Key material and minimum strength
 
-The AES key is wrapped to the receiver public key (`oscarKey` row `oscar`) and unwrapped
+The AES key is wrapped to the receiver public key (`oscarKeys` row `oscar`) and unwrapped
 with the receiver private key. The signature is produced with the sender private key and
-verified with `publicKeys.base64EncodedPublicKey` for the requested `service`. Neither
+verified with `publicKeys.pubKey` for the requested `service`. Neither
 key is interchangeable with the other; a message wrapped to the sender's own key is not
 decryptable and must be rejected.
 
 Both keypairs must be RSA with a modulus of at least 2048 bits. A service whose
 `publicKeys` row holds a smaller key is not v2-capable and must rotate before cutover;
-see the rotation step in the rollout. Deployments whose `oscarKey` row predates the
+see the rotation step in the rollout. Deployments whose `oscarKeys` row predates the
 2048-bit generator must rotate the receiver keypair at rollout step 4, before any sender
 is upgraded, and that rotation is itself a coordinated change because every sender wraps
 to that key.
@@ -171,10 +201,12 @@ container upload limit.
   cryptographic failure; it must not surface as an unhandled exception.
 - External responses use one generic rejection outcome and do not disclose whether key
   unwrap, signature verification, GCM authentication, or parsing failed. The existing
-  `use_http_response_code` behavior is narrowed for version 2: every rejection returns a
-  single status, and only the successful outcomes keep their present distinct codes so
-  that duplicate delivery stays observable to senders. Reconcile the exact codes with the
-  sender owners as part of contract approval and record them here.
+  `use_http_response_code` behavior is narrowed for version 2. Measured legacy codes are
+  `200` accepted, `409` already delivered, `406` signature rejected, and `200` for an
+  unknown service via the error-page forward. Version 2 keeps `200` and `409`, because
+  senders need to distinguish delivery from duplicate, and collapses every rejection —
+  including the unknown-service case that currently returns `200` — onto one status.
+  Confirm that status with the sender owners during approval and record it here.
 - Logs and metrics contain the service identifier, protocol version, and a coarse outcome
   only. They must not contain keys, nonces, signatures, ciphertext, plaintext, or
   cryptographic exception details.

--- a/src/main/java/io/github/carlos_emr/carlos/lab/ca/all/pageUtil/LabUpload2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/lab/ca/all/pageUtil/LabUpload2Action.java
@@ -71,6 +71,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.*;
 import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.security.KeyFactory;
 import java.security.PrivateKey;
 import java.security.PublicKey;
@@ -85,6 +86,13 @@ public class LabUpload2Action extends ActionSupport implements UploadedFilesAwar
     private static final String REQUEST_ATTRIBUTE_AUDIT = "audit";
     private static final String REQUEST_ATTRIBUTE_OUTCOME = "outcome";
     private static final String OUTCOME_EXCEPTION = "exception";
+
+    /**
+     * Deliberately non-specific outcome for a message the receiver refuses before it can
+     * attribute it to a sender. It must not distinguish "no such service" from "key unusable"
+     * or "undecryptable", so a caller cannot probe which services are configured.
+     */
+    private static final String OUTCOME_REJECTED = "rejected";
 
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
 
@@ -103,9 +111,7 @@ public class LabUpload2Action extends ActionSupport implements UploadedFilesAwar
         }
         if (uploadValidationError != null) {
             addActionError(uploadValidationError);
-            request.setAttribute(REQUEST_ATTRIBUTE_OUTCOME, OUTCOME_EXCEPTION);
-            request.setAttribute(REQUEST_ATTRIBUTE_AUDIT, "");
-            return SUCCESS;
+            return respond(OUTCOME_EXCEPTION, "", HttpServletResponse.SC_BAD_REQUEST);
         }
 
         String signature = request.getParameter("signature");
@@ -115,7 +121,16 @@ public class LabUpload2Action extends ActionSupport implements UploadedFilesAwar
         String audit = "";
         Integer httpCode = 200;
 
+        // getClientInfo() returns an empty list when the service is unknown or its stored key
+        // cannot be parsed. Reading element 0 in that state threw out of execute(), and the lab
+        // package maps java.lang.Exception to errorpage.jsp — a JSP forward, which renders HTTP
+        // 200. Senders using use_http_response_code therefore read a misconfigured or retired
+        // service as a successful delivery and silently drop results. Reject it explicitly.
         ArrayList<Object> clientInfo = getClientInfo(service);
+        if (clientInfo.size() < 2) {
+            logger.warn("Rejected lab upload: no usable sender public key for the requested service");
+            return respond(OUTCOME_REJECTED, "", HttpServletResponse.SC_BAD_REQUEST);
+        }
         PublicKey clientKey = (PublicKey) clientInfo.get(0);
         String type = (String) clientInfo.get(1);
 
@@ -123,11 +138,7 @@ public class LabUpload2Action extends ActionSupport implements UploadedFilesAwar
             // Validate the uploaded file to prevent path traversal attacks
             if (importFile == null) {
                 logger.error("No file provided for upload");
-                outcome = OUTCOME_EXCEPTION;
-                httpCode = HttpServletResponse.SC_BAD_REQUEST;
-                request.setAttribute(REQUEST_ATTRIBUTE_OUTCOME, outcome);
-                request.setAttribute(REQUEST_ATTRIBUTE_AUDIT, audit);
-                return SUCCESS;
+                return respond(OUTCOME_EXCEPTION, audit, HttpServletResponse.SC_BAD_REQUEST);
             }
 
             // Validate file is from an allowed temp directory
@@ -135,25 +146,47 @@ public class LabUpload2Action extends ActionSupport implements UploadedFilesAwar
                 importFile = PathValidationUtils.validateUpload(importFile);
             } catch (SecurityException e) {
                 logger.error("Invalid upload source - potential path traversal: " + importFile.getPath());
-                outcome = OUTCOME_EXCEPTION;
-                httpCode = HttpServletResponse.SC_FORBIDDEN;
-                request.setAttribute(REQUEST_ATTRIBUTE_OUTCOME, outcome);
-                request.setAttribute(REQUEST_ATTRIBUTE_AUDIT, audit);
-                return SUCCESS;
+                return respond(OUTCOME_EXCEPTION, audit, HttpServletResponse.SC_FORBIDDEN);
             }
 
-            InputStream is = decryptMessage(Files.newInputStream(importFile.toPath()), key, clientKey);
+            InputStream decrypted = decryptMessage(Files.newInputStream(importFile.toPath()), key, clientKey);
+            if (decrypted == null) {
+                // decryptMessage() logs the cause and returns null; do not tell the caller which
+                // stage failed. Previously this NPE'd downstream and surfaced as a 500.
+                logger.warn("Rejected lab upload: message could not be decrypted");
+                return respond(OUTCOME_REJECTED, audit, HttpServletResponse.SC_BAD_REQUEST);
+            }
+
             String fileName = importFile.getName();
-            String filePath = null;
-            if (type.equals("PDFDOC")) {
-                filePath = Utilities.savePdfFile(is, fileName);
-            } else {
-                filePath = Utilities.saveFile(is, fileName);
-            }
-            File file = PathValidationUtils.validateExistingPath(new File(filePath), PathValidationUtils.resolveConfiguredDirectory(CarlosProperties.getInstance().getProperty("DOCUMENT_DIR"), "DOCUMENT_DIR"));
 
-            if (validateSignature(clientKey, signature, file)) {
+            // Stage the decrypted message OUTSIDE DOCUMENT_DIR until the sender signature
+            // verifies. The wrapping key is the receiver's public key, which every sender holds,
+            // so anyone able to reach this action can produce a message that decrypts cleanly.
+            // The signature is the only evidence the content is genuine, and persisting before
+            // checking it let an unverified message become a stored clinical document that
+            // nothing later removed. The staged copy is owner-only: it holds cleartext PHI.
+            File staged = PathValidationUtils.createSecureTempFile("LabUploadVerify", ".tmp");
+            try {
+                try (InputStream in = decrypted) {
+                    Files.copy(in, staged.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                }
+
+                if (!validateSignature(clientKey, signature, staged)) {
+                    logger.info("failed to validate");
+                    return respond("validation failed", audit, HttpServletResponse.SC_NOT_ACCEPTABLE);
+                }
                 logger.debug("Validated Successfully");
+
+                // Verified: only now may the plaintext become a document. fileName is still
+                // derived from the upload, so stored names are unchanged from before this fix.
+                String filePath;
+                try (InputStream verified = Files.newInputStream(staged.toPath())) {
+                    filePath = type.equals("PDFDOC")
+                            ? Utilities.savePdfFile(verified, fileName)
+                            : Utilities.saveFile(verified, fileName);
+                }
+                File file = PathValidationUtils.validateExistingPath(new File(filePath), PathValidationUtils.resolveConfiguredDirectory(CarlosProperties.getInstance().getProperty("DOCUMENT_DIR"), "DOCUMENT_DIR"));
+
                 MessageHandler msgHandler = HandlerClassFactory.getHandler(type);
 
                 if (type.equals("HHSEMR") && CarlosProperties.getInstance().getProperty("lab.hhsemr.filter_ordering_provider", "false").equals("true")) {
@@ -164,16 +197,12 @@ public class LabUpload2Action extends ActionSupport implements UploadedFilesAwar
                     OtherId providerOtherId = OtherIdManager.searchTable(OtherIdManager.PROVIDER, "STAR", filterHandler.getClientRef());
                     if (providerOtherId == null) {
                         logger.info("Filtering out this message, as we don't have client ref " + filterHandler.getClientRef() + " in our database (" + file + ")");
-                        outcome = "uploaded";
-                        request.setAttribute("outcome", outcome);
-                        return SUCCESS;
+                        return respond("uploaded", audit, HttpServletResponse.SC_OK);
                     }
                 }
 
-
-                is = new FileInputStream(file);
-                try {
-                    int check = FileUploadCheck.addFile(file.getName(), is, "0");
+                try (InputStream stored = new FileInputStream(file)) {
+                    int check = FileUploadCheck.addFile(file.getName(), stored, "0");
                     if (check != FileUploadCheck.UNSUCCESSFUL_SAVE) {
                         if ((audit = msgHandler.parse(loggedInInfo, service, filePath, check, request.getRemoteAddr())) != null) {
                             outcome = "uploaded";
@@ -186,21 +215,35 @@ public class LabUpload2Action extends ActionSupport implements UploadedFilesAwar
                         outcome = "uploaded previously";
                         httpCode = HttpServletResponse.SC_CONFLICT;
                     }
-                } finally {
-                    is.close();
                 }
-            } else {
-                logger.info("failed to validate");
-                outcome = "validation failed";
-                httpCode = HttpServletResponse.SC_NOT_ACCEPTABLE;
+            } finally {
+                Files.deleteIfExists(staged.toPath());
             }
         } catch (Exception e) {
             MiscUtils.getLogger().error("Error", e);
             outcome = OUTCOME_EXCEPTION;
             httpCode = HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
         }
+        return respond(outcome, audit, httpCode);
+    }
+
+    /**
+     * Single exit point for {@link #execute()}.
+     *
+     * <p>Every terminating path routes through here so that a sender passing
+     * {@code use_http_response_code} observes the status the receiver actually recorded.
+     * Several early returns previously assigned a status code and then returned SUCCESS,
+     * which rendered a 200 page and hid the failure from the sender.
+     *
+     * @param outcome  short outcome token, also sent as the error message when the caller
+     *                 requested HTTP status codes
+     * @param audit    handler audit string; null is normalized to empty for the view
+     * @param httpCode status to send when {@code use_http_response_code} is present
+     * @return {@link #NONE} once the response has been written, otherwise {@link #SUCCESS}
+     */
+    private String respond(String outcome, String audit, int httpCode) {
         request.setAttribute(REQUEST_ATTRIBUTE_OUTCOME, outcome);
-        request.setAttribute(REQUEST_ATTRIBUTE_AUDIT, audit);
+        request.setAttribute(REQUEST_ATTRIBUTE_AUDIT, audit == null ? "" : audit);
 
         if (request.getParameter("use_http_response_code") != null) {
             try {
@@ -208,8 +251,9 @@ public class LabUpload2Action extends ActionSupport implements UploadedFilesAwar
             } catch (IOException e) {
                 logger.error("Error", e);
             }
-            return (null);
-        } else return SUCCESS;
+            return NONE;
+        }
+        return SUCCESS;
     }
 
     public LabUpload2Action() {

--- a/src/main/java/io/github/carlos_emr/carlos/lab/ca/all/pageUtil/LabUpload2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/lab/ca/all/pageUtil/LabUpload2Action.java
@@ -237,7 +237,11 @@ public class LabUpload2Action extends ActionSupport implements UploadedFilesAwar
             cipher.init(Cipher.DECRYPT_MODE, key);
             byte[] newSecretKey = cipher.doFinal(Base64.decodeBase64(skey));
 
-            // Decrypt the message using the secret key
+            // Decrypt the message using the secret key.
+            // The bare "AES" transformation resolves to AES/ECB/PKCS5Padding under SunJCE,
+            // so this path has no ciphertext integrity. It is deliberately left unsuppressed:
+            // code scanning alerts 6904 and 5637 must stay open until the legacy format is
+            // removed, because the senders — not this receiver — dictate the wire format.
             // Migration contract and sender coordination gates:
             // docs/security/lab-upload-authenticated-encryption-migration.md
             SecretKeySpec skeySpec = new SecretKeySpec(newSecretKey, "AES");

--- a/src/main/java/io/github/carlos_emr/carlos/lab/ca/all/pageUtil/LabUpload2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/lab/ca/all/pageUtil/LabUpload2Action.java
@@ -238,6 +238,8 @@ public class LabUpload2Action extends ActionSupport implements UploadedFilesAwar
             byte[] newSecretKey = cipher.doFinal(Base64.decodeBase64(skey));
 
             // Decrypt the message using the secret key
+            // Migration contract and sender coordination gates:
+            // docs/security/lab-upload-authenticated-encryption-migration.md
             SecretKeySpec skeySpec = new SecretKeySpec(newSecretKey, "AES");
             Cipher msgCipher = Cipher.getInstance("AES");
             msgCipher.init(Cipher.DECRYPT_MODE, skeySpec);


### PR DESCRIPTION
## Description

Hardens the legacy lab-upload receiver and defines the coordinated migration to an authenticated version 2 envelope. This PR **changes runtime behavior** on the receiver's failure paths; the legacy wire format, request fields, response body, and algorithms are unchanged.

**Receiver fixes (`LabUpload2Action`)**

- Decrypted plaintext is staged in an owner-only temp file, the sender signature is verified, and only then is the message stored in `DOCUMENT_DIR`. Previously an unverified message was written first and never removed.
- The staged file stays owner-only: bytes are written into the existing `0600` file rather than via `Files.copy(..., REPLACE_EXISTING)`, which recreated it with umask permissions.
- The stored copy is compared byte-for-byte with the verified staged copy before parsing, because the `Utilities` save helpers log an `IOException` and still return the path. A truncated copy is deleted and answered with `500`; it is never parsed.
- Unknown service, unusable stored sender key, failed key unwrap, and failed AES block all share one generic `rejected` outcome.
- Receiver-side faults (sender-key lookup failure, receiver private key unavailable) stay `500` so senders keep retrying through a receiver outage.
- Every exit routes through one `respond()` path, so `use_http_response_code` senders see the status the receiver recorded. The upload stream is closed on every path, and a null audit still renders as `<audit>failure</audit>`.

**Sender-visible status changes** (with `use_http_response_code`)

| Case | Before | After |
|------|--------|-------|
| Accepted / duplicate / bad signature | `200` / `409` / `406` | unchanged |
| Unknown service or unusable stored key | `200` HTML error page | `400 rejected` |
| Failed key unwrap | `500` | `400 rejected` |
| Failed AES block/padding | `406` | `400 rejected` |
| Stored copy differs from verified bytes | `200`, ingested | `500`, not parsed |

The legacy path still separates "undecryptable" (`400`) from "unverified" (`406`). Collapsing them is part of the version 2 contract and is not done here.

**Migration contract (docs)**

- documents the current unversioned lab-upload wire format and why the receiver cannot change it independently
- inventories every configured handler family and defines how deployments must identify active sender/vendor owners
- proposes a version 2 AES-256-GCM, RSA-OAEP-SHA-256, and RSA-PSS-SHA-256 contract for external approval
- defines strict version parsing, no-downgrade behavior, generic rejection handling, fixtures, telemetry, rollout, rollback, and legacy-cutoff gates
- links the legacy decryptor to the migration contract

This does not replace the legacy cipher, close alerts 6904/5637, or complete #3413. Sender implementations and contacts are external to this repository, so the version 2 receiver code is gated on deployment owners and vendors.

## Related Issues

Relates to #3413

## How Was This Tested?

- New `LabUpload2ActionUnitTest` (8 tests, real RSA/AES fixtures with synthetic keys and content): valid upload, bad signature stores nothing, the three sender-side rejections share `400 rejected`, both receiver faults return `500`, truncated stored copy is removed and not parsed, null audit passthrough, staged file permissions are owner-only.
- Mutation check: with the staging, AES-mapping, and mismatch fixes reverted, exactly the three corresponding tests fail (staged file observed as `rw-r--r--`).
- `UploadActionBindingSecurityUnitTest`, `UploadActionCallbackValidationUnitTest`, `MutatorActionGetRejectionContractUnitTest` pass; Checkstyle passes.
- Pre-fix legacy outcomes in the doc's verification note were measured against a running receiver.
- Not run: full test suite, Playwright checks.

## Manual Review

- MUST: none remaining
- SHOULD: confirm with sender owners that no active sender depends on the old `200`/`500`/`406` codes for the failure cases in the table above
- COULD: implement receiver telemetry and the approved version 2 decoder in follow-up PRs after the documented owner and fixture gates are complete

## Checklist

- [ ] My commit is signed off for the DCO (latest commit `997b676da0` is unsigned; to be re-signed)
- [x] My commit follows Conventional Commits
- [x] I have not included patient data (PHI)
- [x] I have documented the external coordination blocker
- [x] I have not changed the live legacy wire format (failure-path status codes changed as listed above)

## Summary by Sourcery

Harden the legacy lab-upload receiver and document the coordinated migration path to an approved authenticated-encryption protocol.

New Features:
- Define a coordinated version 2 authenticated-encryption contract for lab uploads and the deployment gates required before legacy protocol removal.

Bug Fixes:
- Prevent unverified lab-upload plaintext from being persisted or parsed.
- Return explicit, generic rejection responses for unknown services and sender-side decryption failures while preserving retryable server errors.

Enhancements:
- Centralize lab-upload response handling so configured HTTP status codes are preserved.
- Document active sender ownership, key requirements, parsing, replay protection, fixtures, telemetry, rollout, rollback, and legacy-cutoff requirements.

Documentation:
- Add the lab-upload authenticated-encryption migration coordination document, including the legacy protocol inventory and proposed AES-256-GCM/RSA-OAEP/RSA-PSS contract.

Tests:
- Add unit coverage for verification ordering, generic rejection mapping, receiver fault handling, storage integrity, and secure staging cleanup.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
For #3413, hardens the legacy lab-upload receiver and defines the coordinated v2 authenticated-encryption migration. Previously, decrypted plaintext could be stored before signature validation and some failures appeared successful; now plaintext is staged owner-only until verification, the stored copy is checked against the verified bytes before parsing, and failures return explicit statuses. The legacy wire format remains compatible.

**Receiver fixes**

- Unknown services, unusable keys, and decryption failures return a generic 400 instead of exposing configuration or producing misleading 200/500 responses.
- Invalid signatures return 406 without leaving staged plaintext; accepted uploads remain 200 and duplicates remain 409.
- A shared response path preserves the requested HTTP status for `use_http_response_code`.

**Migration**

- Documents the byte-exact v2 AES-256-GCM, RSA-OAEP-SHA-256, and RSA-PSS-SHA-256 contract, including strict parsing, freshness, replay protection, fixtures, and telemetry.
- Requires sender-owner approval, key rotation, receiver-first rollout, rollback planning, and a legacy cutoff; the existing AES/ECB path and code-scanning alerts 6904 and 5637 remain until migration completes.

<sup>Written for commit 997b676da0de51e51817bc16ebd6f05c10ee3ae4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

