### PR TITLE
fix(release): embed tagged commit in WAR

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -197,7 +197,7 @@ jobs:
             carlos-release-build-env bash -euo pipefail -c "
               git config --global --add safe.directory /workspace
               mvn se.vandmo:dependency-lock-maven-plugin:check -q
-              mvn clean -DskipTests=true -T 1C package
+              mvn clean -DskipTests=true -DbuildNumber=$TAG_COMMIT -T 1C package
               mvn org.cyclonedx:cyclonedx-maven-plugin:2.9.3:makeAggregateBom \
                 -DoutputFormat=json \
                 -DschemaVersion=1.6 \


### PR DESCRIPTION
## Summary

- pass the validated protected tag commit to Maven's `buildNumber` property during immutable release packaging
- keep the existing post-build WAR provenance assertion
- allow `workflow_dispatch` retries for merge-commit release tags to publish artifacts with the exact tagged SHA

## Root cause

The Maven build-number plugin reports the last content-changing commit for a content-identical GitHub merge commit. Alpha2 therefore embedded PR head `8d1465a...` instead of tagged merge commit `6d4117d...`, and the release workflow correctly refused publication.

## Validation

- `actionlint` passes
- `git diff --check` passes
- local Maven resource filtering with an explicit `-DbuildNumber` value embeds that exact value
- the original tag validation, full build, full tests, JSP compilation, and SBOM generation all passed before the provenance assertion stopped publication

After merge, retry `publish-release.yml` on `main` with tag `2026.08.0-alpha2`.

## Summary by Sourcery

Ensure release WAR files record the exact tagged commit used to build them.

Bug Fixes:
- Embed the validated tagged commit SHA in release WAR artifacts so provenance checks pass for immutable release packaging.

Build:
- Pass the validated tag commit to Maven's build number during release packaging.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Embeds the release tag’s commit SHA in the WAR so provenance matches the tag. Previously the WAR used the last content-changing commit of the merge; now the workflow passes the validated tag commit to Maven via `-DbuildNumber`, so the provenance assertion succeeds and `workflow_dispatch` retries produce artifacts for the exact tagged SHA.

- Rollout: After merge, rerun `publish-release.yml` on `main` with tag `2026.08.0-alpha2` to publish the corrected artifacts.

<sup>Written for commit 4059df109f8cfc97a386d5c23ae7d3e5ab00113c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

