### PR TITLE
chore: set 2026.08.0-alpha1 release metadata

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>io.github.carlos_emr</groupId>
     <artifactId>carlos</artifactId>
     <packaging>war</packaging>
-    <version>0-SNAPSHOT</version>
+    <version>2026.08.0-alpha1</version>
     <name>CARLOS</name>
     <description>CARLOS EMR (Clinical Assisting Recording Ledger Open Source) is a web-based electronic medical record system for Canadian healthcare.</description>
     <inceptionYear>2024</inceptionYear>
@@ -19,7 +19,7 @@
         <url>https://github.com/carlos-emr/carlos</url>
         <connection>scm:git:https://github.com/carlos-emr/carlos.git</connection>
         <developerConnection>scm:git:ssh://git@github.com:carlos-emr/carlos.git</developerConnection>
-        <tag>develop</tag>
+        <tag>2026.08.0-alpha1</tag>
     </scm>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
## Summary

Prepares the Maven project metadata for the `2026.08.0-alpha1` release.

- changes the project version from `0-SNAPSHOT` to `2026.08.0-alpha1`
- changes the Maven SCM tag from the moving `develop` branch to `2026.08.0-alpha1`

## Why

A published release WAR should not carry `SNAPSHOT` coordinates, and its SCM metadata should resolve to the immutable release tag rather than a development branch.

## Validation

- `mvn clean -Dmaven.test.skip=true -Dcheckstyle.skip=true package` succeeds
- output is `target/carlos-2026.08.0-alpha1.war`
- embedded `buildNumber.properties` matches commit `e409f5170a2c97ce7cb4c295270ef6496a2f7a67`
- dependency-lock verification passes
- `git diff --check` passes

## Release follow-up

After this PR merges, move the unpublished `2026.08.0-alpha1` tag to the resulting `main` commit, rebuild from that tag, and publish the WAR plus its SHA-256 checksum as prerelease assets.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares the Maven release metadata for `2026.08.0-alpha1` so the published WAR uses non-SNAPSHOT coordinates and resolves to an immutable SCM tag. Previously built as `0-SNAPSHOT` from `develop`; now builds as `2026.08.0-alpha1` from tag `2026.08.0-alpha1`.

**Review notes**
- Bumps `pom.xml` version from `0-SNAPSHOT` to `2026.08.0-alpha1`.
- Pins SCM `<tag>` from `develop` to `2026.08.0-alpha1` (no runtime behavior changes).

**Release follow-up**
- After merge, move the `2026.08.0-alpha1` tag to the merge commit, rebuild from that tag, and publish the WAR and its SHA-256 checksum as prerelease assets.

<sup>Written for commit e409f5170a2c97ce7cb4c295270ef6496a2f7a67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

