### PR TITLE
chore(release): advance 2026.08 to alpha6 snapshot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>io.github.carlos_emr</groupId>
     <artifactId>carlos</artifactId>
     <packaging>war</packaging>
-    <version>2026.08.0-alpha5</version>
+    <version>2026.08.0-alpha6-SNAPSHOT</version>
     <name>CARLOS</name>
     <description>CARLOS EMR (Clinical Assisting Recording Ledger Open Source) is a web-based electronic medical record system for Canadian healthcare.</description>
     <inceptionYear>2024</inceptionYear>
@@ -19,7 +19,7 @@
         <url>https://github.com/carlos-emr/carlos</url>
         <connection>scm:git:https://github.com/carlos-emr/carlos.git</connection>
         <developerConnection>scm:git:ssh://git@github.com:carlos-emr/carlos.git</developerConnection>
-        <tag>2026.08.0-alpha5</tag>
+        <tag>HEAD</tag>
     </scm>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Now that `2026.08.0-alpha5` is tagged on `main`, advance the release line
to the next development snapshot.

- pom `<version>`: `2026.08.0-alpha5` → `2026.08.0-alpha6-SNAPSHOT`
- pom `<scm><tag>`: `2026.08.0-alpha5` → `HEAD`

`develop` stays `2026.09.0-SNAPSHOT`. Mirrors the prior advance (#3515)
pattern exactly. After this merges I'll forward-merge `release/2026.08`
into `develop` to keep the branches aligned.

Generated with Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Advance the 2026.08 release line to the next development snapshot so ongoing work targets the next alpha. Old: 2026.08.0-alpha5. New: 2026.08.0-alpha6-SNAPSHOT, with `<scm><tag>` set to `HEAD` for correct source links.

- No functional or dependency changes; version metadata only.
- Consumers tracking the snapshot will move to alpha6-SNAPSHOT; pinning to alpha5 is unaffected.

<sup>Written for commit 084f08f66e7c0c6b58abb1c6b80784ff18487a6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

