### PR TITLE
chore(release): advance 2026.08 to alpha5 snapshot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>io.github.carlos_emr</groupId>
     <artifactId>carlos</artifactId>
     <packaging>war</packaging>
-    <version>2026.08.0-alpha4</version>
+    <version>2026.08.0-alpha5-SNAPSHOT</version>
     <name>CARLOS</name>
     <description>CARLOS EMR (Clinical Assisting Recording Ledger Open Source) is a web-based electronic medical record system for Canadian healthcare.</description>
     <inceptionYear>2024</inceptionYear>
@@ -19,7 +19,7 @@
         <url>https://github.com/carlos-emr/carlos</url>
         <connection>scm:git:https://github.com/carlos-emr/carlos.git</connection>
         <developerConnection>scm:git:ssh://git@github.com:carlos-emr/carlos.git</developerConnection>
-        <tag>2026.08.0-alpha4</tag>
+        <tag>HEAD</tag>
     </scm>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
## Summary

- advance the `release/2026.08` maintenance line from released `2026.08.0-alpha4` to `2026.08.0-alpha5-SNAPSHOT`
- restore the Maven SCM tag to `HEAD` for ongoing maintenance development
- keep the immutable `2026.08.0-alpha4` tag and published prerelease unchanged

This follows the successful alpha4 publication and back-merge in #3500. The tagged alpha4 main commit is now part of `release/2026.08` ancestry.

## Impact

New maintenance builds identify as alpha5 snapshots while fixes for the next 2026.08 prerelease are developed. This PR does not create or move any release tag.

## Validation

- `mvn -q help:evaluate -Dexpression=project.version -DforceStdout` → `2026.08.0-alpha5-SNAPSHOT`
- `mvn -B -DskipTests validate`
- dependency lock check passed
- `git diff --check origin/release/2026.08..HEAD`
- DCO sign-off present

## Merge method

Use **Create a merge commit** to retain the signed advancement commit and the established maintenance history.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Advance the 2026.08 maintenance line to 2026.08.0-alpha5-SNAPSHOT and restore the SCM tag to HEAD so ongoing fixes build as alpha5 without altering the published alpha4 release.

- Old behavior: maintenance builds identified as 2026.08.0-alpha4. New behavior: 2026.08.0-alpha5-SNAPSHOT. No functional code changes.
- Updates pom.xml version and sets SCM tag to HEAD; no release tag is created or moved.
- Use Create a merge commit to preserve the signed advancement commit.

<sup>Written for commit 8e0333ffcc75ee839fcba72917c6c6e4e7e518b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3501?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

