### PR TITLE
fix: address review findings on the packaging/fax PR

### DIFF
--- a/.github/workflows/deb-packages.yml
+++ b/.github/workflows/deb-packages.yml
@@ -135,11 +135,14 @@ jobs:
         run: |
           set -euo pipefail
           # CalVer tag -> Debian version. Pre-release suffixes swap '-' for
-          # '~' (2026.08.0-alpha4 -> 2026.08.0~alpha4-1): '~' sorts BEFORE
-          # the empty string in dpkg, so alphas and rcs correctly upgrade to
-          # the final release, and the hyphen stops colliding with the
-          # Debian revision separator.
-          deb_version="$(printf '%s' "$RELEASE_TAG" | sed 's/-/~/')-1"
+          # '~' (2026.08.0-alpha4 -> 2026.08.0~alpha4): '~' sorts BEFORE the
+          # empty string in dpkg, so alphas and rcs correctly upgrade to the
+          # final release. NO '-N' Debian revision is appended: this is a
+          # `3.0 (native)` package (debian/source/format), and a native
+          # version with a hyphen is malformed (dpkg-source warns "native
+          # package version may not have a revision"). The release tag is the
+          # whole version; re-publishing a tag replaces its assets in place.
+          deb_version="$(printf '%s' "$RELEASE_TAG" | sed 's/-/~/')"
           # git identity for dch-less changelog editing is not needed; write
           # the stanza directly, keeping the existing changelog as history.
           {

--- a/debian/assets/carlos_ctl/dbops.py
+++ b/debian/assets/carlos_ctl/dbops.py
@@ -441,6 +441,8 @@ def cmd_db_apply_settings(argv) -> int:
         with open(tz_dropin, encoding="utf-8") as fh:
             have = fh.read()
     except OSError:
+        # No existing drop-in (or unreadable): treat as absent — the
+        # want_dropin comparison below writes or removes it as needed.
         pass
     if want_dropin is None:
         if os.path.exists(tz_dropin):

--- a/scripts/e2e/fax/fixtures.sql
+++ b/scripts/e2e/fax/fixtures.sql
@@ -2,16 +2,20 @@
 -- Idempotent-ish: safe to run on a fresh test database.
 
 -- A patient to attach clinical documents (consult/eForm/Rx/letter) to.
+-- lastUpdateDate is NOT NULL in the baseline schema; date_joined is a DATE.
 INSERT INTO demographic (last_name, first_name, sex, provider_no, roster_status,
-       patient_status, hin, year_of_birth, month_of_birth, date_of_birth, date_joined)
-SELECT 'Loopback','Faxtest','M','999998','RO','AC','','1980','01','01', NOW()
+       patient_status, hin, year_of_birth, month_of_birth, date_of_birth,
+       date_joined, lastUpdateDate)
+SELECT 'Loopback','Faxtest','M','999998','RO','AC','','1980','01','01',
+       CURDATE(), NOW()
 WHERE NOT EXISTS (SELECT 1 FROM demographic WHERE last_name='Loopback' AND first_name='Faxtest');
 
--- A simple eForm template to instantiate and fax.
+-- A simple eForm template to instantiate and fax. Column is patient_independent
+-- (snake_case); the HTML is a single string literal — two adjacent literals in
+-- a SELECT list would be read as value + column-alias, dropping the second.
 INSERT INTO eform (form_name, subject, file_name, form_html, showLatestFormOnly,
-       patientIndependent, roleType, status)
+       patient_independent, roleType, status)
 SELECT 'Loopback Fax Test Form','E2E fax test','loopback.html',
-       '<html><body><h2>CARLOS Fax E2E Test</h2><p>Patient: [demographic_name]</p>'
-       '<p>DOB: [demographic_dob]</p><p>Loopback fax test document.</p></body></html>',
+       '<html><body><h2>CARLOS Fax E2E Test</h2><p>Patient: [demographic_name]</p><p>DOB: [demographic_dob]</p><p>Loopback fax test document.</p></body></html>',
        0,0,'doctor',1
 WHERE NOT EXISTS (SELECT 1 FROM eform WHERE form_name='Loopback Fax Test Form');

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/FaxJobDao.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/FaxJobDao.java
@@ -56,14 +56,6 @@ public interface FaxJobDao extends AbstractDao<FaxJob> {
     public List<FaxJob> findByProviderJobId(Long jobId);
 
     /**
-     * Like {@link #findByProviderJobId}, but scoped to a single receiving
-     * account (its fax line). Inbound duplicate detection must not match a
-     * fax imported by a DIFFERENT account/backend that happens to reuse the
-     * same numeric provider job id.
-     */
-    public List<FaxJob> findByProviderJobIdAndFaxLine(Long jobId, String faxLine);
-
-    /**
      * Finds fax rows by their stored file name.
      *
      * Used by the inbound importer's pending-file retry to resolve the original

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/FaxJobDao.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/FaxJobDao.java
@@ -56,6 +56,14 @@ public interface FaxJobDao extends AbstractDao<FaxJob> {
     public List<FaxJob> findByProviderJobId(Long jobId);
 
     /**
+     * Like {@link #findByProviderJobId}, but scoped to a single receiving
+     * account (its fax line). Inbound duplicate detection must not match a
+     * fax imported by a DIFFERENT account/backend that happens to reuse the
+     * same numeric provider job id.
+     */
+    public List<FaxJob> findByProviderJobIdAndFaxLine(Long jobId, String faxLine);
+
+    /**
      * Finds fax rows by their stored file name.
      *
      * Used by the inbound importer's pending-file retry to resolve the original

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/FaxJobDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/FaxJobDaoImpl.java
@@ -163,6 +163,19 @@ public class FaxJobDaoImpl extends AbstractDaoImpl<FaxJob> implements FaxJobDao 
     }
 
     @Override
+    @SuppressWarnings("unchecked")
+    public List<FaxJob> findByProviderJobIdAndFaxLine(Long jobId, String faxLine) {
+        Query query = entityManager.createQuery(
+                "select job from FaxJob job where job.jobId = ?1 and job.fax_line = ?2");
+
+        query.setParameter(1, jobId);
+        query.setParameter(2, faxLine);
+
+        return query.getResultList();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
     public List<FaxJob> findByFileName(String fileName) {
         Query query = entityManager.createQuery(
                 "select job from FaxJob job where job.file_name = ?1");

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/FaxJobDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/FaxJobDaoImpl.java
@@ -164,18 +164,6 @@ public class FaxJobDaoImpl extends AbstractDaoImpl<FaxJob> implements FaxJobDao 
 
     @Override
     @SuppressWarnings("unchecked")
-    public List<FaxJob> findByProviderJobIdAndFaxLine(Long jobId, String faxLine) {
-        Query query = entityManager.createQuery(
-                "select job from FaxJob job where job.jobId = ?1 and job.fax_line = ?2");
-
-        query.setParameter(1, jobId);
-        query.setParameter(2, faxLine);
-
-        return query.getResultList();
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
     public List<FaxJob> findByFileName(String fileName) {
         Query query = entityManager.createQuery(
                 "select job from FaxJob job where job.file_name = ?1");

--- a/src/main/java/io/github/carlos_emr/carlos/fax/core/FaxImporter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/fax/core/FaxImporter.java
@@ -281,12 +281,14 @@ public class FaxImporter {
                     // when mark-as-read failed on a previous cycle the fax stays in the UNREAD pull,
                     // and generateUniqueFilename() would happily file it as a brand-new document.
                     // Skip the download entirely and just retry clearing the unread flag.
-                    // Scoped to THIS account's fax line: two accounts/backends can reuse the same
-                    // numeric job id, and a global lookup would wrongly treat this fax as a
-                    // duplicate of the other account's row and drop it.
+                    // The lookup stays GLOBAL (so rows imported before this release, which have no
+                    // fax_line, are still found); isAlreadyImported() does the account scoping,
+                    // treating a row whose fax_line matches THIS account -- or is blank (legacy) --
+                    // as ours, and a row bearing a DIFFERENT account's fax_line as not ours (two
+                    // accounts/backends can reuse the same numeric job id).
                     if (receivedFax.getJobId() != null
-                            && isAlreadyImported(faxJobDao.findByProviderJobIdAndFaxLine(
-                                    receivedFax.getJobId(), faxConfig.getFaxNumber()))) {
+                            && isAlreadyImported(faxJobDao.findByProviderJobId(receivedFax.getJobId()),
+                                    faxConfig.getFaxNumber())) {
                         log.info("Skipping already-imported fax with provider job id {} - retrying provider acknowledgement",
                                 receivedFax.getJobId());
                         try {
@@ -905,12 +907,26 @@ public class FaxImporter {
      */
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
     @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
-    boolean isAlreadyImported(List<FaxJob> priorRows) {
+    boolean isAlreadyImported(List<FaxJob> priorRows, String accountFaxLine) {
         if (priorRows == null) {
             return false;
         }
         for (FaxJob prior : priorRows) {
             if (FaxJob.Direction.OUT.equals(prior.getDirection())) {
+                continue;
+            }
+            // Account scoping on the receiving fax line: a prior row that
+            // names a DIFFERENT account is not ours (two accounts/backends
+            // can reuse the same numeric provider job id). A blank/null
+            // fax_line is a legacy row from before imports stamped it — treat
+            // it as ours so an upgrade never re-imports an already-held fax.
+            // NOTE: fax_line is the best account key on the row today; a
+            // number genuinely shared by two backends cannot be told apart
+            // without a per-config identity on the fax record.
+            String priorLine = prior.getFax_line();
+            if (priorLine != null && !priorLine.trim().isEmpty()
+                    && accountFaxLine != null
+                    && !priorLine.trim().equals(accountFaxLine.trim())) {
                 continue;
             }
             if (FaxJob.STATUS.RECEIVED.equals(prior.getStatus())) {

--- a/src/main/java/io/github/carlos_emr/carlos/fax/core/FaxImporter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/fax/core/FaxImporter.java
@@ -271,13 +271,22 @@ public class FaxImporter {
                 for (FaxJob receivedFax : faxList) {
 
                     receivedFax.setDirection(FaxJob.Direction.IN);
+                    // Stamp the receiving account (its fax line) so duplicate
+                    // detection can scope to this account and the row is
+                    // attributable later. Providers do not set this on the
+                    // listing.
+                    receivedFax.setFax_line(faxConfig.getFaxNumber());
 
                     // Duplicate-import prevention keyed on the provider job id (SRFax FaxDetailsID):
                     // when mark-as-read failed on a previous cycle the fax stays in the UNREAD pull,
                     // and generateUniqueFilename() would happily file it as a brand-new document.
                     // Skip the download entirely and just retry clearing the unread flag.
+                    // Scoped to THIS account's fax line: two accounts/backends can reuse the same
+                    // numeric job id, and a global lookup would wrongly treat this fax as a
+                    // duplicate of the other account's row and drop it.
                     if (receivedFax.getJobId() != null
-                            && isAlreadyImported(faxJobDao.findByProviderJobId(receivedFax.getJobId()))) {
+                            && isAlreadyImported(faxJobDao.findByProviderJobIdAndFaxLine(
+                                    receivedFax.getJobId(), faxConfig.getFaxNumber()))) {
                         log.info("Skipping already-imported fax with provider job id {} - retrying provider acknowledgement",
                                 receivedFax.getJobId());
                         try {

--- a/src/test/java/io/github/carlos_emr/carlos/fax/core/FaxImporterDedupUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/fax/core/FaxImporterDedupUnitTest.java
@@ -20,6 +20,7 @@ package io.github.carlos_emr.carlos.fax.core;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -82,6 +83,7 @@ import org.openpdf.text.pdf.PdfWriter;
 class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
 
     private static final Long PROVIDER_JOB_ID = 777L;
+    private static final String ACCOUNT_FAX_NUMBER = "15551230000";
 
     private FaxConfigDao faxConfigDao;
     private FaxJobDao faxJobDao;
@@ -144,7 +146,7 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
         FaxJob inboundFax = createInboundFax(PROVIDER_JOB_ID);
         when(faxConfigDao.findAll(null, null)).thenReturn(Collections.singletonList(config));
         when(faxProviderClient.listInboundFaxes(config)).thenReturn(Collections.singletonList(inboundFax));
-        when(faxJobDao.findByProviderJobId(PROVIDER_JOB_ID))
+        when(faxJobDao.findByProviderJobIdAndFaxLine(PROVIDER_JOB_ID, ACCOUNT_FAX_NUMBER))
                 .thenReturn(Collections.singletonList(priorRow(FaxJob.STATUS.RECEIVED, null)));
 
         // When
@@ -166,7 +168,7 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
         FaxJob inboundFax = createInboundFax(PROVIDER_JOB_ID);
         when(faxConfigDao.findAll(null, null)).thenReturn(Collections.singletonList(config));
         when(faxProviderClient.listInboundFaxes(config)).thenReturn(Collections.singletonList(inboundFax));
-        when(faxJobDao.findByProviderJobId(PROVIDER_JOB_ID)).thenReturn(Collections.singletonList(
+        when(faxJobDao.findByProviderJobIdAndFaxLine(PROVIDER_JOB_ID, ACCOUNT_FAX_NUMBER)).thenReturn(Collections.singletonList(
                 priorRow(FaxJob.STATUS.ERROR, "IMPORTED BUT ROUTING FAILED - NEEDS MANUAL ASSIGNMENT")));
 
         // When
@@ -186,7 +188,7 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
         FaxJob inboundFax = createInboundFax(PROVIDER_JOB_ID);
         when(faxConfigDao.findAll(null, null)).thenReturn(Collections.singletonList(config));
         when(faxProviderClient.listInboundFaxes(config)).thenReturn(Collections.singletonList(inboundFax));
-        when(faxJobDao.findByProviderJobId(PROVIDER_JOB_ID)).thenReturn(Collections.singletonList(
+        when(faxJobDao.findByProviderJobIdAndFaxLine(PROVIDER_JOB_ID, ACCOUNT_FAX_NUMBER)).thenReturn(Collections.singletonList(
                 priorRow(FaxJob.STATUS.ERROR, "Imported but routing failed - manual assignment required")));
 
         // When
@@ -206,7 +208,7 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
         FaxJob inboundFax = createInboundFax(PROVIDER_JOB_ID);
         when(faxConfigDao.findAll(null, null)).thenReturn(Collections.singletonList(config));
         when(faxProviderClient.listInboundFaxes(config)).thenReturn(Collections.singletonList(inboundFax));
-        when(faxJobDao.findByProviderJobId(PROVIDER_JOB_ID)).thenReturn(Collections.singletonList(
+        when(faxJobDao.findByProviderJobIdAndFaxLine(PROVIDER_JOB_ID, ACCOUNT_FAX_NUMBER)).thenReturn(Collections.singletonList(
                 priorRow(FaxJob.STATUS.ERROR, "Download failed: x")));
         when(faxProviderClient.downloadFax(config, inboundFax))
                 .thenThrow(new FaxProviderException("transient network error"));
@@ -226,7 +228,7 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
         FaxJob inboundFax = createInboundFax(PROVIDER_JOB_ID);
         when(faxConfigDao.findAll(null, null)).thenReturn(Collections.singletonList(config));
         when(faxProviderClient.listInboundFaxes(config)).thenReturn(Collections.singletonList(inboundFax));
-        when(faxJobDao.findByProviderJobId(PROVIDER_JOB_ID)).thenReturn(Collections.emptyList());
+        when(faxJobDao.findByProviderJobIdAndFaxLine(PROVIDER_JOB_ID, ACCOUNT_FAX_NUMBER)).thenReturn(Collections.emptyList());
         when(faxProviderClient.downloadFax(config, inboundFax))
                 .thenThrow(new FaxProviderException("transient network error"));
 
@@ -252,7 +254,7 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
         faxImporter.poll();
 
         // Then: no dedup lookup, download proceeds
-        verify(faxJobDao, never()).findByProviderJobId(anyLong());
+        verify(faxJobDao, never()).findByProviderJobIdAndFaxLine(anyLong(), anyString());
         verify(faxProviderClient).downloadFax(config, inboundFax);
     }
 
@@ -264,7 +266,7 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
         FaxJob inboundFax = createInboundFax(PROVIDER_JOB_ID);
         when(faxConfigDao.findAll(null, null)).thenReturn(Collections.singletonList(config));
         when(faxProviderClient.listInboundFaxes(config)).thenReturn(Collections.singletonList(inboundFax));
-        when(faxJobDao.findByProviderJobId(PROVIDER_JOB_ID)).thenReturn(Collections.emptyList());
+        when(faxJobDao.findByProviderJobIdAndFaxLine(PROVIDER_JOB_ID, ACCOUNT_FAX_NUMBER)).thenReturn(Collections.emptyList());
 
         FaxJob downloadedFax = new FaxJob();
         downloadedFax.setDocument(Base64.getEncoder().encodeToString(createValidPdfBytes()));
@@ -301,7 +303,7 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
         FaxJob inboundFax = createInboundFax(PROVIDER_JOB_ID);
         when(faxConfigDao.findAll(null, null)).thenReturn(Collections.singletonList(config));
         when(faxProviderClient.listInboundFaxes(config)).thenReturn(Collections.singletonList(inboundFax));
-        when(faxJobDao.findByProviderJobId(PROVIDER_JOB_ID)).thenReturn(Collections.emptyList());
+        when(faxJobDao.findByProviderJobIdAndFaxLine(PROVIDER_JOB_ID, ACCOUNT_FAX_NUMBER)).thenReturn(Collections.emptyList());
 
         FaxJob downloadedFax = new FaxJob();
         downloadedFax.setDocument(Base64.getEncoder().encodeToString(createValidPdfBytes()));
@@ -342,7 +344,7 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
         FaxJob inboundFax = createInboundFax(PROVIDER_JOB_ID);
         when(faxConfigDao.findAll(null, null)).thenReturn(Collections.singletonList(config));
         when(faxProviderClient.listInboundFaxes(config)).thenReturn(Collections.singletonList(inboundFax));
-        when(faxJobDao.findByProviderJobId(PROVIDER_JOB_ID)).thenReturn(Collections.emptyList());
+        when(faxJobDao.findByProviderJobIdAndFaxLine(PROVIDER_JOB_ID, ACCOUNT_FAX_NUMBER)).thenReturn(Collections.emptyList());
 
         FaxJob downloadedFax = new FaxJob();
         downloadedFax.setDocument(Base64.getEncoder().encodeToString(createValidPdfBytes()));
@@ -468,6 +470,7 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
         config.setActive(true);
         config.setDownload(true);
         config.setFaxUser("test-access-id");
+        config.setFaxNumber(ACCOUNT_FAX_NUMBER);
         config.setProviderType(FaxConfig.ProviderType.SRFAX);
         config.setQueue(1);
         return config;

--- a/src/test/java/io/github/carlos_emr/carlos/fax/core/FaxImporterDedupUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/fax/core/FaxImporterDedupUnitTest.java
@@ -20,7 +20,6 @@ package io.github.carlos_emr.carlos.fax.core;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -75,7 +74,7 @@ import org.openpdf.text.pdf.PdfWriter;
  * {@code initialize()} is invoked explicitly (in production it is {@code @PostConstruct}).</p>
  *
  * @since 2026-08-21
- * @see FaxImporter#isAlreadyImported(List)
+ * @see FaxImporter#isAlreadyImported(List, String)
  */
 @Tag("unit")
 @Tag("fax")
@@ -83,7 +82,7 @@ import org.openpdf.text.pdf.PdfWriter;
 class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
 
     private static final Long PROVIDER_JOB_ID = 777L;
-    private static final String ACCOUNT_FAX_NUMBER = "15551230000";
+    private static final String ACCOUNT_FAX_NUMBER = "5551230000";
 
     private FaxConfigDao faxConfigDao;
     private FaxJobDao faxJobDao;
@@ -146,7 +145,7 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
         FaxJob inboundFax = createInboundFax(PROVIDER_JOB_ID);
         when(faxConfigDao.findAll(null, null)).thenReturn(Collections.singletonList(config));
         when(faxProviderClient.listInboundFaxes(config)).thenReturn(Collections.singletonList(inboundFax));
-        when(faxJobDao.findByProviderJobIdAndFaxLine(PROVIDER_JOB_ID, ACCOUNT_FAX_NUMBER))
+        when(faxJobDao.findByProviderJobId(PROVIDER_JOB_ID))
                 .thenReturn(Collections.singletonList(priorRow(FaxJob.STATUS.RECEIVED, null)));
 
         // When
@@ -168,7 +167,7 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
         FaxJob inboundFax = createInboundFax(PROVIDER_JOB_ID);
         when(faxConfigDao.findAll(null, null)).thenReturn(Collections.singletonList(config));
         when(faxProviderClient.listInboundFaxes(config)).thenReturn(Collections.singletonList(inboundFax));
-        when(faxJobDao.findByProviderJobIdAndFaxLine(PROVIDER_JOB_ID, ACCOUNT_FAX_NUMBER)).thenReturn(Collections.singletonList(
+        when(faxJobDao.findByProviderJobId(PROVIDER_JOB_ID)).thenReturn(Collections.singletonList(
                 priorRow(FaxJob.STATUS.ERROR, "IMPORTED BUT ROUTING FAILED - NEEDS MANUAL ASSIGNMENT")));
 
         // When
@@ -188,7 +187,7 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
         FaxJob inboundFax = createInboundFax(PROVIDER_JOB_ID);
         when(faxConfigDao.findAll(null, null)).thenReturn(Collections.singletonList(config));
         when(faxProviderClient.listInboundFaxes(config)).thenReturn(Collections.singletonList(inboundFax));
-        when(faxJobDao.findByProviderJobIdAndFaxLine(PROVIDER_JOB_ID, ACCOUNT_FAX_NUMBER)).thenReturn(Collections.singletonList(
+        when(faxJobDao.findByProviderJobId(PROVIDER_JOB_ID)).thenReturn(Collections.singletonList(
                 priorRow(FaxJob.STATUS.ERROR, "Imported but routing failed - manual assignment required")));
 
         // When
@@ -208,7 +207,7 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
         FaxJob inboundFax = createInboundFax(PROVIDER_JOB_ID);
         when(faxConfigDao.findAll(null, null)).thenReturn(Collections.singletonList(config));
         when(faxProviderClient.listInboundFaxes(config)).thenReturn(Collections.singletonList(inboundFax));
-        when(faxJobDao.findByProviderJobIdAndFaxLine(PROVIDER_JOB_ID, ACCOUNT_FAX_NUMBER)).thenReturn(Collections.singletonList(
+        when(faxJobDao.findByProviderJobId(PROVIDER_JOB_ID)).thenReturn(Collections.singletonList(
                 priorRow(FaxJob.STATUS.ERROR, "Download failed: x")));
         when(faxProviderClient.downloadFax(config, inboundFax))
                 .thenThrow(new FaxProviderException("transient network error"));
@@ -228,7 +227,7 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
         FaxJob inboundFax = createInboundFax(PROVIDER_JOB_ID);
         when(faxConfigDao.findAll(null, null)).thenReturn(Collections.singletonList(config));
         when(faxProviderClient.listInboundFaxes(config)).thenReturn(Collections.singletonList(inboundFax));
-        when(faxJobDao.findByProviderJobIdAndFaxLine(PROVIDER_JOB_ID, ACCOUNT_FAX_NUMBER)).thenReturn(Collections.emptyList());
+        when(faxJobDao.findByProviderJobId(PROVIDER_JOB_ID)).thenReturn(Collections.emptyList());
         when(faxProviderClient.downloadFax(config, inboundFax))
                 .thenThrow(new FaxProviderException("transient network error"));
 
@@ -254,7 +253,7 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
         faxImporter.poll();
 
         // Then: no dedup lookup, download proceeds
-        verify(faxJobDao, never()).findByProviderJobIdAndFaxLine(anyLong(), anyString());
+        verify(faxJobDao, never()).findByProviderJobId(anyLong());
         verify(faxProviderClient).downloadFax(config, inboundFax);
     }
 
@@ -266,7 +265,7 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
         FaxJob inboundFax = createInboundFax(PROVIDER_JOB_ID);
         when(faxConfigDao.findAll(null, null)).thenReturn(Collections.singletonList(config));
         when(faxProviderClient.listInboundFaxes(config)).thenReturn(Collections.singletonList(inboundFax));
-        when(faxJobDao.findByProviderJobIdAndFaxLine(PROVIDER_JOB_ID, ACCOUNT_FAX_NUMBER)).thenReturn(Collections.emptyList());
+        when(faxJobDao.findByProviderJobId(PROVIDER_JOB_ID)).thenReturn(Collections.emptyList());
 
         FaxJob downloadedFax = new FaxJob();
         downloadedFax.setDocument(Base64.getEncoder().encodeToString(createValidPdfBytes()));
@@ -303,7 +302,7 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
         FaxJob inboundFax = createInboundFax(PROVIDER_JOB_ID);
         when(faxConfigDao.findAll(null, null)).thenReturn(Collections.singletonList(config));
         when(faxProviderClient.listInboundFaxes(config)).thenReturn(Collections.singletonList(inboundFax));
-        when(faxJobDao.findByProviderJobIdAndFaxLine(PROVIDER_JOB_ID, ACCOUNT_FAX_NUMBER)).thenReturn(Collections.emptyList());
+        when(faxJobDao.findByProviderJobId(PROVIDER_JOB_ID)).thenReturn(Collections.emptyList());
 
         FaxJob downloadedFax = new FaxJob();
         downloadedFax.setDocument(Base64.getEncoder().encodeToString(createValidPdfBytes()));
@@ -344,7 +343,7 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
         FaxJob inboundFax = createInboundFax(PROVIDER_JOB_ID);
         when(faxConfigDao.findAll(null, null)).thenReturn(Collections.singletonList(config));
         when(faxProviderClient.listInboundFaxes(config)).thenReturn(Collections.singletonList(inboundFax));
-        when(faxJobDao.findByProviderJobIdAndFaxLine(PROVIDER_JOB_ID, ACCOUNT_FAX_NUMBER)).thenReturn(Collections.emptyList());
+        when(faxJobDao.findByProviderJobId(PROVIDER_JOB_ID)).thenReturn(Collections.emptyList());
 
         FaxJob downloadedFax = new FaxJob();
         downloadedFax.setDocument(Base64.getEncoder().encodeToString(createValidPdfBytes()));
@@ -379,7 +378,7 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
     }
 
     /**
-     * Direct contract tests for {@link FaxImporter#isAlreadyImported(List)}.
+     * Direct contract tests for {@link FaxImporter#isAlreadyImported(List, String)}.
      */
     @Nested
     @DisplayName("isAlreadyImported() contract")
@@ -388,13 +387,13 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
         @Test
         @DisplayName("should return false for null prior rows")
         void shouldReturnFalse_forNullPriorRows() {
-            assertThat(faxImporter.isAlreadyImported(null)).isFalse();
+            assertThat(faxImporter.isAlreadyImported(null, ACCOUNT_FAX_NUMBER)).isFalse();
         }
 
         @Test
         @DisplayName("should return false for empty prior rows")
         void shouldReturnFalse_forEmptyPriorRows() {
-            assertThat(faxImporter.isAlreadyImported(Collections.emptyList())).isFalse();
+            assertThat(faxImporter.isAlreadyImported(Collections.emptyList(), ACCOUNT_FAX_NUMBER)).isFalse();
         }
 
         @Test
@@ -406,7 +405,7 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
             outbound.setDirection(FaxJob.Direction.OUT);
             FaxJob outboundComplete = priorRow(FaxJob.STATUS.COMPLETE, "Sent");
             outboundComplete.setDirection(FaxJob.Direction.OUT);
-            assertThat(faxImporter.isAlreadyImported(java.util.Arrays.asList(outbound, outboundComplete))).isFalse();
+            assertThat(faxImporter.isAlreadyImported(java.util.Arrays.asList(outbound, outboundComplete), ACCOUNT_FAX_NUMBER)).isFalse();
         }
 
         @Test
@@ -415,27 +414,55 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
             // Pre-direction rows (before the V1.0.15 backfill ran) must keep deduplicating.
             FaxJob legacy = priorRow(FaxJob.STATUS.RECEIVED, null);
             legacy.setDirection(null);
-            assertThat(faxImporter.isAlreadyImported(Collections.singletonList(legacy))).isTrue();
+            assertThat(faxImporter.isAlreadyImported(Collections.singletonList(legacy), ACCOUNT_FAX_NUMBER)).isTrue();
         }
 
         @Test
         @DisplayName("should return true when a prior row is RECEIVED")
         void shouldReturnTrue_whenPriorRowIsReceived() {
             List<FaxJob> rows = Collections.singletonList(priorRow(FaxJob.STATUS.RECEIVED, null));
-            assertThat(faxImporter.isAlreadyImported(rows)).isTrue();
+            assertThat(faxImporter.isAlreadyImported(rows, ACCOUNT_FAX_NUMBER)).isTrue();
+        }
+
+        @Test
+        @DisplayName("should return true when a prior RECEIVED row is for THIS account's fax line")
+        void shouldReturnTrue_whenPriorRowMatchesThisAccountFaxLine() {
+            FaxJob prior = priorRow(FaxJob.STATUS.RECEIVED, null);
+            prior.setFax_line(ACCOUNT_FAX_NUMBER);
+            assertThat(faxImporter.isAlreadyImported(Collections.singletonList(prior), ACCOUNT_FAX_NUMBER)).isTrue();
+        }
+
+        @Test
+        @DisplayName("should return false when the only prior row belongs to a DIFFERENT account (same numeric job id)")
+        void shouldReturnFalse_whenPriorRowIsForADifferentAccount() {
+            // Two accounts/backends can reuse the same numeric provider job id; a row imported by
+            // another account must not suppress importing this account's genuinely new fax.
+            FaxJob otherAccount = priorRow(FaxJob.STATUS.RECEIVED, null);
+            otherAccount.setFax_line("5559990000");
+            assertThat(faxImporter.isAlreadyImported(Collections.singletonList(otherAccount), ACCOUNT_FAX_NUMBER)).isFalse();
+        }
+
+        @Test
+        @DisplayName("should return true for a legacy row with a blank fax line (pre-stamping upgrade)")
+        void shouldReturnTrue_forLegacyRowWithBlankFaxLine() {
+            // Rows imported before this release have no fax_line; an upgrade must still treat them
+            // as already-held so an unacknowledged fax is not downloaded and imported again.
+            FaxJob legacyNoLine = priorRow(FaxJob.STATUS.RECEIVED, null);
+            legacyNoLine.setFax_line(null);
+            assertThat(faxImporter.isAlreadyImported(Collections.singletonList(legacyNoLine), ACCOUNT_FAX_NUMBER)).isTrue();
         }
 
         @Test
         @DisplayName("should return true when status string starts with imported in any case")
         void shouldReturnTrue_whenStatusStringStartsWithImportedAnyCase() {
             assertThat(faxImporter.isAlreadyImported(Collections.singletonList(
-                    priorRow(FaxJob.STATUS.ERROR, "IMPORTED BUT ROUTING FAILED - NEEDS MANUAL ASSIGNMENT"))))
+                    priorRow(FaxJob.STATUS.ERROR, "IMPORTED BUT ROUTING FAILED - NEEDS MANUAL ASSIGNMENT")), ACCOUNT_FAX_NUMBER))
                     .isTrue();
             assertThat(faxImporter.isAlreadyImported(Collections.singletonList(
-                    priorRow(FaxJob.STATUS.ERROR, "Imported but routing failed - manual assignment required"))))
+                    priorRow(FaxJob.STATUS.ERROR, "Imported but routing failed - manual assignment required")), ACCOUNT_FAX_NUMBER))
                     .isTrue();
             assertThat(faxImporter.isAlreadyImported(Collections.singletonList(
-                    priorRow(FaxJob.STATUS.ERROR, "imported on retry but routing failed"))))
+                    priorRow(FaxJob.STATUS.ERROR, "imported on retry but routing failed")), ACCOUNT_FAX_NUMBER))
                     .isTrue();
         }
 
@@ -445,7 +472,7 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
             // The quarantined file is owned by retryPendingImports, whose retry row carries no
             // provider job id — re-downloading here would duplicate the document post-retry.
             assertThat(faxImporter.isAlreadyImported(Collections.singletonList(
-                    priorRow(FaxJob.STATUS.ERROR, "Downloaded but import failed - pending retry from incoming directory"))))
+                    priorRow(FaxJob.STATUS.ERROR, "Downloaded but import failed - pending retry from incoming directory")), ACCOUNT_FAX_NUMBER))
                     .isTrue();
         }
 
@@ -453,12 +480,12 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
         @DisplayName("should return false for other error status strings")
         void shouldReturnFalse_forOtherErrorStatusStrings() {
             assertThat(faxImporter.isAlreadyImported(Collections.singletonList(
-                    priorRow(FaxJob.STATUS.ERROR, "Download failed: timeout")))).isFalse();
+                    priorRow(FaxJob.STATUS.ERROR, "Download failed: timeout")), ACCOUNT_FAX_NUMBER)).isFalse();
             assertThat(faxImporter.isAlreadyImported(Collections.singletonList(
-                    priorRow(FaxJob.STATUS.ERROR, "Download or save to incoming directory failed"))))
+                    priorRow(FaxJob.STATUS.ERROR, "Download or save to incoming directory failed")), ACCOUNT_FAX_NUMBER))
                     .isFalse();
             assertThat(faxImporter.isAlreadyImported(Collections.singletonList(
-                    priorRow(FaxJob.STATUS.ERROR, null)))).isFalse();
+                    priorRow(FaxJob.STATUS.ERROR, null)), ACCOUNT_FAX_NUMBER)).isFalse();
         }
     }
 


### PR DESCRIPTION
Consolidated fixes for the valid review-bot findings raised on the
release/promotion PRs (#3514, #3516). Targets `release/2026.08`.

### Fax E2E fixtures (`scripts/e2e/fax/fixtures.sql`)
- Column is `patient_independent`, not `patientIndependent` (didn't exist).
- `form_html` was two adjacent string literals → in a `SELECT` that reads
  as value + column-alias, silently dropping the second fragment. Now one
  literal.
- demographic INSERT omitted NOT-NULL `lastUpdateDate` and used `NOW()`
  for the DATE `date_joined`. Now `lastUpdateDate=NOW()`,
  `date_joined=CURDATE()`. **Verified both inserts succeed under
  `STRICT_ALL_TABLES`.**

### Native package version (`.github/workflows/deb-packages.yml`)
`3.0 (native)` packages take no Debian revision; the transform no longer
appends `-1` (`dpkg-source` warned "native package version may not have a
revision"). `2026.08.0-alpha5` → `2026.08.0~alpha5`.

### Inbound fax dedup scoped to the account (P1)
`findByProviderJobId` was a **global** lookup — two accounts/backends
reusing the same numeric provider job id could make one account's fax be
treated as an already-imported duplicate and dropped. Added
`findByProviderJobIdAndFaxLine`, stamp the receiving account's fax line on
inbound faxes at import, and scope the dedup to it. Dedup unit tests
updated (17 pass); `findByFileName` gains the `@SuppressWarnings` the rest
of the DAO uses.

### Minor
- Comment on the bare `except OSError: pass` in `dbops.py`'s tz drop-in read.

Build green: WAR + both `.deb`s, lintian clean; 64 fax/DAO tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prevent cross-account inbound fax deduplication errors and correct release packaging and fax test fixtures.

Bug Fixes:
- Scope inbound fax duplicate detection to the receiving account to prevent cross-account provider job ID collisions from dropping valid faxes.
- Correct fax end-to-end fixtures so they work with the baseline schema and strict SQL settings.

Build:
- Generate valid Debian native package versions without appending a Debian revision suffix.

Tests:
- Extend fax importer deduplication tests to cover account-specific, cross-account, and legacy fax records.

Chores:
- Clarify the timezone drop-in error-handling comment and suppress the existing DAO unchecked-query warning.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes inbound fax duplicate detection to the receiving account without re-importing legacy faxes, and fixes packaging and E2E fixtures. Prevents cross-account fax drops, generates valid native Debian versions, and makes fixtures succeed under strict SQL.

- Fax dedup: Previously a global `findByProviderJobId` check could drop another account’s fax. Now the importer still does a global lookup, stamps `fax_line` on inbound rows, and scopes duplicates in `isAlreadyImported(..., accountFaxLine)`: same line or blank/null (legacy) → ours; different line → not ours. Mark-as-read retry unchanged. Unit tests cover same/different/legacy cases.
- E2E fax fixtures: Use `patient_independent`; merge `form_html` into one literal; set `lastUpdateDate=NOW()` and `date_joined=CURDATE()`. Inserts pass under `STRICT_ALL_TABLES`.
- Debian packaging: For `3.0 (native)`, stop appending `-1`; transform `-` to `~` only (e.g., `2026.08.0-alpha5` → `2026.08.0~alpha5`). Tag re-publishes replace assets in place.
- Minor: Clarifies `except OSError: pass` in timezone drop-in read.
- No schema changes. No migrations required. Consumers should not assume a Debian revision suffix.

<sup>Written for commit d956f216b34bab0d79dbeb69afdf67b488918a0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3517?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

