### PR TITLE
docs(release): backport maintenance workflow to main

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -81,7 +81,7 @@ body:
     attributes:
       label: Version/Branch
       description: Which version or branch are you using?
-      placeholder: e.g., develop, v2.1.0
+      placeholder: e.g., 2026.08.0-alpha2, release/2026.08, or develop
 
   - type: checkboxes
     id: checklist

--- a/.github/ISSUE_TEMPLATE/regression.yml
+++ b/.github/ISSUE_TEMPLATE/regression.yml
@@ -16,7 +16,7 @@ body:
     attributes:
       label: Last Working Version
       description: Where this worked correctly
-      placeholder: e.g., v2.1.0, commit abc123, or date
+      placeholder: e.g., 2026.08.0-alpha1, commit abc123, or date
     validations:
       required: true
 
@@ -25,7 +25,7 @@ body:
     attributes:
       label: Broken Version
       description: Where it's broken
-      placeholder: e.g., v2.2.0, develop branch, current
+      placeholder: e.g., 2026.08.0-alpha2, release/2026.08, or develop
     validations:
       required: true
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,8 @@
   Thank you for contributing to CARLOS EMR! We appreciate your time and effort.
   Please fill out the sections below to help reviewers understand your changes.
   Normal work targets develop. Supported-release fixes target release/YYYY.MM,
-  and only release-preparation PRs target main. See docs/release-process.md.
+  while current-train release preparation and narrowly scoped release-infrastructure
+  corrections may target main. See docs/release-process.md.
 -->
 
 ## Description
@@ -15,7 +16,15 @@
 
 ## Target Branch
 
-<!-- Explain why this PR targets develop, release/YYYY.MM, or main. -->
+<!--
+Explain why this PR targets develop, release/YYYY.MM, or main.
+- Normal work: topic branch from develop -> develop.
+- Supported fix: topic branch from the oldest affected release/YYYY.MM -> that same branch.
+- Current-train release preparation: maintenance-line preparation branch -> main.
+- Older supported release preparation after main advances: preparation branch -> that release/YYYY.MM.
+- Necessary release-infrastructure correction: topic branch from main -> main, with no application change or tag.
+Maintainers forward-merge supported fixes; do not create duplicate cherry-pick PRs.
+-->
 
 ## How Was This Tested?
 
@@ -33,3 +42,5 @@
 - [ ] I have added tests for new functionality, or this change doesn't need new tests
 - [ ] I have read the [contributing guide](https://github.com/carlos-emr/carlos/blob/develop/CONTRIBUTING.md)
 - [ ] I selected the target branch according to the [release process](https://github.com/carlos-emr/carlos/blob/develop/docs/release-process.md)
+- [ ] I preserved the target branch version/SCM metadata, or this is an explicit release-preparation PR
+- [ ] I did not modify a Flyway migration that exists in a published release tag

--- a/.github/agents/carlos-backend.agent.md
+++ b/.github/agents/carlos-backend.agent.md
@@ -11,7 +11,7 @@ tools: ["*"]
 > versions, snapshots, maintenance fixes, tags, and forward merges.
 > Normal work targets `develop`; supported fixes start from and target the oldest
 > affected `release/YYYY.MM` and are forward-merged while preserving target
-> version metadata. Application changes target `main` only for release
+> version and SCM metadata. Application changes target `main` only for release
 > preparation; narrowly scoped release-infrastructure corrections are also allowed.
 > Tags are immutable.
 

--- a/.github/agents/carlos-backend.agent.md
+++ b/.github/agents/carlos-backend.agent.md
@@ -9,6 +9,11 @@ tools: ["*"]
 
 > **Release policy**: Follow `docs/release-process.md` for target branches, CalVer
 > versions, snapshots, maintenance fixes, tags, and forward merges.
+> Normal work targets `develop`; supported fixes start from and target the oldest
+> affected `release/YYYY.MM` and are forward-merged while preserving target
+> version metadata. Application changes target `main` only for release
+> preparation; narrowly scoped release-infrastructure corrections are also allowed.
+> Tags are immutable.
 
 ## Core Context
 

--- a/.github/agents/carlos-database.agent.md
+++ b/.github/agents/carlos-database.agent.md
@@ -11,7 +11,7 @@ tools: ["*"]
 > versions, snapshots, maintenance fixes, tags, and forward merges.
 > Normal work targets `develop`; supported fixes start from and target the oldest
 > affected `release/YYYY.MM` and are forward-merged while preserving target
-> version metadata. Application changes target `main` only for release preparation;
+> version and SCM metadata. Application changes target `main` only for release preparation;
 > narrowly scoped release-infrastructure corrections are also allowed. Tags and
 > published Flyway migration bytes are immutable.
 

--- a/.github/agents/carlos-database.agent.md
+++ b/.github/agents/carlos-database.agent.md
@@ -9,6 +9,11 @@ tools: ["*"]
 
 > **Release policy**: Follow `docs/release-process.md` for target branches, CalVer
 > versions, snapshots, maintenance fixes, tags, and forward merges.
+> Normal work targets `develop`; supported fixes start from and target the oldest
+> affected `release/YYYY.MM` and are forward-merged while preserving target
+> version metadata. Application changes target `main` only for release preparation;
+> narrowly scoped release-infrastructure corrections are also allowed. Tags and
+> published Flyway migration bytes are immutable.
 
 ## Core Context
 

--- a/.github/agents/carlos-frontend.agent.md
+++ b/.github/agents/carlos-frontend.agent.md
@@ -11,7 +11,7 @@ tools: ["*"]
 > versions, snapshots, maintenance fixes, tags, and forward merges.
 > Normal work targets `develop`; supported fixes start from and target the oldest
 > affected `release/YYYY.MM` and are forward-merged while preserving target
-> version metadata. Application changes target `main` only for release
+> version and SCM metadata. Application changes target `main` only for release
 > preparation; narrowly scoped release-infrastructure corrections are also allowed.
 > Tags are immutable.
 

--- a/.github/agents/carlos-frontend.agent.md
+++ b/.github/agents/carlos-frontend.agent.md
@@ -9,6 +9,11 @@ tools: ["*"]
 
 > **Release policy**: Follow `docs/release-process.md` for target branches, CalVer
 > versions, snapshots, maintenance fixes, tags, and forward merges.
+> Normal work targets `develop`; supported fixes start from and target the oldest
+> affected `release/YYYY.MM` and are forward-merged while preserving target
+> version metadata. Application changes target `main` only for release
+> preparation; narrowly scoped release-infrastructure corrections are also allowed.
+> Tags are immutable.
 
 ## Core Context
 

--- a/.github/agents/carlos-security.agent.md
+++ b/.github/agents/carlos-security.agent.md
@@ -11,7 +11,7 @@ tools: ["*"]
 > versions, snapshots, maintenance fixes, tags, and forward merges.
 > Normal work targets `develop`; supported fixes start from and target the oldest
 > affected `release/YYYY.MM` and are forward-merged while preserving target
-> version metadata. Application changes target `main` only for release
+> version and SCM metadata. Application changes target `main` only for release
 > preparation; narrowly scoped release-infrastructure corrections are also allowed.
 > Tags are immutable.
 

--- a/.github/agents/carlos-security.agent.md
+++ b/.github/agents/carlos-security.agent.md
@@ -9,6 +9,11 @@ tools: ["*"]
 
 > **Release policy**: Follow `docs/release-process.md` for target branches, CalVer
 > versions, snapshots, maintenance fixes, tags, and forward merges.
+> Normal work targets `develop`; supported fixes start from and target the oldest
+> affected `release/YYYY.MM` and are forward-merged while preserving target
+> version metadata. Application changes target `main` only for release
+> preparation; narrowly scoped release-infrastructure corrections are also allowed.
+> Tags are immutable.
 
 ## Core Context
 

--- a/.github/agents/carlos-testing.agent.md
+++ b/.github/agents/carlos-testing.agent.md
@@ -11,7 +11,7 @@ tools: ["*"]
 > versions, snapshots, maintenance fixes, tags, and forward merges.
 > Normal work targets `develop`; supported fixes start from and target the oldest
 > affected `release/YYYY.MM` and are forward-merged while preserving target
-> version metadata. Application changes target `main` only for release
+> version and SCM metadata. Application changes target `main` only for release
 > preparation; narrowly scoped release-infrastructure corrections are also allowed.
 > Tags are immutable.
 

--- a/.github/agents/carlos-testing.agent.md
+++ b/.github/agents/carlos-testing.agent.md
@@ -9,6 +9,11 @@ tools: ["*"]
 
 > **Release policy**: Follow `docs/release-process.md` for target branches, CalVer
 > versions, snapshots, maintenance fixes, tags, and forward merges.
+> Normal work targets `develop`; supported fixes start from and target the oldest
+> affected `release/YYYY.MM` and are forward-merged while preserving target
+> version metadata. Application changes target `main` only for release
+> preparation; narrowly scoped release-infrastructure corrections are also allowed.
+> Tags are immutable.
 
 ## Core Context
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,6 +4,7 @@
 > **Specialized agents**: See `.github/agents/` for domain-specific guidance (security, backend, testing, database, frontend).
 > **Path-specific rules**: See `.github/instructions/` for auto-applied rules on JSP, Action, test, and SQL files.
 > **Release policy**: `docs/release-process.md` is authoritative for branch targets, CalVer versions, snapshots, tags, hotfixes, and forward merges.
+> Start normal work from and target `develop`. Start a supported-release fix from and target the oldest affected `release/YYYY.MM`, then forward-merge it into newer lines while preserving target version metadata. Target `main` only for current-train release preparation or a necessary, narrowly scoped release-infrastructure correction. Never tag a snapshot or move/reuse a release tag, and never edit a Flyway migration present in a published tag.
 
 **PROJECT IDENTITY**: Always refer to this system as "CARLOS EMR" or "CARLOS" in user-facing displays and documentation.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,7 +4,7 @@
 > **Specialized agents**: See `.github/agents/` for domain-specific guidance (security, backend, testing, database, frontend).
 > **Path-specific rules**: See `.github/instructions/` for auto-applied rules on JSP, Action, test, and SQL files.
 > **Release policy**: `docs/release-process.md` is authoritative for branch targets, CalVer versions, snapshots, tags, hotfixes, and forward merges.
-> Start normal work from and target `develop`. Start a supported-release fix from and target the oldest affected `release/YYYY.MM`, then forward-merge it into newer lines while preserving target version metadata. Target `main` only for current-train release preparation or a necessary, narrowly scoped release-infrastructure correction. Never tag a snapshot or move/reuse a release tag, and never edit a Flyway migration present in a published tag.
+> Start normal work from and target `develop`. Start a supported-release fix from and target the oldest affected `release/YYYY.MM`, then forward-merge it into newer lines while preserving target version and SCM metadata. Target `main` only for current-train release preparation or a necessary, narrowly scoped release-infrastructure correction. Never tag a snapshot or move, delete, or reuse a release tag, and never edit a Flyway migration present in a published tag.
 
 **PROJECT IDENTITY**: Always refer to this system as "CARLOS EMR" or "CARLOS" in user-facing displays and documentation.
 

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -192,7 +192,7 @@ jobs:
               echo '========================================='
               echo 'Running SonarCloud Analysis (Branch)'
               echo '========================================='
-              mvn -B verify sonar:sonar \
+              mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:5.7.0.6970:sonar \
                 -Pskip-dependency-lock \
                 -Dmaven.test.failure.ignore=true \
                 -Dsonar.host.url=https://sonarcloud.io \
@@ -222,7 +222,7 @@ jobs:
               echo \"PR Branch: \$PR_BRANCH\"
               echo \"PR Base: \$PR_BASE\"
               echo '========================================='
-              mvn -B verify sonar:sonar \
+              mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:5.7.0.6970:sonar \
                 -Pskip-dependency-lock \
                 -Dmaven.test.failure.ignore=true \
                 -Dsonar.host.url=https://sonarcloud.io \

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -9,8 +9,8 @@
 # all local_repo dependencies are available for the build.
 #
 # Usage:
-# - Triggered on pushes to develop and release/* branches
-# - Triggered on pull requests targeting develop and release/*
+# - Triggered on pushes to main, develop, and release/* branches
+# - Triggered on pull requests targeting main, develop, and release/*
 #
 # Requirements:
 # - SONAR_TOKEN secret must be configured in repository settings
@@ -29,11 +29,13 @@ name: SonarCloud Analysis
 on:
   push:
     branches:
+      - main
       - develop
       - release/*
   pull_request:
     types: [opened, synchronize, reopened]
     branches:
+      - main
       - develop
       - release/*
 
@@ -177,7 +179,7 @@ jobs:
             git config --global --add safe.directory /workspace
           "
 
-      - name: Build and analyze (Push to develop)
+      - name: Build and analyze (Push branch)
         if: github.event_name == 'push'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1033,6 +1033,7 @@ Labels are reserved for cross-cutting attributes that can apply alongside any is
 - **Protected Branches**: `develop`, `main`, `experimental`, and `release/*` - direct commits prohibited
 - **All changes** must go through pull requests with review
 - **Release policy**: `docs/release-process.md` is authoritative for target branches, CalVer, snapshots, tags, maintenance fixes, and forward merges
+- **Release flow**: Start normal work from and target `develop`. Start a supported fix from and target the oldest affected `release/YYYY.MM`; maintainers then forward-merge it into newer lines while preserving target version/SCM metadata. Target `main` only for current-train release preparation or a necessary, narrowly scoped release-infrastructure correction. Never tag a snapshot, move/reuse a release tag, or edit a Flyway migration present in a published tag
 - Claude creates feature branches: `claude/issue-<number>-<timestamp>`
 
 ### Security Checklist (Every Code Change)
@@ -1043,7 +1044,8 @@ Labels are reserved for cross-cutting attributes that can apply alongside any is
 - [ ] No PHI in logs or error messages
 
 ### PR Requirements
-- ✅ Target `develop` for normal work; target `release/YYYY.MM` only for an approved supported-release fix, and `main` only for release preparation
+- ✅ Target `develop` for normal work; target `release/YYYY.MM` only for an approved supported-release fix; use `main` only for current-train release preparation or a necessary release-infrastructure correction
+- ✅ Preserve the target branch snapshot/SCM metadata during forward merges; use merge ancestry rather than routine cherry-picks
 - ✅ Include tests for new functionality
 - ✅ Reference related issues (`fixes #123`)
 - ✅ Add "Generated with Claude Code" signature

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1033,7 +1033,7 @@ Labels are reserved for cross-cutting attributes that can apply alongside any is
 - **Protected Branches**: `develop`, `main`, `experimental`, and `release/*` - direct commits prohibited
 - **All changes** must go through pull requests with review
 - **Release policy**: `docs/release-process.md` is authoritative for target branches, CalVer, snapshots, tags, maintenance fixes, and forward merges
-- **Release flow**: Start normal work from and target `develop`. Start a supported fix from and target the oldest affected `release/YYYY.MM`; maintainers then forward-merge it into newer lines while preserving target version/SCM metadata. Target `main` only for current-train release preparation or a necessary, narrowly scoped release-infrastructure correction. Never tag a snapshot, move/reuse a release tag, or edit a Flyway migration present in a published tag
+- **Release flow**: Start normal work from and target `develop`. Start a supported fix from and target the oldest affected `release/YYYY.MM`; maintainers then forward-merge it into newer lines while preserving target version/SCM metadata. Target `main` only for current-train release preparation or a necessary, narrowly scoped release-infrastructure correction. Never tag a snapshot, move, delete, or reuse a release tag, or edit a Flyway migration present in a published tag
 - Claude creates feature branches: `claude/issue-<number>-<timestamp>`
 
 ### Security Checklist (Every Code Change)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -265,12 +265,20 @@ make install --run-integration-tests  # Integration tests (requires database)
 
 CARLOS uses `develop` as the default integration branch for the next release train.
 Normal feature and bug-fix pull requests target `develop`. High-priority fixes for a
-supported release target its `release/YYYY.MM` maintenance branch, and release-preparation
-pull requests promote exact versions to `main`. **Do not work directly on a protected
+supported release target its `release/YYYY.MM` maintenance branch. Current-train
+release preparation and narrowly scoped release-infrastructure corrections may target
+`main`. **Do not work directly on a protected
 branch** — always create a topic branch.
 
 The canonical [release process](docs/release-process.md) defines CalVer versions, supported
 release lines, forward merges, snapshots, tags, and release publication.
+
+After an approved supported-release fix merges, maintainers forward-merge its maintenance
+branch into every newer supported line and then `develop`, preserving the version and SCM
+metadata on the target branch. Do not open duplicate cherry-pick PRs.
+Published Flyway migration
+files are checksum-frozen; any migration-number collision must be resolved by renumbering
+only an unreleased migration on the newer target line.
 
 ### Internal vs. External Contributors
 
@@ -346,7 +354,12 @@ All changes — from internal and external contributors alike — must go throug
 request. Direct pushes to `develop`, `main`, and other protected branches are not allowed.
 
 - **Target `develop` for normal work**; use `release/YYYY.MM` only for an approved
-  supported-release fix, and `main` only for release preparation
+  supported-release fix; use `main` only for current-train release preparation or a
+  necessary, narrowly scoped release-infrastructure correction
+- **Keep snapshot metadata on work branches**; release preparation alone changes the
+  project version and SCM tag to the exact release value
+- **Never create, move, delete, or reuse release tags**; maintainers create an annotated
+  tag only after the exact release commit has passed review and checks
 - **Reference related issues** (e.g., `fixes #123`)
 - **Include a clear description** of what changed and why
 - **Add tests** for new functionality

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -265,9 +265,9 @@ make install --run-integration-tests  # Integration tests (requires database)
 
 CARLOS uses `develop` as the default integration branch for the next release train.
 Normal feature and bug-fix pull requests target `develop`. High-priority fixes for a
-supported release target its `release/YYYY.MM` maintenance branch. Current-train
-release preparation and narrowly scoped release-infrastructure corrections may target
-`main`. **Do not work directly on a protected
+supported release start from and target the oldest affected `release/YYYY.MM`
+maintenance branch. Current-train release preparation and narrowly scoped
+release-infrastructure corrections may target `main`. **Do not work directly on a protected
 branch** — always create a topic branch.
 
 The canonical [release process](docs/release-process.md) defines CalVer versions, supported

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -859,6 +859,7 @@ Labels are reserved for cross-cutting attributes that can apply alongside any is
 - **Protected Branches**: `develop`, `main`, `experimental`, and `release/*` - direct commits prohibited
 - **All changes** must go through pull requests with review
 - **Release policy**: `docs/release-process.md` is authoritative for target branches, CalVer, snapshots, tags, maintenance fixes, and forward merges
+- **Release flow**: Start normal work from and target `develop`. Start a supported fix from and target the oldest affected `release/YYYY.MM`; maintainers then forward-merge it into newer lines while preserving target version/SCM metadata. Target `main` only for current-train release preparation or a necessary, narrowly scoped release-infrastructure correction. Never tag a snapshot, move/reuse a release tag, or edit a Flyway migration present in a published tag
 - Claude creates feature branches: `claude/issue-<number>-<timestamp>`
 
 ### Security Checklist (Every Code Change)
@@ -869,7 +870,8 @@ Labels are reserved for cross-cutting attributes that can apply alongside any is
 - [ ] No PHI in logs or error messages
 
 ### PR Requirements
-- ✅ Target `develop` for normal work; target `release/YYYY.MM` only for an approved supported-release fix, and `main` only for release preparation
+- ✅ Target `develop` for normal work; target `release/YYYY.MM` only for an approved supported-release fix; use `main` only for current-train release preparation or a necessary release-infrastructure correction
+- ✅ Preserve the target branch snapshot/SCM metadata during forward merges; use merge ancestry rather than routine cherry-picks
 - ✅ Include tests for new functionality
 - ✅ Reference related issues (`fixes #123`)
 - ✅ Add "Generated with Claude Code" signature

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -859,7 +859,7 @@ Labels are reserved for cross-cutting attributes that can apply alongside any is
 - **Protected Branches**: `develop`, `main`, `experimental`, and `release/*` - direct commits prohibited
 - **All changes** must go through pull requests with review
 - **Release policy**: `docs/release-process.md` is authoritative for target branches, CalVer, snapshots, tags, maintenance fixes, and forward merges
-- **Release flow**: Start normal work from and target `develop`. Start a supported fix from and target the oldest affected `release/YYYY.MM`; maintainers then forward-merge it into newer lines while preserving target version/SCM metadata. Target `main` only for current-train release preparation or a necessary, narrowly scoped release-infrastructure correction. Never tag a snapshot, move/reuse a release tag, or edit a Flyway migration present in a published tag
+- **Release flow**: Start normal work from and target `develop`. Start a supported fix from and target the oldest affected `release/YYYY.MM`; maintainers then forward-merge it into newer lines while preserving target version/SCM metadata. Target `main` only for current-train release preparation or a necessary, narrowly scoped release-infrastructure correction. Never tag a snapshot, move, delete, or reuse a release tag, or edit a Flyway migration present in a published tag
 - Claude creates feature branches: `claude/issue-<number>-<timestamp>`
 
 ### Security Checklist (Every Code Change)

--- a/README.md
+++ b/README.md
@@ -37,9 +37,10 @@ should follow the canonical [release process](docs/release-process.md) for
 versioning, target-branch selection, tags, hotfixes, and release verification.
 
 In brief, normal work starts from and targets `develop`; high-priority fixes for
-a supported release start from and target its `release/YYYY.MM` branch; and
-release-preparation PRs promote current-train exact versions to `main`. Older
-supported patches remain on their maintenance branch. Ongoing branches use
+supported releases start from and target the oldest affected `release/YYYY.MM`
+branch before they are forward-merged; and release-preparation PRs promote
+current-train exact versions to `main`. Older supported patches remain on their
+maintenance branch. Ongoing branches use
 `-SNAPSHOT` with SCM tag `HEAD`. Release tags are annotated, immutable, and
 created only on exact non-snapshot release commits.
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ CARLOS follows a CalVer maintenance-branch model. Maintainers and contributors
 should follow the canonical [release process](docs/release-process.md) for
 versioning, target-branch selection, tags, hotfixes, and release verification.
 
+In brief, normal work starts from and targets `develop`; high-priority fixes for
+a supported release start from and target its `release/YYYY.MM` branch; and
+release-preparation PRs promote current-train exact versions to `main`. Older
+supported patches remain on their maintenance branch. Ongoing branches use
+`-SNAPSHOT` with SCM tag `HEAD`. Release tags are annotated, immutable, and
+created only on exact non-snapshot release commits.
+
 ## Contributing
 
 We welcome community involvement! Whether you're reporting bugs, improving documentation,

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -61,6 +61,11 @@ a prerelease or patch as appropriate, and forward-merged into newer supported li
 `develop`. The active 2026.08 line is maintained on `release/2026.08` while development
 of 2026.09 continues on `develop`.
 
+Prepare embargoed remediation through the private security-advisory workflow. At the
+coordinated disclosure point, land it on the oldest affected supported maintenance line,
+then forward-merge it into newer supported lines and `develop` while preserving the
+version and SCM metadata on each target. Existing release tags are never moved or reused.
+
 See the [release process](docs/release-process.md) for the maintenance, tagging, and
 forward-merge policy. Supported maintenance lines may change as releases reach end of
 support; published tags and immutable releases remain available.

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ This directory contains technical documentation for CARLOS EMR (Clinical Assisti
 | **Architecture** | [Struts Actions Summary](struts-actions-summary.md)<br>[Struts Actions Detailed](struts-actions-detailed.md)<br>[Struts Web Endpoints](struts-web-endpoints.md)<br>[Integrator System Architecture](integrator-system-architecture.md) | System architecture, action mappings, and current endpoint/JSP routing rules |
 | **Security** | [Password System](Password_System.md) | Authentication and security architecture |
 | **APIs** | [API Collections Index](api-collections-index.md) | REST API documentation and collections |
-| **Development** | [DS Guideline](dsGuideline.md)<br>[Copyright Header (Magenta)](copyright-header-magenta.md) | Development standards and guidelines |
+| **Development** | [Release Process](release-process.md)<br>[DS Guideline](dsGuideline.md)<br>[Copyright Header (Magenta)](copyright-header-magenta.md) | Branching, releases, and development standards |
 
 ### 🧪 Testing Documentation
 
@@ -34,7 +34,6 @@ Key testing resources:
 | Document | Description |
 |----------|-------------|
 | [MyDrugref](MyDrugref.md) | Drug reference system documentation |
-| [Legacy HAPI Dynamic Loading](legacy-hapi-dynamic-loading.md) | HL7 HAPI integration patterns |
 | [Form Resources README](README-form-resources.md) | Medical forms and resources |
 
 ### 🔧 Technical References
@@ -50,19 +49,21 @@ Key testing resources:
 
 ### For Developers
 
-1. **Writing Tests**: Start with [test/README.md](test/README.md)
-2. **Struts Migration**: Review [Struts Actions Summary](struts-actions-summary.md)
-3. **New Pages and JSP Routing**: Review [Struts Web Endpoints](struts-web-endpoints.md)
-4. **APIs**: Check [API Collections Index](api-collections-index.md)
-5. **Security**: Understand [Password System](Password_System.md)
+1. **Branches and Releases**: Follow the [Release Process](release-process.md)
+2. **Writing Tests**: Start with [test/README.md](test/README.md)
+3. **Struts Migration**: Review [Struts Actions Summary](struts-actions-summary.md)
+4. **New Pages and JSP Routing**: Review [Struts Web Endpoints](struts-web-endpoints.md)
+5. **APIs**: Check [API Collections Index](api-collections-index.md)
+6. **Security**: Understand [Password System](Password_System.md)
 
 ### For New Team Members
 
-1. Read the main project context: `/workspace/CLAUDE.md`
-2. Review development guidelines: [DS Guideline](dsGuideline.md)
-3. Understand the test framework: [test/](test/)
-4. Study the architecture: [Struts Actions](struts-actions-summary.md)
-5. Read the endpoint conventions: [Struts Web Endpoints](struts-web-endpoints.md)
+1. Read the main project context: [CLAUDE.md](../CLAUDE.md)
+2. Follow the branch and release policy: [Release Process](release-process.md)
+3. Review development guidelines: [DS Guideline](dsGuideline.md)
+4. Understand the test framework: [test/](test/)
+5. Study the architecture: [Struts Actions](struts-actions-summary.md)
+6. Read the endpoint conventions: [Struts Web Endpoints](struts-web-endpoints.md)
 
 ## Project Context
 
@@ -101,7 +102,7 @@ When adding new documentation:
 ## Support
 
 For questions about documentation:
-1. Check the main project file: `/workspace/CLAUDE.md`
+1. Check the main project file: [CLAUDE.md](../CLAUDE.md)
 2. Review related documentation in this directory
 3. Consult the test framework guides in [test/](test/)
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -6,10 +6,16 @@ target branch, preparing a release, creating tags, and forwarding fixes.
 
 ## Version format
 
-Release versions and tags use the same value:
+Exact release versions and tags use the same value:
 
 ```text
 YYYY.MM.PATCH[-alphaN|-betaN|-rcN]
+```
+
+Working snapshot versions append `-SNAPSHOT` to the intended exact version:
+
+```text
+YYYY.MM.PATCH[-alphaN|-betaN|-rcN]-SNAPSHOT
 ```
 
 Examples are `2026.08.0-alpha2`, `2026.08.0-rc1`, `2026.08.0`, and
@@ -142,8 +148,11 @@ Then:
 5. Create and push an annotated tag on that exact commit. For example:
 
    ```bash
-   git tag -a 2026.08.0-alpha3 -m "Release 2026.08.0-alpha3"
-   git push origin 2026.08.0-alpha3
+   RELEASE_TAG=2026.08.0-alpha3
+   RELEASE_COMMIT="<verified-publication-target-sha>"
+   git tag -a "$RELEASE_TAG" "$RELEASE_COMMIT" -m "Release $RELEASE_TAG"
+   test "$(git rev-parse "${RELEASE_TAG}^{commit}")" = "$RELEASE_COMMIT"
+   git push origin "$RELEASE_TAG"
    ```
 
 6. The tag workflow re-runs the full build and tests, creates a clean WAR and

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -34,6 +34,27 @@ for a supported release starts from and targets its `release/YYYY.MM` branch.
 Release-preparation PRs are the only application changes that target `main`.
 All protected branches require a reviewed pull request.
 
+`main` is not an integration branch and never moves to a `-SNAPSHOT` version.
+Release-infrastructure or documentation corrections may land there when they
+are required to operate the release process, but those commits are not releases
+and must not be tagged with an existing version. Application development stays
+on `develop` or the applicable maintenance branch.
+
+For example, while 2026.08 is being stabilized and 2026.09 is under active
+development, the intended states are:
+
+| Branch | Example state |
+| --- | --- |
+| `develop` | `2026.09.0-SNAPSHOT`, SCM tag `HEAD` |
+| `release/2026.08` | `2026.08.0-alpha3-SNAPSHOT`, SCM tag `HEAD` |
+| `main` | Exact most recently promoted 2026.08 release metadata |
+
+Advancing a maintenance branch to its next snapshot is bookkeeping for future
+work; it does not by itself justify publishing that prerelease. Before the
+stable release, the planned snapshot may advance through alpha, beta, or release
+candidate identifiers. After `2026.08.0` is stable, the next maintenance version
+is `2026.08.1-SNAPSHOT`, published later as `2026.08.1`.
+
 While a release train is current, each alpha, beta, release candidate, and
 stable release is promoted from its maintenance branch to `main` and tagged on
 the resulting main commit. After `main` advances to a newer train, later patches
@@ -50,24 +71,79 @@ Fixes move forward by merge so Git retains their ancestry:
 4. Resolve version metadata in favor of the target branch, sign off the merge
    commit, and open a PR to the target branch.
 
+For a forward merge into `develop`, retain the newer project version on
+`develop` and `project.scm.tag=HEAD`. For a merge into a newer maintenance line,
+retain the planned snapshot on that line. Never allow version metadata from an
+older line to move a newer line backward.
+
+Versioned Flyway migrations require the same care. Files present in a published
+tag are checksum-frozen. If two lines independently used the same migration
+number, keep every published file byte-for-byte unchanged and renumber only the
+unreleased migration on the newer target line. Update the migration inventories
+and validate the combined common/province sequences before merging.
+
 Do not routinely cherry-pick fixes or merge a newer release line backward into
 an older one. After publishing a release from `main`, back-merge the tagged main
 commit into its maintenance branch before advancing that branch to its next
 snapshot. Keep `develop` on its newer snapshot during every forward merge.
 
+Merge commits must carry a DCO sign-off. If a true forward or back merge connects
+older commits that the automated DCO job cannot verify individually, an
+authorized maintainer may post the exact repository fallback phrase only after
+reviewing the connected history:
+
+```text
+Confirming DCO sign off for all commits
+```
+
+## Supported-release fix cycle
+
+Use this cycle for a high-priority correctness or security fix found in an alpha,
+beta, release candidate, or stable supported release. Keep embargoed security
+work in the private security-advisory workflow until coordinated disclosure; the
+branch-target rules below apply when the fix is landed.
+
+1. Create a topic branch from the oldest affected supported
+   `release/YYYY.MM` branch, not from `main` or `develop`.
+2. Implement and test the fix without removing the maintenance branch
+   `-SNAPSHOT` version or changing its SCM tag from `HEAD`.
+3. Open a reviewed PR back to that same maintenance branch.
+4. After it merges, forward-merge the maintenance branch into each newer
+   supported line and finally `develop`, preserving each target version and SCM
+   metadata. Do not ask contributors to duplicate or cherry-pick the fix.
+5. Continue accumulating approved fixes until the release owner chooses the
+   next prerelease or patch milestone. A snapshot name is an intention, not an
+   obligation to publish immediately.
+6. Publish the milestone using the release preparation and tagging process
+   below. Then back-merge and advance the maintenance branch to its next
+   planned snapshot.
+
 ## Preparing and publishing a release
 
+First choose the publication target:
+
+- While the train is current on `main`, create a preparation branch from its
+  `release/YYYY.MM` branch and open the preparation PR to `main`. Tag the
+  resulting `main` merge commit.
+- After `main` has advanced to a newer train, prepare an older supported patch
+  through a PR to that older `release/YYYY.MM` branch and tag the resulting
+  maintenance-branch head. Never merge an older train backward into `main`.
+
+Then:
+
 1. Freeze merges into the release source branch.
-2. Open a preparation PR that changes the Maven project version from the
-   planned snapshot to the exact release and changes `project.scm.tag` from
-   `HEAD` to the same exact value.
-3. Run and pass all required checks. Merge the PR with a merge commit.
-4. Confirm the source branch head, `pom.xml` version, and SCM tag all match.
-5. Create and push an annotated tag on that exact commit:
+2. On the preparation branch, change the Maven project version from the planned
+   snapshot to the exact release and change `project.scm.tag` from `HEAD` to the
+   same exact value.
+3. Run and pass all required checks. Merge the preparation PR with a merge
+   commit into the publication target selected above.
+4. Fetch the merged target and confirm that its head commit, `pom.xml` version,
+   and SCM tag are the exact values intended for publication.
+5. Create and push an annotated tag on that exact commit. For example:
 
    ```bash
-   git tag -a 2026.08.0-alpha2 -m "Release 2026.08.0-alpha2"
-   git push origin 2026.08.0-alpha2
+   git tag -a 2026.08.0-alpha3 -m "Release 2026.08.0-alpha3"
+   git push origin 2026.08.0-alpha3
    ```
 
 6. The tag workflow re-runs the full build and tests, creates a clean WAR and
@@ -76,14 +152,31 @@ snapshot. Keep `develop` on its newer snapshot during every forward merge.
    release.
 7. Confirm prerelease/latest classification and asset attestations, then unfreeze
    the source branch.
-8. Back-merge the tagged commit and advance the maintenance branch to the next
-   snapshot. Forward-merge the maintenance branch into newer lines.
+8. If publication occurred from `main`, back-merge the tagged commit into its
+   maintenance branch. Advance that branch to the next planned snapshot through
+   a reviewed PR, then forward-merge the maintenance branch into newer lines.
+   If publication occurred directly from an older maintenance branch, advance
+   that branch to its next snapshot and forward-merge it in the same way.
 
 Release tags are permanent declarations. They are annotated, protected, never
 moved, deleted, or reused, and never serve as mutable aliases such as `latest`.
 If publishing fails because of infrastructure, rerun the workflow for the same
 tag. If the tagged code is defective, leave the tag unpublished and prepare the
 next version identifier.
+
+For a retry, dispatch the release workflow with the existing tag. Do not create
+a replacement tag, move the original tag, or tag a newer branch head with the
+same version. The workflow accepts an ancestor only when a prior unsuccessful
+tag-push run provides evidence that this is a retry of the immutable tag.
+
+## Pull-request and CI coverage
+
+Pull requests to `develop`, `main`, and `release/*` run the repository build,
+test, JSP compilation, DCO, commit-format, dependency review, database, and
+security checks as applicable. Trusted same-repository PRs also run SonarCloud.
+The publication workflow is separate: it runs only for a protected CalVer tag or
+an explicit retry of an existing tag, rebuilds from the tagged commit, and never
+publishes a snapshot.
 
 ## Release assets and verification
 


### PR DESCRIPTION
## Summary

Backports the release and maintenance workflow documentation from PR #3476 to `main` so the published branch carries the same branch, version, tagging, Flyway, and release-publication guidance as `develop`.

Also enables SonarCloud analysis for pushes and pull requests involving `main`, while preserving the existing `main` workflow implementation.

## Release integrity

- This is a narrowly scoped documentation/release-infrastructure correction, not a release.
- `pom.xml` remains `2026.08.0-alpha2`.
- `project.scm.tag` remains `2026.08.0-alpha2`.
- No tag is created, moved, deleted, or reused.
- No application code or published Flyway migration is changed.

After this PR merges, its merge commit should be back-merged into `release/2026.08`, preserving `2026.08.0-alpha3-SNAPSHOT` and SCM tag `HEAD`, then forward-merged into `develop`, preserving `2026.09.0-SNAPSHOT` and SCM tag `HEAD`.

## Validation

- `git diff --check origin/main...HEAD`
- Actionlint 1.7.7 on `.github/workflows/sonarcloud.yml`
- YAML parsing for the Sonar workflow and changed issue forms
- Exact content parity with `develop` for the 16 non-conflicting policy files
- Confirmed no `pom.xml` changes and exact `main` release metadata

## Summary by Sourcery

Align main-branch documentation and SonarCloud coverage with the current release and maintenance workflow without changing application or release metadata.

Enhancements:
- Document the authoritative branch, snapshot, forward-merge, immutable-tag, Flyway, security-fix, and release-publication policies across project and contributor guidance.

CI:
- Run SonarCloud analysis for pushes to and pull requests targeting main, while pinning the Maven Sonar scanner invocation.

Documentation:
- Backport release-process guidance and update README, contributing guidance, agent instructions, security guidance, and issue/PR templates to reflect current release practices.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backports the release and maintenance workflow docs to `main` and extends SonarCloud coverage to `main`. Pins the Maven Sonar scanner to a fixed version to ensure reproducible analysis.

- Updates docs, contributor guides, agent prompts, and templates to codify branch targets, forward merges, immutable tags, Flyway rules, snapshot/SCM metadata, and security-fix flow; the docs index now surfaces the release guide.
- Extends SonarCloud triggers to `main` (push and PR) and replaces `sonar:sonar` with pinned `org.sonarsource.scanner.maven:sonar-maven-plugin:5.7.0.6970:sonar`; other build steps are unchanged.
- Not a release: no application code or published Flyway migrations change; `pom.xml` and `project.scm.tag` stay `2026.08.0-alpha2`; no tags are created or modified.

**Review and rollout**
- Review documentation updates and `sonarcloud.yml` trigger/pinning; confirm Actionlint and YAML pass.
- After merge: back-merge into `release/2026.08` (preserve `2026.08.0-alpha3-SNAPSHOT` and SCM `HEAD`), then forward-merge into `develop` (preserve `2026.09.0-SNAPSHOT` and SCM `HEAD`).

<sup>Written for commit 1509020288baa0190efd8c19d2e6b8094ac0a8b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

