### PR TITLE
fix(release): verify assets through draft release ID

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -306,9 +306,8 @@ jobs:
           set -euo pipefail
 
           gh release upload "$RELEASE_TAG" release-assets/* --repo "$REPO" --clobber
-          release_id=$(gh api "repos/$REPO/releases?per_page=100" \
-            --jq ".[] | select(.tag_name == \"$RELEASE_TAG\") | .id" |
-            head -n 1)
+          release_id=$(gh api --paginate "repos/$REPO/releases?per_page=100" \
+            --jq ".[] | select(.tag_name == \"$RELEASE_TAG\") | .id")
           if [ -z "$release_id" ]; then
             echo "::error::Draft release $RELEASE_TAG was not found after asset upload."
             exit 1

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -44,7 +44,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          if release_json=$(gh api "repos/$REPO/releases/tags/$RELEASE_TAG" 2>/dev/null); then
+          if release_json=$(gh release view "$RELEASE_TAG" --repo "$REPO" \
+            --json isDraft --jq '{draft: .isDraft}' 2>/dev/null); then
             if [ "$(jq -r '.draft' <<< "$release_json")" = "false" ]; then
               echo "Release $RELEASE_TAG is already published; nothing to change."
               echo "skip=true" >> "$GITHUB_OUTPUT"
@@ -305,7 +306,14 @@ jobs:
           set -euo pipefail
 
           gh release upload "$RELEASE_TAG" release-assets/* --repo "$REPO" --clobber
-          release_json=$(gh api "repos/$REPO/releases/tags/$RELEASE_TAG")
+          release_id=$(gh api "repos/$REPO/releases?per_page=100" \
+            --jq ".[] | select(.tag_name == \"$RELEASE_TAG\") | .id" |
+            head -n 1)
+          if [ -z "$release_id" ]; then
+            echo "::error::Draft release $RELEASE_TAG was not found after asset upload."
+            exit 1
+          fi
+          release_json=$(gh api "repos/$REPO/releases/$release_id")
 
           for asset in release-assets/*; do
             name=$(basename "$asset")


### PR DESCRIPTION
## Summary

- detect existing draft releases with `gh release view`, which supports drafts
- resolve the draft's numeric release ID from the releases collection after upload
- fetch digest metadata by release ID instead of the tag endpoint, which returns 404 while the release is still a draft

## Failure addressed

Run 32207092813 successfully built and tested alpha2, created attestations, created the draft, and uploaded all four assets. It failed only when `GET /releases/tags/2026.08.0-alpha2` returned 404 for that draft.

## Validation

- `actionlint` passes
- `git diff --check` passes
- `gh release view` finds alpha2 as draft
- releases API resolves alpha2 draft ID `372763124`
- all expected assets are already uploaded with SHA-256 digests

After merge, retry the existing immutable `2026.08.0-alpha2` tag; do not retag.

## Summary by Sourcery

Verify uploaded release assets through their draft release ID so draft releases can be completed reliably.

Bug Fixes:
- Fix release asset verification for draft releases by resolving the draft release ID and retrieving its metadata through the release endpoint.

Enhancements:
- Detect existing draft releases when determining whether a release requires publishing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Verifies release assets by draft release ID so draft releases complete reliably. Previously `GET /releases/tags/{tag}` returned 404 for drafts; now we detect drafts with `gh` and fetch by numeric release ID with pagination. Published-release behavior is unchanged.

- Detect existing drafts with `gh release view ... --json isDraft`.
- After upload, paginate `GET /releases` to resolve the release ID.
- Fetch asset metadata and digests via `GET /releases/{id}`; emit an explicit error if the draft is not found.

**Rollout**
- Retry the existing immutable tag `2026.08.0-alpha2`; do not retag.

<sup>Written for commit 8ce3e666d3b1f0fc2894d803628842089e278020. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

