### PR TITLE
Promote release/2026.08 to main for 2026.08.0-alpha6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>io.github.carlos_emr</groupId>
     <artifactId>carlos</artifactId>
     <packaging>war</packaging>
-    <version>2026.08.0-alpha5</version>
+    <version>2026.08.0-alpha6</version>
     <name>CARLOS</name>
     <description>CARLOS EMR (Clinical Assisting Recording Ledger Open Source) is a web-based electronic medical record system for Canadian healthcare.</description>
     <inceptionYear>2024</inceptionYear>
@@ -19,7 +19,7 @@
         <url>https://github.com/carlos-emr/carlos</url>
         <connection>scm:git:https://github.com/carlos-emr/carlos.git</connection>
         <developerConnection>scm:git:ssh://git@github.com:carlos-emr/carlos.git</developerConnection>
-        <tag>2026.08.0-alpha5</tag>
+        <tag>2026.08.0-alpha6</tag>
     </scm>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Promotes release/2026.08 (now at pom 2026.08.0-alpha6, per #3525) to main
so the 2026.08.0-alpha6 tag can sit on main's head.

Why alpha6: alpha5 was tagged with a non-conventional annotation and the
`Immutable release tags` ruleset (bypass=[]) makes it unfixable, so alpha5
is orphaned/unpublished. alpha6 is the next published alpha. The tree here
is identical to release/2026.08 (diff = 0); only pom version + scm.tag
advance to 2026.08.0-alpha6.

After merge, tag on main's head:

    git tag -a 2026.08.0-alpha6 -m "Release 2026.08.0-alpha6" <main-head>
    git push origin 2026.08.0-alpha6

Note the message MUST be `Release 2026.08.0-alpha6` (the check that failed
alpha5). That triggers publish + both .debs. Then release/2026.08 advances
to 2026.08.0-alpha7-SNAPSHOT and forward-merges to develop.

Generated with Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes release/2026.08 to main by updating the POM version and SCM tag from 2026.08.0-alpha5 to 2026.08.0-alpha6 so the main tag validates and publishes. Alpha5 used a non-conventional annotation and is immutable under the release-tag rules, so alpha6 replaces it without code changes.

**Rollout**
- After merge, tag main’s head exactly: git tag -a 2026.08.0-alpha6 -m "Release 2026.08.0-alpha6" <main-head> && git push origin 2026.08.0-alpha6 (message must match to pass checks and trigger publish and .deb builds).
- Advance release/2026.08 to 2026.08.0-alpha7-SNAPSHOT and forward-merge to develop.

<sup>Written for commit 70827d938e6a0d501f07f317686f48cee2a617b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

