### PR TITLE
chore(release): advance 2026.08 to alpha6 snapshot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>io.github.carlos_emr</groupId>
     <artifactId>carlos</artifactId>
     <packaging>war</packaging>
-    <version>2026.08.0-alpha5</version>
+    <version>2026.08.0-alpha6-SNAPSHOT</version>
     <name>CARLOS</name>
     <description>CARLOS EMR (Clinical Assisting Recording Ledger Open Source) is a web-based electronic medical record system for Canadian healthcare.</description>
     <inceptionYear>2024</inceptionYear>
@@ -19,7 +19,7 @@
         <url>https://github.com/carlos-emr/carlos</url>
         <connection>scm:git:https://github.com/carlos-emr/carlos.git</connection>
         <developerConnection>scm:git:ssh://git@github.com:carlos-emr/carlos.git</developerConnection>
-        <tag>2026.08.0-alpha5</tag>
+        <tag>HEAD</tag>
     </scm>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Moves `release/2026.08` off the released version to the next development
snapshot: `pom.xml` `project.version` → `2026.08.0-alpha6-SNAPSHOT`,
`<scm><tag>` → `HEAD`.

**Merge AFTER** #3513 (prepare alpha5) is merged and the
`2026.08.0-alpha5` tag has been pushed — this branch is based on the
prepare-alpha5 commit, so it goes `2026.08.0-alpha5` →
`2026.08.0-alpha6-SNAPSHOT` cleanly.

Mirrors the prior "advance 2026.08 to alphaN snapshot" step (e.g. #3501).
If 2026.08 is moving to beta/rc/GA rather than another alpha, adjust the
version accordingly before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Advances `release/2026.08` to the next development snapshot: `project.version` 2026.08.0-alpha5 → 2026.08.0-alpha6-SNAPSHOT and `<scm><tag>` → `HEAD`. This resumes post-alpha5 development with no runtime changes.

- Merge after #3513 and after the 2026.08.0-alpha5 tag is pushed; if the next cut is beta/rc/GA, update the version accordingly before merging.
- Branch is synced with `main`; expect only `pom.xml` changes.

<sup>Written for commit 40d6a440da6c075e2ed1ce3a49b46792869fafa8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3515?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

