### PR TITLE
ci(release): attach .debs before publishing (immutable-release fix)

### DIFF
--- a/.github/workflows/deb-packages.yml
+++ b/.github/workflows/deb-packages.yml
@@ -40,10 +40,16 @@ on:
         required: true
         type: string
 
-# Per-tag serialization: a retry racing the original run would upload the
-# same asset names concurrently.
+# ONE GLOBAL group (not per-tag): this workflow now publishes the release and
+# makes the latest-pointer decision, which reads the set of already-published
+# stable releases. Two releases finalizing concurrently could each query while
+# the other is still a draft and both claim --latest, letting the one that
+# publishes last win even if it is older. Global serialization removes that
+# race; it also still prevents a retry racing the original run (which would
+# upload the same asset names at once). Releases are rare and deliberate, so
+# serializing all deb builds costs nothing.
 concurrency:
-  group: deb-packages-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.release.tag_name }}
+  group: deb-packages
   cancel-in-progress: false
 
 permissions:
@@ -123,11 +129,20 @@ jobs:
           draft=$(gh api "repos/$REPO/releases/tags/$RELEASE_TAG" --jq '.draft' 2>/dev/null || echo "")
           debs=$(gh api "repos/$REPO/releases/tags/$RELEASE_TAG" \
             --jq '[.assets[].name | select(endswith(".deb"))] | length' 2>/dev/null || echo 0)
-          if [ "$draft" = "false" ] && [ "${debs:-0}" -ge 2 ]; then
+          if [ "$draft" = "true" ] || [ -z "$draft" ]; then
+            # Draft (or no release yet): proceed to build, attach, and publish.
+            echo "SKIP=false" >> "$GITHUB_ENV"
+          elif [ "${debs:-0}" -ge 2 ]; then
+            # Fully finalized: published with its .debs. Nothing to do (and a
+            # re-upload would 422 against the immutable release).
             echo "Release $RELEASE_TAG is already published with its .deb assets; nothing to do."
             echo "SKIP=true" >> "$GITHUB_ENV"
           else
-            echo "SKIP=false" >> "$GITHUB_ENV"
+            # Published but missing .debs: an immutable release cannot accept
+            # new assets, so this can never be completed. Fail fast and loud
+            # rather than dying later on an opaque HTTP 422 from the upload.
+            echo "::error::Release $RELEASE_TAG is already published but has no .deb assets. Immutable releases cannot accept new assets, so the .debs cannot be attached. This release is permanently WAR-only; ship the .debs with the next release."
+            exit 1
           fi
 
       - name: Download and verify the release WAR

--- a/.github/workflows/deb-packages.yml
+++ b/.github/workflows/deb-packages.yml
@@ -1,20 +1,23 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2026 CARLOS Contributors
 #
-# Build and publish the Debian packages (carlos-emr, carlos-emr-drugref) as
-# assets of a CARLOS release.
+# Build the Debian packages (carlos-emr, carlos-emr-drugref), attach them to
+# the release, and PUBLISH the release as the final step.
 #
-# DESIGN — deliberately a SEPARATE workflow from publish-release.yml, running
-# after the release is published, rather than a job spliced into that
-# carefully-serialized pipeline:
+# DESIGN — a SEPARATE workflow from publish-release.yml, but it FINALIZES the
+# release: publish-release.yml leaves the release as a DRAFT carrying the WAR +
+# SBOM, and this workflow downloads that WAR, builds the .debs, attaches them,
+# and only then flips the release to published. The order matters because the
+# repository enables immutable releases — assets cannot be added once a release
+# is published, so every asset (WAR, SBOM, both .debs) must be in place while it
+# is still a draft.
 #
-#   * The deb ships the release's OWN published WAR, downloaded from the
-#     release and verified against its .sha256 — the same bytes the WAR
-#     attestation covers, with no second Maven compile that could drift.
-#     That is only possible after the WAR asset exists, i.e. post-publish.
-#   * A failure here can never wedge or roll back the release itself; the
-#     workflow_dispatch input exists to retry (or backfill an older release)
-#     without touching the release pipeline.
+#   * The deb ships the release's OWN WAR, downloaded from the draft and
+#     verified against its .sha256 and provenance attestation — the same bytes,
+#     with no second Maven compile that could drift.
+#   * If this workflow fails, the release simply stays a draft (nothing is
+#     half-published); the workflow_dispatch input re-runs it to finish the job
+#     (or to backfill an older release).
 #
 # The build runs inside an ubuntu:26.04 container so the toolchain and the
 # runtime dependency versions are exactly the target distribution's,
@@ -110,11 +113,29 @@ jobs:
             exit 1
           fi
 
-      - name: Download and verify the release WAR
+      - name: Skip if the release is already finalized
         run: |
           set -euo pipefail
-          # The deb ships the exact WAR the release published: the .sha256
-          # catches corrupt/partial downloads, and the attestation check
+          # A completed release is published (non-draft) AND already carries the
+          # two .deb assets. Immutable releases forbid re-uploading, so a re-run
+          # against a finished release would 422 — detect that and stop cleanly.
+          # Uses gh's built-in --jq (system jq is not installed in the image).
+          draft=$(gh api "repos/$REPO/releases/tags/$RELEASE_TAG" --jq '.draft' 2>/dev/null || echo "")
+          debs=$(gh api "repos/$REPO/releases/tags/$RELEASE_TAG" \
+            --jq '[.assets[].name | select(endswith(".deb"))] | length' 2>/dev/null || echo 0)
+          if [ "$draft" = "false" ] && [ "${debs:-0}" -ge 2 ]; then
+            echo "Release $RELEASE_TAG is already published with its .deb assets; nothing to do."
+            echo "SKIP=true" >> "$GITHUB_ENV"
+          else
+            echo "SKIP=false" >> "$GITHUB_ENV"
+          fi
+
+      - name: Download and verify the release WAR
+        if: env.SKIP != 'true'
+        run: |
+          set -euo pipefail
+          # The deb ships the exact WAR the release carries (still a draft):
+          # the .sha256 catches corrupt/partial downloads, and the attestation check
           # below is what makes the stronger claim true — a swapped WAR
           # (even one with a matching swapped .sha256) fails provenance
           # verification and never becomes a package payload.
@@ -132,6 +153,7 @@ jobs:
           echo "CARLOS_WAR=/tmp/release-war/carlos-$RELEASE_TAG.war" >> "$GITHUB_ENV"
 
       - name: Stamp the package version from the release tag
+        if: env.SKIP != 'true'
         run: |
           set -euo pipefail
           # CalVer tag -> Debian version. Pre-release suffixes swap '-' for
@@ -162,6 +184,7 @@ jobs:
           echo "DEB_VERSION=$deb_version" >> "$GITHUB_ENV"
 
       - name: Build the packages
+        if: env.SKIP != 'true'
         run: |
           set -euo pipefail
           # CARLOS_WAR skips the in-tree Maven compile; DrugRef builds from
@@ -178,6 +201,7 @@ jobs:
           ls -la
 
       - name: Lintian gate
+        if: env.SKIP != 'true'
         run: |
           set -euo pipefail
           # Errors fail the build. The overrides files in debian/ carry the
@@ -185,12 +209,14 @@ jobs:
           lintian --fail-on error ../carlos-emr_*.changes
 
       - name: Attest package provenance
+        if: env.SKIP != 'true'
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: |
             release-assets/*.deb
 
       - name: Upload and verify the release assets
+        if: env.SKIP != 'true'
         run: |
           set -euo pipefail
           gh release upload "$RELEASE_TAG" release-assets/* --repo "$REPO" --clobber
@@ -210,3 +236,39 @@ jobs:
             fi
           done
           echo "Published: $(cd release-assets && ls *.deb | tr '\n' ' ')"
+
+      - name: Publish the release
+        if: env.SKIP != 'true'
+        run: |
+          set -euo pipefail
+          # Every asset (WAR, SBOM, both .debs) is now attached to the draft.
+          # Flip it to published — this is the point the release becomes
+          # immutable. The latest-pointer decision lives here (not in
+          # publish-release.yml) because the release is only published once all
+          # assets, including these .debs, are in place.
+          prerelease=false
+          if [[ "$RELEASE_TAG" =~ -(alpha|beta|rc)[1-9][0-9]*$ ]]; then
+            prerelease=true
+          fi
+          release_line=$(sed -E 's/^([0-9]{4}\.[0-9]{2})\..*$/\1/' <<< "$RELEASE_TAG")
+
+          if [ "$prerelease" = "true" ]; then
+            gh release edit "$RELEASE_TAG" --repo "$REPO" --draft=false --prerelease --latest=false
+          else
+            # A maintenance patch published from an OLDER release line must not
+            # steal the repo's "latest release" pointer from a newer train:
+            # mark latest only when this tag tops every published stable
+            # release under the CalVer numeric sort. Paginated so a fixed
+            # --limit cannot miss the newest stable release once the repo grows.
+            latest_flag=--latest
+            existing=$(gh api --paginate "repos/$REPO/releases?per_page=100" \
+              --jq '.[] | select((.draft or .prerelease) | not) | .tag_name')
+            top=$({ printf '%s\n' "$RELEASE_TAG"; printf '%s\n' "$existing"; } \
+              | sed '/^$/d' | sort -t. -k1,1n -k2,2n -k3,3n | tail -1)
+            if [ "$top" != "$RELEASE_TAG" ]; then
+              latest_flag=--latest=false
+              echo "A newer stable release ($top) is already published — not marking $RELEASE_TAG as latest."
+            fi
+            gh release edit "$RELEASE_TAG" --repo "$REPO" --draft=false --prerelease=false "$latest_flag"
+          fi
+          echo "Published release $RELEASE_TAG with WAR, SBOM, and .deb assets."

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -11,12 +11,12 @@ on:
         required: true
         type: string
 
-# One GLOBAL group (not per-tag): the publish step's latest-pointer decision
-# reads the set of already-published stable releases, so two stable tags
-# publishing concurrently could each miss the other (still a draft at query
-# time) and both claim --latest. Releases are rare and deliberate — strict
-# serialization costs nothing and removes the race; same-tag re-runs still
-# queue exactly as before.
+# One GLOBAL group (not per-tag): the release-notes "previous tag" lookup and
+# the draft bookkeeping read the set of existing releases, so serializing all
+# release runs keeps that state consistent. Releases are rare and deliberate —
+# strict serialization costs nothing; same-tag re-runs still queue as before.
+# (The final publish + latest-pointer decision now happens in deb-packages.yml,
+# after the .debs are attached.)
 concurrency:
   group: publish-release
   cancel-in-progress: false
@@ -197,7 +197,7 @@ jobs:
       ref: refs/tags/${{ needs.validate.outputs.tag }}
 
   package-and-publish:
-    name: Package and publish immutable release
+    name: Package release draft and dispatch deb build
     needs: [validate, full-check]
     if: always() && needs.validate.outputs.skip != 'true' && needs.full-check.result == 'success'
     runs-on: ubuntu-latest
@@ -206,12 +206,11 @@ jobs:
       attestations: write
       id-token: write
       # actions:write lets the final step dispatch the Debian-packages
-      # workflow. That explicit dispatch is REQUIRED, not a convenience:
-      # this job publishes the release with the workflow-scoped
-      # GITHUB_TOKEN, and GitHub suppresses workflow triggers for events
-      # created with that token — deb-packages.yml's `release: published`
-      # trigger never fires for releases this pipeline publishes.
-      # workflow_dispatch is exempt from the suppression.
+      # workflow, which attaches the .debs to the draft and publishes it.
+      # An explicit dispatch is REQUIRED: this job leaves the release as a
+      # draft (no release event to trigger on), and even once deb-packages
+      # publishes it, GitHub suppresses workflow triggers for events created
+      # with the workflow-scoped GITHUB_TOKEN. workflow_dispatch is exempt.
       actions: write
     env:
       GH_TOKEN: ${{ github.token }}
@@ -350,41 +349,19 @@ jobs:
             fi
           done
 
-      - name: Publish the immutable release
+      - name: Dispatch the Debian package build that finalizes the release
         run: |
           set -euo pipefail
-
-          if [ "$IS_PRERELEASE" = "true" ]; then
-            gh release edit "$RELEASE_TAG" --repo "$REPO" --draft=false --prerelease --latest=false
-          else
-            # A maintenance patch published from an OLDER release line (the
-            # documented supported-release flow) must not steal the repo's
-            # "latest release" pointer from a newer train: mark latest only
-            # when this tag tops every published stable release under the
-            # CalVer numeric sort (first-ever stable release wins trivially).
-            # Paginated: a fixed --limit would stop seeing the newest stable
-            # release once the repo accumulates more releases than the cap,
-            # letting an old-train patch wrongly grab the latest pointer.
-            latest_flag=--latest
-            existing=$(gh api --paginate "repos/$REPO/releases?per_page=100" \
-              --jq '.[] | select((.draft or .prerelease) | not) | .tag_name')
-            top=$({ printf '%s\n' "$RELEASE_TAG"; printf '%s\n' "$existing"; } \
-              | sed '/^$/d' | sort -t. -k1,1n -k2,2n -k3,3n | tail -1)
-            if [ "$top" != "$RELEASE_TAG" ]; then
-              latest_flag=--latest=false
-              echo "A newer stable release ($top) is already published — not marking $RELEASE_TAG as latest."
-            fi
-            gh release edit "$RELEASE_TAG" --repo "$REPO" --draft=false --prerelease=false "$latest_flag"
-          fi
-
-      - name: Dispatch the Debian package build
-        run: |
-          set -euo pipefail
-          # See the actions:write comment above: the release-published event
-          # this job just caused is invisible to other workflows, so the deb
-          # build is dispatched by hand. Failure here must not unwind the
-          # published release — it reports loudly and the operator retries
-          # with the same dispatch (documented in deb-packages.yml).
+          # The release is still a DRAFT at this point: the WAR + SBOM are
+          # attached but it is NOT published. deb-packages.yml downloads the
+          # WAR from the draft, builds and attaches the .deb assets, and then
+          # publishes the release as its final step — so the immutable release,
+          # once locked, already carries every asset (the repo enables
+          # immutable releases, which forbid attaching assets after publish).
+          # It is dispatched by hand rather than relying on a trigger: this job
+          # has not published anything yet, so there is no release event to
+          # react to, and workflow_dispatch is also exempt from the
+          # GITHUB_TOKEN event suppression noted above.
           # Dispatched on the TAG's own ref: workflow_dispatch requires the
           # workflow file to exist on the dispatched ref, and deb-packages.yml
           # lives on the release lines (and their tags), not necessarily on
@@ -393,6 +370,6 @@ jobs:
           if ! gh workflow run deb-packages.yml --repo "$REPO" \
                  --ref "refs/tags/$RELEASE_TAG" \
                  -f "tag=$RELEASE_TAG"; then
-            echo "::error::Release $RELEASE_TAG is published but the Debian package build could not be dispatched. Run it manually: gh workflow run deb-packages.yml --ref refs/tags/$RELEASE_TAG -f tag=$RELEASE_TAG"
+            echo "::error::Draft release $RELEASE_TAG is ready but the Debian package build could not be dispatched, so the release was NOT published. Run it manually to finalize: gh workflow run deb-packages.yml --ref refs/tags/$RELEASE_TAG -f tag=$RELEASE_TAG"
             exit 1
           fi


### PR DESCRIPTION
## Problem

The repository enables **immutable releases** — assets cannot be added once a
release is published. The pipeline did:

1. `publish-release.yml` creates + **publishes** the release with the WAR →
   GitHub locks it (immutable)
2. `deb-packages.yml` builds the `.deb`s and tries to attach them →
   **`HTTP 422: Cannot upload assets to an immutable release`**

So no release ever shipped its Debian packages, even though the debs build
cleanly (lintian + attestation pass). Observed on `2026.08.0-alpha6`.

## Fix — attach every asset while the release is a DRAFT, then publish

- **`publish-release.yml`**: builds the WAR/SBOM, creates the **draft** release,
  uploads + verifies them, and dispatches the deb build — but **no longer
  publishes**. The publish + latest-pointer logic leaves this workflow.
- **`deb-packages.yml`**: downloads the WAR from the draft, builds / attests /
  attaches the `.deb`s, then **publishes** the release as its final step
  (carrying the latest-pointer decision, unchanged logic). Adds an idempotency
  guard that skips cleanly when the release is already published with its debs
  (a completed release is immutable, so a naive re-run would 422).

## Behaviour

- Success: draft accumulates WAR + SBOM + both `.deb`s, then is published once —
  immutable release carries everything.
- Deb build fails: the release **stays a draft** (nothing half-published);
  re-run `deb-packages.yml` (workflow_dispatch) to finish it.
- Already-published releases (e.g. `alpha6`, published WAR-only under the old
  flow) can't be retrofitted — they're immutable. The **next** release
  (`alpha7`) ships debs once this and the promotion reach `main`.

No change to what the debs contain or how the WAR is verified (same download +
`.sha256` + provenance attestation).

Generated with Claude Code

## Summary by Sourcery

Keep releases as drafts while Debian packages are built and attached, then publish the complete immutable release in one final step.

New Features:
- Finalize releases only after WAR, SBOM, and Debian package assets have all been attached.
- Add safe handling for retries and already-published releases, including clear failure behavior for immutable WAR-only releases.

Bug Fixes:
- Prevent Debian package uploads from failing against immutable releases by keeping releases in draft state until all assets are present.

Enhancements:
- Move release publication and latest-release pointer selection into the Debian packaging workflow.
- Serialize Debian release finalization globally to avoid races in latest-release selection.

CI:
- Update release workflows so the publishing workflow creates and prepares a draft, then dispatches the Debian packaging workflow to complete publication.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Attach Debian packages to the release while it is a draft, then publish once all assets are present. Previously we published with the WAR first and `.deb` uploads failed with HTTP 422 on immutable releases.

- `publish-release.yml` now creates a draft, uploads and verifies the WAR/SBOM, and dispatches the deb workflow; it no longer publishes.
- `deb-packages.yml` downloads the draft’s WAR, builds/lints/attests the `.deb`s, uploads them, then publishes and sets the latest pointer.
- Global serialization for `deb-packages.yml` prevents two concurrently finalizing releases from racing the latest-pointer decision.
- Idempotency guard: skips when already published with `.deb`s; fails fast if already published without `.deb`s; proceeds only for drafts.
- On failure, the release stays a draft; rerun `deb-packages.yml` to finalize. Already-published WAR-only releases cannot be retrofitted.

<sup>Written for commit d79e437adb64816092480ee292f5fae851b40921. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carlos-emr/carlos/pull/3529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

