### PR TITLE
chore(release): back-merge 2026.08.0-alpha3

### DIFF
--- a/database/mysql/migration/README.md
+++ b/database/mysql/migration/README.md
@@ -68,6 +68,34 @@ Demo/patient data is **not** in this baseline — it belongs in a dev-only `demo
   been retired (recoverable from git history). Do not regenerate it — evolve the schema forward.
 - **drugref2 is a separate database** — not managed here (keeps `../development-drugref.sql` + `../drugref/*.sql`).
 
+## MariaDB CLI recovery for V1.0.7
+
+Flyway/JDBC runs negotiate a compatible connection collation, and the development bootstrap pins
+one before applying forward migrations. A manual `mysql`/`mariadb` run through `carlos-ctl db`,
+however, may use `utf8mb4_uca1400_ai_ci` on MariaDB 11.4 or newer. In that session V1.0.7 can stop
+with `ERROR 1267 (Illegal mix of collations)` after its DDL and before its guarded backfill inserts.
+
+If that happens, rerun V1.0.7 with the compatible collation established in the **same client
+session**:
+
+```bash
+{
+  printf '%s\n' 'SET NAMES utf8mb4 COLLATE utf8mb4_general_ci;'
+  cat common/V1.0.7__restore_phcp_diagnosis_groups.sql
+} | sudo EMR_HOME=/usr/local/emr carlos-ctl db oscar
+```
+
+Run this from `database/mysql/migration/`, then continue with V1.0.8 through V1.0.13 in global
+version order. V1.0.7 is safe to rerun: its DDL is repeatable and both inserts exclude rows already
+present. A separate `SET NAMES` invocation does **not** work because the setting ends with that
+client process. Do not add `--force`; continuing after an unrelated SQL error could leave the
+schema in an unknown state.
+
+V1.0.13 is an idempotent no-op after the pinned V1.0.7 rerun. It also fills the missing rows when
+an operator previously bypassed the V1.0.7 error and continued directly to later migrations.
+Automatic protection in the deployment CLI is tracked in
+[carlos-podman #17](https://github.com/carlos-emr/carlos-podman/issues/17).
+
 ## Evolving the schema
 
 Add a forward migration under the right location — `common/` for shared changes, `on/`/`bc/` for

--- a/database/mysql/migration/common/README.md
+++ b/database/mysql/migration/common/README.md
@@ -12,9 +12,11 @@ grouping table and seeds numeric billing diagnoses with ICD-9 chapter categories
 `V1.0.9__remove_carlosdoc_schedule_group_denial.sql` removes the obsolete explicit denial.
 `V1.0.10__seed_default_measurement_groups.sql` seeds the default measurement groups.
 `V1.0.13__fix_phcp_diagnosis_group_backfill_collation.sql` re-runs the V1.0.7 dxphcpgroup
-backfill with a collation-pinned cast, repairing databases where a non-general_ci session
-collation (e.g. MariaDB 11.4+ `character_set_collations` defaults reached via a utf8mb4 CLI
-session) aborted V1.0.7 with ERROR 1267.
+backfill with a collation-pinned cast. Once reached, it repairs missing rows where a
+non-general_ci session collation caused V1.0.7 to abort and an operator bypassed that error. A
+normal fail-fast CLI loop cannot reach V1.0.13 after that failure; use the
+[same-session V1.0.7 recovery procedure](../README.md#mariadb-cli-recovery-for-v107), then continue
+in version order.
 
 Applied together with the selected province (`common` + `on`, or `common` + `bc`). Put **genuinely
 shared future schema changes** here as `V1.0.N__short_description.sql` (sequential, next free version number) so one migration

--- a/database/mysql/migration/common/V1.0.13__fix_phcp_diagnosis_group_backfill_collation.sql
+++ b/database/mysql/migration/common/V1.0.13__fix_phcp_diagnosis_group_backfill_collation.sql
@@ -12,11 +12,14 @@
 -- mysql/mariadb CLI (the carlos-podman deployment path) do.
 --
 -- V1.0.7 itself is left byte-identical to preserve its recorded Flyway
--- checksum. This forward-only migration repeats both backfill INSERTs with the
--- cast pinned to CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci (matching
--- the table), so it works under any session collation. Both INSERTs keep
--- their existence guards, so this is a no-op on databases where V1.0.7
--- completed and fills in the missing rows on databases where it aborted.
+-- checksum. A fail-fast CLI migration loop cannot reach this migration after
+-- V1.0.7 aborts; follow the same-session V1.0.7 recovery procedure in
+-- ../README.md, then continue in version order. This forward-only migration
+-- repeats both backfill INSERTs with the cast pinned to CHARACTER SET utf8mb4
+-- COLLATE utf8mb4_general_ci (matching the table), so it works under any
+-- session collation. Both INSERTs keep their existence guards, so this is a
+-- no-op on databases where V1.0.7 completed and fills missing rows when an
+-- operator previously bypassed the V1.0.7 error and continued.
 
 -- Expand adopted legacy integer-keyed mappings to every exact diagnostic-code
 -- spelling that normalizes to the same integer (see V1.0.7 for the rationale).

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>io.github.carlos_emr</groupId>
     <artifactId>carlos</artifactId>
     <packaging>war</packaging>
-    <version>2026.08.0-alpha3-SNAPSHOT</version>
+    <version>2026.08.0-alpha3</version>
     <name>CARLOS</name>
     <description>CARLOS EMR (Clinical Assisting Recording Ledger Open Source) is a web-based electronic medical record system for Canadian healthcare.</description>
     <inceptionYear>2024</inceptionYear>
@@ -19,7 +19,7 @@
         <url>https://github.com/carlos-emr/carlos</url>
         <connection>scm:git:https://github.com/carlos-emr/carlos.git</connection>
         <developerConnection>scm:git:ssh://git@github.com:carlos-emr/carlos.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>2026.08.0-alpha3</tag>
     </scm>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
## Summary

Back-merge the exact published `2026.08.0-alpha3` state from `main` into `release/2026.08`.

The immutable annotated tag `2026.08.0-alpha3` and `main` both resolve to:

```text
d95f2646e5b321c5927f37ccb6c8c16baa33ff38
```

The release workflow completed successfully and published the verified prerelease, WAR, CycloneDX SBOM, checksums, and provenance attestations.

## Branch comparison

- Base `release/2026.08`: `63cbfd149e341cab568cb6f80e2224c75e22543e`
- Head `main`: `d95f2646e5b321c5927f37ccb6c8c16baa33ff38`
- `main` is 3 commits ahead and 0 commits behind.
- The maintenance branch has not diverged, so the back-merge is clean.
- The file delta contains the alpha3 POM metadata and the reviewed MariaDB V1.0.7 CLI recovery documentation/corrected V1.0.13 comments.

## Merge requirements

Merge this PR into `release/2026.08` after required checks and review. Do not squash or rebase: preserve the published `main` ancestry and the alpha3 merge commit.

## Follow-up

After this PR merges, prepare a separate reviewed PR on `release/2026.08` that advances:

- project version to `2026.08.0-alpha4-SNAPSHOT`
- SCM tag to `HEAD`

Then forward-merge the maintenance state into `develop` while preserving `2026.09.0-SNAPSHOT` and SCM tag `HEAD`.

## Summary by Sourcery

Back-merge the published 2026.08.0-alpha3 state with finalized release metadata and corrected MariaDB migration recovery guidance.

Bug Fixes:
- Document recovery steps for MariaDB CLI migration failures caused by incompatible session collations during V1.0.7.

Enhancements:
- Clarify V1.0.13 migration behavior for completed, interrupted, and bypassed V1.0.7 backfills.

Build:
- Finalize project metadata for the published 2026.08.0-alpha3 release, including the release version and SCM tag.

Documentation:
- Add operator guidance for safely recovering and continuing MySQL/MariaDB schema migrations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Back-merges the published `2026.08.0-alpha3` state from `main` into `release/2026.08` to keep the maintenance branch identical to the verified prerelease. No runtime behavior changes.

- Review and merge
  - Sets `pom.xml` version to `2026.08.0-alpha3` and SCM tag to `2026.08.0-alpha3`.
  - Changes to `database/mysql/migration/common/V1.0.13__*.sql` are comment-only; behavior is unchanged.
  - Adds MariaDB CLI recovery docs for V1.0.7 and clarifies V1.0.13’s role after recovery.
  - Merge with a normal merge commit; do not squash or rebase to preserve released ancestry.

- Follow-up
  - On `release/2026.08`, bump to `2026.08.0-alpha4-SNAPSHOT` and set SCM tag to `HEAD`.
  - Forward-merge `release/2026.08` into `develop` while keeping `2026.09.0-SNAPSHOT` and SCM `HEAD`.

<sup>Written for commit d95f2646e5b321c5927f37ccb6c8c16baa33ff38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

