### PR TITLE
Promote release/2026.08 to main for 2026.08.0-alpha5

### DIFF
--- a/.github/workflows/deb-packages.yml
+++ b/.github/workflows/deb-packages.yml
@@ -142,7 +142,7 @@ jobs:
           # version with a hyphen is malformed (dpkg-source warns "native
           # package version may not have a revision"). The release tag is the
           # whole version; re-publishing a tag replaces its assets in place.
-          deb_version="$(printf '%s' "$RELEASE_TAG" | sed 's/-/~/')"
+          deb_version="$(printf '%s' "$RELEASE_TAG" | sed 's/-/~/g')"
           # git identity for dch-less changelog editing is not needed; write
           # the stanza directly, keeping the existing changelog as history.
           {

--- a/.github/workflows/deb-packages.yml
+++ b/.github/workflows/deb-packages.yml
@@ -135,11 +135,14 @@ jobs:
         run: |
           set -euo pipefail
           # CalVer tag -> Debian version. Pre-release suffixes swap '-' for
-          # '~' (2026.08.0-alpha4 -> 2026.08.0~alpha4-1): '~' sorts BEFORE
-          # the empty string in dpkg, so alphas and rcs correctly upgrade to
-          # the final release, and the hyphen stops colliding with the
-          # Debian revision separator.
-          deb_version="$(printf '%s' "$RELEASE_TAG" | sed 's/-/~/')-1"
+          # '~' (2026.08.0-alpha4 -> 2026.08.0~alpha4): '~' sorts BEFORE the
+          # empty string in dpkg, so alphas and rcs correctly upgrade to the
+          # final release. NO '-N' Debian revision is appended: this is a
+          # `3.0 (native)` package (debian/source/format), and a native
+          # version with a hyphen is malformed (dpkg-source warns "native
+          # package version may not have a revision"). The release tag is the
+          # whole version; re-publishing a tag replaces its assets in place.
+          deb_version="$(printf '%s' "$RELEASE_TAG" | sed 's/-/~/')"
           # git identity for dch-less changelog editing is not needed; write
           # the stanza directly, keeping the existing changelog as history.
           {

--- a/debian/assets/carlos_ctl/dbops.py
+++ b/debian/assets/carlos_ctl/dbops.py
@@ -441,6 +441,8 @@ def cmd_db_apply_settings(argv) -> int:
         with open(tz_dropin, encoding="utf-8") as fh:
             have = fh.read()
     except OSError:
+        # No existing drop-in (or unreadable): treat as absent — the
+        # want_dropin comparison below writes or removes it as needed.
         pass
     if want_dropin is None:
         if os.path.exists(tz_dropin):

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>io.github.carlos_emr</groupId>
     <artifactId>carlos</artifactId>
     <packaging>war</packaging>
-    <version>2026.08.0-alpha6-SNAPSHOT</version>
+    <version>2026.08.0-alpha5</version>
     <name>CARLOS</name>
     <description>CARLOS EMR (Clinical Assisting Recording Ledger Open Source) is a web-based electronic medical record system for Canadian healthcare.</description>
     <inceptionYear>2024</inceptionYear>
@@ -19,7 +19,7 @@
         <url>https://github.com/carlos-emr/carlos</url>
         <connection>scm:git:https://github.com/carlos-emr/carlos.git</connection>
         <developerConnection>scm:git:ssh://git@github.com:carlos-emr/carlos.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>2026.08.0-alpha5</tag>
     </scm>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/scripts/e2e/fax/fixtures.sql
+++ b/scripts/e2e/fax/fixtures.sql
@@ -8,7 +8,11 @@ INSERT INTO demographic (last_name, first_name, sex, provider_no, roster_status,
        date_joined, lastUpdateDate)
 SELECT 'Loopback','Faxtest','M','999998','RO','AC','','1980','01','01',
        CURDATE(), NOW()
-WHERE NOT EXISTS (SELECT 1 FROM demographic WHERE last_name='Loopback' AND first_name='Faxtest');
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM demographic
+    WHERE last_name = 'Loopback' AND first_name = 'Faxtest'
+);
 
 -- A simple eForm template to instantiate and fax. Column is patient_independent
 -- (snake_case); the HTML is a single string literal — two adjacent literals in
@@ -18,4 +22,8 @@ INSERT INTO eform (form_name, subject, file_name, form_html, showLatestFormOnly,
 SELECT 'Loopback Fax Test Form','E2E fax test','loopback.html',
        '<html><body><h2>CARLOS Fax E2E Test</h2><p>Patient: [demographic_name]</p><p>DOB: [demographic_dob]</p><p>Loopback fax test document.</p></body></html>',
        0,0,'doctor',1
-WHERE NOT EXISTS (SELECT 1 FROM eform WHERE form_name='Loopback Fax Test Form');
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM eform
+    WHERE form_name = 'Loopback Fax Test Form'
+);

--- a/scripts/e2e/fax/fixtures.sql
+++ b/scripts/e2e/fax/fixtures.sql
@@ -2,16 +2,20 @@
 -- Idempotent-ish: safe to run on a fresh test database.
 
 -- A patient to attach clinical documents (consult/eForm/Rx/letter) to.
+-- lastUpdateDate is NOT NULL in the baseline schema; date_joined is a DATE.
 INSERT INTO demographic (last_name, first_name, sex, provider_no, roster_status,
-       patient_status, hin, year_of_birth, month_of_birth, date_of_birth, date_joined)
-SELECT 'Loopback','Faxtest','M','999998','RO','AC','','1980','01','01', NOW()
+       patient_status, hin, year_of_birth, month_of_birth, date_of_birth,
+       date_joined, lastUpdateDate)
+SELECT 'Loopback','Faxtest','M','999998','RO','AC','','1980','01','01',
+       CURDATE(), NOW()
 WHERE NOT EXISTS (SELECT 1 FROM demographic WHERE last_name='Loopback' AND first_name='Faxtest');
 
--- A simple eForm template to instantiate and fax.
+-- A simple eForm template to instantiate and fax. Column is patient_independent
+-- (snake_case); the HTML is a single string literal — two adjacent literals in
+-- a SELECT list would be read as value + column-alias, dropping the second.
 INSERT INTO eform (form_name, subject, file_name, form_html, showLatestFormOnly,
-       patientIndependent, roleType, status)
+       patient_independent, roleType, status)
 SELECT 'Loopback Fax Test Form','E2E fax test','loopback.html',
-       '<html><body><h2>CARLOS Fax E2E Test</h2><p>Patient: [demographic_name]</p>'
-       '<p>DOB: [demographic_dob]</p><p>Loopback fax test document.</p></body></html>',
+       '<html><body><h2>CARLOS Fax E2E Test</h2><p>Patient: [demographic_name]</p><p>DOB: [demographic_dob]</p><p>Loopback fax test document.</p></body></html>',
        0,0,'doctor',1
 WHERE NOT EXISTS (SELECT 1 FROM eform WHERE form_name='Loopback Fax Test Form');

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/FaxJobDao.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/FaxJobDao.java
@@ -56,14 +56,6 @@ public interface FaxJobDao extends AbstractDao<FaxJob> {
     public List<FaxJob> findByProviderJobId(Long jobId);
 
     /**
-     * Like {@link #findByProviderJobId}, but scoped to a single receiving
-     * account (its fax line). Inbound duplicate detection must not match a
-     * fax imported by a DIFFERENT account/backend that happens to reuse the
-     * same numeric provider job id.
-     */
-    public List<FaxJob> findByProviderJobIdAndFaxLine(Long jobId, String faxLine);
-
-    /**
      * Finds fax rows by their stored file name.
      *
      * Used by the inbound importer's pending-file retry to resolve the original

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/FaxJobDao.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/FaxJobDao.java
@@ -56,6 +56,14 @@ public interface FaxJobDao extends AbstractDao<FaxJob> {
     public List<FaxJob> findByProviderJobId(Long jobId);
 
     /**
+     * Like {@link #findByProviderJobId}, but scoped to a single receiving
+     * account (its fax line). Inbound duplicate detection must not match a
+     * fax imported by a DIFFERENT account/backend that happens to reuse the
+     * same numeric provider job id.
+     */
+    public List<FaxJob> findByProviderJobIdAndFaxLine(Long jobId, String faxLine);
+
+    /**
      * Finds fax rows by their stored file name.
      *
      * Used by the inbound importer's pending-file retry to resolve the original

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/FaxJobDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/FaxJobDaoImpl.java
@@ -36,6 +36,7 @@ import java.util.Date;
 import java.util.List;
 
 import jakarta.persistence.Query;
+import jakarta.persistence.TypedQuery;
 
 import io.github.carlos_emr.carlos.commn.model.FaxJob;
 import org.springframework.stereotype.Repository;
@@ -169,10 +170,9 @@ public class FaxJobDaoImpl extends AbstractDaoImpl<FaxJob> implements FaxJobDao 
      * match; order is unspecified.
      */
     @Override
-    @SuppressWarnings("unchecked")
     public List<FaxJob> findByFileName(String fileName) {
-        Query query = entityManager.createQuery(
-                "select job from FaxJob job where job.file_name = ?1");
+        TypedQuery<FaxJob> query = entityManager.createQuery(
+                "select job from FaxJob job where job.file_name = ?1", FaxJob.class);
 
         query.setParameter(1, fileName);
 

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/FaxJobDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/FaxJobDaoImpl.java
@@ -163,6 +163,19 @@ public class FaxJobDaoImpl extends AbstractDaoImpl<FaxJob> implements FaxJobDao 
     }
 
     @Override
+    @SuppressWarnings("unchecked")
+    public List<FaxJob> findByProviderJobIdAndFaxLine(Long jobId, String faxLine) {
+        Query query = entityManager.createQuery(
+                "select job from FaxJob job where job.jobId = ?1 and job.fax_line = ?2");
+
+        query.setParameter(1, jobId);
+        query.setParameter(2, faxLine);
+
+        return query.getResultList();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
     public List<FaxJob> findByFileName(String fileName) {
         Query query = entityManager.createQuery(
                 "select job from FaxJob job where job.file_name = ?1");

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/FaxJobDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/FaxJobDaoImpl.java
@@ -162,6 +162,12 @@ public class FaxJobDaoImpl extends AbstractDaoImpl<FaxJob> implements FaxJobDao 
         return query.getResultList();
     }
 
+    /**
+     * All {@link FaxJob} rows whose staged file name equals {@code fileName}.
+     * Used by the retry path to locate the row for a quarantined document
+     * (which carries no provider job id). Returns an empty list when none
+     * match; order is unspecified.
+     */
     @Override
     @SuppressWarnings("unchecked")
     public List<FaxJob> findByFileName(String fileName) {

--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/FaxJobDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/FaxJobDaoImpl.java
@@ -164,18 +164,6 @@ public class FaxJobDaoImpl extends AbstractDaoImpl<FaxJob> implements FaxJobDao 
 
     @Override
     @SuppressWarnings("unchecked")
-    public List<FaxJob> findByProviderJobIdAndFaxLine(Long jobId, String faxLine) {
-        Query query = entityManager.createQuery(
-                "select job from FaxJob job where job.jobId = ?1 and job.fax_line = ?2");
-
-        query.setParameter(1, jobId);
-        query.setParameter(2, faxLine);
-
-        return query.getResultList();
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
     public List<FaxJob> findByFileName(String fileName) {
         Query query = entityManager.createQuery(
                 "select job from FaxJob job where job.file_name = ?1");

--- a/src/main/java/io/github/carlos_emr/carlos/fax/core/FaxImporter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/fax/core/FaxImporter.java
@@ -685,6 +685,9 @@ public class FaxImporter {
                             FaxJob retryFax = new FaxJob();
                             retryFax.setFile_name(pdfFile.getFileName().toString());
                             retryFax.setDirection(FaxJob.Direction.IN);
+                            // Stamp the receiving account like the poll path, so
+                            // dedup scoping and attribution apply to retry rows too.
+                            retryFax.setFax_line(faxConfig.getFaxNumber());
                             try {
                                 retryFax.setStamp(new Date(Files.getLastModifiedTime(pdfFile).toMillis()));
                             } catch (IOException e) {
@@ -907,7 +910,28 @@ public class FaxImporter {
      */
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
     @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
-    boolean isAlreadyImported(List<FaxJob> priorRows, String accountFaxLine) {
+    /**
+     * True when two fax-line values denote the same account, compared on
+     * their last 10 significant digits so a provider-supplied 11-digit line
+     * matches a 10-digit configured number (ConfigureFax2Action stores 10).
+     * A null/blank {@code accountFaxLine} matches nothing (the account has no
+     * line to scope by, so another account's row cannot be confirmed ours).
+     */
+    private static boolean sameFaxLine(String a, String b) {
+        String da = digitsTail(a);
+        String db = digitsTail(b);
+        return !da.isEmpty() && da.equals(db);
+    }
+
+    private static String digitsTail(String v) {
+        if (v == null) {
+            return "";
+        }
+        String digits = v.replaceAll("\\D", "");
+        return digits.length() > 10 ? digits.substring(digits.length() - 10) : digits;
+    }
+
+        boolean isAlreadyImported(List<FaxJob> priorRows, String accountFaxLine) {
         if (priorRows == null) {
             return false;
         }
@@ -923,10 +947,17 @@ public class FaxImporter {
             // NOTE: fax_line is the best account key on the row today; a
             // number genuinely shared by two backends cannot be told apart
             // without a per-config identity on the fax record.
+            // A prior row that names a DIFFERENT account is not ours. A
+            // blank/null prior fax_line is a legacy row (imports did not
+            // stamp it before this release) — treat it as ours so an upgrade
+            // never re-imports an already-held fax. Comparison is on the last
+            // 10 digits so a provider-supplied 11-digit line (e.g. a
+            // middleware backend) still matches a 10-digit configured number.
+            // If THIS account has no fax line to scope by, a row bearing some
+            // OTHER account's line cannot be confirmed ours, so it is skipped.
             String priorLine = prior.getFax_line();
             if (priorLine != null && !priorLine.trim().isEmpty()
-                    && accountFaxLine != null
-                    && !priorLine.trim().equals(accountFaxLine.trim())) {
+                    && !sameFaxLine(priorLine, accountFaxLine)) {
                 continue;
             }
             if (FaxJob.STATUS.RECEIVED.equals(prior.getStatus())) {

--- a/src/main/java/io/github/carlos_emr/carlos/fax/core/FaxImporter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/fax/core/FaxImporter.java
@@ -281,12 +281,14 @@ public class FaxImporter {
                     // when mark-as-read failed on a previous cycle the fax stays in the UNREAD pull,
                     // and generateUniqueFilename() would happily file it as a brand-new document.
                     // Skip the download entirely and just retry clearing the unread flag.
-                    // Scoped to THIS account's fax line: two accounts/backends can reuse the same
-                    // numeric job id, and a global lookup would wrongly treat this fax as a
-                    // duplicate of the other account's row and drop it.
+                    // The lookup stays GLOBAL (so rows imported before this release, which have no
+                    // fax_line, are still found); isAlreadyImported() does the account scoping,
+                    // treating a row whose fax_line matches THIS account -- or is blank (legacy) --
+                    // as ours, and a row bearing a DIFFERENT account's fax_line as not ours (two
+                    // accounts/backends can reuse the same numeric job id).
                     if (receivedFax.getJobId() != null
-                            && isAlreadyImported(faxJobDao.findByProviderJobIdAndFaxLine(
-                                    receivedFax.getJobId(), faxConfig.getFaxNumber()))) {
+                            && isAlreadyImported(faxJobDao.findByProviderJobId(receivedFax.getJobId()),
+                                    faxConfig.getFaxNumber())) {
                         log.info("Skipping already-imported fax with provider job id {} - retrying provider acknowledgement",
                                 receivedFax.getJobId());
                         try {
@@ -905,12 +907,26 @@ public class FaxImporter {
      */
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
     @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
-    boolean isAlreadyImported(List<FaxJob> priorRows) {
+    boolean isAlreadyImported(List<FaxJob> priorRows, String accountFaxLine) {
         if (priorRows == null) {
             return false;
         }
         for (FaxJob prior : priorRows) {
             if (FaxJob.Direction.OUT.equals(prior.getDirection())) {
+                continue;
+            }
+            // Account scoping on the receiving fax line: a prior row that
+            // names a DIFFERENT account is not ours (two accounts/backends
+            // can reuse the same numeric provider job id). A blank/null
+            // fax_line is a legacy row from before imports stamped it — treat
+            // it as ours so an upgrade never re-imports an already-held fax.
+            // NOTE: fax_line is the best account key on the row today; a
+            // number genuinely shared by two backends cannot be told apart
+            // without a per-config identity on the fax record.
+            String priorLine = prior.getFax_line();
+            if (priorLine != null && !priorLine.trim().isEmpty()
+                    && accountFaxLine != null
+                    && !priorLine.trim().equals(accountFaxLine.trim())) {
                 continue;
             }
             if (FaxJob.STATUS.RECEIVED.equals(prior.getStatus())) {

--- a/src/main/java/io/github/carlos_emr/carlos/fax/core/FaxImporter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/fax/core/FaxImporter.java
@@ -271,13 +271,22 @@ public class FaxImporter {
                 for (FaxJob receivedFax : faxList) {
 
                     receivedFax.setDirection(FaxJob.Direction.IN);
+                    // Stamp the receiving account (its fax line) so duplicate
+                    // detection can scope to this account and the row is
+                    // attributable later. Providers do not set this on the
+                    // listing.
+                    receivedFax.setFax_line(faxConfig.getFaxNumber());
 
                     // Duplicate-import prevention keyed on the provider job id (SRFax FaxDetailsID):
                     // when mark-as-read failed on a previous cycle the fax stays in the UNREAD pull,
                     // and generateUniqueFilename() would happily file it as a brand-new document.
                     // Skip the download entirely and just retry clearing the unread flag.
+                    // Scoped to THIS account's fax line: two accounts/backends can reuse the same
+                    // numeric job id, and a global lookup would wrongly treat this fax as a
+                    // duplicate of the other account's row and drop it.
                     if (receivedFax.getJobId() != null
-                            && isAlreadyImported(faxJobDao.findByProviderJobId(receivedFax.getJobId()))) {
+                            && isAlreadyImported(faxJobDao.findByProviderJobIdAndFaxLine(
+                                    receivedFax.getJobId(), faxConfig.getFaxNumber()))) {
                         log.info("Skipping already-imported fax with provider job id {} - retrying provider acknowledgement",
                                 receivedFax.getJobId());
                         try {

--- a/src/main/java/io/github/carlos_emr/carlos/fax/core/FaxImporter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/fax/core/FaxImporter.java
@@ -910,28 +910,7 @@ public class FaxImporter {
      */
     // FindSecBugs IMPROPER_UNICODE: case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision. See docs/static-analysis-workflows.md
     @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "case-insensitive comparison of an internal/domain value (status/flag/enum/MIME/code); not a security or authorization decision")
-    /**
-     * True when two fax-line values denote the same account, compared on
-     * their last 10 significant digits so a provider-supplied 11-digit line
-     * matches a 10-digit configured number (ConfigureFax2Action stores 10).
-     * A null/blank {@code accountFaxLine} matches nothing (the account has no
-     * line to scope by, so another account's row cannot be confirmed ours).
-     */
-    private static boolean sameFaxLine(String a, String b) {
-        String da = digitsTail(a);
-        String db = digitsTail(b);
-        return !da.isEmpty() && da.equals(db);
-    }
-
-    private static String digitsTail(String v) {
-        if (v == null) {
-            return "";
-        }
-        String digits = v.replaceAll("\\D", "");
-        return digits.length() > 10 ? digits.substring(digits.length() - 10) : digits;
-    }
-
-        boolean isAlreadyImported(List<FaxJob> priorRows, String accountFaxLine) {
+    boolean isAlreadyImported(List<FaxJob> priorRows, String accountFaxLine) {
         if (priorRows == null) {
             return false;
         }
@@ -974,6 +953,28 @@ public class FaxImporter {
         }
         return false;
     }
+
+    /**
+     * True when two fax-line values denote the same account, compared on
+     * their last 10 significant digits so a provider-supplied 11-digit line
+     * matches a 10-digit configured number (ConfigureFax2Action stores 10).
+     * A null/blank {@code accountFaxLine} matches nothing (the account has no
+     * line to scope by, so another account's row cannot be confirmed ours).
+     */
+    private static boolean sameFaxLine(String a, String b) {
+        String da = digitsTail(a);
+        String db = digitsTail(b);
+        return !da.isEmpty() && da.equals(db);
+    }
+
+    private static String digitsTail(String v) {
+        if (v == null) {
+            return "";
+        }
+        String digits = v.replaceAll("\\D", "");
+        return digits.length() > 10 ? digits.substring(digits.length() - 10) : digits;
+    }
+
 
     /**
      * Marks the original "Downloaded but import failed - pending retry" rows as imported once

--- a/src/main/java/io/github/carlos_emr/carlos/fax/core/FaxImporter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/fax/core/FaxImporter.java
@@ -918,22 +918,18 @@ public class FaxImporter {
             if (FaxJob.Direction.OUT.equals(prior.getDirection())) {
                 continue;
             }
-            // Account scoping on the receiving fax line: a prior row that
-            // names a DIFFERENT account is not ours (two accounts/backends
-            // can reuse the same numeric provider job id). A blank/null
-            // fax_line is a legacy row from before imports stamped it — treat
-            // it as ours so an upgrade never re-imports an already-held fax.
-            // NOTE: fax_line is the best account key on the row today; a
-            // number genuinely shared by two backends cannot be told apart
-            // without a per-config identity on the fax record.
-            // A prior row that names a DIFFERENT account is not ours. A
-            // blank/null prior fax_line is a legacy row (imports did not
-            // stamp it before this release) — treat it as ours so an upgrade
-            // never re-imports an already-held fax. Comparison is on the last
-            // 10 digits so a provider-supplied 11-digit line (e.g. a
+            // Account scoping on the receiving fax line: two accounts or
+            // backends can reuse the same numeric provider job id, so a prior
+            // row that names a DIFFERENT account is not ours. Comparison is on
+            // the last 10 digits so a provider-supplied 11-digit line (e.g. a
             // middleware backend) still matches a 10-digit configured number.
-            // If THIS account has no fax line to scope by, a row bearing some
-            // OTHER account's line cannot be confirmed ours, so it is skipped.
+            // A blank/null prior fax_line is a legacy row (imports did not
+            // stamp it before this release) — treat it as ours so an upgrade
+            // never re-imports an already-held fax. If THIS account has no
+            // fax line to scope by, a row bearing some other account's line
+            // cannot be confirmed ours, so it is skipped. fax_line is the best
+            // account key on the row today; a number genuinely shared by two
+            // backends cannot be told apart without a per-config identity.
             String priorLine = prior.getFax_line();
             if (priorLine != null && !priorLine.trim().isEmpty()
                     && !sameFaxLine(priorLine, accountFaxLine)) {
@@ -972,7 +968,13 @@ public class FaxImporter {
             return "";
         }
         String digits = v.replaceAll("\\D", "");
-        return digits.length() > 10 ? digits.substring(digits.length() - 10) : digits;
+        // A usable fax line needs at least 10 digits; anything shorter is a
+        // malformed/partial value and is treated as no line (never matches),
+        // so it can neither falsely scope to nor away from a real account.
+        if (digits.length() < 10) {
+            return "";
+        }
+        return digits.substring(digits.length() - 10);
     }
 
 

--- a/src/test/java/io/github/carlos_emr/carlos/fax/core/FaxImporterDedupUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/fax/core/FaxImporterDedupUnitTest.java
@@ -20,6 +20,7 @@ package io.github.carlos_emr.carlos.fax.core;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -82,6 +83,7 @@ import org.openpdf.text.pdf.PdfWriter;
 class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
 
     private static final Long PROVIDER_JOB_ID = 777L;
+    private static final String ACCOUNT_FAX_NUMBER = "15551230000";
 
     private FaxConfigDao faxConfigDao;
     private FaxJobDao faxJobDao;
@@ -144,7 +146,7 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
         FaxJob inboundFax = createInboundFax(PROVIDER_JOB_ID);
         when(faxConfigDao.findAll(null, null)).thenReturn(Collections.singletonList(config));
         when(faxProviderClient.listInboundFaxes(config)).thenReturn(Collections.singletonList(inboundFax));
-        when(faxJobDao.findByProviderJobId(PROVIDER_JOB_ID))
+        when(faxJobDao.findByProviderJobIdAndFaxLine(PROVIDER_JOB_ID, ACCOUNT_FAX_NUMBER))
                 .thenReturn(Collections.singletonList(priorRow(FaxJob.STATUS.RECEIVED, null)));
 
         // When
@@ -166,7 +168,7 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
         FaxJob inboundFax = createInboundFax(PROVIDER_JOB_ID);
         when(faxConfigDao.findAll(null, null)).thenReturn(Collections.singletonList(config));
         when(faxProviderClient.listInboundFaxes(config)).thenReturn(Collections.singletonList(inboundFax));
-        when(faxJobDao.findByProviderJobId(PROVIDER_JOB_ID)).thenReturn(Collections.singletonList(
+        when(faxJobDao.findByProviderJobIdAndFaxLine(PROVIDER_JOB_ID, ACCOUNT_FAX_NUMBER)).thenReturn(Collections.singletonList(
                 priorRow(FaxJob.STATUS.ERROR, "IMPORTED BUT ROUTING FAILED - NEEDS MANUAL ASSIGNMENT")));
 
         // When
@@ -186,7 +188,7 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
         FaxJob inboundFax = createInboundFax(PROVIDER_JOB_ID);
         when(faxConfigDao.findAll(null, null)).thenReturn(Collections.singletonList(config));
         when(faxProviderClient.listInboundFaxes(config)).thenReturn(Collections.singletonList(inboundFax));
-        when(faxJobDao.findByProviderJobId(PROVIDER_JOB_ID)).thenReturn(Collections.singletonList(
+        when(faxJobDao.findByProviderJobIdAndFaxLine(PROVIDER_JOB_ID, ACCOUNT_FAX_NUMBER)).thenReturn(Collections.singletonList(
                 priorRow(FaxJob.STATUS.ERROR, "Imported but routing failed - manual assignment required")));
 
         // When
@@ -206,7 +208,7 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
         FaxJob inboundFax = createInboundFax(PROVIDER_JOB_ID);
         when(faxConfigDao.findAll(null, null)).thenReturn(Collections.singletonList(config));
         when(faxProviderClient.listInboundFaxes(config)).thenReturn(Collections.singletonList(inboundFax));
-        when(faxJobDao.findByProviderJobId(PROVIDER_JOB_ID)).thenReturn(Collections.singletonList(
+        when(faxJobDao.findByProviderJobIdAndFaxLine(PROVIDER_JOB_ID, ACCOUNT_FAX_NUMBER)).thenReturn(Collections.singletonList(
                 priorRow(FaxJob.STATUS.ERROR, "Download failed: x")));
         when(faxProviderClient.downloadFax(config, inboundFax))
                 .thenThrow(new FaxProviderException("transient network error"));
@@ -226,7 +228,7 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
         FaxJob inboundFax = createInboundFax(PROVIDER_JOB_ID);
         when(faxConfigDao.findAll(null, null)).thenReturn(Collections.singletonList(config));
         when(faxProviderClient.listInboundFaxes(config)).thenReturn(Collections.singletonList(inboundFax));
-        when(faxJobDao.findByProviderJobId(PROVIDER_JOB_ID)).thenReturn(Collections.emptyList());
+        when(faxJobDao.findByProviderJobIdAndFaxLine(PROVIDER_JOB_ID, ACCOUNT_FAX_NUMBER)).thenReturn(Collections.emptyList());
         when(faxProviderClient.downloadFax(config, inboundFax))
                 .thenThrow(new FaxProviderException("transient network error"));
 
@@ -252,7 +254,7 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
         faxImporter.poll();
 
         // Then: no dedup lookup, download proceeds
-        verify(faxJobDao, never()).findByProviderJobId(anyLong());
+        verify(faxJobDao, never()).findByProviderJobIdAndFaxLine(anyLong(), anyString());
         verify(faxProviderClient).downloadFax(config, inboundFax);
     }
 
@@ -264,7 +266,7 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
         FaxJob inboundFax = createInboundFax(PROVIDER_JOB_ID);
         when(faxConfigDao.findAll(null, null)).thenReturn(Collections.singletonList(config));
         when(faxProviderClient.listInboundFaxes(config)).thenReturn(Collections.singletonList(inboundFax));
-        when(faxJobDao.findByProviderJobId(PROVIDER_JOB_ID)).thenReturn(Collections.emptyList());
+        when(faxJobDao.findByProviderJobIdAndFaxLine(PROVIDER_JOB_ID, ACCOUNT_FAX_NUMBER)).thenReturn(Collections.emptyList());
 
         FaxJob downloadedFax = new FaxJob();
         downloadedFax.setDocument(Base64.getEncoder().encodeToString(createValidPdfBytes()));
@@ -301,7 +303,7 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
         FaxJob inboundFax = createInboundFax(PROVIDER_JOB_ID);
         when(faxConfigDao.findAll(null, null)).thenReturn(Collections.singletonList(config));
         when(faxProviderClient.listInboundFaxes(config)).thenReturn(Collections.singletonList(inboundFax));
-        when(faxJobDao.findByProviderJobId(PROVIDER_JOB_ID)).thenReturn(Collections.emptyList());
+        when(faxJobDao.findByProviderJobIdAndFaxLine(PROVIDER_JOB_ID, ACCOUNT_FAX_NUMBER)).thenReturn(Collections.emptyList());
 
         FaxJob downloadedFax = new FaxJob();
         downloadedFax.setDocument(Base64.getEncoder().encodeToString(createValidPdfBytes()));
@@ -342,7 +344,7 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
         FaxJob inboundFax = createInboundFax(PROVIDER_JOB_ID);
         when(faxConfigDao.findAll(null, null)).thenReturn(Collections.singletonList(config));
         when(faxProviderClient.listInboundFaxes(config)).thenReturn(Collections.singletonList(inboundFax));
-        when(faxJobDao.findByProviderJobId(PROVIDER_JOB_ID)).thenReturn(Collections.emptyList());
+        when(faxJobDao.findByProviderJobIdAndFaxLine(PROVIDER_JOB_ID, ACCOUNT_FAX_NUMBER)).thenReturn(Collections.emptyList());
 
         FaxJob downloadedFax = new FaxJob();
         downloadedFax.setDocument(Base64.getEncoder().encodeToString(createValidPdfBytes()));
@@ -468,6 +470,7 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
         config.setActive(true);
         config.setDownload(true);
         config.setFaxUser("test-access-id");
+        config.setFaxNumber(ACCOUNT_FAX_NUMBER);
         config.setProviderType(FaxConfig.ProviderType.SRFAX);
         config.setQueue(1);
         return config;

--- a/src/test/java/io/github/carlos_emr/carlos/fax/core/FaxImporterDedupUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/fax/core/FaxImporterDedupUnitTest.java
@@ -433,6 +433,32 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
         }
 
         @Test
+        @DisplayName("should return true when a prior row's 11-digit fax line matches this 10-digit account (normalized)")
+        void shouldReturnTrue_whenPriorFaxLineIs11DigitFormOfThisAccount() {
+            FaxJob prior = priorRow(FaxJob.STATUS.RECEIVED, null);
+            prior.setFax_line("1" + ACCOUNT_FAX_NUMBER); // provider-supplied 11-digit form
+            assertThat(faxImporter.isAlreadyImported(Collections.singletonList(prior), ACCOUNT_FAX_NUMBER)).isTrue();
+        }
+
+        @Test
+        @DisplayName("should return false for a stamped other-account row when THIS account has no fax line")
+        void shouldReturnFalse_whenAccountFaxLineBlankAndPriorRowIsStamped() {
+            FaxJob otherAccount = priorRow(FaxJob.STATUS.RECEIVED, null);
+            otherAccount.setFax_line("5559990000");
+            // Blank account line can't confirm ownership of a stamped row -> not ours.
+            assertThat(faxImporter.isAlreadyImported(Collections.singletonList(otherAccount), "")).isFalse();
+            assertThat(faxImporter.isAlreadyImported(Collections.singletonList(otherAccount), null)).isFalse();
+        }
+
+        @Test
+        @DisplayName("should return true for a legacy blank-fax-line row even when THIS account has no fax line")
+        void shouldReturnTrue_whenAccountFaxLineBlankAndPriorRowLegacyBlank() {
+            FaxJob legacy = priorRow(FaxJob.STATUS.RECEIVED, null);
+            legacy.setFax_line(null);
+            assertThat(faxImporter.isAlreadyImported(Collections.singletonList(legacy), "")).isTrue();
+        }
+
+        @Test
         @DisplayName("should return false when the only prior row belongs to a DIFFERENT account (same numeric job id)")
         void shouldReturnFalse_whenPriorRowIsForADifferentAccount() {
             // Two accounts/backends can reuse the same numeric provider job id; a row imported by

--- a/src/test/java/io/github/carlos_emr/carlos/fax/core/FaxImporterDedupUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/fax/core/FaxImporterDedupUnitTest.java
@@ -20,7 +20,6 @@ package io.github.carlos_emr.carlos.fax.core;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -75,7 +74,7 @@ import org.openpdf.text.pdf.PdfWriter;
  * {@code initialize()} is invoked explicitly (in production it is {@code @PostConstruct}).</p>
  *
  * @since 2026-08-21
- * @see FaxImporter#isAlreadyImported(List)
+ * @see FaxImporter#isAlreadyImported(List, String)
  */
 @Tag("unit")
 @Tag("fax")
@@ -83,7 +82,7 @@ import org.openpdf.text.pdf.PdfWriter;
 class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
 
     private static final Long PROVIDER_JOB_ID = 777L;
-    private static final String ACCOUNT_FAX_NUMBER = "15551230000";
+    private static final String ACCOUNT_FAX_NUMBER = "5551230000";
 
     private FaxConfigDao faxConfigDao;
     private FaxJobDao faxJobDao;
@@ -146,7 +145,7 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
         FaxJob inboundFax = createInboundFax(PROVIDER_JOB_ID);
         when(faxConfigDao.findAll(null, null)).thenReturn(Collections.singletonList(config));
         when(faxProviderClient.listInboundFaxes(config)).thenReturn(Collections.singletonList(inboundFax));
-        when(faxJobDao.findByProviderJobIdAndFaxLine(PROVIDER_JOB_ID, ACCOUNT_FAX_NUMBER))
+        when(faxJobDao.findByProviderJobId(PROVIDER_JOB_ID))
                 .thenReturn(Collections.singletonList(priorRow(FaxJob.STATUS.RECEIVED, null)));
 
         // When
@@ -168,7 +167,7 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
         FaxJob inboundFax = createInboundFax(PROVIDER_JOB_ID);
         when(faxConfigDao.findAll(null, null)).thenReturn(Collections.singletonList(config));
         when(faxProviderClient.listInboundFaxes(config)).thenReturn(Collections.singletonList(inboundFax));
-        when(faxJobDao.findByProviderJobIdAndFaxLine(PROVIDER_JOB_ID, ACCOUNT_FAX_NUMBER)).thenReturn(Collections.singletonList(
+        when(faxJobDao.findByProviderJobId(PROVIDER_JOB_ID)).thenReturn(Collections.singletonList(
                 priorRow(FaxJob.STATUS.ERROR, "IMPORTED BUT ROUTING FAILED - NEEDS MANUAL ASSIGNMENT")));
 
         // When
@@ -188,7 +187,7 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
         FaxJob inboundFax = createInboundFax(PROVIDER_JOB_ID);
         when(faxConfigDao.findAll(null, null)).thenReturn(Collections.singletonList(config));
         when(faxProviderClient.listInboundFaxes(config)).thenReturn(Collections.singletonList(inboundFax));
-        when(faxJobDao.findByProviderJobIdAndFaxLine(PROVIDER_JOB_ID, ACCOUNT_FAX_NUMBER)).thenReturn(Collections.singletonList(
+        when(faxJobDao.findByProviderJobId(PROVIDER_JOB_ID)).thenReturn(Collections.singletonList(
                 priorRow(FaxJob.STATUS.ERROR, "Imported but routing failed - manual assignment required")));
 
         // When
@@ -208,7 +207,7 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
         FaxJob inboundFax = createInboundFax(PROVIDER_JOB_ID);
         when(faxConfigDao.findAll(null, null)).thenReturn(Collections.singletonList(config));
         when(faxProviderClient.listInboundFaxes(config)).thenReturn(Collections.singletonList(inboundFax));
-        when(faxJobDao.findByProviderJobIdAndFaxLine(PROVIDER_JOB_ID, ACCOUNT_FAX_NUMBER)).thenReturn(Collections.singletonList(
+        when(faxJobDao.findByProviderJobId(PROVIDER_JOB_ID)).thenReturn(Collections.singletonList(
                 priorRow(FaxJob.STATUS.ERROR, "Download failed: x")));
         when(faxProviderClient.downloadFax(config, inboundFax))
                 .thenThrow(new FaxProviderException("transient network error"));
@@ -228,7 +227,7 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
         FaxJob inboundFax = createInboundFax(PROVIDER_JOB_ID);
         when(faxConfigDao.findAll(null, null)).thenReturn(Collections.singletonList(config));
         when(faxProviderClient.listInboundFaxes(config)).thenReturn(Collections.singletonList(inboundFax));
-        when(faxJobDao.findByProviderJobIdAndFaxLine(PROVIDER_JOB_ID, ACCOUNT_FAX_NUMBER)).thenReturn(Collections.emptyList());
+        when(faxJobDao.findByProviderJobId(PROVIDER_JOB_ID)).thenReturn(Collections.emptyList());
         when(faxProviderClient.downloadFax(config, inboundFax))
                 .thenThrow(new FaxProviderException("transient network error"));
 
@@ -254,7 +253,7 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
         faxImporter.poll();
 
         // Then: no dedup lookup, download proceeds
-        verify(faxJobDao, never()).findByProviderJobIdAndFaxLine(anyLong(), anyString());
+        verify(faxJobDao, never()).findByProviderJobId(anyLong());
         verify(faxProviderClient).downloadFax(config, inboundFax);
     }
 
@@ -266,7 +265,7 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
         FaxJob inboundFax = createInboundFax(PROVIDER_JOB_ID);
         when(faxConfigDao.findAll(null, null)).thenReturn(Collections.singletonList(config));
         when(faxProviderClient.listInboundFaxes(config)).thenReturn(Collections.singletonList(inboundFax));
-        when(faxJobDao.findByProviderJobIdAndFaxLine(PROVIDER_JOB_ID, ACCOUNT_FAX_NUMBER)).thenReturn(Collections.emptyList());
+        when(faxJobDao.findByProviderJobId(PROVIDER_JOB_ID)).thenReturn(Collections.emptyList());
 
         FaxJob downloadedFax = new FaxJob();
         downloadedFax.setDocument(Base64.getEncoder().encodeToString(createValidPdfBytes()));
@@ -303,7 +302,7 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
         FaxJob inboundFax = createInboundFax(PROVIDER_JOB_ID);
         when(faxConfigDao.findAll(null, null)).thenReturn(Collections.singletonList(config));
         when(faxProviderClient.listInboundFaxes(config)).thenReturn(Collections.singletonList(inboundFax));
-        when(faxJobDao.findByProviderJobIdAndFaxLine(PROVIDER_JOB_ID, ACCOUNT_FAX_NUMBER)).thenReturn(Collections.emptyList());
+        when(faxJobDao.findByProviderJobId(PROVIDER_JOB_ID)).thenReturn(Collections.emptyList());
 
         FaxJob downloadedFax = new FaxJob();
         downloadedFax.setDocument(Base64.getEncoder().encodeToString(createValidPdfBytes()));
@@ -344,7 +343,7 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
         FaxJob inboundFax = createInboundFax(PROVIDER_JOB_ID);
         when(faxConfigDao.findAll(null, null)).thenReturn(Collections.singletonList(config));
         when(faxProviderClient.listInboundFaxes(config)).thenReturn(Collections.singletonList(inboundFax));
-        when(faxJobDao.findByProviderJobIdAndFaxLine(PROVIDER_JOB_ID, ACCOUNT_FAX_NUMBER)).thenReturn(Collections.emptyList());
+        when(faxJobDao.findByProviderJobId(PROVIDER_JOB_ID)).thenReturn(Collections.emptyList());
 
         FaxJob downloadedFax = new FaxJob();
         downloadedFax.setDocument(Base64.getEncoder().encodeToString(createValidPdfBytes()));
@@ -379,7 +378,7 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
     }
 
     /**
-     * Direct contract tests for {@link FaxImporter#isAlreadyImported(List)}.
+     * Direct contract tests for {@link FaxImporter#isAlreadyImported(List, String)}.
      */
     @Nested
     @DisplayName("isAlreadyImported() contract")
@@ -388,13 +387,13 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
         @Test
         @DisplayName("should return false for null prior rows")
         void shouldReturnFalse_forNullPriorRows() {
-            assertThat(faxImporter.isAlreadyImported(null)).isFalse();
+            assertThat(faxImporter.isAlreadyImported(null, ACCOUNT_FAX_NUMBER)).isFalse();
         }
 
         @Test
         @DisplayName("should return false for empty prior rows")
         void shouldReturnFalse_forEmptyPriorRows() {
-            assertThat(faxImporter.isAlreadyImported(Collections.emptyList())).isFalse();
+            assertThat(faxImporter.isAlreadyImported(Collections.emptyList(), ACCOUNT_FAX_NUMBER)).isFalse();
         }
 
         @Test
@@ -406,7 +405,7 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
             outbound.setDirection(FaxJob.Direction.OUT);
             FaxJob outboundComplete = priorRow(FaxJob.STATUS.COMPLETE, "Sent");
             outboundComplete.setDirection(FaxJob.Direction.OUT);
-            assertThat(faxImporter.isAlreadyImported(java.util.Arrays.asList(outbound, outboundComplete))).isFalse();
+            assertThat(faxImporter.isAlreadyImported(java.util.Arrays.asList(outbound, outboundComplete), ACCOUNT_FAX_NUMBER)).isFalse();
         }
 
         @Test
@@ -415,27 +414,55 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
             // Pre-direction rows (before the V1.0.15 backfill ran) must keep deduplicating.
             FaxJob legacy = priorRow(FaxJob.STATUS.RECEIVED, null);
             legacy.setDirection(null);
-            assertThat(faxImporter.isAlreadyImported(Collections.singletonList(legacy))).isTrue();
+            assertThat(faxImporter.isAlreadyImported(Collections.singletonList(legacy), ACCOUNT_FAX_NUMBER)).isTrue();
         }
 
         @Test
         @DisplayName("should return true when a prior row is RECEIVED")
         void shouldReturnTrue_whenPriorRowIsReceived() {
             List<FaxJob> rows = Collections.singletonList(priorRow(FaxJob.STATUS.RECEIVED, null));
-            assertThat(faxImporter.isAlreadyImported(rows)).isTrue();
+            assertThat(faxImporter.isAlreadyImported(rows, ACCOUNT_FAX_NUMBER)).isTrue();
+        }
+
+        @Test
+        @DisplayName("should return true when a prior RECEIVED row is for THIS account's fax line")
+        void shouldReturnTrue_whenPriorRowMatchesThisAccountFaxLine() {
+            FaxJob prior = priorRow(FaxJob.STATUS.RECEIVED, null);
+            prior.setFax_line(ACCOUNT_FAX_NUMBER);
+            assertThat(faxImporter.isAlreadyImported(Collections.singletonList(prior), ACCOUNT_FAX_NUMBER)).isTrue();
+        }
+
+        @Test
+        @DisplayName("should return false when the only prior row belongs to a DIFFERENT account (same numeric job id)")
+        void shouldReturnFalse_whenPriorRowIsForADifferentAccount() {
+            // Two accounts/backends can reuse the same numeric provider job id; a row imported by
+            // another account must not suppress importing this account's genuinely new fax.
+            FaxJob otherAccount = priorRow(FaxJob.STATUS.RECEIVED, null);
+            otherAccount.setFax_line("5559990000");
+            assertThat(faxImporter.isAlreadyImported(Collections.singletonList(otherAccount), ACCOUNT_FAX_NUMBER)).isFalse();
+        }
+
+        @Test
+        @DisplayName("should return true for a legacy row with a blank fax line (pre-stamping upgrade)")
+        void shouldReturnTrue_forLegacyRowWithBlankFaxLine() {
+            // Rows imported before this release have no fax_line; an upgrade must still treat them
+            // as already-held so an unacknowledged fax is not downloaded and imported again.
+            FaxJob legacyNoLine = priorRow(FaxJob.STATUS.RECEIVED, null);
+            legacyNoLine.setFax_line(null);
+            assertThat(faxImporter.isAlreadyImported(Collections.singletonList(legacyNoLine), ACCOUNT_FAX_NUMBER)).isTrue();
         }
 
         @Test
         @DisplayName("should return true when status string starts with imported in any case")
         void shouldReturnTrue_whenStatusStringStartsWithImportedAnyCase() {
             assertThat(faxImporter.isAlreadyImported(Collections.singletonList(
-                    priorRow(FaxJob.STATUS.ERROR, "IMPORTED BUT ROUTING FAILED - NEEDS MANUAL ASSIGNMENT"))))
+                    priorRow(FaxJob.STATUS.ERROR, "IMPORTED BUT ROUTING FAILED - NEEDS MANUAL ASSIGNMENT")), ACCOUNT_FAX_NUMBER))
                     .isTrue();
             assertThat(faxImporter.isAlreadyImported(Collections.singletonList(
-                    priorRow(FaxJob.STATUS.ERROR, "Imported but routing failed - manual assignment required"))))
+                    priorRow(FaxJob.STATUS.ERROR, "Imported but routing failed - manual assignment required")), ACCOUNT_FAX_NUMBER))
                     .isTrue();
             assertThat(faxImporter.isAlreadyImported(Collections.singletonList(
-                    priorRow(FaxJob.STATUS.ERROR, "imported on retry but routing failed"))))
+                    priorRow(FaxJob.STATUS.ERROR, "imported on retry but routing failed")), ACCOUNT_FAX_NUMBER))
                     .isTrue();
         }
 
@@ -445,7 +472,7 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
             // The quarantined file is owned by retryPendingImports, whose retry row carries no
             // provider job id — re-downloading here would duplicate the document post-retry.
             assertThat(faxImporter.isAlreadyImported(Collections.singletonList(
-                    priorRow(FaxJob.STATUS.ERROR, "Downloaded but import failed - pending retry from incoming directory"))))
+                    priorRow(FaxJob.STATUS.ERROR, "Downloaded but import failed - pending retry from incoming directory")), ACCOUNT_FAX_NUMBER))
                     .isTrue();
         }
 
@@ -453,12 +480,12 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
         @DisplayName("should return false for other error status strings")
         void shouldReturnFalse_forOtherErrorStatusStrings() {
             assertThat(faxImporter.isAlreadyImported(Collections.singletonList(
-                    priorRow(FaxJob.STATUS.ERROR, "Download failed: timeout")))).isFalse();
+                    priorRow(FaxJob.STATUS.ERROR, "Download failed: timeout")), ACCOUNT_FAX_NUMBER)).isFalse();
             assertThat(faxImporter.isAlreadyImported(Collections.singletonList(
-                    priorRow(FaxJob.STATUS.ERROR, "Download or save to incoming directory failed"))))
+                    priorRow(FaxJob.STATUS.ERROR, "Download or save to incoming directory failed")), ACCOUNT_FAX_NUMBER))
                     .isFalse();
             assertThat(faxImporter.isAlreadyImported(Collections.singletonList(
-                    priorRow(FaxJob.STATUS.ERROR, null)))).isFalse();
+                    priorRow(FaxJob.STATUS.ERROR, null)), ACCOUNT_FAX_NUMBER)).isFalse();
         }
     }
 

--- a/src/test/java/io/github/carlos_emr/carlos/fax/core/FaxImporterDedupUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/fax/core/FaxImporterDedupUnitTest.java
@@ -469,6 +469,17 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
         }
 
         @Test
+        @DisplayName("should return false when the prior row's fax line is short/malformed (< 10 digits)")
+        void shouldReturnFalse_whenPriorFaxLineIsShortMalformed() {
+            // A prior row carrying a truncated/garbage fax_line has no usable account key; it must
+            // not be treated as a match against this account (else a genuine new fax is suppressed),
+            // and a short value must never coincidentally match another short value.
+            FaxJob shortLine = priorRow(FaxJob.STATUS.RECEIVED, null);
+            shortLine.setFax_line("8476");
+            assertThat(faxImporter.isAlreadyImported(Collections.singletonList(shortLine), ACCOUNT_FAX_NUMBER)).isFalse();
+        }
+
+        @Test
         @DisplayName("should return true for a legacy row with a blank fax line (pre-stamping upgrade)")
         void shouldReturnTrue_forLegacyRowWithBlankFaxLine() {
             // Rows imported before this release have no fax_line; an upgrade must still treat them


### PR DESCRIPTION
Promotes release/2026.08 to main so the 2026.08.0-alpha5 tag can sit on
main's head (repo convention: the release tag's commit is main's head).

Brings to main:
- the turnkey .deb packaging (#3510) + SRFax faxing (#3511)
- all review follow-ups (#3517, #3520): fax-dedup account scoping with
  last-10-digit normalization + blank-account handling, native package
  version, fixtures/doc/lint fixes
- pom + scm.tag set to 2026.08.0-alpha5

The pom is resolved against main's stale 2026.08.0-alpha6-SNAPSHOT (left
by the earlier premature advance) to 2026.08.0-alpha5 — the next release
after the last-published alpha4.

After merge: tag 2026.08.0-alpha5 on main's head -> publishes the release
+ both .debs. Then release/2026.08 advances to 2026.08.0-alpha6-SNAPSHOT.

Generated with Claude Code

## Summary by Sourcery

Promote the 2026.08.0-alpha5 release changes to main with account-safe fax deduplication and corrected native Debian packaging.

New Features:
- Scope inbound fax duplicate detection to the receiving account while preserving upgrade-safe handling of legacy records.
- Publish the 2026.08.0-alpha5 release with native Debian packages using release-compatible versioning.

Bug Fixes:
- Prevent cross-account fax records that reuse provider job IDs from suppressing legitimate imports.
- Correct end-to-end fax fixtures so they remain valid and repeatable against the baseline schema.

Enhancements:
- Stamp receiving fax lines on inbound and retry fax records and normalize account matching to the last 10 digits.
- Use typed fax job queries and improve handling of missing timezone drop-ins.

CI:
- Update Debian package version generation for native packages and release asset replacement.

Tests:
- Expand fax deduplication coverage for account scoping, number normalization, legacy rows, malformed lines, and blank account values.

Chores:
- Set the project and SCM versions to 2026.08.0-alpha5.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes release/2026.08 to main for 2026.08.0-alpha5. Key behavior change: inbound fax de-duplication was global by provider job id; it now scopes to the receiving account’s fax line, comparing the last 10 digits and treating <10-digit lines as no match. Legacy rows with a blank fax line still deduplicate; rows stamped with a different account’s line do not.

- Sets pom.xml project.version and scm.tag to 2026.08.0-alpha5.
- Debian packaging: treat as `3.0 (native)`; replace all hyphens in the release tag with tildes and do not append a Debian revision (e.g., 2026.08.0-alpha5 -> 2026.08.0~alpha5). Re-tagging replaces attached assets.
- Fax importer: stamp the receiving account fax line on inbound and retry paths; keep job-id lookup global and apply account scoping in isAlreadyImported(...) with last-10-digit normalization and malformed-line (<10 digits) rejection. Adds JavaDoc, uses TypedQuery in findByFileName, and keeps the FindSecBugs suppression bound to isAlreadyImported.
- E2E fixtures: fix patient_independent column, use a single HTML literal, set lastUpdateDate, and use CURDATE() for DATE fields to keep inserts valid and idempotent.
- After merge: tag 2026.08.0-alpha5 on main’s head to publish the release and native .debs, then advance `release/2026.08` to 2026.08.0-alpha6-SNAPSHOT. No data migration required.

<sup>Written for commit 433d01ad854db3dc0fbaf60368cfbdd726531e7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3522?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

