### PR TITLE
chore(release): advance 2026.08 to alpha4 snapshot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>io.github.carlos_emr</groupId>
     <artifactId>carlos</artifactId>
     <packaging>war</packaging>
-    <version>2026.08.0-alpha3</version>
+    <version>2026.08.0-alpha4-SNAPSHOT</version>
     <name>CARLOS</name>
     <description>CARLOS EMR (Clinical Assisting Recording Ledger Open Source) is a web-based electronic medical record system for Canadian healthcare.</description>
     <inceptionYear>2024</inceptionYear>
@@ -19,7 +19,7 @@
         <url>https://github.com/carlos-emr/carlos</url>
         <connection>scm:git:https://github.com/carlos-emr/carlos.git</connection>
         <developerConnection>scm:git:ssh://git@github.com:carlos-emr/carlos.git</developerConnection>
-        <tag>2026.08.0-alpha3</tag>
+        <tag>HEAD</tag>
     </scm>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
## Summary

Advance the `release/2026.08` maintenance line after publication and back-merge of `2026.08.0-alpha3`.

This PR changes only release bookkeeping in `pom.xml`:

- project version: `2026.08.0-alpha3` → `2026.08.0-alpha4-SNAPSHOT`
- SCM tag: `2026.08.0-alpha3` → `HEAD`

## Impact

This reopens the 2026.08 maintenance line for approved alpha4 fixes. A snapshot records the next intended milestone; it must not be tagged or published.

The branch is based on the merged alpha3 back-merge commit:

```text
8c1133ac1c2d5787cd672875ad84ae035e7857e6
```

## Validation

- `git diff --check`
- The diff contains only `pom.xml`.
- `mvn help:evaluate -Dexpression=project.version -q -DforceStdout` resolves to `2026.08.0-alpha4-SNAPSHOT`.
- `mvn help:evaluate -Dexpression=project.scm.tag -q -DforceStdout` resolves to `HEAD`.
- `mvn -B -DskipTests validate` passes, including dependency-lock validation.
- Commit `7e71717362756ce9219eb6f3fd511d28abf5e678` includes DCO sign-off.

## Follow-up

After this PR merges, forward-merge `release/2026.08` into `develop` while preserving develop's `2026.09.0-SNAPSHOT` project version and `HEAD` SCM tag.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Advances the 2026.08 maintenance line by updating `pom.xml` to `2026.08.0-alpha4-SNAPSHOT` and setting the SCM tag to `HEAD`. This reopens the line for alpha4 fixes; the snapshot must not be tagged or published.

- Only `pom.xml` changed; no runtime or dependency behavior changes.
- Do not publish artifacts from this branch.
- After merge, forward-merge `release/2026.08` into `develop` while keeping `2026.09.0-SNAPSHOT` and `HEAD` on `develop`.

<sup>Written for commit 7e71717362756ce9219eb6f3fd511d28abf5e678. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

