### PR TITLE
chore(release): start 2026.08.0-alpha3 development

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>io.github.carlos_emr</groupId>
     <artifactId>carlos</artifactId>
     <packaging>war</packaging>
-    <version>2026.08.0-alpha2</version>
+    <version>2026.08.0-alpha3-SNAPSHOT</version>
     <name>CARLOS</name>
     <description>CARLOS EMR (Clinical Assisting Recording Ledger Open Source) is a web-based electronic medical record system for Canadian healthcare.</description>
     <inceptionYear>2024</inceptionYear>
@@ -19,7 +19,7 @@
         <url>https://github.com/carlos-emr/carlos</url>
         <connection>scm:git:https://github.com/carlos-emr/carlos.git</connection>
         <developerConnection>scm:git:ssh://git@github.com:carlos-emr/carlos.git</developerConnection>
-        <tag>2026.08.0-alpha2</tag>
+        <tag>HEAD</tag>
     </scm>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
## What changed

- Advances the 2026.08 maintenance line to `2026.08.0-alpha3-SNAPSHOT`.
- Restores the Maven SCM tag to `HEAD` for ongoing development builds.

## Why

`2026.08.0-alpha2` is now published and immutable. The maintenance branch must return to snapshot metadata before accepting fixes intended for the next 2026.08 prerelease.

## Impact

Future builds from `release/2026.08` are clearly non-release alpha3 development artifacts. The published `2026.08.0-alpha2` tag and release remain unchanged.

## Validation

- Branch starts from merged maintenance head `b074fdc31633190b7564b4c81b2b06c76a5eb0f7`.
- Only the project version and SCM tag in `pom.xml` changed.
- Standard branch protections now cover `release/*`, including CodeQL and code-quality enforcement.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Advance the 2026.08 maintenance line to 2026.08.0-alpha3-SNAPSHOT and reset the Maven SCM tag to HEAD to resume development after publishing 2026.08.0-alpha2. Builds from release/2026.08 now produce alpha3 snapshot artifacts; the alpha2 tag and release are unchanged.

**Review notes**
- Only `pom.xml` changed: `<version>` and `<scm><tag>`.
- No runtime or configuration impact; no migration required.

<sup>Written for commit 175ee907bd950590fbbe22b2f3d8989ca3a970bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3472?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

