### PR TITLE
fix(release): require evidence for tag retries

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -23,6 +23,7 @@ jobs:
     name: Validate release tag
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
     outputs:
       skip: ${{ steps.release-state.outputs.skip }}
@@ -34,7 +35,7 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
-      IS_RETRY: ${{ github.event_name == 'workflow_dispatch' }}
+      IS_DISPATCH: ${{ github.event_name == 'workflow_dispatch' }}
     steps:
       - name: Detect an already-published immutable release
         id: release-state
@@ -117,17 +118,37 @@ jobs:
             "refs/heads/release/$release_line:refs/remotes/origin/release/$release_line" || \
             git fetch --no-tags origin "refs/heads/main:refs/remotes/origin/main"
 
+          is_retry=false
+          if [ "$IS_DISPATCH" = "true" ]; then
+            prior_attempt=$(gh run list --repo "$REPO" --workflow publish-release.yml \
+              --branch "$RELEASE_TAG" --event push --limit 100 \
+              --json headSha,status,conclusion \
+              --jq ".[] | select(.headSha == \"$tag_commit\" and .status == \"completed\" and .conclusion != \"success\") | .headSha" |
+              head -n 1)
+            if [ "$prior_attempt" = "$tag_commit" ]; then
+              is_retry=true
+            fi
+          fi
+
           source_branch=""
-          if [ "$(git rev-parse origin/main)" = "$tag_commit" ] ||
-             { [ "$IS_RETRY" = "true" ] && git merge-base --is-ancestor "$tag_commit" origin/main; }; then
+          main_head=$(git rev-parse origin/main)
+          if [ "$main_head" = "$tag_commit" ]; then
             source_branch=main
-          elif git show-ref --verify --quiet "refs/remotes/origin/release/$release_line" &&
-               { [ "$(git rev-parse "origin/release/$release_line")" = "$tag_commit" ] ||
-                 { [ "$IS_RETRY" = "true" ] &&
-                   git merge-base --is-ancestor "$tag_commit" "origin/release/$release_line"; }; }; then
-            source_branch="release/$release_line"
-          else
-            echo "::error::Tag must point to the current branch head, or be its ancestor during an explicit retry."
+          elif [ "$is_retry" = "true" ] &&
+               git merge-base --is-ancestor "$tag_commit" origin/main; then
+            source_branch=main
+          elif git show-ref --verify --quiet "refs/remotes/origin/release/$release_line"; then
+            release_ref="origin/release/$release_line"
+            release_head=$(git rev-parse "$release_ref")
+            if [ "$release_head" = "$tag_commit" ]; then
+              source_branch="release/$release_line"
+            elif [ "$is_retry" = "true" ] &&
+                 git merge-base --is-ancestor "$tag_commit" "$release_ref"; then
+              source_branch="release/$release_line"
+            fi
+          fi
+          if [ -z "$source_branch" ]; then
+            echo "::error::Tag must be the current branch head; ancestor validation requires a prior unsuccessful tag-push attempt."
             exit 1
           fi
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -120,14 +120,22 @@ jobs:
 
           is_retry=false
           if [ "$IS_DISPATCH" = "true" ]; then
-            prior_attempt=$(gh run list --repo "$REPO" --workflow publish-release.yml \
-              --branch "$RELEASE_TAG" --event push --limit 100 \
-              --json headSha,status,conclusion \
-              --jq ".[] | select(.headSha == \"$tag_commit\" and .status == \"completed\" and .conclusion != \"success\") | .headSha" |
-              head -n 1)
-            if [ "$prior_attempt" = "$tag_commit" ]; then
-              is_retry=true
-            fi
+            while IFS= read -r prior_run_id; do
+              [ -n "$prior_run_id" ] || continue
+              validation_result=$(gh api \
+                "repos/$REPO/actions/runs/$prior_run_id/jobs?filter=all&per_page=100" \
+                --jq '.jobs[] | select(.name == "Validate release tag") | .conclusion' |
+                head -n 1)
+              if [ "$validation_result" = "success" ]; then
+                is_retry=true
+                break
+              fi
+            done < <(
+              gh run list --repo "$REPO" --workflow publish-release.yml \
+                --branch "$RELEASE_TAG" --event push --limit 100 \
+                --json databaseId,headSha,status,conclusion \
+                --jq ".[] | select(.headSha == \"$tag_commit\" and .status == \"completed\" and .conclusion != \"success\") | .databaseId"
+            )
           fi
 
           source_branch=""


### PR DESCRIPTION
## Summary

- require a completed unsuccessful tag-push run for the same tag commit before relaxed retry validation is enabled
- add explicit read-only Actions permission for that evidence lookup
- replace nested shell brace conditions with readable exact-head and retry-ancestor branches
- keep initial/manual first-time publication strict

## Review follow-up

Addresses all unresolved findings on #3467 from Sourcery, Copilot, and Codex.

## Validation

- `actionlint` passes
- `git diff --check` passes
- alpha2 has a matching failed tag-push run, so its legitimate recovery remains supported

## Summary by Sourcery

Harden release tag validation by restricting ancestor-based retries to manual dispatches backed by a prior failed tag-push attempt.

Bug Fixes:
- Require evidence of a prior completed unsuccessful tag-push attempt for the same commit before allowing relaxed release-tag retry validation.

Enhancements:
- Keep initial and first-time manual release publication strict while supporting verified ancestor-based retries for main and release branches.

Chores:
- Grant the release workflow read-only access to GitHub Actions run data and clarify tag validation errors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require evidence of a prior attempt with successful tag validation before allowing relaxed ancestor checks on manual release retries. Previously any manual dispatch enabled ancestor-based validation; now first-time or evidence-free dispatches must tag the current branch head.

- Add `actions: read` and inspect prior tag-push runs: allow retry only if there is a completed non-success workflow for the same commit where the "Validate release tag" job concluded success.
- Derive retry state from evidence (`is_retry`), and rename `IS_RETRY` to `IS_DISPATCH`.
- Replace nested conditions with clear exact-head and retry-ancestor branches for `main` and `release/<line>`; update the error message.
- Required action: To retry, ensure at least one completed unsuccessful tag-push run exists for the same commit with successful tag validation, then trigger a manual dispatch.

<sup>Written for commit bcd85f444ec3bc2373eb5f8d3b44810e13a68ee8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

