### PR TITLE
fix(ci): rename dev drugref image to carlos-drugref-dev

### DIFF
--- a/.github/workflows/container-images.yml
+++ b/.github/workflows/container-images.yml
@@ -12,7 +12,10 @@
 # Containers Managed:
 # - carlos-tomcat-dev: Development container with Java 21, Tomcat, Maven, Node.js
 # - carlos-mariadb-dev: MariaDB database container with schema initialization scripts
-# - carlos-drugref: DrugRef2 service container with Java 11
+# - carlos-drugref-dev: DrugRef2 service container with Java 11
+#   (the bare "carlos-drugref" ghcr name is reserved for the DEPLOYMENT image
+#   published by the carlos-podman repo's Publish Images workflow — dev images
+#   all carry the -dev suffix)
 #
 # Freshness Check Strategy:
 # 1. Calculate SHA256 hash of Dockerfile + build context for each container
@@ -29,7 +32,7 @@
 # - Manual dispatch for forced rebuilds (with force_rebuild option)
 #
 # License:
-# This GitHub Workflow file is part of the Carlos EMR project and is subject
+# This GitHub Workflow file is part of the CARLOS EMR project and is subject
 # to the licensing terms outlined in the repository's LICENSE file.
 
 name: Development Container Images
@@ -177,7 +180,7 @@ jobs:
           # Check each container (name, output_name, context_path, extra_context)
           check_container "tomcat-dev" "tomcat" ".devcontainer/development" ""
           check_container "mariadb-dev" "mariadb" ".devcontainer/db" "database .devcontainer/development/config/shared/my.cnf"
-          check_container "drugref" "drugref" ".devcontainer/drugref" ""
+          check_container "drugref-dev" "drugref" ".devcontainer/drugref" ""
 
   # ===========================================================================
   # Build and push tomcat-dev container
@@ -483,10 +486,10 @@ jobs:
         env:
           CONTENT_HASH: ${{ needs.check-containers.outputs.drugref_hash }}
         run: |
-          echo "Building carlos-drugref container..."
+          echo "Building carlos-drugref-dev container..."
           docker buildx build \
             --load \
-            -t carlos-drugref:test \
+            -t carlos-drugref-dev:test \
             --label "org.openosp.content-hash=$CONTENT_HASH" \
             --label "org.opencontainers.image.source=https://github.com/${{ github.repository }}" \
             --label "org.opencontainers.image.revision=${{ github.sha }}" \
@@ -495,7 +498,7 @@ jobs:
       - name: Test drugref container
         run: |
           echo "Testing container starts correctly..."
-          docker run -d --name test-drugref -p 8081:8080 carlos-drugref:test
+          docker run -d --name test-drugref -p 8081:8080 carlos-drugref-dev:test
 
           echo "Waiting for Tomcat to start..."
           ready=false
@@ -537,13 +540,13 @@ jobs:
       - name: Save tested drugref image
         run: |
           mkdir -p "$RUNNER_TEMP/container-images"
-          docker save carlos-drugref:test -o "$RUNNER_TEMP/container-images/carlos-drugref.tar"
+          docker save carlos-drugref-dev:test -o "$RUNNER_TEMP/container-images/carlos-drugref-dev.tar"
 
       - name: Upload tested drugref image
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: carlos-drugref-image
-          path: ${{ runner.temp }}/container-images/carlos-drugref.tar
+          name: carlos-drugref-dev-image
+          path: ${{ runner.temp }}/container-images/carlos-drugref-dev.tar
           retention-days: 1
 
   publish-drugref:
@@ -557,7 +560,7 @@ jobs:
       - name: Download tested drugref image
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          name: carlos-drugref-image
+          name: carlos-drugref-dev-image
           path: ${{ runner.temp }}/container-images
 
       - name: Log in to Container Registry
@@ -569,7 +572,7 @@ jobs:
 
       - name: Push tested drugref container
         env:
-          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/carlos-drugref
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/carlos-drugref-dev
           CACHE_REF_NAME: ${{ github.base_ref || github.ref_name }}
           SHOULD_PUSH_LATEST: ${{ github.ref_name == 'develop' }}
         run: |
@@ -584,14 +587,14 @@ jobs:
             printf '%s-latest' "$safe_ref"
           }
 
-          docker load -i "$RUNNER_TEMP/container-images/carlos-drugref.tar"
-          docker tag carlos-drugref:test "$IMAGE:${{ github.sha }}"
+          docker load -i "$RUNNER_TEMP/container-images/carlos-drugref-dev.tar"
+          docker tag carlos-drugref-dev:test "$IMAGE:${{ github.sha }}"
           CACHE_TAG=$(cache_tag "$CACHE_REF_NAME")
-          docker tag carlos-drugref:test "$IMAGE:$CACHE_TAG"
+          docker tag carlos-drugref-dev:test "$IMAGE:$CACHE_TAG"
           docker push "$IMAGE:$CACHE_TAG"
           echo "Pushed $IMAGE:$CACHE_TAG"
           if [ "$SHOULD_PUSH_LATEST" = "true" ]; then
-            docker tag carlos-drugref:test "$IMAGE:latest"
+            docker tag carlos-drugref-dev:test "$IMAGE:latest"
             docker push "$IMAGE:latest"
             echo "Pushed $IMAGE:latest"
           fi

--- a/.github/workflows/container-images.yml
+++ b/.github/workflows/container-images.yml
@@ -12,7 +12,7 @@
 # Containers Managed:
 # - carlos-tomcat-dev: Development container with Java 21, Tomcat, Maven, Node.js
 # - carlos-mariadb-dev: MariaDB database container with schema initialization scripts
-# - carlos-drugref-dev: DrugRef2 service container with Java 11
+# - carlos-drugref-dev: DrugRef2 service container with Java 21
 #   (the bare "carlos-drugref" ghcr name is reserved for the DEPLOYMENT image
 #   published by the carlos-podman repo's Publish Images workflow — dev images
 #   all carry the -dev suffix)


### PR DESCRIPTION
## Summary

The dev-container pipeline (`container-images.yml`) published its DrugRef dev image as `ghcr.io/carlos-emr/carlos-drugref` — the only one of the three dev images without the `-dev` suffix (`carlos-tomcat-dev`, `carlos-mariadb-dev`). That bare name is the **deployment** image name used by carlos-podman's Publish Images workflow, whose first drugref publish failed with a 403: the dev package already owned the name and carlos-podman's token has no write access to it.

This renames the dev image to **`carlos-drugref-dev`**, making the dev naming consistent and reserving the bare name for the deployment image:

- `check_container "drugref" ...` → `"drugref-dev"` (freshness check now keys off `carlos-drugref-dev:<cache-tag>`)
- build/save/load/tag/push references and the artifact/tar names follow the rename
- header comment documents why the bare name is off-limits
- header display name fixed to "CARLOS EMR" per the naming rule

## Migration impact

None: nothing consumes the drugref dev image from ghcr — `maven-project.yml`/`sonarcloud.yml`/`spotbugs.yml` pull only `carlos-tomcat-dev`, and the devcontainer builds drugref locally from `.devcontainer/drugref` via compose. On the first post-merge push the freshness check finds no `carlos-drugref-dev` cache image and builds + publishes it fresh. The old `carlos-drugref` package's dev tags can then be pruned (delete versions, not the package — deleting the whole package would risk ghcr name reservation against the deployment publish).

## Validation

- `yaml.safe_load` parses the workflow; `bash -n` passes on all 14 embedded run scripts
- grep confirms no bare `carlos-drugref` references remain in the workflow
- confirmed no other repo file references the ghcr dev image name

Generated with Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014NKLrJmtqdVuRiRVUjVwKg

---
_Generated by [Claude Code](https://claude.ai/code/session_014NKLrJmtqdVuRiRVUjVwKg)_

## Summary by Sourcery

Reserve the bare DrugRef image name for deployment by consistently publishing the development image as `carlos-drugref-dev`.

Bug Fixes:
- Rename the DrugRef development container image to prevent CI publishing conflicts with the deployment image name.

Enhancements:
- Align DrugRef development image naming with the other development containers and document that the bare image name is reserved for deployment.

CI:
- Update freshness checks, build/test jobs, artifacts, and registry publishing to use `carlos-drugref-dev`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renames the DrugRef dev image in CI from `ghcr.io/carlos-emr/carlos-drugref` to `ghcr.io/carlos-emr/carlos-drugref-dev` to align dev naming and free the bare name for deployment publishing. Previously dev pushed to the bare name, causing a 403 in the deployment workflow; dev now publishes to `-dev`.

- Updates the freshness check and all build/test/save/load/tag/push steps and artifacts to `carlos-drugref-dev`.
- Reserves the bare `carlos-drugref` for deployment; fixes the workflow header display name to "CARLOS EMR" and corrects the documented Java version to 21.
- Migration: none. CI does not pull this image and the devcontainer builds DrugRef locally. On first run, the pipeline builds and publishes `carlos-drugref-dev` fresh. Optional: prune legacy dev versions under the `carlos-drugref` package; do not delete the package.

<sup>Written for commit 8d13031eb187dc6bc490ea042fbc631c5a29a310. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

