### PR TITLE
fix(ci): rename dev drugref image to carlos-drugref-dev (main)

### DIFF
--- a/.github/workflows/container-images.yml
+++ b/.github/workflows/container-images.yml
@@ -12,7 +12,10 @@
 # Containers Managed:
 # - carlos-tomcat-dev: Development container with Java 21, Tomcat, Maven, Node.js
 # - carlos-mariadb-dev: MariaDB database container with schema initialization scripts
-# - carlos-drugref: DrugRef2 service container with Java 11
+# - carlos-drugref-dev: DrugRef2 service container with Java 11
+#   (the bare "carlos-drugref" ghcr name is reserved for the DEPLOYMENT image
+#   published by the carlos-podman repo's Publish Images workflow — dev images
+#   all carry the -dev suffix)
 #
 # Freshness Check Strategy:
 # 1. Calculate SHA256 hash of Dockerfile + build context for each container
@@ -29,7 +32,7 @@
 # - Manual dispatch for forced rebuilds (with force_rebuild option)
 #
 # License:
-# This GitHub Workflow file is part of the Carlos EMR project and is subject
+# This GitHub Workflow file is part of the CARLOS EMR project and is subject
 # to the licensing terms outlined in the repository's LICENSE file.
 
 name: Development Container Images
@@ -177,7 +180,7 @@ jobs:
           # Check each container (name, output_name, context_path, extra_context)
           check_container "tomcat-dev" "tomcat" ".devcontainer/development" ""
           check_container "mariadb-dev" "mariadb" ".devcontainer/db" "database .devcontainer/development/config/shared/my.cnf"
-          check_container "drugref" "drugref" ".devcontainer/drugref" ""
+          check_container "drugref-dev" "drugref" ".devcontainer/drugref" ""
 
   # ===========================================================================
   # Build and push tomcat-dev container
@@ -483,10 +486,10 @@ jobs:
         env:
           CONTENT_HASH: ${{ needs.check-containers.outputs.drugref_hash }}
         run: |
-          echo "Building carlos-drugref container..."
+          echo "Building carlos-drugref-dev container..."
           docker buildx build \
             --load \
-            -t carlos-drugref:test \
+            -t carlos-drugref-dev:test \
             --label "org.openosp.content-hash=$CONTENT_HASH" \
             --label "org.opencontainers.image.source=https://github.com/${{ github.repository }}" \
             --label "org.opencontainers.image.revision=${{ github.sha }}" \
@@ -495,7 +498,7 @@ jobs:
       - name: Test drugref container
         run: |
           echo "Testing container starts correctly..."
-          docker run -d --name test-drugref -p 8081:8080 carlos-drugref:test
+          docker run -d --name test-drugref -p 8081:8080 carlos-drugref-dev:test
 
           echo "Waiting for Tomcat to start..."
           ready=false
@@ -537,13 +540,13 @@ jobs:
       - name: Save tested drugref image
         run: |
           mkdir -p "$RUNNER_TEMP/container-images"
-          docker save carlos-drugref:test -o "$RUNNER_TEMP/container-images/carlos-drugref.tar"
+          docker save carlos-drugref-dev:test -o "$RUNNER_TEMP/container-images/carlos-drugref-dev.tar"
 
       - name: Upload tested drugref image
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: carlos-drugref-image
-          path: ${{ runner.temp }}/container-images/carlos-drugref.tar
+          name: carlos-drugref-dev-image
+          path: ${{ runner.temp }}/container-images/carlos-drugref-dev.tar
           retention-days: 1
 
   publish-drugref:
@@ -557,7 +560,7 @@ jobs:
       - name: Download tested drugref image
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          name: carlos-drugref-image
+          name: carlos-drugref-dev-image
           path: ${{ runner.temp }}/container-images
 
       - name: Log in to Container Registry
@@ -569,7 +572,7 @@ jobs:
 
       - name: Push tested drugref container
         env:
-          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/carlos-drugref
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/carlos-drugref-dev
           CACHE_REF_NAME: ${{ github.base_ref || github.ref_name }}
           SHOULD_PUSH_LATEST: ${{ github.ref_name == 'develop' }}
         run: |
@@ -584,14 +587,14 @@ jobs:
             printf '%s-latest' "$safe_ref"
           }
 
-          docker load -i "$RUNNER_TEMP/container-images/carlos-drugref.tar"
-          docker tag carlos-drugref:test "$IMAGE:${{ github.sha }}"
+          docker load -i "$RUNNER_TEMP/container-images/carlos-drugref-dev.tar"
+          docker tag carlos-drugref-dev:test "$IMAGE:${{ github.sha }}"
           CACHE_TAG=$(cache_tag "$CACHE_REF_NAME")
-          docker tag carlos-drugref:test "$IMAGE:$CACHE_TAG"
+          docker tag carlos-drugref-dev:test "$IMAGE:$CACHE_TAG"
           docker push "$IMAGE:$CACHE_TAG"
           echo "Pushed $IMAGE:$CACHE_TAG"
           if [ "$SHOULD_PUSH_LATEST" = "true" ]; then
-            docker tag carlos-drugref:test "$IMAGE:latest"
+            docker tag carlos-drugref-dev:test "$IMAGE:latest"
             docker push "$IMAGE:latest"
             echo "Pushed $IMAGE:latest"
           fi

--- a/.github/workflows/container-images.yml
+++ b/.github/workflows/container-images.yml
@@ -12,7 +12,7 @@
 # Containers Managed:
 # - carlos-tomcat-dev: Development container with Java 21, Tomcat, Maven, Node.js
 # - carlos-mariadb-dev: MariaDB database container with schema initialization scripts
-# - carlos-drugref-dev: DrugRef2 service container with Java 11
+# - carlos-drugref-dev: DrugRef2 service container with Java 21
 #   (the bare "carlos-drugref" ghcr name is reserved for the DEPLOYMENT image
 #   published by the carlos-podman repo's Publish Images workflow — dev images
 #   all carry the -dev suffix)


### PR DESCRIPTION
## Summary

Backport of #3495 (cherry-pick of a764886645) to `main`, per maintainer direction: `container-images.yml` triggers on pushes to `main`, and until the rename lands here any push rebuilds and publishes dev tags to the bare `ghcr.io/carlos-emr/carlos-drugref` name — the name reserved for the **deployment** image published by carlos-podman's Publish Images workflow (whose first publish failed with 403 because the dev package owned it). With this backport, every pushed branch publishes the DrugRef dev image consistently as `carlos-drugref-dev`, matching `carlos-tomcat-dev`/`carlos-mariadb-dev`.

One-file CI workflow change; qualifies as a necessary, narrowly scoped release-infrastructure correction under the release policy. No version metadata is touched (`main` stays at `2026.08.0-alpha3`). No consumers to migrate — CI pulls only `carlos-tomcat-dev` and the devcontainer builds drugref locally.

Companion PR for `release/2026.08`: #3497.

## Validation

- Clean cherry-pick, one file: `.github/workflows/container-images.yml`
- `yaml.safe_load` parses; `bash -n` passes on all embedded run scripts (validated on the identical source commit in #3495, whose PR run also dry-ran the renamed `build-drugref` successfully)

Generated with Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014NKLrJmtqdVuRiRVUjVwKg

---
_Generated by [Claude Code](https://claude.ai/code/session_014NKLrJmtqdVuRiRVUjVwKg)_

## Summary by Sourcery

Rename the DrugRef development container image to reserve the bare `carlos-drugref` name for deployment publishing.

Bug Fixes:
- Publish the DrugRef development image under the `carlos-drugref-dev` registry name so it no longer conflicts with the deployment image.

Enhancements:
- Align DrugRef development image checks, testing, artifacts, and publishing with the project’s `-dev` image naming convention.

CI:
- Update the container image workflow to build, test, cache, and publish `carlos-drugref-dev`.

Chores:
- Correct the workflow’s project branding and document the reserved deployment image name.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renames the DrugRef dev image from `ghcr.io/carlos-emr/carlos-drugref` to `ghcr.io/carlos-emr/carlos-drugref-dev` to align with other dev images and free the bare name for the deployment image. Previously pushes published the dev image to the bare repo and blocked `carlos-podman`’s deploy publish with 403; now the deploy image can publish to `carlos-drugref` without conflict.

- One-file change in `.github/workflows/container-images.yml`; updates build/test/save/upload/publish steps and artifact names to `carlos-drugref-dev` (content-hash and cache tagging unchanged).
- Corrects workflow comments: DrugRef dev container uses Java 21 and the `-dev` suffix; fixes project name to “CARLOS EMR.”
- No migration required: CI does not consume the DrugRef dev image from GHCR; the devcontainer builds DrugRef locally.
- Next push will rebuild and publish `carlos-drugref-dev`; `carlos-podman` can publish `ghcr.io/carlos-emr/carlos-drugref` successfully.

<sup>Written for commit 35506bcfcffce03f8305cb31be962171475a30d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

