### PR TITLE
test(email): cover attachment settings request validation

### DIFF
--- a/src/test/java/io/github/carlos_emr/carlos/email/core/EmailAttachmentSettingsUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/email/core/EmailAttachmentSettingsUnitTest.java
@@ -95,22 +95,20 @@ class EmailAttachmentSettingsUnitTest {
         @Test
         @DisplayName("should return null when exceeding RFC 5321 length limit")
         void shouldReturnNull_whenExceedingMaxLength() {
-            String longLocal = "a".repeat(245);
-            String longEmail = longLocal + "@example.com";
-            assertThat(longEmail.length()).isGreaterThan(254);
-            assertThat(EmailAttachmentSettings.validateEmail(longEmail)).isNull();
+            String local = "a".repeat(64);
+            String domain = "b".repeat(63) + "." + "c".repeat(63) + "." + "d".repeat(62);
+            String email = local + "@" + domain;
+            assertThat(email).hasSize(255);
+            assertThat(EmailAttachmentSettings.validateEmail(email)).isNull();
         }
 
         @Test
         @DisplayName("should return email when at RFC 5321 length limit")
         void shouldReturnEmail_whenAtMaxLength() {
-            // 242 + "@example.com".length() (12) == 254, the RFC 5321 limit this test is about.
-            // The original 241 produced a 253-character address, so the length assertion
-            // below always failed. Nobody saw it: the class was named *Test, which the
-            // Surefire <includes> never select, so it had never run in CI.
-            String local = "a".repeat(242);
-            String email = local + "@example.com";
-            assertThat(email.length()).isEqualTo(254);
+            String local = "a".repeat(64);
+            String domain = "b".repeat(63) + "." + "c".repeat(63) + "." + "d".repeat(61);
+            String email = local + "@" + domain;
+            assertThat(email).hasSize(254);
             assertThat(EmailAttachmentSettings.validateEmail(email)).isEqualTo(email);
         }
     }

--- a/src/test/java/io/github/carlos_emr/carlos/email/core/EmailAttachmentSettingsUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/email/core/EmailAttachmentSettingsUnitTest.java
@@ -38,7 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Tag("fast")
 @Tag("email")
 @DisplayName("EmailAttachmentSettings validation")
-class EmailAttachmentSettingsTest {
+class EmailAttachmentSettingsUnitTest {
 
     @Nested
     @DisplayName("validateEmail")
@@ -104,7 +104,11 @@ class EmailAttachmentSettingsTest {
         @Test
         @DisplayName("should return email when at RFC 5321 length limit")
         void shouldReturnEmail_whenAtMaxLength() {
-            String local = "a".repeat(241);
+            // 242 + "@example.com".length() (12) == 254, the RFC 5321 limit this test is about.
+            // The original 241 produced a 253-character address, so the length assertion
+            // below always failed. Nobody saw it: the class was named *Test, which the
+            // Surefire <includes> never select, so it had never run in CI.
+            String local = "a".repeat(242);
             String email = local + "@example.com";
             assertThat(email.length()).isEqualTo(254);
             assertThat(EmailAttachmentSettings.validateEmail(email)).isEqualTo(email);

--- a/src/test/resources/surefire-unmatched-baseline.txt
+++ b/src/test/resources/surefire-unmatched-baseline.txt
@@ -79,7 +79,6 @@ io.github.carlos_emr.carlos.eform.gate.ViewEFormAddData2ActionTest
 io.github.carlos_emr.carlos.eform.gate.ViewEFormPage2ActionTest
 io.github.carlos_emr.carlos.eform.gate.ViewEFormShowData2ActionTest
 io.github.carlos_emr.carlos.email.action.EmailSend2ActionTest
-io.github.carlos_emr.carlos.email.core.EmailAttachmentSettingsTest
 io.github.carlos_emr.carlos.encounter.oscarMeasurements.pageUtil.EctMeasurements2ActionTest
 io.github.carlos_emr.carlos.encounter.pageUtil.EctDisplayAllergy2ActionTest
 io.github.carlos_emr.carlos.encounter.pageUtil.EctDisplayRx2ActionSortTest

--- a/src/test/resources/surefire-unmatched-baseline.txt
+++ b/src/test/resources/surefire-unmatched-baseline.txt
@@ -48,7 +48,6 @@ io.github.carlos_emr.carlos.demographic.pageUtil.DemographicApptHistory2ActionTe
 io.github.carlos_emr.carlos.demographic.pageUtil.DemographicEdit2ActionTest
 io.github.carlos_emr.carlos.demographic.pageUtil.DemographicEditHelperTest
 io.github.carlos_emr.carlos.demographic.pageUtil.DemographicExportAction42ActionCodeSystemAllowlistTest
-io.github.carlos_emr.carlos.demographic.pageUtil.DemographicExportAction42ActionRequestMethodTest
 io.github.carlos_emr.carlos.demographic.pageUtil.DemographicLinkMsg2ActionTest
 io.github.carlos_emr.carlos.demographic.pageUtil.DemographicPdfLabel2ActionTest
 io.github.carlos_emr.carlos.demographic.pageUtil.DemographicUpdate2ActionTest


### PR DESCRIPTION
The attachment-settings request factory now has regression coverage proving that sender validation, subject sanitization, content limits, and safe encryption/manual-send defaults are applied to HTTP input before it becomes email settings. Remove one stale Surefire baseline entry whose class has already been renamed and enabled.

### Reconciliation with develop

Merged `origin/develop` at `8d77370162` into the existing `fix/email-attachment-settings-dark-test` branch and resolved both conflicts. The original email-test rename and corrected 254/255-character fixtures already landed in develop's broader test-enablement work. Preserve those fixtures and the current removal of manual-password sanitization; do not reintroduce obsolete tests or the old unmatched-test backlog.

The final diff against develop contains only:
- Five request-factory test cases in `EmailAttachmentSettingsUnitTest`.
- Removal of the obsolete `DemographicExportAction42ActionRequestMethodTest` baseline entry; its replacement `*UnitTest` remains selected and tested.

### Validation

- Focused Maven run: **38 tests, zero failures/errors/skips** (35 email-settings tests, two demographic export-method tests, and the Surefire discovery guard). Dependency-lock verification and repository Checkstyle pass; BDD naming passes.
- Mutation checks fail when sender validation is bypassed, subject sanitization is bypassed, automatic sending defaults become unsafe, or the email test is renamed back to the old unselected name. Passing baselines are restored after each probe.
- Installed Ubuntu 26.04 VM: `scripts/email-recovery-playwright-checks.js` passes with no email sent, and `scripts/application-health-playwright-checks.js` passes. Application/runtime, database, packaging and Maven sources are byte-identical to the previously installed and validated `9527846368` package, so this test-only update requires no replacement application binary.
- Deployment health initially flagged only the disposable VM's backup age exceeding two days while it had been stopped. The configured backup job completed and verified its repository successfully; the repeated `carlos-ctl check` passes all checks. No application or browser failure was found. Owned email fixtures were removed, no failed migrations remain, and application restart count is zero.
- ON/common: 28 active Flyway versions; BC/common: 25. No normalized version collisions. All production/schema/configuration/script assets match develop.
- VM uses 6 GiB RAM and a 2 GiB application heap, with host/guest memory guards. Host compilation finishes before VM startup.

### Findings and review status

No new application defect found in this review. The previously identified, separate DrugRef inactive-date defect remains tracked in [drugref2026#13](https://github.com/carlos-emr/drugref2026/issues/13); this PR does not change DrugRef.

Commit `e3f7c13946` is DCO signed. CodeRabbit completed the requested full review without actionable comments. Final hosted CI passes on `e3f7c13946`: **13,492 tests, zero failures/errors, 51 skips**. The default test run includes the five new request-factory cases. All 41 check runs completed with no failures; DCO and CodeRabbit statuses are successful. The six container build/publish jobs are skipped as expected; Sourcery skipped its additional review because its weekly review budget was exhausted. CodeRabbit completed the requested full review. The PR remains open for independent maintainer approval.
