### PR TITLE
chore(release): advance 2026.08 to alpha7 snapshot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>io.github.carlos_emr</groupId>
     <artifactId>carlos</artifactId>
     <packaging>war</packaging>
-    <version>2026.08.0-alpha6</version>
+    <version>2026.08.0-alpha7-SNAPSHOT</version>
     <name>CARLOS</name>
     <description>CARLOS EMR (Clinical Assisting Recording Ledger Open Source) is a web-based electronic medical record system for Canadian healthcare.</description>
     <inceptionYear>2024</inceptionYear>
@@ -19,7 +19,7 @@
         <url>https://github.com/carlos-emr/carlos</url>
         <connection>scm:git:https://github.com/carlos-emr/carlos.git</connection>
         <developerConnection>scm:git:ssh://git@github.com:carlos-emr/carlos.git</developerConnection>
-        <tag>2026.08.0-alpha6</tag>
+        <tag>HEAD</tag>
     </scm>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
2026.08.0-alpha6 is tagged and published on main (release + WAR + SBOM).
Advance the release line to the next development snapshot.

- pom `<version>`: `2026.08.0-alpha6` → `2026.08.0-alpha7-SNAPSHOT`
- pom `<scm><tag>`: `2026.08.0-alpha6` → `HEAD`

`develop` stays `2026.09.0-SNAPSHOT`.

Generated with Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Advances the 2026.08 release line to 2026.08.0-alpha7-SNAPSHOT so new work targets the next alpha after 2026.08.0-alpha6 was tagged and published. Builds now produce snapshot artifacts from HEAD instead of the alpha6 tag.

- Updates pom version to 2026.08.0-alpha7-SNAPSHOT and sets scm.tag to HEAD; no code or runtime changes.
- No migration required; `develop` remains 2026.09.0-SNAPSHOT.

<sup>Written for commit 72ed9908ed558aa1a10ca9ba28fa5bce463b015c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

