### PR TITLE
fix: include CSRF token in schedule provider selection

### DIFF
--- a/scripts/schedule-links-playwright-checks.js
+++ b/scripts/schedule-links-playwright-checks.js
@@ -178,10 +178,14 @@ async function selectProviderFromLastNameSearch(context, schedulePage) {
       && /\/provider\/providercontrol(?:\?|$)/.test(request.url()),
     timeout: 30000,
   }).catch(() => null);
-  const popupPromise = context.waitForEvent('page', { timeout: 10000 });
+  const popupPromise = context.waitForEvent('page', { timeout: 10000 }).catch(() => null);
   await searchInput.fill('test');
   await searchInput.press('Enter');
   const resultPage = await popupPromise;
+  if (!resultPage) {
+    findings.push({ label: 'schedule-provider-search', type: 'missing-search-popup' });
+    return;
+  }
   wirePage(resultPage, 'schedule-provider-search');
   await resultPage.waitForLoadState('domcontentloaded', { timeout: 30000 });
 

--- a/scripts/schedule-links-playwright-checks.js
+++ b/scripts/schedule-links-playwright-checks.js
@@ -214,13 +214,22 @@ async function selectProviderFromLastNameSearch(context, schedulePage) {
     return;
   }
 
+  // Read the token name off the rendered page rather than assuming the configured
+  // org.owasp.csrfguard.TokenName; the popup navigates away once the POST fires.
+  const tokenName = await resultPage.locator('#providerSelectionCsrfToken')
+    .getAttribute('name')
+    .catch(() => null) || 'CSRF-TOKEN';
+
   let providerRequest = await Promise.race([
     requestPromise,
     resultPage.waitForTimeout(100).then(() => null),
   ]);
-  const providerLink = resultPage.locator('a[onclick*="selectProvider("]').first();
-  if (!providerRequest && await providerLink.count()) {
-    await providerLink.click();
+  if (!providerRequest) {
+    // A single-result search auto-submits, so the click can land on a page that is
+    // already navigating. The awaited POST below is the real signal, not the click.
+    await resultPage.locator('a[onclick*="selectProvider("]').first()
+      .click({ timeout: 5000 })
+      .catch(() => {});
   }
 
   providerRequest = providerRequest || await requestPromise;
@@ -250,8 +259,8 @@ async function selectProviderFromLastNameSearch(context, schedulePage) {
       url: response.url(),
     });
   }
-  if (!new URLSearchParams(requestBody).get('CSRF-TOKEN')) {
-    findings.push({ label: 'schedule-provider-search', type: 'missing-csrf-token' });
+  if (!new URLSearchParams(requestBody).get(tokenName)) {
+    findings.push({ label: 'schedule-provider-search', type: 'missing-csrf-token', tokenName });
   }
   await resultPage.waitForLoadState('domcontentloaded', { timeout: 30000 }).catch(() => {});
   await assertNoErrorPage(resultPage, 'schedule-provider-search');

--- a/scripts/schedule-links-playwright-checks.js
+++ b/scripts/schedule-links-playwright-checks.js
@@ -29,6 +29,9 @@ const testPassword = process.env.TEST_PASSWORD || 'carlos2026';
 const testPin = process.env.TEST_PIN || '2026';
 const testProviderLastName = process.env.TEST_PROVIDER_LAST_NAME || '';
 
+// Mirrors org.owasp.csrfguard.TokenName; used only when the rendered name cannot be read.
+const DEFAULT_CSRF_TOKEN_NAME = 'CSRF-TOKEN';
+
 const findings = [];
 const visited = [];
 
@@ -203,6 +206,23 @@ async function selectProviderFromLastNameSearch(context, schedulePage) {
     return;
   }
   wirePage(resultPage, 'schedule-provider-search');
+
+  // A single-result search auto-submits while the page is still parsing, so by the time
+  // the DOM could be queried the popup may already be navigating. Capture the rendered
+  // token name off the initial document response instead, which cannot be raced. The
+  // listener is registered before the document arrives, so it sees the search results.
+  let renderedTokenName = null;
+  resultPage.on('response', async (response) => {
+    if (renderedTokenName || response.request().resourceType() !== 'document') {
+      return;
+    }
+    const html = await response.text().catch(() => '');
+    const match = /id="providerSelectionCsrfToken"[^>]*\sname="([^"]+)"/.exec(html);
+    if (match) {
+      renderedTokenName = match[1];
+    }
+  });
+
   const resultLoaded = await resultPage.waitForLoadState('domcontentloaded', { timeout: 30000 })
     .then(() => true)
     .catch(() => false);
@@ -213,12 +233,6 @@ async function selectProviderFromLastNameSearch(context, schedulePage) {
     }
     return;
   }
-
-  // Read the token name off the rendered page rather than assuming the configured
-  // org.owasp.csrfguard.TokenName; the popup navigates away once the POST fires.
-  const tokenName = await resultPage.locator('#providerSelectionCsrfToken')
-    .getAttribute('name')
-    .catch(() => null) || 'CSRF-TOKEN';
 
   let providerRequest = await Promise.race([
     requestPromise,
@@ -240,6 +254,18 @@ async function selectProviderFromLastNameSearch(context, schedulePage) {
   }
   const response = await responseWithTimeout(providerRequest, 30000);
   const requestBody = providerRequest.postData() || '';
+
+  // The multi-result path never navigates, so a live DOM read still resolves there.
+  // Falling back to the documented default is a last resort and is reported, so the
+  // check can never silently re-assume the name it is supposed to be verifying.
+  const observedTokenName = renderedTokenName
+    || await resultPage.locator('#providerSelectionCsrfToken')
+      .getAttribute('name', { timeout: 2000 })
+      .catch(() => null);
+  if (!observedTokenName) {
+    findings.push({ label: 'schedule-provider-search', type: 'csrf-token-name-unresolved' });
+  }
+  const tokenName = observedTokenName || DEFAULT_CSRF_TOKEN_NAME;
 
   visited.push({
     label: 'schedule-provider-search',

--- a/scripts/schedule-links-playwright-checks.js
+++ b/scripts/schedule-links-playwright-checks.js
@@ -166,6 +166,44 @@ async function clickScheduleLink(context, schedulePage, linkSpec) {
   await assertNoErrorPage(targetPage, linkSpec.label);
 }
 
+async function selectProviderFromLastNameSearch(context, schedulePage) {
+  const searchInput = schedulePage.locator('form[name="findprovider"] input[name="providername"]');
+  if (!await searchInput.count()) {
+    findings.push({ label: 'schedule-provider-search', type: 'missing-search-input' });
+    return;
+  }
+
+  const popupPromise = context.waitForEvent('page', { timeout: 10000 });
+  await searchInput.fill('test');
+  await searchInput.press('Enter');
+  const resultPage = await popupPromise;
+  wirePage(resultPage, 'schedule-provider-search');
+  await resultPage.waitForLoadState('domcontentloaded', { timeout: 30000 });
+
+  const providerLink = resultPage.locator('a[onclick*="selectProvider("]').first();
+  if (!await providerLink.count()) {
+    findings.push({ label: 'schedule-provider-search', type: 'missing-provider-result' });
+    await resultPage.close();
+    return;
+  }
+
+  const responsePromise = resultPage.waitForResponse((response) => {
+    return response.request().method() === 'POST'
+      && /\/provider\/providercontrol(?:\?|$)/.test(response.url());
+  }, { timeout: 30000 });
+  await providerLink.click();
+  const response = await responsePromise;
+  const requestBody = response.request().postData() || '';
+
+  visited.push({ label: 'schedule-provider-search', url: response.url(), status: response.status() });
+  if (!new URLSearchParams(requestBody).get('CSRF-TOKEN')) {
+    findings.push({ label: 'schedule-provider-search', type: 'missing-csrf-token' });
+  }
+  await resultPage.waitForLoadState('domcontentloaded', { timeout: 30000 }).catch(() => {});
+  await assertNoErrorPage(resultPage, 'schedule-provider-search');
+  await resultPage.close();
+}
+
 (async () => {
   const launchOptions = {
     headless: true,
@@ -179,6 +217,8 @@ async function clickScheduleLink(context, schedulePage, linkSpec) {
   try {
     const context = await browser.newContext({ ignoreHTTPSErrors: true, viewport: { width: 1440, height: 1000 } });
     const schedulePage = await login(context);
+
+    await selectProviderFromLastNameSearch(context, schedulePage);
 
     for (const linkSpec of scheduleLinks) {
       await clickScheduleLink(context, schedulePage, linkSpec);

--- a/scripts/schedule-links-playwright-checks.js
+++ b/scripts/schedule-links-playwright-checks.js
@@ -189,13 +189,16 @@ async function selectProviderFromLastNameSearch(context, schedulePage) {
   wirePage(resultPage, 'schedule-provider-search');
   await resultPage.waitForLoadState('domcontentloaded', { timeout: 30000 });
 
+  let providerRequest = await Promise.race([
+    requestPromise,
+    resultPage.waitForTimeout(100).then(() => null),
+  ]);
   const providerLink = resultPage.locator('a[onclick*="selectProvider("]').first();
-  const providerLinkCount = await resultPage.locator('a[onclick*="selectProvider("]').count();
-  if (providerLinkCount > 1) {
+  if (!providerRequest && await providerLink.count()) {
     await providerLink.click();
   }
 
-  const providerRequest = await requestPromise;
+  providerRequest = providerRequest || await requestPromise;
   if (!providerRequest) {
     findings.push({ label: 'schedule-provider-search', type: 'missing-provider-result' });
     await resultPage.close();

--- a/scripts/schedule-links-playwright-checks.js
+++ b/scripts/schedule-links-playwright-checks.js
@@ -223,6 +223,16 @@ async function selectProviderFromLastNameSearch(context, schedulePage) {
   });
   if (!response) {
     findings.push({ label: 'schedule-provider-search', type: 'provider-post-no-response' });
+  } else if (response.status() >= 400
+      && !isExpectedMissingAsset(response.status(), response.url())
+      && !findings.some((finding) => finding.label === 'schedule-provider-search'
+        && finding.type === 'http' && finding.url === response.url())) {
+    findings.push({
+      label: 'schedule-provider-search',
+      type: 'http',
+      status: response.status(),
+      url: response.url(),
+    });
   }
   if (!new URLSearchParams(requestBody).get('CSRF-TOKEN')) {
     findings.push({ label: 'schedule-provider-search', type: 'missing-csrf-token' });

--- a/scripts/schedule-links-playwright-checks.js
+++ b/scripts/schedule-links-playwright-checks.js
@@ -173,6 +173,11 @@ async function selectProviderFromLastNameSearch(context, schedulePage) {
     return;
   }
 
+  const requestPromise = context.waitForEvent('request', {
+    predicate: (request) => request.method() === 'POST'
+      && /\/provider\/providercontrol(?:\?|$)/.test(request.url()),
+    timeout: 30000,
+  }).catch(() => null);
   const popupPromise = context.waitForEvent('page', { timeout: 10000 });
   await searchInput.fill('test');
   await searchInput.press('Enter');
@@ -181,21 +186,28 @@ async function selectProviderFromLastNameSearch(context, schedulePage) {
   await resultPage.waitForLoadState('domcontentloaded', { timeout: 30000 });
 
   const providerLink = resultPage.locator('a[onclick*="selectProvider("]').first();
-  if (!await providerLink.count()) {
+  const providerLinkCount = await resultPage.locator('a[onclick*="selectProvider("]').count();
+  if (providerLinkCount > 1) {
+    await providerLink.click();
+  }
+
+  const providerRequest = await requestPromise;
+  if (!providerRequest) {
     findings.push({ label: 'schedule-provider-search', type: 'missing-provider-result' });
     await resultPage.close();
     return;
   }
+  const response = await providerRequest.response();
+  const requestBody = providerRequest.postData() || '';
 
-  const responsePromise = resultPage.waitForResponse((response) => {
-    return response.request().method() === 'POST'
-      && /\/provider\/providercontrol(?:\?|$)/.test(response.url());
-  }, { timeout: 30000 });
-  await providerLink.click();
-  const response = await responsePromise;
-  const requestBody = response.request().postData() || '';
-
-  visited.push({ label: 'schedule-provider-search', url: response.url(), status: response.status() });
+  visited.push({
+    label: 'schedule-provider-search',
+    url: providerRequest.url(),
+    status: response ? response.status() : null,
+  });
+  if (!response) {
+    findings.push({ label: 'schedule-provider-search', type: 'provider-post-no-response' });
+  }
   if (!new URLSearchParams(requestBody).get('CSRF-TOKEN')) {
     findings.push({ label: 'schedule-provider-search', type: 'missing-csrf-token' });
   }

--- a/scripts/schedule-links-playwright-checks.js
+++ b/scripts/schedule-links-playwright-checks.js
@@ -71,6 +71,20 @@ function safeGoto(page, appPath, options) {
   return page.goto(appUrl(appPath), options); // nosemgrep // NOSONAR - appUrl validates local-only BASE_URL and root-relative paths.
 }
 
+async function responseWithTimeout(request, timeoutMs) {
+  let timeoutId;
+  try {
+    return await Promise.race([
+      request.response(),
+      new Promise((resolve) => {
+        timeoutId = setTimeout(() => resolve(null), timeoutMs);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
 function isExpectedMissingAsset(status, responseUrl) {
   return status === 404 && (/\/imageRenderingServlet\?/.test(responseUrl) || /\/favicon\.ico$/.test(responseUrl));
 }
@@ -215,7 +229,7 @@ async function selectProviderFromLastNameSearch(context, schedulePage) {
     await resultPage.close();
     return;
   }
-  const response = await providerRequest.response();
+  const response = await responseWithTimeout(providerRequest, 30000);
   const requestBody = providerRequest.postData() || '';
 
   visited.push({

--- a/scripts/schedule-links-playwright-checks.js
+++ b/scripts/schedule-links-playwright-checks.js
@@ -16,6 +16,7 @@
  *   TEST_USER=carlosdoc
  *   TEST_PASSWORD=carlos2026
  *   TEST_PIN=2026
+ *   TEST_PROVIDER_LAST_NAME=optional provider last-name prefix; blank lists active providers
  *   ALLOW_NON_LOCAL_BASE_URL=true only when intentionally targeting a non-local test app
  */
 
@@ -26,6 +27,7 @@ const chromePath = process.env.CHROME_PATH || '';
 const testUser = process.env.TEST_USER || 'carlosdoc';
 const testPassword = process.env.TEST_PASSWORD || 'carlos2026';
 const testPin = process.env.TEST_PIN || '2026';
+const testProviderLastName = process.env.TEST_PROVIDER_LAST_NAME || '';
 
 const findings = [];
 const visited = [];
@@ -179,7 +181,7 @@ async function selectProviderFromLastNameSearch(context, schedulePage) {
     timeout: 30000,
   }).catch(() => null);
   const popupPromise = context.waitForEvent('page', { timeout: 10000 }).catch(() => null);
-  await searchInput.fill('test');
+  await searchInput.fill(testProviderLastName);
   await searchInput.press('Enter');
   const resultPage = await popupPromise;
   if (!resultPage) {

--- a/scripts/schedule-links-playwright-checks.js
+++ b/scripts/schedule-links-playwright-checks.js
@@ -187,7 +187,16 @@ async function selectProviderFromLastNameSearch(context, schedulePage) {
     return;
   }
   wirePage(resultPage, 'schedule-provider-search');
-  await resultPage.waitForLoadState('domcontentloaded', { timeout: 30000 });
+  const resultLoaded = await resultPage.waitForLoadState('domcontentloaded', { timeout: 30000 })
+    .then(() => true)
+    .catch(() => false);
+  if (!resultLoaded) {
+    findings.push({ label: 'schedule-provider-search', type: 'search-popup-load-failure' });
+    if (!resultPage.isClosed()) {
+      await resultPage.close();
+    }
+    return;
+  }
 
   let providerRequest = await Promise.race([
     requestPromise,

--- a/scripts/schedule-links-playwright-checks.js
+++ b/scripts/schedule-links-playwright-checks.js
@@ -209,18 +209,20 @@ async function selectProviderFromLastNameSearch(context, schedulePage) {
 
   // A single-result search auto-submits while the page is still parsing, so by the time
   // the DOM could be queried the popup may already be navigating. Capture the rendered
-  // token name off the initial document response instead, which cannot be raced. The
-  // listener is registered before the document arrives, so it sees the search results.
-  let renderedTokenName = null;
-  resultPage.on('response', async (response) => {
-    if (renderedTokenName || response.request().resourceType() !== 'document') {
+  // token name from the document bodies instead, which survive that navigation.
+  // Each parse is retained rather than fired and forgotten, so the read below awaits
+  // them instead of racing them; the push is synchronous, so no response is dropped.
+  const tokenNameParses = [];
+  resultPage.on('response', (response) => {
+    if (response.request().resourceType() !== 'document') {
       return;
     }
-    const html = await response.text().catch(() => '');
-    const match = /id="providerSelectionCsrfToken"[^>]*\sname="([^"]+)"/.exec(html);
-    if (match) {
-      renderedTokenName = match[1];
-    }
+    tokenNameParses.push(response.text()
+      .then((html) => {
+        const match = /id="providerSelectionCsrfToken"[^>]*\sname="([^"]+)"/.exec(html);
+        return match ? match[1] : null;
+      })
+      .catch(() => null));
   });
 
   const resultLoaded = await resultPage.waitForLoadState('domcontentloaded', { timeout: 30000 })
@@ -258,7 +260,8 @@ async function selectProviderFromLastNameSearch(context, schedulePage) {
   // The multi-result path never navigates, so a live DOM read still resolves there.
   // Falling back to the documented default is a last resort and is reported, so the
   // check can never silently re-assume the name it is supposed to be verifying.
-  const observedTokenName = renderedTokenName
+  const capturedTokenName = (await Promise.all(tokenNameParses)).find(Boolean) || null;
+  const observedTokenName = capturedTokenName
     || await resultPage.locator('#providerSelectionCsrfToken')
       .getAttribute('name', { timeout: 2000 })
       .catch(() => null);

--- a/scripts/schedule-links-playwright-checks.js
+++ b/scripts/schedule-links-playwright-checks.js
@@ -17,6 +17,7 @@
  *   TEST_PASSWORD=carlos2026
  *   TEST_PIN=2026
  *   TEST_PROVIDER_LAST_NAME=optional provider last-name prefix; blank lists active providers
+ *   TEST_PROVIDER_SEARCH_ONLY=true to skip the pre-existing schedule-link checks
  *   ALLOW_NON_LOCAL_BASE_URL=true only when intentionally targeting a non-local test app
  */
 
@@ -28,6 +29,7 @@ const testUser = process.env.TEST_USER || 'carlosdoc';
 const testPassword = process.env.TEST_PASSWORD || 'carlos2026';
 const testPin = process.env.TEST_PIN || '2026';
 const testProviderLastName = process.env.TEST_PROVIDER_LAST_NAME || '';
+const testProviderSearchOnly = process.env.TEST_PROVIDER_SEARCH_ONLY === 'true';
 
 // Mirrors org.owasp.csrfguard.TokenName; used only when the rendered name cannot be read.
 const DEFAULT_CSRF_TOKEN_NAME = 'CSRF-TOKEN';
@@ -197,6 +199,18 @@ async function selectProviderFromLastNameSearch(context, schedulePage) {
       && /\/provider\/providercontrol(?:\?|$)/.test(request.url()),
     timeout: 30000,
   }).catch(() => null);
+  const providerSearchPath = new URL(appUrl('/provider/ViewReceptionistFindProvider')).pathname;
+  const tokenNamePromise = context.waitForEvent('response', {
+    predicate: (response) => response.request().resourceType() === 'document'
+      && response.status() === 200
+      && new URL(response.url()).pathname === providerSearchPath,
+    timeout: 30000,
+  }).then((response) => response.text())
+    .then((html) => {
+      const match = /id="providerSelectionCsrfToken"[^>]*\sname="([^"]+)"/.exec(html);
+      return match ? match[1] : null;
+    })
+    .catch(() => null);
   const popupPromise = context.waitForEvent('page', { timeout: 10000 }).catch(() => null);
   await searchInput.fill(testProviderLastName);
   await searchInput.press('Enter');
@@ -207,60 +221,41 @@ async function selectProviderFromLastNameSearch(context, schedulePage) {
   }
   wirePage(resultPage, 'schedule-provider-search');
 
-  // A single-result search auto-submits while the page is still parsing, so by the time
-  // the DOM could be queried the popup may already be navigating. Capture the rendered
-  // token name from the document bodies instead, which survive that navigation.
-  // Each parse is retained rather than fired and forgotten, so the read below awaits
-  // them instead of racing them; the push is synchronous, so no response is dropped.
-  const tokenNameParses = [];
-  resultPage.on('response', (response) => {
-    if (response.request().resourceType() !== 'document') {
-      return;
-    }
-    tokenNameParses.push(response.text()
-      .then((html) => {
-        const match = /id="providerSelectionCsrfToken"[^>]*\sname="([^"]+)"/.exec(html);
-        return match ? match[1] : null;
-      })
-      .catch(() => null));
-  });
-
-  const resultLoaded = await resultPage.waitForLoadState('domcontentloaded', { timeout: 30000 })
+  const resultLoadedPromise = resultPage.waitForLoadState('domcontentloaded', { timeout: 30000 })
     .then(() => true)
     .catch(() => false);
-  if (!resultLoaded) {
-    findings.push({ label: 'schedule-provider-search', type: 'search-popup-load-failure' });
-    if (!resultPage.isClosed()) {
-      await resultPage.close();
-    }
-    return;
-  }
-
   let providerRequest = await Promise.race([
     requestPromise,
-    resultPage.waitForTimeout(100).then(() => null),
+    resultLoadedPromise.then(() => null),
   ]);
   if (!providerRequest) {
-    // A single-result search auto-submits, so the click can land on a page that is
-    // already navigating. The awaited POST below is the real signal, not the click.
-    await resultPage.locator('a[onclick*="selectProvider("]').first()
-      .click({ timeout: 5000 })
-      .catch(() => {});
+    const resultLoaded = await resultLoadedPromise;
+    if (resultLoaded) {
+      await resultPage.locator('a[onclick*="selectProvider("]').first()
+        .click({ timeout: 5000 })
+        .catch(() => {});
+    }
+    providerRequest = await requestPromise;
+    if (!providerRequest && !resultLoaded) {
+      findings.push({ label: 'schedule-provider-search', type: 'search-popup-load-failure' });
+    }
   }
 
-  providerRequest = providerRequest || await requestPromise;
   if (!providerRequest) {
-    findings.push({ label: 'schedule-provider-search', type: 'missing-provider-result' });
+    if (!findings.some((finding) => finding.label === 'schedule-provider-search'
+        && finding.type === 'search-popup-load-failure')) {
+      findings.push({ label: 'schedule-provider-search', type: 'missing-provider-result' });
+    }
     await resultPage.close();
     return;
   }
   const response = await responseWithTimeout(providerRequest, 30000);
   const requestBody = providerRequest.postData() || '';
 
-  // The multi-result path never navigates, so a live DOM read still resolves there.
-  // Falling back to the documented default is a last resort and is reported, so the
-  // check can never silently re-assume the name it is supposed to be verifying.
-  const capturedTokenName = (await Promise.all(tokenNameParses)).find(Boolean) || null;
+  // The page event is emitted only after the initial response starts loading, and every
+  // selection navigates the popup by submitting the generated form. The context response
+  // wait above is therefore registered before the search and preserves the result HTML.
+  const capturedTokenName = await tokenNamePromise;
   const observedTokenName = capturedTokenName
     || await resultPage.locator('#providerSelectionCsrfToken')
       .getAttribute('name', { timeout: 2000 })
@@ -312,8 +307,10 @@ async function selectProviderFromLastNameSearch(context, schedulePage) {
 
     await selectProviderFromLastNameSearch(context, schedulePage);
 
-    for (const linkSpec of scheduleLinks) {
-      await clickScheduleLink(context, schedulePage, linkSpec);
+    if (!testProviderSearchOnly) {
+      for (const linkSpec of scheduleLinks) {
+        await clickScheduleLink(context, schedulePage, linkSpec);
+      }
     }
 
     console.log(JSON.stringify({ visited, findings }, null, 2));
@@ -323,7 +320,9 @@ async function selectProviderFromLastNameSearch(context, schedulePage) {
       throw new Error(`schedule link browser check found ${blockingFindings.length} issue(s)`);
     }
 
-    console.log('PASS schedule links rendered without HTTP or browser console failures');
+    console.log(testProviderSearchOnly
+      ? 'PASS schedule provider search submitted a CSRF-protected selection'
+      : 'PASS schedule links rendered without HTTP or browser console failures');
   } finally {
     await browser.close();
   }

--- a/src/main/resources/oscarResources_en.properties
+++ b/src/main/resources/oscarResources_en.properties
@@ -11284,6 +11284,7 @@ provider.providerDefaultDxCode.btnSearch=Search
 provider.providerDefaultDxCode.btnSave=Save
 provider.providerDefaultDxCode.btnClose=Close
 receptionist.receptionistfindprovider.msgMissingFormConfig=Error: Missing form configuration. Cannot transfer the selected provider.
+receptionist.receptionistfindprovider.msgMissingSecurityToken=Error: this page is missing its security token. Please reload the search results and try again.
 encounter.formFemaleAnnual.formSexualHealthRelationships=Sexual Health/Relationships:
 encounter.formFemaleAnnual.sectionSexualHealth=1. Sexual Health:
 encounter.formFemaleAnnual.preconceptiveCounselling=Preconceptive Counselling (A):

--- a/src/main/resources/oscarResources_es.properties
+++ b/src/main/resources/oscarResources_es.properties
@@ -10253,6 +10253,7 @@ provider.providerDefaultDxCode.btnSearch=Buscar
 provider.providerDefaultDxCode.btnSave=Guardar
 provider.providerDefaultDxCode.btnClose=Cerrar
 receptionist.receptionistfindprovider.msgMissingFormConfig=Error: falta la configuraci\u00f3n del formulario. No se puede transferir el prestador seleccionado.
+receptionist.receptionistfindprovider.msgMissingSecurityToken=Error: a esta p\u00e1gina le falta su token de seguridad. Vuelva a cargar los resultados de la b\u00fasqueda e int\u00e9ntelo de nuevo.
 schedule.scheduledatepopup.formLocation=Ubicaci\u00f3n
 schedule.scheduledatepopup.me=Yo
 schedule.scheduleflipview.btnGoBack=Volver

--- a/src/main/resources/oscarResources_fr.properties
+++ b/src/main/resources/oscarResources_fr.properties
@@ -10766,6 +10766,7 @@ provider.providerDefaultDxCode.btnSearch=Recherche
 provider.providerDefaultDxCode.btnSave=Enregistrer
 provider.providerDefaultDxCode.btnClose=Fermer
 receptionist.receptionistfindprovider.msgMissingFormConfig=Erreur : configuration du formulaire manquante. Impossible de transf\u00e9rer le prestataire s\u00e9lectionn\u00e9.
+receptionist.receptionistfindprovider.msgMissingSecurityToken=Erreur : le jeton de s\u00e9curit\u00e9 de cette page est absent. Veuillez recharger les r\u00e9sultats de recherche et r\u00e9essayer.
 schedule.scheduledatepopup.formLocation=Emplacement
 schedule.scheduledatepopup.me=Moi
 schedule.scheduleflipview.btnGoBack=Retour

--- a/src/main/resources/oscarResources_pl.properties
+++ b/src/main/resources/oscarResources_pl.properties
@@ -10006,6 +10006,7 @@ provider.providerDefaultDxCode.btnSearch=Szukaj
 provider.providerDefaultDxCode.btnSave=Zapisz
 provider.providerDefaultDxCode.btnClose=Zamknij
 receptionist.receptionistfindprovider.msgMissingFormConfig=B\u0142\u0105d: brak konfiguracji formularza. Nie mo\u017cna przekaza\u0107 wybranego \u015bwiadczeniodawcy.
+receptionist.receptionistfindprovider.msgMissingSecurityToken=B\u0142\u0105d: na tej stronie brakuje tokenu zabezpieczaj\u0105cego. Prze\u0142aduj wyniki wyszukiwania i spr\u00f3buj ponownie.
 schedule.scheduledatepopup.formLocation=Lokalizacja
 schedule.scheduledatepopup.me=Ja
 schedule.scheduleflipview.btnGoBack=Wr\u00f3\u0107

--- a/src/main/resources/oscarResources_pt_BR.properties
+++ b/src/main/resources/oscarResources_pt_BR.properties
@@ -10266,6 +10266,7 @@ provider.providerDefaultDxCode.btnSearch=Pesquisar
 provider.providerDefaultDxCode.btnSave=Salvar
 provider.providerDefaultDxCode.btnClose=Fechar
 receptionist.receptionistfindprovider.msgMissingFormConfig=Erro: configura\u00e7\u00e3o de formul\u00e1rio ausente. N\u00e3o \u00e9 poss\u00edvel transferir o prestador selecionado.
+receptionist.receptionistfindprovider.msgMissingSecurityToken=Erro: esta p\u00e1gina est\u00e1 sem o token de seguran\u00e7a. Recarregue os resultados da busca e tente novamente.
 schedule.scheduledatepopup.formLocation=Localiza\u00e7\u00e3o
 schedule.scheduledatepopup.me=Eu
 schedule.scheduleflipview.btnGoBack=Voltar

--- a/src/main/webapp/WEB-INF/jsp/provider/receptionistfindprovider.jsp
+++ b/src/main/webapp/WEB-INF/jsp/provider/receptionistfindprovider.jsp
@@ -309,17 +309,17 @@
         %>
         <script language="JavaScript">
             <!--
-            // Declared outside the branches below so the custom path cannot fall
-            // through to the global window.name when no result name is available.
-            var selectedProviderName = '';
             <%if(caisi) {%>
             var nodes = document.getElementsByName("<carlos:encode value='<%= sp %>' context="javaScriptBlock"/>_name");
+            var name = '';
             if (nodes.length == 1) {
-                selectedProviderName = nodes[0].value;
+                name = nodes[0].value;
             }
-            selectProviderCaisi('<carlos:encode value='<%= sp %>' context="javaScriptBlock"/>', selectedProviderName);
+            selectProviderCaisi('<carlos:encode value='<%= sp %>' context="javaScriptBlock"/>', name);
             <%} else if(custom != null && custom.equals("true")){%>
-            selectProviderCustom('<carlos:encode value='<%= sp %>' context="javaScriptBlock"/>', selectedProviderName);
+            // NOTE: `name` is not declared on this branch, so it resolves to the global
+            // window.name. Pre-existing; fixing it needs a decision on what name to send.
+            selectProviderCustom('<carlos:encode value='<%= sp %>' context="javaScriptBlock"/>', name);
             <%} else {%>
             selectProvider('<carlos:encode value='<%= sp %>' context="javaScriptBlock"/>');
             <%}%>

--- a/src/main/webapp/WEB-INF/jsp/provider/receptionistfindprovider.jsp
+++ b/src/main/webapp/WEB-INF/jsp/provider/receptionistfindprovider.jsp
@@ -38,6 +38,7 @@
 <%@ taglib uri="/WEB-INF/caisi-tag.tld" prefix="caisi" %>
 <%@ taglib uri="owasp.encoder.jakarta.advanced" prefix="e" %>
 <%@ taglib uri="carlos" prefix="carlos" %>
+<%@ taglib uri="https://owasp.org/www-project-csrfguard/Owasp.CsrfGuard.tld" prefix="csrf" %>
 
 <%
     LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
@@ -48,7 +49,7 @@
     String month = request.getParameter("pmonth") != null ? request.getParameter("pmonth") : "5";
     String day = request.getParameter("pday") != null ? request.getParameter("pday") : "8";
 %>
-<%@ page import="java.util.*, java.sql.*, io.github.carlos_emr.*, java.text.*, java.lang.*,java.net.*"
+<%@ page import="java.util.*, java.sql.*, io.github.carlos_emr.*, java.text.*, java.lang.*"
          errorPage="/WEB-INF/jsp/error/errorpage.jsp" %>
 
 <%@page import="io.github.carlos_emr.carlos.utility.SpringUtils" %>
@@ -113,12 +114,29 @@
     <script language="JavaScript">
 
 
-        function selectProvider(p, pn) {
-            newGroupNo = p;
+        function selectProvider(p) {
+            var csrfToken = document.getElementById('providerSelectionCsrfToken');
+            if (!csrfToken || !csrfToken.value) {
+                console.error('Provider selection stopped because the CSRF token is unavailable.');
+                return false;
+            }
+
+            var newGroupNo = p;
             var form = document.createElement('form');
             form.method = 'post';
-            form.action = '<%= request.getContextPath() %>/provider/providercontrol';
-            var fields = {provider_no: '<%=curUser_no%>', start_hour: '<%=startHour%>', end_hour: '<%=endHour%>', every_min: '<%=everyMin%>', color_template: 'deepblue', dboperation: 'updatepreference', displaymode: 'updatepreference', default_servicetype: '<%=defaultServiceType%>', mygroup_no: newGroupNo};
+            form.action = '<carlos:encode value='<%= request.getContextPath() %>' context="javaScriptBlock"/>/provider/providercontrol';
+            var fields = {
+                provider_no: '<carlos:encode value='<%= curUser_no %>' context="javaScriptBlock"/>',
+                start_hour: '<%=startHour%>',
+                end_hour: '<%=endHour%>',
+                every_min: '<%=everyMin%>',
+                color_template: 'deepblue',
+                dboperation: 'updatepreference',
+                displaymode: 'updatepreference',
+                default_servicetype: '<carlos:encode value='<%= defaultServiceType %>' context="javaScriptBlock"/>',
+                mygroup_no: newGroupNo
+            };
+            fields[csrfToken.name] = csrfToken.value;
             for (var key in fields) {
                 var input = document.createElement('input');
                 input.type = 'hidden';
@@ -128,6 +146,7 @@
             }
             document.body.appendChild(form);
             form.submit();
+            return false;
         }
 
         function selectProviderCaisi(p, pn) {
@@ -150,6 +169,9 @@
 </head>
 <body bgcolor="ivory" bgproperties="fixed" onLoad="setfocus()"
       topmargin="0" leftmargin="0" rightmargin="0">
+
+<input type="hidden" id="providerSelectionCsrfToken"
+       name="<csrf:tokenname/>" value="<csrf:tokenvalue/>">
 
 <table border="0" cellspacing="0" cellpadding="0" width="100%">
     <tr>
@@ -239,7 +261,7 @@
             </a></td>
             <%} else { %>
             <a href=#
-               onClick="selectProvider('<%=sp%>','<%=URLEncoder.encode(spnl+", "+spnf)%>')"><%=sp%>
+               onClick="return selectProvider('<carlos:encode value='<%= sp %>' context="javaScriptAttribute"/>')"><carlos:encode value='<%= sp %>' context="html"/>
             </a>
             </td>
             <%} %>

--- a/src/main/webapp/WEB-INF/jsp/provider/receptionistfindprovider.jsp
+++ b/src/main/webapp/WEB-INF/jsp/provider/receptionistfindprovider.jsp
@@ -114,10 +114,14 @@
     <script language="JavaScript">
 
 
+        <fmt:message key="receptionist.receptionistfindprovider.msgMissingSecurityToken" var="missingSecurityTokenMessage"/>
+
         function selectProvider(p) {
             var csrfToken = document.getElementById('providerSelectionCsrfToken');
             if (!csrfToken || !csrfToken.value) {
+                // Fail closed and tell the user: a silent no-op here looks like a dead link.
                 console.error('Provider selection stopped because the CSRF token is unavailable.');
+                alert("${carlos:forJavaScriptBlock(missingSecurityTokenMessage)}");
                 return false;
             }
 
@@ -233,8 +237,10 @@
                 if (bGrpSearch) {
                     g = (MyGroup) o;
                     sp = String.valueOf(g.getId().getMyGroupNo());
-                    spnl = String.valueOf(p.getLastName());
-                    spnf = String.valueOf(p.getFirstName());
+                    // Group rows carry no provider name; the legacy code dereferenced the
+                    // still-null Provider here and made every "." group search throw.
+                    spnl = "";
+                    spnf = "";
                     if (checkRestriction(restrictions, g.getId().getMyGroupNo())) {
                         continue;
                     }
@@ -254,10 +260,10 @@
         <tr bgcolor="<%=bColor?bgcolordef:"white"%>">
             <td>
                 <%if (caisi) { %> <a href=#
-                                     onClick="selectProviderCaisi('<%=sp%>','<%=spnl+", "+spnf%>')"><%=sp%>
+                                     onClick="selectProviderCaisi('<carlos:encode value='<%= sp %>' context="javaScriptAttribute"/>','<carlos:encode value='<%= spnl + ", " + spnf %>' context="javaScriptAttribute"/>')"><carlos:encode value='<%= sp %>' context="html"/>
             </a></td>
             <% } else if (custom != null && custom.equals("true")) { %>
-            <a href="#" onClick="selectProviderCustom('<%=sp%>','<%=spnl+", "+spnf%>')"><%=sp%>
+            <a href="#" onClick="selectProviderCustom('<carlos:encode value='<%= sp %>' context="javaScriptAttribute"/>','<carlos:encode value='<%= spnl + ", " + spnf %>' context="javaScriptAttribute"/>')"><carlos:encode value='<%= sp %>' context="html"/>
             </a></td>
             <%} else { %>
             <a href=#
@@ -265,9 +271,9 @@
             </a>
             </td>
             <%} %>
-            <td><%=spnl%>
+            <td><carlos:encode value='<%= spnl %>' context="html"/>
             </td>
-            <td><%=spnf%>
+            <td><carlos:encode value='<%= spnf %>' context="html"/>
             </td>
         </tr>
         <%
@@ -286,10 +292,10 @@
         %>
         <tr bgcolor="#CCCCFF">
             <td colspan='3'>
-                <%if (caisi) { %> <a href=# onClick="selectProviderCaisi('<%=sp%>','')"><%=sp%>
+                <%if (caisi) { %> <a href=# onClick="selectProviderCaisi('<carlos:encode value='<%= sp %>' context="javaScriptAttribute"/>','')"><carlos:encode value='<%= sp %>' context="html"/>
             </a></td>
             <%} else { %>
-            <a href=# onClick="selectProvider('<%=sp%>','')"><%=sp%>
+            <a href=# onClick="return selectProvider('<carlos:encode value='<%= sp %>' context="javaScriptAttribute"/>')"><carlos:encode value='<%= sp %>' context="html"/>
             </a>
             </td>
             <%} %>
@@ -303,17 +309,19 @@
         %>
         <script language="JavaScript">
             <!--
+            // Declared outside the branches below so the custom path cannot fall
+            // through to the global window.name when no result name is available.
+            var selectedProviderName = '';
             <%if(caisi) {%>
-            var nodes = document.getElementsByName("<%=sp%>_name");
-            var name = '';
+            var nodes = document.getElementsByName("<carlos:encode value='<%= sp %>' context="javaScriptBlock"/>_name");
             if (nodes.length == 1) {
-                name = nodes[0].value;
+                selectedProviderName = nodes[0].value;
             }
-            selectProviderCaisi('<%=sp%>', name);
+            selectProviderCaisi('<carlos:encode value='<%= sp %>' context="javaScriptBlock"/>', selectedProviderName);
             <%} else if(custom != null && custom.equals("true")){%>
-            selectProviderCustom('<%=sp%>', name);
+            selectProviderCustom('<carlos:encode value='<%= sp %>' context="javaScriptBlock"/>', selectedProviderName);
             <%} else {%>
-            selectProvider('<%=sp%>', '');
+            selectProvider('<carlos:encode value='<%= sp %>' context="javaScriptBlock"/>');
             <%}%>
             //-->
         </SCRIPT>

--- a/src/test/java/io/github/carlos_emr/carlos/provider/ScheduleProviderSearchCsrfRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/provider/ScheduleProviderSearchCsrfRegressionTest.java
@@ -73,6 +73,9 @@ class ScheduleProviderSearchCsrfRegressionTest {
 
         assertThat(requestListener).isLessThan(searchSubmit);
         assertThat(browserCheck)
+                .contains("const testProviderLastName = process.env.TEST_PROVIDER_LAST_NAME || '';")
+                .contains("await searchInput.fill(testProviderLastName);")
+                .doesNotContain("await searchInput.fill('test');")
                 .contains("context.waitForEvent('page', { timeout: 10000 }).catch(() => null)")
                 .contains("if (!resultPage)")
                 .contains("type: 'missing-search-popup'")

--- a/src/test/java/io/github/carlos_emr/carlos/provider/ScheduleProviderSearchCsrfRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/provider/ScheduleProviderSearchCsrfRegressionTest.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ */
+package io.github.carlos_emr.carlos.provider;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Guards the Schedule provider-search result POST against losing its CSRF token.
+ *
+ * @since 2026-08-12
+ */
+@DisplayName("Schedule provider search CSRF regression")
+@Tag("unit")
+@Tag("provider")
+@Tag("security")
+class ScheduleProviderSearchCsrfRegressionTest {
+
+    private static final Path PROVIDER_SEARCH = projectRoot().resolve(Path.of(
+            "src", "main", "webapp", "WEB-INF", "jsp", "provider",
+            "receptionistfindprovider.jsp"));
+
+    @Test
+    @DisplayName("should include server-rendered CSRF token in provider selection POST")
+    void shouldIncludeServerRenderedCsrfToken_inProviderSelectionPost() throws IOException {
+        String jsp = Files.readString(PROVIDER_SEARCH, StandardCharsets.UTF_8);
+
+        assertThat(jsp)
+                .contains("prefix=\"csrf\"")
+                .contains("id=\"providerSelectionCsrfToken\"")
+                .contains("name=\"<csrf:tokenname/>\" value=\"<csrf:tokenvalue/>\"")
+                .contains("document.getElementById('providerSelectionCsrfToken')")
+                .contains("fields[csrfToken.name] = csrfToken.value")
+                .contains("onClick=\"return selectProvider(")
+                .contains("context=\"javaScriptBlock\"/>")
+                .contains("context=\"javaScriptAttribute\"/>");
+    }
+
+    @Test
+    @DisplayName("should stop provider selection when CSRF token is unavailable")
+    void shouldStopProviderSelection_whenCsrfTokenIsUnavailable() throws IOException {
+        String jsp = Files.readString(PROVIDER_SEARCH, StandardCharsets.UTF_8);
+        int tokenLookup = requiredIndex(jsp,
+                "var csrfToken = document.getElementById('providerSelectionCsrfToken');");
+        int missingTokenGuard = requiredIndex(jsp, "if (!csrfToken || !csrfToken.value)");
+        int formCreation = requiredIndex(jsp, "var form = document.createElement('form');");
+
+        assertThat(missingTokenGuard).isGreaterThan(tokenLookup).isLessThan(formCreation);
+        assertThat(jsp.substring(missingTokenGuard, formCreation))
+                .contains("return false;");
+    }
+
+    private static int requiredIndex(String source, String token) {
+        int index = source.indexOf(token);
+        assertThat(index).as("required JSP contract: %s", token).isGreaterThanOrEqualTo(0);
+        return index;
+    }
+
+    private static Path projectRoot() {
+        try {
+            Path location = Path.of(ScheduleProviderSearchCsrfRegressionTest.class
+                    .getProtectionDomain()
+                    .getCodeSource()
+                    .getLocation()
+                    .toURI());
+            Path current = Files.isRegularFile(location) ? location.getParent() : location;
+            while (current != null) {
+                if (Files.isRegularFile(current.resolve(
+                        "src/main/webapp/WEB-INF/jsp/provider/receptionistfindprovider.jsp"))) {
+                    return current;
+                }
+                current = current.getParent();
+            }
+        } catch (URISyntaxException e) {
+            throw new IllegalStateException("Unable to resolve test class location", e);
+        }
+        throw new IllegalStateException("Unable to locate CARLOS EMR project root from test classpath");
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/provider/ScheduleProviderSearchCsrfRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/provider/ScheduleProviderSearchCsrfRegressionTest.java
@@ -30,6 +30,8 @@ class ScheduleProviderSearchCsrfRegressionTest {
     private static final Path PROVIDER_SEARCH = projectRoot().resolve(Path.of(
             "src", "main", "webapp", "WEB-INF", "jsp", "provider",
             "receptionistfindprovider.jsp"));
+    private static final Path SCHEDULE_BROWSER_CHECK = projectRoot().resolve(Path.of(
+            "scripts", "schedule-links-playwright-checks.js"));
 
     @Test
     @DisplayName("should include server-rendered CSRF token in provider selection POST")
@@ -59,6 +61,21 @@ class ScheduleProviderSearchCsrfRegressionTest {
         assertThat(missingTokenGuard).isGreaterThan(tokenLookup).isLessThan(formCreation);
         assertThat(jsp.substring(missingTokenGuard, formCreation))
                 .contains("return false;");
+    }
+
+    @Test
+    @DisplayName("should capture provider POST before search can auto-select its only result")
+    void shouldCaptureProviderPost_beforeSearchCanAutoSelectOnlyResult() throws IOException {
+        String browserCheck = Files.readString(SCHEDULE_BROWSER_CHECK, StandardCharsets.UTF_8);
+        int requestListener = requiredIndex(browserCheck,
+                "const requestPromise = context.waitForEvent('request'");
+        int searchSubmit = requiredIndex(browserCheck, "await searchInput.press('Enter');");
+
+        assertThat(requestListener).isLessThan(searchSubmit);
+        assertThat(browserCheck)
+                .contains("const providerLinkCount = await resultPage.locator(")
+                .contains("if (providerLinkCount > 1)")
+                .contains("const providerRequest = await requestPromise;");
     }
 
     private static int requiredIndex(String source, String token) {

--- a/src/test/java/io/github/carlos_emr/carlos/provider/ScheduleProviderSearchCsrfRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/provider/ScheduleProviderSearchCsrfRegressionTest.java
@@ -81,7 +81,9 @@ class ScheduleProviderSearchCsrfRegressionTest {
                 .contains("type: 'search-popup-load-failure'")
                 .contains("let providerRequest = await Promise.race(")
                 .contains("if (!providerRequest && await providerLink.count())")
-                .contains("providerRequest = providerRequest || await requestPromise;");
+                .contains("providerRequest = providerRequest || await requestPromise;")
+                .contains("response.status() >= 400")
+                .contains("finding.type === 'http'");
     }
 
     private static int requiredIndex(String source, String token) {

--- a/src/test/java/io/github/carlos_emr/carlos/provider/ScheduleProviderSearchCsrfRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/provider/ScheduleProviderSearchCsrfRegressionTest.java
@@ -85,6 +85,9 @@ class ScheduleProviderSearchCsrfRegressionTest {
                 .contains("let providerRequest = await Promise.race(")
                 .contains("if (!providerRequest && await providerLink.count())")
                 .contains("providerRequest = providerRequest || await requestPromise;")
+                .contains("responseWithTimeout(providerRequest, 30000)")
+                .contains("get('CSRF-TOKEN')")
+                .contains("type: 'missing-csrf-token'")
                 .contains("response.status() >= 400")
                 .contains("finding.type === 'http'");
     }

--- a/src/test/java/io/github/carlos_emr/carlos/provider/ScheduleProviderSearchCsrfRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/provider/ScheduleProviderSearchCsrfRegressionTest.java
@@ -76,9 +76,9 @@ class ScheduleProviderSearchCsrfRegressionTest {
                 .contains("context.waitForEvent('page', { timeout: 10000 }).catch(() => null)")
                 .contains("if (!resultPage)")
                 .contains("type: 'missing-search-popup'")
-                .contains("const providerLinkCount = await resultPage.locator(")
-                .contains("if (providerLinkCount > 1)")
-                .contains("const providerRequest = await requestPromise;");
+                .contains("let providerRequest = await Promise.race(")
+                .contains("if (!providerRequest && await providerLink.count())")
+                .contains("providerRequest = providerRequest || await requestPromise;");
     }
 
     private static int requiredIndex(String source, String token) {

--- a/src/test/java/io/github/carlos_emr/carlos/provider/ScheduleProviderSearchCsrfRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/provider/ScheduleProviderSearchCsrfRegressionTest.java
@@ -169,8 +169,14 @@ class ScheduleProviderSearchCsrfRegressionTest {
                 .contains("let providerRequest = await Promise.race(")
                 .contains("providerRequest = providerRequest || await requestPromise;")
                 .contains("responseWithTimeout(providerRequest, 30000)")
-                .as("the token name is configurable, so read it from the rendered input")
-                .contains("locator('#providerSelectionCsrfToken')")
+                .as("the token name is configurable, so it must be read from the rendered "
+                        + "page; the auto-select path navigates away, so capture it from "
+                        + "the document response rather than the live DOM")
+                .contains("resultPage.on('response'")
+                .contains("resourceType() !== 'document'")
+                .contains("id=\"providerSelectionCsrfToken\"[^>]*\\sname=\"([^\"]+)\"")
+                .contains("const observedTokenName = renderedTokenName")
+                .contains("type: 'csrf-token-name-unresolved'")
                 .contains("new URLSearchParams(requestBody).get(tokenName)")
                 .contains("type: 'missing-csrf-token'")
                 .contains("response.status() >= 400")

--- a/src/test/java/io/github/carlos_emr/carlos/provider/ScheduleProviderSearchCsrfRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/provider/ScheduleProviderSearchCsrfRegressionTest.java
@@ -73,6 +73,9 @@ class ScheduleProviderSearchCsrfRegressionTest {
 
         assertThat(requestListener).isLessThan(searchSubmit);
         assertThat(browserCheck)
+                .contains("context.waitForEvent('page', { timeout: 10000 }).catch(() => null)")
+                .contains("if (!resultPage)")
+                .contains("type: 'missing-search-popup'")
                 .contains("const providerLinkCount = await resultPage.locator(")
                 .contains("if (providerLinkCount > 1)")
                 .contains("const providerRequest = await requestPromise;");

--- a/src/test/java/io/github/carlos_emr/carlos/provider/ScheduleProviderSearchCsrfRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/provider/ScheduleProviderSearchCsrfRegressionTest.java
@@ -2,6 +2,22 @@
  * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
  *
  * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
  */
 package io.github.carlos_emr.carlos.provider;
 
@@ -10,6 +26,10 @@ import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -60,7 +80,71 @@ class ScheduleProviderSearchCsrfRegressionTest {
 
         assertThat(missingTokenGuard).isGreaterThan(tokenLookup).isLessThan(formCreation);
         assertThat(jsp.substring(missingTokenGuard, formCreation))
+                .as("failing closed must be visible to the user, not console-only")
+                .contains("alert(\"${carlos:forJavaScriptBlock(missingSecurityTokenMessage)}\");")
                 .contains("return false;");
+        assertThat(jsp)
+                .contains("<fmt:message key=\"receptionist.receptionistfindprovider"
+                        + ".msgMissingSecurityToken\" var=\"missingSecurityTokenMessage\"/>");
+    }
+
+    @Test
+    @DisplayName("should route every provider selection call site through the guarded contract")
+    void shouldRouteEveryCallSite_throughGuardedContract() throws IOException {
+        String jsp = Files.readString(PROVIDER_SEARCH, StandardCharsets.UTF_8);
+        Matcher matcher = Pattern.compile("selectProvider\\((.*?)\\)").matcher(jsp);
+
+        List<String> callSites = new ArrayList<>();
+        while (matcher.find()) {
+            callSites.add(matcher.group(1));
+        }
+
+        // One declaration site (`p`) plus the result-row, group-row and auto-select callers.
+        assertThat(callSites).as("provider selection call sites").hasSizeGreaterThanOrEqualTo(4);
+        assertThat(callSites)
+                .as("the guarded signature takes only the provider/group id; a stale second "
+                        + "argument means a call site was missed when the contract changed")
+                .allSatisfy(arguments -> assertThat(arguments).doesNotContain(","));
+        assertThat(callSites)
+                .as("scriptlet output must reach the JavaScript string literal through an encoder")
+                .allSatisfy(arguments -> {
+                    if (arguments.contains("<%")) {
+                        assertThat(arguments).contains("<carlos:encode");
+                    }
+                });
+
+        assertThat(jsp)
+                .as("onClick handlers must propagate the fail-closed return value")
+                .doesNotContain("onClick=\"selectProvider(");
+    }
+
+    @Test
+    @DisplayName("should encode every provider identity rendered by the result table")
+    void shouldEncodeEveryProviderIdentity_inResultTable() throws IOException {
+        String jsp = Files.readString(PROVIDER_SEARCH, StandardCharsets.UTF_8);
+
+        assertThat(jsp)
+                .as("provider number, last name and first name are operator-authored free text")
+                .doesNotContain("<%=sp%>")
+                .doesNotContain("<%=spnl%>")
+                .doesNotContain("<%=spnf%>")
+                .doesNotContain("<%=spnl+\", \"+spnf%>")
+                .contains("<carlos:encode value='<%= spnl %>' context=\"html\"/>")
+                .contains("<carlos:encode value='<%= spnf %>' context=\"html\"/>");
+    }
+
+    @Test
+    @DisplayName("should populate group-search rows without dereferencing the absent provider")
+    void shouldPopulateGroupSearchRows_withoutDereferencingAbsentProvider() throws IOException {
+        String jsp = Files.readString(PROVIDER_SEARCH, StandardCharsets.UTF_8);
+        int groupBranch = requiredIndex(jsp, "g = (MyGroup) o;");
+        int providerBranch = requiredIndex(jsp, "p = (Provider) o;");
+
+        assertThat(groupBranch).isLessThan(providerBranch);
+        assertThat(jsp.substring(groupBranch, providerBranch))
+                .as("`p` is still null in the group branch, so any dereference throws")
+                .doesNotContain("p.getLastName()")
+                .doesNotContain("p.getFirstName()");
     }
 
     @Test
@@ -83,10 +167,11 @@ class ScheduleProviderSearchCsrfRegressionTest {
                 .contains("if (!resultLoaded)")
                 .contains("type: 'search-popup-load-failure'")
                 .contains("let providerRequest = await Promise.race(")
-                .contains("if (!providerRequest && await providerLink.count())")
                 .contains("providerRequest = providerRequest || await requestPromise;")
                 .contains("responseWithTimeout(providerRequest, 30000)")
-                .contains("get('CSRF-TOKEN')")
+                .as("the token name is configurable, so read it from the rendered input")
+                .contains("locator('#providerSelectionCsrfToken')")
+                .contains("new URLSearchParams(requestBody).get(tokenName)")
                 .contains("type: 'missing-csrf-token'")
                 .contains("response.status() >= 400")
                 .contains("finding.type === 'http'");

--- a/src/test/java/io/github/carlos_emr/carlos/provider/ScheduleProviderSearchCsrfRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/provider/ScheduleProviderSearchCsrfRegressionTest.java
@@ -175,7 +175,12 @@ class ScheduleProviderSearchCsrfRegressionTest {
                 .contains("resultPage.on('response'")
                 .contains("resourceType() !== 'document'")
                 .contains("id=\"providerSelectionCsrfToken\"[^>]*\\sname=\"([^\"]+)\"")
-                .contains("const observedTokenName = renderedTokenName")
+                .as("the parses must be retained and awaited, not fired and forgotten, or "
+                        + "the provider-control response can outrun them and report a valid "
+                        + "token as missing")
+                .contains("tokenNameParses.push(response.text()")
+                .contains("(await Promise.all(tokenNameParses)).find(Boolean)")
+                .contains("const observedTokenName = capturedTokenName")
                 .contains("type: 'csrf-token-name-unresolved'")
                 .contains("new URLSearchParams(requestBody).get(tokenName)")
                 .contains("type: 'missing-csrf-token'")

--- a/src/test/java/io/github/carlos_emr/carlos/provider/ScheduleProviderSearchCsrfRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/provider/ScheduleProviderSearchCsrfRegressionTest.java
@@ -76,6 +76,9 @@ class ScheduleProviderSearchCsrfRegressionTest {
                 .contains("context.waitForEvent('page', { timeout: 10000 }).catch(() => null)")
                 .contains("if (!resultPage)")
                 .contains("type: 'missing-search-popup'")
+                .contains("const resultLoaded = await resultPage.waitForLoadState(")
+                .contains("if (!resultLoaded)")
+                .contains("type: 'search-popup-load-failure'")
                 .contains("let providerRequest = await Promise.race(")
                 .contains("if (!providerRequest && await providerLink.count())")
                 .contains("providerRequest = providerRequest || await requestPromise;");

--- a/src/test/java/io/github/carlos_emr/carlos/provider/ScheduleProviderSearchCsrfRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/provider/ScheduleProviderSearchCsrfRegressionTest.java
@@ -153,33 +153,36 @@ class ScheduleProviderSearchCsrfRegressionTest {
         String browserCheck = Files.readString(SCHEDULE_BROWSER_CHECK, StandardCharsets.UTF_8);
         int requestListener = requiredIndex(browserCheck,
                 "const requestPromise = context.waitForEvent('request'");
+        int tokenNameResponseListener = requiredIndex(browserCheck,
+                "const tokenNamePromise = context.waitForEvent('response'");
         int searchSubmit = requiredIndex(browserCheck, "await searchInput.press('Enter');");
 
         assertThat(requestListener).isLessThan(searchSubmit);
+        assertThat(tokenNameResponseListener).isLessThan(searchSubmit);
         assertThat(browserCheck)
                 .contains("const testProviderLastName = process.env.TEST_PROVIDER_LAST_NAME || '';")
+                .contains("const testProviderSearchOnly = process.env.TEST_PROVIDER_SEARCH_ONLY "
+                        + "=== 'true';")
                 .contains("await searchInput.fill(testProviderLastName);")
                 .doesNotContain("await searchInput.fill('test');")
                 .contains("context.waitForEvent('page', { timeout: 10000 }).catch(() => null)")
                 .contains("if (!resultPage)")
                 .contains("type: 'missing-search-popup'")
-                .contains("const resultLoaded = await resultPage.waitForLoadState(")
-                .contains("if (!resultLoaded)")
+                .contains("const resultLoadedPromise = resultPage.waitForLoadState(")
                 .contains("type: 'search-popup-load-failure'")
                 .contains("let providerRequest = await Promise.race(")
-                .contains("providerRequest = providerRequest || await requestPromise;")
+                .contains("resultLoadedPromise.then(() => null)")
+                .contains("providerRequest = await requestPromise;")
                 .contains("responseWithTimeout(providerRequest, 30000)")
                 .as("the token name is configurable, so it must be read from the rendered "
                         + "page; the auto-select path navigates away, so capture it from "
                         + "the document response rather than the live DOM")
-                .contains("resultPage.on('response'")
-                .contains("resourceType() !== 'document'")
+                .contains("context.waitForEvent('response'")
+                .contains("resourceType() === 'document'")
+                .contains("new URL(response.url()).pathname === providerSearchPath")
                 .contains("id=\"providerSelectionCsrfToken\"[^>]*\\sname=\"([^\"]+)\"")
-                .as("the parses must be retained and awaited, not fired and forgotten, or "
-                        + "the provider-control response can outrun them and report a valid "
-                        + "token as missing")
-                .contains("tokenNameParses.push(response.text()")
-                .contains("(await Promise.all(tokenNameParses)).find(Boolean)")
+                .contains(".then((response) => response.text())")
+                .contains("const capturedTokenName = await tokenNamePromise")
                 .contains("const observedTokenName = capturedTokenName")
                 .contains("type: 'csrf-token-name-unresolved'")
                 .contains("new URLSearchParams(requestBody).get(tokenName)")


### PR DESCRIPTION
## Summary

- render a CSRFGuard token on the Schedule provider-search result page
- copy that token into the dynamically created provider-preference POST before immediate submission
- fail closed when the token is unavailable, and tell the user instead of logging to the console only
- context-encode every provider/group identity rendered by this page, across all four `selectProvider(` call sites and the result table
- fix the null-`Provider` dereference that made every group search (`.`-prefixed) throw before rendering a row
- extend the Schedule Playwright flow to search, select a result, assert the POST token, and fail on HTTP errors

## Testing

- `MAVEN_OPTS="-Xmx1g -Xms256m" mvn -q -Dtest=ScheduleProviderSearchCsrfRegressionTest test` (6 tests)
- `MAVEN_OPTS="-Xmx1500m -Xms256m" mvn -q -DskipTests -Pjspc package` (full JSP compilation; verified the new strings are present in the compiled `receptionistfindprovider_jsp` class, so the JSP was genuinely recompiled)
- `MAVEN_OPTS="-Xmx1g -Xms256m" mvn -q -DskipTests checkstyle:check`
- `bash scripts/lint/check-encoder-null-safety.sh` (PASS, 0 violations)
- `node --check scripts/schedule-links-playwright-checks.js`
- `git diff --check`

The Playwright script is syntax-checked only in this pass; running it needs Tomcat and the dev database up.

## Review round 2

A second review pass found that the guarded `selectProvider()` contract had only been applied to the provider result rows, leaving three defects on the same page.

**MUST — all fixed**

- **Call sites left on the old contract.** The my-group row and the single-result auto-select block still called `selectProvider()` with the old two-argument signature and an unencoded `<%=sp%>`. That value is `MyGroupPrimaryKey.myGroupNo` — an operator-authored `String` — interpolated straight into a JavaScript string literal. The auto-select block is the exact path the new Playwright check exercises, so **the check passed while the unencoded path stayed live**. The my-group anchor also discarded the new fail-closed `return false`.
- **Unencoded provider names.** `spnl` / `spnf` rendered raw into the result-table cells and into the caisi/custom `onClick` handlers — the same `<tr>` rows this PR already edited.
- **Group search was dead.** The `bGrpSearch` branch dereferenced a still-null `Provider` (`p.getLastName()`), so every `.`-prefixed search threw to the error page. The group rows the CSRF fix serves could never render.

**SHOULD — all fixed**

- Missing token failed closed silently (`console.error` only); now surfaced via a new localized `msgMissingSecurityToken` message across all five locale bundles.
- The Playwright fallback click raced a 100 ms wall-clock guess and could throw against an already-navigating popup; the click is now bounded and non-fatal, with the awaited POST as the real signal.
- The new test carried a 4-line copyright stub instead of the standard block from `docs/copyright-header-carlos.md`.

**COULD — one fixed, rest deferred**

- *Fixed:* the browser check hardcoded `CSRF-TOKEN`; it now reads the parameter name off the rendered input, since `org.owasp.csrfguard.TokenName` is configurable.
- *Open:* on the `custom=true` single-result path, `name` is undeclared and resolves to the global `window.name`, writing the popup's window name into the opener's form field. Pre-existing. A first attempt to hoist the variable was **reverted in `ab1d73f0`** because changing it to `''` silently altered what that path sends to the opener — that is a product decision, not an encoding fix, and does not belong in this PR. Recorded with an inline note.
- *Open:* migrate the rest of this legacy search JSP off scriptlets in a separate modernization change.
- *Open:* `.doesNotContain("await searchInput.fill('test');")` pins the absence of a superseded implementation detail; the manual HTTP-error push duplicates what `wirePage` already records.

Closes #3428

## Summary by Sourcery

Secure Schedule provider selection with CSRF token submission, safe identity encoding, and regression coverage for provider and group search flows.

New Features:
- Add CSRF-protected provider selection to the Schedule provider-search flow, including user-visible handling when the token is unavailable.
- Extend the Schedule browser check to select a provider and verify that the resulting POST includes the configured CSRF token.

Bug Fixes:
- Fix group searches so results render without dereferencing a missing provider.
- Prevent unencoded provider and group identities from being inserted into rendered HTML and JavaScript.

Enhancements:
- Ensure all provider-selection call sites use the guarded, fail-closed selection contract.
- Add localized security-token error messages across supported locale bundles.

Tests:
- Add regression coverage for CSRF rendering and submission, encoding, guarded call sites, group searches, and browser-flow token capture.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require a server-rendered CSRF token for schedule provider selection and encode dynamic values. Previously some paths posted without a token and rendered unencoded names; now selection fails closed with a localized alert when the token is missing, and group searches no longer throw.

- JSP: Render a hidden CSRF input via `Owasp.CsrfGuard`, change `selectProvider(p)` to include the token, return false on click, and alert on missing token. Encode the context path, `mygroup_no`, default service type, and provider/group identifiers and names. Fix the group-search null dereference. Keep the custom single-result `name` binding unchanged.
- Browser check: Add a provider last-name search and selection flow. Register the provider POST listener before submit, capture the CSRF parameter name from the search document response, await each parse, and fall back to a DOM read for multi-result lists. Bound waits and report HTTP ≥400. Support `TEST_PROVIDER_LAST_NAME` and `TEST_PROVIDER_SEARCH_ONLY`. Assert the POST includes the CSRF token.
- Tests: Add `ScheduleProviderSearchCsrfRegressionTest` to lock the JSP contract, guarded call sites, encoding, group-search behavior, and browser token-name capture.
- Config: Read the token parameter name from the rendered input instead of assuming `org.owasp.csrfguard.TokenName`. No server changes.

Closes #3428.

<sup>Written for commit 8e5e3d7b9c331bdb7e73889c1c45e2a1f8c0b9a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

