### PR TITLE
fix(deps): upgrade Apache CXF to 4.1.8 for pre-auth attachment DoS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -605,7 +605,7 @@ public Example2Action(SomeManager someManager) {
   - Upgraded from 6.8.0 (March 2026) - Jakarta EE namespace migration
   - `*2Action` classes migrated from `com.opensymphony.xwork2.*` to `org.apache.struts2.*`
   - Requires Caffeine 3.2.3 cache dependency for internal caching
-- **Apache CXF 4.1.7**: Web services framework for healthcare integrations (Jakarta EE 10, upgrade to 4.2.x pending Jackson 3 migration)
+- **Apache CXF 4.1.8**: Web services framework for healthcare integrations (Jakarta EE 10, upgrade to 4.2.x pending Jackson 3 migration)
 - **JSP/JSTL**: View layer with extensive medical form templates
 - **Bootstrap 5.3.0**: Modern UI framework loaded from CDN for responsive design
 - **JavaScript/CSS/jQuery**: Frontend with healthcare-specific UI components

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -605,7 +605,7 @@ public Example2Action(SomeManager someManager) {
   - Upgraded from 6.8.0 (March 2026) - Jakarta EE namespace migration
   - `*2Action` classes migrated from `com.opensymphony.xwork2.*` to `org.apache.struts2.*`
   - Requires Caffeine 3.2.3 cache dependency for internal caching
-- **Apache CXF 4.1.5**: Web services framework for healthcare integrations (Jakarta EE 10, upgrade to 4.2.x pending Jackson 3 migration)
+- **Apache CXF 4.1.7**: Web services framework for healthcare integrations (Jakarta EE 10, upgrade to 4.2.x pending Jackson 3 migration)
 - **JSP/JSTL**: View layer with extensive medical form templates
 - **Bootstrap 5.3.0**: Modern UI framework loaded from CDN for responsive design
 - **JavaScript/CSS/jQuery**: Frontend with healthcare-specific UI components

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -457,7 +457,7 @@ private SomeManager someManager = SpringUtils.getBean(SomeManager.class);
   - Upgraded from 6.8.0 (March 2026) - Jakarta EE namespace migration
   - All 458 *2Action files migrated from `com.opensymphony.xwork2.*` to `org.apache.struts2.*`
   - Requires Caffeine 3.2.3 cache dependency for internal caching
-- **Apache CXF 4.1.7**: Web services framework for healthcare integrations (Jakarta EE 10, upgrade to 4.2.x pending Jackson 3 migration)
+- **Apache CXF 4.1.8**: Web services framework for healthcare integrations (Jakarta EE 10, upgrade to 4.2.x pending Jackson 3 migration)
 - **JSP/JSTL**: View layer with extensive medical form templates
 - **Bootstrap 5.3.0**: Modern UI framework loaded from CDN for responsive design
 - **JavaScript/CSS/jQuery**: Frontend with healthcare-specific UI components

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -457,7 +457,7 @@ private SomeManager someManager = SpringUtils.getBean(SomeManager.class);
   - Upgraded from 6.8.0 (March 2026) - Jakarta EE namespace migration
   - All 458 *2Action files migrated from `com.opensymphony.xwork2.*` to `org.apache.struts2.*`
   - Requires Caffeine 3.2.3 cache dependency for internal caching
-- **Apache CXF 4.1.5**: Web services framework for healthcare integrations (Jakarta EE 10, upgrade to 4.2.x pending Jackson 3 migration)
+- **Apache CXF 4.1.7**: Web services framework for healthcare integrations (Jakarta EE 10, upgrade to 4.2.x pending Jackson 3 migration)
 - **JSP/JSTL**: View layer with extensive medical form templates
 - **Bootstrap 5.3.0**: Modern UI framework loaded from CDN for responsive design
 - **JavaScript/CSS/jQuery**: Frontend with healthcare-specific UI components

--- a/dependencies-lock.json
+++ b/dependencies-lock.json
@@ -458,19 +458,19 @@
   }, {
     "groupId" : "com.sun.xml.bind.external",
     "artifactId" : "relaxng-datatype",
-    "version" : "4.0.8",
+    "version" : "4.0.9",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:pk0mMU8nykp8cPv7uiglaX99far1Wnvm9SCaIlVz5yYn9EB/bVEs3PLpD9+M8K36nnDCth9k9Vxfh6KrYV0ekA=="
+    "integrity" : "sha512:a6UwPDyRC/Au0VjpHi6GE6gqq7Teh+nTdnK5VXD/NfpRCKS9W4sgNHdW6FBAZMwh8LEQwV0U+ALWc234dvG31w=="
   }, {
     "groupId" : "com.sun.xml.bind.external",
     "artifactId" : "rngom",
-    "version" : "4.0.8",
+    "version" : "4.0.9",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:mcn6hX8aWycJKzAqJD85+7bBP5KyD6AvT0oGxLhVipUh6WAH38d6YW0gjucdxJaXm9QksKg/i75PIjC1fVyYTw=="
+    "integrity" : "sha512:YFy+VjPT7ivYczS/Wv9BP6/oYJFAFuqMFcqEZixX4YjK4s45iKC1/qi2RyRkKGg7UjL7AfrmVa2Gb8MVFwzlUw=="
   }, {
     "groupId" : "com.sun.xml.bind",
     "artifactId" : "jaxb-core",
@@ -1285,43 +1285,43 @@
   }, {
     "groupId" : "org.apache.artemis",
     "artifactId" : "artemis-commons",
-    "version" : "2.53.0",
+    "version" : "2.54.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:I1BcBPSynU1W4qRZAMHufk3PTFvDJbNr3uKy7B/3iubp53tKdKJeuInx/ubCYDC9uSbsNIedeA7jhNSly7TOIg=="
+    "integrity" : "sha512:PBVd78MIfRlYoG4T8xRrFvJI8fwltxvLcUcDPzpfk2X3Yf0lZsQoKhJYNx7cQVs07Mu6UdvZcJQwhBkset+cMg=="
   }, {
     "groupId" : "org.apache.artemis",
     "artifactId" : "artemis-core-client",
-    "version" : "2.53.0",
+    "version" : "2.54.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:K3K795pdBVdThyEkUjwqf3QarwnCkur07uVMDoyUGtb5ll17Nc2yy2SuURzYtiWZqpu1K7jh1rAB5jsuJBTDpQ=="
+    "integrity" : "sha512:zEuUewnhwV23rbWogX4eFeN9lAZvkstBQ1VENmwSBY1ajl61Ric/I1s97Mo53AmwFDbhLE/uGPFmIVNilE09PQ=="
   }, {
     "groupId" : "org.apache.artemis",
     "artifactId" : "artemis-jakarta-client",
-    "version" : "2.53.0",
+    "version" : "2.54.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:3R+MjxZwLaIMa6V6wbf/qKvxdORLDW7Dho9Zy85p4/ygvZITnIMmH3QkSqBYgwmbJFG28qOaJcdbCV3SRyeYNw=="
+    "integrity" : "sha512:wWEV21jz1k7RAR1cKc58KBDKh2W4tt/t6jWQbH7BqWorXWEO3Ib7x4KwgoPIaE/lCBsg3gVBvq9d1VK+uBhmMw=="
   }, {
     "groupId" : "org.apache.artemis",
     "artifactId" : "artemis-jakarta-server",
-    "version" : "2.53.0",
+    "version" : "2.54.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:t8d+nTXlh/1akMUBAMLkATbOiruj4uWW0U8j2lUp33Ag93zrt4N999de7RcQQav7IzDWXF6y354iJJREaTDpJw=="
+    "integrity" : "sha512:A+7/NVxToRyTuZx1pUErb5MpwKQdoFcpmr1Pv6DGz/Pyy4tcpvQwVQv7QqE2cpfJkijsKwKrMIG9tKfTB1xwSg=="
   }, {
     "groupId" : "org.apache.artemis",
     "artifactId" : "artemis-jakarta-service-extensions",
-    "version" : "2.53.0",
+    "version" : "2.54.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:jIHfebOhHxOEDhSBiXH+6t1NXdh3D6behfyVE0kf55kJ/PsAUpZ7st4m0BDsDfvjII+hGh+nbdhw3LQcWoth6g=="
+    "integrity" : "sha512:MyRV1VkLTYslKl864O+BxAxLpJkxEIC8A1/MDSMMJ89vgvaNMJOONEmb1Eu5uVFNIYykkJAEBREljcLs3IwegA=="
   }, {
     "groupId" : "org.apache.artemis",
     "artifactId" : "artemis-jdbc-store",
@@ -1333,11 +1333,11 @@
   }, {
     "groupId" : "org.apache.artemis",
     "artifactId" : "artemis-journal",
-    "version" : "2.53.0",
+    "version" : "2.54.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:gRCFs2+1EgaZFQLEXWxx+WjEuKNzVpw3yycBrFIHVdrIrsmW3ELDWg3GHi7G1er0ndSWT04LQvKETirEtf7ZUA=="
+    "integrity" : "sha512:9VpgOykRW0f7Hl77nAL9cZfJ60VJaneZaKataT4PvjfWoN9oJ0dcmgdzLf8GG3HRMkCU1b23c8ODyBnaivWh0w=="
   }, {
     "groupId" : "org.apache.artemis",
     "artifactId" : "artemis-lockmanager-api",
@@ -1349,11 +1349,11 @@
   }, {
     "groupId" : "org.apache.artemis",
     "artifactId" : "artemis-selector",
-    "version" : "2.53.0",
+    "version" : "2.54.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:zlRygdXhUaW+x5ebdpbFcRTnfZasz2X43ulRfO1OjHSFGIH6DQ167vC3K4ICN1r2fQY3jvYopE23EOJ0UbJ/yw=="
+    "integrity" : "sha512:MKJWWlh8cMF6b02+TVakiC1JYwiJMoz3Pvk7KgKB4ViyHYyeVZOi/6GcziktpXmm3UwEcxeZq5+pJaPRYaLcFA=="
   }, {
     "groupId" : "org.apache.artemis",
     "artifactId" : "artemis-server",
@@ -1469,27 +1469,27 @@
   }, {
     "groupId" : "org.apache.cxf.services.sts",
     "artifactId" : "cxf-services-sts-core",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:rEMrNYiOszsaA9rq0o8U4d6b+W5kflEch8mtPnXaPrMwrMHDBxDAJ4vs7MtTeSKm1PioUYMLMlCbXNWRM7tMgg=="
+    "integrity" : "sha512:p+UEGwlJVnQrSe9wI73p55Gi/DPdG1TIwe1ZoU/nr+LujADKPUR9O2imBxxnlvcrUVKO1IOduDf+Pc5tSTXVVQ=="
   }, {
     "groupId" : "org.apache.cxf.services.wsn",
     "artifactId" : "cxf-services-wsn-api",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:4r0mV+66zWHrKWU1CDfJCCN0e+VUDExR8XdljJ/FQixP+y15NIR9+nuHsyDrvx2j/8dxI/XHNANltypVehCy8Q=="
+    "integrity" : "sha512:sT1DL/37+mzgfSH0sWqYEcp3hZ+aF1f5XW/9Rd/CCtPx/QrV2OvpaXBs2v9JX8H5cv5dsn14fGa/A7bxAwzXvw=="
   }, {
     "groupId" : "org.apache.cxf.services.wsn",
     "artifactId" : "cxf-services-wsn-core",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:DJOzkzA/1p7Y7HyfBrYZgMHp5jDfm4NBKLsPkGINcYPYEtoH+bywfY7uTueJt3yG2QWoW7U9zJRh6CqAf4ddrA=="
+    "integrity" : "sha512:WktvzP2SsMnnKYdSfe969srSHfz0PDdiBWNl5F3qElNgLeUg3Mp5pGsUvjtJkycJ6w3tBLkot9msGbMWLE1kLA=="
   }, {
     "groupId" : "org.apache.cxf.xjc-utils",
     "artifactId" : "cxf-xjc-runtime",
@@ -1541,467 +1541,467 @@
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "apache-cxf",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "pom",
     "optional" : false,
-    "integrity" : "sha512:i9f5sWP0adcz6pekIsTEjyxJ3lsPZg8boA74ovg1NkA9K1zrq4HjDXXgeqYJliGQhBjQTn/1v/CQZRe2j10evw=="
+    "integrity" : "sha512:hjwr+MpKTqJPu532GFFjtqw94cM/49lL+Mk62CXzZgtt1/hlQGlBc0RXGaw+EeNETVot08UxfqZd9omW321BWg=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-core",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:QkZYu35u7XWvj7QY8RIoOy7Po/dF9GJYiNqvlM4FVOeFfgjQkh3F1AUrc+PwYDMHo0DMWQwNXFlOjx8mVzJCQw=="
+    "integrity" : "sha512:Z762+R4wmJx+3b062Us9F8zELabhWxYHcRbr2Gx+Uzy+lmS1exwSnOuGGTO8CT2ZMcTNXpW713LTc3HCwCdHRQ=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-bindings-coloc",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:/X0K3lrv4zQ029c5M3EJhMG03DS3IAT7fNPnNiLaCIsUMvQMIH2CHPB7Wq0dC3wxS1pk5TN3tBOnXNMMu3sw7Q=="
+    "integrity" : "sha512:hw5+98GVojiStVvHC0NC1jfA0lWEMXJ8qoIdrnBqOcb2f4TmeJW2WUUTPBGs1OvQTu+eQ4d3vh8Lag3E2WPoyQ=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-bindings-corba",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:f5m+LSdVWixEmgiE0yNE2CFQWdg9Lkn/ELnjjheO5dry+2YjBM7+tiFYlfaGz7Q+9WN8CNFqvdG9qa31jsF8yw=="
+    "integrity" : "sha512:4VBWuuqfAip67y8dVVVG/J0bjOACFPWzxOVsz91g7rGtwhJIUCY4EkPCRsIIEZxT7uKGPzsLvTrNYFbUp0ljQg=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-bindings-soap",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:a0ooIaalNSm2SmsPFgvSr/Tba5DsVmpnqcDhSe6TEnVF+pd83RnBM7H77tOeEzDsUlb8DAU5GjjnnWdh99shbg=="
+    "integrity" : "sha512:7ke8GALIcUAYgJi1EvNBLDOw44TwiPPU2/nccCtUq/PvE88RqNCLSlD2uhjhleAULcqYn3f1cuMHLU4NzkvStg=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-bindings-xml",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:KoI+ROJZHjFWYZkIcSrNLtswi9aZam+AyRNT1tugf2XuKJ/BvHh7+J7tGkOC5zAl4g38Ss7Qr4l0CtwTmHNkYw=="
+    "integrity" : "sha512:G4vbxeO1p6bQgcFUWoHrzeQ7bHbJP5SFGZa63fZghRTWjcWd7IcgWu34V/VYJGQCuv3GojmuNnCFT1tovvaJ4w=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-databinding-aegis",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:qXf/Dc2PpXzrJ/ezB20DiM0050rJ36ts6Z4PNzZMEDH+D/Wgy0KBVa2FTKnFgRIRkh5D12wEhV4+lKFIBLgusw=="
+    "integrity" : "sha512:xBGjPFfNqX1aJzSn1e2YLo8zEtUMxMKYGDfzV5FPcqgOcVO4W9JYHy1xQHj4BCakT6FDFf/pXJbzmWsTDYXejA=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-databinding-jaxb",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:D4z3qt7NJ/PO3MRMyqWPJZ4lrzpWTGFco7ZFLOgruVBdiGmCjf72KJo+95jR6uPp+CKFcEFIJOGRLCCw5oCsog=="
+    "integrity" : "sha512:JajZB+xiuRpYJs3LAzIWU2QU5II6ROG4n28P2QDGRdkrSs37YrbLAITk8MBQR/RZHsI8JRyPBILclxkolHGdww=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-features-clustering",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:wzCpy+SL91vERg6ynGx8CjlGsOemPfuRK/3lP9EakWKbkDJVjwOgj0B4rVLcOK03m3brKmxyEZXdhuvDEzYqvA=="
+    "integrity" : "sha512:n1DWJbCHF7rs/Fw1DVRQeHfOdLoEWxH+AetOtXTz8MPflFRePsWmL5YDFPWVon/6cvcMlyPCLkGenfuYSPDMqg=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-features-logging",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:A03eiyCIEv29xq23AwN2eIBmq7ABBFz22wSXsa0zcUQj9bzDUhM7hkF7/wo2gIa5zki7BIGCNqtYvsp+dN/M6g=="
+    "integrity" : "sha512:5DkK50XLPKjiVH7SSVWmdET6FzyO/LrFJ7HSelGarcco2pzrlari1L9mo8w2BfTnunVLLUiakN5vnUT/F2dZeg=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-features-metrics",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:ssNLSmn75EgmEqb146dwydhZtOHAlBPwdvAa8Wtc7GjEdocjtmd/oJl+0gh+gBJhnwUoxeTw2f44rahpDfSfqw=="
+    "integrity" : "sha512:ZvBb2Vh1zdslFxsGRZZj7p3TnN7wAk0+rs/7pBoQHhYVez/FvSIhJfikd6f2iPmKgjuiIxxJ/Qi7kWqGzSkt4Q=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-features-throttling",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:p44E4ylvs9D43ki+GT6j+PY7mJwOuv1GnHS8ifQgLS1YIbE5t7nRL34TA4VQeNj1cBNe4cn1CWJO2f0gihCmmw=="
+    "integrity" : "sha512:wFxKqwepnlpc9utZQ+hAzqhjbs2WzluLjfn3tquU52iM0vEZaJm8xsltRJLB8hHjxeRmxSz1VhQKtZS3i2Hw9g=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-frontend-jaxrs",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:Lv/VDN/Mt6TWQaMkv9kPVV2/5yyOa0B4Ijt/7lnmTsO2jwpzAlEiqLpp5ftK8AmHKCqBccL3wHVN+Nk8KLywpg=="
+    "integrity" : "sha512:W60Uch39HvWMu5TxYoUlRulDg+x/mBT+HWxcYBClpDoCgn23iFMi5VEUdqZ+KQBTyIVBrpd5/GzQLCjNoRtDZQ=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-frontend-jaxws",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:3BmDLgvA7Dg4o7rADgv9A3L6LDdcktgJ3p4r4OlWTcW5FFuNBAmYBqMxGjaI97I6cnEuNdJEppnU3OqBUEbPZg=="
+    "integrity" : "sha512:yi4oEuquofAtx4xc6VULA9br6NWwDF6wXe/0uYjxd2BarTOafwnB8l6aKcdmonC1eWthcMzHgV2f+/JNrehFSA=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-frontend-simple",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:es0ReXqgLDcp2iKHcFZULQIeSsM5HGsAJRkhS+S4axBIbEKH0FmsuVo7hdZCwG6ZokzOXM+5vZZ5m2EnV++WJw=="
+    "integrity" : "sha512:PjvOIaGCqHp+TAyWA1FhZVf6pDvBZzUDkJ7zymJ3jC+6+/5KyM0mxH84Xic3Xv2wdR+dul3IFX5nXP1GQyd3Hw=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-javascript",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:aeXRIs/Yw5oLEe5raHvjo41DW0aDL/pkHqBNOXbvJsvcEw8VNLjNWBze36FOcnj0LxdNO5HL1sUiWL9GE7yqIA=="
+    "integrity" : "sha512:LhmH8UAXcNuAt+al7S51oXPPp/zy3KOH1sL1ZUiM4RF44tEG5aiemUJyDzvlKHatDeDqWxa7lYHYManaBtxjhQ=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-rs-client",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:/GDY/5D3ytUn6/QUHKtC7p0Pw9XltusHlwr5YMxo8fq7k+R9Wc3VLp4rHLO+uw4sJifXHqWT/b1vcwzpvXa9KA=="
+    "integrity" : "sha512:HB4cVxANRjDii+xDTJmcf7Yod7/j7AOryCsfojVWstad7MQr8IyFH6IAHv444hguBty15uU9WZfTPYulBoD+NA=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-rs-extension-search",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:Y36GD562JDlTx1lFM/w/YuvwFZ/dmNtX08B7oLMwVEBI3j8X1ItMdkKpzcSU7KWUgNpIvSD3hgTGFbvO/cnluA=="
+    "integrity" : "sha512:HHqsf4CTIZTPYpATr9i8wRUpKwNPWMXcXFOQmeVouPyQbqZu/a3qBZD2SG5k2NqiyOEkuDemQ3DCgsTnvrsY2w=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-rs-http-sci",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:le48K5uX2L0Rbi9KFwlw2aO/qug8K9rYR1kxtXrSSaKAXu609RdbnKJUnyqqhpw/8PmqdzMC10hv6FqSMWauGA=="
+    "integrity" : "sha512:Zhp/UanlEkPAA9jtN1FwpWG8tsvkOVdzDc+zmJFO0q1EM0nNA0rPjS3oo3ka1T00uYNSuhXUPPWP4aAHxmC72w=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-rs-mp-client",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:QWsRFigTZqWZV8fCObLuJCkubat6V/qdbKACAdojKvb958iO6guz/+CT+NyLLpErWNgNFMGn6QeAwo/RO1ac+A=="
+    "integrity" : "sha512:Ww3G5qq6nU47E1s83H0TcfRuyuKL6T/jmedp2YqKGQH7eyn8RA/GfEtuXgarSipAMo7xY9h7PbuNhhMFWKkl0A=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-rs-security-cors",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:nMp7L/AjJdZYdxJ6Jl0Om0x9qjZHKqWOaWqMpJPbEMd7RXQf9OETvE3fFkJ1/sZoloMlGV5m7R6O5S1OakBmQg=="
+    "integrity" : "sha512:IUlk+0HJIOQrm8rvW3RFmOGuEO9pjqNer2uQcaYqck2eRzekpP3Bph7xTbyVyXGS/rGJ6Xb9vqH5Nn4y341hxw=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-rs-security-http-signature",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:Rpvxp87NORD05wg87QPc2EZMqPyTOU1hraSRPdMm1/Nj7NGIboRz5D8xeu1EOhtoH6NduFl3CjKZflldXdB6hg=="
+    "integrity" : "sha512:2u1fleNPGbZGpJeLCnAP44VTY9y5axQSG7B8gb0rjzgDcRQAiJHBFjqk4/gmrRnx45q8bGGOExkQk7rDP4Kj9Q=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-rs-security-jose-jaxrs",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:MROTUd1oe/2jY9sDGwFXLBASXZIvBKR/+fgvCNFl4qWcLbEnmof7UwTaloJnH1g1BE51HkETFkpOWB+q1WdVmA=="
+    "integrity" : "sha512:MwWXMgOFW0OUl3WPcIZFrNiOGZBKEdwX8h9tRo25hxVsr1YsQDal94gOK3EfIomVV57qnaexxGg8NzS6aTczZA=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-rs-security-oauth2-saml",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:wa18keJHgh/pzLWbith3Wft05wtOXJzriNlHkc1/snF3TOGzLjF2nyc1x3YIiRfUltlTyjPiPqniyMcUG0aYdA=="
+    "integrity" : "sha512:kqeyBDqHqFpsHG+3oeWBBNO1KZ35GOGOJT3RaalxvNPqXWN3PFQKy6MKv+thSZVhRafAHpsQDdY5HHVAB0Y9xA=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-rs-security-oauth2",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:H/A1Wf4jVJgaN6XTkKR94VcKDDeDL7XHmm1Poe+6am6rZ5POsdZPa4rCV7tTYsWH2X7bOWlI0ZBaCLx0ttMQzQ=="
+    "integrity" : "sha512:JY9JntLq9z9BLk45Mz88bsV065Hn9LkKAfYgpZxPJymIzCv97oJZg6aBaKbh/HPDfT9QQhR4ThP1ysqZ6V864w=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-rs-security-sso-oidc",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:oWvdPPGi+VbYHlaYF4j9g3CT/ZgCvWA3C/ZC1Kv00TmRLuwTtjZoG8B3AtsyAypbLfZx01tlgUBUNbAI9MWvqw=="
+    "integrity" : "sha512:Fj9KCumcofTGWyjRqWY8WfQf4DPrnGwblzauSy5WgdPVgIzNMeIkiiAAX9babzsR+aqJs2J0Z5Pa6ahIsoirig=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-rs-security-sso-saml",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:2H0pSpyzfYVulI92gd69VWgqc+wRA4qce3BxlxbmSIhTYGAkdxMRi2lKXt2OLbFL0O0Z8tS54OMQxreyKKGY9Q=="
+    "integrity" : "sha512:FoAFQpEc3H1OrWmcIfVW4vA+Pjv4uOqKiyQbfGcp92q6TmtmLx/9tUgHkfSgfePbF+vO7rympagRdHNdlOo2TA=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-rs-security-xml",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:BIjjtxK8iDityesr+8xczhg70XbPiJn1Yvh+Bhg7+42Gxs2x0EvGvNs5hU0gHGvSrC897mQqbZTApRVxpIBAuA=="
+    "integrity" : "sha512:nznKLZtdbOJSxTd8PjayqaK0MDyv4zmYaAQvJere4b/hVh8tcHG+70jKSJAK6xkUvLzf5ML/xgUYkC1Tj3PC+w=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-rs-sse",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:7atJBM8ipR5iUUicJvpjtApogZQFM5QvNBt92NsLNFUA6phQhetLGsFIyMebUWM+pKvC69VR23pRuSH3KWSCow=="
+    "integrity" : "sha512:2umLREpNBONZTyA9SKBGeQKXSs0xzk5aG4M1jKJDgiXnNZgCHiNzWYKiloZh9gM5bJWHbhEvc5EivqlS3ydwog=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-security-saml",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:o09DfC6h6dkVQjlH9vMW+zuA9eIVm4/UFrY3hjFnST9VN+Tm4uf0lv7uY7YhTS5pmlhHTDsZqlK4/TbS27i1pw=="
+    "integrity" : "sha512:TuRGqYEW1RwcLKnX7D9vaeJ4a5VNCthtyeOcj3oGaQLgTpcoxHHBgE0Ma6xItpwA5hW5eMfxoNqqa6Zc7v17kA=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-security",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:0OtMwbY5ghOqujmTdy8I/UoSK3OvScKbz+KkA6aUpWONkRDwzET/grKfZOG1Dgm2nmTc1eXYTMQC1/Q9myFJ1A=="
+    "integrity" : "sha512:g30XT86tdH7iKouzrHItTr/LXjdxIiN4zuh7EaYoB02ntqffY0qRSOUEeX58zPkEBp7ml4YJc2970cuY3rOLXQ=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-transports-http-hc",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:lFe0AixuBtMBgtFGnRgMyApiW3piFqoRic86OKPMTaIRmMEEeSkOAF7cJ5IEFDGXrl6wdmYw5x6u9qlUZLWNfQ=="
+    "integrity" : "sha512:npUGOrFnTVgSlVhcrPObLMpSVBrGHb2dvBL62Wn0p6wv9FiFintDuHxjNrg+x96u2cVOZ9fpAx5X+PEl+n+Lzg=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-transports-http-netty-client",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:z9ga2OY0IAXXomu4jnp34QYmPgXXvlqpsxy3uI3G1ER+VkW+XkrMkz/3xJB+o3+n+oGfvBx+FEN9f1p+vXSeCw=="
+    "integrity" : "sha512:+p57/+g+xmRaYl/fr9iV82RwIXs9eDwvAUpzyTdYgRE90TWX0W6/VM6BrCahvPvfLTHY8UOaYdcK5kOWdvtBZQ=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-transports-http-netty-server",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:RAkvo/g9tial+LqoU/uhgtYEBYvpaZmdfO6nTzHAsm5Wy42rScHtOAo82kZ+a0lkVlff5aM9/911Hvz4UojI3A=="
+    "integrity" : "sha512:DMCAUp/yDg10mUrSXpMIVmLcCw3z02+adOnei1JDoohax1VNcf2wzjHkjgeWLJ6xumenlh2LqJSVpgC31mL/SQ=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-transports-http-undertow",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:ZMNvhOWY9ZgEPgyo1YeyQ4aoB6qt7pCqZdi7rouhn+Dk5edO1feaTTOmqzcQW3xhINf7CXgnsE0QcBUx/qdoKQ=="
+    "integrity" : "sha512:NhbSjPZAC34iRLdnT/Nb8umX4QYIuGS2doG6t5/QCVHFJGfL12KdreGsem/iRcim9NJ+ZFUSRT62N0Tjub+fMw=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-transports-http",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:vNaqaIIL0ZE7WaonEweVlWP2gAi1GvN/f+9qdu6BYPdi0PZXVb8eT8/z+SpkvBVn1Cul+qByhDAzOQi95Bd8Vw=="
+    "integrity" : "sha512:OonpX1wqU0H+0uXtFHGdpO6uWW1lX7eIRIL5ODRWJsfjU+Jo/HKrkqcCuxxF3n+xgd30PYQ2Dcr+okh1YmFcIg=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-transports-local",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:xbrXMAmu7o0KXAGrBLYmBn53+YbeowBJz9z29iQXqRz2+XkyMHkWjtRR4k4lXoCVI34YjUFtMq/5m4Wgq9Y2Dg=="
+    "integrity" : "sha512:8WceZmggfRSL62uxQJfVJvPiCTTx2rekiJGYDS5unusvT2E7Ik3i3Ygg50fdmJ68y111lcsrH4mE6gp5hf/Aow=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-transports-udp",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:sBOeFuCUQXtsWoex7TvKBMaw7fmVnVjCy+C46vRF3DGh+h1d2M6isNQ0+GzDUwHvNcGwY+NM1OQbH45AwbJIeQ=="
+    "integrity" : "sha512:8iSHLO6wlZOooWpY0H/Y9DrSlQetgaSpeouxT18ht+WZgGtvYa7PJXl+hybSmHtxbnB8HjnVpUX4uwK+Nw1Gsg=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-transports-websocket",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:L/fwpR6AZJfyGIObFjgG4eG6lm6/w026OvziUlCbxVYhHWyh8z41Hiq5CWMbd4c8+uXdmsqKZcIO1ShGOjsbnQ=="
+    "integrity" : "sha512:UixtiusoZFdc9+X3akiWkusnUCCkFRUnc555NVCDjTZphKaJWRHS8RB4sd+TFPk6jMCrWlkwb3+ZiiJEKcbs5g=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-ws-addr",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:mUHgfUcgmSPtsyCeJd9jdHJGSSXyUn3xGYGbZ+av6H2WVvW/vT205qo9F3mtcvxrsVEHCUvTQOENOl6vIR/ueg=="
+    "integrity" : "sha512:eibUlre2bC8xznI/OcyFWTbGI/TL8aKr6uPQUG3SAgOKTDk5clYw2FchoPblGM2inFw1tpDUandyyqmwQGfyNw=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-ws-eventing",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:V9vfNr4uCbdim1pBd+TMur/8SN7yYTbpMDWLKkstzGNI+uakOGqP2+lKCQCLEAPTFNEig4eMqH6Ac4yMZIPBag=="
+    "integrity" : "sha512:7k93CKFUHB33JNp51sKunM+mOml969VEKGhUbaXHMVL8UQBxvuRNBG392gWGGQrrP7HtjlgzrNdz4uI0VT4YaQ=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-ws-mex",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:NPk53MKNtvDhQm6mrSvJMDI65gy0AEgQ52bO+qgWyjbU6XYDkHR2zWF5Zj3l+7ayf6Fx3CPYxFpO1HUIdafCZg=="
+    "integrity" : "sha512:/D4LBjTk69eqBw1i3RbV78gCP3pq+yUUyUWigzvuR2b/4g9NqXxMFxfjQOFlaOZuf/Xc7/+QJttT5GuRk1UzEg=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-ws-policy",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:euGBaJA6uhSay3HoR0ekgUBAdluTve/FbTz+KY+EORyrt1KHlq9GrxA1tBuMAVhhJw1yPBE8XbJIBKwhebFGtw=="
+    "integrity" : "sha512:7oMqQ8pqmAnfOI0i41jdVqAswx4B0bdy/mS1MwWg3XlCnTq1bWZeID1W6Tm9nqdqnXJW0LuJBaTHUPkeJhK3TA=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-ws-rm",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:6FjZ5LPuwJ3WeGFi5uGCwOcPyQHRqJowsrQG4J1HU0X75h3tcIUuYvRcQVbkqvKLKxtTVgPw3KLh7ZhzRHSrDA=="
+    "integrity" : "sha512:R0cuZKF+xhk9wVtru2NYv1LxzfBMMlSSzwHAEb21dUqL8Av6ORNM8Qit6MjjgTqXdFlWw6rYsqnVvxIb1SCwtA=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-ws-security",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:F6m4CNr4tNisbjY3flO3POdnk6C6Wf4J7Fh2HFcF9JlhcqefP5YmSkYd6WVfLYsBi5OpZifbxf3Ud8OH1W7w/g=="
+    "integrity" : "sha512:XbE0hCTTqKBJTMSWV5W02XmW07Y+rKQwEIQBWNl/iEoDwq6xJj8A0wXpko7ym07gGrH7Z1eQWrfNFLxeUcUOHQ=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-ws-transfer",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:rGPWzKveW8AEsGX91Z9RHMi9N/iINuzI8n67JE2gM1vG1KvS8vcrSeolCnpLZwY0OQI8ojYP0vFtXzK3mL2Htw=="
+    "integrity" : "sha512:O5vNahsY1MVxbVBAZpxdRyy+w2JDuchOtCrGM32u9Hhsjnl0anVmjQ/FGPHRzwaz9BgsT0hQmS4GFa8n/blsqA=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-wsdl",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:oqwhlaVZfcitdi+HqR7pGcQ9/r1L+Wpz9xfL8OX2NXrXxJnaGqdiGZamemCKR1GLcpIaY3Kf7vmzRRqvF+ksYw=="
+    "integrity" : "sha512:fHj7bN1Gl8vwnataZOEud4sh69PYJ8+HEFnpcRRzAJXJn9W+hHu7fOiWVjOw7awHv4Q1aXhDK5gZn234XggNYQ=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-testutils",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:Net7wRFXhDdiMNc8UHCkbyrTgP8cFRiZSvNOXq7F8c7eZjCAYy6in39Fz0E+hmVm+e2/T7oIFuLDANqwP84nIQ=="
+    "integrity" : "sha512:ikPHl9VKRwAhUY9/SnAiB81hNxOh2nCPfqDTih4/VYR1LXNHORY6Cgjg1SzBx5iAD0y+5Sq5jbcDsbbE/hxLHA=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-tools-common",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:jLS2VSXKMoNgnxF82b0YBsyDDj0c+vY/TQ0BSXsSH5/iMKscvk+raYvWsTV/dPWoZbfs12YPTrnv/d85jBFc/g=="
+    "integrity" : "sha512:DrMgSwbaazXnS2/XgwmwWIxYKEq5P4+NQBe4F4dqie+rnJySbgQflY4fJ2L2+LvTJH23+p0MNc0bCdWdjiFc3w=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-tools-corba",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:nPYUODwhF0sUjVudu5WnR5+rcg5+sWvGt0zzSK2WIetdF8D4tLPpOnrPWxfCdP4/SypCZZY4/ZcfnvaOWDGn2Q=="
+    "integrity" : "sha512:boF2zfdHQ13KRCz2t+OwB3qdQ5nM/+zBILAj2rt7exas0rptBFvJNr9ZRpdE70TXo9AIzYImCbcEz+lJn5flZQ=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-tools-java2ws",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:+zJZUnuK3kthCGJjgI2Cv8c4hYNc8Hj258P7LGbV9GzLZMMmiTe7gu/CmeIcmn3WV9WtJsa8a8Vzfz9hCsyTag=="
+    "integrity" : "sha512:bWADDKc4bXXrrov/hKOJvxjOoFGFHkDRtIOEPr1iguGO2EGaBPWufXa56OzJbfgomtT9gTObyw9IFvnGF32ahg=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-tools-misctools",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:f++Glj1n2EFAm7kygPLF1htd4v8ZOaDSN1OOSVEb2UDkY6VWKD7OYdTZuGgoyhVpYOyqpSAN7WOiRKEhQJ9ffQ=="
+    "integrity" : "sha512:lS3Neq5wjB4grauEv/ogLvnRkC0JLShaDo55GWrub7+1+mUQsQCPCm1h+PE/6XBICUJlzE4HNWDiaz3ZznbxuQ=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-tools-validator",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:0papW/ernODg0giHcSGS9P3sklGm0BLL9LFCnXlj1fsliXfQioB07DOp5Ag2pq8jPIovl35XP1DJpiR6xlpxBw=="
+    "integrity" : "sha512:oaZr2XyIJHpffKg1jgpaBUcUeYprsQKypGdFtd6V0uux1TczGA/WnE2i5/BsQGiIo5m5SEmAawxacq8zhoHIhg=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-tools-wadlto-jaxrs",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:9lqE+tbx69aViRQ+I80kC3WF27+nhaT3++MlpZuoJjB/oFCtO+m9v9vh9E/iLxmNkqX4Ob57FTzShvDzg8y84Q=="
+    "integrity" : "sha512:rSR5oYAukBi3VI+xjVwCLb66gPB1og6uq0pckrV1KZkROPejbEHinCbWrRxS2P00WIuLZvgpY6bZFuu/uCKXHw=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-tools-wsdlto-core",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:yr/qsCL6wE1eFHr2EKifeLsI1caVlFSx3P/6PRYnSV+0opV7URvX+EoxjqFLX1N5M1a45quh2PWuSsASA8Ptmg=="
+    "integrity" : "sha512:hTFZitraa/4TOpBSSovwX9mojZp14GpqzIiGcVEoHzHHve0p9BHKvWjIHiE/ODOQ8IL1E2eN6fQUkTGaC5Ibqg=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-tools-wsdlto-databinding-jaxb",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:zwttXz5MHsYR8nIi51mFWDfYXMcuxWMWRza5wQcZmYfZHMz+rmj0w2K2Hru/bCxKaj9yz1MYdu7BneQplmfIag=="
+    "integrity" : "sha512:bUU3/7QTPt/slG9fwO4fAh/NRR69Bx/VhNsZQfqoUNML3XNXdS05vnEACrSEOmE3CGyvrWA69GFmXfI0ppIFoA=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-tools-wsdlto-frontend-javascript",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:lRe9VNLxI7qqp6U120nh6/cj4AA4/wiGJe0A5wn4vf5dE71/AT32EUO/xgYZjU6dccs1Q0jNxlLggb63Z/2t9w=="
+    "integrity" : "sha512:aExz7L7hBc50QlwaJfDgXI3v3tvI4ZESWEAwbDBYKr5NYmY3y4vlqnSsotBb+Nw+OllHfoN7LEcv9x/5j9JQaw=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-tools-wsdlto-frontend-jaxws",
-    "version" : "4.1.6",
+    "version" : "4.1.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:DBMR/KpVXYqh1UZyjol0istTutHKBLmrA1La4ascSvwYjyqLkOJEtGLbjwgPqrZxLwByt2QCqlB66attjjINcQ=="
+    "integrity" : "sha512:j+zu272ONByKdQIhb4gTL/ZOYY1i4eFUcnIoLNqQsntI31WukzeUGbw/O1UA/OYaXTIIxy310hG9YrloMB4RjA=="
   }, {
     "groupId" : "org.apache.httpcomponents.client5",
     "artifactId" : "httpclient5-cache",
@@ -2838,11 +2838,11 @@
   }, {
     "groupId" : "org.glassfish.jaxb",
     "artifactId" : "codemodel",
-    "version" : "4.0.8",
+    "version" : "4.0.9",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:uh0tnyzm9qcWXBDRyO1pRaiwgMq0TU+Nhc3A6XevH1kcS6YHxwbclfkP0MgzzJaPEsSC5xgHWWRCu6t9YwFBUw=="
+    "integrity" : "sha512:JrDRfOCtMtgfli9nKiiFeTExk5RliBOSop7lgiwp4kdTC2hcHLg+FXKy6puGU5wXCMCY8TD5L4H7m8nWss9Elg=="
   }, {
     "groupId" : "org.glassfish.jaxb",
     "artifactId" : "jaxb-core",
@@ -2862,11 +2862,11 @@
   }, {
     "groupId" : "org.glassfish.jaxb",
     "artifactId" : "jaxb-xjc",
-    "version" : "4.0.8",
+    "version" : "4.0.9",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:iKH75MImS+eVPLyUokYhE6j10r55DAaF+NUJ58jkGCJ0afNc4adLk+sl3d+jpqJ/VVTbu1gTDwukPL/fYJ5/kQ=="
+    "integrity" : "sha512:syece7m4QvZmIp0JrQEjuS3kIobFIVkRZUTc9KqNBry6zWh9i2NYQLEjOdukh36nVkLSops/0T5XKxYwAg7U6w=="
   }, {
     "groupId" : "org.glassfish.jaxb",
     "artifactId" : "txw2",
@@ -2878,11 +2878,11 @@
   }, {
     "groupId" : "org.glassfish.jaxb",
     "artifactId" : "xsom",
-    "version" : "4.0.8",
+    "version" : "4.0.9",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:ZseevYzO1f7OInJ63oMy4pcVim93LXNj3ksIvHjjyW9gEioqoZV3zoednT84LLLzIU1J/I84uC0d59tafqJ6yg=="
+    "integrity" : "sha512:nPVoOggvek4wRmU79Um+giXSNJi1c+MjmsyTFPlPNwDjHTHE+RWHxKnESwcj8GUEsut2ipY8CHj+zdyIeWfgGg=="
   }, {
     "groupId" : "org.glassfish.web",
     "artifactId" : "jakarta.servlet.jsp.jstl",
@@ -3302,11 +3302,11 @@
   }, {
     "groupId" : "org.ow2.asm",
     "artifactId" : "asm",
-    "version" : "9.9.1",
+    "version" : "9.10.1",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:u0Pqyod3x7K0vOn8Gfm+V0KnNqI0FeJxZDw+FNPYL1ZfbeDinrrFcM5ms5Iezh69TeBqvrYzrijBeJHeVpc4Bw=="
+    "integrity" : "sha512:jbbvo31NVpvyuV2QkxuAZPh+2SjSC7+Njn+mGC6aEdMuaizANKPRc6OO5wzi6p8g9S+dhzDZQB0rxgYGdMGJKA=="
   }, {
     "groupId" : "org.owasp.encoder",
     "artifactId" : "encoder-jakarta-jsp",
@@ -3430,11 +3430,11 @@
   }, {
     "groupId" : "org.slf4j",
     "artifactId" : "jcl-over-slf4j",
-    "version" : "2.0.17",
+    "version" : "2.0.18",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:fvsncbrS5kOw6BTNeKtPmvPqFmZDcAd2YYw5fpdVyhH0t8AAMFYqYZkyydLsURT9JT7OOrvD2y8aBkQx2JkHMw=="
+    "integrity" : "sha512:ai0mq2hzslurA39WIM5aShw1z3nomgn/kA2HOHcjG/EX416d/QWRLDa+C0qJpznIS6ICMf0PdMH88UEmyIRiSA=="
   }, {
     "groupId" : "org.slf4j",
     "artifactId" : "slf4j-api",

--- a/dependencies-lock.json
+++ b/dependencies-lock.json
@@ -440,6 +440,14 @@
     "optional" : false,
     "integrity" : "sha512:AnGbS/ywYK27wa189C1hukmNR74DvHzJjcFyoBq/1oCkyUC/BrfiaHeieuQrLfv2Nk8sAp7/3Rg9v16+7MGAVQ=="
   }, {
+    "groupId" : "com.nimbusds",
+    "artifactId" : "nimbus-jose-jwt",
+    "version" : "10.9.1",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:WULsCVYYQ4SXQls8C5b5ejkQ11iXsnur9XBnOn5TEeBda+RBuXlOsOtSi8nrobqAWnurm2abCI23xUmXjU64wg=="
+  }, {
     "groupId" : "com.sun.istack",
     "artifactId" : "istack-commons-runtime",
     "version" : "4.1.2",
@@ -731,11 +739,11 @@
   }, {
     "groupId" : "io.micrometer",
     "artifactId" : "micrometer-core",
-    "version" : "1.16.2",
+    "version" : "1.17.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:aU1ttfT3djqRZwjnO2cMg9Mjjnq4GeqtohLtrk58ItN5SCKdeKg/6Ai3l+qBQ9St9qvkAUov2A28i7r8RG0LDA=="
+    "integrity" : "sha512:YJx35eRuUX8FpOzIc+8QhEGvoWlvGn0MnlNBQG/jChX0ANTlzdcuhG0HMuqZ2K0o/8B7M+LSkE959kIoNX29iA=="
   }, {
     "groupId" : "io.micrometer",
     "artifactId" : "micrometer-observation",
@@ -1013,11 +1021,11 @@
   }, {
     "groupId" : "jakarta.json.bind",
     "artifactId" : "jakarta.json.bind-api",
-    "version" : "3.0.1",
+    "version" : "3.0.2",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:qJVKq4fiHMiwPwIlTifvwv7sPLI8tNDFXjpLU33rMq4nEbsMPIPk+myf8mUfn50Pnxt7yFziH9S/eiyfCSVi7g=="
+    "integrity" : "sha512:nyqA2kFlHXI89YTLCyo71LeTcAE/xizK+2Nujc3ivmAW4nS0xlW0mkJOCfE8xNEEpEBUhhqBK9xLxFbKedxcOg=="
   }, {
     "groupId" : "jakarta.json",
     "artifactId" : "jakarta.json-api",
@@ -1285,83 +1293,83 @@
   }, {
     "groupId" : "org.apache.artemis",
     "artifactId" : "artemis-commons",
-    "version" : "2.54.0",
+    "version" : "2.55.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:PBVd78MIfRlYoG4T8xRrFvJI8fwltxvLcUcDPzpfk2X3Yf0lZsQoKhJYNx7cQVs07Mu6UdvZcJQwhBkset+cMg=="
+    "integrity" : "sha512:16F+JCQsQAWxmcxq8ncddknWh/n9LkUUnQbLK4uNa2BLIL8J5XvXX3N3Ujj/dX650rTqIZW1NnJIDQ+KRi0Y7w=="
   }, {
     "groupId" : "org.apache.artemis",
     "artifactId" : "artemis-core-client",
-    "version" : "2.54.0",
+    "version" : "2.55.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:zEuUewnhwV23rbWogX4eFeN9lAZvkstBQ1VENmwSBY1ajl61Ric/I1s97Mo53AmwFDbhLE/uGPFmIVNilE09PQ=="
+    "integrity" : "sha512:7EVVRoyVAyQp4yO050k7svltDNikjga0tY202PpWKeEN33BNULH+5iL2TdIr38qsXanr4KODQPAsAfSVwgHULA=="
   }, {
     "groupId" : "org.apache.artemis",
     "artifactId" : "artemis-jakarta-client",
-    "version" : "2.54.0",
+    "version" : "2.55.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:wWEV21jz1k7RAR1cKc58KBDKh2W4tt/t6jWQbH7BqWorXWEO3Ib7x4KwgoPIaE/lCBsg3gVBvq9d1VK+uBhmMw=="
+    "integrity" : "sha512:NCWlQxGYQjKJ83AddZuRjPqvt6FK1mHeGol1YsG2Ld+TzyTVK9D/s/QEE1naBcSTJX3I/DUOxxCIPCZLzR521Q=="
   }, {
     "groupId" : "org.apache.artemis",
     "artifactId" : "artemis-jakarta-server",
-    "version" : "2.54.0",
+    "version" : "2.55.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:A+7/NVxToRyTuZx1pUErb5MpwKQdoFcpmr1Pv6DGz/Pyy4tcpvQwVQv7QqE2cpfJkijsKwKrMIG9tKfTB1xwSg=="
+    "integrity" : "sha512:l38IBcfJAh4vEctiuPpQHq7u3xbl83upbEwqOYaKpYU61doeNRuFMwadm+OmnTW99dmiXb2QxjwDJUWM7J6B6w=="
   }, {
     "groupId" : "org.apache.artemis",
     "artifactId" : "artemis-jakarta-service-extensions",
-    "version" : "2.54.0",
+    "version" : "2.55.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:MyRV1VkLTYslKl864O+BxAxLpJkxEIC8A1/MDSMMJ89vgvaNMJOONEmb1Eu5uVFNIYykkJAEBREljcLs3IwegA=="
+    "integrity" : "sha512:recJXZUl/+Nx3+09w2CldSmqs+8DPTWwqqRiu52xwCviYm24ZwTXx/bjukGGfcUZ0Xq3a/noJ8bczIRMzCiRxg=="
   }, {
     "groupId" : "org.apache.artemis",
     "artifactId" : "artemis-jdbc-store",
-    "version" : "2.52.0",
+    "version" : "2.55.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:0wuWpIU3Zd3fC9BBHADUSjDUW+evsgPDfTSbZYGvmZjaD9/wu5453i0jfqVllXVG0ndnitt5pEEGIkFtmDt8YA=="
+    "integrity" : "sha512:kr2naxOgoXd/AGk83/GO3kS9gvZYLgqt+0P378BT8+JRD+1wBB8O7uKe3Lw5DyfrMf0pcs5AYrl2nwIZuoloEw=="
   }, {
     "groupId" : "org.apache.artemis",
     "artifactId" : "artemis-journal",
-    "version" : "2.54.0",
+    "version" : "2.55.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:9VpgOykRW0f7Hl77nAL9cZfJ60VJaneZaKataT4PvjfWoN9oJ0dcmgdzLf8GG3HRMkCU1b23c8ODyBnaivWh0w=="
+    "integrity" : "sha512:CcVcq7EfYr0xP1YD7fflWAHgCTh1gCe3102CZP5Ui7FehLoQvB5kXSdr0tP0lyjBwFmj4P0Rdiwx+6jTAO+L3g=="
   }, {
     "groupId" : "org.apache.artemis",
     "artifactId" : "artemis-lockmanager-api",
-    "version" : "2.52.0",
+    "version" : "2.55.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:N2u43bE/UuMsKkmh4q0YF0GjuiDjR7fmVzghBCn6xYMz+mDrplOYLf8yYEWu1BRtDX3TJDvUxFr6Jevvc4pljg=="
+    "integrity" : "sha512:1d6wCpHWPhnLv43tgLhGRKLz1lyLIAbTgRu1mhZa5lt2rZuhr0RmmkDENhGgG+hXcZmHYV3favSl/rZzRu+vbg=="
   }, {
     "groupId" : "org.apache.artemis",
     "artifactId" : "artemis-selector",
-    "version" : "2.54.0",
+    "version" : "2.55.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:MKJWWlh8cMF6b02+TVakiC1JYwiJMoz3Pvk7KgKB4ViyHYyeVZOi/6GcziktpXmm3UwEcxeZq5+pJaPRYaLcFA=="
+    "integrity" : "sha512:3dY+B9ZFbUUYKyROfVFZ4SFnwegSmwJMd6INBXhls+1p7bhMJNOnJ6j324nT3NOcILN+F4OxmFuOjfvo3VVw8w=="
   }, {
     "groupId" : "org.apache.artemis",
     "artifactId" : "artemis-server",
-    "version" : "2.52.0",
+    "version" : "2.55.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:ARcVPHDvlS0OmlhdfuMEGU6mt1XB1nOl0CYU0iNj7oNhCUTlO9QEH8DbMiHIbn+ZJo3V9NubmRzjNVStdSyGLg=="
+    "integrity" : "sha512:i3UntupLycg8Wk/A5VhyT7yKXZ193ThPGtj7ZQKeUubrqiUCIpHxadxdSzJP9Qbjp4Wy48uf1clzCCfW3VonGA=="
   }, {
     "groupId" : "org.apache.commons",
     "artifactId" : "commons-beanutils2",
@@ -1469,27 +1477,27 @@
   }, {
     "groupId" : "org.apache.cxf.services.sts",
     "artifactId" : "cxf-services-sts-core",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:p+UEGwlJVnQrSe9wI73p55Gi/DPdG1TIwe1ZoU/nr+LujADKPUR9O2imBxxnlvcrUVKO1IOduDf+Pc5tSTXVVQ=="
+    "integrity" : "sha512:EEAWd6yRB2egC/EtbJHBa+e9DZ1p3m26TasSToBLlUwPxc1x+4P1SXlIGM/J+SRboWsBS83jvEr9mLSivwg3gQ=="
   }, {
     "groupId" : "org.apache.cxf.services.wsn",
     "artifactId" : "cxf-services-wsn-api",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:sT1DL/37+mzgfSH0sWqYEcp3hZ+aF1f5XW/9Rd/CCtPx/QrV2OvpaXBs2v9JX8H5cv5dsn14fGa/A7bxAwzXvw=="
+    "integrity" : "sha512:bAT77M70HvWLy4+qD53a0uHmXr1MrumkDa0RdAwRJCyw+F1qtOwnSNoxXMlYiOi5QfNObXgnWHpmEPUhVM/InA=="
   }, {
     "groupId" : "org.apache.cxf.services.wsn",
     "artifactId" : "cxf-services-wsn-core",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:WktvzP2SsMnnKYdSfe969srSHfz0PDdiBWNl5F3qElNgLeUg3Mp5pGsUvjtJkycJ6w3tBLkot9msGbMWLE1kLA=="
+    "integrity" : "sha512:RyvOSMZu8WzPUvF34J3yR/ld65GiX1EyMboCJwlo40xPmhPArWL46jmwi+G2iINfjlp1C15MHfPTi38yV+zbZA=="
   }, {
     "groupId" : "org.apache.cxf.xjc-utils",
     "artifactId" : "cxf-xjc-runtime",
@@ -1541,467 +1549,467 @@
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "apache-cxf",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "pom",
     "optional" : false,
-    "integrity" : "sha512:hjwr+MpKTqJPu532GFFjtqw94cM/49lL+Mk62CXzZgtt1/hlQGlBc0RXGaw+EeNETVot08UxfqZd9omW321BWg=="
+    "integrity" : "sha512:EYKauysnaKb/G6HGT/EmK3ByOXpUo0/Fj1ZaKpg05GBxCQpxVOlXoajqQciZ8Us9Obe81W+tqLSBU0s78QlSBA=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-core",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:Z762+R4wmJx+3b062Us9F8zELabhWxYHcRbr2Gx+Uzy+lmS1exwSnOuGGTO8CT2ZMcTNXpW713LTc3HCwCdHRQ=="
+    "integrity" : "sha512:DTq1FZhLXLvrWgvcZ3UpzBzy7Zd/U/arwr+AgsknJITBM52sLsdyXGUMNL4ekJHzgTK4YEm6LgaWG15k/YnhGg=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-bindings-coloc",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:hw5+98GVojiStVvHC0NC1jfA0lWEMXJ8qoIdrnBqOcb2f4TmeJW2WUUTPBGs1OvQTu+eQ4d3vh8Lag3E2WPoyQ=="
+    "integrity" : "sha512:OoCNSN33ITHL41X5xEP1HEbJjyt26+PR5o+W0PDGJ8MofEaC7wj2WtJ1knSUh9Q+cdwkzswnJKEjJXG2kcVQzA=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-bindings-corba",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:4VBWuuqfAip67y8dVVVG/J0bjOACFPWzxOVsz91g7rGtwhJIUCY4EkPCRsIIEZxT7uKGPzsLvTrNYFbUp0ljQg=="
+    "integrity" : "sha512:AGyTUpBAX+gLUkSERIovpqx5DWtD17/eqttDXcdzCy765toWCIdDh7+0Mn429O4Cihhf32k/jiWWWOFhGbX8tg=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-bindings-soap",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:7ke8GALIcUAYgJi1EvNBLDOw44TwiPPU2/nccCtUq/PvE88RqNCLSlD2uhjhleAULcqYn3f1cuMHLU4NzkvStg=="
+    "integrity" : "sha512:ldrtrkdn35uCsKkzQmNuGUPyM1OLXS/AdNFwTIIp4a+SDqvEfm0j9D74DJIyAJ8IfZ+Gt4EBTGQvJYPAyPE2/Q=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-bindings-xml",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:G4vbxeO1p6bQgcFUWoHrzeQ7bHbJP5SFGZa63fZghRTWjcWd7IcgWu34V/VYJGQCuv3GojmuNnCFT1tovvaJ4w=="
+    "integrity" : "sha512:m9qCjCbEQhCQWmjxh83ixRQrGn/7RObTjaNTQEeazF8THqRzrx+pVft+ewPqb+CGdZATGxzM8XCRkuPYqZmtpA=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-databinding-aegis",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:xBGjPFfNqX1aJzSn1e2YLo8zEtUMxMKYGDfzV5FPcqgOcVO4W9JYHy1xQHj4BCakT6FDFf/pXJbzmWsTDYXejA=="
+    "integrity" : "sha512:qQ7Our1XSOO/zq8nQrVnn4kRL8SvseS9oFwqeB6hQHxCac12apDuoQ6YL4LMAczeol0/giWmVDaHSkfLq9dKPQ=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-databinding-jaxb",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:JajZB+xiuRpYJs3LAzIWU2QU5II6ROG4n28P2QDGRdkrSs37YrbLAITk8MBQR/RZHsI8JRyPBILclxkolHGdww=="
+    "integrity" : "sha512:OHPnRh4YjVFWTaylZPtRYMCAutNiDKlEtJw2PJgWX+vjiMusCLI8yLOAq48k7hXE5bdlxluv8xhNk/LChcYayQ=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-features-clustering",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:n1DWJbCHF7rs/Fw1DVRQeHfOdLoEWxH+AetOtXTz8MPflFRePsWmL5YDFPWVon/6cvcMlyPCLkGenfuYSPDMqg=="
+    "integrity" : "sha512:gS0+SAnHL4PiOsFK+yiA9Y/siqmFo1fhxNXL1OGdvYAHJhUFgpeb8Kbk0IwvCRIsffbj/r7JlKw+swYeyNkHHA=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-features-logging",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:5DkK50XLPKjiVH7SSVWmdET6FzyO/LrFJ7HSelGarcco2pzrlari1L9mo8w2BfTnunVLLUiakN5vnUT/F2dZeg=="
+    "integrity" : "sha512:CFVWfJ4Tw4Wu9ZIza6cGPTm8735MC5GmKWiWsGQiZ1DoqUxR7QkotYuvKczNqCGSjxAydVgkwLWtsG0uNRhpkA=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-features-metrics",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:ZvBb2Vh1zdslFxsGRZZj7p3TnN7wAk0+rs/7pBoQHhYVez/FvSIhJfikd6f2iPmKgjuiIxxJ/Qi7kWqGzSkt4Q=="
+    "integrity" : "sha512:b21oYicvjw6Xe0iRXaZwwCr1f34J6WU1/1z0b4y/07XTcEq9rVTKyTSpnnglXWovR6MFjBmom/B4UW2gbsZgZQ=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-features-throttling",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:wFxKqwepnlpc9utZQ+hAzqhjbs2WzluLjfn3tquU52iM0vEZaJm8xsltRJLB8hHjxeRmxSz1VhQKtZS3i2Hw9g=="
+    "integrity" : "sha512:Q+Fn3ri5y9z0IIqU/AznDd2bfw0XsZ+uYKfow5skZkSHGw32ahN5ZpUWY3//tddBmrIHAQOkPJAWiUBAECjADQ=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-frontend-jaxrs",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:W60Uch39HvWMu5TxYoUlRulDg+x/mBT+HWxcYBClpDoCgn23iFMi5VEUdqZ+KQBTyIVBrpd5/GzQLCjNoRtDZQ=="
+    "integrity" : "sha512:okTf59FcOqa2XuHiq3D7BuHV8uuxV9Qbg2DczIZT27Au/qRYJmd4oXqqAiWYGe716Xy0z4Jz11xcZZSsvTHk6w=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-frontend-jaxws",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:yi4oEuquofAtx4xc6VULA9br6NWwDF6wXe/0uYjxd2BarTOafwnB8l6aKcdmonC1eWthcMzHgV2f+/JNrehFSA=="
+    "integrity" : "sha512:tHCTlVT9Q8TyjtsAa199PmSVqTobG0KD1/ckWUVpaJyReD76nEhLLRpch8/rx+k2tN7uywcYdrNUOm6RJAKmQQ=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-frontend-simple",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:PjvOIaGCqHp+TAyWA1FhZVf6pDvBZzUDkJ7zymJ3jC+6+/5KyM0mxH84Xic3Xv2wdR+dul3IFX5nXP1GQyd3Hw=="
+    "integrity" : "sha512:rmQ5XaHrDAEZKqgevYbQLmdEByptjKOnA7dMuaNyLhcEynhPVjBRYsIwR7VWinbKlqpX6CDr3nU512h2beBqvA=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-javascript",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:LhmH8UAXcNuAt+al7S51oXPPp/zy3KOH1sL1ZUiM4RF44tEG5aiemUJyDzvlKHatDeDqWxa7lYHYManaBtxjhQ=="
+    "integrity" : "sha512:8olaL5q+dklZzONJuPusgHMKrX30+2V+tTIS3eFDBA8fsoans9saIVTM7qg3D9OjB/G1fBRUUhUJlj4H8nVkbw=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-rs-client",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:HB4cVxANRjDii+xDTJmcf7Yod7/j7AOryCsfojVWstad7MQr8IyFH6IAHv444hguBty15uU9WZfTPYulBoD+NA=="
+    "integrity" : "sha512:SO8LZeK27SXH8UHf3i/4JyFs5gPaIAfKlqcu8JxiCKdAU2LxoDmMViZo1P9E3MQBWIarCw+UvVgMyL3+59/gEQ=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-rs-extension-search",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:HHqsf4CTIZTPYpATr9i8wRUpKwNPWMXcXFOQmeVouPyQbqZu/a3qBZD2SG5k2NqiyOEkuDemQ3DCgsTnvrsY2w=="
+    "integrity" : "sha512:SipuwcvNA8xYFc6hTrjm+2slc02C0fksPs9+WmZ2CafxdSelppHMwqW17g6ttFsjSFiYQT7ICaW4O2ic3Ubmpg=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-rs-http-sci",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:Zhp/UanlEkPAA9jtN1FwpWG8tsvkOVdzDc+zmJFO0q1EM0nNA0rPjS3oo3ka1T00uYNSuhXUPPWP4aAHxmC72w=="
+    "integrity" : "sha512:GBLqRIQbGfjLzZbL+0Fp5QAG9tiwhYptzGMS33aDfXDzPrmTCr4XeHgzr5Ck/w7nple+B1Kgn9XPoD93KbR6mg=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-rs-mp-client",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:Ww3G5qq6nU47E1s83H0TcfRuyuKL6T/jmedp2YqKGQH7eyn8RA/GfEtuXgarSipAMo7xY9h7PbuNhhMFWKkl0A=="
+    "integrity" : "sha512:tspSt9pUHOtZuUMm1jQkZj3asSRbFTNMa+C+b7f2+jPpaTAZty8K2hQjJoqqrA9/f9K0ihopaNlc5t17Hg5AyQ=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-rs-security-cors",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:IUlk+0HJIOQrm8rvW3RFmOGuEO9pjqNer2uQcaYqck2eRzekpP3Bph7xTbyVyXGS/rGJ6Xb9vqH5Nn4y341hxw=="
+    "integrity" : "sha512:gUiKuQEJReIfGhiNs1tMzP8Ix8l5f2ldR/z1d2XR4XAOtXfMheN6Fkuxk1f0okaJ0pS33aR/mlqMj3tpKUflEQ=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-rs-security-http-signature",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:2u1fleNPGbZGpJeLCnAP44VTY9y5axQSG7B8gb0rjzgDcRQAiJHBFjqk4/gmrRnx45q8bGGOExkQk7rDP4Kj9Q=="
+    "integrity" : "sha512:El1Mcg6mer7yn9w41Ec3OixKDILtaQbguv8sMOxj1alqaE4OnlWyXrZzRRr9JU0VmNK5kTtyUjOXPSgHgYsNyA=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-rs-security-jose-jaxrs",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:MwWXMgOFW0OUl3WPcIZFrNiOGZBKEdwX8h9tRo25hxVsr1YsQDal94gOK3EfIomVV57qnaexxGg8NzS6aTczZA=="
+    "integrity" : "sha512:vEMziolCy3zSW0QjSIrcKzXd/J+LdV8NasiDpWlwSGPSG6N7pBydzK2LekGp/m+jfOoUmVst4Mmu9tRGovZeWQ=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-rs-security-oauth2-saml",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:kqeyBDqHqFpsHG+3oeWBBNO1KZ35GOGOJT3RaalxvNPqXWN3PFQKy6MKv+thSZVhRafAHpsQDdY5HHVAB0Y9xA=="
+    "integrity" : "sha512:rhUWBERKKWwc2bJI8U/kNyGxGqPA192kkzj6zFVXnps3K/RTzUckL3wPsSr7+krwTD0jvHX0CkqWrPgNYSjq+Q=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-rs-security-oauth2",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:JY9JntLq9z9BLk45Mz88bsV065Hn9LkKAfYgpZxPJymIzCv97oJZg6aBaKbh/HPDfT9QQhR4ThP1ysqZ6V864w=="
+    "integrity" : "sha512:UPQ/ub2NrBDUf+8NCgqvJymyagMGzseSSycxoWVeVRr/Qcgq9tSe72t1Jq6vT2R10tOONzciZHmVPdmmk92+zw=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-rs-security-sso-oidc",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:Fj9KCumcofTGWyjRqWY8WfQf4DPrnGwblzauSy5WgdPVgIzNMeIkiiAAX9babzsR+aqJs2J0Z5Pa6ahIsoirig=="
+    "integrity" : "sha512:8IHMA1ycWdBY/eAb1ZUizWEsTMK5SODsew5omOOj8ezfDJ+DBPk/VQonmnWtRdxLpmZXqlF71aAgTu4rVY4Uzw=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-rs-security-sso-saml",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:FoAFQpEc3H1OrWmcIfVW4vA+Pjv4uOqKiyQbfGcp92q6TmtmLx/9tUgHkfSgfePbF+vO7rympagRdHNdlOo2TA=="
+    "integrity" : "sha512:dm6U3VGHbqNhdLd0pqMjmpriB7uRCyTb0Du58d/hR6xrSSHxHOznfhibY90k2aTsCEYrcu68WUmrKMYFJakMBw=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-rs-security-xml",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:nznKLZtdbOJSxTd8PjayqaK0MDyv4zmYaAQvJere4b/hVh8tcHG+70jKSJAK6xkUvLzf5ML/xgUYkC1Tj3PC+w=="
+    "integrity" : "sha512:TEnzzkoU8Wfase0JCMOaVYXCpzN6uHl3NAPlG+GAT0H/h9fNgttwF+icga9acmPMI5dndFAoonyMps5psAAkkA=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-rs-sse",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:2umLREpNBONZTyA9SKBGeQKXSs0xzk5aG4M1jKJDgiXnNZgCHiNzWYKiloZh9gM5bJWHbhEvc5EivqlS3ydwog=="
+    "integrity" : "sha512:ux9KYWu230p/XtMmTnU1myreRBRVsYugdD3zX24xhhHdSD++ho+sfDf+AB3Uipif8MbADIHLxUV86JRzEHdpHg=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-security-saml",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:TuRGqYEW1RwcLKnX7D9vaeJ4a5VNCthtyeOcj3oGaQLgTpcoxHHBgE0Ma6xItpwA5hW5eMfxoNqqa6Zc7v17kA=="
+    "integrity" : "sha512:ahBr8SImXoghW/OegYhmWBoz8urtrpK2GdKU1WAYxJbNxxSbjHdWTPglZLW12ps91X0av2xVOMyILhEaXzN/vQ=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-security",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:g30XT86tdH7iKouzrHItTr/LXjdxIiN4zuh7EaYoB02ntqffY0qRSOUEeX58zPkEBp7ml4YJc2970cuY3rOLXQ=="
+    "integrity" : "sha512:7EbHJmp7iJhtl6uVJJqY9vaQ00H+pCIknpsBXLHoTq1gU3fvBlQ7ZL5eQMmoAFpyibyj70TpP2pIJ0Yf8ltQnw=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-transports-http-hc",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:npUGOrFnTVgSlVhcrPObLMpSVBrGHb2dvBL62Wn0p6wv9FiFintDuHxjNrg+x96u2cVOZ9fpAx5X+PEl+n+Lzg=="
+    "integrity" : "sha512:f2fHHu1gjklYrcKmTrQ1jja9JdkZR0lFrF/P9DUYCvvavk5EIobWgAnUuUE6/MnGRe9AgPvEX7I7G5TCL2HS7w=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-transports-http-netty-client",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:+p57/+g+xmRaYl/fr9iV82RwIXs9eDwvAUpzyTdYgRE90TWX0W6/VM6BrCahvPvfLTHY8UOaYdcK5kOWdvtBZQ=="
+    "integrity" : "sha512:iPI0N0GxWRh/Eb+BHFdC+b8ZyUrzgxO9XfJ/zkB6EVI1mqQsaIAFRKza5nzMnrKnrE0F1G2DK/f07dgUVLhrdw=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-transports-http-netty-server",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:DMCAUp/yDg10mUrSXpMIVmLcCw3z02+adOnei1JDoohax1VNcf2wzjHkjgeWLJ6xumenlh2LqJSVpgC31mL/SQ=="
+    "integrity" : "sha512:I9ntw4awxbLzBZKeZz7476mGq6QwA99J9Q0Zc25ZvptWjAGG9e+O3H0qm36RyrvKEzgCs5gMpNNwFZws/Vk+Aw=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-transports-http-undertow",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:NhbSjPZAC34iRLdnT/Nb8umX4QYIuGS2doG6t5/QCVHFJGfL12KdreGsem/iRcim9NJ+ZFUSRT62N0Tjub+fMw=="
+    "integrity" : "sha512:Sy/awbtD4fQNZobCISKvFziOsoUq9HIB4FtaY93gez8IbZLFyd2EahMxMORFtqpYbnCjX5kLTgx9+Z1nNILR4Q=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-transports-http",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:OonpX1wqU0H+0uXtFHGdpO6uWW1lX7eIRIL5ODRWJsfjU+Jo/HKrkqcCuxxF3n+xgd30PYQ2Dcr+okh1YmFcIg=="
+    "integrity" : "sha512:Jn8fjzpWy1s8K5TpFY2miek3lyMzsnjfPigdDdpE97lL8KhCNp9JLOKtUp9IBXdsvzHUz/9zJOoawyPssrI/EA=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-transports-local",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:8WceZmggfRSL62uxQJfVJvPiCTTx2rekiJGYDS5unusvT2E7Ik3i3Ygg50fdmJ68y111lcsrH4mE6gp5hf/Aow=="
+    "integrity" : "sha512:km+JiKWG8BeAospAfNWgfRtiYBorA9PF1nnwvkgwkteY8AROX2EBryYFxnQ4tmKxEsg07CZIAQalCuVsj4bIdA=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-transports-udp",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:8iSHLO6wlZOooWpY0H/Y9DrSlQetgaSpeouxT18ht+WZgGtvYa7PJXl+hybSmHtxbnB8HjnVpUX4uwK+Nw1Gsg=="
+    "integrity" : "sha512:YaQ/VLnFeyzeWcxCn+FcarrmfzAg9ugN/8Oymi71xiIpDf7moJOCWS9CvAYZ5QiZI3fXdfN3ir4ru1D8kGPJTg=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-transports-websocket",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:UixtiusoZFdc9+X3akiWkusnUCCkFRUnc555NVCDjTZphKaJWRHS8RB4sd+TFPk6jMCrWlkwb3+ZiiJEKcbs5g=="
+    "integrity" : "sha512:N0Bo8t5A3QbJUg1lD6/kNZdBDW+NMQWN1t6/UjDUirW2MD+LqYUg+/XgcNLSFXYIRbojNH5wshsTgvHoDcL2Mw=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-ws-addr",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:eibUlre2bC8xznI/OcyFWTbGI/TL8aKr6uPQUG3SAgOKTDk5clYw2FchoPblGM2inFw1tpDUandyyqmwQGfyNw=="
+    "integrity" : "sha512:ktxJPNMFOdW8xVjHhStCaoVkN9IYFQLh9C2/LxWslSUwcWMk0JL/euCnLZYeVl6lG2E7JfmqjYYJHiubiiCp1w=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-ws-eventing",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:7k93CKFUHB33JNp51sKunM+mOml969VEKGhUbaXHMVL8UQBxvuRNBG392gWGGQrrP7HtjlgzrNdz4uI0VT4YaQ=="
+    "integrity" : "sha512:x9r3marJ0gR/bwXuhYBImmjbOYGaw1yxmq8oe5m7DEuafkoqew7EVC4xuK6IuDKXbt2+I4efXE5Kr01vdl9WCQ=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-ws-mex",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:/D4LBjTk69eqBw1i3RbV78gCP3pq+yUUyUWigzvuR2b/4g9NqXxMFxfjQOFlaOZuf/Xc7/+QJttT5GuRk1UzEg=="
+    "integrity" : "sha512:+aZ8ZLgUYZIb15uFJoYED767035XJoJhP4RGKRg8waf0WtpcO6G/pj+UHmYDyFtoW5DWVHtiAi5iG6p8oDrXPA=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-ws-policy",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:7oMqQ8pqmAnfOI0i41jdVqAswx4B0bdy/mS1MwWg3XlCnTq1bWZeID1W6Tm9nqdqnXJW0LuJBaTHUPkeJhK3TA=="
+    "integrity" : "sha512:VRk9X7FbOQharK4aDQdlu6sfYWAOK7loptPlX/BfbNwexzq9VcPouA8EUKoGtfTU7MFyDHDewJMloIzCv7F37Q=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-ws-rm",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:R0cuZKF+xhk9wVtru2NYv1LxzfBMMlSSzwHAEb21dUqL8Av6ORNM8Qit6MjjgTqXdFlWw6rYsqnVvxIb1SCwtA=="
+    "integrity" : "sha512:09BP6lc27w21KmDZ6q5nWTRdlF1apAQqXb63MyvfHPLFvRuwuyFYp2wqk0vABNtWhDpMw2y+IDbEdQYYLbeALg=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-ws-security",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:XbE0hCTTqKBJTMSWV5W02XmW07Y+rKQwEIQBWNl/iEoDwq6xJj8A0wXpko7ym07gGrH7Z1eQWrfNFLxeUcUOHQ=="
+    "integrity" : "sha512:srC8QmG/A86KrVfkD+eeeRQDw1gfwKrNVdn0Q+AU2XIhPPBqdfSv2osoNxBvzdgZNc41h7TO2rzGjOrzAcz7VQ=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-ws-transfer",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:O5vNahsY1MVxbVBAZpxdRyy+w2JDuchOtCrGM32u9Hhsjnl0anVmjQ/FGPHRzwaz9BgsT0hQmS4GFa8n/blsqA=="
+    "integrity" : "sha512:lxf3lrihStJ/00BsLbnrF3NnDuzvDLPGYnS4/UhVdJmHZa/54FH0CJIW5JUzWGYQlqxvttABeMC6j4gtSgTRXg=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-rt-wsdl",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:fHj7bN1Gl8vwnataZOEud4sh69PYJ8+HEFnpcRRzAJXJn9W+hHu7fOiWVjOw7awHv4Q1aXhDK5gZn234XggNYQ=="
+    "integrity" : "sha512:88kQVVqreu+QVsnKX0CKgqK/LaIfmcC/ZMggsOjz4sJOytSVZJXW/CiGi/2zksseVaBvjXqKNfwq+rlT2phueg=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-testutils",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:ikPHl9VKRwAhUY9/SnAiB81hNxOh2nCPfqDTih4/VYR1LXNHORY6Cgjg1SzBx5iAD0y+5Sq5jbcDsbbE/hxLHA=="
+    "integrity" : "sha512:10wJYKv8gacLYCYiPiNEqyVPwqA/EHt/+W7jsYLZrxUoVGTYghYk+atWNZoY4W6IUy+Y/zsnerPTMomLnAdj4w=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-tools-common",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:DrMgSwbaazXnS2/XgwmwWIxYKEq5P4+NQBe4F4dqie+rnJySbgQflY4fJ2L2+LvTJH23+p0MNc0bCdWdjiFc3w=="
+    "integrity" : "sha512:NVbeLtAq5+uoqE9P3ncmHL7MuRXcXeNL+y1uosr4nbitvmxXyuZENaU+/EcWJhypsNkMe33yEmI9r5g+Qe3fuA=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-tools-corba",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:boF2zfdHQ13KRCz2t+OwB3qdQ5nM/+zBILAj2rt7exas0rptBFvJNr9ZRpdE70TXo9AIzYImCbcEz+lJn5flZQ=="
+    "integrity" : "sha512:G2QSvTmVj/d4vkPCPHxpKVu5N59BaQDCTbNsMjIVu2FpcMXifW1RMAxlzMSzzkDFV9jFBmuDC425OzCL9q+ckg=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-tools-java2ws",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:bWADDKc4bXXrrov/hKOJvxjOoFGFHkDRtIOEPr1iguGO2EGaBPWufXa56OzJbfgomtT9gTObyw9IFvnGF32ahg=="
+    "integrity" : "sha512:f8pZZEXfb5OuYKKIIsx82vT4Q1qEhsjiZ/ig3XbHO65OJwSa4SFnXwzFkhIBz4Or5FTfdr7YBqfn0osOrVxIUQ=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-tools-misctools",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:lS3Neq5wjB4grauEv/ogLvnRkC0JLShaDo55GWrub7+1+mUQsQCPCm1h+PE/6XBICUJlzE4HNWDiaz3ZznbxuQ=="
+    "integrity" : "sha512:C9TViTI6IpzrQYFEvUj0HKKmSojECwvlJJe+1tIMnGmdzO0wbiU5kstFUhiTut3EJxjkabcNWoFxQxcwKyVF+A=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-tools-validator",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:oaZr2XyIJHpffKg1jgpaBUcUeYprsQKypGdFtd6V0uux1TczGA/WnE2i5/BsQGiIo5m5SEmAawxacq8zhoHIhg=="
+    "integrity" : "sha512:8iA+s8TfhgqAS8wA2qw0aWh+haTGVS8l3vAIWo0KM0ODhYwPGJjvpdwpWOPKmxxpTJ1lHMc/knKmF2Bivh0xAQ=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-tools-wadlto-jaxrs",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:rSR5oYAukBi3VI+xjVwCLb66gPB1og6uq0pckrV1KZkROPejbEHinCbWrRxS2P00WIuLZvgpY6bZFuu/uCKXHw=="
+    "integrity" : "sha512:xJQSMdWjBGMjihIB2y6yM48l5odiUxVopOAFMcty8gYvArWi6BN1KSI+DttI+qgamSDUAdzFWKL8p4/xpKTDBQ=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-tools-wsdlto-core",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:hTFZitraa/4TOpBSSovwX9mojZp14GpqzIiGcVEoHzHHve0p9BHKvWjIHiE/ODOQ8IL1E2eN6fQUkTGaC5Ibqg=="
+    "integrity" : "sha512:+lsP9EwhAmsVbVgcqLxlK/d4rkfguKHUF0BbJDq9WZoIophXa5h7rseLzKMA54jGE1S1CU/f1vvkBK8rhyArgg=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-tools-wsdlto-databinding-jaxb",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:bUU3/7QTPt/slG9fwO4fAh/NRR69Bx/VhNsZQfqoUNML3XNXdS05vnEACrSEOmE3CGyvrWA69GFmXfI0ppIFoA=="
+    "integrity" : "sha512:f2EWbygwMlqwYKeB6nIYcee3/yFGUIs6jbXU9v+H+/qEY137xI+rNxH+AokHEEbZjsqknRqa+PkLfDcYsHUAJg=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-tools-wsdlto-frontend-javascript",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:aExz7L7hBc50QlwaJfDgXI3v3tvI4ZESWEAwbDBYKr5NYmY3y4vlqnSsotBb+Nw+OllHfoN7LEcv9x/5j9JQaw=="
+    "integrity" : "sha512:QXptmkOb0AV5dZiLQ+TEZYVXtAD5KwqhpvWEmubovP8eqRnyH7uE/0rXVM65d688pNdIE8adIaY554+g7cXuzw=="
   }, {
     "groupId" : "org.apache.cxf",
     "artifactId" : "cxf-tools-wsdlto-frontend-jaxws",
-    "version" : "4.1.7",
+    "version" : "4.1.8",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:j+zu272ONByKdQIhb4gTL/ZOYY1i4eFUcnIoLNqQsntI31WukzeUGbw/O1UA/OYaXTIIxy310hG9YrloMB4RjA=="
+    "integrity" : "sha512:IqjB53DDcfIuR5p9Y/77+XOHjo2fLCaxUnpqAVHp0Ovu75I0dsLA4AM1yQx5Z2gXuO6Bj00v9yU+s+Ra8F/6Uw=="
   }, {
     "groupId" : "org.apache.httpcomponents.client5",
     "artifactId" : "httpclient5-cache",
@@ -2982,11 +2990,11 @@
   }, {
     "groupId" : "org.jctools",
     "artifactId" : "jctools-core",
-    "version" : "4.0.5",
+    "version" : "4.0.6",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:P5W9WN1o6AVEquaF0+2/HYBJDbrFYsp8tFTki8uomjRbeXNGa3k3PCGcGIjc3q0l8NzxBWcM5vyfZIv8d7k9dA=="
+    "integrity" : "sha512:Uw5UakwRqI6DNjc0j2O0WB8m/7lHLTCatwF19BxhEGqJLiCMmfuSvA0th95kJMEUIaiX5doJMOcDIp5zbxXZ2Q=="
   }, {
     "groupId" : "org.jdom",
     "artifactId" : "jdom2",
@@ -3443,6 +3451,14 @@
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:mj5522ZmpglqMCG7Lh2RjzD1idjeUda2APjr2SUVpRCuLY+HkZzC36g2XWTxAZTKyN+g+5UBYO7w6doG9squuQ=="
+  }, {
+    "groupId" : "org.snakeyaml",
+    "artifactId" : "snakeyaml-engine",
+    "version" : "3.0.1",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:gFpkcCCC5JR5AmPDDcGEam1kau1qCcXJz+8BqCXV9i4H4V4f0XpfGF7eW5aBlYmugcMwWKocMQ2QP9CGCL++3Q=="
   }, {
     "groupId" : "org.springframework.security",
     "artifactId" : "spring-security-config",

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <!-- Hapi Fhir Version -->
         <hapifhir.version>8.4.0</hapifhir.version>
         <!-- Apache CXF Version -->
-        <cxf.version>4.1.7</cxf.version>
+        <cxf.version>4.1.8</cxf.version>
         <!-- Netty Version (for transitive dependency security fixes) -->
         <netty.version>4.1.136.Final</netty.version>
         <!-- Drools 10.x KIE API (upgraded from 7.74.1.Final for Jakarta EE compatibility) -->
@@ -320,14 +320,6 @@
                 <groupId>io.opentelemetry</groupId>
                 <artifactId>opentelemetry-api</artifactId>
                 <version>1.62.0</version>
-            </dependency>
-            <!-- Override transitive Artemis 2.50.0 from cxf-services-wsn-core.
-                 Security fix for missing authentication on critical functions (patched in 2.52.0);
-                 see the Dependabot alert for org.apache.artemis:artemis-server 2.50.0. -->
-            <dependency>
-                <groupId>org.apache.artemis</groupId>
-                <artifactId>artemis-server</artifactId>
-                <version>2.52.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <!-- Hapi Fhir Version -->
         <hapifhir.version>8.4.0</hapifhir.version>
         <!-- Apache CXF Version -->
-        <cxf.version>4.1.6</cxf.version>
+        <cxf.version>4.1.7</cxf.version>
         <!-- Netty Version (for transitive dependency security fixes) -->
         <netty.version>4.1.136.Final</netty.version>
         <!-- Drools 10.x KIE API (upgraded from 7.74.1.Final for Jakarta EE compatibility) -->


### PR DESCRIPTION
Fixes #3426

## What

- Upgrade Apache CXF from 4.1.6 to 4.1.8 and regenerate `dependencies-lock.json`.
- Remove the obsolete `artemis-server` 2.52.0 dependency-management override. CXF 4.1.8 now resolves all Artemis modules consistently at 2.55.0.
- Correct the CXF version in `CLAUDE.md` and `GEMINI.md`.

There are no production Java source changes.

## Why 4.1.8

The original 4.1.7 bump fixes CVE-2026-50645, the pre-authentication multipart attachment-header denial of service described in #3426. During manual review, Apache's current advisories showed that stopping at 4.1.7 would leave three relevant issues fixed in 4.1.8:

- CVE-2026-64958: the 4.1.7 attachment-header-count fix was incomplete.
- CVE-2026-54225: attachments had no default maximum size; 4.1.8 adds a 50 MiB default.
- CVE-2026-65432: XXE through imported WSDL/XSD documents.

The attachment processing path is reachable before application authentication: `CXFServlet` owns `/ws/*`, that path is exempt from `LoginFilter`, and CXF's attachment interceptor runs before WSS4J authentication. A library update is therefore required; 4.1.6 has no header-count property that can fully mitigate CVE-2026-50645.

## Dependency review

The lockfile movement is attributable to the CXF patch update. It includes CXF's own dependency-set updates (notably Artemis 2.55.0, JAXB 4.0.9, Micrometer 1.17.0, ASM 9.10.1, and related transitives).

The previous `artemis-server` 2.52.0 override sat underneath newer `artemis-jakarta-server` and client modules, creating an unsupported mixed-version classpath. Removing that obsolete security pin retains a version newer than the originally required fix while allowing every Artemis module to converge at 2.55.0.

## Manual review result

### MUST — fixed

- Do not ship the now-known-vulnerable CXF 4.1.7 release; use 4.1.8.
- Eliminate the mixed Artemis 2.52/2.55 module set.
- Keep the dependency lock and version documentation synchronized.

A repeat review found no remaining MUST issues.

### SHOULD — follow-up

- Replace the `org.apache.cxf:apache-cxf` aggregate POM with only the modules CARLOS uses. The aggregate currently packages unused tooling, CORBA, WSN/Artemis, STS, OAuth2, and multiple server transports, increasing WAR size and security-alert surface.
- Repair the pre-existing JAX-RS publication problem for `/ws/oauth` and `/ws/services`; both documented routes return 404 on `develop` and on this branch.
- Align the SLF4J bridge family (`jcl-over-slf4j` resolves to 2.0.18 while the directly managed `slf4j-api` remains 2.0.17).

### COULD — follow-up

- Add an application-owned multipart regression test that asserts oversized attachment/header requests are rejected, without coupling it too tightly to CXF internals.

## Verification

- `mvn se.vandmo:dependency-lock-maven-plugin:check` — pass.
- Clean `make install --force-clean` package/deploy — pass.
- `mvn -Dtest='**/webserv/**/*Test' surefire:test` — 334 tests, 0 failures/errors/skips.
- Deployed WAR contains CXF 4.1.8 only; the Artemis dependency tree is consistently 2.55.0.
- Tomcat endpoint smoke:
  - `SystemInfoService`, `LoginService`, and `ScheduleService` WSDLs — HTTP 200.
  - `SystemInfoService.isAlive` — HTTP 200, `alive`.
  - `LoginService.login2` — HTTP 200, authenticated.
  - WSS4J-authenticated `ScheduleService.getScheduleTemplateCodes` — HTTP 200.
  - The same schedule request without WS-Security — HTTP 400 SOAP fault, as expected.
  - `/ws/rs/status/checkIfAuthed` without a session — HTTP 401, as expected.

The repository-wide CI test job currently has an unrelated Surefire test-naming/coverage failure inherited from `develop`; the PR's focused web-service tests pass.

## Follow-up context

`pom.xml` still declares the whole `org.apache.cxf:apache-cxf` distribution. CARLOS uses JAX-WS, JAX-RS, and WSS4J, but the aggregate also ships CORBA, UDP/WebSocket/Netty/Undertow transports, WS-Notification with an embedded Artemis stack, STS, WS-Transfer, WS-Eventing, WS-RM, and the CXF code-generation toolchain. Narrowing that dependency belongs in a separate change because it materially changes the runtime classpath.

## Summary by Sourcery

Upgrade Apache CXF and refresh dependency management to deliver security fixes and a consistent runtime dependency set.

Bug Fixes:
- Upgrade Apache CXF to 4.1.8 to address pre-authentication attachment denial-of-service and related security vulnerabilities.

Enhancements:
- Remove the obsolete Artemis version override so resolved Artemis modules converge on a consistent version.
- Synchronize Apache CXF version references in project guidance documentation.

Build:
- Regenerate the dependency lockfile for the updated CXF dependency set.

Documentation:
- Update documented Apache CXF versions in CLAUDE.md and GEMINI.md.

<!-- Generated by sourcery-ai[bot]: start fixed-security -->
- Resolves [CVE-2026-50645 — Apache cxf-core: No restriction on attachment headers per message](https://app.sourcery.ai/dashboard/security/issues?groupId=99687030&issueIds=103979516)
<!-- Generated by sourcery-ai[bot]: end fixed-security -->