### PR TITLE
fix: remove dangling development HRM fixtures

### DIFF
--- a/.devcontainer/db/Dockerfile
+++ b/.devcontainer/db/Dockerfile
@@ -15,6 +15,7 @@ COPY ./.devcontainer/db/scripts/populate_db.sh /docker-entrypoint-initdb.d/popul
 RUN mkdir /scripts
 COPY ./.devcontainer/db/scripts/development.sql /scripts/development.sql
 COPY ./.devcontainer/db/scripts/development_privileges.sql /scripts/development_privileges.sql
+COPY ./.devcontainer/db/scripts/development_hrm_cleanup.sql /scripts/development_hrm_cleanup.sql
 COPY ./database /database
 COPY ./.devcontainer/development/config/shared/my.cnf /etc/mysql/my.cnf
 

--- a/.devcontainer/db/scripts/development_hrm_cleanup.sql
+++ b/.devcontainer/db/scripts/development_hrm_cleanup.sql
@@ -31,6 +31,12 @@ FROM `HRMDocumentToProvider` hrm_provider
 JOIN `DevelopmentDanglingHrm` fixture
   ON fixture.`id` = CAST(hrm_provider.`hrmDocumentId` AS UNSIGNED);
 
+UPDATE `HRMDocument` hrm_document
+JOIN `DevelopmentDanglingHrm` fixture
+  ON fixture.`id` = hrm_document.`parentReport`
+SET hrm_document.`parentReport` = NULL
+WHERE hrm_document.`id` NOT IN (SELECT `id` FROM `DevelopmentDanglingHrm`);
+
 DELETE hrm_document
 FROM `HRMDocument` hrm_document
 JOIN `DevelopmentDanglingHrm` fixture

--- a/.devcontainer/db/scripts/development_hrm_cleanup.sql
+++ b/.devcontainer/db/scripts/development_hrm_cleanup.sql
@@ -1,0 +1,39 @@
+-- The development snapshot contains HRM metadata from July-September 2023, but the
+-- corresponding XML reports are intentionally not distributed with the repository.
+-- Remove only those original snapshot rows. The id and import-time bounds ensure this
+-- repair is safe to reapply without deleting HRM reports created later by developers.
+
+CREATE TEMPORARY TABLE `DevelopmentDanglingHrm` AS
+SELECT `id`
+FROM `HRMDocument`
+WHERE `id` BETWEEN 1 AND 41
+  AND `timeReceived` >= '2023-07-25 00:00:00'
+  AND `timeReceived` < '2023-09-06 00:00:00'
+  AND `reportFile` LIKE 'LabUpload.%';
+
+DELETE hrm_comment
+FROM `HRMDocumentComment` hrm_comment
+JOIN `DevelopmentDanglingHrm` fixture
+  ON fixture.`id` = hrm_comment.`hrmDocumentId`;
+
+DELETE hrm_subclass
+FROM `HRMDocumentSubClass` hrm_subclass
+JOIN `DevelopmentDanglingHrm` fixture
+  ON fixture.`id` = hrm_subclass.`hrmDocumentId`;
+
+DELETE hrm_demographic
+FROM `HRMDocumentToDemographic` hrm_demographic
+JOIN `DevelopmentDanglingHrm` fixture
+  ON fixture.`id` = CAST(hrm_demographic.`hrmDocumentId` AS UNSIGNED);
+
+DELETE hrm_provider
+FROM `HRMDocumentToProvider` hrm_provider
+JOIN `DevelopmentDanglingHrm` fixture
+  ON fixture.`id` = CAST(hrm_provider.`hrmDocumentId` AS UNSIGNED);
+
+DELETE hrm_document
+FROM `HRMDocument` hrm_document
+JOIN `DevelopmentDanglingHrm` fixture
+  ON fixture.`id` = hrm_document.`id`;
+
+DROP TEMPORARY TABLE `DevelopmentDanglingHrm`;

--- a/.devcontainer/db/scripts/development_hrm_cleanup.sql
+++ b/.devcontainer/db/scripts/development_hrm_cleanup.sql
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+
 -- The development snapshot contains HRM metadata from July-September 2023, but the
 -- corresponding XML reports are intentionally not distributed with the repository.
 -- Remove only those original snapshot rows. The id and import-time bounds ensure this

--- a/.devcontainer/db/scripts/populate_db.sh
+++ b/.devcontainer/db/scripts/populate_db.sh
@@ -79,6 +79,8 @@ $SQL drugref2 < /database/mysql/drugref/2026-04-19-drugref-tc-atc-f.sql
 # the baseline reference rows with the demo dataset (patients, appointments, notes, etc.).
 echo 'Loading demo data for development...'
 $SQL oscar < /scripts/development.sql
+echo 'Removing HRM rows whose source fixtures are not distributed...'
+$SQL oscar < /scripts/development_hrm_cleanup.sql
 echo 'Restoring current Administration privileges...'
 $SQL oscar < /scripts/development_privileges.sql
 echo 'Preparing demographic names for development environment...'

--- a/.devcontainer/development/setup/seed_data.sh
+++ b/.devcontainer/development/setup/seed_data.sh
@@ -27,5 +27,5 @@ mariadb -h db -u root --batch --skip-column-names oscar \
     -e "SELECT reportFile FROM HRMDocument WHERE reportFile IS NOT NULL AND reportFile <> ''" \
     > "${hrm_fixture_list}"
 sh /workspace/.devcontainer/development/setup/validate_hrm_fixtures.sh \
-    /var/lib/OscarDocument/oscar/document < "${hrm_fixture_list}"
+    /var/lib/OscarDocument/oscar/document "${hrm_fixture_list}"
 echo "[Bootstrap] Finished copying documents."

--- a/.devcontainer/development/setup/seed_data.sh
+++ b/.devcontainer/development/setup/seed_data.sh
@@ -10,6 +10,8 @@ echo "[Bootstrap] Seeding initial database files..."
 export MYSQL_PWD="${MARIADB_ROOT_PASSWORD:-${MYSQL_ROOT_PASSWORD:-password}}"
 mariadb -h db -u root oscar \
     < /workspace/.devcontainer/db/scripts/development_privileges.sql
+mariadb -h db -u root oscar \
+    < /workspace/.devcontainer/db/scripts/development_hrm_cleanup.sql
 
 # The runtime document volume masks directories created in the image. Recreate
 # the configured incoming-document root in that mounted volume so fresh
@@ -18,4 +20,12 @@ mkdir -p /var/lib/OscarDocument/oscar/incomingdocs
 
 # Seeding initial database files for documents
 cp -vn /db-data/documents/* /var/lib/OscarDocument/oscar/document/
+
+hrm_fixture_list=$(mktemp)
+trap 'rm -f "${hrm_fixture_list}"' EXIT
+mariadb -h db -u root --batch --skip-column-names oscar \
+    -e "SELECT reportFile FROM HRMDocument WHERE reportFile IS NOT NULL AND reportFile <> ''" \
+    > "${hrm_fixture_list}"
+sh /workspace/.devcontainer/development/setup/validate_hrm_fixtures.sh \
+    /var/lib/OscarDocument/oscar/document < "${hrm_fixture_list}"
 echo "[Bootstrap] Finished copying documents."

--- a/.devcontainer/development/setup/validate_hrm_fixtures.sh
+++ b/.devcontainer/development/setup/validate_hrm_fixtures.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+set -eu
+
+document_dir=${1:?usage: validate_hrm_fixtures.sh DOCUMENT_DIR}
+missing_count=0
+
+while IFS= read -r report_file; do
+    [ -n "${report_file}" ] || continue
+
+    if [ ! -f "${document_dir}/${report_file}" ]; then
+        echo "Missing seeded HRM fixture: ${report_file}" >&2
+        missing_count=$((missing_count + 1))
+    fi
+done
+
+if [ "${missing_count}" -ne 0 ]; then
+    echo "ERROR: ${missing_count} seeded HRM report(s) have no document fixture." >&2
+    exit 1
+fi
+
+echo "Validated seeded HRM document references."

--- a/.devcontainer/development/setup/validate_hrm_fixtures.sh
+++ b/.devcontainer/development/setup/validate_hrm_fixtures.sh
@@ -17,6 +17,7 @@ set -eu
 document_dir=${1:?usage: validate_hrm_fixtures.sh DOCUMENT_DIR REPORT_FILE_LIST}
 report_file_list=${2:?usage: validate_hrm_fixtures.sh DOCUMENT_DIR REPORT_FILE_LIST}
 missing_count=0
+invalid_path_count=0
 
 if [ ! -f "${report_file_list}" ]; then
     echo "ERROR: HRM report-file list does not exist: ${report_file_list}" >&2
@@ -29,7 +30,7 @@ while IFS= read -r report_file; do
     case "${report_file}" in
         /*|..|../*|*/..|*/../*)
             echo "Invalid seeded HRM fixture path outside document directory: ${report_file}" >&2
-            missing_count=$((missing_count + 1))
+            invalid_path_count=$((invalid_path_count + 1))
             continue
             ;;
     esac
@@ -42,6 +43,13 @@ done < "${report_file_list}"
 
 if [ "${missing_count}" -ne 0 ]; then
     echo "ERROR: ${missing_count} seeded HRM report(s) have no document fixture." >&2
+fi
+
+if [ "${invalid_path_count}" -ne 0 ]; then
+    echo "ERROR: ${invalid_path_count} seeded HRM report(s) have invalid fixture paths." >&2
+fi
+
+if [ "${missing_count}" -ne 0 ] || [ "${invalid_path_count}" -ne 0 ]; then
     exit 1
 fi
 

--- a/.devcontainer/development/setup/validate_hrm_fixtures.sh
+++ b/.devcontainer/development/setup/validate_hrm_fixtures.sh
@@ -1,4 +1,16 @@
 #!/bin/sh
+##
+# Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+#
+# This software is published under the GPL GNU General Public License.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# CARLOS EMR Project
+# https://github.com/carlos-emr/carlos
+##
 
 set -eu
 

--- a/.devcontainer/development/setup/validate_hrm_fixtures.sh
+++ b/.devcontainer/development/setup/validate_hrm_fixtures.sh
@@ -2,17 +2,31 @@
 
 set -eu
 
-document_dir=${1:?usage: validate_hrm_fixtures.sh DOCUMENT_DIR}
+document_dir=${1:?usage: validate_hrm_fixtures.sh DOCUMENT_DIR REPORT_FILE_LIST}
+report_file_list=${2:?usage: validate_hrm_fixtures.sh DOCUMENT_DIR REPORT_FILE_LIST}
 missing_count=0
+
+if [ ! -f "${report_file_list}" ]; then
+    echo "ERROR: HRM report-file list does not exist: ${report_file_list}" >&2
+    exit 1
+fi
 
 while IFS= read -r report_file; do
     [ -n "${report_file}" ] || continue
+
+    case "${report_file}" in
+        /*|..|../*|*/..|*/../*)
+            echo "Invalid seeded HRM fixture path outside document directory: ${report_file}" >&2
+            missing_count=$((missing_count + 1))
+            continue
+            ;;
+    esac
 
     if [ ! -f "${document_dir}/${report_file}" ]; then
         echo "Missing seeded HRM fixture: ${report_file}" >&2
         missing_count=$((missing_count + 1))
     fi
-done
+done < "${report_file_list}"
 
 if [ "${missing_count}" -ne 0 ]; then
     echo "ERROR: ${missing_count} seeded HRM report(s) have no document fixture." >&2

--- a/src/test/java/io/github/carlos_emr/carlos/hospitalReportManager/HrmDevelopmentFixtureSeedRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/hospitalReportManager/HrmDevelopmentFixtureSeedRegressionTest.java
@@ -114,7 +114,20 @@ class HrmDevelopmentFixtureSeedRegressionTest {
 
         assertThat(result.exitCode()).isEqualTo(1);
         assertThat(result.output())
-                .contains("Invalid seeded HRM fixture path outside document directory");
+                .contains("Invalid seeded HRM fixture path outside document directory")
+                .contains("1 seeded HRM report(s) have invalid fixture paths")
+                .doesNotContain("have no document fixture");
+    }
+
+    @Test
+    @DisplayName("should report invalid paths separately from missing fixtures")
+    void shouldReportInvalidPathsSeparately_whenFixtureIsAlsoMissing() throws Exception {
+        ValidationResult result = runValidator("../outside.xml\nmissing.xml\n");
+
+        assertThat(result.exitCode()).isEqualTo(1);
+        assertThat(result.output())
+                .contains("1 seeded HRM report(s) have invalid fixture paths")
+                .contains("1 seeded HRM report(s) have no document fixture");
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/hospitalReportManager/HrmDevelopmentFixtureSeedRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/hospitalReportManager/HrmDevelopmentFixtureSeedRegressionTest.java
@@ -6,6 +6,7 @@
 package io.github.carlos_emr.carlos.hospitalReportManager;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -26,16 +27,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DisplayName("development HRM fixture seed regressions")
 class HrmDevelopmentFixtureSeedRegressionTest {
 
-    private static final Path CLEANUP_SQL = Path.of(
-            ".devcontainer", "db", "scripts", "development_hrm_cleanup.sql");
-    private static final Path DATABASE_DOCKERFILE =
-            Path.of(".devcontainer", "db", "Dockerfile");
-    private static final Path POPULATE_SCRIPT =
-            Path.of(".devcontainer", "db", "scripts", "populate_db.sh");
-    private static final Path SEED_SCRIPT =
-            Path.of(".devcontainer", "development", "setup", "seed_data.sh");
-    private static final Path VALIDATOR = Path.of(
-            ".devcontainer", "development", "setup", "validate_hrm_fixtures.sh");
+    private static final Path PROJECT_ROOT = projectRoot();
+    private static final Path CLEANUP_SQL = PROJECT_ROOT.resolve(Path.of(
+            ".devcontainer", "db", "scripts", "development_hrm_cleanup.sql"));
+    private static final Path DATABASE_DOCKERFILE = PROJECT_ROOT.resolve(
+            Path.of(".devcontainer", "db", "Dockerfile"));
+    private static final Path POPULATE_SCRIPT = PROJECT_ROOT.resolve(
+            Path.of(".devcontainer", "db", "scripts", "populate_db.sh"));
+    private static final Path SEED_SCRIPT = PROJECT_ROOT.resolve(
+            Path.of(".devcontainer", "development", "setup", "seed_data.sh"));
+    private static final Path VALIDATOR = PROJECT_ROOT.resolve(Path.of(
+            ".devcontainer", "development", "setup", "validate_hrm_fixtures.sh"));
 
     @TempDir
     Path fixtureDirectory;
@@ -56,7 +58,8 @@ class HrmDevelopmentFixtureSeedRegressionTest {
                         "FROM `HRMDocumentSubClass`",
                         "FROM `HRMDocumentToDemographic`",
                         "FROM `HRMDocumentToProvider`",
-                        "FROM `HRMDocument`");
+                        "FROM `HRMDocument`")
+                .contains("SET hrm_document.`parentReport` = NULL");
     }
 
     @Test
@@ -82,7 +85,8 @@ class HrmDevelopmentFixtureSeedRegressionTest {
     @Test
     @DisplayName("should accept seeded HRM references when every fixture exists")
     void shouldAcceptSeededHrmReferences_whenEveryFixtureExists() throws Exception {
-        Files.writeString(fixtureDirectory.resolve("present.xml"), "<hrm/>", StandardCharsets.UTF_8);
+        Files.createDirectories(documentDirectory());
+        Files.writeString(documentDirectory().resolve("present.xml"), "<hrm/>", StandardCharsets.UTF_8);
 
         ValidationResult result = runValidator("present.xml\n");
 
@@ -101,17 +105,71 @@ class HrmDevelopmentFixtureSeedRegressionTest {
                 .contains("1 seeded HRM report(s) have no document fixture");
     }
 
-    private ValidationResult runValidator(String reportFiles) throws Exception {
-        Process process = new ProcessBuilder("sh", VALIDATOR.toString(), fixtureDirectory.toString())
+    @Test
+    @DisplayName("should reject seeded HRM references outside the document directory")
+    void shouldRejectSeededHrmReferences_whenPathEscapesDocumentDirectory() throws Exception {
+        Files.writeString(fixtureDirectory.resolve("outside.xml"), "<hrm/>", StandardCharsets.UTF_8);
+
+        ValidationResult result = runValidator("../outside.xml\n");
+
+        assertThat(result.exitCode()).isEqualTo(1);
+        assertThat(result.output())
+                .contains("Invalid seeded HRM fixture path outside document directory");
+    }
+
+    @Test
+    @DisplayName("should reject validator invocation without an explicit report list")
+    void shouldRejectValidatorInvocation_withoutExplicitReportList() throws Exception {
+        Files.createDirectories(documentDirectory());
+        Process process = new ProcessBuilder("sh", VALIDATOR.toString(),
+                documentDirectory().toString())
                 .redirectErrorStream(true)
                 .start();
-        process.getOutputStream().write(reportFiles.getBytes(StandardCharsets.UTF_8));
-        process.getOutputStream().close();
+
+        assertThat(process.waitFor(10, TimeUnit.SECONDS)).isTrue();
+        String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        assertThat(process.exitValue()).isNotZero();
+        assertThat(output).contains("REPORT_FILE_LIST");
+    }
+
+    private ValidationResult runValidator(String reportFiles) throws Exception {
+        Files.createDirectories(documentDirectory());
+        Path reportFileList = fixtureDirectory.resolve("hrm-report-files.txt");
+        Files.writeString(reportFileList, reportFiles, StandardCharsets.UTF_8);
+        Process process = new ProcessBuilder("sh", VALIDATOR.toString(),
+                documentDirectory().toString(), reportFileList.toString())
+                .redirectErrorStream(true)
+                .start();
 
         assertThat(process.waitFor(10, TimeUnit.SECONDS)).isTrue();
         return new ValidationResult(
                 process.exitValue(),
                 new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8));
+    }
+
+    private Path documentDirectory() {
+        return fixtureDirectory.resolve("documents");
+    }
+
+    private static Path projectRoot() {
+        try {
+            Path location = Path.of(HrmDevelopmentFixtureSeedRegressionTest.class
+                    .getProtectionDomain()
+                    .getCodeSource()
+                    .getLocation()
+                    .toURI());
+            Path current = Files.isRegularFile(location) ? location.getParent() : location;
+            while (current != null) {
+                if (Files.isRegularFile(current.resolve(
+                        ".devcontainer/db/scripts/development_hrm_cleanup.sql"))) {
+                    return current;
+                }
+                current = current.getParent();
+            }
+        } catch (URISyntaxException e) {
+            throw new IllegalStateException("Unable to resolve test class location", e);
+        }
+        throw new IllegalStateException("Unable to locate CARLOS EMR project root from test classpath");
     }
 
     private record ValidationResult(int exitCode, String output) {

--- a/src/test/java/io/github/carlos_emr/carlos/hospitalReportManager/HrmDevelopmentFixtureSeedRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/hospitalReportManager/HrmDevelopmentFixtureSeedRegressionTest.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ */
+package io.github.carlos_emr.carlos.hospitalReportManager;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Guards development HRM cleanup and document-fixture validation.
+ *
+ * @since 2026-08-12
+ */
+@Tag("unit")
+@DisplayName("development HRM fixture seed regressions")
+class HrmDevelopmentFixtureSeedRegressionTest {
+
+    private static final Path CLEANUP_SQL = Path.of(
+            ".devcontainer", "db", "scripts", "development_hrm_cleanup.sql");
+    private static final Path DATABASE_DOCKERFILE =
+            Path.of(".devcontainer", "db", "Dockerfile");
+    private static final Path POPULATE_SCRIPT =
+            Path.of(".devcontainer", "db", "scripts", "populate_db.sh");
+    private static final Path SEED_SCRIPT =
+            Path.of(".devcontainer", "development", "setup", "seed_data.sh");
+    private static final Path VALIDATOR = Path.of(
+            ".devcontainer", "development", "setup", "validate_hrm_fixtures.sh");
+
+    @TempDir
+    Path fixtureDirectory;
+
+    @Test
+    @DisplayName("should remove only undistributed snapshot HRM rows")
+    void shouldRemoveOnlyUndistributedSnapshotHrmRows_whenDevelopmentDataIsSeeded()
+            throws IOException {
+        String cleanupSql = Files.readString(CLEANUP_SQL, StandardCharsets.UTF_8);
+
+        assertThat(cleanupSql)
+                .contains("`id` BETWEEN 1 AND 41")
+                .contains("`timeReceived` >= '2023-07-25 00:00:00'")
+                .contains("`timeReceived` < '2023-09-06 00:00:00'")
+                .contains("`reportFile` LIKE 'LabUpload.%'")
+                .contains(
+                        "FROM `HRMDocumentComment`",
+                        "FROM `HRMDocumentSubClass`",
+                        "FROM `HRMDocumentToDemographic`",
+                        "FROM `HRMDocumentToProvider`",
+                        "FROM `HRMDocument`");
+    }
+
+    @Test
+    @DisplayName("should apply HRM cleanup to fresh and existing development databases")
+    void shouldApplyHrmCleanup_toFreshAndExistingDevelopmentDatabases() throws IOException {
+        String dockerfile = Files.readString(DATABASE_DOCKERFILE, StandardCharsets.UTF_8);
+        String populateScript = Files.readString(POPULATE_SCRIPT, StandardCharsets.UTF_8);
+        String seedScript = Files.readString(SEED_SCRIPT, StandardCharsets.UTF_8);
+
+        assertThat(dockerfile).contains(
+                "COPY ./.devcontainer/db/scripts/development_hrm_cleanup.sql "
+                        + "/scripts/development_hrm_cleanup.sql");
+        assertThat(populateScript)
+                .contains("$SQL oscar < /scripts/development_hrm_cleanup.sql")
+                .satisfies(script -> assertThat(script.indexOf("development_hrm_cleanup.sql"))
+                        .isGreaterThan(script.indexOf("development.sql")));
+        assertThat(seedScript)
+                .contains("< /workspace/.devcontainer/db/scripts/development_hrm_cleanup.sql")
+                .contains("validate_hrm_fixtures.sh")
+                .contains("SELECT reportFile FROM HRMDocument");
+    }
+
+    @Test
+    @DisplayName("should accept seeded HRM references when every fixture exists")
+    void shouldAcceptSeededHrmReferences_whenEveryFixtureExists() throws Exception {
+        Files.writeString(fixtureDirectory.resolve("present.xml"), "<hrm/>", StandardCharsets.UTF_8);
+
+        ValidationResult result = runValidator("present.xml\n");
+
+        assertThat(result.exitCode()).isZero();
+        assertThat(result.output()).contains("Validated seeded HRM document references");
+    }
+
+    @Test
+    @DisplayName("should reject seeded HRM references when a fixture is missing")
+    void shouldRejectSeededHrmReferences_whenFixtureIsMissing() throws Exception {
+        ValidationResult result = runValidator("missing.xml\n");
+
+        assertThat(result.exitCode()).isEqualTo(1);
+        assertThat(result.output())
+                .contains("Missing seeded HRM fixture: missing.xml")
+                .contains("1 seeded HRM report(s) have no document fixture");
+    }
+
+    private ValidationResult runValidator(String reportFiles) throws Exception {
+        Process process = new ProcessBuilder("sh", VALIDATOR.toString(), fixtureDirectory.toString())
+                .redirectErrorStream(true)
+                .start();
+        process.getOutputStream().write(reportFiles.getBytes(StandardCharsets.UTF_8));
+        process.getOutputStream().close();
+
+        assertThat(process.waitFor(10, TimeUnit.SECONDS)).isTrue();
+        return new ValidationResult(
+                process.exitValue(),
+                new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8));
+    }
+
+    private record ValidationResult(int exitCode, String output) {
+    }
+}


### PR DESCRIPTION
## Summary

- remove only the 41 known development-snapshot HRM rows whose XML reports are not distributed
- clean their comment, subclass, demographic, and provider mappings on fresh databases and existing dev volumes
- validate every remaining seeded HRM document reference against the runtime document directory during setup
- add regressions for setup wiring and validator success/failure behavior

## Testing

- `MAVEN_OPTS="-Xmx1g -Xms256m" mvn -q -Dtest=HrmDevelopmentFixtureSeedRegressionTest test` (7 tests after review fixes)
- `MAVEN_OPTS="-Xmx1g -Xms256m" mvn -q -DskipTests checkstyle:check`
- `sh -n .devcontainer/development/setup/seed_data.sh`
- `sh -n .devcontainer/development/setup/validate_hrm_fixtures.sh`
- applied cleanup twice against the standard development MariaDB: all HRM document/mapping counts remained zero
- queried remaining report filenames through the validator: passed with no dangling references
- `git diff --check`

## Fresh manual review

- **MUST:** none
- **SHOULD:** none remaining; cleanup is narrowly fingerprinted by snapshot IDs, import dates, and LabUpload filename prefix so later developer-created HRMs are preserved
- **COULD:** add fully synthetic HRM XML examples in a future fixture-focused PR to restore demo HRM content

Closes #3425

## Summary by Sourcery

Clean up undistributed development HRM snapshot data and ensure seeded HRM document references are validated against available fixtures during development setup.

Enhancements:
- Introduce a database cleanup script that removes only the original snapshot HRM rows and their related mappings while preserving later developer-created HRMs.
- Wire the HRM cleanup script into both fresh database population and devcontainer seeding so existing and new development environments are consistently repaired.
- Add a shell-based validator that checks all seeded HRM report filenames against the runtime document directory and fails setup when fixtures are missing.

Tests:
- Add regression tests to enforce the HRM cleanup query constraints, its integration into setup scripts, and the validator’s success and failure behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes 41 dangling development HRM rows and validates seeded HRM document paths during setup. Previously dev data included `HRMDocument` rows pointing to undistributed XMLs and setup allowed missing or out‑of‑tree paths; now those rows are deleted during build and seed, and setup fails with distinct errors for missing fixtures and for invalid paths.

**Review and rollout**
- Idempotent cleanup SQL scoped to ids 1–41 with `timeReceived` in 2023‑07‑25..2023‑09‑06 and `reportFile` LIKE `LabUpload.%`; removes related comment/subclass/demographic/provider mappings and nulls `parentReport`.
- Wired into DB population and `seed_data.sh`; the DB image copies the cleanup SQL. `validate_hrm_fixtures.sh` enforces document‑root containment, rejects absolute/path‑traversal references, and reports invalid paths separately from missing files.
- Tests cover cleanup/validator wiring and pass/fail cases, including distinguishing invalid paths from missing fixtures; scripts include GPL headers.
- No migration required. Rebuild the dev DB or re‑run `seed_data.sh` to apply.

<sup>Written for commit 48fd22b2efac0c129084d436eca64a7e582af7b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->