### PR TITLE
chore(release): prepare 2026.08.0-alpha6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>io.github.carlos_emr</groupId>
     <artifactId>carlos</artifactId>
     <packaging>war</packaging>
-    <version>2026.08.0-alpha5</version>
+    <version>2026.08.0-alpha6</version>
     <name>CARLOS</name>
     <description>CARLOS EMR (Clinical Assisting Recording Ledger Open Source) is a web-based electronic medical record system for Canadian healthcare.</description>
     <inceptionYear>2024</inceptionYear>
@@ -19,7 +19,7 @@
         <url>https://github.com/carlos-emr/carlos</url>
         <connection>scm:git:https://github.com/carlos-emr/carlos.git</connection>
         <developerConnection>scm:git:ssh://git@github.com:carlos-emr/carlos.git</developerConnection>
-        <tag>2026.08.0-alpha5</tag>
+        <tag>2026.08.0-alpha6</tag>
     </scm>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
## Why alpha6, not alpha5

alpha5 was tagged on main's head, but with a non-conventional annotation
(`CARLOS EMR 2026.08.0-alpha5` instead of the required `Release
2026.08.0-alpha5`), so `publish-release.yml` validation rejected it. The
`Immutable release tags` ruleset enforces deletion/non-fast-forward/update
on `refs/tags/20??.??.*` with **no bypass actors**, so the tag cannot be
moved or deleted by anyone — by design. Per decision to respect that
immutability, we leave the orphaned alpha5 tag in place (unpublished) and
publish **alpha6** as the next alpha.

## This PR

- pom `<version>`: `2026.08.0-alpha5` → `2026.08.0-alpha6`
- pom `<scm><tag>`: `2026.08.0-alpha5` → `2026.08.0-alpha6`

Content is otherwise identical to the alpha5 that was validated live
(packaging + SRFax fax + all review fixes incl. the #3523 nits).

## Next steps after merge

1. Re-promote `release/2026.08` → `main` (main head gets pom alpha6).
2. Tag `2026.08.0-alpha6` on main with message **`Release 2026.08.0-alpha6`** → publishes + both `.deb`s.
3. Advance `release/2026.08` → `2026.08.0-alpha7-SNAPSHOT`; forward-merge to develop.

`develop` stays `2026.09.0-SNAPSHOT`.

Generated with Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Advance the release to 2026.08.0-alpha6 by updating `pom.xml` version and `<scm><tag>`, because alpha5’s tag message violated the required format under immutable tag rules. Content is unchanged from alpha5; this ensures the release pipeline accepts and publishes the tag.

- Rollout
  - Promote `release/2026.08` to `main`.
  - Tag `2026.08.0-alpha6` on `main` with message `Release 2026.08.0-alpha6` to trigger publishing and `.deb` builds.
  - Bump `release/2026.08` to `2026.08.0-alpha7-SNAPSHOT` and forward-merge to `develop` (still `2026.09.0-SNAPSHOT`).

<sup>Written for commit 0b8ee13487a894f4284efc0a147d98285393f929. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3525?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

