### PR TITLE
chore(release): prepare 2026.08.0-alpha4

### DIFF
--- a/.github/workflows/container-images.yml
+++ b/.github/workflows/container-images.yml
@@ -12,7 +12,10 @@
 # Containers Managed:
 # - carlos-tomcat-dev: Development container with Java 21, Tomcat, Maven, Node.js
 # - carlos-mariadb-dev: MariaDB database container with schema initialization scripts
-# - carlos-drugref: DrugRef2 service container with Java 11
+# - carlos-drugref-dev: DrugRef2 service container with Java 11
+#   (the bare "carlos-drugref" ghcr name is reserved for the DEPLOYMENT image
+#   published by the carlos-podman repo's Publish Images workflow — dev images
+#   all carry the -dev suffix)
 #
 # Freshness Check Strategy:
 # 1. Calculate SHA256 hash of Dockerfile + build context for each container
@@ -29,7 +32,7 @@
 # - Manual dispatch for forced rebuilds (with force_rebuild option)
 #
 # License:
-# This GitHub Workflow file is part of the Carlos EMR project and is subject
+# This GitHub Workflow file is part of the CARLOS EMR project and is subject
 # to the licensing terms outlined in the repository's LICENSE file.
 
 name: Development Container Images
@@ -177,7 +180,7 @@ jobs:
           # Check each container (name, output_name, context_path, extra_context)
           check_container "tomcat-dev" "tomcat" ".devcontainer/development" ""
           check_container "mariadb-dev" "mariadb" ".devcontainer/db" "database .devcontainer/development/config/shared/my.cnf"
-          check_container "drugref" "drugref" ".devcontainer/drugref" ""
+          check_container "drugref-dev" "drugref" ".devcontainer/drugref" ""
 
   # ===========================================================================
   # Build and push tomcat-dev container
@@ -483,10 +486,10 @@ jobs:
         env:
           CONTENT_HASH: ${{ needs.check-containers.outputs.drugref_hash }}
         run: |
-          echo "Building carlos-drugref container..."
+          echo "Building carlos-drugref-dev container..."
           docker buildx build \
             --load \
-            -t carlos-drugref:test \
+            -t carlos-drugref-dev:test \
             --label "org.openosp.content-hash=$CONTENT_HASH" \
             --label "org.opencontainers.image.source=https://github.com/${{ github.repository }}" \
             --label "org.opencontainers.image.revision=${{ github.sha }}" \
@@ -495,7 +498,7 @@ jobs:
       - name: Test drugref container
         run: |
           echo "Testing container starts correctly..."
-          docker run -d --name test-drugref -p 8081:8080 carlos-drugref:test
+          docker run -d --name test-drugref -p 8081:8080 carlos-drugref-dev:test
 
           echo "Waiting for Tomcat to start..."
           ready=false
@@ -537,13 +540,13 @@ jobs:
       - name: Save tested drugref image
         run: |
           mkdir -p "$RUNNER_TEMP/container-images"
-          docker save carlos-drugref:test -o "$RUNNER_TEMP/container-images/carlos-drugref.tar"
+          docker save carlos-drugref-dev:test -o "$RUNNER_TEMP/container-images/carlos-drugref-dev.tar"
 
       - name: Upload tested drugref image
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: carlos-drugref-image
-          path: ${{ runner.temp }}/container-images/carlos-drugref.tar
+          name: carlos-drugref-dev-image
+          path: ${{ runner.temp }}/container-images/carlos-drugref-dev.tar
           retention-days: 1
 
   publish-drugref:
@@ -557,7 +560,7 @@ jobs:
       - name: Download tested drugref image
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          name: carlos-drugref-image
+          name: carlos-drugref-dev-image
           path: ${{ runner.temp }}/container-images
 
       - name: Log in to Container Registry
@@ -569,7 +572,7 @@ jobs:
 
       - name: Push tested drugref container
         env:
-          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/carlos-drugref
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/carlos-drugref-dev
           CACHE_REF_NAME: ${{ github.base_ref || github.ref_name }}
           SHOULD_PUSH_LATEST: ${{ github.ref_name == 'develop' }}
         run: |
@@ -584,14 +587,14 @@ jobs:
             printf '%s-latest' "$safe_ref"
           }
 
-          docker load -i "$RUNNER_TEMP/container-images/carlos-drugref.tar"
-          docker tag carlos-drugref:test "$IMAGE:${{ github.sha }}"
+          docker load -i "$RUNNER_TEMP/container-images/carlos-drugref-dev.tar"
+          docker tag carlos-drugref-dev:test "$IMAGE:${{ github.sha }}"
           CACHE_TAG=$(cache_tag "$CACHE_REF_NAME")
-          docker tag carlos-drugref:test "$IMAGE:$CACHE_TAG"
+          docker tag carlos-drugref-dev:test "$IMAGE:$CACHE_TAG"
           docker push "$IMAGE:$CACHE_TAG"
           echo "Pushed $IMAGE:$CACHE_TAG"
           if [ "$SHOULD_PUSH_LATEST" = "true" ]; then
-            docker tag carlos-drugref:test "$IMAGE:latest"
+            docker tag carlos-drugref-dev:test "$IMAGE:latest"
             docker push "$IMAGE:latest"
             echo "Pushed $IMAGE:latest"
           fi

--- a/.github/workflows/container-images.yml
+++ b/.github/workflows/container-images.yml
@@ -12,7 +12,7 @@
 # Containers Managed:
 # - carlos-tomcat-dev: Development container with Java 21, Tomcat, Maven, Node.js
 # - carlos-mariadb-dev: MariaDB database container with schema initialization scripts
-# - carlos-drugref-dev: DrugRef2 service container with Java 11
+# - carlos-drugref-dev: DrugRef2 service container with Java 21
 #   (the bare "carlos-drugref" ghcr name is reserved for the DEPLOYMENT image
 #   published by the carlos-podman repo's Publish Images workflow — dev images
 #   all carry the -dev suffix)

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>io.github.carlos_emr</groupId>
     <artifactId>carlos</artifactId>
     <packaging>war</packaging>
-    <version>2026.08.0-alpha3</version>
+    <version>2026.08.0-alpha4-SNAPSHOT</version>
     <name>CARLOS</name>
     <description>CARLOS EMR (Clinical Assisting Recording Ledger Open Source) is a web-based electronic medical record system for Canadian healthcare.</description>
     <inceptionYear>2024</inceptionYear>
@@ -19,7 +19,7 @@
         <url>https://github.com/carlos-emr/carlos</url>
         <connection>scm:git:https://github.com/carlos-emr/carlos.git</connection>
         <developerConnection>scm:git:ssh://git@github.com:carlos-emr/carlos.git</developerConnection>
-        <tag>2026.08.0-alpha3</tag>
+        <tag>HEAD</tag>
     </scm>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>io.github.carlos_emr</groupId>
     <artifactId>carlos</artifactId>
     <packaging>war</packaging>
-    <version>2026.08.0-alpha4-SNAPSHOT</version>
+    <version>2026.08.0-alpha4</version>
     <name>CARLOS</name>
     <description>CARLOS EMR (Clinical Assisting Recording Ledger Open Source) is a web-based electronic medical record system for Canadian healthcare.</description>
     <inceptionYear>2024</inceptionYear>
@@ -19,7 +19,7 @@
         <url>https://github.com/carlos-emr/carlos</url>
         <connection>scm:git:https://github.com/carlos-emr/carlos.git</connection>
         <developerConnection>scm:git:ssh://git@github.com:carlos-emr/carlos.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>2026.08.0-alpha4</tag>
     </scm>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
## Summary

Prepares the current 2026.08 maintenance line for the `2026.08.0-alpha4` prerelease.

- reconciles the equivalent changes that were merged independently into `main` and `release/2026.08`, preserving both branch histories;
- changes `project.version` from `2026.08.0-alpha4-SNAPSHOT` to `2026.08.0-alpha4`;
- changes `project.scm.tag` from `HEAD` to `2026.08.0-alpha4`.

Against `main`, the net content change is only the two intended POM metadata lines.

## Why

Alpha4 must be promoted from the maintenance line to an exact, non-snapshot commit on `main` before its immutable tag and prerelease can be created. The reconciliation merge prevents the independently merged main/release commits from remaining disconnected.

## Validation

- verified current `main` and `release/2026.08` are both ancestors of this branch;
- `git diff --check origin/main...HEAD`;
- verified the PR's net diff to `main` is limited to `pom.xml`;
- `mvn -B -DskipTests validate` — success, building `2026.08.0-alpha4` with a matching dependency lock.

## Merge and release requirements

Use **Create a merge commit**. Do not squash or rebase, because that would discard the maintenance-line ancestry.

After checks and review pass, merge this PR to `main`. Create the single annotated `2026.08.0-alpha4` tag on that exact `main` merge commit; do not tag the preparation branch or create a second tag on `release/2026.08`. The tagged main commit will be back-merged into the maintenance branch before advancing it to `2026.08.0-alpha5-SNAPSHOT`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes 2026.08.0-alpha4 to a fixed commit on `main` and reconciles `main` and `release/2026.08` histories so the prerelease can be tagged. Updates `pom.xml` only: version from 2026.08.0-alpha3 to 2026.08.0-alpha4 and `scm.tag` to 2026.08.0-alpha4; no runtime changes.

**Merge and release requirements**
- Merge with “Create a merge commit” to preserve maintenance-line ancestry; do not squash or rebase.
- After merging to `main`, create a single annotated tag `2026.08.0-alpha4` on that merge commit only; do not tag the preparation branch or `release/2026.08`.

<sup>Written for commit d772fe655ffcc8ea160da12d86fa776934b31ff2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

