### PR TITLE
fix(consultation): stop discarding referrals when service or consultant is blank

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2Action.java
@@ -166,6 +166,26 @@ public class EctConsultationFormRequest2Action extends ActionSupport {
         }
     }
 
+    /**
+     * Parses an optional numeric form id, returning {@code null} when the field was left blank.
+     *
+     * <p>{@code consultationRequests.serviceId} and {@code .specId} are both nullable, so "not
+     * chosen" is a legitimate stored state. Parsing these with {@code Integer.valueOf} threw
+     * {@link NumberFormatException} on the empty string, and because the enclosing catch only
+     * handles {@link java.text.ParseException} the request died in the Struts global
+     * {@code Exception -> error} mapping: no log, no saved consultation, and a blank page for the
+     * clinician. Blank must therefore be a value here, not an exception.</p>
+     *
+     * @param rawValue the submitted field value; may be {@code null}, empty, or blank
+     * @return the parsed id, or {@code null} when no value was submitted
+     * @throws NumberFormatException if a non-blank value is not a valid integer, which is a
+     *         genuinely malformed request rather than an unfilled field
+     */
+    private static Integer parseOptionalId(String rawValue) {
+        String trimmed = StringUtils.trimToNull(rawValue);
+        return trimmed == null ? null : Integer.valueOf(trimmed);
+    }
+
     private Integer parseUpdateInteger(String rawValue, String logMessage, String actionErrorMessage) {
         try {
             return Integer.parseInt(rawValue);
@@ -392,7 +412,7 @@ public class EctConsultationFormRequest2Action extends ActionSupport {
                     date = DateUtils.parseDate(dateString, format);
                 }
                 consult.setReferralDate(date);
-                consult.setServiceId(Integer.valueOf(this.getService()));
+                consult.setServiceId(parseOptionalId(this.getService()));
 
                 consult.setSignatureImg(signatureId);
 
@@ -454,7 +474,10 @@ public class EctConsultationFormRequest2Action extends ActionSupport {
                 if (CarlosProperties.getInstance().getBooleanProperty("ENABLE_HEALTH_CARE_TEAM_IN_CONSULTATION_REQUESTS", "true")) {
 
                     // when this is enabled the demographicContactId is being posted as a specId variable.
-                    Integer demographicContactId = Integer.valueOf(specId);
+                    // Kept as an Integer: specId is null whenever the consultant field was left blank, and
+                    // unboxing it here threw NPE before the (null-tolerant) lookup below ever ran. The
+                    // update branch already passes the Integer through untouched.
+                    Integer demographicContactId = specId;
 
                     // specId is reset to unknown.
                     specId = 0;
@@ -588,7 +611,7 @@ public class EctConsultationFormRequest2Action extends ActionSupport {
                 }
 
                 consult.setReferralDate(date);
-                consult.setServiceId(Integer.valueOf(this.getService()));
+                consult.setServiceId(parseOptionalId(this.getService()));
                 consult.setSignatureImg(signatureId);
                 consult.setProviderNo(this.getProviderNo());
                 consult.setLetterheadName(this.getLetterheadName());

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConsultationFormRequest.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConsultationFormRequest.jsp
@@ -3346,6 +3346,9 @@ if (userAgent != null) {
                                     loadAllSpecialistsData(function() {
                                         initServiceAutocomplete();
                                         initSpecialistAutocomplete();
+                                        // Resolve text entered while either asynchronous lookup was loading.
+                                        // Existing consultations are restored from their saved IDs immediately below.
+                                        jQuery('#serviceInput').trigger('input');
                                         initializeConsultation(
                                             '<carlos:encode value='<%= String.valueOf(consultUtil.service) %>' context="javaScriptBlock"/>',
                                             '<%=((consultUtil.service==null)?"":SafeEncode.forJavaScript(consultUtil.getServiceName(consultUtil.service.toString())))%>',

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConsultationFormRequest.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConsultationFormRequest.jsp
@@ -1008,7 +1008,6 @@
                     if (String(matchedId) !== String(previousServiceId || '')) {
                         onServiceSelected(matchedId);
                     }
-                    lastResolvedServiceId = String(matchedId);
                 }
             });
         }
@@ -1726,8 +1725,9 @@
         function checkForm(submissionVal, formName) {
             ShowSpin(true);
             var success = true;
+            var isEReferral = document.getElementById('isOceanEReferral') !== null;
 
-            if (typeof checkFormHCT === "function") {
+            if (!isEReferral && typeof checkFormHCT === "function") {
                 if (!checkFormHCT()) {
                     HideSpin();
                     return false;
@@ -1747,7 +1747,6 @@
             // clients, and direct requests so a missing value can never discard the referral.
             // See issue #2241.
             var serviceElement = document.EctConsultationFormRequest2Form.service;
-            var isEReferral = document.getElementById('isOceanEReferral') !== null;
             if (serviceElement && !isEReferral) {
                 var serviceValue = serviceElement.options
                         ? (serviceElement.selectedIndex > 0 ? serviceElement.value : '')

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConsultationFormRequest.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConsultationFormRequest.jsp
@@ -1704,12 +1704,25 @@
             var msg = "<fmt:message key="Errors.service.noServiceSelected"/>";
             msg = msg.replace('<li>', '');
             msg = msg.replace('</li>', '');
-            var serviceOptionsElement = document.EctConsultationFormRequest2Form.service.options;
-            if (serviceOptionsElement && serviceOptionsElement.selectedIndex == 0) {
-                alert(msg);
-                document.EctConsultationFormRequest2Form.service.focus();
-                HideSpin();
-                return false;
+            // `service` is rendered three different ways: a hidden input paired with the
+            // #serviceInput autocomplete (Health Care Team off), a hidden input fixed at "0"
+            // (Health Care Team on), and no field at all on an eReferral, where the service is
+            // read-only text. Reading `.options` only worked for a <select> that this form no
+            // longer renders, so this guard silently passed for every real submission and let a
+            // blank service reach the server. See issue #2241.
+            var serviceElement = document.EctConsultationFormRequest2Form.service;
+            if (serviceElement) {
+                var serviceValue = serviceElement.options
+                        ? (serviceElement.selectedIndex > 0 ? serviceElement.value : '')
+                        : (serviceElement.value || '').trim();
+                if (serviceValue === '') {
+                    alert(msg);
+                    // Focus the visible autocomplete when present; a hidden input cannot take focus.
+                    var serviceInput = document.getElementById('serviceInput');
+                    (serviceInput || serviceElement).focus();
+                    HideSpin();
+                    return false;
+                }
             }
             var faxNumber = document.EctConsultationFormRequest2Form.fax.value;
             faxNumber = faxNumber.trim();

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConsultationFormRequest.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConsultationFormRequest.jsp
@@ -1746,7 +1746,8 @@
             // clients, and direct requests so a missing value can never discard the referral.
             // See issue #2241.
             var serviceElement = document.EctConsultationFormRequest2Form.service;
-            if (serviceElement) {
+            var isEReferral = document.getElementById('isOceanEReferral') !== null;
+            if (serviceElement && !isEReferral) {
                 var serviceValue = serviceElement.options
                         ? (serviceElement.selectedIndex > 0 ? serviceElement.value : '')
                         : (serviceElement.value || '').trim();

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConsultationFormRequest.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConsultationFormRequest.jsp
@@ -1741,7 +1741,10 @@
             // (Health Care Team on), and no field at all on an eReferral, where the service is
             // read-only text. Reading `.options` only worked for a <select> that this form no
             // longer renders, so this guard silently passed for every real submission and let a
-            // blank service reach the server. See issue #2241.
+            // blank service reach the server. The normal interactive form intentionally requires
+            // a service; the action still accepts null defensively for eReferrals, alternate
+            // clients, and direct requests so a missing value can never discard the referral.
+            // See issue #2241.
             var serviceElement = document.EctConsultationFormRequest2Form.service;
             if (serviceElement) {
                 var serviceValue = serviceElement.options

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConsultationFormRequest.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConsultationFormRequest.jsp
@@ -997,7 +997,8 @@
                 var typed = jQuery(this).val().trim().toLowerCase();
                 var matchedId = '';
                 for (var i = 0; i < allServicesData.length; i++) {
-                    if (allServicesData[i].serviceDesc.toLowerCase() === typed) {
+                    var description = (allServicesData[i].serviceDesc || '').trim().toLowerCase();
+                    if (description === typed) {
                         matchedId = allServicesData[i].serviceId;
                         break;
                     }

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConsultationFormRequest.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConsultationFormRequest.jsp
@@ -981,6 +981,28 @@
             jQuery('#serviceInput').on('click', function() {
                 jQuery(this).autocomplete('search', '');
             });
+            // #service is the field actually posted, and the select handler above is the only
+            // thing that ever wrote it. The id therefore survived the clinician clearing the
+            // visible text, so a service that looked deselected was still submitted and the
+            // submit guard (see issue #2241) approved a value nobody could see. Re-resolve the
+            // hidden id from the visible text on every edit: an exact service name keeps its
+            // id, anything else clears it.
+            //
+            // onServiceSelected() is deliberately NOT called here. It wipes the specialist,
+            // phone, fax, address and annotation fields, which must not happen on a keystroke.
+            // The specialist autocomplete re-reads #service on each search, so clearing the id
+            // is already enough to widen that list again.
+            jQuery('#serviceInput').on('input', function() {
+                var typed = jQuery(this).val().trim().toLowerCase();
+                var matchedId = '';
+                for (var i = 0; i < allServicesData.length; i++) {
+                    if (allServicesData[i].serviceDesc.toLowerCase() === typed) {
+                        matchedId = allServicesData[i].serviceId;
+                        break;
+                    }
+                }
+                jQuery('#service').val(matchedId);
+            });
         }
 
         function initSpecialistAutocomplete() {

--- a/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConsultationFormRequest.jsp
+++ b/src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConsultationFormRequest.jsp
@@ -941,6 +941,7 @@
         // All-specialists data for autocomplete (loaded once on page ready)
         var allSpecialistsData = [];
         var allServicesData = [];
+        var lastResolvedServiceId = '';
 
         function loadAllSpecialistsData(callback) {
             jQuery.ajax({
@@ -988,11 +989,11 @@
             // hidden id from the visible text on every edit: an exact service name keeps its
             // id, anything else clears it.
             //
-            // onServiceSelected() is deliberately NOT called here. It wipes the specialist,
-            // phone, fax, address and annotation fields, which must not happen on a keystroke.
-            // The specialist autocomplete re-reads #service on each search, so clearing the id
-            // is already enough to widen that list again.
+            // Keep the last valid id while the text is only a partial/unknown value. That lets us
+            // avoid wiping dependent fields on every keystroke while still detecting when the
+            // clinician has manually entered a different exact service name.
             jQuery('#serviceInput').on('input', function() {
+                var previousServiceId = lastResolvedServiceId;
                 var typed = jQuery(this).val().trim().toLowerCase();
                 var matchedId = '';
                 for (var i = 0; i < allServicesData.length; i++) {
@@ -1002,6 +1003,12 @@
                     }
                 }
                 jQuery('#service').val(matchedId);
+                if (matchedId !== '') {
+                    if (String(matchedId) !== String(previousServiceId || '')) {
+                        onServiceSelected(matchedId);
+                    }
+                    lastResolvedServiceId = String(matchedId);
+                }
             });
         }
 
@@ -1067,6 +1074,7 @@
         }
 
         function onServiceSelected(serviceId) {
+            lastResolvedServiceId = String(serviceId || '');
             // Clear specialist selection when service changes
             jQuery('#specialistInput').val('');
             jQuery('#specialist').val('');
@@ -1093,6 +1101,7 @@
             if ((!currentService || currentService === '' || currentService === '-1') && specData.serviceIds && specData.serviceIds.length > 0) {
                 jQuery('#service').val(specData.serviceIds[0]);
                 jQuery('#serviceInput').val(specData.serviceNames ? specData.serviceNames[0] : '');
+                lastResolvedServiceId = String(specData.serviceIds[0]);
             }
 
             document.getElementById('consult-disclaimer').style.display = 'none';
@@ -1482,6 +1491,7 @@
             if (savedService && savedService !== 'null' && savedService !== '-1') {
                 jQuery('#service').val(savedService);
                 jQuery('#serviceInput').val(savedServiceName || '');
+                lastResolvedServiceId = String(savedService);
                 // Maintain legacy data structure for backward compatibility
                 if (!services[savedService]) {
                     K(savedService, savedServiceName);

--- a/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/ConsultationFormServiceSelectionJspRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/ConsultationFormServiceSelectionJspRegressionTest.java
@@ -75,6 +75,7 @@ class ConsultationFormServiceSelectionJspRegressionTest {
 
         assertThat(jsp)
                 .contains("var isEReferral = document.getElementById('isOceanEReferral') !== null;")
+                .contains("if (!isEReferral && typeof checkFormHCT === \"function\") {")
                 .contains("if (serviceElement && !isEReferral) {");
     }
 
@@ -95,7 +96,11 @@ class ConsultationFormServiceSelectionJspRegressionTest {
                 .contains("if (matchedId !== '') {")
                 .contains("if (String(matchedId) !== String(previousServiceId || '')) {")
                 .contains("onServiceSelected(matchedId);")
-                .contains("lastResolvedServiceId = String(matchedId);");
+                .doesNotContain("lastResolvedServiceId = String(matchedId);");
+
+        assertThat(jsp)
+                .contains("function onServiceSelected(serviceId) {")
+                .contains("lastResolvedServiceId = String(serviceId || '');");
     }
 
     /**

--- a/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/ConsultationFormServiceSelectionJspRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/ConsultationFormServiceSelectionJspRegressionTest.java
@@ -37,9 +37,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Tag("consultation")
 class ConsultationFormServiceSelectionJspRegressionTest {
 
-    private static final Path CONSULT_JSP = Path.of(
-            "src", "main", "webapp", "WEB-INF", "jsp", "encounter", "oscarConsultationRequest",
-            "ConsultationFormRequest.jsp");
+    private static final Path CONSULT_JSP = projectRoot().resolve(
+            "src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConsultationFormRequest.jsp");
 
     @Test
     @DisplayName("Editing the visible service text should re-resolve the hidden service id")
@@ -66,8 +65,8 @@ class ConsultationFormServiceSelectionJspRegressionTest {
     }
 
     @Test
-    @DisplayName("Re-resolving the hidden id should not trigger the destructive service-change cascade")
-    void shouldNotClearSpecialistFields_whenServiceTextIsEdited() throws Exception {
+    @DisplayName("Typing a different exact service should clear consultant-dependent fields")
+    void shouldClearSpecialistFields_whenTypedServiceResolvesToDifferentId() throws Exception {
         String jsp = Files.readString(CONSULT_JSP, StandardCharsets.UTF_8);
 
         int handlerStart = jsp.indexOf("jQuery('#serviceInput').on('input', function() {");
@@ -75,8 +74,19 @@ class ConsultationFormServiceSelectionJspRegressionTest {
 
         String handlerBody = jsp.substring(handlerStart, jsp.indexOf("});", handlerStart));
 
-        // onServiceSelected() wipes specialist, phone, fax, address and annotation. Calling it
-        // per keystroke would destroy data the clinician already entered.
-        assertThat(handlerBody).doesNotContain("onServiceSelected(");
+        // Partial/unknown text leaves matchedId blank, so dependent fields survive intermediate
+        // keystrokes. A different exact service is a real selection change and must clear them.
+        assertThat(handlerBody)
+                .contains("var previousServiceId = lastResolvedServiceId;")
+                .contains("if (matchedId !== '') {")
+                .contains("if (String(matchedId) !== String(previousServiceId || '')) {")
+                .contains("onServiceSelected(matchedId);")
+                .contains("lastResolvedServiceId = String(matchedId);");
+    }
+
+    private static Path projectRoot() {
+        return Path.of(System.getProperty(
+                "maven.multiModuleProjectDirectory",
+                System.getProperty("user.dir")));
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/ConsultationFormServiceSelectionJspRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/ConsultationFormServiceSelectionJspRegressionTest.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.encounter.oscarConsultationRequest;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins the client-side service-selection contract on the consultation request form.
+ *
+ * <p>The posted service is the hidden {@code #service} input, not the visible
+ * {@code #serviceInput} autocomplete the clinician actually reads. Keeping those two in step is
+ * what makes the blank-service submit guard trustworthy, so the wiring is asserted here rather
+ * than left to a browser-only check. See issue #2241.</p>
+ *
+ * @since 2026-08-13
+ */
+@DisplayName("Consultation form service selection JSP regressions")
+@Tag("unit")
+@Tag("consultation")
+class ConsultationFormServiceSelectionJspRegressionTest {
+
+    private static final Path CONSULT_JSP = Path.of(
+            "src", "main", "webapp", "WEB-INF", "jsp", "encounter", "oscarConsultationRequest",
+            "ConsultationFormRequest.jsp");
+
+    @Test
+    @DisplayName("Editing the visible service text should re-resolve the hidden service id")
+    void shouldResyncHiddenServiceId_whenVisibleServiceTextChanges() throws Exception {
+        String jsp = Files.readString(CONSULT_JSP, StandardCharsets.UTF_8);
+
+        assertThat(jsp)
+                .contains("jQuery('#serviceInput').on('input', function() {")
+                .contains("var typed = jQuery(this).val().trim().toLowerCase();")
+                .contains("if (allServicesData[i].serviceDesc.toLowerCase() === typed) {")
+                .contains("matchedId = allServicesData[i].serviceId;")
+                .contains("jQuery('#service').val(matchedId);");
+    }
+
+    @Test
+    @DisplayName("The submit guard should read the posted service field and block a blank value")
+    void shouldBlockSubmission_whenPostedServiceValueIsBlank() throws Exception {
+        String jsp = Files.readString(CONSULT_JSP, StandardCharsets.UTF_8);
+
+        assertThat(jsp)
+                .contains("var serviceElement = document.EctConsultationFormRequest2Form.service;")
+                .contains("if (serviceValue === '') {")
+                .doesNotContain("if (serviceElement.options.selectedIndex");
+    }
+
+    @Test
+    @DisplayName("Re-resolving the hidden id should not trigger the destructive service-change cascade")
+    void shouldNotClearSpecialistFields_whenServiceTextIsEdited() throws Exception {
+        String jsp = Files.readString(CONSULT_JSP, StandardCharsets.UTF_8);
+
+        int handlerStart = jsp.indexOf("jQuery('#serviceInput').on('input', function() {");
+        assertThat(handlerStart).as("the input handler must exist").isGreaterThan(-1);
+
+        String handlerBody = jsp.substring(handlerStart, jsp.indexOf("});", handlerStart));
+
+        // onServiceSelected() wipes specialist, phone, fax, address and annotation. Calling it
+        // per keystroke would destroy data the clinician already entered.
+        assertThat(handlerBody).doesNotContain("onServiceSelected(");
+    }
+}

--- a/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/ConsultationFormServiceSelectionJspRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/ConsultationFormServiceSelectionJspRegressionTest.java
@@ -64,7 +64,7 @@ class ConsultationFormServiceSelectionJspRegressionTest {
                 .contains("var serviceElement = document.EctConsultationFormRequest2Form.service;")
                 .contains("if (serviceElement && !isEReferral) {")
                 .contains("if (serviceValue === '') {")
-                .doesNotContain("if (serviceElement.options.selectedIndex");
+                .doesNotContain("if (serviceOptionsElement && serviceOptionsElement.selectedIndex == 0) {");
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/ConsultationFormServiceSelectionJspRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/ConsultationFormServiceSelectionJspRegressionTest.java
@@ -80,6 +80,24 @@ class ConsultationFormServiceSelectionJspRegressionTest {
     }
 
     @Test
+    @DisplayName("Service text entered while lookups load should be resolved before saved state is restored")
+    void shouldResolveServiceText_whenEnteredBeforeAutocompleteInitialization() throws Exception {
+        String jsp = Files.readString(CONSULT_JSP, StandardCharsets.UTF_8);
+
+        int wiringStart = jsp.indexOf("// Load services and all-specialists data, then wire autocompletes");
+        assertThat(wiringStart).as("the autocomplete wiring block must exist").isGreaterThan(-1);
+
+        String wiring = jsp.substring(wiringStart, jsp.indexOf("//-->", wiringStart));
+        int autocompleteInitialization = wiring.indexOf("initServiceAutocomplete();");
+        int initialResolution = wiring.indexOf("jQuery('#serviceInput').trigger('input');");
+        int savedStateInitialization = wiring.indexOf("initializeConsultation(");
+
+        assertThat(autocompleteInitialization).isGreaterThan(-1);
+        assertThat(initialResolution).isGreaterThan(autocompleteInitialization);
+        assertThat(savedStateInitialization).isGreaterThan(initialResolution);
+    }
+
+    @Test
     @DisplayName("Typing a different exact service should clear consultant-dependent fields")
     void shouldClearSpecialistFields_whenTypedServiceResolvesToDifferentId() throws Exception {
         String jsp = Files.readString(CONSULT_JSP, StandardCharsets.UTF_8);

--- a/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/ConsultationFormServiceSelectionJspRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/ConsultationFormServiceSelectionJspRegressionTest.java
@@ -62,8 +62,19 @@ class ConsultationFormServiceSelectionJspRegressionTest {
 
         assertThat(jsp)
                 .contains("var serviceElement = document.EctConsultationFormRequest2Form.service;")
+                .contains("if (serviceElement && !isEReferral) {")
                 .contains("if (serviceValue === '') {")
                 .doesNotContain("if (serviceElement.options.selectedIndex");
+    }
+
+    @Test
+    @DisplayName("An eReferral should allow its service metadata to be blank")
+    void shouldAllowBlankService_whenConsultationIsEReferral() throws Exception {
+        String jsp = Files.readString(CONSULT_JSP, StandardCharsets.UTF_8);
+
+        assertThat(jsp)
+                .contains("var isEReferral = document.getElementById('isOceanEReferral') !== null;")
+                .contains("if (serviceElement && !isEReferral) {");
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/ConsultationFormServiceSelectionJspRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/ConsultationFormServiceSelectionJspRegressionTest.java
@@ -50,7 +50,8 @@ class ConsultationFormServiceSelectionJspRegressionTest {
         assertThat(jsp)
                 .contains("jQuery('#serviceInput').on('input', function() {")
                 .contains("var typed = jQuery(this).val().trim().toLowerCase();")
-                .contains("if (allServicesData[i].serviceDesc.toLowerCase() === typed) {")
+                .contains("var description = (allServicesData[i].serviceDesc || '').trim().toLowerCase();")
+                .contains("if (description === typed) {")
                 .contains("matchedId = allServicesData[i].serviceId;")
                 .contains("jQuery('#service').val(matchedId);");
     }

--- a/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/ConsultationFormServiceSelectionJspRegressionTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/ConsultationFormServiceSelectionJspRegressionTest.java
@@ -37,8 +37,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Tag("consultation")
 class ConsultationFormServiceSelectionJspRegressionTest {
 
-    private static final Path CONSULT_JSP = projectRoot().resolve(
+    private static final int MAX_PARENT_SEARCH_DEPTH = 5;
+    private static final Path CONSULT_JSP_RELATIVE = Path.of(
             "src/main/webapp/WEB-INF/jsp/encounter/oscarConsultationRequest/ConsultationFormRequest.jsp");
+    private static final Path CONSULT_JSP = resolveProjectPath(CONSULT_JSP_RELATIVE);
 
     @Test
     @DisplayName("Editing the visible service text should re-resolve the hidden service id")
@@ -54,7 +56,7 @@ class ConsultationFormServiceSelectionJspRegressionTest {
     }
 
     @Test
-    @DisplayName("The submit guard should read the posted service field and block a blank value")
+    @DisplayName("The normal interactive form should block a blank posted service value")
     void shouldBlockSubmission_whenPostedServiceValueIsBlank() throws Exception {
         String jsp = Files.readString(CONSULT_JSP, StandardCharsets.UTF_8);
 
@@ -84,9 +86,28 @@ class ConsultationFormServiceSelectionJspRegressionTest {
                 .contains("lastResolvedServiceId = String(matchedId);");
     }
 
-    private static Path projectRoot() {
-        return Path.of(System.getProperty(
-                "maven.multiModuleProjectDirectory",
-                System.getProperty("user.dir")));
+    /**
+     * Resolves a project fixture from the compiled test location. This remains stable when an IDE
+     * or a direct Surefire invocation uses a working directory outside the repository.
+     */
+    private static Path resolveProjectPath(Path relativePath) {
+        try {
+            Path location = Path.of(ConsultationFormServiceSelectionJspRegressionTest.class
+                    .getProtectionDomain()
+                    .getCodeSource()
+                    .getLocation()
+                    .toURI());
+            Path current = Files.isRegularFile(location) ? location.getParent() : location;
+            for (int depth = 0; depth <= MAX_PARENT_SEARCH_DEPTH && current != null; depth++) {
+                Path candidate = current.resolve(relativePath);
+                if (Files.isRegularFile(candidate)) {
+                    return candidate;
+                }
+                current = current.getParent();
+            }
+        } catch (java.net.URISyntaxException e) {
+            throw new IllegalStateException("Unable to resolve consultation test class location", e);
+        }
+        throw new IllegalStateException("Unable to locate project file: " + relativePath);
     }
 }

--- a/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2ActionUnitTest.java
@@ -40,6 +40,7 @@ import java.nio.file.Path;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import io.github.carlos_emr.CarlosProperties;
 import io.github.carlos_emr.carlos.commn.dao.ConsultationRequestDao;
 import io.github.carlos_emr.carlos.commn.dao.ConsultationRequestExtDao;
 import io.github.carlos_emr.carlos.commn.dao.ProfessionalSpecialistDao;
@@ -494,6 +495,86 @@ class EctConsultationFormRequest2ActionUnitTest extends CarlosUnitTestBase {
         assertThat(persisted[0]).isNotNull();
         assertThat(persisted[0].getSignatureImg()).isNull();
         verify(consultationSignatureService, never()).saveConsultationStamp(any(), any(), any());
+    }
+
+    /**
+     * Regression for #2241. Both {@code serviceId} and {@code specId} are nullable columns, so a
+     * blank field is a legitimate "not chosen" value. Parsing them eagerly threw out of the action
+     * into the Struts global {@code Exception -> error} mapping, which logs nothing, so the
+     * clinician's referral was discarded with only a blank page to show for it.
+     *
+     * <p>Every other create test in this class supplies both fields, which is exactly why the
+     * defect survived: the unfilled form was never exercised.</p>
+     */
+    @Test
+    @DisplayName("persists a null serviceId instead of throwing when the service is blank on create")
+    void shouldPersistNullServiceId_whenServiceIsBlankOnCreate() throws Exception {
+        ConsultationRequest[] persisted = capturePersistedConsultationRequest();
+
+        action.setSubmission("Submit");
+        action.setService("");
+        action.setSpecialist("0");
+
+        when(consultationSignatureService.saveConsultationStamp(loggedInInfo, "999998", 1))
+                .thenReturn(new ConsultationStampOutcome(ConsultationStampOutcome.Status.SIGNATURES_DISABLED, null));
+
+        action.execute();
+
+        assertThat(persisted[0]).isNotNull();
+        assertThat(persisted[0].getServiceId()).isNull();
+    }
+
+    /**
+     * Regression for #2241. A blank consultant left {@code specId} null, and the Health Care Team
+     * branch then unboxed it via {@code Integer.valueOf(specId)} before reaching the null-tolerant
+     * lookup — a NullPointerException on the create path only; the update path already passed the
+     * Integer through untouched.
+     */
+    @Test
+    @DisplayName("persists the consultation instead of throwing when the consultant is blank on create")
+    void shouldPersistConsultation_whenConsultantIsBlankOnCreate() throws Exception {
+        ConsultationRequest[] persisted = capturePersistedConsultationRequest();
+
+        // The NPE lived inside the Health Care Team branch, which is skipped entirely when the
+        // property is off. Without forcing it on, this test passes against the unfixed action and
+        // proves nothing.
+        CarlosProperties carlosProperties = mock(CarlosProperties.class);
+        when(carlosProperties.getBooleanProperty("ENABLE_HEALTH_CARE_TEAM_IN_CONSULTATION_REQUESTS", "true"))
+                .thenReturn(true);
+        try (MockedStatic<CarlosProperties> carlosPropertiesMock = mockStatic(CarlosProperties.class)) {
+            carlosPropertiesMock.when(CarlosProperties::getInstance).thenReturn(carlosProperties);
+
+        action.setSubmission("Submit");
+        action.setService("1");
+        action.setSpecialist("");
+
+        when(consultationSignatureService.saveConsultationStamp(loggedInInfo, "999998", 1))
+                .thenReturn(new ConsultationStampOutcome(ConsultationStampOutcome.Status.SIGNATURES_DISABLED, null));
+
+        action.execute();
+        }
+
+        assertThat(persisted[0]).isNotNull();
+        assertThat(persisted[0].getServiceId()).isEqualTo(1);
+    }
+
+    /**
+     * Regression for #2241. The blank-service parse existed on the update branch too, so clearing
+     * the service on an existing consultation discarded the edit the same way.
+     */
+    @Test
+    @DisplayName("merges a null serviceId instead of throwing when the service is blank on update")
+    void shouldMergeNullServiceId_whenServiceIsBlankOnUpdate() throws Exception {
+        action.setSubmission("Update");
+        action.setService("");
+        action.setSpecialist("0");
+
+        when(consultationSignatureService.saveConsultationStamp(loggedInInfo, "999998", 1))
+                .thenReturn(new ConsultationStampOutcome(ConsultationStampOutcome.Status.SIGNATURES_DISABLED, null));
+
+        action.execute();
+
+        verify(consultationRequestDao).merge(any(ConsultationRequest.class));
     }
 
     @Test

--- a/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2ActionUnitTest.java
@@ -535,6 +535,13 @@ class EctConsultationFormRequest2ActionUnitTest extends CarlosUnitTestBase {
     void shouldPersistConsultation_whenConsultantIsBlankOnCreate() throws Exception {
         ConsultationRequest[] persisted = capturePersistedConsultationRequest();
 
+        action.setSubmission("Submit");
+        action.setService("1");
+        action.setSpecialist("");
+
+        when(consultationSignatureService.saveConsultationStamp(loggedInInfo, "999998", 1))
+                .thenReturn(new ConsultationStampOutcome(ConsultationStampOutcome.Status.SIGNATURES_DISABLED, null));
+
         // The NPE lived inside the Health Care Team branch, which is skipped entirely when the
         // property is off. Without forcing it on, this test passes against the unfixed action and
         // proves nothing.
@@ -544,14 +551,7 @@ class EctConsultationFormRequest2ActionUnitTest extends CarlosUnitTestBase {
         try (MockedStatic<CarlosProperties> carlosPropertiesMock = mockStatic(CarlosProperties.class)) {
             carlosPropertiesMock.when(CarlosProperties::getInstance).thenReturn(carlosProperties);
 
-        action.setSubmission("Submit");
-        action.setService("1");
-        action.setSpecialist("");
-
-        when(consultationSignatureService.saveConsultationStamp(loggedInInfo, "999998", 1))
-                .thenReturn(new ConsultationStampOutcome(ConsultationStampOutcome.Status.SIGNATURES_DISABLED, null));
-
-        action.execute();
+            action.execute();
         }
 
         assertThat(persisted[0]).isNotNull();

--- a/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/encounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2ActionUnitTest.java
@@ -66,6 +66,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -574,7 +575,10 @@ class EctConsultationFormRequest2ActionUnitTest extends CarlosUnitTestBase {
 
         action.execute();
 
-        verify(consultationRequestDao).merge(any(ConsultationRequest.class));
+        ArgumentCaptor<ConsultationRequest> mergedConsultation =
+                ArgumentCaptor.forClass(ConsultationRequest.class);
+        verify(consultationRequestDao).merge(mergedConsultation.capture());
+        assertThat(mergedConsultation.getValue().getServiceId()).isNull();
     }
 
     @Test


### PR DESCRIPTION
Fixes #2241

## What

Submitting a consultation request with **Service** or **Consultant** left blank discarded the referral: nothing saved, nothing logged, blank page. This makes both fields safe to leave empty and repairs the client-side guard that was supposed to catch it.

## The two faults

Both reachable from the same form, both in `EctConsultationFormRequest2Action`:

| Blank field | Line | Exception | Paths |
|---|---|---|---|
| Service | `:395`, `:594` | `Integer.valueOf("")` → `NumberFormatException` | create + update |
| Consultant | `:457` | `Integer.valueOf(specId)` unboxes a null `Integer` → `NullPointerException` | create only |

The enclosing `try` at `:343` is closed by `catch (ParseException)` at `:507`, which catches neither. Both therefore escaped into the Struts global `Exception -> error` mapping in `struts-encounter.xml:38`, whose interceptor does not log by default — so the only server-side trace of a lost referral was an unrelated-looking CSRF filter warning.

`consultationRequests.serviceId` and `.specId` are both **nullable**, so "not chosen" is a legitimate stored state. `parseOptionalId` treats blank as `null` while still rejecting genuinely malformed input. The consultant fix simply stops unboxing — `getHealthCareMemberbyId` already null-guards, and the update branch at `:607` already passed the `Integer` through untouched, so this makes create match update.

## The client-side guard was dead code

`ConsultationFormRequest.jsp:1707` read `.options` on `service`. This form renders `service` as a **hidden input** (or omits it entirely on an eReferral), never a `<select>` — so `.options` was `undefined`, the condition short-circuited, and the "no service selected" alert never fired for any real submission. It now reads the field's value across all three rendered shapes and focuses the visible `#serviceInput` autocomplete rather than a hidden input that cannot take focus.

## Tests

Three regression tests in `EctConsultationFormRequest2ActionUnitTest`, all **verified to fail without the production change**:

```
shouldPersistNullServiceId_whenServiceIsBlankOnCreate   -> NumberFormatException: For input string: ""
shouldMergeNullServiceId_whenServiceIsBlankOnUpdate     -> NumberFormatException: For input string: ""
shouldPersistConsultation_whenConsultantIsBlankOnCreate -> NullPointerException: Cannot invoke
                                                           "java.lang.Integer.intValue()" because "specId" is null
```

The consultant test explicitly forces `ENABLE_HEALTH_CARE_TEAM_IN_CONSULTATION_REQUESTS` on. Without that it passes against the unfixed action, because the NPE lives in a branch unit tests otherwise skip — worth knowing if this area is touched again.

Every pre-existing create test in that class supplies both fields, which is why the defect survived: the unfilled form was never exercised.

`EctConsultationFormRequest2ActionUnitTest` — **26 tests, 0 failures**.

## Reproduced against a live deployment

`develop@03c0211e56`, Playwright + direct DB queries:

| Service | Consultant | Before | After this change |
|---|---|---|---|
| set | set | saves | saves |
| empty | set | blank page, no row | saves with null serviceId |
| set | empty | blank page, no row | saves |
| empty | empty | blank page, no row | saves |

## Deliberately out of scope

- **The blank page itself** is a separate defect and is tracked in #3434: the Struts `error` result renders as a 0-byte body because `CsrfGuardScriptInjectionFilter` resets an already-committed buffer, and the exception is never logged. That is not consultation-specific. With this PR the consultation form no longer *reaches* that path, but any other action that throws still will.
- **A JSP/Java default mismatch found while investigating**, not fixed here: `ConsultationFormRequest.jsp` gates the Health Care Team markup with `defaultVal="false"` while the action reads `getBooleanProperty(..., "true")`. When the property is unset the JSP renders the non-HCT form while the action processes it as HCT, where the posted `specialist` value means a `demographicContactId` rather than a `specId`. That is a data-correctness question needing a product decision on which default is authoritative, so I have not changed it. Worth its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prevent consultation referrals from being lost when optional Service or Consultant fields are blank, and ensure the form validates and submits service selections reliably.

Bug Fixes:
- Preserve consultation referrals when Service or Consultant is left blank by storing null values instead of discarding the request.
- Repair consultation form validation and service selection handling so blank services are detected correctly while eReferrals remain exempt.

Enhancements:
- Keep the visible service autocomplete and submitted service identifier synchronized, including when service text changes or is entered before lookup initialization.

Tests:
- Add regression coverage for blank Service and Consultant values on consultation create and update paths.
- Add JSP regression coverage for service synchronization, validation, eReferral exemptions, and asynchronous initialization.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves consultation referrals when Service or Consultant are blank. Old behavior threw and hit the Struts error path; new behavior saves nulls, blocks blank Service in the interactive form, and allows eReferrals to omit service metadata.

- Server (`EctConsultationFormRequest2Action`): use `parseOptionalId` for `serviceId` on create/update (blank → null; malformed rejected); keep `specId` as an `Integer` in the Health Care Team path to avoid NPE when Consultant is blank.
- Client (`ConsultationFormRequest.jsp`): keep hidden `#service` synced with `#serviceInput`, track the last resolved id and only cascade when it changes; submit guard reads the posted value and focuses `#serviceInput`; resolve service text typed before lookups load; skip Health Care Team validation for eReferrals.
- Tests/Rollout: regression tests cover blank Service (create/update), blank Consultant (create, HCT on), and JSP wiring; no migrations, nullable columns unchanged.

<sup>Written for commit 81b42437a52c1255273fa9e06cdb84894f636688. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

