### PR TITLE
fix(casemgmt): expire abandoned note locks

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementEntry2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementEntry2Action.java
@@ -686,10 +686,8 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
     private static CasemgmtNoteLock isNoteEdited(Long noteId, Integer demographicNo,
             String providerNo, String ipAddress, String sessionId) {
         CasemgmtNoteLockDao noteLockDao = SpringUtils.getBean(CasemgmtNoteLockDao.class);
-        String configuredTimeout = CarlosProperties.getInstance()
-                .getProperty(NOTE_LOCK_TIMEOUT_MINUTES_PROPERTY, "5");
         return acquireNoteLock(noteLockDao, noteId, demographicNo, providerNo, ipAddress,
-                sessionId, new Date(), parseNoteLockTimeoutMillis(configuredTimeout));
+                sessionId, new Date(), getNoteLockTimeoutMillis());
     }
 
     /**
@@ -746,6 +744,12 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
             // Fall through to the safe default.
         }
         return DEFAULT_NOTE_LOCK_TIMEOUT_MILLIS;
+    }
+
+    private static long getNoteLockTimeoutMillis() {
+        String configuredTimeout = CarlosProperties.getInstance()
+                .getProperty(NOTE_LOCK_TIMEOUT_MINUTES_PROPERTY, "5");
+        return parseNoteLockTimeoutMillis(configuredTimeout);
     }
 
     static boolean isNoteLockExpired(CasemgmtNoteLock noteLock, Date now, long timeoutMillis) {
@@ -1991,12 +1995,13 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
 
     /**
      * Checks whether the current HTTP session holds a valid note lock for the given demographic.
-     * Performs two validations:
+     * Performs three validations:
      * <ol>
      *   <li>The database lock's session ID matches the session-stored lock's session ID
      *       (detects if another window/session has taken over the lock)</li>
      *   <li>The current request's session ID matches the session-stored lock's session ID
      *       (detects session ID staleness after rotation or migration)</li>
+     *   <li>The database lease has not passed its configured inactivity timeout</li>
      * </ol>
      *
      * @param demo String the demographic number to check lock ownership for
@@ -2010,7 +2015,7 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
                 return false;
             }
             return renewNoteLock(casemgmtNoteLockDao, casemgmtNoteLockSession,
-                    request.getSession().getId(), new Date());
+                    request.getSession().getId(), new Date(), getNoteLockTimeoutMillis());
         } catch (Exception e) {
             logger.warn("Lock check failed unexpectedly", e);
             return false;
@@ -2023,11 +2028,13 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
      * replacement by another editor.
      */
     static synchronized boolean renewNoteLock(CasemgmtNoteLockDao noteLockDao,
-            CasemgmtNoteLock sessionLock, String currentSessionId, Date now) {
+            CasemgmtNoteLock sessionLock, String currentSessionId, Date now,
+            long timeoutMillis) {
         CasemgmtNoteLock databaseLock = noteLockDao.find(sessionLock.getId());
         if (databaseLock == null
                 || !Objects.equals(databaseLock.getSessionId(), sessionLock.getSessionId())
-                || !Objects.equals(currentSessionId, sessionLock.getSessionId())) {
+                || !Objects.equals(currentSessionId, sessionLock.getSessionId())
+                || isNoteLockExpired(databaseLock, now, timeoutMillis)) {
             return false;
         }
 

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementEntry2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementEntry2Action.java
@@ -81,6 +81,7 @@ import java.io.PrintWriter;
 import java.io.Serializable;
 import java.lang.reflect.Array;
 import java.text.ParseException;
+import java.time.Duration;
 import java.util.*;
 import org.owasp.encoder.Encode;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -112,6 +113,9 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
     @SuppressWarnings("java:S1075") // fixed allowlist target; making this configurable would weaken redirect hardening
     private static final String CASE_MANAGEMENT_LIST_REDIRECT_PATH = "/CaseManagementView?method=view";
     private static final int REMOVED_ISSUE_MESSAGE_OVERHEAD = 64;
+    static final String NOTE_LOCK_TIMEOUT_MINUTES_PROPERTY = "casemgmt.note_lock_timeout_minutes";
+    static final long DEFAULT_NOTE_LOCK_TIMEOUT_MILLIS = Duration.ofMinutes(5).toMillis();
+    private static final long NOTE_LOCK_RENEW_INTERVAL_MILLIS = Duration.ofSeconds(30).toMillis();
 
     private static String appendRemovedIssueMessage(String noteText, Locale locale, ResourceBundle props, CharSequence issueNames) {
         String originalNote = StringUtils.defaultString(noteText);
@@ -679,43 +683,89 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
         return note;
     }
 
-    private static synchronized CasemgmtNoteLock isNoteEdited(Long note_id, Integer demographicNo, String providerNo, String ipAddress, String sessionId) {
-        CasemgmtNoteLockDao casemgmtNoteLockDao = SpringUtils.getBean(CasemgmtNoteLockDao.class);
-        CasemgmtNoteLock casemgmtNoteLock = casemgmtNoteLockDao.findByNoteDemo(demographicNo, note_id);
+    private static CasemgmtNoteLock isNoteEdited(Long noteId, Integer demographicNo,
+            String providerNo, String ipAddress, String sessionId) {
+        CasemgmtNoteLockDao noteLockDao = SpringUtils.getBean(CasemgmtNoteLockDao.class);
+        String configuredTimeout = CarlosProperties.getInstance()
+                .getProperty(NOTE_LOCK_TIMEOUT_MINUTES_PROPERTY, "5");
+        return acquireNoteLock(noteLockDao, noteId, demographicNo, providerNo, ipAddress,
+                sessionId, new Date(), parseNoteLockTimeoutMillis(configuredTimeout));
+    }
 
-        //We determine the lock status of the note
-        if (casemgmtNoteLock != null) {
-            //it has a lock; check if lock is same user
-            if (casemgmtNoteLock.getProviderNo().equals(providerNo)) {
-                //Same user has this note open elsewhere
-                casemgmtNoteLock.setLockedBySameUser(true);
-            } else if (note_id != 0) {
-                //Another user is editing same note
-                casemgmtNoteLock.setLocked(true);
-            } else if (note_id == 0) {
-                logger.debug("STATIC isNoteEdited CREATING LOCK NOTE ID 0 DEMO: " + demographicNo + " PROVIDER: " + providerNo);
-                casemgmtNoteLock = new CasemgmtNoteLock();
-                casemgmtNoteLock.setDemographicNo(demographicNo);
-                casemgmtNoteLock.setIpAddress(ipAddress);
-                casemgmtNoteLock.setNoteId(note_id);
-                casemgmtNoteLock.setProviderNo(providerNo);
-                casemgmtNoteLock.setSessionId(sessionId);
-                casemgmtNoteLock.setLockAcquired(new Date());
-                casemgmtNoteLockDao.persist(casemgmtNoteLock);
-            }
-        } else {
-            logger.debug("STATIC isNoteEdited CREATING NEW LOCK DEMO: " + demographicNo + " PROVIDER: " + providerNo);
-            casemgmtNoteLock = new CasemgmtNoteLock();
-            casemgmtNoteLock.setDemographicNo(demographicNo);
-            casemgmtNoteLock.setIpAddress(ipAddress);
-            casemgmtNoteLock.setNoteId(note_id);
-            casemgmtNoteLock.setProviderNo(providerNo);
-            casemgmtNoteLock.setSessionId(sessionId);
-            casemgmtNoteLock.setLockAcquired(new Date());
-            casemgmtNoteLockDao.persist(casemgmtNoteLock);
+    /**
+     * Acquires an encounter-note edit lease, recovering an abandoned lease once its configured
+     * inactivity timeout has elapsed. The synchronized boundary preserves the legacy
+     * single-process check-and-create behavior while stale cleanup and replacement occur.
+     */
+    static synchronized CasemgmtNoteLock acquireNoteLock(CasemgmtNoteLockDao noteLockDao,
+            Long noteId, Integer demographicNo, String providerNo, String ipAddress,
+            String sessionId, Date now, long timeoutMillis) {
+        CasemgmtNoteLock noteLock = noteLockDao.findByNoteDemo(demographicNo, noteId);
+
+        if (isNoteLockExpired(noteLock, now, timeoutMillis)) {
+            logger.info("Replacing expired encounter note lock after inactivity timeout");
+            noteLockDao.remove(noteLock.getId());
+            noteLock = null;
         }
 
-        return casemgmtNoteLock;
+        if (noteLock != null) {
+            noteLock.setLocked(false);
+            noteLock.setLockedBySameUser(false);
+            if (Objects.equals(noteLock.getProviderNo(), providerNo)) {
+                noteLock.setLockedBySameUser(true);
+            } else if (noteId != 0) {
+                noteLock.setLocked(true);
+            } else {
+                logger.debug("STATIC isNoteEdited CREATING LOCK NOTE ID 0 DEMO: "
+                        + demographicNo + " PROVIDER: " + providerNo);
+                noteLock = createNoteLock(noteId, demographicNo, providerNo, ipAddress,
+                        sessionId, now);
+                noteLockDao.persist(noteLock);
+            }
+        } else {
+            logger.debug("STATIC isNoteEdited CREATING NEW LOCK DEMO: " + demographicNo
+                    + " PROVIDER: " + providerNo);
+            noteLock = createNoteLock(noteId, demographicNo, providerNo, ipAddress,
+                    sessionId, now);
+            noteLockDao.persist(noteLock);
+        }
+
+        return noteLock;
+    }
+
+    static long parseNoteLockTimeoutMillis(String configuredMinutes) {
+        if (StringUtils.isBlank(configuredMinutes)) {
+            return DEFAULT_NOTE_LOCK_TIMEOUT_MILLIS;
+        }
+        try {
+            long minutes = Long.parseLong(configuredMinutes.trim());
+            if (minutes > 0 && minutes <= Duration.ofDays(1).toMinutes()) {
+                return Duration.ofMinutes(minutes).toMillis();
+            }
+        } catch (NumberFormatException ignored) {
+            // Fall through to the safe default.
+        }
+        return DEFAULT_NOTE_LOCK_TIMEOUT_MILLIS;
+    }
+
+    static boolean isNoteLockExpired(CasemgmtNoteLock noteLock, Date now, long timeoutMillis) {
+        if (noteLock == null) {
+            return false;
+        }
+        Date lastActivity = noteLock.getLockAcquired();
+        return lastActivity == null || now.getTime() - lastActivity.getTime() >= timeoutMillis;
+    }
+
+    private static CasemgmtNoteLock createNoteLock(Long noteId, Integer demographicNo,
+            String providerNo, String ipAddress, String sessionId, Date now) {
+        CasemgmtNoteLock noteLock = new CasemgmtNoteLock();
+        noteLock.setDemographicNo(demographicNo);
+        noteLock.setIpAddress(ipAddress);
+        noteLock.setNoteId(noteId);
+        noteLock.setProviderNo(providerNo);
+        noteLock.setSessionId(sessionId);
+        noteLock.setLockAcquired(now);
+        return noteLock;
     }
 
     // FindSecBugs XSS_SERVLET: response is JSON/encoded/static/binary/text content, not an HTML XSS sink.
@@ -778,10 +828,16 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
             logger.warn("updateNoteLock: lock not found - lock may have been released");
             return null;
         }
+        if (!canTransferNoteLock(casemgmtNoteLock, loggedInInfo.getLoggedInProviderNo())) {
+            logger.warn("updateNoteLock: refusing to transfer another provider's active lock");
+            response.setStatus(HttpServletResponse.SC_CONFLICT);
+            return null;
+        }
 
         casemgmtNoteLock.setIpAddress(request.getRemoteAddr());
         String currentSessionId = request.getSession().getId();
         casemgmtNoteLock.setSessionId(currentSessionId);
+        casemgmtNoteLock.setLockAcquired(new Date());
         logger.debug("UPDATING LOCK DEMO {} LOCK IP {}", LogSafe.sanitize(demoNo), LogSafe.sanitize(casemgmtNoteLock.getIpAddress()));
         casemgmtNoteLockDao.merge(casemgmtNoteLock);
 
@@ -789,6 +845,10 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
 
         return null;
 
+    }
+
+    static boolean canTransferNoteLock(CasemgmtNoteLock noteLock, String providerNo) {
+        return noteLock != null && Objects.equals(noteLock.getProviderNo(), providerNo);
     }
 
     private void setChecked_oldCme(List<CheckBoxBean> checkedList, CaseManagementIssue cmi) {
@@ -1949,17 +2009,36 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
             if (casemgmtNoteLockSession == null) {
                 return false;
             }
-            CasemgmtNoteLock casemgmtNoteLock = casemgmtNoteLockDao.find(casemgmtNoteLockSession.getId());
-            if (casemgmtNoteLock == null) {
-                return false;
-            }
-            String currentSessionId = request.getSession().getId();
-            return Objects.equals(casemgmtNoteLock.getSessionId(), casemgmtNoteLockSession.getSessionId())
-                && Objects.equals(currentSessionId, casemgmtNoteLockSession.getSessionId());
+            return renewNoteLock(casemgmtNoteLockDao, casemgmtNoteLockSession,
+                    request.getSession().getId(), new Date());
         } catch (Exception e) {
             logger.warn("Lock check failed unexpectedly", e);
             return false;
         }
+    }
+
+    /**
+     * Verifies and periodically renews a lock lease while sharing the acquisition monitor.
+     * This prevents a local request from renewing an old row concurrently with stale-lock
+     * replacement by another editor.
+     */
+    static synchronized boolean renewNoteLock(CasemgmtNoteLockDao noteLockDao,
+            CasemgmtNoteLock sessionLock, String currentSessionId, Date now) {
+        CasemgmtNoteLock databaseLock = noteLockDao.find(sessionLock.getId());
+        if (databaseLock == null
+                || !Objects.equals(databaseLock.getSessionId(), sessionLock.getSessionId())
+                || !Objects.equals(currentSessionId, sessionLock.getSessionId())) {
+            return false;
+        }
+
+        Date lastActivity = databaseLock.getLockAcquired();
+        if (lastActivity == null
+                || now.getTime() - lastActivity.getTime() >= NOTE_LOCK_RENEW_INTERVAL_MILLIS) {
+            databaseLock.setLockAcquired(now);
+            sessionLock.setLockAcquired(now);
+            noteLockDao.merge(databaseLock);
+        }
+        return true;
     }
 
     private void releaseNoteLock(String providerNo, Integer demographicNo, Long noteId) {

--- a/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementEntry2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementEntry2Action.java
@@ -832,20 +832,18 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
             logger.warn("updateNoteLock: lock not found - lock may have been released");
             return null;
         }
-        if (!canTransferNoteLock(casemgmtNoteLock, loggedInInfo.getLoggedInProviderNo())) {
-            logger.warn("updateNoteLock: refusing to transfer another provider's active lock");
+        CasemgmtNoteLock transferredLock = transferNoteLock(casemgmtNoteLockDao,
+                casemgmtNoteLock, loggedInInfo.getLoggedInProviderNo(), request.getRemoteAddr(),
+                request.getSession().getId(), new Date(), getNoteLockTimeoutMillis());
+        if (transferredLock == null) {
+            logger.warn("updateNoteLock: refusing to transfer an expired or unowned lock");
             response.setStatus(HttpServletResponse.SC_CONFLICT);
             return null;
         }
 
-        casemgmtNoteLock.setIpAddress(request.getRemoteAddr());
-        String currentSessionId = request.getSession().getId();
-        casemgmtNoteLock.setSessionId(currentSessionId);
-        casemgmtNoteLock.setLockAcquired(new Date());
-        logger.debug("UPDATING LOCK DEMO {} LOCK IP {}", LogSafe.sanitize(demoNo), LogSafe.sanitize(casemgmtNoteLock.getIpAddress()));
-        casemgmtNoteLockDao.merge(casemgmtNoteLock);
+        logger.debug("UPDATING LOCK DEMO {} LOCK IP {}", LogSafe.sanitize(demoNo), LogSafe.sanitize(transferredLock.getIpAddress()));
 
-        session.setAttribute("casemgmtNoteLock" + demoNo, casemgmtNoteLock); // nosemgrep: tainted-session-from-http-request, tainted-session-from-http-request-deepsemgrep
+        session.setAttribute("casemgmtNoteLock" + demoNo, transferredLock); // nosemgrep: tainted-session-from-http-request, tainted-session-from-http-request-deepsemgrep
 
         return null;
 
@@ -853,6 +851,25 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
 
     static boolean canTransferNoteLock(CasemgmtNoteLock noteLock, String providerNo) {
         return noteLock != null && Objects.equals(noteLock.getProviderNo(), providerNo);
+    }
+
+    static synchronized CasemgmtNoteLock transferNoteLock(CasemgmtNoteLockDao noteLockDao,
+            CasemgmtNoteLock requestedLock, String providerNo, String ipAddress,
+            String sessionId, Date now, long timeoutMillis) {
+        if (requestedLock == null || requestedLock.getId() == null) {
+            return null;
+        }
+        CasemgmtNoteLock databaseLock = noteLockDao.find(requestedLock.getId());
+        if (!canTransferNoteLock(databaseLock, providerNo)
+                || isNoteLockExpired(databaseLock, now, timeoutMillis)) {
+            return null;
+        }
+
+        databaseLock.setIpAddress(ipAddress);
+        databaseLock.setSessionId(sessionId);
+        databaseLock.setLockAcquired(now);
+        noteLockDao.merge(databaseLock);
+        return databaseLock;
     }
 
     private void setChecked_oldCme(List<CheckBoxBean> checkedList, CaseManagementIssue cmi) {
@@ -2039,8 +2056,7 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
         }
 
         Date lastActivity = databaseLock.getLockAcquired();
-        if (lastActivity == null
-                || now.getTime() - lastActivity.getTime() >= NOTE_LOCK_RENEW_INTERVAL_MILLIS) {
+        if (now.getTime() - lastActivity.getTime() >= NOTE_LOCK_RENEW_INTERVAL_MILLIS) {
             databaseLock.setLockAcquired(now);
             sessionLock.setLockAcquired(now);
             noteLockDao.merge(databaseLock);

--- a/src/main/resources/carlos.properties
+++ b/src/main/resources/carlos.properties
@@ -1332,6 +1332,10 @@ default_phu=20
 #e.g. [04-Apr-2018 .: Tel-Progress Note]
 encounter.remove_empty_tmp_notes=no
 
+# Encounter note locks are inactivity leases. Active note saves renew the lease; if a
+# browser closes without releasing its lock, another editor can recover after this many minutes.
+casemgmt.note_lock_timeout_minutes=5
+
 #[OSCAREMR-6436] Display Ohip No. on Printed PDF Consultation Request
 consultation_display_practitioner_no=false
 

--- a/src/test/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementNoteLockLeaseUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementNoteLockLeaseUnitTest.java
@@ -145,6 +145,44 @@ class CaseManagementNoteLockLeaseUnitTest {
     }
 
     @Test
+    @DisplayName("should transfer an active lock owned by the same provider")
+    void shouldTransferActiveLock_whenProviderOwnsLease() {
+        CasemgmtNoteLockDao noteLockDao = mock(CasemgmtNoteLockDao.class);
+        CasemgmtNoteLock requestedLock = noteLock(20L, "provider-a", "session-a",
+                new Date(NOW.getTime() - Duration.ofMinutes(1).toMillis()));
+        CasemgmtNoteLock databaseLock = noteLock(20L, "provider-a", "session-a",
+                requestedLock.getLockAcquired());
+        when(noteLockDao.find(20L)).thenReturn(databaseLock);
+
+        CasemgmtNoteLock transferred = CaseManagementEntry2Action.transferNoteLock(noteLockDao,
+                requestedLock, "provider-a", "127.0.0.2", "session-b", NOW, FIVE_MINUTES);
+
+        assertThat(transferred).isSameAs(databaseLock);
+        assertThat(transferred.getIpAddress()).isEqualTo("127.0.0.2");
+        assertThat(transferred.getSessionId()).isEqualTo("session-b");
+        assertThat(transferred.getLockAcquired()).isEqualTo(NOW);
+        verify(noteLockDao).merge(databaseLock);
+    }
+
+    @Test
+    @DisplayName("should reject takeover after the inactivity timeout")
+    void shouldRejectTakeover_afterInactivityTimeout() {
+        CasemgmtNoteLockDao noteLockDao = mock(CasemgmtNoteLockDao.class);
+        CasemgmtNoteLock requestedLock = noteLock(21L, "provider-a", "session-a",
+                new Date(NOW.getTime() - FIVE_MINUTES));
+        CasemgmtNoteLock databaseLock = noteLock(21L, "provider-a", "session-a",
+                requestedLock.getLockAcquired());
+        when(noteLockDao.find(21L)).thenReturn(databaseLock);
+
+        CasemgmtNoteLock transferred = CaseManagementEntry2Action.transferNoteLock(noteLockDao,
+                requestedLock, "provider-a", "127.0.0.2", "session-b", NOW, FIVE_MINUTES);
+
+        assertThat(transferred).isNull();
+        assertThat(databaseLock.getSessionId()).isEqualTo("session-a");
+        verify(noteLockDao, never()).merge(databaseLock);
+    }
+
+    @Test
     @DisplayName("should renew an owned lock after the heartbeat interval")
     void shouldRenewLock_whenHeartbeatIntervalElapsed() {
         CasemgmtNoteLockDao noteLockDao = mock(CasemgmtNoteLockDao.class);

--- a/src/test/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementNoteLockLeaseUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementNoteLockLeaseUnitTest.java
@@ -1,0 +1,193 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.casemgmt.web;
+
+import io.github.carlos_emr.carlos.commn.dao.CasemgmtNoteLockDao;
+import io.github.carlos_emr.carlos.commn.model.CasemgmtNoteLock;
+
+import java.time.Duration;
+import java.util.Date;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@DisplayName("Case management note lock inactivity leases")
+@Tag("unit")
+@Tag("casemgmt")
+class CaseManagementNoteLockLeaseUnitTest {
+
+    private static final long FIVE_MINUTES = Duration.ofMinutes(5).toMillis();
+    private static final Date NOW = new Date(Duration.ofHours(2).toMillis());
+
+    @Test
+    @DisplayName("should protect an active lock held by another provider")
+    void shouldProtectLock_whenAnotherProviderIsActive() {
+        CasemgmtNoteLockDao noteLockDao = mock(CasemgmtNoteLockDao.class);
+        CasemgmtNoteLock activeLock = noteLock(11L, "provider-a", "session-a",
+                new Date(NOW.getTime() - Duration.ofMinutes(1).toMillis()));
+        when(noteLockDao.findByNoteDemo(1, 42L)).thenReturn(activeLock);
+
+        CasemgmtNoteLock result = CaseManagementEntry2Action.acquireNoteLock(noteLockDao,
+                42L, 1, "provider-b", "127.0.0.1", "session-b", NOW, FIVE_MINUTES);
+
+        assertThat(result).isSameAs(activeLock);
+        assertThat(result.isLocked()).isTrue();
+        assertThat(result.isLockedBySameUser()).isFalse();
+        verify(noteLockDao, never()).remove(11L);
+        verify(noteLockDao, never()).persist(result);
+    }
+
+    @Test
+    @DisplayName("should retain the takeover prompt for an active lock held by the same provider")
+    void shouldPromptForTakeover_whenSameProviderIsActiveElsewhere() {
+        CasemgmtNoteLockDao noteLockDao = mock(CasemgmtNoteLockDao.class);
+        CasemgmtNoteLock activeLock = noteLock(12L, "provider-a", "session-a",
+                new Date(NOW.getTime() - Duration.ofMinutes(1).toMillis()));
+        when(noteLockDao.findByNoteDemo(1, 42L)).thenReturn(activeLock);
+
+        CasemgmtNoteLock result = CaseManagementEntry2Action.acquireNoteLock(noteLockDao,
+                42L, 1, "provider-a", "127.0.0.1", "session-b", NOW, FIVE_MINUTES);
+
+        assertThat(result).isSameAs(activeLock);
+        assertThat(result.isLocked()).isFalse();
+        assertThat(result.isLockedBySameUser()).isTrue();
+        verify(noteLockDao, never()).remove(12L);
+        verify(noteLockDao, never()).persist(result);
+    }
+
+    @Test
+    @DisplayName("should replace an expired lock from an abandoned session")
+    void shouldReplaceLock_whenPriorSessionIsAbandoned() {
+        CasemgmtNoteLockDao noteLockDao = mock(CasemgmtNoteLockDao.class);
+        CasemgmtNoteLock expiredLock = noteLock(13L, "provider-a", "session-a",
+                new Date(NOW.getTime() - FIVE_MINUTES));
+        when(noteLockDao.findByNoteDemo(1, 42L)).thenReturn(expiredLock);
+
+        CasemgmtNoteLock result = CaseManagementEntry2Action.acquireNoteLock(noteLockDao,
+                42L, 1, "provider-b", "127.0.0.2", "session-b", NOW, FIVE_MINUTES);
+
+        assertThat(result).isNotSameAs(expiredLock);
+        assertThat(result.getProviderNo()).isEqualTo("provider-b");
+        assertThat(result.getSessionId()).isEqualTo("session-b");
+        assertThat(result.getDemographicNo()).isEqualTo(1);
+        assertThat(result.getNoteId()).isEqualTo(42L);
+        assertThat(result.getLockAcquired()).isEqualTo(NOW);
+        assertThat(result.isLocked()).isFalse();
+        assertThat(result.isLockedBySameUser()).isFalse();
+        verify(noteLockDao).remove(13L);
+        verify(noteLockDao).persist(result);
+    }
+
+    @Test
+    @DisplayName("should treat a legacy lock without an activity timestamp as abandoned")
+    void shouldReplaceLock_whenActivityTimestampIsMissing() {
+        CasemgmtNoteLockDao noteLockDao = mock(CasemgmtNoteLockDao.class);
+        CasemgmtNoteLock undatedLock = noteLock(14L, "provider-a", "session-a", null);
+        when(noteLockDao.findByNoteDemo(1, 42L)).thenReturn(undatedLock);
+
+        CasemgmtNoteLock result = CaseManagementEntry2Action.acquireNoteLock(noteLockDao,
+                42L, 1, "provider-b", "127.0.0.2", "session-b", NOW, FIVE_MINUTES);
+
+        assertThat(result).isNotSameAs(undatedLock);
+        verify(noteLockDao).remove(14L);
+        verify(noteLockDao).persist(result);
+    }
+
+    @Test
+    @DisplayName("should use the safe default for invalid timeout configuration")
+    void shouldUseDefaultTimeout_whenConfigurationIsInvalid() {
+        assertThat(CaseManagementEntry2Action.parseNoteLockTimeoutMillis(null))
+                .isEqualTo(CaseManagementEntry2Action.DEFAULT_NOTE_LOCK_TIMEOUT_MILLIS);
+        assertThat(CaseManagementEntry2Action.parseNoteLockTimeoutMillis("not-a-number"))
+                .isEqualTo(CaseManagementEntry2Action.DEFAULT_NOTE_LOCK_TIMEOUT_MILLIS);
+        assertThat(CaseManagementEntry2Action.parseNoteLockTimeoutMillis("0"))
+                .isEqualTo(CaseManagementEntry2Action.DEFAULT_NOTE_LOCK_TIMEOUT_MILLIS);
+        assertThat(CaseManagementEntry2Action.parseNoteLockTimeoutMillis("1441"))
+                .isEqualTo(CaseManagementEntry2Action.DEFAULT_NOTE_LOCK_TIMEOUT_MILLIS);
+        assertThat(CaseManagementEntry2Action.parseNoteLockTimeoutMillis("15"))
+                .isEqualTo(Duration.ofMinutes(15).toMillis());
+    }
+
+    @Test
+    @DisplayName("should allow takeover only when the provider owns the lock")
+    void shouldAllowTakeover_onlyForOwningProvider() {
+        CasemgmtNoteLock lock = noteLock(15L, "provider-a", "session-a", NOW);
+
+        assertThat(CaseManagementEntry2Action.canTransferNoteLock(lock, "provider-a")).isTrue();
+        assertThat(CaseManagementEntry2Action.canTransferNoteLock(lock, "provider-b")).isFalse();
+        assertThat(CaseManagementEntry2Action.canTransferNoteLock(null, "provider-a")).isFalse();
+    }
+
+    @Test
+    @DisplayName("should renew an owned lock after the heartbeat interval")
+    void shouldRenewLock_whenHeartbeatIntervalElapsed() {
+        CasemgmtNoteLockDao noteLockDao = mock(CasemgmtNoteLockDao.class);
+        CasemgmtNoteLock sessionLock = noteLock(16L, "provider-a", "session-a",
+                new Date(NOW.getTime() - Duration.ofMinutes(1).toMillis()));
+        CasemgmtNoteLock databaseLock = noteLock(16L, "provider-a", "session-a",
+                sessionLock.getLockAcquired());
+        when(noteLockDao.find(16L)).thenReturn(databaseLock);
+
+        boolean renewed = CaseManagementEntry2Action.renewNoteLock(noteLockDao,
+                sessionLock, "session-a", NOW);
+
+        assertThat(renewed).isTrue();
+        assertThat(databaseLock.getLockAcquired()).isEqualTo(NOW);
+        assertThat(sessionLock.getLockAcquired()).isEqualTo(NOW);
+        verify(noteLockDao).merge(databaseLock);
+    }
+
+    @Test
+    @DisplayName("should reject renewal after another session takes the lock")
+    void shouldRejectRenewal_whenSessionLostLock() {
+        CasemgmtNoteLockDao noteLockDao = mock(CasemgmtNoteLockDao.class);
+        CasemgmtNoteLock sessionLock = noteLock(17L, "provider-a", "session-a",
+                new Date(NOW.getTime() - Duration.ofMinutes(1).toMillis()));
+        CasemgmtNoteLock databaseLock = noteLock(17L, "provider-a", "session-b", NOW);
+        when(noteLockDao.find(17L)).thenReturn(databaseLock);
+
+        boolean renewed = CaseManagementEntry2Action.renewNoteLock(noteLockDao,
+                sessionLock, "session-a", NOW);
+
+        assertThat(renewed).isFalse();
+        verify(noteLockDao, never()).merge(databaseLock);
+    }
+
+    private static CasemgmtNoteLock noteLock(Long id, String providerNo, String sessionId,
+            Date lastActivity) {
+        CasemgmtNoteLock lock = new CasemgmtNoteLock();
+        lock.setId(id);
+        lock.setDemographicNo(1);
+        lock.setNoteId(42L);
+        lock.setProviderNo(providerNo);
+        lock.setSessionId(sessionId);
+        lock.setLockAcquired(lastActivity);
+        return lock;
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementNoteLockLeaseUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/casemgmt/web/CaseManagementNoteLockLeaseUnitTest.java
@@ -155,7 +155,7 @@ class CaseManagementNoteLockLeaseUnitTest {
         when(noteLockDao.find(16L)).thenReturn(databaseLock);
 
         boolean renewed = CaseManagementEntry2Action.renewNoteLock(noteLockDao,
-                sessionLock, "session-a", NOW);
+                sessionLock, "session-a", NOW, FIVE_MINUTES);
 
         assertThat(renewed).isTrue();
         assertThat(databaseLock.getLockAcquired()).isEqualTo(NOW);
@@ -173,7 +173,40 @@ class CaseManagementNoteLockLeaseUnitTest {
         when(noteLockDao.find(17L)).thenReturn(databaseLock);
 
         boolean renewed = CaseManagementEntry2Action.renewNoteLock(noteLockDao,
-                sessionLock, "session-a", NOW);
+                sessionLock, "session-a", NOW, FIVE_MINUTES);
+
+        assertThat(renewed).isFalse();
+        verify(noteLockDao, never()).merge(databaseLock);
+    }
+
+    @Test
+    @DisplayName("should reject renewal after the inactivity timeout")
+    void shouldRejectRenewal_afterInactivityTimeout() {
+        CasemgmtNoteLockDao noteLockDao = mock(CasemgmtNoteLockDao.class);
+        CasemgmtNoteLock sessionLock = noteLock(18L, "provider-a", "session-a",
+                new Date(NOW.getTime() - FIVE_MINUTES));
+        CasemgmtNoteLock databaseLock = noteLock(18L, "provider-a", "session-a",
+                sessionLock.getLockAcquired());
+        when(noteLockDao.find(18L)).thenReturn(databaseLock);
+
+        boolean renewed = CaseManagementEntry2Action.renewNoteLock(noteLockDao,
+                sessionLock, "session-a", NOW, FIVE_MINUTES);
+
+        assertThat(renewed).isFalse();
+        assertThat(databaseLock.getLockAcquired()).isNotEqualTo(NOW);
+        verify(noteLockDao, never()).merge(databaseLock);
+    }
+
+    @Test
+    @DisplayName("should reject renewal of a legacy lock without activity timestamp")
+    void shouldRejectRenewal_whenActivityTimestampIsMissing() {
+        CasemgmtNoteLockDao noteLockDao = mock(CasemgmtNoteLockDao.class);
+        CasemgmtNoteLock sessionLock = noteLock(19L, "provider-a", "session-a", null);
+        CasemgmtNoteLock databaseLock = noteLock(19L, "provider-a", "session-a", null);
+        when(noteLockDao.find(19L)).thenReturn(databaseLock);
+
+        boolean renewed = CaseManagementEntry2Action.renewNoteLock(noteLockDao,
+                sessionLock, "session-a", NOW, FIVE_MINUTES);
 
         assertThat(renewed).isFalse();
         verify(noteLockDao, never()).merge(databaseLock);


### PR DESCRIPTION
## Description

Treat encounter note locks as short inactivity leases so a failed browser-close beacon cannot block later editing for the full two-hour HTTP session lifetime.

- expire and atomically replace abandoned locks after a configurable five-minute inactivity timeout
- renew active leases during the existing save/autosave lock check, limited to one write every 30 seconds
- keep active locks from other providers protected and preserve the same-provider takeover prompt
- refuse the takeover endpoint when the logged-in provider does not own the active lock
- treat legacy lock rows without an activity timestamp as abandoned

## Related Issues

Fixes #3423

## How Was This Tested?

- `MAVEN_OPTS="-Xmx1g -Xms256m" mvn -q -Dtest=CaseManagementNoteLockLeaseUnitTest test` — 12 tests passed after review fixes
- `MAVEN_OPTS="-Xmx1g -Xms256m" mvn -q -DskipTests checkstyle:check`
- `git diff --check`

The focused 12-test suite covers active locks held by another provider, same-provider takeover prompts, expired and legacy undated lock recovery, timeout validation, provider ownership enforcement, active lease renewal, and rejection after another session takes the lock.

## Manual Review

### MUST

- **Addressed before opening:** serialize lease renewal with acquisition so expiry and heartbeat cannot race within one application process.
- **Addressed before opening:** prevent `updateNoteLock` from transferring another provider’s active lock.
- Re-review found no remaining MUST findings.

### SHOULD

- None remaining. The inactivity duration is configurable and defaults to five minutes; renewal is rate-limited to avoid a database write on every five-second autosave.

### COULD

- Cross-node database locking could further harden clustered deployments, but CARLOS currently relies on the existing single-application synchronized acquisition model. That architectural expansion is not warranted in this focused recovery fix.

## Checklist

- [x] Commits are DCO signed
- [x] Commit uses Conventional Commits
- [x] No patient data or PHI is included
- [x] Focused automated tests were added
- [x] Contributing guide reviewed

## Summary by Sourcery

Convert encounter note edit locks into short-lived inactivity leases with automatic expiry and renewal to prevent abandoned sessions from blocking later editing.

Bug Fixes:
- Expire and replace abandoned encounter note locks after a configurable inactivity timeout so failed browser closures no longer block editing.
- Prevent the note lock takeover endpoint from transferring locks that are owned by a different provider, enforcing provider ownership semantics.

Enhancements:
- Introduce configurable inactivity timeout and heartbeat interval for note lock leases, with safe defaults and validation of configuration values.
- Share a synchronized acquisition and renewal model for note lock leases to avoid races between stale-lock cleanup and active lease renewal.

Documentation:
- Document the new encounter note lock inactivity timeout configuration in carlos.properties.

Tests:
- Add unit tests covering lock protection for other providers, same-provider takeover prompts, expired and legacy lock recovery, timeout parsing, provider ownership enforcement, and lease renewal behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expire abandoned encounter‑note locks by converting them to short inactivity leases and rejecting expired takeovers, so a missed browser‑close beacon no longer blocks edits for hours. Previously a missed beacon could hold a lock for the two‑hour session; now we reclaim and atomically replace locks after 5 minutes of inactivity while keeping active editors protected.

- Configurable timeout via `casemgmt.note_lock_timeout_minutes` (default 5; invalid values fall back to default and are bounded to 1 day). Lease renewal occurs on save/autosave and `updateNoteLock`, rate‑limited to every 30s.
- Renewal rejects expired or mismatched sessions; `hasNoteLock` validates and renews active leases, and fails when the lease is expired.
- Preserve same‑provider takeover prompt; block cross‑provider transfers and return 409 on `updateNoteLock` when the requester does not own the lock or the lease is expired.
- Treat legacy locks without an activity timestamp as abandoned and replace them on acquisition.
- Synchronize acquisition and renewal to avoid races with stale‑lock cleanup; single‑process semantics preserved.
- Focused unit tests cover expiry, renewal, legacy recovery, provider ownership enforcement, and expired‑takeover rejection.

<sup>Written for commit 4ac23048a75e5f956e0399464177e3aab621c56c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->