### PR TITLE
fix(ci/docs): release-machinery follow-ups from a post-merge audit

### DIFF
--- a/.github/workflows/pr-type-labels.yml
+++ b/.github/workflows/pr-type-labels.yml
@@ -108,10 +108,15 @@ jobs:
             exit 0
           fi
           # Create-if-missing, then apply: gh pr edit refuses unknown labels.
+          # The create tolerates losing a race with another PR's concurrent
+          # run (per-PR concurrency groups don't serialize across PRs; an
+          # already-exists failure is success for our purposes) — the
+          # add-label below still fails loudly if the label truly is absent.
           if ! gh label list --repo "$REPO" --limit 200 --json name --jq '.[].name' \
               | grep -qxF "$desired"; then
             gh label create "$desired" --repo "$REPO" --color BFD4F2 \
-              --description "Release-notes category (applied from the PR title prefix)"
+              --description "Release-notes category (applied from the PR title prefix)" \
+              || echo "label create failed (likely created concurrently) — applying anyway"
           fi
           gh pr edit "$PR" --repo "$REPO" --add-label "$desired"
           echo "applied: $desired"

--- a/.github/workflows/pr-type-labels.yml
+++ b/.github/workflows/pr-type-labels.yml
@@ -77,6 +77,7 @@ jobs:
               refactor) desired="type: refactor" ;;
               docs)     desired="type: documentation" ;;
               test|tests) desired="type: tests" ;;
+              deps)     desired="type: dependencies" ;;
             esac
           fi
           if [ -z "$desired" ] && [[ "${ACTOR,,}" == dependabot* ]]; then

--- a/.github/workflows/pr-type-labels.yml
+++ b/.github/workflows/pr-type-labels.yml
@@ -1,0 +1,117 @@
+# GitHub Workflow: PR Type Labels
+#
+# Description:
+# Applies the `type: *` labels that .github/release.yml's generated release
+# notes categorize by, derived from the PR's Conventional Commits title
+# prefix. Without this, no automation labels PRs at all and every entry in
+# the generated notes falls into the "Other changes" catch-all.
+#
+# Mapping (title prefix -> label):
+#   feat            -> type: feature        perf     -> type: performance
+#   fix             -> type: bug            refactor -> type: refactor
+#   docs            -> type: documentation  test(s)  -> type: tests
+#   any(security)   -> type: security       (scope wins over the prefix)
+#   any(deps)/deps  -> type: dependencies   (Dependabot PRs included)
+#   chore/ci/build/style/update -> no label (lands under "Other changes")
+#
+# Security posture: pull_request_target runs with write permissions, so this
+# job deliberately performs NO checkout and executes NO code from the PR —
+# it only reads the PR title (handled as data, passed via env) and edits
+# labels through the gh CLI.
+#
+# License:
+# This GitHub Workflow file is part of the Carlos EMR project and is subject
+# to the licensing terms outlined in the repository's LICENSE file.
+#
+# Last Updated:
+# August 2026
+
+name: PR Type Labels
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened]
+
+permissions:
+  pull-requests: write
+  issues: write  # label creation goes through the Issues API
+
+concurrency:
+  group: pr-type-labels-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Derive and apply the type label from the PR title
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          TITLE: ${{ github.event.pull_request.title }}
+          ACTOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          set -euo pipefail
+
+          # Conventional Commits: type(scope)!: subject — capture type+scope.
+          # (The regex lives in a variable: inline parens inside [[ =~ ]]
+          # are a bash parse error.)
+          cc_re='^([A-Za-z]+)(\(([^)]*)\))?!?:'
+          prefix=""; scope=""
+          if [[ "$TITLE" =~ $cc_re ]]; then
+            prefix="${BASH_REMATCH[1],,}"
+            scope="${BASH_REMATCH[3],,}"
+          fi
+
+          desired=""
+          case "$scope" in
+            security) desired="type: security" ;;
+            deps|dependencies) desired="type: dependencies" ;;
+          esac
+          if [ -z "$desired" ]; then
+            case "$prefix" in
+              feat)     desired="type: feature" ;;
+              fix)      desired="type: bug" ;;
+              perf)     desired="type: performance" ;;
+              refactor) desired="type: refactor" ;;
+              docs)     desired="type: documentation" ;;
+              test|tests) desired="type: tests" ;;
+            esac
+          fi
+          if [ -z "$desired" ] && [[ "${ACTOR,,}" == dependabot* ]]; then
+            desired="type: dependencies"
+          fi
+
+          # The managed set: exactly the `type: *` labels release.yml
+          # categorizes by. Stale managed labels are swapped out when a
+          # title edit changes the mapping; labels outside this set are
+          # never touched.
+          managed=("type: security" "type: feature" "type: enhancement" \
+                   "type: bug" "type: performance" "type: refactor" \
+                   "type: dependencies" "type: documentation" "type: tests")
+          current=$(gh pr view "$PR" --repo "$REPO" --json labels --jq '.labels[].name')
+
+          for label in "${managed[@]}"; do
+            if [ "$label" != "$desired" ] && grep -qxF "$label" <<< "$current"; then
+              gh pr edit "$PR" --repo "$REPO" --remove-label "$label"
+              echo "removed stale label: $label"
+            fi
+          done
+
+          if [ -z "$desired" ]; then
+            echo "title prefix '${prefix:-none}' maps to no type label — the PR lands under 'Other changes'"
+            exit 0
+          fi
+          if grep -qxF "$desired" <<< "$current"; then
+            echo "label already present: $desired"
+            exit 0
+          fi
+          # Create-if-missing, then apply: gh pr edit refuses unknown labels.
+          if ! gh label list --repo "$REPO" --limit 200 --json name --jq '.[].name' \
+              | grep -qxF "$desired"; then
+            gh label create "$desired" --repo "$REPO" --color BFD4F2 \
+              --description "Release-notes category (applied from the PR title prefix)"
+          fi
+          gh pr edit "$PR" --repo "$REPO" --add-label "$desired"
+          echo "applied: $desired"

--- a/.github/workflows/pr-type-labels.yml
+++ b/.github/workflows/pr-type-labels.yml
@@ -20,7 +20,7 @@
 # labels through the gh CLI.
 #
 # License:
-# This GitHub Workflow file is part of the Carlos EMR project and is subject
+# This GitHub Workflow file is part of the CARLOS EMR project and is subject
 # to the licensing terms outlined in the repository's LICENSE file.
 #
 # Last Updated:
@@ -113,7 +113,7 @@ jobs:
           # run (per-PR concurrency groups don't serialize across PRs; an
           # already-exists failure is success for our purposes) — the
           # add-label below still fails loudly if the label truly is absent.
-          if ! gh label list --repo "$REPO" --limit 200 --json name --jq '.[].name' \
+          if ! gh api --paginate "repos/$REPO/labels?per_page=100" --jq '.[].name' \
               | grep -qxF "$desired"; then
             gh label create "$desired" --repo "$REPO" --color BFD4F2 \
               --description "Release-notes category (applied from the PR title prefix)" \

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -253,8 +253,18 @@ jobs:
             printf '%s\n' "$build_properties"
             exit 1
           fi
-          if grep -qi SNAPSHOT pom.xml || [[ "$war" == *SNAPSHOT* ]] || [[ "$sbom" == *SNAPSHOT* ]]; then
-            echo "::error::Release artifacts must not contain snapshot version metadata."
+          # Check the RESOLVED project version, not the raw pom text: a
+          # future comment, property name, or pinned dependency containing
+          # the word "snapshot" must not block every release. The artifact
+          # filenames are checked too — they embed the version the WAR/SBOM
+          # were actually built as.
+          project_version=$(python3 -c '
+          import xml.etree.ElementTree as ET
+          ns = {"m": "http://maven.apache.org/POM/4.0.0"}
+          v = ET.parse("pom.xml").getroot().find("m:version", ns)
+          print("" if v is None else (v.text or ""))')
+          if [[ "${project_version^^}" == *SNAPSHOT* ]] || [[ "$war" == *SNAPSHOT* ]] || [[ "$sbom" == *SNAPSHOT* ]]; then
+            echo "::error::Release artifacts must not contain snapshot version metadata (project.version='$project_version')."
             exit 1
           fi
 
@@ -332,5 +342,19 @@ jobs:
           if [ "$IS_PRERELEASE" = "true" ]; then
             gh release edit "$RELEASE_TAG" --repo "$REPO" --draft=false --prerelease --latest=false
           else
-            gh release edit "$RELEASE_TAG" --repo "$REPO" --draft=false --prerelease=false --latest
+            # A maintenance patch published from an OLDER release line (the
+            # documented supported-release flow) must not steal the repo's
+            # "latest release" pointer from a newer train: mark latest only
+            # when this tag tops every published stable release under the
+            # CalVer numeric sort (first-ever stable release wins trivially).
+            latest_flag=--latest
+            existing=$(gh release list --repo "$REPO" --exclude-drafts --exclude-pre-releases \
+              --limit 200 --json tagName --jq '.[].tagName')
+            top=$({ printf '%s\n' "$RELEASE_TAG"; printf '%s\n' "$existing"; } \
+              | sed '/^$/d' | sort -t. -k1,1n -k2,2n -k3,3n | tail -1)
+            if [ "$top" != "$RELEASE_TAG" ]; then
+              latest_flag=--latest=false
+              echo "A newer stable release ($top) is already published — not marking $RELEASE_TAG as latest."
+            fi
+            gh release edit "$RELEASE_TAG" --repo "$REPO" --draft=false --prerelease=false "$latest_flag"
           fi

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -292,9 +292,10 @@ jobs:
         run: |
           set -euo pipefail
 
-          previous_tag=$(gh release list --repo "$REPO" --limit 100 \
-            --json tagName,isDraft,publishedAt \
-            --jq ".[] | select(.isDraft == false) | .tagName" |
+          # Paginated: a fixed --limit would silently miss the same-line
+          # predecessor once the repo accumulates more releases than the cap.
+          previous_tag=$(gh api --paginate "repos/$REPO/releases?per_page=100" \
+            --jq '.[] | select(.draft | not) | .tag_name' |
             grep -E "^$RELEASE_LINE\." |
             grep -Fxv "$RELEASE_TAG" |
             head -n 1 || true)
@@ -353,9 +354,12 @@ jobs:
             # "latest release" pointer from a newer train: mark latest only
             # when this tag tops every published stable release under the
             # CalVer numeric sort (first-ever stable release wins trivially).
+            # Paginated: a fixed --limit would stop seeing the newest stable
+            # release once the repo accumulates more releases than the cap,
+            # letting an old-train patch wrongly grab the latest pointer.
             latest_flag=--latest
-            existing=$(gh release list --repo "$REPO" --exclude-drafts --exclude-pre-releases \
-              --limit 200 --json tagName --jq '.[].tagName')
+            existing=$(gh api --paginate "repos/$REPO/releases?per_page=100" \
+              --jq '.[] | select((.draft or .prerelease) | not) | .tag_name')
             top=$({ printf '%s\n' "$RELEASE_TAG"; printf '%s\n' "$existing"; } \
               | sed '/^$/d' | sort -t. -k1,1n -k2,2n -k3,3n | tail -1)
             if [ "$top" != "$RELEASE_TAG" ]; then

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -11,8 +11,14 @@ on:
         required: true
         type: string
 
+# One GLOBAL group (not per-tag): the publish step's latest-pointer decision
+# reads the set of already-published stable releases, so two stable tags
+# publishing concurrently could each miss the other (still a draft at query
+# time) and both claim --latest. Releases are rare and deliberate — strict
+# serialization costs nothing and removes the race; same-tag re-runs still
+# queue exactly as before.
 concurrency:
-  group: release-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+  group: publish-release
   cancel-in-progress: false
 
 permissions:

--- a/database/mysql/migration/README.md
+++ b/database/mysql/migration/README.md
@@ -31,9 +31,11 @@ migration/
 
 The **genesis baseline** is `V1` + the province `V1.0.1`/`V1.0.2` files (frozen). Everything from
 `V1.0.3` onward is a forward delta. The highest version currently in use is `V1.0.13`. The next
-Ontario or shared migration is `V1.0.14`; the next BC-only migration is `V1.0.11` because Ontario
-and BC locations are mutually exclusive (the version line is global only across `common` + the
-selected province — see below).
+Ontario or shared migration is `V1.0.14` — and so is the next BC-only migration: although Ontario
+and BC locations are mutually exclusive (a number used only under `on/` could in principle recur
+under `bc/`), the shared `common/` line is in EVERY database's path, and Flyway (no `outOfOrder`)
+never applies a new migration numbered below the highest it has already run — `common/V1.0.13` —
+so a `bc/V1.0.11` would silently never reach BC installs and would fail `flyway validate`.
 
 A database applies **`common` + exactly one province** location, selected by `flyway.locations`:
 

--- a/database/mysql/migration/README.md
+++ b/database/mysql/migration/README.md
@@ -30,12 +30,14 @@ migration/
 ```
 
 The **genesis baseline** is `V1` + the province `V1.0.1`/`V1.0.2` files (frozen). Everything from
-`V1.0.3` onward is a forward delta. The highest version currently in use is `V1.0.13`. The next
-Ontario or shared migration is `V1.0.14` — and so is the next BC-only migration: although Ontario
-and BC locations are mutually exclusive (a number used only under `on/` could in principle recur
-under `bc/`), the shared `common/` line is in EVERY database's path, and Flyway (no `outOfOrder`)
-never applies a new migration numbered below the highest it has already run — `common/V1.0.13` —
-so a `bc/V1.0.11` would silently never reach BC installs and would fail `flyway validate`.
+`V1.0.3` onward is a forward delta. The highest version currently in use is `V1.0.13`, and the
+next free number for ANY location — shared or province — is `V1.0.14`. The version line is global:
+the shared `common/` line is in EVERY database's path, and on an **already-migrated database**
+Flyway (no `outOfOrder`) never applies a new migration numbered below the highest it has already
+run — `common/V1.0.13` today. A hypothetical new `bc/V1.0.11` would apply fine on a fresh install
+(version order places it before `common/V1.0.13`) but would silently never run on existing BC
+databases and would fail `flyway validate` there — so never number a new migration at or below the
+global high-water mark, even if that number was only ever used under the other province.
 
 A database applies **`common` + exactly one province** location, selected by `flyway.locations`:
 

--- a/database/mysql/migration/bc/README.md
+++ b/database/mysql/migration/bc/README.md
@@ -9,5 +9,7 @@ Forward deltas (not part of the frozen baseline):
 
 Applied together with `common/` for a BC install (`flyway.locations=filesystem:.../migration/common,filesystem:.../migration/bc` (see `flyway.conf` for the real paths)). New BC-only
 changes go here as `V1.0.N__short_description.sql` (sequential, next free version number). The
-version line is global across `common` + `bc`, so the next free BC-only number is `V1.0.11` (the
-highest migration in the BC path is the shared `V1.0.10`; see `../README.md`).
+version line is global across `common` + `bc`, so the next free BC-only number is `V1.0.14` (the
+highest migration in the BC path is the shared `common/V1.0.13`; a lower number — even one only
+ever used under `on/` — would be out-of-order below the applied `V1.0.13` and Flyway would never
+run it; see `../README.md`).

--- a/database/mysql/migration/bc/README.md
+++ b/database/mysql/migration/bc/README.md
@@ -9,7 +9,5 @@ Forward deltas (not part of the frozen baseline):
 
 Applied together with `common/` for a BC install (`flyway.locations=filesystem:.../migration/common,filesystem:.../migration/bc` (see `flyway.conf` for the real paths)). New BC-only
 changes go here as `V1.0.N__short_description.sql` (sequential, next free version number). The
-version line is global across `common` + `bc`, so the next free BC-only number is `V1.0.14` (the
-highest migration in the BC path is the shared `common/V1.0.13`; a lower number — even one only
-ever used under `on/` — would be out-of-order below the applied `V1.0.13` and Flyway would never
-run it; see `../README.md`).
+version line is global across `common` + `bc`, so the next free BC-only number is `V1.0.14` — see
+`../README.md` for why a lower number must never be reused.


### PR DESCRIPTION
A high-effort post-merge audit of the release machinery (#3463 + #3470 + follow-ups) surfaced four still-valid issues; each was verified against current develop before fixing. (Two more audit findings — the DCO "Update branch" exemption and the strict-head retry check — were already fixed on develop by #3480/#3486-era commits, so they are not touched here.)

## 1. Migration READMEs advised an out-of-order BC number (docs-only, but a real trap)

`bc/README.md` and `migration/README.md` said the next BC-only migration is `V1.0.11` ("highest in the BC path is the shared V1.0.10"). Stale twice over: the shared `common/V1.0.13` collation fix is in **every** database's Flyway path, and `flyway.conf` sets no `outOfOrder` — so a new `bc/V1.0.11` would resolve below the already-applied `V1.0.13`, silently never run on BC installs, and fail `flyway validate`. Both READMEs now say `V1.0.14` and explain why ON/BC mutual exclusivity doesn't permit numbers below the shared line's high-water mark.

## 2. Every stable release grabbed `--latest`

A maintenance patch published from an older `release/YYYY.MM` line (exactly the flow `docs/release-process.md` prescribes) would steal GitHub's "latest release" pointer from the newer train. The publish step now marks latest only when the tag tops every published stable release under a CalVer numeric sort. Verified against old-train-patch, newest-train-patch, first-ever-stable, and numeric-vs-lexicographic patch cases (`2026.09.10` > `2026.09.9`).

## 3. The SNAPSHOT guard grepped the whole pom

`grep -qi SNAPSHOT pom.xml` meant any future comment, property name, or pinned dependency containing "snapshot" would block **every** release. The guard now checks the resolved `project.version` (XML-parsed; verified it extracts `2026.09.0-SNAPSHOT` from the current pom) plus the artifact filenames.

## 4. `release.yml`'s changelog categories were inert

Generated release notes categorize by `type: *` PR labels, but nothing applied those labels to PRs — every entry fell into "Other changes". New `pr-type-labels.yml` derives the label from the Conventional Commits title prefix (a `(security)`/`(deps)` scope wins over the prefix; Dependabot maps to dependencies), swaps stale managed labels on title edits, creates missing labels before applying, and never touches labels outside the managed set. `pull_request_target` with **no checkout and no PR code execution** — the title is data via env. Mapping verified against 12 title/actor cases.

## Testing

Both workflows: `yaml.safe_load` clean + `bash -n` on every embedded script. Latest-guard sort, label mapping, and pom version parse each functionally tested (6/6, 12/12, and live-pom cases respectively). Docs changes cross-checked against `ls database/mysql/migration/*/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014NKLrJmtqdVuRiRVUjVwKg

---
_Generated by [Claude Code](https://claude.ai/code/session_014NKLrJmtqdVuRiRVUjVwKg)_

## Summary by Sourcery

Harden release automation and migration guidance while enabling accurate pull-request categorization in generated release notes.

New Features:
- Automatically apply managed release-note type labels to pull requests from Conventional Commit titles and Dependabot authors.

Bug Fixes:
- Prevent older release trains from taking the latest-release pointer and avoid blocking releases because unrelated POM text contains SNAPSHOT.
- Correct migration guidance so new migrations use the global version high-water mark and avoid Flyway ordering failures.

Enhancements:
- Serialize release publication and use paginated release queries for reliable latest-release decisions.

CI:
- Add a secure pull-request labeling workflow that runs without checking out or executing pull-request code.

Documentation:
- Update MySQL migration documentation to require V1.0.14 or later and explain the global Flyway version ordering.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens release workflows and corrects migration docs after a post-merge audit. Prevents older-line patches from taking Latest, narrows the SNAPSHOT guard to the resolved version, paginates lookups to avoid truncation, and auto-labels PRs so generated release notes categorize correctly.

- Migration docs: `migration/README.md` and `bc/README.md` set the next BC-only migration to V1.0.14 and clarify the global version line: lower-numbered province migrations would run only on fresh installs but are skipped on already-migrated databases (no `outOfOrder`) and fail `flyway validate`. Required action: create BC-only migrations at V1.0.14 or higher.
- Release publish: older behavior always set `--latest`. New behavior marks Latest only when the tag is the highest published stable by numeric CalVer sort; the first stable still marks Latest. Also serializes publication and paginates release lookups to avoid missing newer stables as the repo grows.
- SNAPSHOT guard: older behavior grepped `pom.xml`. New behavior checks the resolved `project.version` (XML-parsed) and artifact filenames; comments or dependency names containing “snapshot” no longer block releases.
- PR labeling: adds `pr-type-labels.yml` to apply `type: *` labels from Conventional Commits titles. Handles `(security)`/`(deps)` scopes, a `deps:` prefix, and Dependabot; swaps stale managed labels; creates missing labels (tolerates create races), paginates label lookups, and leaves non-managed labels untouched. Runs on `pull_request_target` with no checkout or PR code execution.

<sup>Written for commit 173072fbeb2d2b9726e6eec5435dbe18b84feddc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

