### PR TITLE
fix(security): authorize patient access before combining eDoc PDFs

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/CtlDocumentDao.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/CtlDocumentDao.java
@@ -31,6 +31,7 @@
  */
 package io.github.carlos_emr.carlos.commn.dao;
 
+import java.util.Collection;
 import java.util.List;
 
 import io.github.carlos_emr.carlos.commn.model.CtlDocument;
@@ -40,5 +41,16 @@ public interface CtlDocumentDao extends AbstractDao<CtlDocument> {
     public CtlDocument getCtrlDocument(Integer docId);
 
     public List<CtlDocument> findByDocumentNoAndModule(Integer ctlDocNo, String module);
+
+    /**
+     * Finds every module link for the supplied document numbers.
+     * Null document numbers and duplicate values are ignored. A null, empty, or
+     * all-null collection returns an empty list. The returned list is never null
+     * and has no defined ordering.
+     *
+     * @param documentNos document numbers whose module links should be returned
+     * @return all matching module links, or an empty list when none match
+     */
+    public List<CtlDocument> findByDocumentNos(Collection<Integer> documentNos);
 
 }

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/CtlDocumentDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/CtlDocumentDaoImpl.java
@@ -31,9 +31,11 @@
  */
 package io.github.carlos_emr.carlos.commn.dao;
 
+import java.util.Collection;
 import java.util.List;
 
 import jakarta.persistence.Query;
+import jakarta.persistence.TypedQuery;
 
 import io.github.carlos_emr.carlos.commn.model.CtlDocument;
 import org.springframework.stereotype.Repository;
@@ -63,6 +65,25 @@ public class CtlDocumentDaoImpl extends AbstractDaoImpl<CtlDocument> implements 
         @SuppressWarnings("unchecked")
         List<CtlDocument> cList = query.getResultList();
         return cList;
+    }
+
+    @Override
+    public List<CtlDocument> findByDocumentNos(Collection<Integer> documentNos) {
+        if (documentNos == null || documentNos.isEmpty()) {
+            return List.of();
+        }
+        List<Integer> candidates = documentNos.stream()
+                .filter(java.util.Objects::nonNull)
+                .distinct()
+                .toList();
+        if (candidates.isEmpty()) {
+            return List.of();
+        }
+        TypedQuery<CtlDocument> query = entityManager.createQuery(
+                "select x from CtlDocument x where x.id.documentNo in :documentNos",
+                CtlDocument.class);
+        query.setParameter("documentNos", candidates);
+        return query.getResultList();
     }
 
 }

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2Action.java
@@ -36,10 +36,17 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import io.github.carlos_emr.carlos.commn.dao.CtlDocumentDao;
+import io.github.carlos_emr.carlos.commn.dao.DocumentDao;
+import io.github.carlos_emr.carlos.commn.model.CtlDocument;
+import io.github.carlos_emr.carlos.commn.model.Document;
 import io.github.carlos_emr.carlos.documentManager.EDocUtil;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
@@ -64,13 +71,16 @@ public class CombinePDF2Action extends ActionSupport {
 
 
     private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
+    private transient CtlDocumentDao ctlDocumentDao = SpringUtils.getBean(CtlDocumentDao.class);
+    private transient DocumentDao documentDao = SpringUtils.getBean(DocumentDao.class);
 
     // FindSecBugs PATH_TRAVERSAL_IN: path validated for directory containment via PathValidationUtils before use
     @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "path validated for directory containment via PathValidationUtils before use")
     public String execute() {
 
-        if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_edoc", "w", null)) {
-            throw new SecurityException("missing required sec object (_doc)");
+        LoggedInInfo loggedInInfo = LoggedInInfo.getLoggedInInfoFromSession(request);
+        if (!securityInfoManager.hasPrivilege(loggedInInfo, "_edoc", "w", null)) {
+            throw new SecurityException("missing required sec object (_edoc)");
         }
 
         String[] files = request.getParameterValues("docNo");
@@ -78,12 +88,44 @@ public class CombinePDF2Action extends ActionSupport {
         ArrayList<Object> alist = new ArrayList<Object>();
         if (files != null) {
             MiscUtils.getLogger().debug("size = " + files.length);
-            EDocUtil docData = new EDocUtil();
+            List<Integer> documentNos = new ArrayList<>();
+            for (String file : files) {
+                try {
+                    documentNos.add(Integer.valueOf(file));
+                } catch (NumberFormatException e) {
+                    response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+                    return NONE;
+                }
+            }
+            List<CtlDocument> documentLinks = ctlDocumentDao.findByDocumentNos(documentNos);
+            Map<Integer, List<CtlDocument>> linksByDocumentNo = new HashMap<>();
+            for (CtlDocument documentLink : documentLinks) {
+                if (documentLink == null || documentLink.getId() == null
+                        || documentLink.getId().getDocumentNo() == null) {
+                    continue;
+                }
+                linksByDocumentNo
+                        .computeIfAbsent(documentLink.getId().getDocumentNo(), ignored -> new ArrayList<>())
+                        .add(documentLink);
+            }
+            List<Document> documents = new ArrayList<>();
+            for (Integer documentNo : documentNos) {
+                Document document = documentDao.find(documentNo.intValue());
+                if (document == null || document.getDocfilename() == null || document.getDocfilename().isBlank()) {
+                    response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+                    return NONE;
+                }
+                if (!isAuthorizedDocumentScope(loggedInInfo, document, linksByDocumentNo.get(documentNo))) {
+                    response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+                    return NONE;
+                }
+                documents.add(document);
+            }
             File documentDir = PathValidationUtils.resolveConfiguredDirectory(CarlosProperties.getInstance().getProperty("DOCUMENT_DIR"), "DOCUMENT_DIR");
             Path filePath;
-            for (int i = 0; i < files.length; i++) {
-                String filename = docData.getDocumentName(files[i]);
-                filePath = PathValidationUtils.validateExistingPath(new File(documentDir, filename), documentDir).toPath();
+            for (Document document : documents) {
+                filePath = PathValidationUtils.validateExistingPath(
+                        new File(documentDir, document.getDocfilename()), documentDir).toPath();
                 alist.add(filePath.toAbsolutePath().toString());
             }
             if (alist.size() > 0) {
@@ -142,6 +184,55 @@ public class CombinePDF2Action extends ActionSupport {
             }
         }
         return SUCCESS;
+    }
+
+    boolean isAuthorizedDocumentScope(
+            LoggedInInfo loggedInInfo, Document document, List<CtlDocument> documentLinks) {
+        if (documentLinks == null || documentLinks.isEmpty()) {
+            return false;
+        }
+
+        boolean hasDemographicLink = false;
+        for (CtlDocument documentLink : documentLinks) {
+            String module = documentLink.getId().getModule();
+            Integer moduleId = documentLink.getId().getModuleId();
+            if (isDemographicModule(module)) {
+                hasDemographicLink = true;
+                if (moduleId == null
+                        || !securityInfoManager.isAllowedAccessToPatientRecord(loggedInInfo, moduleId)) {
+                    return false;
+                }
+            }
+        }
+        if (hasDemographicLink) {
+            return true;
+        }
+
+        boolean hasProviderLink = documentLinks.stream()
+                .anyMatch(documentLink -> EDocUtil.isProviderModule(documentLink.getId().getModule()));
+        if (!hasProviderLink) {
+            return false;
+        }
+        if (document.getPublic1() == 1) {
+            return true;
+        }
+        Integer providerNo = parseProviderNo(loggedInInfo.getLoggedInProviderNo());
+        return providerNo != null && documentLinks.stream()
+                .anyMatch(documentLink -> EDocUtil.isProviderModule(documentLink.getId().getModule())
+                        && providerNo.equals(documentLink.getId().getModuleId()));
+    }
+
+    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "ASCII database module identifier is matched case-insensitively for legacy compatibility")
+    private boolean isDemographicModule(String module) {
+        return "demographic".equalsIgnoreCase(module);
+    }
+
+    private Integer parseProviderNo(String providerNo) {
+        try {
+            return providerNo != null ? Integer.valueOf(providerNo) : null;
+        } catch (NumberFormatException e) {
+            return null;
+        }
     }
 
     /**

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2Action.java
@@ -88,6 +88,19 @@ public class CombinePDF2Action extends ActionSupport {
     private final transient ProgramManager programManager;
     private final transient ProgramManager2 programManager2;
 
+    /**
+     * Authorizes access to every requested eDoc and streams their combined PDF.
+     *
+     * <p>The caller must have the {@code _edoc} write privilege; otherwise this method throws a
+     * {@link SecurityException}. Invalid, unauthorized, missing, or excessive requests return
+     * {@link #NONE} with HTTP 400, 403, 404, or 413 respectively. PDF output is streamed directly
+     * and also returns {@code NONE}. When no {@code docNo} values are supplied, no response is
+     * streamed and {@link #SUCCESS} is returned.
+     *
+     * @return {@link #NONE} when the request is rejected or handled directly, otherwise
+     *         {@link #SUCCESS}
+     * @throws SecurityException when the caller lacks the {@code _edoc} write privilege
+     */
     // FindSecBugs PATH_TRAVERSAL_IN: path validated for directory containment via PathValidationUtils before use
     @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "path validated for directory containment via PathValidationUtils before use")
     public String execute() {
@@ -245,7 +258,19 @@ public class CombinePDF2Action extends ActionSupport {
             return false;
         }
 
-        boolean hasValidDemographicLink = false;
+        DemographicAuthorization demographicAuthorization = evaluateDemographicAuthorization(
+                loggedInInfo, documentLinks, demographicExistence);
+        if (demographicAuthorization != DemographicAuthorization.NO_VALID_LINK) {
+            return demographicAuthorization == DemographicAuthorization.AUTHORIZED;
+        }
+        return isAuthorizedProviderScope(loggedInInfo, document, documentLinks);
+    }
+
+    private DemographicAuthorization evaluateDemographicAuthorization(
+            LoggedInInfo loggedInInfo,
+            List<CtlDocument> documentLinks,
+            Map<Integer, Boolean> demographicExistence) {
+        boolean hasValidLink = false;
         for (CtlDocument documentLink : documentLinks) {
             String module = documentLink.getId().getModule();
             Integer moduleId = documentLink.getId().getModuleId();
@@ -253,16 +278,19 @@ public class CombinePDF2Action extends ActionSupport {
                 if (!isExistingDemographic(moduleId, demographicExistence)) {
                     continue;
                 }
-                hasValidDemographicLink = true;
+                hasValidLink = true;
                 if (!securityInfoManager.isAllowedAccessToPatientRecord(loggedInInfo, moduleId)) {
-                    return false;
+                    return DemographicAuthorization.DENIED;
                 }
             }
         }
-        if (hasValidDemographicLink) {
-            return true;
-        }
+        return hasValidLink
+                ? DemographicAuthorization.AUTHORIZED
+                : DemographicAuthorization.NO_VALID_LINK;
+    }
 
+    private boolean isAuthorizedProviderScope(
+            LoggedInInfo loggedInInfo, Document document, List<CtlDocument> documentLinks) {
         boolean hasProviderLink = documentLinks.stream()
                 .anyMatch(documentLink -> EDocUtil.isProviderModule(documentLink.getId().getModule()));
         if (!hasProviderLink) {
@@ -275,6 +303,12 @@ public class CombinePDF2Action extends ActionSupport {
         return providerNo != null && documentLinks.stream()
                 .anyMatch(documentLink -> EDocUtil.isProviderModule(documentLink.getId().getModule())
                         && providerNo.equals(documentLink.getId().getModuleId()));
+    }
+
+    private enum DemographicAuthorization {
+        AUTHORIZED,
+        DENIED,
+        NO_VALID_LINK
     }
 
     private Set<Long> getProgramDomain(LoggedInInfo loggedInInfo) {

--- a/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2Action.java
+++ b/src/main/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2Action.java
@@ -37,17 +37,27 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import io.github.carlos_emr.carlos.PMmodule.model.ProgramProvider;
+import io.github.carlos_emr.carlos.PMmodule.service.ProgramManager;
 import io.github.carlos_emr.carlos.commn.dao.CtlDocumentDao;
+import io.github.carlos_emr.carlos.commn.dao.DemographicDao;
 import io.github.carlos_emr.carlos.commn.dao.DocumentDao;
 import io.github.carlos_emr.carlos.commn.model.CtlDocument;
+import io.github.carlos_emr.carlos.commn.model.Demographic;
 import io.github.carlos_emr.carlos.commn.model.Document;
 import io.github.carlos_emr.carlos.documentManager.EDocUtil;
+import io.github.carlos_emr.carlos.log.LogAction;
+import io.github.carlos_emr.carlos.log.LogConst;
+import io.github.carlos_emr.carlos.managers.ProgramManager2;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
 import io.github.carlos_emr.carlos.utility.MiscUtils;
@@ -66,13 +76,17 @@ import org.apache.struts2.ServletActionContext;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class CombinePDF2Action extends ActionSupport {
+    private static final int MAX_DOCUMENTS_TO_COMBINE = 100;
+
     HttpServletRequest request = ServletActionContext.getRequest();
     HttpServletResponse response = ServletActionContext.getResponse();
 
-
-    private SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
-    private transient CtlDocumentDao ctlDocumentDao = SpringUtils.getBean(CtlDocumentDao.class);
-    private transient DocumentDao documentDao = SpringUtils.getBean(DocumentDao.class);
+    private final transient SecurityInfoManager securityInfoManager;
+    private final transient CtlDocumentDao ctlDocumentDao;
+    private final transient DocumentDao documentDao;
+    private final transient DemographicDao demographicDao;
+    private final transient ProgramManager programManager;
+    private final transient ProgramManager2 programManager2;
 
     // FindSecBugs PATH_TRAVERSAL_IN: path validated for directory containment via PathValidationUtils before use
     @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "path validated for directory containment via PathValidationUtils before use")
@@ -84,19 +98,29 @@ public class CombinePDF2Action extends ActionSupport {
         }
 
         String[] files = request.getParameterValues("docNo");
-        String ContentDisposition = request.getParameter("ContentDisposition");
-        ArrayList<Object> alist = new ArrayList<Object>();
+        String contentDisposition = request.getParameter("ContentDisposition");
+        List<Object> inputPaths = new ArrayList<>();
         if (files != null) {
             MiscUtils.getLogger().debug("size = " + files.length);
-            List<Integer> documentNos = new ArrayList<>();
+            if (files.length > MAX_DOCUMENTS_TO_COMBINE) {
+                response.setStatus(HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE);
+                return NONE;
+            }
+            Set<Integer> uniqueDocumentNos = new LinkedHashSet<>();
             for (String file : files) {
                 try {
-                    documentNos.add(Integer.valueOf(file));
+                    Integer documentNo = Integer.valueOf(file);
+                    if (documentNo <= 0) {
+                        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+                        return NONE;
+                    }
+                    uniqueDocumentNos.add(documentNo);
                 } catch (NumberFormatException e) {
                     response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
                     return NONE;
                 }
             }
+            List<Integer> documentNos = new ArrayList<>(uniqueDocumentNos);
             List<CtlDocument> documentLinks = ctlDocumentDao.findByDocumentNos(documentNos);
             Map<Integer, List<CtlDocument>> linksByDocumentNo = new HashMap<>();
             for (CtlDocument documentLink : documentLinks) {
@@ -109,13 +133,20 @@ public class CombinePDF2Action extends ActionSupport {
                         .add(documentLink);
             }
             List<Document> documents = new ArrayList<>();
+            Map<Integer, Boolean> demographicExistence = new HashMap<>();
+            Set<Long> programDomain = getProgramDomain(loggedInInfo);
             for (Integer documentNo : documentNos) {
                 Document document = documentDao.find(documentNo.intValue());
                 if (document == null || document.getDocfilename() == null || document.getDocfilename().isBlank()) {
                     response.setStatus(HttpServletResponse.SC_NOT_FOUND);
                     return NONE;
                 }
-                if (!isAuthorizedDocumentScope(loggedInInfo, document, linksByDocumentNo.get(documentNo))) {
+                if (!isAuthorizedDocumentScope(
+                        loggedInInfo,
+                        document,
+                        linksByDocumentNo.get(documentNo),
+                        demographicExistence,
+                        programDomain)) {
                     response.setStatus(HttpServletResponse.SC_FORBIDDEN);
                     return NONE;
                 }
@@ -126,19 +157,11 @@ public class CombinePDF2Action extends ActionSupport {
             for (Document document : documents) {
                 filePath = PathValidationUtils.validateExistingPath(
                         new File(documentDir, document.getDocfilename()), documentDir).toPath();
-                alist.add(filePath.toAbsolutePath().toString());
+                inputPaths.add(filePath.toAbsolutePath().toString());
             }
-            if (alist.size() > 0) {
-                response.setContentType("application/pdf");  //octet-stream
-                if (ContentDisposition != null && ContentDisposition.equals("inline")) {
-                    response.setHeader("Transfer-Encoding", "chunked");
-                    response.setHeader("Cache-Control", "cache, must-revalidate"); // IE workaround
-                    response.setHeader("Pragma", "public"); // IE workaround
-                    response.setHeader("Content-Disposition", "inline; filename=\"combinedPDF-" + UtilDateUtilities.getToday("yyyy-MM-dd.hh.mm.ss") + ".pdf\"");
-                } else {
-
-                    response.setHeader("Content-Disposition", "attachment; filename=\"combinedPDF-" + UtilDateUtilities.getToday("yyyy-MM-dd.hh.mm.ss") + ".pdf\"");
-                }
+            if (!inputPaths.isEmpty()) {
+                auditDocumentReads(loggedInInfo, documents);
+                configurePdfResponse(contentDisposition);
                 File tempPdf = null;
                 try {
                     // Merge to a secure temp file (not an in-memory buffer): the skipped count is known
@@ -147,16 +170,16 @@ public class CombinePDF2Action extends ActionSupport {
                     tempPdf = PathValidationUtils.createSecureTempFile("combinedPDF" + System.currentTimeMillis(), ".pdf");
                     int skipped;
                     try (FileOutputStream tmpOut = new FileOutputStream(tempPdf)) {
-                        skipped = ConcatPDF.concat(alist, tmpOut);
+                        skipped = ConcatPDF.concat(inputPaths, tmpOut);
                     }
                     if (skipped > 0) {
                         // Some documents could not be included: refuse to serve a truncated PDF.
                         MiscUtils.getLogger().error("Combine PDF: {} of {} document(s) could not be included",
-                                skipped, alist.size());
+                                skipped, inputPaths.size());
                         if (!response.isCommitted()) {
                             response.reset();
                             response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
-                                    skipped + " of " + alist.size() + " document(s) could not be included; combined PDF not produced");
+                                    skipped + " of " + inputPaths.size() + " document(s) could not be included; combined PDF not produced");
                         }
                     } else {
                         Files.copy(tempPdf.toPath(), response.getOutputStream());
@@ -186,25 +209,57 @@ public class CombinePDF2Action extends ActionSupport {
         return SUCCESS;
     }
 
+    void configurePdfResponse(String contentDisposition) {
+        response.setContentType("application/pdf");
+        response.setHeader("Cache-Control", "private, no-store, max-age=0");
+        response.setHeader("Pragma", "no-cache");
+        response.setDateHeader("Expires", 0);
+        response.setHeader("X-Content-Type-Options", "nosniff");
+        String disposition = "inline".equals(contentDisposition) ? "inline" : "attachment";
+        response.setHeader(
+                "Content-Disposition",
+                disposition + "; filename=\"combinedPDF-"
+                        + UtilDateUtilities.getToday("yyyy-MM-dd.hh.mm.ss") + ".pdf\"");
+    }
+
     boolean isAuthorizedDocumentScope(
             LoggedInInfo loggedInInfo, Document document, List<CtlDocument> documentLinks) {
+        return isAuthorizedDocumentScope(
+                loggedInInfo,
+                document,
+                documentLinks,
+                new HashMap<>(),
+                getProgramDomain(loggedInInfo));
+    }
+
+    private boolean isAuthorizedDocumentScope(
+            LoggedInInfo loggedInInfo,
+            Document document,
+            List<CtlDocument> documentLinks,
+            Map<Integer, Boolean> demographicExistence,
+            Set<Long> programDomain) {
+        if (!isAuthorizedDocumentProgramScope(loggedInInfo, document, programDomain)) {
+            return false;
+        }
         if (documentLinks == null || documentLinks.isEmpty()) {
             return false;
         }
 
-        boolean hasDemographicLink = false;
+        boolean hasValidDemographicLink = false;
         for (CtlDocument documentLink : documentLinks) {
             String module = documentLink.getId().getModule();
             Integer moduleId = documentLink.getId().getModuleId();
             if (isDemographicModule(module)) {
-                hasDemographicLink = true;
-                if (moduleId == null
-                        || !securityInfoManager.isAllowedAccessToPatientRecord(loggedInInfo, moduleId)) {
+                if (!isExistingDemographic(moduleId, demographicExistence)) {
+                    continue;
+                }
+                hasValidDemographicLink = true;
+                if (!securityInfoManager.isAllowedAccessToPatientRecord(loggedInInfo, moduleId)) {
                     return false;
                 }
             }
         }
-        if (hasDemographicLink) {
+        if (hasValidDemographicLink) {
             return true;
         }
 
@@ -220,6 +275,58 @@ public class CombinePDF2Action extends ActionSupport {
         return providerNo != null && documentLinks.stream()
                 .anyMatch(documentLink -> EDocUtil.isProviderModule(documentLink.getId().getModule())
                         && providerNo.equals(documentLink.getId().getModuleId()));
+    }
+
+    private Set<Long> getProgramDomain(LoggedInInfo loggedInInfo) {
+        List<ProgramProvider> programProviders = programManager2.getProgramDomain(
+                loggedInInfo, loggedInInfo.getLoggedInProviderNo());
+        if (programProviders == null || programProviders.isEmpty()) {
+            return Set.of();
+        }
+        Set<Long> programIds = new HashSet<>();
+        for (ProgramProvider programProvider : programProviders) {
+            if (programProvider != null && programProvider.getProgramId() != null) {
+                programIds.add(programProvider.getProgramId());
+            }
+        }
+        return programIds;
+    }
+
+    private boolean isAuthorizedDocumentProgramScope(
+            LoggedInInfo loggedInInfo, Document document, Set<Long> programDomain) {
+        Integer programId = document.getProgramId();
+        if (programId != null
+                && CarlosProperties.getInstance().getBooleanProperty("FILTER_ON_FACILITY", "true")
+                && !programManager.hasAccessBasedOnCurrentFacility(loggedInInfo, programId)) {
+            return false;
+        }
+        return !Boolean.TRUE.equals(document.isRestrictToProgram())
+                || programId == null
+                || programId == -1
+                || programDomain.contains(programId.longValue());
+    }
+
+    void auditDocumentReads(LoggedInInfo loggedInInfo, List<Document> documents) {
+        for (Document document : documents) {
+            LogAction.addLog(
+                    loggedInInfo,
+                    LogConst.READ,
+                    LogConst.CON_DOCUMENT,
+                    String.valueOf(document.getDocumentNo()),
+                    null,
+                    "combined PDF");
+        }
+    }
+
+    private boolean isExistingDemographic(
+            Integer demographicNo, Map<Integer, Boolean> demographicExistence) {
+        if (demographicNo == null || demographicNo <= 0) {
+            return false;
+        }
+        return demographicExistence.computeIfAbsent(demographicNo, id -> {
+            Demographic demographic = demographicDao.getDemographicById(id);
+            return demographic != null && id.equals(demographic.getDemographicNo());
+        });
     }
 
     @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "ASCII database module identifier is matched case-insensitively for legacy compatibility")
@@ -239,6 +346,28 @@ public class CombinePDF2Action extends ActionSupport {
      * Creates a new instance of CombinePDF2Action
      */
     public CombinePDF2Action() {
+        this(
+                SpringUtils.getBean(SecurityInfoManager.class),
+                SpringUtils.getBean(CtlDocumentDao.class),
+                SpringUtils.getBean(DocumentDao.class),
+                SpringUtils.getBean(DemographicDao.class),
+                SpringUtils.getBean(ProgramManager.class),
+                SpringUtils.getBean(ProgramManager2.class));
+    }
+
+    CombinePDF2Action(
+            SecurityInfoManager securityInfoManager,
+            CtlDocumentDao ctlDocumentDao,
+            DocumentDao documentDao,
+            DemographicDao demographicDao,
+            ProgramManager programManager,
+            ProgramManager2 programManager2) {
+        this.securityInfoManager = securityInfoManager;
+        this.ctlDocumentDao = ctlDocumentDao;
+        this.documentDao = documentDao;
+        this.demographicDao = demographicDao;
+        this.programManager = programManager;
+        this.programManager2 = programManager2;
     }
 
 }

--- a/src/test/java/io/github/carlos_emr/carlos/commn/dao/CtlDocumentDaoIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/commn/dao/CtlDocumentDaoIntegrationTest.java
@@ -87,6 +87,7 @@ public class CtlDocumentDaoIntegrationTest extends CarlosTestBase {
         @BeforeEach
         void setUp() {
             createCtlDocument(20001, "demographic", "A");
+            createCtlDocument(20001, "provider", "A");
             createCtlDocument(20002, "demographic", "A");
             createCtlDocument(20003, "encounter", "A");
         }
@@ -108,8 +109,23 @@ public class CtlDocumentDaoIntegrationTest extends CarlosTestBase {
                     List.of(20001, 20002, 20003, 20001));
 
             assertThat(results)
-                    .extracting(document -> document.getId().getDocumentNo())
-                    .containsExactlyInAnyOrder(20001, 20002, 20003);
+                    .extracting(
+                            document -> document.getId().getDocumentNo(),
+                            document -> document.getId().getModule())
+                    .containsExactlyInAnyOrder(
+                            tuple(20001, "demographic"),
+                            tuple(20001, "provider"),
+                            tuple(20002, "demographic"),
+                            tuple(20003, "encounter"));
+        }
+
+        @Test
+        @Tag("query")
+        @DisplayName("should return empty for null, empty, or all-null document numbers")
+        void shouldReturnEmpty_forNoUsableDocumentNos() {
+            assertThat(ctlDocumentDao.findByDocumentNos(null)).isEmpty();
+            assertThat(ctlDocumentDao.findByDocumentNos(List.of())).isEmpty();
+            assertThat(ctlDocumentDao.findByDocumentNos(java.util.Arrays.asList(null, null))).isEmpty();
         }
 
         @Test

--- a/src/test/java/io/github/carlos_emr/carlos/commn/dao/CtlDocumentDaoIntegrationTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/commn/dao/CtlDocumentDaoIntegrationTest.java
@@ -102,6 +102,18 @@ public class CtlDocumentDaoIntegrationTest extends CarlosTestBase {
 
         @Test
         @Tag("query")
+        @DisplayName("should find all module links for multiple document numbers")
+        void shouldFindDocuments_byDocumentNos() {
+            List<CtlDocument> results = ctlDocumentDao.findByDocumentNos(
+                    List.of(20001, 20002, 20003, 20001));
+
+            assertThat(results)
+                    .extracting(document -> document.getId().getDocumentNo())
+                    .containsExactlyInAnyOrder(20001, 20002, 20003);
+        }
+
+        @Test
+        @Tag("query")
         @DisplayName("should return empty for non-existent document-module combination")
         void shouldReturnEmpty_whenDocumentModuleNotFound() {
             List<CtlDocument> results = ctlDocumentDao.findByDocumentNoAndModule(99999, "nonexistent");

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2ActionUnitTest.java
@@ -21,11 +21,19 @@
  */
 package io.github.carlos_emr.carlos.documentManager.actions;
 
+import io.github.carlos_emr.CarlosProperties;
+import io.github.carlos_emr.carlos.PMmodule.model.ProgramProvider;
+import io.github.carlos_emr.carlos.PMmodule.service.ProgramManager;
 import io.github.carlos_emr.carlos.commn.dao.CtlDocumentDao;
+import io.github.carlos_emr.carlos.commn.dao.DemographicDao;
 import io.github.carlos_emr.carlos.commn.dao.DocumentDao;
 import io.github.carlos_emr.carlos.commn.model.CtlDocument;
 import io.github.carlos_emr.carlos.commn.model.CtlDocumentPK;
+import io.github.carlos_emr.carlos.commn.model.Demographic;
 import io.github.carlos_emr.carlos.commn.model.Document;
+import io.github.carlos_emr.carlos.log.LogAction;
+import io.github.carlos_emr.carlos.log.LogConst;
+import io.github.carlos_emr.carlos.managers.ProgramManager2;
 import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
 import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
 import io.github.carlos_emr.carlos.utility.LoggedInInfo;
@@ -36,15 +44,19 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.MockedStatic;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.List;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
@@ -61,18 +73,25 @@ class CombinePDF2ActionUnitTest extends CarlosUnitTestBase {
     private MockHttpServletResponse response;
     private CtlDocumentDao ctlDocumentDao;
     private DocumentDao documentDao;
+    private DemographicDao demographicDao;
+    private ProgramManager programManager;
+    private ProgramManager2 programManager2;
     private SecurityInfoManager securityInfoManager;
     private LoggedInInfo loggedInInfo;
     private CombinePDF2Action action;
+    private String previousFacilityFilter;
 
     @BeforeEach
     void setUp() {
         securityInfoManager = mock(SecurityInfoManager.class);
         ctlDocumentDao = mock(CtlDocumentDao.class);
         documentDao = mock(DocumentDao.class);
-        registerMock(SecurityInfoManager.class, securityInfoManager);
-        registerMock(CtlDocumentDao.class, ctlDocumentDao);
-        registerMock(DocumentDao.class, documentDao);
+        demographicDao = mock(DemographicDao.class);
+        programManager = mock(ProgramManager.class);
+        programManager2 = mock(ProgramManager2.class);
+
+        previousFacilityFilter = CarlosProperties.getInstance().getProperty("FILTER_ON_FACILITY");
+        CarlosProperties.getInstance().setProperty("FILTER_ON_FACILITY", "true");
 
         request = new MockHttpServletRequest();
         response = new MockHttpServletResponse();
@@ -81,17 +100,33 @@ class CombinePDF2ActionUnitTest extends CarlosUnitTestBase {
         LoggedInInfo.setLoggedInInfoIntoSession(request.getSession(), loggedInInfo);
         request.setParameter("docNo", "321");
         when(securityInfoManager.hasPrivilege(loggedInInfo, "_edoc", "w", null)).thenReturn(true);
+        when(demographicDao.getDemographicById(anyInt())).thenAnswer(invocation -> {
+            Demographic demographic = new Demographic();
+            demographic.setDemographicNo(invocation.getArgument(0));
+            return demographic;
+        });
 
         servletActionContext = mockStatic(ServletActionContext.class);
         servletActionContext.when(ServletActionContext::getRequest).thenReturn(request);
         servletActionContext.when(ServletActionContext::getResponse).thenReturn(response);
-        action = new CombinePDF2Action();
+        action = new CombinePDF2Action(
+                securityInfoManager,
+                ctlDocumentDao,
+                documentDao,
+                demographicDao,
+                programManager,
+                programManager2);
     }
 
     @AfterEach
     void tearDown() {
         if (servletActionContext != null) {
             servletActionContext.close();
+        }
+        if (previousFacilityFilter == null) {
+            CarlosProperties.getInstance().remove("FILTER_ON_FACILITY");
+        } else {
+            CarlosProperties.getInstance().setProperty("FILTER_ON_FACILITY", previousFacilityFilter);
         }
     }
 
@@ -105,6 +140,48 @@ class CombinePDF2ActionUnitTest extends CarlosUnitTestBase {
         assertThat(result).isEqualTo(ActionSupport.NONE);
         assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_BAD_REQUEST);
         verifyNoInteractions(ctlDocumentDao, documentDao);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"0", "-1"})
+    @DisplayName("should reject non-positive document numbers before any lookup")
+    void shouldRejectNonPositiveDocumentNumbers_beforeAnyLookup(String documentNo) {
+        request.setParameter("docNo", documentNo);
+
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_BAD_REQUEST);
+        verifyNoInteractions(ctlDocumentDao, documentDao);
+    }
+
+    @Test
+    @DisplayName("should reject an excessive number of documents before any lookup")
+    void shouldRejectExcessiveDocumentCount_beforeAnyLookup() {
+        String[] documentNos = IntStream.rangeClosed(1, 101)
+                .mapToObj(String::valueOf)
+                .toArray(String[]::new);
+        request.setParameter("docNo", documentNos);
+
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE);
+        verifyNoInteractions(ctlDocumentDao, documentDao);
+    }
+
+    @Test
+    @DisplayName("should deduplicate document numbers while preserving request order")
+    void shouldDeduplicateDocumentNumbers_preservingRequestOrder() {
+        request.setParameter("docNo", "321", "654", "321");
+        when(ctlDocumentDao.findByDocumentNos(List.of(321, 654))).thenReturn(List.of());
+
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_NOT_FOUND);
+        verify(ctlDocumentDao).findByDocumentNos(List.of(321, 654));
+        verify(documentDao).find(321);
     }
 
     @Test
@@ -151,6 +228,138 @@ class CombinePDF2ActionUnitTest extends CarlosUnitTestBase {
     }
 
     @Test
+    @DisplayName("should allow an existing demographic within the caller's patient-record access")
+    void shouldAllowExistingDemographicWithinPatientRecordAccess() {
+        Document document = new Document();
+        when(securityInfoManager.isAllowedAccessToPatientRecord(loggedInInfo, 123)).thenReturn(true);
+
+        boolean authorized = action.isAuthorizedDocumentScope(
+                loggedInInfo, document, List.of(demographicLink(321, 123)));
+
+        assertThat(authorized).isTrue();
+        verify(demographicDao).getDemographicById(123);
+        verify(securityInfoManager).isAllowedAccessToPatientRecord(loggedInInfo, 123);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {-1, 0})
+    @DisplayName("should reject unmatched or invalid demographic links")
+    void shouldRejectNonPositiveDemographicLinks(int demographicNo) {
+        Document document = new Document();
+
+        boolean authorized = action.isAuthorizedDocumentScope(
+                loggedInInfo, document, List.of(demographicLink(321, demographicNo)));
+
+        assertThat(authorized).isFalse();
+        verifyNoInteractions(demographicDao);
+    }
+
+    @Test
+    @DisplayName("should reject demographic links that do not resolve to a patient")
+    void shouldRejectNonexistentDemographicLinks() {
+        Document document = new Document();
+        when(demographicDao.getDemographicById(456)).thenReturn(null);
+
+        boolean authorized = action.isAuthorizedDocumentScope(
+                loggedInInfo, document, List.of(demographicLink(321, 456)));
+
+        assertThat(authorized).isFalse();
+        verify(demographicDao).getDemographicById(456);
+    }
+
+    @Test
+    @DisplayName("should use an explicit provider link when a demographic link is unmatched")
+    void shouldUseProviderLinkWhenDemographicLinkIsUnmatched() {
+        Document document = new Document();
+        document.setPublic1(0);
+
+        boolean authorized = action.isAuthorizedDocumentScope(loggedInInfo, document, List.of(
+                demographicLink(321, -1),
+                providerLink(321, 999998)));
+
+        assertThat(authorized).isTrue();
+        verifyNoInteractions(demographicDao);
+    }
+
+    @Test
+    @DisplayName("should reject when any valid demographic link is outside patient-record access")
+    void shouldRejectWhenAnyValidDemographicLinkIsUnauthorized() {
+        Document document = new Document();
+        when(securityInfoManager.isAllowedAccessToPatientRecord(loggedInInfo, 123)).thenReturn(true);
+        when(securityInfoManager.isAllowedAccessToPatientRecord(loggedInInfo, 456)).thenReturn(false);
+
+        boolean authorized = action.isAuthorizedDocumentScope(loggedInInfo, document, List.of(
+                demographicLink(321, 123),
+                demographicLink(321, 456)));
+
+        assertThat(authorized).isFalse();
+        verify(securityInfoManager).isAllowedAccessToPatientRecord(loggedInInfo, 123);
+        verify(securityInfoManager).isAllowedAccessToPatientRecord(loggedInInfo, 456);
+    }
+
+    @Test
+    @DisplayName("should reject documents outside the current facility")
+    void shouldRejectDocumentsOutsideCurrentFacility() {
+        Document document = new Document();
+        document.setProgramId(77);
+        when(programManager.hasAccessBasedOnCurrentFacility(loggedInInfo, 77)).thenReturn(false);
+
+        boolean authorized = action.isAuthorizedDocumentScope(
+                loggedInInfo, document, List.of(providerLink(321, 999998)));
+
+        assertThat(authorized).isFalse();
+        verifyNoInteractions(demographicDao);
+    }
+
+    @Test
+    @DisplayName("should reject program-restricted documents outside the provider domain")
+    void shouldRejectProgramRestrictedDocumentsOutsideProviderDomain() {
+        Document document = new Document();
+        document.setProgramId(77);
+        document.setRestrictToProgram(true);
+        when(programManager.hasAccessBasedOnCurrentFacility(loggedInInfo, 77)).thenReturn(true);
+        when(programManager2.getProgramDomain(loggedInInfo, "999998")).thenReturn(List.of());
+
+        boolean authorized = action.isAuthorizedDocumentScope(
+                loggedInInfo, document, List.of(providerLink(321, 999998)));
+
+        assertThat(authorized).isFalse();
+    }
+
+    @Test
+    @DisplayName("should allow program-restricted documents inside the provider domain")
+    void shouldAllowProgramRestrictedDocumentsInsideProviderDomain() {
+        Document document = new Document();
+        document.setProgramId(77);
+        document.setRestrictToProgram(true);
+        ProgramProvider programProvider = mock(ProgramProvider.class);
+        when(programProvider.getProgramId()).thenReturn(77L);
+        when(programManager.hasAccessBasedOnCurrentFacility(loggedInInfo, 77)).thenReturn(true);
+        when(programManager2.getProgramDomain(loggedInInfo, "999998"))
+                .thenReturn(List.of(programProvider));
+
+        boolean authorized = action.isAuthorizedDocumentScope(
+                loggedInInfo, document, List.of(providerLink(321, 999998)));
+
+        assertThat(authorized).isTrue();
+    }
+
+    @Test
+    @DisplayName("should honor disabled facility filtering")
+    void shouldHonorDisabledFacilityFiltering() {
+        CarlosProperties.getInstance().setProperty("FILTER_ON_FACILITY", "false");
+        Document document = new Document();
+        document.setProgramId(77);
+        when(programManager.hasAccessBasedOnCurrentFacility(loggedInInfo, 77)).thenReturn(false);
+
+        boolean authorized = action.isAuthorizedDocumentScope(
+                loggedInInfo, document, List.of(providerLink(321, 999998)));
+
+        assertThat(authorized).isTrue();
+        verifyNoInteractions(programManager);
+    }
+
+    @Test
     @DisplayName("should allow public provider documents with mixed-case legacy links")
     void shouldAllowPublicProviderDocumentsWithMixedCaseLegacyLinks() {
         Document document = new Document();
@@ -187,6 +396,35 @@ class CombinePDF2ActionUnitTest extends CarlosUnitTestBase {
                 loggedInInfo, document, List.of(providerLink(321, 999998)))).isTrue();
         assertThat(action.isAuthorizedDocumentScope(
                 loggedInInfo, document, List.of(providerLink(321, 123456)))).isFalse();
+    }
+
+    @Test
+    @DisplayName("should mark PDF responses private and non-cacheable")
+    void shouldConfigurePdfResponsesAsPrivateAndNonCacheable() {
+        action.configurePdfResponse("inline");
+
+        assertThat(response.getContentType()).isEqualTo("application/pdf");
+        assertThat(response.getHeader("Cache-Control")).isEqualTo("private, no-store, max-age=0");
+        assertThat(response.getHeader("Pragma")).isEqualTo("no-cache");
+        assertThat(response.getDateHeader("Expires")).isZero();
+        assertThat(response.getHeader("X-Content-Type-Options")).isEqualTo("nosniff");
+        assertThat(response.getHeader("Content-Disposition")).startsWith("inline; filename=\"combinedPDF-");
+    }
+
+    @Test
+    @DisplayName("should audit every document read for a combined PDF")
+    void shouldAuditEveryDocumentReadForCombinedPdf() {
+        Document first = new Document();
+        first.setDocumentNo(321);
+        Document second = new Document();
+        second.setDocumentNo(654);
+
+        action.auditDocumentReads(loggedInInfo, List.of(first, second));
+
+        logActionMock.verify(() -> LogAction.addLog(
+                loggedInInfo, LogConst.READ, LogConst.CON_DOCUMENT, "321", null, "combined PDF"));
+        logActionMock.verify(() -> LogAction.addLog(
+                loggedInInfo, LogConst.READ, LogConst.CON_DOCUMENT, "654", null, "combined PDF"));
     }
 
     private CtlDocument demographicLink(Integer documentNo, Integer demographicNo) {

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2ActionUnitTest.java
@@ -186,7 +186,7 @@ class CombinePDF2ActionUnitTest extends CarlosUnitTestBase {
 
     @Test
     @DisplayName("should reject missing documents before resolving their paths")
-    void shouldRejectMissingDocumentsBeforeResolvingPaths() {
+    void shouldRejectMissingDocuments_beforeResolvingPaths() {
         when(ctlDocumentDao.findByDocumentNos(List.of(321)))
                 .thenReturn(List.of(demographicLink(321, 123)));
         when(securityInfoManager.isAllowedAccessToPatientRecord(loggedInInfo, 123)).thenReturn(true);
@@ -200,7 +200,7 @@ class CombinePDF2ActionUnitTest extends CarlosUnitTestBase {
 
     @Test
     @DisplayName("should reject callers without eDoc write access before querying documents")
-    void shouldRejectCallerWithoutEdocWriteAccessBeforeQueryingDocuments() {
+    void shouldRejectCallerWithoutEdocWriteAccess_beforeQueryingDocuments() {
         when(securityInfoManager.hasPrivilege(loggedInInfo, "_edoc", "w", null)).thenReturn(false);
 
         assertThatThrownBy(action::execute)
@@ -212,7 +212,7 @@ class CombinePDF2ActionUnitTest extends CarlosUnitTestBase {
 
     @Test
     @DisplayName("should reject documents outside the caller's patient-record access")
-    void shouldRejectDocumentsOutsidePatientRecordAccess() {
+    void shouldRejectDocuments_outsidePatientRecordAccess() {
         Document document = new Document();
         document.setDocfilename("patient-document.pdf");
         when(ctlDocumentDao.findByDocumentNos(List.of(321)))
@@ -229,7 +229,7 @@ class CombinePDF2ActionUnitTest extends CarlosUnitTestBase {
 
     @Test
     @DisplayName("should allow an existing demographic within the caller's patient-record access")
-    void shouldAllowExistingDemographicWithinPatientRecordAccess() {
+    void shouldAllowExistingDemographic_withinPatientRecordAccess() {
         Document document = new Document();
         when(securityInfoManager.isAllowedAccessToPatientRecord(loggedInInfo, 123)).thenReturn(true);
 
@@ -244,7 +244,7 @@ class CombinePDF2ActionUnitTest extends CarlosUnitTestBase {
     @ParameterizedTest
     @ValueSource(ints = {-1, 0})
     @DisplayName("should reject unmatched or invalid demographic links")
-    void shouldRejectNonPositiveDemographicLinks(int demographicNo) {
+    void shouldRejectNonPositiveDemographicLinks_whenUnmatchedOrInvalid(int demographicNo) {
         Document document = new Document();
 
         boolean authorized = action.isAuthorizedDocumentScope(
@@ -256,7 +256,7 @@ class CombinePDF2ActionUnitTest extends CarlosUnitTestBase {
 
     @Test
     @DisplayName("should reject demographic links that do not resolve to a patient")
-    void shouldRejectNonexistentDemographicLinks() {
+    void shouldRejectNonexistentDemographicLinks_whenPatientDoesNotResolve() {
         Document document = new Document();
         when(demographicDao.getDemographicById(456)).thenReturn(null);
 
@@ -269,7 +269,7 @@ class CombinePDF2ActionUnitTest extends CarlosUnitTestBase {
 
     @Test
     @DisplayName("should use an explicit provider link when a demographic link is unmatched")
-    void shouldUseProviderLinkWhenDemographicLinkIsUnmatched() {
+    void shouldUseProviderLink_whenDemographicLinkIsUnmatched() {
         Document document = new Document();
         document.setPublic1(0);
 
@@ -283,7 +283,7 @@ class CombinePDF2ActionUnitTest extends CarlosUnitTestBase {
 
     @Test
     @DisplayName("should reject when any valid demographic link is outside patient-record access")
-    void shouldRejectWhenAnyValidDemographicLinkIsUnauthorized() {
+    void shouldRejectDocument_whenAnyValidDemographicLinkIsUnauthorized() {
         Document document = new Document();
         when(securityInfoManager.isAllowedAccessToPatientRecord(loggedInInfo, 123)).thenReturn(true);
         when(securityInfoManager.isAllowedAccessToPatientRecord(loggedInInfo, 456)).thenReturn(false);
@@ -299,7 +299,7 @@ class CombinePDF2ActionUnitTest extends CarlosUnitTestBase {
 
     @Test
     @DisplayName("should reject documents outside the current facility")
-    void shouldRejectDocumentsOutsideCurrentFacility() {
+    void shouldRejectDocuments_outsideCurrentFacility() {
         Document document = new Document();
         document.setProgramId(77);
         when(programManager.hasAccessBasedOnCurrentFacility(loggedInInfo, 77)).thenReturn(false);
@@ -313,7 +313,7 @@ class CombinePDF2ActionUnitTest extends CarlosUnitTestBase {
 
     @Test
     @DisplayName("should reject program-restricted documents outside the provider domain")
-    void shouldRejectProgramRestrictedDocumentsOutsideProviderDomain() {
+    void shouldRejectProgramRestrictedDocuments_outsideProviderDomain() {
         Document document = new Document();
         document.setProgramId(77);
         document.setRestrictToProgram(true);
@@ -328,7 +328,7 @@ class CombinePDF2ActionUnitTest extends CarlosUnitTestBase {
 
     @Test
     @DisplayName("should allow program-restricted documents inside the provider domain")
-    void shouldAllowProgramRestrictedDocumentsInsideProviderDomain() {
+    void shouldAllowProgramRestrictedDocuments_insideProviderDomain() {
         Document document = new Document();
         document.setProgramId(77);
         document.setRestrictToProgram(true);
@@ -346,7 +346,7 @@ class CombinePDF2ActionUnitTest extends CarlosUnitTestBase {
 
     @Test
     @DisplayName("should honor disabled facility filtering")
-    void shouldHonorDisabledFacilityFiltering() {
+    void shouldHonorFacilitySetting_whenFilteringIsDisabled() {
         CarlosProperties.getInstance().setProperty("FILTER_ON_FACILITY", "false");
         Document document = new Document();
         document.setProgramId(77);
@@ -361,7 +361,7 @@ class CombinePDF2ActionUnitTest extends CarlosUnitTestBase {
 
     @Test
     @DisplayName("should allow public provider documents with mixed-case legacy links")
-    void shouldAllowPublicProviderDocumentsWithMixedCaseLegacyLinks() {
+    void shouldAllowPublicProviderDocuments_withMixedCaseLegacyLinks() {
         Document document = new Document();
         document.setPublic1(1);
 
@@ -373,7 +373,7 @@ class CombinePDF2ActionUnitTest extends CarlosUnitTestBase {
 
     @Test
     @DisplayName("should enforce patient access for mixed-case demographic links")
-    void shouldEnforcePatientAccessForMixedCaseDemographicLinks() {
+    void shouldEnforcePatientAccess_forMixedCaseDemographicLinks() {
         Document document = new Document();
         document.setPublic1(1);
         when(securityInfoManager.isAllowedAccessToPatientRecord(loggedInInfo, 123)).thenReturn(false);
@@ -388,7 +388,7 @@ class CombinePDF2ActionUnitTest extends CarlosUnitTestBase {
 
     @Test
     @DisplayName("should allow private provider documents only for the linked provider")
-    void shouldAllowPrivateProviderDocumentsOnlyForLinkedProvider() {
+    void shouldAllowPrivateProviderDocuments_forLinkedProviderOnly() {
         Document document = new Document();
         document.setPublic1(0);
 
@@ -400,7 +400,7 @@ class CombinePDF2ActionUnitTest extends CarlosUnitTestBase {
 
     @Test
     @DisplayName("should mark PDF responses private and non-cacheable")
-    void shouldConfigurePdfResponsesAsPrivateAndNonCacheable() {
+    void shouldConfigurePdfResponses_asPrivateAndNonCacheable() {
         action.configurePdfResponse("inline");
 
         assertThat(response.getContentType()).isEqualTo("application/pdf");
@@ -413,7 +413,7 @@ class CombinePDF2ActionUnitTest extends CarlosUnitTestBase {
 
     @Test
     @DisplayName("should audit every document read for a combined PDF")
-    void shouldAuditEveryDocumentReadForCombinedPdf() {
+    void shouldAuditEveryDocumentRead_forCombinedPdf() {
         Document first = new Document();
         first.setDocumentNo(321);
         Document second = new Document();

--- a/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2ActionUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/documentManager/actions/CombinePDF2ActionUnitTest.java
@@ -1,0 +1,211 @@
+/**
+ * Copyright (c) 2026 CARLOS Contributors. All Rights Reserved.
+ *
+ * This software is published under the GPL GNU General Public License.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ * CARLOS EMR Project
+ * https://github.com/carlos-emr/carlos
+ */
+package io.github.carlos_emr.carlos.documentManager.actions;
+
+import io.github.carlos_emr.carlos.commn.dao.CtlDocumentDao;
+import io.github.carlos_emr.carlos.commn.dao.DocumentDao;
+import io.github.carlos_emr.carlos.commn.model.CtlDocument;
+import io.github.carlos_emr.carlos.commn.model.CtlDocumentPK;
+import io.github.carlos_emr.carlos.commn.model.Document;
+import io.github.carlos_emr.carlos.managers.SecurityInfoManager;
+import io.github.carlos_emr.carlos.test.unit.CarlosUnitTestBase;
+import io.github.carlos_emr.carlos.utility.LoggedInInfo;
+import org.apache.struts2.ActionSupport;
+import org.apache.struts2.ServletActionContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@DisplayName("CombinePDF2Action")
+@Tag("unit")
+@Tag("documentManager")
+class CombinePDF2ActionUnitTest extends CarlosUnitTestBase {
+
+    private MockedStatic<ServletActionContext> servletActionContext;
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+    private CtlDocumentDao ctlDocumentDao;
+    private DocumentDao documentDao;
+    private SecurityInfoManager securityInfoManager;
+    private LoggedInInfo loggedInInfo;
+    private CombinePDF2Action action;
+
+    @BeforeEach
+    void setUp() {
+        securityInfoManager = mock(SecurityInfoManager.class);
+        ctlDocumentDao = mock(CtlDocumentDao.class);
+        documentDao = mock(DocumentDao.class);
+        registerMock(SecurityInfoManager.class, securityInfoManager);
+        registerMock(CtlDocumentDao.class, ctlDocumentDao);
+        registerMock(DocumentDao.class, documentDao);
+
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+        loggedInInfo = mock(LoggedInInfo.class);
+        when(loggedInInfo.getLoggedInProviderNo()).thenReturn("999998");
+        LoggedInInfo.setLoggedInInfoIntoSession(request.getSession(), loggedInInfo);
+        request.setParameter("docNo", "321");
+        when(securityInfoManager.hasPrivilege(loggedInInfo, "_edoc", "w", null)).thenReturn(true);
+
+        servletActionContext = mockStatic(ServletActionContext.class);
+        servletActionContext.when(ServletActionContext::getRequest).thenReturn(request);
+        servletActionContext.when(ServletActionContext::getResponse).thenReturn(response);
+        action = new CombinePDF2Action();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (servletActionContext != null) {
+            servletActionContext.close();
+        }
+    }
+
+    @Test
+    @DisplayName("should reject invalid document numbers before any lookup")
+    void shouldRejectInvalidDocumentNumbers_beforeAnyLookup() {
+        request.setParameter("docNo", "not-a-number");
+
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_BAD_REQUEST);
+        verifyNoInteractions(ctlDocumentDao, documentDao);
+    }
+
+    @Test
+    @DisplayName("should reject missing documents before resolving their paths")
+    void shouldRejectMissingDocumentsBeforeResolvingPaths() {
+        when(ctlDocumentDao.findByDocumentNos(List.of(321)))
+                .thenReturn(List.of(demographicLink(321, 123)));
+        when(securityInfoManager.isAllowedAccessToPatientRecord(loggedInInfo, 123)).thenReturn(true);
+        when(documentDao.find(321)).thenReturn(null);
+
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("should reject callers without eDoc write access before querying documents")
+    void shouldRejectCallerWithoutEdocWriteAccessBeforeQueryingDocuments() {
+        when(securityInfoManager.hasPrivilege(loggedInInfo, "_edoc", "w", null)).thenReturn(false);
+
+        assertThatThrownBy(action::execute)
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("_edoc");
+
+        verifyNoInteractions(ctlDocumentDao, documentDao);
+    }
+
+    @Test
+    @DisplayName("should reject documents outside the caller's patient-record access")
+    void shouldRejectDocumentsOutsidePatientRecordAccess() {
+        Document document = new Document();
+        document.setDocfilename("patient-document.pdf");
+        when(ctlDocumentDao.findByDocumentNos(List.of(321)))
+                .thenReturn(List.of(demographicLink(321, 123)));
+        when(documentDao.find(321)).thenReturn(document);
+        when(securityInfoManager.isAllowedAccessToPatientRecord(loggedInInfo, 123)).thenReturn(false);
+
+        String result = action.execute();
+
+        assertThat(result).isEqualTo(ActionSupport.NONE);
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_FORBIDDEN);
+        verify(documentDao).find(321);
+    }
+
+    @Test
+    @DisplayName("should allow public provider documents with mixed-case legacy links")
+    void shouldAllowPublicProviderDocumentsWithMixedCaseLegacyLinks() {
+        Document document = new Document();
+        document.setPublic1(1);
+
+        boolean authorized = action.isAuthorizedDocumentScope(
+                loggedInInfo, document, List.of(providerLink("PrOvIdErS", 321, 123456)));
+
+        assertThat(authorized).isTrue();
+    }
+
+    @Test
+    @DisplayName("should enforce patient access for mixed-case demographic links")
+    void shouldEnforcePatientAccessForMixedCaseDemographicLinks() {
+        Document document = new Document();
+        document.setPublic1(1);
+        when(securityInfoManager.isAllowedAccessToPatientRecord(loggedInInfo, 123)).thenReturn(false);
+
+        boolean authorized = action.isAuthorizedDocumentScope(loggedInInfo, document, List.of(
+                demographicLink("DeMoGrApHiC", 321, 123),
+                providerLink(321, 999998)));
+
+        assertThat(authorized).isFalse();
+        verify(securityInfoManager).isAllowedAccessToPatientRecord(loggedInInfo, 123);
+    }
+
+    @Test
+    @DisplayName("should allow private provider documents only for the linked provider")
+    void shouldAllowPrivateProviderDocumentsOnlyForLinkedProvider() {
+        Document document = new Document();
+        document.setPublic1(0);
+
+        assertThat(action.isAuthorizedDocumentScope(
+                loggedInInfo, document, List.of(providerLink(321, 999998)))).isTrue();
+        assertThat(action.isAuthorizedDocumentScope(
+                loggedInInfo, document, List.of(providerLink(321, 123456)))).isFalse();
+    }
+
+    private CtlDocument demographicLink(Integer documentNo, Integer demographicNo) {
+        return demographicLink("demographic", documentNo, demographicNo);
+    }
+
+    private CtlDocument demographicLink(String module, Integer documentNo, Integer demographicNo) {
+        CtlDocument ctlDocument = new CtlDocument();
+        ctlDocument.setId(new CtlDocumentPK(module, demographicNo, documentNo));
+        return ctlDocument;
+    }
+
+    private CtlDocument providerLink(Integer documentNo, Integer providerNo) {
+        return providerLink("provider", documentNo, providerNo);
+    }
+
+    private CtlDocument providerLink(String module, Integer documentNo, Integer providerNo) {
+        CtlDocument ctlDocument = new CtlDocument();
+        ctlDocument.setId(new CtlDocumentPK(module, providerNo, documentNo));
+        return ctlDocument;
+    }
+}


### PR DESCRIPTION
## The problem

`CombinePDF2Action` accepted a list of `docNo` values and combined them with no check that the requesting provider may see the patients those documents belong to.

The `_edoc` write privilege was enforced, but that is a module-level right, not a per-patient one. Any user who could reach the combine route could name arbitrary document numbers and receive their contents merged into a single PDF.

## Changes

- Resolve each document to its demographic links through `CtlDocumentDao` and require `isAllowedAccessToPatientRecord` for each.
- Refuse with 403 when a document has no demographic link, or the provider is not permitted.
- Reject invalid document numbers with 400 before any lookup runs.
- Preserve provider-scoped and legacy link shapes deliberately: a document may be linked by provider rather than demographic, and legacy rows carry link data in a different module column. Both are matched rather than treated as unlinked.

## Why this is a separate PR

This work was written inside the outbound email archive access branch (#3204) but does not belong to it. Splitting it out lets it be reviewed and merged on its own, ahead of the archive stack.

One piece was deliberately left behind: #3204 also makes this action refuse documents that back an outbound email archive artifact. That depends on `OutboundEmailArchiveDao` and stays with the archive lane. It is the only part of the original change not carried over.

## Note on the tests

`CombinePDF2ActionTest` is renamed to `*UnitTest`. The name it had is not selected by the pom's Surefire `<includes>`, so as written these authorization tests would never have run in CI — which for a security check is worse than having none, since the file reads like coverage.

## Verification

23/23 CombinePDF2Action unit tests and 5/5 CtlDocumentDao integration tests pass. Checkstyle and diff hygiene pass. The Surefire dark-test guard still passes.

## Context

Part of the #3204 split described in the [status update on #3096](https://github.com/carlos-emr/carlos/pull/3096#issuecomment-5344912812).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enforce per-document access controls before combining and returning eDoc PDFs.

Bug Fixes:
- Authorize every eDoc in a combined PDF request against patient, provider, facility, and program visibility before serving its contents.
- Reject malformed, missing, unauthorized, and oversized document requests with appropriate HTTP errors.

Enhancements:
- Support bulk document-link lookup while preserving demographic, provider-scoped, and legacy document associations.
- Prevent combined PDFs from being cached and record an audit entry for each document read.

Tests:
- Add DAO integration coverage and unit tests for document validation, authorization scopes, response security, and audit logging.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Authorizes each eDoc before combining PDFs so callers can no longer read documents outside their patient access. The combine route previously merged any `docNo` list with only `_edoc` write; it now validates each document, checks demographic and provider scopes, and enforces facility/program restrictions, returning 400/403/404/413 where appropriate.

- Adds `CtlDocumentDao.findByDocumentNos(Collection<Integer>)` for bulk link lookup.
- Rejects invalid, duplicate, or excessive (over 100) document numbers early.
- Requires `isAllowedAccessToPatientRecord` for demographic links; provider-linked documents pass only when public or owned by the caller.
- Enforces `FILTER_ON_FACILITY` and program-restricted document visibility.
- Hardens the PDF response with no-store caching and audits each document read.
- Adds unit and DAO integration tests; the original test class was renamed so CI runs it.
- No DB or config changes; refusing documents that back outbound email archive artifacts remains in #3204.

<sup>Written for commit 0d45af73583eaa2bc9c5a5d006d10bf9be59635b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


