### PR TITLE
chore(release): prepare 2026.08.0-alpha5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>io.github.carlos_emr</groupId>
     <artifactId>carlos</artifactId>
     <packaging>war</packaging>
-    <version>2026.08.0-alpha5-SNAPSHOT</version>
+    <version>2026.08.0-alpha5</version>
     <name>CARLOS</name>
     <description>CARLOS EMR (Clinical Assisting Recording Ledger Open Source) is a web-based electronic medical record system for Canadian healthcare.</description>
     <inceptionYear>2024</inceptionYear>
@@ -19,7 +19,7 @@
         <url>https://github.com/carlos-emr/carlos</url>
         <connection>scm:git:https://github.com/carlos-emr/carlos.git</connection>
         <developerConnection>scm:git:ssh://git@github.com:carlos-emr/carlos.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>2026.08.0-alpha5</tag>
     </scm>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Sets `project.version` and `<scm><tag>` in `pom.xml` from
`2026.08.0-alpha5-SNAPSHOT` / `HEAD` to `2026.08.0-alpha5`, so the
release tag `2026.08.0-alpha5` passes `publish-release.yml`'s validate
step (which requires `tag == project.version == project.scm.tag` and
rejects `-SNAPSHOT`).

Mirrors the prior `agent/prepare-2026-08-alphaN` PRs.

**Release sequence** (this is step 1):
1. Merge this PR into `release/2026.08`.
2. Push the annotated tag `2026.08.0-alpha5` at the merge commit →
   `publish-release.yml` publishes the release and dispatches
   `deb-packages.yml`, which builds and attaches the `carlos-emr` and
   `carlos-emr-drugref` `.deb` assets (verified against the WAR's build
   attestation).
3. Advance `release/2026.08` back to the next `-SNAPSHOT`.
4. Promote `main` to the released state.

No functional change; the .deb packaging and SRFax fax work (#3510) is
already on `release/2026.08`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares the 2026.08.0-alpha5 release by setting Maven version and SCM tag to the exact release value. Was 2026.08.0-alpha5-SNAPSHOT and HEAD; now 2026.08.0-alpha5 and 2026.08.0-alpha5 to satisfy `publish-release.yml`’s validation (requires tag == project.version == project.scm.tag). No functional change.

**Rollout**
- Merge into release/2026.08, then push the annotated tag 2026.08.0-alpha5 at the merge commit to trigger `publish-release.yml` (which dispatches `deb-packages.yml` to build and attach the `carlos-emr` and `carlos-emr-drugref` .deb assets).
- After publish, bump release/2026.08 back to the next -SNAPSHOT and promote main.

<sup>Written for commit ac0fd1c4b275b315630b9c73775f22df39fda80f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

