### PR TITLE
chore(release): prepare 2026.08.0-alpha3

### DIFF
--- a/.devcontainer/db/scripts/populate_db.sh
+++ b/.devcontainer/db/scripts/populate_db.sh
@@ -51,6 +51,11 @@ trap 'rm -f "${LOAD_SQL}"' EXIT
   cat "${MIG}/common/V1__baseline_schema.sql" \
       "${MIG}/on/V1.0.1__on_schema.sql" \
       "${MIG}/on/V1.0.2__on_data.sql"
+  # The genesis files issue a bare SET NAMES utf8mb4, whose default collation is
+  # uca1400 on current MariaDB images. Re-pin the connection before the forward
+  # chain so the checksum-frozen V1.0.7 migration can compare against its
+  # utf8mb4_general_ci table and the later repair migration remains reachable.
+  echo "SET NAMES utf8mb4 COLLATE utf8mb4_general_ci;"
   if [ -n "${FORWARD}" ]; then
     for f in ${FORWARD}; do
       echo "-- including $(basename "$f")" >&2

--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -6,7 +6,7 @@
 #
 # This check can also pass if an authorized maintainer with write or higher
 # repository permission posts a PR comment containing:
-#   Confirming DCO sign off for all commits
+#   Confirming DCO sign off for all commits at <full PR head SHA>
 #
 # This workflow intentionally uses pull_request_target and the GitHub API
 # instead of checking out PR code. That lets it post guidance comments on fork
@@ -249,12 +249,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          commit_json=$(curl -fsSL \
-            -H "Authorization: Bearer $GH_TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/$REPO/commits/$HEAD_SHA")
-          latest_commit_at=$(jq -r '.commit.committer.date // .commit.author.date' <<< "$commit_json")
-          latest_commit_epoch=$(date -d "$latest_commit_at" +%s)
+          expected_confirmation="$CONFIRMATION_PHRASE at $HEAD_SHA"
 
           page=1
           found=false
@@ -277,22 +272,14 @@ jobs:
             while IFS= read -r comment; do
               body=$(jq -r '.body // ""' <<< "$comment")
               author=$(jq -r '.author' <<< "$comment")
-              created_at=$(jq -r '.created_at' <<< "$comment")
               updated_at=$(jq -r '.updated_at' <<< "$comment")
-              created_epoch=$(date -d "$created_at" +%s)
-              updated_epoch=$(date -d "$updated_at" +%s)
               comment_confirmed_at="$updated_at"
-              comment_confirmed_epoch="$updated_epoch"
-              if [ "$updated_epoch" -lt "$created_epoch" ]; then
-                echo "::error::PR #$PR_NUMBER: DCO confirmation comment timestamp integrity check failed for $author: updated_at ($updated_at) is earlier than created_at ($created_at)."
-                exit 1
-              fi
 
               if printf '%s\n' "$body" | grep -qiF "$CONFIRMATION_PHRASE"; then
-                if [ "$comment_confirmed_epoch" -le "$latest_commit_epoch" ]; then
+                if ! printf '%s\n' "$body" | grep -qiFx "$expected_confirmation"; then
                   stale_confirmation_found=true
-                  # Continue scanning so every stale confirmation gets a warning and a newer fresh confirmation can still pass.
-                  echo "::warning::PR #$PR_NUMBER: Ignoring stale DCO confirmation from $author at $comment_confirmed_at (latest commit is $latest_commit_at). A fresh confirmation is required after the latest commit."
+                  # Continue scanning so every confirmation for an earlier revision gets a warning and a current confirmation can still pass.
+                  echo "::warning::PR #$PR_NUMBER: Ignoring DCO confirmation from $author at $comment_confirmed_at because it is not bound to the current PR head $HEAD_SHA. Post the exact confirmation for the current revision."
                   continue
                 fi
 
@@ -323,7 +310,6 @@ jobs:
             done < <(jq -c '.[] | {
               body: .body,
               author: .user.login,
-              created_at: .created_at,
               updated_at: .updated_at
             }' <<< "$comments")
 
@@ -339,7 +325,6 @@ jobs:
           echo "confirming_permission=$confirming_permission" >> "$GITHUB_OUTPUT"
           echo "confirming_role=$confirming_role" >> "$GITHUB_OUTPUT"
           echo "confirming_at=$confirming_at" >> "$GITHUB_OUTPUT"
-          echo "latest_commit_at=$latest_commit_at" >> "$GITHUB_OUTPUT"
           echo "stale_confirmation_found=$stale_confirmation_found" >> "$GITHUB_OUTPUT"
 
       - name: Report result
@@ -355,9 +340,9 @@ jobs:
           CONFIRMING_PERMISSION: ${{ steps.manual_check.outputs.confirming_permission }}
           CONFIRMING_ROLE: ${{ steps.manual_check.outputs.confirming_role }}
           CONFIRMING_AT: ${{ steps.manual_check.outputs.confirming_at }}
-          LATEST_COMMIT_AT: ${{ steps.manual_check.outputs.latest_commit_at }}
           STALE_CONFIRMATION_FOUND: ${{ steps.manual_check.outputs.stale_confirmation_found }}
           DCO_TRUNCATED: ${{ steps.dco_check.outputs.dco_truncated }}
+          CONFIRMATION_PHRASE: Confirming DCO sign off for all commits
         run: |
           set -euo pipefail
 
@@ -485,7 +470,7 @@ jobs:
                 echo ""
                 echo "Thank you, **$CONFIRMING_USER** ($CONFIRMING_ROLE)."
                 echo ""
-                echo "The DCO check has passed using manual PR sign-off. No commit changes are required."
+                echo "The DCO check has passed using manual sign-off for PR head \`$HEAD_SHA\`. No commit changes are required."
               } > /tmp/dco_success_comment.md
               if ! post_comment /tmp/dco_success_comment.md; then
                 echo "::warning::DCO passed, but the workflow could not post its optional success comment."
@@ -504,7 +489,9 @@ jobs:
               echo ""
               echo "Please reduce the PR commit count or have an authorized maintainer with write or higher repository permission post the manual confirmation phrase below after reviewing DCO coverage."
               echo ""
-              echo "> Confirming DCO sign off for all commits"
+              echo '```text'
+              echo "$CONFIRMATION_PHRASE at $HEAD_SHA"
+              echo '```'
               echo ""
               echo "See https://developercertificate.org/ for DCO details."
             } > /tmp/dco_failure_comment.md
@@ -538,9 +525,11 @@ jobs:
               echo ""
               echo "### Manual confirmation fallback"
               echo ""
-              echo "An authorized maintainer with write or higher repository permission can confirm DCO sign-off after reviewing the connected history by posting this exact phrase:"
+              echo "An authorized maintainer with write or higher repository permission can confirm DCO sign-off after reviewing the connected history by posting this exact phrase for the current PR revision:"
               echo ""
-              echo "> Confirming DCO sign off for all commits"
+              echo '```text'
+              echo "$CONFIRMATION_PHRASE at $HEAD_SHA"
+              echo '```'
               echo ""
               echo "See https://developercertificate.org/ for DCO details."
             } > /tmp/dco_failure_comment.md

--- a/.github/workflows/pr-type-labels.yml
+++ b/.github/workflows/pr-type-labels.yml
@@ -1,0 +1,125 @@
+# GitHub Workflow: PR Type Labels
+#
+# Description:
+# Applies the `type: *` labels that .github/release.yml's generated release
+# notes categorize by, derived from the PR's Conventional Commits title
+# prefix. Without this, no automation labels PRs at all and every entry in
+# the generated notes falls into the "Other changes" catch-all.
+#
+# Mapping (title prefix -> label):
+#   feat            -> type: feature        perf     -> type: performance
+#   fix             -> type: bug            refactor -> type: refactor
+#   docs            -> type: documentation  test(s)  -> type: tests
+#   any(security)   -> type: security       (scope wins over the prefix)
+#   any(deps)/deps  -> type: dependencies   (Dependabot PRs included)
+#   chore/ci/build/style/update -> no label (lands under "Other changes")
+#
+# Security posture: pull_request_target runs with write permissions, so this
+# job deliberately performs NO checkout and executes NO code from the PR —
+# it only reads the PR title (handled as data, passed via env) and edits
+# labels through the gh CLI.
+#
+# License:
+# This GitHub Workflow file is part of the CARLOS EMR project and is subject
+# to the licensing terms outlined in the repository's LICENSE file.
+#
+# Last Updated:
+# August 2026
+
+name: PR Type Labels
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened]
+
+permissions:
+  pull-requests: write
+  issues: write  # label creation goes through the Issues API
+
+concurrency:
+  group: pr-type-labels-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Derive and apply the type label from the PR title
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          TITLE: ${{ github.event.pull_request.title }}
+          ACTOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          set -euo pipefail
+
+          # Conventional Commits: type(scope)!: subject — capture type+scope.
+          # (The regex lives in a variable: inline parens inside [[ =~ ]]
+          # are a bash parse error.)
+          cc_re='^([A-Za-z]+)(\(([^)]*)\))?!?:'
+          prefix=""; scope=""
+          if [[ "$TITLE" =~ $cc_re ]]; then
+            prefix="${BASH_REMATCH[1],,}"
+            scope="${BASH_REMATCH[3],,}"
+          fi
+
+          desired=""
+          case "$scope" in
+            security) desired="type: security" ;;
+            deps|dependencies) desired="type: dependencies" ;;
+          esac
+          if [ -z "$desired" ]; then
+            case "$prefix" in
+              feat)     desired="type: feature" ;;
+              fix)      desired="type: bug" ;;
+              perf)     desired="type: performance" ;;
+              refactor) desired="type: refactor" ;;
+              docs)     desired="type: documentation" ;;
+              test|tests) desired="type: tests" ;;
+              deps)     desired="type: dependencies" ;;
+            esac
+          fi
+          if [ -z "$desired" ] && [[ "${ACTOR,,}" == dependabot* ]]; then
+            desired="type: dependencies"
+          fi
+
+          # The managed set: exactly the `type: *` labels release.yml
+          # categorizes by. Stale managed labels are swapped out when a
+          # title edit changes the mapping; labels outside this set are
+          # never touched. `type: enhancement` is a legacy alias for
+          # `type: feature`; it remains managed only so stale uses are
+          # removed rather than propagated by the automation.
+          managed=("type: security" "type: feature" "type: enhancement" \
+                   "type: bug" "type: performance" "type: refactor" \
+                   "type: dependencies" "type: documentation" "type: tests")
+          current=$(gh pr view "$PR" --repo "$REPO" --json labels --jq '.labels[].name')
+
+          for label in "${managed[@]}"; do
+            if [ "$label" != "$desired" ] && grep -qxF "$label" <<< "$current"; then
+              gh pr edit "$PR" --repo "$REPO" --remove-label "$label"
+              echo "removed stale label: $label"
+            fi
+          done
+
+          if [ -z "$desired" ]; then
+            echo "title prefix '${prefix:-none}' maps to no type label — the PR lands under 'Other changes'"
+            exit 0
+          fi
+          if grep -qxF "$desired" <<< "$current"; then
+            echo "label already present: $desired"
+            exit 0
+          fi
+          # Create-if-missing, then apply: gh pr edit refuses unknown labels.
+          # The create tolerates losing a race with another PR's concurrent
+          # run (per-PR concurrency groups don't serialize across PRs; an
+          # already-exists failure is success for our purposes) — the
+          # add-label below still fails loudly if the label truly is absent.
+          if ! gh api --paginate "repos/$REPO/labels?per_page=100" --jq '.[].name' \
+              | grep -qxF "$desired"; then
+            gh label create "$desired" --repo "$REPO" --color BFD4F2 \
+              --description "Release-notes category (applied from the PR title prefix)" \
+              || echo "label create failed (likely created concurrently) — applying anyway"
+          fi
+          gh pr edit "$PR" --repo "$REPO" --add-label "$desired"
+          echo "applied: $desired"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -11,8 +11,14 @@ on:
         required: true
         type: string
 
+# One GLOBAL group (not per-tag): the publish step's latest-pointer decision
+# reads the set of already-published stable releases, so two stable tags
+# publishing concurrently could each miss the other (still a draft at query
+# time) and both claim --latest. Releases are rare and deliberate — strict
+# serialization costs nothing and removes the race; same-tag re-runs still
+# queue exactly as before.
 concurrency:
-  group: release-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+  group: publish-release
   cancel-in-progress: false
 
 permissions:
@@ -23,6 +29,7 @@ jobs:
     name: Validate release tag
     runs-on: ubuntu-latest
     permissions:
+      # Required to inspect prior workflow runs and validation-job results for dispatch retries.
       actions: read
       contents: read
     outputs:
@@ -252,8 +259,18 @@ jobs:
             printf '%s\n' "$build_properties"
             exit 1
           fi
-          if grep -qi SNAPSHOT pom.xml || [[ "$war" == *SNAPSHOT* ]] || [[ "$sbom" == *SNAPSHOT* ]]; then
-            echo "::error::Release artifacts must not contain snapshot version metadata."
+          # Check the RESOLVED project version, not the raw pom text: a
+          # future comment, property name, or pinned dependency containing
+          # the word "snapshot" must not block every release. The artifact
+          # filenames are checked too — they embed the version the WAR/SBOM
+          # were actually built as.
+          project_version=$(python3 -c '
+          import xml.etree.ElementTree as ET
+          ns = {"m": "http://maven.apache.org/POM/4.0.0"}
+          v = ET.parse("pom.xml").getroot().find("m:version", ns)
+          print("" if v is None else (v.text or ""))')
+          if [[ "${project_version^^}" == *SNAPSHOT* ]] || [[ "$war" == *SNAPSHOT* ]] || [[ "$sbom" == *SNAPSHOT* ]]; then
+            echo "::error::Release artifacts must not contain snapshot version metadata (project.version='$project_version')."
             exit 1
           fi
 
@@ -275,9 +292,10 @@ jobs:
         run: |
           set -euo pipefail
 
-          previous_tag=$(gh release list --repo "$REPO" --limit 100 \
-            --json tagName,isDraft,publishedAt \
-            --jq ".[] | select(.isDraft == false) | .tagName" |
+          # Paginated: a fixed --limit would silently miss the same-line
+          # predecessor once the repo accumulates more releases than the cap.
+          previous_tag=$(gh api --paginate "repos/$REPO/releases?per_page=100" \
+            --jq '.[] | select(.draft | not) | .tag_name' |
             grep -E "^$RELEASE_LINE\." |
             grep -Fxv "$RELEASE_TAG" |
             head -n 1 || true)
@@ -331,5 +349,22 @@ jobs:
           if [ "$IS_PRERELEASE" = "true" ]; then
             gh release edit "$RELEASE_TAG" --repo "$REPO" --draft=false --prerelease --latest=false
           else
-            gh release edit "$RELEASE_TAG" --repo "$REPO" --draft=false --prerelease=false --latest
+            # A maintenance patch published from an OLDER release line (the
+            # documented supported-release flow) must not steal the repo's
+            # "latest release" pointer from a newer train: mark latest only
+            # when this tag tops every published stable release under the
+            # CalVer numeric sort (first-ever stable release wins trivially).
+            # Paginated: a fixed --limit would stop seeing the newest stable
+            # release once the repo accumulates more releases than the cap,
+            # letting an old-train patch wrongly grab the latest pointer.
+            latest_flag=--latest
+            existing=$(gh api --paginate "repos/$REPO/releases?per_page=100" \
+              --jq '.[] | select((.draft or .prerelease) | not) | .tag_name')
+            top=$({ printf '%s\n' "$RELEASE_TAG"; printf '%s\n' "$existing"; } \
+              | sed '/^$/d' | sort -t. -k1,1n -k2,2n -k3,3n | tail -1)
+            if [ "$top" != "$RELEASE_TAG" ]; then
+              latest_flag=--latest=false
+              echo "A newer stable release ($top) is already published — not marking $RELEASE_TAG as latest."
+            fi
+            gh release edit "$RELEASE_TAG" --repo "$REPO" --draft=false --prerelease=false "$latest_flag"
           fi

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -22,7 +22,7 @@
 # to the licensing terms outlined in the repository's LICENSE file.
 #
 # Last Updated:
-# April 2026
+# August 2026
 
 name: SonarCloud Analysis
 
@@ -231,3 +231,15 @@ jobs:
                 \"-Dsonar.pullrequest.branch=\$PR_BRANCH\" \
                 \"-Dsonar.pullrequest.base=\$PR_BASE\" \
                             "
+
+      # The dev container runs as root and leaves root-owned files in the
+      # mounted workspace (.m2-cache, .sonar-cache, target/**). The post-job
+      # cache save runs as the runner user: it re-evaluates the cache key's
+      # hashFiles('**/pom.xml', ...) across the workspace and tars the cache
+      # directories, so unreadable root-owned paths fail the job even after a
+      # successful analysis. Only cold-cache runs hit this — an exact-key
+      # cache hit skips the save step entirely, which is why warm-cache runs
+      # never saw it. Restore runner ownership before the post steps run.
+      - name: Fix workspace ownership for cache save
+        if: always()
+        run: sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,13 +73,17 @@ git push --force-with-lease
 #### Manual DCO Confirmation (Alternate)
 
 If you cannot amend your commits (e.g., force-push is not possible), an authorized user
-can retroactively confirm DCO sign-off by posting a PR comment with the exact phrase:
+with `write` or higher repository permission can retroactively confirm DCO sign-off after
+reviewing the connected history. The comment must contain the exact phrase followed by
+the current full 40-character PR head SHA:
 
-> Confirming DCO sign off for all commits
+```text
+Confirming DCO sign off for all commits at <full-pr-head-sha>
+```
 
-This will re-trigger the DCO check and allow it to pass. Only users with an established
-repository relationship (OWNER, MEMBER, COLLABORATOR, or CONTRIBUTOR) can use this
-alternate confirmation. First-time contributors must use the commit sign-off method.
+This will re-trigger the DCO check and allow it to pass only for that exact revision. Any
+subsequent push changes the PR head SHA and requires a new maintainer confirmation.
+Contributors without `write` access must use the commit sign-off method.
 
 ## Ways to Contribute
 

--- a/database/mysql/migration/README.md
+++ b/database/mysql/migration/README.md
@@ -68,6 +68,34 @@ Demo/patient data is **not** in this baseline — it belongs in a dev-only `demo
   been retired (recoverable from git history). Do not regenerate it — evolve the schema forward.
 - **drugref2 is a separate database** — not managed here (keeps `../development-drugref.sql` + `../drugref/*.sql`).
 
+## MariaDB CLI recovery for V1.0.7
+
+Flyway/JDBC runs negotiate a compatible connection collation, and the development bootstrap pins
+one before applying forward migrations. A manual `mysql`/`mariadb` run through `carlos-ctl db`,
+however, may use `utf8mb4_uca1400_ai_ci` on MariaDB 11.4 or newer. In that session V1.0.7 can stop
+with `ERROR 1267 (Illegal mix of collations)` after its DDL and before its guarded backfill inserts.
+
+If that happens, rerun V1.0.7 with the compatible collation established in the **same client
+session**:
+
+```bash
+{
+  printf '%s\n' 'SET NAMES utf8mb4 COLLATE utf8mb4_general_ci;'
+  cat common/V1.0.7__restore_phcp_diagnosis_groups.sql
+} | sudo EMR_HOME=/usr/local/emr carlos-ctl db oscar
+```
+
+Run this from `database/mysql/migration/`, then continue with V1.0.8 through V1.0.13 in global
+version order. V1.0.7 is safe to rerun: its DDL is repeatable and both inserts exclude rows already
+present. A separate `SET NAMES` invocation does **not** work because the setting ends with that
+client process. Do not add `--force`; continuing after an unrelated SQL error could leave the
+schema in an unknown state.
+
+V1.0.13 is an idempotent no-op after the pinned V1.0.7 rerun. It also fills the missing rows when
+an operator previously bypassed the V1.0.7 error and continued directly to later migrations.
+Automatic protection in the deployment CLI is tracked in
+[carlos-podman #17](https://github.com/carlos-emr/carlos-podman/issues/17).
+
 ## Evolving the schema
 
 Add a forward migration under the right location — `common/` for shared changes, `on/`/`bc/` for

--- a/database/mysql/migration/README.md
+++ b/database/mysql/migration/README.md
@@ -17,6 +17,7 @@ migration/
            V1.0.8__expand_appointment_type_location.sql
            V1.0.9__remove_carlosdoc_schedule_group_denial.sql
            V1.0.10__seed_default_measurement_groups.sql
+           V1.0.13__fix_phcp_diagnosis_group_backfill_collation.sql
   on/      V1.0.1__on_schema.sql            # Ontario-only tables (structure)
            V1.0.2__on_data.sql              # Ontario reference data (rows)
            V1.0.4__on_performance_indexes.sql
@@ -29,10 +30,14 @@ migration/
 ```
 
 The **genesis baseline** is `V1` + the province `V1.0.1`/`V1.0.2` files (frozen). Everything from
-`V1.0.3` onward is a forward delta. The highest version currently shipped is `V1.0.12`. The next
-Ontario or shared migration is `V1.0.13`; the next BC-only migration is `V1.0.11` because Ontario
-and BC locations are mutually exclusive (the version line is global only across `common` + the
-selected province — see below).
+`V1.0.3` onward is a forward delta. The highest version currently in use is `V1.0.13`, and the
+next free number for ANY location — shared or province — is `V1.0.14`. The version line is global:
+the shared `common/` line is in EVERY database's path, and on an **already-migrated database**
+Flyway (no `outOfOrder`) never applies a new migration numbered below the highest it has already
+run — `common/V1.0.13` today. A hypothetical new `bc/V1.0.11` would apply fine on a fresh install
+(version order places it before `common/V1.0.13`) but would silently never run on existing BC
+databases and would fail `flyway validate` there — so never number a new migration at or below the
+global high-water mark, even if that number was only ever used under the other province.
 
 A database applies **`common` + exactly one province** location, selected by `flyway.locations`:
 

--- a/database/mysql/migration/bc/README.md
+++ b/database/mysql/migration/bc/README.md
@@ -9,5 +9,5 @@ Forward deltas (not part of the frozen baseline):
 
 Applied together with `common/` for a BC install (`flyway.locations=filesystem:.../migration/common,filesystem:.../migration/bc` (see `flyway.conf` for the real paths)). New BC-only
 changes go here as `V1.0.N__short_description.sql` (sequential, next free version number). The
-version line is global across `common` + `bc`, so the next free BC-only number is `V1.0.11` (the
-highest migration in the BC path is the shared `V1.0.10`; see `../README.md`).
+version line is global across `common` + `bc`, so the next free BC-only number is `V1.0.14` — see
+`../README.md` for why a lower number must never be reused.

--- a/database/mysql/migration/common/README.md
+++ b/database/mysql/migration/common/README.md
@@ -11,9 +11,13 @@ grouping table and seeds numeric billing diagnoses with ICD-9 chapter categories
 `V1.0.8__expand_appointment_type_location.sql` expands appointment type locations.
 `V1.0.9__remove_carlosdoc_schedule_group_denial.sql` removes the obsolete explicit denial.
 `V1.0.10__seed_default_measurement_groups.sql` seeds the default measurement groups.
+`V1.0.13__fix_phcp_diagnosis_group_backfill_collation.sql` re-runs the V1.0.7 dxphcpgroup
+backfill with a collation-pinned cast, repairing databases where a non-general_ci session
+collation (e.g. MariaDB 11.4+ `character_set_collations` defaults reached via a utf8mb4 CLI
+session) aborted V1.0.7 with ERROR 1267.
 
 Applied together with the selected province (`common` + `on`, or `common` + `bc`). Put **genuinely
 shared future schema changes** here as `V1.0.N__short_description.sql` (sequential, next free version number) so one migration
 covers both provinces. The version line is global across `common` + the selected province, so the
-next free number accounts for province deltas too. Ontario already uses `V1.0.12`, so the next
-shared version is `V1.0.13` (see `../README.md`).
+next free number accounts for province deltas too. The highest version in use is the shared
+`V1.0.13`, so the next shared (or Ontario) version is `V1.0.14` (see `../README.md`).

--- a/database/mysql/migration/common/README.md
+++ b/database/mysql/migration/common/README.md
@@ -12,9 +12,11 @@ grouping table and seeds numeric billing diagnoses with ICD-9 chapter categories
 `V1.0.9__remove_carlosdoc_schedule_group_denial.sql` removes the obsolete explicit denial.
 `V1.0.10__seed_default_measurement_groups.sql` seeds the default measurement groups.
 `V1.0.13__fix_phcp_diagnosis_group_backfill_collation.sql` re-runs the V1.0.7 dxphcpgroup
-backfill with a collation-pinned cast, repairing databases where a non-general_ci session
-collation (e.g. MariaDB 11.4+ `character_set_collations` defaults reached via a utf8mb4 CLI
-session) aborted V1.0.7 with ERROR 1267.
+backfill with a collation-pinned cast. Once reached, it repairs missing rows where a
+non-general_ci session collation caused V1.0.7 to abort and an operator bypassed that error. A
+normal fail-fast CLI loop cannot reach V1.0.13 after that failure; use the
+[same-session V1.0.7 recovery procedure](../README.md#mariadb-cli-recovery-for-v107), then continue
+in version order.
 
 Applied together with the selected province (`common` + `on`, or `common` + `bc`). Put **genuinely
 shared future schema changes** here as `V1.0.N__short_description.sql` (sequential, next free version number) so one migration

--- a/database/mysql/migration/common/V1.0.13__fix_phcp_diagnosis_group_backfill_collation.sql
+++ b/database/mysql/migration/common/V1.0.13__fix_phcp_diagnosis_group_backfill_collation.sql
@@ -1,0 +1,102 @@
+-- Re-run the V1.0.7 dxphcpgroup backfill with a collation-safe comparison.
+--
+-- V1.0.7's legacy-expansion join compares the utf8mb4_general_ci dxcode column
+-- against a bare CAST(... AS CHAR). That cast takes the SESSION's default
+-- utf8mb4 collation, so on servers whose session collation for utf8mb4 is not
+-- in the general_ci family — for example MariaDB 11.4+ images that ship
+-- character_set_collations = utf8mb4=uca1400_ai_ci, reached through a utf8mb4
+-- client session — the comparison fails with ERROR 1267 (illegal mix of
+-- collations) and V1.0.7 aborts after its DDL but before either backfill
+-- INSERT. JDBC/Flyway sessions negotiate a compatible collation, which is why
+-- managed migrations never hit this; migrations applied through the
+-- mysql/mariadb CLI (the carlos-podman deployment path) do.
+--
+-- V1.0.7 itself is left byte-identical to preserve its recorded Flyway
+-- checksum. This forward-only migration repeats both backfill INSERTs with the
+-- cast pinned to CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci (matching
+-- the table), so it works under any session collation. Both INSERTs keep
+-- their existence guards, so this is a no-op on databases where V1.0.7
+-- completed and fills in the missing rows on databases where it aborted.
+
+-- Expand adopted legacy integer-keyed mappings to every exact diagnostic-code
+-- spelling that normalizes to the same integer (see V1.0.7 for the rationale).
+INSERT INTO dxphcpgroup (dxcode, level1, level2, lastUpdateUser, lastUpdateDate)
+SELECT codes.dxcode,
+       legacy.level1,
+       legacy.level2,
+       legacy.lastUpdateUser,
+       legacy.lastUpdateDate
+FROM (
+  SELECT diagnostic_code AS dxcode,
+         CAST(diagnostic_code AS UNSIGNED) AS numeric_code
+  FROM diagnosticcode
+  WHERE diagnostic_code REGEXP '^[0-9]{1,5}$'
+  GROUP BY diagnostic_code
+) codes
+JOIN dxphcpgroup legacy
+  ON legacy.dxcode REGEXP '^[0-9]{1,5}$'
+  -- Pin the cast's charset AND collation: a bare CAST(... AS CHAR) inherits
+  -- the session collation and can clash with the table's utf8mb4_general_ci.
+  AND legacy.dxcode = CAST(CAST(legacy.dxcode AS UNSIGNED) AS CHAR CHARACTER SET utf8mb4) COLLATE utf8mb4_general_ci
+  AND CAST(legacy.dxcode AS UNSIGNED) = codes.numeric_code
+LEFT JOIN dxphcpgroup exact_mapping
+  ON exact_mapping.dxcode = codes.dxcode
+WHERE exact_mapping.dxcode IS NULL;
+
+-- Seed the remaining numeric billing diagnoses with the ICD-9 chapter
+-- taxonomy (identical to V1.0.7's second INSERT; guarded, so a completed
+-- V1.0.7 makes this a no-op).
+INSERT INTO dxphcpgroup (dxcode, level1, level2, lastUpdateUser, lastUpdateDate)
+SELECT codes.dxcode,
+       CASE
+         WHEN codes.category_code <= 139 THEN '01 Infectious and parasitic diseases'
+         WHEN codes.category_code <= 239 THEN '02 Neoplasms'
+         WHEN codes.category_code <= 279 THEN '03 Endocrine, nutritional, metabolic, and immunity disorders'
+         WHEN codes.category_code <= 289 THEN '04 Diseases of blood and blood-forming organs'
+         WHEN codes.category_code <= 319 THEN '05 Mental disorders'
+         WHEN codes.category_code <= 389 THEN '06 Diseases of the nervous system and sense organs'
+         WHEN codes.category_code <= 459 THEN '07 Diseases of the circulatory system'
+         WHEN codes.category_code <= 519 THEN '08 Diseases of the respiratory system'
+         WHEN codes.category_code <= 579 THEN '09 Diseases of the digestive system'
+         WHEN codes.category_code <= 629 THEN '10 Diseases of the genitourinary system'
+         WHEN codes.category_code <= 679 THEN '11 Complications of pregnancy, childbirth, and the puerperium'
+         WHEN codes.category_code <= 709 THEN '12 Diseases of the skin and subcutaneous tissue'
+         WHEN codes.category_code <= 739 THEN '13 Diseases of the musculoskeletal system and connective tissue'
+         WHEN codes.category_code <= 759 THEN '14 Congenital anomalies'
+         WHEN codes.category_code <= 779 THEN '15 Conditions originating in the perinatal period'
+         WHEN codes.category_code <= 799 THEN '16 Symptoms, signs, and ill-defined conditions'
+         ELSE '17 Injury and poisoning'
+       END,
+       CASE
+         WHEN codes.category_code <= 139 THEN 'ICD-9 001-139'
+         WHEN codes.category_code <= 239 THEN 'ICD-9 140-239'
+         WHEN codes.category_code <= 279 THEN 'ICD-9 240-279'
+         WHEN codes.category_code <= 289 THEN 'ICD-9 280-289'
+         WHEN codes.category_code <= 319 THEN 'ICD-9 290-319'
+         WHEN codes.category_code <= 389 THEN 'ICD-9 320-389'
+         WHEN codes.category_code <= 459 THEN 'ICD-9 390-459'
+         WHEN codes.category_code <= 519 THEN 'ICD-9 460-519'
+         WHEN codes.category_code <= 579 THEN 'ICD-9 520-579'
+         WHEN codes.category_code <= 629 THEN 'ICD-9 580-629'
+         WHEN codes.category_code <= 679 THEN 'ICD-9 630-679'
+         WHEN codes.category_code <= 709 THEN 'ICD-9 680-709'
+         WHEN codes.category_code <= 739 THEN 'ICD-9 710-739'
+         WHEN codes.category_code <= 759 THEN 'ICD-9 740-759'
+         WHEN codes.category_code <= 779 THEN 'ICD-9 760-779'
+         WHEN codes.category_code <= 799 THEN 'ICD-9 780-799'
+         ELSE 'ICD-9 800-999'
+       END,
+       'migration',
+       CURRENT_TIMESTAMP
+FROM (
+  SELECT diagnostic_code AS dxcode,
+         CAST(LEFT(diagnostic_code, 3) AS UNSIGNED) AS category_code
+  FROM diagnosticcode
+  WHERE diagnostic_code REGEXP '^[0-9]{1,5}$'
+  GROUP BY diagnostic_code
+) codes
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM dxphcpgroup existing
+  WHERE existing.dxcode = codes.dxcode
+);

--- a/database/mysql/migration/common/V1.0.13__fix_phcp_diagnosis_group_backfill_collation.sql
+++ b/database/mysql/migration/common/V1.0.13__fix_phcp_diagnosis_group_backfill_collation.sql
@@ -12,11 +12,14 @@
 -- mysql/mariadb CLI (the carlos-podman deployment path) do.
 --
 -- V1.0.7 itself is left byte-identical to preserve its recorded Flyway
--- checksum. This forward-only migration repeats both backfill INSERTs with the
--- cast pinned to CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci (matching
--- the table), so it works under any session collation. Both INSERTs keep
--- their existence guards, so this is a no-op on databases where V1.0.7
--- completed and fills in the missing rows on databases where it aborted.
+-- checksum. A fail-fast CLI migration loop cannot reach this migration after
+-- V1.0.7 aborts; follow the same-session V1.0.7 recovery procedure in
+-- ../README.md, then continue in version order. This forward-only migration
+-- repeats both backfill INSERTs with the cast pinned to CHARACTER SET utf8mb4
+-- COLLATE utf8mb4_general_ci (matching the table), so it works under any
+-- session collation. Both INSERTs keep their existence guards, so this is a
+-- no-op on databases where V1.0.7 completed and fills missing rows when an
+-- operator previously bypassed the V1.0.7 error and continued.
 
 -- Expand adopted legacy integer-keyed mappings to every exact diagnostic-code
 -- spelling that normalizes to the same integer (see V1.0.7 for the rationale).

--- a/database/mysql/migration/on/README.md
+++ b/database/mysql/migration/on/README.md
@@ -12,5 +12,5 @@ Forward deltas (not part of the frozen baseline):
 
 Applied together with `common/` for an Ontario install (`flyway.locations=filesystem:.../migration/common,filesystem:.../migration/on` (see `flyway.conf` for the real paths)). New
 Ontario-only changes go here as `V1.0.N__short_description.sql` (sequential, next free version number).
-The version line is global across `common` + `on`, so the next free number is `V1.0.13` (see
+The version line is global across `common` + `on`, so the next free number is `V1.0.14` (see
 `../README.md`).

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -96,11 +96,14 @@ snapshot. Keep `develop` on its newer snapshot during every forward merge.
 Merge commits must carry a DCO sign-off. If a true forward or back merge connects
 older commits that the automated DCO job cannot verify individually, an
 authorized maintainer may post the exact repository fallback phrase only after
-reviewing the connected history:
+reviewing the connected history. The phrase must include the current full
+40-character PR head SHA so that it approves only that exact revision:
 
 ```text
-Confirming DCO sign off for all commits
+Confirming DCO sign off for all commits at <full-pr-head-sha>
 ```
+
+Any subsequent push changes the PR head SHA and requires a new confirmation.
 
 ## Supported-release fix cycle
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>io.github.carlos_emr</groupId>
     <artifactId>carlos</artifactId>
     <packaging>war</packaging>
-    <version>2026.08.0-alpha2</version>
+    <version>2026.08.0-alpha3-SNAPSHOT</version>
     <name>CARLOS</name>
     <description>CARLOS EMR (Clinical Assisting Recording Ledger Open Source) is a web-based electronic medical record system for Canadian healthcare.</description>
     <inceptionYear>2024</inceptionYear>
@@ -19,7 +19,7 @@
         <url>https://github.com/carlos-emr/carlos</url>
         <connection>scm:git:https://github.com/carlos-emr/carlos.git</connection>
         <developerConnection>scm:git:ssh://git@github.com:carlos-emr/carlos.git</developerConnection>
-        <tag>2026.08.0-alpha2</tag>
+        <tag>HEAD</tag>
     </scm>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>io.github.carlos_emr</groupId>
     <artifactId>carlos</artifactId>
     <packaging>war</packaging>
-    <version>2026.08.0-alpha3-SNAPSHOT</version>
+    <version>2026.08.0-alpha3</version>
     <name>CARLOS</name>
     <description>CARLOS EMR (Clinical Assisting Recording Ledger Open Source) is a web-based electronic medical record system for Canadian healthcare.</description>
     <inceptionYear>2024</inceptionYear>
@@ -19,7 +19,7 @@
         <url>https://github.com/carlos-emr/carlos</url>
         <connection>scm:git:https://github.com/carlos-emr/carlos.git</connection>
         <developerConnection>scm:git:ssh://git@github.com:carlos-emr/carlos.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>2026.08.0-alpha3</tag>
     </scm>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
## Summary

Prepare the `2026.08.0-alpha3` prerelease from the verified `release/2026.08` tip `63cbfd149e341cab568cb6f80e2224c75e22543e` for promotion to `main`.

This changes only release metadata in `pom.xml`:

- project version: `2026.08.0-alpha3`
- SCM tag: `2026.08.0-alpha3`

## Release impact

After this PR passes protected-branch checks and is merged with a merge commit, the resulting exact `main` head is the only commit that should receive the immutable annotated tag `2026.08.0-alpha3`. The tag workflow will rebuild and verify the WAR, SBOM, checksums, and provenance before publishing the GitHub prerelease.

Do not create, move, or push the tag before this PR is merged and the resulting `main` commit and metadata are verified.

## Validation

- The branch is based on the current `release/2026.08` tip.
- `mvn help:evaluate -Dexpression=project.version -q -DforceStdout` returns `2026.08.0-alpha3`.
- `mvn help:evaluate -Dexpression=project.scm.tag -q -DforceStdout` returns `2026.08.0-alpha3`.
- `mvn -B -DskipTests validate` passes, including dependency-lock validation.
- `git diff --check` passes.
- The tag and GitHub release do not already exist.

## Required follow-up after publication

1. Confirm the GitHub release is published as a prerelease with verified assets.
2. Back-merge the tagged `main` commit into `release/2026.08`.
3. Advance `release/2026.08` to `2026.08.0-alpha4-SNAPSHOT` with SCM tag `HEAD` through a reviewed PR.
4. Forward-merge the maintenance changes into `develop` while preserving `2026.09.0-SNAPSHOT` and SCM tag `HEAD`.

## Summary by Sourcery

Prepare the 2026.08.0-alpha3 prerelease while hardening release governance, CI automation, and MariaDB migration recovery.

New Features:
- Add automatic pull-request type labels based on Conventional Commit titles for release-note categorization.
- Add a forward database migration to repair incomplete diagnostic-group backfills caused by MariaDB collation errors.

Bug Fixes:
- Prevent release publishing races and ensure older stable release lines cannot incorrectly claim the latest pointer.
- Make release validation use the resolved project version and support complete release history pagination.
- Require manual DCO confirmations to be tied to the exact current pull-request head revision.
- Prevent cold-cache SonarCloud runs from failing when generated workspace files have incorrect ownership.
- Ensure development database bootstrapping uses a compatible collation for forward migrations.

Enhancements:
- Clarify database migration versioning, MariaDB recovery, and release procedures.

CI:
- Serialize release publication and improve release workflow validation and latest-release handling.
- Harden DCO, SonarCloud, and pull-request labeling workflows.

Deployment:
- Add automatic recovery coverage for collation-related diagnostic backfill failures through Flyway.

Documentation:
- Update contribution, release, and database migration documentation for SHA-bound DCO approval and migration recovery/versioning.

Chores:
- Prepare the project metadata for the 2026.08.0-alpha3 prerelease.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares the 2026.08.0-alpha3 prerelease and hardens CI/release governance. Adds a forward-only migration to repair a MariaDB 11.4 collation conflict that could abort the V1.0.7 backfill via CLI; docs now include a same-session V1.0.7 recovery path.

- DCO manual confirmation must include the current PR head SHA; earlier confirmations are ignored. Phrase: "Confirming DCO sign off for all commits at <full PR head SHA>".
- Release publication is serialized; "latest" is set only when the tag is the newest stable under CalVer. SNAPSHOT checks read the resolved `project.version`.
- New PR auto-labeler derives `type: *` labels from Conventional Commit titles, including `(security)`/`(deps)` and Dependabot.
- SonarCloud workflow restores workspace ownership so cold-cache runs can save caches reliably.
- Dev container DB bootstrap re-pins session collation before forward migrations.
- New `common/V1.0.13__fix_phcp_diagnosis_group_backfill_collation.sql` re-runs the V1.0.7 backfill with a collation-pinned cast; it is a no-op where V1.0.7 completed and fills rows where CLI sessions aborted with ERROR 1267. Migration docs updated (including the same-session V1.0.7 CLI recovery procedure); next free version across all locations is now `V1.0.14`.

- After merge, tag only the resulting `main` commit as `2026.08.0-alpha3` and let the tag workflow publish. Then back-merge to `release/2026.08` and advance it to `2026.08.0-alpha4-SNAPSHOT`. No manual DB steps are required; Flyway will apply `common/V1.0.13` automatically where needed.

<sup>Written for commit 8c406a32559bb261db3b9537ac64ed538e128183. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

