### PR TITLE
chore: start 2026.08.0-alpha2 development

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,5 +31,5 @@
 - [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
 - [ ] I have not included any patient data (PHI) in this PR
 - [ ] I have added tests for new functionality, or this change doesn't need new tests
-- [ ] I have read the [contributing guide](CONTRIBUTING.md)
-- [ ] I selected the target branch according to the [release process](docs/release-process.md)
+- [ ] I have read the [contributing guide](https://github.com/carlos-emr/carlos/blob/develop/CONTRIBUTING.md)
+- [ ] I selected the target branch according to the [release process](https://github.com/carlos-emr/carlos/blob/develop/docs/release-process.md)

--- a/.github/workflows/container-images.yml
+++ b/.github/workflows/container-images.yml
@@ -43,7 +43,6 @@ on:
       - staging/*
       - hotfix/*
       - release/*
-      - release/*
   pull_request:
     branches:
       - main
@@ -51,6 +50,7 @@ on:
       - experimental
       - staging/*
       - hotfix/*
+      - release/*
   workflow_dispatch:
     inputs:
       force_rebuild:

--- a/.github/workflows/db-schema-verify.yml
+++ b/.github/workflows/db-schema-verify.yml
@@ -100,6 +100,22 @@ jobs:
           set -euo pipefail
           cd database/mysql
           MYSQL="mariadb -h 127.0.0.1 -uroot"
+
+          unique_single_column_index_count() {
+            local schema_name=$1
+            local table_name=$2
+            local index_name=$3
+            local column_name=$4
+
+            $MYSQL -N -e "
+              SELECT COUNT(*) FROM (
+                SELECT index_name FROM information_schema.statistics
+                WHERE table_schema='${schema_name}' AND table_name='${table_name}' AND index_name='${index_name}'
+                GROUP BY index_name
+                HAVING COUNT(*)=1 AND MIN(column_name)='${column_name}' AND MIN(seq_in_index)=1 AND MIN(non_unique)=0
+              ) AS exact_index"
+          }
+
           # jdbc:mariadb — the MariaDB driver bundled in the pinned Flyway CLI, matching the
           # jdbc:mariadb URLs release/postinst and carlos-ctl use against the same server.
           JDBC="jdbc:mariadb://127.0.0.1:3306/carlos_${PROV}?allowPublicKeyRetrieval=true&useSSL=false"
@@ -157,10 +173,10 @@ jobs:
             exit 1
           fi
           if [ "${PROV}" = "on" ]; then
-            OHIP_FILENAME_UQ=$($MYSQL -N carlos_on -e "SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema='carlos_on' AND table_name='billing_on_diskname' AND index_name='billing_on_diskname_ohipfilename_uq' AND non_unique=0")
-            HTML_FILENAME_UQ=$($MYSQL -N carlos_on -e "SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema='carlos_on' AND table_name='billing_on_filename' AND index_name='billing_on_filename_htmlfilename_uq' AND non_unique=0")
+            OHIP_FILENAME_UQ=$(unique_single_column_index_count carlos_on billing_on_diskname billing_on_diskname_ohipfilename_uq ohipfilename)
+            HTML_FILENAME_UQ=$(unique_single_column_index_count carlos_on billing_on_filename billing_on_filename_htmlfilename_uq htmlfilename)
             if [ "${OHIP_FILENAME_UQ}" != "1" ] || [ "${HTML_FILENAME_UQ}" != "1" ]; then
-              echo "::error::Ontario billing filename unique indexes are missing after migrate"
+              echo "::error::CARLOS EMR Ontario billing filename unique indexes are missing or malformed after migrate"
               exit 1
             fi
           fi
@@ -341,6 +357,15 @@ jobs:
               exit 1
             fi
           done
+
+          if [ "${PROV}" = "on" ]; then
+            ADOPT_OHIP_FILENAME_UQ=$(unique_single_column_index_count "${ADOPT_DB}" billing_on_diskname billing_on_diskname_ohipfilename_uq ohipfilename)
+            ADOPT_HTML_FILENAME_UQ=$(unique_single_column_index_count "${ADOPT_DB}" billing_on_filename billing_on_filename_htmlfilename_uq htmlfilename)
+            if [ "${ADOPT_OHIP_FILENAME_UQ}" != "1" ] || [ "${ADOPT_HTML_FILENAME_UQ}" != "1" ]; then
+              echo "::error::CARLOS EMR Ontario billing filename unique indexes are missing or malformed after adopted migrate"
+              exit 1
+            fi
+          fi
 
           ADOPT_TABLES=$($MYSQL -N -e "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema='${ADOPT_DB}' AND table_name<>'flyway_schema_history'")
           if [ "${ADOPT_TABLES}" -lt 300 ]; then

--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -422,23 +422,38 @@ jobs:
 
           delete_failure_comment() {
             local page=1
+            local comments=""
+            local comment_count=0
             local failure_id=""
 
             while true; do
-              comments=$(curl -fsSL \
+              if ! comments=$(curl -fsSL \
                 -H "Authorization: Bearer $GH_TOKEN" \
                 -H "Accept: application/vnd.github+json" \
-                "https://api.github.com/repos/$REPO/issues/$PR_NUMBER/comments?per_page=100&page=$page")
+                "https://api.github.com/repos/$REPO/issues/$PR_NUMBER/comments?per_page=100&page=$page"); then
+                return 1
+              fi
 
-              if [ "$(jq 'length' <<< "$comments")" = "0" ]; then
+              if ! comment_count=$(jq -er \
+                'if type == "array" then length else error("comments response is not an array") end' \
+                <<< "$comments"); then
+                return 1
+              fi
+              if [ "$comment_count" -eq 0 ]; then
                 break
               fi
 
-              failure_id=$(jq -r '.[] | select((.body // "") | contains("<!-- dco-check-failed -->")) | .id' <<< "$comments" | head -n 1)
+              if ! failure_id=$(jq -r \
+                '[.[] | select((.body // "") | contains("<!-- dco-check-failed -->")) | .id][0] // ""' \
+                <<< "$comments"); then
+                return 1
+              fi
               if [ -n "$failure_id" ]; then
-                curl -fsS -X DELETE \
+                if ! curl -fsS -X DELETE \
                   -H "Authorization: Bearer $GH_TOKEN" \
-                  "https://api.github.com/repos/$REPO/issues/comments/$failure_id"
+                  "https://api.github.com/repos/$REPO/issues/comments/$failure_id"; then
+                  return 1
+                fi
                 break
               fi
 

--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -450,7 +450,8 @@ jobs:
             echo "DCO check passed via manual confirmation from $CONFIRMING_USER ($CONFIRMING_ASSOCIATION) at $CONFIRMING_AT."
             # Keep pull_request_target statuses current when an existing fresh confirmation is reused.
             # Deleting an absent failure comment is a no-op; posting the same status again is safe.
-            delete_failure_comment
+            delete_failure_comment || \
+              echo "::warning::DCO passed, but the workflow could not remove its prior failure comment."
             set_dco_status success "DCO manually confirmed by $CONFIRMING_USER"
             if [ "$EVENT_NAME" = "issue_comment" ]; then
               {
@@ -460,7 +461,9 @@ jobs:
                 echo ""
                 echo "The DCO check has passed using manual PR sign-off. No commit changes are required."
               } > /tmp/dco_success_comment.md
-              post_comment /tmp/dco_success_comment.md
+              if ! post_comment /tmp/dco_success_comment.md; then
+                echo "::warning::DCO passed, but the workflow could not post its optional success comment."
+              fi
             fi
             exit 0
           fi

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -5,7 +5,7 @@
 # dependency graph to GitHub for security monitoring.
 #
 # Trigger:
-# - Runs on push to main, develop, and release/* when pom.xml or the lock file changes
+# - Runs on pushes to the configured branches when pom.xml or the lock file changes
 # - Does NOT run on pull requests (maven-project.yml handles PR validation)
 #
 # Jobs:

--- a/.github/workflows/maven-project.yml
+++ b/.github/workflows/maven-project.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          ref: ${{ inputs.ref || github.sha }}
+          ref: ${{ inputs.ref != '' && inputs.ref || github.sha }}
 
       - name: Log in to Container Registry
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
@@ -192,7 +192,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          ref: ${{ inputs.ref || github.sha }}
+          ref: ${{ inputs.ref != '' && inputs.ref || github.sha }}
 
       - name: Restore Maven cache
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
@@ -316,7 +316,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          ref: ${{ inputs.ref || github.sha }}
+          ref: ${{ inputs.ref != '' && inputs.ref || github.sha }}
       - name: Run encoder null-safety lint
         run: bash scripts/lint/check-encoder-null-safety.sh
       - name: Run encoder null-safety lint fixtures
@@ -335,7 +335,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          ref: ${{ inputs.ref || github.sha }}
+          ref: ${{ inputs.ref != '' && inputs.ref || github.sha }}
 
       - name: Restore Maven cache
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0

--- a/.github/workflows/maven-project.yml
+++ b/.github/workflows/maven-project.yml
@@ -79,6 +79,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ inputs.ref != '' && inputs.ref || github.sha }}
+          persist-credentials: false
 
       - name: Log in to Container Registry
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
@@ -193,6 +194,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ inputs.ref != '' && inputs.ref || github.sha }}
+          persist-credentials: false
 
       - name: Restore Maven cache
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
@@ -317,6 +319,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ inputs.ref != '' && inputs.ref || github.sha }}
+          persist-credentials: false
       - name: Run encoder null-safety lint
         run: bash scripts/lint/check-encoder-null-safety.sh
       - name: Run encoder null-safety lint fixtures
@@ -336,6 +339,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ inputs.ref != '' && inputs.ref || github.sha }}
+          persist-credentials: false
 
       - name: Restore Maven cache
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -58,6 +58,7 @@ jobs:
         with:
           ref: refs/tags/${{ env.RELEASE_TAG }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Validate CalVer, annotation, source branch, and Maven metadata
         if: steps.release-state.outputs.skip != 'true'
@@ -99,9 +100,10 @@ jobs:
           fi
 
           release_line=$(sed -E 's/^([0-9]{4}\.[0-9]{2})\..*$/\1/' <<< "$RELEASE_TAG")
-          git fetch --no-tags origin main \
+          git fetch --no-tags origin \
+            "refs/heads/main:refs/remotes/origin/main" \
             "refs/heads/release/$release_line:refs/remotes/origin/release/$release_line" || \
-            git fetch --no-tags origin main
+            git fetch --no-tags origin "refs/heads/main:refs/remotes/origin/main"
 
           source_branch=""
           if [ "$(git rev-parse origin/main)" = "$tag_commit" ]; then
@@ -149,7 +151,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      packages: read
       attestations: write
       id-token: write
     env:
@@ -158,43 +159,20 @@ jobs:
       TAG_COMMIT: ${{ needs.validate.outputs.commit }}
       RELEASE_LINE: ${{ needs.validate.outputs.line }}
       IS_PRERELEASE: ${{ needs.validate.outputs.prerelease }}
-      REGISTRY: ghcr.io
-      IMAGE_PREFIX: ${{ github.repository_owner }}
       REPO: ${{ github.repository }}
     steps:
       - name: Checkout the complete tagged history
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: refs/tags/${{ env.RELEASE_TAG }}
+          persist-credentials: false
           fetch-depth: 0
 
-      - name: Log in to the container registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Restore Maven cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: .m2-cache
-          key: ${{ runner.os }}-release-maven-${{ hashFiles('**/pom.xml', '**/dependencies-lock*.json', 'local_repo/**') }}
-          restore-keys: |
-            ${{ runner.os }}-release-maven-
-            ${{ runner.os }}-maven-
-
-      - name: Pull or build the trusted development container
-        env:
-          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/carlos-tomcat-dev:latest
+      - name: Build the release environment from tagged source
         run: |
           set -euo pipefail
 
-          if docker pull "$IMAGE"; then
-            docker tag "$IMAGE" carlos-tomcat-dev
-          else
-            docker build --pull -t carlos-tomcat-dev .devcontainer/development
-          fi
+          docker build --pull -t carlos-release-build-env .devcontainer/development
 
       - name: Build the WAR and CycloneDX SBOM from a clean checkout
         run: |
@@ -205,7 +183,7 @@ jobs:
             -v "$GITHUB_WORKSPACE:/workspace" \
             -v "$GITHUB_WORKSPACE/.m2-cache:/root/.m2" \
             -w /workspace \
-            carlos-tomcat-dev bash -euo pipefail -c "
+            carlos-release-build-env bash -euo pipefail -c "
               git config --global --add safe.directory /workspace
               mvn se.vandmo:dependency-lock-maven-plugin:check -q
               mvn clean -DskipTests=true -T 1C package

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -199,7 +199,7 @@ jobs:
           sbom="target/carlos-$RELEASE_TAG-cyclonedx.json"
           test -f "$war"
           test -f "$sbom"
-          jar tf "$war" >/dev/null
+          unzip -t "$war" >/dev/null
 
           build_properties=$(unzip -p "$war" WEB-INF/classes/buildNumber.properties)
           if ! grep -qxF "git-sha-1=$TAG_COMMIT" <<< "$build_properties"; then

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -141,7 +141,6 @@ jobs:
     uses: ./.github/workflows/maven-project.yml
     with:
       ref: refs/tags/${{ needs.validate.outputs.tag }}
-    secrets: inherit
 
   package-and-publish:
     name: Package and publish immutable release
@@ -241,6 +240,13 @@ jobs:
             sha256sum "carlos-$RELEASE_TAG.war" > "carlos-$RELEASE_TAG.war.sha256"
             sha256sum "carlos-$RELEASE_TAG-cyclonedx.json" > "carlos-$RELEASE_TAG-cyclonedx.json.sha256"
           )
+
+      - name: Attest the WAR and SBOM provenance
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: |
+            release-assets/carlos-${{ env.RELEASE_TAG }}.war
+            release-assets/carlos-${{ env.RELEASE_TAG }}-cyclonedx.json
 
       - name: Create or resume the draft release
         run: |

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -37,6 +37,10 @@ on:
       - develop
       - release/*
 
+concurrency:
+  group: sonarcloud-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 env:
   REGISTRY: ghcr.io
   IMAGE_PREFIX: ${{ github.repository_owner }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -291,6 +291,10 @@ protected branches.
 
 ### External Contributor Workflow (Fork-Based)
 
+Choose the base branch before starting: use `develop` for normal work, or the
+applicable `release/YYYY.MM` branch for an approved supported-release fix. Use
+the same value as `BASE_BRANCH` in the commands and pull-request target below.
+
 1. **Fork** the CARLOS repository on GitHub and **clone your fork** locally
 2. **Add the upstream remote** so you can keep your fork up to date:
    ```bash
@@ -298,11 +302,12 @@ protected branches.
    ```
 3. **Sync your fork** before starting new work:
    ```bash
-   git checkout develop
-   git pull upstream develop
-   git push origin develop
+   BASE_BRANCH=develop  # or release/YYYY.MM for an approved maintenance fix
+   git checkout "$BASE_BRANCH"
+   git pull upstream "$BASE_BRANCH"
+   git push origin "$BASE_BRANCH"
    ```
-4. **Create a feature branch** from `develop` (never work directly on `develop`):
+4. **Create a topic branch** from the selected base (never work directly on a protected branch):
    ```bash
    git checkout -b your-feature-name
    ```
@@ -316,15 +321,16 @@ protected branches.
    ```bash
    git push origin your-feature-name
    ```
-9. **Open a pull request** on GitHub from your fork's branch to `carlos-emr/carlos:develop`
+9. **Open a pull request** from your fork's branch to the same CARLOS `BASE_BRANCH`
 
 ### Internal Contributor Workflow
 
 1. **Clone** the CARLOS repository directly
-2. **Create a feature branch** from `develop` (never work directly on `develop`):
+2. **Create a topic branch** from the selected base (never work directly on a protected branch):
    ```bash
-   git checkout develop
-   git pull origin develop
+   BASE_BRANCH=develop  # or release/YYYY.MM for an approved maintenance fix
+   git checkout "$BASE_BRANCH"
+   git pull origin "$BASE_BRANCH"
    git checkout -b feature/your-feature-name
    ```
 3. **Make and test your changes** following the [code standards](#code-standards) below
@@ -332,7 +338,7 @@ protected branches.
    ```bash
    git commit -s -m "fix: description of your change"
    ```
-5. **Push your branch** and **open a pull request** targeting `develop`
+5. **Push your branch** and **open a pull request** targeting the same `BASE_BRANCH`
 
 ### Pull Request Guidelines
 

--- a/README.md
+++ b/README.md
@@ -26,9 +26,10 @@ For installation instructions, see [.devcontainer/README.md](.devcontainer/READM
 
 ## Releases
 
-Published source archives, versioned WAR files, checksums, SBOMs, and release
-attestations are available on the [GitHub Releases](https://github.com/carlos-emr/carlos/releases)
-page. Alpha, beta, and release-candidate builds are prereleases and should be
+Published source archives, versioned WAR files, checksums, and SBOMs are
+available on the [GitHub Releases](https://github.com/carlos-emr/carlos/releases)
+page. Signed provenance attestations are verifiable as described in the release
+process. Alpha, beta, and release-candidate builds are prereleases and should be
 evaluated before production deployment.
 
 CARLOS follows a CalVer maintenance-branch model. Maintainers and contributors

--- a/database/mysql/migration/on/V1.0.11__billing_filename_unique_indexes.sql
+++ b/database/mysql/migration/on/V1.0.11__billing_filename_unique_indexes.sql
@@ -3,13 +3,46 @@
 -- installs and Flyway-adopted upgrades.
 --
 -- Existing CARLOS installations may already have these exact indexes from
--- update-2026-05-03-billing-disk-filename-unique.sql. IF NOT EXISTS keeps
--- Flyway adoption idempotent for those databases. If an installation has
+-- update-2026-05-03-billing-disk-filename-unique.sql. The guarded statements
+-- keep Flyway adoption idempotent on both MySQL and MariaDB. If an
+-- installation has
 -- duplicate non-NULL filenames and no index yet, the CREATE fails rather than
 -- silently discarding or rewriting billing data.
 
-CREATE UNIQUE INDEX IF NOT EXISTS billing_on_diskname_ohipfilename_uq
-  ON billing_on_diskname (ohipfilename);
+SET @index_present = (
+  SELECT COUNT(*) = 1
+    AND MIN(column_name) = 'ohipfilename'
+    AND MIN(non_unique) = 0
+    AND MIN(seq_in_index) = 1
+  FROM information_schema.statistics
+  WHERE table_schema = DATABASE()
+    AND table_name = 'billing_on_diskname'
+    AND index_name = 'billing_on_diskname_ohipfilename_uq'
+);
+SET @ddl = IF(
+  @index_present,
+  'SELECT 1',
+  'CREATE UNIQUE INDEX billing_on_diskname_ohipfilename_uq ON billing_on_diskname (ohipfilename)'
+);
+PREPARE index_statement FROM @ddl;
+EXECUTE index_statement;
+DEALLOCATE PREPARE index_statement;
 
-CREATE UNIQUE INDEX IF NOT EXISTS billing_on_filename_htmlfilename_uq
-  ON billing_on_filename (htmlfilename);
+SET @index_present = (
+  SELECT COUNT(*) = 1
+    AND MIN(column_name) = 'htmlfilename'
+    AND MIN(non_unique) = 0
+    AND MIN(seq_in_index) = 1
+  FROM information_schema.statistics
+  WHERE table_schema = DATABASE()
+    AND table_name = 'billing_on_filename'
+    AND index_name = 'billing_on_filename_htmlfilename_uq'
+);
+SET @ddl = IF(
+  @index_present,
+  'SELECT 1',
+  'CREATE UNIQUE INDEX billing_on_filename_htmlfilename_uq ON billing_on_filename (htmlfilename)'
+);
+PREPARE index_statement FROM @ddl;
+EXECUTE index_statement;
+DEALLOCATE PREPARE index_statement;

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -71,8 +71,9 @@ snapshot. Keep `develop` on its newer snapshot during every forward merge.
    ```
 
 6. The tag workflow re-runs the full build and tests, creates a clean WAR and
-   CycloneDX SBOM, verifies their provenance, attaches checksums, and publishes
-   a draft as an immutable GitHub release.
+   CycloneDX SBOM, generates signed provenance attestations, attaches and
+   verifies checksums, then publishes the verified draft as an immutable GitHub
+   release.
 7. Confirm prerelease/latest classification and asset attestations, then unfreeze
    the source branch.
 8. Back-merge the tagged commit and advance the maintenance branch to the next
@@ -100,6 +101,7 @@ download before deployment:
 sha256sum --check carlos-VERSION.war.sha256
 sha256sum --check carlos-VERSION-cyclonedx.json.sha256
 gh attestation verify carlos-VERSION.war --repo carlos-emr/carlos
+gh attestation verify carlos-VERSION-cyclonedx.json --repo carlos-emr/carlos
 ```
 
 Alpha, beta, and release-candidate versions are GitHub prereleases. Only stable

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>io.github.carlos_emr</groupId>
     <artifactId>carlos</artifactId>
     <packaging>war</packaging>
-    <version>2026.08.0-alpha1</version>
+    <version>2026.08.0-alpha2-SNAPSHOT</version>
     <name>CARLOS</name>
     <description>CARLOS EMR (Clinical Assisting Recording Ledger Open Source) is a web-based electronic medical record system for Canadian healthcare.</description>
     <inceptionYear>2024</inceptionYear>
@@ -19,7 +19,7 @@
         <url>https://github.com/carlos-emr/carlos</url>
         <connection>scm:git:https://github.com/carlos-emr/carlos.git</connection>
         <developerConnection>scm:git:ssh://git@github.com:carlos-emr/carlos.git</developerConnection>
-        <tag>2026.08.0-alpha1</tag>
+        <tag>HEAD</tag>
     </scm>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/release/make_CARLOS_deb.sh
+++ b/release/make_CARLOS_deb.sh
@@ -67,8 +67,18 @@ db_name=oscar_15
 ## tolerate fields without default values that are not named in the query
 db_switch=\'?characterEncoding=UTF-8\\\&zeroDateTimeBehavior=round\\\&useOldAliasMetadataBehavior=true\\\&jdbcCompliantTruncation=false\'
 
-# and the target of mvn 3 is
-TARGET=carlos-0-SNAPSHOT.war
+# Derive the WAR name from Maven so CalVer changes cannot break packaging.
+if ! MAVEN_FINAL_NAME=$(mvn -f "${REPO_ROOT}/pom.xml" \
+    help:evaluate -Dexpression=project.build.finalName \
+    -Dstyle.color=never -q -DforceStdout); then
+    echo "ERROR: Could not determine Maven project.build.finalName." >&2
+    exit 1
+fi
+if [[ ! "$MAVEN_FINAL_NAME" =~ ^[A-Za-z0-9._+-]+$ ]]; then
+    echo "ERROR: Unsafe Maven project.build.finalName: $MAVEN_FINAL_NAME" >&2
+    exit 1
+fi
+TARGET="${MAVEN_FINAL_NAME}.war"
 
 buildDateTime=$(date)
 SHA1=""


### PR DESCRIPTION
## Summary

Initialize the supported 2026.08 maintenance line after alpha1:

- set the Maven project version to `2026.08.0-alpha2-SNAPSHOT`
- set `project.scm.tag` to `HEAD`
- carry all shared governance follow-ups into the maintenance line: DCO reliability, signed WAR/SBOM attestations, clean source-built release packaging, least-privilege checkout/reuse, Maven-derived Debian WAR naming, portable MySQL/MariaDB index migration, exact fresh/adopted schema assertions, and branch-aware docs/triggers

The branch is based directly on governance commit `3f4f86a4fb`, so it contains the release automation and policy but excludes the develop-only `2026.09.0-SNAPSHOT` commit.

## Validation

- Maven project version: `2026.08.0-alpha2-SNAPSHOT`
- Maven SCM tag: `HEAD`
- Maven build final name: `carlos-2026.08.0-alpha2-SNAPSHOT`
- dependency-lock validation
- `actionlint` v1.7.7 across all workflows
- `bash -n release/make_CARLOS_deb.sh`
- `git diff --check`

## Summary by Sourcery

Initialize the 2026.08.0-alpha2 maintenance snapshot with updated version metadata and carry forward release governance, security, packaging, database, and branch workflow improvements.

Bug Fixes:
- Make DCO workflow status handling resilient when GitHub API comment operations fail.
- Ensure database migration and schema verification correctly support and validate billing filename unique indexes on MySQL and MariaDB.

Enhancements:
- Harden release and CI workflows with least-privilege checkouts, branch-aware ref handling, build concurrency, and source-built release environments.
- Derive Debian WAR packaging names from Maven metadata and strengthen release artifact validation.
- Document maintenance-branch contribution workflows and signed WAR/SBOM attestation verification.

Build:
- Advance the Maven project to 2026.08.0-alpha2-SNAPSHOT and reset the SCM tag to HEAD.

CI:
- Update workflow triggers and validation to cover release branches and exact fresh/adopted schema assertions.

Documentation:
- Update release and contributor documentation for maintenance branches, provenance attestations, and artifact verification.