### PR TITLE
fix(fax): harden inbound-dedup scoping + native version (review follow-ups)

### DIFF
--- a/.github/workflows/deb-packages.yml
+++ b/.github/workflows/deb-packages.yml
@@ -142,7 +142,7 @@ jobs:
           # version with a hyphen is malformed (dpkg-source warns "native
           # package version may not have a revision"). The release tag is the
           # whole version; re-publishing a tag replaces its assets in place.
-          deb_version="$(printf '%s' "$RELEASE_TAG" | sed 's/-/~/')"
+          deb_version="$(printf '%s' "$RELEASE_TAG" | sed 's/-/~/g')"
           # git identity for dch-less changelog editing is not needed; write
           # the stanza directly, keeping the existing changelog as history.
           {

--- a/scripts/e2e/fax/fixtures.sql
+++ b/scripts/e2e/fax/fixtures.sql
@@ -8,7 +8,11 @@ INSERT INTO demographic (last_name, first_name, sex, provider_no, roster_status,
        date_joined, lastUpdateDate)
 SELECT 'Loopback','Faxtest','M','999998','RO','AC','','1980','01','01',
        CURDATE(), NOW()
-WHERE NOT EXISTS (SELECT 1 FROM demographic WHERE last_name='Loopback' AND first_name='Faxtest');
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM demographic
+    WHERE last_name = 'Loopback' AND first_name = 'Faxtest'
+);
 
 -- A simple eForm template to instantiate and fax. Column is patient_independent
 -- (snake_case); the HTML is a single string literal — two adjacent literals in
@@ -18,4 +22,8 @@ INSERT INTO eform (form_name, subject, file_name, form_html, showLatestFormOnly,
 SELECT 'Loopback Fax Test Form','E2E fax test','loopback.html',
        '<html><body><h2>CARLOS Fax E2E Test</h2><p>Patient: [demographic_name]</p><p>DOB: [demographic_dob]</p><p>Loopback fax test document.</p></body></html>',
        0,0,'doctor',1
-WHERE NOT EXISTS (SELECT 1 FROM eform WHERE form_name='Loopback Fax Test Form');
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM eform
+    WHERE form_name = 'Loopback Fax Test Form'
+);

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/FaxJobDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/FaxJobDaoImpl.java
@@ -162,6 +162,12 @@ public class FaxJobDaoImpl extends AbstractDaoImpl<FaxJob> implements FaxJobDao 
         return query.getResultList();
     }
 
+    /**
+     * All {@link FaxJob} rows whose staged file name equals {@code fileName}.
+     * Used by the retry path to locate the row for a quarantined document
+     * (which carries no provider job id). Returns an empty list when none
+     * match; order is unspecified.
+     */
     @Override
     @SuppressWarnings("unchecked")
     public List<FaxJob> findByFileName(String fileName) {

--- a/src/main/java/io/github/carlos_emr/carlos/fax/core/FaxImporter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/fax/core/FaxImporter.java
@@ -685,6 +685,9 @@ public class FaxImporter {
                             FaxJob retryFax = new FaxJob();
                             retryFax.setFile_name(pdfFile.getFileName().toString());
                             retryFax.setDirection(FaxJob.Direction.IN);
+                            // Stamp the receiving account like the poll path, so
+                            // dedup scoping and attribution apply to retry rows too.
+                            retryFax.setFax_line(faxConfig.getFaxNumber());
                             try {
                                 retryFax.setStamp(new Date(Files.getLastModifiedTime(pdfFile).toMillis()));
                             } catch (IOException e) {
@@ -907,7 +910,28 @@ public class FaxImporter {
      */
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
     @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
-    boolean isAlreadyImported(List<FaxJob> priorRows, String accountFaxLine) {
+    /**
+     * True when two fax-line values denote the same account, compared on
+     * their last 10 significant digits so a provider-supplied 11-digit line
+     * matches a 10-digit configured number (ConfigureFax2Action stores 10).
+     * A null/blank {@code accountFaxLine} matches nothing (the account has no
+     * line to scope by, so another account's row cannot be confirmed ours).
+     */
+    private static boolean sameFaxLine(String a, String b) {
+        String da = digitsTail(a);
+        String db = digitsTail(b);
+        return !da.isEmpty() && da.equals(db);
+    }
+
+    private static String digitsTail(String v) {
+        if (v == null) {
+            return "";
+        }
+        String digits = v.replaceAll("\\D", "");
+        return digits.length() > 10 ? digits.substring(digits.length() - 10) : digits;
+    }
+
+        boolean isAlreadyImported(List<FaxJob> priorRows, String accountFaxLine) {
         if (priorRows == null) {
             return false;
         }
@@ -923,10 +947,17 @@ public class FaxImporter {
             // NOTE: fax_line is the best account key on the row today; a
             // number genuinely shared by two backends cannot be told apart
             // without a per-config identity on the fax record.
+            // A prior row that names a DIFFERENT account is not ours. A
+            // blank/null prior fax_line is a legacy row (imports did not
+            // stamp it before this release) — treat it as ours so an upgrade
+            // never re-imports an already-held fax. Comparison is on the last
+            // 10 digits so a provider-supplied 11-digit line (e.g. a
+            // middleware backend) still matches a 10-digit configured number.
+            // If THIS account has no fax line to scope by, a row bearing some
+            // OTHER account's line cannot be confirmed ours, so it is skipped.
             String priorLine = prior.getFax_line();
             if (priorLine != null && !priorLine.trim().isEmpty()
-                    && accountFaxLine != null
-                    && !priorLine.trim().equals(accountFaxLine.trim())) {
+                    && !sameFaxLine(priorLine, accountFaxLine)) {
                 continue;
             }
             if (FaxJob.STATUS.RECEIVED.equals(prior.getStatus())) {

--- a/src/main/java/io/github/carlos_emr/carlos/fax/core/FaxImporter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/fax/core/FaxImporter.java
@@ -910,28 +910,7 @@ public class FaxImporter {
      */
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
     @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
-    /**
-     * True when two fax-line values denote the same account, compared on
-     * their last 10 significant digits so a provider-supplied 11-digit line
-     * matches a 10-digit configured number (ConfigureFax2Action stores 10).
-     * A null/blank {@code accountFaxLine} matches nothing (the account has no
-     * line to scope by, so another account's row cannot be confirmed ours).
-     */
-    private static boolean sameFaxLine(String a, String b) {
-        String da = digitsTail(a);
-        String db = digitsTail(b);
-        return !da.isEmpty() && da.equals(db);
-    }
-
-    private static String digitsTail(String v) {
-        if (v == null) {
-            return "";
-        }
-        String digits = v.replaceAll("\\D", "");
-        return digits.length() > 10 ? digits.substring(digits.length() - 10) : digits;
-    }
-
-        boolean isAlreadyImported(List<FaxJob> priorRows, String accountFaxLine) {
+    boolean isAlreadyImported(List<FaxJob> priorRows, String accountFaxLine) {
         if (priorRows == null) {
             return false;
         }
@@ -974,6 +953,28 @@ public class FaxImporter {
         }
         return false;
     }
+
+    /**
+     * True when two fax-line values denote the same account, compared on
+     * their last 10 significant digits so a provider-supplied 11-digit line
+     * matches a 10-digit configured number (ConfigureFax2Action stores 10).
+     * A null/blank {@code accountFaxLine} matches nothing (the account has no
+     * line to scope by, so another account's row cannot be confirmed ours).
+     */
+    private static boolean sameFaxLine(String a, String b) {
+        String da = digitsTail(a);
+        String db = digitsTail(b);
+        return !da.isEmpty() && da.equals(db);
+    }
+
+    private static String digitsTail(String v) {
+        if (v == null) {
+            return "";
+        }
+        String digits = v.replaceAll("\\D", "");
+        return digits.length() > 10 ? digits.substring(digits.length() - 10) : digits;
+    }
+
 
     /**
      * Marks the original "Downloaded but import failed - pending retry" rows as imported once

--- a/src/test/java/io/github/carlos_emr/carlos/fax/core/FaxImporterDedupUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/fax/core/FaxImporterDedupUnitTest.java
@@ -433,6 +433,32 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
         }
 
         @Test
+        @DisplayName("should return true when a prior row's 11-digit fax line matches this 10-digit account (normalized)")
+        void shouldReturnTrue_whenPriorFaxLineIs11DigitFormOfThisAccount() {
+            FaxJob prior = priorRow(FaxJob.STATUS.RECEIVED, null);
+            prior.setFax_line("1" + ACCOUNT_FAX_NUMBER); // provider-supplied 11-digit form
+            assertThat(faxImporter.isAlreadyImported(Collections.singletonList(prior), ACCOUNT_FAX_NUMBER)).isTrue();
+        }
+
+        @Test
+        @DisplayName("should return false for a stamped other-account row when THIS account has no fax line")
+        void shouldReturnFalse_whenAccountFaxLineBlankAndPriorRowIsStamped() {
+            FaxJob otherAccount = priorRow(FaxJob.STATUS.RECEIVED, null);
+            otherAccount.setFax_line("5559990000");
+            // Blank account line can't confirm ownership of a stamped row -> not ours.
+            assertThat(faxImporter.isAlreadyImported(Collections.singletonList(otherAccount), "")).isFalse();
+            assertThat(faxImporter.isAlreadyImported(Collections.singletonList(otherAccount), null)).isFalse();
+        }
+
+        @Test
+        @DisplayName("should return true for a legacy blank-fax-line row even when THIS account has no fax line")
+        void shouldReturnTrue_whenAccountFaxLineBlankAndPriorRowLegacyBlank() {
+            FaxJob legacy = priorRow(FaxJob.STATUS.RECEIVED, null);
+            legacy.setFax_line(null);
+            assertThat(faxImporter.isAlreadyImported(Collections.singletonList(legacy), "")).isTrue();
+        }
+
+        @Test
         @DisplayName("should return false when the only prior row belongs to a DIFFERENT account (same numeric job id)")
         void shouldReturnFalse_whenPriorRowIsForADifferentAccount() {
             // Two accounts/backends can reuse the same numeric provider job id; a row imported by


### PR DESCRIPTION
Addresses the valid review findings raised on #3517/#3518. None can occur
in the SRFax-only single-account packaged deployment, but they're correct
hardening for middleware/multi-account use and cheap now.

- **Fax-line normalization** (P1): account scoping compares the last 10
  digits, so a provider 11-digit fax line matches a 10-digit configured
  number.
- **Blank account line**: a prior row bearing a DIFFERENT account's fax
  line is no longer treated as ours when this account has no line (legacy
  blank rows still are) — closes the cross-account false-dedup gap.
- **Retry rows stamped**: `retryPendingImports` rows now carry the account
  fax line like the poll path.
- **`deb-packages.yml`**: `sed 's/-/~/g'` (all hyphens) — defensive.
- **JavaDoc** for `findByFileName`.
- **`fixtures.sql`**: NOT EXISTS subqueries reformatted for SQLFluff LT14;
  re-verified under `STRICT_ALL_TABLES`.

Dedup unit tests extended (11-digit normalization, blank-account
stamped-vs-legacy, same/different account) — **23 pass**; WAR + both debs
build; lintian clean.

Once merged, I'll refresh the develop forward-merge (#3518) so it carries
these too; `main` picks them up at the promotion. Tracked in #3519.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Harden inbound fax deduplication and packaging version handling for multi-account deployments.

Bug Fixes:
- Harden inbound fax deduplication to prevent cross-account false matches while preserving compatibility with legacy unstamped rows.
- Normalize fax-line comparisons so 10-digit configured numbers match provider-supplied 11-digit values.
- Stamp fax lines on retry-import rows to maintain account attribution and deduplication scoping.

Enhancements:
- Document the fax job filename lookup behavior and reformat SQL fixtures for lint compliance.

Build:
- Make Debian package version normalization replace all hyphens in release tags.

Tests:
- Extend fax deduplication coverage for normalized numbers, blank account lines, legacy rows, and cross-account scoping.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens inbound fax deduplication by scoping matches to the receiving account and normalizing fax-line comparison. Previously, stamped rows from another account could dedup when this account had no fax line and comparisons were exact-string; now stamped other-account rows are ignored when this account’s line is blank, legacy blank rows still dedup, and comparisons use the last 10 digits so provider 11-digit lines match 10-digit numbers.

- Normalizes fax-line comparison to the last 10 digits to align provider 11-digit inputs with 10-digit configured numbers.
- Skips stamped other-account rows when this account’s fax line is blank/null; continues to accept legacy blank rows to avoid re-imports after upgrade.
- Stamps `retryPendingImports` rows with the account fax line so dedup scoping and attribution apply to retries.
- In `deb-packages.yml`, replaces all hyphens in the version transform (`sed 's/-/~/g'`) for native package version safety.
- Docs/lint: adds JavaDoc to `FaxJobDaoImpl.findByFileName`, reformats SQL fixtures for SQLFluff LT14, and keeps `@SuppressFBWarnings(IMPROPER_UNICODE)` bound to `isAlreadyImported` (no behavior change).

<sup>Written for commit 3b32293d8cc3d9a445376ece7f2fa6b4632103f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

