### PR TITLE
fax: address review nits on account-scoped dedup + DAO typing

### DIFF
--- a/src/main/java/io/github/carlos_emr/carlos/commn/dao/FaxJobDaoImpl.java
+++ b/src/main/java/io/github/carlos_emr/carlos/commn/dao/FaxJobDaoImpl.java
@@ -36,6 +36,7 @@ import java.util.Date;
 import java.util.List;
 
 import jakarta.persistence.Query;
+import jakarta.persistence.TypedQuery;
 
 import io.github.carlos_emr.carlos.commn.model.FaxJob;
 import org.springframework.stereotype.Repository;
@@ -169,10 +170,9 @@ public class FaxJobDaoImpl extends AbstractDaoImpl<FaxJob> implements FaxJobDao 
      * match; order is unspecified.
      */
     @Override
-    @SuppressWarnings("unchecked")
     public List<FaxJob> findByFileName(String fileName) {
-        Query query = entityManager.createQuery(
-                "select job from FaxJob job where job.file_name = ?1");
+        TypedQuery<FaxJob> query = entityManager.createQuery(
+                "select job from FaxJob job where job.file_name = ?1", FaxJob.class);
 
         query.setParameter(1, fileName);
 

--- a/src/main/java/io/github/carlos_emr/carlos/fax/core/FaxImporter.java
+++ b/src/main/java/io/github/carlos_emr/carlos/fax/core/FaxImporter.java
@@ -918,22 +918,18 @@ public class FaxImporter {
             if (FaxJob.Direction.OUT.equals(prior.getDirection())) {
                 continue;
             }
-            // Account scoping on the receiving fax line: a prior row that
-            // names a DIFFERENT account is not ours (two accounts/backends
-            // can reuse the same numeric provider job id). A blank/null
-            // fax_line is a legacy row from before imports stamped it — treat
-            // it as ours so an upgrade never re-imports an already-held fax.
-            // NOTE: fax_line is the best account key on the row today; a
-            // number genuinely shared by two backends cannot be told apart
-            // without a per-config identity on the fax record.
-            // A prior row that names a DIFFERENT account is not ours. A
-            // blank/null prior fax_line is a legacy row (imports did not
-            // stamp it before this release) — treat it as ours so an upgrade
-            // never re-imports an already-held fax. Comparison is on the last
-            // 10 digits so a provider-supplied 11-digit line (e.g. a
+            // Account scoping on the receiving fax line: two accounts or
+            // backends can reuse the same numeric provider job id, so a prior
+            // row that names a DIFFERENT account is not ours. Comparison is on
+            // the last 10 digits so a provider-supplied 11-digit line (e.g. a
             // middleware backend) still matches a 10-digit configured number.
-            // If THIS account has no fax line to scope by, a row bearing some
-            // OTHER account's line cannot be confirmed ours, so it is skipped.
+            // A blank/null prior fax_line is a legacy row (imports did not
+            // stamp it before this release) — treat it as ours so an upgrade
+            // never re-imports an already-held fax. If THIS account has no
+            // fax line to scope by, a row bearing some other account's line
+            // cannot be confirmed ours, so it is skipped. fax_line is the best
+            // account key on the row today; a number genuinely shared by two
+            // backends cannot be told apart without a per-config identity.
             String priorLine = prior.getFax_line();
             if (priorLine != null && !priorLine.trim().isEmpty()
                     && !sameFaxLine(priorLine, accountFaxLine)) {
@@ -972,7 +968,13 @@ public class FaxImporter {
             return "";
         }
         String digits = v.replaceAll("\\D", "");
-        return digits.length() > 10 ? digits.substring(digits.length() - 10) : digits;
+        // A usable fax line needs at least 10 digits; anything shorter is a
+        // malformed/partial value and is treated as no line (never matches),
+        // so it can neither falsely scope to nor away from a real account.
+        if (digits.length() < 10) {
+            return "";
+        }
+        return digits.substring(digits.length() - 10);
     }
 
 

--- a/src/test/java/io/github/carlos_emr/carlos/fax/core/FaxImporterDedupUnitTest.java
+++ b/src/test/java/io/github/carlos_emr/carlos/fax/core/FaxImporterDedupUnitTest.java
@@ -469,6 +469,17 @@ class FaxImporterDedupUnitTest extends CarlosUnitTestBase {
         }
 
         @Test
+        @DisplayName("should return false when the prior row's fax line is short/malformed (< 10 digits)")
+        void shouldReturnFalse_whenPriorFaxLineIsShortMalformed() {
+            // A prior row carrying a truncated/garbage fax_line has no usable account key; it must
+            // not be treated as a match against this account (else a genuine new fax is suppressed),
+            // and a short value must never coincidentally match another short value.
+            FaxJob shortLine = priorRow(FaxJob.STATUS.RECEIVED, null);
+            shortLine.setFax_line("8476");
+            assertThat(faxImporter.isAlreadyImported(Collections.singletonList(shortLine), ACCOUNT_FAX_NUMBER)).isFalse();
+        }
+
+        @Test
         @DisplayName("should return true for a legacy row with a blank fax line (pre-stamping upgrade)")
         void shouldReturnTrue_forLegacyRowWithBlankFaxLine() {
             // Rows imported before this release have no fax_line; an upgrade must still treat them


### PR DESCRIPTION
Addresses the three copilot review comments raised on the alpha5
promotion PR (#3522). All valid, all minor; none change SRFax deployment
behavior.

1. **FaxImporter** — collapse the duplicated account-scoping comment
   block (three overlapping paragraphs) into one concise explanation.
2. **FaxImporter.digitsTail()** — a value with `< 10` digits is now
   treated as *no usable fax line* (returns `""`) instead of being
   returned unchanged, so a malformed/partial `fax_line` can never
   coincidentally match another short value or a real account. Added
   `shouldReturnFalse_whenPriorFaxLineIsShortMalformed` regression test.
3. **FaxJobDaoImpl.findByFileName()** — switched to `TypedQuery<FaxJob>`
   for compile-time type safety and removed the
   `@SuppressWarnings("unchecked")`.

Compiles clean; `FaxImporterDedupUnitTest` 24/24 + `FaxImporterCriticalGapsTest` green.

Merge before re-merging #3522 so alpha5 ships with these fixes.

Generated with Claude Code

## Summary by Sourcery

Harden account-scoped fax deduplication and improve DAO type safety.

Bug Fixes:
- Treat malformed fax lines with fewer than 10 digits as unusable during fax import deduplication to prevent false account matches.

Enhancements:
- Consolidate account-scoping documentation in FaxImporter.
- Use typed FaxJob queries in FaxJobDaoImpl and remove the unchecked warning suppression.

Tests:
- Add regression coverage for short or malformed prior fax lines.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens account-scoped dedup and improves DAO type safety. Previously, the importer kept <10-digit fax_line tails; now it treats them as no line to prevent false cross-account matches while leaving behavior for valid 10+ digit lines unchanged.

- Collapses duplicated account-scoping comment in the importer for clarity.
- digitsTail: values with fewer than 10 digits now return an empty string, preventing malformed/partial fax_line values from matching; adds a regression test.
- `FaxJobDaoImpl.findByFileName()` now uses `TypedQuery<FaxJob>` and removes `@SuppressWarnings("unchecked")`.

- Merge before re-merging #3522 so alpha5 includes these fixes.
- No migrations. Behavior unchanged for valid lines; only malformed short values stop matching.

<sup>Written for commit f688f26e8e192b23d5a830176a3722bbf0292d78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3523?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

