### PR TITLE
fix(release): allow immutable tag retries after branch advances

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -34,6 +34,7 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+      IS_RETRY: ${{ github.event_name == 'workflow_dispatch' }}
     steps:
       - name: Detect an already-published immutable release
         id: release-state
@@ -117,13 +118,16 @@ jobs:
             git fetch --no-tags origin "refs/heads/main:refs/remotes/origin/main"
 
           source_branch=""
-          if [ "$(git rev-parse origin/main)" = "$tag_commit" ]; then
+          if [ "$(git rev-parse origin/main)" = "$tag_commit" ] ||
+             { [ "$IS_RETRY" = "true" ] && git merge-base --is-ancestor "$tag_commit" origin/main; }; then
             source_branch=main
           elif git show-ref --verify --quiet "refs/remotes/origin/release/$release_line" &&
-               [ "$(git rev-parse "origin/release/$release_line")" = "$tag_commit" ]; then
+               { [ "$(git rev-parse "origin/release/$release_line")" = "$tag_commit" ] ||
+                 { [ "$IS_RETRY" = "true" ] &&
+                   git merge-base --is-ancestor "$tag_commit" "origin/release/$release_line"; }; }; then
             source_branch="release/$release_line"
           else
-            echo "::error::Tag must point to the current head of main or release/$release_line."
+            echo "::error::Tag must point to the current branch head, or be its ancestor during an explicit retry."
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

- keep exact branch-HEAD validation for initial tag-push releases
- permit an explicit `workflow_dispatch` retry when the immutable tag remains reachable from `main` or its matching maintenance branch
- preserve annotated-tag, exact POM/SCM metadata, and protected release-line validation

## Root cause

The alpha2 retry correctly used the existing protected tag, but merging the packaging fix advanced `main`. The recovery dispatch then rejected the tag before packaging because it required the tag to remain the current branch head, which makes post-fix retries impossible.

## Validation

- `actionlint` passes
- `git diff --check` passes
- the alpha2 tag remains an ancestor of current `main`
- initial push behavior remains strict

## Summary by Sourcery

Allow immutable release tags to be retried after their source branch advances while keeping initial release validation strict.

Bug Fixes:
- Allow explicit workflow-dispatch release retries to use an immutable tag that remains an ancestor of the current main or matching maintenance branch after the branch advances.

Enhancements:
- Preserve strict current-branch-head validation for initial tag-push releases and existing protected release-line checks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows retries of immutable release tags when `main` or the maintenance branch has advanced. Previously retries required the tag to equal the current branch head and failed after any merge; now an explicit `workflow_dispatch` retry succeeds if the tag is an ancestor of `main` or `release/<line>`.

- Adds `IS_RETRY` and updates validation: initial tag-push still requires tag == branch head; `workflow_dispatch` retries accept ancestor commits via `git merge-base`.
- Clarifies the failure message for non-reachable tags; preserves annotated-tag and release-line protections.
- To retry a failed release, trigger `workflow_dispatch` with the tag; the tag must be reachable from `main` or its matching maintenance branch.

<sup>Written for commit 5703f8566da784238d8dcde9520ca54e2d8084a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

