### PR TITLE
fix(db): repair PHCP diagnosis backfill via forward-only V1.0.12

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -229,3 +229,15 @@ jobs:
                 \"-Dsonar.pullrequest.branch=\$PR_BRANCH\" \
                 \"-Dsonar.pullrequest.base=\$PR_BASE\" \
                             "
+
+      # The dev container runs as root and leaves root-owned files in the
+      # mounted workspace (.m2-cache, .sonar-cache, target/**). The post-job
+      # cache save runs as the runner user: it re-evaluates the cache key's
+      # hashFiles('**/pom.xml', ...) across the workspace and tars the cache
+      # directories, so unreadable root-owned paths fail the job even after a
+      # successful analysis. Only cold-cache runs hit this — an exact-key
+      # cache hit skips the save step entirely, which is why develop pushes
+      # never saw it. Restore runner ownership before the post steps run.
+      - name: Fix workspace ownership for cache save
+        if: always()
+        run: sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE"

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -22,7 +22,7 @@
 # to the licensing terms outlined in the repository's LICENSE file.
 #
 # Last Updated:
-# April 2026
+# August 2026
 
 name: SonarCloud Analysis
 
@@ -190,7 +190,7 @@ jobs:
               echo '========================================='
               echo 'Running SonarCloud Analysis (Branch)'
               echo '========================================='
-              mvn -B verify sonar:sonar \
+              mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:5.7.0.6970:sonar \
                 -Pskip-dependency-lock \
                 -Dmaven.test.failure.ignore=true \
                 -Dsonar.host.url=https://sonarcloud.io \
@@ -220,7 +220,7 @@ jobs:
               echo \"PR Branch: \$PR_BRANCH\"
               echo \"PR Base: \$PR_BASE\"
               echo '========================================='
-              mvn -B verify sonar:sonar \
+              mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:5.7.0.6970:sonar \
                 -Pskip-dependency-lock \
                 -Dmaven.test.failure.ignore=true \
                 -Dsonar.host.url=https://sonarcloud.io \

--- a/database/mysql/migration/README.md
+++ b/database/mysql/migration/README.md
@@ -17,6 +17,7 @@ migration/
            V1.0.8__expand_appointment_type_location.sql
            V1.0.9__remove_carlosdoc_schedule_group_denial.sql
            V1.0.10__seed_default_measurement_groups.sql
+           V1.0.12__fix_phcp_diagnosis_group_backfill_collation.sql
   on/      V1.0.1__on_schema.sql            # Ontario-only tables (structure)
            V1.0.2__on_data.sql              # Ontario reference data (rows)
            V1.0.4__on_performance_indexes.sql
@@ -28,8 +29,8 @@ migration/
 ```
 
 The **genesis baseline** is `V1` + the province `V1.0.1`/`V1.0.2` files (frozen). Everything from
-`V1.0.3` onward is a forward delta. The highest version currently shipped is `V1.0.11`. The next
-Ontario or shared migration is `V1.0.12`; the next BC-only migration is `V1.0.11` because Ontario
+`V1.0.3` onward is a forward delta. The highest version currently shipped is `V1.0.12`. The next
+Ontario or shared migration is `V1.0.13`; the next BC-only migration is `V1.0.11` because Ontario
 and BC locations are mutually exclusive (the version line is global only across `common` + the
 selected province — see below).
 

--- a/database/mysql/migration/common/README.md
+++ b/database/mysql/migration/common/README.md
@@ -11,9 +11,13 @@ grouping table and seeds numeric billing diagnoses with ICD-9 chapter categories
 `V1.0.8__expand_appointment_type_location.sql` expands appointment type locations.
 `V1.0.9__remove_carlosdoc_schedule_group_denial.sql` removes the obsolete explicit denial.
 `V1.0.10__seed_default_measurement_groups.sql` seeds the default measurement groups.
+`V1.0.12__fix_phcp_diagnosis_group_backfill_collation.sql` re-runs the V1.0.7 dxphcpgroup
+backfill with a collation-pinned cast, repairing databases where a non-general_ci session
+collation (e.g. MariaDB 11.4+ `character_set_collations` defaults reached via a utf8mb4 CLI
+session) aborted V1.0.7 with ERROR 1267.
 
 Applied together with the selected province (`common` + `on`, or `common` + `bc`). Put **genuinely
 shared future schema changes** here as `V1.0.N__short_description.sql` (sequential, next free version number) so one migration
 covers both provinces. The version line is global across `common` + the selected province, so the
-next free number accounts for province deltas too. Ontario already uses `V1.0.11`, so the next
-shared version is `V1.0.12` (see `../README.md`).
+next free number accounts for province deltas too. The highest version in use is the shared
+`V1.0.12`, so the next shared (or Ontario) version is `V1.0.13` (see `../README.md`).

--- a/database/mysql/migration/common/V1.0.12__fix_phcp_diagnosis_group_backfill_collation.sql
+++ b/database/mysql/migration/common/V1.0.12__fix_phcp_diagnosis_group_backfill_collation.sql
@@ -1,36 +1,25 @@
--- Restore the diagnosis grouping lookup required by the legacy PHCP encounter report.
--- The original report shipped without this table or a distributable PHCP-specific data set.
--- Seed the numeric billing diagnoses with the standard ICD-9 chapter taxonomy so every
--- diagnosis the report can parse has a stable, non-misleading category.
+-- Re-run the V1.0.7 dxphcpgroup backfill with a collation-safe comparison.
+--
+-- V1.0.7's legacy-expansion join compares the utf8mb4_general_ci dxcode column
+-- against a bare CAST(... AS CHAR). That cast takes the SESSION's default
+-- utf8mb4 collation, so on servers whose session collation for utf8mb4 is not
+-- in the general_ci family — for example MariaDB 11.4+ images that ship
+-- character_set_collations = utf8mb4=uca1400_ai_ci, reached through a utf8mb4
+-- client session — the comparison fails with ERROR 1267 (illegal mix of
+-- collations) and V1.0.7 aborts after its DDL but before either backfill
+-- INSERT. JDBC/Flyway sessions negotiate a compatible collation, which is why
+-- managed migrations never hit this; migrations applied through the
+-- mysql/mariadb CLI (the carlos-podman deployment path) do.
+--
+-- V1.0.7 itself is left byte-identical to preserve its recorded Flyway
+-- checksum. This forward-only migration repeats both backfill INSERTs with the
+-- cast pinned to CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci (matching
+-- the table), so it works under any session collation. Both INSERTs keep
+-- their existence guards, so this is a no-op on databases where V1.0.7
+-- completed and fills in the missing rows on databases where it aborted.
 
-CREATE TABLE IF NOT EXISTS dxphcpgroup (
-  dxcode varchar(5) NOT NULL,
-  level1 varchar(100) NOT NULL,
-  level2 varchar(100) NOT NULL,
-  lastUpdateUser varchar(100) NOT NULL DEFAULT 'migration',
-  lastUpdateDate timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  PRIMARY KEY (dxcode)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
-
--- Preserve clinic-specific legacy groupings while bringing adopted tables up to the
--- audit-column convention required for new CARLOS tables. Legacy tables used an
--- integer key, which collapsed distinct zero-padded diagnoses (for example, BC
--- 0320 and 320) into one group. The source diagnostic code is at most five
--- characters, so use its exact string representation for new mappings.
-ALTER TABLE dxphcpgroup
-  MODIFY COLUMN dxcode varchar(5) NOT NULL,
-  ADD COLUMN IF NOT EXISTS lastUpdateUser varchar(100) NOT NULL DEFAULT 'migration',
-  ADD COLUMN IF NOT EXISTS lastUpdateDate timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP;
-
-ALTER TABLE dxphcpgroup
-  ENGINE=InnoDB,
-  CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
-
--- An adopted integer key has already lost its original padding. Preserve the
--- clinic's legacy matching behavior by expanding that mapping to every exact
--- diagnostic-code spelling that previously normalized to the same integer. This
--- intentionally copies an ambiguous legacy 320 mapping to both 320 and 0320;
--- future exact-string lookups can then distinguish newly edited mappings.
+-- Expand adopted legacy integer-keyed mappings to every exact diagnostic-code
+-- spelling that normalizes to the same integer (see V1.0.7 for the rationale).
 INSERT INTO dxphcpgroup (dxcode, level1, level2, lastUpdateUser, lastUpdateDate)
 SELECT codes.dxcode,
        legacy.level1,
@@ -46,12 +35,17 @@ FROM (
 ) codes
 JOIN dxphcpgroup legacy
   ON legacy.dxcode REGEXP '^[0-9]{1,5}$'
-  AND legacy.dxcode = CAST(CAST(legacy.dxcode AS UNSIGNED) AS CHAR)
+  -- Pin the cast's charset AND collation: a bare CAST(... AS CHAR) inherits
+  -- the session collation and can clash with the table's utf8mb4_general_ci.
+  AND legacy.dxcode = CAST(CAST(legacy.dxcode AS UNSIGNED) AS CHAR CHARACTER SET utf8mb4) COLLATE utf8mb4_general_ci
   AND CAST(legacy.dxcode AS UNSIGNED) = codes.numeric_code
 LEFT JOIN dxphcpgroup exact_mapping
   ON exact_mapping.dxcode = codes.dxcode
 WHERE exact_mapping.dxcode IS NULL;
 
+-- Seed the remaining numeric billing diagnoses with the ICD-9 chapter
+-- taxonomy (identical to V1.0.7's second INSERT; guarded, so a completed
+-- V1.0.7 makes this a no-op).
 INSERT INTO dxphcpgroup (dxcode, level1, level2, lastUpdateUser, lastUpdateDate)
 SELECT codes.dxcode,
        CASE

--- a/database/mysql/migration/common/V1.0.7__restore_phcp_diagnosis_groups.sql
+++ b/database/mysql/migration/common/V1.0.7__restore_phcp_diagnosis_groups.sql
@@ -46,7 +46,12 @@ FROM (
 ) codes
 JOIN dxphcpgroup legacy
   ON legacy.dxcode REGEXP '^[0-9]{1,5}$'
-  AND legacy.dxcode = CAST(CAST(legacy.dxcode AS UNSIGNED) AS CHAR)
+  -- The CHAR cast must carry an explicit charset + collation: MariaDB 11.4 changed the
+  -- session default utf8mb4 collation to utf8mb4_uca1400_ai_ci, so a bare CAST(... AS CHAR)
+  -- compared against this table's utf8mb4_general_ci column fails with ERROR 1267
+  -- (illegal mix of collations). Pinning general_ci matches the table on every
+  -- supported MariaDB/MySQL version.
+  AND legacy.dxcode = CAST(CAST(legacy.dxcode AS UNSIGNED) AS CHAR CHARACTER SET utf8mb4) COLLATE utf8mb4_general_ci
   AND CAST(legacy.dxcode AS UNSIGNED) = codes.numeric_code
 LEFT JOIN dxphcpgroup exact_mapping
   ON exact_mapping.dxcode = codes.dxcode


### PR DESCRIPTION
## Description

`V1.0.7__restore_phcp_diagnosis_groups.sql` aborts with **ERROR 1267 (illegal mix of collations)** when applied through a utf8mb4 CLI session on MariaDB builds whose `character_set_collations` maps utf8mb4 to `uca1400_ai_ci` (the pinned `mariadb:11.4.12` image ships `utf8mb4=utf8mb4_uca1400_ai_ci` — verified live). The bare `CAST(... AS CHAR)` in the legacy-backfill join takes that session collation and clashes with the table's `utf8mb4_general_ci` `dxcode` column. Flyway/JDBC sessions negotiate a compatible collation, which is why `db-schema-verify` never saw it; the carlos-podman deployment applies migrations through the mariadb CLI and hit it on a fresh install.

Per review feedback, this PR uses the repo's forward-only migration pattern (an earlier revision edited V1.0.7 in place, which would have changed its recorded Flyway checksum):

- **V1.0.7 stays byte-identical** — its Flyway checksum is preserved everywhere, including the packaged `run_flyway_migrate adopt` upgrade path.
- **New `common/V1.0.12__fix_phcp_diagnosis_group_backfill_collation.sql`** repeats both dxphcpgroup backfill INSERTs with the cast pinned to `CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci`. Both INSERTs keep their existence guards: a no-op where V1.0.7 completed, and it fills the missing rows where a hostile session collation aborted V1.0.7.
- Migration READMEs updated (V1.0.12 listed; next shared version V1.0.13).
- `.github/workflows/sonarcloud.yml` hardened after two cold-cache failures on this PR: the analysis goal is fully qualified and version-pinned (prefix resolution no longer depends on cache warmth), and an `always()` chown step restores workspace ownership so the post-job cache save works on cache-miss runs (root-owned container leftovers previously failed `hashFiles` and the cache tar).

**Division of labor with the deployment repo:** the CLI fresh-install path is fixed in the companion carlos-emr/carlos-podman#11, whose QUICKSTART migration recipes now pin the session (`SET NAMES utf8mb4 COLLATE utf8mb4_general_ci`) so the entire chain — including the untouched V1.0.7 — applies cleanly through the CLI. Upstream, V1.0.12 repairs any database that already aborted at V1.0.7 and keeps the backfill correct under any session collation going forward.

## Related Issues

None filed — found during carlos-podman deployment validation.

## Target Branch

`develop` — normal bug-fix work per the release process.

## How Was This Tested?

On a fresh `mariadb:11.4.12` container (image ships `character_set_collations = utf8mb4=utf8mb4_uca1400_ai_ci`), applying migrations via the `mariadb` CLI:

- **Pinned session** (the updated carlos-podman recipe): full Ontario chain V1 → V1.0.12 applies cleanly with the **original V1.0.7**; 533 backfill rows; 428 tables.
- **Unpinned utf8mb4 session** (the failure mode): V1.0.7 reproducibly aborts with ERROR 1267 (0 rows); applying V1.0.12 under that same hostile session repairs to the identical 533 rows.
- V1.0.12 re-runs are no-ops under both utf8mb4 and utf8mb3 sessions.
- CI's `flyway-baseline (on)` and `(bc)` jobs pass on this head — real Flyway applies the unchanged V1.0.7 plus V1.0.12.
- SonarCloud quality gate passes (0 new issues) after the workflow hardening.

## Checklist

- [ ] My commits are signed off for the [DCO](https://developercertificate.org/) (`git commit -s`) — the two later commits are; the first predates it and is covered by manual confirmation
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format, or I've written clear commit messages and will use the format next time
- [x] I have not included any patient data (PHI) in this PR
- [x] I have added tests for new functionality, or this change doesn't need new tests
- [x] I have read the [contributing guide](https://github.com/carlos-emr/carlos/blob/develop/CONTRIBUTING.md)
- [x] I selected the target branch according to the [release process](https://github.com/carlos-emr/carlos/blob/develop/docs/release-process.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014NKLrJmtqdVuRiRVUjVwKg