### PR TITLE
fix: remove unnecessary encodeRedirectURL wrapper in MsgClearMessage2Action

### DIFF
--- a/src/test/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgClearMessage2ActionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/messenger/pageUtil/MsgClearMessage2ActionTest.java
@@ -13,6 +13,7 @@
 package io.github.carlos_emr.carlos.messenger.pageUtil;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.never;
@@ -32,7 +33,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockitoAnnotations;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
@@ -58,12 +58,21 @@ class MsgClearMessage2ActionTest extends CarlosWebTestBase {
 
     @BeforeEach
     void setUp() {
-        MockitoAnnotations.openMocks(this);
         replaceSpringUtilsBean(SecurityInfoManager.class, mockSecurityInfoManager);
 
         mockResponse = spy(new MockHttpServletResponse());
         setUpActionContext();
         action = new MsgClearMessage2Action();
+    }
+
+    @Test
+    @DisplayName("should reject clearing attachments without message write privilege")
+    void shouldRejectClear_whenMessageWritePrivilegeDenied() {
+        denyPrivilege("_msg", "w");
+
+        assertThatThrownBy(() -> executeAction(action))
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("_msg");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Fixes 2 open code scanning alerts assigned to me, both on the same line: [#26209](https://github.com/carlos-emr/carlos/security/code-scanning/26209) (SpotBugs + Find Security Bugs `URL_REWRITING`) and [#26211](https://github.com/carlos-emr/carlos/security/code-scanning/26211) (SonarCloud `javasecurity:S5146` open redirect).
- Both were introduced by PR #2909's null-check fix, which wrapped the redirect target in `response.encodeRedirectURL(...)`. That wrapper is the only use of `encodeRedirectURL` anywhere in the codebase — session tracking here is cookie-based, so it added no functional benefit, and it's what caused both scanners to lose track of the fact that the redirect target is a hardcoded literal path (`request.getContextPath() + "/messenger/DisplayMessages"`), not user-controlled data.
- Redirects directly now, matching the existing sibling pattern in `MsgReDisplayMessages2Action` (same package), which has no open alerts.

## Test plan
- [x] Added `MsgClearMessage2ActionTest` (security-check enforcement, null-session-bean redirect target/return value, success path clearing attachments) — `mvn test -Dtest=MsgClearMessage2ActionTest` passes (3/3).
- [ ] Confirm CodeQL/SonarCloud/SpotBugs re-scan closes alerts #26209 and #26211 once CI runs on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Simplify messenger clear-message redirect handling and add targeted tests for security and session behavior.

Bug Fixes:
- Remove unnecessary URL rewriting wrapper from the null-session redirect in MsgClearMessage2Action to avoid false-positive open-redirect and URL rewriting security alerts.

Tests:
- Add MsgClearMessage2ActionTest to cover security privilege enforcement, null-session-bean redirect behavior without URL rewriting, and successful attachment clearing when the session bean is present.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the `response.encodeRedirectURL(...)` wrapper in `MsgClearMessage2Action` and redirects to a fixed same‑origin path. This stops `;jsessionid` URL rewriting and resolves the false open‑redirect/URL‑rewriting alerts (#26209, #26211).

**Changes**
- Redirects to `request.getContextPath() + "/messenger/DisplayMessages"`, matching `MsgReDisplayMessages2Action` and assuming cookie‑based sessions.
- Adds `@SuppressFBWarnings("UNVALIDATED_REDIRECT")` with a justification to avoid future false positives.
- Extends `MsgClearMessage2ActionTest` to enforce denial when `"_msg"` write privilege is missing (throws `SecurityException`), assert the exact redirect without `encodeRedirectURL` or `;jsessionid`, and verify attachment clearing.

<sup>Written for commit 063cb75ca35e604321e54273579211e9b1c162fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

