### PR TITLE
chore(release): prepare 2026.08.0-alpha5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>io.github.carlos_emr</groupId>
     <artifactId>carlos</artifactId>
     <packaging>war</packaging>
-    <version>2026.08.0-alpha6-SNAPSHOT</version>
+    <version>2026.08.0-alpha5</version>
     <name>CARLOS</name>
     <description>CARLOS EMR (Clinical Assisting Recording Ledger Open Source) is a web-based electronic medical record system for Canadian healthcare.</description>
     <inceptionYear>2024</inceptionYear>
@@ -19,7 +19,7 @@
         <url>https://github.com/carlos-emr/carlos</url>
         <connection>scm:git:https://github.com/carlos-emr/carlos.git</connection>
         <developerConnection>scm:git:ssh://git@github.com:carlos-emr/carlos.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>2026.08.0-alpha5</tag>
     </scm>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Sets project.version and <scm><tag> to 2026.08.0-alpha5 so the
2026.08.0-alpha5 tag passes publish-release.yml validation.

Why alpha5 (not alpha6): the last published release is 2026.08.0-alpha4;
alpha5 was never tagged — an earlier advance jumped the pom straight to
alpha6-SNAPSHOT, skipping the unreleased alpha5. This corrects that:
alpha5 is the next real release and includes all the packaging + SRFax
fax + review-hardening work.

Release sequence:
1. Merge this -> release/2026.08.
2. Promote release/2026.08 -> main (main head becomes this commit).
3. Tag 2026.08.0-alpha5 on main -> publishes the release + both .debs.
4. Advance release/2026.08 -> 2026.08.0-alpha6-SNAPSHOT.

develop stays 2026.09.0-SNAPSHOT throughout.

Generated with Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares the 2026.08.0-alpha5 release by aligning `pom.xml` `project.version` and `<scm><tag>` with the alpha5 tag so `publish-release.yml` validation passes and the release publishes. Previously: `version` 2026.08.0-alpha6-SNAPSHOT with `<scm><tag>` HEAD; now: `version` 2026.08.0-alpha5 with `<scm><tag>` 2026.08.0-alpha5.

- Merge into `release/2026.08`, promote to `main`, then tag `main` with 2026.08.0-alpha5 to run `publish-release.yml` and publish both .debs.
- After tagging, advance `release/2026.08` to 2026.08.0-alpha6-SNAPSHOT; `develop` remains 2026.09.0-SNAPSHOT.

<sup>Written for commit c118570717b11a048424080797464cd84f00c9a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

